### PR TITLE
[sql/lua] Avatar conditional mods from gear

### DIFF
--- a/scripts/globals/item_utils.lua
+++ b/scripts/globals/item_utils.lua
@@ -265,3 +265,26 @@ xi.itemUtils.removeMultipleEffects = function(target, effects, count, random)
         return removed
     end
 end
+
+-- for applying pet mods based on arbitrary conditions
+-- I.E. avatar attack only for a particular pet
+-- example usage in fervor_ring.lua
+-- can pass nil for petId to apply to all pets
+xi.itemUtils.handlePetLatentMods = function(owner, petId, mods, give)
+    local pet = owner:getPet()
+
+    if
+        pet and
+        (not petId or pet:getPetID() == petId)
+    then
+        if give then
+            for _, mod in ipairs(mods) do
+                pet:addMod(mod[1], mod[2])
+            end
+        else
+            for _, mod in ipairs(mods) do
+                pet:delMod(mod[1], mod[2])
+            end
+        end
+    end
+end

--- a/scripts/items/fervor_ring.lua
+++ b/scripts/items/fervor_ring.lua
@@ -1,0 +1,36 @@
+-----------------------------------
+-- ID: 11675
+-- Fervor Ring
+-- Pet mod via latent effect
+-----------------------------------
+local itemObject = {}
+local listenerName = 'PET_MOD_LATENT_11675'
+local latentPetId = xi.petId.IFRIT
+local latentMods =
+{
+    { xi.mod.MATT, 2 },
+}
+
+itemObject.onItemCheck = function(target)
+    return 0
+end
+
+itemObject.onItemEquip  = function(user, item)
+    xi.itemUtils.handlePetLatentMods(user, latentPetId, latentMods, true)
+
+    user:addListener('MAGIC_STATE_EXIT', listenerName, function(player, spell)
+        if
+            spell:getSpellGroup() == xi.magic.spellGroup.SUMMONING
+        then
+            xi.itemUtils.handlePetLatentMods(user, latentPetId, latentMods, true)
+        end
+    end)
+end
+
+itemObject.onItemUnequip = function(user, item)
+    xi.itemUtils.handlePetLatentMods(user, latentPetId, latentMods, false)
+
+    user:removeListener(listenerName)
+end
+
+return itemObject

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -169,9 +169,12 @@ INSERT INTO `item_latents` VALUES (11727,68,1,16,4);
 INSERT INTO `item_latents` VALUES (11727,68,1,16,5);
 INSERT INTO `item_latents` VALUES (11727,68,1,16,6);
 
+-- Diabolos's Rope
+INSERT INTO `item_latents` VALUES (11752,346,1,9,16);    -- Diabolos perpetuation cost -1
+
 -- Destrier Beret
-INSERT INTO `item_latents` VALUES (11811,64,1,50,31);   -- Combat Skill Gain +1
-INSERT INTO `item_latents` VALUES (11811,65,1,50,31);   -- Magic Skill Gain +1
+INSERT INTO `item_latents` VALUES (11811,64,1,50,31);    -- Combat Skill Gain +1
+INSERT INTO `item_latents` VALUES (11811,65,1,50,31);    -- Magic Skill Gain +1
 INSERT INTO `item_latents` VALUES (11811,76,12,50,31);   -- MOVE_SPEED_GEAR_BONUS +12%
 INSERT INTO `item_latents` VALUES (11811,369,1,50,31);   -- Adds "Refresh"
 INSERT INTO `item_latents` VALUES (11811,370,1,50,31);   -- Adds "Regen"
@@ -220,6 +223,10 @@ INSERT INTO `item_latents` VALUES (12402,384,100,8,14);  -- Wyvern Targe Latent 
 INSERT INTO `item_latents` VALUES (12403,2,10,8,15);
 INSERT INTO `item_latents` VALUES (12403,5,5,8,15);
 INSERT INTO `item_latents` VALUES (12461,369,1,13,4);
+
+-- Accord Hat
+INSERT INTO `item_latents` VALUES (12493,346,1,9,9); -- Fenrir perpetuation cost -1
+
 INSERT INTO `item_latents` VALUES (12589,370,2,13,3);
 INSERT INTO `item_latents` VALUES (12621,370,2,13,3);
 INSERT INTO `item_latents` VALUES (12717,71,5,13,6);
@@ -756,7 +763,8 @@ INSERT INTO `item_latents` VALUES (14055,23,7,1,75);     -- Attack+7 when HP >75
 -- Unicorn Mittens +1
 INSERT INTO `item_latents` VALUES (14056,23,8,1,75);     -- Attack+8 when HP >75%
 
