### PR TITLE
[cpp] Allow samba to work if party leader is on another process

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1381,26 +1381,32 @@ namespace battleutils
 
                 if (PAttacker->objtype == TYPE_PC && PAttacker->PParty != nullptr)
                 {
-                    if (auto* PLeader = dynamic_cast<CCharEntity*>(PAttacker->PParty->GetLeader()))
+                    if (auto* PChar = dynamic_cast<CCharEntity*>(PAttacker))
                     {
-                        PLeader->ForPartyWithTrusts([&](CBattleEntity* PMember)
-                                                    {
+                        // clang-format off
+                        PChar->ForPartyWithTrusts([&](CBattleEntity* PMember)
+                        {
                             if (attackerID == PMember->id)
                             {
                                 power = PDefender->StatusEffectContainer->GetStatusEffect(daze)->GetPower();
-                            } });
+                            }
+                        });
+                        // clang-format on
                     }
                 }
                 else if (PAttacker->objtype == TYPE_TRUST)
                 {
-                    if (auto* PMaster = dynamic_cast<CCharEntity*>(PAttacker->PMaster))
+                    if (auto* PChar = dynamic_cast<CCharEntity*>(PAttacker->PMaster))
                     {
-                        PMaster->ForPartyWithTrusts([&](CBattleEntity* PMember)
-                                                    {
+                        // clang-format off
+                        PChar->ForPartyWithTrusts([&](CBattleEntity* PMember)
+                        {
                             if (attackerID == PMember->id)
                             {
                                 power = PDefender->StatusEffectContainer->GetStatusEffect(daze)->GetPower();
-                            } });
+                            }
+                        });
+                        // clang-format on
                     }
                 }
                 else if (PAttacker->PMaster == nullptr)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Sambas store the targid of the source, and anyone hitting a mob with a daze does a quick loop of their party members to see if they get the daze benefit.

Before this PR, the party leader had to be in the same zone cluster, or the `dynamic_cast` would fail and nobody (including the originator of the samba) would get a benefit

## Steps to test these changes

Use drain samba with multiple people in the party in a multi cluster setup. Have party leader `!zone` to somewhere in the other cluster and see samba effects continue working