### PR TITLE
[sql] Kupo shield should be synth skills only

### DIFF
--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -61532,7 +61532,6 @@ INSERT INTO `item_mods` VALUES (26403,109,129);  -- SHIELD: 129
 INSERT INTO `item_mods` VALUES (26403,160,-800); -- DMG: -800
 -- TODO: Null all damage
 -- Kupo Shield
-INSERT INTO `item_mods` VALUES (26406,127,3); -- FISH: 3
 INSERT INTO `item_mods` VALUES (26406,128,3); -- WOOD: 3
 INSERT INTO `item_mods` VALUES (26406,129,3); -- SMITH: 3
 INSERT INTO `item_mods` VALUES (26406,130,3); -- GOLDSMITH: 3


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

[Kupo Shield](https://www.bg-wiki.com/ffxi/Kupo_Shield) is not "all crafts" it is only "synthesis skill". Fishing is not a synthesis and nothing is found that would indicate it improves fishing skill. Going to chalk this up to data entry error

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
