### PR TITLE
[LUA] Erle NM

### DIFF
--- a/scripts/zones/Rolanberry_Fields_[S]/IDs.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/IDs.lua
@@ -3,6 +3,8 @@
 -----------------------------------
 zones = zones or {}
 
+local erleID = GetFirstID('Erle')
+
 zones[xi.zone.ROLANBERRY_FIELDS_S] =
 {
     text =
@@ -35,6 +37,11 @@ zones[xi.zone.ROLANBERRY_FIELDS_S] =
         DELICIEUSE_DELPHINE_PH =
         {
             [17150279] = 17150280, -- -484.535 -23.756 -467.462
+        },
+
+        ERLE_PH =
+        {
+            [erleID - 6] = erleID, -- -298.487 3.637 54.586
         },
 
         VOIDWALKER =

--- a/scripts/zones/Rolanberry_Fields_[S]/mobs/Death_Jacket.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/mobs/Death_Jacket.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- Area: Rolanberry Fields [S]
+--  Mob: Death Jacket
+-- Note: PH for Erle
+-----------------------------------
+local ID = zones[xi.zone.ROLANBERRY_FIELDS_S]
+-----------------------------------
+local entity = {}
+
+entity.onMobDeath = function(mob, player, optParams)
+end
+
+entity.onMobDespawn = function(mob)
+    xi.mob.phOnDespawn(mob, ID.mob.ERLE_PH, 10, 5400) -- 1.5 hour
+end
+
+return entity

--- a/scripts/zones/Rolanberry_Fields_[S]/mobs/Erle.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/mobs/Erle.lua
@@ -1,8 +1,20 @@
 -----------------------------------
 -- Area: Rolanberry Fields [S]
 --   NM: Erle
+-- https://www.bg-wiki.com/ffxi/Erle
+-- TODO allow deaggro based on distance (core CMobEntity::CanDeaggro() forces NM and Battlefield mobs to never stop chasing)
 -----------------------------------
 local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMod(xi.mod.TRIPLE_ATTACK, 35)
+    mob:setMod(xi.mod.MDEF, 100)
+    mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
+end
+
+entity.onAdditionalEffect = function(mob, target, damage)
+    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENAERO, { power = math.random(25, 50) })
+end
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 512)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Includes both commits, but #5382 will absorb the first, sql, commit

[Erle](https://www.bg-wiki.com/ffxi/Erle) 
- Captures found that he could double attack about 10% of the time and triple attack about 35% of the time, which matches with him being a warrior (like other bees) with high chance to triple attack
![image](https://github.com/LandSandBoat/server/assets/131182600/15a84cb0-e89f-4a50-8151-e4dbad9ff9af)
![image](https://github.com/LandSandBoat/server/assets/131182600/6660f013-4501-423e-a3dc-4fdd2afd6f8b)


## Steps to test these changes

Update `Death_Jacket.lua` with `xi.mob.phOnDespawn(mob, ID.mob.ERLE_PH, 100, 5400, { immediate = true }) -- 1.5 hour` to make 100% to spawn Erle immediately
Kill single PH: 17150075
See Erle link with and link other bees as well as use no mobskills and cast the relevant spells