### PR TITLE
[CPP] Fix pet skills missing PrimaryTargetID

### DIFF
--- a/src/map/entities/petentity.cpp
+++ b/src/map/entities/petentity.cpp
@@ -506,6 +506,7 @@ void CPetEntity::OnPetSkillFinished(CPetSkillState& state, action_t& action)
     }
 
     PSkill->setTotalTargets(targets);
+    PSkill->setPrimaryTargetID(PTarget->id);
     PSkill->setTP(state.GetSpentTP());
     PSkill->setHPP(GetHPP());
 

--- a/src/map/lua/lua_petskill.cpp
+++ b/src/map/lua/lua_petskill.cpp
@@ -75,6 +75,11 @@ uint16 CLuaPetSkill::getTotalTargets()
     return m_PLuaPetSkill->getTotalTargets();
 }
 
+uint32 CLuaPetSkill::getPrimaryTargetID()
+{
+    return m_PLuaPetSkill->getPrimaryTargetID();
+}
+
 uint16 CLuaPetSkill::getMsg()
 {
     return m_PLuaPetSkill->getMsg();
@@ -121,6 +126,7 @@ void CLuaPetSkill::Register()
     SOL_REGISTER("getParam", CLuaPetSkill::getParam);
     SOL_REGISTER("getID", CLuaPetSkill::getID);
     SOL_REGISTER("getTotalTargets", CLuaPetSkill::getTotalTargets);
+    SOL_REGISTER("getPrimaryTargetID", CLuaPetSkill::getPrimaryTargetID);
     SOL_REGISTER("getTP", CLuaPetSkill::getTP);
     SOL_REGISTER("getMobHPP", CLuaPetSkill::getMobHPP);
 }

--- a/src/map/lua/lua_petskill.h
+++ b/src/map/lua/lua_petskill.h
@@ -52,6 +52,7 @@ public:
     void   setMsg(uint16 message);
     uint16 getMsg();
     uint16 getTotalTargets();
+    uint32 getPrimaryTargetID();
 
     bool operator==(const CLuaPetSkill& other) const
     {

--- a/src/map/petskill.cpp
+++ b/src/map/petskill.cpp
@@ -41,6 +41,7 @@ CPetSkill::CPetSkill(uint16 id)
 , m_TP(0)
 , m_HPP(0)
 , m_TotalTargets(1)
+, m_PrimaryTargetID(0)
 {
 }
 
@@ -105,6 +106,11 @@ void CPetSkill::setSkillFinishCategory(uint8 category)
 void CPetSkill::setTotalTargets(uint16 targets)
 {
     m_TotalTargets = targets;
+}
+
+void CPetSkill::setPrimaryTargetID(uint32 targid)
+{
+    m_PrimaryTargetID = targid;
 }
 
 void CPetSkill::setAnimationID(uint16 animID)
@@ -187,6 +193,11 @@ uint8 CPetSkill::getHPP() const
 uint16 CPetSkill::getTotalTargets() const
 {
     return m_TotalTargets;
+}
+
+uint32 CPetSkill::getPrimaryTargetID() const
+{
+    return m_PrimaryTargetID;
 }
 
 uint16 CPetSkill::getMsg() const

--- a/src/map/petskill.h
+++ b/src/map/petskill.h
@@ -53,6 +53,7 @@ public:
     int16  getTP() const;
     uint8  getHPP() const;
     uint16 getTotalTargets() const;
+    uint32 getPrimaryTargetID() const;
     uint16 getMsgForAction() const;
     float  getRadius() const;
     int16  getParam() const;
@@ -76,6 +77,7 @@ public:
     void setTP(int16 tp);
     void setHPP(uint8 hpp);
     void setTotalTargets(uint16 targets);
+    void setPrimaryTargetID(uint32 targid);
     void setParam(int16 value);
     void setKnockback(uint8 knockback);
     void setPrimarySkillchain(uint8 skillchain);
@@ -106,6 +108,7 @@ private:
     int16  m_TP;  // the tp at the time of finish readying (for scripts)
     uint8  m_HPP; // HPP at the time of using mob skill (for scripts)
     uint16 m_TotalTargets;
+    uint32 m_PrimaryTargetID; // primary target ID
 };
 
 #endif


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The following error occurs when attempting to use Astral Flow abilities on some Avatars:

```
[04/15/24 14:12:49:673][map][error] luautils::onPetAbility: ./scripts/globals/mobskills.lua:306: attempt to call method 'getPrimaryTargetID' (a nil value)
stack traceback:
	./scripts/globals/mobskills.lua:306: in function 'mobMagicalMove'
	./scripts/actions/abilities/pets/inferno.lua:18: in function <./scripts/actions/abilities/pets/inferno.lua:10> (luautils::OnPetAbility:4213)
```

Pet skills seems to be missing the primary target ID that was implemented in https://github.com/LandSandBoat/server/pull/5315. So this will just implement that so the error above no longer occurs.

## Steps to test these changes

1. !changejob 15 99
2. Summon Ifrit
3. Use Astral Flow
4. Use Inferno on a mob
