### PR TITLE
[CPP] Exclude dynamic entities from query cache

### DIFF
--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -247,11 +247,16 @@ QueryByNameResult_t const& CZone::queryEntitiesByName(std::string const& pattern
 {
     TracyZoneScoped;
 
-    // Use memoization since lookups are typically for the same mob names
-    auto result = m_queryByNameResults.find(pattern);
-    if (result != m_queryByNameResults.end())
+    // Always ignore cache for queries explicitly looking for dynamic entities
+    // TODO: make this memoization work for dynamic entities somehow?
+    if (pattern.rfind("DE_", 0) != 0)
     {
-        return result->second;
+        // Use memoization since lookups are typically for the same mob names
+        auto result = m_queryByNameResults.find(pattern);
+        if (result != m_queryByNameResults.end())
+        {
+            return result->second;
+        }
     }
 
     std::vector<CBaseEntity*> entities;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Currently, `queryEntitiesByName` caches the list of entities based on the search pattern. This is fine for static entities initialized at zone startup, but dynamic entities cannot fit this paradigm. I've racked my brain for various methods of doing this, and settled on what I imagine will not be the acceptable one. This technically works if your query starts with `DE_`, but the more I think about this the less I think we can cleanly have this function cache while also supporting dynamic entities. There's a few scenario that must be considered:

- Query for a particular pattern is run and has no dynamic entities in it. DE is inserted that matches the name pattern and query is run again. The memoization will return the previous list and not include the DE
- Query for a particular pattern is run and includes a DE. The DE is then deallocated and the query is run again. This time you get an entity object returned by `queryEntitiesByName` which doesn't actually map to an existing entity in the zone (since the cache uses `std::move` to store the entity list)
- The rest are variations on multiple DE with the same name being created/destroyed and attempting to query for the most current list.

Essentially, this PR only addresses the last one. Perhaps the first 2 scenarios are acceptable and we accept that queries don't get cached if they start with `DE_` explicitly? I had an idea to check the list of entities in the cache for having nullptr records using `zoneutil::GetEntity`, but i'm pretty sure that's less efficient on average than just running the full query every time.

Finally, another idea I had was to set a bool to cache a query and if any result is a dynamic entity, then don't save the entity list at all. This would catch scenario 2 and 3, but still not 1. Again I'm somewhat convinced dynamic entities break the paradigm of this function's optimization altogether.

## Steps to test these changes

This particular fix simply ignores the cache when `zone:queryEntitiesByName(str)` is run with `str` starting with `DE_`. 

Inserting a dynamic entity in the zone and running the query multiple times can be shown to always return the real list of entities with the particular name. 