### PR TITLE
Core: Mixin rewrite

### DIFF
--- a/scripts/commands/fafnir.lua
+++ b/scripts/commands/fafnir.lua
@@ -56,11 +56,11 @@ commandObj.onTrigger = function(player)
         -- after this mob has died. Defaults to false.
         releaseIdOnDisappear = true,
 
-        -- You can apply mixins like you would with regular mobs. mixinOptions aren't supported yet.
+        -- You can apply mixins like you would with regular mobs.
         mixins =
         {
-            require('scripts/mixins/rage'),
-            require('scripts/mixins/job_special'),
+            'rage',
+            'job_special',
         },
 
         -- The 'whooshy' special animation that plays when Trusts or Dynamis mobs spawn

--- a/scripts/globals/mixins.lua
+++ b/scripts/globals/mixins.lua
@@ -3,13 +3,27 @@
 --  Contains helper functions for
 --  applying mixins
 -----------------------------------
+xi = xi or {}
 
-function applyMixins(entity, mixins, mixinOptions)
+xi.applyMixins = function(entity, mixins)
+    -- TODO: This could probably be made nicely with recursion
+    if type(mixins) == 'string' then
+        mixins = { mixins }
+    elseif type(mixins) == 'function' then
+        mixins = { mixins }
+    end
+
     for i, v in pairs(mixins) do
         if type(v) == 'table' then
-            applyMixins(entity, v, mixinOptions)
-        else
-            v(entity, mixinOptions)
+            if type(v[1]) == 'string' then
+                xi.mixins[v[1]](entity, v[2])
+            elseif type(v[1]) == 'function' then
+                v[1](entity, v[2])
+            end
+        elseif type(v) == 'string' then
+            xi.mixins[v](entity)
+        elseif type(v) == 'function' then
+            v(entity)
         end
     end
 end

--- a/scripts/globals/mixins.lua
+++ b/scripts/globals/mixins.lua
@@ -5,25 +5,35 @@
 -----------------------------------
 xi = xi or {}
 
-xi.applyMixins = function(entity, mixins)
-    -- TODO: This could probably be made nicely with recursion
-    if type(mixins) == 'string' then
-        mixins = { mixins }
-    elseif type(mixins) == 'function' then
-        mixins = { mixins }
+xi.applyMixins = function(entity, mixins, params)
+    if type(mixins) == 'string' or type(mixins) == 'function' then
+        if type(mixins) == 'string' then
+            xi.mixins[mixins](entity, params)
+        else
+            mixins(entity, params)
+        end
+        return
     end
 
-    for i, v in pairs(mixins) do
-        if type(v) == 'table' then
-            if type(v[1]) == 'string' then
-                xi.mixins[v[1]](entity, v[2])
-            elseif type(v[1]) == 'function' then
-                v[1](entity, v[2])
+    if type(mixins) == 'table' then
+        if type(mixins[1]) == 'string' or type(mixins[1]) == 'function' then
+            if mixins[2] then
+                xi.applyMixins(entity, mixins[1], mixins[2])
+            else
+                for _, mixin in ipairs(mixins) do
+                    if type(mixin) == 'string' then
+                        xi.mixins[mixin](entity)
+                    elseif type(mixin) == 'function' then
+                        mixin(entity)
+                    end
+                end
             end
-        elseif type(v) == 'string' then
-            xi.mixins[v](entity)
-        elseif type(v) == 'function' then
-            v(entity)
+            return
+        elseif type(mixins[1]) == 'table' then
+            for _, mixin in ipairs(mixins) do
+                xi.applyMixins(entity, mixin[1], mixin[2])
+            end
+            return
         end
     end
 end

--- a/scripts/globals/mixins.lua
+++ b/scripts/globals/mixins.lua
@@ -37,3 +37,17 @@ xi.applyMixins = function(entity, mixins, params)
         end
     end
 end
+
+xi.applyZoneMobMixins = function(zone, mixins, params)
+    local mobs = zone:getMobs()
+    for _, mob in ipairs(mobs) do
+        xi.applyMixins(mob, mixins, params)
+    end
+end
+
+xi.applyZoneNPCMixins = function(zone, mixins, params)
+    local npcs = zone:getNPCs()
+    for _, npc in ipairs(npcs) do
+        xi.applyMixins(npc, mixins, params)
+    end
+end

--- a/scripts/mixins/rage.lua
+++ b/scripts/mixins/rage.lua
@@ -10,11 +10,12 @@ https://ffxiclopedia.fandom.com/wiki/Rage
 
 require('scripts/globals/mixins')
 
-g_mixins = g_mixins or {}
+local mixin = function(rageMob, params)
+    -- TODO: Refactor everyone to use params, not setting the local var
+    local rageTimer = params.rageTimer or 1200 -- 20 minutes
 
-g_mixins.rage = function(rageMob)
     rageMob:addListener('SPAWN', 'RAGE_SPAWN', function(mob)
-        mob:setLocalVar('[rage]timer', 1200) -- 20 minutes
+        mob:setLocalVar('[rage]timer', rageTimer)
     end)
 
     rageMob:addListener('ENGAGE', 'RAGE_ENGAGE', function(mob)
@@ -36,6 +37,10 @@ g_mixins.rage = function(rageMob)
             end
 
             -- TODO: ATT, DEF, MACC, MATT, EVA, attack speed all increase
+
+            if type(params.additionalStartFn) == 'function' then
+                params.additionalStartFn(mob)
+            end
         end
     end)
 
