### PR TITLE
[core] Cleanup calculateMeleePDIF lua call from battleutils

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2912,7 +2912,7 @@ namespace battleutils
                 return pDIF;
             }
 
-            result = meleePDIFFunc(luaAttackerEntity, CLuaBaseEntity(PDefender), weaponType, bonusAttPercent, isCritical, result.get<bool>(0), false, false);
+            result = meleePDIFFunc(luaAttackerEntity, CLuaBaseEntity(PDefender), weaponType, bonusAttPercent, isCritical, result.get<bool>(0), false, 0.0, false);
             if (!result.valid())
             {
                 sol::error err = result;

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2904,22 +2904,22 @@ namespace battleutils
 
         if (meleePDIFFunc.valid() && levelCorrectionFunc.valid())
         {
-            auto result = levelCorrectionFunc(luaAttackerEntity);
-            if (!result.valid())
+            auto levelCorrectionResult = levelCorrectionFunc(luaAttackerEntity);
+            if (!levelCorrectionResult.valid())
             {
-                sol::error err = result;
+                sol::error err = levelCorrectionResult;
                 ShowError("battleutils::GetDamageRatio(): %s", err.what());
                 return pDIF;
             }
 
-            result = meleePDIFFunc(luaAttackerEntity, CLuaBaseEntity(PDefender), weaponType, bonusAttPercent, isCritical, result.get<bool>(0), false, 0.0, false);
-            if (!result.valid())
+            auto meleePDIFFuncResult = meleePDIFFunc(luaAttackerEntity, CLuaBaseEntity(PDefender), weaponType, bonusAttPercent, isCritical, levelCorrectionResult.get<bool>(0), false, 0.0, false);
+            if (!meleePDIFFuncResult.valid())
             {
-                sol::error err = result;
+                sol::error err = meleePDIFFuncResult;
                 ShowError("battleutils::GetDamageRatio(): %s", err.what());
                 return pDIF;
             }
-            pDIF = result.get<float>(0);
+            pDIF = meleePDIFFuncResult.get<float>(0);
         }
         else
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

calculateMeleePDIF call from c++ was missing a param that was non-functional, but it's aligned now.
The lua calls in GetDamageRatio were not properly destructing the protected_function_result which left things on the stack:
![image](https://github.com/LandSandBoat/server/assets/60417494/d4acf156-78e1-4c02-ae54-b35d9fb4216c)

seems to fix #5248
## Steps to test these changes

Give yourself and a bunch of trusts 30% JA haste, gear haste, magic haste and 100% quad attack, auto attack an immortal mob for > 10~ minutes and not crash.
