### PR TITLE
[core] Prevent sending bazaar browsing packets for hidden GMs

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -7767,7 +7767,10 @@ void SmallPacket0x104(map_session_data_t* const PSession, CCharEntity* const PCh
                 PTarget->BazaarCustomers.erase(PTarget->BazaarCustomers.begin() + i--);
             }
         }
-        PTarget->pushPacket(new CBazaarCheckPacket(PChar, BAZAAR_LEAVE));
+        if (!PChar->m_isGMHidden || (PChar->m_isGMHidden && PTarget->m_GMlevel >= PChar->m_GMlevel))
+        {
+            PTarget->pushPacket(new CBazaarCheckPacket(PChar, BAZAAR_LEAVE));
+        }
     }
     PChar->BazaarID.clean();
 }
@@ -7804,7 +7807,10 @@ void SmallPacket0x105(map_session_data_t* const PSession, CCharEntity* const PCh
 
         EntityID_t EntityID = { PChar->id, PChar->targid };
 
-        PTarget->pushPacket(new CBazaarCheckPacket(PChar, BAZAAR_ENTER));
+        if (!PChar->m_isGMHidden || (PChar->m_isGMHidden && PTarget->m_GMlevel >= PChar->m_GMlevel))
+        {
+            PTarget->pushPacket(new CBazaarCheckPacket(PChar, BAZAAR_ENTER));
+        }
         PTarget->BazaarCustomers.emplace_back(EntityID);
 
         CItemContainer* PBazaar = PTarget->getStorage(LOC_INVENTORY);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR prevents sending bazaar packets to players if the person checking the bazaar is a hidden GM. This change was requested by GMs on Horizon as they wanted to be able to check the players bazaar without letting the player know there is a hidden GM observing them. Note importantly if the GM purchases an item from the bazaar the player is still notified.

This is a PR from ASB/Horizon coming upstream.

## Steps to test these changes
The change can be tested by having a hidden GM try to interact with the bazaar of a non-GM character or a GM char of an equal or lower level.
