### PR TITLE
Move Maat battlefield win logic to Shattering Stars Quest

### DIFF
--- a/scripts/quests/jeuno/LB05_1_Shattering_Stars.lua
+++ b/scripts/quests/jeuno/LB05_1_Shattering_Stars.lua
@@ -16,6 +16,43 @@ quest.reward =
     title = xi.title.STAR_BREAKER,
 }
 
+local maatBattlefieldIds =
+{
+    [xi.zone.BALGAS_DAIS]        = { 101, 102, 103 },
+    [xi.zone.CHAMBER_OF_ORACLES] = { 194, 195, 196 },
+    [xi.zone.HORLAIS_PEAK]       = {   5,   6,   7 },
+    [xi.zone.QUBIA_ARENA]        = { 517, 518, 519 },
+    [xi.zone.WAUGHROON_SHRINE]   = {  70,  71,  72 },
+}
+
+local maatBattlefieldZone =
+{
+    onEventFinish =
+    {
+        [32001] = function(player, csid, option, npc)
+            local battlefieldWin = player:getLocalVar('battlefieldWin')
+
+            for _, battlefieldId in ipairs(maatBattlefieldIds[player:getZoneID()]) do
+                if battlefieldWin == battlefieldId then
+                    local jobId        = player:getMainJob()
+                    local maatsCapMask = player:getCharVar('maatsCap')
+
+                    if player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS) == QUEST_ACCEPTED then
+                        npcUtil.giveItem(player, xi.item.SCROLL_OF_INSTANT_WARP)
+                        quest:setVar(player, 'Prog', jobId)
+                    end
+
+                    if not utils.mask.getBit(maatsCapMask, jobId - 1) then
+                        player:setCharVar('maatsCap', utils.mask.setBit(maatsCapMask, jobId - 1, true))
+                    end
+
+                    player:addTitle(xi.title.MAAT_MASHER)
+                end
+            end
+        end,
+    },
+}
+
 quest.sections =
 {
     -- Section: Quest available.
@@ -105,6 +142,20 @@ quest.sections =
                 end,
             },
         },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status >= QUEST_ACCEPTED and
+                player:getMainJob() <= 15 and
+                player:getMainLvl() >= 66
+        end,
+
+        [xi.zone.BALGAS_DAIS]        = maatBattlefieldZone,
+        [xi.zone.CHAMBER_OF_ORACLES] = maatBattlefieldZone,
+        [xi.zone.HORLAIS_PEAK]       = maatBattlefieldZone,
+        [xi.zone.QUBIA_ARENA]        = maatBattlefieldZone,
+        [xi.zone.WAUGHROON_SHRINE]   = maatBattlefieldZone,
     },
 }
 

--- a/scripts/zones/Balgas_Dais/bcnms/shattering_stars.lua
+++ b/scripts/zones/Balgas_Dais/bcnms/shattering_stars.lua
@@ -18,6 +18,9 @@ end
 battlefieldObject.onBattlefieldLeave = function(player, battlefield, leavecode)
     if leavecode == xi.battlefield.leaveCode.WON then
         local _, clearTime, partySize = battlefield:getRecord()
+
+        player:setLocalVar('battlefieldWin', battlefield:getID())
+
         player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar('[cs]bit'), 0)
     elseif leavecode == xi.battlefield.leaveCode.LOST then
         player:startEvent(32002)
@@ -28,21 +31,6 @@ battlefieldObject.onEventUpdate = function(player, csid, option, npc)
 end
 
 battlefieldObject.onEventFinish = function(player, csid, option, npc)
-    if csid == 32001 then
-        local pjob = player:getMainJob()
-        local maatsCap = player:getCharVar('maatsCap')
-
-        if player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS) == QUEST_ACCEPTED then
-            npcUtil.giveItem(player, xi.item.SCROLL_OF_INSTANT_WARP)
-            player:setCharVar('Quest[3][132]Prog', pjob)
-        end
-
-        if not utils.mask.getBit(maatsCap, pjob - 1) then
-            player:setCharVar('maatsCap', utils.mask.setBit(maatsCap, pjob - 1, true))
-        end
-
-        player:addTitle(xi.title.MAAT_MASHER)
-    end
 end
 
 return battlefieldObject

--- a/scripts/zones/Chamber_of_Oracles/bcnms/shattering_stars.lua
+++ b/scripts/zones/Chamber_of_Oracles/bcnms/shattering_stars.lua
@@ -18,6 +18,9 @@ end
 battlefieldObject.onBattlefieldLeave = function(player, battlefield, leavecode)
     if leavecode == xi.battlefield.leaveCode.WON then
         local _, clearTime, partySize = battlefield:getRecord()
+
+        player:setLocalVar('battlefieldWin', battlefield:getID())
+
         player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar('[cs]bit'), 0)
     elseif leavecode == xi.battlefield.leaveCode.LOST then
         player:startEvent(32002)
@@ -28,21 +31,6 @@ battlefieldObject.onEventUpdate = function(player, csid, option, npc)
 end
 
 battlefieldObject.onEventFinish = function(player, csid, option, npc)
