### PR TITLE
[core] Add safety to GetTarget and update target in more cases

### DIFF
--- a/src/map/ai/states/ability_state.cpp
+++ b/src/map/ai/states/ability_state.cpp
@@ -82,18 +82,21 @@ CAbility* CAbilityState::GetAbility()
 void CAbilityState::ApplyEnmity()
 {
     auto* PTarget = GetTarget();
-    if (m_PAbility->getValidTarget() & TARGET_ENEMY && PTarget->allegiance != m_PEntity->allegiance)
+    if (PTarget)
     {
-        if (PTarget->objtype == TYPE_MOB && !(m_PAbility->getCE() == 0 && m_PAbility->getVE() == 0))
+        if (m_PAbility->getValidTarget() & TARGET_ENEMY && PTarget->allegiance != m_PEntity->allegiance)
         {
-            CMobEntity* mob = (CMobEntity*)PTarget;
-            mob->PEnmityContainer->UpdateEnmity(m_PEntity, m_PAbility->getCE(), m_PAbility->getVE(), false, m_PAbility->getID() == ABILITY_CHARM);
-            battleutils::ClaimMob(mob, m_PEntity);
+            if (PTarget->objtype == TYPE_MOB && !(m_PAbility->getCE() == 0 && m_PAbility->getVE() == 0))
+            {
+                CMobEntity* mob = (CMobEntity*)PTarget;
+                mob->PEnmityContainer->UpdateEnmity(m_PEntity, m_PAbility->getCE(), m_PAbility->getVE(), false, m_PAbility->getID() == ABILITY_CHARM);
+                battleutils::ClaimMob(mob, m_PEntity);
+            }
         }
-    }
-    else if (PTarget->allegiance == m_PEntity->allegiance)
-    {
-        battleutils::GenerateInRangeEnmity(m_PEntity, m_PAbility->getCE(), m_PAbility->getVE());
+        else if (PTarget->allegiance == m_PEntity->allegiance)
+        {
+            battleutils::GenerateInRangeEnmity(m_PEntity, m_PAbility->getCE(), m_PAbility->getVE());
+        }
     }
 }
 

--- a/src/map/ai/states/item_state.cpp
+++ b/src/map/ai/states/item_state.cpp
@@ -283,7 +283,7 @@ void CItemState::InterruptItem(action_t& action)
         action.actiontype = ACTION_ITEM_INTERRUPT;
 
         actionList_t& actionList  = action.getNewActionList();
-        actionList.ActionTargetID = (m_PEntity->IsValidTarget(m_targid, m_PItem->getValidTarget(), m_errorMsg) ? GetTarget()->id : 0);
+        actionList.ActionTargetID = (m_PEntity->IsValidTarget(m_targid, m_PItem->getValidTarget(), m_errorMsg) ? GetTarget() && GetTarget()->id : 0);
 
         actionTarget_t& actionTarget = actionList.getNewActionTarget();
 

--- a/src/map/ai/states/state.cpp
+++ b/src/map/ai/states/state.cpp
@@ -26,6 +26,8 @@ CState::CState(CBaseEntity* PEntity, uint16 _targid)
 : m_PEntity(PEntity)
 , m_targid(_targid)
 {
+    // TODO: determine if this should go here;
+    // m_PTarget = m_PEntity->GetEntity(_targid);
 }
 
 void CState::UpdateTarget(uint16 targid)
@@ -65,7 +67,7 @@ void CState::ResetEntryTime()
 
 void CState::SetTarget(uint16 _targid)
 {
-    if (_targid != m_targid)
+    if (!m_PTarget || _targid != m_targid || (m_PTarget && m_PTarget->targid != _targid))
     {
         m_targid = _targid;
         UpdateTarget(_targid);

--- a/src/map/ai/states/trigger_state.cpp
+++ b/src/map/ai/states/trigger_state.cpp
@@ -36,7 +36,7 @@ bool CTriggerState::Update(time_point tick)
 {
     if (!IsCompleted())
     {
-        auto* PChar = static_cast<CCharEntity*>(GetTarget());
+        auto* PChar = dynamic_cast<CCharEntity*>(GetTarget());
         if (PChar && door && m_PEntity->animation == ANIMATION_CLOSE_DOOR)
         {
             close                = true;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Apparently CState::SetTarget would fail to call CState::UpdateTarget leaving `m_PTarget` null when it probably shouldn't be.
Adds some safety to GetTarget() calls from CState child classes
fixes #5284 

## Steps to test these changes

Use states and see no problems, see #5284 
