### PR TITLE
[SQL] Fix Sneaking Boots missing enhance Stealth mod

### DIFF
--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -28459,7 +28459,8 @@ INSERT INTO `item_mods` VALUES (15697,20,6); -- WATER_RES: 6
 INSERT INTO `item_mods` VALUES (15697,26,2); -- RACC: 2
 
 -- Sneaking Boots
-INSERT INTO `item_mods` VALUES (15698,1,9); -- DEF: 9
+INSERT INTO `item_mods` VALUES (15698,1,9);   -- DEF: 9
+INSERT INTO `item_mods` VALUES (15698,358,1); -- STEALTH: 1 -- TODO: Stealth trait needs retail verification, real value unknown
 
 -- Templar Sabatons
 INSERT INTO `item_mods` VALUES (15699,1,11);  -- DEF: 11


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Sneaking Boots are missing an item mod that enhances the effect of Stealth (a NIN trait). A 75 NIN has a Stealth mod value of 3 so 1 seems to make sense here. No information on the wikis regarding the actual value so may require retail verification.

## Steps to test these changes

1. !additem 15698
2. Equip the boots
3. !getmod 358