### PR TITLE
[core] [lua] Fix mobskill TP return issue for AoE skills

### DIFF
--- a/scripts/actions/mobskills/acid_breath.lua
+++ b/scripts/actions/mobskills/acid_breath.lua
@@ -19,7 +19,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STR_DOWN, power, tick, duration)
 
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.1, 1, xi.element.WATER, 200)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.1, 1, xi.element.WATER, 200)
     local dmg    = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.WATER)

--- a/scripts/actions/mobskills/aeolian_void.lua
+++ b/scripts/actions/mobskills/aeolian_void.lua
@@ -15,7 +15,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, 60)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 15, 0, 60)
 
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.25, 2.5, xi.element.EARTH, 300)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.25, 2.5, xi.element.EARTH, 300)
     local dmg    = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.EARTH, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.EARTH)

--- a/scripts/actions/mobskills/aqua_breath.lua
+++ b/scripts/actions/mobskills/aqua_breath.lua
@@ -13,7 +13,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.25, 1.5, xi.element.WATER, 400)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.25, 1.5, xi.element.WATER, 400)
     local dmg    = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.WATER)

--- a/scripts/actions/mobskills/bad_breath.lua
+++ b/scripts/actions/mobskills/bad_breath.lua
@@ -20,7 +20,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 15, 0, 60)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.WEIGHT, 50, 0, 60)
 
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.15, 3, xi.element.EARTH, 500)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.15, 3, xi.element.EARTH, 500)
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.EARTH, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.EARTH)
 

--- a/scripts/actions/mobskills/blizzard_breath.lua
+++ b/scripts/actions/mobskills/blizzard_breath.lua
@@ -11,7 +11,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.5, 1, xi.element.ICE, 700)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.5, 1, xi.element.ICE, 700)
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.ICE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.ICE)

--- a/scripts/actions/mobskills/bubble_shower.lua
+++ b/scripts/actions/mobskills/bubble_shower.lua
@@ -11,7 +11,7 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STR_DOWN, 10, 3, 120)
 
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.15, 5, xi.element.WATER, 200)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.15, 5, xi.element.WATER, 200)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.WATER)

--- a/scripts/actions/mobskills/chaos_breath.lua
+++ b/scripts/actions/mobskills/chaos_breath.lua
@@ -11,7 +11,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.5, 1, xi.element.DARK, 700)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.5, 1, xi.element.DARK, 700)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.DARK, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 

--- a/scripts/actions/mobskills/cold_breath.lua
+++ b/scripts/actions/mobskills/cold_breath.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 20)
 
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.2, 0.75, xi.element.ICE, 600)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.2, 0.75, xi.element.ICE, 600)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.ICE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.ICE)

--- a/scripts/actions/mobskills/dark_spore.lua
+++ b/scripts/actions/mobskills/dark_spore.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 15, 3, 120)
 
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.25, 2, xi.element.DARK, 800)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.25, 2, xi.element.DARK, 800)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.DARK, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 

--- a/scripts/actions/mobskills/diffusion_ray.lua
+++ b/scripts/actions/mobskills/diffusion_ray.lua
@@ -10,7 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.2, 0.65, xi.element.LIGHT, 500)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.2, 0.65, xi.element.LIGHT, 500)
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.damageType.BREATH, xi.attackType.LIGHT, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.LIGHT)
 

--- a/scripts/actions/mobskills/dragon_breath.lua
+++ b/scripts/actions/mobskills/dragon_breath.lua
@@ -21,7 +21,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.2, 1.25, xi.element.FIRE, 1400)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.2, 1.25, xi.element.FIRE, 1400)
     dmgmod = utils.conalDamageAdjustment(mob, target, skill, dmgmod, 0.9)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)

--- a/scripts/actions/mobskills/earth_breath.lua
+++ b/scripts/actions/mobskills/earth_breath.lua
@@ -12,7 +12,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.167, 1.875, xi.element.EARTH, 500)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.167, 1.875, xi.element.EARTH, 500)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.EARTH, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.EARTH)

