### PR TITLE
[lua] Timeleft missing parameter for 2 instances

### DIFF
--- a/scripts/zones/Lebros_Cavern/instances/wamoura_farm_raid.lua
+++ b/scripts/zones/Lebros_Cavern/instances/wamoura_farm_raid.lua
@@ -25,7 +25,7 @@ instanceObject.onInstanceCreatedCallback = function(player, instance)
 end
 
 instanceObject.onInstanceTimeUpdate = function(instance, elapsed)
-    xi.instance.updateInstanceTime(instance, elapsed, ID)
+    xi.instance.updateInstanceTime(instance, elapsed, ID.text)
 end
 
 instanceObject.onInstanceFailure = function(instance)

--- a/scripts/zones/Nyzul_Isle/instances/nyzul_isle_investigation.lua
+++ b/scripts/zones/Nyzul_Isle/instances/nyzul_isle_investigation.lua
@@ -126,7 +126,7 @@ end
 
 -- Instance 'tick'
 instanceObject.onInstanceTimeUpdate = function(instance, elapsed)
-    xi.instance.updateInstanceTime(instance, elapsed)
+    xi.instance.updateInstanceTime(instance, elapsed, ID.text)
 end
 
 -- On fail


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

server console spam due to missing text table if all players in instance are dead:

![image](https://github.com/LandSandBoat/server/assets/131182600/7da2375c-bbed-4d61-b361-6b9d168e5038)

I believe it also fails to report timeleft

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
