### PR TITLE
[LUA]Usable Items now display count and item on use.

### DIFF
--- a/scripts/enum/item.lua
+++ b/scripts/enum/item.lua
@@ -2215,6 +2215,7 @@ xi.item =
     DEATHBALL                           = 4566,
     BOWL_OF_QUADAV_STEW                 = 4569,
     BIRD_EGG                            = 4570,
+    CLUMP_OF_BEAUGREENS                 = 4571,
     SAUSAGE                             = 4578,
     LOAF_OF_PUMPERNICKEL                = 4591,
     BOWL_OF_WISDOM_SOUP                 = 4592,

--- a/scripts/items/acid_bolt_quiver.lua
+++ b/scripts/items/acid_bolt_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.ACID_BOLT, 99)
+    npcUtil.giveItem(target, { { xi.item.ACID_BOLT, 99 } })
 end
 
 return itemObject

--- a/scripts/items/adaman_bolt_quiver.lua
+++ b/scripts/items/adaman_bolt_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.ADAMAN_BOLT, 99)
+    npcUtil.giveItem(target, { { xi.item.ADAMAN_BOLT, 99 } })
 end
 
 return itemObject

--- a/scripts/items/adaman_bullet_pouch.lua
+++ b/scripts/items/adaman_bullet_pouch.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.ADAMAN_BULLET, 99)
+    npcUtil.giveItem(target, { { xi.item.ADAMAN_BULLET, 99 } })
 end
 
 return itemObject

--- a/scripts/items/antlion_quiver.lua
+++ b/scripts/items/antlion_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.ANTLION_ARROW, 99)
+    npcUtil.giveItem(target, { { xi.item.ANTLION_ARROW, 99 } })
 end
 
 return itemObject

--- a/scripts/items/apple_au_lait_tank.lua
+++ b/scripts/items/apple_au_lait_tank.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.FLASK_OF_APPLE_AU_LAIT, 1)
+    npcUtil.giveItem(target, { { xi.item.FLASK_OF_APPLE_AU_LAIT, 1 } })
 end
 
 return itemObject

--- a/scripts/items/beetle_quiver.lua
+++ b/scripts/items/beetle_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.BEETLE_ARROW, 99)
+    npcUtil.giveItem(target, { { xi.item.BEETLE_ARROW, 99 } })
 end
 
 return itemObject

--- a/scripts/items/beitetsu_box.lua
+++ b/scripts/items/beitetsu_box.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.BEITETSU, math.random(15, 30))
+    npcUtil.giveItem(target, { { xi.item.BEITETSU, math.random(15, 30) } })
 end
 
 return itemObject

--- a/scripts/items/beitetsu_parcel.lua
+++ b/scripts/items/beitetsu_parcel.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.BEITETSU, math.random(3, 15))
+    npcUtil.giveItem(target, { { xi.item.BEITETSU, math.random(3, 15) } })
 end
 
 return itemObject

--- a/scripts/items/beryllium_bolt_quiver.lua
+++ b/scripts/items/beryllium_bolt_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.BERYLLIUM_BOLT, 99)
+    npcUtil.giveItem(target, { { xi.item.BERYLLIUM_BOLT, 99 } })
 end
 
 return itemObject

--- a/scripts/items/beryllium_quiver.lua
+++ b/scripts/items/beryllium_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.BERYLLIUM_ARROW, 99)
+    npcUtil.giveItem(target, { { xi.item.BERYLLIUM_ARROW, 99 } })
 end
 
 return itemObject

--- a/scripts/items/blind_bolt_quiver.lua
+++ b/scripts/items/blind_bolt_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.BLIND_BOLT, 99)
+    npcUtil.giveItem(target, { { xi.item.BLIND_BOLT, 99 } })
 end
 
 return itemObject

--- a/scripts/items/bloody_bolt_quiver.lua
+++ b/scripts/items/bloody_bolt_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.BLOODY_BOLT, 99)
+    npcUtil.giveItem(target, { { xi.item.BLOODY_BOLT, 99 } })
 end
 
 return itemObject

--- a/scripts/items/bolt_belt.lua
+++ b/scripts/items/bolt_belt.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.BRONZE_BOLT, 99)
+    npcUtil.giveItem(target, { { xi.item.BRONZE_BOLT, 99 } })
 end
 
 return itemObject

--- a/scripts/items/bone_quiver.lua
+++ b/scripts/items/bone_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.BONE_ARROW, 99)
+    npcUtil.giveItem(target, { { xi.item.BONE_ARROW, 99 } })
 end
 
 return itemObject

--- a/scripts/items/boulder_box.lua
+++ b/scripts/items/boulder_box.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.RIFTBORN_BOULDER, math.random(15, 30))
+    npcUtil.giveItem(target, { { xi.item.RIFTBORN_BOULDER, math.random(15, 30) } })
 end
 
 return itemObject

--- a/scripts/items/bronze_bandolier.lua
+++ b/scripts/items/bronze_bandolier.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.BRONZE_BULLET, 99)
+    npcUtil.giveItem(target, { { xi.item.BRONZE_BULLET, 99 } })
 end
 
 return itemObject

--- a/scripts/items/bronze_bolt_quiver.lua
+++ b/scripts/items/bronze_bolt_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.BRONZE_BOLT, 99)
+    npcUtil.giveItem(target, { { xi.item.BRONZE_BOLT, 99 } })
 end
 
 return itemObject

--- a/scripts/items/bronze_bullet_pouch.lua
+++ b/scripts/items/bronze_bullet_pouch.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.BRONZE_BULLET, 99)
+    npcUtil.giveItem(target, { { xi.item.BRONZE_BULLET, 99 } })
 end
 
 return itemObject

--- a/scripts/items/bullet_pouch.lua
+++ b/scripts/items/bullet_pouch.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.BULLET, 99)
+    npcUtil.giveItem(target, { { xi.item.BULLET, 99 } })
 end
 
 return itemObject

--- a/scripts/items/casaba_melon_tank.lua
+++ b/scripts/items/casaba_melon_tank.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.BOTTLE_OF_MELON_JUICE, 1)
+    npcUtil.giveItem(target, { { xi.item.BOTTLE_OF_MELON_JUICE, 1 } })
 end
 
 return itemObject

--- a/scripts/items/chocobo_shield_+1.lua
+++ b/scripts/items/chocobo_shield_+1.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.SAKURA_BISCUIT, 1)
+    npcUtil.giveItem(target, { { xi.item.SAKURA_BISCUIT, 1 } })
 end
 
 return itemObject

--- a/scripts/items/chocobo_shirt.lua
+++ b/scripts/items/chocobo_shirt.lua
@@ -20,7 +20,7 @@ itemObject.onItemUse = function(target)
     -- 4102 Light
     -- 4103 Dark
     local itemID = 4095 + VanadielDayElement()
