### PR TITLE
small change to Vrtra to remove full localvar reset

### DIFF
--- a/scripts/zones/King_Ranperres_Tomb/mobs/Vrtra.lua
+++ b/scripts/zones/King_Ranperres_Tomb/mobs/Vrtra.lua
@@ -7,7 +7,9 @@ local entity = {}
 local offsets = { 1, 3, 5, 2, 4, 6 }
 
 entity.onMobEngage = function(mob, target)
-    mob:resetLocalVars()
+    -- Reset the onMobFight variables
+    mob:setLocalVar('spawnTime', 0)
+    mob:setLocalVar('twohourTime', 0)
 end
 
 entity.onMobFight = function(mob, target)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adjusts Vrtra's engage function to not wipe all localvars. There's only 2 used in onMobFight to track progress of the fight, a full localvar reset clears many unrelated things.

Specifically, our custom claimshield and rage timer mechanics on CEXI.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
