### PR TITLE
[core] Remove usage of `new`, remove `CStateInitException`, template `pushPacket`

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -18,7 +18,6 @@ function(set_project_warnings project_name)
       /wd4457 # declaration of 'var' hides function parameter
       /wd4458 # declaration of 'var' hides class member
       /wd4459 # declaration of 'var' hides global declaration
-      /wd5272 # throwing an object of non-copyable type 'type' is non-standard -> CStateInitException
 
       # TODO: concurrentqueue triggers this. Remove once MSVC fixes it.
       # https://developercommunity2.visualstudio.com/t/C4554-triggers-when-both-lhs-and-rhs-is/10034931

--- a/modules/renamer/cpp/renamer.cpp
+++ b/modules/renamer/cpp/renamer.cpp
@@ -15,7 +15,7 @@ class RenamerModule : public CPPModule
             return;
         }
 
-        auto* customPacket = new CBasicPacket();
+        auto customPacket = std::make_unique<CBasicPacket>();
         customPacket->setType(0x1FF);
         customPacket->setSize(0x100);
         for (std::size_t i = 0; i < data.size(); ++i)

--- a/src/map/ai/ai_container.h
+++ b/src/map/ai/ai_container.h
@@ -134,13 +134,16 @@ public:
 protected:
     // input controller
     std::unique_ptr<CController> Controller;
+
     // current synchronized server time (before AI loop execution)
     time_point m_Tick;
     time_point m_PrevTick;
+
     // entity who holds this AI
     CBaseEntity* PEntity;
 
     void CheckCompletedStates();
+
     template <typename T, typename... Args>
     bool ChangeState(Args&&... args)
     {
@@ -165,6 +168,7 @@ protected:
         }
         return false;
     }
+
     template <typename T, typename... Args>
     bool ForceChangeState(Args&&... args)
     {

--- a/src/map/ai/ai_container.h
+++ b/src/map/ai/ai_container.h
@@ -158,9 +158,9 @@ protected:
                 m_stateStack.emplace(std::make_unique<T>(std::forward<Args>(args)...));
                 return true;
             }
-            catch (CStateInitException& e)
+            catch (CStateInitException&)
             {
-                PEntity->HandleErrorMessage(e.packet);
+                // PEntity->HandleErrorMessage(e.packet);
             }
         }
         return false;
@@ -180,9 +180,9 @@ protected:
             m_stateStack.emplace(std::make_unique<T>(std::forward<Args>(args)...));
             return true;
         }
-        catch (CStateInitException& e)
+        catch (CStateInitException&)
         {
-            PEntity->HandleErrorMessage(e.packet);
+            // PEntity->HandleErrorMessage(e.packet);
         }
         return false;
     }

--- a/src/map/ai/states/ability_state.cpp
+++ b/src/map/ai/states/ability_state.cpp
@@ -159,7 +159,7 @@ bool CAbilityState::CanUseAbility()
         auto* PChar = static_cast<CCharEntity*>(m_PEntity);
         if (PChar->PRecastContainer->HasRecast(RECAST_ABILITY, PAbility->getRecastId(), PAbility->getRecastTime()))
         {
-            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_WAIT_LONGER));
+            PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, MSGBASIC_WAIT_LONGER);
             return false;
         }
 
@@ -170,7 +170,7 @@ bool CAbilityState::CanUseAbility()
             (!PAbility->isPetAbility() && !charutils::hasAbility(PChar, PAbility->getID())) ||
             (PAbility->isPetAbility() && PAbility->getID() >= ABILITY_HEALING_RUBY && !charutils::hasPetAbility(PChar, PAbility->getID() - ABILITY_HEALING_RUBY)))
         {
-            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_UNABLE_TO_USE_JA2));
+            PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, MSGBASIC_UNABLE_TO_USE_JA2);
             return false;
         }
 
@@ -178,7 +178,7 @@ bool CAbilityState::CanUseAbility()
         {
             if (PChar != PTarget && distance(PChar->loc.p, PTarget->loc.p) > PAbility->getRange())
             {
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PTarget, 0, 0, MSGBASIC_TOO_FAR_AWAY));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PTarget, 0, 0, MSGBASIC_TOO_FAR_AWAY);
                 return false;
             }
 
@@ -193,7 +193,7 @@ bool CAbilityState::CanUseAbility()
                 // Blood pact MP costs are stored under animation ID
                 if (PChar->health.mp < PAbility->getAnimationID())
                 {
-                    PChar->pushPacket(new CMessageBasicPacket(PChar, PTarget, 0, 0, MSGBASIC_UNABLE_TO_USE_JA));
+                    PChar->pushPacket<CMessageBasicPacket>(PChar, PTarget, 0, 0, MSGBASIC_UNABLE_TO_USE_JA);
                     return false;
                 }
             }
@@ -202,7 +202,7 @@ bool CAbilityState::CanUseAbility()
             int32        errNo      = luautils::OnAbilityCheck(PChar, PTarget, PAbility, &PMsgTarget);
             if (errNo != 0)
             {
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PMsgTarget, PAbility->getID(), PAbility->getID(), errNo));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PMsgTarget, PAbility->getID(), PAbility->getID(), errNo);
                 return false;
             }
             return true;

--- a/src/map/ai/states/attack_state.cpp
+++ b/src/map/ai/states/attack_state.cpp
@@ -74,7 +74,7 @@ bool CAttackState::Update(time_point tick)
         }
         else if (m_PEntity->OnAttackError(*this))
         {
-            m_PEntity->HandleErrorMessage(m_errorMsg);
+            m_PEntity->HandleErrorMessage(std::move(m_errorMsg));
         }
         if (m_PEntity->GetBattleTargetID() == 0)
         {
@@ -132,7 +132,7 @@ void CAttackState::UpdateTarget(uint16 targid)
                         if (PChar->IsValidTarget(PPotentialTarget.second->targid, TARGET_ENEMY, errMsg))
                         {
                             newTargid = PPotentialTarget.second->targid;
-                            PChar->pushPacket(new CLockOnPacket(PChar, static_cast<CBattleEntity*>(PPotentialTarget.second)));
+                            PChar->pushPacket<CLockOnPacket>(PChar, static_cast<CBattleEntity*>(PPotentialTarget.second));
                             break;
                         }
                     }

--- a/src/map/ai/states/death_state.cpp
+++ b/src/map/ai/states/death_state.cpp
@@ -65,7 +65,7 @@ bool CDeathState::Update(time_point tick)
         auto* PChar = static_cast<CCharEntity*>(m_PEntity);
         if (PChar->m_hasRaise)
         {
-            PChar->pushPacket(new CRaiseTractorMenuPacket(PChar, TYPE_RAISE));
+            PChar->pushPacket<CRaiseTractorMenuPacket>(PChar, TYPE_RAISE);
             m_raiseSent = true;
         }
     }

--- a/src/map/ai/states/item_state.cpp
+++ b/src/map/ai/states/item_state.cpp
@@ -130,8 +130,8 @@ CItemState::CItemState(CCharEntity* PEntity, uint16 targid, uint8 loc, uint8 slo
 
     m_PItem->setSubType(ITEM_LOCKED);
 
-    m_PEntity->pushPacket(new CInventoryAssignPacket(m_PItem, INV_NOSELECT));
-    m_PEntity->pushPacket(new CInventoryFinishPacket());
+    m_PEntity->pushPacket<CInventoryAssignPacket>(m_PItem, INV_NOSELECT);
+    m_PEntity->pushPacket<CInventoryFinishPacket>();
 }
 
 void CItemState::UpdateTarget(CBaseEntity* target)
@@ -211,15 +211,15 @@ void CItemState::Cleanup(time_point tick)
 
     if (PItem && PItem == m_PItem)
     {
-        m_PEntity->pushPacket(new CInventoryAssignPacket(m_PItem, INV_NORMAL));
+        m_PEntity->pushPacket<CInventoryAssignPacket>(m_PItem, INV_NORMAL);
     }
     else
     {
         m_PItem = nullptr;
     }
 
-    m_PEntity->pushPacket(new CInventoryItemPacket(m_PItem, m_location, m_slot));
-    m_PEntity->pushPacket(new CInventoryFinishPacket());
+    m_PEntity->pushPacket<CInventoryItemPacket>(m_PItem, m_location, m_slot);
+    m_PEntity->pushPacket<CInventoryFinishPacket>();
 }
 
 bool CItemState::CanChangeState()
@@ -294,7 +294,7 @@ void CItemState::InterruptItem(action_t& action)
         actionTarget.messageID  = 0;
         actionTarget.knockback  = 0;
 
-        m_PEntity->pushPacket(m_errorMsg.release());
+        m_PEntity->pushPacket(std::move(m_errorMsg));
     }
 }
 

--- a/src/map/ai/states/range_state.cpp
+++ b/src/map/ai/states/range_state.cpp
@@ -124,7 +124,7 @@ bool CRangeState::Update(time_point tick)
 
             if (auto* PChar = dynamic_cast<CCharEntity*>(m_PEntity))
             {
-                PChar->pushPacket(m_errorMsg.release());
+                PChar->pushPacket(std::move(m_errorMsg));
             }
             // reset aim time so interrupted players only have to wait the correct 2.7s until next shot
             m_aimTime = std::chrono::seconds(0);

--- a/src/map/ai/states/state.cpp
+++ b/src/map/ai/states/state.cpp
@@ -77,9 +77,9 @@ bool CState::HasErrorMsg() const
     return m_errorMsg != nullptr;
 }
 
-CBasicPacket* CState::GetErrorMsg()
+CBasicPacketPtr CState::GetErrorMsg()
 {
-    return m_errorMsg.release();
+    return std::move(m_errorMsg);
 }
 
 bool CState::DoUpdate(time_point tick)

--- a/src/map/ai/states/state.cpp
+++ b/src/map/ai/states/state.cpp
@@ -72,16 +72,6 @@ void CState::SetTarget(uint16 _targid)
     }
 }
 
-bool CState::HasErrorMsg() const
-{
-    return m_errorMsg != nullptr;
-}
-
-CBasicPacketPtr CState::GetErrorMsg()
-{
-    return std::move(m_errorMsg);
-}
-
 bool CState::DoUpdate(time_point tick)
 {
     UpdateTarget(m_targid);

--- a/src/map/ai/states/state.h
+++ b/src/map/ai/states/state.h
@@ -51,8 +51,9 @@ public:
     void         SetTarget(uint16 targid);
 
     bool HasErrorMsg() const;
+
     /* Releases ownership to the caller */
-    CBasicPacket* GetErrorMsg();
+    CBasicPacketPtr GetErrorMsg();
 
     bool DoUpdate(time_point tick);
     // try interrupt (on hit)
@@ -80,7 +81,7 @@ protected:
     void       Complete();
     time_point GetEntryTime() const;
 
-    std::unique_ptr<CBasicPacket> m_errorMsg;
+    CBasicPacketPtr m_errorMsg;
 
     CBaseEntity* const m_PEntity;
     uint16             m_targid{ 0 };

--- a/src/map/ai/states/state.h
+++ b/src/map/ai/states/state.h
@@ -29,17 +29,6 @@
 
 class CBattleEntity;
 
-class CStateInitException : public std::exception
-{
-public:
-    explicit CStateInitException(std::unique_ptr<CBasicPacket> _msg)
-    : std::exception()
-    , packet(std::move(_msg))
-    {
-    }
-    std::unique_ptr<CBasicPacket> packet;
-};
-
 class CState
 {
 public:
@@ -49,11 +38,6 @@ public:
 
     CBaseEntity* GetTarget() const;
     void         SetTarget(uint16 targid);
-
-    bool HasErrorMsg() const;
-
-    /* Releases ownership to the caller */
-    CBasicPacketPtr GetErrorMsg();
 
     bool DoUpdate(time_point tick);
     // try interrupt (on hit)
@@ -80,8 +64,6 @@ protected:
     uint16     GetTargetID() const;
     void       Complete();
     time_point GetEntryTime() const;
-
-    CBasicPacketPtr m_errorMsg;
 
     CBaseEntity* const m_PEntity;
     uint16             m_targid{ 0 };

--- a/src/map/anticheat.cpp
+++ b/src/map/anticheat.cpp
@@ -139,7 +139,7 @@ namespace anticheat
         if (action & CHEAT_ACTION_WARN)
         {
             // The message in the warning column in DB is sent as a system message to the offender
-            PChar->pushPacket(new CChatMessagePacket(PChar, CHAT_MESSAGE_TYPE::MESSAGE_SYSTEM_1, warningmsg));
+            PChar->pushPacket<CChatMessagePacket>(PChar, CHAT_MESSAGE_TYPE::MESSAGE_SYSTEM_1, warningmsg);
         }
         if ((action & CHEAT_ACTION_JAIL) && (!settings::get<bool>("map.ANTICHEAT_JAIL_DISABLE")))
         {

--- a/src/map/attackround.cpp
+++ b/src/map/attackround.cpp
@@ -389,7 +389,7 @@ void CAttackRound::CreateAttacks(CItemWeapon* PWeapon, PHYSICAL_ATTACK_DIRECTION
                 PChar->RequestPersist(CHAR_PERSIST::EQUIP);
             }
             charutils::UpdateItem(PChar, loc, slot, -ammoCount);
-            PChar->pushPacket(new CInventoryFinishPacket());
+            PChar->pushPacket<CInventoryFinishPacket>();
         }
     }
 

--- a/src/map/campaign_system.cpp
+++ b/src/map/campaign_system.cpp
@@ -185,7 +185,7 @@ namespace campaign
 
     void SendUpdate(CCharEntity* PChar)
     {
-        PChar->pushPacket(new CCampaignPacket(PChar, CState, 0));
-        PChar->pushPacket(new CCampaignPacket(PChar, CState, 1));
+        PChar->pushPacket<CCampaignPacket>(PChar, CState, 0);
+        PChar->pushPacket<CCampaignPacket>(PChar, CState, 1);
     }
 }; // namespace campaign

--- a/src/map/char_recast_container.cpp
+++ b/src/map/char_recast_container.cpp
@@ -171,8 +171,8 @@ void CCharRecastContainer::Check()
                     uint8  containerID = id & 0xFF;
                     CItem* PItem       = m_PChar->getStorage(containerID)->GetItem(slotID);
 
-                    m_PChar->pushPacket(new CInventoryItemPacket(PItem, containerID, slotID));
-                    m_PChar->pushPacket(new CInventoryFinishPacket());
+                    m_PChar->pushPacket<CInventoryItemPacket>(PItem, containerID, slotID);
+                    m_PChar->pushPacket<CInventoryFinishPacket>();
                 }
                 if (type == RECAST_ITEM || type == RECAST_MAGIC || type == RECAST_LOOT)
                 {

--- a/src/map/conquest_system.cpp
+++ b/src/map/conquest_system.cpp
@@ -475,7 +475,7 @@ namespace conquest
                 luautils::OnConquestUpdate(PZone, Conquest_Tally_End, influence, owner, ranking, isConquestAlliance);
                 PZone->ForEachChar([](CCharEntity* PChar)
                 {
-                    PChar->pushPacket(new CConquestPacket(PChar));
+                    PChar->pushPacket<CConquestPacket>(PChar);
                     PChar->PLatentEffectContainer->CheckLatentsZone();
                 });
             }

--- a/src/map/entities/automatonentity.cpp
+++ b/src/map/entities/automatonentity.cpp
@@ -194,7 +194,7 @@ void CAutomatonEntity::PostTick()
     {
         if (PMaster && PMaster->objtype == TYPE_PC)
         {
-            ((CCharEntity*)PMaster)->pushPacket(new CCharJobExtraPacket((CCharEntity*)PMaster, PMaster->GetMJob() == JOB_PUP));
+            ((CCharEntity*)PMaster)->pushPacket<CCharJobExtraPacket>((CCharEntity*)PMaster, PMaster->GetMJob() == JOB_PUP);
         }
     }
 }

--- a/src/map/entities/baseentity.h
+++ b/src/map/entities/baseentity.h
@@ -292,7 +292,7 @@ public:
     void   SetModelId(uint16 modelId); // Set new modelid
     uint16 GetModelId() const;         // Get the modelid
 
-    virtual void HandleErrorMessage(std::unique_ptr<CBasicPacket>&){};
+    virtual void HandleErrorMessage(CBasicPacketPtr&&){};
 
     bool IsDynamicEntity() const;
 

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -340,9 +340,8 @@ void CCharEntity::updateCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint8 
     if (existing == PendingCharPackets.end())
     {
         // No existing packet update for the given char, so we push new packet
-        CCharPacket* packet = new CCharPacket(PChar, type, updatemask);
-        PacketList.emplace_back(packet);
-        PendingCharPackets.emplace(PChar->id, packet);
+        PacketList.emplace_back(std::make_unique<CCharPacket>(PChar, type, updatemask));
+        PendingCharPackets.emplace(PChar->id, std::make_unique<CCharPacket>(PChar, type, updatemask));
     }
     else
     {
@@ -357,9 +356,8 @@ void CCharEntity::updateEntityPacket(CBaseEntity* PEntity, ENTITYUPDATE type, ui
     if (existing == PendingEntityPackets.end())
     {
         // No existing packet update for the given entity, so we push new packet
-        CEntityUpdatePacket* packet = new CEntityUpdatePacket(PEntity, type, updatemask);
-        PacketList.emplace_back(packet);
-        PendingEntityPackets.emplace(PEntity->id, packet);
+        PacketList.emplace_back(std::make_unique<CEntityUpdatePacket>(PEntity, type, updatemask));
+        PendingEntityPackets.emplace(PEntity->id, std::make_unique<CEntityUpdatePacket>(PEntity, type, updatemask));
     }
     else
     {

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -302,8 +302,7 @@ void CCharEntity::clearPacketList()
 {
     while (!PacketList.empty())
     {
-        auto* packet = popPacket();
-        destroy(packet);
+        popPacket();
     }
 }
 
@@ -369,9 +368,10 @@ void CCharEntity::updateEntityPacket(CBaseEntity* PEntity, ENTITYUPDATE type, ui
     }
 }
 
-CBasicPacket* CCharEntity::popPacket()
+CBasicPacketPtr CCharEntity::popPacket()
 {
-    CBasicPacket* PPacket = PacketList.front();
+    auto PPacket = std::move(PacketList.front());
+    PacketList.pop_front();
 
     // Clean up pending maps
     switch (PPacket->getType())
@@ -389,11 +389,10 @@ CBasicPacket* CCharEntity::popPacket()
             break;
     }
 
-    PacketList.pop_front();
     return PPacket;
 }
 
-PacketList_t CCharEntity::getPacketList()
+PacketList_t& CCharEntity::getPacketList()
 {
     return PacketList;
 }
@@ -407,8 +406,7 @@ void CCharEntity::erasePackets(uint8 num)
 {
     for (auto i = 0; i < num; i++)
     {
-        auto* packet = popPacket();
-        destroy(packet);
+        popPacket();
     }
 }
 

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -307,36 +307,32 @@ void CCharEntity::clearPacketList()
     }
 }
 
-void CCharEntity::pushPacket(CBasicPacket* packet)
+void CCharEntity::pushPacket(CBasicPacketPtr&& packet)
 {
     TracyZoneScoped;
     TracyZoneString(getName());
     TracyZoneHex16(packet->getType());
 
-    moduleutils::OnPushPacket(this, packet);
+    // TODO
+    // moduleutils::OnPushPacket(this, packet);
 
     if (packet->getType() == 0x5B)
     {
         if (PendingPositionPacket)
         {
             PendingPositionPacket->copy(packet);
-            destroy(packet);
         }
         else
         {
-            PendingPositionPacket = packet;
-            PacketList.emplace_back(packet);
+            PendingPositionPacket = std::make_unique<CBasicPacket>();
+            PendingPositionPacket->copy(packet);
+            PacketList.emplace_back(std::move(packet));
         }
     }
     else
     {
-        PacketList.emplace_back(packet);
+        PacketList.emplace_back(std::move(packet));
     }
-}
-
-void CCharEntity::pushPacket(std::unique_ptr<CBasicPacket> packet)
-{
-    pushPacket(packet.release());
 }
 
 void CCharEntity::updateCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint8 updatemask)
@@ -804,7 +800,7 @@ void CCharEntity::PostTick()
     {
         updatemask |= UPDATE_HP;
         m_EquipSwap = false;
-        pushPacket(new CCharAppearancePacket(this));
+        pushPacket<CCharAppearancePacket>(this);
     }
 
     if (ReloadParty())
@@ -814,11 +810,11 @@ void CCharEntity::PostTick()
 
     if (m_EffectsChanged)
     {
-        pushPacket(new CCharUpdatePacket(this));
-        pushPacket(new CCharSyncPacket(this));
-        pushPacket(new CCharJobExtraPacket(this, true));
-        pushPacket(new CCharJobExtraPacket(this, false));
-        pushPacket(new CStatusEffectPacket(this));
+        pushPacket<CCharUpdatePacket>(this);
+        pushPacket<CCharSyncPacket>(this);
+        pushPacket<CCharJobExtraPacket>(this, true);
+        pushPacket<CCharJobExtraPacket>(this, false);
+        pushPacket<CStatusEffectPacket>(this);
         if (PParty)
         {
             PParty->PushEffectsPacket();
@@ -847,14 +843,14 @@ void CCharEntity::PostTick()
             // clang-format off
             ForAlliance([&](auto PEntity)
             {
-                static_cast<CCharEntity*>(PEntity)->pushPacket(new CCharHealthPacket(this));
+                static_cast<CCharEntity*>(PEntity)->pushPacket<CCharHealthPacket>(this);
             });
             // clang-format on
         }
         // Do not send an update packet when only the position has change
         if (updatemask ^ UPDATE_POS)
         {
-            pushPacket(new CCharUpdatePacket(this));
+            pushPacket<CCharUpdatePacket>(this);
         }
         updatemask = 0;
     }
@@ -953,7 +949,7 @@ void CCharEntity::OnChangeTarget(CBattleEntity* PNewTarget)
 {
     TracyZoneScoped;
     battleutils::RelinquishClaim(this);
-    pushPacket(new CLockOnPacket(this, PNewTarget));
+    pushPacket<CLockOnPacket>(this, PNewTarget);
     PLatentEffectContainer->CheckLatentsTargetChange();
 }
 
@@ -1116,11 +1112,11 @@ void CCharEntity::OnCastInterrupted(CMagicState& state, action_t& action, MSGBAS
     TracyZoneScoped;
     CBattleEntity::OnCastInterrupted(state, action, msg, blockedCast);
 
-    auto* message = state.GetErrorMsg();
+    auto message = state.GetErrorMsg();
 
     if (message && action.actiontype != ACTION_MAGIC_INTERRUPT) // Interrupt is handled elsewhere
     {
-        pushPacket(message);
+        pushPacket(std::move(message));
     }
 }
 
@@ -1313,12 +1309,12 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
     auto* PAbility = state.GetAbility();
     if (this->PRecastContainer->HasRecast(RECAST_ABILITY, PAbility->getRecastId(), PAbility->getRecastTime()))
     {
-        pushPacket(new CMessageBasicPacket(this, this, 0, 0, MSGBASIC_WAIT_LONGER));
+        pushPacket<CMessageBasicPacket>(this, this, 0, 0, MSGBASIC_WAIT_LONGER);
         return;
     }
     if (this->StatusEffectContainer->HasStatusEffect(EFFECT_AMNESIA))
     {
-        pushPacket(new CMessageBasicPacket(this, this, 0, 0, MSGBASIC_UNABLE_TO_USE_JA2));
+        pushPacket<CMessageBasicPacket>(this, this, 0, 0, MSGBASIC_UNABLE_TO_USE_JA2);
         return;
     }
 
@@ -1344,7 +1340,7 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
     {
         if (this != PTarget && distance(this->loc.p, PTarget->loc.p) > PAbility->getRange())
         {
-            pushPacket(new CMessageBasicPacket(this, PTarget, 0, 0, MSGBASIC_TOO_FAR_AWAY));
+            pushPacket<CMessageBasicPacket>(this, PTarget, 0, 0, MSGBASIC_TOO_FAR_AWAY);
             return;
         }
         if (PAbility->getID() >= ABILITY_HEALING_RUBY && PAbility->getID() <= ABILITY_PERFECT_DEFENSE)
@@ -1358,7 +1354,7 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
 
             if (this->health.mp < mpCost)
             {
-                pushPacket(new CMessageBasicPacket(this, PTarget, 0, 0, MSGBASIC_UNABLE_TO_USE_JA));
+                pushPacket<CMessageBasicPacket>(this, PTarget, 0, 0, MSGBASIC_UNABLE_TO_USE_JA);
                 return;
             }
         }
@@ -1652,7 +1648,7 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
             PRecastContainer->Add(RECAST_ABILITY, (recastID == 173 ? 174 : 173), action.recast);
         }
 
-        pushPacket(new CCharRecastPacket(this));
+        pushPacket<CCharRecastPacket>(this);
 
         // #TODO: refactor
         //  if (this->getMijinGakure())
@@ -1954,12 +1950,12 @@ bool CCharEntity::IsMobOwner(CBattleEntity* PBattleTarget)
     return found;
 }
 
-void CCharEntity::HandleErrorMessage(std::unique_ptr<CBasicPacket>& msg)
+void CCharEntity::HandleErrorMessage(CBasicPacketPtr&& msg)
 {
     TracyZoneScoped;
-    if (msg && !isCharmed)
+    if (!isCharmed)
     {
-        pushPacket(msg.release());
+        pushPacket(std::move(msg));
     }
 }
 
@@ -2077,7 +2073,7 @@ void CCharEntity::OnItemFinish(CItemState& state, action_t& action)
     if (!PItem->isType(ITEM_EQUIPMENT) && (PItem->getQuantity() < 1 || PItem->getReserve() > 0))
     {
         ShowWarning("OnItemFinish: %s attempted to use reserved/insufficient %s (%u).", this->getName(), PItem->getName(), PItem->getID());
-        this->pushPacket(new CMessageBasicPacket(this, this, PItem->getID(), 0, MSGBASIC_ITEM_FAILS_TO_ACTIVATE));
+        this->pushPacket<CMessageBasicPacket>(this, this, PItem->getID(), 0, MSGBASIC_ITEM_FAILS_TO_ACTIVATE);
 
         return;
     }
@@ -2152,7 +2148,7 @@ CBattleEntity* CCharEntity::IsValidTarget(uint16 targid, uint16 validTargetFlags
             // Target is blocking assistance
             errMsg = std::make_unique<CMessageSystemPacket>(0, 0, MSGSYSTEM::TARGET_IS_CURRENTLY_BLOCKING);
             // Interaction was blocked
-            static_cast<CCharEntity*>(PTarget)->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::BLOCKED_BY_BLOCKAID));
+            static_cast<CCharEntity*>(PTarget)->pushPacket<CMessageSystemPacket>(0, 0, MSGSYSTEM::BLOCKED_BY_BLOCKAID);
         }
         else if (IsMobOwner(PTarget))
         {
@@ -2385,7 +2381,7 @@ void CCharEntity::UpdateMoghancement()
     // Always show which moghancement the player has if they have one at all
     if (newMoghancementID != 0)
     {
-        pushPacket(new CMessageSpecialPacket(this, luautils::GetTextIDVariable(getZone(), "KEYITEM_OBTAINED"), newMoghancementID, 0, 0, 0, false));
+        pushPacket<CMessageSpecialPacket>(this, luautils::GetTextIDVariable(getZone(), "KEYITEM_OBTAINED"), newMoghancementID, 0, 0, 0, false);
     }
 
     if (newMoghancementID != m_moghancementID)
@@ -2407,17 +2403,17 @@ void CCharEntity::UpdateMoghancement()
         uint8 currentTable = m_moghancementID >> 9;
         if (newTable == currentTable)
         {
-            pushPacket(new CKeyItemsPacket(this, (KEYS_TABLE)newTable));
+            pushPacket<CKeyItemsPacket>(this, (KEYS_TABLE)newTable);
         }
         else
         {
             if (newTable != 0)
             {
-                pushPacket(new CKeyItemsPacket(this, (KEYS_TABLE)newTable));
+                pushPacket<CKeyItemsPacket>(this, (KEYS_TABLE)newTable);
             }
             if (currentTable != 0)
             {
-                pushPacket(new CKeyItemsPacket(this, (KEYS_TABLE)currentTable));
+                pushPacket<CKeyItemsPacket>(this, (KEYS_TABLE)currentTable);
             }
         }
         charutils::SaveKeyItems(this);
@@ -2757,11 +2753,11 @@ void CCharEntity::tryStartNextEvent()
 
     if (currentEvent->strings.empty())
     {
-        pushPacket(new CEventPacket(this, currentEvent));
+        pushPacket<CEventPacket>(this, currentEvent);
     }
     else
     {
-        pushPacket(new CEventStringPacket(this, currentEvent));
+        pushPacket<CEventStringPacket>(this, currentEvent);
     }
 }
 
@@ -2770,13 +2766,13 @@ void CCharEntity::skipEvent()
     TracyZoneScoped;
     if (!m_Locked && !isInEvent() && (!currentEvent->cutsceneOptions.empty() || currentEvent->interruptText != 0))
     {
-        pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::EVENT_SKIPPED));
-        pushPacket(new CReleasePacket(this, RELEASE_TYPE::SKIPPING));
+        pushPacket<CMessageSystemPacket>(0, 0, MSGSYSTEM::EVENT_SKIPPED);
+        pushPacket<CReleasePacket>(this, RELEASE_TYPE::SKIPPING);
         m_Substate = CHAR_SUBSTATE::SUBSTATE_NONE;
 
         if (currentEvent->interruptText != 0)
         {
-            pushPacket(new CMessageTextPacket(currentEvent->targetEntity, currentEvent->interruptText, false));
+            pushPacket<CMessageTextPacket>(currentEvent->targetEntity, currentEvent->interruptText, false);
         }
 
         endCurrentEvent();

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -401,9 +401,16 @@ public:
 
     uint8 GetGender();
 
-    void          clearPacketList();
-    void          pushPacket(CBasicPacket*);                                                     // Adding a copy of a package to the PacketList
-    void          pushPacket(std::unique_ptr<CBasicPacket>);                                     // Push packet to packet list
+    void clearPacketList();
+
+    void pushPacket(CBasicPacketPtr&& packet);
+
+    template <typename T, typename... Args>
+    void pushPacket(Args&&... args)
+    {
+        pushPacket(std::make_unique<T>(std::forward<Args>(args)...));
+    }
+
     void          updateCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint8 updatemask);     // Push or update a char packet
     void          updateEntityPacket(CBaseEntity* PEntity, ENTITYUPDATE type, uint8 updatemask); // Push or update an entity update packet
     bool          isPacketListEmpty();
@@ -411,7 +418,7 @@ public:
     PacketList_t  getPacketList(); // Return a COPY of packet list
     size_t        getPacketCount();
     void          erasePackets(uint8 num); // Erase num elements from front of packet list
-    virtual void  HandleErrorMessage(std::unique_ptr<CBasicPacket>&) override;
+    virtual void  HandleErrorMessage(CBasicPacketPtr&&) override;
 
     CLinkshell*    PLinkshell1;
     CLinkshell*    PLinkshell2;
@@ -513,7 +520,7 @@ public:
 
     CItemEquipment* getEquip(SLOTTYPE slot);
 
-    CBasicPacket* PendingPositionPacket = nullptr;
+    CBasicPacketPtr PendingPositionPacket = nullptr;
 
     bool requestedInfoSync = false;
 

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -286,7 +286,7 @@ class CRangeState;
 class CItemState;
 class CItemUsable;
 
-typedef std::deque<CBasicPacket*>      PacketList_t;
+typedef std::deque<CBasicPacketPtr>    PacketList_t;
 typedef std::map<uint32, CBaseEntity*> SpawnIDList_t;
 typedef std::vector<EntityID_t>        BazaarList_t;
 
@@ -411,14 +411,14 @@ public:
         pushPacket(std::make_unique<T>(std::forward<Args>(args)...));
     }
 
-    void          updateCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint8 updatemask);     // Push or update a char packet
-    void          updateEntityPacket(CBaseEntity* PEntity, ENTITYUPDATE type, uint8 updatemask); // Push or update an entity update packet
-    bool          isPacketListEmpty();
-    CBasicPacket* popPacket();     // Get first packet from PacketList
-    PacketList_t  getPacketList(); // Return a COPY of packet list
-    size_t        getPacketCount();
-    void          erasePackets(uint8 num); // Erase num elements from front of packet list
-    virtual void  HandleErrorMessage(CBasicPacketPtr&&) override;
+    void            updateCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint8 updatemask);     // Push or update a char packet
+    void            updateEntityPacket(CBaseEntity* PEntity, ENTITYUPDATE type, uint8 updatemask); // Push or update an entity update packet
+    bool            isPacketListEmpty();
+    CBasicPacketPtr popPacket(); // Get first packet from PacketList
+    PacketList_t&   getPacketList();
+    size_t          getPacketCount();
+    void            erasePackets(uint8 num); // Erase num elements from front of packet list
+    virtual void    HandleErrorMessage(CBasicPacketPtr&&) override;
 
     CLinkshell*    PLinkshell1;
     CLinkshell*    PLinkshell2;

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -640,9 +640,9 @@ private:
     uint8      dataToPersist = 0;
     time_point nextDataPersistTime;
 
-    PacketList_t                                     PacketList;           // The list of packets to be sent to the character during the next network cycle
-    std::unordered_map<uint32, CCharPacket*>         PendingCharPackets;   // Keep track of which char packets are queued up for this char, such that they can be updated
-    std::unordered_map<uint32, CEntityUpdatePacket*> PendingEntityPackets; // Keep track of which entity update packets are queued up for this char, such that they can be updated
+    PacketList_t                                                     PacketList;           // The list of packets to be sent to the character during the next network cycle
+    std::unordered_map<uint32, std::unique_ptr<CCharPacket>>         PendingCharPackets;   // Keep track of which char packets are queued up for this char, such that they can be updated
+    std::unordered_map<uint32, std::unique_ptr<CEntityUpdatePacket>> PendingEntityPackets; // Keep track of which entity update packets are queued up for this char, such that they can be updated
 };
 
 #endif

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -474,7 +474,7 @@ void CMobEntity::PostTick()
         // If this mob is charmed, it should sync with its master
         if (PMaster && PMaster->PPet == this && PMaster->objtype == TYPE_PC)
         {
-            ((CCharEntity*)PMaster)->pushPacket(new CPetSyncPacket((CCharEntity*)PMaster));
+            ((CCharEntity*)PMaster)->pushPacket<CPetSyncPacket>((CCharEntity*)PMaster);
         }
 
         updatemask = 0;

--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -152,7 +152,7 @@ public:
     float        GetRoamRate();
     virtual bool ValidTarget(CBattleEntity* PInitiator, uint16 targetFlags) override;
 
-    virtual void HandleErrorMessage(std::unique_ptr<CBasicPacket>&) override
+    virtual void HandleErrorMessage(std::unique_ptr<CBasicPacket>&&) override
     {
     }
     virtual void Die() override;

--- a/src/map/entities/petentity.cpp
+++ b/src/map/entities/petentity.cpp
@@ -209,7 +209,7 @@ void CPetEntity::PostTick()
 
         if (PMaster && PMaster->PPet == this)
         {
-            ((CCharEntity*)PMaster)->pushPacket(new CPetSyncPacket((CCharEntity*)PMaster));
+            ((CCharEntity*)PMaster)->pushPacket<CPetSyncPacket>((CCharEntity*)PMaster);
         }
 
         updatemask = 0;

--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -74,7 +74,7 @@ void CTrustEntity::PostTick()
             // clang-format off
             PMaster->ForParty([this](auto PMember)
             {
-                static_cast<CCharEntity*>(PMember)->pushPacket(new CCharHealthPacket(this));
+                static_cast<CCharEntity*>(PMember)->pushPacket<CCharHealthPacket>(this);
             });
             // clang-format on
         }
@@ -110,7 +110,7 @@ void CTrustEntity::Spawn()
     // we need to skip CMobEntity's spawn because it calculates stats (and our stats are already calculated)
     CBattleEntity::Spawn();
     luautils::OnMobSpawn(this);
-    ((CCharEntity*)PMaster)->pushPacket(new CEntitySetNamePacket(this));
+    ((CCharEntity*)PMaster)->pushPacket<CEntitySetNamePacket>(this);
 }
 
 void CTrustEntity::OnAbility(CAbilityState& state, action_t& action)

--- a/src/map/job_points.cpp
+++ b/src/map/job_points.cpp
@@ -468,7 +468,7 @@ namespace jobpointutils
 
         if (sendUpdate)
         {
-            PChar->pushPacket(new CCharSpellsPacket(PChar));
+            PChar->pushPacket<CCharSpellsPacket>(PChar);
         }
     }
 } // namespace jobpointutils

--- a/src/map/linkshell.cpp
+++ b/src/map/linkshell.cpp
@@ -209,16 +209,16 @@ void CLinkshell::ChangeMemberRank(const std::string& MemberName, uint8 toSack)
                                    static_cast<uint8>(PItemLinkshell->GetLSType()), PMember->id);
                     }
 
-                    PMember->pushPacket(new CInventoryAssignPacket(PItemLinkshell, INV_NORMAL));
-                    PMember->pushPacket(new CLinkshellEquipPacket(PMember, lsID));
-                    PMember->pushPacket(new CInventoryItemPacket(PItemLinkshell, LocationID, SlotID));
+                    PMember->pushPacket<CInventoryAssignPacket>(PItemLinkshell, INV_NORMAL);
+                    PMember->pushPacket<CLinkshellEquipPacket>(PMember, lsID);
+                    PMember->pushPacket<CInventoryItemPacket>(PItemLinkshell, LocationID, SlotID);
                 }
 
                 charutils::SaveCharStats(PMember);
                 charutils::SaveCharEquip(PMember);
 
-                PMember->pushPacket(new CInventoryFinishPacket());
-                PMember->pushPacket(new CCharUpdatePacket(PMember));
+                PMember->pushPacket<CInventoryFinishPacket>();
+                PMember->pushPacket<CCharUpdatePacket>(PMember);
                 return;
             }
         }
@@ -260,8 +260,8 @@ void CLinkshell::RemoveMemberByName(const std::string& MemberName, uint8 kickerR
                     PMember->updatemask |= UPDATE_HP;
                 }
 
-                PMember->pushPacket(new CInventoryAssignPacket(PItemLinkshell, INV_NORMAL));
-                PMember->pushPacket(new CLinkshellEquipPacket(PMember, lsNum));
+                PMember->pushPacket<CInventoryAssignPacket>(PItemLinkshell, INV_NORMAL);
+                PMember->pushPacket<CLinkshellEquipPacket>(PMember, lsNum);
             }
 
             for (uint8 LocationID = 0; LocationID < CONTAINER_ID::MAX_CONTAINER_ID; ++LocationID)
@@ -281,7 +281,7 @@ void CLinkshell::RemoveMemberByName(const std::string& MemberName, uint8 kickerR
                                 sql->EscapeStringLen(extra, (const char*)newPItemLinkshell->m_extra, sizeof(newPItemLinkshell->m_extra));
                                 const char* Query = "UPDATE char_inventory SET extra = '%s' WHERE charid = %u AND location = %u AND slot = %u LIMIT 1";
                                 sql->Query(Query, extra, PMember->id, LocationID, SlotID);
-                                PMember->pushPacket(new CInventoryItemPacket(newPItemLinkshell, LocationID, SlotID));
+                                PMember->pushPacket<CInventoryItemPacket>(newPItemLinkshell, LocationID, SlotID);
                             }
                         }
                     }
@@ -291,15 +291,15 @@ void CLinkshell::RemoveMemberByName(const std::string& MemberName, uint8 kickerR
             charutils::SaveCharStats(PMember);
             charutils::SaveCharEquip(PMember);
 
-            PMember->pushPacket(new CInventoryFinishPacket());
-            PMember->pushPacket(new CCharUpdatePacket(PMember));
+            PMember->pushPacket<CInventoryFinishPacket>();
+            PMember->pushPacket<CCharUpdatePacket>(PMember);
             if (breakLinkshell)
             {
-                PMember->pushPacket(new CMessageStandardPacket(MsgStd::LinkshellNoLongerExists));
+                PMember->pushPacket<CMessageStandardPacket>(MsgStd::LinkshellNoLongerExists);
             }
             else
             {
-                PMember->pushPacket(new CMessageStandardPacket(MsgStd::LinkshellKicked));
+                PMember->pushPacket<CMessageStandardPacket>(MsgStd::LinkshellKicked);
             }
 
             return;

--- a/src/map/linkshell.h
+++ b/src/map/linkshell.h
@@ -25,6 +25,8 @@
 #include "common/cbasetypes.h"
 #include "common/mmo.h"
 
+#include "packets/basic.h"
+
 #include <vector>
 
 class CBasicPacket;
@@ -54,7 +56,7 @@ public:
     void RemoveMemberByName(const std::string& MemberName, uint8 kickerRank, bool breakLinkshell = false);
     void ChangeMemberRank(const std::string& MemberName, uint8 toSack);
 
-    void PushPacket(uint32 senderID, CBasicPacket* packet);
+    void PushPacket(uint32 senderID, CBasicPacketPtr&& packet);
     void PushLinkshellMessage(CCharEntity* PChar, bool ls1);
 
     std::vector<CCharEntity*> members;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -762,7 +762,7 @@ void CLuaBaseEntity::injectPacket(std::string const& filename)
 
     if (File)
     {
-        CBasicPacket* PPacket = new CBasicPacket();
+        auto PPacket = std::make_unique<CBasicPacket>();
 
         fseek(File, 1, SEEK_SET);
         if (fread(&size, 1, 1, File) != 1)
@@ -780,7 +780,7 @@ void CLuaBaseEntity::injectPacket(std::string const& filename)
             return;
         }
 
-        ((CCharEntity*)m_PBaseEntity)->pushPacket(PPacket);
+        ((CCharEntity*)m_PBaseEntity)->pushPacket(std::move(PPacket));
 
         fclose(File);
     }
@@ -11160,14 +11160,14 @@ void CLuaBaseEntity::countdown(sol::object const& secondsObj)
     }
 
     CCharEntity* PChar  = (CCharEntity*)m_PBaseEntity;
-    auto*        packet = new CObjectiveUtilityPacket();
+    auto         packet = std::make_unique<CObjectiveUtilityPacket>();
 
     if (secondsObj.is<uint32>())
     {
         packet->addCountdown(secondsObj.as<uint32>());
     }
 
-    PChar->pushPacket(packet);
+    PChar->pushPacket(std::move(packet));
 }
 
 /************************************************************************

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -204,7 +204,7 @@ void CLuaBaseEntity::showText(CLuaBaseEntity* mob, uint16 messageID, sol::object
 
     if (m_PBaseEntity->objtype == TYPE_PC)
     {
-        static_cast<CCharEntity*>(m_PBaseEntity)->pushPacket(new CMessageSpecialPacket(PBaseEntity, messageID, param0, param1, param2, param3));
+        static_cast<CCharEntity*>(m_PBaseEntity)->pushPacket<CMessageSpecialPacket>(PBaseEntity, messageID, param0, param1, param2, param3);
     }
     else
     {
@@ -284,7 +284,7 @@ void CLuaBaseEntity::messageText(CLuaBaseEntity* PLuaBaseEntity, uint16 messageI
     if (auto player = dynamic_cast<CCharEntity*>(m_PBaseEntity))
     {
         player->gotMessage = true;
-        player->pushPacket(new CMessageTextPacket(PTarget, messageID, showName, mode));
+        player->pushPacket<CMessageTextPacket>(PTarget, messageID, showName, mode);
     }
     else
     { // broadcast in range
@@ -314,7 +314,7 @@ void CLuaBaseEntity::printToPlayer(std::string const& message, sol::object const
 
     if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
     {
-        PChar->pushPacket(new CChatMessagePacket(PChar, messageType, message, name));
+        PChar->pushPacket<CChatMessagePacket>(PChar, messageType, message, name);
     }
 }
 
@@ -405,7 +405,7 @@ void CLuaBaseEntity::messageBasic(uint16 messageID, sol::object const& p0, sol::
 
     if (m_PBaseEntity->objtype == TYPE_PC)
     {
-        static_cast<CCharEntity*>(m_PBaseEntity)->pushPacket(new CMessageBasicPacket(m_PBaseEntity, PTarget, param0, param1, messageID));
+        static_cast<CCharEntity*>(m_PBaseEntity)->pushPacket<CMessageBasicPacket>(m_PBaseEntity, PTarget, param0, param1, messageID);
     }
     else
     {
@@ -436,7 +436,7 @@ void CLuaBaseEntity::messageName(uint16 messageID, sol::object const& entity, so
 
     if (CCharEntity* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
     {
-        PChar->pushPacket(new CMessageNamePacket(PChar, messageID, PNameEntity, param0, param1, param2, param3, chatType));
+        PChar->pushPacket<CMessageNamePacket>(PChar, messageID, PNameEntity, param0, param1, param2, param3, chatType);
     }
     else
     {
@@ -485,7 +485,7 @@ void CLuaBaseEntity::messageSpecial(uint16 messageID, sol::variadic_args va)
     uint32 param3   = va.get_type(3) == sol::type::number ? va.get<uint32>(3) : 0;
     bool   showName = va.get_type(4) == sol::type::boolean ? va.get<bool>(4) : false;
 
-    static_cast<CCharEntity*>(m_PBaseEntity)->pushPacket(new CMessageSpecialPacket(m_PBaseEntity, messageID, param0, param1, param2, param3, showName));
+    static_cast<CCharEntity*>(m_PBaseEntity)->pushPacket<CMessageSpecialPacket>(m_PBaseEntity, messageID, param0, param1, param2, param3, showName);
 }
 
 /************************************************************************
@@ -506,7 +506,7 @@ void CLuaBaseEntity::messageSystem(MSGSYSTEM messageID, sol::object const& p0, s
     uint32 param0 = (p0 != sol::lua_nil) ? p0.as<uint32>() : 0;
     uint32 param1 = (p1 != sol::lua_nil) ? p1.as<uint32>() : 0;
 
-    static_cast<CCharEntity*>(m_PBaseEntity)->pushPacket(new CMessageSystemPacket(param0, param1, messageID));
+    static_cast<CCharEntity*>(m_PBaseEntity)->pushPacket<CMessageSystemPacket>(param0, param1, messageID);
 }
 
 /************************************************************************
@@ -536,7 +536,7 @@ void CLuaBaseEntity::messageCombat(sol::object const& speaker, int32 p0, int32 p
         PSpeaker = m_PBaseEntity;
     }
 
-    PChar->pushPacket(new CMessageCombatPacket(PSpeaker, PChar, p0, p1, message));
+    PChar->pushPacket<CMessageCombatPacket>(PSpeaker, PChar, p0, p1, message);
 }
 
 /************************************************************************
@@ -550,7 +550,7 @@ void CLuaBaseEntity::messageStandard(uint16 messageID)
 {
     if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
     {
-        PChar->pushPacket(new CMessageStandardPacket(messageID));
+        PChar->pushPacket<CMessageStandardPacket>(messageID);
     }
 }
 
@@ -560,7 +560,7 @@ void CLuaBaseEntity::customMenu(sol::object const& obj)
         PChar && obj.get_type() == sol::type::table)
     {
         auto menuString = luautils::SetCustomMenuContext(PChar, obj.as<sol::table>());
-        PChar->pushPacket(new CChatMessagePacket(PChar, MESSAGE_GMPROMPT, menuString.c_str(), "_CUSTOM_MENU"));
+        PChar->pushPacket<CChatMessagePacket>(PChar, MESSAGE_GMPROMPT, menuString.c_str(), "_CUSTOM_MENU");
     }
 }
 
@@ -843,7 +843,7 @@ void CLuaBaseEntity::entityVisualPacket(std::string const& command, sol::object 
         PNpc                           = PLuaBaseEntity->m_PBaseEntity;
     }
 
-    static_cast<CCharEntity*>(m_PBaseEntity)->pushPacket(new CEntityVisualPacket(PNpc, command.c_str()));
+    static_cast<CCharEntity*>(m_PBaseEntity)->pushPacket<CEntityVisualPacket>(PNpc, command.c_str());
 }
 
 /************************************************************************
@@ -870,7 +870,7 @@ void CLuaBaseEntity::entityAnimationPacket(const char* command, sol::object cons
 
     if (m_PBaseEntity->objtype == TYPE_PC)
     {
-        static_cast<CCharEntity*>(m_PBaseEntity)->pushPacket(new CEntityAnimationPacket(m_PBaseEntity, PTarget, command));
+        static_cast<CCharEntity*>(m_PBaseEntity)->pushPacket<CEntityAnimationPacket>(m_PBaseEntity, PTarget, command);
     }
     else
     {
@@ -1098,7 +1098,7 @@ void CLuaBaseEntity::updateEvent(sol::variadic_args va)
         }
     }
 
-    static_cast<CCharEntity*>(m_PBaseEntity)->pushPacket(new CEventUpdatePacket(params));
+    static_cast<CCharEntity*>(m_PBaseEntity)->pushPacket<CEventUpdatePacket>(params);
 }
 
 /************************************************************************
@@ -1132,7 +1132,7 @@ void CLuaBaseEntity::updateEventString(sol::variadic_args va)
     uint32 param8 = va.get_type(12) == sol::type::number ? va.get<uint32>(12) : 0;
 
     ((CCharEntity*)m_PBaseEntity)
-        ->pushPacket(new CEventUpdateStringPacket(string0, string1, string2, string3, param0, param1, param2, param3, param4, param5, param6, param7, param8));
+        ->pushPacket<CEventUpdateStringPacket>(string0, string1, string2, string3, param0, param1, param2, param3, param4, param5, param6, param7, param8);
 }
 
 /************************************************************************
@@ -1200,12 +1200,12 @@ void CLuaBaseEntity::release()
     {
         // Message: Event skipped
         releaseType = RELEASE_TYPE::SKIPPING;
-        PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::EVENT_SKIPPED));
+        PChar->pushPacket<CMessageSystemPacket>(0, 0, MSGSYSTEM::EVENT_SKIPPED);
     }
 
     PChar->inSequence = false;
-    PChar->pushPacket(new CReleasePacket(PChar, releaseType));
-    PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::EVENT));
+    PChar->pushPacket<CReleasePacket>(PChar, releaseType);
+    PChar->pushPacket<CReleasePacket>(PChar, RELEASE_TYPE::EVENT);
     PChar->endCurrentEvent();
 }
 
@@ -2264,7 +2264,7 @@ void CLuaBaseEntity::changeMusic(uint8 blockID, uint8 musicTrackID)
     }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
-    PChar->pushPacket(new CChangeMusicPacket(blockID, musicTrackID));
+    PChar->pushPacket<CChangeMusicPacket>(blockID, musicTrackID);
 }
 
 /************************************************************************
@@ -2286,14 +2286,14 @@ void CLuaBaseEntity::sendMenu(uint32 menu)
     switch (menu)
     {
         case 1:
-            PChar->pushPacket(new CMenuMogPacket());
+            PChar->pushPacket<CMenuMogPacket>();
             break;
         case 2:
-            PChar->pushPacket(new CShopMenuPacket(PChar));
-            PChar->pushPacket(new CShopItemsPacket(PChar));
+            PChar->pushPacket<CShopMenuPacket>(PChar);
+            PChar->pushPacket<CShopItemsPacket>(PChar);
             break;
         case 3:
-            PChar->pushPacket(new CAuctionHousePacket(2));
+            PChar->pushPacket<CAuctionHousePacket>(2);
             break;
         default:
             ShowDebug("Menu %i not implemented, yet.", menu);
@@ -2343,11 +2343,11 @@ bool CLuaBaseEntity::sendGuild(uint16 guildID, uint8 open, uint8 close, uint8 ho
     auto*           PChar      = static_cast<CCharEntity*>(m_PBaseEntity);
 
     PChar->PGuildShop = PGuildShop;
-    PChar->pushPacket(new CGuildMenuPacket(status, open, close, holiday));
+    PChar->pushPacket<CGuildMenuPacket>(status, open, close, holiday);
 
     if (status == GUILD_OPEN)
     {
-        PChar->pushPacket(new CGuildMenuBuyPacket(PChar, PGuildShop));
+        PChar->pushPacket<CGuildMenuBuyPacket>(PChar, PGuildShop);
     }
 
     return status == GUILD_OPEN;
@@ -2774,8 +2774,8 @@ void CLuaBaseEntity::showPosition()
 
     // TODO: Fix c-style cast
     static_cast<CCharEntity*>(m_PBaseEntity)
-        ->pushPacket(new CMessageStandardPacket((int32)m_PBaseEntity->loc.p.x, (int32)m_PBaseEntity->loc.p.y, (int32)m_PBaseEntity->loc.p.z,
-                                                m_PBaseEntity->loc.p.rotation, MsgStd::Compass));
+        ->pushPacket<CMessageStandardPacket>((int32)m_PBaseEntity->loc.p.x, (int32)m_PBaseEntity->loc.p.y, (int32)m_PBaseEntity->loc.p.z,
+                                             m_PBaseEntity->loc.p.rotation, MsgStd::Compass);
 }
 
 /************************************************************************
@@ -2921,7 +2921,7 @@ void CLuaBaseEntity::setPos(sol::variadic_args va)
             if (ipp == 0)
             {
                 ShowWarning(fmt::format("Char {} requested zone ({}) returned IPP of 0", PChar->name, zoneid));
-                PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::COULD_NOT_ENTER)); // You could not enter the next area.
+                PChar->pushPacket<CMessageSystemPacket>(0, 0, MSGSYSTEM::COULD_NOT_ENTER); // You could not enter the next area.
                 return;
             }
 
@@ -2934,7 +2934,7 @@ void CLuaBaseEntity::setPos(sol::variadic_args va)
         }
         else if (PChar->status != STATUS_TYPE::DISAPPEAR)
         {
-            PChar->pushPacket(new CPositionPacket(PChar));
+            PChar->pushPacket<CPositionPacket>(PChar);
         }
     }
     m_PBaseEntity->updatemask |= UPDATE_POS;
@@ -3945,7 +3945,7 @@ bool CLuaBaseEntity::delItem(uint16 itemID, int32 quantity, sol::object const& c
     if (SlotID != ERROR_SLOTID)
     {
         charutils::UpdateItem(PChar, location, SlotID, -quantity);
-        PChar->pushPacket(new CInventoryFinishPacket());
+        PChar->pushPacket<CInventoryFinishPacket>();
 
         return true;
     }
@@ -4318,11 +4318,11 @@ bool CLuaBaseEntity::addLinkpearl(std::string const& lsname, bool equip)
                     PItemLinkPearl->setSubType(ITEM_LOCKED);
                     PChar->equip[SLOT_LINK2]    = PItemLinkPearl->getSlotID();
                     PChar->equipLoc[SLOT_LINK2] = LOC_INVENTORY;
-                    PChar->pushPacket(new CInventoryAssignPacket(PItemLinkPearl, INV_LINKSHELL));
+                    PChar->pushPacket<CInventoryAssignPacket>(PItemLinkPearl, INV_LINKSHELL);
                     charutils::SaveCharEquip(PChar);
-                    PChar->pushPacket(new CLinkshellEquipPacket(PChar, PItemLinkPearl->GetLSID()));
-                    PChar->pushPacket(new CInventoryItemPacket(PItemLinkPearl, LOC_INVENTORY, PItemLinkPearl->getSlotID()));
-                    PChar->pushPacket(new CInventoryFinishPacket());
+                    PChar->pushPacket<CLinkshellEquipPacket>(PChar, PItemLinkPearl->GetLSID());
+                    PChar->pushPacket<CInventoryItemPacket>(PItemLinkPearl, LOC_INVENTORY, PItemLinkPearl->getSlotID());
+                    PChar->pushPacket<CInventoryFinishPacket>();
                     charutils::LoadInventory(PChar);
                 }
                 return true;
@@ -4345,7 +4345,7 @@ auto CLuaBaseEntity::addSoulPlate(std::string const& name, uint16 mobFamily, uin
         // Deduct Blank Plate
         battleutils::RemoveAmmo(PChar);
 
-        PChar->pushPacket(new CInventoryFinishPacket());
+        PChar->pushPacket<CInventoryFinishPacket>();
 
         // Used Soul Plate
         CItem* PItem = itemutils::GetItem(2477);
@@ -4407,7 +4407,7 @@ void CLuaBaseEntity::changeContainerSize(uint8 locationID, int8 newSize)
         auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
         PChar->getStorage(locationID)->AddBuff(newSize);
-        PChar->pushPacket(new CInventorySizePacket(PChar));
+        PChar->pushPacket<CInventorySizePacket>(PChar);
         charutils::SaveCharInventoryCapacity(PChar);
     }
     else
@@ -4472,7 +4472,7 @@ void CLuaBaseEntity::confirmTrade()
         }
     }
     PChar->TradeContainer->Clean();
-    PChar->pushPacket(new CInventoryFinishPacket());
+    PChar->pushPacket<CInventoryFinishPacket>();
 }
 
 /************************************************************************
@@ -4506,7 +4506,7 @@ void CLuaBaseEntity::tradeComplete()
         }
     }
     PChar->TradeContainer->Clean();
-    PChar->pushPacket(new CInventoryFinishPacket());
+    PChar->pushPacket<CInventoryFinishPacket>();
 }
 
 std::optional<CLuaTradeContainer> CLuaBaseEntity::getTrade()
@@ -4629,7 +4629,7 @@ void CLuaBaseEntity::setEquipBlock(uint16 equipBlock)
     {
         auto* PChar         = static_cast<CCharEntity*>(m_PBaseEntity);
         PChar->m_EquipBlock = equipBlock;
-        PChar->pushPacket(new CCharJobsPacket(PChar));
+        PChar->pushPacket<CCharJobsPacket>(PChar);
     }
 }
 
@@ -4659,9 +4659,9 @@ void CLuaBaseEntity::lockEquipSlot(uint8 slot)
     charutils::EquipItem(PChar, 0, slot, LOC_INVENTORY);
 
     PChar->m_EquipBlock |= 1 << slot;
-    PChar->pushPacket(new CCharAppearancePacket(PChar));
-    PChar->pushPacket(new CEquipPacket(0, slot, LOC_INVENTORY));
-    PChar->pushPacket(new CCharJobsPacket(PChar));
+    PChar->pushPacket<CCharAppearancePacket>(PChar);
+    PChar->pushPacket<CEquipPacket>(0, slot, LOC_INVENTORY);
+    PChar->pushPacket<CCharJobsPacket>(PChar);
     PChar->updatemask |= UPDATE_LOOK;
 }
 
@@ -4689,7 +4689,7 @@ void CLuaBaseEntity::unlockEquipSlot(uint8 slot)
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
     PChar->m_EquipBlock &= ~(1 << slot);
-    PChar->pushPacket(new CCharJobsPacket(PChar));
+    PChar->pushPacket<CCharJobsPacket>(PChar);
 }
 
 /************************************************************************
@@ -5161,7 +5161,7 @@ void CLuaBaseEntity::setModelId(uint16 modelId, sol::object const& slotObj)
         }
 
         auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
-        PChar->pushPacket(new CCharAppearancePacket(PChar));
+        PChar->pushPacket<CCharAppearancePacket>(PChar);
     }
     else
     {
@@ -5209,7 +5209,7 @@ void CLuaBaseEntity::setCostume(uint16 costume)
     {
         PChar->m_Costume = costume;
         PChar->updatemask |= UPDATE_LOOK;
-        PChar->pushPacket(new CCharUpdatePacket(PChar));
+        PChar->pushPacket<CCharUpdatePacket>(PChar);
     }
 }
 
@@ -5252,7 +5252,7 @@ void CLuaBaseEntity::setCostume2(uint16 costume)
     {
         PChar->m_Costume2 = costume;
         PChar->updatemask |= UPDATE_LOOK;
-        PChar->pushPacket(new CCharAppearancePacket(PChar));
+        PChar->pushPacket<CCharAppearancePacket>(PChar);
     }
 }
 /************************************************************************
@@ -5310,7 +5310,7 @@ void CLuaBaseEntity::setAnimationSub(uint8 animationsub)
         if (m_PBaseEntity->objtype == TYPE_PC)
         {
             auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
-            PChar->pushPacket(new CCharUpdatePacket(PChar));
+            PChar->pushPacket<CCharUpdatePacket>(PChar);
         }
         else
         {
@@ -5758,7 +5758,7 @@ void CLuaBaseEntity::setSpeed(uint8 speedVal)
         if (m_PBaseEntity->objtype == TYPE_PC)
         {
             auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
-            PChar->pushPacket(new CCharUpdatePacket(PChar));
+            PChar->pushPacket<CCharUpdatePacket>(PChar);
         }
         else
         {
@@ -5905,16 +5905,16 @@ void CLuaBaseEntity::changeJob(uint8 newJob)
     charutils::SaveCharExp(PChar, PChar->GetMJob());
     PChar->updatemask |= UPDATE_HP;
 
-    PChar->pushPacket(new CCharJobsPacket(PChar));
-    PChar->pushPacket(new CCharStatsPacket(PChar));
-    PChar->pushPacket(new CCharSkillsPacket(PChar));
-    PChar->pushPacket(new CCharRecastPacket(PChar));
-    PChar->pushPacket(new CCharAbilitiesPacket(PChar));
-    PChar->pushPacket(new CCharUpdatePacket(PChar));
-    PChar->pushPacket(new CMenuMeritPacket(PChar));
-    PChar->pushPacket(new CMonipulatorPacket1(PChar));
-    PChar->pushPacket(new CMonipulatorPacket2(PChar));
-    PChar->pushPacket(new CCharSyncPacket(PChar));
+    PChar->pushPacket<CCharJobsPacket>(PChar);
+    PChar->pushPacket<CCharStatsPacket>(PChar);
+    PChar->pushPacket<CCharSkillsPacket>(PChar);
+    PChar->pushPacket<CCharRecastPacket>(PChar);
+    PChar->pushPacket<CCharAbilitiesPacket>(PChar);
+    PChar->pushPacket<CCharUpdatePacket>(PChar);
+    PChar->pushPacket<CMenuMeritPacket>(PChar);
+    PChar->pushPacket<CMonipulatorPacket1>(PChar);
+    PChar->pushPacket<CMonipulatorPacket2>(PChar);
+    PChar->pushPacket<CCharSyncPacket>(PChar);
 }
 
 /************************************************************************
@@ -5981,7 +5981,7 @@ void CLuaBaseEntity::unlockJob(uint8 JobID)
         }
 
         charutils::SaveCharJob(PChar, static_cast<JOBTYPE>(JobID));
-        PChar->pushPacket(new CCharJobsPacket(PChar));
+        PChar->pushPacket<CCharJobsPacket>(PChar);
     }
 }
 
@@ -6104,16 +6104,16 @@ void CLuaBaseEntity::setLevel(uint8 level)
         charutils::SaveCharExp(PChar, PChar->GetMJob());
         PChar->updatemask |= UPDATE_HP;
 
-        PChar->pushPacket(new CCharJobsPacket(PChar));
-        PChar->pushPacket(new CCharStatsPacket(PChar));
-        PChar->pushPacket(new CCharSkillsPacket(PChar));
-        PChar->pushPacket(new CCharRecastPacket(PChar));
-        PChar->pushPacket(new CCharAbilitiesPacket(PChar));
-        PChar->pushPacket(new CCharUpdatePacket(PChar));
-        PChar->pushPacket(new CMenuMeritPacket(PChar));
-        PChar->pushPacket(new CMonipulatorPacket1(PChar));
-        PChar->pushPacket(new CMonipulatorPacket2(PChar));
-        PChar->pushPacket(new CCharSyncPacket(PChar));
+        PChar->pushPacket<CCharJobsPacket>(PChar);
+        PChar->pushPacket<CCharStatsPacket>(PChar);
+        PChar->pushPacket<CCharSkillsPacket>(PChar);
+        PChar->pushPacket<CCharRecastPacket>(PChar);
+        PChar->pushPacket<CCharAbilitiesPacket>(PChar);
+        PChar->pushPacket<CCharUpdatePacket>(PChar);
+        PChar->pushPacket<CMenuMeritPacket>(PChar);
+        PChar->pushPacket<CMonipulatorPacket1>(PChar);
+        PChar->pushPacket<CMonipulatorPacket2>(PChar);
+        PChar->pushPacket<CCharSyncPacket>(PChar);
     }
 }
 
@@ -6161,16 +6161,16 @@ void CLuaBaseEntity::setsLevel(uint8 slevel)
     charutils::SaveCharJob(PChar, PChar->GetSJob());
     charutils::SaveCharExp(PChar, PChar->GetMJob());
 
-    PChar->pushPacket(new CCharJobsPacket(PChar));
-    PChar->pushPacket(new CCharStatsPacket(PChar));
-    PChar->pushPacket(new CCharSkillsPacket(PChar));
-    PChar->pushPacket(new CCharRecastPacket(PChar));
-    PChar->pushPacket(new CCharAbilitiesPacket(PChar));
-    PChar->pushPacket(new CCharUpdatePacket(PChar));
-    PChar->pushPacket(new CMenuMeritPacket(PChar));
-    PChar->pushPacket(new CMonipulatorPacket1(PChar));
-    PChar->pushPacket(new CMonipulatorPacket2(PChar));
-    PChar->pushPacket(new CCharSyncPacket(PChar));
+    PChar->pushPacket<CCharJobsPacket>(PChar);
+    PChar->pushPacket<CCharStatsPacket>(PChar);
+    PChar->pushPacket<CCharSkillsPacket>(PChar);
+    PChar->pushPacket<CCharRecastPacket>(PChar);
+    PChar->pushPacket<CCharAbilitiesPacket>(PChar);
+    PChar->pushPacket<CCharUpdatePacket>(PChar);
+    PChar->pushPacket<CMenuMeritPacket>(PChar);
+    PChar->pushPacket<CMonipulatorPacket1>(PChar);
+    PChar->pushPacket<CMonipulatorPacket2>(PChar);
+    PChar->pushPacket<CCharSyncPacket>(PChar);
 }
 
 /************************************************************************
@@ -6269,14 +6269,14 @@ uint8 CLuaBaseEntity::levelRestriction(sol::object const& level)
                     PChar->PAutomaton->setElementalCapacityBonus(PChar->getMod(Mod::AUTO_ELEM_CAPACITY));
                 }
 
-                PChar->pushPacket(new CCharJobsPacket(PChar));
-                PChar->pushPacket(new CCharStatsPacket(PChar));
-                PChar->pushPacket(new CCharSkillsPacket(PChar));
-                PChar->pushPacket(new CCharRecastPacket(PChar));
-                PChar->pushPacket(new CCharAbilitiesPacket(PChar));
-                PChar->pushPacket(new CCharSpellsPacket(PChar));
-                PChar->pushPacket(new CCharUpdatePacket(PChar));
-                PChar->pushPacket(new CCharSyncPacket(PChar));
+                PChar->pushPacket<CCharJobsPacket>(PChar);
+                PChar->pushPacket<CCharStatsPacket>(PChar);
+                PChar->pushPacket<CCharSkillsPacket>(PChar);
+                PChar->pushPacket<CCharRecastPacket>(PChar);
+                PChar->pushPacket<CCharAbilitiesPacket>(PChar);
+                PChar->pushPacket<CCharSpellsPacket>(PChar);
+                PChar->pushPacket<CCharUpdatePacket>(PChar);
+                PChar->pushPacket<CCharSyncPacket>(PChar);
                 PChar->updatemask |= UPDATE_HP;
             }
 
@@ -6324,7 +6324,7 @@ uint8 CLuaBaseEntity::levelRestriction(sol::object const& level)
                                 resetRecast(RECAST_ABILITY, 205);
                             }
 
-                            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_AUTO_EXCEEDS_CAPACITY));
+                            PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, MSGBASIC_AUTO_EXCEEDS_CAPACITY);
                             petutils::DespawnPet(PChar);
                             return PChar->m_LevelRestriction;
                         }
@@ -6553,7 +6553,7 @@ void CLuaBaseEntity::addTitle(uint16 titleID)
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
     PChar->profile.title = titleID;
-    PChar->pushPacket(new CCharStatsPacket(PChar));
+    PChar->pushPacket<CCharStatsPacket>(PChar);
 
     charutils::addTitle(PChar, titleID);
     charutils::SaveTitles(PChar);
@@ -6600,7 +6600,7 @@ void CLuaBaseEntity::delTitle(uint16 titleID)
             PChar->profile.title = 0;
         }
 
-        PChar->pushPacket(new CCharStatsPacket(PChar));
+        PChar->pushPacket<CCharStatsPacket>(PChar);
         charutils::SaveTitles(PChar);
     }
 }
@@ -6987,7 +6987,7 @@ void CLuaBaseEntity::addQuest(uint8 questLogID, uint16 questID)
         if (current == 0)
         {
             PChar->m_questLog[questLogID].current[questID / 8] |= (1 << (questID % 8));
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, questLogID, LOG_QUEST_CURRENT));
+            PChar->pushPacket<CQuestMissionLogPacket>(PChar, questLogID, LOG_QUEST_CURRENT);
 
             charutils::SaveQuestsList(PChar);
         }
@@ -7022,8 +7022,8 @@ void CLuaBaseEntity::delCurrentQuest(uint8 questLogID, uint16 questID)
         {
             PChar->m_questLog[questLogID].current[questID / 8] &= ~(1 << (questID % 8));
 
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, questLogID, LOG_QUEST_CURRENT));
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, questLogID, LOG_QUEST_COMPLETE));
+            PChar->pushPacket<CQuestMissionLogPacket>(PChar, questLogID, LOG_QUEST_CURRENT);
+            PChar->pushPacket<CQuestMissionLogPacket>(PChar, questLogID, LOG_QUEST_COMPLETE);
 
             charutils::SaveQuestsList(PChar);
         }
@@ -7061,8 +7061,8 @@ void CLuaBaseEntity::delQuest(uint8 questLogID, uint16 questID)
             PChar->m_questLog[questLogID].current[questID / 8] &= ~(1 << (questID % 8));
             PChar->m_questLog[questLogID].complete[questID / 8] &= ~(1 << (questID % 8));
 
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, questLogID, LOG_QUEST_CURRENT));
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, questLogID, LOG_QUEST_COMPLETE));
+            PChar->pushPacket<CQuestMissionLogPacket>(PChar, questLogID, LOG_QUEST_CURRENT);
+            PChar->pushPacket<CQuestMissionLogPacket>(PChar, questLogID, LOG_QUEST_COMPLETE);
 
             charutils::SaveQuestsList(PChar);
         }
@@ -7153,8 +7153,8 @@ void CLuaBaseEntity::completeQuest(uint8 questLogID, uint16 questID)
             PChar->m_questLog[questLogID].current[questID / 8] &= ~(1 << (questID % 8));
             PChar->m_questLog[questLogID].complete[questID / 8] |= (1 << (questID % 8));
 
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, questLogID, LOG_QUEST_CURRENT));
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, questLogID, LOG_QUEST_COMPLETE));
+            PChar->pushPacket<CQuestMissionLogPacket>(PChar, questLogID, LOG_QUEST_CURRENT);
+            PChar->pushPacket<CQuestMissionLogPacket>(PChar, questLogID, LOG_QUEST_COMPLETE);
             charutils::SaveQuestsList(PChar);
             roeutils::event(ROE_QUEST_COMPLETE, PChar, RoeDatagramList{});
         }
@@ -7189,7 +7189,7 @@ void CLuaBaseEntity::addMission(uint8 missionLogID, uint16 missionID)
         }
 
         PChar->m_missionLog[missionLogID].current = missionID;
-        PChar->pushPacket(new CQuestMissionLogPacket(PChar, missionLogID, LOG_MISSION_CURRENT));
+        PChar->pushPacket<CQuestMissionLogPacket>(PChar, missionLogID, LOG_MISSION_CURRENT);
 
         charutils::SaveMissionsList(PChar);
     }
@@ -7225,12 +7225,12 @@ void CLuaBaseEntity::delMission(uint8 missionLogID, uint16 missionID)
         if (current == missionID)
         {
             PChar->m_missionLog[missionLogID].current = missionLogID > 2 ? 0 : -1;
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, missionLogID, LOG_MISSION_CURRENT));
+            PChar->pushPacket<CQuestMissionLogPacket>(PChar, missionLogID, LOG_MISSION_CURRENT);
         }
         if (complete)
         {
             PChar->m_missionLog[missionLogID].complete[missionID] = false;
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, missionLogID, LOG_MISSION_COMPLETE));
+            PChar->pushPacket<CQuestMissionLogPacket>(PChar, missionLogID, LOG_MISSION_COMPLETE);
         }
         charutils::SaveMissionsList(PChar);
     }
@@ -7345,9 +7345,9 @@ void CLuaBaseEntity::completeMission(uint8 missionLogID, uint16 missionID)
             if ((missionLogID != MISSION_COP) && (missionID < 64))
             {
                 PChar->m_missionLog[missionLogID].complete[missionID] = true;
-                PChar->pushPacket(new CQuestMissionLogPacket(PChar, missionLogID, LOG_MISSION_COMPLETE));
+                PChar->pushPacket<CQuestMissionLogPacket>(PChar, missionLogID, LOG_MISSION_COMPLETE);
             }
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, missionLogID, LOG_MISSION_CURRENT));
+            PChar->pushPacket<CQuestMissionLogPacket>(PChar, missionLogID, LOG_MISSION_CURRENT);
 
             charutils::SaveMissionsList(PChar);
             roeutils::event(ROE_MISSION_COMPLETE, PChar, RoeDatagramList{});
@@ -7404,7 +7404,7 @@ void CLuaBaseEntity::setMissionStatus(uint8 missionLogID, sol::object const& arg
         missionStatus |= missionStatusValue << (4 * missionStatusPos);
         PChar->m_missionLog[missionLogID].statusLower = missionStatus;
         PChar->m_missionLog[missionLogID].statusUpper = missionStatus >> 16;
-        PChar->pushPacket(new CQuestMissionLogPacket(PChar, missionLogID, LOG_MISSION_CURRENT));
+        PChar->pushPacket<CQuestMissionLogPacket>(PChar, missionLogID, LOG_MISSION_CURRENT);
     }
     else
     {
@@ -7552,8 +7552,8 @@ bool CLuaBaseEntity::setEminenceProgress(uint16 recordID, uint32 progress, sol::
 
     if (total && progressNotify)
     {
-        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, recordID, 0, MSGBASIC_ROE_RECORD));
-        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, progress, total, MSGBASIC_ROE_PROGRESS));
+        PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, recordID, 0, MSGBASIC_ROE_RECORD);
+        PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, progress, total, MSGBASIC_ROE_PROGRESS);
     }
 
     return result;
@@ -7919,7 +7919,7 @@ void CLuaBaseEntity::addAssault(uint8 missionID)
     }
 
     PChar->m_assaultLog.current = missionID;
-    PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_ASSAULT, LOG_MISSION_CURRENT));
+    PChar->pushPacket<CQuestMissionLogPacket>(PChar, MISSION_ASSAULT, LOG_MISSION_CURRENT);
 
     charutils::SaveMissionsList(PChar);
 }
@@ -7944,7 +7944,7 @@ void CLuaBaseEntity::delAssault(uint8 missionID)
     if (current == missionID)
     {
         PChar->m_assaultLog.current = 0;
-        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_ASSAULT, LOG_MISSION_CURRENT));
+        PChar->pushPacket<CQuestMissionLogPacket>(PChar, MISSION_ASSAULT, LOG_MISSION_CURRENT);
     }
 
     charutils::SaveMissionsList(PChar);
@@ -8011,8 +8011,8 @@ void CLuaBaseEntity::completeAssault(uint8 missionID)
 
     PChar->m_assaultLog.current             = 0;
     PChar->m_assaultLog.complete[missionID] = true;
-    PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_ASSAULT, LOG_MISSION_CURRENT));
-    PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_ASSAULT, LOG_MISSION_COMPLETE));
+    PChar->pushPacket<CQuestMissionLogPacket>(PChar, MISSION_ASSAULT, LOG_MISSION_CURRENT);
+    PChar->pushPacket<CQuestMissionLogPacket>(PChar, MISSION_ASSAULT, LOG_MISSION_COMPLETE);
 
     charutils::SaveMissionsList(PChar);
 }
@@ -8043,11 +8043,11 @@ void CLuaBaseEntity::addKeyItem(uint16 keyItemID)
     }
 
     charutils::addKeyItem(PChar, keyItemID);
-    PChar->pushPacket(new CKeyItemsPacket(PChar, static_cast<KEYS_TABLE>(table)));
+    PChar->pushPacket<CKeyItemsPacket>(PChar, static_cast<KEYS_TABLE>(table));
 
     if (table == 6)
     {
-        PChar->pushPacket(new CCharMountsPacket(PChar));
+        PChar->pushPacket<CCharMountsPacket>(PChar);
     }
 
     charutils::SaveKeyItems(PChar);
@@ -8097,7 +8097,7 @@ void CLuaBaseEntity::delKeyItem(uint16 keyItemID)
     }
 
     charutils::delKeyItem(PChar, keyItemID);
-    PChar->pushPacket(new CKeyItemsPacket(PChar, static_cast<KEYS_TABLE>(table)));
+    PChar->pushPacket<CKeyItemsPacket>(PChar, static_cast<KEYS_TABLE>(table));
 
     charutils::SaveKeyItems(PChar);
 }
@@ -8146,7 +8146,7 @@ void CLuaBaseEntity::unseenKeyItem(uint16 keyItemID)
     }
 
     charutils::unseenKeyItem(PChar, keyItemID);
-    PChar->pushPacket(new CKeyItemsPacket(PChar, static_cast<KEYS_TABLE>(table)));
+    PChar->pushPacket<CKeyItemsPacket>(PChar, static_cast<KEYS_TABLE>(table));
 
     charutils::SaveKeyItems(PChar);
 }
@@ -8266,9 +8266,9 @@ void CLuaBaseEntity::setMerits(uint8 numPoints)
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
     PChar->PMeritPoints->SetMeritPoints(numPoints);
-    PChar->pushPacket(new CMenuMeritPacket(PChar));
-    PChar->pushPacket(new CMonipulatorPacket1(PChar));
-    PChar->pushPacket(new CMonipulatorPacket2(PChar));
+    PChar->pushPacket<CMenuMeritPacket>(PChar);
+    PChar->pushPacket<CMonipulatorPacket1>(PChar);
+    PChar->pushPacket<CMonipulatorPacket2>(PChar);
 
     charutils::SaveCharExp(PChar, PChar->GetMJob());
 }
@@ -8330,7 +8330,7 @@ void CLuaBaseEntity::setCapacityPoints(uint16 amount)
     CCharEntity* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
     PChar->PJobPoints->SetCapacityPoints(amount);
-    PChar->pushPacket(new CMenuJobPointsPacket(PChar));
+    PChar->pushPacket<CMenuJobPointsPacket>(PChar);
 }
 
 /************************************************************************
@@ -8351,7 +8351,7 @@ void CLuaBaseEntity::setJobPoints(uint16 amount)
     CCharEntity* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
     PChar->PJobPoints->SetJobPoints(amount);
-    PChar->pushPacket(new CMenuJobPointsPacket(PChar));
+    PChar->pushPacket<CMenuJobPointsPacket>(PChar);
 }
 
 /************************************************************************
@@ -8386,7 +8386,7 @@ void CLuaBaseEntity::masterJob()
         }
     }
 
-    PChar->pushPacket(new CMenuJobPointsPacket(PChar));
+    PChar->pushPacket<CMenuJobPointsPacket>(PChar);
 }
 
 /************************************************************************
@@ -8630,7 +8630,7 @@ void CLuaBaseEntity::addCP(int32 cp)
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
     charutils::AddPoints(PChar, charutils::GetConquestPointsName(PChar).c_str(), cp);
-    PChar->pushPacket(new CConquestPacket(PChar));
+    PChar->pushPacket<CConquestPacket>(PChar);
 }
 
 /************************************************************************
@@ -8651,7 +8651,7 @@ void CLuaBaseEntity::delCP(int32 cp)
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
     charutils::AddPoints(PChar, charutils::GetConquestPointsName(PChar).c_str(), -cp);
-    PChar->pushPacket(new CConquestPacket(PChar));
+    PChar->pushPacket<CConquestPacket>(PChar);
 }
 
 /************************************************************************
@@ -9497,7 +9497,7 @@ void CLuaBaseEntity::capSkill(uint8 skill)
         PChar->RealSkills.skill[skill]    = maxSkill; // set to capped
         PChar->WorkingSkills.skill[skill] = maxSkill / 10;
         PChar->WorkingSkills.skill[skill] |= 0x8000; // set blue capped flag
-        PChar->pushPacket(new CCharSkillsPacket(PChar));
+        PChar->pushPacket<CCharSkillsPacket>(PChar);
         charutils::CheckWeaponSkill(PChar, skill);
         /* and ignore this part
         //reapply modifiers if valid
@@ -9545,7 +9545,7 @@ void CLuaBaseEntity::capAllSkills()
         PChar->WorkingSkills.skill[i] |= 0x8000; // set blue capped flag
     }
     charutils::CheckWeaponSkill(PChar, SKILL_NONE);
-    PChar->pushPacket(new CCharSkillsPacket(PChar));
+    PChar->pushPacket<CCharSkillsPacket>(PChar);
 }
 
 /************************************************************************
@@ -9597,7 +9597,7 @@ void CLuaBaseEntity::setSkillLevel(uint8 SkillID, uint16 SkillAmount)
     charutils::CheckWeaponSkill(PChar, SkillID);
     charutils::SaveCharSkills(PChar, SkillID);
 
-    PChar->pushPacket(new CCharSkillsPacket(PChar));
+    PChar->pushPacket<CCharSkillsPacket>(PChar);
 }
 
 /************************************************************************
@@ -9650,7 +9650,7 @@ void CLuaBaseEntity::setSkillRank(uint8 skillID, uint8 newrank)
         jobpointutils::RefreshGiftMods(PChar);
         charutils::BuildingCharSkillsTable(PChar);
         charutils::SaveCharSkills(PChar, skillID);
-        PChar->pushPacket(new CCharSkillsPacket(PChar));
+        PChar->pushPacket<CCharSkillsPacket>(PChar);
     }
 }
 
@@ -9693,7 +9693,7 @@ void CLuaBaseEntity::addLearnedWeaponskill(uint8 wsUnlockId)
     charutils::addLearnedWeaponskill(PChar, wsUnlockId);
     charutils::BuildingCharWeaponSkills(PChar);
     charutils::SaveLearnedAbilities(PChar);
-    PChar->pushPacket(new CCharAbilitiesPacket(PChar));
+    PChar->pushPacket<CCharAbilitiesPacket>(PChar);
 }
 
 /************************************************************************
@@ -9734,7 +9734,7 @@ void CLuaBaseEntity::delLearnedWeaponskill(uint8 wsUnlockId)
     charutils::delLearnedWeaponskill(PChar, wsUnlockId);
     charutils::BuildingCharWeaponSkills(PChar);
     charutils::SaveLearnedAbilities(PChar);
-    PChar->pushPacket(new CCharAbilitiesPacket(PChar));
+    PChar->pushPacket<CCharAbilitiesPacket>(PChar);
 }
 
 /************************************************************************
@@ -9801,8 +9801,8 @@ void CLuaBaseEntity::addLearnedAbility(uint16 abilityID)
     {
         charutils::addAbility(PChar, abilityID);
         charutils::SaveLearnedAbilities(PChar);
-        PChar->pushPacket(new CCharAbilitiesPacket(PChar));
-        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, 442));
+        PChar->pushPacket<CCharAbilitiesPacket>(PChar);
+        PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, 442);
     }
 }
 
@@ -9874,7 +9874,7 @@ void CLuaBaseEntity::delLearnedAbility(uint16 abilityID)
     if (charutils::delLearnedAbility(PChar, abilityID))
     {
         charutils::SaveLearnedAbilities(PChar);
-        PChar->pushPacket(new CCharAbilitiesPacket(PChar));
+        PChar->pushPacket<CCharAbilitiesPacket>(PChar);
     }
 }
 
@@ -9903,12 +9903,12 @@ void CLuaBaseEntity::addSpell(uint16 spellID, sol::variadic_args va)
     {
         if (sendUpdate)
         {
-            PChar->pushPacket(new CCharSpellsPacket(PChar));
+            PChar->pushPacket<CCharSpellsPacket>(PChar);
         }
 
         if (!silentLog)
         {
-            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, 23));
+            PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, 23);
         }
 
         if (save)
@@ -9985,7 +9985,7 @@ void CLuaBaseEntity::delSpell(uint16 spellID)
     if (charutils::delSpell(PChar, spellID))
     {
         charutils::DeleteSpell(PChar, spellID);
-        PChar->pushPacket(new CCharSpellsPacket(PChar));
+        PChar->pushPacket<CCharSpellsPacket>(PChar);
     }
 }
 
@@ -10009,9 +10009,9 @@ void CLuaBaseEntity::recalculateSkillsTable()
     charutils::BuildingCharSkillsTable(PChar);
     charutils::BuildingCharWeaponSkills(PChar);
 
-    PChar->pushPacket(new CCharSkillsPacket(PChar));
-    PChar->pushPacket(new CCharRecastPacket(PChar));
-    PChar->pushPacket(new CCharAbilitiesPacket(PChar));
+    PChar->pushPacket<CCharSkillsPacket>(PChar);
+    PChar->pushPacket<CCharRecastPacket>(PChar);
+    PChar->pushPacket<CCharAbilitiesPacket>(PChar);
 }
 
 /************************************************************************
@@ -10042,7 +10042,7 @@ void CLuaBaseEntity::recalculateAbilitiesTable()
         charutils::BuildingCharPetAbilityTable(PChar, PPetEntity, PPetEntity->m_PetID);
     }
 
-    PChar->pushPacket(new CCharAbilitiesPacket(PChar));
+    PChar->pushPacket<CCharAbilitiesPacket>(PChar);
 }
 
 /************************************************************************
@@ -10717,7 +10717,7 @@ void CLuaBaseEntity::instanceEntry(CLuaBaseEntity* PLuaBaseEntity, uint32 respon
 
     CBaseEntity* PTarget = PLuaBaseEntity->m_PBaseEntity;
 
-    static_cast<CCharEntity*>(m_PBaseEntity)->pushPacket(new CInstanceEntryPacket(PTarget, response));
+    static_cast<CCharEntity*>(m_PBaseEntity)->pushPacket<CInstanceEntryPacket>(PTarget, response);
 }
 
 /************************************************************************
@@ -11062,7 +11062,7 @@ void CLuaBaseEntity::sendRaise(uint8 raiseLevel)
         {
             PChar->m_hasArise = true;
         }
-        PChar->pushPacket(new CRaiseTractorMenuPacket(PChar, TYPE_RAISE));
+        PChar->pushPacket<CRaiseTractorMenuPacket>(PChar, TYPE_RAISE);
     }
 }
 
@@ -11119,7 +11119,7 @@ void CLuaBaseEntity::sendTractor(float xPos, float yPos, float zPos, uint8 rotat
         PChar->m_StartActionPos.z        = zPos;
         PChar->m_StartActionPos.rotation = rotation;
 
-        PChar->pushPacket(new CRaiseTractorMenuPacket(PChar, TYPE_TRACTOR));
+        PChar->pushPacket<CRaiseTractorMenuPacket>(PChar, TYPE_TRACTOR);
     }
 }
 
@@ -11209,8 +11209,8 @@ void CLuaBaseEntity::objectiveUtility(sol::object const& obj)
         return;
     }
 
-    CCharEntity* PChar  = (CCharEntity*)m_PBaseEntity;
-    auto*        packet = new CObjectiveUtilityPacket();
+    CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
+    auto        packet = std::make_unique<CObjectiveUtilityPacket>();
 
     if (obj.is<sol::table>())
     {
@@ -11284,7 +11284,7 @@ void CLuaBaseEntity::objectiveUtility(sol::object const& obj)
         }
     }
 
-    PChar->pushPacket(packet);
+    PChar->pushPacket(std::move(packet));
 }
 
 /************************************************************************
@@ -11299,7 +11299,7 @@ void CLuaBaseEntity::enableEntities(sol::object const& obj)
     {
         if (obj.is<std::vector<uint32>>())
         {
-            PChar->pushPacket(new CEntityEnableList(obj.as<std::vector<uint32>>()));
+            PChar->pushPacket<CEntityEnableList>(obj.as<std::vector<uint32>>());
         }
     }
     else
@@ -11407,8 +11407,8 @@ void CLuaBaseEntity::addRecast(uint8 recastCont, uint16 recastID, uint32 duratio
         if (PBattleEntity->objtype == TYPE_PC)
         {
             CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
-            PChar->pushPacket(new CCharSkillsPacket(PChar));
-            PChar->pushPacket(new CCharRecastPacket(PChar));
+            PChar->pushPacket<CCharSkillsPacket>(PChar);
+            PChar->pushPacket<CCharRecastPacket>(PChar);
         }
     }
 }
@@ -11458,8 +11458,8 @@ void CLuaBaseEntity::resetRecast(uint8 rType, uint16 recastID)
             PChar->PRecastContainer->Add(recastContainer, recastID, 0);
         }
 
-        PChar->pushPacket(new CCharSkillsPacket(PChar));
-        PChar->pushPacket(new CCharRecastPacket(PChar));
+        PChar->pushPacket<CCharSkillsPacket>(PChar);
+        PChar->pushPacket<CCharRecastPacket>(PChar);
     }
 }
 
@@ -11479,8 +11479,8 @@ void CLuaBaseEntity::resetRecasts()
 
         PChar->PRecastContainer->Del(RECAST_MAGIC);
         PChar->PRecastContainer->Del(RECAST_ABILITY);
-        PChar->pushPacket(new CCharSkillsPacket(PChar));
-        PChar->pushPacket(new CCharRecastPacket(PChar));
+        PChar->pushPacket<CCharSkillsPacket>(PChar);
+        PChar->pushPacket<CCharRecastPacket>(PChar);
     }
 }
 
@@ -11634,16 +11634,16 @@ void CLuaBaseEntity::recalculateStats()
 
         PChar->UpdateHealth();
 
-        PChar->pushPacket(new CCharJobsPacket(PChar));
-        PChar->pushPacket(new CCharStatsPacket(PChar));
-        PChar->pushPacket(new CCharSkillsPacket(PChar));
-        PChar->pushPacket(new CCharRecastPacket(PChar));
-        PChar->pushPacket(new CCharAbilitiesPacket(PChar));
-        PChar->pushPacket(new CCharUpdatePacket(PChar));
-        PChar->pushPacket(new CMenuMeritPacket(PChar));
-        PChar->pushPacket(new CMonipulatorPacket1(PChar));
-        PChar->pushPacket(new CMonipulatorPacket2(PChar));
-        PChar->pushPacket(new CCharSyncPacket(PChar));
+        PChar->pushPacket<CCharJobsPacket>(PChar);
+        PChar->pushPacket<CCharStatsPacket>(PChar);
+        PChar->pushPacket<CCharSkillsPacket>(PChar);
+        PChar->pushPacket<CCharRecastPacket>(PChar);
+        PChar->pushPacket<CCharAbilitiesPacket>(PChar);
+        PChar->pushPacket<CCharUpdatePacket>(PChar);
+        PChar->pushPacket<CMenuMeritPacket>(PChar);
+        PChar->pushPacket<CMonipulatorPacket1>(PChar);
+        PChar->pushPacket<CMonipulatorPacket2>(PChar);
+        PChar->pushPacket<CCharSyncPacket>(PChar);
     }
 }
 
@@ -13232,7 +13232,7 @@ void CLuaBaseEntity::setStatDebilitation(uint16 statDebil)
     {
         auto* PChar{ static_cast<CCharEntity*>(m_PBaseEntity) };
         PChar->m_StatsDebilitation = statDebil;
-        PChar->pushPacket(new CCharJobsPacket(PChar));
+        PChar->pushPacket<CCharJobsPacket>(PChar);
     }
 }
 
@@ -14129,7 +14129,7 @@ void CLuaBaseEntity::trustPartyMessage(uint32 message_id)
         PMaster->ForParty([&](CBattleEntity* PMember)
         {
             auto* PCharMember = static_cast<CCharEntity*>(PMember);
-            PCharMember->pushPacket(new CMessageCombatPacket(PTrust, PMember, message_id, 0, 711));
+            PCharMember->pushPacket<CMessageCombatPacket>(PTrust, PMember, message_id, 0, 711);
         });
         // clang-format on
     }

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -116,14 +116,14 @@ void ReportErrorToPlayer(CBaseEntity* PEntity, std::string const& message = "") 
                 {
                     auto        channel = MESSAGE_NS_SHOUT;
                     std::string breaker = "================";
-                    PChar->pushPacket(new CChatMessagePacket(PChar, channel, breaker.c_str()));
-                    PChar->pushPacket(new CChatMessagePacket(PChar, channel, "!!! Lua error !!!"));
+                    PChar->pushPacket<CChatMessagePacket>(PChar, channel, breaker.c_str());
+                    PChar->pushPacket<CChatMessagePacket>(PChar, channel, "!!! Lua error !!!");
                     for (auto const& part : split(message, "\n"))
                     {
                         auto str = replace(part, "\t", "    ");
-                        PChar->pushPacket(new CChatMessagePacket(PChar, channel, str.c_str()));
+                        PChar->pushPacket<CChatMessagePacket>(PChar, channel, str.c_str());
                     }
-                    PChar->pushPacket(new CChatMessagePacket(PChar, channel, breaker.c_str()));
+                    PChar->pushPacket<CChatMessagePacket>(PChar, channel, breaker.c_str());
                 }
             }
         }
@@ -2163,7 +2163,7 @@ namespace luautils
         if (PChar->currentEvent->scriptFile.find("/bcnms/") > 0 && PChar->health.hp <= 0)
         { // for some reason the event doesnt enforce death afterwards
             PChar->animation = ANIMATION_DEATH;
-            PChar->pushPacket(new CRaiseTractorMenuPacket(PChar, TYPE_HOMEPOINT));
+            PChar->pushPacket<CRaiseTractorMenuPacket>(PChar, TYPE_HOMEPOINT);
             PChar->updatemask |= UPDATE_HP;
         }
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -355,8 +355,8 @@ int32 do_init(int32 argc, char** argv)
         }
 
         fmt::print("Promoting {} to GM level {}\n", PChar->name, level);
-        PChar->pushPacket(new CChatMessagePacket(PChar, MESSAGE_SYSTEM_3,
-            fmt::format("You have been set to GM level {}.", level), ""));
+        PChar->pushPacket<CChatMessagePacket>(PChar, MESSAGE_SYSTEM_3,
+            fmt::format("You have been set to GM level {}.", level), "");
     });
 
     gConsoleService->RegisterCommand("reload_settings", "Reload settings files.",

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -882,7 +882,7 @@ int32 send_parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_da
     CCharEntity* PChar = map_session_data->PChar;
     TracyZoneString(PChar->name);
 
-    CBasicPacket* PSmallPacket = nullptr;
+    CBasicPacketPtr PSmallPacket = nullptr;
 
     uint32 PacketSize  = UINT32_MAX;
     size_t PacketCount = std::clamp<size_t>(PChar->getPacketCount(), 0, MAX_PACKETS_PER_COMPRESSION);
@@ -898,13 +898,13 @@ int32 send_parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_da
     {
         do
         {
-            *buffsize               = FFXI_HEADER_SIZE;
-            PacketList_t packetList = PChar->getPacketList();
-            packets                 = 0;
+            *buffsize        = FFXI_HEADER_SIZE;
+            auto& packetList = PChar->getPacketList();
+            packets          = 0;
 
             while (!packetList.empty() && *buffsize + packetList.front()->getSize() < MAX_BUFFER_SIZE && static_cast<size_t>(packets) < PacketCount)
             {
-                PSmallPacket = packetList.front();
+                PSmallPacket = std::move(packetList.front());
                 packetList.pop_front();
 
                 PSmallPacket->setSequence(map_session_data->server_packet_id);

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -966,7 +966,6 @@ int32 send_parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_da
             }
         }
     } while (PacketSize == static_cast<uint32>(-1));
-    PChar->erasePackets(packets);
     TotalPacketsSentPerTick += packets;
     TracyZoneString(fmt::format("Sending {} packets", packets));
 

--- a/src/map/merit.cpp
+++ b/src/map/merit.cpp
@@ -350,7 +350,7 @@ void CMeritPoints::RaiseMerit(MERIT_TYPE merit)
             if (charutils::addSpell(m_PChar, PMerit->spellid))
             {
                 charutils::SaveSpell(m_PChar, PMerit->spellid);
-                m_PChar->pushPacket(new CCharSpellsPacket(m_PChar));
+                m_PChar->pushPacket<CCharSpellsPacket>(m_PChar);
             }
         }
 
@@ -359,7 +359,7 @@ void CMeritPoints::RaiseMerit(MERIT_TYPE merit)
             charutils::addLearnedWeaponskill(m_PChar, PMerit->wsunlockid);
             charutils::BuildingCharWeaponSkills(m_PChar);
             charutils::SaveLearnedAbilities(m_PChar);
-            m_PChar->pushPacket(new CCharAbilitiesPacket(m_PChar));
+            m_PChar->pushPacket<CCharAbilitiesPacket>(m_PChar);
         }
 
         PMerit->count++;
@@ -383,7 +383,7 @@ void CMeritPoints::LowerMerit(MERIT_TYPE merit)
         if (charutils::delSpell(m_PChar, PMerit->spellid))
         {
             charutils::DeleteSpell(m_PChar, PMerit->spellid);
-            m_PChar->pushPacket(new CCharSpellsPacket(m_PChar));
+            m_PChar->pushPacket<CCharSpellsPacket>(m_PChar);
 
             // Reset traits
             charutils::BuildingCharTraitsTable(m_PChar);
@@ -395,7 +395,7 @@ void CMeritPoints::LowerMerit(MERIT_TYPE merit)
         charutils::delLearnedWeaponskill(m_PChar, PMerit->wsunlockid);
         charutils::BuildingCharWeaponSkills(m_PChar);
         charutils::SaveLearnedAbilities(m_PChar);
-        m_PChar->pushPacket(new CCharAbilitiesPacket(m_PChar));
+        m_PChar->pushPacket<CCharAbilitiesPacket>(m_PChar);
     }
 }
 

--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -104,7 +104,7 @@ namespace message
                     // TODO: disconnect the client, but leave the character in the disconnecting state
                     // PChar->status = STATUS_SHUTDOWN;
                     // won't save their position (since this is the wrong thread) but not a huge deal
-                    // PChar->pushPacket(new CServerIPPacket(PChar, 1, 0));
+                    // PChar->pushPacket<CServerIPPacket>(PChar, 1, 0);
                 }
                 break;
             }
@@ -296,7 +296,7 @@ namespace message
                         // Target is blocking assistance
                         send(MSG_DIRECT, extra.data(), sizeof(uint32), new CMessageSystemPacket(0, 0, MSGSYSTEM::TARGET_IS_CURRENTLY_BLOCKING));
                         // Interaction was blocked
-                        PInvitee->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::BLOCKED_BY_BLOCKAID));
+                        PInvitee->pushPacket<CMessageSystemPacket>(0, 0, MSGSYSTEM::BLOCKED_BY_BLOCKAID);
                         // You cannot invite that person at this time.
                         send(MSG_DIRECT, extra.data(), sizeof(uint32), new CMessageStandardPacket(PInvitee, 0, 0, MsgStd::CannotInvite));
                         break;
@@ -329,7 +329,7 @@ namespace message
                 {
                     if (inviteAnswer == 0)
                     {
-                        PInviter->pushPacket(new CMessageStandardPacket(PInviter, 0, 0, MsgStd::InvitationDeclined));
+                        PInviter->pushPacket<CMessageStandardPacket>(PInviter, 0, 0, MsgStd::InvitationDeclined);
                     }
                     else
                     {

--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -166,9 +166,9 @@ namespace message
 
                 if (PParty)
                 {
-                    CBasicPacket* newPacket = new CBasicPacket();
+                    auto newPacket = std::make_unique<CBasicPacket>();
                     memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
-                    PParty->PushPacket(senderid, 0, newPacket);
+                    PParty->PushPacket(senderid, 0, std::move(newPacket));
                 }
                 break;
             }
@@ -202,9 +202,9 @@ namespace message
                 {
                     for (auto& currentParty : PAlliance->partyList)
                     {
-                        CBasicPacket* newPacket = new CBasicPacket();
+                        auto newPacket = std::make_unique<CBasicPacket>();
                         memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
-                        currentParty->PushPacket(senderid, 0, newPacket);
+                        currentParty->PushPacket(senderid, 0, std::move(newPacket));
                     }
                 }
                 break;
@@ -215,9 +215,9 @@ namespace message
                 CLinkshell* PLinkshell  = linkshell::GetLinkshell(linkshellID);
                 if (PLinkshell)
                 {
-                    CBasicPacket* newPacket = new CBasicPacket();
+                    auto newPacket = std::make_unique<CBasicPacket>();
                     memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
-                    PLinkshell->PushPacket(ref<uint32>((uint8*)extra.data(), 4), newPacket);
+                    PLinkshell->PushPacket(ref<uint32>((uint8*)extra.data(), 4), std::move(newPacket));
                 }
                 break;
             }
@@ -227,9 +227,9 @@ namespace message
                 CUnityChat* PUnityChat = unitychat::GetUnityChat(leader);
                 if (PUnityChat)
                 {
-                    CBasicPacket* newPacket = new CBasicPacket();
+                    auto newPacket = std::make_unique<CBasicPacket>();
                     memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
-                    PUnityChat->PushPacket(ref<uint32>((uint8*)extra.data(), 4), newPacket);
+                    PUnityChat->PushPacket(ref<uint32>((uint8*)extra.data(), 4), std::move(newPacket));
                 }
                 break;
             }
@@ -245,10 +245,9 @@ namespace message
                             // don't push to sender
                             if (PChar->id != ref<uint32>((uint8*)extra.data(), 0))
                             {
-                                CBasicPacket* newPacket = new CBasicPacket();
+                                auto newPacket = std::make_unique<CBasicPacket>();
                                 memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
-
-                                PChar->pushPacket(newPacket);
+                                PChar->pushPacket(std::move(newPacket));
                             }
                         });
                     }
@@ -263,9 +262,9 @@ namespace message
                 {
                     PZone->ForEachChar([&packet](CCharEntity* PChar)
                     {
-                        CBasicPacket* newPacket = new CBasicPacket();
+                        auto newPacket = std::make_unique<CBasicPacket>();
                         memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
-                        PChar->pushPacket(newPacket);
+                        PChar->pushPacket(std::move(newPacket));
                     });
                 });
                 // clang-format on
@@ -310,9 +309,9 @@ namespace message
 
                     PInvitee->InvitePending.id     = ref<uint32>((uint8*)extra.data(), 6);
                     PInvitee->InvitePending.targid = ref<uint16>((uint8*)extra.data(), 10);
-                    CBasicPacket* newPacket        = new CBasicPacket();
+                    auto newPacket                 = std::make_unique<CBasicPacket>();
                     memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
-                    PInvitee->pushPacket(newPacket);
+                    PInvitee->pushPacket(std::move(newPacket));
                 }
                 break;
             }
@@ -500,9 +499,9 @@ namespace message
                 CCharEntity* PChar = zoneutils::GetChar(ref<uint32>((uint8*)extra.data(), 0));
                 if (PChar)
                 {
-                    CBasicPacket* newPacket = new CBasicPacket();
+                    auto newPacket = std::make_unique<CBasicPacket>();
                     memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
-                    PChar->pushPacket(newPacket);
+                    PChar->pushPacket(std::move(newPacket));
                 }
                 break;
             }

--- a/src/map/monstrosity.cpp
+++ b/src/map/monstrosity.cpp
@@ -380,14 +380,14 @@ void monstrosity::SendFullMonstrosityUpdate(CCharEntity* PChar)
 
     luautils::OnMonstrosityUpdate(PChar);
 
-    PChar->pushPacket(new CMonipulatorPacket1(PChar));
-    PChar->pushPacket(new CMonipulatorPacket2(PChar));
-    PChar->pushPacket(new CCharJobsPacket(PChar));
-    PChar->pushPacket(new CCharJobExtraPacket(PChar, true));
-    PChar->pushPacket(new CCharJobExtraPacket(PChar, false));
-    PChar->pushPacket(new CCharAppearancePacket(PChar));
-    PChar->pushPacket(new CCharStatsPacket(PChar));
-    PChar->pushPacket(new CCharAbilitiesPacket(PChar));
+    PChar->pushPacket<CMonipulatorPacket1>(PChar);
+    PChar->pushPacket<CMonipulatorPacket2>(PChar);
+    PChar->pushPacket<CCharJobsPacket>(PChar);
+    PChar->pushPacket<CCharJobExtraPacket>(PChar, true);
+    PChar->pushPacket<CCharJobExtraPacket>(PChar, false);
+    PChar->pushPacket<CCharAppearancePacket>(PChar);
+    PChar->pushPacket<CCharStatsPacket>(PChar);
+    PChar->pushPacket<CCharAbilitiesPacket>(PChar);
 
     PChar->updatemask |= UPDATE_LOOK;
 }

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -411,16 +411,16 @@ void SmallPacket0x00A(map_session_data_t* const PSession, CCharEntity* const PCh
                             uint16 handsId    = getModelIdFromStorageSlot(PChar, PMannequin->m_extra[10 + 5]);
                             uint16 legId      = getModelIdFromStorageSlot(PChar, PMannequin->m_extra[10 + 6]);
                             uint16 feetId     = getModelIdFromStorageSlot(PChar, PMannequin->m_extra[10 + 7]);
-                            PChar->pushPacket(new CInventoryCountPacket(safeContainerId, slotIndex, headId, bodyId, handsId, legId, feetId, mainId, subId, rangeId));
+                            PChar->pushPacket<CInventoryCountPacket>(safeContainerId, slotIndex, headId, bodyId, handsId, legId, feetId, mainId, subId, rangeId);
                         }
                     }
                 }
             }
         }
 
-        PChar->pushPacket(new CDownloadingDataPacket());
-        PChar->pushPacket(new CZoneInPacket(PChar, PChar->currentEvent));
-        PChar->pushPacket(new CZoneVisitedPacket(PChar));
+        PChar->pushPacket<CDownloadingDataPacket>();
+        PChar->pushPacket<CZoneInPacket>(PChar, PChar->currentEvent);
+        PChar->pushPacket<CZoneVisitedPacket>(PChar);
     }
 }
 
@@ -434,14 +434,14 @@ void SmallPacket0x00A(map_session_data_t* const PSession, CCharEntity* const PCh
 void SmallPacket0x00C(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket& data)
 {
     TracyZoneScoped;
-    PChar->pushPacket(new CInventorySizePacket(PChar));
-    PChar->pushPacket(new CMenuConfigPacket(PChar));
-    PChar->pushPacket(new CCharJobsPacket(PChar));
+    PChar->pushPacket<CInventorySizePacket>(PChar);
+    PChar->pushPacket<CMenuConfigPacket>(PChar);
+    PChar->pushPacket<CCharJobsPacket>(PChar);
 
     if (charutils::hasKeyItem(PChar, 2544))
     {
         // Only send Job Points Packet if the player has unlocked them
-        PChar->pushPacket(new CJobPointDetailsPacket(PChar));
+        PChar->pushPacket<CJobPointDetailsPacket>(PChar);
     }
 
     // TODO: While in mog house; treasure pool is not created.
@@ -589,12 +589,12 @@ void SmallPacket0x00F(map_session_data_t* const PSession, CCharEntity* const PCh
     charutils::SendKeyItems(PChar);
     charutils::SendQuestMissionLog(PChar);
 
-    PChar->pushPacket(new CCharSpellsPacket(PChar));
-    PChar->pushPacket(new CCharMountsPacket(PChar));
-    PChar->pushPacket(new CCharAbilitiesPacket(PChar));
-    PChar->pushPacket(new CCharSyncPacket(PChar));
-    PChar->pushPacket(new CBazaarMessagePacket(PChar));
-    PChar->pushPacket(new CMeritPointsCategoriesPacket(PChar));
+    PChar->pushPacket<CCharSpellsPacket>(PChar);
+    PChar->pushPacket<CCharMountsPacket>(PChar);
+    PChar->pushPacket<CCharAbilitiesPacket>(PChar);
+    PChar->pushPacket<CCharSyncPacket>(PChar);
+    PChar->pushPacket<CBazaarMessagePacket>(PChar);
+    PChar->pushPacket<CMeritPointsCategoriesPacket>(PChar);
 
     charutils::SendInventory(PChar);
 
@@ -621,7 +621,7 @@ void SmallPacket0x011(map_session_data_t* const PSession, CCharEntity* const PCh
     {
         if (PChar->equip[i] != 0)
         {
-            PChar->pushPacket(new CEquipPacket(PChar->equip[i], i, PChar->equipLoc[i]));
+            PChar->pushPacket<CEquipPacket>(PChar->equip[i], i, PChar->equipLoc[i]);
         }
     }
 
@@ -634,7 +634,7 @@ void SmallPacket0x011(map_session_data_t* const PSession, CCharEntity* const PCh
     {
         // On zone change, only sending a version message if mismatch
         // if ((bool)sql->GetUIntData(0))
-        // PChar->pushPacket(new CChatMessagePacket(PChar, CHAT_MESSAGE_TYPE::MESSAGE_SYSTEM_1, "Server does not support this client version."));
+        // PChar->pushPacket<CChatMessagePacket>(PChar, CHAT_MESSAGE_TYPE::MESSAGE_SYSTEM_1, "Server does not support this client version.");
     }
 }
 
@@ -703,7 +703,7 @@ void SmallPacket0x015(map_session_data_t* const PSession, CCharEntity* const PCh
 
         if (PChar->PWideScanTarget != nullptr)
         {
-            PChar->pushPacket(new CWideScanTrackPacket(PChar->PWideScanTarget));
+            PChar->pushPacket<CWideScanTrackPacket>(PChar->PWideScanTarget);
 
             if (PChar->PWideScanTarget->status == STATUS_TYPE::DISAPPEAR)
             {
@@ -727,7 +727,7 @@ void SmallPacket0x016(map_session_data_t* const PSession, CCharEntity* const PCh
     if (targid == PChar->targid)
     {
         PChar->updateCharPacket(PChar, ENTITY_SPAWN, UPDATE_ALL_CHAR);
-        PChar->pushPacket(new CCharUpdatePacket(PChar));
+        PChar->pushPacket<CCharUpdatePacket>(PChar);
     }
     else
     {
@@ -899,7 +899,7 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
 
             if (PChar->m_Costume != 0 || PChar->animation == ANIMATION_SYNTH)
             {
-                PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::STANDARD));
+                PChar->pushPacket<CReleasePacket>(PChar, RELEASE_TYPE::STANDARD);
                 return;
             }
 
@@ -912,7 +912,7 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
                 PChar->getZone() != ZONEID::ZONE_FERETORY &&
                 !settings::get<bool>("main.MONSTROSITY_TRIGGER_NPCS"))
             {
-                PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::STANDARD));
+                PChar->pushPacket<CReleasePacket>(PChar, RELEASE_TYPE::STANDARD);
                 return;
             }
 
@@ -933,7 +933,7 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
             if (!PChar->isNpcLocked())
             {
                 PChar->eventPreparation->reset();
-                PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::STANDARD));
+                PChar->pushPacket<CReleasePacket>(PChar, RELEASE_TYPE::STANDARD);
             }
         }
         break;
@@ -999,14 +999,14 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
                 }
             }
 
-            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, 22));
+            PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, 22);
         }
         break;
         case 0x07: // weaponskill
         {
             if (!PChar->PAI->IsEngaged() && settings::get<bool>("map.PREVENT_UNENGAGED_WS")) // Prevent Weaponskill usage if player isn't engaged.
             {
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_UNABLE_TO_USE_WS));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, MSGBASIC_UNABLE_TO_USE_WS);
                 return;
             }
 
@@ -1030,7 +1030,7 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
             {
                 if (JobAbilityID >= ABILITY_FOOT_KICK && JobAbilityID <= ABILITY_PENTAPECK) // Is this a BST ability?
                 {
-                    PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_UNABLE_TO_USE_JA2));
+                    PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, MSGBASIC_UNABLE_TO_USE_JA2);
                     return;
                 }
             }
@@ -1122,7 +1122,7 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
                 {
                     charutils::UpdateItem(PChar, LOC_INVENTORY, slotID, -1);
 
-                    PChar->pushPacket(new CInventoryFinishPacket());
+                    PChar->pushPacket<CInventoryFinishPacket>();
                     PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CChocoboDiggingPacket(PChar));
 
                     // dig is possible
@@ -1131,13 +1131,13 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
                 else
                 {
                     // unable to dig yet
-                    PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_WAIT_LONGER));
+                    PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, MSGBASIC_WAIT_LONGER);
                 }
             }
             else
             {
                 // You don't have any gysahl greens
-                PChar->pushPacket(new CMessageSystemPacket(4545, 0, MSGSYSTEM::YOU_DONT_HAVE_ANY));
+                PChar->pushPacket<CMessageSystemPacket>(4545, 0, MSGSYSTEM::YOU_DONT_HAVE_ANY);
             }
         }
         break;
@@ -1199,24 +1199,24 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
                 if (type == 0x00 && PChar->getBlockingAid()) // /blockaid off
                 {
                     // Blockaid canceled
-                    PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::BLOCKAID_CANCELED));
+                    PChar->pushPacket<CMessageSystemPacket>(0, 0, MSGSYSTEM::BLOCKAID_CANCELED);
                     PChar->setBlockingAid(false);
                 }
                 else if (type == 0x01 && !PChar->getBlockingAid()) // /blockaid on
                 {
                     // Blockaid activated
-                    PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::BLOCKAID_ACTIVATED));
+                    PChar->pushPacket<CMessageSystemPacket>(0, 0, MSGSYSTEM::BLOCKAID_ACTIVATED);
                     PChar->setBlockingAid(true);
                 }
                 else if (type == 0x02) // /blockaid
                 {
                     // Blockaid is currently active/inactive
-                    PChar->pushPacket(new CMessageSystemPacket(0, 0, PChar->getBlockingAid() ? MSGSYSTEM::BLOCKAID_CURRENTLY_ACTIVE : MSGSYSTEM::BLOCKAID_CURRENTLY_INACTIVE));
+                    PChar->pushPacket<CMessageSystemPacket>(0, 0, PChar->getBlockingAid() ? MSGSYSTEM::BLOCKAID_CURRENTLY_ACTIVE : MSGSYSTEM::BLOCKAID_CURRENTLY_INACTIVE);
                 }
             }
             else
             {
-                PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::CANNOT_USE_COMMAND_AT_THE_MOMENT));
+                PChar->pushPacket<CMessageSystemPacket>(0, 0, MSGSYSTEM::CANNOT_USE_COMMAND_AT_THE_MOMENT);
             }
         }
         break;
@@ -1231,30 +1231,30 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
 
             if (PChar->animation != ANIMATION_NONE)
             {
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, 71));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, 71);
             }
             else if (!PChar->loc.zone->CanUseMisc(MISC_MOUNT))
             {
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_CANNOT_USE_IN_AREA));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, MSGBASIC_CANNOT_USE_IN_AREA);
             }
             else if (PChar->GetMLevel() < 20)
             {
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 20, 0, 773));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 20, 0, 773);
             }
             else if (charutils::hasKeyItem(PChar, 3072 + MountID))
             {
                 if (PChar->PRecastContainer->HasRecast(RECAST_ABILITY, 256, 60))
                 {
-                    PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, 94));
+                    PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, 94);
 
                     // add recast timer
-                    // PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, 202));
+                    // PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, 202);
                     return;
                 }
 
                 if (PChar->PNotorietyContainer->hasEnmity())
                 {
-                    PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_YOUR_MOUNT_REFUSES));
+                    PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, MSGBASIC_YOUR_MOUNT_REFUSES);
                     return;
                 }
 
@@ -1269,7 +1269,7 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
                                                               true);
 
                 PChar->PRecastContainer->Add(RECAST_ABILITY, 256, 60);
-                PChar->pushPacket(new CCharRecastPacket(PChar));
+                PChar->pushPacket<CCharRecastPacket>(PChar);
 
                 luautils::OnPlayerMount(PChar);
             }
@@ -1295,7 +1295,7 @@ void SmallPacket0x01B(map_session_data_t* const PSession, CCharEntity* const PCh
     TracyZoneScoped;
     // 0 - world pass, 2 - gold world pass; +1 - purchase
 
-    PChar->pushPacket(new CWorldPassPacket(data.ref<uint8>(0x04) & 1 ? (uint32)xirand::GetRandomNumber(9999999999) : 0));
+    PChar->pushPacket<CWorldPassPacket>(data.ref<uint8>(0x04) & 1 ? (uint32)xirand::GetRandomNumber(9999999999) : 0);
 }
 
 /************************************************************************
@@ -1393,7 +1393,7 @@ void SmallPacket0x028(map_session_data_t* const PSession, CCharEntity* const PCh
 
         if (slipData != 0)
         {
-            PChar->pushPacket(new CMessageStandardPacket(MsgStd::CannotBeProcessed));
+            PChar->pushPacket<CMessageStandardPacket>(MsgStd::CannotBeProcessed);
             return;
         }
     }
@@ -1468,10 +1468,10 @@ void SmallPacket0x029(map_session_data_t* const PSession, CCharEntity* const PCh
             CItem* PSlotItem = PChar->getStorage(FromLocationID)->GetItem(slotID);
             if (PSlotItem != nullptr)
             {
-                PChar->pushPacket(new CInventoryItemPacket(PSlotItem, FromLocationID, slotID));
+                PChar->pushPacket<CInventoryItemPacket>(PSlotItem, FromLocationID, slotID);
             }
         }
-        PChar->pushPacket(new CInventoryFinishPacket());
+        PChar->pushPacket<CInventoryFinishPacket>();
 
         return;
     }
@@ -1509,8 +1509,8 @@ void SmallPacket0x029(map_session_data_t* const PSession, CCharEntity* const PCh
             {
                 PChar->getStorage(FromLocationID)->InsertItem(nullptr, FromSlotID);
 
-                PChar->pushPacket(new CInventoryItemPacket(nullptr, FromLocationID, FromSlotID));
-                PChar->pushPacket(new CInventoryItemPacket(PItem, ToLocationID, NewSlotID));
+                PChar->pushPacket<CInventoryItemPacket>(nullptr, FromLocationID, FromSlotID);
+                PChar->pushPacket<CInventoryItemPacket>(PItem, ToLocationID, NewSlotID);
             }
             else
             {
@@ -1528,16 +1528,16 @@ void SmallPacket0x029(map_session_data_t* const PSession, CCharEntity* const PCh
                 CItem* PSlotItem = PChar->getStorage(ToLocationID)->GetItem(slotID);
                 if (PSlotItem != nullptr)
                 {
-                    PChar->pushPacket(new CInventoryItemPacket(PSlotItem, ToLocationID, slotID));
+                    PChar->pushPacket<CInventoryItemPacket>(PSlotItem, ToLocationID, slotID);
                 }
             }
-            PChar->pushPacket(new CInventoryFinishPacket());
+            PChar->pushPacket<CInventoryFinishPacket>();
 
             ShowError("SmallPacket0x29: Location %u Slot %u is full", ToLocationID, ToSlotID);
             return;
         }
     }
-    PChar->pushPacket(new CInventoryFinishPacket());
+    PChar->pushPacket<CInventoryFinishPacket>();
 }
 
 /************************************************************************
@@ -1568,14 +1568,14 @@ void SmallPacket0x032(map_session_data_t* const PSession, CCharEntity* const PCh
         // If the player is the same as the target, don't allow the trade
         if (PChar->id == PTarget->id)
         {
-            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, 155));
+            PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, 155);
             return;
         }
 
         // If either player is in prison don't allow the trade.
         if (jailutils::InPrison(PChar) || jailutils::InPrison(PTarget))
         {
-            PChar->pushPacket(new CTradeActionPacket(PTarget, 0x07));
+            PChar->pushPacket<CTradeActionPacket>(PTarget, 0x07);
             return;
         }
 
@@ -1583,7 +1583,7 @@ void SmallPacket0x032(map_session_data_t* const PSession, CCharEntity* const PCh
         if (PChar->animation == ANIMATION_SYNTH || PTarget->animation == ANIMATION_SYNTH)
         {
             ShowDebug("%s trade request with %s was blocked.", PChar->getName(), PTarget->getName());
-            PChar->pushPacket(new CTradeActionPacket(PTarget, 0x07));
+            PChar->pushPacket<CTradeActionPacket>(PTarget, 0x07);
             return;
         }
 
@@ -1592,10 +1592,10 @@ void SmallPacket0x032(map_session_data_t* const PSession, CCharEntity* const PCh
         {
             ShowDebug("%s is blocking trades", PTarget->getName());
             // Target is blocking assistance
-            PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::TARGET_IS_CURRENTLY_BLOCKING));
+            PChar->pushPacket<CMessageSystemPacket>(0, 0, MSGSYSTEM::TARGET_IS_CURRENTLY_BLOCKING);
             // Interaction was blocked
-            PTarget->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::BLOCKED_BY_BLOCKAID));
-            PChar->pushPacket(new CTradeActionPacket(PTarget, 0x07));
+            PTarget->pushPacket<CMessageSystemPacket>(0, 0, MSGSYSTEM::BLOCKED_BY_BLOCKAID);
+            PChar->pushPacket<CTradeActionPacket>(PTarget, 0x07);
             return;
         }
 
@@ -1607,7 +1607,7 @@ void SmallPacket0x032(map_session_data_t* const PSession, CCharEntity* const PCh
 
         if (!PTarget->UContainer->IsContainerEmpty())
         {
-            PChar->pushPacket(new CTradeActionPacket(PTarget, 0x07));
+            PChar->pushPacket<CTradeActionPacket>(PTarget, 0x07);
             ShowDebug("%s's UContainer is not empty. %s cannot trade with them at this time", PTarget->getName(), PChar->getName());
             return;
         }
@@ -1616,7 +1616,7 @@ void SmallPacket0x032(map_session_data_t* const PSession, CCharEntity* const PCh
         if ((PTarget->TradePending.targid != 0 && lastTargetTradeTimeSeconds < 60) || PTarget->UContainer->GetType() == UCONTAINER_TRADE)
         {
             // Can't trade with someone who's already got a pending trade before timeout
-            PChar->pushPacket(new CTradeActionPacket(PTarget, 0x07));
+            PChar->pushPacket<CTradeActionPacket>(PTarget, 0x07);
             return;
         }
 
@@ -1632,8 +1632,8 @@ void SmallPacket0x032(map_session_data_t* const PSession, CCharEntity* const PCh
                 POldTradeTarget->TradePending.clean();
                 PChar->TradePending.clean();
 
-                POldTradeTarget->pushPacket(new CTradeActionPacket(PChar, 0x07));
-                PChar->pushPacket(new CTradeActionPacket(POldTradeTarget, 0x07));
+                POldTradeTarget->pushPacket<CTradeActionPacket>(PChar, 0x07);
+                PChar->pushPacket<CTradeActionPacket>(POldTradeTarget, 0x07);
                 return;
             }
         }
@@ -1645,7 +1645,7 @@ void SmallPacket0x032(map_session_data_t* const PSession, CCharEntity* const PCh
         PTarget->lastTradeInvite     = server_clock::now();
         PTarget->TradePending.id     = PChar->id;
         PTarget->TradePending.targid = PChar->targid;
-        PTarget->pushPacket(new CTradeRequestPacket(PChar));
+        PTarget->pushPacket<CTradeRequestPacket>(PChar);
     }
 }
 
@@ -1684,10 +1684,10 @@ void SmallPacket0x033(map_session_data_t* const PSession, CCharEntity* const PCh
                         if (distance(PChar->loc.p, PTarget->loc.p) < 6)
                         {
                             PChar->UContainer->SetType(UCONTAINER_TRADE);
-                            PChar->pushPacket(new CTradeActionPacket(PTarget, action));
+                            PChar->pushPacket<CTradeActionPacket>(PTarget, action);
 
                             PTarget->UContainer->SetType(UCONTAINER_TRADE);
-                            PTarget->pushPacket(new CTradeActionPacket(PChar, action));
+                            PTarget->pushPacket<CTradeActionPacket>(PChar, action);
                             return;
                         }
                     }
@@ -1714,7 +1714,7 @@ void SmallPacket0x033(map_session_data_t* const PSession, CCharEntity* const PCh
                 }
 
                 PTarget->TradePending.clean();
-                PTarget->pushPacket(new CTradeActionPacket(PChar, action));
+                PTarget->pushPacket<CTradeActionPacket>(PChar, action);
 
                 PChar->TradePending.clean();
             }
@@ -1725,25 +1725,25 @@ void SmallPacket0x033(map_session_data_t* const PSession, CCharEntity* const PCh
                 if (PChar->TradePending.id == PTarget->id && PTarget->TradePending.id == PChar->id)
                 {
                     PChar->UContainer->SetLock();
-                    PTarget->pushPacket(new CTradeActionPacket(PChar, action));
+                    PTarget->pushPacket<CTradeActionPacket>(PChar, action);
 
                     if (PTarget->UContainer->IsLocked())
                     {
                         if (charutils::CanTrade(PChar, PTarget) && charutils::CanTrade(PTarget, PChar))
                         {
                             charutils::DoTrade(PChar, PTarget);
-                            PTarget->pushPacket(new CTradeActionPacket(PTarget, 9));
+                            PTarget->pushPacket<CTradeActionPacket>(PTarget, 9);
 
                             charutils::DoTrade(PTarget, PChar);
-                            PChar->pushPacket(new CTradeActionPacket(PChar, 9));
+                            PChar->pushPacket<CTradeActionPacket>(PChar, 9);
                         }
                         else
                         {
                             // Failed to trade
                             // Either players containers are full or illegal item trade attempted
                             ShowDebug("%s->%s trade failed (full inventory or illegal items)", PChar->getName(), PTarget->getName());
-                            PChar->pushPacket(new CTradeActionPacket(PTarget, 1));
-                            PTarget->pushPacket(new CTradeActionPacket(PChar, 1));
+                            PChar->pushPacket<CTradeActionPacket>(PTarget, 1);
+                            PTarget->pushPacket<CTradeActionPacket>(PChar, 1);
                         }
                         PChar->TradePending.clean();
                         PChar->UContainer->Clean();
@@ -1821,7 +1821,7 @@ void SmallPacket0x034(map_session_data_t* const PSession, CCharEntity* const PCh
                     if ((!PItemLinkshell1 && !PItemLinkshell2) || ((!PItemLinkshell1 || PItemLinkshell1->GetLSID() != PItemLinkshell->GetLSID()) &&
                                                                    (!PItemLinkshell2 || PItemLinkshell2->GetLSID() != PItemLinkshell->GetLSID())))
                     {
-                        PChar->pushPacket(new CMessageStandardPacket(MsgStd::LinkshellEquipBeforeUsing));
+                        PChar->pushPacket<CMessageStandardPacket>(MsgStd::LinkshellEquipBeforeUsing);
                         PItem->setReserve(0);
                         PChar->UContainer->SetItem(tradeSlotID, nullptr);
                     }
@@ -1849,9 +1849,9 @@ void SmallPacket0x034(map_session_data_t* const PSession, CCharEntity* const PCh
                 PChar->UContainer->SetItem(tradeSlotID, nullptr);
             }
             ShowDebug("%s->%s trade pushing packet to %s", PChar->getName(), PTarget->getName(), PChar->getName());
-            PChar->pushPacket(new CTradeItemPacket(PItem, tradeSlotID));
+            PChar->pushPacket<CTradeItemPacket>(PItem, tradeSlotID);
             ShowDebug("%s->%s trade pushing packet to %s", PChar->getName(), PTarget->getName(), PTarget->getName());
-            PTarget->pushPacket(new CTradeUpdatePacket(PItem, tradeSlotID));
+            PTarget->pushPacket<CTradeUpdatePacket>(PItem, tradeSlotID);
 
             PChar->UContainer->UnLock();
             PTarget->UContainer->UnLock();
@@ -1874,7 +1874,7 @@ void SmallPacket0x036(map_session_data_t* const PSession, CCharEntity* const PCh
     if (PChar->StatusEffectContainer->HasStatusEffectByFlag(EFFECTFLAG_INVISIBLE))
     {
         // "You cannot use that command while invisible."
-        PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::CANNOT_WHILE_INVISIBLE));
+        PChar->pushPacket<CMessageSystemPacket>(0, 0, MSGSYSTEM::CANNOT_WHILE_INVISIBLE);
         return;
     }
 
@@ -1955,7 +1955,7 @@ void SmallPacket0x037(map_session_data_t* const PSession, CCharEntity* const PCh
     }
     else
     {
-        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, 56));
+        PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, 56);
     }
 }
 
@@ -2029,7 +2029,7 @@ void SmallPacket0x03A(map_session_data_t* const PSession, CCharEntity* const PCh
             }
         }
     }
-    PChar->pushPacket(new CInventoryFinishPacket());
+    PChar->pushPacket<CInventoryFinishPacket>();
 }
 
 /************************************************************************
@@ -2102,7 +2102,7 @@ void SmallPacket0x03B(map_session_data_t* const PSession, CCharEntity* const PCh
             return;
         }
 
-        PChar->pushPacket(new CInventoryAssignPacket(PItem, status));
+        PChar->pushPacket<CInventoryAssignPacket>(PItem, status);
     };
 
     switch (action)
@@ -2190,9 +2190,9 @@ void SmallPacket0x03B(map_session_data_t* const PSession, CCharEntity* const PCh
     auto rows = sql->AffectedRows();
     if (ret != SQL_ERROR && rows != 0)
     {
-        PChar->pushPacket(new CInventoryItemPacket(PMannequin, mannequinStorageLoc, mannequinStorageLocSlot));
-        PChar->pushPacket(new CInventoryCountPacket(mannequinStorageLoc, mannequinStorageLocSlot, headId, bodyId, handsId, legId, feetId, mainId, subId, rangeId));
-        PChar->pushPacket(new CInventoryFinishPacket());
+        PChar->pushPacket<CInventoryItemPacket>(PMannequin, mannequinStorageLoc, mannequinStorageLocSlot);
+        PChar->pushPacket<CInventoryCountPacket>(mannequinStorageLoc, mannequinStorageLocSlot, headId, bodyId, handsId, legId, feetId, mainId, subId, rangeId);
+        PChar->pushPacket<CInventoryFinishPacket>();
     }
     else
     {
@@ -2235,7 +2235,7 @@ void SmallPacket0x03D(map_session_data_t* const PSession, CCharEntity* const PCh
     if (ret == SQL_ERROR || sql->NumRows() != 1 || sql->NextRow() != SQL_SUCCESS)
     {
         // Send failed
-        PChar->pushPacket(new CBlacklistPacket(0, "", 0x02));
+        PChar->pushPacket<CBlacklistPacket>(0, "", 0x02);
         return;
     }
 
@@ -2249,18 +2249,18 @@ void SmallPacket0x03D(map_session_data_t* const PSession, CCharEntity* const PCh
         if (blacklistutils::IsBlacklisted(PChar->id, charid))
         {
             // We cannot readd this person, fail to add
-            PChar->pushPacket(new CBlacklistPacket(0, "", 0x02));
+            PChar->pushPacket<CBlacklistPacket>(0, "", 0x02);
             return;
         }
 
         // Attempt to add this person
         if (blacklistutils::AddBlacklisted(PChar->id, charid))
         {
-            PChar->pushPacket(new CBlacklistPacket(accid, name, cmd));
+            PChar->pushPacket<CBlacklistPacket>(accid, name, cmd);
         }
         else
         {
-            PChar->pushPacket(new CBlacklistPacket(0, "", 0x02));
+            PChar->pushPacket<CBlacklistPacket>(0, "", 0x02);
         }
     }
 
@@ -2270,24 +2270,24 @@ void SmallPacket0x03D(map_session_data_t* const PSession, CCharEntity* const PCh
         if (!blacklistutils::IsBlacklisted(PChar->id, charid))
         {
             // We cannot remove this person, fail to remove
-            PChar->pushPacket(new CBlacklistPacket(0, "", 0x02));
+            PChar->pushPacket<CBlacklistPacket>(0, "", 0x02);
             return;
         }
 
         // Attempt to remove this person
         if (blacklistutils::DeleteBlacklisted(PChar->id, charid))
         {
-            PChar->pushPacket(new CBlacklistPacket(accid, name, cmd));
+            PChar->pushPacket<CBlacklistPacket>(accid, name, cmd);
         }
         else
         {
-            PChar->pushPacket(new CBlacklistPacket(0, "", 0x02));
+            PChar->pushPacket<CBlacklistPacket>(0, "", 0x02);
         }
     }
     else
     {
         // Send failed
-        PChar->pushPacket(new CBlacklistPacket(0, "", 0x02));
+        PChar->pushPacket<CBlacklistPacket>(0, "", 0x02);
     }
 }
 
@@ -2367,8 +2367,8 @@ void SmallPacket0x04B(map_session_data_t* const PSession, CCharEntity* const PCh
 
     std::string login_message = luautils::GetServerMessage(msg_language);
 
-    PChar->pushPacket(new CServerMessagePacket(login_message, msg_language, msg_timestamp, msg_offset));
-    PChar->pushPacket(new CCharSyncPacket(PChar));
+    PChar->pushPacket<CServerMessagePacket>(login_message, msg_language, msg_timestamp, msg_offset);
+    PChar->pushPacket<CCharSyncPacket>(PChar);
 
     // todo: kill player til theyre dead and bsod
     const char* fmtQuery = "SELECT version_mismatch FROM accounts_sessions WHERE charid = %u";
@@ -2377,7 +2377,7 @@ void SmallPacket0x04B(map_session_data_t* const PSession, CCharEntity* const PCh
     {
         if ((bool)sql->GetUIntData(0))
         {
-            PChar->pushPacket(new CChatMessagePacket(PChar, CHAT_MESSAGE_TYPE::MESSAGE_SYSTEM_1, "Server does not support this client version."));
+            PChar->pushPacket<CChatMessagePacket>(PChar, CHAT_MESSAGE_TYPE::MESSAGE_SYSTEM_1, "Server does not support this client version.");
         }
     }
 }
@@ -2522,7 +2522,7 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                 }
                 for (uint8 i = 0; i < 8; ++i)
                 {
-                    PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, PChar->UContainer->GetItem(i), i, items, 1));
+                    PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, PChar->UContainer->GetItem(i), i, items, 1);
                 }
             }
             return;
@@ -2602,8 +2602,8 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                     if (ret != SQL_ERROR && sql->AffectedRows() == 1 && charutils::UpdateItem(PChar, LOC_INVENTORY, invslot, -(int32)quantity))
                     {
                         PChar->UContainer->SetItem(slotID, PUBoxItem);
-                        PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, PUBoxItem, slotID, PChar->UContainer->GetItemsCount(), 1));
-                        PChar->pushPacket(new CInventoryFinishPacket());
+                        PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, PUBoxItem, slotID, PChar->UContainer->GetItemsCount(), 1);
+                        PChar->pushPacket<CInventoryFinishPacket>();
                     }
                     else
                     {
@@ -2665,8 +2665,8 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                                 if (ret != SQL_ERROR && sql->AffectedRows() == 1)
                                 {
                                     PItem->setSent(true);
-                                    PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, PItem, slotID, send_items, 0x02));
-                                    PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, PItem, slotID, send_items, 0x01));
+                                    PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, PItem, slotID, send_items, 0x02);
+                                    PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, PItem, slotID, send_items, 0x01);
                                     commit = true;
                                 }
                             }
@@ -2723,10 +2723,10 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                             {
                                 PChar->UContainer->GetItem(slotID)->setSent(false);
                                 commit = true;
-                                PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, PChar->UContainer->GetItem(slotID), slotID,
-                                                                         PChar->UContainer->GetItemsCount(), 0x02));
-                                PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, PChar->UContainer->GetItem(slotID), slotID,
-                                                                         PChar->UContainer->GetItemsCount(), 0x01));
+                                PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, PChar->UContainer->GetItem(slotID), slotID,
+                                                                      PChar->UContainer->GetItemsCount(), 0x02);
+                                PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, PChar->UContainer->GetItem(slotID), slotID,
+                                                                      PChar->UContainer->GetItemsCount(), 0x01);
                             }
                             else if (ret != SQL_ERROR && sql->AffectedRows() == 0)
                             {
@@ -2752,11 +2752,11 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                             if (ret != SQL_ERROR && sql->AffectedRows() == 1)
                             {
                                 ShowError("Deleting orphaned outbox record. PlayerID: %d slotID: %d itemID: %d", PChar->id, slotID, PItem->getID());
-                                PChar->pushPacket(new CDeliveryBoxPacket(0x0F, boxtype, 0, 1));
+                                PChar->pushPacket<CDeliveryBoxPacket>(0x0F, boxtype, 0, 1);
                             }
                         }
                         // error message: "Delivery orders are currently backlogged."
-                        PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, 0, -1));
+                        PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, 0, -1);
                     }
 
                     sql->SetAutoCommit(isAutoCommitOn);
@@ -2801,8 +2801,8 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                 received_items = (uint8)sql->NumRows();
             }
 
-            PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, 0xFF, 0x02));
-            PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, received_items, 0x01));
+            PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, 0xFF, 0x02);
+            PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, received_items, 0x01);
 
             return;
         }
@@ -2868,8 +2868,8 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                                         {
                                             PChar->UContainer->SetItem(slotID, PItem);
                                             // TODO: increment "count" for every new item, if needed
-                                            PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, nullptr, slotID, 1, 2));
-                                            PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, PItem, slotID, 1, 1));
+                                            PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, nullptr, slotID, 1, 2);
+                                            PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, PItem, slotID, 1, 1);
                                             commit = true;
                                         }
                                     }
@@ -2884,7 +2884,7 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
 
                         sql->TransactionRollback();
                         ShowError("Could not find new item to add to delivery box. PlayerID: %d Box :%d Slot: %d", PChar->id, boxtype, slotID);
-                        PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, 0, 0xEB));
+                        PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, 0, 0xEB);
                     }
                 }
                 sql->SetAutoCommit(isAutoCommitOn);
@@ -2919,8 +2919,8 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                             ret = sql->Query("DELETE FROM delivery_box WHERE charid = %u AND box = 2 AND slot = %u LIMIT 1;", PChar->id, deliverySlotID);
                             if (ret != SQL_ERROR && sql->AffectedRows() == 1)
                             {
-                                PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, 0, 0x02));
-                                PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, PItem, deliverySlotID, received_items, 0x01));
+                                PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, 0, 0x02);
+                                PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, PItem, deliverySlotID, received_items, 0x01);
                                 PChar->UContainer->SetItem(deliverySlotID, nullptr);
                                 destroy(PItem);
                             }
@@ -2941,7 +2941,7 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
 
             if (!PChar->UContainer->IsSlotEmpty(slotID))
             {
-                PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, PChar->UContainer->GetItem(slotID), slotID, 1, 1));
+                PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, PChar->UContainer->GetItem(slotID), slotID, 1, 1);
             }
 
             return;
@@ -2996,7 +2996,7 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                                 if (ret != SQL_ERROR && sql->AffectedRows() > 0)
                                 {
                                     PChar->UContainer->SetItem(slotID, nullptr);
-                                    PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, PItem, slotID, PChar->UContainer->GetItemsCount(), 1));
+                                    PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, PItem, slotID, PChar->UContainer->GetItemsCount(), 1);
                                     destroy(PItem);
                                     commit = true;
                                 }
@@ -3009,7 +3009,7 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                         sql->TransactionRollback();
                         ShowError("Could not finalize delivery return transaction. PlayerID: %d SenderID :%d ItemID: %d Quantity: %d", PChar->id, senderID,
                                   item_id, quantity);
-                        PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, PItem, slotID, PChar->UContainer->GetItemsCount(), 0xEB));
+                        PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, PItem, slotID, PChar->UContainer->GetItemsCount(), 0xEB);
                     }
 
                     sql->SetAutoCommit(isAutoCommitOn);
@@ -3036,7 +3036,7 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
 
                 if (!PItem->isType(ITEM_CURRENCY) && PChar->getStorage(LOC_INVENTORY)->GetFreeSlotsCount() == 0)
                 {
-                    PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, PItem, slotID, PChar->UContainer->GetItemsCount(), 0xB9));
+                    PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, PItem, slotID, PChar->UContainer->GetItemsCount(), 0xB9);
                     return;
                 }
 
@@ -3068,7 +3068,7 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                     if (!commit || !sql->TransactionCommit())
                     {
                         sql->TransactionRollback();
-                        PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, PItem, slotID, PChar->UContainer->GetItemsCount(), 0xBA));
+                        PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, PItem, slotID, PChar->UContainer->GetItemsCount(), 0xBA);
                         if (!invErr)
                         { // only display error in log if there's a database problem, not if inv is full or rare item conflict
                             ShowError("Could not finalize receive transaction. PlayerID: %d Action: 0x0A", PChar->id);
@@ -3076,8 +3076,8 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                     }
                     else
                     {
-                        PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, PItem, slotID, PChar->UContainer->GetItemsCount(), 1));
-                        PChar->pushPacket(new CInventoryFinishPacket());
+                        PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, PItem, slotID, PChar->UContainer->GetItemsCount(), 1);
+                        PChar->pushPacket<CInventoryFinishPacket>();
                         PChar->UContainer->SetItem(slotID, nullptr);
                         destroy(PItem);
                     }
@@ -3105,7 +3105,7 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                     CItem* PItem = PChar->UContainer->GetItem(slotID);
                     PChar->UContainer->SetItem(slotID, nullptr);
 
-                    PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, PItem, slotID, PChar->UContainer->GetItemsCount(), 1));
+                    PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, PItem, slotID, PChar->UContainer->GetItemsCount(), 1);
                     destroy(PItem);
                 }
             }
@@ -3128,19 +3128,19 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                 ret          = sql->Query("SELECT COUNT(*) FROM chars WHERE charid = '%u' AND accid = '%u' LIMIT 1;", PChar->id, accid);
                 if (ret != SQL_ERROR && sql->NextRow() == SQL_SUCCESS && sql->GetUIntData(0))
                 {
-                    PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, 0xFF, 0x02));
-                    PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, 0x01, 0x01));
+                    PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, 0xFF, 0x02);
+                    PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, 0x01, 0x01);
                 }
                 else
                 {
-                    PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, 0xFF, 0x02));
-                    PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, 0x00, 0x01));
+                    PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, 0xFF, 0x02);
+                    PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, 0x00, 0x01);
                 }
             }
             else
             {
-                PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, 0xFF, 0x02));
-                PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, 0x00, 0xFB));
+                PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, 0xFF, 0x02);
+                PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, 0x00, 0xFB);
             }
             return;
         }
@@ -3168,7 +3168,7 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
     }
 
     // Open mail, close mail
-    PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, 0, 1));
+    PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, 0, 1);
 }
 
 /************************************************************************
@@ -3218,10 +3218,10 @@ void SmallPacket0x04E(map_session_data_t* const PSession, CCharEntity* const PCh
             {
                 if (PItem->isSubType(ITEM_CHARGED) && ((CItemUsable*)PItem)->getCurrentCharges() < ((CItemUsable*)PItem)->getMaxCharges())
                 {
-                    PChar->pushPacket(new CAuctionHousePacket(action, 197, 0, 0, 0, 0));
+                    PChar->pushPacket<CAuctionHousePacket>(action, 197, 0, 0, 0, 0);
                     return;
                 }
-                PChar->pushPacket(new CAuctionHousePacket(action, PItem, quantity, price));
+                PChar->pushPacket<CAuctionHousePacket>(action, PItem, quantity, price);
             }
         }
         break;
@@ -3233,7 +3233,7 @@ void SmallPacket0x04E(map_session_data_t* const PSession, CCharEntity* const PCh
             {
                 PChar->m_ah_history.clear();
                 PChar->m_AHHistoryTimestamp = curTick;
-                PChar->pushPacket(new CAuctionHousePacket(action));
+                PChar->pushPacket<CAuctionHousePacket>(action);
 
                 // A single SQL query for the player's AH history which is stored in a Char Entity struct + vector.
                 const char* Query = "SELECT itemid, price, stack FROM auction_house WHERE seller = %u and sale=0 ORDER BY id ASC LIMIT 7;";
@@ -3256,7 +3256,7 @@ void SmallPacket0x04E(map_session_data_t* const PSession, CCharEntity* const PCh
             }
             else
             {
-                PChar->pushPacket(new CAuctionHousePacket(action, 246, 0, 0, 0, 0)); // try again in a little while msg
+                PChar->pushPacket<CAuctionHousePacket>(action, 246, 0, 0, 0, 0); // try again in a little while msg
                 break;
             }
         }
@@ -3267,7 +3267,7 @@ void SmallPacket0x04E(map_session_data_t* const PSession, CCharEntity* const PCh
 
             for (size_t auctionSlot = 0; auctionSlot < totalItemsOnAh; auctionSlot++)
             {
-                PChar->pushPacket(new CAuctionHousePacket(0x0C, (uint8)auctionSlot, PChar));
+                PChar->pushPacket<CAuctionHousePacket>(0x0C, (uint8)auctionSlot, PChar);
             }
         }
         break;
@@ -3279,7 +3279,7 @@ void SmallPacket0x04E(map_session_data_t* const PSession, CCharEntity* const PCh
             {
                 if (PItem->isSubType(ITEM_CHARGED) && ((CItemUsable*)PItem)->getCurrentCharges() < ((CItemUsable*)PItem)->getMaxCharges())
                 {
-                    PChar->pushPacket(new CAuctionHousePacket(action, 197, 0, 0, 0, 0));
+                    PChar->pushPacket<CAuctionHousePacket>(action, 197, 0, 0, 0, 0);
                     return;
                 }
 
@@ -3289,7 +3289,7 @@ void SmallPacket0x04E(map_session_data_t* const PSession, CCharEntity* const PCh
                     if (PItem->getStackSize() == 1 || PItem->getStackSize() != PItem->getQuantity())
                     {
                         ShowError("SmallPacket0x04E::AuctionHouse: Incorrect quantity of item %s", PItem->getName());
-                        PChar->pushPacket(new CAuctionHousePacket(action, 197, 0, 0, 0, 0)); // Failed to place up
+                        PChar->pushPacket<CAuctionHousePacket>(action, 197, 0, 0, 0, 0); // Failed to place up
                         return;
                     }
                     auctionFee = (uint32)(settings::get<uint32>("map.AH_BASE_FEE_STACKS") + (price * settings::get<float>("map.AH_TAX_RATE_STACKS") / 100));
@@ -3304,7 +3304,7 @@ void SmallPacket0x04E(map_session_data_t* const PSession, CCharEntity* const PCh
                 auto PGil = PChar->getStorage(LOC_INVENTORY)->GetItem(0);
                 if (PGil->getQuantity() < auctionFee || PGil->getReserve() > 0)
                 {
-                    PChar->pushPacket(new CAuctionHousePacket(action, 197, 0, 0, 0, 0)); // Not enough gil to pay fee
+                    PChar->pushPacket<CAuctionHousePacket>(action, 197, 0, 0, 0, 0); // Not enough gil to pay fee
                     return;
                 }
 
@@ -3322,7 +3322,7 @@ void SmallPacket0x04E(map_session_data_t* const PSession, CCharEntity* const PCh
 
                 if (settings::get<uint8>("map.AH_LIST_LIMIT") && ah_listings >= settings::get<uint8>("map.AH_LIST_LIMIT"))
                 {
-                    PChar->pushPacket(new CAuctionHousePacket(action, 197, 0, 0, 0, 0)); // Failed to place up
+                    PChar->pushPacket<CAuctionHousePacket>(action, 197, 0, 0, 0, 0); // Failed to place up
                     return;
                 }
 
@@ -3331,14 +3331,14 @@ void SmallPacket0x04E(map_session_data_t* const PSession, CCharEntity* const PCh
                 if (sql->Query(fmtQuery, PItem->getID(), quantity == 0, PChar->id, PChar->getName(), (uint32)time(nullptr), price) == SQL_ERROR)
                 {
                     ShowError("SmallPacket0x04E::AuctionHouse: Cannot insert item %s to database", PItem->getName());
-                    PChar->pushPacket(new CAuctionHousePacket(action, 197, 0, 0, 0, 0)); // failed to place up
+                    PChar->pushPacket<CAuctionHousePacket>(action, 197, 0, 0, 0, 0); // failed to place up
                     return;
                 }
                 charutils::UpdateItem(PChar, LOC_INVENTORY, slot, -(int32)(quantity != 0 ? 1 : PItem->getStackSize()));
                 charutils::UpdateItem(PChar, LOC_INVENTORY, 0, -(int32)auctionFee); // Deduct AH fee
 
-                PChar->pushPacket(new CAuctionHousePacket(action, 1, 0, 0, 0, 0));           // Merchandise put up on auction msg
-                PChar->pushPacket(new CAuctionHousePacket(0x0C, (uint8)ah_listings, PChar)); // Inform history of slot
+                PChar->pushPacket<CAuctionHousePacket>(action, 1, 0, 0, 0, 0);           // Merchandise put up on auction msg
+                PChar->pushPacket<CAuctionHousePacket>(0x0C, (uint8)ah_listings, PChar); // Inform history of slot
             }
         }
         break;
@@ -3348,7 +3348,7 @@ void SmallPacket0x04E(map_session_data_t* const PSession, CCharEntity* const PCh
 
             if (PChar->getStorage(LOC_INVENTORY)->GetFreeSlotsCount() == 0)
             {
-                PChar->pushPacket(new CAuctionHousePacket(action, 0xE5, 0, 0, 0, 0));
+                PChar->pushPacket<CAuctionHousePacket>(action, 0xE5, 0, 0, 0, 0);
             }
             else
             {
@@ -3362,7 +3362,7 @@ void SmallPacket0x04E(map_session_data_t* const PSession, CCharEntity* const PCh
                         {
                             if (PChar->getStorage(LocID)->SearchItem(itemid) != ERROR_SLOTID)
                             {
-                                PChar->pushPacket(new CAuctionHousePacket(action, 0xE5, 0, 0, 0, 0));
+                                PChar->pushPacket<CAuctionHousePacket>(action, 0xE5, 0, 0, 0, 0);
                                 return;
                             }
                         }
@@ -3383,8 +3383,8 @@ void SmallPacket0x04E(map_session_data_t* const PSession, CCharEntity* const PCh
                             {
                                 charutils::UpdateItem(PChar, LOC_INVENTORY, 0, -(int32)(price));
 
-                                PChar->pushPacket(new CAuctionHousePacket(action, 0x01, itemid, price, quantity, PItem->getStackSize()));
-                                PChar->pushPacket(new CInventoryFinishPacket());
+                                PChar->pushPacket<CAuctionHousePacket>(action, 0x01, itemid, price, quantity, PItem->getStackSize());
+                                PChar->pushPacket<CInventoryFinishPacket>();
                             }
                             return;
                         }
@@ -3393,11 +3393,11 @@ void SmallPacket0x04E(map_session_data_t* const PSession, CCharEntity* const PCh
                 // You were unable to buy the {qty} {item}
                 if (PItem)
                 {
-                    PChar->pushPacket(new CAuctionHousePacket(action, 0xC5, itemid, price, quantity, PItem->getStackSize()));
+                    PChar->pushPacket<CAuctionHousePacket>(action, 0xC5, itemid, price, quantity, PItem->getStackSize());
                 }
                 else
                 {
-                    PChar->pushPacket(new CAuctionHousePacket(action, 0xC5, itemid, price, quantity, 0));
+                    PChar->pushPacket<CAuctionHousePacket>(action, 0xC5, itemid, price, quantity, 0);
                 }
             }
         }
@@ -3424,8 +3424,8 @@ void SmallPacket0x04E(map_session_data_t* const PSession, CCharEntity* const PCh
                             if (SlotID != ERROR_SLOTID)
                             {
                                 sql->TransactionCommit();
-                                PChar->pushPacket(new CAuctionHousePacket(action, 0, PChar, slotid, false));
-                                PChar->pushPacket(new CInventoryFinishPacket());
+                                PChar->pushPacket<CAuctionHousePacket>(action, 0, PChar, slotid, false);
+                                PChar->pushPacket<CInventoryFinishPacket>();
                                 sql->SetAutoCommit(isAutoCommitOn);
                                 return;
                             }
@@ -3441,12 +3441,12 @@ void SmallPacket0x04E(map_session_data_t* const PSession, CCharEntity* const PCh
                 }
             }
             // Let client know something went wrong
-            PChar->pushPacket(new CAuctionHousePacket(action, 0xE5, PChar, slotid, true)); // Inventory full, unable to remove msg
+            PChar->pushPacket<CAuctionHousePacket>(action, 0xE5, PChar, slotid, true); // Inventory full, unable to remove msg
         }
         break;
         case 0x0D:
         {
-            PChar->pushPacket(new CAuctionHousePacket(action, slotid, PChar));
+            PChar->pushPacket<CAuctionHousePacket>(action, slotid, PChar);
         }
         break;
     }
@@ -3554,7 +3554,7 @@ void SmallPacket0x052(map_session_data_t* const PSession, CCharEntity* const PCh
     // in this list the slot of whats being updated is old value, replace with new in 116
     // Should Push 0x116 (size 68) in responce
     // 0x04 is start, contains 16 4 byte parts repersently each slot in order
-    PChar->pushPacket(new CAddtoEquipSet(PChar, data));
+    PChar->pushPacket<CAddtoEquipSet>(PChar, data);
 }
 
 /************************************************************************
@@ -3580,7 +3580,7 @@ void SmallPacket0x053(map_session_data_t* const PSession, CCharEntity* const PCh
     }
     else if (type == 2)
     {
-        PChar->pushPacket(new CMessageStandardPacket(PChar->getStyleLocked() ? MsgStd::StyleLockIsOn : MsgStd::StyleLockIsOff));
+        PChar->pushPacket<CMessageStandardPacket>(PChar->getStyleLocked() ? MsgStd::StyleLockIsOn : MsgStd::StyleLockIsOff);
     }
     else if (type == 3)
     {
@@ -3664,8 +3664,8 @@ void SmallPacket0x053(map_session_data_t* const PSession, CCharEntity* const PCh
 
     if (type != 1 && type != 2)
     {
-        PChar->pushPacket(new CCharAppearancePacket(PChar));
-        PChar->pushPacket(new CCharSyncPacket(PChar));
+        PChar->pushPacket<CCharAppearancePacket>(PChar);
+        PChar->pushPacket<CCharSyncPacket>(PChar);
     }
 }
 
@@ -3689,12 +3689,12 @@ void SmallPacket0x058(map_session_data_t* const PSession, CCharEntity* const PCh
         // uint16 resultMax  = data.ref<uint16>(0x0E); // Unused, maximum in range is always 16 greater
         uint16 resultMin = data.ref<uint16>(0x0C);
 
-        PChar->pushPacket(new CSynthSuggestionListPacket(skillID, skillLevel, skillRank, resultMin));
+        PChar->pushPacket<CSynthSuggestionListPacket>(skillID, skillLevel, skillRank, resultMin);
     }
     else
     {
         uint16 selectedRecipeOffset = data.ref<uint16>(0x10);
-        PChar->pushPacket(new CSynthSuggestionRecipePacket(skillID, skillLevel, skillRank, selectedRecipeOffset));
+        PChar->pushPacket<CSynthSuggestionRecipePacket>(skillID, skillLevel, skillRank, selectedRecipeOffset);
     }
 }
 
@@ -3722,12 +3722,12 @@ void SmallPacket0x059(map_session_data_t* const PSession, CCharEntity* const PCh
 void SmallPacket0x05A(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket& data)
 {
     TracyZoneScoped;
-    PChar->pushPacket(new CConquestPacket(PChar));
+    PChar->pushPacket<CConquestPacket>(PChar);
 
     // TODO: This is unstable across multiple processes. Fix me.
     // CampaignState state = campaign::GetCampaignState();
-    // PChar->pushPacket(new CCampaignPacket(PChar, state, 0));
-    // PChar->pushPacket(new CCampaignPacket(PChar, state, 1));
+    // PChar->pushPacket<CCampaignPacket>(PChar, state, 0);
+    // PChar->pushPacket<CCampaignPacket>(PChar, state, 1);
 }
 
 /************************************************************************
@@ -3773,7 +3773,7 @@ void SmallPacket0x05B(map_session_data_t* const PSession, CCharEntity* const PCh
         }
     }
 
-    PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::EVENT));
+    PChar->pushPacket<CReleasePacket>(PChar, RELEASE_TYPE::EVENT);
     PChar->updatemask |= UPDATE_HP;
 }
 
@@ -3819,10 +3819,10 @@ void SmallPacket0x05C(map_session_data_t* const PSession, CCharEntity* const PCh
             PChar->loc.p.rotation = data.ref<uint8>(0x1F);
         }
 
-        PChar->pushPacket(new CCSPositionPacket(PChar));
-        PChar->pushPacket(new CPositionPacket(PChar));
+        PChar->pushPacket<CCSPositionPacket>(PChar);
+        PChar->pushPacket<CPositionPacket>(PChar);
     }
-    PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::EVENT));
+    PChar->pushPacket<CReleasePacket>(PChar, RELEASE_TYPE::EVENT);
 }
 
 /************************************************************************
@@ -3836,7 +3836,7 @@ void SmallPacket0x05D(map_session_data_t* const PSession, CCharEntity* const PCh
     TracyZoneScoped;
     if (jailutils::InPrison(PChar))
     {
-        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_CANNOT_USE_IN_AREA));
+        PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, MSGBASIC_CANNOT_USE_IN_AREA);
         return;
     }
 
@@ -4036,8 +4036,8 @@ void SmallPacket0x05E(map_session_data_t* const PSession, CCharEntity* const PCh
 
                 PChar->loc.p.rotation += 128;
 
-                PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::COULD_NOT_ENTER)); // You could not enter the next area.
-                PChar->pushPacket(new CCSPositionPacket(PChar));
+                PChar->pushPacket<CMessageSystemPacket>(0, 0, MSGSYSTEM::COULD_NOT_ENTER); // You could not enter the next area.
+                PChar->pushPacket<CCSPositionPacket>(PChar);
 
                 PChar->status = STATUS_TYPE::NORMAL;
                 return;
@@ -4046,8 +4046,8 @@ void SmallPacket0x05E(map_session_data_t* const PSession, CCharEntity* const PCh
             {
                 PChar->loc.p.rotation += 128;
 
-                PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::COULD_NOT_ENTER)); // You could not enter the next area.
-                PChar->pushPacket(new CCSPositionPacket(PChar));
+                PChar->pushPacket<CMessageSystemPacket>(0, 0, MSGSYSTEM::COULD_NOT_ENTER); // You could not enter the next area.
+                PChar->pushPacket<CCSPositionPacket>(PChar);
 
                 PChar->status = STATUS_TYPE::NORMAL;
                 return;
@@ -4062,8 +4062,8 @@ void SmallPacket0x05E(map_session_data_t* const PSession, CCharEntity* const PCh
 
                     PChar->loc.p.rotation += 128;
 
-                    PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::COULD_NOT_ENTER)); // You could not enter the next area.
-                    PChar->pushPacket(new CCSPositionPacket(PChar));
+                    PChar->pushPacket<CMessageSystemPacket>(0, 0, MSGSYSTEM::COULD_NOT_ENTER); // You could not enter the next area.
+                    PChar->pushPacket<CCSPositionPacket>(PChar);
 
                     PChar->status = STATUS_TYPE::NORMAL;
                     return;
@@ -4104,8 +4104,8 @@ void SmallPacket0x05E(map_session_data_t* const PSession, CCharEntity* const PCh
 
         PChar->loc.p.rotation += 128;
 
-        PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::COULD_NOT_ENTER)); // You could not enter the next area.
-        PChar->pushPacket(new CCSPositionPacket(PChar));
+        PChar->pushPacket<CMessageSystemPacket>(0, 0, MSGSYSTEM::COULD_NOT_ENTER); // You could not enter the next area.
+        PChar->pushPacket<CCSPositionPacket>(PChar);
 
         PChar->status = STATUS_TYPE::NORMAL;
 
@@ -4131,8 +4131,8 @@ void SmallPacket0x060(map_session_data_t* const PSession, CCharEntity* const PCh
     std::string updateString = std::string((char*)data[12]);
     luautils::OnEventUpdate(PChar, updateString);
 
-    PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::EVENT));
-    PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::PLAYERINPUT));
+    PChar->pushPacket<CReleasePacket>(PChar, RELEASE_TYPE::EVENT);
+    PChar->pushPacket<CReleasePacket>(PChar, RELEASE_TYPE::PLAYERINPUT);
 }
 
 /************************************************************************
@@ -4144,25 +4144,25 @@ void SmallPacket0x060(map_session_data_t* const PSession, CCharEntity* const PCh
 void SmallPacket0x061(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket& data)
 {
     TracyZoneScoped;
-    PChar->pushPacket(new CCharUpdatePacket(PChar));
-    PChar->pushPacket(new CCharHealthPacket(PChar));
-    PChar->pushPacket(new CCharStatsPacket(PChar));
-    PChar->pushPacket(new CCharSkillsPacket(PChar));
-    PChar->pushPacket(new CCharRecastPacket(PChar));
-    PChar->pushPacket(new CMenuMeritPacket(PChar));
-    PChar->pushPacket(new CMonipulatorPacket1(PChar));
-    PChar->pushPacket(new CMonipulatorPacket2(PChar));
+    PChar->pushPacket<CCharUpdatePacket>(PChar);
+    PChar->pushPacket<CCharHealthPacket>(PChar);
+    PChar->pushPacket<CCharStatsPacket>(PChar);
+    PChar->pushPacket<CCharSkillsPacket>(PChar);
+    PChar->pushPacket<CCharRecastPacket>(PChar);
+    PChar->pushPacket<CMenuMeritPacket>(PChar);
+    PChar->pushPacket<CMonipulatorPacket1>(PChar);
+    PChar->pushPacket<CMonipulatorPacket2>(PChar);
 
     if (charutils::hasKeyItem(PChar, 2544))
     {
         // Only send Job Points Packet if the player has unlocked them
-        PChar->pushPacket(new CMenuJobPointsPacket(PChar));
-        PChar->pushPacket(new CJobPointDetailsPacket(PChar));
+        PChar->pushPacket<CMenuJobPointsPacket>(PChar);
+        PChar->pushPacket<CJobPointDetailsPacket>(PChar);
     }
 
-    PChar->pushPacket(new CCharJobExtraPacket(PChar, true));
-    PChar->pushPacket(new CCharJobExtraPacket(PChar, false));
-    PChar->pushPacket(new CStatusEffectPacket(PChar));
+    PChar->pushPacket<CCharJobExtraPacket>(PChar, true);
+    PChar->pushPacket<CCharJobExtraPacket>(PChar, false);
+    PChar->pushPacket<CStatusEffectPacket>(PChar);
 }
 
 /************************************************************************
@@ -4249,7 +4249,7 @@ void SmallPacket0x06E(map_session_data_t* const PSession, CCharEntity* const PCh
     if (jailutils::InPrison(PChar))
     {
         // Initiator is in prison.  Send error message.
-        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_CANNOT_USE_IN_AREA));
+        PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, MSGBASIC_CANNOT_USE_IN_AREA);
         return;
     }
 
@@ -4260,7 +4260,7 @@ void SmallPacket0x06E(map_session_data_t* const PSession, CCharEntity* const PCh
             {
                 if (PChar->PParty && PChar->PParty->IsFull())
                 {
-                    PChar->pushPacket(new CMessageStandardPacket(PChar, 0, 0, MsgStd::CannotInvite));
+                    PChar->pushPacket<CMessageStandardPacket>(PChar, 0, 0, MsgStd::CannotInvite);
                     break;
                 }
                 CCharEntity* PInvitee = nullptr;
@@ -4283,7 +4283,7 @@ void SmallPacket0x06E(map_session_data_t* const PSession, CCharEntity* const PCh
                     if (PInvitee->isDead() || jailutils::InPrison(PInvitee) || PInvitee->InvitePending.id != 0 || PInvitee->PParty != nullptr)
                     {
                         ShowDebug("%s is dead, in jail, has a pending invite, or is already in a party", PInvitee->getName());
-                        PChar->pushPacket(new CMessageStandardPacket(PChar, 0, 0, MsgStd::CannotInvite));
+                        PChar->pushPacket<CMessageStandardPacket>(PChar, 0, 0, MsgStd::CannotInvite);
                         break;
                     }
                     // check /blockaid
@@ -4291,27 +4291,27 @@ void SmallPacket0x06E(map_session_data_t* const PSession, CCharEntity* const PCh
                     {
                         ShowDebug("%s is blocking party invites", PInvitee->getName());
                         // Target is blocking assistance
-                        PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::TARGET_IS_CURRENTLY_BLOCKING));
+                        PChar->pushPacket<CMessageSystemPacket>(0, 0, MSGSYSTEM::TARGET_IS_CURRENTLY_BLOCKING);
                         // Interaction was blocked
-                        PInvitee->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::BLOCKED_BY_BLOCKAID));
+                        PInvitee->pushPacket<CMessageSystemPacket>(0, 0, MSGSYSTEM::BLOCKED_BY_BLOCKAID);
                         // You cannot invite that person at this time.
-                        PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::YOU_CANNOT_INVITE_THAT_PERSON));
+                        PChar->pushPacket<CMessageSystemPacket>(0, 0, MSGSYSTEM::YOU_CANNOT_INVITE_THAT_PERSON);
                         break;
                     }
                     if (PInvitee->StatusEffectContainer->HasStatusEffect(EFFECT_LEVEL_SYNC))
                     {
                         ShowDebug("%s has level sync, unable to send invite", PInvitee->getName());
-                        PChar->pushPacket(new CMessageStandardPacket(PChar, 0, 0, MsgStd::CannotInviteLevelSync));
+                        PChar->pushPacket<CMessageStandardPacket>(PChar, 0, 0, MsgStd::CannotInviteLevelSync);
                         break;
                     }
 
                     PInvitee->InvitePending.id     = PChar->id;
                     PInvitee->InvitePending.targid = PChar->targid;
-                    PInvitee->pushPacket(new CPartyInvitePacket(charid, targid, PChar, INVITE_PARTY));
+                    PInvitee->pushPacket<CPartyInvitePacket>(charid, targid, PChar, INVITE_PARTY);
                     ShowDebug("Sent party invite packet to %s", PInvitee->getName());
                     if (PChar->PParty && PChar->PParty->GetSyncTarget())
                     {
-                        PInvitee->pushPacket(new CMessageStandardPacket(PInvitee, 0, 0, MsgStd::LevelSyncWarning));
+                        PInvitee->pushPacket<CMessageStandardPacket>(PInvitee, 0, 0, MsgStd::LevelSyncWarning);
                     }
                 }
                 else
@@ -4331,7 +4331,7 @@ void SmallPacket0x06E(map_session_data_t* const PSession, CCharEntity* const PCh
             else // in party but not leader, cannot invite
             {
                 ShowDebug("%s is not party leader, cannot send invite", PChar->getName());
-                PChar->pushPacket(new CMessageStandardPacket(PChar, 0, 0, MsgStd::NotPartyLeader));
+                PChar->pushPacket<CMessageStandardPacket>(PChar, 0, 0, MsgStd::NotPartyLeader);
             }
             break;
 
@@ -4362,11 +4362,11 @@ void SmallPacket0x06E(map_session_data_t* const PSession, CCharEntity* const PCh
                     {
                         ShowDebug("%s is blocking alliance invites", PInvitee->getName());
                         // Target is blocking assistance
-                        PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::TARGET_IS_CURRENTLY_BLOCKING));
+                        PChar->pushPacket<CMessageSystemPacket>(0, 0, MSGSYSTEM::TARGET_IS_CURRENTLY_BLOCKING);
                         // Interaction was blocked
-                        PInvitee->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::BLOCKED_BY_BLOCKAID));
+                        PInvitee->pushPacket<CMessageSystemPacket>(0, 0, MSGSYSTEM::BLOCKED_BY_BLOCKAID);
                         // You cannot invite that person at this time.
-                        PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::YOU_CANNOT_INVITE_THAT_PERSON));
+                        PChar->pushPacket<CMessageSystemPacket>(0, 0, MSGSYSTEM::YOU_CANNOT_INVITE_THAT_PERSON);
                         break;
                     }
                     // make sure intvitee isn't dead or in jail, they are an unallied party leader and don't already have an invite pending
@@ -4374,19 +4374,19 @@ void SmallPacket0x06E(map_session_data_t* const PSession, CCharEntity* const PCh
                         PInvitee->PParty->GetLeader() != PInvitee || PInvitee->PParty->m_PAlliance)
                     {
                         ShowDebug("%s is dead, in jail, has a pending invite, or is already in a party/alliance", PInvitee->getName());
-                        PChar->pushPacket(new CMessageStandardPacket(PChar, 0, 0, MsgStd::CannotInvite));
+                        PChar->pushPacket<CMessageStandardPacket>(PChar, 0, 0, MsgStd::CannotInvite);
                         break;
                     }
                     if (PInvitee->StatusEffectContainer->HasStatusEffect(EFFECT_LEVEL_SYNC))
                     {
                         ShowDebug("%s has level sync, unable to send invite", PInvitee->getName());
-                        PChar->pushPacket(new CMessageStandardPacket(PChar, 0, 0, MsgStd::CannotInviteLevelSync));
+                        PChar->pushPacket<CMessageStandardPacket>(PChar, 0, 0, MsgStd::CannotInviteLevelSync);
                         break;
                     }
 
                     PInvitee->InvitePending.id     = PChar->id;
                     PInvitee->InvitePending.targid = PChar->targid;
-                    PInvitee->pushPacket(new CPartyInvitePacket(charid, targid, PChar, INVITE_ALLIANCE));
+                    PInvitee->pushPacket<CPartyInvitePacket>(charid, targid, PChar, INVITE_ALLIANCE);
                     ShowDebug("Sent party invite packet to %s", PInvitee->getName());
                 }
                 else
@@ -4711,7 +4711,7 @@ void SmallPacket0x074(map_session_data_t* const PSession, CCharEntity* const PCh
         {
             ShowDebug("%s declined party invite from %s", PChar->getName(), PInviter->getName());
             // invitee declined invite
-            PInviter->pushPacket(new CMessageStandardPacket(PInviter, 0, 0, MsgStd::InvitationDeclined));
+            PInviter->pushPacket<CMessageStandardPacket>(PInviter, 0, 0, MsgStd::InvitationDeclined);
             PChar->InvitePending.clean();
             return;
         }
@@ -4730,7 +4730,7 @@ void SmallPacket0x074(map_session_data_t* const PSession, CCharEntity* const PCh
                     if (PInviter->PParty->m_PAlliance->isFull() || PInviter->PParty->m_PAlliance->getMainParty() != PInviter->PParty)
                     {
                         ShowDebug("Alliance is full, invite to %s cancelled", PChar->getName());
-                        PChar->pushPacket(new CMessageStandardPacket(PChar, 0, 0, MsgStd::CannotBeProcessed));
+                        PChar->pushPacket<CMessageStandardPacket>(PChar, 0, 0, MsgStd::CannotBeProcessed);
                         PChar->InvitePending.clean();
                         return;
                     }
@@ -4744,7 +4744,7 @@ void SmallPacket0x074(map_session_data_t* const PSession, CCharEntity* const PCh
                 else if (PChar->PParty->HasTrusts() || PInviter->PParty->HasTrusts())
                 {
                     // Cannot form alliance if you have Trusts
-                    PChar->pushPacket(new CMessageStandardPacket(PChar, 0, 0, MsgStd::TrustCannotJoinAlliance));
+                    PChar->pushPacket<CMessageStandardPacket>(PChar, 0, 0, MsgStd::TrustCannotJoinAlliance);
                     return;
                 }
                 else
@@ -4775,9 +4775,9 @@ void SmallPacket0x074(map_session_data_t* const PSession, CCharEntity* const PCh
                 {
                     if (PInviter->PParty->IsFull())
                     { // someone else accepted invitation
-                        // PInviter->pushPacket(new CMessageStandardPacket(PInviter, 0, 0, 14)); Don't think retail sends error packet to inviter on full pt
+                        // PInviter->pushPacket<CMessageStandardPacket>(PInviter, 0, 0, 14); Don't think retail sends error packet to inviter on full pt
                         ShowDebug("Someone else accepted party invite, %s cannot be added to party", PChar->getName());
-                        PChar->pushPacket(new CMessageStandardPacket(PChar, 0, 0, MsgStd::CannotBeProcessed));
+                        PChar->pushPacket<CMessageStandardPacket>(PChar, 0, 0, MsgStd::CannotBeProcessed);
                     }
                     else
                     {
@@ -4788,7 +4788,7 @@ void SmallPacket0x074(map_session_data_t* const PSession, CCharEntity* const PCh
             }
             else
             {
-                PChar->pushPacket(new CMessageStandardPacket(PChar, 0, 0, MsgStd::CannotJoinLevelSync));
+                PChar->pushPacket<CMessageStandardPacket>(PChar, 0, 0, MsgStd::CannotJoinLevelSync);
             }
         }
     }
@@ -4824,7 +4824,7 @@ void SmallPacket0x076(map_session_data_t* const PSession, CCharEntity* const PCh
     else
     {
         // previous CPartyDefine was dropped or otherwise didn't work?
-        PChar->pushPacket(new CPartyDefinePacket(nullptr, false));
+        PChar->pushPacket<CPartyDefinePacket>(nullptr, false);
     }
 }
 
@@ -4910,7 +4910,7 @@ void SmallPacket0x077(map_session_data_t* const PSession, CCharEntity* const PCh
 void SmallPacket0x078(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket& data)
 {
     TracyZoneScoped;
-    PChar->pushPacket(new CPartySearchPacket(PChar));
+    PChar->pushPacket<CPartySearchPacket>(PChar);
 }
 
 /************************************************************************
@@ -4960,8 +4960,8 @@ void SmallPacket0x083(map_session_data_t* const PSession, CCharEntity* const PCh
             {
                 charutils::UpdateItem(PChar, LOC_INVENTORY, 0, -(int32)(price * quantity));
                 ShowInfo("User '%s' purchased %u of item of ID %u [from VENDOR] ", PChar->getName(), quantity, itemID);
-                PChar->pushPacket(new CShopBuyPacket(shopSlotID, quantity));
-                PChar->pushPacket(new CInventoryFinishPacket());
+                PChar->pushPacket<CShopBuyPacket>(shopSlotID, quantity);
+                PChar->pushPacket<CInventoryFinishPacket>();
             }
         }
     }
@@ -4988,7 +4988,7 @@ void SmallPacket0x084(map_session_data_t* const PSession, CCharEntity* const PCh
             quantity = std::min(quantity, PItem->getQuantity());
             // Store item-to-sell in the last slot of the shop container
             PChar->Container->setItem(PChar->Container->getExSize(), itemID, slotID, quantity);
-            PChar->pushPacket(new CShopAppraisePacket(slotID, PItem->getBasePrice()));
+            PChar->pushPacket<CShopAppraisePacket>(slotID, PItem->getBasePrice());
         }
         return;
     }
@@ -5038,8 +5038,8 @@ void SmallPacket0x085(map_session_data_t* const PSession, CCharEntity* const PCh
         charutils::UpdateItem(PChar, LOC_INVENTORY, 0, quantity * PItem->getBasePrice());
         charutils::UpdateItem(PChar, LOC_INVENTORY, slotID, -(int32)quantity);
         ShowInfo("SmallPacket0x085: Player '%s' sold %u of itemID %u [to VENDOR] ", PChar->getName(), quantity, itemID);
-        PChar->pushPacket(new CMessageStandardPacket(nullptr, itemID, quantity, MsgStd::Sell));
-        PChar->pushPacket(new CInventoryFinishPacket());
+        PChar->pushPacket<CMessageStandardPacket>(nullptr, itemID, quantity, MsgStd::Sell);
+        PChar->pushPacket<CInventoryFinishPacket>();
         PChar->Container->setItem(PChar->Container->getSize() - 1, 0, -1, 0);
     }
 }
@@ -5056,7 +5056,7 @@ void SmallPacket0x096(map_session_data_t* const PSession, CCharEntity* const PCh
     if (jailutils::InPrison(PChar))
     {
         // Prevent crafting in prison
-        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_CANNOT_USE_IN_AREA));
+        PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, MSGBASIC_CANNOT_USE_IN_AREA);
         return;
     }
 
@@ -5071,7 +5071,7 @@ void SmallPacket0x096(map_session_data_t* const PSession, CCharEntity* const PCh
     // Thus players can synth on whatever fps they want
     if (PChar->m_LastSynthTime + 15s > server_clock::now())
     {
-        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, 94));
+        PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, 94);
         return;
     }
 
@@ -5097,10 +5097,10 @@ void SmallPacket0x096(map_session_data_t* const PSession, CCharEntity* const PCh
 
             PTarget->TradePending.clean();
             PTarget->UContainer->Clean();
-            PTarget->pushPacket(new CTradeActionPacket(PChar, 0x01));
-            PChar->pushPacket(new CTradeActionPacket(PTarget, 0x01));
+            PTarget->pushPacket<CTradeActionPacket>(PChar, 0x01);
+            PChar->pushPacket<CTradeActionPacket>(PTarget, 0x01);
         }
-        PChar->pushPacket(new CMessageStandardPacket(MsgStd::CannotBeProcessed));
+        PChar->pushPacket<CMessageStandardPacket>(MsgStd::CannotBeProcessed);
         PChar->TradePending.clean();
         PChar->UContainer->Clean();
         return;
@@ -5119,7 +5119,7 @@ void SmallPacket0x096(map_session_data_t* const PSession, CCharEntity* const PCh
     {
         // Detect invalid crystal usage
         // Prevent crafting exploit to crash on container size > 8
-        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_CANNOT_USE_IN_AREA));
+        PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, MSGBASIC_CANNOT_USE_IN_AREA);
         return;
     }
 
@@ -5352,7 +5352,7 @@ void SmallPacket0x0AA(map_session_data_t* const PSession, CCharEntity* const PCh
                 PChar->PGuildShop->GetItem(shopSlotID)->setQuantity(PChar->PGuildShop->GetItem(shopSlotID)->getQuantity() - quantity);
                 PChar->pushPacket(
                     new CGuildMenuBuyUpdatePacket(PChar, PChar->PGuildShop->GetItem(PChar->PGuildShop->SearchItem(itemID))->getQuantity(), itemID, quantity));
-                PChar->pushPacket(new CInventoryFinishPacket());
+                PChar->pushPacket<CInventoryFinishPacket>();
             }
         }
     }
@@ -5384,7 +5384,7 @@ void SmallPacket0x0AB(map_session_data_t* const PSession, CCharEntity* const PCh
     TracyZoneScoped;
     if (PChar->PGuildShop != nullptr)
     {
-        PChar->pushPacket(new CGuildMenuBuyPacket(PChar, PChar->PGuildShop));
+        PChar->pushPacket<CGuildMenuBuyPacket>(PChar, PChar->PGuildShop);
     }
 }
 
@@ -5421,9 +5421,9 @@ void SmallPacket0x0AC(map_session_data_t* const PSession, CCharEntity* const PCh
                     charutils::UpdateItem(PChar, LOC_INVENTORY, 0, shopItem->getSellPrice() * quantity);
                     ShowInfo("SmallPacket0x0AC: Player '%s' sold %u of itemID %u [to GUILD] ", PChar->getName(), quantity, itemID);
                     PChar->PGuildShop->GetItem(shopSlotID)->setQuantity(PChar->PGuildShop->GetItem(shopSlotID)->getQuantity() + quantity);
-                    PChar->pushPacket(new CGuildMenuSellUpdatePacket(PChar, PChar->PGuildShop->GetItem(PChar->PGuildShop->SearchItem(itemID))->getQuantity(),
-                                                                     itemID, quantity));
-                    PChar->pushPacket(new CInventoryFinishPacket());
+                    PChar->pushPacket<CGuildMenuSellUpdatePacket>(PChar, PChar->PGuildShop->GetItem(PChar->PGuildShop->SearchItem(itemID))->getQuantity(),
+                                                                  itemID, quantity);
+                    PChar->pushPacket<CInventoryFinishPacket>();
                 }
             }
             // TODO: error messages!
@@ -5443,7 +5443,7 @@ void SmallPacket0x0AD(map_session_data_t* const PSession, CCharEntity* const PCh
     TracyZoneScoped;
     if (PChar->PGuildShop != nullptr)
     {
-        PChar->pushPacket(new CGuildMenuSellPacket(PChar, PChar->PGuildShop));
+        PChar->pushPacket<CGuildMenuSellPacket>(PChar, PChar->PGuildShop);
     }
 }
 
@@ -5492,7 +5492,7 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
             }
             else
             {
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_CANNOT_IN_THIS_AREA));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, MSGBASIC_CANNOT_IN_THIS_AREA);
             }
         }
         else
@@ -5643,7 +5643,7 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                         }
                         else // You must wait longer to perform that action.
                         {
-                            PChar->pushPacket(new CMessageStandardPacket(PChar, 0, MsgStd::WaitLonger));
+                            PChar->pushPacket<CMessageStandardPacket>(PChar, 0, MsgStd::WaitLonger);
                         }
 
                         if (settings::get<bool>("map.AUDIT_CHAT") && settings::get<uint8>("map.AUDIT_YELL"))
@@ -5662,7 +5662,7 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                     }
                     else // You cannot use that command in this area.
                     {
-                        PChar->pushPacket(new CMessageStandardPacket(PChar, 0, MsgStd::CannotHere));
+                        PChar->pushPacket<CMessageStandardPacket>(PChar, 0, MsgStd::CannotHere);
                     }
                 }
                 break;
@@ -5712,7 +5712,7 @@ void SmallPacket0x0B6(map_session_data_t* const PSession, CCharEntity* const PCh
 
     if (jailutils::InPrison(PChar))
     {
-        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_CANNOT_USE_IN_AREA));
+        PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, MSGBASIC_CANNOT_USE_IN_AREA);
         return;
     }
 
@@ -5775,9 +5775,9 @@ void SmallPacket0x0BE(map_session_data_t* const PSession, CCharEntity* const PCh
             if (sql->Query("UPDATE char_exp SET mode = %u WHERE charid = %u", operation, PChar->id) != SQL_ERROR)
             {
                 PChar->MeritMode = operation;
-                PChar->pushPacket(new CMenuMeritPacket(PChar));
-                PChar->pushPacket(new CMonipulatorPacket1(PChar));
-                PChar->pushPacket(new CMonipulatorPacket2(PChar));
+                PChar->pushPacket<CMenuMeritPacket>(PChar);
+                PChar->pushPacket<CMonipulatorPacket1>(PChar);
+                PChar->pushPacket<CMonipulatorPacket2>(PChar);
             }
         }
         break;
@@ -5795,17 +5795,17 @@ void SmallPacket0x0BE(map_session_data_t* const PSession, CCharEntity* const PCh
                     {
                         case 0:
                             PChar->PMeritPoints->LowerMerit(merit);
-                            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, data.ref<uint16>(0x06), PMerit->count, MSGBASIC_MERIT_DECREASE));
+                            PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, data.ref<uint16>(0x06), PMerit->count, MSGBASIC_MERIT_DECREASE);
                             break;
                         case 1:
                             PChar->PMeritPoints->RaiseMerit(merit);
-                            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, data.ref<uint16>(0x06), PMerit->count, MSGBASIC_MERIT_INCREASE));
+                            PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, data.ref<uint16>(0x06), PMerit->count, MSGBASIC_MERIT_INCREASE);
                             break;
                     }
-                    PChar->pushPacket(new CMenuMeritPacket(PChar));
-                    PChar->pushPacket(new CMonipulatorPacket1(PChar));
-                    PChar->pushPacket(new CMonipulatorPacket2(PChar));
-                    PChar->pushPacket(new CMeritPointsCategoriesPacket(PChar, merit));
+                    PChar->pushPacket<CMenuMeritPacket>(PChar);
+                    PChar->pushPacket<CMonipulatorPacket1>(PChar);
+                    PChar->pushPacket<CMonipulatorPacket2>(PChar);
+                    PChar->pushPacket<CMeritPointsCategoriesPacket>(PChar, merit);
 
                     charutils::SaveCharExp(PChar, PChar->GetMJob());
                     PChar->PMeritPoints->SaveMeritPoints(PChar->id);
@@ -5819,14 +5819,14 @@ void SmallPacket0x0BE(map_session_data_t* const PSession, CCharEntity* const PCh
                     PChar->UpdateHealth();
                     PChar->addHP(PChar->GetMaxHP());
                     PChar->addMP(PChar->GetMaxMP());
-                    PChar->pushPacket(new CCharUpdatePacket(PChar));
-                    PChar->pushPacket(new CCharStatsPacket(PChar));
-                    PChar->pushPacket(new CCharSkillsPacket(PChar));
-                    PChar->pushPacket(new CCharRecastPacket(PChar));
-                    PChar->pushPacket(new CCharAbilitiesPacket(PChar));
-                    PChar->pushPacket(new CCharJobExtraPacket(PChar, true));
-                    PChar->pushPacket(new CCharJobExtraPacket(PChar, true));
-                    PChar->pushPacket(new CCharSyncPacket(PChar));
+                    PChar->pushPacket<CCharUpdatePacket>(PChar);
+                    PChar->pushPacket<CCharStatsPacket>(PChar);
+                    PChar->pushPacket<CCharSkillsPacket>(PChar);
+                    PChar->pushPacket<CCharRecastPacket>(PChar);
+                    PChar->pushPacket<CCharAbilitiesPacket>(PChar);
+                    PChar->pushPacket<CCharJobExtraPacket>(PChar, true);
+                    PChar->pushPacket<CCharJobExtraPacket>(PChar, true);
+                    PChar->pushPacket<CCharSyncPacket>(PChar);
                 }
             }
         }
@@ -5850,8 +5850,8 @@ void SmallPacket0x0BF(map_session_data_t* const PSession, CCharEntity* const PCh
         if (PChar->PJobPoints->IsJobPointExist(jpType))
         {
             PChar->PJobPoints->RaiseJobPoint(jpType);
-            PChar->pushPacket(new CMenuJobPointsPacket(PChar));
-            PChar->pushPacket(new CJobPointUpdatePacket(PChar, jpType));
+            PChar->pushPacket<CMenuJobPointsPacket>(PChar);
+            PChar->pushPacket<CJobPointUpdatePacket>(PChar, jpType);
         }
     }
 }
@@ -5868,7 +5868,7 @@ void SmallPacket0x0C0(map_session_data_t* const PSession, CCharEntity* const PCh
     if (charutils::hasKeyItem(PChar, 2544))
     {
         // Only send Job Points Packet if the player has unlocked them
-        PChar->pushPacket(new CJobPointDetailsPacket(PChar));
+        PChar->pushPacket<CJobPointDetailsPacket>(PChar);
     }
 }
 
@@ -5961,12 +5961,12 @@ void SmallPacket0x0C4(map_session_data_t* const PSession, CCharEntity* const PCh
 
                 if (sql->Query(Query, DecodedName, extra, PChar->id, SlotID) != SQL_ERROR && sql->AffectedRows() != 0)
                 {
-                    PChar->pushPacket(new CInventoryItemPacket(PItemLinkshell, LocationID, SlotID));
+                    PChar->pushPacket<CInventoryItemPacket>(PItemLinkshell, LocationID, SlotID);
                 }
             }
             else
             {
-                PChar->pushPacket(new CMessageStandardPacket(MsgStd::LinkshellUnavailable));
+                PChar->pushPacket<CMessageStandardPacket>(MsgStd::LinkshellUnavailable);
                 // DE
                 // 20
                 // 1D
@@ -5998,7 +5998,7 @@ void SmallPacket0x0C4(map_session_data_t* const PSession, CCharEntity* const PCh
                         PChar->updatemask |= UPDATE_HP;
                     }
 
-                    PChar->pushPacket(new CInventoryAssignPacket(PItemLinkshell, INV_NORMAL));
+                    PChar->pushPacket<CInventoryAssignPacket>(PItemLinkshell, INV_NORMAL);
                 }
                 break;
                 case 1: // equip linkshell
@@ -6011,14 +6011,14 @@ void SmallPacket0x0C4(map_session_data_t* const PSession, CCharEntity* const PCh
                         sql->EscapeStringLen(extra, (const char*)PItemLinkshell->m_extra, sizeof(PItemLinkshell->m_extra));
                         const char* Query = "UPDATE char_inventory SET extra = '%s' WHERE charid = %u AND location = %u AND slot = %u LIMIT 1";
                         sql->Query(Query, extra, PChar->id, PItemLinkshell->getLocationID(), PItemLinkshell->getSlotID());
-                        PChar->pushPacket(new CInventoryItemPacket(PItemLinkshell, PItemLinkshell->getLocationID(), PItemLinkshell->getSlotID()));
-                        PChar->pushPacket(new CInventoryFinishPacket());
-                        PChar->pushPacket(new CMessageStandardPacket(MsgStd::LinkshellNoLongerExists));
+                        PChar->pushPacket<CInventoryItemPacket>(PItemLinkshell, PItemLinkshell->getLocationID(), PItemLinkshell->getSlotID());
+                        PChar->pushPacket<CInventoryFinishPacket>();
+                        PChar->pushPacket<CMessageStandardPacket>(MsgStd::LinkshellNoLongerExists);
                         return;
                     }
                     if (PItemLinkshell->GetLSID() == 0)
                     {
-                        PChar->pushPacket(new CMessageStandardPacket(MsgStd::LinkshellNoLongerExists));
+                        PChar->pushPacket<CMessageStandardPacket>(MsgStd::LinkshellNoLongerExists);
                         return;
                     }
                     if (OldLinkshell != nullptr) // switching linkshell group
@@ -6030,7 +6030,7 @@ void SmallPacket0x0C4(map_session_data_t* const PSession, CCharEntity* const PCh
                             linkshell::DelOnlineMember(PChar, POldItemLinkshell);
 
                             POldItemLinkshell->setSubType(ITEM_UNLOCKED);
-                            PChar->pushPacket(new CInventoryAssignPacket(POldItemLinkshell, INV_NORMAL));
+                            PChar->pushPacket<CInventoryAssignPacket>(POldItemLinkshell, INV_NORMAL);
                         }
                     }
                     linkshell::AddOnlineMember(PChar, PItemLinkshell, lsNum);
@@ -6045,18 +6045,18 @@ void SmallPacket0x0C4(map_session_data_t* const PSession, CCharEntity* const PCh
                         PChar->updatemask |= UPDATE_HP;
                     }
 
-                    PChar->pushPacket(new CInventoryAssignPacket(PItemLinkshell, INV_LINKSHELL));
+                    PChar->pushPacket<CInventoryAssignPacket>(PItemLinkshell, INV_LINKSHELL);
                 }
                 break;
             }
             charutils::SaveCharStats(PChar);
             charutils::SaveCharEquip(PChar);
 
-            PChar->pushPacket(new CLinkshellEquipPacket(PChar, lsNum));
-            PChar->pushPacket(new CInventoryItemPacket(PItemLinkshell, LocationID, SlotID));
+            PChar->pushPacket<CLinkshellEquipPacket>(PChar, lsNum);
+            PChar->pushPacket<CInventoryItemPacket>(PItemLinkshell, LocationID, SlotID);
         }
-        PChar->pushPacket(new CInventoryFinishPacket());
-        PChar->pushPacket(new CCharUpdatePacket(PChar));
+        PChar->pushPacket<CInventoryFinishPacket>();
+        PChar->pushPacket<CCharUpdatePacket>(PChar);
     }
 }
 
@@ -6139,7 +6139,7 @@ void SmallPacket0x0D2(map_session_data_t* const PSession, CCharEntity* const PCh
     {
         if (PPartyMember->getZone() == PChar->getZone() && ((CCharEntity*)PPartyMember)->m_moghouseID == PChar->m_moghouseID)
         {
-            PChar->pushPacket(new CPartyMapPacket((CCharEntity*)PPartyMember));
+            PChar->pushPacket<CPartyMapPacket>((CCharEntity*)PPartyMember);
         }
     });
     // clang-format on
@@ -6196,7 +6196,7 @@ void SmallPacket0x0DB(map_session_data_t* const PSession, CCharEntity* const PCh
         charutils::SaveLanguages(PChar);
     }
 
-    PChar->pushPacket(new CMenuConfigPacket(PChar));
+    PChar->pushPacket<CMenuConfigPacket>(PChar);
 }
 
 /************************************************************************
@@ -6250,7 +6250,7 @@ void SmallPacket0x0DC(map_session_data_t* const PSession, CCharEntity* const PCh
             }
             if (flags != PChar->nameflags.flags)
             {
-                PChar->pushPacket(new CMessageSystemPacket(0, 0, param == 1 ? MSGSYSTEM::CHARACTER_INFO_HIDDEN : MSGSYSTEM::CHARACTER_INFO_SHOWN));
+                PChar->pushPacket<CMessageSystemPacket>(0, 0, param == 1 ? MSGSYSTEM::CHARACTER_INFO_HIDDEN : MSGSYSTEM::CHARACTER_INFO_SHOWN);
             }
             break;
         }
@@ -6316,8 +6316,8 @@ void SmallPacket0x0DC(map_session_data_t* const PSession, CCharEntity* const PCh
             // in this flag, that assumption may need to be re-evaluated.
             if (flags != PChar->menuConfigFlags.byte4)
             {
-                PChar->pushPacket(new CCharAppearancePacket(PChar));
-                PChar->pushPacket(new CMessageStandardPacket(param == 1 ? MsgStd::HeadgearHide : MsgStd::HeadgearShow));
+                PChar->pushPacket<CCharAppearancePacket>(PChar);
+                PChar->pushPacket<CMessageStandardPacket>(param == 1 ? MsgStd::HeadgearHide : MsgStd::HeadgearShow);
             }
             break;
         }
@@ -6336,9 +6336,9 @@ void SmallPacket0x0DC(map_session_data_t* const PSession, CCharEntity* const PCh
 
     charutils::SaveCharStats(PChar);
     charutils::SaveMenuConfigFlags(PChar);
-    PChar->pushPacket(new CMenuConfigPacket(PChar));
-    PChar->pushPacket(new CCharUpdatePacket(PChar));
-    PChar->pushPacket(new CCharSyncPacket(PChar));
+    PChar->pushPacket<CMenuConfigPacket>(PChar);
+    PChar->pushPacket<CCharUpdatePacket>(PChar);
+    PChar->pushPacket<CCharSyncPacket>(PChar);
 }
 
 /************************************************************************
@@ -6369,16 +6369,16 @@ void SmallPacket0x0DD(map_session_data_t* const PSession, CCharEntity* const PCh
     {
         if (PChar->id == id)
         {
-            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_CHECKPARAM_NAME));
-            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_CHECKPARAM_ILVL));
-            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, PChar->ACC(0, 0), PChar->ATT(), MSGBASIC_CHECKPARAM_PRIMARY));
+            PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, MSGBASIC_CHECKPARAM_NAME);
+            PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, MSGBASIC_CHECKPARAM_ILVL);
+            PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, PChar->ACC(0, 0), PChar->ATT(), MSGBASIC_CHECKPARAM_PRIMARY);
             if (PChar->getEquip(SLOT_SUB) && PChar->getEquip(SLOT_SUB)->isType(ITEM_WEAPON))
             {
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, PChar->ACC(1, 0), PChar->ATT(), MSGBASIC_CHECKPARAM_AUXILIARY));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, PChar->ACC(1, 0), PChar->ATT(), MSGBASIC_CHECKPARAM_AUXILIARY);
             }
             else
             {
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_CHECKPARAM_AUXILIARY));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, MSGBASIC_CHECKPARAM_AUXILIARY);
             }
             if (PChar->getEquip(SLOT_RANGED) && PChar->getEquip(SLOT_RANGED)->isType(ITEM_WEAPON))
             {
@@ -6396,44 +6396,44 @@ void SmallPacket0x0DD(map_session_data_t* const PSession, CCharEntity* const PCh
             }
             else
             {
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_CHECKPARAM_RANGE));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, MSGBASIC_CHECKPARAM_RANGE);
             }
-            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, PChar->EVA(), PChar->DEF(), MSGBASIC_CHECKPARAM_DEFENSE));
+            PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, PChar->EVA(), PChar->DEF(), MSGBASIC_CHECKPARAM_DEFENSE);
         }
         else if (PChar->PPet && PChar->PPet->id == id)
         {
-            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar->PPet, 0, 0, MSGBASIC_CHECKPARAM_NAME));
-            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar->PPet, PChar->PPet->ACC(0, 0), PChar->PPet->ATT(), MSGBASIC_CHECKPARAM_PRIMARY));
+            PChar->pushPacket<CMessageBasicPacket>(PChar, PChar->PPet, 0, 0, MSGBASIC_CHECKPARAM_NAME);
+            PChar->pushPacket<CMessageBasicPacket>(PChar, PChar->PPet, PChar->PPet->ACC(0, 0), PChar->PPet->ATT(), MSGBASIC_CHECKPARAM_PRIMARY);
             if (PChar->getEquip(SLOT_SUB) && PChar->getEquip(SLOT_SUB)->isType(ITEM_WEAPON))
             {
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar->PPet, PChar->PPet->ACC(1, 0), PChar->PPet->ATT(), MSGBASIC_CHECKPARAM_AUXILIARY));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar->PPet, PChar->PPet->ACC(1, 0), PChar->PPet->ATT(), MSGBASIC_CHECKPARAM_AUXILIARY);
             }
             else
             {
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar->PPet, 0, 0, MSGBASIC_CHECKPARAM_AUXILIARY));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar->PPet, 0, 0, MSGBASIC_CHECKPARAM_AUXILIARY);
             }
             if (PChar->getEquip(SLOT_RANGED) && PChar->getEquip(SLOT_RANGED)->isType(ITEM_WEAPON))
             {
                 int skill = ((CItemWeapon*)PChar->getEquip(SLOT_RANGED))->getSkillType();
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar->PPet, PChar->PPet->RACC(skill), PChar->PPet->RATT(skill), MSGBASIC_CHECKPARAM_RANGE));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar->PPet, PChar->PPet->RACC(skill), PChar->PPet->RATT(skill), MSGBASIC_CHECKPARAM_RANGE);
             }
             else if (PChar->getEquip(SLOT_AMMO) && PChar->getEquip(SLOT_AMMO)->isType(ITEM_WEAPON))
             {
                 int skill = ((CItemWeapon*)PChar->getEquip(SLOT_AMMO))->getSkillType();
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar->PPet, PChar->PPet->RACC(skill), PChar->PPet->RATT(skill), MSGBASIC_CHECKPARAM_RANGE));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar->PPet, PChar->PPet->RACC(skill), PChar->PPet->RATT(skill), MSGBASIC_CHECKPARAM_RANGE);
             }
             else
             {
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar->PPet, 0, 0, MSGBASIC_CHECKPARAM_RANGE));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar->PPet, 0, 0, MSGBASIC_CHECKPARAM_RANGE);
             }
-            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar->PPet, PChar->PPet->EVA(), PChar->PPet->DEF(), MSGBASIC_CHECKPARAM_DEFENSE));
+            PChar->pushPacket<CMessageBasicPacket>(PChar, PChar->PPet, PChar->PPet->EVA(), PChar->PPet->DEF(), MSGBASIC_CHECKPARAM_DEFENSE);
         }
     }
     else
     {
         if (jailutils::InPrison(PChar))
         {
-            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_CANNOT_USE_IN_AREA));
+            PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, MSGBASIC_CANNOT_USE_IN_AREA);
             return;
         }
 
@@ -6452,7 +6452,7 @@ void SmallPacket0x0DD(map_session_data_t* const PSession, CCharEntity* const PCh
 
                 if (PTarget->m_Type & MOBTYPE_NOTORIOUS || PTarget->m_Type & MOBTYPE_BATTLEFIELD || PTarget->getMobMod(MOBMOD_CHECK_AS_NM) > 0)
                 {
-                    PChar->pushPacket(new CMessageBasicPacket(PChar, PTarget, 0, 0, 249));
+                    PChar->pushPacket<CMessageBasicPacket>(PChar, PTarget, 0, 0, 249);
                 }
                 else
                 {
@@ -6492,7 +6492,7 @@ void SmallPacket0x0DD(map_session_data_t* const PSession, CCharEntity* const PCh
                         MessageID += 3;
                     }
 
-                    PChar->pushPacket(new CMessageBasicPacket(PChar, PTarget, mobLvl, MessageValue, MessageID));
+                    PChar->pushPacket<CMessageBasicPacket>(PChar, PTarget, mobLvl, MessageValue, MessageID);
                 }
             }
             break;
@@ -6502,18 +6502,18 @@ void SmallPacket0x0DD(map_session_data_t* const PSession, CCharEntity* const PCh
 
                 if (PTarget->m_PMonstrosity)
                 {
-                    PChar->pushPacket(new CMessageStandardPacket(PTarget, 0, 0, MsgStd::MonstrosityCheckOut));
-                    PTarget->pushPacket(new CMessageStandardPacket(PChar, 0, 0, MsgStd::MonstrosityCheckIn));
+                    PChar->pushPacket<CMessageStandardPacket>(PTarget, 0, 0, MsgStd::MonstrosityCheckOut);
+                    PTarget->pushPacket<CMessageStandardPacket>(PChar, 0, 0, MsgStd::MonstrosityCheckIn);
                     return;
                 }
 
                 if (!PChar->m_isGMHidden || (PChar->m_isGMHidden && PTarget->m_GMlevel >= PChar->m_GMlevel))
                 {
-                    PTarget->pushPacket(new CMessageStandardPacket(PChar, 0, 0, MsgStd::Examine));
+                    PTarget->pushPacket<CMessageStandardPacket>(PChar, 0, 0, MsgStd::Examine);
                 }
 
-                PChar->pushPacket(new CBazaarMessagePacket(PTarget));
-                PChar->pushPacket(new CCheckPacket(PChar, PTarget));
+                PChar->pushPacket<CBazaarMessagePacket>(PTarget);
+                PChar->pushPacket<CCheckPacket>(PChar, PTarget);
             }
             break;
             default:
@@ -6640,7 +6640,7 @@ void SmallPacket0x0E2(map_session_data_t* const PSession, CCharEntity* const PCh
             break;
         }
     }
-    PChar->pushPacket(new CMessageStandardPacket(MsgStd::LinkshellNoAccess));
+    PChar->pushPacket<CMessageStandardPacket>(MsgStd::LinkshellNoAccess);
 }
 
 /************************************************************************
@@ -6732,7 +6732,7 @@ void SmallPacket0x0E8(map_session_data_t* const PSession, CCharEntity* const PCh
                 PChar->StatusEffectContainer->AddStatusEffect(new CStatusEffect(EFFECT_HEALING, 0, 0, settings::get<uint8>("map.HEALING_TICK_DELAY"), 0));
                 return;
             }
-            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, 345));
+            PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, 345);
         }
         break;
         case ANIMATION_HEALING:
@@ -6802,7 +6802,7 @@ void SmallPacket0x0EB(map_session_data_t* const PSession, CCharEntity* const PCh
         return;
     }
 
-    PChar->pushPacket(new CSpecialReleasePacket(PChar));
+    PChar->pushPacket<CSpecialReleasePacket>(PChar);
 }
 
 /************************************************************************
@@ -7049,7 +7049,7 @@ void SmallPacket0x0FA(map_session_data_t* const PSession, CCharEntity* const PCh
 
         PItem->setSubType(ITEM_LOCKED);
 
-        PChar->pushPacket(new CFurnitureInteractPacket(PItem, containerID, slotID));
+        PChar->pushPacket<CFurnitureInteractPacket>(PItem, containerID, slotID);
 
         char extra[sizeof(PItem->m_extra) * 2 + 1];
         sql->EscapeStringLen(extra, (const char*)PItem->m_extra, sizeof(PItem->m_extra));
@@ -7067,12 +7067,12 @@ void SmallPacket0x0FA(map_session_data_t* const PSession, CCharEntity* const PCh
                 PChar->getStorage(LOC_STORAGE)->AddBuff(PItem->getStorage());
             }
 
-            PChar->pushPacket(new CInventorySizePacket(PChar));
+            PChar->pushPacket<CInventorySizePacket>(PChar);
 
             luautils::OnFurniturePlaced(PChar, PItem);
         }
-        PChar->pushPacket(new CInventoryItemPacket(PItem, containerID, slotID));
-        PChar->pushPacket(new CInventoryFinishPacket());
+        PChar->pushPacket<CInventoryItemPacket>(PItem, containerID, slotID);
+        PChar->pushPacket<CInventoryFinishPacket>();
     }
 }
 
@@ -7122,7 +7122,7 @@ void SmallPacket0x0FB(map_session_data_t* const PSession, CCharEntity* const PCh
             // If this furniture is a mannequin, clear its appearance and unlock all items that were on it!
             if (PItem->isMannequin())
             {
-                PChar->pushPacket(new CInventoryCountPacket(containerID, slotID, 0, 0, 0, 0, 0, 0, 0, 0));
+                PChar->pushPacket<CInventoryCountPacket>(containerID, slotID, 0, 0, 0, 0, 0, 0, 0, 0);
                 for (uint8 i = 0; i < 8; ++i)
                 {
                     if (PItem->m_extra[10 + i] > 0)
@@ -7132,7 +7132,7 @@ void SmallPacket0x0FB(map_session_data_t* const PSession, CCharEntity* const PCh
                         {
                             continue;
                         }
-                        PChar->pushPacket(new CInventoryAssignPacket(PEquippedItem, INV_NORMAL));
+                        PChar->pushPacket<CInventoryAssignPacket>(PEquippedItem, INV_NORMAL);
                         PItem->m_extra[10 + i] = 0;
                     }
                 }
@@ -7163,12 +7163,12 @@ void SmallPacket0x0FB(map_session_data_t* const PSession, CCharEntity* const PCh
                     PChar->getStorage(LOC_STORAGE)->AddBuff(-(int8)PItem->getStorage());
                 }
 
-                PChar->pushPacket(new CInventorySizePacket(PChar));
+                PChar->pushPacket<CInventorySizePacket>(PChar);
 
                 luautils::OnFurnitureRemoved(PChar, PItem);
             }
-            PChar->pushPacket(new CInventoryItemPacket(PItem, containerID, PItem->getSlotID()));
-            PChar->pushPacket(new CInventoryFinishPacket());
+            PChar->pushPacket<CInventoryItemPacket>(PItem, containerID, PItem->getSlotID());
+            PChar->pushPacket<CInventoryFinishPacket>();
         }
         else
         {
@@ -7228,7 +7228,7 @@ void SmallPacket0x0FC(map_session_data_t* const PSession, CCharEntity* const PCh
     if (CItemFlowerpot::getPlantFromSeed(itemID) != FLOWERPOT_PLANT_NONE)
     {
         // Planting a seed in the flowerpot
-        PChar->pushPacket(new CMessageStandardPacket(itemID, 132)); // "Your moogle plants the <seed> in the flowerpot."
+        PChar->pushPacket<CMessageStandardPacket>(itemID, 132); // "Your moogle plants the <seed> in the flowerpot."
         PPotItem->cleanPot();
         PPotItem->setPlant(CItemFlowerpot::getPlantFromSeed(itemID));
         PPotItem->setPlantTimestamp(CVanaTime::getInstance()->getVanaTime());
@@ -7238,7 +7238,7 @@ void SmallPacket0x0FC(map_session_data_t* const PSession, CCharEntity* const PCh
     else if (itemID >= 4096 && itemID <= 4111)
     {
         // Feeding the plant a crystal
-        PChar->pushPacket(new CMessageStandardPacket(itemID, 136)); // "Your moogle uses the <item> on the plant."
+        PChar->pushPacket<CMessageStandardPacket>(itemID, 136); // "Your moogle uses the <item> on the plant."
         if (PPotItem->getStage() == FLOWERPOT_STAGE_FIRST_SPROUTS_CRYSTAL)
         {
             PPotItem->setFirstCrystalFeed(CItemFlowerpot::getElementFromItem(itemID));
@@ -7256,12 +7256,12 @@ void SmallPacket0x0FC(map_session_data_t* const PSession, CCharEntity* const PCh
     const char* Query = "UPDATE char_inventory SET extra = '%s' WHERE charid = %u AND location = %u AND slot = %u";
     sql->Query(Query, extra, PChar->id, PPotItem->getLocationID(), PPotItem->getSlotID());
 
-    PChar->pushPacket(new CFurnitureInteractPacket(PPotItem, potContainerID, potSlotID));
+    PChar->pushPacket<CFurnitureInteractPacket>(PPotItem, potContainerID, potSlotID);
 
-    PChar->pushPacket(new CInventoryItemPacket(PPotItem, potContainerID, potSlotID));
+    PChar->pushPacket<CInventoryItemPacket>(PPotItem, potContainerID, potSlotID);
 
     charutils::UpdateItem(PChar, containerID, slotID, -1);
-    PChar->pushPacket(new CInventoryFinishPacket());
+    PChar->pushPacket<CInventoryFinishPacket>();
 }
 
 /************************************************************************
@@ -7295,19 +7295,19 @@ void SmallPacket0x0FD(map_session_data_t* const PSession, CCharEntity* const PCh
 
     if (PItem->isPlanted())
     {
-        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, CItemFlowerpot::getSeedID(PItem->getPlant()), 0, MSGBASIC_GARDENING_SEED_SOWN));
+        PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, CItemFlowerpot::getSeedID(PItem->getPlant()), 0, MSGBASIC_GARDENING_SEED_SOWN);
         if (PItem->isTree())
         {
             if (PItem->getStage() > FLOWERPOT_STAGE_FIRST_SPROUTS_CRYSTAL)
             {
                 if (PItem->getExtraCrystalFeed() != FLOWERPOT_ELEMENT_NONE)
                 {
-                    PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, CItemFlowerpot::getItemFromElement(PItem->getExtraCrystalFeed()), 0,
-                                                              MSGBASIC_GARDENING_CRYSTAL_USED));
+                    PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, CItemFlowerpot::getItemFromElement(PItem->getExtraCrystalFeed()), 0,
+                                                           MSGBASIC_GARDENING_CRYSTAL_USED);
                 }
                 else
                 {
-                    PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_GARDENING_CRYSTAL_NONE));
+                    PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, MSGBASIC_GARDENING_CRYSTAL_NONE);
                 }
             }
         }
@@ -7315,12 +7315,12 @@ void SmallPacket0x0FD(map_session_data_t* const PSession, CCharEntity* const PCh
         {
             if (PItem->getCommonCrystalFeed() != FLOWERPOT_ELEMENT_NONE)
             {
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, CItemFlowerpot::getItemFromElement(PItem->getCommonCrystalFeed()), 0,
-                                                          MSGBASIC_GARDENING_CRYSTAL_USED));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, CItemFlowerpot::getItemFromElement(PItem->getCommonCrystalFeed()), 0,
+                                                       MSGBASIC_GARDENING_CRYSTAL_USED);
             }
             else
             {
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_GARDENING_CRYSTAL_NONE));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, MSGBASIC_GARDENING_CRYSTAL_NONE);
             }
         }
 
@@ -7334,7 +7334,7 @@ void SmallPacket0x0FD(map_session_data_t* const PSession, CCharEntity* const PCh
         }
     }
 
-    PChar->pushPacket(new CFurnitureInteractPacket(PItem, containerID, slotID));
+    PChar->pushPacket<CFurnitureInteractPacket>(PItem, containerID, slotID);
 }
 
 /************************************************************************
@@ -7389,7 +7389,7 @@ void SmallPacket0x0FE(map_session_data_t* const PSession, CCharEntity* const PCh
             uint8 totalFreeSlots              = PChar->getStorage(LOC_MOGSAFE)->GetFreeSlotsCount() + PChar->getStorage(LOC_MOGSAFE2)->GetFreeSlotsCount();
             if (requiredSlots > totalFreeSlots || totalQuantity == 0)
             {
-                PChar->pushPacket(new CMessageStandardPacket(MsgStd::MoghouseCantPickUp)); // Kupo. I can't pick anything right now, kupo.
+                PChar->pushPacket<CMessageStandardPacket>(MsgStd::MoghouseCantPickUp); // Kupo. I can't pick anything right now, kupo.
                 return;
             }
             uint8 remainingQuantity = totalQuantity;
@@ -7402,10 +7402,10 @@ void SmallPacket0x0FE(map_session_data_t* const PSession, CCharEntity* const PCh
                 }
                 remainingQuantity -= quantity;
             }
-            PChar->pushPacket(new CMessageStandardPacket(resultID, totalQuantity, 134)); // Your moogle <quantity> <item> from the plant!
+            PChar->pushPacket<CMessageStandardPacket>(resultID, totalQuantity, 134); // Your moogle <quantity> <item> from the plant!
         }
 
-        PChar->pushPacket(new CFurnitureInteractPacket(PItem, containerID, slotID));
+        PChar->pushPacket<CFurnitureInteractPacket>(PItem, containerID, slotID);
         PItem->cleanPot();
 
         char extra[sizeof(PItem->m_extra) * 2 + 1];
@@ -7413,8 +7413,8 @@ void SmallPacket0x0FE(map_session_data_t* const PSession, CCharEntity* const PCh
         const char* Query = "UPDATE char_inventory SET extra = '%s' WHERE charid = %u AND location = %u AND slot = %u";
         sql->Query(Query, extra, PChar->id, PItem->getLocationID(), PItem->getSlotID());
 
-        PChar->pushPacket(new CInventoryItemPacket(PItem, containerID, slotID));
-        PChar->pushPacket(new CInventoryFinishPacket());
+        PChar->pushPacket<CInventoryItemPacket>(PItem, containerID, slotID);
+        PChar->pushPacket<CInventoryFinishPacket>();
     }
 }
 
@@ -7445,8 +7445,8 @@ void SmallPacket0x0FF(map_session_data_t* const PSession, CCharEntity* const PCh
 
     if (PItem != nullptr && PItem->isPlanted() && PItem->getStage() > FLOWERPOT_STAGE_INITIAL && PItem->getStage() < FLOWERPOT_STAGE_WILTED && !PItem->isDried())
     {
-        PChar->pushPacket(new CMessageStandardPacket(itemID, 133)); // Your moogle dries the plant in the <item>.
-        PChar->pushPacket(new CFurnitureInteractPacket(PItem, containerID, slotID));
+        PChar->pushPacket<CMessageStandardPacket>(itemID, 133); // Your moogle dries the plant in the <item>.
+        PChar->pushPacket<CFurnitureInteractPacket>(PItem, containerID, slotID);
         PItem->setDried(true);
 
         char extra[sizeof(PItem->m_extra) * 2 + 1];
@@ -7454,8 +7454,8 @@ void SmallPacket0x0FF(map_session_data_t* const PSession, CCharEntity* const PCh
         const char* Query = "UPDATE char_inventory SET extra = '%s' WHERE charid = %u AND location = %u AND slot = %u";
         sql->Query(Query, extra, PChar->id, PItem->getLocationID(), PItem->getSlotID());
 
-        PChar->pushPacket(new CInventoryItemPacket(PItem, containerID, slotID));
-        PChar->pushPacket(new CInventoryFinishPacket());
+        PChar->pushPacket<CInventoryItemPacket>(PItem, containerID, slotID);
+        PChar->pushPacket<CInventoryFinishPacket>();
     }
 }
 
@@ -7566,18 +7566,18 @@ void SmallPacket0x100(map_session_data_t* const PSession, CCharEntity* const PCh
 
         charutils::SaveCharStats(PChar);
 
-        PChar->pushPacket(new CCharJobsPacket(PChar));
-        PChar->pushPacket(new CCharUpdatePacket(PChar));
-        PChar->pushPacket(new CCharStatsPacket(PChar));
-        PChar->pushPacket(new CCharSkillsPacket(PChar));
-        PChar->pushPacket(new CCharRecastPacket(PChar));
-        PChar->pushPacket(new CCharAbilitiesPacket(PChar));
-        PChar->pushPacket(new CCharJobExtraPacket(PChar, true));
-        PChar->pushPacket(new CCharJobExtraPacket(PChar, false));
-        PChar->pushPacket(new CMenuMeritPacket(PChar));
-        PChar->pushPacket(new CMonipulatorPacket1(PChar));
-        PChar->pushPacket(new CMonipulatorPacket2(PChar));
-        PChar->pushPacket(new CCharSyncPacket(PChar));
+        PChar->pushPacket<CCharJobsPacket>(PChar);
+        PChar->pushPacket<CCharUpdatePacket>(PChar);
+        PChar->pushPacket<CCharStatsPacket>(PChar);
+        PChar->pushPacket<CCharSkillsPacket>(PChar);
+        PChar->pushPacket<CCharRecastPacket>(PChar);
+        PChar->pushPacket<CCharAbilitiesPacket>(PChar);
+        PChar->pushPacket<CCharJobExtraPacket>(PChar, true);
+        PChar->pushPacket<CCharJobExtraPacket>(PChar, false);
+        PChar->pushPacket<CMenuMeritPacket>(PChar);
+        PChar->pushPacket<CMonipulatorPacket1>(PChar);
+        PChar->pushPacket<CMonipulatorPacket2>(PChar);
+        PChar->pushPacket<CCharSyncPacket>(PChar);
     }
 }
 
@@ -7630,10 +7630,10 @@ void SmallPacket0x102(map_session_data_t* const PSession, CCharEntity* const PCh
                 }
             }
             charutils::BuildingCharTraitsTable(PChar);
-            PChar->pushPacket(new CCharAbilitiesPacket(PChar));
-            PChar->pushPacket(new CCharJobExtraPacket(PChar, true));
-            PChar->pushPacket(new CCharJobExtraPacket(PChar, false));
-            PChar->pushPacket(new CCharStatsPacket(PChar));
+            PChar->pushPacket<CCharAbilitiesPacket>(PChar);
+            PChar->pushPacket<CCharJobExtraPacket>(PChar, true);
+            PChar->pushPacket<CCharJobExtraPacket>(PChar, false);
+            PChar->pushPacket<CCharStatsPacket>(PChar);
             PChar->UpdateHealth();
         }
         else
@@ -7667,10 +7667,10 @@ void SmallPacket0x102(map_session_data_t* const PSession, CCharEntity* const PCh
 
                     blueutils::SetBlueSpell(PChar, spell, spellIndex, true);
                     charutils::BuildingCharTraitsTable(PChar);
-                    PChar->pushPacket(new CCharAbilitiesPacket(PChar));
-                    PChar->pushPacket(new CCharJobExtraPacket(PChar, true));
-                    PChar->pushPacket(new CCharJobExtraPacket(PChar, false));
-                    PChar->pushPacket(new CCharStatsPacket(PChar));
+                    PChar->pushPacket<CCharAbilitiesPacket>(PChar);
+                    PChar->pushPacket<CCharJobExtraPacket>(PChar, true);
+                    PChar->pushPacket<CCharJobExtraPacket>(PChar, false);
+                    PChar->pushPacket<CCharStatsPacket>(PChar);
                     PChar->UpdateHealth();
                 }
                 else
@@ -7736,8 +7736,8 @@ void SmallPacket0x102(map_session_data_t* const PSession, CCharEntity* const PCh
                 }
             }
         }
-        PChar->pushPacket(new CCharJobExtraPacket(PChar, true));
-        PChar->pushPacket(new CCharJobExtraPacket(PChar, false));
+        PChar->pushPacket<CCharJobExtraPacket>(PChar, true);
+        PChar->pushPacket<CCharJobExtraPacket>(PChar, false);
         puppetutils::SaveAutomaton(PChar);
     }
     else if (PChar->loc.zone->GetID() == ZONE_FERETORY && PChar->m_PMonstrosity != nullptr)
@@ -7767,7 +7767,7 @@ void SmallPacket0x104(map_session_data_t* const PSession, CCharEntity* const PCh
                 PTarget->BazaarCustomers.erase(PTarget->BazaarCustomers.begin() + i--);
             }
         }
-        PTarget->pushPacket(new CBazaarCheckPacket(PChar, BAZAAR_LEAVE));
+        PTarget->pushPacket<CBazaarCheckPacket>(PChar, BAZAAR_LEAVE);
     }
     PChar->BazaarID.clean();
 }
@@ -7804,7 +7804,7 @@ void SmallPacket0x105(map_session_data_t* const PSession, CCharEntity* const PCh
 
         EntityID_t EntityID = { PChar->id, PChar->targid };
 
-        PTarget->pushPacket(new CBazaarCheckPacket(PChar, BAZAAR_ENTER));
+        PTarget->pushPacket<CBazaarCheckPacket>(PChar, BAZAAR_ENTER);
         PTarget->BazaarCustomers.emplace_back(EntityID);
 
         CItemContainer* PBazaar = PTarget->getStorage(LOC_INVENTORY);
@@ -7815,7 +7815,7 @@ void SmallPacket0x105(map_session_data_t* const PSession, CCharEntity* const PCh
 
             if ((PItem != nullptr) && (PItem->getCharPrice() != 0))
             {
-                PChar->pushPacket(new CBazaarItemPacket(PItem, SlotID, PChar->loc.zone->GetTax()));
+                PChar->pushPacket<CBazaarItemPacket>(PItem, SlotID, PChar->loc.zone->GetTax());
             }
         }
     }
@@ -7857,7 +7857,7 @@ void SmallPacket0x106(map_session_data_t* const PSession, CCharEntity* const PCh
 
     if (PChar->id == PTarget->id || PBuyerInventory->GetFreeSlotsCount() == 0)
     {
-        PChar->pushPacket(new CBazaarPurchasePacket(PTarget, false));
+        PChar->pushPacket<CBazaarPurchasePacket>(PTarget, false);
         return;
     }
 
@@ -7872,7 +7872,7 @@ void SmallPacket0x106(map_session_data_t* const PSession, CCharEntity* const PCh
     if (PCharGil == nullptr || !PCharGil->isType(ITEM_CURRENCY) || PCharGil->getReserve() > 0)
     {
         // Player has no gil
-        PChar->pushPacket(new CBazaarPurchasePacket(PTarget, false));
+        PChar->pushPacket<CBazaarPurchasePacket>(PTarget, false);
         return;
     }
 
@@ -7886,7 +7886,7 @@ void SmallPacket0x106(map_session_data_t* const PSession, CCharEntity* const PCh
         {
             // Exploit attempt
             ShowWarning("Bazaar purchase exploit attempt by: %s", PChar->getName());
-            PChar->pushPacket(new CBazaarPurchasePacket(PTarget, false));
+            PChar->pushPacket<CBazaarPurchasePacket>(PTarget, false);
             return;
         }
 
@@ -7904,14 +7904,14 @@ void SmallPacket0x106(map_session_data_t* const PSession, CCharEntity* const PCh
         charutils::UpdateItem(PChar, LOC_INVENTORY, 0, -(int32)PriceWithTax);
         charutils::UpdateItem(PTarget, LOC_INVENTORY, 0, Price);
 
-        PChar->pushPacket(new CBazaarPurchasePacket(PTarget, true));
+        PChar->pushPacket<CBazaarPurchasePacket>(PTarget, true);
 
-        PTarget->pushPacket(new CBazaarConfirmationPacket(PChar, PItem));
+        PTarget->pushPacket<CBazaarConfirmationPacket>(PChar, PItem);
 
         charutils::UpdateItem(PTarget, LOC_INVENTORY, SlotID, -Quantity);
 
-        PTarget->pushPacket(new CInventoryItemPacket(PBazaar->GetItem(SlotID), LOC_INVENTORY, SlotID));
-        PTarget->pushPacket(new CInventoryFinishPacket());
+        PTarget->pushPacket<CInventoryItemPacket>(PBazaar->GetItem(SlotID), LOC_INVENTORY, SlotID);
+        PTarget->pushPacket<CInventoryFinishPacket>();
 
         bool BazaarIsEmpty = true;
 
@@ -7933,13 +7933,13 @@ void SmallPacket0x106(map_session_data_t* const PSession, CCharEntity* const PCh
             {
                 if (PCustomer->id != PChar->id)
                 {
-                    PCustomer->pushPacket(new CBazaarConfirmationPacket(PChar, SlotID, Quantity));
+                    PCustomer->pushPacket<CBazaarConfirmationPacket>(PChar, SlotID, Quantity);
                 }
-                PCustomer->pushPacket(new CBazaarItemPacket(PBazaar->GetItem(SlotID), SlotID, PChar->loc.zone->GetTax()));
+                PCustomer->pushPacket<CBazaarItemPacket>(PBazaar->GetItem(SlotID), SlotID, PChar->loc.zone->GetTax());
 
                 if (BazaarIsEmpty)
                 {
-                    PCustomer->pushPacket(new CBazaarClosePacket(PTarget));
+                    PCustomer->pushPacket<CBazaarClosePacket>(PTarget);
                 }
             }
         }
@@ -7950,7 +7950,7 @@ void SmallPacket0x106(map_session_data_t* const PSession, CCharEntity* const PCh
         }
         return;
     }
-    PChar->pushPacket(new CBazaarPurchasePacket(PTarget, false));
+    PChar->pushPacket<CBazaarPurchasePacket>(PTarget, false);
 }
 
 /************************************************************************
@@ -8019,8 +8019,8 @@ void SmallPacket0x10A(map_session_data_t* const PSession, CCharEntity* const PCh
         PItem->setCharPrice(price);
         PItem->setSubType((price == 0 ? ITEM_UNLOCKED : ITEM_LOCKED));
 
-        PChar->pushPacket(new CInventoryItemPacket(PItem, LOC_INVENTORY, slotID));
-        PChar->pushPacket(new CInventoryFinishPacket());
+        PChar->pushPacket<CInventoryItemPacket>(PItem, LOC_INVENTORY, slotID);
+        PChar->pushPacket<CInventoryFinishPacket>();
     }
 }
 
@@ -8039,7 +8039,7 @@ void SmallPacket0x10B(map_session_data_t* const PSession, CCharEntity* const PCh
 
         if (PCustomer != nullptr && PCustomer->id == PChar->BazaarCustomers[i].id)
         {
-            PCustomer->pushPacket(new CBazaarClosePacket(PChar));
+            PCustomer->pushPacket<CBazaarClosePacket>(PChar);
         }
     }
     PChar->BazaarCustomers.clear();
@@ -8061,7 +8061,7 @@ void SmallPacket0x10C(map_session_data_t* const PSession, CCharEntity* const PCh
     {
         uint16 recordID = data.ref<uint32>(0x04);
         roeutils::AddEminenceRecord(PChar, recordID);
-        PChar->pushPacket(new CRoeSparkUpdatePacket(PChar));
+        PChar->pushPacket<CRoeSparkUpdatePacket>(PChar);
         roeutils::onRecordTake(PChar, recordID);
     }
 }
@@ -8078,7 +8078,7 @@ void SmallPacket0x10D(map_session_data_t* const PSession, CCharEntity* const PCh
     if (settings::get<bool>("main.ENABLE_ROE"))
     {
         roeutils::DelEminenceRecord(PChar, data.ref<uint32>(0x04));
-        PChar->pushPacket(new CRoeSparkUpdatePacket(PChar));
+        PChar->pushPacket<CRoeSparkUpdatePacket>(PChar);
     }
 }
 
@@ -8107,7 +8107,7 @@ void SmallPacket0x10E(map_session_data_t* const PSession, CCharEntity* const PCh
 void SmallPacket0x10F(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket& data)
 {
     TracyZoneScoped;
-    PChar->pushPacket(new CCurrencyPacket1(PChar));
+    PChar->pushPacket<CCurrencyPacket1>(PChar);
 }
 
 /************************************************************************
@@ -8139,7 +8139,7 @@ void SmallPacket0x111(map_session_data_t* const PSession, CCharEntity* const PCh
 {
     TracyZoneScoped;
     charutils::SetStyleLock(PChar, data.ref<uint8>(0x04));
-    PChar->pushPacket(new CCharAppearancePacket(PChar));
+    PChar->pushPacket<CCharAppearancePacket>(PChar);
 }
 
 /************************************************************************
@@ -8152,24 +8152,24 @@ void SmallPacket0x112(map_session_data_t* const PSession, CCharEntity* const PCh
 {
     TracyZoneScoped;
     // Send spark updates
-    PChar->pushPacket(new CRoeSparkUpdatePacket(PChar));
+    PChar->pushPacket<CRoeSparkUpdatePacket>(PChar);
 
     if (settings::get<bool>("main.ENABLE_ROE"))
     {
         // Current RoE quests
-        PChar->pushPacket(new CRoeUpdatePacket(PChar));
+        PChar->pushPacket<CRoeUpdatePacket>(PChar);
 
         // Players logging in to a new timed record get one-time message
         if (PChar->m_eminenceCache.notifyTimedRecord)
         {
             PChar->m_eminenceCache.notifyTimedRecord = false;
-            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, roeutils::GetActiveTimedRecord(), 0, MSGBASIC_ROE_TIMED));
+            PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, roeutils::GetActiveTimedRecord(), 0, MSGBASIC_ROE_TIMED);
         }
 
         // 4-part Eminence Completion bitmap
         for (int i = 0; i < 4; i++)
         {
-            PChar->pushPacket(new CRoeQuestLogPacket(PChar, i));
+            PChar->pushPacket<CRoeQuestLogPacket>(PChar, i);
         }
     }
 }
@@ -8227,7 +8227,7 @@ void SmallPacket0x113(map_session_data_t* const PSession, CCharEntity* const PCh
 void SmallPacket0x114(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket& data)
 {
     TracyZoneScoped;
-    PChar->pushPacket(new CMapMarkerPacket(PChar));
+    PChar->pushPacket<CMapMarkerPacket>(PChar);
 }
 
 /************************************************************************
@@ -8239,7 +8239,7 @@ void SmallPacket0x114(map_session_data_t* const PSession, CCharEntity* const PCh
 void SmallPacket0x115(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket& data)
 {
     TracyZoneScoped;
-    PChar->pushPacket(new CCurrencyPacket2(PChar));
+    PChar->pushPacket<CCurrencyPacket2>(PChar);
 }
 
 /************************************************************************
@@ -8251,8 +8251,8 @@ void SmallPacket0x115(map_session_data_t* const PSession, CCharEntity* const PCh
 void SmallPacket0x116(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket& data)
 {
     TracyZoneScoped;
-    PChar->pushPacket(new CRoeSparkUpdatePacket(PChar));
-    PChar->pushPacket(new CMenuUnityPacket(PChar));
+    PChar->pushPacket<CRoeSparkUpdatePacket>(PChar);
+    PChar->pushPacket<CMenuUnityPacket>(PChar);
 }
 
 /************************************************************************
@@ -8265,8 +8265,8 @@ void SmallPacket0x116(map_session_data_t* const PSession, CCharEntity* const PCh
 void SmallPacket0x117(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket& data)
 {
     TracyZoneScoped;
-    PChar->pushPacket(new CRoeSparkUpdatePacket(PChar));
-    PChar->pushPacket(new CMenuUnityPacket(PChar));
+    PChar->pushPacket<CRoeSparkUpdatePacket>(PChar);
+    PChar->pushPacket<CMenuUnityPacket>(PChar);
 }
 
 /************************************************************************
@@ -8298,7 +8298,7 @@ void SmallPacket0x11B(map_session_data_t* const PSession, CCharEntity* const PCh
     PChar->m_jobMasterDisplay = data.ref<uint8>(0x04) > 0;
 
     charutils::SaveJobMasterDisplay(PChar);
-    PChar->pushPacket(new CCharUpdatePacket(PChar));
+    PChar->pushPacket<CCharUpdatePacket>(PChar);
 }
 
 /************************************************************************
@@ -8312,7 +8312,7 @@ void SmallPacket0x11D(map_session_data_t* const PSession, CCharEntity* const PCh
     TracyZoneScoped;
     if (jailutils::InPrison(PChar))
     {
-        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_CANNOT_USE_IN_AREA));
+        PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, MSGBASIC_CANNOT_USE_IN_AREA);
         return;
     }
 

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -5350,8 +5350,7 @@ void SmallPacket0x0AA(map_session_data_t* const PSession, CCharEntity* const PCh
                 charutils::UpdateItem(PChar, LOC_INVENTORY, 0, -(int32)(item->getBasePrice() * quantity));
                 ShowInfo("SmallPacket0x0AA: Player '%s' purchased %u of itemID %u [from GUILD] ", PChar->getName(), quantity, itemID);
                 PChar->PGuildShop->GetItem(shopSlotID)->setQuantity(PChar->PGuildShop->GetItem(shopSlotID)->getQuantity() - quantity);
-                PChar->pushPacket(
-                    new CGuildMenuBuyUpdatePacket(PChar, PChar->PGuildShop->GetItem(PChar->PGuildShop->SearchItem(itemID))->getQuantity(), itemID, quantity));
+                PChar->pushPacket<CGuildMenuBuyUpdatePacket>(PChar, PChar->PGuildShop->GetItem(PChar->PGuildShop->SearchItem(itemID))->getQuantity(), itemID, quantity);
                 PChar->pushPacket<CInventoryFinishPacket>();
             }
         }
@@ -6384,15 +6383,13 @@ void SmallPacket0x0DD(map_session_data_t* const PSession, CCharEntity* const PCh
             {
                 int skill      = ((CItemWeapon*)PChar->getEquip(SLOT_RANGED))->getSkillType();
                 int bonusSkill = ((CItemWeapon*)PChar->getEquip(SLOT_RANGED))->getILvlSkill();
-                PChar->pushPacket(
-                    new CMessageBasicPacket(PChar, PChar, PChar->RACC(skill, bonusSkill), PChar->RATT(skill, bonusSkill), MSGBASIC_CHECKPARAM_RANGE));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, PChar->RACC(skill, bonusSkill), PChar->RATT(skill, bonusSkill), MSGBASIC_CHECKPARAM_RANGE);
             }
             else if (PChar->getEquip(SLOT_AMMO) && PChar->getEquip(SLOT_AMMO)->isType(ITEM_WEAPON))
             {
                 int skill      = ((CItemWeapon*)PChar->getEquip(SLOT_AMMO))->getSkillType();
                 int bonusSkill = ((CItemWeapon*)PChar->getEquip(SLOT_AMMO))->getILvlSkill();
-                PChar->pushPacket(
-                    new CMessageBasicPacket(PChar, PChar, PChar->RACC(skill, bonusSkill), PChar->RATT(skill, bonusSkill), MSGBASIC_CHECKPARAM_RANGE));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, PChar->RACC(skill, bonusSkill), PChar->RATT(skill, bonusSkill), MSGBASIC_CHECKPARAM_RANGE);
             }
             else
             {

--- a/src/map/packets/basic.h
+++ b/src/map/packets/basic.h
@@ -30,6 +30,10 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 
 #define PACKET_SIZE 0x104
 
+class CBasicPacket;
+
+typedef std::unique_ptr<CBasicPacket> CBasicPacketPtr;
+
 enum ENTITYUPDATE
 {
     ENTITY_SPAWN,
@@ -117,7 +121,12 @@ public:
     /// <param name="other"></param>
     void copy(CBasicPacket* other)
     {
-        memcpy(data, other->data, PACKET_SIZE);
+        std::memcpy(data, other->data, PACKET_SIZE);
+    }
+
+    void copy(CBasicPacketPtr& other)
+    {
+        std::memcpy(data, other->data, PACKET_SIZE);
     }
 
     /* Getters for the header */

--- a/src/map/packets/char_check.cpp
+++ b/src/map/packets/char_check.cpp
@@ -84,7 +84,7 @@ CCheckPacket::CCheckPacket(CCharEntity* PChar, CCharEntity* PTarget)
             {
                 ref<uint8>(0x0B) = count;
 
-                PChar->pushPacket(new CBasicPacket(*this));
+                PChar->pushPacket<CBasicPacket>(*this);
 
                 this->setSize(0x0C);
                 memset(data + (0x0B), 0, PACKET_SIZE - 11);
@@ -95,12 +95,12 @@ CCheckPacket::CCheckPacket(CCharEntity* PChar, CCharEntity* PTarget)
     if (count == 0)
     {
         this->setSize(0x28);
-        PChar->pushPacket(new CBasicPacket(*this));
+        PChar->pushPacket<CBasicPacket>(*this);
     }
     else if (count != 8)
     {
         ref<uint8>(0x0B) = (count > 8 ? count - 8 : count);
-        PChar->pushPacket(new CBasicPacket(*this));
+        PChar->pushPacket<CBasicPacket>(*this);
     }
 
     this->setSize(0x54);

--- a/src/map/packets/guild_menu_buy.cpp
+++ b/src/map/packets/guild_menu_buy.cpp
@@ -61,7 +61,7 @@ CGuildMenuBuyPacket::CGuildMenuBuyPacket(CCharEntity* PChar, CItemContainer* PGu
                 ref<uint8>(0xF4) = ItemCount;
                 ref<uint8>(0xF5) = (PacketCount == 0 ? 0x40 : PacketCount);
 
-                PChar->pushPacket(new CBasicPacket(*this));
+                PChar->pushPacket<CBasicPacket>(*this);
 
                 ItemCount = 0;
                 PacketCount++;

--- a/src/map/packets/guild_menu_sell.cpp
+++ b/src/map/packets/guild_menu_sell.cpp
@@ -59,7 +59,7 @@ CGuildMenuSellPacket::CGuildMenuSellPacket(CCharEntity* PChar, CItemContainer* P
             ref<uint8>(0xF4) = ItemCount;
             ref<uint8>(0xF5) = (PacketCount == 0 ? 0x40 : PacketCount);
 
-            PChar->pushPacket(new CBasicPacket(*this));
+            PChar->pushPacket<CBasicPacket>(*this);
 
             ItemCount = 0;
             PacketCount++;

--- a/src/map/packets/jobpoint_details.cpp
+++ b/src/map/packets/jobpoint_details.cpp
@@ -53,7 +53,7 @@ CJobPointDetailsPacket::CJobPointDetailsPacket(CCharEntity* PChar)
         // Send a packet every 2 jobs...
         if (i % 2 == 1)
         {
-            PChar->pushPacket(new CBasicPacket(*this));
+            PChar->pushPacket<CBasicPacket>(*this);
 
             // Reset Data
             uint8 jpPacketSize = JP_DETAIL_DATA_SIZE * 20;

--- a/src/map/packets/menu_unity.cpp
+++ b/src/map/packets/menu_unity.cpp
@@ -53,7 +53,7 @@ CMenuUnityPacket::CMenuUnityPacket(CCharEntity* PChar)
     ref<uint8>(0x08) = 0x00;
     ref<uint8>(0x09) = 0x00; // Type 0
 
-    PChar->pushPacket(new CBasicPacket(*this));
+    PChar->pushPacket<CBasicPacket>(*this);
 
     // CMenuUnityPacket: Update Type 0x0001
     // Full Unity Results: Total contributing members in Unity
@@ -69,7 +69,7 @@ CMenuUnityPacket::CMenuUnityPacket(CCharEntity* PChar)
         ref<uint32>(i * 4 + 0x10) = unity_previous[i].first;
     }
 
-    PChar->pushPacket(new CBasicPacket(*this));
+    PChar->pushPacket<CBasicPacket>(*this);
 
     // CMenuUnityPacket: Update Type 0x0002
     // Full Unity Results: Total Points gained this week per unity
@@ -85,7 +85,7 @@ CMenuUnityPacket::CMenuUnityPacket(CCharEntity* PChar)
         ref<uint32>(i * 4 + 0x10) = unity_previous[i].second;
     }
 
-    PChar->pushPacket(new CBasicPacket(*this));
+    PChar->pushPacket<CBasicPacket>(*this);
 
     for (int i = 3; i < 32; i++)
     {
@@ -96,7 +96,7 @@ CMenuUnityPacket::CMenuUnityPacket(CCharEntity* PChar)
         ref<uint8>(0x06) = 0x88; // Variable Data Size
         ref<uint8>(0x09) = i;    // Type 3
 
-        PChar->pushPacket(new CBasicPacket(*this));
+        PChar->pushPacket<CBasicPacket>(*this);
     }
 
     // CMenuUnityPacket: Update Type 0x0100
@@ -108,7 +108,7 @@ CMenuUnityPacket::CMenuUnityPacket(CCharEntity* PChar)
     ref<uint8>(0x08) = 0x01;
     ref<uint8>(0x09) = 0x00; // Type 0100
 
-    PChar->pushPacket(new CBasicPacket(*this));
+    PChar->pushPacket<CBasicPacket>(*this);
 
     // CMenuUnityPacket: Update Type 0x0101
     // Partial Unity Ranking: Total Members in Unity
@@ -125,7 +125,7 @@ CMenuUnityPacket::CMenuUnityPacket(CCharEntity* PChar)
         ref<uint32>(i * 4 + 0x10) = unity_current[i].first;
     }
 
-    PChar->pushPacket(new CBasicPacket(*this));
+    PChar->pushPacket<CBasicPacket>(*this);
 
     // CMenuUnityPacket: Update Type 0x0102
     // Partial Unity Ranking: Total Points this week in Unity
@@ -142,7 +142,7 @@ CMenuUnityPacket::CMenuUnityPacket(CCharEntity* PChar)
         ref<uint32>(i * 4 + 0x10) = unity_current[i].second;
     }
 
-    PChar->pushPacket(new CBasicPacket(*this));
+    PChar->pushPacket<CBasicPacket>(*this);
 
     for (int i = 3; i < 32; i++)
     {
@@ -154,6 +154,6 @@ CMenuUnityPacket::CMenuUnityPacket(CCharEntity* PChar)
         ref<uint8>(0x08) = 0x01;
         ref<uint8>(0x09) = i; // Type 0103
 
-        PChar->pushPacket(new CBasicPacket(*this));
+        PChar->pushPacket<CBasicPacket>(*this);
     }
 }

--- a/src/map/packets/merit_points_categories.cpp
+++ b/src/map/packets/merit_points_categories.cpp
@@ -66,7 +66,7 @@ CMeritPointsCategoriesPacket::CMeritPointsCategoriesPacket(CCharEntity* PChar)
     {
         MeritPointsCategoriesPacket(PChar, i * MAX_MERITS_IN_PACKET);
 
-        PChar->pushPacket(new CBasicPacket(*this));
+        PChar->pushPacket<CBasicPacket>(*this);
     }
     MeritPointsCategoriesPacket(PChar, static_cast<uint8>(5 * MAX_MERITS_IN_PACKET));
 }

--- a/src/map/packets/shop_items.cpp
+++ b/src/map/packets/shop_items.cpp
@@ -39,7 +39,7 @@ CShopItemsPacket::CShopItemsPacket(CCharEntity* PChar)
     {
         if (i == 20)
         {
-            PChar->pushPacket(new CBasicPacket(*this));
+            PChar->pushPacket<CBasicPacket>(*this);
 
             i = 0;
             this->setSize(0x08);

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -135,7 +135,7 @@ void CParty::DisbandParty(bool playerInitiated)
             PChar->PLatentEffectContainer->CheckLatentsPartyJobs();
             PChar->PLatentEffectContainer->CheckLatentsPartyMembers(members.size());
             PChar->PLatentEffectContainer->CheckLatentsPartyAvatar();
-            PChar->pushPacket(new CPartyMemberUpdatePacket(PChar, 0, 0, PChar->getZone()));
+            PChar->pushPacket<CPartyMemberUpdatePacket>(PChar, 0, 0, PChar->getZone());
 
             // TODO: TreasurePool should stay with the last character, but now it is not critical
 
@@ -149,7 +149,7 @@ void CParty::DisbandParty(bool playerInitiated)
             CStatusEffect* sync = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_LEVEL_SYNC);
             if (sync && sync->GetDuration() == 0)
             {
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 30, 553));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 30, 553);
                 sync->SetStartTime(server_clock::now());
                 sync->SetDuration(30000);
             }
@@ -316,7 +316,7 @@ void CParty::RemoveMember(CBattleEntity* PEntity)
                     CStatusEffect* sync = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_LEVEL_SYNC);
                     if (sync && sync->GetDuration() == 0)
                     {
-                        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 30, 553));
+                        PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 30, 553);
                         sync->SetStartTime(server_clock::now());
                         sync->SetDuration(30000);
                     }
@@ -329,7 +329,7 @@ void CParty::RemoveMember(CBattleEntity* PEntity)
                         CStatusEffect* sync = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_LEVEL_SYNC);
                         if (sync && sync->GetDuration() == 0)
                         {
-                            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 30, 553));
+                            PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 30, 553);
                             sync->SetStartTime(server_clock::now());
                             sync->SetDuration(30000);
                         }
@@ -337,9 +337,9 @@ void CParty::RemoveMember(CBattleEntity* PEntity)
                 }
                 PChar->PLatentEffectContainer->CheckLatentsPartyMembers(members.size());
 
-                PChar->pushPacket(new CPartyDefinePacket(nullptr));
-                PChar->pushPacket(new CPartyMemberUpdatePacket(PChar, 0, 0, PChar->getZone()));
-                PChar->pushPacket(new CCharUpdatePacket(PChar));
+                PChar->pushPacket<CPartyDefinePacket>(nullptr);
+                PChar->pushPacket<CPartyMemberUpdatePacket>(PChar, 0, 0, PChar->getZone());
+                PChar->pushPacket<CCharUpdatePacket>(PChar);
                 PChar->PParty = nullptr;
 
                 sql->Query("DELETE FROM accounts_parties WHERE charid = %u;", PChar->id);
@@ -404,7 +404,7 @@ void CParty::DelMember(CBattleEntity* PEntity)
                     CStatusEffect* sync = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_LEVEL_SYNC);
                     if (sync && sync->GetDuration() == 0)
                     {
-                        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 30, 553));
+                        PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 30, 553);
                         sync->SetStartTime(server_clock::now());
                         sync->SetDuration(30000);
                     }
@@ -417,7 +417,7 @@ void CParty::DelMember(CBattleEntity* PEntity)
                         CStatusEffect* sync = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_LEVEL_SYNC);
                         if (sync && sync->GetDuration() == 0)
                         {
-                            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 30, 553));
+                            PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 30, 553);
                             sync->SetStartTime(server_clock::now());
                             sync->SetDuration(30000);
                         }
@@ -425,9 +425,9 @@ void CParty::DelMember(CBattleEntity* PEntity)
                 }
                 PChar->PLatentEffectContainer->CheckLatentsPartyMembers(members.size());
 
-                PChar->pushPacket(new CPartyDefinePacket(nullptr));
-                PChar->pushPacket(new CPartyMemberUpdatePacket(PChar, 0, 0, PChar->getZone()));
-                PChar->pushPacket(new CCharUpdatePacket(PChar));
+                PChar->pushPacket<CPartyDefinePacket>(nullptr);
+                PChar->pushPacket<CPartyMemberUpdatePacket>(PChar, 0, 0, PChar->getZone());
+                PChar->pushPacket<CCharUpdatePacket>(PChar);
                 PChar->PParty = nullptr;
 
                 if (PChar->PTreasurePool != nullptr && PChar->PTreasurePool->GetPoolType() != TREASUREPOOL_ZONE)
@@ -619,9 +619,9 @@ void CParty::AddMember(CBattleEntity* PEntity)
 
             charutils::SaveCharStats(PChar);
 
-            PChar->pushPacket(new CMenuConfigPacket(PChar));
-            PChar->pushPacket(new CCharUpdatePacket(PChar));
-            PChar->pushPacket(new CCharSyncPacket(PChar));
+            PChar->pushPacket<CMenuConfigPacket>(PChar);
+            PChar->pushPacket<CCharUpdatePacket>(PChar);
+            PChar->pushPacket<CCharSyncPacket>(PChar);
         }
         PChar->PTreasurePool->UpdatePool(PChar);
 
@@ -630,7 +630,7 @@ void CParty::AddMember(CBattleEntity* PEntity)
         {
             if (PChar->getZone() == m_PSyncTarget->getZone())
             {
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, m_PSyncTarget->GetMLevel(), 540));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, m_PSyncTarget->GetMLevel(), 540);
                 PChar->StatusEffectContainer->AddStatusEffect(new CStatusEffect(EFFECT_LEVEL_SYNC, EFFECT_LEVEL_SYNC, m_PSyncTarget->GetMLevel(), 0, 0), true);
                 PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DISPELABLE | EFFECTFLAG_ON_ZONE);
                 PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, new CCharSyncPacket(PChar));
@@ -690,9 +690,9 @@ void CParty::AddMember(uint32 id)
             charutils::SaveCharStats(PChar);
 
             PChar->status = STATUS_UPDATE;
-            PChar->pushPacket(new CMenuConfigPacket(PChar));
-            PChar->pushPacket(new CCharUpdatePacket(PChar));
-            PChar->pushPacket(new CCharSyncPacket(PChar));
+            PChar->pushPacket<CMenuConfigPacket>(PChar);
+            PChar->pushPacket<CCharUpdatePacket>(PChar);
+            PChar->pushPacket<CCharSyncPacket>(PChar);
         }
         PChar->PTreasurePool->UpdatePool(PChar);*/
     }
@@ -822,7 +822,7 @@ void CParty::ReloadParty()
                 CCharEntity* PChar = (CCharEntity*)member;
                 PChar->ReloadPartyDec();
                 uint16 alliance = 0;
-                PChar->pushPacket(new CPartyDefinePacket(party));
+                PChar->pushPacket<CPartyDefinePacket>(party);
                 // auto effects = std::make_unique<CPartyEffectsPacket>();
                 uint8 j = 0;
                 for (auto&& memberinfo : info)
@@ -835,14 +835,14 @@ void CParty::ReloadParty()
                     auto* PPartyMember = zoneutils::GetChar(memberinfo.id);
                     if (PPartyMember)
                     {
-                        PChar->pushPacket(new CPartyMemberUpdatePacket(PPartyMember, j, memberinfo.flags, PChar->getZone()));
+                        PChar->pushPacket<CPartyMemberUpdatePacket>(PPartyMember, j, memberinfo.flags, PChar->getZone());
                         // if (memberinfo.partyid == party->GetPartyID() && PPartyMember != PChar)
                         //    effects->AddMemberEffects(PChar);
                     }
                     else
                     {
                         uint16 zoneid = memberinfo.zone == 0 ? memberinfo.prev_zone : memberinfo.zone;
-                        PChar->pushPacket(new CPartyMemberUpdatePacket(memberinfo.id, memberinfo.name, memberinfo.flags, j, zoneid));
+                        PChar->pushPacket<CPartyMemberUpdatePacket>(memberinfo.id, memberinfo.name, memberinfo.flags, j, zoneid);
                     }
                     j++;
                 }
@@ -863,7 +863,7 @@ void CParty::ReloadParty()
             PChar->PLatentEffectContainer->CheckLatentsPartyMembers(members.size());
             PChar->PLatentEffectContainer->CheckLatentsPartyAvatar();
             PChar->ReloadPartyDec();
-            PChar->pushPacket(new CPartyDefinePacket(this, PLeader && PChar->getZone() == PLeader->getZone()));
+            PChar->pushPacket<CPartyDefinePacket>(this, PLeader && PChar->getZone() == PLeader->getZone());
             // auto effects = std::make_unique<CPartyEffectsPacket>();
             uint8 j = 0;
             for (auto&& memberinfo : info)
@@ -871,7 +871,7 @@ void CParty::ReloadParty()
                 auto* PPartyMember = zoneutils::GetChar(memberinfo.id);
                 if (PPartyMember)
                 {
-                    PChar->pushPacket(new CPartyMemberUpdatePacket(PPartyMember, j, memberinfo.flags, PChar->getZone()));
+                    PChar->pushPacket<CPartyMemberUpdatePacket>(PPartyMember, j, memberinfo.flags, PChar->getZone());
                     // if (PPartyMember != PChar)
                     //    effects->AddMemberEffects(PChar);
 
@@ -883,14 +883,14 @@ void CParty::ReloadParty()
                         {
                             j++;
                             // trusts don't persist over zonelines, so we know their zone has be the same as the leader.
-                            PChar->pushPacket(new CPartyMemberUpdatePacket(PTrust, j));
+                            PChar->pushPacket<CPartyMemberUpdatePacket>(PTrust, j);
                         }
                     }
                 }
                 else
                 {
                     uint16 zoneid = memberinfo.zone == 0 ? memberinfo.prev_zone : memberinfo.zone;
-                    PChar->pushPacket(new CPartyMemberUpdatePacket(memberinfo.id, memberinfo.name, memberinfo.flags, j, zoneid));
+                    PChar->pushPacket<CPartyMemberUpdatePacket>(memberinfo.id, memberinfo.name, memberinfo.flags, j, zoneid);
                 }
                 j++;
             }
@@ -902,7 +902,7 @@ void CParty::ReloadParty()
 void CParty::ReloadPartyMembers(CCharEntity* PChar)
 {
     PChar->ReloadPartyDec();
-    PChar->pushPacket(new CPartyDefinePacket(this));
+    PChar->pushPacket<CPartyDefinePacket>(this);
 
     int alliance = 0;
 
@@ -919,12 +919,12 @@ void CParty::ReloadPartyMembers(CCharEntity* PChar)
         CCharEntity* PPartyMember = zoneutils::GetChar(memberinfo.id);
         if (PPartyMember)
         {
-            PChar->pushPacket(new CPartyMemberUpdatePacket(PPartyMember, j, memberinfo.flags, PChar->getZone()));
+            PChar->pushPacket<CPartyMemberUpdatePacket>(PPartyMember, j, memberinfo.flags, PChar->getZone());
         }
         else
         {
             uint16 zoneid = memberinfo.zone == 0 ? memberinfo.prev_zone : memberinfo.zone;
-            PChar->pushPacket(new CPartyMemberUpdatePacket(memberinfo.id, memberinfo.name, memberinfo.flags, j, zoneid));
+            PChar->pushPacket<CPartyMemberUpdatePacket>(memberinfo.id, memberinfo.name, memberinfo.flags, j, zoneid);
         }
         j++;
     }
@@ -1055,12 +1055,12 @@ void CParty::SetSyncTarget(const std::string& MemberName, uint16 message)
             // enable level sync
             if (PChar->GetMLevel() < 10)
             {
-                ((CCharEntity*)GetLeader())->pushPacket(new CMessageBasicPacket((CCharEntity*)GetLeader(), (CCharEntity*)GetLeader(), 0, 10, 541));
+                ((CCharEntity*)GetLeader())->pushPacket<CMessageBasicPacket>((CCharEntity*)GetLeader(), (CCharEntity*)GetLeader(), 0, 10, 541);
                 return;
             }
             else if (PChar->getZone() != GetLeader()->getZone())
             {
-                ((CCharEntity*)GetLeader())->pushPacket(new CMessageBasicPacket((CCharEntity*)GetLeader(), (CCharEntity*)GetLeader(), 0, 0, 542));
+                ((CCharEntity*)GetLeader())->pushPacket<CMessageBasicPacket>((CCharEntity*)GetLeader(), (CCharEntity*)GetLeader(), 0, 0, 542);
                 return;
             }
             else
@@ -1069,7 +1069,7 @@ void CParty::SetSyncTarget(const std::string& MemberName, uint16 message)
                 {
                     if (member->StatusEffectContainer->HasStatusEffect({ EFFECT_LEVEL_RESTRICTION, EFFECT_LEVEL_SYNC, EFFECT_SJ_RESTRICTION, EFFECT_CONFRONTATION, EFFECT_BATTLEFIELD }))
                     {
-                        ((CCharEntity*)GetLeader())->pushPacket(new CMessageBasicPacket((CCharEntity*)GetLeader(), (CCharEntity*)GetLeader(), 0, 0, 543));
+                        ((CCharEntity*)GetLeader())->pushPacket<CMessageBasicPacket>((CCharEntity*)GetLeader(), (CCharEntity*)GetLeader(), 0, 0, 543);
                         return;
                     }
                 }
@@ -1085,7 +1085,7 @@ void CParty::SetSyncTarget(const std::string& MemberName, uint16 message)
 
                     if (member->status != STATUS_TYPE::DISAPPEAR && member->getZone() == PChar->getZone())
                     {
-                        member->pushPacket(new CMessageStandardPacket(PChar->GetMLevel(), 0, 0, 0, static_cast<MsgStd>(message)));
+                        member->pushPacket<CMessageStandardPacket>(PChar->GetMLevel(), 0, 0, 0, static_cast<MsgStd>(message));
                         member->StatusEffectContainer->AddStatusEffect(new CStatusEffect(EFFECT_LEVEL_SYNC, EFFECT_LEVEL_SYNC, PChar->GetMLevel(), 0, 0), true);
                         member->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DISPELABLE | EFFECTFLAG_ON_ZONE);
                         member->loc.zone->PushPacket(member, CHAR_INRANGE, new CCharSyncPacket(member));
@@ -1116,7 +1116,7 @@ void CParty::SetSyncTarget(const std::string& MemberName, uint16 message)
                         CStatusEffect* sync = member->StatusEffectContainer->GetStatusEffect(EFFECT_LEVEL_SYNC);
                         if (sync && sync->GetDuration() == 0)
                         {
-                            member->pushPacket(new CMessageBasicPacket(member, member, 10, 30, message));
+                            member->pushPacket<CMessageBasicPacket>(member, member, 10, 30, message);
                             sync->SetStartTime(server_clock::now());
                             sync->SetDuration(30000);
                         }
@@ -1161,7 +1161,7 @@ void CParty::PushPacket(uint32 senderID, uint16 ZoneID, CBasicPacket* packet)
         {
             if (ZoneID == 0 || member->getZone() == ZoneID)
             {
-                member->pushPacket(new CBasicPacket(*packet));
+                member->pushPacket<CBasicPacket>(*packet);
             }
         }
     }
@@ -1249,9 +1249,9 @@ void CParty::RefreshSync()
             charutils::BuildingCharAbilityTable(member);
             charutils::BuildingCharWeaponSkills(member);
             charutils::CheckValidEquipment(member);
-            member->pushPacket(new CCharAbilitiesPacket(member));
+            member->pushPacket<CCharAbilitiesPacket>(member);
         }
-        member->pushPacket(new CMessageBasicPacket(member, member, 0, syncLevel, 540));
+        member->pushPacket<CMessageBasicPacket>(member, member, 0, syncLevel, 540);
     }
     m_PSyncTarget = sync;
 }

--- a/src/map/party.h
+++ b/src/map/party.h
@@ -25,6 +25,8 @@
 #include "common/cbasetypes.h"
 #include "map.h"
 
+#include "packets/basic.h"
+
 #include <vector>
 
 class CBasicPacket;
@@ -98,7 +100,7 @@ public:
 
     std::size_t GetMemberCountAcrossAllProcesses();
 
-    void PushPacket(uint32 senderID, uint16 ZoneID, CBasicPacket* packet); // Send a packet to all group members, with the exception of PPartyMember
+    void PushPacket(uint32 senderID, uint16 ZoneID, CBasicPacketPtr&& packet); // Send a packet to all group members, with the exception of PPartyMember
     void PushEffectsPacket();
     void EffectsChanged();
 

--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -258,7 +258,7 @@ namespace roeutils
 
         for (int i = 0; i < 4; i++)
         {
-            PChar->pushPacket(new CRoeQuestLogPacket(PChar, i));
+            PChar->pushPacket<CRoeQuestLogPacket>(PChar, i);
         }
 
         charutils::SaveEminenceData(PChar);
@@ -304,7 +304,7 @@ namespace roeutils
         if (!roeutils::RoeSystem.ImplementedRecords.test(recordID))
         {
             std::string message = "The record #" + std::to_string(recordID) + " is not implemented at this time.";
-            PChar->pushPacket(new CChatMessagePacket(PChar, MESSAGE_NS_SAY, message, "RoE System"));
+            PChar->pushPacket<CChatMessagePacket>(PChar, MESSAGE_NS_SAY, message, "RoE System");
             return false;
         }
 
@@ -327,8 +327,8 @@ namespace roeutils
                 PChar->m_eminenceLog.active[i] = recordID;
                 PChar->m_eminenceCache.activemap.set(recordID);
 
-                PChar->pushPacket(new CRoeUpdatePacket(PChar));
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, recordID, 0, MSGBASIC_ROE_START));
+                PChar->pushPacket<CRoeUpdatePacket>(PChar);
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, recordID, 0, MSGBASIC_ROE_START);
                 charutils::SaveEminenceData(PChar);
                 return true;
             }
@@ -356,7 +356,7 @@ namespace roeutils
                     std::swap(PChar->m_eminenceLog.active[j], PChar->m_eminenceLog.active[j + 1]);
                     std::swap(PChar->m_eminenceLog.progress[j], PChar->m_eminenceLog.progress[j + 1]);
                 }
-                PChar->pushPacket(new CRoeUpdatePacket(PChar));
+                PChar->pushPacket<CRoeUpdatePacket>(PChar);
                 charutils::SaveEminenceData(PChar);
                 return true;
             }
@@ -396,7 +396,7 @@ namespace roeutils
                 }
 
                 PChar->m_eminenceLog.progress[i] = progress;
-                PChar->pushPacket(new CRoeUpdatePacket(PChar));
+                PChar->pushPacket<CRoeUpdatePacket>(PChar);
                 SaveEminenceDataNice(PChar);
                 return true;
             }
@@ -427,7 +427,7 @@ namespace roeutils
 
         if (sendUpdate)
         {
-            PChar->pushPacket(new CCharSpellsPacket(PChar));
+            PChar->pushPacket<CCharSpellsPacket>(PChar);
         }
     }
 
@@ -531,11 +531,11 @@ namespace roeutils
         auto timedRecordID              = GetActiveTimedRecord();
         PChar->m_eminenceLog.active[30] = timedRecordID;
         PChar->m_eminenceCache.activemap.set(timedRecordID);
-        PChar->pushPacket(new CRoeUpdatePacket(PChar));
+        PChar->pushPacket<CRoeUpdatePacket>(PChar);
 
         if (timedRecordID)
         {
-            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, timedRecordID, 0, MSGBASIC_ROE_TIMED));
+            PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, timedRecordID, 0, MSGBASIC_ROE_TIMED);
             SetEminenceRecordCompletion(PChar, timedRecordID, false);
         }
     }
@@ -551,7 +551,7 @@ namespace roeutils
                 PChar->m_eminenceLog.progress[i] = 0;
             }
         }
-        PChar->pushPacket(new CRoeUpdatePacket(PChar));
+        PChar->pushPacket<CRoeUpdatePacket>(PChar);
 
         // Set completion for daily records to 0
         for (auto record : RoeSystem.DailyRecordIDs)
@@ -573,7 +573,7 @@ namespace roeutils
 
         for (int i = 0; i < 4; i++)
         {
-            PChar->pushPacket(new CRoeQuestLogPacket(PChar, i));
+            PChar->pushPacket<CRoeQuestLogPacket>(PChar, i);
         }
     }
 
@@ -629,7 +629,7 @@ namespace roeutils
                 PChar->m_eminenceLog.progress[i] = 0;
             }
         }
-        PChar->pushPacket(new CRoeUpdatePacket(PChar));
+        PChar->pushPacket<CRoeUpdatePacket>(PChar);
 
         // Set completion for daily records to 0
         for (auto record : RoeSystem.WeeklyRecordIDs)
@@ -652,7 +652,7 @@ namespace roeutils
 
         for (int i = 0; i < 4; i++)
         {
-            PChar->pushPacket(new CRoeQuestLogPacket(PChar, i));
+            PChar->pushPacket<CRoeQuestLogPacket>(PChar, i);
         }
     }
 

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -615,7 +615,7 @@ void CStatusEffectContainer::RemoveStatusEffect(CStatusEffect* PStatusEffect, bo
             {
                 if (!silent && !(PStatusEffect->HasEffectFlag(EFFECTFLAG_NO_LOSS_MESSAGE)))
                 {
-                    PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, PStatusEffect->GetIcon(), 0, 206));
+                    PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, PStatusEffect->GetIcon(), 0, 206);
                 }
             }
 

--- a/src/map/treasure_pool.cpp
+++ b/src/map/treasure_pool.cpp
@@ -221,7 +221,7 @@ uint8 CTreasurePool::AddItem(uint16 ItemID, CBaseEntity* PEntity)
 
     for (auto& member : members)
     {
-        member->pushPacket(new CTreasureFindItemPacket(&m_PoolItems[FreeSlotID], PEntity, false));
+        member->pushPacket<CTreasureFindItemPacket>(&m_PoolItems[FreeSlotID], PEntity, false);
     }
     if (m_TreasurePoolType == TREASUREPOOL_SOLO)
     {
@@ -242,7 +242,7 @@ void CTreasurePool::UpdatePool(CCharEntity* PChar)
     {
         for (auto& m_PoolItem : m_PoolItems)
         {
-            PChar->pushPacket(new CTreasureFindItemPacket(&m_PoolItem, nullptr, true));
+            PChar->pushPacket<CTreasureFindItemPacket>(&m_PoolItem, nullptr, true);
         }
     }
 }
@@ -287,7 +287,7 @@ void CTreasurePool::LotItem(CCharEntity* PChar, uint8 SlotID, uint16 Lot)
     // Player lots Item for XXX message
     for (auto& member : members)
     {
-        member->pushPacket(new CTreasureLotItemPacket(highestLotter, highestLot, PChar, SlotID, Lot));
+        member->pushPacket<CTreasureLotItemPacket>(highestLotter, highestLot, PChar, SlotID, Lot);
     }
 
     // if all lotters have lotted, evaluate immediately.
@@ -347,7 +347,7 @@ void CTreasurePool::PassItem(CCharEntity* PChar, uint8 SlotID)
     // Player lots Item for XXX message
     for (auto& member : members)
     {
-        member->pushPacket(new CTreasureLotItemPacket(highestLotter, highestLot, PChar, SlotID, PassedLot));
+        member->pushPacket<CTreasureLotItemPacket>(highestLotter, highestLot, PChar, SlotID, PassedLot);
     }
 
     // if all lotters have lotted, evaluate immediately.
@@ -507,7 +507,7 @@ void CTreasurePool::TreasureWon(CCharEntity* winner, uint8 SlotID)
 
     for (auto& member : members)
     {
-        member->pushPacket(new CTreasureLotItemPacket(winner, SlotID, 0, ITEMLOT_WIN));
+        member->pushPacket<CTreasureLotItemPacket>(winner, SlotID, 0, ITEMLOT_WIN);
     }
     m_count--;
 
@@ -527,7 +527,7 @@ void CTreasurePool::TreasureError(CCharEntity* winner, uint8 SlotID)
 
     for (auto& member : members)
     {
-        member->pushPacket(new CTreasureLotItemPacket(winner, SlotID, -1, ITEMLOT_WINERROR));
+        member->pushPacket<CTreasureLotItemPacket>(winner, SlotID, -1, ITEMLOT_WINERROR);
     }
     m_count--;
 
@@ -547,7 +547,7 @@ void CTreasurePool::TreasureLost(uint8 SlotID)
 
     for (auto& member : members)
     {
-        member->pushPacket(new CTreasureLotItemPacket(SlotID, ITEMLOT_WINERROR));
+        member->pushPacket<CTreasureLotItemPacket>(SlotID, ITEMLOT_WINERROR);
     }
     m_count--;
 

--- a/src/map/unitychat.cpp
+++ b/src/map/unitychat.cpp
@@ -56,17 +56,17 @@ bool CUnityChat::DelMember(CCharEntity* PChar)
     return !members.empty();
 }
 
-void CUnityChat::PushPacket(uint32 senderID, CBasicPacket* packet)
+void CUnityChat::PushPacket(uint32 senderID, CBasicPacketPtr&& packet)
 {
     for (auto& member : members)
     {
         if (member->id != senderID && member->status != STATUS_TYPE::DISAPPEAR && !jailutils::InPrison(member))
         {
-            CBasicPacket* newPacket = new CBasicPacket(*packet);
-            member->pushPacket(newPacket);
+            auto newPacket = std::make_unique<CBasicPacket>();
+            newPacket->copy(packet);
+            member->pushPacket(std::move(newPacket));
         }
     }
-    destroy(packet);
 }
 
 namespace unitychat

--- a/src/map/unitychat.h
+++ b/src/map/unitychat.h
@@ -35,7 +35,7 @@ public:
     void AddMember(CCharEntity* PChar);
     bool DelMember(CCharEntity* PChar);
 
-    void PushPacket(uint32 senderID, CBasicPacket* packet);
+    void PushPacket(uint32 senderID, CBasicPacketPtr&& packet);
 
     std::vector<CCharEntity*> members;
 

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4244,7 +4244,7 @@ namespace battleutils
             {
                 // Futae Takes 2 of Your Tools
                 charutils::UpdateItem(PChar, LOC_INVENTORY, SlotID, -2);
-                PChar->pushPacket(new CInventoryFinishPacket());
+                PChar->pushPacket<CInventoryFinishPacket>();
             }
             else
             {
@@ -4260,7 +4260,7 @@ namespace battleutils
                 if (ConsumeTool && xirand::GetRandomNumber(100) > chance)
                 {
                     charutils::UpdateItem(PChar, LOC_INVENTORY, SlotID, -1);
-                    PChar->pushPacket(new CInventoryFinishPacket());
+                    PChar->pushPacket<CInventoryFinishPacket>();
                 }
             }
         }
@@ -4933,8 +4933,8 @@ namespace battleutils
 
             charutils::BuildingCharAbilityTable((CCharEntity*)PCharmer);
             charutils::BuildingCharPetAbilityTable((CCharEntity*)PCharmer, (CPetEntity*)PVictim, PVictim->id);
-            ((CCharEntity*)PCharmer)->pushPacket(new CCharUpdatePacket((CCharEntity*)PCharmer));
-            ((CCharEntity*)PCharmer)->pushPacket(new CPetSyncPacket((CCharEntity*)PCharmer));
+            ((CCharEntity*)PCharmer)->pushPacket<CCharUpdatePacket>((CCharEntity*)PCharmer);
+            ((CCharEntity*)PCharmer)->pushPacket<CPetSyncPacket>((CCharEntity*)PCharmer);
             PCharmer->ForAlliance([&PVictim](CBattleEntity* PMember)
                                   {
                 if (static_cast<CCharEntity*>(PMember)->PClaimedMob == PVictim)
@@ -5699,13 +5699,13 @@ namespace battleutils
                 if (EntityToLockon != nullptr)
                 {
                     // lock on to the new target!
-                    PChar->pushPacket(new CLockOnPacket(PChar, EntityToLockon));
+                    PChar->pushPacket<CLockOnPacket>(PChar, EntityToLockon);
                 }
             }
             else if (EntityToAssist->GetBattleTargetID() != 0)
             {
                 // lock on to the new target!
-                PChar->pushPacket(new CLockOnPacket(PChar, EntityToAssist->GetBattleTarget()));
+                PChar->pushPacket<CLockOnPacket>(PChar, EntityToAssist->GetBattleTarget());
             }
         }
     }
@@ -6025,7 +6025,7 @@ namespace battleutils
                     if (PMember->objtype == TYPE_PC)
                     {
                         CCharEntity* PChar = static_cast<CCharEntity*>(PMember);
-                        PChar->pushPacket(new CPositionPacket(PChar));
+                        PChar->pushPacket<CPositionPacket>(PChar);
                     }
                     else
                     {
@@ -6810,13 +6810,13 @@ namespace battleutils
                 charutils::UnequipItem(PChar, SLOT_AMMO);
                 PChar->RequestPersist(CHAR_PERSIST::EQUIP);
                 charutils::UpdateItem(PChar, loc, slot, -quantity);
-                PChar->pushPacket(new CInventoryFinishPacket());
+                PChar->pushPacket<CInventoryFinishPacket>();
                 return true;
             }
             else
             {
                 charutils::UpdateItem(PChar, PChar->equipLoc[SLOT_AMMO], PChar->equip[SLOT_AMMO], -quantity);
-                PChar->pushPacket(new CInventoryFinishPacket());
+                PChar->pushPacket<CInventoryFinishPacket>();
                 return false;
             }
         }

--- a/src/map/utils/blacklistutils.cpp
+++ b/src/map/utils/blacklistutils.cpp
@@ -66,7 +66,7 @@ namespace blacklistutils
         const char* query = "SELECT c.charid, c.charname FROM char_blacklist AS b INNER JOIN chars AS c ON b.charid_target = c.charid WHERE charid_owner = %u;";
         if (sql->Query(query, PChar->id) == SQL_ERROR || sql->NumRows() == 0)
         {
-            PChar->pushPacket(new CStopDownloadingPacket(PChar, blacklist));
+            PChar->pushPacket<CStopDownloadingPacket>(PChar, blacklist);
             return;
         }
 
@@ -82,7 +82,7 @@ namespace blacklistutils
 
             if (currentCount >= 12)
             {
-                PChar->pushPacket(new CStopDownloadingPacket(PChar, blacklist));
+                PChar->pushPacket<CStopDownloadingPacket>(PChar, blacklist);
                 blacklist.clear();
                 currentCount = 0;
             }
@@ -91,7 +91,7 @@ namespace blacklistutils
         // Push remaining entries..
         if (!blacklist.empty())
         {
-            PChar->pushPacket(new CStopDownloadingPacket(PChar, blacklist));
+            PChar->pushPacket<CStopDownloadingPacket>(PChar, blacklist);
         }
     }
 

--- a/src/map/utils/blueutils.cpp
+++ b/src/map/utils/blueutils.cpp
@@ -153,7 +153,7 @@ namespace blueutils
                             PBlueMage->pushPacket(
                                 new CMessageBasicPacket(PBlueMage, PBlueMage, static_cast<uint16>(PSpell->getID()), 0, MSGBASIC_LEARNS_SPELL));
                             charutils::SaveSpell(PBlueMage, static_cast<uint16>(PSpell->getID()));
-                            PBlueMage->pushPacket(new CCharSpellsPacket(PBlueMage));
+                            PBlueMage->pushPacket<CCharSpellsPacket>(PBlueMage);
                         }
                     }
                     break; // only one attempt at learning a spell, regardless of learn or not.
@@ -192,9 +192,9 @@ namespace blueutils
             }
         }
         charutils::BuildingCharTraitsTable(PChar);
-        PChar->pushPacket(new CCharJobExtraPacket(PChar, true));
-        PChar->pushPacket(new CCharJobExtraPacket(PChar, false));
-        PChar->pushPacket(new CCharStatsPacket(PChar));
+        PChar->pushPacket<CCharJobExtraPacket>(PChar, true);
+        PChar->pushPacket<CCharJobExtraPacket>(PChar, false);
+        PChar->pushPacket<CCharStatsPacket>(PChar);
         charutils::CalculateStats(PChar);
         PChar->UpdateHealth();
         SaveSetSpells(PChar);

--- a/src/map/utils/blueutils.cpp
+++ b/src/map/utils/blueutils.cpp
@@ -150,8 +150,7 @@ namespace blueutils
                     {
                         if (charutils::addSpell(PBlueMage, static_cast<uint16>(PSpell->getID())))
                         {
-                            PBlueMage->pushPacket(
-                                new CMessageBasicPacket(PBlueMage, PBlueMage, static_cast<uint16>(PSpell->getID()), 0, MSGBASIC_LEARNS_SPELL));
+                            PBlueMage->pushPacket<CMessageBasicPacket>(PBlueMage, PBlueMage, static_cast<uint16>(PSpell->getID()), 0, MSGBASIC_LEARNS_SPELL);
                             charutils::SaveSpell(PBlueMage, static_cast<uint16>(PSpell->getID()));
                             PBlueMage->pushPacket<CCharSpellsPacket>(PBlueMage);
                         }

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1172,23 +1172,23 @@ namespace charutils
         // --------------------------------
         for (int8 areaID = 0; areaID <= QUESTS_COALITION; areaID++)
         {
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, areaID, LOG_QUEST_CURRENT));
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, areaID, LOG_QUEST_COMPLETE));
+            PChar->pushPacket<CQuestMissionLogPacket>(PChar, areaID, LOG_QUEST_CURRENT);
+            PChar->pushPacket<CQuestMissionLogPacket>(PChar, areaID, LOG_QUEST_COMPLETE);
         }
 
         // Completed Missions:
         // --------------------------------
         // Completed missions for Nation + Zilart Missions are all sent in single packet
-        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_ZILART, LOG_MISSION_COMPLETE));
+        PChar->pushPacket<CQuestMissionLogPacket>(PChar, MISSION_ZILART, LOG_MISSION_COMPLETE);
 
         // Completed missions for TOAU and WOTG are sent in the same packet
-        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_TOAU, LOG_MISSION_COMPLETE));
+        PChar->pushPacket<CQuestMissionLogPacket>(PChar, MISSION_TOAU, LOG_MISSION_COMPLETE);
 
         // Completed Assaults were sent in the same packet as completed TOAU quests
 
         // Completed Campaign Operations
-        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_CAMPAIGN, LOG_MISSION_COMPLETE));
-        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_CAMPAIGN, LOG_CAMPAIGN_TWO));
+        PChar->pushPacket<CQuestMissionLogPacket>(PChar, MISSION_CAMPAIGN, LOG_MISSION_COMPLETE);
+        PChar->pushPacket<CQuestMissionLogPacket>(PChar, MISSION_CAMPAIGN, LOG_CAMPAIGN_TWO);
 
         // Current Missions:
         // --------------------------------
@@ -1196,7 +1196,7 @@ namespace charutils
 
         // Current Nation, Zilart, COP, Add-On, SOA, and ROV missions are all sent in a shared, single packet.
         // So sending this packet updates multiple Mission logs at once.
-        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_ZILART, LOG_MISSION_CURRENT));
+        PChar->pushPacket<CQuestMissionLogPacket>(PChar, MISSION_ZILART, LOG_MISSION_CURRENT);
     }
 
     /************************************************************************
@@ -1209,7 +1209,7 @@ namespace charutils
     {
         for (uint8 table = 0; table < MAX_KEYS_TABLE; table++)
         {
-            PChar->pushPacket(new CKeyItemsPacket(PChar, (KEYS_TABLE)table));
+            PChar->pushPacket<CKeyItemsPacket>(PChar, (KEYS_TABLE)table);
         }
     }
 
@@ -1235,11 +1235,11 @@ namespace charutils
                 CItem* PItem = PChar->getStorage(LocationID)->GetItem(slotID);
                 if (PItem != nullptr)
                 {
-                    PChar->pushPacket(new CInventoryItemPacket(PItem, LocationID, slotID));
+                    PChar->pushPacket<CInventoryItemPacket>(PItem, LocationID, slotID);
                 }
             }
 
-            PChar->pushPacket(new CInventoryFinishPacket(LocationID));
+            PChar->pushPacket<CInventoryFinishPacket>(LocationID);
         };
 
         // Send important items first
@@ -1260,7 +1260,7 @@ namespace charutils
             if (PItem != nullptr)
             {
                 PItem->setSubType(ITEM_LOCKED);
-                PChar->pushPacket(new CInventoryAssignPacket(PItem, INV_NODROP));
+                PChar->pushPacket<CInventoryAssignPacket>(PItem, INV_NODROP);
             }
         }
 
@@ -1270,9 +1270,9 @@ namespace charutils
             PItem->setSubType(ITEM_LOCKED);
 
             PChar->nameflags.flags |= FLAG_LINKSHELL;
-            PChar->pushPacket(new CInventoryItemPacket(PItem, PChar->equipLoc[SLOT_LINK1], PChar->equip[SLOT_LINK1]));
-            PChar->pushPacket(new CInventoryAssignPacket(PItem, INV_LINKSHELL));
-            PChar->pushPacket(new CLinkshellEquipPacket(PChar, 1));
+            PChar->pushPacket<CInventoryItemPacket>(PItem, PChar->equipLoc[SLOT_LINK1], PChar->equip[SLOT_LINK1]);
+            PChar->pushPacket<CInventoryAssignPacket>(PItem, INV_LINKSHELL);
+            PChar->pushPacket<CLinkshellEquipPacket>(PChar, 1);
         }
         else
         {
@@ -1284,12 +1284,12 @@ namespace charutils
         {
             PItem->setSubType(ITEM_LOCKED);
 
-            PChar->pushPacket(new CInventoryItemPacket(PItem, PChar->equipLoc[SLOT_LINK2], PChar->equip[SLOT_LINK2]));
-            PChar->pushPacket(new CInventoryAssignPacket(PItem, INV_LINKSHELL));
-            PChar->pushPacket(new CLinkshellEquipPacket(PChar, 2));
+            PChar->pushPacket<CInventoryItemPacket>(PItem, PChar->equipLoc[SLOT_LINK2], PChar->equip[SLOT_LINK2]);
+            PChar->pushPacket<CInventoryAssignPacket>(PItem, INV_LINKSHELL);
+            PChar->pushPacket<CLinkshellEquipPacket>(PChar, 2);
         }
 
-        PChar->pushPacket(new CInventoryFinishPacket()); // "Finish" type
+        PChar->pushPacket<CInventoryFinishPacket>(); // "Finish" type
     }
 
     /************************************************************************
@@ -1337,7 +1337,7 @@ namespace charutils
             {
                 if (!silence)
                 {
-                    PChar->pushPacket(new CMessageStandardPacket(PChar, PItem->getID(), 0, MsgStd::ItemEx));
+                    PChar->pushPacket<CMessageStandardPacket>(PChar, PItem->getID(), 0, MsgStd::ItemEx);
                 }
                 destroy(PItem);
                 return ERROR_SLOTID;
@@ -1378,8 +1378,8 @@ namespace charutils
                 destroy(PItem);
                 return ERROR_SLOTID;
             }
-            PChar->pushPacket(new CInventoryItemPacket(PItem, LocationID, SlotID));
-            PChar->pushPacket(new CInventoryFinishPacket());
+            PChar->pushPacket<CInventoryItemPacket>(PItem, LocationID, SlotID);
+            PChar->pushPacket<CInventoryFinishPacket>();
         }
         else
         {
@@ -1455,16 +1455,16 @@ namespace charutils
         charutils::SaveCharExp(PChar, PChar->GetMJob());
         PChar->updatemask |= UPDATE_HP;
 
-        PChar->pushPacket(new CCharJobsPacket(PChar));
-        PChar->pushPacket(new CCharStatsPacket(PChar));
-        PChar->pushPacket(new CCharSkillsPacket(PChar));
-        PChar->pushPacket(new CCharRecastPacket(PChar));
-        PChar->pushPacket(new CCharAbilitiesPacket(PChar));
-        PChar->pushPacket(new CCharUpdatePacket(PChar));
-        PChar->pushPacket(new CMenuMeritPacket(PChar));
-        PChar->pushPacket(new CMonipulatorPacket1(PChar));
-        PChar->pushPacket(new CMonipulatorPacket2(PChar));
-        PChar->pushPacket(new CCharSyncPacket(PChar));
+        PChar->pushPacket<CCharJobsPacket>(PChar);
+        PChar->pushPacket<CCharStatsPacket>(PChar);
+        PChar->pushPacket<CCharSkillsPacket>(PChar);
+        PChar->pushPacket<CCharRecastPacket>(PChar);
+        PChar->pushPacket<CCharAbilitiesPacket>(PChar);
+        PChar->pushPacket<CCharUpdatePacket>(PChar);
+        PChar->pushPacket<CMenuMeritPacket>(PChar);
+        PChar->pushPacket<CMonipulatorPacket1>(PChar);
+        PChar->pushPacket<CMonipulatorPacket2>(PChar);
+        PChar->pushPacket<CCharSyncPacket>(PChar);
     }
 
     /************************************************************************
@@ -1500,8 +1500,8 @@ namespace charutils
                 {
                     PItemContainer->InsertItem(nullptr, SlotID);
 
-                    PChar->pushPacket(new CInventoryItemPacket(nullptr, LocationID, SlotID));
-                    PChar->pushPacket(new CInventoryItemPacket(PItemContainer->GetItem(NewSlotID), LocationID, NewSlotID));
+                    PChar->pushPacket<CInventoryItemPacket>(nullptr, LocationID, SlotID);
+                    PChar->pushPacket<CInventoryItemPacket>(PItemContainer->GetItem(NewSlotID), LocationID, NewSlotID);
                     return NewSlotID;
                 }
                 PItemContainer->InsertItem(nullptr, NewSlotID); // We cancel all changes in the container
@@ -1524,7 +1524,7 @@ namespace charutils
         if (PItem == nullptr)
         {
             ShowDebug("UpdateItem: No item in slot %u", slotID);
-            PChar->pushPacket(new CInventoryItemPacket(nullptr, LocationID, slotID));
+            PChar->pushPacket<CInventoryItemPacket>(nullptr, LocationID, slotID);
             return 0;
         }
 
@@ -1563,7 +1563,7 @@ namespace charutils
             if (sql->Query(Query, newQuantity, PChar->id, LocationID, slotID) != SQL_ERROR)
             {
                 PItem->setQuantity(newQuantity);
-                PChar->pushPacket(new CInventoryModifyPacket(LocationID, slotID, newQuantity));
+                PChar->pushPacket<CInventoryModifyPacket>(LocationID, slotID, newQuantity);
             }
         }
         else if (newQuantity == 0)
@@ -1573,7 +1573,7 @@ namespace charutils
             if (sql->Query(Query, PChar->id, LocationID, slotID) != SQL_ERROR)
             {
                 PChar->getStorage(LocationID)->InsertItem(nullptr, slotID);
-                PChar->pushPacket(new CInventoryItemPacket(nullptr, LocationID, slotID));
+                PChar->pushPacket<CInventoryItemPacket>(nullptr, LocationID, slotID);
 
                 if (PChar->getStyleLocked() && !HasItem(PChar, ItemID))
                 {
@@ -1619,8 +1619,8 @@ namespace charutils
         if (charutils::UpdateItem(PChar, container, slotID, -quantity) != 0)
         {
             ShowInfo("Player %s DROPPING itemID: %s (%u) quantity: %u", PChar->getName(), itemutils::GetItemPointer(ItemID)->getName(), ItemID, quantity);
-            PChar->pushPacket(new CMessageStandardPacket(nullptr, ItemID, quantity, MsgStd::ThrowAway));
-            PChar->pushPacket(new CInventoryFinishPacket());
+            PChar->pushPacket<CMessageStandardPacket>(nullptr, ItemID, quantity, MsgStd::ThrowAway);
+            PChar->pushPacket<CInventoryFinishPacket>();
         }
     }
 
@@ -1784,8 +1784,8 @@ namespace charutils
             PChar->PLatentEffectContainer->DelLatentEffects(((CItemEquipment*)PItem)->getReqLvl(), equipSlotID);
             PChar->delPetModifiers(&((CItemEquipment*)PItem)->petModList);
 
-            PChar->pushPacket(new CInventoryAssignPacket(PItem, INV_NORMAL)); // ???
-            PChar->pushPacket(new CEquipPacket(0, equipSlotID, LOC_INVENTORY));
+            PChar->pushPacket<CInventoryAssignPacket>(PItem, INV_NORMAL); // ???
+            PChar->pushPacket<CEquipPacket>(0, equipSlotID, LOC_INVENTORY);
 
             switch (equipSlotID)
             {
@@ -2233,7 +2233,7 @@ namespace charutils
 
         if (PChar->getStyleLocked() != isStyleLocked)
         {
-            PChar->pushPacket(new CMessageStandardPacket(isStyleLocked ? MsgStd::StyleLockOn : MsgStd::StyleLockOff));
+            PChar->pushPacket<CMessageStandardPacket>(isStyleLocked ? MsgStd::StyleLockOn : MsgStd::StyleLockOff);
         }
         PChar->setStyleLocked(isStyleLocked);
     }
@@ -2431,9 +2431,9 @@ namespace charutils
                 OtherContainer->InsertItem(nullptr, slotID);
 
                 // Send update packets
-                PChar->pushPacket(new CInventoryItemPacket(nullptr, container, slotID));
-                PChar->pushPacket(new CInventoryItemPacket(PItem, LOC_RECYCLEBIN, NewSlotID));
-                PChar->pushPacket(new CMessageStandardPacket(nullptr, PItem->getID(), quantity, MsgStd::ThrowAway));
+                PChar->pushPacket<CInventoryItemPacket>(nullptr, container, slotID);
+                PChar->pushPacket<CInventoryItemPacket>(PItem, LOC_RECYCLEBIN, NewSlotID);
+                PChar->pushPacket<CMessageStandardPacket>(nullptr, PItem->getID(), quantity, MsgStd::ThrowAway);
             }
             else
             {
@@ -2472,15 +2472,15 @@ namespace charutils
             }
 
             // Send update packets
-            PChar->pushPacket(new CInventoryItemPacket(nullptr, container, slotID));
+            PChar->pushPacket<CInventoryItemPacket>(nullptr, container, slotID);
             for (int i = 1; i <= 10; ++i)
             {
                 CItem* PUpdatedItem = RecycleBin->GetItem(i);
-                PChar->pushPacket(new CInventoryItemPacket(PUpdatedItem, LOC_RECYCLEBIN, i));
+                PChar->pushPacket<CInventoryItemPacket>(PUpdatedItem, LOC_RECYCLEBIN, i);
             }
-            PChar->pushPacket(new CMessageStandardPacket(nullptr, PItem->getID(), quantity, MsgStd::ThrowAway));
+            PChar->pushPacket<CMessageStandardPacket>(nullptr, PItem->getID(), quantity, MsgStd::ThrowAway);
         }
-        PChar->pushPacket(new CInventoryFinishPacket());
+        PChar->pushPacket<CInventoryFinishPacket>();
     }
 
     void EmptyRecycleBin(CCharEntity* PChar)
@@ -2626,7 +2626,7 @@ namespace charutils
             auto PMainItem   = dynamic_cast<CItemWeapon*>(PChar->getEquip(SLOT_MAIN));
             if (PItemWeapon && PItemWeapon->getSkillType() == SKILL_NONE && (!PMainItem || !PMainItem->isTwoHanded()))
             {
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, 0x200));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, 0x200);
                 return;
             }
 
@@ -2649,7 +2649,7 @@ namespace charutils
                 RemoveSub(PChar);
             }
 
-            PChar->pushPacket(new CEquipPacket(slotID, equipSlotID, containerID));
+            PChar->pushPacket<CEquipPacket>(slotID, equipSlotID, containerID);
         }
         else
         {
@@ -2670,8 +2670,8 @@ namespace charutils
 
                         // Do not forget to update the timer when equipping the subject
 
-                        PChar->pushPacket(new CInventoryItemPacket(PItem, containerID, slotID));
-                        PChar->pushPacket(new CInventoryFinishPacket());
+                        PChar->pushPacket<CInventoryItemPacket>(PItem, containerID, slotID);
+                        PChar->pushPacket<CInventoryFinishPacket>();
                     }
                     PItem->setSubType(ITEM_LOCKED);
 
@@ -2689,8 +2689,8 @@ namespace charutils
                     PChar->PLatentEffectContainer->CheckLatentsEquip(equipSlotID);
                     PChar->addPetModifiers(&PItem->petModList);
 
-                    PChar->pushPacket(new CEquipPacket(slotID, equipSlotID, containerID));
-                    PChar->pushPacket(new CInventoryAssignPacket(PItem, INV_NODROP));
+                    PChar->pushPacket<CEquipPacket>(slotID, equipSlotID, containerID);
+                    PChar->pushPacket<CInventoryAssignPacket>(PItem, INV_NODROP);
                 }
             }
         }
@@ -2711,7 +2711,7 @@ namespace charutils
             }
 
             BuildingCharWeaponSkills(PChar);
-            PChar->pushPacket(new CCharAbilitiesPacket(PChar));
+            PChar->pushPacket<CCharAbilitiesPacket>(PChar);
         }
 
         if (PItem != nullptr)
@@ -2773,7 +2773,7 @@ namespace charutils
             CheckUnarmedWeapon(PChar);
         }
 
-        PChar->pushPacket(new CCharAppearancePacket(PChar));
+        PChar->pushPacket<CCharAppearancePacket>(PChar);
 
         BuildingCharWeaponSkills(PChar);
         PChar->RequestPersist(CHAR_PERSIST::EQUIP);
@@ -2901,7 +2901,7 @@ namespace charutils
 
         if (PetID == 0)
         { // technically Fire Spirit but we're using this to null the abilities shown
-            PChar->pushPacket(new CCharAbilitiesPacket(PChar));
+            PChar->pushPacket<CCharAbilitiesPacket>(PChar);
             return;
         }
 
@@ -2965,7 +2965,7 @@ namespace charutils
                 addPetAbility(PChar, abilityid - ABILITY_HEALING_RUBY);
             }
         }
-        PChar->pushPacket(new CCharAbilitiesPacket(PChar));
+        PChar->pushPacket<CCharAbilitiesPacket>(PChar);
     }
 
     /************************************************************************
@@ -3438,13 +3438,13 @@ namespace charutils
                 }
 
                 PChar->RealSkills.skill[SkillID] += SkillAmount;
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, SkillID, SkillAmount, 38));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, SkillID, SkillAmount, 38);
 
                 if ((CurSkill / 10) < (CurSkill + SkillAmount) / 10) // if gone up a level
                 {
                     PChar->WorkingSkills.skill[SkillID] += 1;
-                    PChar->pushPacket(new CCharSkillsPacket(PChar));
-                    PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, SkillID, (CurSkill + SkillAmount) / 10, 53));
+                    PChar->pushPacket<CCharSkillsPacket>(PChar);
+                    PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, SkillID, (CurSkill + SkillAmount) / 10, 53);
 
                     CheckWeaponSkill(PChar, SkillID);
                     /* ignoring this for now
@@ -3487,8 +3487,8 @@ namespace charutils
             if (curSkill == PSkill->getSkillLevel() && (battleutils::CanUseWeaponskill(PChar, PSkill)))
             {
                 addWeaponSkill(PChar, PSkill->getID());
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, PSkill->getID(), PSkill->getID(), 45));
-                PChar->pushPacket(new CCharAbilitiesPacket(PChar));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, PSkill->getID(), PSkill->getID(), 45);
+                PChar->pushPacket<CCharAbilitiesPacket>(PChar);
             }
         }
     }
@@ -3698,7 +3698,7 @@ namespace charutils
     void setTitle(CCharEntity* PChar, uint16 Title)
     {
         PChar->profile.title = Title;
-        PChar->pushPacket(new CCharStatsPacket(PChar));
+        PChar->pushPacket<CCharStatsPacket>(PChar);
 
         addTitle(PChar, Title);
         SaveTitles(PChar);
@@ -3986,7 +3986,7 @@ namespace charutils
                 for (auto PMember : members)
                 {
                     UpdateItem(PMember, LOC_INVENTORY, 0, gilPerPerson);
-                    PMember->pushPacket(new CMessageBasicPacket(PMember, PMember, gilPerPerson, 0, 565));
+                    PMember->pushPacket<CMessageBasicPacket>(PMember, PMember, gilPerPerson, 0, 565);
                 }
             }
         }
@@ -3995,7 +3995,7 @@ namespace charutils
             // Check for gilfinder
             gil += gil * PChar->getMod(Mod::GILFINDER) / 100;
             UpdateItem(PChar, LOC_INVENTORY, 0, static_cast<int32>(gil));
-            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, static_cast<int32>(gil), 0, 565));
+            PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, static_cast<int32>(gil), 0, 565);
         }
     }
 
@@ -4108,7 +4108,7 @@ namespace charutils
                         {
                             if (CCharEntity* PChar = dynamic_cast<CCharEntity*>(PMember))
                             {
-                                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, 545));
+                                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, 545);
                             }
                         }
                     });
@@ -4473,7 +4473,7 @@ namespace charutils
                     // pet or companion exp penalty needs to be added here
                     if (distance(PMember->loc.p, PMob->loc.p) > 100)
                     {
-                        PMember->pushPacket(new CMessageBasicPacket(PMember, PMember, 0, 0, 37));
+                        PMember->pushPacket<CMessageBasicPacket>(PMember, PMember, 0, 0, 37);
                         return;
                     }
 
@@ -4642,17 +4642,17 @@ namespace charutils
             {
                 if (PChar->capacityChain.chainNumber != 0)
                 {
-                    PChar->pushPacket(new CMessageCombatPacket(PChar, PChar, capacityPoints, PChar->capacityChain.chainNumber, 735));
+                    PChar->pushPacket<CMessageCombatPacket>(PChar, PChar, capacityPoints, PChar->capacityChain.chainNumber, 735);
                 }
                 else
                 {
-                    PChar->pushPacket(new CMessageCombatPacket(PChar, PChar, capacityPoints, 0, 718));
+                    PChar->pushPacket<CMessageCombatPacket>(PChar, PChar, capacityPoints, 0, 718);
                 }
                 PChar->capacityChain.chainNumber++;
             }
             else
             {
-                PChar->pushPacket(new CMessageCombatPacket(PChar, PChar, capacityPoints, 0, 718));
+                PChar->pushPacket<CMessageCombatPacket>(PChar, PChar, capacityPoints, 0, 718);
             }
 
             // Add capacity points
@@ -4660,7 +4660,7 @@ namespace charutils
             {
                 PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CMessageCombatPacket(PChar, PMob, PChar->PJobPoints->GetJobPoints(), 0, 719));
             }
-            PChar->pushPacket(new CMenuJobPointsPacket(PChar));
+            PChar->pushPacket<CMenuJobPointsPacket>(PChar);
 
             if (PMob != PChar) // Only mob kills count for gain EXP records
             {
@@ -4748,17 +4748,17 @@ namespace charutils
                 BuildingCharTraitsTable(PChar);
                 BuildingCharWeaponSkills(PChar);
 
-                PChar->pushPacket(new CCharJobsPacket(PChar));
-                PChar->pushPacket(new CCharUpdatePacket(PChar));
-                PChar->pushPacket(new CCharSkillsPacket(PChar));
-                PChar->pushPacket(new CCharRecastPacket(PChar));
-                PChar->pushPacket(new CCharAbilitiesPacket(PChar));
-                PChar->pushPacket(new CMenuMeritPacket(PChar));
-                PChar->pushPacket(new CMonipulatorPacket1(PChar));
-                PChar->pushPacket(new CMonipulatorPacket2(PChar));
-                PChar->pushPacket(new CCharJobExtraPacket(PChar, true));
-                PChar->pushPacket(new CCharJobExtraPacket(PChar, false));
-                PChar->pushPacket(new CCharSyncPacket(PChar));
+                PChar->pushPacket<CCharJobsPacket>(PChar);
+                PChar->pushPacket<CCharUpdatePacket>(PChar);
+                PChar->pushPacket<CCharSkillsPacket>(PChar);
+                PChar->pushPacket<CCharRecastPacket>(PChar);
+                PChar->pushPacket<CCharAbilitiesPacket>(PChar);
+                PChar->pushPacket<CMenuMeritPacket>(PChar);
+                PChar->pushPacket<CMonipulatorPacket1>(PChar);
+                PChar->pushPacket<CMonipulatorPacket2>(PChar);
+                PChar->pushPacket<CCharJobExtraPacket>(PChar, true);
+                PChar->pushPacket<CCharJobExtraPacket>(PChar, false);
+                PChar->pushPacket<CCharSyncPacket>(PChar);
 
                 PChar->UpdateHealth();
 
@@ -4789,7 +4789,7 @@ namespace charutils
         }
 
         SaveCharExp(PChar, PChar->GetMJob());
-        PChar->pushPacket(new CCharStatsPacket(PChar));
+        PChar->pushPacket<CCharStatsPacket>(PChar);
     }
 
     /************************************************************************
@@ -4836,22 +4836,22 @@ namespace charutils
                 {
                     if (onLimitMode)
                     {
-                        PChar->pushPacket(new CMessageCombatPacket(PChar, PChar, exp, PChar->expChain.chainNumber, 372));
+                        PChar->pushPacket<CMessageCombatPacket>(PChar, PChar, exp, PChar->expChain.chainNumber, 372);
                     }
                     else
                     {
-                        PChar->pushPacket(new CMessageCombatPacket(PChar, PChar, exp, PChar->expChain.chainNumber, 253));
+                        PChar->pushPacket<CMessageCombatPacket>(PChar, PChar, exp, PChar->expChain.chainNumber, 253);
                     }
                 }
                 else
                 {
                     if (onLimitMode)
                     {
-                        PChar->pushPacket(new CMessageCombatPacket(PChar, PChar, exp, 0, 371));
+                        PChar->pushPacket<CMessageCombatPacket>(PChar, PChar, exp, 0, 371);
                     }
                     else
                     {
-                        PChar->pushPacket(new CMessageCombatPacket(PChar, PChar, exp, 0, 8));
+                        PChar->pushPacket<CMessageCombatPacket>(PChar, PChar, exp, 0, 8);
                     }
                 }
                 PChar->expChain.chainNumber++;
@@ -4860,11 +4860,11 @@ namespace charutils
             {
                 if (onLimitMode)
                 {
-                    PChar->pushPacket(new CMessageCombatPacket(PChar, PChar, exp, 0, 371));
+                    PChar->pushPacket<CMessageCombatPacket>(PChar, PChar, exp, 0, 371);
                 }
                 else
                 {
-                    PChar->pushPacket(new CMessageCombatPacket(PChar, PChar, exp, 0, 8));
+                    PChar->pushPacket<CMessageCombatPacket>(PChar, PChar, exp, 0, 8);
                 }
             }
         }
@@ -4898,7 +4898,7 @@ namespace charutils
             if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_SANCTION) && (region >= REGION_TYPE::WEST_AHT_URHGAN && region <= REGION_TYPE::ALZADAAL))
             {
                 charutils::AddPoints(PChar, "imperial_standing", (int32)(exp * 0.1f));
-                PChar->pushPacket(new CConquestPacket(PChar));
+                PChar->pushPacket<CConquestPacket>(PChar);
             }
 
             // Cruor Drops in Abyssea zones.
@@ -4917,7 +4917,7 @@ namespace charutils
                 // TODO: Implement this once formula for Cruor attainment is implemented
                 // if (Cruor >= 1)
                 // {
-                //     PChar->pushPacket(new CMessageSpecialPacket(PChar, TextID, Cruor, Total + Cruor, 0, 0));
+                //     PChar->pushPacket<CMessageSpecialPacket>(PChar, TextID, Cruor, Total + Cruor, 0, 0);
                 //     charutils::AddPoints(PChar, "cruor", Cruor);
                 // }
             }
@@ -4981,20 +4981,20 @@ namespace charutils
                 SaveCharJob(PChar, PChar->GetMJob());
                 SaveCharExp(PChar, PChar->GetMJob());
 
-                PChar->pushPacket(new CCharJobsPacket(PChar));
-                PChar->pushPacket(new CCharUpdatePacket(PChar));
-                PChar->pushPacket(new CCharSkillsPacket(PChar));
-                PChar->pushPacket(new CCharRecastPacket(PChar));
-                PChar->pushPacket(new CCharAbilitiesPacket(PChar));
-                PChar->pushPacket(new CMenuMeritPacket(PChar));
-                PChar->pushPacket(new CMonipulatorPacket1(PChar));
-                PChar->pushPacket(new CMonipulatorPacket2(PChar));
-                PChar->pushPacket(new CCharJobExtraPacket(PChar, true));
-                PChar->pushPacket(new CCharJobExtraPacket(PChar, true));
-                PChar->pushPacket(new CCharSyncPacket(PChar));
+                PChar->pushPacket<CCharJobsPacket>(PChar);
+                PChar->pushPacket<CCharUpdatePacket>(PChar);
+                PChar->pushPacket<CCharSkillsPacket>(PChar);
+                PChar->pushPacket<CCharRecastPacket>(PChar);
+                PChar->pushPacket<CCharAbilitiesPacket>(PChar);
+                PChar->pushPacket<CMenuMeritPacket>(PChar);
+                PChar->pushPacket<CMonipulatorPacket1>(PChar);
+                PChar->pushPacket<CMonipulatorPacket2>(PChar);
+                PChar->pushPacket<CCharJobExtraPacket>(PChar, true);
+                PChar->pushPacket<CCharJobExtraPacket>(PChar, true);
+                PChar->pushPacket<CCharSyncPacket>(PChar);
 
                 PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CMessageCombatPacket(PChar, PMob, PChar->jobs.job[PChar->GetMJob()], 0, 9));
-                PChar->pushPacket(new CCharStatsPacket(PChar));
+                PChar->pushPacket<CCharStatsPacket>(PChar);
 
                 luautils::OnPlayerLevelUp(PChar);
                 roeutils::event(ROE_EVENT::ROE_LEVELUP, PChar, RoeDatagramList{});
@@ -5006,13 +5006,13 @@ namespace charutils
         SaveCharStats(PChar);
         SaveCharJob(PChar, PChar->GetMJob());
         SaveCharExp(PChar, PChar->GetMJob());
-        PChar->pushPacket(new CCharStatsPacket(PChar));
+        PChar->pushPacket<CCharStatsPacket>(PChar);
 
         if (onLimitMode)
         {
-            PChar->pushPacket(new CMenuMeritPacket(PChar));
-            PChar->pushPacket(new CMonipulatorPacket1(PChar));
-            PChar->pushPacket(new CMonipulatorPacket2(PChar));
+            PChar->pushPacket<CMenuMeritPacket>(PChar);
+            PChar->pushPacket<CMonipulatorPacket1>(PChar);
+            PChar->pushPacket<CMonipulatorPacket2>(PChar);
         }
 
         if (PMob != PChar) // Only mob kills count for gain EXP records
@@ -5972,14 +5972,14 @@ namespace charutils
     {
         PChar->UContainer->Clean();
         PChar->UContainer->SetType(UCONTAINER_SEND_DELIVERYBOX);
-        PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, 0, 1));
+        PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, 0, 1);
     }
 
     void OpenRecvBox(CCharEntity* PChar, uint8 action, uint8 boxtype)
     {
         PChar->UContainer->Clean();
         PChar->UContainer->SetType(UCONTAINER_RECV_DELIVERYBOX);
-        PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, 0, 1));
+        PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, 0, 1);
     }
 
     bool isSendBoxOpen(CCharEntity* PChar)
@@ -6209,7 +6209,7 @@ namespace charutils
                 PSyncTarget->StatusEffectContainer->HasStatusEffect(EFFECT_LEVEL_SYNC) &&
                 PSyncTarget->StatusEffectContainer->GetStatusEffect(EFFECT_LEVEL_SYNC)->GetDuration() == 0)
             {
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, PSyncTarget->GetMLevel(), 540));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, PSyncTarget->GetMLevel(), 540);
                 PChar->StatusEffectContainer->AddStatusEffect(new CStatusEffect(EFFECT_LEVEL_SYNC, EFFECT_LEVEL_SYNC, PSyncTarget->GetMLevel(), 0, 0), true);
                 PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DISPELABLE);
             }
@@ -6330,11 +6330,11 @@ namespace charutils
             sql->Query(rankingQuery, evalPoints, PChar->profile.unity_leader);
             roeutils::UpdateUnityTrust(PChar, true);
 
-            PChar->pushPacket(new CCharStatsPacket(PChar));
+            PChar->pushPacket<CCharStatsPacket>(PChar);
         }
         else if (strcmp(type, "spark_of_eminence") == 0)
         {
-            PChar->pushPacket(new CRoeSparkUpdatePacket(PChar));
+            PChar->pushPacket<CRoeSparkUpdatePacket>(PChar);
         }
     }
 
@@ -6348,7 +6348,7 @@ namespace charutils
 
         if (strcmp(type, "spark_of_eminence") == 0)
         {
-            PChar->pushPacket(new CRoeSparkUpdatePacket(PChar));
+            PChar->pushPacket<CRoeSparkUpdatePacket>(PChar);
         }
     }
 
@@ -6444,7 +6444,7 @@ namespace charutils
             PChar->resetPetZoningInfo();
         }
 
-        PChar->pushPacket(new CServerIPPacket(PChar, type, ipp));
+        PChar->pushPacket<CServerIPPacket>(PChar, type, ipp);
     }
 
     void ForceLogout(CCharEntity* PChar)
@@ -6501,7 +6501,7 @@ namespace charutils
             {
                 // weapon is now broken
                 PChar->PLatentEffectContainer->CheckLatentsWeaponBreak(slotid);
-                PChar->pushPacket(new CCharStatsPacket(PChar));
+                PChar->pushPacket<CCharStatsPacket>(PChar);
             }
             char extra[sizeof(PWeapon->m_extra) * 2 + 1];
             sql->EscapeStringLen(extra, (const char*)PWeapon->m_extra, sizeof(PWeapon->m_extra));

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -6711,9 +6711,9 @@ namespace charutils
 
     void SendTimerPacket(CCharEntity* PChar, uint32 seconds)
     {
-        auto* timerPacket = new CObjectiveUtilityPacket();
+        auto timerPacket = std::make_unique<CObjectiveUtilityPacket>();
         timerPacket->addCountdown(seconds);
-        PChar->pushPacket(timerPacket);
+        PChar->pushPacket(std::move(timerPacket));
     }
 
     void SendTimerPacket(CCharEntity* PChar, duration dur)
@@ -6724,8 +6724,7 @@ namespace charutils
 
     void SendClearTimerPacket(CCharEntity* PChar)
     {
-        auto* timerPacket = new CObjectiveUtilityPacket();
-        PChar->pushPacket(timerPacket);
+        PChar->pushPacket<CObjectiveUtilityPacket>();
     }
 
     time_t getTraverserEpoch(CCharEntity* PChar)

--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -1365,7 +1365,7 @@ namespace fishingutils
 
                 if (SendUpdate)
                 {
-                    PChar->pushPacket(new CInventoryFinishPacket());
+                    PChar->pushPacket<CInventoryFinishPacket>();
                 }
             }
         }
@@ -1399,7 +1399,7 @@ namespace fishingutils
                 uint8 location = PRanged->getLocationID();
                 charutils::UpdateItem(PChar, location, PRanged->getSlotID(), -1);
                 charutils::AddItem(PChar, location, PRod->brokenRodId, 1);
-                PChar->pushPacket(new CInventoryFinishPacket());
+                PChar->pushPacket<CInventoryFinishPacket>();
             }
         }
     }
@@ -1438,37 +1438,37 @@ namespace fishingutils
         {
             case FISHINGFAILTYPE_LINESNAP:
                 PChar->animation = ANIMATION_FISHING_LINE_BREAK;
-                PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_LINEBREAK));
+                PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_LINEBREAK);
                 break;
             case FISHINGFAILTYPE_RODBREAK:
                 PChar->animation = ANIMATION_FISHING_ROD_BREAK;
-                PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_RODBREAK));
+                PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_RODBREAK);
                 break;
             case FISHINGFAILTYPE_RODBREAK_TOOBIG:
                 PChar->animation = ANIMATION_FISHING_ROD_BREAK;
-                PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_RODBREAK_TOOBIG));
+                PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_RODBREAK_TOOBIG);
                 break;
             case FISHINGFAILTYPE_RODBREAK_TOOHEAVY:
                 PChar->animation = ANIMATION_FISHING_ROD_BREAK;
-                PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_RODBREAK_TOOHEAVY));
+                PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_RODBREAK_TOOHEAVY);
                 break;
             case FISHINGFAILTYPE_LOST_TOOSMALL:
                 PChar->animation = ANIMATION_FISHING_STOP;
-                PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_LOST_TOOSMALL));
+                PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_LOST_TOOSMALL);
                 break;
             case FISHINGFAILTYPE_LOST_LOWSKILL:
                 PChar->animation = ANIMATION_FISHING_STOP;
-                PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_LOST_LOWSKILL));
+                PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_LOST_LOWSKILL);
                 break;
             case FISHINGFAILTYPE_LOST_TOOBIG:
                 PChar->animation = ANIMATION_FISHING_STOP;
-                PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_LOST_TOOBIG));
+                PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_LOST_TOOBIG);
                 break;
             case FISHINGFAILTYPE_LOST:
             case FISHINGFAILTYPE_NONE:
             default:
                 PChar->animation = ANIMATION_FISHING_STOP;
-                PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_LOST));
+                PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_LOST);
                 break;
         }
 
@@ -1481,7 +1481,7 @@ namespace fishingutils
         PChar->animation     = ANIMATION_FISHING_STOP;
         PChar->updatemask |= UPDATE_HP;
 
-        PChar->pushPacket(new CMessageTextPacket(PChar, messageOffset + FISHMESSAGEOFFSET_NOCATCH));
+        PChar->pushPacket<CMessageTextPacket>(PChar, messageOffset + FISHMESSAGEOFFSET_NOCATCH);
 
         return 1;
     }
@@ -1501,7 +1501,7 @@ namespace fishingutils
                 ShowError("Invalid ItemID %i for fished item\n", FishID);
                 PChar->animation = ANIMATION_FISHING_STOP;
                 PChar->updatemask |= UPDATE_HP;
-                PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_LOST));
+                PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_LOST);
                 return 0;
             }
 
@@ -1548,7 +1548,7 @@ namespace fishingutils
                 ShowError("Invalid ItemID %i for fished item\n", ItemID);
                 PChar->animation = ANIMATION_FISHING_STOP;
                 PChar->updatemask |= UPDATE_HP;
-                PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_LOST));
+                PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_LOST);
                 return 0;
             }
 
@@ -1588,7 +1588,7 @@ namespace fishingutils
 
             PChar->animation = ANIMATION_FISHING_STOP;
             PChar->updatemask |= UPDATE_HP;
-            PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_LOST));
+            PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_LOST);
 
             return 0;
         }
@@ -1645,7 +1645,7 @@ namespace fishingutils
             ShowError("Invalid NpcID %i for fished chest\n", NpcID);
             PChar->animation = ANIMATION_FISHING_STOP;
             PChar->updatemask |= UPDATE_HP;
-            PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_LOST));
+            PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_LOST);
             return 0;
         }
 
@@ -1683,28 +1683,28 @@ namespace fishingutils
         switch (response->sense)
         {
             case FISHINGSENSETYPE_GOOD:
-                PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_GOOD_FEELING));
+                PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_GOOD_FEELING);
                 break;
             case FISHINGSENSETYPE_BAD:
-                PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_BAD_FEELING));
+                PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_BAD_FEELING);
                 break;
             case FISHINGSENSETYPE_TERRIBLE:
-                PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_TERRIBLE_FEELING));
+                PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_TERRIBLE_FEELING);
                 break;
             case FISHINGSENSETYPE_NOSKILL_FEELING:
-                PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_NOSKILL_FEELING));
+                PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_NOSKILL_FEELING);
                 break;
             case FISHINGSENSETYPE_NOSKILL_SURE_FEELING:
-                PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_NOSKILL_SURE_FEELING));
+                PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_NOSKILL_SURE_FEELING);
                 break;
             case FISHINGSENSETYPE_NOSKILL_POSITIVEFEELING:
-                PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_NOSKILL_POSITIVE_FEELING));
+                PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_NOSKILL_POSITIVE_FEELING);
                 break;
             case FISHINGSENSETYPE_KEEN_ANGLERS_SENSE:
-                PChar->pushPacket(new CMessageSpecialPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_KEEN_ANGLERS_SENSE, response->catchid, 3, 3, 3));
+                PChar->pushPacket<CMessageSpecialPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_KEEN_ANGLERS_SENSE, response->catchid, 3, 3, 3);
                 break;
             case FISHINGSENSETYPE_EPIC_CATCH:
-                PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_EPIC_CATCH));
+                PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_EPIC_CATCH);
                 break;
         }
     }
@@ -1716,13 +1716,13 @@ namespace fishingutils
         switch (response->catchtype)
         {
             case FISHINGCATCHTYPE_SMALLFISH:
-                PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_HOOKED_SMALL_FISH));
+                PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_HOOKED_SMALL_FISH);
                 break;
             case FISHINGCATCHTYPE_BIGFISH:
-                PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_HOOKED_LARGE_FISH));
+                PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_HOOKED_LARGE_FISH);
                 break;
             case FISHINGCATCHTYPE_ITEM:
-                PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_HOOKED_ITEM));
+                PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_HOOKED_ITEM);
                 break;
             case FISHINGCATCHTYPE_MOB:
             {
@@ -1730,7 +1730,7 @@ namespace fishingutils
 
                 if (CanFishMob(PMob))
                 {
-                    PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_HOOKED_MONSTER));
+                    PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_HOOKED_MONSTER);
                 }
                 else
                 {
@@ -1743,7 +1743,7 @@ namespace fishingutils
             }
             break;
             case FISHINGCATCHTYPE_CHEST:
-                PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_HOOKED_ITEM));
+                PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_HOOKED_ITEM);
                 break;
         }
         return true;
@@ -1882,13 +1882,13 @@ namespace fishingutils
             if (skillAmount > 0)
             {
                 PChar->RealSkills.skill[SKILL_FISHING] += skillAmount;
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, SKILL_FISHING, skillAmount, 38));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, SKILL_FISHING, skillAmount, 38);
 
                 if ((charSkill / 10) < (charSkill + skillAmount) / 10)
                 {
                     PChar->WorkingSkills.skill[SKILL_FISHING] += 0x20;
-                    PChar->pushPacket(new CCharSkillsPacket(PChar));
-                    PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, SKILL_FISHING, (charSkill + skillAmount) / 10, 53));
+                    PChar->pushPacket<CCharSkillsPacket>(PChar);
+                    PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, SKILL_FISHING, (charSkill + skillAmount) / 10, 53);
                 }
 
                 charutils::SaveCharSkills(PChar, SKILL_FISHING);
@@ -1918,7 +1918,7 @@ namespace fishingutils
             PChar->hookedFish = nullptr;
         }
 
-        PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::FISHING));
+        PChar->pushPacket<CReleasePacket>(PChar, RELEASE_TYPE::FISHING);
     }
 
     void StartFishing(CCharEntity* PChar)
@@ -1926,8 +1926,8 @@ namespace fishingutils
         if (!settings::get<bool>("map.FISHING_ENABLE"))
         {
             ShowWarning("Fishing is currently disabled");
-            PChar->pushPacket(new CChatMessagePacket(PChar, CHAT_MESSAGE_TYPE::MESSAGE_SYSTEM_1, "Fishing is currently disabled"));
-            PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::FISHING));
+            PChar->pushPacket<CChatMessagePacket>(PChar, CHAT_MESSAGE_TYPE::MESSAGE_SYSTEM_1, "Fishing is currently disabled");
+            PChar->pushPacket<CReleasePacket>(PChar, RELEASE_TYPE::FISHING);
             return;
         }
 
@@ -1942,8 +1942,8 @@ namespace fishingutils
 
         if (PChar->nextFishTime > vanaTime)
         {
-            PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_CANNOTFISH_MOMENT));
-            PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::FISHING));
+            PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_CANNOTFISH_MOMENT);
+            PChar->pushPacket<CReleasePacket>(PChar, RELEASE_TYPE::FISHING);
             return;
         }
         else
@@ -1971,9 +1971,9 @@ namespace fishingutils
             // If in the middle of something else, can't fish
             if (PChar->animation != ANIMATION_NONE)
             {
-                PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_CANNOTFISH_MOMENT));
-                PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::CANNOT_USE_COMMAND_AT_THE_MOMENT));
-                PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::FISHING));
+                PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_CANNOTFISH_MOMENT);
+                PChar->pushPacket<CMessageSystemPacket>(0, 0, MSGSYSTEM::CANNOT_USE_COMMAND_AT_THE_MOMENT);
+                PChar->pushPacket<CReleasePacket>(PChar, RELEASE_TYPE::FISHING);
 
                 return;
             }
@@ -1984,8 +1984,8 @@ namespace fishingutils
             // If no rod, then can't fish
             if ((Rod == nullptr) || !(Rod->isType(ITEM_WEAPON)) || (Rod->getSkillType() != SKILL_FISHING))
             {
-                PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_NOROD));
-                PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::FISHING));
+                PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_NOROD);
+                PChar->pushPacket<CReleasePacket>(PChar, RELEASE_TYPE::FISHING);
 
                 return;
             }
@@ -1993,8 +1993,8 @@ namespace fishingutils
             // If no bait, then can't fish
             if ((Bait == nullptr) || !(Bait->isType(ITEM_WEAPON)) || (Bait->getSkillType() != SKILL_FISHING))
             {
-                PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_NOBAIT));
-                PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::FISHING));
+                PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_NOBAIT);
+                PChar->pushPacket<CReleasePacket>(PChar, RELEASE_TYPE::FISHING);
 
                 return;
             }
@@ -2010,14 +2010,14 @@ namespace fishingutils
             }
             else
             {
-                PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::CANNOT_USE_COMMAND_AT_THE_MOMENT));
-                PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::FISHING));
+                PChar->pushPacket<CMessageSystemPacket>(0, 0, MSGSYSTEM::CANNOT_USE_COMMAND_AT_THE_MOMENT);
+                PChar->pushPacket<CReleasePacket>(PChar, RELEASE_TYPE::FISHING);
             }
         }
         else
         {
-            PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::CANNOT_USE_COMMAND_AT_THE_MOMENT));
-            PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::FISHING));
+            PChar->pushPacket<CMessageSystemPacket>(0, 0, MSGSYSTEM::CANNOT_USE_COMMAND_AT_THE_MOMENT);
+            PChar->pushPacket<CReleasePacket>(PChar, RELEASE_TYPE::FISHING);
 
             return;
         }
@@ -2700,8 +2700,8 @@ namespace fishingutils
                 if (response == nullptr || fishingArea == nullptr || response->fishingToken != PChar->fishingToken)
                 {
                     CatchNothing(PChar, FISHINGFAILTYPE_NONE);
-                    PChar->pushPacket(new CCharUpdatePacket(PChar));
-                    PChar->pushPacket(new CCharSyncPacket(PChar));
+                    PChar->pushPacket<CCharUpdatePacket>(PChar);
+                    PChar->pushPacket<CCharSyncPacket>(PChar);
                 }
                 else if (response->hooked && response->catchtype > 0 && response->catchid > 0)
                 {
@@ -2714,11 +2714,11 @@ namespace fishingutils
                     // send then response sense message
                     SendSenseMessage(PChar, response);
                     // play the sweating animation
-                    PChar->pushPacket(new CEntityAnimationPacket(PChar, PChar, "hitl"));
+                    PChar->pushPacket<CEntityAnimationPacket>(PChar, PChar, "hitl");
                     PChar->updatemask |= UPDATE_HP;
                     // send the fishing packet
                     PChar->animation = ANIMATION_FISHING_FISH;
-                    PChar->pushPacket(new CFishingPacket(response->stamina, response->regen, response->response, response->attackdmg, response->delay, response->heal, response->timelimit, response->hooksense, response->special));
+                    PChar->pushPacket<CFishingPacket>(response->stamina, response->regen, response->response, response->attackdmg, response->delay, response->heal, response->timelimit, response->hooksense, response->special);
                 }
                 else
                 {
@@ -2788,7 +2788,7 @@ namespace fishingutils
                     PChar->animation = ANIMATION_FISHING_LINE_BREAK;
                     PChar->updatemask |= UPDATE_HP;
                     BaitLoss(PChar, false, true);
-                    PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_LOST_LOWSKILL));
+                    PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_LOST_LOWSKILL);
 
                     if (PChar->hookedFish)
                     {
@@ -2801,7 +2801,7 @@ namespace fishingutils
                     PChar->animation = ANIMATION_FISHING_LINE_BREAK;
                     PChar->updatemask |= UPDATE_HP;
                     BaitLoss(PChar, true, true);
-                    PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_LINEBREAK));
+                    PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_LINEBREAK);
 
                     if (PChar->hookedFish)
                     {
@@ -2817,13 +2817,13 @@ namespace fishingutils
 
                     if (PChar->hookedFish && PChar->hookedFish->hooked && BaitLoss(PChar, false, true))
                     {
-                        PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_GIVEUP_BAITLOSS));
+                        PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_GIVEUP_BAITLOSS);
                         PChar->hookedFish->successtype = FISHINGSUCCESSTYPE_NONE;
                     }
                     else if (PChar->hookedFish && !PChar->hookedFish->hooked)
                     {
-                        PChar->pushPacket(new CMessageTextPacket(
-                            PChar, MessageOffset + FISHMESSAGEOFFSET_GIVEUP));
+                        PChar->pushPacket<CMessageTextPacket>(
+                            PChar, MessageOffset + FISHMESSAGEOFFSET_GIVEUP);
                         PChar->hookedFish->successtype = FISHINGSUCCESSTYPE_NONE;
                     }
                 }
@@ -2833,7 +2833,7 @@ namespace fishingutils
                     PChar->animation = ANIMATION_FISHING_STOP;
                     PChar->updatemask |= UPDATE_HP;
                     BaitLoss(PChar, false, true);
-                    PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_LOST));
+                    PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_LOST);
 
                     if (PChar->hookedFish)
                     {
@@ -2846,7 +2846,7 @@ namespace fishingutils
             case FISHACTION_WARNING:
             {
                 // message: "You don't know how much longer you can keep this one on the line..."
-                PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_WARNING));
+                PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_WARNING);
                 return;
             }
             break;

--- a/src/map/utils/gardenutils.cpp
+++ b/src/map/utils/gardenutils.cpp
@@ -122,7 +122,7 @@ namespace gardenutils
 
                         if (sendPacket)
                         {
-                            PChar->pushPacket(new CInventoryItemPacket(PPotItem, containerID, slotID));
+                            PChar->pushPacket<CInventoryItemPacket>(PPotItem, containerID, slotID);
                         }
                     }
                 }

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1075,8 +1075,8 @@ namespace petutils
 
         charutils::BuildingCharAbilityTable(static_cast<CCharEntity*>(PMaster));
         charutils::BuildingCharPetAbilityTable(static_cast<CCharEntity*>(PMaster), PPet, PPet->m_PetID);
-        static_cast<CCharEntity*>(PMaster)->pushPacket(new CCharUpdatePacket(static_cast<CCharEntity*>(PMaster)));
-        static_cast<CCharEntity*>(PMaster)->pushPacket(new CPetSyncPacket(static_cast<CCharEntity*>(PMaster)));
+        static_cast<CCharEntity*>(PMaster)->pushPacket<CCharUpdatePacket>(static_cast<CCharEntity*>(PMaster));
+        static_cast<CCharEntity*>(PMaster)->pushPacket<CPetSyncPacket>(static_cast<CCharEntity*>(PMaster));
 
         // check latents affected by pets
         static_cast<CCharEntity*>(PMaster)->PLatentEffectContainer->CheckLatentsPetType();
@@ -1331,9 +1331,9 @@ namespace petutils
 
         charutils::BuildingCharAbilityTable(PChar);
         PChar->PPet = nullptr;
-        PChar->pushPacket(new CCharUpdatePacket(PChar));
-        PChar->pushPacket(new CCharAbilitiesPacket(PChar));
-        PChar->pushPacket(new CPetSyncPacket(PChar));
+        PChar->pushPacket<CCharUpdatePacket>(PChar);
+        PChar->pushPacket<CCharAbilitiesPacket>(PChar);
+        PChar->pushPacket<CPetSyncPacket>(PChar);
     }
 
     void DespawnPet(CBattleEntity* PMaster)

--- a/src/map/utils/puppetutils.cpp
+++ b/src/map/utils/puppetutils.cpp
@@ -193,7 +193,7 @@ namespace puppetutils
             if (addBit(id & 0xFF, (uint8*)PChar->m_unlockedAttachments.attachments, sizeof(PChar->m_unlockedAttachments.attachments)))
             {
                 SaveAutomaton(PChar);
-                PChar->pushPacket(new CCharJobExtraPacket(PChar, PChar->GetMJob() == JOB_PUP));
+                PChar->pushPacket<CCharJobExtraPacket>(PChar, PChar->GetMJob() == JOB_PUP);
                 return true;
             }
             return false;
@@ -203,7 +203,7 @@ namespace puppetutils
             if (addBit(id & 0x0F, &PChar->m_unlockedAttachments.frames, sizeof(PChar->m_unlockedAttachments.frames)))
             {
                 SaveAutomaton(PChar);
-                PChar->pushPacket(new CCharJobExtraPacket(PChar, PChar->GetMJob() == JOB_PUP));
+                PChar->pushPacket<CCharJobExtraPacket>(PChar, PChar->GetMJob() == JOB_PUP);
                 return true;
             }
             return false;
@@ -213,7 +213,7 @@ namespace puppetutils
             if (addBit(id & 0x0F, &PChar->m_unlockedAttachments.heads, sizeof(PChar->m_unlockedAttachments.heads)))
             {
                 SaveAutomaton(PChar);
-                PChar->pushPacket(new CCharJobExtraPacket(PChar, PChar->GetMJob() == JOB_PUP));
+                PChar->pushPacket<CCharJobExtraPacket>(PChar, PChar->GetMJob() == JOB_PUP);
                 return true;
             }
             return false;
@@ -672,7 +672,7 @@ namespace puppetutils
                 }
 
                 PChar->RealSkills.skill[SkillID] += SkillAmount;
-                PChar->pushPacket(new CMessageBasicPacket(PAutomaton, PAutomaton, SkillID, SkillAmount, 38));
+                PChar->pushPacket<CMessageBasicPacket>(PAutomaton, PAutomaton, SkillID, SkillAmount, 38);
 
                 if ((CurSkill / 10) < (CurSkill + SkillAmount) / 10) // if gone up a level
                 {
@@ -688,8 +688,8 @@ namespace puppetutils
                         PAutomaton->WorkingSkills.elemental       = amaSkill;
                         PAutomaton->WorkingSkills.dark            = amaSkill;
                     }
-                    PChar->pushPacket(new CCharJobExtraPacket(PChar, PChar->GetMJob() == JOB_PUP));
-                    PChar->pushPacket(new CMessageBasicPacket(PAutomaton, PAutomaton, SkillID, (CurSkill + SkillAmount) / 10, 53));
+                    PChar->pushPacket<CCharJobExtraPacket>(PChar, PChar->GetMJob() == JOB_PUP);
+                    PChar->pushPacket<CMessageBasicPacket>(PAutomaton, PAutomaton, SkillID, (CurSkill + SkillAmount) / 10, 53);
                 }
                 charutils::SaveCharSkills(PChar, SkillID);
             }

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -112,7 +112,7 @@ namespace synthutils
 
                     if (currentSkill < (skillValue * 10 - 150)) // Check player skill against recipe level. Range must be 14 or less.
                     {
-                        PChar->pushPacket(new CSynthMessagePacket(PChar, SYNTH_NOSKILL));
+                        PChar->pushPacket<CSynthMessagePacket>(PChar, SYNTH_NOSKILL);
                         return false;
                     }
                 }
@@ -120,7 +120,7 @@ namespace synthutils
             }
         }
 
-        PChar->pushPacket(new CSynthMessagePacket(PChar, SYNTH_BADRECIPE));
+        PChar->pushPacket<CSynthMessagePacket>(PChar, SYNTH_BADRECIPE);
         return false;
     }
 
@@ -618,13 +618,13 @@ namespace synthutils
 
                 // Skill Up addition:
                 PChar->RealSkills.skill[skillID] += skillUpAmount;
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, skillID, skillUpAmount, 38));
+                PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, skillID, skillUpAmount, 38);
 
                 if ((charSkill / 10) < (charSkill + skillUpAmount) / 10)
                 {
                     PChar->WorkingSkills.skill[skillID] += 0x20;
-                    PChar->pushPacket(new CCharSkillsPacket(PChar));
-                    PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, skillID, (charSkill + skillUpAmount) / 10, 53));
+                    PChar->pushPacket<CCharSkillsPacket>(PChar);
+                    PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, skillID, (charSkill + skillUpAmount) / 10, 53);
                 }
 
                 charutils::SaveCharSkills(PChar, skillID);
@@ -633,13 +633,13 @@ namespace synthutils
                 if (skillCumulation > settings::get<uint16>("map.CRAFT_SPECIALIZATION_POINTS"))
                 {
                     PChar->RealSkills.skill[skillHighest] -= skillUpAmount;
-                    PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, skillHighest, skillUpAmount, 310));
+                    PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, skillHighest, skillUpAmount, 310);
 
                     if ((PChar->RealSkills.skill[skillHighest] + skillUpAmount) / 10 > (PChar->RealSkills.skill[skillHighest]) / 10)
                     {
                         PChar->WorkingSkills.skill[skillHighest] -= 0x20;
-                        PChar->pushPacket(new CCharSkillsPacket(PChar));
-                        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, skillHighest, (PChar->RealSkills.skill[skillHighest] - skillUpAmount) / 10, 53));
+                        PChar->pushPacket<CCharSkillsPacket>(PChar);
+                        PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, skillHighest, (PChar->RealSkills.skill[skillHighest] - skillUpAmount) / 10, 53);
                     }
 
                     charutils::SaveCharSkills(PChar, skillHighest);
@@ -718,7 +718,7 @@ namespace synthutils
                     }
                     else
                     {
-                        PChar->pushPacket(new CInventoryAssignPacket(PItem, INV_NORMAL));
+                        PChar->pushPacket<CInventoryAssignPacket>(PItem, INV_NORMAL);
                     }
                 }
                 invSlotID = nextSlotID;
@@ -759,7 +759,7 @@ namespace synthutils
             PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, new CSynthResultMessagePacket(PChar, SYNTH_FAIL));
         }
 
-        PChar->pushPacket(new CSynthMessagePacket(PChar, SYNTH_FAIL, 29695));
+        PChar->pushPacket<CSynthMessagePacket>(PChar, SYNTH_FAIL, 29695);
 
         return 0;
     }
@@ -870,14 +870,14 @@ namespace synthutils
                 if (PCraftItem != nullptr)
                 {
                     PCraftItem->setSubType(ITEM_LOCKED);
-                    PChar->pushPacket(new CInventoryAssignPacket(PCraftItem, INV_NOSELECT));
+                    PChar->pushPacket<CInventoryAssignPacket>(PCraftItem, INV_NOSELECT);
                 }
             }
         }
 
         PChar->animation = ANIMATION_SYNTH;
         PChar->updatemask |= UPDATE_HP;
-        PChar->pushPacket(new CCharUpdatePacket(PChar));
+        PChar->pushPacket<CCharUpdatePacket>(PChar);
 
         if (PChar->loc.zone->GetID() != 255 && PChar->loc.zone->GetID() != 0)
         {
@@ -885,7 +885,7 @@ namespace synthutils
         }
         else
         {
-            PChar->pushPacket(new CSynthAnimationPacket(PChar, effect, result));
+            PChar->pushPacket<CSynthAnimationPacket>(PChar, effect, result);
         }
 
         return 0;
@@ -990,18 +990,18 @@ namespace synthutils
 
                     sql->Query(fmtQuery, signature_esc, PChar->id, invSlotID);
                 }
-                PChar->pushPacket(new CInventoryItemPacket(PItem, LOC_INVENTORY, invSlotID));
+                PChar->pushPacket<CInventoryItemPacket>(PItem, LOC_INVENTORY, invSlotID);
             }
 
-            PChar->pushPacket(new CInventoryFinishPacket());
+            PChar->pushPacket<CInventoryFinishPacket>();
             if (PChar->loc.zone->GetID() != 255 && PChar->loc.zone->GetID() != 0)
             {
                 PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, new CSynthResultMessagePacket(PChar, SYNTH_SUCCESS, itemID, quantity));
-                PChar->pushPacket(new CSynthMessagePacket(PChar, SYNTH_SUCCESS, itemID, quantity));
+                PChar->pushPacket<CSynthMessagePacket>(PChar, SYNTH_SUCCESS, itemID, quantity);
             }
             else
             {
-                PChar->pushPacket(new CSynthMessagePacket(PChar, SYNTH_SUCCESS, itemID, quantity));
+                PChar->pushPacket<CSynthMessagePacket>(PChar, SYNTH_SUCCESS, itemID, quantity);
             }
 
             // Calculate what craft this recipe "belongs" to based on highest skill required
@@ -1041,7 +1041,7 @@ namespace synthutils
 
         PChar->animation = ANIMATION_NONE;
         PChar->updatemask |= UPDATE_HP;
-        PChar->pushPacket(new CCharUpdatePacket(PChar));
+        PChar->pushPacket<CCharUpdatePacket>(PChar);
         return 0;
     }
 

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -352,7 +352,7 @@ void CZoneEntities::MusicChange(uint8 BlockID, uint8 MusicTrackID)
 
         if (PCurrentChar != nullptr)
         {
-            PCurrentChar->pushPacket(new CChangeMusicPacket(BlockID, MusicTrackID));
+            PCurrentChar->pushPacket<CChangeMusicPacket>(BlockID, MusicTrackID);
         }
     }
 }
@@ -671,7 +671,7 @@ void CZoneEntities::SpawnTRUSTs(CCharEntity* PChar)
                     PChar->SpawnTRUSTList.insert(SpawnTrustItr, SpawnIDList_t::value_type(PCurrentTrust->id, PCurrentTrust));
                     if (PMaster)
                     {
-                        PChar->pushPacket(new CEntitySetNamePacket(PCurrentTrust));
+                        PChar->pushPacket<CEntitySetNamePacket>(PCurrentTrust);
                         PChar->updateEntityPacket(PCurrentTrust, ENTITY_SPAWN, UPDATE_ALL_MOB);
                     }
                 }
@@ -901,7 +901,7 @@ void CZoneEntities::SpawnPCs(CCharEntity* PChar)
             CCharEntity* candidateChar            = candidatePair.second;
             PChar->SpawnPCList[candidateChar->id] = candidateChar;
             PChar->updateCharPacket(candidateChar, ENTITY_SPAWN, UPDATE_ALL_CHAR);
-            PChar->pushPacket(new CCharSyncPacket(candidateChar));
+            PChar->pushPacket<CCharSyncPacket>(candidateChar);
         }
     }
 }
@@ -1232,7 +1232,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
                 TracyZoneCString("CHAR_INRANGE_SELF");
                 if (PEntity->objtype == TYPE_PC)
                 {
-                    ((CCharEntity*)PEntity)->pushPacket(new CBasicPacket(*packet));
+                    ((CCharEntity*)PEntity)->pushPacket<CBasicPacket>(*packet);
                 }
             }
             [[fallthrough]];
@@ -1293,7 +1293,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
                                     SpawnIDList_t::const_iterator iter = spawnlist.lower_bound(id);
                                     if (!(iter == spawnlist.end() || spawnlist.key_comp()(id, iter->first)))
                                     {
-                                        PCurrentChar->pushPacket(new CBasicPacket(*packet));
+                                        PCurrentChar->pushPacket<CBasicPacket>(*packet);
                                     }
                                 };
 
@@ -1320,7 +1320,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
                             }
                             else
                             {
-                                PCurrentChar->pushPacket(new CBasicPacket(*packet));
+                                PCurrentChar->pushPacket<CBasicPacket>(*packet);
                             }
                         }
                     }
@@ -1338,7 +1338,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
                         if (distance(PEntity->loc.p, PCurrentChar->loc.p) < 180 &&
                             ((PEntity->objtype != TYPE_PC) || (((CCharEntity*)PEntity)->m_moghouseID == PCurrentChar->m_moghouseID)))
                         {
-                            PCurrentChar->pushPacket(new CBasicPacket(*packet));
+                            PCurrentChar->pushPacket<CBasicPacket>(*packet);
                         }
                     }
                 }
@@ -1355,7 +1355,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
                     {
                         if (PEntity != PCurrentChar)
                         {
-                            PCurrentChar->pushPacket(new CBasicPacket(*packet));
+                            PCurrentChar->pushPacket<CBasicPacket>(*packet);
                         }
                     }
                 }
@@ -1370,13 +1370,13 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
 void CZoneEntities::WideScan(CCharEntity* PChar, uint16 radius)
 {
     TracyZoneScoped;
-    PChar->pushPacket(new CWideScanPacket(WIDESCAN_BEGIN));
+    PChar->pushPacket<CWideScanPacket>(WIDESCAN_BEGIN);
     for (EntityList_t::const_iterator it = m_npcList.begin(); it != m_npcList.end(); ++it)
     {
         CNpcEntity* PNpc = (CNpcEntity*)it->second;
         if (PNpc->isWideScannable() && distance(PChar->loc.p, PNpc->loc.p) < radius)
         {
-            PChar->pushPacket(new CWideScanPacket(PChar, PNpc));
+            PChar->pushPacket<CWideScanPacket>(PChar, PNpc);
         }
     }
     for (EntityList_t::const_iterator it = m_mobList.begin(); it != m_mobList.end(); ++it)
@@ -1384,10 +1384,10 @@ void CZoneEntities::WideScan(CCharEntity* PChar, uint16 radius)
         CMobEntity* PMob = (CMobEntity*)it->second;
         if (PMob->isWideScannable() && distance(PChar->loc.p, PMob->loc.p) < radius)
         {
-            PChar->pushPacket(new CWideScanPacket(PChar, PMob));
+            PChar->pushPacket<CWideScanPacket>(PChar, PMob);
         }
     }
-    PChar->pushPacket(new CWideScanPacket(WIDESCAN_END));
+    PChar->pushPacket<CWideScanPacket>(WIDESCAN_END);
 }
 
 void CZoneEntities::ZoneServer(time_point tick)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Removes the pattern of using `new` to create objects, in favour of `std::make_unique` and some templated helpers.
- Removes `CStateInitException` and the new warning-disable we have in MSVC, and rewrites parts of the state system to accommodate this (no more throwing in constructors to signify an error, or holding onto error packets in the state, etc.)
- I've expanded the scope of this to be more than just packets. This'll apply to StatusEffects and anywhere else I can sniff out calls to `new`, where we're creating shared objects and not closely managing the lifetimes of them.

*TODO* 
- Rewriting state system
- The other new calls
- Extensive testing

## Steps to test these changes

Everything works as normal, but will need extensive testing of all systems and before/after monitoring with Tracy for both performance and memory usage.