-    target:addItem(itemID, math.random(2, 12))
+    npcUtil.giveItem(target, { { itemID, math.random(2, 12) } })
 end
 
 return itemObject

--- a/scripts/items/combat_casters_quiver.lua
+++ b/scripts/items/combat_casters_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.COMBAT_CASTERS_ARROW)
+    npcUtil.giveItem(target, { { xi.item.COMBAT_CASTERS_ARROW } })
 end
 
 return itemObject

--- a/scripts/items/corsair_bullet_pouch.lua
+++ b/scripts/items/corsair_bullet_pouch.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.CORSAIR_BULLET, 99)
+    npcUtil.giveItem(target, { { xi.item.CORSAIR_BULLET, 99 } })
 end
 
 return itemObject

--- a/scripts/items/cotton_coin_purse.lua
+++ b/scripts/items/cotton_coin_purse.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.ALEXANDRITE, math.random(5, 20))
+    npcUtil.giveItem(target, { { xi.item.ALEXANDRITE, math.random(5, 20) } })
 end
 
 return itemObject

--- a/scripts/items/creek_maillot_+1.lua
+++ b/scripts/items/creek_maillot_+1.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.BERRY_SNOW_CONE, 1)
+    npcUtil.giveItem(target, { { xi.item.BERRY_SNOW_CONE, 1 } })
 end
 
 return itemObject

--- a/scripts/items/creek_top_+1.lua
+++ b/scripts/items/creek_top_+1.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.BERRY_SNOW_CONE, 1)
+    npcUtil.giveItem(target, { { xi.item.BERRY_SNOW_CONE, 1 } })
 end
 
 return itemObject

--- a/scripts/items/dark_adaman_bolt_quiver.lua
+++ b/scripts/items/dark_adaman_bolt_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.DARK_ADAMAN_BOLT, 99)
+    npcUtil.giveItem(target, { { xi.item.DARK_ADAMAN_BOLT, 99 } })
 end
 
 return itemObject

--- a/scripts/items/dark_adaman_bullet_pouch.lua
+++ b/scripts/items/dark_adaman_bullet_pouch.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.DARK_ADAMAN_BULLET, 99)
+    npcUtil.giveItem(target, { { xi.item.DARK_ADAMAN_BULLET, 99 } })
 end
 
 return itemObject

--- a/scripts/items/dark_card_case.lua
+++ b/scripts/items/dark_card_case.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.DARK_CARD, 99)
+    npcUtil.giveItem(target, { { xi.item.DARK_CARD, 99 } })
 end
 
 return itemObject

--- a/scripts/items/dark_cluster.lua
+++ b/scripts/items/dark_cluster.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.DARK_CRYSTAL, 12)
+    npcUtil.giveItem(target, { { xi.item.DARK_CRYSTAL, 12 } })
 end
 
 return itemObject

--- a/scripts/items/darkling_bolt_quiver.lua
+++ b/scripts/items/darkling_bolt_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.DARKLING_BOLT, 99)
+    npcUtil.giveItem(target, { { xi.item.DARKLING_BOLT, 99 } })
 end
 
 return itemObject

--- a/scripts/items/darksteel_bolt_quiver.lua
+++ b/scripts/items/darksteel_bolt_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.DARKSTEEL_BOLT, 99)
+    npcUtil.giveItem(target, { { xi.item.DARKSTEEL_BOLT, 99 } })
 end
 
 return itemObject

--- a/scripts/items/date_shuriken_pouch.lua
+++ b/scripts/items/date_shuriken_pouch.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.DATE_SHURIKEN, 99)
+    npcUtil.giveItem(target, { { xi.item.DATE_SHURIKEN, 99 } })
 end
 
 return itemObject

--- a/scripts/items/decennial_coat_+1.lua
+++ b/scripts/items/decennial_coat_+1.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.BOWL_OF_MOOGURT, 1)
+    npcUtil.giveItem(target, { { xi.item.BOWL_OF_MOOGURT, 1 } })
 end
 
 return itemObject

--- a/scripts/items/decennial_dress_+1.lua
+++ b/scripts/items/decennial_dress_+1.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.BOWL_OF_MOOGURT, 1)
+    npcUtil.giveItem(target, { { xi.item.BOWL_OF_MOOGURT, 1 } })
 end
 
 return itemObject

--- a/scripts/items/demon_quiver.lua
+++ b/scripts/items/demon_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.DEMON_ARROW, 99)
+    npcUtil.giveItem(target, { { xi.item.DEMON_ARROW, 99 } })
 end
 
 return itemObject

--- a/scripts/items/divine_bolt_quiver.lua
+++ b/scripts/items/divine_bolt_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.DIVINE_BOLT, 99)
+    npcUtil.giveItem(target, { { xi.item.DIVINE_BOLT, 99 } })
 end
 
 return itemObject

--- a/scripts/items/divine_bullet_pouch.lua
+++ b/scripts/items/divine_bullet_pouch.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.DIVINE_BULLET, 99)
+    npcUtil.giveItem(target, { { xi.item.DIVINE_BULLET, 99 } })
 end
 
 return itemObject

--- a/scripts/items/divine_quiver.lua
+++ b/scripts/items/divine_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.DIVINE_ARROW, 99)
+    npcUtil.giveItem(target, { { xi.item.DIVINE_ARROW, 99 } })
 end
 
 return itemObject

--- a/scripts/items/dragon_tank.lua
+++ b/scripts/items/dragon_tank.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.FLASK_OF_DRAGON_FRUIT_AU_LAIT, 1)
+    npcUtil.giveItem(target, { { xi.item.FLASK_OF_DRAGON_FRUIT_AU_LAIT, 1 } })
 end
 
 return itemObject

--- a/scripts/items/dream_hat_+1.lua
+++ b/scripts/items/dream_hat_+1.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.GINGER_COOKIE, math.random(1, 10))
+    npcUtil.giveItem(target, { { xi.item.GINGER_COOKIE, math.random(1, 10) } })
 end
 
 return itemObject

--- a/scripts/items/dune_gilet_+1.lua
+++ b/scripts/items/dune_gilet_+1.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.BERRY_SNOW_CONE, 1)
+    npcUtil.giveItem(target, { { xi.item.BERRY_SNOW_CONE, 1 } })
 end
 
 return itemObject

--- a/scripts/items/dweomer_bullet_pouch.lua
+++ b/scripts/items/dweomer_bullet_pouch.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.DWEOMER_BULLET, 99)
+    npcUtil.giveItem(target, { { xi.item.DWEOMER_BULLET, 99 } })
 end
 
 return itemObject

--- a/scripts/items/earth_card_case.lua
+++ b/scripts/items/earth_card_case.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.EARTH_CARD, 99)
+    npcUtil.giveItem(target, { { xi.item.EARTH_CARD, 99 } })
 end
 
 return itemObject

