### PR TITLE
[lua] Pet magic burst message and accbonus

### DIFF
--- a/scripts/actions/abilities/pets/aerial_blast.lua
+++ b/scripts/actions/abilities/pets/aerial_blast.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     local damage = 48 + (level * 8)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WIND)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WIND, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)
 
     summoner:setMP(0)

--- a/scripts/actions/abilities/pets/aero_ii.lua
+++ b/scripts/actions/abilities/pets/aero_ii.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     local damage = math.floor(45 + 0.025 * tp)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WIND)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WIND, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.WIND)

--- a/scripts/actions/abilities/pets/aero_iv.lua
+++ b/scripts/actions/abilities/pets/aero_iv.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     local damage = math.floor(325 + 0.025 * tp)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WIND)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WIND, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.WIND)

--- a/scripts/actions/abilities/pets/blizzard_ii.lua
+++ b/scripts/actions/abilities/pets/blizzard_ii.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     local damage = math.floor(45 + 0.025 * tp)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.ICE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.ICE)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.ICE, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.ICE, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.ICE)

--- a/scripts/actions/abilities/pets/blizzard_iv.lua
+++ b/scripts/actions/abilities/pets/blizzard_iv.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     local damage = math.floor(325 + 0.025 * tp)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.ICE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.ICE)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.ICE, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.ICE, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.ICE)

--- a/scripts/actions/abilities/pets/burning_strike.lua
+++ b/scripts/actions/abilities/pets/burning_strike.lua
@@ -20,7 +20,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     --get the resisted damage
     damage.dmg = damage.dmg * resist
     --add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
-    damage.dmg = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, 1)
+    damage.dmg = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.FIRE, petskill)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, petskill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     target:updateEnmityFromDamage(pet, totaldamage)

--- a/scripts/actions/abilities/pets/clarsach_call.lua
+++ b/scripts/actions/abilities/pets/clarsach_call.lua
@@ -17,7 +17,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
 
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WIND)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WIND, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)
 
     summoner:setMP(0)

--- a/scripts/actions/abilities/pets/diamond_dust.lua
+++ b/scripts/actions/abilities/pets/diamond_dust.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     local damage = 48 + (level * 8)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.ICE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.ICE)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.ICE, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.ICE, 1)
 
     summoner:setMP(0)

--- a/scripts/actions/abilities/pets/earthen_fury.lua
+++ b/scripts/actions/abilities/pets/earthen_fury.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     local damage = 48 + (level * 8)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.EARTH, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.EARTH)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.EARTH, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, 1)
 
     summoner:setMP(0)

--- a/scripts/actions/abilities/pets/fire_ii.lua
+++ b/scripts/actions/abilities/pets/fire_ii.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     local damage = math.floor(45 + 0.025 * tp)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.FIRE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.FIRE)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.FIRE, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.FIRE)

--- a/scripts/actions/abilities/pets/fire_iv.lua
+++ b/scripts/actions/abilities/pets/fire_iv.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     local damage = math.floor(325 + 0.025 * tp)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.FIRE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.FIRE)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.FIRE, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.FIRE)

--- a/scripts/actions/abilities/pets/flaming_crush.lua
+++ b/scripts/actions/abilities/pets/flaming_crush.lua
@@ -21,7 +21,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     --get the resisted damage
     damage.dmg = damage.dmg * resist
     --add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
-    damage.dmg = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, 1)
+    damage.dmg = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.FIRE, petskill)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, petskill, target, xi.attackType.PHYSICAL, xi.damageType.FIRE, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.FIRE)
     target:updateEnmityFromDamage(pet, totaldamage)

--- a/scripts/actions/abilities/pets/geocrush.lua
+++ b/scripts/actions/abilities/pets/geocrush.lua
@@ -27,7 +27,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     local damage = math.floor(512 + 1.72 * (tp + 1))
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.EARTH, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.EARTH)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.EARTH, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.EARTH)

