### PR TITLE
[lua] snake eye to automatic 11 only when previous roll is 5+

### DIFF
--- a/scripts/globals/job_utils/corsair.lua
+++ b/scripts/globals/job_utils/corsair.lua
@@ -254,7 +254,7 @@ xi.job_utils.corsair.useDoubleUp = function(caster, target, ability, action)
         caster:setLocalVar('corsairActiveRoll', duEffect:getSubType())
         local snakeEye = caster:getStatusEffect(xi.effect.SNAKE_EYE)
         if snakeEye then
-            if prevRoll:getPower() >= 5 and math.random(100) < snakeEye:getPower() then
+            if roll >= 5 and math.random(100) < snakeEye:getPower() then
                 roll = 11
             else
                 roll = roll + 1


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Snake eye effect should give a chance to automatic roll 11 only when the roll _power_ is 5+, old code was checking the previous roll's effectID

## Steps to test these changes

Fully merit snake eye and see that you only ever roll 11 when previous roll power is 5+