@@ -51,8 +56,12 @@ g_mixins.rage = function(rageMob)
             end
 
             -- TODO: ATT, DEF, MACC, MATT, EVA, attack speed all decrease
+
+            if type(params.additionalEndFn) == 'function' then
+                params.additionalEndFn(mob)
+            end
         end
     end)
 end
 
-return g_mixins.rage
+return mixin

--- a/scripts/mixins/spawn_casket.lua
+++ b/scripts/mixins/spawn_casket.lua
@@ -2,12 +2,15 @@
 require('scripts/globals/caskets')
 require('scripts/globals/mixins')
 
-g_mixins = g_mixins or {}
+xi = xi or {}
+xi.mixins = xi.mixins or {}
+
+local mixin = {}
 
 -----------------------------------
 -- Casket zone check
 -----------------------------------
-g_mixins.spawn_casket = function(casketMob)
+mixin.spawn_casket = function(casketMob)
     casketMob:addListener('DEATH', 'DEATH_SPAWN_CASKET', function(mob, player, isKiller)
         local mobPos = mob:getPos()
 
@@ -24,4 +27,4 @@ g_mixins.spawn_casket = function(casketMob)
     end)
 end
 
-return g_mixins.spawn_casket
+return mixin

--- a/scripts/mixins/zones/Gustav_Tunnel.lua
+++ b/scripts/mixins/zones/Gustav_Tunnel.lua
@@ -1,4 +1,0 @@
------------------------------------
--- Caskets
------------------------------------
-mixins = { require('scripts/mixins/spawn_casket') }

--- a/scripts/mixins/zones/Jugner_Forest.lua
+++ b/scripts/mixins/zones/Jugner_Forest.lua
@@ -1,4 +1,0 @@
------------------------------------
--- Caskets
------------------------------------
-mixins = { require('scripts/mixins/spawn_casket') }

--- a/scripts/zones/Abyssea-La_Theine/mobs/Briareus.lua
+++ b/scripts/zones/Abyssea-La_Theine/mobs/Briareus.lua
@@ -2,8 +2,6 @@
 -- Area: Abyssea - La Theine
 --  Mob: Briareus
 -----------------------------------
-mixins = { require('scripts/mixins/rage') }
------------------------------------
 local entity = {}
 
 local useMeikyoShisui = function(mob)
@@ -25,8 +23,11 @@ local mercurialEffects =
     [1111] = { 2578, useMeikyoShisui }, -- Colossal Slam + 2H
 }
 
+entity.onMobInitialize = function(mob)
+    xi.applyMixins(mob, xi.mixins.rage, { rageTimer = 5400 })
+end
+
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('[rage]timer', 5400) -- 90 minutes
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/Abyssea-La_Theine/mobs/Briareus.lua
+++ b/scripts/zones/Abyssea-La_Theine/mobs/Briareus.lua
@@ -24,7 +24,7 @@ local mercurialEffects =
 }
 
 entity.onMobInitialize = function(mob)
-    xi.applyMixins(mob, xi.mixins.rage, { rageTimer = 5400 })
+    xi.applyMixins(mob, xi.mixins.rage, { rageTimer = utils.minutes(90) })
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/Alzadaal_Undersea_Ruins/mobs/Cheese_Hoarder_Gigiroon.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/mobs/Cheese_Hoarder_Gigiroon.lua
@@ -3,16 +3,14 @@
 --  ZNM: Cheese Hoarder Gigiroon
 -- TODO: Running around mechanic and dropping bombs
 -----------------------------------
-mixins = { require('scripts/mixins/rage') }
------------------------------------
 local entity = {}
 
 entity.onMobInitialize = function(mob)
+    xi.applyMixins(mob, xi.mixins.rage, { rageTimer = utils.minutes(60) })
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 300)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('[rage]timer', 3600) -- 60 minutes
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/Alzadaal_Undersea_Ruins/mobs/Ob.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/mobs/Ob.lua
@@ -2,17 +2,15 @@
 -- Area: Alzadaal Undersea Ruins
 --  Mob: Ob
 -----------------------------------
-mixins = { require('scripts/mixins/rage') }
------------------------------------
 local entity = {}
 -- Todo: Pups can make it change frames, Overload causes Rage
 
 entity.onMobInitialize = function(mob)
+    xi.applyMixins(mob, xi.mixins.rage, { rageTimer = utils.minutes(60) })
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 300)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('[rage]timer', 3600) -- 60 minutes
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Arrapago_Reef/mobs/Lil_Apkallu.lua
+++ b/scripts/zones/Arrapago_Reef/mobs/Lil_Apkallu.lua
@@ -2,17 +2,15 @@
 -- Area: Arrapago Reef
 --  ZNM: Lil Apkallu
 -----------------------------------
-mixins = { require('scripts/mixins/rage') }
------------------------------------
 local entity = {}
 -- Todo: Apkallu hate, Hundred Fists, Movement and TP pattern
 
 entity.onMobInitialize = function(mob)
+    xi.applyMixins(mob, xi.mixins.rage, { rageTimer = utils.minutes(60) })
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 300)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('[rage]timer', 3600) -- 60 minutes
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Arrapago_Reef/mobs/Velionis.lua
+++ b/scripts/zones/Arrapago_Reef/mobs/Velionis.lua
@@ -2,11 +2,10 @@
 -- Area: Arrapago Reef
 --  ZNM: Velionis
 -----------------------------------
