### PR TITLE
[core] Fix a bunch of "new" with no "delete" from Valgrind tests

### DIFF
--- a/src/common/taskmgr.cpp
+++ b/src/common/taskmgr.cpp
@@ -27,6 +27,17 @@
 #include "common/tracy.h"
 #include "common/utils.h"
 
+CTaskMgr::~CTaskMgr()
+{
+    while (!m_TaskList.empty())
+    {
+        CTask* PTask = m_TaskList.top();
+        m_TaskList.pop();
+
+        destroy(PTask);
+    }
+}
+
 CTaskMgr::CTask* CTaskMgr::AddTask(std::string const& InitName, time_point InitTick, std::any InitData, TASKTYPE InitType, TaskFunc_t InitFunc, duration InitInterval)
 {
     TracyZoneScoped;
@@ -56,6 +67,7 @@ void CTaskMgr::RemoveTask(std::string const& TaskName)
         m_TaskList.pop();
 
         // Don't add tasks we're trying to remove to the new pq
+        // FIXME: duplicate task names AREN'T checked on insert!
         if (PTask->m_name != TaskName)
         {
             newPq.push(PTask);
@@ -63,6 +75,7 @@ void CTaskMgr::RemoveTask(std::string const& TaskName)
         else
         {
             ++tasksRemoved;
+            destroy(PTask);
         }
     }
 

--- a/src/common/taskmgr.h
+++ b/src/common/taskmgr.h
@@ -43,6 +43,7 @@ class CTaskMgr : public Singleton<CTaskMgr>
 {
 public:
     class CTask;
+    ~CTaskMgr();
     enum TASKTYPE
     {
         TASK_INTERVAL,

--- a/src/map/ability.cpp
+++ b/src/map/ability.cpp
@@ -434,6 +434,31 @@ namespace ability
         }
     }
 
+    void CleanupAbilitiesList()
+    {
+        // Call delete on Charge_t* in PChargeslist, because these are not STL containers and will not be destructed
+        for (auto* charge : PChargesList)
+        {
+            destroy(charge);
+        }
+
+        // Delete everything in the abilities list
+        for (int i = 0; i < MAX_ABILITY_ID; i++)
+        {
+            if (PAbilityList[i])
+            {
+                destroy(PAbilityList[i]);
+            }
+        }
+
+        // Clear every vector that now has invalid pointers
+        for (auto vec : PAbilitiesList)
+        {
+            vec.clear();
+        }
+
+        PChargesList.clear();
+    }
     /************************************************************************
      *                                                                       *
      *  Get Ability By ID                                                    *

--- a/src/map/ability.h
+++ b/src/map/ability.h
@@ -773,6 +773,7 @@ private:
 namespace ability
 {
     void LoadAbilitiesList();
+    void CleanupAbilitiesList();
 
     CAbility* GetAbility(uint16 AbilityID);
 

--- a/src/map/ai/controllers/automaton_controller.cpp
+++ b/src/map/ai/controllers/automaton_controller.cpp
@@ -145,7 +145,7 @@ bool CAutomatonController::shouldStandBack()
 
     if (PMaster)
     {
-        CItemWeapon* animator = static_cast<CItemWeapon*>(PMaster->m_Weapons[SLOT_AMMO]);
+        CItemWeapon* animator = dynamic_cast<CItemWeapon*>(PMaster->m_Weapons[SLOT_AMMO]);
 
         if (animator && animator->getSubSkillType() == SUBSKILLTYPE::SUBSKILL_ANIMATOR_II)
         {

--- a/src/map/attackround.cpp
+++ b/src/map/attackround.cpp
@@ -294,7 +294,7 @@ void CAttackRound::CreateAttacks(CItemWeapon* PWeapon, PHYSICAL_ATTACK_DIRECTION
     // Daken is handled separately in CreateDakenAttack() and Zanshin in src/map/entities/battleentity.cpp#L1768
 
     // Checking Mikage Effect - Hits Vary With Num of Utsusemi Shadows for Main Weapon
-    if (m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_MIKAGE) && m_attacker->m_Weapons[SLOT_MAIN]->getID() == PWeapon->getID())
+    if (m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_MIKAGE) && m_attacker->m_Weapons[SLOT_MAIN] && m_attacker->m_Weapons[SLOT_MAIN]->getID() == PWeapon->getID())
     {
         auto shadows = (uint8)m_attacker->getMod(Mod::UTSUSEMI);
         AddAttackSwing(PHYSICAL_ATTACK_TYPE::NORMAL, direction, shadows);

--- a/src/map/entities/baseentity.cpp
+++ b/src/map/entities/baseentity.cpp
@@ -197,12 +197,12 @@ void CBaseEntity::ResetLocalVars()
     m_localVars.clear();
 }
 
-uint32 CBaseEntity::GetLocalVar(const char* var)
+uint32 CBaseEntity::GetLocalVar(std::string var)
 {
     return m_localVars[var];
 }
 
-void CBaseEntity::SetLocalVar(const char* var, uint32 val)
+void CBaseEntity::SetLocalVar(std::string var, uint32 val)
 {
     m_localVars[var] = val;
 }

--- a/src/map/entities/baseentity.h
+++ b/src/map/entities/baseentity.h
@@ -281,8 +281,8 @@ public:
     void         SendZoneUpdate();
 
     void   ResetLocalVars();
-    uint32 GetLocalVar(const char* var);
-    void   SetLocalVar(const char* var, uint32 val);
+    uint32 GetLocalVar(std::string var);
+    void   SetLocalVar(std::string var, uint32 val);
 
     // pre-tick update
     virtual void Tick(time_point) = 0;

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -62,10 +62,10 @@ CBattleEntity::CBattleEntity()
 
     m_magicEvasion = 0;
 
-    m_Weapons[SLOT_MAIN]   = new CItemWeapon(0);
-    m_Weapons[SLOT_SUB]    = new CItemWeapon(0);
-    m_Weapons[SLOT_RANGED] = new CItemWeapon(0);
-    m_Weapons[SLOT_AMMO]   = new CItemWeapon(0);
+    m_Weapons[SLOT_MAIN]   = nullptr;
+    m_Weapons[SLOT_SUB]    = nullptr;
+    m_Weapons[SLOT_RANGED] = nullptr;
+    m_Weapons[SLOT_AMMO]   = nullptr;
     m_dualWield            = false;
 
     memset(&health, 0, sizeof(health));
@@ -381,8 +381,8 @@ float CBattleEntity::GetMeleeRange() const
 
 int16 CBattleEntity::GetRangedWeaponDelay(bool tp)
 {
-    CItemWeapon* PRange = (CItemWeapon*)m_Weapons[SLOT_RANGED];
-    CItemWeapon* PAmmo  = (CItemWeapon*)m_Weapons[SLOT_AMMO];
+    CItemWeapon* PRange = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_RANGED]);
+    CItemWeapon* PAmmo  = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_AMMO]);
 
     // base delay
     int16 delay = 0;
@@ -408,7 +408,7 @@ int16 CBattleEntity::GetRangedWeaponDelay(bool tp)
 
 int16 CBattleEntity::GetAmmoDelay()
 {
-    CItemWeapon* PAmmo = (CItemWeapon*)m_Weapons[SLOT_AMMO];
+    CItemWeapon* PAmmo = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_AMMO]);
 
     int delay = 0;
     if (PAmmo != nullptr && PAmmo->getDamage() != 0)

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -275,6 +275,7 @@ CCharEntity::~CCharEntity()
     destroy(CraftContainer);
     destroy(PMeritPoints);
     destroy(PJobPoints);
+    destroy(PLatentEffectContainer);
 
     PGuildShop = nullptr;
 

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -121,6 +121,11 @@ CMobEntity::CMobEntity()
     PEnmityContainer     = new CEnmityContainer(this);
     SpellContainer       = new CMobSpellContainer(this);
 
+    m_Weapons[SLOT_MAIN]   = new CItemWeapon(0);
+    m_Weapons[SLOT_SUB]    = new CItemWeapon(0);
+    m_Weapons[SLOT_RANGED] = new CItemWeapon(0);
+    m_Weapons[SLOT_AMMO]   = new CItemWeapon(0);
+
     PAI = std::make_unique<CAIContainer>(this, std::make_unique<CPathFind>(this), std::make_unique<CMobController>(this), std::make_unique<CTargetFind>(this));
 }
 
@@ -136,8 +141,24 @@ void CMobEntity::setEntityFlags(uint32 EntityFlags)
 
 CMobEntity::~CMobEntity()
 {
+    destroy(m_Weapons[SLOT_MAIN]);
+    destroy(m_Weapons[SLOT_SUB]);
+    destroy(m_Weapons[SLOT_RANGED]);
+    destroy(m_Weapons[SLOT_AMMO]);
     destroy(PEnmityContainer);
     destroy(SpellContainer);
+
+    if (PParty)
+    {
+        if (PParty->HasOnlyOneMember())
+        {
+            destroy(PParty);
+        }
+        else
+        {
+            PParty->DelMember(this);
+        }
+    }
 }
 
 /************************************************************************

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -15805,7 +15805,10 @@ void CLuaBaseEntity::setDelay(uint16 delay)
     }
 
     auto* PMobEntity = static_cast<CMobEntity*>(m_PBaseEntity);
-    static_cast<CItemWeapon*>(PMobEntity->m_Weapons[SLOT_MAIN])->setDelay(delay);
+    if (auto* PItemWeapon = dynamic_cast<CItemWeapon*>(PMobEntity->m_Weapons[SLOT_MAIN]))
+    {
+        PItemWeapon->setDelay(delay);
+    }
 }
 
 /************************************************************************
@@ -15823,7 +15826,10 @@ void CLuaBaseEntity::setDamage(uint16 damage)
     }
 
     auto* PMobEntity = static_cast<CMobEntity*>(m_PBaseEntity);
-    static_cast<CItemWeapon*>(PMobEntity->m_Weapons[SLOT_MAIN])->setDamage(damage);
+    if (auto* PItemWeapon = dynamic_cast<CItemWeapon*>(PMobEntity->m_Weapons[SLOT_MAIN]))
+    {
+        PItemWeapon->setDamage(damage);
+    }
 }
 
 /************************************************************************

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -396,10 +396,15 @@ void do_final(int code)
     destroy_arr(g_PBuff);
     destroy_arr(PTempBuff);
 
+    ability::CleanupAbilitiesList();
     itemutils::FreeItemList();
     battleutils::FreeWeaponSkillsList();
     battleutils::FreeMobSkillList();
     battleutils::FreePetSkillList();
+    fishingutils::CleanupFishing();
+    guildutils::Cleanup();
+    mobutils::Cleanup();
+    traits::ClearTraitsList();
 
     petutils::FreePetList();
     trustutils::FreeTrustList();
@@ -417,6 +422,13 @@ void do_final(int code)
 
     timer_final();
     socket_final();
+
+    for (auto session : map_session_list)
+    {
+        destroy_arr(session.second->server_packet_data);
+        destroy(session.second);
+    }
+
     luautils::cleanup();
     logging::ShutDown();
 

--- a/src/map/navmesh.cpp
+++ b/src/map/navmesh.cpp
@@ -117,7 +117,13 @@ CNavMesh::CNavMesh(uint16 zoneID)
     m_hit.maxPath = 20;
 }
 
-CNavMesh::~CNavMesh() = default;
+CNavMesh::~CNavMesh()
+{
+    if (m_navMesh)
+    {
+        dtFreeNavMesh(m_navMesh);
+    }
+}
 
 bool CNavMesh::load(std::string const& filename)
 {
@@ -142,7 +148,7 @@ bool CNavMesh::load(std::string const& filename)
         return false;
     }
 
-    m_navMesh.reset(dtAllocNavMesh());
+    m_navMesh = dtAllocNavMesh();
     if (!m_navMesh)
     {
         return false;
@@ -178,7 +184,7 @@ bool CNavMesh::load(std::string const& filename)
     }
 
     // init detour nav mesh path finder
-    status = m_navMeshQuery.init(m_navMesh.get(), MAX_NAV_POLYS);
+    status = m_navMeshQuery.init(m_navMesh, MAX_NAV_POLYS);
 
     if (dtStatusFailed(status))
     {
@@ -198,7 +204,8 @@ void CNavMesh::reload()
 
 void CNavMesh::unload()
 {
-    m_navMesh.reset();
+    dtFreeNavMesh(m_navMesh);
+    m_navMesh = nullptr;
 }
 
 std::vector<pathpoint_t> CNavMesh::findPath(const position_t& start, const position_t& end)

--- a/src/map/navmesh.h
+++ b/src/map/navmesh.h
@@ -132,12 +132,12 @@ public:
 private:
     bool onSameFloor(const position_t& start, float* spos, const position_t& end, float* epos, dtQueryFilter& filter);
 
-    std::string                m_filename;
-    uint16                     m_zoneID;
-    dtRaycastHit               m_hit{};
-    dtPolyRef                  m_hitPath[20]{};
-    std::shared_ptr<dtNavMesh> m_navMesh;
-    dtNavMeshQuery             m_navMeshQuery;
+    std::string    m_filename;
+    uint16         m_zoneID;
+    dtRaycastHit   m_hit{};
+    dtPolyRef      m_hitPath[20]{};
+    dtNavMesh*     m_navMesh;
+    dtNavMeshQuery m_navMeshQuery;
 };
 
 #endif

--- a/src/map/packets/server_message.cpp
+++ b/src/map/packets/server_message.cpp
@@ -51,6 +51,7 @@ CServerMessagePacket::CServerMessagePacket(const std::string& message, int8 lang
         auto textSize = (uint8)(sndLength + sndLength % 2);
         this->setSize(((((0x14 + textSize) + 4) >> 1) & 0xFE) * 2);
 
-        std::memcpy(data + 0x18, message.c_str() + message_offset, sndLength);
+        // TODO: can
+        std::memcpy(data + 0x18, message.c_str() + message_offset, std::min(sndLength, message.length() - message_offset));
     }
 }

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -117,13 +117,12 @@ void CParty::DisbandParty(bool playerInitiated)
         m_PAlliance->removeParty(this);
     }
     m_PSyncTarget = nullptr;
-    SetQuarterMaster("");
-
-    m_PLeader   = nullptr;
-    m_PAlliance = nullptr;
+    m_PLeader     = nullptr;
+    m_PAlliance   = nullptr;
 
     if (m_PartyType == PARTY_PCS)
     {
+        SetQuarterMaster("");
         PushPacket(0, 0, new CPartyDefinePacket(nullptr));
 
         for (auto& member : members)
@@ -1130,6 +1129,7 @@ void CParty::SetSyncTarget(const std::string& MemberName, uint16 message)
     }
 }
 
+// FIXME: add case for "" membername
 void CParty::SetQuarterMaster(const std::string& MemberName)
 {
     CBattleEntity* PEntity = GetMemberByName(MemberName);

--- a/src/map/trait.cpp
+++ b/src/map/trait.cpp
@@ -110,6 +110,18 @@ namespace traits
         }
     }
 
+    void ClearTraitsList()
+    {
+        // Manually cleanup traits list
+        for (auto jobTraitList : PTraitsList)
+        {
+            for (auto traitList : jobTraitList)
+            {
+                destroy(traitList);
+            }
+            jobTraitList.clear();
+        }
+    }
     /************************************************************************
      *                                                                       *
      *  Get List of Traits by Main Job or Sub Job                            *

--- a/src/map/trait.h
+++ b/src/map/trait.h
@@ -222,6 +222,7 @@ typedef std::vector<CTrait*> TraitList_t;
 namespace traits
 {
     void LoadTraitsList();
+    void ClearTraitsList();
 
     TraitList_t* GetTraits(uint8 JobID);
 }; // namespace traits

--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -3283,4 +3283,53 @@ namespace fishingutils
         LoadFishingCatchLists();
         CreateFishingPools();
     }
+
+    void CleanupFishing()
+    {
+        for (auto fish : FishList)
+        {
+            destroy(fish.second->reqFish);
+            destroy(fish.second);
+        }
+        FishList.clear();
+
+        for (auto rod : FishingRods)
+        {
+            destroy(rod.second);
+        }
+        FishingRods.clear();
+
+        for (auto bait : FishingBaits)
+        {
+            destroy(bait.second);
+        }
+        FishingBaits.clear();
+
+        for (auto fishmoblist : FishZoneMobList)
+        {
+            for (auto fishmob : fishmoblist.second)
+            {
+                destroy(fishmob.second);
+            }
+            fishmoblist.second.clear();
+        }
+        FishZoneMobList.clear();
+
+        for (auto fishArealist : FishingAreaList)
+        {
+            for (auto fishArea : fishArealist.second)
+            {
+                destroy_arr(fishArea.second->areaBounds);
+                destroy(fishArea.second);
+            }
+            fishArealist.second.clear();
+        }
+        FishingAreaList.clear();
+
+        for (auto fish : FishList)
+        {
+            destroy(fish.second);
+        }
+        FishList.clear();
+    };
 } // namespace fishingutils

--- a/src/map/utils/fishingutils.h
+++ b/src/map/utils/fishingutils.h
@@ -1017,6 +1017,7 @@ namespace fishingutils
     void LoadFishGroups();
     void LoadFishingCatchLists();
     void InitializeFishingSystem();
+    void CleanupFishing();
 }; // namespace fishingutils
 
 #endif // _FISHINGUTILS_H

--- a/src/map/utils/guildutils.cpp
+++ b/src/map/utils/guildutils.cpp
@@ -112,6 +112,22 @@ namespace guildutils
         UpdateGuildPointsPattern();
     }
 
+    void Cleanup()
+    {
+        // Delete pointers and cleanup vectors manually
+        for (auto guild : g_PGuildList)
+        {
+            destroy(guild);
+        }
+        g_PGuildList.clear();
+
+        for (auto itemContainer : g_PGuildShopList)
+        {
+            destroy(itemContainer);
+        }
+        g_PGuildList.clear();
+    }
+
     void UpdateGuildsStock()
     {
         for (auto* PGuildShop : g_PGuildShopList)

--- a/src/map/utils/guildutils.h
+++ b/src/map/utils/guildutils.h
@@ -36,6 +36,7 @@ class CGuild;
 namespace guildutils
 {
     void Initialize();
+    void Cleanup();
     void UpdateGuildsStock();
     void UpdateGuildPointsPattern();
 

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -1322,6 +1322,65 @@ namespace mobutils
         }
     }
 
+    void Cleanup()
+    {
+        // Manually delete and clean up pointers
+        for (auto spawnMod : mobSpawnModsList)
+        {
+            if (spawnMod.second)
+            {
+                for (auto mobMods : spawnMod.second->mobMods)
+                {
+                    destroy(mobMods);
+                }
+
+                for (auto mods : spawnMod.second->mods)
+                {
+                    destroy(mods);
+                }
+                destroy(spawnMod.second);
+            }
+        }
+        mobSpawnModsList.clear();
+
+        for (auto mobFamilyMods : mobFamilyModsList)
+        {
+            if (mobFamilyMods.second)
+            {
+                for (auto mobMods : mobFamilyMods.second->mobMods)
+                {
+                    destroy(mobMods);
+                }
+
+                for (auto mods : mobFamilyMods.second->mods)
+                {
+                    destroy(mods);
+                }
+
+                destroy(mobFamilyMods.second);
+            }
+        }
+        mobFamilyModsList.clear();
+
+        for (auto mobPoolMods : mobPoolModsList)
+        {
+            if (mobPoolMods.second)
+            {
+                for (auto mobMods : mobPoolMods.second->mobMods)
+                {
+                    destroy(mobMods);
+                }
+
+                for (auto mods : mobPoolMods.second->mods)
+                {
+                    destroy(mods);
+                }
+                destroy(mobPoolMods.second);
+            }
+        }
+        mobPoolModsList.clear();
+    }
+
     ModsList_t* GetMobFamilyMods(uint16 familyId, bool create)
     {
         if (mobFamilyModsList[familyId])

--- a/src/map/utils/mobutils.h
+++ b/src/map/utils/mobutils.h
@@ -73,6 +73,7 @@ namespace mobutils
     void   GetAvailableSpells(CMobEntity* PMob);
     void   InitializeMob(CMobEntity* PMob);
     void   LoadSqlModifiers();
+    void   Cleanup();
 
     // get modifiers for pool / family / spawn
     ModsList_t* GetMobFamilyMods(uint16 familyId, bool create = false);

--- a/src/map/utils/trustutils.cpp
+++ b/src/map/utils/trustutils.cpp
@@ -336,6 +336,16 @@ namespace trustutils
 
     void FreeTrustList()
     {
+        for (auto trust : g_PTrustList)
+        {
+            destroy(trust);
+        }
+        g_PTrustList.clear();
+
+        for (auto trustID : g_PTrustIDList)
+        {
+            destroy(trustID);
+        }
         g_PTrustIDList.clear();
     }
 

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -137,8 +137,36 @@ CZone::CZone(ZONEID ZoneID, REGION_TYPE RegionID, CONTINENT_TYPE ContinentID, ui
 CZone::~CZone()
 {
     destroy(m_TreasurePool);
-    destroy(m_CampaignHandler);
     destroy(m_zoneEntities);
+    destroy(m_BattlefieldHandler);
+
+    if (m_CampaignHandler)
+    {
+        destroy(m_CampaignHandler);
+    }
+
+    if (m_navMesh)
+    {
+        destroy(m_navMesh);
+    }
+
+    if (lineOfSight)
+    {
+        destroy(lineOfSight);
+    }
+
+    // Manually delete and clear m_triggerAreaList
+    for (auto triggerArea : m_triggerAreaList)
+    {
+        destroy(triggerArea);
+    }
+    m_triggerAreaList.clear();
+
+    for (auto zoneLine : m_zoneLineList)
+    {
+        destroy(zoneLine);
+    }
+    m_zoneLineList.clear();
 }
 
 ZONEID CZone::GetID()
@@ -426,9 +454,9 @@ void CZone::LoadZoneSettings()
         {
             m_TreasurePool = new CTreasurePool(TREASUREPOOL_ZONE);
         }
-        if (m_CampaignHandler->m_PZone == nullptr)
+        if (m_CampaignHandler && m_CampaignHandler->m_PZone == nullptr)
         {
-            m_CampaignHandler = nullptr;
+            destroy(m_CampaignHandler);
         }
     }
     else

--- a/src/map/zone_entities.h
+++ b/src/map/zone_entities.h
@@ -87,6 +87,7 @@ public:
     EntityList_t m_petList;
     EntityList_t m_trustList;
     EntityList_t m_npcList;
+    EntityList_t m_TransportList;
     EntityList_t m_charList;
 
     uint16           nextDynamicTargID; // The next dynamic targ ID to chosen -- SE rotates them forwards and skips entries that already exist.
@@ -99,9 +100,8 @@ public:
     ~CZoneEntities();
 
 private:
-    CZone*       m_zone;
-    CBaseEntity* m_Transport; // Transport indicator in the zone
-    time_point   m_EffectCheckTime{ server_clock::now() };
+    CZone*     m_zone;
+    time_point m_EffectCheckTime{ server_clock::now() };
 
     time_point computeTime{ server_clock::now() };
     uint16     lastCharComputeTargId;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Clean up some static/dynamic casts in CItemEquip, apparently fix SpawnTransport to spawn multiple transports instead of just one, which is neat I guess. Small cleanup with dynamic entities parties getting deleted when all mobs die.

Does not attempt to fix some edge case CParty leaks upon `exit`.  and this is by no means comprehensive, I didn't test things like BCNMs, assaults, etc. just starting a server, logging in, summoning trusts, pets, !fafnir and running `exit` immediately.

Valgrind memory leak check:
Before:
![image](https://github.com/LandSandBoat/server/assets/60417494/513ae00c-f47a-45ce-b3d0-f076cfa97c48)

After:
![image](https://github.com/LandSandBoat/server/assets/60417494/ff0fdd6d-65b9-4c93-9654-b06e9d0f08ec)

## Steps to test these changes

There should be no noticeable changes.
