### PR TITLE
DB: Fix index counting and passing in preparedStmt

### DIFF
--- a/src/common/database.cpp
+++ b/src/common/database.cpp
@@ -130,6 +130,7 @@ std::unique_ptr<sql::ResultSet> db::query(std::string const& rawQuery)
         auto stmt = state.connection->createStatement();
         try
         {
+            DebugSQL(fmt::format("query: {}", rawQuery));
             return std::unique_ptr<sql::ResultSet>(stmt->executeQuery(rawQuery.data()));
         }
         catch (const std::exception& e)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes https://github.com/LandSandBoat/server/issues/5329

Tested with:
```cpp
    db::preparedStmt("UPDATE chars SET titles = ? WHERE charid = ?", db::encodeToBlob(testStruct), 1);
```
