### PR TITLE
[core] Fix mob hundred fists delay

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -311,10 +311,6 @@ bool CBattleEntity::Rest(float rate)
 int16 CBattleEntity::GetWeaponDelay(bool tp)
 {
     TracyZoneScoped;
-    if (StatusEffectContainer->HasStatusEffect(EFFECT_HUNDRED_FISTS) && !tp)
-    {
-        return 1700;
-    }
     uint16 WeaponDelay = 9999;
     if (auto* weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_MAIN]))
     {
@@ -369,6 +365,13 @@ int16 CBattleEntity::GetWeaponDelay(bool tp)
         // This should be enforced on -delay equipment, martial arts, dual wield, and haste, hence MinimumDelay * 0.2.
         // TODO: Could be converted to value/1024 if the exact cap is ever determined.
         MinimumDelay -= (uint16)(MinimumDelay * 0.8);
+
+        // if hundred fists then use the min delay (as hundred fists also reduces base delay by 80%
+        if (StatusEffectContainer->HasStatusEffect(EFFECT_HUNDRED_FISTS) && !tp)
+        {
+            WeaponDelay = MinimumDelay;
+        }
+
         WeaponDelay = (WeaponDelay < MinimumDelay) ? MinimumDelay : WeaponDelay;
     }
     return WeaponDelay;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR changes the delay of mobs using hundred fists to be more accurate to actual retail captures. The captures by Siknoz are from a variety of mobs including from RoZ, CoP, ToAU, and WoTG (see captures [here](https://discord.com/channels/443544205206355968/674750598939279400/1220077549347016724)). 

(monk mobs are back!)

## Steps to test these changes
Fight mobs that use hundred fists and compare speed before and after this PR. The mobs should attack much faster.
