### PR TITLE
[LUA] WS crit cratio max should be 1 higher than normal cratio max

### DIFF
--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -19,6 +19,13 @@ require('scripts/globals/combat/physical_utilities')
 xi = xi or {}
 xi.weaponskills = xi.weaponskills or {}
 
+local printDebug = function(player, textToPrint)
+    -- prints to map server if pet has local var
+    if player:getLocalVar('debug') == 1 then
+        player:printToPlayer(textToPrint, xi.msg.channel.SYSTEM_3)
+    end
+end
+
 -- Obtains alpha, used for working out WSC on legacy servers
 -- Retail has no alpha anymore as of 2014 Weaponskill functions
 local function getAlpha(level)
@@ -359,10 +366,15 @@ local function getSingleHitDamage(attacker, target, dmg, ftp, wsParams, calcPara
                 finaldmg = finaldmg + magicdmg
             end
 
+            printDebug(attacker, fmt('{}: dmg-{} pdif-{} min-{} max-{} critmin-{} critmax-{}', attacker:getName(), finaldmg, calcParams.pdif, calcParams.cratio[1], calcParams.cratio[2], calcParams.ccritratio[1], calcParams.ccritratio[2]))
+
             calcParams.hitsLanded = calcParams.hitsLanded + 1
         else
+            printDebug(attacker, fmt('{}: Shadow absorbed', attacker:getName()))
             calcParams.shadowsAbsorbed = calcParams.shadowsAbsorbed + 1
         end
+    else
+        printDebug(attacker, fmt('{}: Swing missed', attacker:getName()))
     end
 
     return finaldmg, calcParams
@@ -427,6 +439,7 @@ local function calculateWsMods(attacker, calcParams, wsParams)
         wsMods = wsMods + attacker:getStat(modList[1]) * paramValue
     end
 
+    printDebug(attacker, fmt('WSMods: {} Alpha: {} fSTR: {}', wsMods, calcParams.alpha, calcParams.fSTR))
     return wsMods * calcParams.alpha + calcParams.fSTR
 end
 
@@ -469,9 +482,11 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
 
     local wsMods   = calculateWsMods(attacker, calcParams, wsParams)
     local mainBase = calcParams.weaponDamage[1] + wsMods + calcParams.bonusWSmods
+    printDebug(attacker, fmt('WS Base dmg: {}+{}+{}', calcParams.weaponDamage[1], wsMods, calcParams.bonusWSmods))
 
     -- Calculate fTP multiplier
     local ftp = xi.weaponskills.fTP(tp, wsParams.ftpMod) + calcParams.bonusfTP
+    printDebug(attacker, fmt('WS FTP: {}+{}', ftp - calcParams.bonusfTP, calcParams.bonusfTP))
 
     -- Calculate critrates
     -- TODO: calc per-hit with weapon crit+% on each hand (if dual wielding)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The issue fixed a couple weeks ago related to crit ws always critting made me wonder why we didn't notice sooner, and i found that cratio is being heavily limited for crit attacks

The cratio clamp is not properly extending the max, artificially limiting the dmg output of weaponskill hits that crit. We need to adjust two things:
- clamp the cratio at 1 more than the max for crits
- Adjust the `getMeleePDifRange` function to not hard cap at 3, now that we have a pdif weapon table, we can copy the logic from the `xi.combat.physical.calculateMeleePDIF` function

Edit: i've added a `printDebug` local function [similar to here](https://github.com/LandSandBoat/server/blob/2436717ba375711d9c494f510854c4507293e3cd/scripts/globals/pets/avatar.lua#L17). Set the localvar `debug` equal to 1 on a player and they get pdif prints for each ws hit

![image](https://github.com/LandSandBoat/server/assets/131182600/c11d7c79-97dd-43d4-9d0f-69cf86aced29)


## Steps to test these changes

print of the cratio values inside of the ws function affected (`xi.weaponskills.cMeleeRatio`)

print(fmt("{}: cratio-{} min-{} max-{} critmin-{} critmax-{}", attacker:getName(), cratio, pdif[1], pdif[2], pdifcrit[1], pdifcrit[2]))

Then use ws for various weapon types after setting the target's def high/low to see the ranges scaling across pdif max and attack vs def of attacker/defender
- `!setmod def -500`
- `!setmod def 1000`

example of club vs h2h, then 3rd is h2h with defender having very high def:
![image](https://github.com/LandSandBoat/server/assets/131182600/97e5dfcb-5023-4f5b-a70c-526e85f9adbb)

