### PR TITLE
[cpp] Add mobskill bindings for skillchain properties

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1961,7 +1961,7 @@ void CBattleEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
         }
         else
         {
-            damage = luautils::OnMobWeaponSkill(PTargetFound, this, PSkill, &action);
+            damage = luautils::OnMobWeaponSkill(PTargetFound, this, &PSkill, &action);
             this->PAI->EventHandler.triggerListener("WEAPONSKILL_USE", CLuaBaseEntity(this), CLuaBaseEntity(PTargetFound), PSkill->getID(), state.GetSpentTP(), CLuaAction(&action), damage);
             PTarget->PAI->EventHandler.triggerListener("WEAPONSKILL_TAKE", CLuaBaseEntity(PTargetFound), CLuaBaseEntity(this), PSkill->getID(), state.GetSpentTP(), CLuaAction(&action));
         }

--- a/src/map/lua/lua_mobskill.cpp
+++ b/src/map/lua/lua_mobskill.cpp
@@ -50,6 +50,27 @@ void CLuaMobSkill::setMsg(uint16 message)
     m_PLuaMobSkill->setMsg(message);
 }
 
+std::tuple<uint8, uint8, uint8> CLuaMobSkill::getSkillchainProps()
+{
+    return { m_PLuaMobSkill->getPrimarySkillchain(), m_PLuaMobSkill->getSecondarySkillchain(), m_PLuaMobSkill->getTertiarySkillchain() };
+}
+
+/************************************************************************
+ *  Function: setSkillchainProps()
+ *  Purpose : Change the skillchain properties of a mobskill
+ *  Example : skill:setSkillchainProps(xi.skillchainType.LIGHT, xi.skillchainType.COMPRESSION, xi.skillchainType.SCISSION)
+ *  Notes   : Can be used to change the properties of a particular skill based on certain conditions (mob has a partciular buff, etc)
+ *              Take care of when this is called, as doing it without a clone of the mobskill will set it globally
+ *              I.E. if used in onMobSkillCheck, this will set it globally
+ *                   but, if used within mob or mobskill onMobWeaponSkill, it will set it for this particular execution of the skill only
+ ************************************************************************/
+void CLuaMobSkill::setSkillchainProps(uint8 prop1, uint8 prop2, uint8 prop3)
+{
+    m_PLuaMobSkill->setPrimarySkillchain(prop1);
+    m_PLuaMobSkill->setSecondarySkillchain(prop2);
+    m_PLuaMobSkill->setTertiarySkillchain(prop3);
+}
+
 bool CLuaMobSkill::hasMissMsg()
 {
     return m_PLuaMobSkill->hasMissMsg();
@@ -118,6 +139,8 @@ void CLuaMobSkill::Register()
 {
     SOL_USERTYPE("CMobSkill", CLuaMobSkill);
     SOL_REGISTER("setMsg", CLuaMobSkill::setMsg);
+    SOL_REGISTER("getSkillchainProps", CLuaMobSkill::getSkillchainProps);
+    SOL_REGISTER("setSkillchainProps", CLuaMobSkill::setSkillchainProps);
     SOL_REGISTER("getMsg", CLuaMobSkill::getMsg);
     SOL_REGISTER("hasMissMsg", CLuaMobSkill::hasMissMsg);
     SOL_REGISTER("isAoE", CLuaMobSkill::isAoE);

--- a/src/map/lua/lua_mobskill.h
+++ b/src/map/lua/lua_mobskill.h
@@ -50,6 +50,8 @@ public:
     bool   isSingle();
     bool   hasMissMsg();
     void   setMsg(uint16 message);
+    auto   getSkillchainProps() -> std::tuple<uint8, uint8, uint8>;
+    void   setSkillchainProps(uint8 prop1, uint8 prop2, uint8 prop3);
     uint16 getMsg();
     uint16 getTotalTargets();
     uint32 getPrimaryTargetID();

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -3775,7 +3775,7 @@ namespace luautils
         return 0;
     }
 
-    int32 OnMobWeaponSkill(CBaseEntity* PTarget, CBaseEntity* PMob, CMobSkill* PMobSkill, action_t* action)
+    int32 OnMobWeaponSkill(CBaseEntity* PTarget, CBaseEntity* PMob, CMobSkill** PMobSkill, action_t* action)
     {
         TracyZoneScoped;
 
@@ -3787,7 +3787,7 @@ namespace luautils
             auto onMobWeaponSkill = lua["xi"]["zones"][zone]["mobs"][name]["onMobWeaponSkill"];
             if (onMobWeaponSkill.valid())
             {
-                auto result = onMobWeaponSkill(CLuaBaseEntity(PTarget), CLuaBaseEntity(PMob), CLuaMobSkill(PMobSkill), CLuaAction(action));
+                auto result = onMobWeaponSkill(CLuaBaseEntity(PTarget), CLuaBaseEntity(PMob), CLuaMobSkill(*PMobSkill), CLuaAction(action));
                 if (!result.valid())
                 {
                     sol::error err = result;
@@ -3798,7 +3798,7 @@ namespace luautils
         }
 
         // Mob Skill Script
-        auto mobskill_name = PMobSkill->getName();
+        auto mobskill_name = (*PMobSkill)->getName();
 
         auto onMobWeaponSkill = lua["xi"]["actions"]["mobskills"][mobskill_name]["onMobWeaponSkill"];
         if (!onMobWeaponSkill.valid())
@@ -3806,7 +3806,7 @@ namespace luautils
             return 0;
         }
 
-        auto result = onMobWeaponSkill(CLuaBaseEntity(PTarget), CLuaBaseEntity(PMob), CLuaMobSkill(PMobSkill));
+        auto result = onMobWeaponSkill(CLuaBaseEntity(PTarget), CLuaBaseEntity(PMob), CLuaMobSkill(*PMobSkill));
         if (!result.valid())
         {
             sol::error err = result;

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -282,7 +282,7 @@ namespace luautils
     void OnBattlefieldDestroy(CBattlefield* PBattlefield);
 
     uint16 OnMobWeaponSkillPrepare(CBattleEntity* PMob, CBattleEntity* PTarget);
-    int32  OnMobWeaponSkill(CBaseEntity* PChar, CBaseEntity* PMob, CMobSkill* PMobSkill, action_t* action);
+    int32  OnMobWeaponSkill(CBaseEntity* PChar, CBaseEntity* PMob, CMobSkill** PMobSkill, action_t* action);
     int32  OnMobSkillCheck(CBaseEntity* PChar, CBaseEntity* PMob, CMobSkill* PMobSkill); // triggers before mob weapon skill is used, returns 0 if the move is valid
     auto   OnMobSkillTarget(CBattleEntity* PTarget, CBaseEntity* PMob, CMobSkill* PMobSkill) -> CBattleEntity*;
     int32  OnAutomatonAbilityCheck(CBaseEntity* PChar, CAutomatonEntity* PAutomaton, CMobSkill* PMobSkill);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Currently, mobskills can skillchain, but only if they're defined in the db to do so. This binding would allow the ability to set skillchain properties for a mobskill via lua. The way that mobskill states are coded though, we have to take care when these two new bindings are called
- if they are called in a check function, before the mob goes into the mobskill state, it would adjust globally all mobskills
  - i.e. `final_sting.lua` inside `mobskillObject.onMobSkillCheck` calling `skill:setSkillchainProps(xi.skillchainType.FUSION, xi.skillchainType.COMPRESSION, xi.skillchainType.SCISSION)` (even with a conditional) would make every future final sting have those sc properties. 
  - Or more specifically if we did something like create a `GetMobskillByID` function
- Some plumbing in `luautils` is adjusted to make the cloned mobskill be passed through to each call of `damage = luautils::OnMobWeaponSkill(...`, allowing the adjustments of a mobskill to be reflected in calls to `lua["xi"]["zones"][zone]["mobs"][name]["onMobWeaponSkill"]` and `lua["xi"]["actions"]["mobskills"][mobskill_name]["onMobWeaponSkill"]`
  - This means that for particular mobs, we can do the following:

something like this in their mob lua:
```
entity.onMobWeaponSkill = function(target, mob, skill, action)
    if skill:getID() == 336 then
        skill:setSkillchainProps(xi.skillchainType.FUSION, xi.skillchainType.COMPRESSION, xi.skillchainType.SCISSION)
    end
end
```
or this in the final_sting lua
```
mobskillObject.onMobWeaponSkill = function(target, mob, skill)
    if mob:getName() == 'Digger_Wasp' then -- or perhaps if the mob has a certain buff mob:getStatusEffect?
        skill:setSkillchainProps(xi.skillchainType.FUSION, xi.skillchainType.COMPRESSION, xi.skillchainType.SCISSION)
    end
```
and make final sting create fusion for Digger Wasps, for example

I am not well-versed in partciular sc properties and how they chain together, so the above example is purely theoretical.

The primary use-case would be for bst jug pets. Alternative uses would be for partciular battlefield encounters where the NMs should skillchain using regular mobskills (ark angels, Bozzetto Enceladus, Bozzetto Shade, certain tonberries), or just modules for generic custom content.


Digger Wasp in action self-skillchaining at low hp using only lua inside the Digger_Wasp lua file:

![image](https://github.com/LandSandBoat/server/assets/131182600/33da46b3-8713-4e1d-8d0b-6fd410ca3ad5)


## Steps to test these changes

The end result is that all existing functionality is untouched, but the above workflows can be utilized to change sc properties on a mobskill

`print(fmt("{}-{}-{}", skill:getSkillchainProps()))` in the `onMobWeaponskill` function of any particular skill now shows the active sc properties that will apply to the target. This can be used to verify mob/ws level lua changes.