--- a/scripts/actions/abilities/pets/grand_fall.lua
+++ b/scripts/actions/abilities/pets/grand_fall.lua
@@ -28,7 +28,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     local damage = math.floor(512 + 1.72 * (tp + 1))
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.WATER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WATER)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WATER, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.WATER, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.WATER)

--- a/scripts/actions/abilities/pets/heavenly_strike.lua
+++ b/scripts/actions/abilities/pets/heavenly_strike.lua
@@ -27,7 +27,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     local damage = math.floor(512 + 1.72 * (tp + 1))
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.ICE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.ICE)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.ICE, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.ICE, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.ICE)

--- a/scripts/actions/abilities/pets/howling_moon.lua
+++ b/scripts/actions/abilities/pets/howling_moon.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     local damage = 48 + (level * 8)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.DARK, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.DARK)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.DARK, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.DARK, 1)
 
     summoner:setMP(0)

--- a/scripts/actions/abilities/pets/inferno.lua
+++ b/scripts/actions/abilities/pets/inferno.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     local damage = 48 + (level * 8)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.FIRE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.FIRE)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.FIRE, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, 1)
 
     summoner:setMP(0)

--- a/scripts/actions/abilities/pets/judgment_bolt.lua
+++ b/scripts/actions/abilities/pets/judgment_bolt.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     local damage = 48 + (level * 8)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.THUNDER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.THUNDER)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.THUNDER, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.THUNDER, 1)
 
     summoner:setMP(0)

--- a/scripts/actions/abilities/pets/level_X_holy.lua
+++ b/scripts/actions/abilities/pets/level_X_holy.lua
@@ -28,7 +28,7 @@ abilityObject.onPetAbility = function(target, pet, skill, master, action)
     -- Only have an effect if target's level is divisible by die roll
     if target:getMainLvl() % power == 0 then
         local info = xi.mobskills.mobMagicalMove(pet, target, skill, basedmg, ele, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT, 10)
-        dmg = xi.mobskills.mobAddBonuses(pet, target, info.dmg, ele)
+        dmg = xi.mobskills.mobAddBonuses(pet, target, info.dmg, ele, skill)
         dmg = xi.summon.avatarFinalAdjustments(dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHT, 1)
 
         -- TODO: Magic burst?

--- a/scripts/actions/abilities/pets/meteor_strike.lua
+++ b/scripts/actions/abilities/pets/meteor_strike.lua
@@ -27,7 +27,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     local damage = math.floor(512 + 1.72 * (tp + 1))
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.FIRE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.FIRE)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.FIRE, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.FIRE)

--- a/scripts/actions/abilities/pets/nether_blast.lua
+++ b/scripts/actions/abilities/pets/nether_blast.lua
@@ -11,7 +11,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     local level = pet:getMainLvl()
     local damage = 5 * level + 10
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.element.DARK, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.DARK)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.DARK, skill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.DARK)

--- a/scripts/actions/abilities/pets/searing_light.lua
+++ b/scripts/actions/abilities/pets/searing_light.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
 
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.LIGHT, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.LIGHT)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.LIGHT, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.LIGHT, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.LIGHT)

--- a/scripts/actions/abilities/pets/somnolence.lua
+++ b/scripts/actions/abilities/pets/somnolence.lua
@@ -13,7 +13,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     local duration = 120
 
     dmg = dmg * resist
-    dmg = xi.mobskills.mobAddBonuses(pet, target, dmg, xi.element.DARK)
+    dmg = xi.mobskills.mobAddBonuses(pet, target, dmg, xi.element.DARK, skill)
 
     -- TODO: spell is nil here
     --dmg = finalMagicAdjustments(pet, target, spell, dmg)

--- a/scripts/actions/abilities/pets/sonic_buffet.lua
+++ b/scripts/actions/abilities/pets/sonic_buffet.lua
@@ -18,7 +18,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     local damage = math.floor(37.5 * (2.0 + 0.1 * tp / 150)) -- fTP starts at 2.0 and scales every 150 tp by .1 for a range of 2.0 to 4.0. Base value ballparked from retail.
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WIND)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WIND, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.WIND)

