### PR TITLE
[Quest] Fix Wild Card soft lock

### DIFF
--- a/scripts/globals/treasure.lua
+++ b/scripts/globals/treasure.lua
@@ -1107,12 +1107,12 @@ xi.treasure.treasureInfo =
                 {
                     {
                         test = function(player)
-                            return player:getCharVar('WildCard') == 2
+                            return not player:hasKeyItem(xi.ki.JOKER_CARD) and
+                                (player:getCharVar('[2][77]Prog') == 2 or player:getCharVar('[2][77]Prog') == 3)
                         end,
 
                         code = function(player)
                             npcUtil.giveKeyItem(player, xi.ki.JOKER_CARD)
-                            player:setCharVar('WildCard', 3)
                         end,
                     },
                 },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes an issue with the Wild Card quest that causes a soft lock making players unable to progress if they receive the cutscene with Apururu instead of Joker (if they are below rank 9). This would put their WildCard progress at 3, but the coffer only checks if their progress is at 2.

## Steps to test these changes

1. !completequest 2 42 name
2. !completequest 2 76 name
3. !addquest 2 77 name
4. !setplayervar name [2][77]Prog 3 (should work with 2 or 3)
5. !additem 1057
6. !pos 219 16 -49 169 name Coffer should give you Joker Card KI
7. !pos -26 -13 259 239 name to receive the cutscene
8. !pos -194 -10 -119 238 name to complete the quest
