### PR TITLE
[core] Fix scaling of range critical hit rate from AGI

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2822,7 +2822,7 @@ namespace battleutils
             critRate = 1;
         }
 
-        // Crit rate delta from stats caps at +-15
+        // Crit rate delta from stats caps at 15
         return std::min(critRate, 15);
     }
 
@@ -2871,15 +2871,13 @@ namespace battleutils
         // https://www.bg-wiki.com/bg/Critical_Hit_Rate
         int32 attackerAgi = PAttacker->AGI();
         int32 defenderAgi = PDefender->AGI();
-        int32 dAGI        = attackerAgi - defenderAgi;
-        int32 dAgiAbs     = std::abs(dAGI);
+        int32 dAgi        = attackerAgi - defenderAgi;
+        // Only consider positive dAgi
+        int32 dAgiPositive = std::max(0, dAgi);
 
-        // Default to +0 crit rate
-        int32 critRate = 0;
+        int32 critRate = dAgiPositive / 10;
 
-        critRate = dAgiAbs / 10;
-
-        return std::min(critRate, 15);
+        return critRate;
     }
 
     /************************************************************************


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This fixes a small issue related to critical hit rate calculation from AGI. Essentially, instead of using abs(dAGI), we should be using max(0, dAGI) so that negative dAGI do not have any impact on crit hit rate (this completes the fix started in my [previous PR](https://github.com/LandSandBoat/server/pull/5142), and thus should have been there, my apologies). Also no source that I could find denotes a known cap (unlike for dDex and critical hit rate), thus I removed the cap (see [bg-wiki here](https://www.bg-wiki.com/ffxi/Critical_Hit_Rate)).

## Steps to test these changes
Fight mobs with higher AGI and lower AGI (than player) and use RAs and track critical hit rate
