### PR TITLE
[core] Set unarmed weapons on char load if main slot is null

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1097,6 +1097,12 @@ namespace charutils
         {
             ShowError("Loading error from char_equip");
         }
+
+        // Fill in the unarmed psuedo-weapons if no item was equipped
+        if (PChar->m_Weapons[SLOT_MAIN] == nullptr)
+        {
+            CheckUnarmedWeapon(PChar);
+        }
     }
 
     /************************************************************************


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Set unarmed weapons on char load if main slot is null

fixes #5380 

## Steps to test these changes

see #5380 