--- a/scripts/items/earth_cluster.lua
+++ b/scripts/items/earth_cluster.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.EARTH_CRYSTAL, 12)
+    npcUtil.giveItem(target, { { xi.item.EARTH_CRYSTAL, 12 } })
 end
 
 return itemObject

--- a/scripts/items/elixir_tank.lua
+++ b/scripts/items/elixir_tank.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.ELIXIR, 1)
+    npcUtil.giveItem(target, { { xi.item.ELIXIR, 1 } })
 end
 
 return itemObject

--- a/scripts/items/escritorio.lua
+++ b/scripts/items/escritorio.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.CONE_CALAMARY, 1)
+    npcUtil.giveItem(target, { { xi.item.CONE_CALAMARY, 1 } })
 end
 
 return itemObject

--- a/scripts/items/ether_tank.lua
+++ b/scripts/items/ether_tank.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.ETHER, 1)
+    npcUtil.giveItem(target, { { xi.item.ETHER, 1 } })
 end
 
 return itemObject

--- a/scripts/items/fancy_gilet.lua
+++ b/scripts/items/fancy_gilet.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.PERSIKOS_SNOW_CONE)
+    npcUtil.giveItem(target, { { xi.item.PERSIKOS_SNOW_CONE, 1 } })
 end
 
 return itemObject

--- a/scripts/items/fancy_top.lua
+++ b/scripts/items/fancy_top.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.PERSIKOS_SNOW_CONE)
+    npcUtil.giveItem(target, { { xi.item.PERSIKOS_SNOW_CONE, 1 } })
 end
 
 return itemObject

--- a/scripts/items/fire_card_case.lua
+++ b/scripts/items/fire_card_case.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.FIRE_CARD, 99)
+    npcUtil.giveItem(target, { { xi.item.FIRE_CARD, 99 } })
 end
 
 return itemObject

--- a/scripts/items/fire_cluster.lua
+++ b/scripts/items/fire_cluster.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.FIRE_CRYSTAL, 12)
+    npcUtil.giveItem(target, { { xi.item.FIRE_CRYSTAL, 12 } })
 end
 
 return itemObject

--- a/scripts/items/fuma_shuriken_pouch.lua
+++ b/scripts/items/fuma_shuriken_pouch.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.FUMA_SHURIKEN, 99)
+    npcUtil.giveItem(target, { { xi.item.FUMA_SHURIKEN, 99 } })
 end
 
 return itemObject

--- a/scripts/items/fusion_bolt_quiver.lua
+++ b/scripts/items/fusion_bolt_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.FUSION_BOLT, 99)
+    npcUtil.giveItem(target, { { xi.item.FUSION_BOLT, 99 } })
 end
 
 return itemObject

--- a/scripts/items/galette_des_rois.lua
+++ b/scripts/items/galette_des_rois.lua
@@ -26,7 +26,7 @@ end
 itemObject.onItemUse = function(target)
     target:addStatusEffect(xi.effect.FOOD, 0, 0, 10800, 5875)
     local rand = math.random(784, 815)
-    target:addItem(rand) -- Random Jewel
+    npcUtil.giveItem(target, { { rand, 1 } })
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/gargouille_quiver.lua
+++ b/scripts/items/gargouille_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.GARGOUILLE_ARROW, 99)
+    npcUtil.giveItem(target, { { xi.item.GARGOUILLE_ARROW, 99 } })
 end
 
 return itemObject

--- a/scripts/items/hatchling_shield.lua
+++ b/scripts/items/hatchling_shield.lua
@@ -28,7 +28,7 @@ end
 
 itemObject.onItemUse = function(target)
     local egg = eggTable[math.random(1, #eggTable)]
-    target:addItem(egg[1], math.random(egg[2], egg[3]))
+    npcUtil.giveItem(target, { { egg[1], math.random(egg[2], egg[3]) } })
 end
 
 return itemObject

--- a/scripts/items/heavy_metal_pouch.lua
+++ b/scripts/items/heavy_metal_pouch.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.PLATE_OF_HEAVY_METAL, math.random(3, 19))
+    npcUtil.giveItem(target, { { xi.item.PLATE_OF_HEAVY_METAL, math.random(3, 19) } })
 end
 
 return itemObject

--- a/scripts/items/hi-elixir_tank.lua
+++ b/scripts/items/hi-elixir_tank.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.HI_ELIXIR, 1)
+    npcUtil.giveItem(target, { { xi.item.HI_ELIXIR, 1 } })
 end
 
 return itemObject

--- a/scripts/items/hi-ether_tank.lua
+++ b/scripts/items/hi-ether_tank.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.HI_ETHER, 1)
+    npcUtil.giveItem(target, { { xi.item.HI_ETHER, 1 } })
 end
 
 return itemObject

--- a/scripts/items/hi-potion_tank.lua
+++ b/scripts/items/hi-potion_tank.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.HI_POTION, 1)
+    npcUtil.giveItem(target, { { xi.item.HI_POTION, 1 } })
 end
 
 return itemObject

--- a/scripts/items/hikogami_yukata.lua
+++ b/scripts/items/hikogami_yukata.lua
@@ -9,7 +9,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.SUPER_SCOOP, 1)
+    npcUtil.giveItem(target, { { xi.item.SUPER_SCOOP, 1 } })
 end
 
 return itemObject

--- a/scripts/items/himegami_yukata.lua
+++ b/scripts/items/himegami_yukata.lua
@@ -9,7 +9,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.SUPER_SCOOP, 1)
+    npcUtil.giveItem(target, { { xi.item.SUPER_SCOOP, 1 } })
 end
 
 return itemObject

--- a/scripts/items/holy_bolt_quiver.lua
+++ b/scripts/items/holy_bolt_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.HOLY_BOLT, 99)
+    npcUtil.giveItem(target, { { xi.item.HOLY_BOLT, 99 } })
 end
 
 return itemObject

--- a/scripts/items/horn_quiver.lua
+++ b/scripts/items/horn_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.HORN_ARROW, 99)
+    npcUtil.giveItem(target, { { xi.item.HORN_ARROW, 99 } })
 end
 
 return itemObject

--- a/scripts/items/ice_card_case.lua
+++ b/scripts/items/ice_card_case.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.ICE_CARD, 99)
+    npcUtil.giveItem(target, { { xi.item.ICE_CARD, 99 } })
 end
 
 return itemObject

--- a/scripts/items/ice_cluster.lua
+++ b/scripts/items/ice_cluster.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.ICE_CRYSTAL, 12)
+    npcUtil.giveItem(target, { { xi.item.ICE_CRYSTAL, 12 } })
 end
 
 return itemObject

