### PR TITLE
[sql] Remove dispelable flag from Reraise

### DIFF
--- a/sql/status_effects.sql
+++ b/sql/status_effects.sql
@@ -147,7 +147,7 @@ INSERT INTO `status_effects` VALUES (109,'barblind',41,106,0,0,0,0,7,0,500);
 INSERT INTO `status_effects` VALUES (110,'barsilence',41,106,0,0,0,0,2,0,500);
 INSERT INTO `status_effects` VALUES (111,'barpetrify',41,106,0,0,0,0,3,0,500);
 INSERT INTO `status_effects` VALUES (112,'barvirus',41,106,0,0,0,0,6,0,500);
-INSERT INTO `status_effects` VALUES (113,'reraise',41,0,0,0,0,0,7,0,900);
+INSERT INTO `status_effects` VALUES (113,'reraise',40,0,0,0,0,0,7,0,900);
 INSERT INTO `status_effects` VALUES (114,'cover',4194336,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (115,'unlimited_shot',4194336,73,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (116,'phalanx',33,0,0,0,0,0,7,0,1050);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Makes reraise undispelable, retail proof:
![image](https://github.com/LandSandBoat/server/assets/60417494/edd2ccd6-2888-4941-9707-5a776dfcb7d6)
(no effect, not resists the spell)

## Steps to test these changes

See dispel fail to dispel reraise after PR