### PR TITLE
[world] Update influence in xi_world to not reset values on gain

### DIFF
--- a/src/world/conquest_system.cpp
+++ b/src/world/conquest_system.cpp
@@ -186,28 +186,24 @@ bool ConquestSystem::updateInfluencePoints(int points, unsigned int nation, REGI
         return false;
     }
 
-    int influences[4]{};
+    std::string query = "SELECT sandoria_influence, bastok_influence, windurst_influence, beastmen_influence FROM conquest_system WHERE region_id = %d";
 
+    auto rset = db::query(fmt::sprintf(query.c_str(), static_cast<uint8>(region)));
+    if (!rset || rset->rowsCount() == 0 || !rset->next())
     {
-        std::string query = "SELECT sandoria_influence, bastok_influence, windurst_influence, beastmen_influence FROM conquest_system WHERE region_id = %d";
+        return false;
+    }
 
-        auto rset = db::query(fmt::sprintf(query.c_str(), static_cast<uint8>(region)));
-        if (!rset || rset->rowsCount() == 0 || !rset->next())
-        {
-            return false;
-        }
+    int influences[4] = {
+        rset->getInt("sandoria_influence"),
+        rset->getInt("bastok_influence"),
+        rset->getInt("windurst_influence"),
+        rset->getInt("beastmen_influence"),
+    };
 
-        int influences[4] = {
-            rset->getInt("sandoria_influence"),
-            rset->getInt("bastok_influence"),
-            rset->getInt("windurst_influence"),
-            rset->getInt("beastmen_influence"),
-        };
-
-        if (influences[nation] == 5000)
-        {
-            return false;
-        }
+    if (influences[nation] == 5000)
+    {
+        return false;
     }
 
     auto lost = 0;
@@ -225,11 +221,11 @@ bool ConquestSystem::updateInfluencePoints(int points, unsigned int nation, REGI
 
     influences[nation] += lost;
 
-    auto rset = db::query(fmt::sprintf("UPDATE conquest_system SET sandoria_influence = %d, bastok_influence = %d, "
-                                       "windurst_influence = %d, beastmen_influence = %d WHERE region_id = %u",
-                                       influences[0], influences[1], influences[2], influences[3], static_cast<uint8>(region)));
+    auto rset2 = db::query(fmt::sprintf("UPDATE conquest_system SET sandoria_influence = %d, bastok_influence = %d, "
+                                        "windurst_influence = %d, beastmen_influence = %d WHERE region_id = %u",
+                                        influences[0], influences[1], influences[2], influences[3], static_cast<uint8>(region)));
 
-    return !rset;
+    return !rset2;
 }
 
 void ConquestSystem::updateWeekConquest()


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Decided to dig into #5419 myself.

Turning off world server stopped the influence reset, which led me to trace the logic from a `MSG_MAP2WORLD_REGIONAL_EVENT` message.

Found in [this commit](https://github.com/LandSandBoat/server/commit/07a9e09c1643054b507788922f9f932291636a47) the code that changed and noticed a duplicate definition of `int influences[4]`. The issue in #5419 is due to a scope inception where the code that runs is ignored and influences[4] is used with default values.

It's not clear to me why this wouldn't show nonzero influence for the nation gaining points with this bug, but this PR appears to fix it. I'm assuming the scheduled calculations ensure influence is not zero across the board?

## Steps to test these changes

Reset region_id 0's values in `conquest_system` table to zeroes in all 3 Nationcolumns and 5000 in beastmen
change job to level 1, give signet, and kill a mob in ronfaure
see influence update:
![image](https://github.com/LandSandBoat/server/assets/131182600/f5c3b6b1-1acb-47e9-8aa9-f7587c086219)
