### PR TITLE
[core] [lua] Audit Hasso and Desperate Blows (2H only stats)

### DIFF
--- a/scripts/effects/hasso.lua
+++ b/scripts/effects/hasso.lua
@@ -6,18 +6,18 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.STR, effect:getPower())
-    target:addMod(xi.mod.HASTE_ABILITY, 1000)
-    target:addMod(xi.mod.ACC, 10)
+    target:addMod(xi.mod.TWOHAND_STR, effect:getPower())
+    target:addMod(xi.mod.TWOHAND_HASTE_ABILITY, 1000)
+    target:addMod(xi.mod.TWOHAND_ACC, 10)
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.STR, effect:getPower())
-    target:delMod(xi.mod.HASTE_ABILITY, 1000)
-    target:delMod(xi.mod.ACC, 10)
+    target:delMod(xi.mod.TWOHAND_STR, effect:getPower())
+    target:delMod(xi.mod.TWOHAND_HASTE_ABILITY, 1000)
+    target:delMod(xi.mod.TWOHAND_ACC, 10)
 end
 
 return effectObject

--- a/scripts/effects/last_resort.lua
+++ b/scripts/effects/last_resort.lua
@@ -8,7 +8,7 @@ effectObject.onEffectGain = function(target, effect)
 
     target:addMod(xi.mod.ATT, 2 * jpValue)
     target:addMod(xi.mod.ATTP, 25 + target:getMerit(xi.merit.LAST_RESORT_EFFECT))
-    target:addMod(xi.mod.HASTE_ABILITY, target:getMod(xi.mod.DESPERATE_BLOWS) + target:getMerit(xi.merit.DESPERATE_BLOWS))
+    target:addMod(xi.mod.TWOHAND_HASTE_ABILITY, target:getMod(xi.mod.DESPERATE_BLOWS) + target:getMerit(xi.merit.DESPERATE_BLOWS))
 
     -- Gear that affects this mod is handled by a Latent Effect because the gear must remain equipped
     target:addMod(xi.mod.DEFP, -25 - target:getMerit(xi.merit.LAST_RESORT_EFFECT))
@@ -22,7 +22,7 @@ effectObject.onEffectLose = function(target, effect)
 
     target:delMod(xi.mod.ATT, 2 * jpValue)
     target:delMod(xi.mod.ATTP, 25 + target:getMerit(xi.merit.LAST_RESORT_EFFECT))
-    target:delMod(xi.mod.HASTE_ABILITY, target:getMod(xi.mod.DESPERATE_BLOWS) + target:getMerit(xi.merit.DESPERATE_BLOWS))
+    target:delMod(xi.mod.TWOHAND_HASTE_ABILITY, target:getMod(xi.mod.DESPERATE_BLOWS) + target:getMerit(xi.merit.DESPERATE_BLOWS))
     -- Gear that affects this mod is handled by a Latent Effect because the gear must remain equipped
     target:delMod(xi.mod.DEFP, -25 - target:getMerit(xi.merit.LAST_RESORT_EFFECT))
 end

--- a/scripts/enum/mod.lua
+++ b/scripts/enum/mod.lua
@@ -30,6 +30,8 @@ xi.mod =
     MND                             = 13,
     CHR                             = 14,
 
+    TWOHAND_STR                     = 218, -- Same as STR, but only active when using a two handed weapon (e.g. Hasso)
+
     -- Magic Evasion versus elements
     -- This has been repeatedly mixed up with SDT - be careful!
     FIRE_MEVA                       = 15,
@@ -55,6 +57,7 @@ xi.mod =
     RATT                            = 24,
     ACC                             = 25,
     RACC                            = 26,
+    TWOHAND_ACC                     = 219, -- Same as ACC, but only active when using a two handed weapon (e.g. Hasso)
     ENMITY                          = 27,
     ENMITY_LOSS_REDUCTION           = 427,
     MATT                            = 28,
