### PR TITLE
[LUA] re-apply mantra to the target

### DIFF
--- a/scripts/globals/job_utils/monk.lua
+++ b/scripts/globals/job_utils/monk.lua
@@ -132,7 +132,7 @@ end
 xi.job_utils.monk.useMantra = function(player, target, ability)
     local merits = player:getMerit(xi.merit.MANTRA)
 
-    player:delStatusEffect(xi.effect.MAX_HP_BOOST)
+    target:delStatusEffect(xi.effect.MAX_HP_BOOST) -- TODO: confirm which versions of HP boost mantra can overwrite
     target:addStatusEffect(xi.effect.MAX_HP_BOOST, merits, 0, 180)
 
     return xi.effect.MANTRA -- TODO: implement xi.effect.MANTRA


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Removes the mantra buff from the target of the ability instead of the player. These are the same objects when solo but when in a party the monk was losing mantra immediately after gaining it

## Steps to test these changes

Use mantra in a party and see that all party members in range have hp boost afterwards