### PR TITLE
Fix animation ID for newly added Jump ability in #5415

### DIFF
--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -746,7 +746,7 @@ INSERT INTO `mob_skills` VALUES (728,64,'sweet_breath',1,40.0,2000,1500,4,0,0,0,
 INSERT INTO `mob_skills` VALUES (730,438,'meikyo_shisui',0,7.0,2000,0,1,2,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (731,18,'mijin_gakure',1,20.0,2000,0,4,2,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (732,438,'call_wyvern',0,7.0,2000,0,1,2,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (733,477,'jump',0,9.5,2000,0,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (733,351,'jump',0,9.5,2000,0,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (734,438,'astral_flow',0,7.0,2000,0,1,2,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (735,19,'eagle_eye_shot',0,25.0,2000,0,4,2,0,0,0,0,0); -- goblin
 INSERT INTO `mob_skills` VALUES (736,20,'eagle_eye_shot',0,25.0,2000,0,4,2,0,0,0,0,0); -- antica


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
I missed updating this animation ID in #5415 

```
[Actor: 17125655 (Draketrader Zlodgodd)] Jump > Cat: 11 ID: 733 Anim: 351 Msg: 188

[Actor: 17125655 (Draketrader Zlodgodd)] Jump > Cat: 11 ID: 733 Anim: 351 Msg: 185

[Actor: 17125655 (Draketrader Zlodgodd)] Jump > Cat: 11 ID: 733 Anim: 351 Msg: 188

[Actor: 17125655 (Draketrader Zlodgodd)] Jump > Cat: 11 ID: 733 Anim: 351 Msg: 185

[Actor: 17125655 (Draketrader Zlodgodd)] Jump > Cat: 11 ID: 733 Anim: 351 Msg: 188

[Actor: 17125655 (Draketrader Zlodgodd)] Jump > Cat: 11 ID: 733 Anim: 351 Msg: 188

[Actor: 17125655 (Draketrader Zlodgodd)] Jump > Cat: 11 ID: 733 Anim: 351 Msg: 188

[Actor: 17125655 (Draketrader Zlodgodd)] Jump > Cat: 11 ID: 733 Anim: 351 Msg: 188

[Actor: 17125655 (Draketrader Zlodgodd)] Jump > Cat: 11 ID: 733 Anim: 351 Msg: 188

[Actor: 17125655 (Draketrader Zlodgodd)] Jump > Cat: 11 ID: 1064 Anim: 351 Msg: 188
```

## Steps to test these changes
!gotoid 17125655
!exec target:useMobAbility(733)

Jump animation will not appear janky.
