### PR TITLE
Redo "Begin enumerating some of these magic numbers in core"

### DIFF
--- a/documentation/MessageSystemIDs.log
+++ b/documentation/MessageSystemIDs.log
@@ -1,4 +1,4 @@
-These are typically used with messageBasic. Other message types may possibly use the same index.
+These are typically used with messageSystem or messageStandard. Other message types may possibly use the same index.
 Found in ROM/27/76.dat
 
 0 - You could not enter the next area.

--- a/documentation/message.log
+++ b/documentation/message.log
@@ -1,5 +1,5 @@
 These are typically used with messageBasic. Other message types may possibly use the same index.
-Found in ROM/27/76.dat
+Found in ROM/27/72.dat
 
 000 - dummy (internally used to display nothing)
 001 - <actor> hits <target> for <amount> points of damage.

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -40,6 +40,7 @@
 #include "packets/lock_on.h"
 #include "packets/menu_raisetractor.h"
 #include "packets/message_special.h"
+#include "packets/message_standard.h"
 #include "packets/message_system.h"
 #include "packets/message_text.h"
 #include "packets/release.h"
@@ -2150,9 +2151,9 @@ CBattleEntity* CCharEntity::IsValidTarget(uint16 targid, uint16 validTargetFlags
         if (PTarget->objtype == TYPE_PC && charutils::IsAidBlocked(this, static_cast<CCharEntity*>(PTarget)))
         {
             // Target is blocking assistance
-            errMsg = std::make_unique<CMessageSystemPacket>(0, 0, MSGSYSTEM::TARGET_IS_CURRENTLY_BLOCKING);
+            errMsg = std::make_unique<CMessageSystemPacket>(0, 0, MsgStd::TargetIsCurrentlyBlocking);
             // Interaction was blocked
-            static_cast<CCharEntity*>(PTarget)->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::BLOCKED_BY_BLOCKAID));
+            static_cast<CCharEntity*>(PTarget)->pushPacket(new CMessageSystemPacket(0, 0, MsgStd::BlockedByBlockaid));
         }
         else if (IsMobOwner(PTarget))
         {
@@ -2770,7 +2771,7 @@ void CCharEntity::skipEvent()
     TracyZoneScoped;
     if (!m_Locked && !isInEvent() && (!currentEvent->cutsceneOptions.empty() || currentEvent->interruptText != 0))
     {
-        pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::EVENT_SKIPPED));
+        pushPacket(new CMessageSystemPacket(0, 0, MsgStd::EventSkipped));
         pushPacket(new CReleasePacket(this, RELEASE_TYPE::SKIPPING));
         m_Substate = CHAR_SUBSTATE::SUBSTATE_NONE;
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -495,7 +495,7 @@ void CLuaBaseEntity::messageSpecial(uint16 messageID, sol::variadic_args va)
  *  Notes   :
  ************************************************************************/
 
-void CLuaBaseEntity::messageSystem(MSGSYSTEM messageID, sol::object const& p0, sol::object const& p1)
+void CLuaBaseEntity::messageSystem(MsgStd messageID, sol::object const& p0, sol::object const& p1)
 {
     if (m_PBaseEntity->objtype != TYPE_PC)
     {
@@ -1200,7 +1200,7 @@ void CLuaBaseEntity::release()
     {
         // Message: Event skipped
         releaseType = RELEASE_TYPE::SKIPPING;
-        PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::EVENT_SKIPPED));
+        PChar->pushPacket(new CMessageSystemPacket(0, 0, MsgStd::EventSkipped));
     }
 
     PChar->inSequence = false;
@@ -2921,7 +2921,7 @@ void CLuaBaseEntity::setPos(sol::variadic_args va)
             if (ipp == 0)
             {
                 ShowWarning(fmt::format("Char {} requested zone ({}) returned IPP of 0", PChar->name, zoneid));
-                PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::COULD_NOT_ENTER)); // You could not enter the next area.
+                PChar->pushPacket(new CMessageSystemPacket(0, 0, MsgStd::CouldNotEnter)); // You could not enter the next area.
                 return;
             }
 

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -24,7 +24,7 @@
 
 #include "common/cbasetypes.h"
 #include "luautils.h"
-#include "packets/message_system.h"
+#include "packets/message_standard.h"
 
 class CBaseEntity;
 class CCharEntity;
