### PR TITLE
[cpp] Ensure proper mapping from db to player rank array

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -472,9 +472,9 @@ namespace charutils
         {
             PChar->profile.rankpoints = rset->getUInt("rank_points");
 
-            PChar->profile.rank[0] = (uint8)rset->getInt("rank_points");
-            PChar->profile.rank[1] = (uint8)rset->getInt("rank_sandoria");
-            PChar->profile.rank[2] = (uint8)rset->getInt("rank_bastok");
+            PChar->profile.rank[0] = (uint8)rset->getInt("rank_sandoria");
+            PChar->profile.rank[1] = (uint8)rset->getInt("rank_bastok");
+            PChar->profile.rank[2] = (uint8)rset->getInt("rank_windurst");
 
             PChar->profile.fame[0]      = (uint16)rset->getInt("fame_sandoria");
             PChar->profile.fame[1]      = (uint16)rset->getInt("fame_bastok");

--- a/src/search/data_loader.cpp
+++ b/src/search/data_loader.cpp
@@ -277,8 +277,23 @@ std::list<SearchEntity*> CDataLoader::GetPlayersList(search_req sr, int* count)
             PPlayer->slvl     = (uint8)rset->getInt("slvl");
             PPlayer->race     = (uint8)rset->getInt("race");
 
-            // TODO: This is quite fragile, replace this with a switch statement
-            PPlayer->rank = (uint8)rset->getInt(rset->findColumn("nation") + PPlayer->nation);
+            // TODO: Use a nation enum?
+            switch (PPlayer->nation)
+            {
+                case 0:
+                    PPlayer->rank = (uint8)rset->getInt("rank_sandoria");
+                    break;
+                case 1:
+                    PPlayer->rank = (uint8)rset->getInt("rank_bastok");
+                    break;
+                case 2:
+                    PPlayer->rank = (uint8)rset->getInt("rank_bastok");
+                    break;
+                default:
+                    ShowWarning("Inconsistent player nation allegiance : %d", PPlayer->nation);
+                    PPlayer->rank = (uint8)0;
+                    break;
+            }
 
             PPlayer->zone        = (PPlayer->zone == 0 ? PPlayer->prevzone : PPlayer->zone);
             PPlayer->languages   = (uint8)rset->getUInt("languages");
@@ -489,8 +504,23 @@ std::list<SearchEntity*> CDataLoader::GetPartyList(uint32 PartyID, uint32 Allian
             PPlayer->slvl   = (uint8)rset->getInt("slvl");
             PPlayer->race   = (uint8)rset->getInt("race");
 
-            // TODO: This is quite fragile, replace this with a switch statement
-            PPlayer->rank = (uint8)rset->getInt(rset->findColumn("nation") + PPlayer->nation);
+            // TODO: Use a nation enum?
+            switch (PPlayer->nation)
+            {
+                case 0:
+                    PPlayer->rank = (uint8)rset->getInt("rank_sandoria");
+                    break;
+                case 1:
+                    PPlayer->rank = (uint8)rset->getInt("rank_bastok");
+                    break;
+                case 2:
+                    PPlayer->rank = (uint8)rset->getInt("rank_bastok");
+                    break;
+                default:
+                    ShowWarning("Inconsistent player nation allegiance : %d", PPlayer->nation);
+                    PPlayer->rank = (uint8)0;
+                    break;
+            }
 
             PPlayer->languages   = (uint8)rset->getUInt("languages");
             PPlayer->mentor      = rset->getUInt("nnameflags") & NFLAG_MENTOR;
@@ -578,8 +608,23 @@ std::list<SearchEntity*> CDataLoader::GetLinkshellList(uint32 LinkshellID)
             PPlayer->slvl   = (uint8)rset->getInt("slvl");
             PPlayer->race   = (uint8)rset->getInt("race");
 
-            // TODO: This is quite fragile, replace this with a switch statement
-            PPlayer->rank = (uint8)rset->getInt(rset->findColumn("nation") + PPlayer->nation);
+            // TODO: Use a nation enum?
+            switch (PPlayer->nation)
+            {
+                case 0:
+                    PPlayer->rank = (uint8)rset->getInt("rank_sandoria");
+                    break;
+                case 1:
+                    PPlayer->rank = (uint8)rset->getInt("rank_bastok");
+                    break;
+                case 2:
+                    PPlayer->rank = (uint8)rset->getInt("rank_bastok");
+                    break;
+                default:
+                    ShowWarning("Inconsistent player nation allegiance : %d", PPlayer->nation);
+                    PPlayer->rank = (uint8)0;
+                    break;
+            }
 
             PPlayer->linkshellid1   = rset->getInt("linkshellid1");
             PPlayer->linkshellid2   = rset->getInt("linkshellid2");


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

![image](https://github.com/LandSandBoat/server/assets/131182600/69ef9465-6633-4af2-88fd-fd1a39e71255)

Recent changes to db handler had a little mistake in renaming indexes to column names. Result is a player allied with windurst shows their rank for bastok, and a player aligned with sandoria reports rank 0 (depending on nation rank points i assume)

Edit: worth mentioning that this was tested with multiple player nation allegiances and confirmed profile, search linkshell, search party, and generic search returns the proper nation

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
