### PR TITLE
Ensure mobs don't turn during combat when inactive

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -24,6 +24,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "ai/ai_container.h"
 #include "ai/helpers/targetfind.h"
 #include "ai/states/ability_state.h"
+#include "ai/states/inactive_state.h"
 #include "ai/states/magic_state.h"
 #include "ai/states/weaponskill_state.h"
 #include "common/utils.h"
@@ -588,12 +589,15 @@ void CMobController::DoCombatTick(time_point tick)
         PMob->PAI->EventHandler.triggerListener("COMBAT_TICK", CLuaBaseEntity(PMob));
         luautils::OnMobFight(PMob, PTarget);
 
-        // Try to spellcast (this is done first so things like Chainspell spam is prioritised over TP moves etc.
-        if (IsSpecialSkillReady(currentDistance) && TrySpecialSkill())
+        if (PMob->PAI->IsCurrentState<CInactiveState>())
         {
             return;
         }
-        else if (IsSpellReady(currentDistance) && TryCastSpell())
+        else if (IsSpecialSkillReady(currentDistance) && TrySpecialSkill())
+        {
+            return;
+        }
+        else if (IsSpellReady(currentDistance) && TryCastSpell()) // Try to spellcast (this is done first so things like Chainspell spam is prioritised over TP moves etc.
         {
             return;
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Currently, mobs will turn if they are able to take an action based on time/tp but are otherwise inactive due to sleep/stun

Wings used a [catchall within the facetarget function](https://github.com/Wings-XI/LegacyWingsXI/commit/cf8cb96180a190a41f61ae7c0f976027c695d84c), but I believe adding this check in the mob combat tick function (the change in this PR) is sufficient.

## Steps to test these changes

sleep a mob, give it 3k tp, and see that it doesn't turn to you. poison it and see it immediately turns and mobskills when the tick breaks sleep