### PR TITLE
[LUA] Shijin Spiral plague duration

### DIFF
--- a/scripts/actions/weaponskills/shijin_spiral.lua
+++ b/scripts/actions/weaponskills/shijin_spiral.lua
@@ -29,7 +29,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if damage > 0 then
-        local duration = (tp / 1000) + 4
+        local duration = 3 * ((tp / 1000) + 5) -- Plague effect is -50TP/tick and lasts for 5-8 ticks.
         if not target:hasStatusEffect(xi.effect.PLAGUE) then
             target:addStatusEffect(xi.effect.PLAGUE, 5, 0, duration)
         end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
[Shijin Spiral](https://www.bg-wiki.com/ffxi/Shijin_Spiral) should give 5-8 _ticks_ of plague, not 4-7 seconds. I suspect "5-8" means 30s with resists lowering duration but there's no good way to verify that I imagine.

## Steps to test these changes

Shijin mobs, see duration of effect. Here's godmode at 3k tp for full duration

![image](https://github.com/LandSandBoat/server/assets/131182600/b01d0495-35b9-485d-a625-bd9de1bafe06)
