### PR TITLE
[LUA] Lb2 mob pathing

### DIFF
--- a/scripts/zones/Xarcabard/mobs/Boreal_Coeurl.lua
+++ b/scripts/zones/Xarcabard/mobs/Boreal_Coeurl.lua
@@ -8,43 +8,87 @@ local ID = zones[xi.zone.XARCABARD]
 -----------------------------------
 local entity = {}
 
-local pathNodes = 
+local pathNodes =
 {
-    { x = 580.23, y = -9.68,  z = 290.94, }, -- 1 (Origin)
-    { x = 578.95, y = -10.00, z = 285.33, }, -- 2
-    { x = 581.13, y = -10.00, z = 274.86, }, -- 3
-    { x = 578.93, y = -9.52,  z = 268.83, }, -- 4
-    { x = 580.00, y = -10.00, z = 260.17, }, -- 5
-    { x = 578.93, y = -9.52,  z = 268.83, }, -- 4
-    { x = 581.13, y = -10.00, z = 274.86, }, -- 3
-    { x = 578.95, y = -10.00, z = 285.33, }, -- 2
-    { x = 580.23, y = -9.68,  z = 290.94, }, -- 1 (Origin)
+    { x = 578.95, y = -10,   z = 285.33 },
+    { x = 581.13, y = -10,   z = 274.86 },
+    { x = 581.11, y = -9.65, z = 290.31 },
+    { x = 578.95, y = -10,   z = 285.33 },
+    { x = 581.11, y = -9.65, z = 290.31 },
+    { x = 578.93, y = -9.52, z = 268.83 },
+    { x = 581.11, y = -9.65, z = 290.31 },
+    { x = 578.93, y = -9.52, z = 268.83 },
+    { x = 580,    y = -10,   z = 280.17 },
+    { x = 581.13, y = -10,   z = 274.86 },
 }
 
-entity.onMobSpawn = function(mob)
-    -- Failsafe to make sure NPC is down when NM is up
-    if xi.settings.main.OLDSCHOOL_G2 then
-        GetNPCByID(ID.npc.BOREAL_COEURL_QM):showNPC(0)
+local baseSpeed = 60
+local lookDelay = 600
+
+-- recursive if mob is waiting at path point
+local function rotateMob(mob)
+    if mob:getSpeed() == 0 then
+        local rotationDirection = mob:getLocalVar('rotationDirection')
+        local rotationChange = 6
+
+        if rotationDirection == 1 then
+            rotationChange = -1 * rotationChange
+        end
+
+        if math.random() < .25 then
+            rotationChange = 0
+            mob:setLocalVar('rotationDirection', (rotationDirection + 1) % 2)
+        end
+
+        mob:setRotation((mob:getPos()['rot'] + rotationChange) % 256)
+        mob:timer(lookDelay, function(mobArg)
+            rotateMob(mobArg)
+        end)
+    end
+end
+
+entity.onPathPoint = function(mob)
+    if math.random() < 0.5 then
+        mob:setSpeed(0)
+        mob:timer(math.random(4000, 8000), function(mobArg)
+            mobArg:setSpeed(baseSpeed)
+        end)
+
+        mob:timer(lookDelay, function(mobArg)
+            rotateMob(mobArg)
+        end)
     end
 end
 
 entity.onMobRoam = function(mob)
-    local PathingIndex = mob:getLocalVar('PathingIndex')
-    local ResumePathingIndex = mob:getLocalVar('ResumePathingIndex')
-    
-    if mob:isFollowingPath() then
-        mob:setLocalVar('ResumePathingIndex', os.time() + 4) -- Make sure mob is waiting 4 seconds to path after stopping
-    elseif (os.time() > ResumePathingIndex) then
-        if (math.random() > .25) then
-            PathingIndex = PathingIndex + math.random(1,3)
-        else
-            PathingIndex = PathingIndex - math.random(1,3)
+    local pathingIndex = mob:getLocalVar('pathingIndex')
+
+    if
+        not mob:isFollowingPath() and
+        mob:getSpeed() ~= 0
+    then
+        local pathFlag = xi.pathflag.SLIDE
+        if math.random() < .5 then
+            -- sometimes he runs between points
+            mob:setSpeed(baseSpeed * 1.5)
+            pathFlag = pathFlag + xi.pathflag.RUN
         end