--- a/scripts/actions/mobskills/fiery_breath.lua
+++ b/scripts/actions/mobskills/fiery_breath.lua
@@ -22,7 +22,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.2, 1.25, xi.element.FIRE, 1400)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.2, 1.25, xi.element.FIRE, 1400)
     dmgmod = utils.conalDamageAdjustment(mob, target, skill, dmgmod, 0.9)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)

--- a/scripts/actions/mobskills/fire_break.lua
+++ b/scripts/actions/mobskills/fire_break.lua
@@ -10,7 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.5, 1, xi.element.FIRE, 700)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.5, 1, xi.element.FIRE, 700)
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.FIRE)

--- a/scripts/actions/mobskills/flame_breath.lua
+++ b/scripts/actions/mobskills/flame_breath.lua
@@ -10,7 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.2, 0.75, xi.element.FIRE, 600)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.2, 0.75, xi.element.FIRE, 600)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.FIRE)

--- a/scripts/actions/mobskills/flying_hip_press.lua
+++ b/scripts/actions/mobskills/flying_hip_press.lua
@@ -20,7 +20,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         cap = math.random(300, 700)
     end
 
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.333, 1.2, xi.element.WIND, cap)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.333, 1.2, xi.element.WIND, cap)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.WIND, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.WIND)

--- a/scripts/actions/mobskills/foul_breath.lua
+++ b/scripts/actions/mobskills/foul_breath.lua
@@ -17,7 +17,7 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.DISEASE, 1, 0, 300)
 
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.333, 0.625, xi.element.FIRE, 500)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.333, 0.625, xi.element.FIRE, 500)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 

--- a/scripts/actions/mobskills/frost_breath.lua
+++ b/scripts/actions/mobskills/frost_breath.lua
@@ -17,7 +17,7 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 25, 0, 120)
 
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.333, 0.625, xi.element.ICE, 500)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.333, 0.625, xi.element.ICE, 500)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.ICE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.ICE)

--- a/scripts/actions/mobskills/geotic_breath.lua
+++ b/scripts/actions/mobskills/geotic_breath.lua
@@ -22,7 +22,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.2, 1.25, xi.element.EARTH, 1400)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.2, 1.25, xi.element.EARTH, 1400)
     dmgmod = utils.conalDamageAdjustment(mob, target, skill, dmgmod, 0.9)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.EARTH, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)

--- a/scripts/actions/mobskills/glacial_breath.lua
+++ b/scripts/actions/mobskills/glacial_breath.lua
@@ -22,7 +22,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.2, 1.25, xi.element.ICE, 1400)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.2, 1.25, xi.element.ICE, 1400)
     dmgmod = utils.conalDamageAdjustment(mob, target, skill, dmgmod, 0.9)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.ICE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)

--- a/scripts/actions/mobskills/heat_breath.lua
+++ b/scripts/actions/mobskills/heat_breath.lua
@@ -10,7 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.5, 1, xi.element.FIRE, 500)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.5, 1, xi.element.FIRE, 500)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 

--- a/scripts/actions/mobskills/hecatomb_wave.lua
+++ b/scripts/actions/mobskills/hecatomb_wave.lua
@@ -12,7 +12,7 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 15, 0, 180)
 
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.1, 1.5, xi.element.WIND, 400)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.1, 1.5, xi.element.WIND, 400)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.WIND, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.WIND)

--- a/scripts/actions/mobskills/hiemal_storm.lua
+++ b/scripts/actions/mobskills/hiemal_storm.lua
@@ -14,7 +14,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.2, 1.25, xi.element.ICE, 1400)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.2, 1.25, xi.element.ICE, 1400)
     dmgmod = utils.conalDamageAdjustment(mob, target, skill, dmgmod, 0.9)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.ICE, xi.mobskills.shadowBehavior.WIPE_SHADOWS)

--- a/scripts/actions/mobskills/incinerate.lua
+++ b/scripts/actions/mobskills/incinerate.lua
@@ -9,7 +9,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.25, 0.75, xi.element.FIRE)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.25, 0.75, xi.element.FIRE)
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.FIRE)

