### PR TITLE
[core] data_loader.cpp fixes

### DIFF
--- a/src/search/data_loader.cpp
+++ b/src/search/data_loader.cpp
@@ -629,7 +629,7 @@ std::list<SearchEntity*> CDataLoader::GetLinkshellList(uint32 LinkshellID)
             PPlayer->linkshellid1   = rset->getInt("linkshellid1");
             PPlayer->linkshellid2   = rset->getInt("linkshellid2");
             PPlayer->linkshellrank1 = rset->getInt("linkshellrank1");
-            PPlayer->linkshellrank2 = rset->getInt("linkshellrank1");
+            PPlayer->linkshellrank2 = rset->getInt("linkshellrank2");
 
             uint32 partyid  = rset->getUInt("partyid");
             uint32 nameflag = rset->getUInt("nameflags");

--- a/src/search/data_loader.cpp
+++ b/src/search/data_loader.cpp
@@ -287,7 +287,7 @@ std::list<SearchEntity*> CDataLoader::GetPlayersList(search_req sr, int* count)
                     PPlayer->rank = (uint8)rset->getInt("rank_bastok");
                     break;
                 case 2:
-                    PPlayer->rank = (uint8)rset->getInt("rank_bastok");
+                    PPlayer->rank = (uint8)rset->getInt("rank_windurst");
                     break;
                 default:
                     ShowWarning("Inconsistent player nation allegiance : %d", PPlayer->nation);
@@ -514,7 +514,7 @@ std::list<SearchEntity*> CDataLoader::GetPartyList(uint32 PartyID, uint32 Allian
                     PPlayer->rank = (uint8)rset->getInt("rank_bastok");
                     break;
                 case 2:
-                    PPlayer->rank = (uint8)rset->getInt("rank_bastok");
+                    PPlayer->rank = (uint8)rset->getInt("rank_windurst");
                     break;
                 default:
                     ShowWarning("Inconsistent player nation allegiance : %d", PPlayer->nation);
@@ -618,7 +618,7 @@ std::list<SearchEntity*> CDataLoader::GetLinkshellList(uint32 LinkshellID)
                     PPlayer->rank = (uint8)rset->getInt("rank_bastok");
                     break;
                 case 2:
-                    PPlayer->rank = (uint8)rset->getInt("rank_bastok");
+                    PPlayer->rank = (uint8)rset->getInt("rank_windurst");
                     break;
                 default:
                     ShowWarning("Inconsistent player nation allegiance : %d", PPlayer->nation);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a couple issues in data_loader.cpp that were affecting player/linkshell search

1. There was an issue that was causing windurst players to load bastok rank from the database causing a mismatch from what would be expected in /sea all, linkshell seach, etc. 
2. There was an issue where linkshell 1 and linkshell 2 both pulled member permissions from linkshell1 where as linkshell 2 should have its own.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

1. Have a windurst player in your server or set yourself as nation windurst. Use !setrank <name> <number> to set ranks of current nation. Observe that player searches reflect what you changed rank to.

1b. Have two players make a linkshell. Add each other to both linkshells. Equip both linkshells.
- Player 1 Owns Linkshell 1.
- Player 2 Owns Linkshell 2.
- Player 2 equips Linkshell 2(They own it) in Linkshell slot 1 and equips Player 1's linkshell in slot 2.
- Player 2 does a player seach in Linkshell slot 2(Linkshell 1 equipped) menu. Player 2 should NOT be listed as a shell owner in player 1's linkshell.

<!-- Clear and detailed steps to test your changes here -->
