### PR TITLE
[cpp] Ensure player smn avatars assist from any range

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -185,8 +185,8 @@ void CMobController::TryLink()
         {
             if (PTarget->objtype == TYPE_PC)
             {
-                std::unique_ptr<CBasicPacket> errMsg;
-                if (PTarget->PPet->CanAttack(PMob, errMsg))
+                auto* PChar = dynamic_cast<CCharEntity*>(PTarget);
+                if (PChar && PChar->IsMobOwner(PMob))
                 {
                     petutils::AttackTarget(PTarget, PMob);
                 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Started as a bug report, but in testing to create the report I ended up figuring out how to fix it

SMN avatar should attack a mob that aggros the SMN even with no action taken by the smn

[This PR](https://github.com/LandSandBoat/server/pull/5186/files) seems to have made it not work until the mob has a battletarget (which means the mob has to get close enough to act/attack the player), is within melee range of the avatar, and is claimed, since the `battleutils::CanAttack` function requires those last 2 things

This PR doesn't revert the requirement to have the mob be actionable, but it doesn't go all the way to requiring everything from `battleutils::CanAttack`

## Steps to test these changes

Summon an avatar and aggro a mob without acting on it, see your pet assists. Similarly, act on it with say smn/rdm and casting dia.

Before this change the first would not attack at all, second would wait to assist until the mob got within melee range of the pet.
