### PR TITLE
[CPP] Fix Fisherman's Smock missing bonuses

### DIFF
--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -576,6 +576,7 @@ namespace fishingutils
                 bonus += 1;
                 break;
             case FISHERMANS_APRON:
+            case FISHERMANS_SMOCK:
                 bonus += 3;
                 break;
         }
@@ -2338,7 +2339,7 @@ namespace fishingutils
 
         fishing_gear_t gear = GetFishingGear(PChar);
 
-        if (gear.body == FISHERMANS_APRON && ItemPoolWeight > 0)
+        if ((gear.body == FISHERMANS_APRON || gear.body == FISHERMANS_SMOCK) && ItemPoolWeight > 0)
         {
             uint16 sub = (uint16)std::floor(ItemPoolWeight * 0.25f);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The Fisherman's Smock is an upgraded version of the Fisherman's Apron with the same bonuses as well as some additional. Currently the fishingutils code is only checking for if the Apron is equipped, but it should be checking for both the Smock and Apron since they have the same bonuses for reducing items fished up. It also seems that the Apron has a additional bonus when worn that the Smock should most likely also have as well.

## Steps to test these changes

1. !additem 11337
2. !additem 17011
3. !additem 17405
4. !setskill 48 110
5. !pos -194 -2 82 240
6. Equip the Smock, rod, and lure
7. Attempt to fish

To ensure the bonuses are being applied I added ShowWarnings after lines 579 and 2343 locally to verify that each case was properly being passed. It's a bit difficult to test this directly in game due to it's random nature.

![image](https://github.com/LandSandBoat/server/assets/166072302/92337fed-89ad-4665-aa10-020bd39452c6)