### PR TITLE
SCH Indescript Markings - Populate dynamic zone IDs and remove weather requirements

### DIFF
--- a/scripts/zones/Fort_Karugo-Narugo_[S]/IDs.lua
+++ b/scripts/zones/Fort_Karugo-Narugo_[S]/IDs.lua
@@ -47,7 +47,7 @@ zones[xi.zone.FORT_KARUGO_NARUGO_S] =
     npc =
     {
         CAMPAIGN_NPC_OFFSET = GetFirstID('Caulaise_RK'), -- San, Bas, Win, Flag +4, CA
-        INDESCRIPT_MARKINGS = 17171273,
+        INDESCRIPT_MARKINGS = GetFirstID('Indescript_Markings'),
         LOGGING             = GetTableOfIDs('Logging_Point'),
     },
 }

--- a/scripts/zones/Fort_Karugo-Narugo_[S]/Zone.lua
+++ b/scripts/zones/Fort_Karugo-Narugo_[S]/Zone.lua
@@ -3,8 +3,6 @@
 -----------------------------------
 require('scripts/globals/dark_ixion')
 -----------------------------------
-local ID = zones[xi.zone.FORT_KARUGO_NARUGO_S]
------------------------------------
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
@@ -34,18 +32,6 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
 end
 
 zoneObject.onZoneWeatherChange = function(weather)
-    local npc = GetNPCByID(ID.npc.INDESCRIPT_MARKINGS)
-
-    if npc ~= nil then
-        if
-            weather == xi.weather.DUST_STORM or
-            weather == xi.weather.SAND_STORM
-        then
-            npc:setStatus(xi.status.DISAPPEAR)
-        else
-            npc:setStatus(xi.status.NORMAL)
-        end
-    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Grauberg_[S]/IDs.lua
+++ b/scripts/zones/Grauberg_[S]/IDs.lua
@@ -53,7 +53,7 @@ zones[xi.zone.GRAUBERG_S] =
     {
         CAMPAIGN_NPC_OFFSET = GetFirstID('Ulaciont_RK'), -- San, Bas, Win, Flag +4, CA
         HARVESTING          = GetTableOfIDs('Harvesting_Point'),
-        INDESCRIPT_MARKINGS = 17142587,
+        INDESCRIPT_MARKINGS = GetFirstID('Indescript_Markings'),
     },
 }
 

--- a/scripts/zones/Grauberg_[S]/Zone.lua
+++ b/scripts/zones/Grauberg_[S]/Zone.lua
@@ -3,8 +3,6 @@
 -----------------------------------
 require('scripts/globals/dark_ixion')
 -----------------------------------
-local ID = zones[xi.zone.GRAUBERG_S]
------------------------------------
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
@@ -34,18 +32,6 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
 end
 
 zoneObject.onZoneWeatherChange = function(weather)
-    local npc = GetNPCByID(ID.npc.INDESCRIPT_MARKINGS)
-
-    if npc ~= nil then
-        if
-            weather == xi.weather.WIND or
-            weather == xi.weather.GALES
-        then
-            npc:setStatus(xi.status.NORMAL)
-        else
-            npc:setStatus(xi.status.DISAPPEAR)
-        end
-    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Grauberg_[S]/npcs/Indescript_Markings.lua
+++ b/scripts/zones/Grauberg_[S]/npcs/Indescript_Markings.lua
@@ -17,6 +17,7 @@ entity.onTrigger = function(player, npc)
 
     -- SCH AF Quest - Boots
     if
+        npc:getID() == ID.npcs.INDESCRIPT_MARKINGS and -- Second markings are bcnm entrance
         gownQuestProgress > 0 and
         gownQuestProgress < 3 and
         not player:hasKeyItem(xi.ki.SAMPLE_OF_GRAUBERG_CHERT)

--- a/scripts/zones/Meriphataud_Mountains_[S]/IDs.lua
+++ b/scripts/zones/Meriphataud_Mountains_[S]/IDs.lua
@@ -74,7 +74,7 @@ zones[xi.zone.MERIPHATAUD_MOUNTAINS_S] =
     npc =
     {
         CAMPAIGN_NPC_OFFSET = GetFirstID('Raurart_RK'), -- San, Bas, Win, Flag +4, CA
-        INDESCRIPT_MARKINGS = 17175343,
+        INDESCRIPT_MARKINGS = GetFirstID('Indescript_Markings'),
     },
 }
 

