### PR TITLE
DB: Add preparedStmtWithRowCount

### DIFF
--- a/src/common/database.h
+++ b/src/common/database.h
@@ -32,9 +32,6 @@
 #include <conncpp.hpp>
 
 // @note Everything in database-land is 1-indexed, not 0-indexed.
-// TODO: Rename this namespace from db to sql when migration is complete.
-// mariadb-connector-cpp uses sql namespace for all of its classes, so it
-// will be clearer if we use it too.
 namespace db
 {
     namespace detail
@@ -144,6 +141,12 @@ namespace db
         }
     } // namespace detail
 
+    // @brief Execute a query with the given query string.
+    // @param query The query string to execute.
+    // @return A unique pointer to the result set of the query.
+    // @note Everything in database-land is 1-indexed, not 0-indexed.
+    auto query(std::string const& rawQuery) -> std::unique_ptr<sql::ResultSet>;
+
     // @brief Execute a prepared statement with the given query string and arguments.
     // @param query The query string to execute.
     // @param args The arguments to bind to the prepared statement.
@@ -195,6 +198,86 @@ namespace db
                 ShowError(e.what());
                 return nullptr;
             }
+        });
+        // clang-format on
+    }
+
+    // @brief Execute a prepared statement with the given query string and arguments.
+    // @param query The query string to execute.
+    // @param args The arguments to bind to the prepared statement.
+    // @return A pair of: unique pointer to the result set of the query, number of rows affected by the query as told by MariaDB's ROW_COUNT().
+    // @note If the query hasn't been seen before it will generate a prepared statement for it to be used immediately and in the future.
+    // @note Everything in database-land is 1-indexed, not 0-indexed.
+    // @note This is a workaround for the fact that MariaDB's C++ connector hasn't yet implemented ResultSet::rowUpdated(), ResultSet::rowInserted(),
+    //       and ResultSet::rowDeleted().
+    template <typename... Args>
+    std::pair<std::unique_ptr<sql::ResultSet>, std::size_t> preparedStmtWithRowCount(std::string const& rawQuery, Args&&... args)
+    {
+        TracyZoneScoped;
+        TracyZoneString(rawQuery);
+
+        // clang-format off
+        return detail::getState().write([&](detail::State& state) -> std::pair<std::unique_ptr<sql::ResultSet>, std::size_t>
+        {
+            auto& lazyPreparedStatements = state.lazyPreparedStatements;
+
+            // TODO: combine the two versions of this function into one, with the string-handling version
+            // just being a wrapped which does the lookup below and then calls the enum version.
+
+            // If we don't have it, lazily make it
+            if (lazyPreparedStatements.find(rawQuery) == lazyPreparedStatements.end())
+            {
+                try
+                {
+                    lazyPreparedStatements[rawQuery] = std::unique_ptr<sql::PreparedStatement>(state.connection->prepareStatement(rawQuery.c_str()));
+                }
+                catch (const std::exception& e)
+                {
+                    ShowError("Failed to lazy prepare query: %s", str(rawQuery.c_str()));
+                    ShowError(e.what());
+                    return { nullptr, 0 };
+                }
+            }
+
+            auto rowCountQuery = "SELECT ROW_COUNT() AS count";
+            if (lazyPreparedStatements.find(rowCountQuery) == lazyPreparedStatements.end())
+            {
+                try
+                {
+                    lazyPreparedStatements[rowCountQuery] = std::unique_ptr<sql::PreparedStatement>(state.connection->prepareStatement(rowCountQuery));
+                }
+                catch (const std::exception& e)
+                {
+                    ShowError("Failed to lazy prepare query: %s", str(rowCountQuery));
+                    ShowError(e.what());
+                    return { nullptr, 0 };
+                }
+            }
+
+            auto& stmt      = lazyPreparedStatements[rawQuery];
+            auto& countStmt = lazyPreparedStatements[rowCountQuery];
+            try
+            {
+                // NOTE: Everything is 1-indexed, but we're going to increment right away insider binder!
+                auto counter = 0;
+                db::detail::binder(stmt, counter, std::forward<Args>(args)...);
+                auto rset  = std::unique_ptr<sql::ResultSet>(stmt->executeQuery());
+                auto rset2 = std::unique_ptr<sql::ResultSet>(countStmt->executeQuery());
+                if (!rset2 || !rset2->next())
+                {
+                    ShowError("Failed to get row count");
+                    return { nullptr, 0 };
+                }
+                auto rowCount = rset2->getUInt("count");
+                return { std::move(rset), rowCount };
+            }
+            catch (const std::exception& e)
+            {
+                ShowError("Query Failed: %s", str(rawQuery.c_str()));
+                ShowError(e.what());
+                return { nullptr, 0 };
+            }
+
         });
         // clang-format on
     }
@@ -284,10 +367,4 @@ namespace db
             std::memcpy(&destination, blobStr.c_str(), std::min(sizeof(T), blobStr.length()));
         }
     }
-
-    // @brief Execute a query with the given query string.
-    // @param query The query string to execute.
-    // @return A unique pointer to the result set of the query.
-    // @note Everything in database-land is 1-indexed, not 0-indexed.
-    auto query(std::string const& rawQuery) -> std::unique_ptr<sql::ResultSet>;
 } // namespace db


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Does some items in https://github.com/LandSandBoat/server/issues/5361

## Steps to test these changes

```cpp
    auto [rset, rowCount] = db::preparedStmtRowCount("UPDATE chars SET nation = ? WHERE charid = ?", 2, 1);
    ShowInfoFmt("rowCount: {}", rowCount);
```
