### PR TITLE
[core] Fix linking between normal (non-master) mobs and mob pets

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -210,7 +210,9 @@ void CMobController::TryLink()
         for (auto& member : PMob->PParty->members)
         {
             CMobEntity* PPartyMember = dynamic_cast<CMobEntity*>(member);
-            if (!PPartyMember)
+            // Note if the mob to link with this one is a pet then do not link
+            // Pets only link with their masters
+            if (!PPartyMember || (PPartyMember && PPartyMember->PMaster))
             {
                 continue;
             }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Currently on LSB normal (non-master) mobs and mob pets of the same family link both ways. Thus fighting the pet can link the normal mob and fighting the normal mob can link the pet. On retail fighting the pet can link the normal mob but not vice versa (see the testing steps for expected behavior). Mob pets only link with their masters. This PR fixes this issue by adding a check in the `TryLink` function in the mob controller.

## Steps to test these changes
1. Go to Qufim for example and fight an Acrophies and then pull it near a Giga's Leech. Notice that the leech does not link.
2. Use !goto player to clear hate and then fight the Giga's Leech and pull it near an Acrophies. Notice the Acrophies does link.
3. Use !goto player to clear hate and then fight the Giga. Notice the Giga's Leech does link.
