### PR TITLE
[cpp/lua] Ranged attack tweaks

### DIFF
--- a/scripts/effects/velocity_shot.lua
+++ b/scripts/effects/velocity_shot.lua
@@ -6,24 +6,17 @@ local effectObject = {}
 effectObject.onEffectGain = function(target, effect)
     local jpValue = target:getJobPointLevel(xi.jp.VELOCITY_SHOT_EFFECT)
 
-    target:addMod(xi.mod.RATT, jpValue * 2)
-    target:addMod(xi.mod.ATTP, -15)
-    target:addMod(xi.mod.HASTE_ABILITY, -1500)
-    target:addMod(xi.mod.RATTP, 15)
-    target:addMod(xi.mod.RANGED_DELAYP, -10)
+    effect:addMod(xi.mod.RATT, jpValue * 2)
+    effect:addMod(xi.mod.ATTP, -15)
+    effect:addMod(xi.mod.HASTE_ABILITY, -1500)
+    effect:addMod(xi.mod.RATTP, 15)
+    effect:addMod(xi.mod.RANGED_DELAYP, -15)
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    local jpValue = target:getJobPointLevel(xi.jp.VELOCITY_SHOT_EFFECT)
-
-    target:delMod(xi.mod.RATT, jpValue * 2)
-    target:delMod(xi.mod.ATTP, -15)
-    target:delMod(xi.mod.HASTE_ABILITY, -1500)
-    target:delMod(xi.mod.RATTP, 15)
-    target:delMod(xi.mod.RANGED_DELAYP, -10)
 end
 
 return effectObject

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1843,14 +1843,7 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
     // loop for barrage hits, if a miss occurs, the loop will end
     for (uint8 i = 1; i <= hitCount; ++i)
     {
-        if (PTarget->StatusEffectContainer->HasStatusEffect(EFFECT_PERFECT_DODGE, 0))
-        {
-            actionTarget.messageID  = 32;
-            actionTarget.reaction   = REACTION::EVADE;
-            actionTarget.speceffect = SPECEFFECT::NONE;
-            hitCount                = i; // end barrage, shot missed
-        }
-        else if (xirand::GetRandomNumber(100) < battleutils::GetRangedHitRate(this, PTarget, isBarrage)) // hit!
+        if (xirand::GetRandomNumber(100) < battleutils::GetRangedHitRate(this, PTarget, isBarrage)) // hit!
         {
             // absorbed by shadow
             if (battleutils::IsAbsorbByShadow(PTarget, this))

--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -294,14 +294,7 @@ void CTrustEntity::OnRangedAttack(CRangeState& state, action_t& action)
     // loop for barrage hits, if a miss occurs, the loop will end
     for (uint8 i = 1; i <= hitCount; ++i)
     {
-        if (PTarget->StatusEffectContainer->HasStatusEffect(EFFECT_PERFECT_DODGE, 0))
-        {
-            actionTarget.messageID  = 32;
-            actionTarget.reaction   = REACTION::EVADE;
-            actionTarget.speceffect = SPECEFFECT::NONE;
-            hitCount                = i; // end barrage, shot missed
-        }
-        else if (xirand::GetRandomNumber(100) < battleutils::GetRangedHitRate(this, PTarget, isBarrage)) // hit!
+        if (xirand::GetRandomNumber(100) < battleutils::GetRangedHitRate(this, PTarget, isBarrage)) // hit!
         {
             // absorbed by shadow
             if (battleutils::IsAbsorbByShadow(PTarget, this))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Doing some checks on ranged attack delay accuracy, and came across 2 issues:
- Perfect Dodge should not stop ranged attacks from landing
  - https://www.bg-wiki.com/ffxi/Perfect_Dodge
  - Fixed this for player and trust entities in this PR. The ranged attack code for mobs is... something else
- Velocity shot should give 15% ranged delay reduction
  - https://www.bg-wiki.com/ffxi/Velocity_Shot

Updated the effect lua to map mods to the effect so we don't need to repeat the code

## Steps to test these changes

Testing would just be to make a mob use PD: `!exec player:getTarget():useMobAbility(693)` and see that melee misses but RA still land
second is simple enough to just use Velocity shot, then check the mods: `!getmod RANGE_DELAYP`, then drop the effect and see the mods drop off cleanly
