### PR TITLE
[cpp]Suppress console error when non-weapon in slot <= 3

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -13841,6 +13841,11 @@ uint8 CLuaBaseEntity::getWeaponSkillType(uint8 slotID)
         {
             return PWeapon->getSkillType();
         }
+        else
+        {
+            // nothing in offhand or non-weapon (shield/grip)
+            return 0;
+        }
     }
 
     ShowError("lua::getWeaponSkillType :: Invalid slot specified!");


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

`getWeaponSkillType()` lua binding gives a map server error when calling this on a valid slot without a valid weapon. This can be an ammo slot without ammo, ranged slot without weapon, offhand with shield, etc. There's no reason to show an error in those cases. This PR will simply return the same thing that it was returning before, but print nothing in the map server console

Closes #5210 .

## Steps to test these changes

weaponskill with a sword in main hand
- without anything in offhand
- with a shield in offhand
- with a second sword in offhand

See that you get no errors in console and ostensibly weaponskills are still functioning properly.
