### PR TITLE
[core] [lua] Move autoattack pdif to lua

### DIFF
--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -324,22 +324,24 @@ xi.combat.physical.calculateFTP = function(actor, tpFactor)
     return fTP
 end
 
-xi.combat.physical.calculateMeleePDIF = function(actor, target, weaponType, wsAttackMod, isCritical, applyLevelCorrection, tpIgnoresDefense, tpFactor)
+xi.combat.physical.calculateMeleePDIF = function(actor, target, weaponType, wsAttackMod, isCritical, applyLevelCorrection, tpIgnoresDefense, tpFactor, isWeaponskill)
     local pDif = 0
 
     ----------------------------------------
     -- Step 1: Attack / Defense Ratio
     ----------------------------------------
     local baseRatio     = 0
-    local actorAttack   = math.floor(actor:getStat(xi.mod.ATT) * wsAttackMod)
-    local targetDefense = target:getStat(xi.mod.DEF)
+    local actorAttack   = math.max(1, math.floor(actor:getStat(xi.mod.ATT) * wsAttackMod))
+    local targetDefense = math.max(1, target:getStat(xi.mod.DEF))
 
-    -- Actor Attack modifiers.
-    if actor:hasStatusEffect(xi.effect.BUILDING_FLOURISH) then
-        local flourishEffect = actor:getStatusEffect(xi.effect.BUILDING_FLOURISH)
+    -- Actor Weaponskill Specific Attack modifiers.
+    if isWeaponskill then
+        if actor:hasStatusEffect(xi.effect.BUILDING_FLOURISH) then
+            local flourishEffect = actor:getStatusEffect(xi.effect.BUILDING_FLOURISH)
 
-        if flourishEffect:getPower() >= 2 then -- 2 or more Finishing Moves used.
-            actorAttack = actorAttack + 25 + flourishEffect:getSubPower()
+            if flourishEffect:getPower() >= 2 then -- 2 or more Finishing Moves used.
+                actorAttack = actorAttack + 25 + flourishEffect:getSubPower()
+            end
         end
     end
 