-mixins = { require('scripts/mixins/rage') }
------------------------------------
 local entity = {}
 
 entity.onMobInitialize = function(mob)
+    xi.applyMixins(mob, xi.mixins.rage, { rageTimer = utils.minutes(60) })
     mob:setMobMod(xi.mobMod.AUTO_SPIKES, 1)
     mob:addStatusEffect(xi.effect.BLAZE_SPIKES, 200, 0, 0) -- Wiki says "180-230" and we have NO DATA! We don't know what the players conditions/gear was.
     mob:getStatusEffect(xi.effect.BLAZE_SPIKES):setEffectFlags(xi.effectFlag.DEATH)
@@ -14,7 +13,6 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('[rage]timer', 3600) -- 60 minutes
     mob:setAutoAttackEnabled(false)
     mob:setMod(xi.mod.FASTCAST, 15)
     mob:setLocalVar('HPP', 90)

--- a/scripts/zones/Aydeewa_Subterrane/mobs/Chigre.lua
+++ b/scripts/zones/Aydeewa_Subterrane/mobs/Chigre.lua
@@ -2,17 +2,15 @@
 -- Area: Aydeewa Subterrane
 --  ZNM: Chigre
 -----------------------------------
-mixins = { require('scripts/mixins/rage') }
------------------------------------
 local entity = {}
 -- Todo: add enailments, Drain samba on target if all ailments on, very fast enmity decay, capture speed
 
 entity.onMobInitialize = function(mob)
+    xi.applyMixins(mob, xi.mixins.rage, { rageTimer = utils.minutes(60) })
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 300)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('[rage]timer', 3600) -- 60 minutes
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Behemoths_Dominion/mobs/Behemoth.lua
+++ b/scripts/zones/Behemoths_Dominion/mobs/Behemoth.lua
@@ -3,13 +3,14 @@
 --  HNM: Behemoth
 -----------------------------------
 local ID = zones[xi.zone.BEHEMOTHS_DOMINION]
-mixins = { require('scripts/mixins/rage') }
 -----------------------------------
 local entity = {}
 
-entity.onMobSpawn = function(mob)
-    mob:setLocalVar('[rage]timer', 1800) -- 30 minutes
+entity.onMobInitialize = function(mob)
+    xi.applyMixins(mob, xi.mixins.rage, { rageTimer = utils.minutes(30) })
+end
 
+entity.onMobSpawn = function(mob)
     -- Despawn the ???
     GetNPCByID(ID.npc.BEHEMOTH_QM):setStatus(xi.status.DISAPPEAR)
 end

--- a/scripts/zones/Behemoths_Dominion/mobs/King_Behemoth.lua
+++ b/scripts/zones/Behemoths_Dominion/mobs/King_Behemoth.lua
@@ -3,18 +3,16 @@
 --  HNM: King Behemoth
 -----------------------------------
 local ID = zones[xi.zone.BEHEMOTHS_DOMINION]
-mixins = { require('scripts/mixins/rage') }
 -----------------------------------
 local entity = {}
 
 entity.onMobInitialize = function(mob)
+    xi.applyMixins(mob, xi.mixins.rage, { rageTimer = utils.minutes(60) })
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 60)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('[rage]timer', 3600) -- 60 minutes
-
     -- Despawn the ???
     GetNPCByID(ID.npc.BEHEMOTH_QM):setStatus(xi.status.DISAPPEAR)
 end

--- a/scripts/zones/Dragons_Aery/mobs/Fafnir.lua
+++ b/scripts/zones/Dragons_Aery/mobs/Fafnir.lua
@@ -3,12 +3,14 @@
 --  HNM: Fafnir
 -----------------------------------
 local ID = zones[xi.zone.DRAGONS_AERY]
-mixins = { require('scripts/mixins/rage') }
 -----------------------------------
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    xi.applyMixins(mob, mixins.rage, { rageTimer = utils.minutes(60) })
+end
+
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('[rage]timer', 3600) -- 60 minutes
     mob:setMobMod(xi.mobMod.WEAPON_BONUS, 50) -- Level 90 + 50 = 140 Base Weapon Damage
 
     -- Despawn the ???

--- a/scripts/zones/Dragons_Aery/mobs/Nidhogg.lua
+++ b/scripts/zones/Dragons_Aery/mobs/Nidhogg.lua
@@ -3,12 +3,14 @@
 --  HNM: Nidhogg
 -----------------------------------
 local ID = zones[xi.zone.DRAGONS_AERY]
-mixins = { require('scripts/mixins/rage') }
 -----------------------------------
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    xi.applyMixins(mob, mixins.rage, { rageTimer = utils.minutes(60) })
+end
+
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('[rage]timer', 3600) -- 60 minutes
     mob:setMobMod(xi.mobMod.WEAPON_BONUS, 50) -- Level 90 + 50 = 140 Base Weapon Damage
 
     -- Despawn the ???

--- a/scripts/zones/FeiYin/mobs/Capricious_Cassie.lua
+++ b/scripts/zones/FeiYin/mobs/Capricious_Cassie.lua
@@ -2,11 +2,10 @@
 -- Area: Fei'Yin
 --   NM: Capricious Cassie
 -----------------------------------
-mixins = { require('scripts/mixins/rage') }
------------------------------------
 local entity = {}
 
 entity.onMobInitialize = function(mob)
