### PR TITLE
[CPP] Fix party members area targetable in Mog House

### DIFF
--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -288,7 +288,10 @@ void CTargetFind::addAllInParty(CBattleEntity* PTarget, bool withPet)
     {
         static_cast<CCharEntity*>(PTarget)->ForPartyWithTrusts([this, withPet](CBattleEntity* PMember)
         {
-            addEntity(PMember, withPet);
+            if (!PMember->isInMogHouse())
+            {
+                addEntity(PMember, withPet);
+            }
         });
     }
     else

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -128,6 +128,16 @@ bool CBattleEntity::isInAssault()
     return false;
 }
 
+bool CBattleEntity::isInMogHouse()
+{
+    if (this->objtype == TYPE_PC)
+    {
+        return static_cast<CCharEntity*>(this)->m_moghouseID;
+    }
+
+    return false;
+}
+
 // return true if the mob has immunity
 bool CBattleEntity::hasImmunity(uint32 imID)
 {

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -567,6 +567,7 @@ public:
     bool isAlive();
     bool isInAssault();
     bool isInDynamis();
+    bool isInMogHouse();
     bool hasImmunity(uint32 imID);
     bool isAsleep();
     bool isMounted();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

When 2 characters are in a group together when one is inside a Mog House there is no check to prevent that character from being buffed or teleported by the other party member. This adds a checks and the necessary method to CBattleEntity to check if the current player character entity is inside of a Mog House. Fixes issue: https://github.com/LandSandBoat/server/issues/4789

## Steps to test these changes

1. Log in with 2 characters
2. Move one character as close to 0,0,0 as possible (easiest place is probably Aht Urhgan Whitegate next to the fountain !pos 10 0 10 50)
3. Move the other character inside the Mog House (!pos -100 0 -80 50 will put you close)
4. Both characters need to be in a party together
5. Use an area targetable ability or spell on the character outside (any -ra spells, teleports, job abilities, etc.)