### PR TITLE
[core] Escape more user input

### DIFF
--- a/src/common/sql.cpp
+++ b/src/common/sql.cpp
@@ -285,10 +285,15 @@ size_t SqlConnection::EscapeString(char* out_to, const char* from)
 std::string SqlConnection::EscapeString(std::string const& input)
 {
     TracyZoneScoped;
-    std::string escaped_full_string;
-    escaped_full_string.reserve(input.size() * 2 + 1);
-    EscapeString(escaped_full_string.data(), input.data());
-    return escaped_full_string;
+    const char*  inputCString = input.c_str();
+    const size_t len          = strlen(inputCString);
+    char*        buffer       = new char[len * 2 + 1];
+    EscapeStringLen(buffer, inputCString, len);
+
+    std::string escapedString = buffer;
+    destroy(buffer);
+
+    return escapedString;
 }
 
 int32 SqlConnection::QueryStr(const char* query)

--- a/src/common/sql.cpp
+++ b/src/common/sql.cpp
@@ -308,6 +308,8 @@ int32 SqlConnection::QueryStr(const char* query)
         ShowError(query);
     }
 
+    // False positive, it is detecting ";" as a macro
+    // cppcheck-suppress unknownMacro
     DebugSQL(query);
 
     if (self == nullptr)

--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -113,7 +113,7 @@ namespace message
                 char characterName[PacketNameLength] = {};
                 memcpy(&characterName, reinterpret_cast<char*>(extra.data()) + 4, PacketNameLength - 1);
 
-                CCharEntity* PChar = zoneutils::GetCharByName(characterName);
+                CCharEntity* PChar = zoneutils::GetCharByName(sql->EscapeString(characterName));
                 if (PChar && PChar->status != STATUS_TYPE::DISAPPEAR && !jailutils::InPrison(PChar))
                 {
                     std::unique_ptr<CBasicPacket> newPacket = std::make_unique<CBasicPacket>();
@@ -514,7 +514,7 @@ namespace message
                 {
                     char memberName[PacketNameLength] = {};
                     memcpy(&memberName, reinterpret_cast<char*>(extra.data()) + 4, PacketNameLength - 1);
-                    PLinkshell->ChangeMemberRank(memberName, ref<uint8>((uint8*)extra.data(), 28));
+                    PLinkshell->ChangeMemberRank(sql->EscapeString(memberName), ref<uint8>((uint8*)extra.data(), 28));
                 }
                 break;
             }
@@ -522,7 +522,8 @@ namespace message
             {
                 char memberName[PacketNameLength] = {};
                 memcpy(&memberName, reinterpret_cast<char*>(extra.data()) + 4, PacketNameLength - 1);
-                CCharEntity* PChar = zoneutils::GetCharByName(memberName);
+
+                CCharEntity* PChar = zoneutils::GetCharByName(sql->EscapeString(memberName));
 
                 if (PChar && PChar->PLinkshell1 && PChar->PLinkshell1->getID() == ref<uint32>((uint8*)extra.data(), 24))
                 {
@@ -530,7 +531,7 @@ namespace message
                     CItemLinkshell* targetLS   = (CItemLinkshell*)PChar->getEquip(SLOT_LINK1);
                     if (targetLS && (kickerRank == LSTYPE_LINKSHELL || (kickerRank == LSTYPE_PEARLSACK && targetLS->GetLSType() == LSTYPE_LINKPEARL)))
                     {
-                        PChar->PLinkshell1->RemoveMemberByName(memberName,
+                        PChar->PLinkshell1->RemoveMemberByName(PChar->getName(),
                                                                (targetLS->GetLSType() == (uint8)LSTYPE_LINKSHELL ? (uint8)LSTYPE_PEARLSACK : kickerRank));
                     }
                 }
@@ -540,7 +541,7 @@ namespace message
                     CItemLinkshell* targetLS   = (CItemLinkshell*)PChar->getEquip(SLOT_LINK2);
                     if (targetLS && (kickerRank == LSTYPE_LINKSHELL || (kickerRank == LSTYPE_PEARLSACK && targetLS->GetLSType() == LSTYPE_LINKPEARL)))
                     {
-                        PChar->PLinkshell2->RemoveMemberByName(memberName, kickerRank);
+                        PChar->PLinkshell2->RemoveMemberByName(PChar->getName(), kickerRank);
                     }
                 }
                 break;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
More user inputs are escaped

## Steps to test these changes

Use commands that have strings in them, such as /tell, /pcmd kick, /pcmd leader, create a linkshell, blacklist a player, use alliance commands, kick a player from party/linkshell/alliance, and see them unchanged.