--- a/scripts/zones/Pashhow_Marshlands_[S]/IDs.lua
+++ b/scripts/zones/Pashhow_Marshlands_[S]/IDs.lua
@@ -98,7 +98,7 @@ zones[xi.zone.PASHHOW_MARSHLANDS_S] =
     npc =
     {
         CAMPAIGN_NPC_OFFSET        = GetFirstID('Yuvalbaux_RK'), -- San, Bas, Win, Flag +4, CA
-        INDESCRIPT_MARKINGS_OFFSET = 17146627,
+        INDESCRIPT_MARKINGS_OFFSET = GetFirstID('Indescript_Markings'),
     },
 }
 

--- a/scripts/zones/Pashhow_Marshlands_[S]/Zone.lua
+++ b/scripts/zones/Pashhow_Marshlands_[S]/Zone.lua
@@ -1,8 +1,6 @@
 -----------------------------------
 -- Zone: Pashhow_Marshlands_[S] (90)
 -----------------------------------
-local ID = zones[xi.zone.PASHHOW_MARSHLANDS_S]
------------------------------------
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
@@ -28,24 +26,6 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
 end
 
 zoneObject.onZoneWeatherChange = function(weather)
-    local npc = GetNPCByID(ID.npc.INDESCRIPT_MARKINGS_OFFSET + 1) -- Indescript Markings (BOOTS)
-
-    if npc then
-        if weather == xi.weather.RAIN or weather == xi.weather.THUNDER then
-            npc:setStatus(xi.status.DISAPPEAR)
-        else
-            npc:setStatus(xi.status.NORMAL)
-        end
-    end
-
-    npc = GetNPCByID(ID.npc.INDESCRIPT_MARKINGS_OFFSET + 2) -- Indescript Markings (BODY)
-    if npc then
-        if weather == xi.weather.RAIN then
-            npc:setStatus(xi.status.DISAPPEAR)
-        else
-            npc:setStatus(xi.status.NORMAL)
-        end
-    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Vunkerl_Inlet_[S]/IDs.lua
+++ b/scripts/zones/Vunkerl_Inlet_[S]/IDs.lua
@@ -31,7 +31,7 @@ zones[xi.zone.VUNKERL_INLET_S] =
     },
     npc =
     {
-        INDESCRIPT_MARKINGS = 17118009,
+        INDESCRIPT_MARKINGS = GetFirstID('Indescript_Markings'),
         CAMPAIGN_NPC_OFFSET = GetFirstID('Toulsard_RK'), -- RK, LC, MC, flag +4, CA
     },
 }

--- a/scripts/zones/Vunkerl_Inlet_[S]/Zone.lua
+++ b/scripts/zones/Vunkerl_Inlet_[S]/Zone.lua
@@ -23,15 +23,6 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.onZoneWeatherChange = function(weather)
-    local npc = GetNPCByID(ID.npc.INDESCRIPT_MARKINGS) -- Indescript Markings
-
-    if npc ~= nil then
-        if weather == xi.weather.FOG or weather == xi.weather.THUNDER then
-            npc:setStatus(xi.status.DISAPPEAR)
-        elseif VanadielHour() >= 16 or VanadielHour() <= 6 then
-            npc:setStatus(xi.status.NORMAL)
-        end
-    end
 end
 
 zoneObject.onGameHour = function(zone)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The various sch AF quests require finding Indescript Markings. In a time past (har har) these markings required particular weather to be active, but that's no longer the case:
- https://www.bg-wiki.com/ffxi/Scholar%27s_Pants
- https://www.bg-wiki.com/ffxi/Scholar%27s_Gown
- https://www.bg-wiki.com/ffxi/Scholar%27s_Loafers

Also note that 2nd and 3rd markings in pashow were slightly in the air, moved them down a bit

## Steps to test these changes

Go to the various zones and `!gotoname Indescript_Markings` to see that all except the second in Grauberg are visible

Logic to move when a quest-holder collects their key item is unchanged.
