### PR TITLE
Fix logic for determining skill type for damage ratio

### DIFF
--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -108,33 +108,23 @@ void CAttack::SetCritical(bool value)
             }
         }
 
-        SKILLTYPE skilltype = SKILLTYPE::SKILL_NONE;
+        SKILLTYPE skilltype  = SKILLTYPE::SKILL_NONE;
+        SLOTTYPE  weaponSlot = static_cast<SLOTTYPE>(GetWeaponSlot());
 
         if (m_attacker->objtype == TYPE_PC)
         {
-            SLOTTYPE slot = SLOT_MAIN;
-
-            if (m_attackDirection == PHYSICAL_ATTACK_DIRECTION::RIGHTATTACK)
+            if (auto* weapon = dynamic_cast<CItemWeapon*>(m_attacker->m_Weapons[weaponSlot]))
             {
-                slot = SLOT_SUB;
+                skilltype = static_cast<SKILLTYPE>(weapon->getSkillType());
             }
-
-            if (m_attacker->objtype == TYPE_PC)
+            else
             {
-                if (auto* weapon = dynamic_cast<CItemWeapon*>(m_attacker->m_Weapons[slot]))
-                {
-                    skilltype = static_cast<SKILLTYPE>(weapon->getSkillType());
-                }
-                else
-                {
-                    skilltype = SKILLTYPE::SKILL_HAND_TO_HAND;
-                }
+                skilltype = SKILLTYPE::SKILL_HAND_TO_HAND;
             }
         }
 
         // need to pass the weapon slot because damage ratio depends on ATT which varies by slot
-        SLOTTYPE weaponSlot = static_cast<SLOTTYPE>(GetWeaponSlot());
-        m_damageRatio       = battleutils::GetDamageRatio(m_attacker, m_victim, m_isCritical, attBonus, skilltype, weaponSlot);
+        m_damageRatio = battleutils::GetDamageRatio(m_attacker, m_victim, m_isCritical, attBonus, skilltype, weaponSlot);
     }
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes an issue with the logic that determines the correct skill for use when calculating the damage ratio. Specifically, the current code has a transpositional error such that `m_attackDirection == PHYSICAL_ATTACK_DIRECTION::RIGHTATTACK` implies `SUB` slot while the `GetWeaponSlot` method implies the opposite. Thus currently on LSB when dual wielding the skill used for each hand is reversed and when with no sub weapon (no dual wield) the default `SKILL_NONE` is used for the main weapon rather than the actual skill.

This PR changes the code of `SetCritical` to directly use `GetWeaponSlot` so the logic is the same and thus the correct skill is used.

## Steps to test these changes
A bit difficult to test directly, one way is to add a showdebug statement to print out the skill type in `SetCritical` and then try different weapon types with both dual wielding and without, and notice that the correct skill type is used
