### PR TITLE
[core] [lua] Fix Fomor hate clearing and aggro

### DIFF
--- a/scripts/mixins/fomor_hate.lua
+++ b/scripts/mixins/fomor_hate.lua
@@ -15,6 +15,12 @@ g_mixins.fomor_hate = function(fomorMob)
                         adj = 2 -- default: most fomor add 2 hate
                     end
 
+                    -- if not a fomor then decrease hate instead of increase
+                    -- Note cannot use negatives in fomorHateAdj because local vars can only be positive
+                    if mob:getFamily() ~= 115 and mob:getFamily() ~= 359 then
+                        adj = -adj
+                    end
+
                     member:setCharVar('FOMOR_HATE', utils.clamp(hate + adj, 0, 60))
                 end
             end

--- a/scripts/zones/Lufaise_Meadows/mobs/Gigas_Braver.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Gigas_Braver.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Lufaise_Meadows/mobs/Gigas_Catapulter.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Gigas_Catapulter.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Lufaise_Meadows/mobs/Gigas_Fighter.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Gigas_Fighter.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Lufaise_Meadows/mobs/Gigas_Martialist.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Gigas_Martialist.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Lufaise_Meadows/mobs/Gigas_Slinger.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Gigas_Slinger.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Lufaise_Meadows/mobs/Gigas_Warwolf.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Gigas_Warwolf.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Lufaise_Meadows/mobs/Gigas_Wrestler.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Gigas_Wrestler.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Lufaise_Meadows/mobs/Orcish_Beastrider.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Orcish_Beastrider.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Lufaise_Meadows/mobs/Orcish_Bowshooter.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Orcish_Bowshooter.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Lufaise_Meadows/mobs/Orcish_Brawler.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Orcish_Brawler.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Lufaise_Meadows/mobs/Orcish_Footsoldier.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Orcish_Footsoldier.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Lufaise_Meadows/mobs/Orcish_Gladiator.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Orcish_Gladiator.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Lufaise_Meadows/mobs/Orcish_Impaler.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Orcish_Impaler.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Lufaise_Meadows/mobs/Orcish_Nightraider.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Orcish_Nightraider.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Lufaise_Meadows/mobs/Orcish_Stonelauncher.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Orcish_Stonelauncher.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Lufaise_Meadows/mobs/Orcish_Trooper.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Orcish_Trooper.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Misareaux_Coast/mobs/Gigas_Braver.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Gigas_Braver.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Misareaux_Coast/mobs/Gigas_Catapulter.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Gigas_Catapulter.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Misareaux_Coast/mobs/Gigas_Martialist.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Gigas_Martialist.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Misareaux_Coast/mobs/Gigas_Warwolf.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Gigas_Warwolf.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Misareaux_Coast/mobs/Gration.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Gration.lua
@@ -8,7 +8,7 @@ local entity = {}
 
 entity.onMobSpawn = function(mob)
     mob:addStatusEffect(xi.effect.KILLER_INSTINCT, 40, 0, 0)
-    mob:setLocalVar('fomorHateAdj', -2)
+    mob:setLocalVar('fomorHateAdj', 2)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Misareaux_Coast/mobs/Orcish_Bowshooter.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Orcish_Bowshooter.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Misareaux_Coast/mobs/Orcish_Footsoldier.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Orcish_Footsoldier.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Misareaux_Coast/mobs/Orcish_Gladiator.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Orcish_Gladiator.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Misareaux_Coast/mobs/Orcish_Stonelauncher.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Orcish_Stonelauncher.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Misareaux_Coast/mobs/Orcish_Trooper.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Orcish_Trooper.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Mahisha.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Mahisha.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Minotaur.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Minotaur.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -2)
+    mob:setLocalVar('fomorHateAdj', 2)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Stegotaur.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Stegotaur.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Teratotaur.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Teratotaur.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -1)
+    mob:setLocalVar('fomorHateAdj', 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -1153,6 +1153,17 @@ bool CMobController::CanAggroTarget(CBattleEntity* PTarget)
             return false;
         }
 
+        // Do not aggro if a normal CoP Fomor and the player has low enough fomor hate
+        if (PMob->m_Family == 115 && !(PMob->m_Type & MOBTYPE_NOTORIOUS) &&
+            (PMob->getZone() >= ZONE_LUFAISE_MEADOWS && PMob->getZone() <= ZONE_SACRARIUM) &&
+            PTarget->objtype == TYPE_PC)
+        {
+            if (static_cast<CCharEntity*>(PTarget)->getCharVar("FOMOR_HATE") < 8)
+            {
+                return false;
+            }
+        }
+
         // Don't aggro I'm an underground worm
         if ((PMob->m_roamFlags & ROAMFLAG_WORM) && PMob->IsNameHidden())
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes two fomor hate issues: 

Firstly, the PR allows clearing fomor hate by killing certain mobs (like gigas and beastmen in misareaux coast). This was previously not working because those mobs had code attempting to set local vars to negative numbers which is not possible (because local vars are stored as uint in c++ land). This PR fixes this by setting the local vars to positive numbers and then multiplying these numbers by -1 in the fomor hate mixin if the mob is not a fomor.

Secondly, the PR prevents aggro if the player has the lowest level of fomor hate. This is done by adding a check in `CMobController::CanAggroTarget`.

This is an ASB PR coming upstream.

## Steps to test these changes
Check the char variable FOMOR_HATE after killing, for example, fomor in sacrarium and after killing gigas and beastmen in misareaux coast. Also check if fomor aggro in, for example, sacrarium with <8 FOMOR_HATE and >= 8 FOMOR_HATE.