-            
-        PathingIndex = utils.clamp(PathingIndex % #pathNodes, 1, #pathNodes) -- Keep PathingIndex between the valid range
-        mob:setLocalVar('PathingIndex', PathingIndex)
-        mob:setLocalVar('ResumePathingIndex', os.time() + 6) -- Make sure mob is waiting at least 6 seconds to path after it's last stop
-        mob:pathTo(pathNodes[PathingIndex].x, pathNodes[PathingIndex].y, pathNodes[PathingIndex].z, xi.path.flag.RUN)
+
+        pathingIndex = (pathingIndex + 1) % #pathNodes + 1 -- Keep PathingIndex between the valid range
+        mob:setLocalVar('pathingIndex', pathingIndex)
+        mob:pathTo(pathNodes[pathingIndex].x, pathNodes[pathingIndex].y, pathNodes[pathingIndex].z, pathFlag)
+    end
+end
+
+entity.onMobEngage = function(mob)
+    mob:setSpeed(baseSpeed)
+end
+
+entity.onMobSpawn = function(mob)
+    mob:setSpeed(baseSpeed)
+    -- Failsafe to make sure NPC is down when NM is up
+    if xi.settings.main.OLDSCHOOL_G2 then
+        GetNPCByID(ID.npc.BOREAL_COEURL_QM):showNPC(0)
     end
 end
 

--- a/scripts/zones/Xarcabard/mobs/Boreal_Coeurl.lua
+++ b/scripts/zones/Xarcabard/mobs/Boreal_Coeurl.lua
@@ -8,10 +8,43 @@ local ID = zones[xi.zone.XARCABARD]
 -----------------------------------
 local entity = {}
 
+local pathNodes = 
+{
+    { x = 580.23, y = -9.68,  z = 290.94, }, -- 1 (Origin)
+    { x = 578.95, y = -10.00, z = 285.33, }, -- 2
+    { x = 581.13, y = -10.00, z = 274.86, }, -- 3
+    { x = 578.93, y = -9.52,  z = 268.83, }, -- 4
+    { x = 580.00, y = -10.00, z = 260.17, }, -- 5
+    { x = 578.93, y = -9.52,  z = 268.83, }, -- 4
+    { x = 581.13, y = -10.00, z = 274.86, }, -- 3
+    { x = 578.95, y = -10.00, z = 285.33, }, -- 2
+    { x = 580.23, y = -9.68,  z = 290.94, }, -- 1 (Origin)
+}
+
 entity.onMobSpawn = function(mob)
     -- Failsafe to make sure NPC is down when NM is up
     if xi.settings.main.OLDSCHOOL_G2 then
         GetNPCByID(ID.npc.BOREAL_COEURL_QM):showNPC(0)
+    end
+end
+
+entity.onMobRoam = function(mob)
+    local PathingIndex = mob:getLocalVar('PathingIndex')
+    local ResumePathingIndex = mob:getLocalVar('ResumePathingIndex')
+    
+    if mob:isFollowingPath() then
+        mob:setLocalVar('ResumePathingIndex', os.time() + 4) -- Make sure mob is waiting 4 seconds to path after stopping
+    elseif (os.time() > ResumePathingIndex) then
+        if (math.random() > .25) then
+            PathingIndex = PathingIndex + math.random(1,3)
+        else
+            PathingIndex = PathingIndex - math.random(1,3)
+        end
+            
+        PathingIndex = utils.clamp(PathingIndex % #pathNodes, 1, #pathNodes) -- Keep PathingIndex between the valid range
+        mob:setLocalVar('PathingIndex', PathingIndex)
+        mob:setLocalVar('ResumePathingIndex', os.time() + 6) -- Make sure mob is waiting at least 6 seconds to path after it's last stop
+        mob:pathTo(pathNodes[PathingIndex].x, pathNodes[PathingIndex].y, pathNodes[PathingIndex].z, xi.path.flag.RUN)
     end
 end
 

--- a/scripts/zones/Xarcabard/mobs/Boreal_Hound.lua
+++ b/scripts/zones/Xarcabard/mobs/Boreal_Hound.lua
@@ -7,11 +7,48 @@
 local ID = zones[xi.zone.XARCABARD]
 -----------------------------------
 local entity = {}
+local pathNodes =
+{
+    { x = -22.73, y = -24.65, z = -496.18, }, --1 
+    { x = -21.28, y = -25.58, z = -490.78, }, --2 (Origin)
+    { x = -19.06, y = -26.00, z = -485.64, }, --3
+    { x = -19.69, y = -26.00, z = -479.90, }, --4
+    { x = -18.87, y = -25.38, z = -475.00, }, --5
+    { x = -19.82, y = -25.73, z = -473.84, }, --6
+    { x = -19.52, y = -26.40, z = -467.73, }, --7
+    { x = -21.14, y = -26.26, z = -463.24, }, --8
+    { x = -19.52, y = -26.40, z = -467.73, }, --7
+    { x = -19.82, y = -25.73, z = -473.84, }, --6
+    { x = -18.87, y = -25.38, z = -475.00, }, --5
+    { x = -19.69, y = -26.00, z = -479.90, }, --4
+    { x = -19.06, y = -26.00, z = -485.64, }, --3
+    { x = -21.28, y = -25.58, z = -490.78, }, --2 (Origin)
+}
 
 entity.onMobSpawn = function(mob)
     -- Failsafe to make sure NPC is down when NM is up
     if xi.settings.main.OLDSCHOOL_G2 then
         GetNPCByID(ID.npc.BOREAL_HOUND_QM):showNPC(0)
+    end
+end
+
+entity.onMobRoam = function(mob)
+    local PathingIndex = mob:getLocalVar('PathingIndex')
+    local ResumePathingIndex = mob:getLocalVar('ResumePathingIndex')
+    
+    if mob:isFollowingPath() then
+        mob:setLocalVar('ResumePathingIndex', os.time() + 4) -- Make sure mob is waiting 4 seconds to path after stopping
+    elseif (os.time() > ResumePathingIndex) then
+        if (math.random() > .25) then
+            PathingIndex = PathingIndex + math.random(1,3)
+        else
+            PathingIndex = PathingIndex - math.random(1,3)
+        end
+            
+        PathingIndex = utils.clamp(PathingIndex % #pathNodes, 1, #pathNodes) -- Keep PathingIndex between the valid range
+        mob:setLocalVar('PathingIndex', PathingIndex)
+        mob:setLocalVar('ResumePathingIndex', os.time() + 6) -- Make sure mob is waiting at least 6 seconds to path after it's last stop
+        mob:pathTo(pathNodes[PathingIndex].x, pathNodes[PathingIndex].y, pathNodes[PathingIndex].z, xi.path.flag.RUN)
     end
 end
 

--- a/scripts/zones/Xarcabard/mobs/Boreal_Hound.lua
+++ b/scripts/zones/Xarcabard/mobs/Boreal_Hound.lua
@@ -7,48 +7,90 @@
 local ID = zones[xi.zone.XARCABARD]
 -----------------------------------
 local entity = {}
+
 local pathNodes =
 {
-    { x = -22.73, y = -24.65, z = -496.18, }, --1 
-    { x = -21.28, y = -25.58, z = -490.78, }, --2 (Origin)
-    { x = -19.06, y = -26.00, z = -485.64, }, --3
-    { x = -19.69, y = -26.00, z = -479.90, }, --4
-    { x = -18.87, y = -25.38, z = -475.00, }, --5
-    { x = -19.82, y = -25.73, z = -473.84, }, --6
-    { x = -19.52, y = -26.40, z = -467.73, }, --7
-    { x = -21.14, y = -26.26, z = -463.24, }, --8
-    { x = -19.52, y = -26.40, z = -467.73, }, --7
-    { x = -19.82, y = -25.73, z = -473.84, }, --6
-    { x = -18.87, y = -25.38, z = -475.00, }, --5
-    { x = -19.69, y = -26.00, z = -479.90, }, --4
-    { x = -19.06, y = -26.00, z = -485.64, }, --3
-    { x = -21.28, y = -25.58, z = -490.78, }, --2 (Origin)
+    { x = -22.73, y = -24.65, z = -496.18 },
+    { x = -19.06, y = -26,    z = -485.64 },
+    { x = -19.69, y = -26,    z = -479.9 },
+    { x = -19.82, y = -25.73, z = -473.84 },
+    { x = -21.14, y = -26.26, z = -463.24 },
+    { x = -22.73, y = -24.65, z = -496.18 },
+    { x = -21.28, y = -25.58, z = -490.78 },
+    { x = -19.06, y = -26,    z = -485.64 },
+    { x = -19.69, y = -26,    z = -479.9 },
+    { x = -19.82, y = -25.73, z = -473.84 },
+    { x = -19.52, y = -26.4,  z = -467.73 },
+    { x = -21.14, y = -26.26, z = -463.24 },
 }
 
-entity.onMobSpawn = function(mob)
-    -- Failsafe to make sure NPC is down when NM is up
-    if xi.settings.main.OLDSCHOOL_G2 then
-        GetNPCByID(ID.npc.BOREAL_HOUND_QM):showNPC(0)
+local baseSpeed = 60
+local lookDelay = 600
+
+-- recursive if mob is waiting at path point
+local function rotateMob(mob)
+    if mob:getSpeed() == 0 then
+        local rotationDirection = mob:getLocalVar('rotationDirection')
+        local rotationChange = 6
+
+        if rotationDirection == 1 then
+            rotationChange = -1 * rotationChange
+        end
+
+        if math.random() < .25 then
+            rotationChange = 0
+            mob:setLocalVar('rotationDirection', (rotationDirection + 1) % 2)
+        end
+
+        mob:setRotation((mob:getPos()['rot'] + rotationChange) % 256)
+        mob:timer(lookDelay, function(mobArg)
+            rotateMob(mobArg)
+        end)
+    end
+end
+
+entity.onPathPoint = function(mob)
+    if math.random() < 0.5 then
+        mob:setSpeed(0)
+        mob:timer(math.random(4000, 8000), function(mobArg)
+            mobArg:setSpeed(baseSpeed)
+        end)
+
+        mob:timer(lookDelay, function(mobArg)
+            rotateMob(mobArg)
+        end)
     end
 end
 
 entity.onMobRoam = function(mob)
-    local PathingIndex = mob:getLocalVar('PathingIndex')
-    local ResumePathingIndex = mob:getLocalVar('ResumePathingIndex')
-    
-    if mob:isFollowingPath() then
-        mob:setLocalVar('ResumePathingIndex', os.time() + 4) -- Make sure mob is waiting 4 seconds to path after stopping
-    elseif (os.time() > ResumePathingIndex) then
-        if (math.random() > .25) then
-            PathingIndex = PathingIndex + math.random(1,3)
-        else
-            PathingIndex = PathingIndex - math.random(1,3)
+    local pathingIndex = mob:getLocalVar('pathingIndex')
+
+    if
+        not mob:isFollowingPath() and
+        mob:getSpeed() ~= 0
+    then
+        local pathFlag = xi.pathflag.SLIDE
+        if math.random() < .5 then
+            -- sometimes he runs between points
+            mob:setSpeed(baseSpeed * 1.5)
+            pathFlag = pathFlag + xi.pathflag.RUN
         end
-            
-        PathingIndex = utils.clamp(PathingIndex % #pathNodes, 1, #pathNodes) -- Keep PathingIndex between the valid range
-        mob:setLocalVar('PathingIndex', PathingIndex)
-        mob:setLocalVar('ResumePathingIndex', os.time() + 6) -- Make sure mob is waiting at least 6 seconds to path after it's last stop
-        mob:pathTo(pathNodes[PathingIndex].x, pathNodes[PathingIndex].y, pathNodes[PathingIndex].z, xi.path.flag.RUN)
+
+        pathingIndex = (pathingIndex + 1) % #pathNodes + 1 -- Keep PathingIndex between the valid range
+        mob:setLocalVar('pathingIndex', pathingIndex)
+        mob:pathTo(pathNodes[pathingIndex].x, pathNodes[pathingIndex].y, pathNodes[pathingIndex].z, pathFlag)
+    end
+end
+
+entity.onMobEngage = function(mob)
+    mob:setSpeed(baseSpeed)
+end
+
+entity.onMobSpawn = function(mob)
+    mob:setSpeed(baseSpeed)
+    -- Failsafe to make sure NPC is down when NM is up
+    if xi.settings.main.OLDSCHOOL_G2 then
+        GetNPCByID(ID.npc.BOREAL_HOUND_QM):showNPC(0)
     end
 end
 

--- a/scripts/zones/Xarcabard/mobs/Boreal_Tiger.lua
+++ b/scripts/zones/Xarcabard/mobs/Boreal_Tiger.lua
@@ -8,10 +8,46 @@ local ID = zones[xi.zone.XARCABARD]
 -----------------------------------
 local entity = {}
 
+local pathNodes =
+{
+    { x = 343.35, y = -28.87, z = 375.09, }, -- 1
+    { x = 341.02, y = -29.66, z = 370.29, }, -- 2 (Origin)
+    { x = 338.78, y = -30.00, z = 365.52, }, -- 3
+    { x = 339.92, y = -30.00, z = 358.61, }, -- 4
+    { x = 339.50, y = -30.39, z = 351.29, }, -- 5
+    { x = 340.52, y = -28.85, z = 343.67, }, -- 6
+    { x = 343.43, y = -28.58, z = 337.09, }, -- 7
+    { x = 340.52, y = -28.85, z = 343.67, }, -- 6
+    { x = 339.50, y = -30.39, z = 351.29, }, -- 5
+    { x = 339.92, y = -30.00, z = 358.61, }, -- 4
+    { x = 338.78, y = -30.00, z = 365.52, }, -- 3
+    { x = 341.02, y = -29.66, z = 370.29, }, -- 2 (Origin)
+}
+
 entity.onMobSpawn = function(mob)
     -- Failsafe to make sure NPC is down when NM is up
     if xi.settings.main.OLDSCHOOL_G2 then
         GetNPCByID(ID.npc.BOREAL_TIGER_QM):showNPC(0)
+    end
+end
+
+entity.onMobRoam = function(mob)
+    local PathingIndex = mob:getLocalVar('PathingIndex')
+    local ResumePathingIndex = mob:getLocalVar('ResumePathingIndex')
+    
+    if mob:isFollowingPath() then
+        mob:setLocalVar('ResumePathingIndex', os.time() + 4) -- Make sure mob is waiting 4 seconds to path after stopping
+    elseif (os.time() > ResumePathingIndex) then
+        if (math.random() > .25) then
+            PathingIndex = PathingIndex + math.random(1,3)
+        else
+            PathingIndex = PathingIndex - math.random(1,3)
+        end
+            
+        PathingIndex = utils.clamp(PathingIndex % #pathNodes, 1, #pathNodes) -- Keep PathingIndex between the valid range
+        mob:setLocalVar('PathingIndex', PathingIndex)
+        mob:setLocalVar('ResumePathingIndex', os.time() + 6) -- Make sure mob is waiting at least 6 seconds to path after it's last stop
+        mob:pathTo(pathNodes[PathingIndex].x, pathNodes[PathingIndex].y, pathNodes[PathingIndex].z, xi.path.flag.RUN)
     end
 end
 

--- a/scripts/zones/Xarcabard/mobs/Boreal_Tiger.lua
+++ b/scripts/zones/Xarcabard/mobs/Boreal_Tiger.lua
@@ -10,44 +10,82 @@ local entity = {}
 
 local pathNodes =
 {
-    { x = 343.35, y = -28.87, z = 375.09, }, -- 1
-    { x = 341.02, y = -29.66, z = 370.29, }, -- 2 (Origin)
-    { x = 338.78, y = -30.00, z = 365.52, }, -- 3
-    { x = 339.92, y = -30.00, z = 358.61, }, -- 4
-    { x = 339.50, y = -30.39, z = 351.29, }, -- 5
-    { x = 340.52, y = -28.85, z = 343.67, }, -- 6
-    { x = 343.43, y = -28.58, z = 337.09, }, -- 7
-    { x = 340.52, y = -28.85, z = 343.67, }, -- 6
-    { x = 339.50, y = -30.39, z = 351.29, }, -- 5
-    { x = 339.92, y = -30.00, z = 358.61, }, -- 4
-    { x = 338.78, y = -30.00, z = 365.52, }, -- 3
-    { x = 341.02, y = -29.66, z = 370.29, }, -- 2 (Origin)
+    { x = 339.5,  y = -30.39, z = 351.29 },
+    { x = 340.52, y = -28.85, z = 343.67 },
+    { x = 343.43, y = -28.58, z = 337.09 },
+    { x = 339.92, y = -30,    z = 358.61 },
+    { x = 338.78, y = -30,    z = 365.52 },
+    { x = 341.02, y = -29.66, z = 370.29 },
+    { x = 343.35, y = -28.87, z = 375.09 },
 }
 
-entity.onMobSpawn = function(mob)
-    -- Failsafe to make sure NPC is down when NM is up
-    if xi.settings.main.OLDSCHOOL_G2 then
-        GetNPCByID(ID.npc.BOREAL_TIGER_QM):showNPC(0)
+local baseSpeed = 60
+local lookDelay = 600
+
+-- recursive if mob is waiting at path point
+local function rotateMob(mob)
+    if mob:getSpeed() == 0 then
+        local rotationDirection = mob:getLocalVar('rotationDirection')
+        local rotationChange = 6
+
+        if rotationDirection == 1 then
+            rotationChange = -1 * rotationChange
+        end
+
+        if math.random() < .25 then
+            rotationChange = 0
+            mob:setLocalVar('rotationDirection', (rotationDirection + 1) % 2)
+        end
+
+        mob:setRotation((mob:getPos()['rot'] + rotationChange) % 256)
+        mob:timer(lookDelay, function(mobArg)
+            rotateMob(mobArg)
+        end)
+    end
+end
+
+entity.onPathPoint = function(mob)
+    if math.random() < 0.5 then
+        mob:setSpeed(0)
+        mob:timer(math.random(4000, 8000), function(mobArg)
+            mobArg:setSpeed(baseSpeed)
+        end)
+
+        mob:timer(lookDelay, function(mobArg)
+            rotateMob(mobArg)
+        end)
     end
 end
 
 entity.onMobRoam = function(mob)
-    local PathingIndex = mob:getLocalVar('PathingIndex')
-    local ResumePathingIndex = mob:getLocalVar('ResumePathingIndex')
-    
-    if mob:isFollowingPath() then
-        mob:setLocalVar('ResumePathingIndex', os.time() + 4) -- Make sure mob is waiting 4 seconds to path after stopping
-    elseif (os.time() > ResumePathingIndex) then
-        if (math.random() > .25) then
-            PathingIndex = PathingIndex + math.random(1,3)
-        else
-            PathingIndex = PathingIndex - math.random(1,3)
+    local pathingIndex = mob:getLocalVar('pathingIndex')
+
+    if
+        not mob:isFollowingPath() and
+        mob:getSpeed() ~= 0
+    then
+        local pathFlag = xi.pathflag.SLIDE
+        if math.random() < .5 then
+            -- sometimes he runs between points
+            mob:setSpeed(baseSpeed * 1.5)
+            pathFlag = pathFlag + xi.pathflag.RUN
         end
-            
-        PathingIndex = utils.clamp(PathingIndex % #pathNodes, 1, #pathNodes) -- Keep PathingIndex between the valid range
-        mob:setLocalVar('PathingIndex', PathingIndex)
-        mob:setLocalVar('ResumePathingIndex', os.time() + 6) -- Make sure mob is waiting at least 6 seconds to path after it's last stop
-        mob:pathTo(pathNodes[PathingIndex].x, pathNodes[PathingIndex].y, pathNodes[PathingIndex].z, xi.path.flag.RUN)
+
+        pathingIndex = (pathingIndex + 1) % #pathNodes + 1 -- Keep PathingIndex between the valid range
+        mob:setLocalVar('pathingIndex', pathingIndex)
+        mob:pathTo(pathNodes[pathingIndex].x, pathNodes[pathingIndex].y, pathNodes[pathingIndex].z, pathFlag)
+    end
+end
+
+entity.onMobEngage = function(mob)
+    mob:setSpeed(baseSpeed)
+end
+
+entity.onMobSpawn = function(mob)
+    mob:setSpeed(baseSpeed)
+    -- Failsafe to make sure NPC is down when NM is up
+    if xi.settings.main.OLDSCHOOL_G2 then
+        GetNPCByID(ID.npc.BOREAL_TIGER_QM):showNPC(0)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Continues the work of Nemisis in [this PR](https://github.com/LandSandBoat/server/pull/5271). He is still getting accustomed to LSB processes, learning git, and we discussed it would be better to collab and have me make the PR this time.

Closes https://github.com/LandSandBoat/server/issues/2850 .

Packet captures we collected while mounted, then analyzed.

All 3 NMs have this same basic behavior:
- path between a pretty tight area, to well-defined points that, while not perfectly repeating, repeat close enough to say that we should just cycle through them.
- Sometimes they ran between points, and sometimes they walked (seen by his speed in the packet cap)
- When arriving at a pathpoint
  - Sometimes stay for one packet, then move on. 
  - If they stay, they stay for 4-8 seconds while looking around, turning a little at a time

The `pathNodes` were generated by exporting each NM's packet capture to excel, splitting out the position data, and using formula trickery to find when the mobs arrived at a pathNode:

![image](https://github.com/LandSandBoat/server/assets/131182600/c13399aa-4c78-4ed7-8965-6441601c2c9b)

Filtered on "eq" and dumped that into a list of pathNodes. Then looked for the trend to repeat and snipped off the rest of the list.

The "look around" mechanic was witnessed as such while a mob's position didn't move:

![image](https://github.com/LandSandBoat/server/assets/131182600/f557d7dd-905f-43e4-ad5f-5039cb88b9f7)

So we came up with the following pathing flow:
- can't use a patrol path with waits, due to
  - `onPathPoint` being called _after_ a mob has waited
  - and because the captures show that waiting at a point is not pre-determined
- Pathing within `pathNodes` could be random, but since the list of points is so small and waiting at a point is random, we chose to simplify the rest of the logic
- When reaching a path node, it's decided if they should wait or not
  - If they wait, a timer is set for 4-8s to have them continue their path
  - while waiting, `rotateMob` is called every 600 ms to rotate a little bit
    - a small chance to not rotate and switch directions is there to match the retail behavior of mostly turning in the same direction, but changing on occasion
    - if we did truly random rotate direction then it would dart back and forth and look unnatural
- we set his base speed higher _sometimes_ when going to the next pathNode
  - `xi.pathflag.RUN` made him clip through things, so we used `xi.pathflag.SLIDE` so they didn't overshoot

## Steps to test these changes

Go to xarc, then go and witness each mob:
- `!gotoname Boreal_Tiger`
- `!gotoname Boreal_Coeurl`
- `!gotoname Boreal_Hound`

https://imgur.com/Fh4xc5S