### PR TITLE
Fix crafting skill level parameter for Image Support NPCs

### DIFF
--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Hadayah.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Hadayah.lua
@@ -12,7 +12,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local skillLevel = player:getSkillLevel(xi.skill.ALCHEMY)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.ALCHEMY)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.ALCHEMY) then
         if not player:hasStatusEffect(xi.effect.ALCHEMY_IMAGERY) then

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Shahau.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Shahau.lua
@@ -12,7 +12,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local skillLevel = player:getSkillLevel(xi.skill.ALCHEMY)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.ALCHEMY)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.ALCHEMY) then
         if not player:hasStatusEffect(xi.effect.ALCHEMY_IMAGERY) then

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Sulbahn.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Sulbahn.lua
@@ -22,7 +22,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local skillLevel = player:getSkillLevel(xi.skill.ALCHEMY)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.ALCHEMY)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.ALCHEMY) then
         player:startEvent(636, 2, skillLevel, 0, 511, 0, 0, 7, xi.item.IMPERIAL_BRONZE_PIECE)

--- a/scripts/zones/Al_Zahbi/npcs/Gidappa.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Gidappa.lua
@@ -25,7 +25,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local skillLevel = player:getSkillLevel(xi.skill.CLOTHCRAFT)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.CLOTHCRAFT)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.CLOTHCRAFT) then
         if not player:hasStatusEffect(xi.effect.CLOTHCRAFT_IMAGERY) then

--- a/scripts/zones/Al_Zahbi/npcs/Macici.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Macici.lua
@@ -25,7 +25,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local skillLevel = player:getSkillLevel(xi.skill.SMITHING)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.SMITHING)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.SMITHING) then
         if not player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) then

--- a/scripts/zones/Al_Zahbi/npcs/Nudahaal.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Nudahaal.lua
@@ -25,7 +25,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local skillLevel = player:getSkillLevel(xi.skill.BONECRAFT)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.BONECRAFT)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.BONECRAFT) then
         if not player:hasStatusEffect(xi.effect.BONECRAFT_IMAGERY) then

--- a/scripts/zones/Al_Zahbi/npcs/Numaaf.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Numaaf.lua
@@ -25,7 +25,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local skillLevel = player:getSkillLevel(xi.skill.COOKING)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.COOKING)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.COOKING) then
         if not player:hasStatusEffect(xi.effect.COOKING_IMAGERY) then

--- a/scripts/zones/Al_Zahbi/npcs/Rajaaha.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Rajaaha.lua
@@ -25,7 +25,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local skillLevel = player:getSkillLevel(xi.skill.GOLDSMITHING)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.GOLDSMITHING)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.GOLDSMITHING) then
         if not player:hasStatusEffect(xi.effect.GOLDSMITHING_IMAGERY) then

--- a/scripts/zones/Al_Zahbi/npcs/Yudi_Yolhbi.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Yudi_Yolhbi.lua
@@ -25,7 +25,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local skillLevel = player:getSkillLevel(xi.skill.WOODWORKING)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.WOODWORKING)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.WOODWORKING) then
         if not player:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) then

--- a/scripts/zones/Al_Zahbi/npcs/Zwaluh.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Zwaluh.lua
@@ -25,7 +25,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local skillLevel = player:getSkillLevel(xi.skill.LEATHERCRAFT)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.LEATHERCRAFT)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.LEATHERCRAFT) then
         if not player:hasStatusEffect(xi.effect.LEATHERCRAFT_IMAGERY) then

--- a/scripts/zones/Bastok_Markets/npcs/Fatimah.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Fatimah.lua
@@ -12,7 +12,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local skillLevel = player:getSkillLevel(xi.skill.GOLDSMITHING)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.GOLDSMITHING)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.GOLDSMITHING)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.GOLDSMITHING) then

--- a/scripts/zones/Bastok_Markets/npcs/Ulrike.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Ulrike.lua
@@ -13,7 +13,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.GOLDSMITHING)
-    local skillLevel = player:getSkillLevel(xi.skill.GOLDSMITHING)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.GOLDSMITHING)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.GOLDSMITHING) then
         if not player:hasStatusEffect(xi.effect.GOLDSMITHING_IMAGERY) then

--- a/scripts/zones/Bastok_Markets/npcs/Wulfnoth.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Wulfnoth.lua
@@ -13,7 +13,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.GOLDSMITHING)
-    local skillLevel = player:getSkillLevel(xi.skill.GOLDSMITHING)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.GOLDSMITHING)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.GOLDSMITHING) then
         if not player:hasStatusEffect(xi.effect.GOLDSMITHING_IMAGERY) then

