### PR TITLE
[core] Various ability state improvements

### DIFF
--- a/scripts/actions/abilities/restoring_breath.lua
+++ b/scripts/actions/abilities/restoring_breath.lua
@@ -7,6 +7,8 @@
 -----------------------------------
 local abilityObject = {}
 
+-- TODO: find out what checks can result in being unable to use ability on the pet --
+-- such as if the wyvern has amnesia, stun, etc
 abilityObject.onAbilityCheck = function(player, target, ability)
     -- You can't actually use Restoring Breath on retail unless your wyvern is up
     -- This is on the pet menu, but just in case...

--- a/scripts/actions/abilities/smiting_breath.lua
+++ b/scripts/actions/abilities/smiting_breath.lua
@@ -7,6 +7,8 @@
 -----------------------------------
 local abilityObject = {}
 
+-- TODO: find out what checks can result in being unable to use ability on the pet --
+-- such as if the wyvern has amnesia, stun, etc
 abilityObject.onAbilityCheck = function(player, target, ability)
     -- You can't actually use Restoring Breath on retail unless your wyvern is up
     -- This is on the pet menu, but just in case...

--- a/src/map/ai/states/ability_state.cpp
+++ b/src/map/ai/states/ability_state.cpp
@@ -52,7 +52,8 @@ CAbilityState::CAbilityState(CBattleEntity* PEntity, uint16 targid, uint16 abili
     SetTarget(PTarget->targid);
     m_PAbility = std::make_unique<CAbility>(*PAbility);
     m_castTime = PAbility->getCastTime();
-    if (m_castTime > 0s)
+
+    if (m_castTime > 0s && CanUseAbility())
     {
         action_t action;
         action.id              = PEntity->id;
@@ -65,8 +66,12 @@ CAbilityState::CAbilityState(CBattleEntity* PEntity, uint16 targid, uint16 abili
         actionTarget.messageID = 326;
         actionTarget.param     = PAbility->getID();
         PEntity->loc.zone->PushPacket(PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+        m_PEntity->PAI->EventHandler.triggerListener("ABILITY_START", CLuaBaseEntity(m_PEntity), CLuaAbility(PAbility));
     }
-    m_PEntity->PAI->EventHandler.triggerListener("ABILITY_START", CLuaBaseEntity(m_PEntity), CLuaAbility(PAbility));
+    else
+    {
+        m_PEntity->PAI->EventHandler.triggerListener("ABILITY_START", CLuaBaseEntity(m_PEntity), CLuaAbility(PAbility));
+    }
 }
 
 CAbility* CAbilityState::GetAbility()
@@ -174,7 +179,7 @@ bool CAbilityState::CanUseAbility()
             return false;
         }
 
-        if (PChar->IsValidTarget(PTarget->targid, PAbility->getValidTarget(), errMsg))
+        if (PTarget && PChar->IsValidTarget(PTarget->targid, PAbility->getValidTarget(), errMsg))
         {
             if (PChar != PTarget && distance(PChar->loc.p, PTarget->loc.p) > PAbility->getRange())
             {
@@ -211,19 +216,36 @@ bool CAbilityState::CanUseAbility()
     }
     else
     {
+        bool   tooFarAway      = false;
+        bool   cancelAbility   = false;
         bool   hasAmnesia      = m_PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_AMNESIA);
         bool   hasImpairment   = m_PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_IMPAIRMENT);
         uint16 impairmentPower = hasImpairment ? m_PEntity->StatusEffectContainer->GetStatusEffect(EFFECT_IMPAIRMENT)->GetPower() : 0;
 
+        if (!PTarget)
+        {
+            cancelAbility = true;
+        }
+
         if (hasAmnesia ||
             (hasImpairment && (impairmentPower == 0x01 || impairmentPower == 0x03)))
         {
-            return false;
+            cancelAbility = true;
         }
 
-        if (m_PEntity->IsValidTarget(PTarget->targid, PAbility->getValidTarget(), errMsg))
+        if (PTarget && m_PEntity->IsValidTarget(PTarget->targid, PAbility->getValidTarget(), errMsg))
         {
             if (m_PEntity != PTarget && distance(m_PEntity->loc.p, PTarget->loc.p) > PAbility->getRange())
+            {
+                cancelAbility = true;
+                tooFarAway    = true;
+            }
+        }
+
+        if (cancelAbility)
+        {
+            // Only create a packet if the ability isn't instant
+            if (m_castTime > 0s)
             {
                 // Create this action packet that also sort of looks like an animation cancel packet to emit a red "Target is too far away" message.
                 // Captured from a red "<target> is too far away" message from healing breath IV
@@ -241,12 +263,11 @@ bool CAbilityState::CanUseAbility()
                 actionTarget.reaction        = REACTION::MISS;
                 actionTarget.speceffect      = static_cast<SPECEFFECT>(0x24);
                 actionTarget.param           = 0; // Observed as 639 on retail, but I'm not sure that it actually does anything.
-                actionTarget.messageID       = MSGBASIC_TOO_FAR_AWAY_RED;
+                actionTarget.messageID       = tooFarAway ? MSGBASIC_TOO_FAR_AWAY_RED : 0;
 
                 m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
-
-                return false;
             }
+            return false;
         }
 
         // TODO: should luautils::OnAbilityCheck go here too?


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

    * Add checks for nullptr PTarget
    * Prevent ability with non-instant cast from starting if the entity has amnesia/impairment
    * Do not emit "too far away" message if the non-instant ability is canceled due to amnesia/impairment


## Steps to test these changes

Give your wyvern amnesia and attempt to use Restoring Breath/Smiting Breath and see it NOT use an ability
Give your wyvern amnesia immediately after it using a breath of some kind and see it cancel the ability without a "too far away" message