@@ -347,7 +349,7 @@ xi.combat.physical.calculateMeleePDIF = function(actor, target, weaponType, wsAt
     local ignoreDefenseFactor = 1
 
     if tpIgnoresDefense then
-        ignoreDefenseFactor = tpFactor
+        ignoreDefenseFactor = 1.0 - tpFactor
     end
 
     targetDefense = math.floor(targetDefense * ignoreDefenseFactor)
@@ -379,9 +381,10 @@ xi.combat.physical.calculateMeleePDIF = function(actor, target, weaponType, wsAt
     ----------------------------------------
     -- Step 3: wRatio and pDif Caps (Melee)
     ----------------------------------------
-    local wRatio       = cRatio + isCritical
+    local wRatio       = cRatio + (isCritical and 1.0 or 0)
     local pDifUpperCap = 0
     local pDifLowerCap = 0
+    local pDifFinalCap = pDifWeaponCapTable[weaponType][1] + (isCritical and 1.0 or 0) -- TODO: Add 'Damage Limit +' Trait here.
 
     -- pDIF upper cap.
     if wRatio < 0.5 then
@@ -393,7 +396,7 @@ xi.combat.physical.calculateMeleePDIF = function(actor, target, weaponType, wsAt
     elseif wRatio < 1.5 then
         pDifUpperCap = wRatio + wRatio * 0.25
     else
-        pDifUpperCap = utils.clamp(wRatio + 0.375, 1, 3)
+        pDifUpperCap = math.min(wRatio + 0.375, pDifFinalCap)
     end
 
     -- pDIF lower cap.
@@ -414,9 +417,7 @@ xi.combat.physical.calculateMeleePDIF = function(actor, target, weaponType, wsAt
     ----------------------------------------
     -- Step 4: Apply weapon type caps.
     ----------------------------------------
-    local pDifFinalCap = pDifWeaponCapTable[weaponType][1] + isCritical -- TODO: Add 'Damage Limit +' Trait here.
-
-    pDif = utils.clamp(pDif, 0, pDifFinalCap)
+    pDif = utils.clamp(pDif, 0, pDifFinalCap) -- TODO: Add 'Damage Limit +' Trait here.
 
     ----------------------------------------
     -- Step 5: Melee random factor.
@@ -425,25 +426,35 @@ xi.combat.physical.calculateMeleePDIF = function(actor, target, weaponType, wsAt
 
     pDif = pDif * meleeRandom
 
+    -- Crit damage bonus is a final modifier
+    if isCritical then
+        local critDamageBonus = utils.clamp(actor:getMod(xi.mod.CRIT_DMG_INCREASE) - target:getMod(xi.mod.CRIT_DEF_BONUS), 0, 100)
+        pDif = pDif * (100 + critDamageBonus) / 100
+    end
+
     return pDif
 end
 
-xi.combat.physical.calculateRangedPDIF = function(actor, target, weaponType, wsAttackMod, isCritical, applyLevelCorrection, tpIgnoresDefense, tpFactor)
+xi.combat.physical.calculateRangedPDIF = function(actor, target, weaponType, wsAttackMod, isCritical, applyLevelCorrection, tpIgnoresDefense, tpFactor, isWeaponskill)
     local pDif = 0
 
     ----------------------------------------
     -- Step 1: Attack / Defense Ratio
     ----------------------------------------
     local baseRatio     = 0
-    local actorAttack   = math.floor(actor:getStat(xi.mod.RATT) * wsAttackMod)
-    local targetDefense = target:getStat(xi.mod.DEF)
+    local actorAttack   = math.max(1, math.floor(actor:getStat(xi.mod.RATT) * wsAttackMod))
+    local targetDefense = math.max(1, target:getStat(xi.mod.DEF))
 
-    -- Actor Ranged Attack modifiers.
-    if actor:hasStatusEffect(xi.effect.BUILDING_FLOURISH) then
-        local flourishEffect = actor:getStatusEffect(xi.effect.BUILDING_FLOURISH)
+    -- Actor Weaponskill Specific Ranged Attack modifiers.
+    if isWeaponskill then
+        -- TODO: verify this actually works on ranged WS.
+        -- This is a real concern now that RNG/DNC and COR/DNC can actually get level 50 subs through master levels.
+        if actor:hasStatusEffect(xi.effect.BUILDING_FLOURISH) then
+            local flourishEffect = actor:getStatusEffect(xi.effect.BUILDING_FLOURISH)
 
-        if flourishEffect:getPower() >= 2 then -- 2 or more Finishing Moves used.
-            actorAttack = actorAttack + 25 + flourishEffect:getSubPower()
+            if flourishEffect:getPower() >= 2 then -- 2 or more Finishing Moves used.
+                actorAttack = actorAttack + 25 + flourishEffect:getSubPower()
+            end
         end
     end
 
@@ -451,7 +462,7 @@ xi.combat.physical.calculateRangedPDIF = function(actor, target, weaponType, wsA
     local ignoreDefenseFactor = 1
 
     if tpIgnoresDefense then
-        ignoreDefenseFactor = tpFactor
+        ignoreDefenseFactor = 1.0 - tpFactor
     end
 
     targetDefense = math.floor(targetDefense * ignoreDefenseFactor)
@@ -505,19 +516,25 @@ xi.combat.physical.calculateRangedPDIF = function(actor, target, weaponType, wsA
     ----------------------------------------
     -- Step 4: Apply weapon type caps.
     ----------------------------------------
-    local pDifFinalCap = pDifWeaponCapTable[weaponType][1] + isCritical -- TODO: Add 'Damage Limit +' Trait here.
+    local pDifFinalCap = pDifWeaponCapTable[weaponType][1] -- TODO: Add 'Damage Limit +' Trait here.
 
     pDif = utils.clamp(pDif, 0, pDifFinalCap)
 
     ----------------------------------------
     -- Step 5: Ranged critical factor. Bypasses caps.
     ----------------------------------------
-    if isCritical == 1 then
+    if isCritical then
         pDif = pDif * 1.25
     end
 
     -- Step 6: Distance correction and True Shot.
     -- TODO: Implement distance correction and True shot...
+
+    -- Crit damage bonus is a final modifier
+    if isCritical then
+        local critDamageBonus = utils.clamp(actor:getMod(xi.mod.CRIT_DMG_INCREASE) - target:getMod(xi.mod.CRIT_DEF_BONUS), 0, 100)
+        pDif = pDif * (100 + critDamageBonus) / 100
+    end
 
     return pDif
 end

--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -99,16 +99,40 @@ void CAttack::SetCritical(bool value)
     }
     else
     {
-        float attBonus = 0.f;
+        float attBonus = 1.0f;
         if (m_attackType == PHYSICAL_ATTACK_TYPE::KICK)
         {
             if (CStatusEffect* footworkEffect = m_attacker->StatusEffectContainer->GetStatusEffect(EFFECT_FOOTWORK))
             {
-                attBonus = footworkEffect->GetSubPower() / 256.f; // Mod is out of 256
+                attBonus = 1 + (footworkEffect->GetSubPower() / 256.f); // Mod is out of 256
             }
         }
 
-        m_damageRatio = battleutils::GetDamageRatio(m_attacker, m_victim, m_isCritical, attBonus);
+        SKILLTYPE skilltype = SKILLTYPE::SKILL_NONE;
+
+        if (m_attacker->objtype == TYPE_PC)
+        {
+            SLOTTYPE slot = SLOT_MAIN;
+
+            if (m_attackDirection == PHYSICAL_ATTACK_DIRECTION::RIGHTATTACK)
+            {
+                slot = SLOT_SUB;
+            }
+
+            if (m_attacker->objtype == TYPE_PC)
+            {
+                if (auto* weapon = dynamic_cast<CItemWeapon*>(m_attacker->m_Weapons[slot]))
+                {
+                    skilltype = static_cast<SKILLTYPE>(weapon->getSkillType());
+                }
+                else
+                {
+                    skilltype = SKILLTYPE::SKILL_HAND_TO_HAND;
+                }
+            }
+        }
+
+        m_damageRatio = battleutils::GetDamageRatio(m_attacker, m_victim, m_isCritical, attBonus, skilltype);
     }
 }
 

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2179,9 +2179,22 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                     else
                     {
                         int16 naturalh2hDMG = 0;
-                        if (auto* targ_weapon = dynamic_cast<CItemWeapon*>(PTarget->m_Weapons[SLOT_MAIN]);
-                            (targ_weapon && targ_weapon->getSkillType() == SKILL_HAND_TO_HAND) ||
-                            (PTarget->objtype == TYPE_MOB && PTarget->GetMJob() == JOB_MNK))
+                        auto* targ_weapon   = dynamic_cast<CItemWeapon*>(PTarget->m_Weapons[SLOT_MAIN]);
+                        SKILLTYPE skilltype = SKILLTYPE::SKILL_NONE;
+
+                        if (PTarget->objtype == TYPE_PC)
+                        {
+                            if (targ_weapon)
+                            {
+                                skilltype = static_cast<SKILLTYPE>(targ_weapon->getSkillType());
+                            }
+                            else
+                            {
+                                skilltype = SKILLTYPE::SKILL_HAND_TO_HAND;
+                            }
+                        }
+
+                        if (skilltype == SKILLTYPE::SKILL_HAND_TO_HAND || (PTarget->objtype == TYPE_MOB && PTarget->GetMJob() == JOB_MNK))
                         {
                             naturalh2hDMG = (int16)((PTarget->GetSkill(SKILL_HAND_TO_HAND) * 0.11f) + 3);
                         }
@@ -2199,7 +2212,7 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                             csJpAtkBonus = 1 + ((static_cast<float>(targetDex) / 100) * csJpModifier);
                         }
 
-                        float DamageRatio = battleutils::GetDamageRatio(PTarget, this, attack.IsCritical(), csJpAtkBonus);
+                        float DamageRatio = battleutils::GetDamageRatio(PTarget, this, attack.IsCritical(), csJpAtkBonus, skilltype);
                         auto  damage      = (int32)((PTarget->GetMainWeaponDmg() + naturalh2hDMG + battleutils::GetFSTR(PTarget, this, SLOT_MAIN)) * DamageRatio);
 
                         actionTarget.spikesParam =
@@ -2207,9 +2220,7 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                         actionTarget.spikesMessage = 33;
                         if (PTarget->objtype == TYPE_PC)
                         {
-                            auto* targ_weapon = dynamic_cast<CItemWeapon*>(PTarget->m_Weapons[SLOT_MAIN]);
-                            uint8 skilltype   = (targ_weapon == nullptr ? (uint8)SKILL_HAND_TO_HAND : targ_weapon->getSkillType());
-                            charutils::TrySkillUP((CCharEntity*)PTarget, (SKILLTYPE)skilltype, GetMLevel());
+                            charutils::TrySkillUP((CCharEntity*)PTarget, skilltype, GetMLevel());
                         } // In case the Automaton can counter
                         else if (PTarget->objtype == TYPE_PET && PTarget->PMaster && PTarget->PMaster->objtype == TYPE_PC &&
                                  static_cast<CPetEntity*>(PTarget)->getPetType() == PET_TYPE::AUTOMATON)

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2178,9 +2178,9 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                     }
                     else
                     {
-                        int16 naturalh2hDMG = 0;
-                        auto* targ_weapon   = dynamic_cast<CItemWeapon*>(PTarget->m_Weapons[SLOT_MAIN]);
-                        SKILLTYPE skilltype = SKILLTYPE::SKILL_NONE;
+                        int16     naturalh2hDMG = 0;
+                        auto*     targ_weapon   = dynamic_cast<CItemWeapon*>(PTarget->m_Weapons[SLOT_MAIN]);
+                        SKILLTYPE skilltype     = SKILLTYPE::SKILL_NONE;
 
                         if (PTarget->objtype == TYPE_PC)
                         {

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -13571,39 +13571,6 @@ bool CLuaBaseEntity::isWeaponTwoHanded()
 }
 
 /************************************************************************
- *  Function: getMeleeHitDamage()
- *  Purpose : Calculates and returns total damage for a single hit
- *  Example : getMeleeHitDamage(Attacker,Local Hit Rate)
- *  Notes   : Battleutils calculates hit rate already, so inserting hit rate
- *          : here only increases chance of missing (assuming < 100)?
- *          : Not currently used in any scripts (handled by battleutils) - Is this even needed?
- ************************************************************************/
-
-int CLuaBaseEntity::getMeleeHitDamage(CLuaBaseEntity* PLuaBaseEntity, sol::object const& arg1)
-{
-    if (m_PBaseEntity->objtype == TYPE_NPC)
-    {
-        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->getName());
-        return 0;
-    }
-
-    CBattleEntity* PAttacker = static_cast<CBattleEntity*>(m_PBaseEntity);
-    CBattleEntity* PDefender = static_cast<CBattleEntity*>(PLuaBaseEntity->GetBaseEntity());
-
-    uint8 hitrate = (arg1 == sol::lua_nil) ? battleutils::GetHitRate(PAttacker, PDefender) : arg1.as<uint8>();
-
-    if (xirand::GetRandomNumber(100) < hitrate)
-    {
-        float DamageRatio = battleutils::GetDamageRatio(PAttacker, PDefender, false, 0.f);
-        int   damage      = (uint16)((PAttacker->GetMainWeaponDmg() + battleutils::GetFSTR(PAttacker, PDefender, SLOT_MAIN)) * DamageRatio);
-
-        return damage;
-    }
-
-    return -1;
-}
-
-/************************************************************************
  *  Function: getWeaponDmg()
  *  Purpose : Returns the real damage value of a Weapon in the Main slot
  *  Example : local weaponDamage = attacker:getWeaponDmg()
@@ -17817,7 +17784,6 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("handleAfflatusMiseryDamage", CLuaBaseEntity::handleAfflatusMiseryDamage);
 
     SOL_REGISTER("isWeaponTwoHanded", CLuaBaseEntity::isWeaponTwoHanded);
-    SOL_REGISTER("getMeleeHitDamage", CLuaBaseEntity::getMeleeHitDamage);
     SOL_REGISTER("getWeaponDmg", CLuaBaseEntity::getWeaponDmg);
     SOL_REGISTER("getWeaponDmgRank", CLuaBaseEntity::getWeaponDmgRank);
     SOL_REGISTER("getOffhandDmg", CLuaBaseEntity::getOffhandDmg);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -692,15 +692,14 @@ public:
     void  handleAfflatusMiseryDamage(double damage);
 
     bool   isWeaponTwoHanded();
-    int    getMeleeHitDamage(CLuaBaseEntity* PLuaBaseEntity, sol::object const& arg1); // gets the damage of a single hit vs the specified mob
-    uint16 getWeaponDmg();                                                             // gets the current equipped weapons' DMG rating
-    uint16 getWeaponDmgRank();                                                         // gets the current equipped weapons' DMG rating for Rank calc
-    uint16 getOffhandDmg();                                                            // gets the current equipped offhand's DMG rating (used in WS calcs)
-    uint16 getOffhandDmgRank();                                                        // gets the current equipped offhand's DMG rating for Rank calc
-    uint16 getRangedDmg();                                                             // Get ranged weapon DMG rating
-    uint16 getRangedDmgRank();                                                         // Get ranged weapond DMG rating used for calculating rank
-    uint16 getAmmoDmg();                                                               // Get ammo DMG rating
-    uint16 getWeaponHitCount(bool offhand);                                            // Get PC weapon hit count (Occasionally Attacks N times weapons)
+    uint16 getWeaponDmg();                  // gets the current equipped weapons' DMG rating
+    uint16 getWeaponDmgRank();              // gets the current equipped weapons' DMG rating for Rank calc
+    uint16 getOffhandDmg();                 // gets the current equipped offhand's DMG rating (used in WS calcs)
+    uint16 getOffhandDmgRank();             // gets the current equipped offhand's DMG rating for Rank calc
+    uint16 getRangedDmg();                  // Get ranged weapon DMG rating
+    uint16 getRangedDmgRank();              // Get ranged weapond DMG rating used for calculating rank
+    uint16 getAmmoDmg();                    // Get ammo DMG rating
+    uint16 getWeaponHitCount(bool offhand); // Get PC weapon hit count (Occasionally Attacks N times weapons)
 
     void removeAmmo();
 

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -814,7 +814,7 @@ namespace battleutils
                 bool crit = battleutils::GetCritHitRate(PDefender, PAttacker, true) > xirand::GetRandomNumber(100);
 
                 // Dmg math.
-                float  DamageRatio = GetDamageRatio(PDefender, PAttacker, crit, 0.f, skilltype);
+                float  DamageRatio = GetDamageRatio(PDefender, PAttacker, crit, 1.f, skilltype);
                 uint16 dmg         = (uint32)((PDefender->GetMainWeaponDmg() + battleutils::GetFSTR(PDefender, PAttacker, SLOT_MAIN)) * DamageRatio);
                 dmg                = attackutils::CheckForDamageMultiplier(((CCharEntity*)PDefender), dynamic_cast<CItemWeapon*>(PDefender->m_Weapons[SLOT_MAIN]), dmg,
                                                                            PHYSICAL_ATTACK_TYPE::NORMAL, SLOT_MAIN);
@@ -2899,8 +2899,8 @@ namespace battleutils
         float pDIF = 1.0f;
 
         auto levelCorrectionFunc = lua["xi"]["combat"]["levelCorrection"]["isLevelCorrectedZone"];
-        auto meleePDIFFunc = lua["xi"]["combat"]["physical"]["calculateMeleePDIF"];
-        auto luaAttackerEntity = CLuaBaseEntity(PAttacker);
+        auto meleePDIFFunc       = lua["xi"]["combat"]["physical"]["calculateMeleePDIF"];
+        auto luaAttackerEntity   = CLuaBaseEntity(PAttacker);
 
         if (meleePDIFFunc.valid() && levelCorrectionFunc.valid())
         {

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -151,7 +151,7 @@ namespace battleutils
     float GetBlockRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
     uint8 GetParryRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
     uint8 GetGuardRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
-    float GetDamageRatio(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool isCritical, float bonusAttPercent);
+    float GetDamageRatio(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool isCritical, float bonusAttPercent, SKILLTYPE weaponType);
 
     int32 TakePhysicalDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, PHYSICAL_ATTACK_TYPE physicalAttackType, int32 damage, bool isBlocked,
                              uint8 slot, uint16 tpMultiplier, CBattleEntity* taChar, bool giveTPtoVictim, bool giveTPtoAttacker, bool isCounter = false,
@@ -201,7 +201,6 @@ namespace battleutils
     uint16 doSoulEaterEffect(CCharEntity* m_PChar, uint32 damage);
     uint16 doConsumeManaEffect(CCharEntity* m_PChar, uint32 damage);
     int32  getOverWhelmDamageBonus(CCharEntity* m_PChar, CBattleEntity* PDefender, int32 damage);
-    uint16 jumpAbility(CBattleEntity* PAttacker, CBattleEntity* PVictim, uint8 tier);
 
     void  TransferEnmity(CBattleEntity* PHateReceiver, CBattleEntity* PHateGiver, CMobEntity* PMob, uint8 percentToTransfer);
     uint8 getBarrageShotCount(CCharEntity* PChar);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Moves auto attack PDIF calculation out to lua.

*Fix Footwork attack bonus being an 80% attack reduction instead of 20% attack bonus (yes, really)
* Changes how crit bonuses are handled to add 1.0 pDIF as expected
* add isWeaponskill to add ability to check for weaponskills (flourishes, other possible bonuses)
* Change ignore DEF to make more sense when it hooks up to weaponskills later
* Add critical defense bonus

## Steps to test these changes

Test auto attacks, counters, crits, various crit buffs, various other things, etc and see damage work correctly.