### PR TITLE
[Quest] Against All Odds - Door House charvar has incorrect casing

### DIFF
--- a/scripts/zones/Windurst_Waters/npcs/Door_House.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Door_House.lua
@@ -63,13 +63,13 @@ entity.onEventFinish = function(player, csid, option, npc)
         player:delKeyItem(xi.ki.LELEROONS_LETTER_GREEN)
     elseif csid == 943 then
         player:tradeComplete()
-        player:setCharVar('LeleroonsletterGreen', 3)
+        player:setCharVar('LeleroonsLetterGreen', 3)
     elseif csid == 946 then
         player:tradeComplete()
-        player:setCharVar('LeleroonsletterGreen', 4)
+        player:setCharVar('LeleroonsLetterGreen', 4)
         player:setCharVar('corAfSubmitDay', VanadielUniqueDay())
     elseif csid == 944 then
-        player:setCharVar('LeleroonsletterGreen', 5)
+        player:setCharVar('LeleroonsLetterGreen', 5)
         player:addItem(xi.item.CORSAIRS_GANTS) -- corsair's gants
         player:messageSpecial(ID.text.ITEM_OBTAINED, xi.item.CORSAIRS_GANTS)
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

After receiving Against All Odds when you attempt to commission the COR Artifact gloves you are required to trade items to the Door House in Windurst Waters. However, there is some incorrect casing in the charvar LeleroonsLetterGreen which causes some weirdness when doing so.

## Steps to test these changes

1. !addquest 6 26 name
2. !setplayervar name LeleroonsLetterGreen 1
3. !addkeyitem 845
4. !pos -200 -4 -111 238
5. Get the CS from the door (removes green letter KI)
6. !additem 823
7. !additem 879
8. !additem 1829
9. !additem 2304
10. Trade items to the door
11. !additem 2186 4
12. Trade coins to the door
13. Trying the door again should result in wait CS
14. Wait until next Vana day to receive Corsair's Gants