--- a/scripts/actions/abilities/pets/stone_ii.lua
+++ b/scripts/actions/abilities/pets/stone_ii.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     local damage = math.floor(45 + 0.025 * tp)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.EARTH, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.EARTH)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.EARTH, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.EARTH)

--- a/scripts/actions/abilities/pets/stone_iv.lua
+++ b/scripts/actions/abilities/pets/stone_iv.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
 
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.EARTH, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.EARTH)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.EARTH, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.EARTH)

--- a/scripts/actions/abilities/pets/thunder_ii.lua
+++ b/scripts/actions/abilities/pets/thunder_ii.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     local damage = math.floor(45 + 0.025 * tp)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.THUNDER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.THUNDER)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.THUNDER, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.THUNDER, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.THUNDER)

--- a/scripts/actions/abilities/pets/thunder_iv.lua
+++ b/scripts/actions/abilities/pets/thunder_iv.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     local damage = math.floor(325 + 0.025 * tp)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.THUNDER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.THUNDER)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.THUNDER, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.THUNDER, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.THUNDER)

--- a/scripts/actions/abilities/pets/thunderspark.lua
+++ b/scripts/actions/abilities/pets/thunderspark.lua
@@ -21,7 +21,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     --get the resisted damage
     damage.dmg = damage.dmg * resist
     --add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
-    damage.dmg = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, 1)
+    damage.dmg = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.THUNDER, petskill)
 
     local tp = pet:getTP()
     if tp < 1000 then

--- a/scripts/actions/abilities/pets/thunderstorm.lua
+++ b/scripts/actions/abilities/pets/thunderstorm.lua
@@ -27,7 +27,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     local damage = math.floor(512 + 1.72 * (tp + 1))
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.THUNDER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.THUNDER)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.THUNDER, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.THUNDER, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.THUNDER)

--- a/scripts/actions/abilities/pets/tidal_wave.lua
+++ b/scripts/actions/abilities/pets/tidal_wave.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     local damage = 48 + (level * 8)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.WATER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WATER)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WATER, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.WATER, 1)
 
     summoner:setMP(0)

--- a/scripts/actions/abilities/pets/tornado_ii.lua
+++ b/scripts/actions/abilities/pets/tornado_ii.lua
@@ -22,7 +22,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     local damage = math.floor(512 + 1.72 * (tp + 1))
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WIND)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WIND, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)
 
     pet:setTP(0) -- not possible to get Occult Acumen on avatars yet, so unable to determine if magical BPs can return TP.

--- a/scripts/actions/abilities/pets/water_ii.lua
+++ b/scripts/actions/abilities/pets/water_ii.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     local damage = math.floor(45 + 0.025 * tp)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.WATER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WATER)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WATER, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.WATER, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.WATER)

--- a/scripts/actions/abilities/pets/water_iv.lua
+++ b/scripts/actions/abilities/pets/water_iv.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
 
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.WATER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WATER)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WATER, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.WATER, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.WATER)

--- a/scripts/actions/abilities/pets/wind_blade.lua
+++ b/scripts/actions/abilities/pets/wind_blade.lua
@@ -28,7 +28,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     local damage = math.floor(512 + 1.72 * (tp + 1))
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WIND)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WIND, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.WIND)

