### PR TITLE
[lua] Spawn ix'drk last from QM to retain claim

### DIFF
--- a/scripts/zones/The_Garden_of_RuHmet/npcs/qm_ixaern_drk.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/npcs/qm_ixaern_drk.lua
@@ -37,7 +37,9 @@ entity.onTrigger = function(player, npc)
         -- this player has animosity
         -- spawn Ix'Aern DRK and its two minions near the QM
         player:messageSpecial(ID.text.MENACING_CREATURES)
-        npcUtil.popFromQM(player, npc, { ID.mob.IXAERN_DRK, ID.mob.IXAERN_DRK + 1, ID.mob.IXAERN_DRK + 2 }, { radius = 3 })
+
+        -- spawn Ix'DRK last so it retains claim
+        npcUtil.popFromQM(player, npc, { ID.mob.IXAERN_DRK + 1, ID.mob.IXAERN_DRK + 2, ID.mob.IXAERN_DRK }, { radius = 3, claim = true })
 
         -- move QM to random location, and reset animosity
         local pos = math.random(1, 4)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Does what it says on the tin, Ix'DRK should spawn last so claim is retained
Retail proof:
[2024-03-24 13-25-10.webm](https://github.com/LandSandBoat/server/assets/60417494/eff77fc4-b4a1-4e6f-afd3-51b1f91f08d4)

Note that this isn't an exact duplicate of retail -- on LSB all mobs spawn claimed for a sec then the 2 adds lose claim. As seen above, they shouldn't spawn claimed at all.

## Steps to test these changes

Pop ix'drk and see that you retain claim on ix'drk after doing no actions on anything.