### PR TITLE
[LUA] building flourish is a percentage increase in attack

### DIFF
--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -342,7 +342,7 @@ xi.combat.physical.calculateMeleePDIF = function(actor, target, weaponType, wsAt
             local flourishEffect = actor:getStatusEffect(xi.effect.BUILDING_FLOURISH)
 
             if flourishEffect:getPower() >= 2 then -- 2 or more Finishing Moves used.
-                actorAttack = actorAttack + 25 + flourishEffect:getSubPower()
+                actorAttack = math.floor(actorAttack * (125 + flourishEffect:getSubPower()) / 100)
             end
         end
     end
@@ -458,7 +458,7 @@ xi.combat.physical.calculateRangedPDIF = function(actor, target, weaponType, wsA
             local flourishEffect = actor:getStatusEffect(xi.effect.BUILDING_FLOURISH)
 
             if flourishEffect:getPower() >= 2 then -- 2 or more Finishing Moves used.
-                actorAttack = actorAttack + 25 + flourishEffect:getSubPower()
+                actorAttack = math.floor(actorAttack * (125 + flourishEffect:getSubPower()) / 100)
             end
         end
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The new physical util used for cpp attack rounds has considerations for weaponskills, but isn't used for them yet. It was brought to my attention that building flourish isn't treated properly here, so might as well adjust before it goes into use

## Steps to test these changes

remove the `isWeaponskill` restriction on these two sections of code and print pdif numbers while autoattacking before and after having building flourish to see that the attack is indeed being increased by 25%

```
    pDif = math.random(pDifLowerCap * 1000, pDifUpperCap * 1000) / 1000
print(fmt("{}: {}", actor:getName(), pDifLowerCap))
```

![image](https://github.com/LandSandBoat/server/assets/131182600/c293b925-5339-470f-9263-5462954acdad)

before and after using building flourish
