### PR TITLE
[cpp] Range state exit listener

### DIFF
--- a/documentation/AI_Events.txt
+++ b/documentation/AI_Events.txt
@@ -29,6 +29,7 @@ TAKE_DAMAGE - Entity, amount, optionalAttacker, attackType, damageType
 CRITICAL_TAKE - Target, Attacker
 
 RANGE_START - Entity, action
+RANGE_STATE_EXIT - Entity, Target, action
 
 ABILITY_START - Entity, Ability
 ABILITY_USE - Entity, Target, Ability, action

--- a/src/map/ai/states/range_state.cpp
+++ b/src/map/ai/states/range_state.cpp
@@ -129,6 +129,7 @@ bool CRangeState::Update(time_point tick)
             // reset aim time so interrupted players only have to wait the correct 2.7s until next shot
             m_aimTime = std::chrono::seconds(0);
             m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+            m_PEntity->PAI->EventHandler.triggerListener("RANGE_STATE_EXIT", CLuaBaseEntity(m_PEntity), nullptr, CLuaAction(&action));
         }
         else
         {
@@ -136,9 +137,9 @@ bool CRangeState::Update(time_point tick)
 
             m_PEntity->OnRangedAttack(*this, action);
             m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+            m_PEntity->PAI->EventHandler.triggerListener("RANGE_STATE_EXIT", CLuaBaseEntity(m_PEntity), CLuaBaseEntity(PTarget), CLuaAction(&action));
         }
 
-        m_PEntity->PAI->EventHandler.triggerListener("RANGE_STATE_EXIT", CLuaBaseEntity(m_PEntity), CLuaBaseEntity(PTarget), CLuaAction(&action));
         Complete();
     }
 

--- a/src/map/ai/states/range_state.cpp
+++ b/src/map/ai/states/range_state.cpp
@@ -137,6 +137,8 @@ bool CRangeState::Update(time_point tick)
             m_PEntity->OnRangedAttack(*this, action);
             m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
         }
+
+        m_PEntity->PAI->EventHandler.triggerListener("RANGE_STATE_EXIT", CLuaBaseEntity(m_PEntity), CLuaBaseEntity(PTarget), CLuaAction(&action));
         Complete();
     }
 

--- a/src/map/lua/lua_action.cpp
+++ b/src/map/lua/lua_action.cpp
@@ -106,6 +106,19 @@ void CLuaAction::messageID(uint32 actionTargetID, uint16 messageID)
     }
 }
 
+std::optional<uint16> CLuaAction::getMsg(uint32 actionTargetID)
+{
+    for (auto&& actionList : m_PLuaAction->actionLists)
+    {
+        if (actionList.ActionTargetID == actionTargetID)
+        {
+            return actionList.actionTargets[0].messageID;
+        }
+    }
+
+    return std::nullopt;
+}
+
 std::optional<uint16> CLuaAction::getAnimation(uint32 actionTargetID)
 {
     for (auto&& actionList : m_PLuaAction->actionLists)
@@ -243,6 +256,7 @@ void CLuaAction::Register()
     SOL_REGISTER("getParam", CLuaAction::getParam);
     SOL_REGISTER("param", CLuaAction::param);
     SOL_REGISTER("messageID", CLuaAction::messageID);
+    SOL_REGISTER("getMsg", CLuaAction::getMsg);
     SOL_REGISTER("getAnimation", CLuaAction::getAnimation);
     SOL_REGISTER("setAnimation", CLuaAction::setAnimation);
     SOL_REGISTER("getCategory", CLuaAction::getCategory);

--- a/src/map/lua/lua_action.h
+++ b/src/map/lua/lua_action.h
@@ -49,6 +49,7 @@ public:
     uint16 getParam(uint32 actionTargetID);
     void   param(uint32 actionTargetID, int32 param);
     void   messageID(uint32 actionTargetID, uint16 messageID);
+    auto   getMsg(uint32 actionTargetID) -> std::optional<uint16>;
     auto   getAnimation(uint32 actionTargetID) -> std::optional<uint16>;
     void   setAnimation(uint32 actionTargetID, uint16 animation);
     auto   getCategory() -> uint8;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Breaking out a commit from [this PR](https://github.com/LandSandBoat/server/pull/4868/commits/d09cda9e4879f3a53047c616088e17607342173a).

Also resolves the issue of interupted range attacks giving a CLuaBaseEntity warning

results of a simple `RANGE_STATE_EXIT` listener that prints `player` and `target`:

![image](https://github.com/LandSandBoat/server/assets/131182600/6f36f895-efe9-4ccc-8855-47dac7a0ee04)

First is letting the RA complete, second is interrupting it

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
