### PR TITLE
[lua] Instance Entry logic cleanup

### DIFF
--- a/scripts/globals/instance.lua
+++ b/scripts/globals/instance.lua
@@ -395,7 +395,18 @@ xi.instance.onEventUpdate = function(player, csid, option, npc)
         player:setLocalVar('INSTANCE_REQUESTED', 1)
     end
 
-    return player:getInstance() ~= nil
+    if
+        player:getInstance() ~= nil or
+        (player:getLocalVar('INSTANCE_REQUESTED') > 0 and
+        player:getLocalVar('INSTANCE_REQUESTED') < 10)
+    then
+        -- return true so we don't immediately call the cancel event update (since instances don't immediately load), but
+        -- increment variable to eventually return false if instance fails to load and trigger onInstanceCreatedCallback
+        player:setLocalVar('INSTANCE_REQUESTED', player:getLocalVar('INSTANCE_REQUESTED') + 1)
+        return true
+    else
+        return false
+    end
 end
 
 -- 'Default' behaviour. It's up to each instance whether or not they want to use this logic
@@ -440,10 +451,10 @@ xi.instance.onInstanceCreatedCallback = function(player, instance)
 
                 v:timer(35000, function(playerArg)
                     -- failsafe to bring all players into instance
-                    -- taking care not to shadow any existing variables
                     -- if a player doesn't receive the event packet, the whole party will be stuck in blackscreen
                     -- timer is destroyed if onEventFinish works properly and player gets zoned
                     -- a properly-functioning event loop will take 20s to zoning into the instance
+                    -- this _should_ be completely unnecessary due to the looping logic with INSTANCE_REQUESTED, but just in case
                     local instanceArg = playerArg:getInstance()
                     if instanceArg then
                         print(fmt('Player {} failed to cleanly transition into instance event, forcing entry via setPos.', playerArg:getName()))

--- a/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20m.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20m.lua
@@ -21,10 +21,11 @@ entity.onEventUpdate = function(player, csid, option, npc)
     -- Force the Nyzul Isle loop to bail out
     if xi.instance.onEventUpdate(player, csid, option, npc) then
         player:setLocalVar('NYZUL_INSTANCE', 1)
-    -- This was causing entry to fail out, and 116 to not be hit.  Handled inside
-    -- Path of Darkness instance script.
-    -- else
-    --     v:updateEvent(405, 3, 3, 3, 3, 3, 3, 3)
+    else
+        -- stops the loop of checking all party member requirements
+        -- and cleanly bails in onEventFinish
+        player:setLocalVar('NYZUL_INSTANCE', 0)
+        player:updateEvent(405, 3, 3, 3, 3, 3, 3, 3)
     end
 end
 

--- a/scripts/zones/Rala_Waterways/npcs/Antiquated_Sluice_Gate.lua
+++ b/scripts/zones/Rala_Waterways/npcs/Antiquated_Sluice_Gate.lua
@@ -16,6 +16,7 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
+    -- TODO if instance creation fails, the player will be stuck in a cutscene
     if xi.instance.onEventUpdate(player, csid, option, npc) then
         if csid == 5511 and option == 843 then
             print(1)

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -44,6 +44,7 @@ global_objects=(
 
     set
     printf
+    fmt
     switch
     getVanaMidnight
     getMidnight


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

### Issue 1
First off, instance entry requirement checks and join logic wasn't properly filtering on the zoneid of the initiator:
- a player could be in another zone in the same map process and if all players met requirements (key item check, mission progress, etc), the instance would start and all players in the party (within the map process) would be entered into the instance

### Fix 1
This PR fixes that by adding proper zoneid filters in both the `xi.instance.onEventUpdate` and `xi.instance.onInstanceCreatedCallback` player-party loops

### Issue 2
Second, and closely related, was the fact that the initiator wasn't always getting the proper event packets to get sent into the instance. This caused everyone in the party to be stuck at a black screen:
- initiator stuck at the runic portal in a black screen
- rest of the party stuck at a black screen inside of nyzul

![image](https://github.com/LandSandBoat/server/assets/131182600/3570fbcc-e415-45ff-9e4f-c55d24f59ac8)

### Fix 2
This PR "fixes" that by adding a catchall timer on every player that meets entry requirements after instance is confirmed created (inside of `xi.instance.onInstanceCreatedCallback`) to print to the map server and use `setPos` to send the player into the instance. This ensures that even parties with players getting incorrect event timings (or i assume client version issues that cause the events to not function properly) will eventually get into the instance and start the encounter

Also, small change was made to the _order_ of calling `setInstance` on players to always make the initiator (the `player` in the callback) the instance commander and also send the instance join event last to them. This appeasr to make the process work more cleanly to not cause `player:getEventTarget()` to return nil due to initiator being done with the initial cutscene. This issue is actually caught by the catchall 35s timer, but best to not let situations exist that can hit that

### Issue 3
Currently, there's commented code in the nyzul isle runic portal entrance (position `125, 0, 20` in alzadaal undersea ruins) that blocks the call to cancel the event. It is listed as having messed up entry to Path of Darkness instance. 

This causes the initiator's game to stay in the event forever while party members exist in the zone that don't meet the entry requirements

I started digging and found that the issue lies in `xi.instance.onEventUpdate` returning false if a player doesn't meet the entry requirements, but returns `player:getInstance() ~= nil` if the party does meet the requirements. This is a fundamental flaw as the `player:createInstance` call adds the instance to a queue to register the player into an instance. This is not instant.

### Fix 3
This PR fixes that by adding a counter to the logic in `xi.instance.onEventUpdate` to allow it to check a few times before failing out and returning false, which causes the initiator to drop out of the event, and updated nyzul runic portal to support the softer return logic in `xi.instance.onEventUpdate` (Note: every other call to this doesn't even check the requirements properly

### Notes
Note that the choice of 35s fallback timer and 9 checks for `player:getInstance() ~= nil` is arbitrary and best-effort to make a clean server-client interaction. These values could be updated of course. 

There would be a slight issue if 9 tries exited out, but then the instance eventually did the callback. ultimately the instance would load and bring all players in, but depending on how long that time between `createInstance` and the callback was, the player could run out of range, etc. The catchall that brings the player into the zone happens on the callback, so if the timing was too bad then a player could zone in and be included in the fight.

## Steps to test these changes

Testing that the entry logic to limit to same zone:
- create party of two members, edit `scripts\zones\Nyzul_Isle\instances\path_of_darkness.lua` to return true for `registryRequirements`
  - have one player stand at entrance to alz, other enter the runic portal. You'll get message that player is too far and cleanly exit event
  - have one player stand in aht urgan, other player can enter Path of Darkness no problem

Testing updated event timing to get all players into zone
- Have two members stand at the runic portal and enter the instance
  - have one or both run `!release` after the teleport animation starts
  - see that after 35s they get sent into instance anyway with a map server log

Testing the cleaner returns of `xi.instance.onEventUpdate`
- edit `scripts\globals\instance.lua` to comment out `player:createInstance(instanceId)`
  - This will cause the logic to work exactly the same, but we'll never get the callback from instance creation: `xi.instance.onInstanceCreatedCallback`
- enter like normal and see that after a bit of a wait, the player is returned to normal and entry event exits
  - adding prints to where we disabled `createInstance` as well as inside the `onEventUpdate` function, you'll see this in the map server log
![image](https://github.com/LandSandBoat/server/assets/131182600/a9b1db6b-1b5d-4acd-9b61-0b8ec2fa1a11)
![image](https://github.com/LandSandBoat/server/assets/131182600/af9110d8-cbd8-4775-bba8-c9d61b88ef4e)


A proper flow of entering with 2 members can hit this `xi.instance.onEventUpdate` function 3 times with a pretty beefy server setup:
![image](https://github.com/LandSandBoat/server/assets/131182600/08d3be4a-a6eb-45ef-a636-3cad3c5643f5)
Confirming the need to let this `player:getInstance() ~= nil` check be a little softer