### PR TITLE
Adjust teleporters in Castle Zvahl Keep

### DIFF
--- a/scripts/zones/Castle_Zvahl_Keep/Zone.lua
+++ b/scripts/zones/Castle_Zvahl_Keep/Zone.lua
@@ -4,14 +4,15 @@
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
-    -- TODO: Change these trigger areas to radials.
-    zone:registerTriggerArea(1, -301, -50, -22, -297, -49, -17) -- central porter on map 3
-    zone:registerTriggerArea(2, -275, -54,   3, -271, -53,   7) -- NE porter on map 3
-    zone:registerTriggerArea(3, -275, -54, -47, -271, -53, -42) -- SE porter on map 3
-    zone:registerTriggerArea(4, -330, -54,   3, -326, -53,   7) -- NW porter on map 3
-    zone:registerTriggerArea(5, -328, -54, -47, -324, -53, -42) -- SW porter on map 3
-    zone:registerTriggerArea(6, -528, -74,  84, -526, -73,  89) -- N porter on map 4
-    zone:registerTriggerArea(7, -528, -74,  30, -526, -73,  36) -- S porter on map 4
+    -- TODO: Change these trigger areas to radials except 8, which already is.
+    zone:registerTriggerArea(1, -301, -50, -22, -297, -49, -17)    -- central porter on map 3
+    zone:registerTriggerArea(2, -275, -54,   3, -271, -53,   7)    -- NE porter on map 3
+    zone:registerTriggerArea(3, -275, -54, -47, -271, -53, -42)    -- SE porter on map 3
+    zone:registerTriggerArea(4, -330, -54,   3, -326, -53,   7)    -- NW porter on map 3
+    zone:registerTriggerArea(5, -328, -54, -47, -324, -53, -42)    -- SW porter on map 3
+    zone:registerTriggerArea(6, -528, -74,  84, -526, -73,  89)    -- N porter on map 4
+    zone:registerTriggerArea(7, -528, -74,  30, -526, -73,  36)    -- S porter on map 4
+    zone:registerTriggerArea(8, -459.9908, 2.5, 60.1056,  0, 0, 0) -- Hidden room porter on map 4
 
     xi.treasure.initZone(zone)
 end
@@ -37,17 +38,19 @@ end
 local teleportEventsByArea =
 {
     [1] = 0, -- Teleports player to far NE corner
-    [2] = 2, -- Teleports player to ??
-    [3] = 1, -- Teleports player to far SE corner
-    [4] = 1, -- Teleports player to far SE corner
-    [5] = 5, -- Teleports player to H-7 on map 4 (south or north part, randomly)
-    [6] = 6, -- Teleports player to position "A" on map 2
-    [7] = 7, -- Teleports player to position G-8 on map 2
+    [2] = 2, -- Teleports player to far SE corner
+    [3] = 1, -- Teleports player to far SW corner (from middle-SE porter)
+    [4] = 3, -- Teleports player to far SW corner (from middle-NW porter)
+    [5] = 4, -- Teleports player to the top of the stairs on map 4
+    [6] = 6, -- Teleports player to position to one of several random positions
+    [7] = 7, -- Teleports player to position to one of several random positions
+    [8] = 5, -- Teleports player to H-7 on map 4 platform near the ore door (south or north part randomly)
 }
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)
     local areaId = triggerArea:GetTriggerAreaID()
 
+    -- TODO: these should only work when matching floor spot is animated (beastmen/BCNM symbol)
     if teleportEventsByArea[areaId] then
         player:startCutscene(teleportEventsByArea[areaId])
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
I got on retail and compared each trigger and landing position to what we had. We were missing one entirely as well.

Closes #2889

Adds some missing TODOs for thinsg as well.

## Steps to test these changes
- `!zone 162`
- `!cs 0` and then run off the edge so that you start with center platform, which will correctly teleport you back to the northeast corner. go to each middle platform in order just like retail. last one will send you to the top of the stairs.
- once at the top of the stairs, you have several different portal you can go test: the hidden room before the ore door, which will send you to one of the 2 platforms by the ore down, and back down the stairs you will find yourself at the northwest corner and that portal will send you back to the southwest corner. My memory says it should have sent me back to the center, but retail tests proved my memory wrong.
- go back to the hidden room portal, but instead of stepping on it, alter your positional height up and down to see that the radial type never affects that set of coordinates on any other maps in the zone (I went up and down 600 yalms - I think we're safe). This test was needed because radial type trigger areas have no vertical restraints at all, they go on for infinity. **We should probably make one of the zero'd arguments a max distance arg and allow 0 to keep the current infinity behavior but that's a "not today and not Teo" problem.**

Packets confirm that 4 of the transports all have 1 cs id each, despite sharing positions they can dump you at. (1 and 3, 6 and 7). I used what retail did rather than reusing the same numbers.