### PR TITLE
[core] Fix two worm casting issues

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -498,6 +498,15 @@ bool CMobController::CanCastSpells()
         }
     }
 
+    // worms only cast if target is outside of melee range
+    if (PMob->m_Family == 258)
+    {
+        if (PTarget && distance(PMob->loc.p, PTarget->loc.p) <= PMob->GetMeleeRange())
+        {
+            return false;
+        }
+    }
+
     return IsMagicCastingEnabled();
 }
 
@@ -960,7 +969,7 @@ void CMobController::DoRoamTick(time_point tick)
                                                                             (uint8)PMob->getMobMod(MOBMOD_ROAM_TURNS), PMob->m_roamFlags))
                 {
                     // #TODO: #AIToScript (event probably)
-                    if (PMob->m_roamFlags & ROAMFLAG_WORM)
+                    if (PMob->m_roamFlags & ROAMFLAG_WORM && !PMob->PAI->IsCurrentState<CMagicState>())
                     {
                         // move down
                         PMob->animationsub = 1;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes two issues with worms casting. Firstly, worms should only cast when their target is outside of melee range (see [here](https://www.bg-wiki.com/ffxi/Category:Worm)). Secondly, worms should not go underground during the middle of casting (as this interrupts their casting).

This is an ASB fix coming upstream.

## Steps to test these changes
To test the first change go fight any worm and move into and out of melee range to see casting behavior. To test the second change go to for example the Phantom Worm spawn area (which has a lot of worms close together) and watch to see that they no longer interrupt their own casting.
