### PR TITLE
[lua] Fix incorrect zone ID table

### DIFF
--- a/scripts/zones/Grauberg_[S]/npcs/Indescript_Markings.lua
+++ b/scripts/zones/Grauberg_[S]/npcs/Indescript_Markings.lua
@@ -17,7 +17,7 @@ entity.onTrigger = function(player, npc)
 
     -- SCH AF Quest - Boots
     if
-        npc:getID() == ID.npcs.INDESCRIPT_MARKINGS and -- Second markings are bcnm entrance
+        npc:getID() == ID.npc.INDESCRIPT_MARKINGS and -- Second markings are bcnm entrance
         gownQuestProgress > 0 and
         gownQuestProgress < 3 and
         not player:hasKeyItem(xi.ki.SAMPLE_OF_GRAUBERG_CHERT)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

My previous PR to clean up the sch af indescript markings left this typo to the table:

![image](https://github.com/LandSandBoat/server/assets/131182600/3402c4c2-225f-4b56-bc46-f72068d91bc1)

Apologies for that. It was the last one I fixed and obviously didn't test after putting that final restriction due to there being a second Markings in the zone

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