--- a/scripts/items/iron_bullet_pouch.lua
+++ b/scripts/items/iron_bullet_pouch.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.IRON_BULLET, 99)
+    npcUtil.giveItem(target, { { xi.item.IRON_BULLET, 99 } })
 end
 
 return itemObject

--- a/scripts/items/iron_musketeers_quiver.lua
+++ b/scripts/items/iron_musketeers_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.IRON_MUSKETEERS_BOLT)
+    npcUtil.giveItem(target, { { xi.item.IRON_MUSKETEERS_BOLT } })
 end
 
 return itemObject

--- a/scripts/items/iron_quiver.lua
+++ b/scripts/items/iron_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.IRON_ARROW, 99)
+    npcUtil.giveItem(target, { { xi.item.IRON_ARROW, 99 } })
 end
 
 return itemObject

--- a/scripts/items/juji_shuriken_pouch.lua
+++ b/scripts/items/juji_shuriken_pouch.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.JUJI_SHURIKEN, 99)
+    npcUtil.giveItem(target, { { xi.item.JUJI_SHURIKEN, 99 } })
 end
 
 return itemObject

--- a/scripts/items/kabura_quiver.lua
+++ b/scripts/items/kabura_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.KABURA_ARROW, 99)
+    npcUtil.giveItem(target, { { xi.item.KABURA_ARROW, 99 } })
 end
 
 return itemObject

--- a/scripts/items/key_ring_belt.lua
+++ b/scripts/items/key_ring_belt.lua
@@ -9,7 +9,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.SKELETON_KEY)
+    npcUtil.giveItem(target, { { xi.item.SKELETON_KEY, 1 } })
 end
 
 return itemObject

--- a/scripts/items/koga_shuriken_pouch.lua
+++ b/scripts/items/koga_shuriken_pouch.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.KOGA_SHURIKEN, 99)
+    npcUtil.giveItem(target, { { xi.item.KOGA_SHURIKEN, 99 } })
 end
 
 return itemObject

--- a/scripts/items/light_card_case.lua
+++ b/scripts/items/light_card_case.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.LIGHT_CARD, 99)
+    npcUtil.giveItem(target, { { xi.item.LIGHT_CARD, 99 } })
 end
 
 return itemObject

--- a/scripts/items/light_cluster.lua
+++ b/scripts/items/light_cluster.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.LIGHT_CRYSTAL, 12)
+    npcUtil.giveItem(target, { { xi.item.LIGHT_CRYSTAL, 12 } })
 end
 
 return itemObject

--- a/scripts/items/lightning_cluster.lua
+++ b/scripts/items/lightning_cluster.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.LIGHTNING_CRYSTAL, 12)
+    npcUtil.giveItem(target, { { xi.item.LIGHTNING_CRYSTAL, 12 } })
 end
 
 return itemObject

--- a/scripts/items/linen_coin_purse.lua
+++ b/scripts/items/linen_coin_purse.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.ALEXANDRITE, math.random(50, 99))
+    npcUtil.giveItem(target, { { xi.item.ALEXANDRITE, math.random(50, 99) } })
 end
 
 return itemObject

--- a/scripts/items/little_worm_belt.lua
+++ b/scripts/items/little_worm_belt.lua
@@ -9,7 +9,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.LITTLE_WORM, 12)
+    npcUtil.giveItem(target, { { xi.item.LITTLE_WORM, 12 } })
 end
 
 return itemObject

--- a/scripts/items/lugworm_belt.lua
+++ b/scripts/items/lugworm_belt.lua
@@ -9,7 +9,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.LUGWORM, 12)
+    npcUtil.giveItem(target, { { xi.item.LUGWORM, 12 } })
 end
 
 return itemObject

--- a/scripts/items/magnus_stone_pouch.lua
+++ b/scripts/items/magnus_stone_pouch.lua
@@ -9,7 +9,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.MAGNUS_STONE, 99)
+    npcUtil.giveItem(target, { { xi.item.MAGNUS_STONE, 99 } })
 end
 
 return itemObject

--- a/scripts/items/manji_shuriken_pouch.lua
+++ b/scripts/items/manji_shuriken_pouch.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.MANJI_SHURIKEN, 99)
+    npcUtil.giveItem(target, { { xi.item.MANJI_SHURIKEN, 99 } })
 end
 
 return itemObject

--- a/scripts/items/marine_gilet_+1.lua
+++ b/scripts/items/marine_gilet_+1.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.BERRY_SNOW_CONE, 1)
+    npcUtil.giveItem(target, { { xi.item.BERRY_SNOW_CONE, 1 } })
 end
 
 return itemObject

--- a/scripts/items/marine_top_+1.lua
+++ b/scripts/items/marine_top_+1.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.BERRY_SNOW_CONE, 1)
+    npcUtil.giveItem(target, { { xi.item.BERRY_SNOW_CONE, 1 } })
 end
 
 return itemObject

--- a/scripts/items/moogle_suit.lua
+++ b/scripts/items/moogle_suit.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.MOG_MISSILE, 1)
+    npcUtil.giveItem(target, { { xi.item.MOG_MISSILE, 1 } })
 end
 
 return itemObject

--- a/scripts/items/mythril_bolt_quiver.lua
+++ b/scripts/items/mythril_bolt_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.MYTHRIL_BOLT, 99)
+    npcUtil.giveItem(target, { { xi.item.MYTHRIL_BOLT, 99 } })
 end
 
 return itemObject

--- a/scripts/items/nebimonite_belt.lua
+++ b/scripts/items/nebimonite_belt.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.NEBIMONITE)
+    npcUtil.giveItem(target, { { xi.item.NEBIMONITE, 1 } })
 end
 
 return itemObject

--- a/scripts/items/oberon_bullet_pouch.lua
+++ b/scripts/items/oberon_bullet_pouch.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.OBERON_BULLET, 99)
+    npcUtil.giveItem(target, { { xi.item.OBERON_BULLET, 99 } })
 end
 
 return itemObject

--- a/scripts/items/old_bolt_box.lua
+++ b/scripts/items/old_bolt_box.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.DOGBOLT, math.random(10, 20))
+    npcUtil.giveItem(target, { { xi.item.DOGBOLT, math.random(10, 20) } })
 end
 
 return itemObject

--- a/scripts/items/old_bolt_box_+1.lua
+++ b/scripts/items/old_bolt_box_+1.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.DOGBOLT_P1, math.random(10, 20))
+    npcUtil.giveItem(target, { { xi.item.DOGBOLT_P1, math.random(10, 20) } })
 end
 
 return itemObject

--- a/scripts/items/old_bolt_box_+2.lua
+++ b/scripts/items/old_bolt_box_+2.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.DOGBOLT_P2, math.random(10, 20))
+    npcUtil.giveItem(target, { { xi.item.DOGBOLT_P2, math.random(10, 20) } })
 end
 
 return itemObject

