### PR TITLE
[lua] Aura steal should be possible even on mob with steal items

### DIFF
--- a/scripts/globals/job_utils/thief.lua
+++ b/scripts/globals/job_utils/thief.lua
@@ -411,7 +411,7 @@ xi.job_utils.thief.useSteal = function(player, target, ability, action)
 
     -- Attempt Aura steal
     -- local effect = xi.effect.NONE
-    if stolen == 0 and player:hasTrait(75) then
+    if player:hasTrait(75) then
         local resist = applyResistanceAbility(player, target, xi.element.NONE, 0, 0)
         -- local effectStealSuccess = false
         if resist > 0.0625 then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Aura steal was coded to only try if `mob:getStealItem()` returned zero, but it should also attempt to steal a buff also if a mob has stealable items still but the steal failed.

## Steps to test these changes

no aura steal merits, attempt steal on dynamis mob with a buff (whm or blm) repeatedly (mob at full hp should be very low chance to actually steal an item). See that you still get regular "steal fails" messages
merit aura steal to max to get capped 95% chance to steal a buff when steal fails and basic resist check passes.