### PR TITLE
[LUA] Elemental Siphon should not be usable with no pet

### DIFF
--- a/scripts/actions/abilities/elemental_siphon.lua
+++ b/scripts/actions/abilities/elemental_siphon.lua
@@ -13,10 +13,10 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 
     if pet then
         petID = pet:getPetID()
-    end
 
-    if petID >= xi.petId.FIRE_SPIRIT and petID <= xi.petId.DARK_SPIRIT then -- spirits
-        return 0, 0
+        if petID >= xi.petId.FIRE_SPIRIT and petID <= xi.petId.DARK_SPIRIT then -- spirits
+            return 0, 0
+        end
     end
 
     return xi.msg.basic.UNABLE_TO_USE_JA, 0
@@ -30,6 +30,8 @@ abilityObject.onUseAbility = function(player, target, ability)
     -- element order: fire, ice, wind, earth, thunder, water, light, dark
     if spirit then
         spiritEle = spirit:getPetID() + 1
+    else
+        return 0
     end
 
     local pEquipMods = player:getMod(xi.mod.ENHANCES_ELEMENTAL_SIPHON)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Elemental siphon is usable without a pet, since petID is initialized to zero, the ID of fire spirit

The current code would also spit errors due to `spirit` being undefined in the ability use section. I'm not sure it's possible to hit that with the updated `onAbilityCheck`, but I've added a check there as well to cleanly return 0:

![image](https://github.com/LandSandBoat/server/assets/131182600/7a98cc08-9bb1-4b78-b8f4-6e3befcb3e36)


## Steps to test these changes

Summon an avatar, see that siphon is not usable, release and see it's still not usable, summon spirit and see siphon is usable.