### PR TITLE
[cpp] Update lvl restriction on sync target level up

### DIFF
--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -1237,6 +1237,7 @@ void CParty::RefreshSync()
         if (member->GetMLevel() != NewMLevel)
         {
             charutils::RemoveAllEquipMods(member);
+            member->m_LevelRestriction = NewMLevel;
             member->SetMLevel(NewMLevel);
             member->SetSLevel(member->jobs.job[member->GetSJob()]);
             charutils::ApplyAllEquipMods(member);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Updates the character property `m_LevelRestriction` for all members when the level sync target levels up.

Best i can tell this is only used for 
- blu spells to determine if the spell is valid to set 
- del experience points function to determine how much exp to lose on death
- leveling up to determine what the new level should be
  - I suspect before this PR's change if you were level 35, synced to 35, sync target levels to 36, then leveled up you would stay 35 until the sync leveled up again

## Steps to test these changes

Before change, sync to a lvl 35 player, have blu in the party, level the sync target to 36, see pinecone bomb as white in the blue spells menu, but you cannot set it

rezone see you can set it

compile these changes, see that you can set it without rezoning after leveling from 35 to 36