--- a/scripts/actions/mobskills/laser_shower.lua
+++ b/scripts/actions/mobskills/laser_shower.lua
@@ -16,7 +16,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.2, 1.25, xi.element.LIGHT, 1600)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.2, 1.25, xi.element.LIGHT, 1600)
     local dis = ((mob:checkDistance(target) * 2) / 20)
 
     dmgmod = dmgmod * dis

--- a/scripts/actions/mobskills/magma_fan.lua
+++ b/scripts/actions/mobskills/magma_fan.lua
@@ -10,7 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.5, 1.25, xi.element.FIRE, 600)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.5, 1.25, xi.element.FIRE, 600)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.FIRE)

--- a/scripts/actions/mobskills/magnetite_cloud.lua
+++ b/scripts/actions/mobskills/magnetite_cloud.lua
@@ -11,7 +11,7 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.WEIGHT, 50, 0, 120)
 
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.167, 1.875, xi.element.EARTH, 509)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.167, 1.875, xi.element.EARTH, 509)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.EARTH, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.EARTH)

--- a/scripts/actions/mobskills/methane_breath.lua
+++ b/scripts/actions/mobskills/methane_breath.lua
@@ -10,7 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.2, 1.875, xi.element.FIRE, 400)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.2, 1.875, xi.element.FIRE, 400)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 

--- a/scripts/actions/mobskills/numbing_breath.lua
+++ b/scripts/actions/mobskills/numbing_breath.lua
@@ -12,7 +12,7 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 20, 0, 60)
 
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.2, 1.875, xi.element.ICE, 500)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.2, 1.875, xi.element.ICE, 500)
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.ICE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.ICE)
     return dmg

--- a/scripts/actions/mobskills/pet_flame_breath.lua
+++ b/scripts/actions/mobskills/pet_flame_breath.lua
@@ -11,7 +11,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.3, 0.75, xi.element.FIRE, 460)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.3, 0.75, xi.element.FIRE, 460)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.FIRE)

--- a/scripts/actions/mobskills/pet_frost_breath.lua
+++ b/scripts/actions/mobskills/pet_frost_breath.lua
@@ -10,7 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.3, 0.75, xi.element.ICE, 460)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.3, 0.75, xi.element.ICE, 460)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.ICE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.ICE)

--- a/scripts/actions/mobskills/pet_gust_breath.lua
+++ b/scripts/actions/mobskills/pet_gust_breath.lua
@@ -10,7 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.3, 0.75, xi.element.WIND, 460)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.3, 0.75, xi.element.WIND, 460)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.WIND, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.WIND)

--- a/scripts/actions/mobskills/pet_hydro_breath.lua
+++ b/scripts/actions/mobskills/pet_hydro_breath.lua
@@ -10,7 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.3, 0.75, xi.element.WATER, 460)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.3, 0.75, xi.element.WATER, 460)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.WATER)

--- a/scripts/actions/mobskills/pet_lightning_breath.lua
+++ b/scripts/actions/mobskills/pet_lightning_breath.lua
@@ -10,7 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.3, 0.75, xi.element.THUNDER, 460)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.3, 0.75, xi.element.THUNDER, 460)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.THUNDER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.THUNDER)

--- a/scripts/actions/mobskills/pet_sand_breath.lua
+++ b/scripts/actions/mobskills/pet_sand_breath.lua
@@ -10,7 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.3, 0.75, xi.element.EARTH, 460)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.3, 0.75, xi.element.EARTH, 460)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.EARTH, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.EARTH)

--- a/scripts/actions/mobskills/plague_breath.lua
+++ b/scripts/actions/mobskills/plague_breath.lua
@@ -14,7 +14,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, power, 3, 60)
 
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.1, 2, xi.element.WATER, 250)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.1, 2, xi.element.WATER, 250)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.WATER)

--- a/scripts/actions/mobskills/poison_breath.lua
+++ b/scripts/actions/mobskills/poison_breath.lua
@@ -14,7 +14,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, power, 3, 60)
 
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.1, 1.25, xi.element.WATER, 200)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.1, 1.25, xi.element.WATER, 200)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.WATER)