@@ -60,7 +60,7 @@ public:
                      sol::object const& p2, sol::object const& p3, sol::object const& chat);
     void messagePublic(uint16 messageID, CLuaBaseEntity const* PEntity, sol::object const& arg2, sol::object const& arg3);
     void messageSpecial(uint16 messageID, sol::variadic_args va);
-    void messageSystem(MSGSYSTEM messageID, sol::object const& p0, sol::object const& p1);
+    void messageSystem(MsgStd messageID, sol::object const& p0, sol::object const& p1);
     void messageCombat(sol::object const& speaker, int32 p0, int32 p1, int16 message);
     void messageStandard(uint16 messageID);
 

--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
 Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -294,9 +294,9 @@ namespace message
                     {
                         ref<uint32>((uint8*)extra.data(), 0) = ref<uint32>((uint8*)extra.data(), 6);
                         // Target is blocking assistance
-                        send(MSG_DIRECT, extra.data(), sizeof(uint32), new CMessageSystemPacket(0, 0, MSGSYSTEM::TARGET_IS_CURRENTLY_BLOCKING));
+                        send(MSG_DIRECT, extra.data(), sizeof(uint32), new CMessageSystemPacket(0, 0, MsgStd::TargetIsCurrentlyBlocking));
                         // Interaction was blocked
-                        PInvitee->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::BLOCKED_BY_BLOCKAID));
+                        PInvitee->pushPacket(new CMessageSystemPacket(0, 0, MsgStd::BlockedByBlockaid));
                         // You cannot invite that person at this time.
                         send(MSG_DIRECT, extra.data(), sizeof(uint32), new CMessageStandardPacket(PInvitee, 0, 0, MsgStd::CannotInvite));
                         break;

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -1137,7 +1137,7 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
             else
             {
                 // You don't have any gysahl greens
-                PChar->pushPacket(new CMessageSystemPacket(4545, 0, MSGSYSTEM::YOU_DONT_HAVE_ANY));
+                PChar->pushPacket(new CMessageSystemPacket(4545, 0, MsgStd::YouDontHaveAny));
             }
         }
         break;
@@ -1199,24 +1199,24 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
                 if (type == 0x00 && PChar->getBlockingAid()) // /blockaid off
                 {
                     // Blockaid canceled
-                    PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::BLOCKAID_CANCELED));
+                    PChar->pushPacket(new CMessageSystemPacket(0, 0, MsgStd::BlockaidCanceled));
                     PChar->setBlockingAid(false);
                 }
                 else if (type == 0x01 && !PChar->getBlockingAid()) // /blockaid on
                 {
                     // Blockaid activated
-                    PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::BLOCKAID_ACTIVATED));
+                    PChar->pushPacket(new CMessageSystemPacket(0, 0, MsgStd::BlockaidActivated));
                     PChar->setBlockingAid(true);
                 }
                 else if (type == 0x02) // /blockaid
                 {
                     // Blockaid is currently active/inactive
-                    PChar->pushPacket(new CMessageSystemPacket(0, 0, PChar->getBlockingAid() ? MSGSYSTEM::BLOCKAID_CURRENTLY_ACTIVE : MSGSYSTEM::BLOCKAID_CURRENTLY_INACTIVE));
+                    PChar->pushPacket(new CMessageSystemPacket(0, 0, PChar->getBlockingAid() ? MsgStd::BlockaidCurrentlyActive : MsgStd::BlockaidCurrentlyInactive));
                 }
             }
             else
             {
-                PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::CANNOT_USE_COMMAND_AT_THE_MOMENT));
+                PChar->pushPacket(new CMessageSystemPacket(0, 0, MsgStd::CannotUseCommandAtTheMoment));
             }
         }
         break;
@@ -1592,9 +1592,9 @@ void SmallPacket0x032(map_session_data_t* const PSession, CCharEntity* const PCh
         {
             ShowDebug("%s is blocking trades", PTarget->getName());
             // Target is blocking assistance
-            PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::TARGET_IS_CURRENTLY_BLOCKING));
+            PChar->pushPacket(new CMessageSystemPacket(0, 0, MsgStd::TargetIsCurrentlyBlocking));
             // Interaction was blocked
