### PR TITLE
[LUA] Fix mob skills that bind instantly clearing effect

### DIFF
--- a/scripts/actions/mobskills/bad_breath.lua
+++ b/scripts/actions/mobskills/bad_breath.lua
@@ -22,7 +22,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.15, 3, xi.element.EARTH, 500)
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.EARTH, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
-    target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.EARTH)
+    target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.EARTH, { breakBind = false })
 
     return dmg
 end

--- a/scripts/actions/mobskills/binding_microtube.lua
+++ b/scripts/actions/mobskills/binding_microtube.lua
@@ -15,7 +15,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 2.45
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 5, xi.element.NONE, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.NONE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
-    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.NONE)
+    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.NONE, { breakBind = false })
     return dmg
 end
 

--- a/scripts/actions/mobskills/blastbomb.lua
+++ b/scripts/actions/mobskills/blastbomb.lua
@@ -14,7 +14,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.FIRE, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
-    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.FIRE)
+    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.FIRE, { breakBind = false })
     return dmg
 end
 

--- a/scripts/actions/mobskills/cold_breath.lua
+++ b/scripts/actions/mobskills/cold_breath.lua
@@ -16,7 +16,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.2, 0.75, xi.element.ICE, 600)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.ICE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
-    target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.ICE)
+    target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.ICE, { breakBind = false })
     return dmg
 end
 

--- a/scripts/actions/mobskills/dragonfall.lua
+++ b/scripts/actions/mobskills/dragonfall.lua
@@ -24,7 +24,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 30)
 
-    target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
+    target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING, { breakBind = false })
     return dmg
 end
 

--- a/scripts/actions/mobskills/entangle.lua
+++ b/scripts/actions/mobskills/entangle.lua
@@ -35,7 +35,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
         mob:resetEnmity(target)
-        target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
+        target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING, { breakBind = false })
         skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 30))
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, 50, 0, 60)
 

--- a/scripts/actions/mobskills/homing_missle.lua
+++ b/scripts/actions/mobskills/homing_missle.lua
@@ -19,7 +19,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         dmg = targetcurrentHP - hpset
     end
 
-    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.ELEMENTAL)
+    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.ELEMENTAL, { breakBind = false })
     return dmg
 end
 

--- a/scripts/actions/mobskills/hyper_pulse.lua
+++ b/scripts/actions/mobskills/hyper_pulse.lua
@@ -22,7 +22,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 4)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.WEIGHT, 50, 0, 30)
 
-    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.DARK)
+    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.DARK, { breakBind = false })
     return dmg
 end
 

--- a/scripts/actions/mobskills/ice_break.lua
+++ b/scripts/actions/mobskills/ice_break.lua
@@ -14,7 +14,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.ICE, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.ICE, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
-    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.ICE)
+    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.ICE, { breakBind = false })
     return dmg
 end
 

--- a/scripts/actions/mobskills/inertia_stream.lua
+++ b/scripts/actions/mobskills/inertia_stream.lua
@@ -14,7 +14,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 2
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.ICE, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.damageType.MAGICAL, xi.attackType.ICE, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
-    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.EARTH)
+    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.EARTH, { breakBind = false })
     return dmg
 end
 

--- a/scripts/actions/mobskills/lethe_arrows.lua
+++ b/scripts/actions/mobskills/lethe_arrows.lua
@@ -21,7 +21,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 120)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.AMNESIA, 1, 0, 120)
 
-    target:takeDamage(dmg, mob, xi.attackType.RANGED, xi.damageType.PIERCING)
+    target:takeDamage(dmg, mob, xi.attackType.RANGED, xi.damageType.PIERCING, { breakBind = false })
     return dmg
 end
 

--- a/scripts/actions/mobskills/pile_pitch.lua
+++ b/scripts/actions/mobskills/pile_pitch.lua
@@ -14,7 +14,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local damage = currentHP * .90
     local dmg = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.NONE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 30)
-    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.NONE)
+    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.NONE, { breakBind = false })
     mob:resetEnmity(target)
     return dmg
 end

--- a/scripts/actions/mobskills/pl_vulcanian_impact.lua
+++ b/scripts/actions/mobskills/pl_vulcanian_impact.lua
@@ -24,7 +24,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         dmg = targetcurrentHP - hpset
     end
 
-    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.FIRE)
+    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.FIRE, { breakBind = false })
     return dmg
 end
 

--- a/scripts/actions/mobskills/pleiades_ray.lua
+++ b/scripts/actions/mobskills/pleiades_ray.lua
@@ -32,7 +32,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, duration)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 1250, 0, duration)
 
-    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.FIRE)
+    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.FIRE, { breakBind = false })
     return dmg
 end
 

--- a/scripts/actions/mobskills/rail_cannon_1.lua
+++ b/scripts/actions/mobskills/rail_cannon_1.lua
@@ -14,7 +14,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.LIGHT, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHT, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
-    target:delHP(dmg)
+    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.LIGHT, { breakBind = false })
     return dmg
 end
 

--- a/scripts/actions/mobskills/rail_cannon_2.lua
+++ b/scripts/actions/mobskills/rail_cannon_2.lua
@@ -14,7 +14,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.LIGHT, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHT, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
-    target:delHP(dmg)
+    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.LIGHT, { breakBind = false })
     return dmg
 end
 

--- a/scripts/actions/mobskills/rail_cannon_3.lua
+++ b/scripts/actions/mobskills/rail_cannon_3.lua
@@ -14,7 +14,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.LIGHT, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHT, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
-    target:delHP(dmg)
+    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.LIGHT, { breakBind = false })
     return dmg
 end
 

--- a/scripts/actions/mobskills/regurgitation.lua
+++ b/scripts/actions/mobskills/regurgitation.lua
@@ -16,7 +16,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.WATER, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
-    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.WATER)
+    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.WATER, { breakBind = false })
     return dmg
 end
 

--- a/scripts/actions/mobskills/zephyr_arrow.lua
+++ b/scripts/actions/mobskills/zephyr_arrow.lua
@@ -19,7 +19,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 5
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.RANGED, xi.damageType.PIERCING, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
-    target:takeDamage(dmg, mob, xi.attackType.RANGED, xi.damageType.PIERCING)
+    target:takeDamage(dmg, mob, xi.attackType.RANGED, xi.damageType.PIERCING, { breakBind = false })
     return dmg
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Currently when a mob uses a skill that causes a bind and also deals damage the bind status effect instantly clears due to the damage taken. There's already an existing flag for takeDamage to prevent it from removing bind so we'll just utilize that for each mob skill that both binds and deals damage.

## Steps to test these changes

1. Find a mob
2. !exec target:useMobAbility(X)

Bad Breath - 319/727
Binding Microtube - 3468
Blastbomb - 638
Cold Breath - 349
Dragonfall - 937
Entangle - 332
Homing Missile - 2058
Hyper Pulse - 1237
Ice Break - 676
Inertia Stream - no ID/record exists in mob_skills.sql
Lethe Arrows - 2194
Pile Pitch - 1235
PL Vulcanian Impact - 594
Pleiades Ray - 1807
Rail Cannon 1 - 2051
Rail Cannon 2 - 2048
Rail Cannon 3 - 2045
Regurgitation - 2153
Zephyr Arrow - 2193