--- a/scripts/actions/mobskills/polar_blast.lua
+++ b/scripts/actions/mobskills/polar_blast.lua
@@ -27,7 +27,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.01, 0.1, xi.element.ICE, 700)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.01, 0.1, xi.element.ICE, 700)
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.ICE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 15, 0, 60)

--- a/scripts/actions/mobskills/pyric_blast.lua
+++ b/scripts/actions/mobskills/pyric_blast.lua
@@ -27,7 +27,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.01, 0.1, xi.element.FIRE, 700)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.01, 0.1, xi.element.FIRE, 700)
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PLAGUE, 5, 3, 60)

--- a/scripts/actions/mobskills/radiant_breath.lua
+++ b/scripts/actions/mobskills/radiant_breath.lua
@@ -13,7 +13,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 1250, 0, 120)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, 120)
 
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.2, 0.75, xi.element.LIGHT, 700)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.2, 0.75, xi.element.LIGHT, 700)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.LIGHT, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.LIGHT)

--- a/scripts/actions/mobskills/sable_breath.lua
+++ b/scripts/actions/mobskills/sable_breath.lua
@@ -20,7 +20,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.2, 1.25, xi.element.DARK, 1400)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.2, 1.25, xi.element.DARK, 1400)
     dmgmod = utils.conalDamageAdjustment(mob, target, skill, dmgmod, 0.9)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.DARK, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)

--- a/scripts/actions/mobskills/sand_breath.lua
+++ b/scripts/actions/mobskills/sand_breath.lua
@@ -11,7 +11,7 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 20, 0, 180)
 
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.2, 0.75, xi.element.EARTH, 800)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.2, 0.75, xi.element.EARTH, 800)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.EARTH, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.EARTH)

--- a/scripts/actions/mobskills/silence_gas.lua
+++ b/scripts/actions/mobskills/silence_gas.lua
@@ -12,7 +12,7 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, 60)
 
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.25, 2, xi.element.WIND, 800)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.25, 2, xi.element.WIND, 800)
     local dmg    = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.WIND, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.WIND)

--- a/scripts/actions/mobskills/splash_breath.lua
+++ b/scripts/actions/mobskills/splash_breath.lua
@@ -9,7 +9,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.1, 0.75, xi.element.WATER, 400)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.1, 0.75, xi.element.WATER, 400)
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.WATER)
     return dmg

--- a/scripts/actions/mobskills/sulfurous_breath.lua
+++ b/scripts/actions/mobskills/sulfurous_breath.lua
@@ -14,7 +14,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.2, 0.75, xi.element.FIRE, 700)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.2, 0.75, xi.element.FIRE, 700)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.FIRE)

--- a/scripts/actions/mobskills/sweet_breath.lua
+++ b/scripts/actions/mobskills/sweet_breath.lua
@@ -10,7 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.125, 3, xi.element.WATER, 500)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.125, 3, xi.element.WATER, 500)
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.WATER)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLEEP_I, 1, 0, 30)

--- a/scripts/actions/mobskills/syphon_discharge.lua
+++ b/scripts/actions/mobskills/syphon_discharge.lua
@@ -15,7 +15,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.1, 1.25, xi.element.WATER, 200)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.1, 1.25, xi.element.WATER, 200)
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.WATER)

--- a/scripts/actions/mobskills/thunder_breath.lua
+++ b/scripts/actions/mobskills/thunder_breath.lua
@@ -14,7 +14,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.5, 1, xi.element.THUNDER, 700)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.5, 1, xi.element.THUNDER, 700)
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.THUNDER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.THUNDER)

--- a/scripts/actions/mobskills/thunderbolt_breath.lua
+++ b/scripts/actions/mobskills/thunderbolt_breath.lua
@@ -17,7 +17,7 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STUN, 1, 0, 7)
 
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.333, 0.625, xi.element.THUNDER, 500)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.333, 0.625, xi.element.THUNDER, 500)
     local dmg    = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.THUNDER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.THUNDER)

--- a/scripts/actions/mobskills/vapor_spray.lua
+++ b/scripts/actions/mobskills/vapor_spray.lua
@@ -10,7 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.3, 0.75, xi.element.WATER, 600)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.3, 0.75, xi.element.WATER, 600)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.WATER)