--- a/scripts/items/old_bolt_box_+3.lua
+++ b/scripts/items/old_bolt_box_+3.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.DOGBOLT_P3, math.random(10, 20))
+    npcUtil.giveItem(target, { { xi.item.DOGBOLT_P3, math.random(10, 20) } })
 end
 
 return itemObject

--- a/scripts/items/old_bolt_box_+4.lua
+++ b/scripts/items/old_bolt_box_+4.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.DOGBOLT_P4, math.random(10, 20))
+    npcUtil.giveItem(target, { { xi.item.DOGBOLT_P4, math.random(10, 20) } })
 end
 
 return itemObject

--- a/scripts/items/old_bolt_box_+5.lua
+++ b/scripts/items/old_bolt_box_+5.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.DOGBOLT_P5, math.random(10, 20))
+    npcUtil.giveItem(target, { { xi.item.DOGBOLT_P5, math.random(10, 20) } })
 end
 
 return itemObject

--- a/scripts/items/old_bullet_box.lua
+++ b/scripts/items/old_bullet_box.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.ANTIQUE_BULLET, math.random(10, 20))
+    npcUtil.giveItem(target, { { xi.item.ANTIQUE_BULLET, math.random(10, 20) } })
 end
 
 return itemObject

--- a/scripts/items/old_bullet_box_+1.lua
+++ b/scripts/items/old_bullet_box_+1.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.ANTIQUE_BULLET_P1, math.random(10, 20))
+    npcUtil.giveItem(target, { { xi.item.ANTIQUE_BULLET_P1, math.random(10, 20) } })
 end
 
 return itemObject

--- a/scripts/items/old_quiver.lua
+++ b/scripts/items/old_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.CRUDE_ARROW, math.random(10, 20))
+    npcUtil.giveItem(target, { { xi.item.CRUDE_ARROW, math.random(10, 20) } })
 end
 
 return itemObject

--- a/scripts/items/old_quiver_+1.lua
+++ b/scripts/items/old_quiver_+1.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.CRUDE_ARROW_P1, math.random(10, 20))
+    npcUtil.giveItem(target, { { xi.item.CRUDE_ARROW_P1, math.random(10, 20) } })
 end
 
 return itemObject

--- a/scripts/items/old_quiver_+2.lua
+++ b/scripts/items/old_quiver_+2.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.CRUDE_ARROW_P2, math.random(10, 20))
+    npcUtil.giveItem(target, { { xi.item.CRUDE_ARROW_P2, math.random(10, 20) } })
 end
 
 return itemObject

--- a/scripts/items/old_quiver_+3.lua
+++ b/scripts/items/old_quiver_+3.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.CRUDE_ARROW_P3, math.random(10, 20))
+    npcUtil.giveItem(target, { { xi.item.CRUDE_ARROW_P3, math.random(10, 20) } })
 end
 
 return itemObject

--- a/scripts/items/old_quiver_+4.lua
+++ b/scripts/items/old_quiver_+4.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.CRUDE_ARROW_P4, math.random(10, 20))
+    npcUtil.giveItem(target, { { xi.item.CRUDE_ARROW_P4, math.random(10, 20) } })
 end
 
 return itemObject

--- a/scripts/items/old_quiver_+5.lua
+++ b/scripts/items/old_quiver_+5.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.CRUDE_ARROW_P5, math.random(10, 20))
+    npcUtil.giveItem(target, { { xi.item.CRUDE_ARROW_P5, math.random(10, 20) } })
 end
 
 return itemObject

--- a/scripts/items/old_quiver_+6.lua
+++ b/scripts/items/old_quiver_+6.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.CRUDE_ARROW_P6, math.random(10, 20))
+    npcUtil.giveItem(target, { { xi.item.CRUDE_ARROW_P6, math.random(10, 20) } })
 end
 
 return itemObject

--- a/scripts/items/old_quiver_+7.lua
+++ b/scripts/items/old_quiver_+7.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.CRUDE_ARROW_P7, math.random(10, 20))
+    npcUtil.giveItem(target, { { xi.item.CRUDE_ARROW_P7, math.random(10, 20) } })
 end
 
 return itemObject

--- a/scripts/items/onago_yukata.lua
+++ b/scripts/items/onago_yukata.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.MUTEPPO, 99)
+    npcUtil.giveItem(target, { { xi.item.MUTEPPO, 99 } })
 end
 
 return itemObject

--- a/scripts/items/onnagimi_yukata.lua
+++ b/scripts/items/onnagimi_yukata.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.DATECHOCHIN, 99)
+    npcUtil.giveItem(target, { { xi.item.DATECHOCHIN, 99 } })
 end
 
 return itemObject

--- a/scripts/items/orange_au_lait_tank.lua
+++ b/scripts/items/orange_au_lait_tank.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.FLASK_OF_ORANGE_AU_LAIT, 1)
+    npcUtil.giveItem(target, { { xi.item.FLASK_OF_ORANGE_AU_LAIT, 1 } })
 end
 
 return itemObject

--- a/scripts/items/orichalcum_bullet_pouch.lua
+++ b/scripts/items/orichalcum_bullet_pouch.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.ORICHALCUM_BULLET, 99)
+    npcUtil.giveItem(target, { { xi.item.ORICHALCUM_BULLET, 99 } })
 end
 
 return itemObject

--- a/scripts/items/otoko_yukata.lua
+++ b/scripts/items/otoko_yukata.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.MUTEPPO, 99)
+    npcUtil.giveItem(target, { { xi.item.MUTEPPO, 99 } })
 end
 
 return itemObject

--- a/scripts/items/otokogimi_yukata.lua
+++ b/scripts/items/otokogimi_yukata.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.DATECHOCHIN, 99)
+    npcUtil.giveItem(target, { { xi.item.DATECHOCHIN, 99 } })
 end
 
 return itemObject

--- a/scripts/items/pamama_au_lait_tank.lua
+++ b/scripts/items/pamama_au_lait_tank.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.FLASK_OF_PAMAMA_AU_LAIT, 1)
+    npcUtil.giveItem(target, { { xi.item.FLASK_OF_PAMAMA_AU_LAIT, 1 } })
 end
 
 return itemObject

--- a/scripts/items/pear_au_lait_tank.lua
+++ b/scripts/items/pear_au_lait_tank.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.FLASK_OF_PEAR_AU_LAIT, 1)
+    npcUtil.giveItem(target, { { xi.item.FLASK_OF_PEAR_AU_LAIT, 1 } })
 end
 
 return itemObject

--- a/scripts/items/pellet_belt.lua
+++ b/scripts/items/pellet_belt.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.PEBBLE, 12)
+    npcUtil.giveItem(target, { { xi.item.PEBBLE, 12 } })
 end
 
 return itemObject

