### PR TITLE
[SQL] Add Track Pants +1 mod

### DIFF
--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -70165,6 +70165,10 @@ INSERT INTO `item_mods` VALUES (27324,170,4);    -- FASTCAST: 4
 INSERT INTO `item_mods` VALUES (27324,374,10);   -- CURE_POTENCY: 10
 INSERT INTO `item_mods` VALUES (27324,384,500);  -- HASTE_GEAR: 500
 
+-- Track Pants +1
+INSERT INTO `item_mods` VALUES (27326,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (27326,76,8);  -- MOVE_SPEED_GEAR_BONUS: 8
+
 -- Agoge Calligae
 INSERT INTO `item_mods` VALUES (27328,1,57);    -- DEF: 57
 INSERT INTO `item_mods` VALUES (27328,2,7);     -- HP: 7


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a missing item mods for movement speed bonus on Track Pants +1.

## Steps to test these changes

1. !additem 27326
2. Equip the pants
3. Using the mobdb addon target yourself, speed should show 5.4 yalms/second (+8%)
4. It should also add 2 def
