### PR TITLE
Fix mob being used as npc from GetFirstID use

### DIFF
--- a/scripts/zones/PsoXja/IDs.lua
+++ b/scripts/zones/PsoXja/IDs.lua
@@ -44,7 +44,7 @@ zones[xi.zone.PSOXJA] =
     npc =
     {
         STONE_DOOR_OFFSET          = 16814446, -- _090 in npc_list
-        TREASURE_CHEST             = GetFirstID('Treasure_Chest'),
+        TREASURE_CHEST             = 16814558,
     },
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

#5371 updated chests to use `GetFirstID`, but Pso'Xja has a Treasure Chest mob. `GetFirstID` grabs mobs and npcs, and mobs have a lower ID range, so the first ID returned is the mob instead of the npc. I think this is the only one, was throwing a warning on launch. I think maybe [this part](https://github.com/LandSandBoat/server/blob/c52c5ead30d044380d7b1b9b947533e026f86468/.github/workflows/build.yml#L622-L640) of the build check should be checking for "warn" instead of "warning" unless I'm reading that wrong.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