--- a/scripts/items/persikos_au_lait_tank.lua
+++ b/scripts/items/persikos_au_lait_tank.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.FLASK_OF_PERSIKOS_AU_LAIT, 1)
+    npcUtil.giveItem(target, { { xi.item.FLASK_OF_PERSIKOS_AU_LAIT, 1 } })
 end
 
 return itemObject

--- a/scripts/items/pinwheel_belt.lua
+++ b/scripts/items/pinwheel_belt.lua
@@ -9,7 +9,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.PINWHEEL, 99) -- pinwheel
+    npcUtil.giveItem(target, { { xi.item.PINWHEEL, 99 } }) -- pinwheel
 end
 
 return itemObject

--- a/scripts/items/pluton_box.lua
+++ b/scripts/items/pluton_box.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.PLUTON, math.random(15, 30))
+    npcUtil.giveItem(target, { { xi.item.PLUTON, math.random(15, 30) } })
 end
 
 return itemObject

--- a/scripts/items/porxie_quiver.lua
+++ b/scripts/items/porxie_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.PORXIE_ARROW, 99)
+    npcUtil.giveItem(target, { { xi.item.PORXIE_ARROW, 99 } })
 end
 
 return itemObject

--- a/scripts/items/potion_tank.lua
+++ b/scripts/items/potion_tank.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.POTION, 1)
+    npcUtil.giveItem(target, { { xi.item.POTION, 1 } })
 end
 
 return itemObject

--- a/scripts/items/rabbit_cap.lua
+++ b/scripts/items/rabbit_cap.lua
@@ -10,10 +10,10 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(math.random(xi.item.A_EGG, xi.item.Z_EGG))
+    npcUtil.giveItem(target, { { math.random(xi.item.A_EGG, xi.item.Z_EGG), 1 } })
 
     if math.random(1, 5) > 4 then
-        target:addItem(math.random(xi.item.A_EGG, xi.item.Z_EGG))
+        npcUtil.giveItem(target, { { math.random(xi.item.A_EGG, xi.item.Z_EGG), 1 } })
     end
 end
 

--- a/scripts/items/raetic_quiver.lua
+++ b/scripts/items/raetic_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.RAETIC_ARROW, 99)
+    npcUtil.giveItem(target, { { xi.item.RAETIC_ARROW, 99 } })
 end
 
 return itemObject

--- a/scripts/items/redeyes.lua
+++ b/scripts/items/redeyes.lua
@@ -9,8 +9,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.ANGELWING, 99) -- Angelwing x99
-    target:messageBasic(xi.msg.basic.ITEM_OBTAINED, 5441)
+    npcUtil.giveItem(target, { { xi.item.ANGELWING, 99 } }) -- Angelwing x99
 end
 
 return itemObject

--- a/scripts/items/river_top_+1.lua
+++ b/scripts/items/river_top_+1.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.BERRY_SNOW_CONE, 1)
+    npcUtil.giveItem(target, { { xi.item.BERRY_SNOW_CONE, 1 } })
 end
 
 return itemObject

--- a/scripts/items/rotten_quiver.lua
+++ b/scripts/items/rotten_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.OLD_ARROW, 99)
+    npcUtil.giveItem(target, { { xi.item.OLD_ARROW, 99 } })
 end
 
 return itemObject

--- a/scripts/items/rusty_bolt_case.lua
+++ b/scripts/items/rusty_bolt_case.lua
@@ -9,7 +9,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.RUSTY_BOLT, 99) -- 99x rusty_bolt
+    npcUtil.giveItem(target, { { xi.item.RUSTY_BOLT, 99 } })-- 99x rusty_bolt
 end
 
 return itemObject

--- a/scripts/items/ruszor_quiver.lua
+++ b/scripts/items/ruszor_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.RUSZOR_ARROW, 99)
+    npcUtil.giveItem(target, { { xi.item.RUSZOR_ARROW, 99 } })
 end
 
 return itemObject

--- a/scripts/items/sasuke_shuriken_pouch.lua
+++ b/scripts/items/sasuke_shuriken_pouch.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.SASUKE_SHURIKEN, 99)
+    npcUtil.giveItem(target, { { xi.item.SASUKE_SHURIKEN, 99 } })
 end
 
 return itemObject

--- a/scripts/items/sasuke_shuriken_pouch_+1.lua
+++ b/scripts/items/sasuke_shuriken_pouch_+1.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.SASUKE_SHURIKEN_P1, 99)
+    npcUtil.giveItem(target, { { xi.item.SASUKE_SHURIKEN_P1, 99 } })
 end
 
 return itemObject

--- a/scripts/items/scorpion_quiver.lua
+++ b/scripts/items/scorpion_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.SCORPION_ARROW, 99)
+    npcUtil.giveItem(target, { { xi.item.SCORPION_ARROW, 99 } })
 end
 
 return itemObject

--- a/scripts/items/seki_shuriken_pouch.lua
+++ b/scripts/items/seki_shuriken_pouch.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.SEKI_SHURIKEN, 99)
+    npcUtil.giveItem(target, { { xi.item.SEKI_SHURIKEN, 99 } })
 end
 
 return itemObject

--- a/scripts/items/sha_wujings_lance_+1.lua
+++ b/scripts/items/sha_wujings_lance_+1.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.FLASK_OF_DISTILLED_WATER, 12)
+    npcUtil.giveItem(target, { { xi.item.FLASK_OF_DISTILLED_WATER, 12 } })
 end
 
 return itemObject

--- a/scripts/items/sheep_cap_+1.lua
+++ b/scripts/items/sheep_cap_+1.lua
@@ -12,9 +12,22 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    local giftList = { 4363, 4505, 1845, 4366, 919, 2213, 4571, 4504, 8929, 4367, 833 }
+    local giftList =
+    {
+        xi.item.FAERIE_APPLE,
+        xi.item.SUNFLOWER_SEEDS,
+        xi.item.CLUMP_OF_RED_MOKO_GRASS,
+        xi.item.LA_THEINE_CABBAGE,
+        xi.item.CLUMP_OF_BOYAHDA_MOSS,
+        xi.item.HANDFUL_OF_PINE_NUTS,
+        xi.item.CLUMP_OF_BEAUGREENS,
+        xi.item.ACORN,
+        xi.item.CLUMP_OF_BATAGREENS,
+        xi.item.CLUMP_OF_MOKO_GRASS
+    }
+
     local gift = math.random(1, 11)
-    target:addItem(giftList[gift])
+    npcUtil.giveItem(target, { { giftList[gift], 1 } })
 end
 
 return itemObject

--- a/scripts/items/shuriken_pouch.lua
+++ b/scripts/items/shuriken_pouch.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.SHURIKEN, 99)
+    npcUtil.giveItem(target, { { xi.item.SHURIKEN, 99 } })
 end
 
 return itemObject

