### PR TITLE
Don't let Maidens Virelai try to charm and already charmed target

### DIFF
--- a/scripts/actions/spells/songs/maidens_virelai.lua
+++ b/scripts/actions/spells/songs/maidens_virelai.lua
@@ -14,32 +14,39 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
     -- Per wiki, Virelai wipes all shadows even if it resists or the target is immune to charm
     -- This can't be done in the onSpellCast function (that runs after it "hits")
     spell:setFlag(xi.magic.spellFlag.WIPE_SHADOWS)
+    -- TODO:
+    -- 1. move "spell:setFlag()" to a SpellFlags group of get/set/add/del functions
+    -- 2. move spell flags to the spell table, so we don't have to do hacky things inside the casting check!
 
     return 0
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    -- local dCHR = (caster:getStat(xi.mod.CHR) - target:getStat(xi.mod.CHR))
-    local bonus = 0 -- No idea what value, but seems likely to need this edited later to get retail resist rates.
-    local params = {}
-    params.diff = nil
-    params.attribute = xi.mod.CHR
-    params.skillType = xi.skill.SINGING
-    params.bonus = bonus
-    params.effect = xi.effect.CHARM_I
-    local resist = applyResistanceEffect(caster, target, spell, params)
-
-    if resist >= 0.25 and caster:getCharmChance(target, false) > 0 then
-        spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
-        if caster:isMob() then
-            target:addStatusEffect(xi.effect.CHARM_I, 0, 0, 30 * resist)
-            caster:charm(target)
-        else
-            caster:charmPet(target)
-        end
+    if target:hasStatusEffect(xi.effect.CHARM_I) then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     else
-        -- Resist
-        spell:setMsg(xi.msg.basic.MAGIC_RESIST)
+        -- local dCHR = (caster:getStat(xi.mod.CHR) - target:getStat(xi.mod.CHR))
+        local bonus = 0 -- No idea what value, but seems likely to need this edited later to get retail resist rates.
+        local params = {}
+        params.diff = nil
+        params.attribute = xi.mod.CHR
+        params.skillType = xi.skill.SINGING
+        params.bonus = bonus
+        params.effect = xi.effect.CHARM_I
+        local resist = applyResistanceEffect(caster, target, spell, params)
+
+        if resist >= 0.25 and caster:getCharmChance(target, false) > 0 then
+            spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            if caster:isMob() then
+                target:addStatusEffect(xi.effect.CHARM_I, 0, 0, 30 * resist)
+                caster:charm(target)
+            else
+                caster:charmPet(target)
+            end
+        else
+            -- Resist
+            spell:setMsg(xi.msg.basic.MAGIC_RESIST)
+        end
     end
 
     return xi.effect.CHARM_I

--- a/scripts/globals/spells/enfeebling_spell.lua
+++ b/scripts/globals/spells/enfeebling_spell.lua
@@ -240,7 +240,7 @@ xi.spells.enfeebling.calculatePotency = function(caster, target, spellId, spellE
 
     potency = math.floor(potency)
 
-    -- Apply Saboteur Effect when aplicable.
+    -- Apply Saboteur Effect when applicable.
     local applySaboteur = pTable[spellId][11]
 
     if
@@ -455,12 +455,12 @@ xi.spells.enfeebling.useEnfeeblingSpell = function(caster, target, spell)
             target:isMob() and
             immunobreakTable[spellEffect] and          -- Only certain effects can be immunobroken.
             skillType == xi.skill.ENFEEBLING_MAGIC and -- Only Enfeebling magic can immunobreak.
-            resistRank > 4                             -- Only mobs with a resistace rank of 5+ (50% EEM) can be immunobroken.
+            resistRank > 4                             -- Only mobs with a resistance rank of 5+ (50% EEM) can be immunobroken.
         then
             local immunobreakRandom = math.random(1, 100)
             local immunobreakChance = magicHitRate / (1 + rankModifier) + caster:getMerit(xi.merit.IMMUNOBREAK_CHANCE)
 
-            -- We successfuly trigger Immunobreak. Change tagret modifier and set correct message.
+            -- We successfully trigger Immunobreak. Change target modifier and set correct message.
             if immunobreakRandom <= immunobreakChance then
                 target:setMod(immunobreakTable[spellEffect][1], rankModifier + 1) -- TODO: Add equipment modifier (x2) here.
 


### PR DESCRIPTION
Also fixed a few typos

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
See #5268

We shouldn't be able to try and charm someone that was already charmed. However, i do not consider this a fix to that issue : the actual crash in that issue came from the charmed entities pathing AI. 


## Steps to test these changes
Have 1 party member get charmed. Then try and cast Virelai on them, see it have no effect.