-INSERT INTO `item_latents` VALUES (14062,346,0,9,8);
+-- Carbunle Mitts
+INSERT INTO `item_latents` VALUES (14062,346,0,9,8);     -- Perpetuation placeholder (real logic is in status_effect_container.cpp)
 
 -- Garden Bangles / Feronia's Bangles
 INSERT INTO `item_latents` VALUES (14065,370,1,26,0);    -- Daytime: Regen +1HP/tick
@@ -905,8 +913,11 @@ INSERT INTO `item_latents` VALUES (14363,5,20,53,0);     -- MP +20 in areas insi
 -- Rasetsu Samue
 INSERT INTO `item_latents` VALUES (14376,291,1,0,25);    -- Counter+1 when HP <25%
 
-INSERT INTO `item_latents` VALUES (14401,346,1,9,7);
-INSERT INTO `item_latents` VALUES (14410,346,1,9,6);
+-- Duende Cotehardie
+INSERT INTO `item_latents` VALUES (14401,346,1,9,7);     -- Dark Spirit perpetuation -1
+
+-- Nimbus Doublet
+INSERT INTO `item_latents` VALUES (14410,346,1,9,6);     -- Light Spirit perpetuation -1
 
 -- Gaudy Harness
 INSERT INTO `item_latents` VALUES (14413,369,1,5,49);    -- "Refresh" effect while MP under 49 (actual number,not %)
@@ -2769,6 +2780,9 @@ INSERT INTO `item_latents` VALUES (23804,416,5,30,0);    -- Watersday: NULL_PHYS
 INSERT INTO `item_latents` VALUES (23804,476,5,30,0);    -- Watersday: MAGIC_NULL 5% chance
 INSERT INTO `item_latents` VALUES (23804,958,25,30,0);   -- Watersday: STATUSRES +20
 -- TODO: "Occasionaly null breath dmg" OR "Occasionally null all damage"
+
+-- Carbie Cap +1
+INSERT INTO `item_latents` VALUES (25633,346,1,9,8);     -- Carbuncle perpetuation -1
 
 INSERT INTO `item_latents` VALUES (27342,63,10,13,64);   -- Fallen's Sollerets,"Last Resort"+1
 INSERT INTO `item_latents` VALUES (27343,63,10,13,64);   -- Fallen's Sollerets +1,"Last Resort"+1

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -58884,6 +58884,9 @@ INSERT INTO `item_mods` VALUES (25629,68,36);    -- EVA: 36
 INSERT INTO `item_mods` VALUES (25629,161,-500); -- DMGPHYS: -500
 INSERT INTO `item_mods` VALUES (25629,384,700);  -- HASTE_GEAR: 700
 
+-- Carbie Cap +1
+INSERT INTO `item_mods` VALUES (25633,1,2);  -- DEF: 2
+
 -- Terminal Helm
 INSERT INTO `item_mods` VALUES (25634,1,111);    -- DEF: 111
 INSERT INTO `item_mods` VALUES (25634,2,41);     -- HP: 41


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The first commit is cleanup of a few simple latents based on a particular avatar being out
- [Carbie Cap +1](https://www.bg-wiki.com/ffxi/Carbie_Cap_%2B1)
- [Diabolos's Rope](https://www.bg-wiki.com/ffxi/Diabolos%27s_Rope)
- [Accord Hat](https://www.bg-wiki.com/ffxi/Accord_Hat)

In auditing these pet-specific items, I ran across the issue mentioned in https://github.com/LandSandBoat/server/issues/3627 , this PR attempts to make a method of applying pet-based mods via arbitrary conditionals using the item lua file

A working example of [Fervor Ring](https://www.bg-wiki.com/ffxi/Fervor_Ring) is in the 2nd commit

Remaining items would be:
- [Evoker's Gages](https://www.bg-wiki.com/ffxi/Evoker%27s_Gages)
- [Karura Hachigane](https://www.bg-wiki.com/ffxi/Karura_Hachigane)
- [Morana Pigaches](https://www.bg-wiki.com/ffxi/Morana_Pigaches)
- [Fenrir's Crown](https://www.bg-wiki.com/ffxi/Fenrir%27s_Crown)
- [Affinity](https://www.bg-wiki.com/ffxi/Affinity_Earring)/[Fidelity](https://www.bg-wiki.com/ffxi/Fidelity_Earring) Earring
  - I imagine the function in `xi.itemUtils` would not be needed here, since it applies to all pets. Just need a simple `player:addPetMod(` and `player:delPetMod(` when the conditions are met/lost. The trick would be in determining the conditions. a `TICK` listener with a localvar could definitely do it
  - These would be a little more complex, and I think out of scope for this PR

There are very few pieces of gear with these restrictive conditions and this lua method works. Gauging responses before I code the rest of the items

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
