### PR TITLE
[cpp] Update sql syntax for offline tick effect loading from db

### DIFF
--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1562,7 +1562,7 @@ void CStatusEffectContainer::LoadStatusEffects()
 
             if (flags & EFFECTFLAG_OFFLINE_TICK)
             {
-                auto timestamp = _sql->GetUIntData(9);
+                auto timestamp = rset->getUInt("timestamp");
                 if (server_clock::now() < time_point() + std::chrono::seconds(timestamp) + std::chrono::seconds(duration))
                 {
                     duration = (uint32)std::chrono::duration_cast<std::chrono::seconds>(time_point() + std::chrono::seconds(timestamp) +


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Offline effects that continue ticking down aren't being loaded from the db properly due to the updated query call in this function.

## Steps to test these changes

- Go into dynamis, run `!exec print(player:getStatusEffect(xi.effect.DYNAMIS):getTimeRemaining())` (GM characters get the buff upon entry)
- you'll see something close to 1 hour
- log out and log back in
- run the command again, see that the duration ticked while offline (before this change you'd get a fresh duration)
