### PR TITLE
[core] [lua] Fix drg subbing pup jank

### DIFF
--- a/scripts/actions/abilities/dismiss.lua
+++ b/scripts/actions/abilities/dismiss.lua
@@ -8,7 +8,9 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    return 0, 0
+    -- You can't actually use dismiss on retail unless your wyvern is up
+    -- This is on the pet menu, but just in case...
+    return xi.job_utils.dragoon.abilityCheckRequiresPet(player, target, ability, false)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -844,7 +844,10 @@ namespace charutils
         BuildingCharTraitsTable(PChar);
 
         // Order matters as this uses merits and JP gifts.
-        puppetutils::LoadAutomaton(PChar);
+        if (PChar->petZoningInfo.petID >= PETID_HARLEQUINFRAME && PChar->petZoningInfo.petID <= PETID_STORMWAKERFRAME)
+        {
+            puppetutils::LoadAutomaton(PChar);
+        }
 
         PChar->animation = (HP == 0 ? ANIMATION_DEATH : ANIMATION_NONE);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes #5440
Add check for if you have a wyvern when using dismiss

## Steps to test these changes

change job to drg/pup, zone into town with a wyvern, zone out and still have a wyvern
also be unable to use dismiss if you zone out with an automaton, unsure why it's in the JA list right now after zoning but I added a bandaid. DRG wyvern pet abilities just shouldn't be there after zoning with an automaton.