### PR TITLE
[core] Fix SMN player avatar auto attack issue (that can steal claim)

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -183,7 +183,18 @@ void CMobController::TryLink()
     {
         if (PTarget->PPet->objtype == TYPE_PET && ((CPetEntity*)PTarget->PPet)->getPetType() == PET_TYPE::AVATAR)
         {
-            petutils::AttackTarget(PTarget, PMob);
+            if (PTarget->objtype == TYPE_PC)
+            {
+                std::unique_ptr<CBasicPacket> errMsg;
+                if (PTarget->PPet->CanAttack(PMob, errMsg))
+                {
+                    petutils::AttackTarget(PTarget, PMob);
+                }
+            }
+            else
+            {
+                petutils::AttackTarget(PTarget, PMob);
+            }
         }
     }
 
@@ -211,7 +222,7 @@ void CMobController::TryLink()
                 if (PPartyMember->m_roamFlags & ROAMFLAG_IGNORE)
                 {
                     // force into attack action
-                    //#TODO
+                    // #TODO
                     PPartyMember->PAI->Engage(PTarget->targid);
                 }
             }
@@ -831,7 +842,7 @@ void CMobController::DoRoamTick(time_point tick)
 
         return;
     }
-    //#TODO
+    // #TODO
     else if (PMob->GetDespawnTime() > time_point::min() && PMob->GetDespawnTime() < m_Tick)
     {
         Despawn();
@@ -946,7 +957,7 @@ void CMobController::DoRoamTick(time_point tick)
                 else if (PMob->CanRoam() && PMob->PAI->PathFind->RoamAround(PMob->m_SpawnPoint, PMob->GetRoamDistance(),
                                                                             (uint8)PMob->getMobMod(MOBMOD_ROAM_TURNS), PMob->m_roamFlags))
                 {
-                    //#TODO: #AIToScript (event probably)
+                    // #TODO: #AIToScript (event probably)
                     if (PMob->m_roamFlags & ROAMFLAG_WORM)
                     {
                         // move down

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -540,6 +540,7 @@ public:
 
     virtual bool ValidTarget(CBattleEntity* PInitiator, uint16 targetFlags) override;
     virtual bool CanUseSpell(CSpell*) override;
+    bool         IsMobOwner(CBattleEntity* PTarget);
 
     virtual void Die() override;
     void         Die(duration _duration);
@@ -599,7 +600,6 @@ public:
 
 protected:
     void changeMoghancement(uint16 moghancementID, bool isAdding);
-    bool IsMobOwner(CBattleEntity* PTarget);
     void TrackArrowUsageForScavenge(CItemWeapon* PAmmo);
 
 private:

--- a/src/map/entities/petentity.cpp
+++ b/src/map/entities/petentity.cpp
@@ -384,6 +384,23 @@ bool CPetEntity::ValidTarget(CBattleEntity* PInitiator, uint16 targetFlags)
     return CMobEntity::ValidTarget(PInitiator, targetFlags);
 }
 
+bool CPetEntity::CanAttack(CBattleEntity* PTarget, std::unique_ptr<CBasicPacket>& errMsg)
+{
+    // prevent pets from attacking mobs that the PC master does not own
+    if (this->PMaster)
+    {
+        auto* PChar = dynamic_cast<CCharEntity*>(this->PMaster);
+        if (PChar && !PChar->IsMobOwner(PTarget))
+        {
+            errMsg = std::make_unique<CMessageBasicPacket>(this, PTarget, 0, 0, MSGBASIC_ALREADY_CLAIMED);
+            PAI->Disengage();
+            return false;
+        }
+    }
+
+    return CBattleEntity::CanAttack(PTarget, errMsg);
+}
+
 void CPetEntity::OnPetSkillFinished(CPetSkillState& state, action_t& action)
 {
     TracyZoneScoped;

--- a/src/map/entities/petentity.h
+++ b/src/map/entities/petentity.h
@@ -72,6 +72,7 @@ public:
     virtual void      OnAbility(CAbilityState&, action_t&) override;
     virtual bool      ValidTarget(CBattleEntity* PInitiator, uint16 targetFlags) override;
     void              OnPetSkillFinished(CPetSkillState& state, action_t& action);
+    virtual bool      CanAttack(CBattleEntity* PTarget, std::unique_ptr<CBasicPacket>& errMsg) override;
 
 private:
     PET_TYPE   m_PetType;      // the type of pet e.g. avatar/wyvern/jugpet etc


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes an issue whereby SMN player avatars do not respect mob ownership, thus allowing a SMN or /SMN to steam claim of a mob (such as HNM). The SMN can do this by, for example, spamming cure on another player that has a mob claimed (to gain mob attention), then the avatar will auto-attack the mob (to defend the SMN) and the attack will transfer mob ownership to the SMN (going from purple mob directly to red).

This PR fixes the issue by checking the CanAttack function of the avatar before having the avatar auto-attack to defend the SMN. The PR implements the CanAttack function of PetEntity which checks the mob ownership of the master and then calls the parent CanAttack function of BattleEntity. Also the IsMobOwner function of CharEntity is moved from protected to public so the CanAttack function can call.

This is a PR from ASB coming upstream.

## Steps to test these changes
With two characters, have player A claim a mob and then !hp 1 themselves, have player B with an avatar out then spam cure on Player A, and notice that even if the mob turns and starts attacking player B the avatar will not attack the mob and will transfer ownership to Player A.