+    xi.applyMixins(mob, xi.mixins.rage)
     mob:setMobMod(xi.mobMod.DRAW_IN, 2)
 end
 

--- a/scripts/zones/Garlaige_Citadel/mobs/Serket.lua
+++ b/scripts/zones/Garlaige_Citadel/mobs/Serket.lua
@@ -2,16 +2,14 @@
 -- Area: Garlaige Citadel (200)
 --   NM: Serket
 -----------------------------------
-mixins = { require('scripts/mixins/rage') }
------------------------------------
 local entity = {}
 
 entity.onMobInitialize = function(mob)
+    xi.applyMixins(mob, xi.mixins.rage, { rageTimer = utils.minutes(30) })
     mob:setMobMod(xi.mobMod.DRAW_IN, 1)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('[rage]timer', 1800) -- 30 minutes
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Gustav_Tunnel/Zone.lua
+++ b/scripts/zones/Gustav_Tunnel/Zone.lua
@@ -6,6 +6,8 @@ local ID = zones[xi.zone.GUSTAV_TUNNEL]
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
+    xi.mixins.applyZoneMobMixins(zone, xi.mixins.spawn_casket)
+
     UpdateNMSpawnPoint(ID.mob.BUNE)
     GetMobByID(ID.mob.BUNE):setRespawnTime(math.random(900, 10800))
 end

--- a/scripts/zones/Jugner_Forest/Zone.lua
+++ b/scripts/zones/Jugner_Forest/Zone.lua
@@ -14,6 +14,8 @@ end
 zoneObject.onInitialize = function(zone)
     zone:registerTriggerArea(1, -484, 10, 292, 0, 0, 0) -- Sets Mark for "Under Oath" Quest cutscene.
 
+    xi.mixins.applyZoneMobMixins(zone, xi.mixins.spawn_casket)
+
     UpdateNMSpawnPoint(ID.mob.FRAELISSA)
     GetMobByID(ID.mob.FRAELISSA):setRespawnTime(math.random(900, 10800))
 

--- a/scripts/zones/Jugner_Forest/mobs/King_Arthro.lua
+++ b/scripts/zones/Jugner_Forest/mobs/King_Arthro.lua
@@ -2,15 +2,12 @@
 -- Area: Jugner Forest
 --   NM: King Arthro
 -----------------------------------
-mixins =
-{
-    require('scripts/mixins/job_special'),
-    require('scripts/mixins/rage')
-}
------------------------------------
 local entity = {}
 
 entity.onMobInitialize = function(mob)
+    xi.applyMixins(mob, mixins.rage, { rageTimer = utils.minutes(60) })
+    xi.applyMixins(mob, mixins.job_special)
+
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
     mob:setMod(xi.mod.UFASTCAST, 100)
 end

--- a/scripts/zones/Jugner_Forest/mobs/Knight_Crab.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Knight_Crab.lua
@@ -3,9 +3,13 @@
 --  Mob: Knight Crab
 -----------------------------------
 local ID = zones[xi.zone.JUGNER_FOREST]
-mixins = { require('scripts/mixins/rage') }
 -----------------------------------
 local entity = {}
+
+entity.onMobInitialize = function(mob)
+    -- 5 minute rage timer (ffxiah says 5, ffxiclopedia says 5-10, bg doesn't say at all)
+    xi.applyMixins(mob, mixins.rage, { rageTimer = utils.minutes(5) })
+end
 
 entity.onMobSpawn = function(mob)
     -- If respawn and variable is not 0, then it respawned before someone killed all 10 crabs
@@ -14,9 +18,6 @@ entity.onMobSpawn = function(mob)
     if kingArthro:getLocalVar('[POP]King_Arthro') > 0 then
         kingArthro:setLocalVar('[POP]King_Arthro', kingArthro:getLocalVar('[POP]King_Arthro')  - 1)
     end
-
-    -- 5 minute rage timer (ffxiah says 5, ffxiclopedia says 5-10, bg doesn't say at all)
-    mob:setLocalVar('[rage]timer', 300)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Labyrinth_of_Onzozo/mobs/Lord_of_Onzozo.lua
+++ b/scripts/zones/Labyrinth_of_Onzozo/mobs/Lord_of_Onzozo.lua
@@ -2,11 +2,10 @@
 -- Area: Labyrinth of Onzozo
 --   NM: Lord of Onzozo
 -----------------------------------
-mixins = { require('scripts/mixins/rage') }
------------------------------------
 local entity = {}
 
 entity.onMobInitialize = function(mob)
+    xi.applyMixins(mob, xi.mixins.rage)
     mob:setMobMod(xi.mobMod.DRAW_IN, 1)
 end
 

--- a/scripts/zones/Lufaise_Meadows/mobs/Flockbock.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Flockbock.lua
@@ -4,11 +4,11 @@
 -- https://www.bg-wiki.com/ffxi/Flockbock
 -- TODO: NM has several possible spawn locations
 -----------------------------------
-mixins = { require('scripts/mixins/rage') }
------------------------------------
 local entity = {}
 
 entity.onMobInitialize = function(mob)
+    xi.applyMixins(mob, xi.mixins.rage, { rageTimer = utils.minutes(60) })
+
     -- Has enhanced double attack.
     -- TODO: Exact STP value needs to be researched further
     mob:setMod(xi.mod.DOUBLE_ATTACK, 50)
@@ -24,8 +24,6 @@ entity.onMobSpawn = function(mob)
             mob:resetEnmity(target)
         end
     end)
-
-    mob:setLocalVar('[rage]timer', 3600) -- 60 minutes
 end
 
 -- TODO: Mob's movement speed is increased while chasing target.

--- a/scripts/zones/Mamook/mobs/Chamrosh.lua
+++ b/scripts/zones/Mamook/mobs/Chamrosh.lua
@@ -5,16 +5,14 @@
 -- 2.5 mins. st form mimics all spells 2nd form cast spells from list only
 -- todo: when mimics a spell will cast the next tier spell
 -----------------------------------
-mixins = { require('scripts/mixins/rage') }
------------------------------------
 local entity = {}
 
 entity.onMobInitialize = function(mob)
+    xi.applyMixins(mob, xi.mixins.rage, { rageTimer = utils.minutes(60) })
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 300)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('[rage]timer', 3600) -- 60 minutes
     mob:setLocalVar('changeTime', 150)
     mob:setLocalVar('useWise', math.random(25, 50))
     mob:addMod(xi.mod.UFASTCAST, 150)

