### PR TITLE
[lua] Chi blast is now breath damage

### DIFF
--- a/scripts/globals/ability.lua
+++ b/scripts/globals/ability.lua
@@ -4,7 +4,7 @@
 xi = xi or {}
 xi.ability = xi.ability or {}
 
-xi.ability.adjustDamage = function(dmg, mob, skill, target, skilltype, skillparam, shadowbehav) -- seems to only be used for Wyvern breaths
+xi.ability.adjustDamage = function(dmg, mob, skill, target, skilltype, skillparam, shadowbehav) -- seems to only be used for Wyvern breaths and chi blast
     -- physical attack missed, skip rest
     local msg = skill:getMsg()
     if

--- a/scripts/globals/job_utils/monk.lua
+++ b/scripts/globals/job_utils/monk.lua
@@ -78,9 +78,7 @@ xi.job_utils.monk.useChiBlast = function(player, target, ability)
 
     local dmg = math.floor(player:getStat(xi.mod.MND) * (0.5 + (math.random() / 2))) * multiplier
 
-    dmg = utils.stoneskin(target, dmg)
-    target:takeDamage(dmg, player, xi.attackType.SPECIAL, xi.damageType.ELEMENTAL)
-    target:updateEnmityFromDamage(player, dmg)
+    dmg = xi.ability.adjustDamage(dmg, target, ability, target, xi.attackType.BREATH, nil, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:updateClaim(player)
     player:delStatusEffect(xi.effect.BOOST)
 


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Chi blast is now breath damage
Chi blast also now adjusts for Phalanx

https://www.bg-wiki.com/ffxi/Chi_Blast (spirit damage aka breath damage)
https://wiki.ffo.jp/html/3268.html
![image](https://github.com/LandSandBoat/server/assets/60417494/c28ab2a8-947f-4900-8c77-65b23820e5fe)

## Steps to test these changes

Use chi blast against things with BDT, see them take reduced damage