--- a/scripts/zones/Bastok_Mines/npcs/Sieglinde.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Sieglinde.lua
@@ -12,7 +12,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local skillCap   = xi.crafting.getCraftSkillCap(player, xi.skill.ALCHEMY)
-    local skillLevel = player:getSkillLevel(xi.skill.ALCHEMY)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.ALCHEMY)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.ALCHEMY) then
         if not player:hasStatusEffect(xi.effect.ALCHEMY_IMAGERY) then

--- a/scripts/zones/Bastok_Mines/npcs/Titus.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Titus.lua
@@ -12,7 +12,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local skillCap   = xi.crafting.getCraftSkillCap(player, xi.skill.ALCHEMY)
-    local skillLevel = player:getSkillLevel(xi.skill.ALCHEMY)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.ALCHEMY)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.ALCHEMY) then
         if not player:hasStatusEffect(xi.effect.ALCHEMY_IMAGERY) then

--- a/scripts/zones/Metalworks/npcs/Hugues.lua
+++ b/scripts/zones/Metalworks/npcs/Hugues.lua
@@ -13,7 +13,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.SMITHING)
-    local skillLevel = player:getSkillLevel(xi.skill.SMITHING)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.SMITHING)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.SMITHING) then
         if not player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) then

--- a/scripts/zones/Metalworks/npcs/Romero.lua
+++ b/scripts/zones/Metalworks/npcs/Romero.lua
@@ -13,7 +13,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.SMITHING)
-    local skillLevel = player:getSkillLevel(xi.skill.SMITHING)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.SMITHING)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.SMITHING) then
         if not player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) then

--- a/scripts/zones/Metalworks/npcs/Wise_Owl.lua
+++ b/scripts/zones/Metalworks/npcs/Wise_Owl.lua
@@ -12,7 +12,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local skillLevel = player:getSkillLevel(xi.skill.SMITHING)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.SMITHING)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.SMITHING)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.SMITHING) then

--- a/scripts/zones/Northern_San_dOria/npcs/Amarefice.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Amarefice.lua
@@ -13,7 +13,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.WOODWORKING)
-    local skillLevel = player:getSkillLevel(xi.skill.WOODWORKING)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.WOODWORKING)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.WOODWORKING) then
         if not player:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) then

--- a/scripts/zones/Northern_San_dOria/npcs/Beadurinc.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Beadurinc.lua
@@ -13,7 +13,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.SMITHING)
-    local skillLevel = player:getSkillLevel(xi.skill.SMITHING)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.SMITHING)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.SMITHING) then
         if not player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) then

--- a/scripts/zones/Northern_San_dOria/npcs/Greubaque.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Greubaque.lua
@@ -12,7 +12,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local skillLevel = player:getSkillLevel(xi.skill.SMITHING)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.SMITHING)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.SMITHING)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.SMITHING) then

--- a/scripts/zones/Northern_San_dOria/npcs/Pinok-Morok.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Pinok-Morok.lua
@@ -13,7 +13,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.SMITHING)
-    local skillLevel = player:getSkillLevel(xi.skill.SMITHING)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.SMITHING)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.SMITHING) then
         if not player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) then

--- a/scripts/zones/Northern_San_dOria/npcs/Ramua.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Ramua.lua
@@ -13,7 +13,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.WOODWORKING)
-    local skillLevel = player:getSkillLevel(xi.skill.WOODWORKING)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.WOODWORKING)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.WOODWORKING) then
         if not player:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) then

--- a/scripts/zones/Northern_San_dOria/npcs/Ulycille.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Ulycille.lua
@@ -12,7 +12,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local skillLevel = player:getSkillLevel(xi.skill.WOODWORKING)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.WOODWORKING)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.WOODWORKING)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.WOODWORKING) then

--- a/scripts/zones/Port_Windurst/npcs/Degong.lua
+++ b/scripts/zones/Port_Windurst/npcs/Degong.lua
@@ -13,7 +13,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.FISHING)
-    local skillLevel = player:getSkillLevel(xi.skill.FISHING)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.FISHING)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.FISHING) then
         if not player:hasStatusEffect(xi.effect.FISHING_IMAGERY) then

--- a/scripts/zones/Port_Windurst/npcs/Erabu-Fumulubu.lua
+++ b/scripts/zones/Port_Windurst/npcs/Erabu-Fumulubu.lua
@@ -13,7 +13,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.FISHING)
-    local skillLevel = player:getSkillLevel(xi.skill.FISHING)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.FISHING)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.FISHING) then
         if not player:hasStatusEffect(xi.effect.FISHING_IMAGERY) then