-            PTarget->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::BLOCKED_BY_BLOCKAID));
+            PTarget->pushPacket(new CMessageSystemPacket(0, 0, MsgStd::BlockedByBlockaid));
             PChar->pushPacket(new CTradeActionPacket(PTarget, 0x07));
             return;
         }
@@ -1874,7 +1874,7 @@ void SmallPacket0x036(map_session_data_t* const PSession, CCharEntity* const PCh
     if (PChar->StatusEffectContainer->HasStatusEffectByFlag(EFFECTFLAG_INVISIBLE))
     {
         // "You cannot use that command while invisible."
-        PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::CANNOT_WHILE_INVISIBLE));
+        PChar->pushPacket(new CMessageSystemPacket(0, 0, MsgStd::CannotWhileInvisible));
         return;
     }
 
@@ -4036,7 +4036,7 @@ void SmallPacket0x05E(map_session_data_t* const PSession, CCharEntity* const PCh
 
                 PChar->loc.p.rotation += 128;
 
-                PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::COULD_NOT_ENTER)); // You could not enter the next area.
+                PChar->pushPacket(new CMessageSystemPacket(0, 0, MsgStd::CouldNotEnter)); // You could not enter the next area.
                 PChar->pushPacket(new CCSPositionPacket(PChar));
 
                 PChar->status = STATUS_TYPE::NORMAL;
@@ -4046,7 +4046,7 @@ void SmallPacket0x05E(map_session_data_t* const PSession, CCharEntity* const PCh
             {
                 PChar->loc.p.rotation += 128;
 
-                PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::COULD_NOT_ENTER)); // You could not enter the next area.
+                PChar->pushPacket(new CMessageSystemPacket(0, 0, MsgStd::CouldNotEnter)); // You could not enter the next area.
                 PChar->pushPacket(new CCSPositionPacket(PChar));
 
                 PChar->status = STATUS_TYPE::NORMAL;
@@ -4062,7 +4062,7 @@ void SmallPacket0x05E(map_session_data_t* const PSession, CCharEntity* const PCh
 
                     PChar->loc.p.rotation += 128;
 
-                    PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::COULD_NOT_ENTER)); // You could not enter the next area.
+                    PChar->pushPacket(new CMessageSystemPacket(0, 0, MsgStd::CouldNotEnter)); // You could not enter the next area.
                     PChar->pushPacket(new CCSPositionPacket(PChar));
 
                     PChar->status = STATUS_TYPE::NORMAL;
@@ -4104,7 +4104,7 @@ void SmallPacket0x05E(map_session_data_t* const PSession, CCharEntity* const PCh
 
         PChar->loc.p.rotation += 128;
 
-        PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::COULD_NOT_ENTER)); // You could not enter the next area.
+        PChar->pushPacket(new CMessageSystemPacket(0, 0, MsgStd::CouldNotEnter)); // You could not enter the next area.
         PChar->pushPacket(new CCSPositionPacket(PChar));
 
         PChar->status = STATUS_TYPE::NORMAL;
@@ -4291,11 +4291,11 @@ void SmallPacket0x06E(map_session_data_t* const PSession, CCharEntity* const PCh
                     {
                         ShowDebug("%s is blocking party invites", PInvitee->getName());
                         // Target is blocking assistance
-                        PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::TARGET_IS_CURRENTLY_BLOCKING));
+                        PChar->pushPacket(new CMessageSystemPacket(0, 0, MsgStd::TargetIsCurrentlyBlocking));
                         // Interaction was blocked
-                        PInvitee->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::BLOCKED_BY_BLOCKAID));
+                        PInvitee->pushPacket(new CMessageSystemPacket(0, 0, MsgStd::BlockedByBlockaid));
                         // You cannot invite that person at this time.
-                        PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::YOU_CANNOT_INVITE_THAT_PERSON));
+                        PChar->pushPacket(new CMessageSystemPacket(0, 0, MsgStd::CannotInvite));
                         break;
                     }
                     if (PInvitee->StatusEffectContainer->HasStatusEffect(EFFECT_LEVEL_SYNC))
@@ -4362,11 +4362,11 @@ void SmallPacket0x06E(map_session_data_t* const PSession, CCharEntity* const PCh
                     {
                         ShowDebug("%s is blocking alliance invites", PInvitee->getName());
                         // Target is blocking assistance
-                        PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::TARGET_IS_CURRENTLY_BLOCKING));
+                        PChar->pushPacket(new CMessageSystemPacket(0, 0, MsgStd::TargetIsCurrentlyBlocking));
                         // Interaction was blocked
