### PR TITLE
[login] Don't close file if file pointer is null

### DIFF
--- a/src/login/cert_helpers.h
+++ b/src/login/cert_helpers.h
@@ -37,8 +37,8 @@ namespace certificateHelpers
                 {
                     ShowInfo(fmt::format("Found existing login.key"));
                 }
+                fclose(fileHandle);
             }
-            fclose(fileHandle);
         }
 
         if (std::filesystem::exists("login.cert"))
@@ -62,7 +62,6 @@ namespace certificateHelpers
                         ShowWarning("Existing login.cert is not valid for the current time. Please regenerate or obtain a new certificate.");
                     }
                 }
-
                 fclose(fileHandle);
             }
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a potential crash on fclose if file is nullptr

## Steps to test these changes

Have expired cert, don't crash