### PR TITLE
[LUA] Fix players appear in Aht Urhgan fountain during ship arrival cutscenes

### DIFF
--- a/scripts/zones/Aht_Urhgan_Whitegate/Zone.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/Zone.lua
@@ -26,10 +26,13 @@ zoneObject.onZoneIn = function(player, prevZone)
         player:getZPos() == 0
     then
         if prevZone == xi.zone.OPEN_SEA_ROUTE_TO_AL_ZAHBI then
+            player:setPos(-11, 5, -142, 192)
             cs = 201
-        elseif prevZone == xi.zone.SILVER_SEA_ROUTE_TO_AL_ZAHBI then
-            cs = 204
-        elseif prevZone == xi.zone.SILVER_SEA_ROUTE_TO_NASHMAU then
+        elseif
+            prevZone == xi.zone.SILVER_SEA_ROUTE_TO_AL_ZAHBI or
+            prevZone == xi.zone.SILVER_SEA_ROUTE_TO_NASHMAU
+        then
+            player:setPos(11, 5, 142, 64)
             cs = 204
         else
             -- MOG HOUSE EXIT


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

When arriving into Aht Urhgan from a ship players initially appear at the default location (0, 0, 0) which coincidentally is inside of the fountain in the center of the city. While here they are able to be targeted by other players.

Instead of keeping them here we will instead place them underneath their intended arrival point so that they are not targetable by other players and load the general area they're supposed to first. Also cleans up a bit of the if/else logic since they use the same cutscene id.

The positions used are nearly identical to the actual position after the cutscene, however they are underneath the ground so they are not seen/targetable by other players. If we place them at the actual intended arrival position then they appear during the cutscene which looks a bit strange. If there is a more optimal position for this please let me know.

## Steps to test these changes

1. !zone Silver Sea route to Al Zahbi or !zone Open Sea route to Al Zahbi
2. !zone Aht Urhgan Whitegate or wait for the ship to dock