-                        PInvitee->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::BLOCKED_BY_BLOCKAID));
+                        PInvitee->pushPacket(new CMessageSystemPacket(0, 0, MsgStd::BlockedByBlockaid));
                         // You cannot invite that person at this time.
-                        PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::YOU_CANNOT_INVITE_THAT_PERSON));
+                        PChar->pushPacket(new CMessageSystemPacket(0, 0, MsgStd::CannotInvite));
                         break;
                     }
                     // make sure intvitee isn't dead or in jail, they are an unallied party leader and don't already have an invite pending
@@ -6250,7 +6250,7 @@ void SmallPacket0x0DC(map_session_data_t* const PSession, CCharEntity* const PCh
             }
             if (flags != PChar->nameflags.flags)
             {
-                PChar->pushPacket(new CMessageSystemPacket(0, 0, param == 1 ? MSGSYSTEM::CHARACTER_INFO_HIDDEN : MSGSYSTEM::CHARACTER_INFO_SHOWN));
+                PChar->pushPacket(new CMessageSystemPacket(0, 0, param == 1 ? MsgStd::CharacterInfoHidden : MsgStd::CharacterInfoShown));
             }
             break;
         }

--- a/src/map/packets/message_basic.h
+++ b/src/map/packets/message_basic.h
@@ -31,6 +31,8 @@
  * in the messageID parameter.
  * Located in 1-27-72.xml if using MassExtractor -full-scan
  */
