### PR TITLE
Fix PH entries for Antican Magister

### DIFF
--- a/scripts/zones/Quicksand_Caves/IDs.lua
+++ b/scripts/zones/Quicksand_Caves/IDs.lua
@@ -57,7 +57,15 @@ zones[xi.zone.QUICKSAND_CAVES] =
         },
         ANTICAN_MAGISTER_PH     =
         {
-            [17629280] = 17629280, -- 856.187 1.120 -657.310
+            -- Antican Magister is a lottery of various Antica at (C-6).
+            -- https://www.bg-wiki.com/ffxi/Antican_Magister
+
+            -- Antican Hastatus
+            [17629409] = GetFirstID('Antican_Magister'),
+            -- Antican Princeps
+            [17629410] = GetFirstID('Antican_Magister'),
+            -- Antican Signifier
+            [17629411] = GetFirstID('Antican_Magister'),
         },
         ANTICAN_PRAEFECTUS_PH   =
         {

--- a/scripts/zones/Quicksand_Caves/mobs/Antican_Princeps.lua
+++ b/scripts/zones/Quicksand_Caves/mobs/Antican_Princeps.lua
@@ -21,6 +21,7 @@ end
 entity.onMobDespawn = function(mob)
     xi.mob.phOnDespawn(mob, ID.mob.SAGITTARIUS_X_XIII_PH, 10, 14400) -- 4 hours
     xi.mob.phOnDespawn(mob, ID.mob.ANTICAN_PRAEFECTUS_PH, 10, 3600) -- 1 hour
+    xi.mob.phOnDespawn(mob, ID.mob.ANTICAN_MAGISTER_PH, 10, 3600) -- 1 hour
 end
 
 return entity

--- a/scripts/zones/Quicksand_Caves/mobs/Antican_Signifer.lua
+++ b/scripts/zones/Quicksand_Caves/mobs/Antican_Signifer.lua
@@ -20,6 +20,7 @@ end
 
 entity.onMobDespawn = function(mob)
     xi.mob.phOnDespawn(mob, ID.mob.CENTURIO_X_I_PH, 10, 9000) -- 2.5 hours
+    xi.mob.phOnDespawn(mob, ID.mob.ANTICAN_MAGISTER_PH, 10, 3600) -- 1 hour
     xi.mob.phOnDespawn(mob, ID.mob.ANTICAN_PROCONSUL_PH, 10, 3600) -- 1 hour
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
FIx the placeholder entry for Antican Magister.

https://www.bg-wiki.com/ffxi/Antican_Magister
https://ffxiclopedia.fandom.com/wiki/Antican_Magister

## Steps to test these changes
Set the spawn chance in each of the mob Lua's to 100% and kill each placeholder in the area of C-6 QSC