### PR TITLE
[lua] Player avatar BPs give proper miss message and only physical miss from PD

### DIFF
--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -261,11 +261,18 @@ local attackTypeShields =
 }
 
 xi.summon.avatarFinalAdjustments = function(dmg, mob, skill, target, skilltype, damagetype, shadowbehav)
+    local missMessage = xi.msg.basic.SKILL_MISS
+    if mob:getCurrentAction() == xi.action.PET_MOBABILITY_FINISH then
+        missMessage = xi.msg.basic.JA_MISS_2
+    end
+
     -- Physical Attack Missed
     if
         skilltype == xi.attackType.PHYSICAL and
         dmg == 0
     then
+        skill:setMsg(missMessage)
+
         return 0
     end
 
@@ -325,10 +332,12 @@ xi.summon.avatarFinalAdjustments = function(dmg, mob, skill, target, skilltype, 
 
     -- handle pd
     if
-        target:hasStatusEffect(xi.effect.PERFECT_DODGE) or
-        target:hasStatusEffect(xi.effect.ALL_MISS) and
+        (target:hasStatusEffect(xi.effect.PERFECT_DODGE) or
+        target:hasStatusEffect(xi.effect.ALL_MISS)) and
         skilltype == xi.attackType.PHYSICAL
     then
+        skill:setMsg(missMessage)
+
         return 0
     end
 


### PR DESCRIPTION
Don't miss when magical abilities are against a PD target

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Player avatars simply do zero dmg when they miss from reasons other than simple accuracy checks. This resolves that with setting the proper miss message.

Also, Magical abilites were missing during PD due to a logic mistake with parenthesis

## Steps to test these changes

force a mob to use PD: `!exec player:getTarget():useMobAbility(xi.jsa.PERFECT_DODGE)`
![image](https://github.com/LandSandBoat/server/assets/131182600/bf46b90b-c915-4f07-beda-7da055109a2e)

and when tiamat goes in the air
![image](https://github.com/LandSandBoat/server/assets/131182600/e6b3778d-9e72-4032-ab26-af57c7e5cd0f)
