### PR TITLE
[Interaction] Fix mission 8-1 CS playing inside MH

### DIFF
--- a/scripts/missions/sandoria/8_1_Coming_of_Age.lua
+++ b/scripts/missions/sandoria/8_1_Coming_of_Age.lua
@@ -181,7 +181,10 @@ mission.sections =
             onZoneIn =
             {
                 function(player, prevZone)
-                    if mission:getVar(player, 'Progress') < os.time() then
+                    if
+                        mission:getVar(player, 'Progress') < os.time() and
+                        not player:isInMogHouse()
+                    then
                         return 16
                     end
                 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes players being able to trigger a CS via zoning inside the mog house, resulting in this
![imagen](https://github.com/LandSandBoat/server/assets/60053999/0085ea09-84a2-4a9d-bb29-864300c4a781)

## Steps to test these changes

Do the mission and not trigger the CS inside the MH
