### PR TITLE
[core] Fix ranged delay calculation for throwing

### DIFF
--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -591,16 +591,16 @@ public:
     int32 GetMaxMP() const;
     void  UpdateHealth(); // recalculation of the maximum amount of hp and mp, as well as adjusting their current values
 
-    int16  GetWeaponDelay(bool tp);       // returns delay of combined weapons
-    float  GetMeleeRange() const;         // returns the distance considered to be within melee range of the entity
-    int16  GetRangedWeaponDelay(bool tp); // returns delay of ranged weapon + ammo where applicable
-    int16  GetAmmoDelay();                // returns delay of ammo (for cooldown between shots)
-    uint16 GetMainWeaponDmg();            // returns total main hand DMG
-    uint16 GetSubWeaponDmg();             // returns total sub weapon DMG
-    uint16 GetRangedWeaponDmg();          // returns total ranged weapon DMG
-    uint16 GetMainWeaponRank();           // returns total main hand DMG Rank
-    uint16 GetSubWeaponRank();            // returns total sub weapon DMG Rank
-    uint16 GetRangedWeaponRank();         // returns total ranged weapon DMG Rank
+    int16  GetWeaponDelay(bool tp);              // returns delay of combined weapons
+    float  GetMeleeRange() const;                // returns the distance considered to be within melee range of the entity
+    int16  GetRangedWeaponDelay(bool forTPCalc); // returns delay of ranged weapon + ammo where applicable
+    int16  GetAmmoDelay();                       // returns delay of ammo (for cooldown between shots)
+    uint16 GetMainWeaponDmg();                   // returns total main hand DMG
+    uint16 GetSubWeaponDmg();                    // returns total sub weapon DMG
+    uint16 GetRangedWeaponDmg();                 // returns total ranged weapon DMG
+    uint16 GetMainWeaponRank();                  // returns total main hand DMG Rank
+    uint16 GetSubWeaponRank();                   // returns total sub weapon DMG Rank
+    uint16 GetRangedWeaponRank();                // returns total ranged weapon DMG Rank
 
     uint16 GetSkill(uint16 SkillID); // the current value of the skill (not the maximum, but limited by the level)
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes an issue with ranged delay calculations in battleentity.cpp. Specifically the function GetRangedWeaponDelay currently gives 0 delay for throwing weapons such a pebbles, which results in basically instant throws. This is primarily because the function only considers the case of ranged weapons like bows with ammo.

This PR fixes this issue by changing the logic to consider also the case where there is no ranged weapon but only ammo (for throwing). Also the function logic is refactored to use getBaseDelay so no need to use a conversion like ((X * 60) / 1000).

This is PR from ASB coming upstream.

## Steps to test these changes
Test different combinations of ranged weapons and throwing weapons and test delay
