### PR TITLE
[core] [lua] Add GM command to print all local vars of a target entity

### DIFF
--- a/scripts/commands/getlocalvars.lua
+++ b/scripts/commands/getlocalvars.lua
@@ -1,0 +1,33 @@
+-----------------------------------
+-- Func: getlocalvars
+-- Desc: Gets all local vars of a target
+-----------------------------------
+local commandObj = {}
+
+commandObj.cmdprops =
+{
+    permission = 1,
+    parameters = ''
+}
+
+commandObj.onTrigger = function(player)
+    local targ = player:getCursorTarget()
+    if targ == nil then
+        return
+    end
+
+    local vars = {}
+    vars = targ:getLocalVars()
+
+    if #vars > 0 then
+        player:printToPlayer(string.format('Printing local vars for entity: %s', targ:getName()), xi.msg.channel.SYSTEM_3)
+        player:printToPlayer('----------------------------------', xi.msg.channel.SYSTEM_3)
+        for _, var in pairs(vars) do
+            player:printToPlayer(string.format('"%s" : %u', var['varname'], var['value']), xi.msg.channel.SYSTEM_3)
+        end
+    else
+        player:printToPlayer(string.format('No local vars for entity: %s', targ:getName()), xi.msg.channel.SYSTEM_3)
+    end
+end
+
+return commandObj

--- a/src/map/entities/baseentity.cpp
+++ b/src/map/entities/baseentity.cpp
@@ -202,6 +202,11 @@ uint32 CBaseEntity::GetLocalVar(std::string var)
     return m_localVars[var];
 }
 
+std::map<std::string, uint32>& CBaseEntity::GetLocalVars()
+{
+    return m_localVars;
+}
+
 void CBaseEntity::SetLocalVar(std::string var, uint32 val)
 {
     m_localVars[var] = val;

--- a/src/map/entities/baseentity.h
+++ b/src/map/entities/baseentity.h
@@ -283,6 +283,7 @@ public:
     void   ResetLocalVars();
     uint32 GetLocalVar(std::string var);
     void   SetLocalVar(std::string var, uint32 val);
+    auto   GetLocalVars() -> std::map<std::string, uint32>&;
 
     // pre-tick update
     virtual void Tick(time_point) = 0;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -665,6 +665,28 @@ void CLuaBaseEntity::setVolatileCharVar(std::string const& varName, int32 value,
 }
 
 /************************************************************************
+ *  Function: getLocalVars()
+ *  Purpose : Returns all variables assigned locally to an entity
+ *  Example : local localVars = KingArthro:getLocalVars()
+ *  Notes   :
+ ************************************************************************/
+
+auto CLuaBaseEntity::getLocalVars() -> sol::table
+{
+    auto  table     = lua.create_table();
+    auto& localVars = m_PBaseEntity->GetLocalVars();
+
+    for (auto const& [varName, value] : localVars)
+    {
+        auto subtable       = lua.create_table();
+        subtable["varname"] = varName;
+        subtable["value"]   = value;
+        table.add(subtable);
+    }
+    return table;
+}
+
+/************************************************************************
  *  Function: getLocalVar()
  *  Purpose : Returns a variable assigned locally to an entity
  *  Example : if KingArthro:getLocalVar("[POP]King_Arthro") > 0 then
@@ -17198,6 +17220,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("setVar", CLuaBaseEntity::setCharVar); // Compatibility binding
     SOL_REGISTER("incrementCharVar", CLuaBaseEntity::incrementCharVar);
     SOL_REGISTER("setVolatileCharVar", CLuaBaseEntity::setVolatileCharVar);
+    SOL_REGISTER("getLocalVars", CLuaBaseEntity::getLocalVars);
     SOL_REGISTER("getLocalVar", CLuaBaseEntity::getLocalVar);
     SOL_REGISTER("setLocalVar", CLuaBaseEntity::setLocalVar);
     SOL_REGISTER("resetLocalVars", CLuaBaseEntity::resetLocalVars);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -72,6 +72,7 @@ public:
     void   setCharVarExpiration(std::string const& varName, uint32 expiry); // Sets character variable expiration timestamp
     void   incrementCharVar(std::string const& varname, int32 value);       // Increments/decrements/sets a character variable
     void   setVolatileCharVar(std::string const& varName, int32 value, sol::object const& expiry);
+    auto   getLocalVars() -> sol::table;
     uint32 getLocalVar(std::string const& var);
     void   setLocalVar(std::string const& var, uint32 val);
     void   resetLocalVars();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR adds a GM command to print out all local vars of an entity. This command is very useful for GMs when a player reports some mob or player issue and the GM wants to collect information to later pass on to devs (who are often not online for real time debugging of the mob or player).

This is from ASB and coming upstream.

## Steps to test these changes

Target a mob or player as a GM (level 1+) and use !getlocalvars