--- a/scripts/actions/mobskills/venom_breath.lua
+++ b/scripts/actions/mobskills/venom_breath.lua
@@ -10,7 +10,7 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, math.random(20, 40), 3, 60)
 
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.3, 1.875, xi.element.WATER, 500)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.3, 1.875, xi.element.WATER, 500)
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.ICE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.ICE)
     return dmg

--- a/scripts/actions/mobskills/violent_rupture.lua
+++ b/scripts/actions/mobskills/violent_rupture.lua
@@ -17,7 +17,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STR_DOWN, power, 3, duration)
 
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.1, 1, xi.element.FIRE, 200)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.1, 1, xi.element.FIRE, 200)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 

--- a/scripts/actions/mobskills/wind_breath.lua
+++ b/scripts/actions/mobskills/wind_breath.lua
@@ -10,7 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.3, 0.75, xi.element.WIND, 460)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.3, 0.75, xi.element.WIND, 460)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.WIND, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.WIND)

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -230,8 +230,8 @@ xi.mobskills.mobPhysicalMove = function(mob, target, skill, numHits, accMod, dmg
         finaldmg   = 0
         hitslanded = 0
         skill:setMsg(xi.msg.basic.SKILL_MISS)
-    -- calculate tp return of mob skill
-    else
+    -- calculate tp return of mob skill and add if hit primary target
+    elseif skill:getPrimaryTargetID() == target:getID() then
         local tpReturn = xi.combat.tp.getSingleMeleeHitTPReturn(mob, target)
         tpReturn = tpReturn + 10 * (hitslanded - 1) -- extra hits give 10 TP each
         mob:addTP(tpReturn)
@@ -302,8 +302,8 @@ xi.mobskills.mobMagicalMove = function(mob, target, skill, damage, element, dmgm
     finaldmg       = finaldmg * resist * magicDefense
     returninfo.dmg = finaldmg
 
-    -- magical mob skills are single hit so provide single Melee hit TP return
-    if finaldmg > 0 then
+    -- magical mob skills are single hit so provide single Melee hit TP return if primary target
+    if finaldmg > 0 and skill:getPrimaryTargetID() == target:getID() then
         local tpReturn = xi.combat.tp.getSingleMeleeHitTPReturn(mob, target)
         mob:addTP(tpReturn)
     end
@@ -403,7 +403,7 @@ end
 -- base is calculated from main level to create a minimum
 -- Equation: (HP * percent) + (LVL / base)
 -- cap is optional, defines a maximum damage
-xi.mobskills.mobBreathMove = function(mob, target, percent, base, element, cap)
+xi.mobskills.mobBreathMove = function(mob, target, skill, percent, base, element, cap)
     local damage = (mob:getHP() * percent) + (mob:getMainLvl() / base)
 
     if not cap then
@@ -452,8 +452,8 @@ xi.mobskills.mobBreathMove = function(mob, target, percent, base, element, cap)
         damage = utils.clamp(utils.stoneskin(target, damage), -99999, 99999)
     end
 
-    -- breath mob skills are single hit so provide single Melee hit TP return
-    if damage > 0 then
+    -- breath mob skills are single hit so provide single Melee hit TP return if primary target
+    if damage > 0 and skill:getPrimaryTargetID() == target:getID() then
         local tpReturn = xi.combat.tp.getSingleMeleeHitTPReturn(mob, target)
         mob:addTP(tpReturn)
     end

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1916,6 +1916,7 @@ void CBattleEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
     }
 
     PSkill->setTotalTargets(targets);
+    PSkill->setPrimaryTargetID(PTarget->id);
     PSkill->setTP(state.GetSpentTP());
     PSkill->setHPP(GetHPP());
 

--- a/src/map/lua/lua_mobskill.cpp
+++ b/src/map/lua/lua_mobskill.cpp
@@ -75,6 +75,11 @@ uint16 CLuaMobSkill::getTotalTargets()
     return m_PLuaMobSkill->getTotalTargets();
 }
 
