### PR TITLE
[LUA] Fix Koyol-Futenol missing Pandemonium Queller title

### DIFF
--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Koyol-Futenol.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Koyol-Futenol.lua
@@ -88,6 +88,7 @@ local titleInfo =
             xi.title.MOON_CHARIOTEER,
             xi.title.BLOODY_BERSERKER,
             xi.title.THE_SIXTH_SERPENT,
+            xi.title.PANDEMONIUM_QUELLER,
             xi.title.OUPIRE_IMPALER,
             xi.title.HEIR_OF_THE_BLESSED_RADIANCE,
             xi.title.HEIR_OF_THE_BLIGHTED_GLOOM,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Koyol-Futenol is currently missing the Pandemonium Queller title which causes him to display the Oupire Impaler title as Pandemonium Queller instead. Adding the missing title results in both titles being properly 

## Steps to test these changes

1. !addtitle 549 (Pandemonium Queller)
2. !addtitle 558 (Oupire Impaler)
3. Update your title in some way (!addtitle doesn't properly update your char so the title changer won't list these titles unless you do this, killing an NM that gives a title worked most reliably for me)
4. !pos -129 2 -20 50
5. Both titles should be listed under 400 gil and properly update if selected

![image](https://github.com/LandSandBoat/server/assets/166072302/c060e403-43cd-41c4-8d5a-3c2cbb715393)
