### PR TITLE
[LUA] DNC step accuracy (of behavior and acc)

### DIFF
--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -242,7 +242,7 @@ xi.job_utils.dancer.useStepAbility = function(player, target, ability, action, s
         player:delTP(100 + player:getMod(xi.mod.STEP_TP_CONSUMED))
     end
 
-    if math.random() <= xi.weaponskills.getHitRate(player, target, true, player:getMod(xi.mod.STEP_ACCURACY)) then
+    if math.random() <= xi.weaponskills.getHitRate(player, target, true, 10 + player:getMod(xi.mod.STEP_ACCURACY)) then
         local maxSteps         = player:getMainJob() == xi.job.DNC and 10 or 5
         local debuffEffect     = target:getStatusEffect(stepEffect)
         local origDebuffStacks = 0

--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -243,8 +243,10 @@ xi.job_utils.dancer.useStepAbility = function(player, target, ability, action, s
     end
 
     if math.random() <= xi.weaponskills.getHitRate(player, target, true, player:getMod(xi.mod.STEP_ACCURACY)) then
-        local debuffEffect = target:getStatusEffect(stepEffect)
-        hitType            = hitId
+        local maxSteps         = player:getMainJob() == xi.job.DNC and 10 or 5
+        local debuffEffect     = target:getStatusEffect(stepEffect)
+        local origDebuffStacks = 0
+        hitType                = hitId
 
         -- Apply Finishing Moves
         local fmEffect   = player:getStatusEffect(xi.effect.FINISHING_MOVE_1)
@@ -263,16 +265,23 @@ xi.job_utils.dancer.useStepAbility = function(player, target, ability, action, s
 
         -- Handle Target Debuffs
         if debuffEffect then
-            debuffStacks   = debuffStacks + debuffEffect:getPower()
-            debuffDuration = debuffEffect:getDuration()
+            origDebuffStacks = debuffEffect:getPower()
+            debuffStacks     = debuffStacks + origDebuffStacks
+            debuffDuration   = debuffEffect:getDuration()
 
-            debuffStacks   = math.min(debuffStacks, 10)
+            debuffStacks   = math.min(debuffStacks, maxSteps)
             debuffDuration = math.min(debuffEffect:getDuration() + 30 + stepDurationGift, 120 + stepDurationGift)
 
-            target:delStatusEffectSilent(stepEffect)
+            if maxSteps >= origDebuffStacks then
+                target:delStatusEffectSilent(stepEffect)
+            end
         end
 
-        target:addStatusEffect(stepEffect, debuffStacks, 0, debuffDuration)
+        if maxSteps >= origDebuffStacks then
+            target:addStatusEffect(stepEffect, debuffStacks, 0, debuffDuration)
+        else
+            ability:setMsg(xi.msg.basic.JA_NO_EFFECT)
+        end
     else
         ability:setMsg(xi.msg.basic.JA_MISS)
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Har har, get it... accuracy

Steps should have an innate +10 accuracy.

Also, sub dancer can only apply up to level 5 steps, the steps have no effect if a more powerful effect is active. If the max step level is greater or equal to the existing power, the JA refreshes the duration 

## Steps to test these changes

Some screenshots to show testing of the second change:

![image](https://github.com/LandSandBoat/server/assets/131182600/55f89cfa-7a7d-439a-b032-5bfb5989768f)

Not shown in this second screenshot is starting as only sub dnc, re-applying a level 5 daze

![image](https://github.com/LandSandBoat/server/assets/131182600/15e7ad9c-4e1e-4b1b-b021-3d903c8aef97)

