### PR TITLE
[lua] Use retail accurate skill formula for removing doom with cursna

### DIFF
--- a/scripts/actions/spells/white/cursna.lua
+++ b/scripts/actions/spells/white/cursna.lua
@@ -9,12 +9,15 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local curse = target:getStatusEffect(xi.effect.CURSE_I)
+    local curse  = target:getStatusEffect(xi.effect.CURSE_I)
     local curse2 = target:getStatusEffect(xi.effect.CURSE_II)
-    local bane = target:getStatusEffect(xi.effect.BANE)
-    local bonus = caster:getMod(xi.mod.ENHANCES_CURSNA) + target:getMod(xi.mod.ENHANCES_CURSNA_RCVD)
-    local power = 25 * ((100 + bonus) / 100) -- This 25 is temp until the skill calculation is in.
-    local final = nil
+    local bane   = target:getStatusEffect(xi.effect.BANE)
+    local bonus  = caster:getMod(xi.mod.ENHANCES_CURSNA) + target:getMod(xi.mod.ENHANCES_CURSNA_RCVD)
+    local skill  = caster:getSkillLevel(xi.skill.HEALING_MAGIC)
+    local final  = nil
+
+    -- https://www.bg-wiki.com/ffxi/Cursna, https://wiki.ffo.jp/html/1962.html
+    local power = (10 + (skill / 30)) * (1 + (bonus / 100))
 
     spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     if target:hasStatusEffect(xi.effect.DOOM) and power > math.random(1, 100) then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Puts in the Cursna formula that uses healing skill for Doom removal, see

https://www.bg-wiki.com/ffxi/Cursna, https://wiki.ffo.jp/html/1962.html


## Steps to test these changes

Test Cursna with doom rates, alternatively print `power` for the rate and see it match retail formula
