### PR TITLE
[Fix] Correct Iridescence bonus based on staff quality.

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -390,47 +390,38 @@ function getCureFinal(caster, spell, basecure, minCure, isBlueMagic)
     end
 
     local dayWeatherBonus = 1
-    local ele = spell:getElement()
+    local spellElement    = spell:getElement()
+    local castersWeather  = caster:getWeather()
 
-    local castersWeather = caster:getWeather()
+    -- Calculate Weather bonus + Iridescence bonus.
+    if
+        math.random(1, 100) <= 33 or
+        caster:getMod(elementalObi[spellElement]) >= 1
+    then
+        -- Strong weathers.
+        if castersWeather == xi.magic.singleWeatherStrong[spellElement] then
+            dayWeatherBonus = dayWeatherBonus + 0.1 + caster:getMod(xi.mod.IRIDESCENCE) * 0.05
+        elseif castersWeather == xi.magic.doubleWeatherStrong[spellElement] then
+            dayWeatherBonus = dayWeatherBonus + 0.25 + caster:getMod(xi.mod.IRIDESCENCE) * 0.05
 
-    if castersWeather == xi.magic.singleWeatherStrong[ele] then
-        if caster:getMod(xi.mod.IRIDESCENCE) >= 1 then
-            if math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 then
-                dayWeatherBonus = dayWeatherBonus + 0.10
-            end
-        end
-
-        if math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 then
-            dayWeatherBonus = dayWeatherBonus + 0.10
-        end
-    elseif castersWeather == xi.magic.singleWeatherWeak[ele] then
-        if math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 then
-            dayWeatherBonus = dayWeatherBonus - 0.10
-        end
-    elseif castersWeather == xi.magic.doubleWeatherStrong[ele] then
-        if caster:getMod(xi.mod.IRIDESCENCE) >= 1 then
-            if math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 then
-                dayWeatherBonus = dayWeatherBonus + 0.10
-            end
-        end
-
-        if math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 then
-            dayWeatherBonus = dayWeatherBonus + 0.25
-        end
-    elseif castersWeather == xi.magic.doubleWeatherWeak[ele] then
-        if math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 then
-            dayWeatherBonus = dayWeatherBonus - 0.25
+        -- Weak weathers.
+        elseif castersWeather == xi.magic.singleWeatherWeak[spellElement] then
+            dayWeatherBonus = dayWeatherBonus - 0.1 - caster:getMod(xi.mod.IRIDESCENCE) * 0.05
+        elseif castersWeather == xi.magic.doubleWeatherWeak[spellElement] then
+            dayWeatherBonus = dayWeatherBonus - 0.25 - caster:getMod(xi.mod.IRIDESCENCE) * 0.05
         end
     end
 
+    -- Calculate day element bonus.
     local dayElement = VanadielDayElement()
-    if dayElement == ele then
-        if math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 then
+
+    if
+        math.random(1, 100) <= 33 or
+        caster:getMod(elementalObi[spellElement]) >= 1
+    then
+        if dayElement == spellElement then
             dayWeatherBonus = dayWeatherBonus + 0.10
-        end
-    elseif dayElement == elementDescendant[ele] then
-        if math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 then
+        elseif dayElement == elementDescendant[spellElement] then
             dayWeatherBonus = dayWeatherBonus - 0.10
         end
     end
@@ -439,7 +430,13 @@ function getCureFinal(caster, spell, basecure, minCure, isBlueMagic)
         dayWeatherBonus = 1.4
     end
 
-    local final = math.floor(math.floor(math.floor(math.floor(basecure) * potency) * dayWeatherBonus) * rapture) * dSeal
+    -- Floor and return.
+    local final = math.floor(basecure)
+    final       = math.floor(final * potency)
+    final       = math.floor(final * dayWeatherBonus)
+    final       = math.floor(final * rapture)
+    final       = math.floor(final * dSeal)
+
     return final
 end
 

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -524,7 +524,7 @@ xi.spells.damage.calculateDayAndWeather = function(caster, spellId, spellElement
         isHelixSpell = true
     end
 
-    -- Calculate Weather bonus
+    -- Calculate Weather bonus + Iridescence bonus.
     if
         math.random(1, 100) <= 33 or
         caster:getMod(xi.combat.element.elementalObi[spellElement]) >= 1 or
@@ -532,15 +532,15 @@ xi.spells.damage.calculateDayAndWeather = function(caster, spellId, spellElement
     then
         -- Strong weathers.
         if weather == xi.combat.element.strongSingleWeather[spellElement] then
-            dayAndWeather = dayAndWeather + caster:getMod(xi.mod.IRIDESCENCE) * 0.1 + 0.1
+            dayAndWeather = dayAndWeather + 0.1 + caster:getMod(xi.mod.IRIDESCENCE) * 0.05
         elseif weather == xi.combat.element.strongDoubleWeather[spellElement] then
-            dayAndWeather = dayAndWeather + caster:getMod(xi.mod.IRIDESCENCE) * 0.1 + 0.25
+            dayAndWeather = dayAndWeather + 0.25 + caster:getMod(xi.mod.IRIDESCENCE) * 0.05
 
         -- Weak weathers.
         elseif weather == xi.combat.element.weakSingleWeather[spellElement] then
-            dayAndWeather = dayAndWeather - caster:getMod(xi.mod.IRIDESCENCE) * 0.1 - 0.1
+            dayAndWeather = dayAndWeather - 0.1 - caster:getMod(xi.mod.IRIDESCENCE) * 0.05
         elseif weather == xi.combat.element.weakDoubleWeather[spellElement] then
-            dayAndWeather = dayAndWeather - caster:getMod(xi.mod.IRIDESCENCE) * 0.1 - 0.25
+            dayAndWeather = dayAndWeather - 0.25 - caster:getMod(xi.mod.IRIDESCENCE) * 0.05
         end
     end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Makes Iridescence give the apropiate bonus (5% * staff quality), instead of a flat 10% no matter what.

## Steps to test these changes

Cast, preferably with an obi that forces weather bonuses, and an iridial or Chatoyant staff.
See potency actually vary.