### PR TITLE
[lua] Southern Sandora Title NPC Fix

### DIFF
--- a/scripts/zones/Southern_San_dOria/npcs/Moozo-Koozo.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Moozo-Koozo.lua
@@ -161,14 +161,14 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.title.changerOnTrigger(player, eventId, titleInfo)
+    xi.titleChanger.onTrigger(player, eventId, titleInfo)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    xi.title.changerOnEventFinish(player, csid, option, eventId, titleInfo)
+    xi.titleChanger.onEventFinish(player, csid, option, eventId, titleInfo)
 end
 
 return entity


### PR DESCRIPTION
Corrects the onTrigger and onEventFinish functions that were missed when migrated out of title.lua.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Corrects the onTrigger and onEventFinish for Moozu-Koozu in Southern Sandoria.

The functions were not updated when they got migrated out of title.lua into title_changer.lua.

A search through scripts showed this was the only NPC not updated.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

Talk to Moozu-Koozu, see that his event triggers as normal instead of a lua error.

<!-- Clear and detailed steps to test your changes here -->