+uint32 CLuaMobSkill::getPrimaryTargetID()
+{
+    return m_PLuaMobSkill->getPrimaryTargetID();
+}
+
 uint16 CLuaMobSkill::getMsg()
 {
     return m_PLuaMobSkill->getMsg();
@@ -121,6 +126,7 @@ void CLuaMobSkill::Register()
     SOL_REGISTER("getParam", CLuaMobSkill::getParam);
     SOL_REGISTER("getID", CLuaMobSkill::getID);
     SOL_REGISTER("getTotalTargets", CLuaMobSkill::getTotalTargets);
+    SOL_REGISTER("getPrimaryTargetID", CLuaMobSkill::getPrimaryTargetID);
     SOL_REGISTER("getTP", CLuaMobSkill::getTP);
     SOL_REGISTER("getMobHPP", CLuaMobSkill::getMobHPP);
 }

--- a/src/map/lua/lua_mobskill.h
+++ b/src/map/lua/lua_mobskill.h
@@ -52,6 +52,7 @@ public:
     void   setMsg(uint16 message);
     uint16 getMsg();
     uint16 getTotalTargets();
+    uint32 getPrimaryTargetID();
 
     bool operator==(const CLuaMobSkill& other) const
     {

--- a/src/map/mobskill.cpp
+++ b/src/map/mobskill.cpp
@@ -25,6 +25,7 @@
 CMobSkill::CMobSkill(uint16 id)
 : m_ID(id)
 , m_TotalTargets(1)
+, m_primaryTargetID(0)
 , m_Param(0)
 , m_AnimID(0)
 , m_Aoe(0)
@@ -99,6 +100,11 @@ void CMobSkill::setMsg(uint16 msg)
 void CMobSkill::setTotalTargets(uint16 targets)
 {
     m_TotalTargets = targets;
+}
+
+void CMobSkill::setPrimaryTargetID(uint32 targid)
+{
+    m_primaryTargetID = targid;
 }
 
 void CMobSkill::setAnimationID(uint16 animID)
@@ -210,6 +216,11 @@ uint8 CMobSkill::getHPP() const
 uint16 CMobSkill::getTotalTargets() const
 {
     return m_TotalTargets;
+}
+
+uint32 CMobSkill::getPrimaryTargetID() const
+{
+    return m_primaryTargetID;
 }
 
 uint16 CMobSkill::getMsg() const

--- a/src/map/mobskill.h
+++ b/src/map/mobskill.h
@@ -67,6 +67,7 @@ public:
     int16  getTP() const;
     uint8  getHPP() const;
     uint16 getTotalTargets() const;
+    uint32 getPrimaryTargetID() const;
     uint16 getMsgForAction() const;
     float  getRadius() const;
     int16  getParam() const;
@@ -89,6 +90,7 @@ public:
     void setTP(int16 tp);
     void setHPP(uint8 hpp);
     void setTotalTargets(uint16 targets);
+    void setPrimaryTargetID(uint32 targid);
     void setParam(int16 value);
     void setKnockback(uint8 knockback);
     void setPrimarySkillchain(uint8 skillchain);
@@ -101,6 +103,7 @@ public:
 private:
     uint16 m_ID;
     uint16 m_TotalTargets;
+    uint32 m_primaryTargetID; // primary target ID
     int16  m_Param;
     uint16 m_AnimID;
     uint8  m_Aoe;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes an issue with mobskills whereby a mob is gaining TP for each player hit by an AoE mobskill. The fix leverages a similar pattern to the Spell object by adding PrimaryTargetID functions to the MobSkill object. Also adds the skill object as a parameter to `xi.mobskills.mobBreathMove` (similar to `mobPhysicalMove` and `mobMagicMove` which already passes the skill), so that `mobBreathMove` can also leverage the `getPrimaryTargetID` function.

## Steps to test these changes
Fight different mobs with AoE mobskills of different types (magic, physical, and breath) and check mob TP before and after the skill to see that mob should gain small amount of TP (like 80 TP) if the skill hit the primary target and should not add more tp for non-primary targets hit.
