### PR TITLE
Fix join type in API query

### DIFF
--- a/src/world/http_server.cpp
+++ b/src/world/http_server.cpp
@@ -201,7 +201,7 @@ void HTTPServer::LockingUpdate()
         {
             auto rset = db::query("SELECT chars.pos_zone, COUNT(*) AS `count` "
                                   "FROM chars "
-                                  "LEFT JOIN accounts_sessions "
+                                  "INNER JOIN accounts_sessions "
                                   "ON chars.charid = accounts_sessions.charid "
                                   "GROUP BY pos_zone");
             if (rset && rset->rowsCount())


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a join in the HTTP API. We only want the chars that have an active session.

## Steps to test these changes

Run the world server with HTTP_ENABLED set, navigate to http://localhost:8088/api/zones and see numbers that make sense.