+
+// Todo: move to enum class
 enum MSGBASIC_ID : uint16
 {
     MSGBASIC_NONE                  = 0,   // Display nothing

--- a/src/map/packets/message_system.cpp
+++ b/src/map/packets/message_system.cpp
@@ -23,7 +23,7 @@
 
 #include "message_system.h"
 
-CMessageSystemPacket::CMessageSystemPacket(uint32 param0, uint32 param1, MSGSYSTEM messageID)
+CMessageSystemPacket::CMessageSystemPacket(uint32 param0, uint32 param1, MsgStd messageID)
 {
     this->setType(0x53);
     this->setSize(0x10);

--- a/src/map/packets/message_system.h
+++ b/src/map/packets/message_system.h
@@ -25,60 +25,12 @@
 #include "common/cbasetypes.h"
 
 #include "basic.h"
-
-// Found in ROM/27/76.dat
-// clang-format off
-enum class MSGSYSTEM : uint16
-{
-    // COULD_NOT_ENTER                  = 0,   // You could not enter the next area. (duplicate)
-    // COULD_NOT_ENTER                  = 1,   // You could not enter the next area. (duplicate)
-    COULD_NOT_ENTER                  = 2,   // You could not enter the next area.
-    // COULD_NOT_ENTER                  = 3,   // You could not enter the next area. (duplicate)
-    // COULD_NOT_ENTER                  = 4,   // You could not enter the next area. (duplicate)
-    COULD_NOT_ENTER_YOUR_ROOM        = 5,   // You could not enter your room.
-
-    YOU_CANNOT_INVITE_THAT_PERSON    = 23,  // You cannot invite that person at this time.
-
-    YOU_DONT_HAVE_ANY                = 39,  // You don't have any <item>.
-
-    EVENT_SKIPPED                    = 117, // Event skipped.
-
-    CHOCOBO_REFUSED_TO_ENTER         = 138, // The chocobo refused to enter the next area.
-
-    CANNOT_USE_COMMAND_AT_THE_MOMENT = 142, // You cannot use that command at the moment. Please try again later.
-
-    CANNOT_WHILE_INVISIBLE           = 172, // You cannot use that command while invisible.
-
-    CHARACTER_INFO_HIDDEN            = 175, // Your character information is now hidden.
-    CHARACTER_INFO_SHOWN             = 176, // Your character information is now shown.
-
-    TELL_RECIPITENT_AWAY             = 181, // Your tell was not received. The recipient is currently away.
-    PERSON_ALREADY_IN_ALLIANCE       = 182, // That person is already in an alliance.
-    UNABLE_TO_PROCESS_REQUEST        = 183, // Unable to process request.
-    EXPANSION_PACK_NOT_REGISTERED    = 184, // Unable to enter next area. Expansion pack not registered.
-    EXPANSION_PACK_NOT_INSTALLED     = 185, // Unable to enter next area. Expansion pack not installed.
-
-    BLOCKAID_ACTIVATED               = 221, // Blockaid activated. Magical assistance, trades, party invites etc. from non-party/alliance characters will be blocked. This effect will continue until changing areas, or executing the "/blockaid off" command.
-    BLOCKAID_CANCELED                = 222, // Blockaid canceled. Magical assistance, trades, party invites etc. from non-party/alliance characters will be allowed.
-    BLOCKAID_CURRENTLY_ACTIVE        = 223, // Blockaid is currently active. ("/blockaid off" to cancel.)
-    BLOCKAID_CURRENTLY_INACTIVE      = 224, // Blockaid is currently inactive.
-
-    TARGET_IS_CURRENTLY_BLOCKING     = 225, // Target is currently blocking outside magical assistance, trades, and party invites.
-    BLOCKED_BY_BLOCKAID              = 226, // Interaction from a non-party character was blocked by /blockaid.
-
-    TRUST_NO_SEEKING_PARTY           = 296, // You cannot use Trust magic while seeking a party.
-    TRUST_DELAY_NEW_PARTY_MEMBER     = 297, // While inviting a party member, you must wait a while before using Trust magic.
-    TRUST_MAXIMUM_NUMBER             = 298, // You have called forth your maximum number of alter egos.
-    TRUST_ALREADY_CALLED             = 299, // That alter ego has already been called forth.
-    TRUST_NO_ENMITY                  = 300, // You cannot use Trust magic while having gained enmity.
-    TRUST_SOLO_OR_LEADER             = 301, // You cannot use Trust magic unless you are solo or the party leader.
-};
-// clang-format on
+#include "message_standard.h"
 
 class CMessageSystemPacket : public CBasicPacket
 {
 public:
-    CMessageSystemPacket(uint32 param0, uint32 param1, MSGSYSTEM messageID);
+    CMessageSystemPacket(uint32 param0, uint32 param1, MsgStd messageID);
 };
 
 #endif

--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -36,6 +36,7 @@
 #include "packets/inventory_finish.h"
 #include "packets/inventory_item.h"
 #include "packets/message_special.h"
+#include "packets/message_standard.h"
 #include "packets/message_system.h"
 #include "packets/message_text.h"
 #include "packets/release.h"
@@ -1972,7 +1973,7 @@ namespace fishingutils
             if (PChar->animation != ANIMATION_NONE)
             {
                 PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_CANNOTFISH_MOMENT));
-                PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::CANNOT_USE_COMMAND_AT_THE_MOMENT));
+                PChar->pushPacket(new CMessageSystemPacket(0, 0, MsgStd::CannotUseCommandAtTheMoment));
                 PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::FISHING));
 
                 return;
@@ -2010,13 +2011,13 @@ namespace fishingutils
             }
             else
             {
-                PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::CANNOT_USE_COMMAND_AT_THE_MOMENT));
+                PChar->pushPacket(new CMessageSystemPacket(0, 0, MsgStd::CannotUseCommandAtTheMoment));
                 PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::FISHING));
             }
         }
         else
         {
-            PChar->pushPacket(new CMessageSystemPacket(0, 0, MSGSYSTEM::CANNOT_USE_COMMAND_AT_THE_MOMENT));
+            PChar->pushPacket(new CMessageSystemPacket(0, 0, MsgStd::CannotUseCommandAtTheMoment));
             PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::FISHING));
 
             return;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
(note: I started with a revert and then wound up squashing my revert)

This reverts commits 3721dd511dcd9047e52fef9e1e06a8f02ee6e43c and c4700f03e50435edc57e28ce38e0a06d8bcb1e0a and then combines what was placed into MSGSYSTEM with MsgStd, because:
1. It's the same dat in the client and should be one list.
2. I used the wrong format for an enum class, like many enum classes we have not yet reformatted

I changed a few of the enum names to be a bit more verbose for human readability. Placeholdering for future enum work is now also gutted. The end result here should be a good bit tidier. Caught some typos as well.

There is further work that can and should be done, but I am not up for it at this time.

## Steps to test these changes
`!exec player:messageSystem(id here)`