### PR TITLE
Fix one hour recast reduction from JP gift

### DIFF
--- a/scripts/actions/abilities/astral_conduit.lua
+++ b/scripts/actions/abilities/astral_conduit.lua
@@ -8,7 +8,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
 
     return 0, 0
 end

--- a/scripts/actions/abilities/astral_flow.lua
+++ b/scripts/actions/abilities/astral_flow.lua
@@ -8,7 +8,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
 
     return 0, 0
 end

--- a/scripts/actions/abilities/azure_lore.lua
+++ b/scripts/actions/abilities/azure_lore.lua
@@ -8,7 +8,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
 
     return 0, 0
 end

--- a/scripts/actions/abilities/caper_emissarius.lua
+++ b/scripts/actions/abilities/caper_emissarius.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
         return xi.msg.basic.CANNOT_ON_THAT_TARG, 0
     end
 
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
     return 0, 0
 end
 

--- a/scripts/actions/abilities/clarion_call.lua
+++ b/scripts/actions/abilities/clarion_call.lua
@@ -8,7 +8,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
 
     return 0, 0
 end

--- a/scripts/actions/abilities/cutting_cards.lua
+++ b/scripts/actions/abilities/cutting_cards.lua
@@ -7,7 +7,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
     return 0, 0
 end
 

--- a/scripts/actions/abilities/eagle_eye_shot.lua
+++ b/scripts/actions/abilities/eagle_eye_shot.lua
@@ -25,7 +25,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
                     skilltype == xi.skill.THROWING
                 )
             then
-                ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+                ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
                 return 0, 0
             end
         end

--- a/scripts/actions/abilities/elemental_sforzo.lua
+++ b/scripts/actions/abilities/elemental_sforzo.lua
@@ -8,7 +8,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
 
     return 0, 0
 end

--- a/scripts/actions/abilities/familiar.lua
+++ b/scripts/actions/abilities/familiar.lua
@@ -20,7 +20,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
     end
 
     pet:setLocalVar('ReceivedFamiliar', 1)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
 
     return 0, 0
 end

--- a/scripts/actions/abilities/fly_high.lua
+++ b/scripts/actions/abilities/fly_high.lua
@@ -8,7 +8,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
     return 0, 0
 end
 

--- a/scripts/actions/abilities/grand_pas.lua
+++ b/scripts/actions/abilities/grand_pas.lua
@@ -8,7 +8,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
 
     return 0, 0
 end

--- a/scripts/actions/abilities/heady_artifice.lua
+++ b/scripts/actions/abilities/heady_artifice.lua
@@ -7,7 +7,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
 
     return 0, 0
 end

--- a/scripts/actions/abilities/meikyo_shisui.lua
+++ b/scripts/actions/abilities/meikyo_shisui.lua
@@ -8,7 +8,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
 
     return 0, 0
 end

--- a/scripts/actions/abilities/mijin_gakure.lua
+++ b/scripts/actions/abilities/mijin_gakure.lua
@@ -8,7 +8,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
     return 0, 0
 end
 

--- a/scripts/actions/abilities/mikage.lua
+++ b/scripts/actions/abilities/mikage.lua
@@ -8,7 +8,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
 
     return 0, 0
 end

--- a/scripts/actions/abilities/overdrive.lua
+++ b/scripts/actions/abilities/overdrive.lua
@@ -14,7 +14,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
     elseif not pet:isAutomaton() then
         return xi.msg.basic.NO_EFFECT_ON_PET, 0
     else
-        ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+        ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
         return 0, 0
     end
 end

--- a/scripts/actions/abilities/overkill.lua
+++ b/scripts/actions/abilities/overkill.lua
@@ -8,7 +8,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
 
     return 0, 0
 end

--- a/scripts/actions/abilities/soul_voice.lua
+++ b/scripts/actions/abilities/soul_voice.lua
@@ -8,7 +8,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
 
     return 0, 0
 end

--- a/scripts/actions/abilities/tabula_rasa.lua
+++ b/scripts/actions/abilities/tabula_rasa.lua
@@ -8,7 +8,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
 
     return 0, 0
 end

--- a/scripts/actions/abilities/trance.lua
+++ b/scripts/actions/abilities/trance.lua
@@ -8,7 +8,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
 
     return 0, 0
 end

--- a/scripts/actions/abilities/unbridled_wisdom.lua
+++ b/scripts/actions/abilities/unbridled_wisdom.lua
@@ -8,7 +8,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
 
     return 0, 0
 end

--- a/scripts/actions/abilities/unleash.lua
+++ b/scripts/actions/abilities/unleash.lua
@@ -8,7 +8,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
 
     return 0, 0
 end