--- a/scripts/items/silver_bullet_pouch.lua
+++ b/scripts/items/silver_bullet_pouch.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.SILVER_BULLET, 99)
+    npcUtil.giveItem(target, { { xi.item.SILVER_BULLET, 99 } })
 end
 
 return itemObject

--- a/scripts/items/silver_quiver.lua
+++ b/scripts/items/silver_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.SILVER_ARROW, 99)
+    npcUtil.giveItem(target, { { xi.item.SILVER_ARROW, 99 } })
 end
 
 return itemObject

--- a/scripts/items/sleep_bolt_quiver.lua
+++ b/scripts/items/sleep_bolt_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.SLEEP_BOLT, 99)
+    npcUtil.giveItem(target, { { xi.item.SLEEP_BOLT, 99 } })
 end
 
 return itemObject

--- a/scripts/items/sleep_quiver.lua
+++ b/scripts/items/sleep_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.SLEEP_ARROW, 99)
+    npcUtil.giveItem(target, { { xi.item.SLEEP_ARROW, 99 } })
 end
 
 return itemObject

--- a/scripts/items/spartan_bullet_pouch.lua
+++ b/scripts/items/spartan_bullet_pouch.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.SPARTAN_BULLET, 99)
+    npcUtil.giveItem(target, { { xi.item.SPARTAN_BULLET, 99 } })
 end
 
 return itemObject

--- a/scripts/items/steel_bullet_pouch.lua
+++ b/scripts/items/steel_bullet_pouch.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.STEEL_BULLET, 99)
+    npcUtil.giveItem(target, { { xi.item.STEEL_BULLET, 99 } })
 end
 
 return itemObject

--- a/scripts/items/stone_quiver.lua
+++ b/scripts/items/stone_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.STONE_ARROW, 99)
+    npcUtil.giveItem(target, { { xi.item.STONE_ARROW, 99 } })
 end
 
 return itemObject

--- a/scripts/items/super_reraiser_tank.lua
+++ b/scripts/items/super_reraiser_tank.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.SUPER_RERAISER, 1)
+    npcUtil.giveItem(target, { { xi.item.SUPER_RERAISER, 1 } })
 end
 
 return itemObject

--- a/scripts/items/tathlum_belt.lua
+++ b/scripts/items/tathlum_belt.lua
@@ -9,7 +9,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.TATHLUM, 8) -- tathlum
+    npcUtil.giveItem(target, { { xi.item.TATHLUM, 8 } })
 end
 
 return itemObject

--- a/scripts/items/temple_knights_quiver.lua
+++ b/scripts/items/temple_knights_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.TEMPLE_KNIGHTS_ARROW)
+    npcUtil.giveItem(target, { { xi.item.TEMPLE_KNIGHTS_ARROW, 1 } })
 end
 
 return itemObject

--- a/scripts/items/thunder_card_case.lua
+++ b/scripts/items/thunder_card_case.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.THUNDER_CARD, 99)
+    npcUtil.giveItem(target, { { xi.item.THUNDER_CARD, 99 } })
 end
 
 return itemObject

--- a/scripts/items/toolbag_chonofuda.lua
+++ b/scripts/items/toolbag_chonofuda.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.CHONOFUDA, 99)
+    npcUtil.giveItem(target, { { xi.item.CHONOFUDA, 99 } })
 end
 
 return itemObject

--- a/scripts/items/toolbag_furu.lua
+++ b/scripts/items/toolbag_furu.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.FURUSUMI, 99)
+    npcUtil.giveItem(target, { { xi.item.FURUSUMI, 99 } })
 end
 
 return itemObject

--- a/scripts/items/toolbag_hiraishin.lua
+++ b/scripts/items/toolbag_hiraishin.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.HIRAISHIN, 99)
+    npcUtil.giveItem(target, { { xi.item.HIRAISHIN, 99 } })
 end
 
 return itemObject

--- a/scripts/items/toolbag_inoshishinofuda.lua
+++ b/scripts/items/toolbag_inoshishinofuda.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.INOSHISHINOFUDA, 99)
+    npcUtil.giveItem(target, { { xi.item.INOSHISHINOFUDA, 99 } })
 end
 
 return itemObject

--- a/scripts/items/toolbag_jinko.lua
+++ b/scripts/items/toolbag_jinko.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.JINKO, 99)
+    npcUtil.giveItem(target, { { xi.item.JINKO, 99 } })
 end
 
 return itemObject

--- a/scripts/items/toolbag_jusatsu.lua
+++ b/scripts/items/toolbag_jusatsu.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.JUSATSU, 99)
+    npcUtil.giveItem(target, { { xi.item.JUSATSU, 99 } })
 end
 
 return itemObject

--- a/scripts/items/toolbag_kabenro.lua
+++ b/scripts/items/toolbag_kabenro.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.KABENRO, 99)
+    npcUtil.giveItem(target, { { xi.item.KABENRO, 99 } })
 end
 
 return itemObject

--- a/scripts/items/toolbag_kaginawa.lua
+++ b/scripts/items/toolbag_kaginawa.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.KAGINAWA, 99)
+    npcUtil.giveItem(target, { { xi.item.KAGINAWA, 99 } })
 end
 
 return itemObject

--- a/scripts/items/toolbag_kawahori-ogi.lua
+++ b/scripts/items/toolbag_kawahori-ogi.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.KAWAHORI_OGI, 99)
+    npcUtil.giveItem(target, { { xi.item.KAWAHORI_OGI, 99 } })
 end
 
 return itemObject

--- a/scripts/items/toolbag_kodoku.lua
+++ b/scripts/items/toolbag_kodoku.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.KODOKU, 99)
+    npcUtil.giveItem(target, { { xi.item.KODOKU, 99 } })
 end
 
 return itemObject

--- a/scripts/items/toolbag_makibishi.lua
+++ b/scripts/items/toolbag_makibishi.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.MAKIBISHI, 99)
+    npcUtil.giveItem(target, { { xi.item.MAKIBISHI, 99 } })
 end
 
 return itemObject

--- a/scripts/items/toolbag_mizu-deppo.lua
+++ b/scripts/items/toolbag_mizu-deppo.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.MIZU_DEPPO, 99)
+    npcUtil.giveItem(target, { { xi.item.MIZU_DEPPO, 99 } })
 end
 
 return itemObject

--- a/scripts/items/toolbag_mokujin.lua
+++ b/scripts/items/toolbag_mokujin.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.MOKUJIN, 99)
+    npcUtil.giveItem(target, { { xi.item.MOKUJIN, 99 } })
 end
 
 return itemObject

--- a/scripts/items/toolbag_ranka.lua
+++ b/scripts/items/toolbag_ranka.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.RANKA, 99)
+    npcUtil.giveItem(target, { { xi.item.RANKA, 99 } })
 end
 
 return itemObject

