### PR TITLE
Fix extractFromBlob overwriting initialized values

### DIFF
--- a/src/common/database.h
+++ b/src/common/database.h
@@ -275,6 +275,9 @@ namespace db
         if (!rset->isNull(blobKey.c_str()))
         {
             auto blobStr = rset->getString(blobKey.c_str());
+            // Login server creates new chars with null blobs. Map server then initializes.
+            // We don't want to overwrite the initialized map data with null blobs / 0 values.
+            // See: login_helpers.cpp saveCharacter() and charutils::LoadChar
             std::memset(&destination, 0x00, sizeof(T));
             std::memcpy(&destination, blobStr.c_str(), std::min(sizeof(T), blobStr.length()));
         }

--- a/src/common/database.h
+++ b/src/common/database.h
@@ -270,14 +270,13 @@ namespace db
 
         TracyZoneScoped;
 
-        std::memset(&destination, 0x00, sizeof(T));
-
         // If we use getString on a null blob we will get back garbage data.
         // This will introduce difficult to track down crashes.
         if (!rset->isNull(blobKey.c_str()))
         {
             auto blobStr = rset->getString(blobKey.c_str());
-            std::memcpy(&destination, blobStr.c_str(), sizeof(T));
+            std::memset(&destination, 0x00, sizeof(T));
+            std::memcpy(&destination, blobStr.c_str(), std::min(sizeof(T), blobStr.length()));
         }
     }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

`db::extractFromBlob` overwrites initialized values. Previously this was done like this:
```cpp

            size_t length = 0;
            char* buf     = nullptr;
            sql->GetData(13, &buf, &length);
            memcpy(&PChar->m_something, buf, (length > sizeof(PChar->m_something) ? sizeof(PChar->m_something) : length));
```
I think this change is equivalent. I also removed the `memset` only because it wasn't used before and I'm not sure if it would cause any unintended behavior with existing data, idk. I think I can add that back without issue if it's wanted, wrapped inside the null check though because we don't want to overwrite initialized data.

## Steps to test these changes

Make a new character, check that mission log has initialized (valid) data. I think everything else that uses this used the same pattern before, except maybe monstrosity.
