### PR TITLE
[core] Add function to send item(s) to a delivery box

### DIFF
--- a/scripts/enum/send_to_delivery_box.lua
+++ b/scripts/enum/send_to_delivery_box.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- Return codes for SendItemToDeliveryBox function
+-----------------------------------
+xi = xi or {}
+
+xi.sendToDBoxReturnCode =
+{
+    -- Successfully delivered the requested quantity
+    SUCCESS                       = 0,
+    -- Success but requested quantity was larger than
+    -- item stack size so only delivered a single stack
+    SUCCESS_LIMITED_TO_STACK_SIZE = 1,
+    PLAYER_NOT_FOUND              = 2,
+    ITEM_NOT_FOUND                = 3,
+    QUERY_ERROR                   = 4
+}

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -224,6 +224,7 @@ namespace luautils
         lua.set_function("GetContainerFilenamesList", &luautils::GetContainerFilenamesList);
         lua.set_function("GetCachedInstanceScript", &luautils::GetCachedInstanceScript);
         lua.set_function("GetItemIDByName", &luautils::GetItemIDByName);
+        lua.set_function("SendItemToDeliveryBox", &luautils::SendItemToDeliveryBox);
         lua.set_function("SendLuaFuncStringToZone", &luautils::SendLuaFuncStringToZone);
         lua.set_function("RoeParseRecords", &roeutils::ParseRecords);
         lua.set_function("RoeParseTimed", &roeutils::ParseTimedSchedule);
@@ -5590,6 +5591,84 @@ namespace luautils
         }
 
         customMenuContext.erase(PChar->id);
+    }
+
+    SendToDBoxReturnCode SendItemToDeliveryBox(std::string const& playerName, uint16 itemId, uint32 quantity, std::string senderText)
+    {
+        const char* getPlayerIDQuery = "SELECT charid FROM chars WHERE charname = '%s'";
+        int32       queryRet         = _sql->Query(getPlayerIDQuery, playerName);
+        uint32      playerID         = 0;
+
+        if (queryRet != SQL_ERROR && _sql->NumRows() != 0 && _sql->NextRow() == SQL_SUCCESS)
+        {
+            playerID = _sql->GetIntData(0);
+        }
+        else
+        {
+            return SendToDBoxReturnCode::PLAYER_NOT_FOUND;
+        }
+
+        auto isGil = itemId == 65535;
+
+        // Check to confirm that the item legitimately exists
+        // exclude gil as gil does not have an item pointer
+        auto* PItem = itemutils::GetItemPointer(itemId);
+        if (PItem == nullptr && !isGil)
+        {
+            return SendToDBoxReturnCode::ITEM_NOT_FOUND;
+        }
+
+        // default stack size of gil
+        uint32 stackSize = 999999999;
+        // if not gil then get the actual stack size
+        if (!isGil)
+        {
+            stackSize = PItem->getStackSize();
+        }
+
+        bool quantityMoreThanStackSize = quantity > stackSize;
+
+        // limit the quantity to the stack size of the item
+        quantity = std::clamp<uint32>(quantity, 1, stackSize);
+
+        bool isAutoCommitOn = _sql->GetAutoCommit();
+
+        if (_sql->SetAutoCommit(false) && _sql->TransactionStart())
+        {
+            const char* Query = "INSERT INTO delivery_box (charid, box, itemid, quantity, senderid, sender) VALUES ("
+                                "%u, "     // Player ID
+                                "1, "      // Box ID == 1
+                                "%u, "     // Item ID
+                                "%u, "     // Quantity
+                                "%u, "     // Sender ID ( =Player ID )
+                                "'%s'); "; // Sender Text
+            int32 ret = _sql->Query(Query, playerID, itemId, quantity, playerID, senderText);
+
+            if (ret == SQL_ERROR)
+            {
+                _sql->TransactionRollback();
+                _sql->SetAutoCommit(isAutoCommitOn);
+                return SendToDBoxReturnCode::QUERY_ERROR;
+            }
+            else
+            {
+                _sql->TransactionCommit();
+                _sql->SetAutoCommit(isAutoCommitOn);
+            }
+
+            if (quantityMoreThanStackSize)
+            {
+                return SendToDBoxReturnCode::SUCCESS_LIMITED_TO_STACK_SIZE;
+            }
+            else
+            {
+                return SendToDBoxReturnCode::SUCCESS;
+            }
+        }
+        else
+        {
+            return SendToDBoxReturnCode::QUERY_ERROR;
+        }
     }
 
     uint16 GetItemIDByName(std::string const& name)

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -63,6 +63,15 @@ extern sol::state lua;
 #include "lua_trigger_area.h"
 #include "lua_zone.h"
 
+enum class SendToDBoxReturnCode : uint8
+{
+    SUCCESS                       = 0,
+    SUCCESS_LIMITED_TO_STACK_SIZE = 1,
+    PLAYER_NOT_FOUND              = 2,
+    ITEM_NOT_FOUND                = 3,
+    QUERY_ERROR                   = 4
+};
+
 class CAbility;
 class CSpell;
 class CBaseEntity;
@@ -354,6 +363,7 @@ namespace luautils
 
     // Retrive the first itemId that matches a name
     uint16 GetItemIDByName(std::string const& name);
+    auto   SendItemToDeliveryBox(std::string const& playerName, uint16 itemId, uint32 quantity, std::string senderText) -> SendToDBoxReturnCode;
 
     std::optional<CLuaBaseEntity> GenerateDynamicEntity(CZone* PZone, CInstance* PInstance, sol::table table);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR adds a lua function called SendItemToDeliveryBox that sends a specified item to a players delivery box. The function takes params including name of player, item id, quantity, and message to display as the sender (such as "Server Staff" or "GM"). And it leverages an enum of return codes to indicate the outcome of the request.

The main purpose of the function is to allow lua GM commands to be built that leverage the function. For example a GM command might be !deliveritem that would allow GMs to refund (due to a game bug) some item(s) even if the player is not online when the GM is processing the ticket.

This is an ASB addition coming upstream.

## Steps to test these changes
Can call the command with !exec and try sending different items to players delivery boxes