-    if csid == 32001 then
-        local pjob = player:getMainJob()
-        local maatsCap = player:getCharVar('maatsCap')
-
-        if player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS) == QUEST_ACCEPTED then
-            npcUtil.giveItem(player, xi.item.SCROLL_OF_INSTANT_WARP)
-            player:setCharVar('Quest[3][132]Prog', pjob)
-        end
-
-        if not utils.mask.getBit(maatsCap, pjob - 1) then
-            player:setCharVar('maatsCap', utils.mask.setBit(maatsCap, pjob - 1, true))
-        end
-
-        player:addTitle(xi.title.MAAT_MASHER)
-    end
 end
 
 return battlefieldObject

--- a/scripts/zones/Horlais_Peak/bcnms/shattering_stars.lua
+++ b/scripts/zones/Horlais_Peak/bcnms/shattering_stars.lua
@@ -17,6 +17,9 @@ end
 battlefieldObject.onBattlefieldLeave = function(player, battlefield, leavecode)
     if leavecode == xi.battlefield.leaveCode.WON then
         local _, clearTime, partySize = battlefield:getRecord()
+
+        player:setLocalVar('battlefieldWin', battlefield:getID())
+
         player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar('[cs]bit'), 0)
     elseif leavecode == xi.battlefield.leaveCode.LOST then
         player:startEvent(32002)
@@ -27,21 +30,6 @@ battlefieldObject.onEventUpdate = function(player, csid, option, npc)
 end
 
 battlefieldObject.onEventFinish = function(player, csid, option, npc)
-    if csid == 32001 then
-        local pjob = player:getMainJob()
-        local maatsCap = player:getCharVar('maatsCap')
-
-        if player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS) == QUEST_ACCEPTED then
-            npcUtil.giveItem(player, xi.item.SCROLL_OF_INSTANT_WARP)
-            player:setCharVar('Quest[3][132]Prog', pjob)
-        end
-
-        if not utils.mask.getBit(maatsCap, pjob - 1) then
-            player:setCharVar('maatsCap', utils.mask.setBit(maatsCap, pjob - 1, true))
-        end
-
-        player:addTitle(xi.title.MAAT_MASHER)
-    end
 end
 
 return battlefieldObject

--- a/scripts/zones/QuBia_Arena/bcnms/shattering_stars.lua
+++ b/scripts/zones/QuBia_Arena/bcnms/shattering_stars.lua
@@ -17,6 +17,9 @@ end
 battlefieldObject.onBattlefieldLeave = function(player, battlefield, leavecode)
     if leavecode == xi.battlefield.leaveCode.WON then
         local _, clearTime, partySize = battlefield:getRecord()
+
+        player:setLocalVar('battlefieldWin', battlefield:getID())
+
         player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar('[cs]bit'), 0)
     elseif leavecode == xi.battlefield.leaveCode.LOST then
         player:startEvent(32002)
@@ -27,21 +30,6 @@ battlefieldObject.onEventUpdate = function(player, csid, option, npc)
 end
 
 battlefieldObject.onEventFinish = function(player, csid, option, npc)
-    if csid == 32001 then
-        local pjob = player:getMainJob()
-        local maatsCap = player:getCharVar('maatsCap')
-
-        if player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS) == QUEST_ACCEPTED then
-            npcUtil.giveItem(player, xi.item.SCROLL_OF_INSTANT_WARP)
-            player:setCharVar('Quest[3][132]Prog', pjob)
-        end
-
-        if not utils.mask.getBit(maatsCap, pjob - 1) then
-            player:setCharVar('maatsCap', utils.mask.setBit(maatsCap, pjob - 1, true))
-        end
-
-        player:addTitle(xi.title.MAAT_MASHER)
-    end
 end
 
 return battlefieldObject

--- a/scripts/zones/Waughroon_Shrine/bcnms/shattering_stars.lua
+++ b/scripts/zones/Waughroon_Shrine/bcnms/shattering_stars.lua
@@ -18,6 +18,9 @@ end
 battlefieldObject.onBattlefieldLeave = function(player, battlefield, leavecode)
     if leavecode == xi.battlefield.leaveCode.WON then
         local _, clearTime, partySize = battlefield:getRecord()
+
+        player:setLocalVar('battlefieldWin', battlefield:getID())
+
         player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar('[cs]bit'), 0)
     elseif leavecode == xi.battlefield.leaveCode.LOST then
         player:startEvent(32002)
@@ -28,21 +31,6 @@ battlefieldObject.onEventUpdate = function(player, csid, option, npc)
 end
 
 battlefieldObject.onEventFinish = function(player, csid, option, npc)
-    if csid == 32001 then
-        local pjob = player:getMainJob()
-        local maatsCap = player:getCharVar('maatsCap')
-
-        if player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS) == QUEST_ACCEPTED then
-            npcUtil.giveItem(player, xi.item.SCROLL_OF_INSTANT_WARP)
-            player:setCharVar('Quest[3][132]Prog', pjob)
-        end
-
-        if not utils.mask.getBit(maatsCap, pjob - 1) then
-            player:setCharVar('maatsCap', utils.mask.setBit(maatsCap, pjob - 1, true))
-        end
-
-        player:addTitle(xi.title.MAAT_MASHER)
-    end
 end
 
 return battlefieldObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Moves the battlefield win event for Shattering Stars to the interaction framework quest script

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No changes should be observed
<!-- Clear and detailed steps to test your changes here -->
