### PR TITLE
[LUA] Fix BLU physical magic displays misses as 0 dmg

### DIFF
--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -285,6 +285,10 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
         hitsdone = hitsdone + 1
     end
 
+    if finaldmg <= 0 then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+    end
+
     return xi.spells.blue.applySpellDamage(caster, target, spell, finaldmg, params, trickAttackTarget)
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Currently when BLU use physical based magic and it misses it will display as doing 0 damage to a mob. Instead we'll display that the magic had no effect on the target to better indicate that the spell missed.

## Steps to test these changes

1. !changejob 16 99
2. !addallspells
3. Set some physical spells in town
4. Use a physical BLU spell on a mob