### PR TITLE
Implementation of nightmare sleep mechanics

### DIFF
--- a/scripts/actions/abilities/pets/nightmare.lua
+++ b/scripts/actions/abilities/pets/nightmare.lua
@@ -1,0 +1,45 @@
+-----------------------------------
+-- Nightmare - Player's Avatar
+-- AoE Sleep
+-- Sleep that is not broken from DoT effects (any dmg source that doesn't break bind).
+-- This version of it is from a player's avatar. The sleep is broken by most damage sources except other DoTs
+--
+-- see mobskills/nightmare.lua for full explanation
+-----------------------------------
+local abilityObject = {}
+
+abilityObject.onAbilityCheck = function(player, target, ability)
+    return 0, 0
+end
+
+abilityObject.onPetAbility = function(target, pet, skill)
+    local duration = 90
+    local dotdamage = 2
+    local sleepTier = 1
+    local dINT = pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
+    local bonus = xi.summon.getSummoningSkillOverCap(pet)
+    local resm = xi.mobskills.applyPlayerResistance(pet, -1, target, dINT, bonus, xi.element.DARK)
+    if resm < 0.5 then
+        skill:setMsg(xi.msg.basic.JA_MISS_2) -- resist message
+        return xi.effect.SLEEP_I
+    end
+
+    duration = duration * resm
+    if
+        target:hasImmunity(1) or
+        target:hasStatusEffect(xi.effect.SLEEP_I) or
+        target:hasStatusEffect(xi.effect.SLEEP_II) or
+        target:hasStatusEffect(xi.effect.LULLABY)
+    then
+        --No effect
+        skill:setMsg(xi.msg.basic.JA_NO_EFFECT_2)
+    elseif target:addStatusEffect(xi.effect.SLEEP_I, 1, 0, duration, 0, dotdamage, sleepTier) then
+        skill:setMsg(xi.msg.basic.JA_GAIN_EFFECT)
+    else
+        skill:setMsg(xi.msg.basic.JA_MISS_2)
+    end
+
+    return xi.effect.SLEEP_I
+end
+
+return abilityObject

--- a/scripts/actions/mobskills/nightmare.lua
+++ b/scripts/actions/mobskills/nightmare.lua
@@ -1,0 +1,41 @@
+-----------------------------------
+-- Nightmare - NM Diabolos
+-- AoE Sleep
+-- Sleep that is not broken from DoT effects (any dmg source that doesn't break bind).
+-- + I.e. if a mob has helix, nightmare will still sleep the target
+-- When this sleep is applied, it is accompanied by a Bio effect. That Bio effect doesn't break _any_ types of sleep
+-- + I.e. if you nightmare a mob, then layer sleep II, the mob will stay asleep
+-- The Bio does that by explicitly dealing lua dmg each tick with the `wakeUp` flag set to false.
+--
+-- This NM/Mob version of sleep also doesn't break from any other dmg sources
+-- + I.e. NM diabolos applies nightmare, then uses Camisado. You will not wake up
+-- the identifier for this more-powerful Nightmare sleep is when the tier > 1. There are references other files
+-- + status_effect_container.cpp
+-- + lua_baseentity.cpp
+-- + actions/pets/nightmare.lua
+-- + effects/sleep.lua
+-- + effects/bio.lua
+--
+-- DoT damage is 2/tick for player avatars and 15/tick for NM/Mobs
+--
+-- TL;DR - SLEEP_I with tier > 0 is a nightmare sleep. Tier > 1 is an NM/mob nightmare that can't be broken except from cures
+--
+-- Note that the sleep effect is not the thing doing damage. When nightmare is applied, you also get a Bio effect
+-- if you erase the bio effect, the Sleep (with a tier > 0) still behaves exactly the same as before
+-- The AMOUNT of damage done to the target is irrelevant to the behavior of nightmare sleep, only the source of the damage and the source of the Nightmare.
+-----------------------------------
+
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    local dotdamage = 15
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLEEP_I, 1, 0, math.random(20, 30), 0, dotdamage, 2))
+
+    return xi.effect.SLEEP_I
+end
+
+return mobskillObject

