### PR TITLE
[RUN] Swordplay corrections and cleanup

### DIFF
--- a/scripts/enum/mod.lua
+++ b/scripts/enum/mod.lua
@@ -491,6 +491,7 @@ xi.mod =
     PARRY_SPIKES                = 1022, -- Battuta parry spikes rate
     PARRY_SPIKES_DMG            = 1023, -- Battuta parry spikes damage
     SPECIAL_ATTACK_EVASION      = 1024, -- Foil "Special Attack" evasion
+    AUGMENTS_SLEIGHT_OF_SWORD   = 277,  -- Enhances bonus "Subtle Blow" per merit.
 
     FIRE_AFFINITY_DMG               = 347,
     ICE_AFFINITY_DMG                = 348,

--- a/scripts/globals/job_utils/rune_fencer.lua
+++ b/scripts/globals/job_utils/rune_fencer.lua
@@ -288,25 +288,15 @@ xi.job_utils.rune_fencer.useRuneEnchantment = function(player, target, ability, 
 end
 
 xi.job_utils.rune_fencer.useSwordplay = function(player, target, ability)
-    local power = 0 --Swordplay starts at +0 bonus without swaps
+    -- Calculate power. (Accuracy and Evasion) https://www.bg-wiki.com/ffxi/Swordplay
+    local power = 3                                               -- Naked swordplay starts at 3. Retail confirmed.
+    power       = power + power * player:getMod(xi.mod.SWORDPLAY) -- "Swordplay + X" Where X is TICKS.
 
-    -- see https://www.bg-wiki.com/ffxi/Sleight_of_Sword for levels
-    local meritBonus = player:getMerit(xi.merit.MERIT_SLEIGHT_OF_SWORD)
-    local augBonus   = 0 -- augBonus = 2 per level of merit
+    -- Calculate subPower. (Subtle blow) https://www.bg-wiki.com/ffxi/Sleight_of_Sword
+    local subPower = player:getMerit(xi.merit.MERIT_SLEIGHT_OF_SWORD)                            -- Each merit adds 5 "Subtle Blow".
+    subPower       = subPower + (subPower / 5) * player:getMod(xi.mod.AUGMENTS_SLEIGHT_OF_SWORD) -- Add augment effect IF player has augment.
 
-    -- gear bonuses from https://www.bg-wiki.com/ffxi/Swordplay
-    if player:getMainJob() == xi.job.RUN and target:getMainLvl() == 99 then -- don't bother with gear boost checks until 99 and main RUN
-        local tickPower = 3 -- Tick power appears to be 3/tick, not 6/tick if RUN main and 3/tick if RUN sub; source : https://www.ffxiah.com/forum/topic/37086/endeavoring-to-awaken-a-guide-to-rune-fencer/180/#3615377
-
-        -- add starting tick bonuses if appropriate gear is equipped
-        power = tickPower + player:getMod(xi.mod.SWORDPLAY)
-    end
-
-    if power > 0 then -- add aug bonus if appropriate gear is equipped. Note: ilvl 109+ "relic" or "AF2" gear always has the augment, so no need to check exdata. RUN does not have AF/AF2/AF3 gear below i109.
-        augBonus = (meritBonus / 5) * 2
-    end
-
-    player:addStatusEffect(xi.effect.SWORDPLAY, power, 3, 120, 0, meritBonus + augBonus, 0)
+    player:addStatusEffect(xi.effect.SWORDPLAY, power, 3, 120, 0, subPower, 0)
 end
 
 xi.job_utils.rune_fencer.onSwordplayEffectGain = function(target, effect)

--- a/scripts/globals/job_utils/rune_fencer.lua
+++ b/scripts/globals/job_utils/rune_fencer.lua
@@ -337,7 +337,7 @@ xi.job_utils.rune_fencer.onSwordplayEffectTick = function(target, effect)
 
         if tickPower > 0 then
             target:addMod(xi.mod.ACC, tickPower)
-            target:addMod(xi.mod.EVASION, tickPower)
+            target:addMod(xi.mod.EVA, tickPower)
         end
 
         power = math.min(power + tickPower, maxPower)
@@ -350,7 +350,7 @@ xi.job_utils.rune_fencer.onSwordplayEffectLose = function(target, effect)
     local subPower = effect:getSubPower()
 
     target:delMod(xi.mod.ACC, power)
-    target:delMod(xi.mod.EVASION, power)
+    target:delMod(xi.mod.EVA, power)
 
     if subPower > 0 then
         target:delMod(xi.mod.SUBTLE_BLOW, subPower)

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -50148,7 +50148,7 @@ INSERT INTO `item_mods` VALUES (23217,384,300); -- HASTE_GEAR: 3%
 INSERT INTO `item_mods` VALUES (23217,487,8);   -- MAG_BURST_BONUS: 8
 INSERT INTO `item_mods` VALUES (23217,901,13);  -- ELEMENTAL_CELERITY: -13
 
--- Futhark Mitons : 2
+-- Futhark Mitons +2
 INSERT INTO `item_mods` VALUES (23218,1,102);   -- DEF: 102
 INSERT INTO `item_mods` VALUES (23218,2,35);    -- HP: 35
 INSERT INTO `item_mods` VALUES (23218,8,16);    -- STR: 16

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -750,6 +750,7 @@ enum class Mod
     PARRY_SPIKES                = 1022, // Battuta parry spikes rate
     PARRY_SPIKES_DMG            = 1023, // Battuta parry spikes damage
     SPECIAL_ATTACK_EVASION      = 1024, // Foil "Special Attack" evasion
+    AUGMENTS_SLEIGHT_OF_SWORD   = 277,  // Enhances bonus "Subtle Blow" per merit.
 
     // Stores the amount of elemental affinity (elemental staves mostly) - damage, acc, and perpetuation is all handled separately
     FIRE_AFFINITY_DMG    = 347, // They're stored separately due to Magian stuff - they can grant different levels of
@@ -1009,7 +1010,7 @@ enum class Mod
     // SPARE IDs:
     // 141
     // 220 to 223
-    // 273 to 277
+    // 273 to 276
     //
     // SPARE = 1080 and onward
 };


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Changes modifier used for evasion, so evasion changes reflect on /checkparam
- Confirmed in retail that initial power when naked is 3 per tick, no matter if job is main or sub. Changes reflect that.
- Created a new modifier for the "Futhark Mitons". This was made because the code assumed gear with augment would also have "Swordplay +X" modifier. And while this is true for retail right now, this may not be the case in the future or for any servers that want to customize their gear.

## Steps to test these changes

Use Swordplay. Use /checkparam and see both acc and eva change.
Other than that, swordplay should work exactly the same.