@@ -557,6 +560,7 @@ xi.mod =
     EXP_BONUS                       = 382,
     HASTE_ABILITY                   = 383,
     HASTE_GEAR                      = 384,
+    TWOHAND_HASTE_ABILITY           = 217, -- Only applies to auto attacks when using two handed weapons, additive to HASTE_ABILITY
     SHIELD_BASH                     = 385,
     KICK_DMG                        = 386,
     CHARM_CHANCE                    = 391,

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -341,6 +341,11 @@ int16 CBattleEntity::GetWeaponDelay(bool tp)
             int16 hasteAbility = std::clamp<int16>(getMod(Mod::HASTE_ABILITY), -2500, 2500); // 25% cap
             int16 hasteGear    = std::clamp<int16>(getMod(Mod::HASTE_GEAR), -2500, 2500);    // 25%
 
+            if (weapon->isTwoHanded())
+            {
+                hasteAbility = std::clamp<int16>(getMod(Mod::HASTE_ABILITY) + getMod(Mod::TWOHAND_HASTE_ABILITY), -2500, 2500); // 25% cap
+            }
+
             // Check if we are using a special attack list that should not be affected by attack speed debuffs
             // Example: Wyrm's flying auto attack speed should not be modified by debuffs.
             bool specialAttackList = false;
