### PR TITLE
[core] Allow interruption of certain player events when being attacked

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1757,6 +1757,14 @@ void CBattleEntity::OnCastFinished(CMagicState& state, action_t& action)
         // Should not be removed by AoE effects that don't target the player or
         // buffs cast by other players or mobs.
         PActionTarget->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DETECTABLE);
+
+        if (auto PChar = dynamic_cast<CCharEntity*>(PActionTarget))
+        {
+            if (PChar->isInEvent() && !PChar->m_Locked)
+            {
+                PChar->release();
+            }
+        }
     }
 
     this->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_MAGIC_END);
@@ -2033,6 +2041,14 @@ void CBattleEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
         if (PSkill->getValidTargets() & TARGET_ENEMY)
         {
             PTargetFound->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DETECTABLE);
+
+            if (auto PChar = dynamic_cast<CCharEntity*>(PTargetFound))
+            {
+                if (PChar->isInEvent() && !PChar->m_Locked)
+                {
+                    PChar->release();
+                }
+            }
         }
 
         if (PTargetFound->isDead())
@@ -2107,10 +2123,15 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
     TracyZoneScoped;
     auto* PTarget = static_cast<CBattleEntity*>(state.GetTarget());
 
-    if (PTarget->objtype == TYPE_PC)
+    if (auto PChar = dynamic_cast<CCharEntity*>(PTarget))
     {
         // TODO: Should not be removed by AoE effects that don't target the player.
-        PTarget->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DETECTABLE);
+        PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DETECTABLE);
+
+        if (PChar->isInEvent() && !PChar->m_Locked)
+        {
+            PChar->release();
+        }
     }
 
     battleutils::ClaimMob(PTarget, this); // Mobs get claimed whether or not your attack actually is intimidated/paralyzed

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -2876,6 +2876,23 @@ void CCharEntity::skipEvent()
     }
 }
 
+void CCharEntity::release()
+{
+    RELEASE_TYPE releaseType = RELEASE_TYPE::STANDARD;
+
+    if (isInEvent())
+    {
+        // Message: Event skipped
+        releaseType = RELEASE_TYPE::SKIPPING;
+        pushPacket(new CMessageSystemPacket(0, 0, MsgStd::EventSkipped));
+    }
+
+    inSequence = false;
+    pushPacket(new CReleasePacket(this, releaseType));
+    pushPacket(new CReleasePacket(this, RELEASE_TYPE::EVENT));
+    endCurrentEvent();
+}
+
 void CCharEntity::setLocked(bool locked)
 {
     TracyZoneScoped;

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -563,6 +563,7 @@ public:
     void tryStartNextEvent();
     void skipEvent();
     void setLocked(bool locked);
+    void release();
 
     void UpdateMoghancement();
     bool hasMoghancement(uint16 moghancementID) const;

--- a/src/map/entities/petentity.cpp
+++ b/src/map/entities/petentity.cpp
@@ -617,6 +617,14 @@ void CPetEntity::OnPetSkillFinished(CPetSkillState& state, action_t& action)
         if (PSkill->getValidTargets() & TARGET_ENEMY)
         {
             PTargetFound->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DETECTABLE);
+
+            if (auto PChar = dynamic_cast<CCharEntity*>(PTargetFound))
+            {
+                if (PChar->isInEvent() && !PChar->m_Locked)
+                {
+                    PChar->release();
+                }
+            }
         }
 
         if (PTargetFound->isDead())

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -1197,21 +1197,10 @@ void CLuaBaseEntity::release()
         return;
     }
 
-    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
-
-    RELEASE_TYPE releaseType = RELEASE_TYPE::STANDARD;
-
-    if (PChar->isInEvent())
+    if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
     {
-        // Message: Event skipped
-        releaseType = RELEASE_TYPE::SKIPPING;
-        PChar->pushPacket(new CMessageSystemPacket(0, 0, MsgStd::EventSkipped));
+        PChar->release();
     }
-
-    PChar->inSequence = false;
-    PChar->pushPacket(new CReleasePacket(PChar, releaseType));
-    PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::EVENT));
-    PChar->endCurrentEvent();
 }
 
 /************************************************************************


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR adds interruptibility to certain events when the player is the target of an aggressive action (like an attack or mob ability). On retail such events are primarily menu-based events like when confirming the use of a teleporter in sky or sea. The retail behavior (and event interruption) can be seen for example in this [retail video](https://www.youtube.com/watch?v=qWCVSUmPX1Q). 

Specifically the PR moves release function from lua base entity to char entity so it can be easily called in battle entity code (such as onAttack). The battle entity code itself checks in several places for aggressive actions (at the same locations where detectable status effects (like invis) are removed from targets of aggressive actions), and if the player is not locked in a CS then it releases the player from the event.

The current PR is a draft to get comments as I am not an expert on events.

## Steps to test these changes
Attempt to use different teleporters and NPCs while being attacked by mobs.