--- a/scripts/zones/Mount_Zhayolm/mobs/Brass_Borer.lua
+++ b/scripts/zones/Mount_Zhayolm/mobs/Brass_Borer.lua
@@ -3,16 +3,14 @@
 --  ZNM: Brass Borer
 -- TODO: Halting movement during stance change.
 -----------------------------------
-mixins = { require('scripts/mixins/rage') }
------------------------------------
 local entity = {}
 
 entity.onMobInitialize = function(mob)
+    xi.applyMixins(mob, xi.mixins.rage, { rageTimer = utils.minutes(60) })
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 300)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('[rage]timer', 3600) -- 60 minutes
     mob:setLocalVar('formTime', os.time() + math.random(43, 47))
     mob:setLocalVar('defUp', math.random(25, 50))
     mob:setLocalVar('DEF', math.random(3, 5))

--- a/scripts/zones/Mount_Zhayolm/mobs/Claret.lua
+++ b/scripts/zones/Mount_Zhayolm/mobs/Claret.lua
@@ -5,17 +5,15 @@
 -- Spawned with Pectin: !additem 2591
 -- Wiki: http://ffxiclopedia.wikia.com/wiki/Claret
 -----------------------------------
-mixins = { require('scripts/mixins/rage') }
------------------------------------
 local entity = {}
 
 entity.onMobInitialize = function(mob)
+    xi.applyMixins(mob, xi.mixins.rage, { rageTimer = utils.minutes(60) })
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 300)
     mob:setMobMod(xi.mobMod.TARGET_DISTANCE_OFFSET, 50)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('[rage]timer', 3600) -- 60 minutes
     mob:addMod(xi.mod.REGEN, math.floor(mob:getMaxHP() * 0.004))
     mob:addMod(xi.mod.BIND_MEVA, 40)
     mob:addMod(xi.mod.MOVE_SPEED_STACKABLE, 15)

--- a/scripts/zones/Mount_Zhayolm/mobs/Sarameya.lua
+++ b/scripts/zones/Mount_Zhayolm/mobs/Sarameya.lua
@@ -6,11 +6,10 @@
 -- Wiki: http://ffxiclopedia.wikia.com/wiki/Sarameya
 -- TODO: PostAIRewrite: Code the Howl effect and gradual resists.
 -----------------------------------
-mixins = { require('scripts/mixins/rage') }
------------------------------------
 local entity = {}
 
 entity.onMobInitialize = function(mob)
+    xi.applyMixins(mob, xi.mixins.rage, { rageTimer = utils.minutes(60) })
     mob:setMobMod(xi.mobMod.GA_CHANCE, 50)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
 end
@@ -21,7 +20,6 @@ entity.onMobSpawn = function(mob)
     mob:addMod(xi.mod.SILENCE_MEVA, 20)
     mob:addMod(xi.mod.GRAVITY_MEVA, 20)
     mob:addMod(xi.mod.LULLABY_MEVA, 30)
-    mob:setLocalVar('[rage]timer', 3600) -- 60 minutes
 end
 
 entity.onMobRoam = function(mob)

--- a/scripts/zones/Rolanberry_Fields/mobs/Simurgh.lua
+++ b/scripts/zones/Rolanberry_Fields/mobs/Simurgh.lua
@@ -2,9 +2,11 @@
 -- Area: Rolanberry Fields (110)
 --  HNM: Simurgh
 -----------------------------------
-mixins = { require('scripts/mixins/rage') }
------------------------------------
 local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.applyMixins(mob, mixins.rage)
+end
 
 entity.onMobDeath = function(mob, player, optParams)
     player:addTitle(xi.title.SIMURGH_POACHER)

--- a/scripts/zones/Sauromugue_Champaign/mobs/Roc.lua
+++ b/scripts/zones/Sauromugue_Champaign/mobs/Roc.lua
@@ -2,9 +2,11 @@
 -- Area: Sauromugue Champaign (120)
 --  HNM: Roc
 -----------------------------------
-mixins = { require('scripts/mixins/rage') }
------------------------------------
 local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.applyMixins(mob, mixins.rage)
+end
 
 entity.onMobDeath = function(mob, player, optParams)
     player:addTitle(xi.title.ROC_STAR)

