### PR TITLE
Ensure mobs don't feedback loop and spam TP moves at low hp

### DIFF
--- a/scripts/enum/mob_mod.lua
+++ b/scripts/enum/mob_mod.lua
@@ -85,4 +85,5 @@ xi.mobMod =
     CAN_PARRY              = 75, -- Check if a mob is allowed to have parry rank (Rank Value 1-5)
     NO_WIDESCAN            = 76, -- Disables widescan for a specific mob
     TRUST_DISTANCE         = 77, -- TRUSTS ONLY: Set movement type/distance. See trust.lua for details.
+    MOBSKILL_DELAY         = 78, -- Delay (in ms) before using a mobskill after using a mobskill.
 }

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -1202,6 +1202,13 @@ void CMobController::TapDeclaimTime()
     m_DeclaimTime = m_Tick;
 }
 
+// To ensure mobskills don't get spammed with high regain/low hp.
+// This affects the automatic mobskill selection to give 0% chance until after this time
+void CMobController::TapLastMobSkillTime()
+{
+    m_LastMobSkillTime = m_Tick + std::chrono::milliseconds(PMob->getMobMod(MOBMOD_MOBSKILL_DELAY));
+}
+
 bool CMobController::Cast(uint16 targid, SpellID spellid)
 {
     TracyZoneScoped;

--- a/src/map/ai/controllers/mob_controller.h
+++ b/src/map/ai/controllers/mob_controller.h
@@ -48,6 +48,7 @@ public:
     bool         CanAggroTarget(CBattleEntity*);
     void         TapDeaggroTime();
     void         TapDeclaimTime();
+    void         TapLastMobSkillTime();
     virtual bool Cast(uint16 targid, SpellID spellid) override;
 
 protected:

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -21,6 +21,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 
 #include "mobskill_state.h"
 #include "ai/ai_container.h"
+#include "ai/controllers/mob_controller.h"
 #include "enmity_container.h"
 #include "entities/battleentity.h"
 #include "entities/mobentity.h"
@@ -75,6 +76,12 @@ CMobSkillState::CMobSkillState(CBattleEntity* PEntity, uint16 targid, uint16 wsi
         m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
     }
     m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_STATE_ENTER", CLuaBaseEntity(m_PEntity), m_PSkill->getID());
+
+    auto mobController = dynamic_cast<CMobController*>(m_PEntity->PAI->GetController());
+    if (mobController)
+    {
+        mobController->TapLastMobSkillTime();
+    }
     SpendCost();
 }
 
@@ -126,6 +133,11 @@ bool CMobSkillState::Update(time_point tick)
             static_cast<CMobEntity*>(PTarget)->PEnmityContainer->UpdateEnmity(m_PEntity, 0, 0);
         }
         m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_STATE_EXIT", CLuaBaseEntity(m_PEntity), m_PSkill->getID());
+        auto mobController = dynamic_cast<CMobController*>(m_PEntity->PAI->GetController());
+        if (mobController)
+        {
+            mobController->TapLastMobSkillTime();
+        }
 
         if (m_PEntity->objtype == TYPE_PET && m_PEntity->PMaster && m_PEntity->PMaster->objtype == TYPE_PC && (m_PSkill->isBloodPactRage() || m_PSkill->isBloodPactWard()))
         {

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -378,7 +378,7 @@ uint16 CMobEntity::TPUseChance()
         return 0;
     }
 
-    if (health.tp == 3000 || (GetHPP() <= 25 && health.tp >= 1000))
+    if (health.tp == 3000 || (GetHPP() <= 25 && health.tp >= 1000) || (GetHPP() <= 50 && health.tp >= 2000))
     {
         return 10000;
     }

--- a/src/map/mob_modifier.h
+++ b/src/map/mob_modifier.h
@@ -106,6 +106,7 @@ enum MOBMODIFIER : int
     MOBMOD_CAN_PARRY              = 75, // Check if a mob is allowed to have parry rank (Rank Value 1-5)
     MOBMOD_NO_WIDESCAN            = 76, // Disables widescan for a specific mob
     MOBMOD_TRUST_DISTANCE         = 77, // TRUSTS ONLY: Set movement type/distance. See trust.lua for details.
+    MOBMOD_MOBSKILL_DELAY         = 78, // Delay (in ms) before using a mobskill after using a mobskill.
 };
 
 #endif

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -1168,6 +1168,7 @@ namespace mobutils
 
         PMob->defaultMobMod(MOBMOD_SKILL_LIST, PMob->m_MobSkillList);
         PMob->defaultMobMod(MOBMOD_LINK_RADIUS, 10);
+        PMob->defaultMobMod(MOBMOD_MOBSKILL_DELAY, 1000);
         PMob->defaultMobMod(MOBMOD_TP_USE_CHANCE,
                             92); // 92 = 0.92% chance per 400ms tick (50% chance by 30 seconds) while mob HPP>25 and mob TP >=1000 but <3000
         PMob->defaultMobMod(MOBMOD_SIGHT_RANGE, (int16)CMobEntity::sight_range);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Mobs can get into a feedback loop where they will spam TP moves without even trying to do other things (include move at all)

example of this would be king behemoth below 25% hp with a small amount of regain. Essentially he spams flame armor no matter what his target is.

The main issue lies in the timestamp `m_LastMobSkillTime` never coming into play. We create a new public function in `mob_controller` to update that timestamp. Simply updating it won't actually change behavior though since we always compare `m_Tick` with that timestamp before checking TPUseChance, ~so we also add 0-5s RNG. This timestamp is then tapped when entering the mobskill state, as well as exiting the mobskill state (the former in case the mobskill gets interrupted, TP is consumed so we should resume the same behavior).~

Edit: Updated to use a flat mobmod, default to 1s. After discussing with a few people this mobmod should _probably_ be set to the attack delay of the mob, but 1s works well and being a mobmod allows specific mobs to be tuned separately. 

Finally, added the condition that TPUseChance is 100% if below 50% HP and above 2k tp

This has _always_ been an issue with DSP, etc... but the recent update to allow mobs to gain TP from their mobskills has made it even more apparent.

~KB is a very extreme example, but with before the chnages this same setup he would literally stand in place:~

https://imgur.com/Gkhaco3

~I suspect there is some hard minimum for mobskills, but random 1s-6s delay before even considering TPUseChance seems reasonable~

Note that these changes only affect the `mob_controller` automatic selection of mobskills. `mob:useMobAbility` is unaffected

## Steps to test these changes

`!getmobmod 78` to see the default behavior being used, set to different values with high regain to see the limit in action
