### PR TITLE
[lua]Fix merit stat enum offsets

### DIFF
--- a/scripts/enum/merit.lua
+++ b/scripts/enum/merit.lua
@@ -74,15 +74,16 @@ xi.merit =
     -- HP
     MAX_HP                      = meritCategory.HP_MP + 0x00,
     MAX_MP                      = meritCategory.HP_MP + 0x02,
+    MAX_MERIT                   = meritCategory.HP_MP + 0x04,
 
     -- ATTRIBUTES
     STR                         = meritCategory.ATTRIBUTES + 0x00,
     DEX                         = meritCategory.ATTRIBUTES + 0x02,
     VIT                         = meritCategory.ATTRIBUTES + 0x04,
-    AGI                         = meritCategory.ATTRIBUTES + 0x08,
-    INT                         = meritCategory.ATTRIBUTES + 0x0A,
-    MND                         = meritCategory.ATTRIBUTES + 0x0C,
-    CHR                         = meritCategory.ATTRIBUTES + 0x0E,
+    AGI                         = meritCategory.ATTRIBUTES + 0x06,
+    INT                         = meritCategory.ATTRIBUTES + 0x08,
+    MND                         = meritCategory.ATTRIBUTES + 0x0A,
+    CHR                         = meritCategory.ATTRIBUTES + 0x0C,
 
     -- COMBAT SKILLS
     H2H                         = meritCategory.COMBAT + 0x00,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

I didn't full audit, but spot checked and other categories seemed good. I suspect this was never noticed since most of the time these categories aren't being looked at in lua. There was a missing category in the HP/MP group and the offsets for attributes were not offset properly. Used [this as reference](https://github.com/LandSandBoat/server/blob/8ca07a25d92b820a5b1985402f8f670ca8d8c893/src/map/merit.h#L115), and it matched up perfectly (of course)


## Steps to test these changes

Update the enum in this screenshot instead of using raw offsets:

![image](https://github.com/LandSandBoat/server/assets/131182600/8f35a1be-6bf4-4679-8d4a-1c876158905a)
