### PR TITLE
[lua] Return cleanly when flourish checker has no finishing moves

### DIFF
--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -178,7 +178,11 @@ xi.job_utils.dancer.checkFlourishAbility = function(player, target, ability, com
     end
 
     -- Finishing Move check.
-    local numFinishingMoves = player:getStatusEffect(xi.effect.FINISHING_MOVE_1):getPower()
+    local numFinishingMoves = 0
+    local flourishEffect = player:getStatusEffect(xi.effect.FINISHING_MOVE_1)
+    if flourishEffect then
+        numFinishingMoves = flourishEffect:getPower()
+    end
 
     if numFinishingMoves >= minimumCost then
         return 0, 0


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

When using a flourish ability with no finishing moves buff, the check function exits early. This is both not ideal and it reports the wrong message (unable to use ability vs not enough finishing moves)

## Steps to test these changes

Use `/ja "violent flourish" <t>` with no finishing moves before this change, see these logs: 

![image](https://github.com/LandSandBoat/server/assets/131182600/5e222097-b317-45af-89b4-2c503e8d5529)

after change, cleanly blocks ability with the proper message id