### PR TITLE
[core] Cleanup allies of battlefields even if they are not alive

### DIFF
--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -628,7 +628,9 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
                 {
                     if (std::find(m_AllyList.begin(), m_AllyList.end(), PMobEntity) != m_AllyList.end())
                     {
-                        if (PMobEntity->isAlive() && PMobEntity->PAI->IsSpawned())
+                        // We should not put an isAlive check here because some ally can be dead at cleanup
+                        // but not despawned (for example Prishe in Dawn fight)
+                        if (PMobEntity->PAI->IsSpawned())
                         {
                             PEntity->status = STATUS_TYPE::DISAPPEAR;
                             PEntity->loc.zone->UpdateEntityPacket(PEntity, ENTITY_DESPAWN, UPDATE_NONE);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR removes the condition that allies must be alive to be cleaned up at the clean up stage of battlefields. Currently this condition causes issues with allies that can be dead but do not despawn (such as Prishe in Dawn fight), for example causing players to see multiple extra dead Prishes (from previous groups).

This is a fix from ASB coming upstream.

## Steps to test these changes
Enter Dawn fight and engage Promathia, then !hp 0 Prishe and leave the battlefield. Then reenter and see that there is not an extra dead Prishe on the ground.
