### PR TITLE
[LUA] Ensure player EES gets 5x multiplier

### DIFF
--- a/scripts/actions/abilities/eagle_eye_shot.lua
+++ b/scripts/actions/abilities/eagle_eye_shot.lua
@@ -44,6 +44,7 @@ abilityObject.onUseAbility = function(player, target, ability, action)
     params.numHits = 1
 
     -- TP params.
+    local tp          = 1000 -- to ensure ftp multiplier is applied
     params.ftpMod     = { 5.0, 5.0, 5.0 }
     params.critVaries = { 0.0, 0.0, 0.0 }
 
@@ -62,7 +63,7 @@ abilityObject.onUseAbility = function(player, target, ability, action)
     local jpValue = player:getJobPointLevel(xi.jp.EAGLE_EYE_SHOT_EFFECT)
     player:addMod(xi.mod.ALL_WSDMG_ALL_HITS, jpValue * 3)
 
-    local damage, _, tpHits, extraHits = xi.weaponskills.doRangedWeaponskill(player, target, 0, params, 0, action, true)
+    local damage, _, tpHits, extraHits = xi.weaponskills.doRangedWeaponskill(player, target, 0, params, tp, action, true)
 
     -- Set the message id ourselves
     if tpHits + extraHits > 0 then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Player Eagle Eye Shot has all the right parameters, but `xi.weaponskills.ftp` requires tp between 1k and 3k, afaict there is nothing that varies with TP in the chain of logic (i.e we could pass 1k or 3k tp and get the same results in this PR).

## Steps to test these changes

Do regular ranged attack, then EES... see they are about the same dmg

apply patch and see EES doing about 5x dmg