--- a/scripts/zones/Valley_of_Sorrows/mobs/Adamantoise.lua
+++ b/scripts/zones/Valley_of_Sorrows/mobs/Adamantoise.lua
@@ -3,13 +3,14 @@
 --  HNM: Adamantoise
 -----------------------------------
 local ID = zones[xi.zone.VALLEY_OF_SORROWS]
-mixins = { require('scripts/mixins/rage') }
 -----------------------------------
 local entity = {}
 
-entity.onMobSpawn = function(mob)
-    mob:setLocalVar('[rage]timer', 1800) -- 30 minutes
+entity.onMobInitialize = function(mob)
+    xi.applyMixins(mob, mixins.rage, { rageTimer = utils.minutes(30) })
+end
 
+entity.onMobSpawn = function(mob)
     -- Despawn the ???
     GetNPCByID(ID.npc.ADAMANTOISE_QM):setStatus(xi.status.DISAPPEAR)
 end

--- a/scripts/zones/Valley_of_Sorrows/mobs/Aspidochelone.lua
+++ b/scripts/zones/Valley_of_Sorrows/mobs/Aspidochelone.lua
@@ -3,13 +3,14 @@
 --  HNM: Aspidochelone
 -----------------------------------
 local ID = zones[xi.zone.VALLEY_OF_SORROWS]
-mixins = { require('scripts/mixins/rage') }
 -----------------------------------
 local entity = {}
 
-entity.onMobSpawn = function(mob)
-    mob:setLocalVar('[rage]timer', 3600) -- 60 minutes
+entity.onMobInitialize = function(mob)
+    xi.applyMixins(mob, mixins.rage, { rageTimer = utils.minutes(60) })
+end
 
+entity.onMobSpawn = function(mob)
     -- Despawn the ???
     GetNPCByID(ID.npc.ADAMANTOISE_QM):setStatus(xi.status.DISAPPEAR)
 end

--- a/scripts/zones/Wajaom_Woodlands/mobs/Gotoh_Zha_the_Redolent.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Gotoh_Zha_the_Redolent.lua
@@ -2,12 +2,6 @@
 -- Area: Wajaom Woodlands
 --  ZNM: Gotoh Zha the Redolent
 -----------------------------------
-mixins =
-{
-    require('scripts/mixins/job_special'),
-    require('scripts/mixins/rage')
-}
------------------------------------
 -- Detailed Notes & Todos
 -- (please remove these if you handle any)
 -- 1. Find out if stats (INT, MND, MAB..)
@@ -30,10 +24,7 @@ mixins =
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 300)
-end
-
-entity.onMobSpawn = function(mob)
+    xi.applyMixins(mob, xi.mixins.rage, { rageTimer = utils.minutes(60) })
     xi.mix.jobSpecial.config(mob, {
         specials =
         {
@@ -42,7 +33,11 @@ entity.onMobSpawn = function(mob)
         },
     })
 
-    mob:setLocalVar('[rage]timer', 3600) -- 60 minutes
+
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 300)
+end
+
+entity.onMobSpawn = function(mob)
     mob:setSpellList(296) -- Set BLM spell list
 end
 

--- a/scripts/zones/Wajaom_Woodlands/mobs/Iriz_Ima.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Iriz_Ima.lua
@@ -2,16 +2,14 @@
 -- Area: Wajaom Woodlands
 --  ZNM: Iriz Ima
 -----------------------------------
-mixins = { require('scripts/mixins/rage') }
------------------------------------
 local entity = {}
 
 entity.onMobInitialize = function(mob)
+    xi.applyMixins(mob, xi.mixins.rage, { rageTimer = utils.minutes(60) })
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 300)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('[rage]timer', 3600) -- 60 minutes
     mob:setLocalVar('BreakChance', 5)
 end
 

--- a/scripts/zones/Wajaom_Woodlands/mobs/Tinnin.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Tinnin.lua
@@ -5,15 +5,12 @@
 -- Spawned with Monkey Wine: @additem 2573
 -- Wiki: http://ffxiclopedia.wikia.com/wiki/Tinnin
 -----------------------------------
-mixins =
-{
-    require('scripts/mixins/job_special'),
-    require('scripts/mixins/rage')
-}
------------------------------------
 local entity = {}
 
 entity.onMobInitialize = function(mob)
+    xi.applyMixins(mob, xi.mixins.rage, { rageTimer = utils.minutes(60) })
+    xi.applyMixins(mob, xi.mixins.job_special)
+
     mob:setMobMod(xi.mobMod.GIL_MIN, 12000)
     mob:setMobMod(xi.mobMod.GIL_MAX, 30000)
     mob:setMobMod(xi.mobMod.MUG_GIL, 8000)
@@ -23,7 +20,6 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('[rage]timer', 3600) -- 60 minutes
     mob:setHP(mob:getMaxHP() / 2)
     mob:setUnkillable(true)
     mob:setMod(xi.mod.REGEN, 50)

--- a/scripts/zones/Wajaom_Woodlands/mobs/Vulpangue.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Vulpangue.lua
@@ -2,16 +2,14 @@
 -- Area: Wajaom Woodlands
 --  ZNM: Vulpangue
 -----------------------------------
-mixins = { require('scripts/mixins/rage') }
------------------------------------
 local entity = {}
 
 entity.onMobInitialize = function(mob)