--- a/scripts/actions/abilities/pets/zantetsuken.lua
+++ b/scripts/actions/abilities/pets/zantetsuken.lua
@@ -18,7 +18,7 @@ abilityObject.onPetAbility = function(target, pet, skill, master)
         end
 
         dmg = xi.mobskills.mobMagicalMove(pet, target, skill, dmg, xi.element.DARK, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-        dmg = xi.mobskills.mobAddBonuses(pet, target, dmg.dmg, xi.element.DARK)
+        dmg = xi.mobskills.mobAddBonuses(pet, target, dmg.dmg, xi.element.DARK, skill)
         dmg = xi.summon.avatarFinalAdjustments(dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, 1)
         target:takeDamage(dmg, pet, xi.attackType.MAGICAL, xi.damageType.DARK)
         target:updateEnmityFromDamage(pet, dmg)

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -288,15 +288,23 @@ xi.mobskills.mobMagicalMove = function(mob, target, skill, damage, element, dmgm
     local finaldmg = damage * mab * dmgmod
 
     -- get resistance
-    local avatarAccBonus = 0
+    local petAccBonus = 0
     if mob:isPet() and mob:getMaster() ~= nil then
         local master = mob:getMaster()
         if mob:isAvatar() then
-            avatarAccBonus = utils.clamp(master:getSkillLevel(xi.skill.SUMMONING_MAGIC) - master:getMaxSkillLevel(mob:getMainLvl(), xi.job.SMN, xi.skill.SUMMONING_MAGIC), 0, 200)
+            petAccBonus = utils.clamp(master:getSkillLevel(xi.skill.SUMMONING_MAGIC) - master:getMaxSkillLevel(mob:getMainLvl(), xi.job.SMN, xi.skill.SUMMONING_MAGIC), 0, 200)
+        end
+
+        local skillchainTier, _ = xi.magicburst.formMagicBurst(element, target)
+        if
+            mob:getPetID() > 0 and
+            skillchainTier > 0
+        then
+            petAccBonus = petAccBonus + 30
         end
     end
 
-    local resist       = xi.mobskills.applyPlayerResistance(mob, nil, target, mob:getStat(xi.mod.INT)-target:getStat(xi.mod.INT), avatarAccBonus, element)
+    local resist       = xi.mobskills.applyPlayerResistance(mob, nil, target, mob:getStat(xi.mod.INT)-target:getStat(xi.mod.INT), petAccBonus, element)
     local magicDefense = getElementalDamageReduction(target, element)
 
     finaldmg       = finaldmg * resist * magicDefense
@@ -337,7 +345,7 @@ xi.mobskills.applyPlayerResistance = function(mob, effect, target, diff, bonus, 
     return getMagicResist(p)
 end
 
-xi.mobskills.mobAddBonuses = function(caster, target, dmg, ele) -- used for SMN magical bloodpacts, despite the name.
+xi.mobskills.mobAddBonuses = function(caster, target, dmg, ele, skill) -- used for SMN magical bloodpacts, despite the name.
     local magicDefense = getElementalDamageReduction(target, ele)
     dmg = math.floor(dmg * magicDefense)
 
@@ -375,6 +383,14 @@ xi.mobskills.mobAddBonuses = function(caster, target, dmg, ele) -- used for SMN 
     dmg             = math.floor(dmg * dayWeatherBonus)
 
     local burst = calculateMobMagicBurst(caster, ele, target)
+    if
+        skill and
+        burst > 1.0 and
+        caster:getPetID() > 0 -- all pets except charmed pets can get magic burst message, but only with petskill action
+    then
+        skill:setMsg(xi.msg.basic.JA_MAGIC_BURST)
+    end
+
     dmg         = math.floor(dmg * burst)
 
     local mdefBarBonus = 0
@@ -485,7 +501,15 @@ xi.mobskills.mobFinalAdjustments = function(dmg, mob, skill, target, attackType,
 
     -- set message to damage
     -- this is for AoE because its only set once
-    skill:setMsg(xi.msg.basic.DAMAGE)
+    if
+        mob:getCurrentAction() == xi.action.PET_MOBABILITY_FINISH
+    then
+        if skill:getMsg() ~= xi.msg.basic.JA_MAGIC_BURST then
+            skill:setMsg(xi.msg.basic.USES_JA_TAKE_DAMAGE)
+        end
+    else
+        skill:setMsg(xi.msg.basic.DAMAGE)
+    end
 
     --Handle shadows depending on shadow behaviour / attackType
     if

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -300,7 +300,7 @@ xi.mobskills.mobMagicalMove = function(mob, target, skill, damage, element, dmgm
             mob:getPetID() > 0 and
             skillchainTier > 0
         then
-            petAccBonus = petAccBonus + 30
+            petAccBonus = petAccBonus + 25
         end
     end
 
@@ -501,9 +501,7 @@ xi.mobskills.mobFinalAdjustments = function(dmg, mob, skill, target, attackType,
 
     -- set message to damage
     -- this is for AoE because its only set once
-    if
-        mob:getCurrentAction() == xi.action.PET_MOBABILITY_FINISH
-    then
+    if mob:getCurrentAction() == xi.action.PET_MOBABILITY_FINISH then
         if skill:getMsg() ~= xi.msg.basic.JA_MAGIC_BURST then
             skill:setMsg(xi.msg.basic.USES_JA_TAKE_DAMAGE)
         end

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -278,9 +278,7 @@ xi.summon.avatarFinalAdjustments = function(dmg, mob, skill, target, skilltype, 
 
     -- set message to damage
     -- this is for AoE because its only set once
-    if
-        mob:getCurrentAction() == xi.action.PET_MOBABILITY_FINISH
-    then
+    if mob:getCurrentAction() == xi.action.PET_MOBABILITY_FINISH then
         if skill:getMsg() ~= xi.msg.basic.JA_MAGIC_BURST then
             skill:setMsg(xi.msg.basic.USES_JA_TAKE_DAMAGE)
         end

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -278,7 +278,15 @@ xi.summon.avatarFinalAdjustments = function(dmg, mob, skill, target, skilltype, 
 
     -- set message to damage
     -- this is for AoE because its only set once
-    skill:setMsg(xi.msg.basic.DAMAGE)
+    if
+        mob:getCurrentAction() == xi.action.PET_MOBABILITY_FINISH
+    then
+        if skill:getMsg() ~= xi.msg.basic.JA_MAGIC_BURST then
+            skill:setMsg(xi.msg.basic.USES_JA_TAKE_DAMAGE)
+        end
+    else
+        skill:setMsg(xi.msg.basic.DAMAGE)
+    end
 
     -- Handle shadows depending on shadow behaviour / skilltype
     dmg = utils.takeShadows(target, dmg, shadowbehav)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements "Magic Burst!" messages for smn petskills

The `JA_MAGIC_BURST` message is only valid for petskill-type actions, so as the rest of the smn abilities get moved over they will all get the message.

example of MB on the primary target
![image](https://github.com/LandSandBoat/server/assets/131182600/7c114ca9-2b81-4c26-b33a-0ca6bb45c2a6)

example of MB on secondary target
![image](https://github.com/LandSandBoat/server/assets/131182600/7fde1c96-cc27-4757-af3d-0b4332115185)

Nether blast message unchanged as it doesn't use the petskill action type yet (Note that it still gets bonus acc/damage)
![image](https://github.com/LandSandBoat/server/assets/131182600/c59b3b7d-6b1a-4b7b-a1a8-75648cb8167c)

Confirmed wyvern breaths already have the MB message, so the final thing would be jug pets for bst. None of these are moved to petskills as far as I know, but as they do this logic will catch them due to applying when `petID() >0` and `actionType== xi.action.PET_MOBABILITY_FINISH`

Bst Jug pets currently use mobskill lua files, so they (correctly) do not get the call to `xi.mobskills.mobAddBonuses`, but when they get reworked their lua should mimic avatar blood pact lua files and it should "just work"

Confirmation that bst jugs should magic burst from [this retail update](https://forum.square-enix.com/ffxi/threads/46068-Feb-19-2015-(JST)-Version-Update)
![image](https://github.com/LandSandBoat/server/assets/131182600/c9edf6cd-1954-4b50-b124-c201e59db7a8)

Note: this also fixes the default damage message for petskills, as they should be using `xi.msg.basic.USES_JA_TAKE_DAMAGE` instead of the mobskill/weaponskill `xi.msg.basic.DAMAGE` message id.

## Steps to test these changes

create skillchains and use various abilities to see you get magic burst if the elements match.
