### PR TITLE
[cpp] Improve RA phase timing and descriptions

### DIFF
--- a/src/map/ai/states/range_state.h
+++ b/src/map/ai/states/range_state.h
@@ -54,8 +54,8 @@ protected:
 private:
     CBattleEntity* const m_PEntity;
     duration             m_aimTime{};                                           // The calculated "phase 1" delay based on weapon and job trait reductions
-    const duration       m_returnWeaponDelay = std::chrono::milliseconds(1500); // Phase 2: Putting the weapon back after a shot
-    const duration       m_freePhaseTime     = std::chrono::milliseconds(1100); // Phase 3: The cooldown after a ranged attack is executed.
+    const duration       m_returnWeaponDelay = std::chrono::milliseconds(1000); // Phase 2: Putting the weapon back after a shot (time between shot and being able to move)
+    const duration       m_freePhaseTime     = std::chrono::milliseconds(1100); // Phase 3: The cooldown after a ranged attack is executed. (time after being able to move befer you stop getting "you must wait longer" when attempting to Range Attack again)
     bool                 m_rapidShot{ false };
     position_t           m_startPos;
 };


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The Ranged Attack state timing changes recently definitely _felt_ wrong but it's taken some time to quantify what that meant. (The structure is great, though. Functions well and clarifies the partitioning of the ranged states)

I've collected a bit of captures from retail and I'm getting video as well to share here with details, but the TL;DR is: phase 2 1.5s is too long, phase 1 and phase 3 are correct, best i can tell

Expanding on the changes in this PR:
- Updated the wording of the comments to explicitly describe what each phase is accounting for
- Updated the phase 2 (put away weapon) delay to match the timing from various retail captures that show very close to 1s delay between the packet of the shot firing at the target and being able to move again

To be clear, aimtime delay was found to be too long in a previous PR due to mismatch in velocity shot potency, but the underlying calculations are correct. The 1.1s (you must wait longer) delay seems to be right on the money based on packet captures

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
