### PR TITLE
[core] Replace usage of std::thread with nonstd::jthread

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -74,6 +74,8 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "utils/trustutils.h"
 #include "utils/zoneutils.h"
 
+#include <nonstd/jthread.hpp>
+
 #ifdef WIN32
 #include <io.h>
 #endif
@@ -91,7 +93,7 @@ uint16  map_port = 0;
 
 map_session_list_t map_session_list = {};
 
-std::thread messageThread;
+nonstd::jthread messageThread;
 
 std::unique_ptr<SqlConnection> sql;
 
@@ -225,7 +227,7 @@ int32 do_init(int32 argc, char** argv)
 
     ShowInfo("do_init: starting ZMQ thread");
     message::init();
-    messageThread = std::thread(message::listen);
+    messageThread = nonstd::jthread(message::listen);
 
     ShowInfo("do_init: loading items");
     itemutils::Initialize();
@@ -411,10 +413,7 @@ void do_final(int code)
     zoneutils::FreeZoneList();
 
     message::close();
-    if (messageThread.joinable())
-    {
-        messageThread.join();
-    }
+    messageThread.join();
 
     CTaskMgr::delInstance();
     CVanaTime::delInstance();

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -80,6 +80,7 @@ typedef u_int SOCKET;
 #include "packets/search_comment.h"
 #include "packets/search_list.h"
 
+#include <nonstd/jthread.hpp>
 #include <task_system.hpp>
 
 #define DEFAULT_BUFLEN 1024
@@ -384,7 +385,7 @@ int32 main(int32 argc, char** argv)
         // clang-format on
     }
 
-    std::thread taskManagerThread(TaskManagerThread, std::ref(requestExit));
+    nonstd::jthread taskManagerThread(TaskManagerThread, std::ref(requestExit));
 
     auto taskSystem = ts::task_system(4);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Replace usage of `std::thread` with the lifetime-managed-auto-joining `nonstd::jthread`.

## Steps to test these changes

You can startup xi_map and xi_search as normal, CTRL-C-ing out of them, or using console exit command