+    xi.applyMixins(mob, xi.mixins.rage, { rageTimer = utils.minutes(60) })
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 300)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('[rage]timer', 3600) -- 60 minutes
     mob:addMod((xi.mod.FIRE_ABSORB + VanadielDayElement() - 1), 100)
     mob:addMod(xi.mod.WIND_ABSORB, 100)
     mob:setLocalVar('HPP', 90)

--- a/src/map/instance_loader.cpp
+++ b/src/map/instance_loader.cpp
@@ -283,7 +283,6 @@ CInstance* CInstanceLoader::LoadInstance()
         for (auto PMob : instance->m_mobList)
         {
             luautils::OnMobInitialize(PMob.second);
-            luautils::ApplyMixins(PMob.second);
             ((CMobEntity*)PMob.second)->saveModifiers();
             ((CMobEntity*)PMob.second)->saveMobModifiers();
 

--- a/src/map/lua/lua_battlefield.cpp
+++ b/src/map/lua/lua_battlefield.cpp
@@ -305,9 +305,6 @@ void CLuaBattlefield::lose()
 
 void CLuaBattlefield::addGroups(sol::table const& groups, bool hasMultipleArenas)
 {
-    // get the global function "applyMixins"
-    sol::function applyMixins = lua["applyMixins"];
-
     // Ensure that each area has its own super linking
     int16 superlinkId = 1000 * m_PLuaBattlefield->GetArea();
     // The lowest entity ID allowed within the battlefield. Used for battlefields with multiple areas.
@@ -580,23 +577,6 @@ void CLuaBattlefield::addGroups(sol::table const& groups, bool hasMultipleArenas
                     PMob->setMobMod(modifier.first.as<uint16>(), modifier.second.as<uint16>());
                 }
                 PMob->saveMobModifiers();
-            }
-        }
-
-        auto mixins = groupData["mixins"];
-        if (mixins.valid() && applyMixins.valid())
-        {
-            // get the parameter "mixinOptions" (optional)
-            auto mixinOptions = groupData["mixinOptions"];
-
-            for (CBaseEntity* entity : groupEntities)
-            {
-                auto result = applyMixins(CLuaBaseEntity(entity), mixins, mixinOptions);
-                if (!result.valid())
-                {
-                    sol::error err = result;
-                    ShowError("luautils::applyMixins: %s", err.what());
-                }
             }
         }
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -342,7 +342,7 @@ namespace luautils
 
         moduleutils::LoadLuaModules();
 
-        filewatcher = std::make_unique<Filewatcher>(std::vector<std::string>{ "scripts", "modules", "settings", "mixins" });
+        filewatcher = std::make_unique<Filewatcher>(std::vector<std::string>{ "scripts", "modules", "settings" });
 
         TracyReportLuaMemory(lua.lua_state());
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2888,108 +2888,6 @@ namespace luautils
         return 0;
     }
 
-    // Called during server startup, file reads are OK!
-    int32 ApplyMixins(CBaseEntity* PMob)
-    {
-        TracyZoneScoped;
-
-        if (PMob == nullptr || PMob->objtype != TYPE_MOB)
-        {
-            return -1;
-        }
-
-        // Clear out globals
-        lua.set("mixins", sol::lua_nil);
-        lua.set("mixinOptions", sol::lua_nil);
-
-        auto zone_name = PMob->loc.zone->getName();
-        auto name      = PMob->getName();
-
-        auto filename = fmt::format("./scripts/zones/{}/mobs/{}.lua", zone_name, name);
-
-        auto script_result = lua.safe_script_file(filename);
-        if (!script_result.valid())
-        {
-            return -1;
-        }
-
-        // get the global function "applyMixins"
-        sol::function applyMixins = lua["applyMixins"];
-        if (!applyMixins.valid())
-        {
-            return -1;
-        }
-
-        // get the parameter "mixins"
-        auto mixins = lua["mixins"];
-        if (!mixins.valid())
-        {
-            return -1;
-        }
-
-        // get the parameter "mixinOptions" (optional)
-        auto mixinOptions = lua["mixinOptions"];
-
-        auto result = applyMixins(CLuaBaseEntity(PMob), mixins, mixinOptions);
-        if (!result.valid())
-        {
-            sol::error err = result;
-            ShowError("luautils::applyMixins: %s", err.what());
-        }
-
-        return 0;
-    }
-
-    // Called during server startup, file reads are OK!
-    int32 ApplyZoneMixins(CBaseEntity* PMob)
-    {
-        TracyZoneScoped;
-
-        if (PMob == nullptr || PMob->objtype != TYPE_MOB)
-        {
-            return -1;
-        }
-
-        // Clear out any previous global definitions
-        lua.set("mixins", sol::lua_nil);
-        lua.set("mixinOptions", sol::lua_nil);
-
-        auto filename = fmt::format("./scripts/mixins/zones/{}.lua", PMob->loc.zone->getName());
-
-        auto script_result = lua.safe_script_file(filename);
-        if (!script_result.valid())
-        {
-            return -1;
-        }
-
-        // get the global function "applyMixins"
-        sol::function applyMixins = lua["applyMixins"];
-        if (!applyMixins.valid())
-        {
-            return -1;
-        }
-
-        // get the parameter "mixins"
-        auto mixins = lua["mixins"];
-        if (!mixins.valid())
-        {
-            return -1;
-        }
-
-        // get the parameter "mixinOptions" (optional)
-        auto mixinOptions = lua["mixinOptions"];
-
-        auto result = applyMixins(CLuaBaseEntity(PMob), mixins, mixinOptions);
-        if (!result.valid())
-        {
-            sol::error err = result;
-            ShowError("luautils::applyMixins %s", err.what());
-            return -1;
-        }
-
-        return 0;
-    }
-
     int32 OnPath(CBaseEntity* PEntity)
     {
         TracyZoneScoped;
@@ -5789,23 +5687,9 @@ namespace luautils
         }
         else if (auto* PMob = dynamic_cast<CMobEntity*>(PEntity))
         {
-            auto mixins = table["mixins"].get_or<sol::table>(sol::lua_nil);
-            if (mixins.valid())
-            {
-                // Use the global function "applyMixins"
-                auto result = lua["applyMixins"](CLuaBaseEntity(PMob), mixins);
-                if (!result.valid())
-                {
-                    sol::error err = result;
-                    ShowError("applyMixins: %s: %s", PMob->name.c_str(), err.what());
-                }
-            }
-
             luautils::OnEntityLoad(PMob);
 
             luautils::OnMobInitialize(PMob);
-            luautils::ApplyMixins(PMob);
-            luautils::ApplyZoneMixins(PMob);
 
             PMob->saveModifiers();
             PMob->saveMobModifiers();

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -303,7 +303,16 @@ namespace luautils
             }
         }
 