--- a/scripts/actions/abilities/wild_card.lua
+++ b/scripts/actions/abilities/wild_card.lua
@@ -8,7 +8,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
 
     return 0, 0
 end

--- a/scripts/actions/abilities/yaegasumi.lua
+++ b/scripts/actions/abilities/yaegasumi.lua
@@ -8,7 +8,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
 
     return 0, 0
 end

--- a/scripts/globals/job_utils/black_mage.lua
+++ b/scripts/globals/job_utils/black_mage.lua
@@ -11,12 +11,12 @@ xi.job_utils.black_mage = xi.job_utils.black_mage or {}
 -- Ability Check Functions
 -----------------------------------
 xi.job_utils.black_mage.checkManafont = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
     return 0, 0
 end
 
 xi.job_utils.black_mage.checkSubtleSorcery = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
     return 0, 0
 end
 

--- a/scripts/globals/job_utils/dark_knight.lua
+++ b/scripts/globals/job_utils/dark_knight.lua
@@ -21,13 +21,13 @@ xi.job_utils.dark_knight.checkArcaneCrest = function(player, target, ability)
 end
 
 xi.job_utils.dark_knight.checkBloodWeapon = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
 
     return 0, 0
 end
 
 xi.job_utils.dark_knight.checkSoulEnslavement = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
 
     return 0, 0
 end

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -133,7 +133,7 @@ xi.job_utils.dragoon.abilityCheckRequiresPet = function(player, target, ability,
         end
 
         if ability:getID() == xi.jobAbility.SPIRIT_SURGE then
-            ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+            ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
         end
 
         return 0, 0

--- a/scripts/globals/job_utils/monk.lua
+++ b/scripts/globals/job_utils/monk.lua
@@ -18,12 +18,12 @@ local chakraStatusEffects =
 -- Ability Check Functions
 -----------------------------------
 xi.job_utils.monk.checkHundredFists = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
     return 0, 0
 end
 
 xi.job_utils.monk.checkInnerStrength = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
     return 0, 0
 end
 

--- a/scripts/globals/job_utils/paladin.lua
+++ b/scripts/globals/job_utils/paladin.lua
@@ -24,7 +24,7 @@ xi.job_utils.paladin.checkIntervene = function(player, target, ability)
     if player:getShieldSize() == 0 then
         return xi.msg.basic.REQUIRES_SHIELD, 0
     else
-        ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+        ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
 
         return 0, 0
     end
@@ -34,7 +34,7 @@ xi.job_utils.paladin.checkInvincible = function(player, target, ability)
     local jpValue = player:getJobPointLevel(xi.jp.INVINCIBLE_EFFECT)
 
     ability:setVE(ability:getVE() + 100 * jpValue)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
 
     return 0, 0
 end

--- a/scripts/globals/job_utils/red_mage.lua
+++ b/scripts/globals/job_utils/red_mage.lua
@@ -11,12 +11,12 @@ xi.job_utils.red_mage = xi.job_utils.red_mage or {}
 -- Ability Check Functions
 -----------------------------------
 xi.job_utils.red_mage.checkChainspell = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
     return 0, 0
 end
 
 xi.job_utils.red_mage.checkStymie = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
     return 0, 0
 end
 

--- a/scripts/globals/job_utils/thief.lua
+++ b/scripts/globals/job_utils/thief.lua
@@ -108,13 +108,13 @@ xi.job_utils.thief.checkDespoil = function(player, target, ability)
 end
 
 xi.job_utils.thief.checkLarceny = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
 
     return 0, 0
 end
 
 xi.job_utils.thief.checkPerfectDodge = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
 
     return 0, 0
 end

--- a/scripts/globals/job_utils/warrior.lua
+++ b/scripts/globals/job_utils/warrior.lua
@@ -9,12 +9,12 @@ xi.job_utils.warrior = xi.job_utils.warrior or {}
 -- Ability Check Functions
 -----------------------------------
 xi.job_utils.warrior.checkBrazenRush = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
     return 0, 0
 end
 
 xi.job_utils.warrior.checkMightyStrikes = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
     return 0, 0
 end
 

--- a/scripts/globals/job_utils/white_mage.lua
+++ b/scripts/globals/job_utils/white_mage.lua
@@ -26,12 +26,12 @@ local removables =
 -- Ability Check Functions
 -----------------------------------
 xi.job_utils.white_mage.checkAsylum = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
     return 0, 0
 end
 
 xi.job_utils.white_mage.checkBenediction = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
     return 0, 0
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Changes one hour reduction to be properly multiplied by 60 so one point in ONE_HOUR_RECAST  is 1 minute. Also prevents the value to go negative if the recast timer setting is changed or other custom shenanigans.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

Use a one hour ability with a job with maxed out JP gift, or spawn an item with a custom augment.

<!-- Clear and detailed steps to test your changes here -->
