### PR TITLE
[core] Change dynamic targids to linearly ramp

### DIFF
--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -521,13 +521,7 @@ void CZoneEntities::AssignDynamicTargIDandLongID(CBaseEntity* PEntity)
 
     lastDynamicTargID = targid;
 
-    auto id = 0x1000000 + (m_zone->GetID() << 12) + targid;
-
-    // Add 0x100 if targid is >= 0x800 -- observed on retail.
-    if (targid >= 0x800)
-    {
-        id += 0x100;
-    }
+    auto id = 0x01000000 | (m_zone->GetID() << 0x0C) | (targid + 0x0100);
 
     dynamicTargIds.insert(targid);
 

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -73,7 +73,7 @@ namespace
 typedef std::pair<float, CCharEntity*> CharScorePair;
 
 CZoneEntities::CZoneEntities(CZone* zone)
-: lastDynamicTargID(0x6FF) // Start at 0x6FF so the first one used is 0x700. See AssignDynamicTargIDandLongID
+: nextDynamicTargID(0x700) // Start of dynamic entity range // TODO: Make this into a constexpr somewhere.
 , m_zone(zone)
 , m_Transport(nullptr)
 , lastCharComputeTargId(0)
@@ -490,7 +490,7 @@ void CZoneEntities::AssignDynamicTargIDandLongID(CBaseEntity* PEntity)
 {
     // NOTE: 0x0E (entity_update) entity updates are valid for 0 to 1023 and 1792 to 2303
     // Step targid up linearly from 0x700 one by one to 0x8FF unless that ID is already occupied.
-    uint16 targid = lastDynamicTargID + 1;
+    uint16 targid = nextDynamicTargID;
 
     // Wrap around 0x8FF to 0x700
     if (targid > 0x8FF)
@@ -519,7 +519,8 @@ void CZoneEntities::AssignDynamicTargIDandLongID(CBaseEntity* PEntity)
         counter++;
     }
 
-    lastDynamicTargID = targid;
+    // We found our targid, the next dynamic entity will want to start searching at +1 of this.
+    nextDynamicTargID = targid + 1;
 
     auto id = 0x01000000 | (m_zone->GetID() << 0x0C) | (targid + 0x0100);
 

--- a/src/map/zone_entities.h
+++ b/src/map/zone_entities.h
@@ -89,7 +89,7 @@ public:
     EntityList_t m_npcList;
     EntityList_t m_charList;
 
-    uint16           lastDynamicTargID; // The last dynamic targ ID chosen -- SE rotates them forwards and skips entries that already exist.
+    uint16           nextDynamicTargID; // The next dynamic targ ID to chosen -- SE rotates them forwards and skips entries that already exist.
     std::set<uint16> charTargIds;       // sorted set of targids for characters
     std::set<uint16> dynamicTargIds;    // sorted set of targids for dynamic entities
 

--- a/src/map/zone_entities.h
+++ b/src/map/zone_entities.h
@@ -89,8 +89,9 @@ public:
     EntityList_t m_npcList;
     EntityList_t m_charList;
 
-    std::set<uint16> charTargIds;    // sorted set of targids for characters
-    std::set<uint16> dynamicTargIds; // sorted set of targids for dynamic entities
+    uint16           lastDynamicTargID; // The last dynamic targ ID chosen -- SE rotates them forwards and skips entries that already exist.
+    std::set<uint16> charTargIds;       // sorted set of targids for characters
+    std::set<uint16> dynamicTargIds;    // sorted set of targids for dynamic entities
 
     std::vector<std::pair<uint16, time_point>> dynamicTargIdsToDelete; // list of targids pending deletion at a later date
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

On retail, IDs are not recycled as soon as possible -- They appear to increase until they wrap.
This may fix issues with stale flags/looks.

Adjust long form ID to match retail:

Retail in The Colosseum (yes I managed to get the lowest ID!):
![image](https://github.com/LandSandBoat/server/assets/60417494/daa3cfd4-7644-4d06-842f-e8613dd61e5d)

LSB:
![image](https://github.com/LandSandBoat/server/assets/60417494/79456461-9fba-4132-96d7-9747ad28e608)


## Steps to test these changes
!fafnir, summon pets, trusts, see nothing different (to the player)