-        // Load Commands
+        // Load mixins into the cache
+        for (auto const& entry : sorted_directory_iterator<std::filesystem::recursive_directory_iterator>("./scripts/mixins"))
+        {
+            if (entry.extension() == ".lua")
+            {
+                CacheLuaObjectFromFile(entry.relative_path().generic_string());
+            }
+        }
+
+        // Load commands into cache
         for (auto const& entry : sorted_directory_iterator<std::filesystem::directory_iterator>("./scripts/commands"))
         {
             if (entry.extension() == ".lua")
@@ -331,10 +340,9 @@ namespace luautils
             }
         }
 
-        // Handle settings
         moduleutils::LoadLuaModules();
 
-        filewatcher = std::make_unique<Filewatcher>(std::vector<std::string>{ "scripts", "modules", "settings" });
+        filewatcher = std::make_unique<Filewatcher>(std::vector<std::string>{ "scripts", "modules", "settings", "mixins" });
 
         TracyReportLuaMemory(lua.lua_state());
 

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -259,8 +259,6 @@ namespace luautils
     bool  OnTrustSpellCastCheckBattlefieldTrusts(CBattleEntity* PCaster); // Triggered if spell is a trust spell during onCast to determine to interrupt spell or not
 
     int32 OnMobInitialize(CBaseEntity* PMob);
-    int32 ApplyMixins(CBaseEntity* PMob);
-    int32 ApplyZoneMixins(CBaseEntity* PMob);
     int32 OnMobSpawn(CBaseEntity* PMob);
     int32 OnMobRoamAction(CBaseEntity* PMob); // triggers when event mob is ready for a custom roam action
     int32 OnMobRoam(CBaseEntity* PMob);

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -1655,8 +1655,6 @@ namespace mobutils
                 luautils::OnEntityLoad(PMob);
 
                 luautils::OnMobInitialize(PMob);
-                luautils::ApplyMixins(PMob);
-                luautils::ApplyZoneMixins(PMob);
 
                 PMob->saveModifiers();
                 PMob->saveMobModifiers();

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -648,8 +648,6 @@ namespace zoneutils
                 mobutils::AddSqlModifiers(PMob);
 
                 luautils::OnMobInitialize(PMob);
-                luautils::ApplyMixins(PMob);
-                luautils::ApplyZoneMixins(PMob);
 
                 PMob->saveModifiers();
                 PMob->saveMobModifiers();

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -37,11 +37,6 @@ global_objects=(
     utils
     npcUtil
 
-    mixins
-    g_mixins
-    applyMixins
-    mixinOptions
-
     set
     printf
     fmt


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

I'm slammed with work, so this is all I'll have time to do until next week. 

- Rip out all the C++ guts that mixins had their own special routing for
- Reorganise and cache the mixin files (they're just single functions, really)
- Add a helper to apply those mixins on `entity.onMobInitialize` (will need to be added for every mob with mixins)
- Added a quick example to prove the concept works:

```
[04/10/24 11:12:04:320][map][info] Loading Mobs (zoneutils::LoadMOBList:383)
[04/10/24 11:12:08:414][map][info] Loading Mob scripts (zoneutils::LoadMOBList:635)
[04/10/24 11:12:15:205][map][lua] Original rage mixin applied! (lua_print:203)
[04/10/24 11:12:15:205][map][lua] Rage module applied (and run)! (lua_print:203)
[04/10/24 11:12:15:206][map][lua] Original rage mixin applied! (lua_print:203)
[04/10/24 11:12:15:206][map][lua] Rage module applied (and run)! (lua_print:203)
[04/10/24 11:12:15:206][map][lua] Original rage mixin applied! (lua_print:203)
[04/10/24 11:12:15:206][map][lua] Rage module applied (and run)! (lua_print:203)
```

^ (remember there are 3x instances of Briareus)

### TODO

- Zone mixins (removing all those files that define them and add to `onZoneInit` etc.)
- All the busywork of changing all the scripts that use mixins
- Handling the `option` objects


Closes https://github.com/LandSandBoat/server/issues/5374