--- a/scripts/items/toolbag_ryuno.lua
+++ b/scripts/items/toolbag_ryuno.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.RYUNO, 99)
+    npcUtil.giveItem(target, { { xi.item.RYUNO, 99 } })
 end
 
 return itemObject

--- a/scripts/items/toolbag_sairui-ran.lua
+++ b/scripts/items/toolbag_sairui-ran.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.SAIRUI_RAN, 99)
+    npcUtil.giveItem(target, { { xi.item.SAIRUI_RAN, 99 } })
 end
 
 return itemObject

--- a/scripts/items/toolbag_sanjaku-tenugui.lua
+++ b/scripts/items/toolbag_sanjaku-tenugui.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.SANJAKU_TENUGUI, 99)
+    npcUtil.giveItem(target, { { xi.item.SANJAKU_TENUGUI, 99 } })
 end
 
 return itemObject

--- a/scripts/items/toolbag_shihei.lua
+++ b/scripts/items/toolbag_shihei.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.SHIHEI, 99)
+    npcUtil.giveItem(target, { { xi.item.SHIHEI, 99 } })
 end
 
 return itemObject

--- a/scripts/items/toolbag_shikanofuda.lua
+++ b/scripts/items/toolbag_shikanofuda.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.SHIKANOFUDA, 99)
+    npcUtil.giveItem(target, { { xi.item.SHIKANOFUDA, 99 } })
 end
 
 return itemObject

--- a/scripts/items/toolbag_shinobi-tabi.lua
+++ b/scripts/items/toolbag_shinobi-tabi.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.SHINOBI_TABI, 99)
+    npcUtil.giveItem(target, { { xi.item.SHINOBI_TABI, 99 } })
 end
 
 return itemObject

--- a/scripts/items/toolbag_soshi.lua
+++ b/scripts/items/toolbag_soshi.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.SOSHI, 99)
+    npcUtil.giveItem(target, { { xi.item.SOSHI, 99 } })
 end
 
 return itemObject

--- a/scripts/items/toolbag_tsurara.lua
+++ b/scripts/items/toolbag_tsurara.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.TSURARA, 99)
+    npcUtil.giveItem(target, { { xi.item.TSURARA, 99 } })
 end
 
 return itemObject

--- a/scripts/items/toolbag_uchitake.lua
+++ b/scripts/items/toolbag_uchitake.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.UCHITAKE, 99)
+    npcUtil.giveItem(target, { { xi.item.UCHITAKE, 99 } })
 end
 
 return itemObject

--- a/scripts/items/trump_card_case.lua
+++ b/scripts/items/trump_card_case.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.TRUMP_CARD, 99)
+    npcUtil.giveItem(target, { { xi.item.TRUMP_CARD, 99 } })
 end
 
 return itemObject

--- a/scripts/items/venom_bolt_quiver.lua
+++ b/scripts/items/venom_bolt_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.VENOM_BOLT, 99)
+    npcUtil.giveItem(target, { { xi.item.VENOM_BOLT, 99 } })
 end
 
 return itemObject

--- a/scripts/items/virtue_stone_pouch.lua
+++ b/scripts/items/virtue_stone_pouch.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.VIRTUE_STONE, 99)
+    npcUtil.giveItem(target, { { xi.item.VIRTUE_STONE, 99 } })
 end
 
 return itemObject

--- a/scripts/items/voluspa_bolt_quiver.lua
+++ b/scripts/items/voluspa_bolt_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.VOLUSPA_BOLT, 99)
+    npcUtil.giveItem(target, { { xi.item.VOLUSPA_BOLT, 99 } })
 end
 
 return itemObject

--- a/scripts/items/voluspa_bullet_pouch.lua
+++ b/scripts/items/voluspa_bullet_pouch.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.VOLUSPA_BULLET, 99)
+    npcUtil.giveItem(target, { { xi.item.VOLUSPA_BULLET, 99 } })
 end
 
 return itemObject

--- a/scripts/items/voluspa_quiver.lua
+++ b/scripts/items/voluspa_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.VOLUSPA_ARROW, 99)
+    npcUtil.giveItem(target, { { xi.item.VOLUSPA_ARROW, 99 } })
 end
 
 return itemObject

--- a/scripts/items/water_card_case.lua
+++ b/scripts/items/water_card_case.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.WATER_CARD, 99)
+    npcUtil.giveItem(target, { { xi.item.WATER_CARD, 99 } })
 end
 
 return itemObject

--- a/scripts/items/water_cluster.lua
+++ b/scripts/items/water_cluster.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.WATER_CRYSTAL, 12)
+    npcUtil.giveItem(target, { { xi.item.WATER_CRYSTAL, 12 } })
 end
 
 return itemObject

--- a/scripts/items/water_tank.lua
+++ b/scripts/items/water_tank.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.FLASK_OF_DISTILLED_WATER, 12)
+    npcUtil.giveItem(target, { { xi.item.FLASK_OF_DISTILLED_WATER, 12 } })
 end
 
 return itemObject

--- a/scripts/items/wind_card_case.lua
+++ b/scripts/items/wind_card_case.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.WIND_CARD, 99)
+    npcUtil.giveItem(target, { { xi.item.WIND_CARD, 99 } })
 end
 
 return itemObject

--- a/scripts/items/wind_cluster.lua
+++ b/scripts/items/wind_cluster.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.WIND_CRYSTAL, 12)
+    npcUtil.giveItem(target, { { xi.item.WIND_CRYSTAL, 12 } })
 end
 
 return itemObject

--- a/scripts/items/woodsy_gilet_+1.lua
+++ b/scripts/items/woodsy_gilet_+1.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.BERRY_SNOW_CONE, 1)
+    npcUtil.giveItem(target, { { xi.item.BERRY_SNOW_CONE, 1 } })
 end
 
 return itemObject

--- a/scripts/items/woodsy_top_+1.lua
+++ b/scripts/items/woodsy_top_+1.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addItem(xi.item.BERRY_SNOW_CONE, 1)
+    npcUtil.giveItem(target, { { xi.item.BERRY_SNOW_CONE, 1 } })
 end
 
 return itemObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
After speaking with Zach and Teo, it seems that addItem no longer has the message "Obtained [Quantity] Item) "baked" in. npcUtil however does. 
Modified all usable items with target:addItem to npcUtil.giveItem(target, {  { Item, [Quantity]  }  } )

Now will display the useable items Obtained: [Quantity] Item.  
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
locate usable item in scripts/items/USABLE ITEM (ie acid_bolt_quiver, woodsy_top_+1)
!additem 
equip item 
use item.

![image](https://github.com/LandSandBoat/server/assets/13935086/828b6920-5f41-4e8e-a0cc-5cecb224bb0f)

<!-- Clear and detailed steps to test your changes here -->
