### PR TITLE
[core] Small slot_sub audit for H2H usage

### DIFF
--- a/src/map/attackround.cpp
+++ b/src/map/attackround.cpp
@@ -32,17 +32,11 @@
  *                                                                        *
  ************************************************************************/
 CAttackRound::CAttackRound(CBattleEntity* attacker, CBattleEntity* defender)
-: m_subWeaponType(DAMAGE_TYPE::NONE)
 {
     m_attacker          = attacker;
     m_defender          = defender;
     m_kickAttackOccured = false;
     m_sataOccured       = false;
-
-    if (auto* weapon = dynamic_cast<CItemWeapon*>(attacker->m_Weapons[SLOT_SUB]))
-    {
-        m_subWeaponType = weapon->getDmgType();
-    }
 
     // Grab a trick attack assistant.
     m_taEntity = battleutils::getAvailableTrickAttackChar(attacker, attacker->GetBattleTarget());

--- a/src/map/attackround.h
+++ b/src/map/attackround.h
@@ -67,7 +67,6 @@ private:
     std::vector<CAttack> m_attackSwings;           // The list of attacks for this round.
     bool                 m_sataOccured;            // Flag: Did SATA occur during the round?
     bool                 m_kickAttackOccured;      // Flag: Did a kick attack occur during the round?
-    DAMAGE_TYPE          m_subWeaponType;          // The sub weapon type.
 };
 
 #endif

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -794,14 +794,16 @@ uint16 CBattleEntity::ACC(uint8 attackNumber, uint8 offsetAccuracy)
 
     if (this->objtype & TYPE_PC)
     {
-        uint8  skill     = 0;
-        uint16 iLvlSkill = 0;
+        uint8  skill       = 0;
+        uint16 iLvlSkill   = 0;
+        auto   PMainWeapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_MAIN]);
+
         if (attackNumber == 0)
         {
-            if (auto* weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_MAIN]))
+            if (PMainWeapon)
             {
-                skill     = weapon->getSkillType();
-                iLvlSkill = weapon->getILvlSkill();
+                skill     = PMainWeapon->getSkillType();
+                iLvlSkill = PMainWeapon->getILvlSkill();
                 if (skill == SKILL_NONE && GetSkill(SKILL_HAND_TO_HAND) > 0)
                 {
                     skill = SKILL_HAND_TO_HAND;
@@ -822,6 +824,11 @@ uint16 CBattleEntity::ACC(uint8 attackNumber, uint8 offsetAccuracy)
                         skill = SKILL_HAND_TO_HAND;
                     }
                 }
+            }
+            else if (PMainWeapon && PMainWeapon->isHandToHand())
+            {
+                iLvlSkill = PMainWeapon->getILvlSkill();
+                skill     = SKILL_HAND_TO_HAND;
             }
         }
         else if (attackNumber == 2)


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Remove some unused variable
* Fix ACC not getting accuracy for h2h on second fist
Fixes #5253 

## Steps to test these changes

Use h2h and see your acc is normal on the second fist