### PR TITLE
[lua] Entering empyrean paradox softlocks player

### DIFF
--- a/scripts/globals/player.lua
+++ b/scripts/globals/player.lua
@@ -229,9 +229,11 @@ xi.player.onGameIn = function(player, firstLogin, zoning)
 
     -- remember time player zoned in (e.g., to support zone-in delays)
     player:setLocalVar('ZoneInTime', os.time())
+    player:setLocalVar('ZoningIn', 1)
 
     -- Slight delay to ensure player is fully logged in
     player:timer(2500, function(playerArg)
+        player:setLocalVar('ZoningIn', 0)
         -- Login Campaign rewards points once daily
         xi.events.loginCampaign.onGameIn(playerArg)
     end)

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1887,6 +1887,12 @@ namespace luautils
     {
         TracyZoneScoped;
 
+        // Do not enter trigger areas while loading in. Set in xi.player.onGameIn
+        if (PChar->GetLocalVar("ZoningIn") > 0)
+        {
+            return 0;
+        }
+
         std::string                 filename;
         std::optional<CLuaInstance> optInstance = std::nullopt;
         if (PChar->PInstance)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

~~Changes the default position in the Empyrean Paradox to stop~~ zoning in and immediately triggering a triggerarea creates a mismatch between the server and client player state:
- server thinks the player is in event 100
- client has no idea and can run around


when this happens the player cannot change equipment (packet 0x050 is equipitem) 
![image](https://github.com/LandSandBoat/server/assets/131182600/eb171ddb-c188-4b27-adea-90c299741a25)

and if they interact with the BCNM npc the client softlocks. `!release` will release the player and proper functionality resumes.

Edit: reworked the PR to be a more general solution

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Zone into Empyrean Paradox via gm command to put you at 0,0,0. Default location puts you on the elevator inside of a trigger area