--- a/scripts/zones/Port_Windurst/npcs/Panja-Nanja.lua
+++ b/scripts/zones/Port_Windurst/npcs/Panja-Nanja.lua
@@ -12,7 +12,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local skillLevel = player:getSkillLevel(xi.skill.FISHING)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.FISHING)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.FISHING)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.FISHING) then

--- a/scripts/zones/Southern_San_dOria/npcs/Kipopo.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Kipopo.lua
@@ -21,7 +21,7 @@ end
 entity.onTrigger = function(player, npc)
     local sayItWithAHandbagCS = player:getCharVar('sayItWithAHandbagCS')
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.LEATHERCRAFT)
-    local skillLevel = player:getSkillLevel(xi.skill.LEATHERCRAFT)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.LEATHERCRAFT)
 
     if
         player:getQuestStatus(xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.SAY_IT_WITH_A_HANDBAG) == QUEST_COMPLETED and

--- a/scripts/zones/Southern_San_dOria/npcs/Orechiniel.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Orechiniel.lua
@@ -11,7 +11,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local skillLevel = player:getSkillLevel(xi.skill.LEATHERCRAFT)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.LEATHERCRAFT)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.LEATHERCRAFT)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.LEATHERCRAFT) then

--- a/scripts/zones/Southern_San_dOria/npcs/Tek_Lengyon.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Tek_Lengyon.lua
@@ -13,7 +13,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.LEATHERCRAFT)
-    local skillLevel = player:getSkillLevel(xi.skill.LEATHERCRAFT)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.LEATHERCRAFT)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.LEATHERCRAFT) then
         if not player:hasStatusEffect(xi.effect.LEATHERCRAFT_IMAGERY) then

--- a/scripts/zones/Windurst_Waters/npcs/Hakeem.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Hakeem.lua
@@ -13,7 +13,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.COOKING)
-    local skillLevel = player:getSkillLevel(xi.skill.COOKING)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.COOKING)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.COOKING) then
         if not player:hasStatusEffect(xi.effect.COOKING_IMAGERY) then

--- a/scripts/zones/Windurst_Waters/npcs/Jacodaut.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Jacodaut.lua
@@ -13,7 +13,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.COOKING)
-    local skillLevel = player:getSkillLevel(xi.skill.COOKING)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.COOKING)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.COOKING) then
         if not player:hasStatusEffect(xi.effect.COOKING_IMAGERY) then

--- a/scripts/zones/Windurst_Waters/npcs/Kipo-Opo.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Kipo-Opo.lua
@@ -12,7 +12,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local skillLevel = player:getSkillLevel(xi.skill.COOKING)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.COOKING)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.COOKING)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.COOKING) then

--- a/scripts/zones/Windurst_Woods/npcs/Kyaa_Taali.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Kyaa_Taali.lua
@@ -13,7 +13,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.BONECRAFT)
-    local skillLevel = player:getSkillLevel(xi.skill.BONECRAFT)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.BONECRAFT)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.BONECRAFT) then
         if not player:hasStatusEffect(xi.effect.BONECRAFT_IMAGERY) then

--- a/scripts/zones/Windurst_Woods/npcs/Lih_Pituu.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Lih_Pituu.lua
@@ -25,7 +25,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local skillLevel = player:getSkillLevel(xi.skill.BONECRAFT)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.BONECRAFT)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.BONECRAFT)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.BONECRAFT) then

--- a/scripts/zones/Windurst_Woods/npcs/Nikkoko.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Nikkoko.lua
@@ -13,7 +13,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.CLOTHCRAFT)
-    local skillLevel = player:getSkillLevel(xi.skill.CLOTHCRAFT)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.CLOTHCRAFT)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.CLOTHCRAFT) then
         if not player:hasStatusEffect(xi.effect.CLOTHCRAFT_IMAGERY) then

--- a/scripts/zones/Windurst_Woods/npcs/Ronana.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Ronana.lua
@@ -13,7 +13,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.BONECRAFT)
-    local skillLevel = player:getSkillLevel(xi.skill.BONECRAFT)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.BONECRAFT)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.BONECRAFT) then
         if not player:hasStatusEffect(xi.effect.BONECRAFT_IMAGERY) then

--- a/scripts/zones/Windurst_Woods/npcs/Terude-Harude.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Terude-Harude.lua
@@ -12,7 +12,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local skillLevel = player:getSkillLevel(xi.skill.CLOTHCRAFT)
+    local skillLevel = xi.crafting.getRealSkill(player, xi.skill.CLOTHCRAFT)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.CLOTHCRAFT)
 
     if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.CLOTHCRAFT) then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes #5387

Uses Real Skill value for Image Support NPC event parameter
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Set skill to exceed various ranks and observe Information on Synthesis Materials that only appropriate ranks are displayed
<!-- Clear and detailed steps to test your changes here -->