@@ -658,6 +663,11 @@ int32 CBattleEntity::takeDamage(int32 amount, CBattleEntity* attacker /* = nullp
 
 uint16 CBattleEntity::STR()
 {
+    // Hasso gives STR only if main weapon is two handed
+    if (auto* weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_MAIN]); weapon->isTwoHanded())
+    {
+        return std::clamp(stats.STR + m_modStat[Mod::STR] + m_modStat[Mod::TWOHAND_STR], 0, 999);
+    }
     return std::clamp(stats.STR + m_modStat[Mod::STR], 0, 999);
 }
 
@@ -825,6 +835,7 @@ uint16 CBattleEntity::ACC(uint8 attackNumber, uint8 offsetAccuracy)
         if (auto* weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_MAIN]); weapon && weapon->isTwoHanded())
         {
             ACC += (int16)(DEX() * 0.75);
+            ACC += m_modStat[Mod::TWOHAND_ACC];
         }
         else
         {

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -41,6 +41,8 @@ enum class Mod
     MND = 13, // Mind
     CHR = 14, // Charisma
 
+    TWOHAND_STR = 218, // Same as STR, but only active when using a two handed weapon (e.g. Hasso)
+
     // Magic Evasion versus elements
     // This has been repeatedly mixed up with SDT - be careful!
     FIRE_MEVA    = 15, // Fire Magic Evasion
@@ -67,6 +69,8 @@ enum class Mod
 
     ACC  = 25, // Accuracy
     RACC = 26, // Ranged Accuracy
+
+    TWOHAND_ACC = 219, // Same as ACC, but only active when using a two handed weapon (e.g. Hasso)
 
     ENMITY                = 27,  // Enmity
     ENMITY_LOSS_REDUCTION = 427, // Reduces Enmity lost when taking damage
@@ -260,10 +264,11 @@ enum class Mod
     TACTICAL_GUARD = 899, // Tp increase when guarding
     GUARD_PERCENT  = 976, // Guard Percent
 
-    HASTE_MAGIC    = 167, // Haste (and Slow) from magic - 10000 base, 375 = 3.75%
-    HASTE_ABILITY  = 383, // Haste (and Slow) from abilities - 10000 base, 375 = 3.75%
-    HASTE_GEAR     = 384, // Haste (and Slow) from equipment - 10000 base, 375 = 3.75%
-    SPELLINTERRUPT = 168, // % Spell Interruption Rate
+    HASTE_MAGIC           = 167, // Haste (and Slow) from magic - 10000 base, 375 = 3.75%
+    HASTE_ABILITY         = 383, // Haste (and Slow) from abilities - 10000 base, 375 = 3.75%
+    HASTE_GEAR            = 384, // Haste (and Slow) from equipment - 10000 base, 375 = 3.75%
+    TWOHAND_HASTE_ABILITY = 217, // Haste (and Slow) from abilities - 10000 base, 375 = 3.75% - Only applies to auto attacks when using two handed weapons, additive to HASTE_ABILITY
+    SPELLINTERRUPT        = 168, // % Spell Interruption Rate
 
     // New movement speed modifiers.
     MOVE_SPEED_OVERIDE        = 169, // Modifier used to overide regular speed caps. (GM speed and Feast of Swords)
@@ -1003,7 +1008,7 @@ enum class Mod
     //
     // SPARE IDs:
     // 141
-    // 217 to 223
+    // 220 to 223
     // 273 to 277
     //
     // SPARE = 1080 and onward

--- a/src/map/packets/char_stats.cpp
+++ b/src/map/packets/char_stats.cpp
@@ -27,6 +27,7 @@
 #include "char_stats.h"
 
 #include "entities/charentity.h"
+#include "items/item_weapon.h"
 #include "modifier.h"
 #include "roe.h"
 #include "utils/charutils.h"
@@ -49,7 +50,15 @@ CCharStatsPacket::CCharStatsPacket(CCharEntity* PChar)
 
     memcpy(data + (0x14), &PChar->stats, 14); // TODO: it won't work with merits
 
-    ref<uint16>(0x22) = std::clamp<int16>(PChar->getMod(Mod::STR), -999 + PChar->stats.STR, 999 - PChar->stats.STR);
+    // Hasso gives STR only if main weapon is two handed
+    if (auto* weapon = dynamic_cast<CItemWeapon*>(PChar->m_Weapons[SLOT_MAIN]); weapon->isTwoHanded())
+    {
+        ref<uint16>(0x22) = std::clamp<int16>(PChar->getMod(Mod::STR) + PChar->getMod(Mod::TWOHAND_STR), -999 + PChar->stats.STR, 999 - PChar->stats.STR);
+    }
+    else
+    {
+        ref<uint16>(0x22) = std::clamp<int16>(PChar->getMod(Mod::STR), -999 + PChar->stats.STR, 999 - PChar->stats.STR);
+    }
     ref<uint16>(0x24) = std::clamp<int16>(PChar->getMod(Mod::DEX), -999 + PChar->stats.DEX, 999 - PChar->stats.DEX);
     ref<uint16>(0x26) = std::clamp<int16>(PChar->getMod(Mod::VIT), -999 + PChar->stats.VIT, 999 - PChar->stats.VIT);
     ref<uint16>(0x28) = std::clamp<int16>(PChar->getMod(Mod::AGI), -999 + PChar->stats.AGI, 999 - PChar->stats.AGI);

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -2028,8 +2028,7 @@ namespace charutils
 
                         if (!((CItemWeapon*)PChar->m_Weapons[SLOT_MAIN])->isTwoHanded())
                         {
-                            PChar->StatusEffectContainer->DelStatusEffect(EFFECT_HASSO);
-                            PChar->StatusEffectContainer->DelStatusEffect(EFFECT_SEIGAN);
+                            PChar->StatusEffectContainer->DelStatusEffect(EFFECT_SEIGAN); // TODO: make seigan-specific effects not function without a 2H weapon so it doesn't have to be deleted if a weapon is removed
                         }
                     }
                     PChar->look.main = PItem->getModelId();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Per retail testing, STR, ACC and Job Ability haste from hasso only applies when you have a two handed weapon equipped. Additionally, the ability haste from Hasso is apparently not factored in to recast timers.

Desperate Blows also only works on 2H weapons, and its 25% JA haste (from 99 DRK with 5/5 DB merits) doesn't effect recast timers either.

## Steps to test these changes

Use hasso, see its effects only work on 2H (use the equip menu, `!exec print(player:getStat(xi.mod.STR))` and `!exec print(player:getACC())`)
Breakpoint to check that the delay is being set properly in BattleEntity.cpp.
