### PR TITLE
[Lua] Correct 'Smite of rage' shadow behavior and fTP

### DIFF
--- a/scripts/actions/mobskills/smite_of_rage.lua
+++ b/scripts/actions/mobskills/smite_of_rage.lua
@@ -10,11 +10,14 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 1
-    local accmod = 1
-    local dmgmod = 2.7
+    local accmod  = 1
+    local dmgmod  = mob:getWeaponDmg() * 0.03
+
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
-    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded * math.random(2, 3))
+    local dmg  = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, xi.mobskills.shadowBehavior.NUMSHADOWS_1)
+
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
+
     return dmg
 end
 

--- a/scripts/actions/mobskills/smite_of_rage.lua
+++ b/scripts/actions/mobskills/smite_of_rage.lua
@@ -11,10 +11,10 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 1
     local accmod  = 1
-    local dmgmod  = mob:getWeaponDmg() * 0.03
+    local dmgmod  = 3
 
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
-    local dmg  = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, xi.mobskills.shadowBehavior.NUMSHADOWS_1)
+    local dmg  = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Smite of Rage is currently consuming between 2-3 shadows. It is a single hit weaponskill. 
This change removes the random removal of 2-3 shadows as well as updates the mobskill script to align with current LSB standard.
Tested as Lv75 SAM on Aura Weapons.

![image](https://github.com/LandSandBoat/server/assets/65316697/08207bb1-26a9-43bc-9d9f-239f7fafa2a9)

## Steps to test these changes
Go to your favorite 'weapon' mob and spam !exec target:useMobAbility(513)
