### PR TITLE
[cpp] Properly ensures weapon is not null for str check

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -663,8 +663,10 @@ int32 CBattleEntity::takeDamage(int32 amount, CBattleEntity* attacker /* = nullp
 
 uint16 CBattleEntity::STR()
 {
+    auto* weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_MAIN]);
+
     // Hasso gives STR only if main weapon is two handed
-    if (auto* weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_MAIN]); weapon->isTwoHanded())
+    if (weapon && weapon->isTwoHanded())
     {
         return std::clamp(stats.STR + m_modStat[Mod::STR] + m_modStat[Mod::TWOHAND_STR], 0, 999);
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
The new 2-hand-only str buff added a check for weapon type. Under most circumstances this couldn't get a nullptr so the logic to check for dynamic cast success seems to have not been tested.

screenshot of the crash we saw:

![image](https://github.com/LandSandBoat/server/assets/131182600/3a735bdf-4c8c-4f49-82e8-6268dd8cd560)


which led to a bit of brainstorming to reproduce, and came up with these steps:

- remove all weapons (probably only main is needed)
- `!addeffect str_down 50`
- `/logout`
- log back in
- server crash


## Steps to test these changes

Perform the above steps after applying patch and effect gain is successful on login
