### PR TITLE
Stratagem time left correction at low levels

### DIFF
--- a/src/map/ai/controllers/player_controller.cpp
+++ b/src/map/ai/controllers/player_controller.cpp
@@ -127,7 +127,12 @@ bool CPlayerController::Ability(uint16 targid, uint16 abilityid)
             Recast_t* recast = PChar->PRecastContainer->GetRecast(RECAST_ABILITY, PAbility->getRecastId());
             // Set recast time in seconds to the normal recast time minus any charge time with the difference of the current time minus when the recast was set.
             // Abilities without a charge will have zero chargeTime
-            uint32 recastSeconds = recast->RecastTime - recast->chargeTime - ((uint32)time(nullptr) - recast->TimeStamp);
+            uint32 recastSeconds = recast->RecastTime - ((uint32)time(nullptr) - recast->TimeStamp);
+            // Abilities with a single charge (low-level scholoar stratagems) behave like abilities without a charge
+            if (recast->maxCharges > 1)
+            {
+                recastSeconds -= (recast->maxCharges - 1) * recast->chargeTime;
+            }
 
             PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_UNABLE_TO_USE_JA2));
             PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, recastSeconds, 0, MSGBASIC_TIME_LEFT));


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

2 things
- low level scholar has stratagem charges, but only 1, so they function like a normal job ability
  - Before change a scholar with stratagems on cooldown would underflow the time left:
  
![image](https://github.com/LandSandBoat/server/assets/131182600/73cdfbc5-c336-4691-ad5a-d0c5eb346a46)

- when you have more stratagems the time reported by the chat log ended up being the time to a full set of stratagems (i think?)
  - This "Time Left" message is only ever given when you have zero charges, so we can infer the time until the next charge. This (incorrect time) was with 75 sch:
  
![image](https://github.com/LandSandBoat/server/assets/131182600/81c79988-b24b-446c-9fe2-8315d0b87e12)

The new logic will 
- do unchanged behavior for JA that don't have charges
- treat abilities that have maxcharges == 1 the same as above (instead of underflowing)
- report "time left" for abilities with maxcharges > 1 to be the time until the next charge is available

## Steps to test these changes

Use stratagems at various levels of scholar and see that the time left reported matches the game client UI:
![image](https://github.com/LandSandBoat/server/assets/131182600/f15b6d16-85cc-4529-8bf4-93603e6eec93)
