### PR TITLE
[core] [lua] Fix mob meikyo shisui and mob skill tp gain

### DIFF
--- a/scripts/actions/mobskills/meikyo_shisui.lua
+++ b/scripts/actions/mobskills/meikyo_shisui.lua
@@ -14,6 +14,9 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     mob:addTP(3000)
 
+    -- use local var counter to ensure only three mobskills count for Meikyo Shisui
+    mob:setLocalVar('[MeikyoShisui]MobSkillCount', 3)
+
     return xi.effect.MEIKYO_SHISUI
 end
 

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -230,6 +230,11 @@ xi.mobskills.mobPhysicalMove = function(mob, target, skill, numHits, accMod, dmg
         finaldmg   = 0
         hitslanded = 0
         skill:setMsg(xi.msg.basic.SKILL_MISS)
+    -- calculate tp return of mob skill
+    else
+        local tpReturn = xi.combat.tp.getSingleMeleeHitTPReturn(mob, target)
+        tpReturn = tpReturn + 10 * (hitslanded - 1) -- extra hits give 10 TP each
+        mob:addTP(tpReturn)
     end
 
     returninfo.dmg        = finaldmg
@@ -296,6 +301,12 @@ xi.mobskills.mobMagicalMove = function(mob, target, skill, damage, element, dmgm
 
     finaldmg       = finaldmg * resist * magicDefense
     returninfo.dmg = finaldmg
+
+    -- magical mob skills are single hit so provide single Melee hit TP return
+    if finaldmg > 0 then
+        local tpReturn = xi.combat.tp.getSingleMeleeHitTPReturn(mob, target)
+        mob:addTP(tpReturn)
+    end
 
     return returninfo
 end
@@ -439,6 +450,12 @@ xi.mobskills.mobBreathMove = function(mob, target, percent, base, element, cap)
     -- Handle Stoneskin
     if damage > 0 then
         damage = utils.clamp(utils.stoneskin(target, damage), -99999, 99999)
+    end
+
+    -- breath mob skills are single hit so provide single Melee hit TP return
+    if damage > 0 then
+        local tpReturn = xi.combat.tp.getSingleMeleeHitTPReturn(mob, target)
+        mob:addTP(tpReturn)
     end
 
     return damage

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -92,6 +92,13 @@ void CMobSkillState::SpendCost()
             m_spentTP = m_PEntity->addTP(-1000);
             m_PEntity->StatusEffectContainer->DelStatusEffect(EFFECT_SEKKANOKI);
         }
+        else if (m_PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_MEIKYO_SHISUI) &&
+                 m_PEntity->GetLocalVar("[MeikyoShisui]MobSkillCount") > 0)
+        {
+            auto currentCount = m_PEntity->GetLocalVar("[MeikyoShisui]MobSkillCount");
+            m_PEntity->SetLocalVar("[MeikyoShisui]MobSkillCount", currentCount - 1);
+            m_spentTP = m_PEntity->addTP(-1000);
+        }
         else
         {
             m_spentTP            = m_PEntity->health.tp;

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -382,6 +382,12 @@ uint16 CMobEntity::TPUseChance()
         return 10000;
     }
 
+    // mobs use three mob skills in a row under Meikyo Shisui
+    if (StatusEffectContainer->HasStatusEffect(EFFECT_MEIKYO_SHISUI) && GetLocalVar("[MeikyoShisui]MobSkillCount") > 0)
+    {
+        return 10000;
+    }
+
     return (uint16)getMobMod(MOBMOD_TP_USE_CHANCE);
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes several issues with mobskills and TP:
1. Currently, mobs using Meikyo Shisui get 3000 TP but do not use multiple mob skills in a row (the first mobskill just wipes the 3000 tp). This PR fixes this by giving mobs 3000 TP and then allowing them to use 3 mob skills in a row (each consumes 1000 TP, so first skill is at 3000, second at 2000 and so on). This leverages a local var on the mob which is set upon using Meikyo Shisui.

2. Currently, mobs using mob skills do not gain TP from these moves. This PR fixes this by adding code in mobskill.lua to add the correct TP for different types of mob skills. The formula is essentially similar to players.

## Steps to test these changes

1. Fight a SAM mob and watch the mob use three mob skills in a row after using Meikyo Shisui.

2. Fight mobs and monitor mobs TP with for example !exec print(target:getTP()) before and after mob skills.
