### PR TITLE
Catch having another pet for luopan

### DIFF
--- a/scripts/globals/job_utils/geomancer.lua
+++ b/scripts/globals/job_utils/geomancer.lua
@@ -333,6 +333,8 @@ end
 xi.job_utils.geomancer.geoOnMagicCastingCheck = function(caster, target, spell)
     if hasLuopan(caster) then
         return xi.msg.basic.LUOPAN_ALREADY_PLACED
+    elseif caster:getPet() then
+        return xi.msg.basic.ALREADY_HAS_A_PET
     elseif not caster:canUseMisc(xi.zoneMisc.PET) then
         return xi.msg.basic.CANT_BE_USED_IN_AREA
     else


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Simple fix but funny bug without the extra condition. If you don't check for an existing pet, the model of your pet changes (and persists in the case of a charmed pet):

![image](https://github.com/LandSandBoat/server/assets/131182600/ad99742c-e1ce-4646-a31d-a169c186dc1a)


## Steps to test these changes

geo sub any pet job, have a variety of pets and see geo-* spells aren't usable:

![image](https://github.com/LandSandBoat/server/assets/131182600/23e4c4ce-ec88-4cd9-88c0-6e4a8224de73)