--- a/scripts/effects/bio.lua
+++ b/scripts/effects/bio.lua
@@ -1,23 +1,33 @@
 -----------------------------------
 -- xi.effect.BIO
+-- Tier > 0 signals this is a bio that doesn't break sleep
+-- See mobskills/nightmare.lua for full explanation
 -----------------------------------
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
     local power = effect:getPower()
     local subpower = effect:getSubPower()
-    target:addMod(xi.mod.ATTP, -subpower)
-    target:addMod(xi.mod.REGEN_DOWN, power)
+    effect:addMod(xi.mod.ATTP, -subpower)
+    if effect:getTier() == 0 then
+        effect:addMod(xi.mod.REGEN_DOWN, power)
+    end
 end
 
 effectObject.onEffectTick = function(target, effect)
+    -- bio with subpower > 0 is a signal that we don't wake up targets from this dot damage
+    -- handle diabolos nightmare bio damage explicitly
+    if effect:getTier() > 0 then
+        -- re-using logic from helix effect processing
+        local dmg = utils.stoneskin(target, effect:getPower())
+
+        if dmg > 0 then
+            target:takeDamage(dmg, nil, nil, nil, { wakeUp = false, breakBind = false })
+        end
+    end
 end
 
 effectObject.onEffectLose = function(target, effect)
-    local power = effect:getPower()
-    local subpower = effect:getSubPower()
-    target:delMod(xi.mod.ATTP, -subpower)
-    target:delMod(xi.mod.REGEN_DOWN, power)
 end
 
 return effectObject

--- a/scripts/effects/sleep.lua
+++ b/scripts/effects/sleep.lua
@@ -6,6 +6,19 @@ local effectObject = {}
 effectObject.onEffectGain = function(target, effect)
     -- Immunobreak reset.
     target:setMod(xi.mod.SLEEP_IMMUNOBREAK, 0)
+
+    if effect:getTier() > 0 then
+        -- bio with subpower > 0 is a signal that we don't wake up targets from this dot damage
+        -- dot damage = sleep subpower
+        -- see mobskills/nightmare.lua for full explanation
+        local attpReduction = 10
+        if effect:getTier() > 1 then
+            attpReduction = effect:getSubPower()
+        end
+
+        target:delStatusEffectSilent(xi.effect.BIO)
+        target:addStatusEffect(xi.effect.BIO, effect:getSubPower(), 3, effect:getDuration(), 0, attpReduction, 1)
+    end
 end
 
 effectObject.onEffectTick = function(target, effect)

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -681,7 +681,7 @@ xi.mobskills.mobDrainStatusEffectMove = function(mob, target)
 end
 
 -- Adds a status effect to a target
-xi.mobskills.mobStatusEffectMove = function(mob, target, typeEffect, power, tick, duration)
+xi.mobskills.mobStatusEffectMove = function(mob, target, typeEffect, power, tick, duration, subType, subPower, tier)
     if target:canGainStatusEffect(typeEffect, power) then
         local statmod = xi.mod.INT
         local element = mob:getStatusEffectElement(typeEffect)
@@ -689,7 +689,7 @@ xi.mobskills.mobStatusEffectMove = function(mob, target, typeEffect, power, tick
 
         if resist >= 0.25 then
             local totalDuration = utils.clamp(duration * resist, 1)
-            target:addStatusEffect(typeEffect, power, tick, totalDuration)
+            target:addStatusEffect(typeEffect, power, tick, totalDuration, subType, subPower, tier)
 
             return xi.msg.basic.SKILL_ENFEEB_IS
         end

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -9186,6 +9186,28 @@ void CLuaBaseEntity::takeDamage(int32 damage, sol::object const& attacker, sol::
         breakBind     = flag_map["breakBind"];
     }
 
+    // Check to see if the target has a nightmare effect active, reset wakeUp accordingly
+    // see mobskills/nightmare.lua for full explanation
+    if (
+        PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_SLEEP) &&
+        PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_SLEEP)->GetTier() > 0)
+    {
+        // Don't break nightmare sleep from any dmg that doesn't break bind (DoT damage)
+        if (breakBind == false)
+        {
+            wakeUp = false;
+        }
+
+        // Diabolos NM/mob ability
+        // "Damage will not wake you up from Nightmare, only Cure and Benediction (Benediction will also remove the Bio effect)."
+        if (
+            wakeUp == true &&
+            PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_SLEEP)->GetTier() > 1)
+        {
+            wakeUp = false;
+        }
+    }
+
     ATTACK_TYPE attackType = (atkType != sol::lua_nil) ? static_cast<ATTACK_TYPE>(atkType.as<uint8>()) : ATTACK_TYPE::NONE;
     DAMAGE_TYPE damageType = (dmgType != sol::lua_nil) ? static_cast<DAMAGE_TYPE>(dmgType.as<uint8>()) : DAMAGE_TYPE::NONE;
 

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -792,6 +792,16 @@ void CStatusEffectContainer::DelStatusEffectsByFlag(uint32 flag, bool silent)
     {
         if (PStatusEffect->HasEffectFlag(flag))
         {
+            // If this is an NM/Mob Nightmare sleep, it can be removed explictly by a cure
+            // see mobskills/nightmare.lua for full explanation
+            if (
+                flag & EFFECTFLAG_DAMAGE &&
+                PStatusEffect->GetStatusID() == EFFECT_SLEEP &&
+                PStatusEffect->GetTier() > 1)
+            {
+                continue;
+            }
+
             RemoveStatusEffect(PStatusEffect, silent);
         }
     }
@@ -1929,7 +1939,16 @@ void CStatusEffectContainer::TickRegen(time_point tick)
             {
                 DelStatusEffectSilent(EFFECT_HEALING);
                 m_POwner->takeDamage(damage);
-                WakeUp();
+
+                // If target has nightmare sleep. Don't break sleep from REGEN_DOWN damage
+                // see mobskills/nightmare.lua for full explanation
+                if (
+                    !(
+                        m_POwner->StatusEffectContainer->GetStatusEffect(EFFECT_SLEEP) &&
+                        m_POwner->StatusEffectContainer->GetStatusEffect(EFFECT_SLEEP)->GetTier() > 0))
+                {
+                    WakeUp();
+                }
             }
         }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Resolves #851 .

player avatar using nightmare on a mob:
![image](https://github.com/LandSandBoat/server/assets/131182600/9a53f33a-cecd-4035-95e7-54efcd48332a)

the `no_effect` mob is one that already had nightmare sleep.

![image](https://github.com/LandSandBoat/server/assets/131182600/9fe98487-9f29-4ee6-a63a-dc48dd61bffa)

after nightmare applied, see that there's the attp reduction as well as hp reduction (hp goes from 240 to 238), which implies the bio effect is successfully applied

sleep not being broken by helix:

![image](https://github.com/LandSandBoat/server/assets/131182600/55fb2ceb-c16f-4488-8403-33b9db7c0fa3)


Finally, a really hacky way to test the mobskill side of things:

![image](https://github.com/LandSandBoat/server/assets/131182600/97188dc2-06dd-4445-b010-ce80784733a1)

Force a mob to use nightmare and see that the player gets sleep and bio and doesn't get woken by attacks

Onto the details:
- Nightmare abilities apply a sleep and a bio effect: evidence in the linked issue #851
- Nightmare sleep is unbroken by any DoT
  - NM/Mob version also is unbroken by _all_ damage sources: https://www.bg-wiki.com/ffxi/Promathia_Mission_3-5
- The Bio effect from Nightmare does not break any sleep effects

## Steps to test these changes

Run through the steps above. Code for waking a slept player is unchanged but confirming that nightmare sleep is woken up by Cures would be a plus
