### PR TITLE
[LUA] Fix Aura Steal not applying shadows stolen

### DIFF
--- a/scripts/globals/job_utils/thief.lua
+++ b/scripts/globals/job_utils/thief.lua
@@ -417,10 +417,18 @@ xi.job_utils.thief.useSteal = function(player, target, ability, action)
         if resist > 0.0625 then
             local auraStealChance = math.min(player:getMerit(xi.merit.AURA_STEAL), 95)
             if math.random(100) < auraStealChance then
+                local targetShadows = target:getMod(xi.mod.UTSUSEMI)
+
                 stolen = player:stealStatusEffect(target)
                 if stolen ~= 0 then
                     ability:setMsg(xi.msg.basic.STEAL_EFFECT)
                     action:setAnimation(target:getID(), 181)
+
+                    if stolen == xi.effect.COPY_IMAGE then
+                        if targetShadows > 0 then
+                            player:setMod(xi.mod.UTSUSEMI, targetShadows)
+                        end
+                    end
                 end
             -- else
             --     effect = target:dispelStatusEffect()


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

When a THF with Aura Steal merits for Steal attempts to take a mob's Utsusemi (of any kind) the effect looks like it is stolen but the modifier for Utsusemi is lost which is what is used in takeShadows. Hits from enemies will not clear the buff nor will abilities that should wipe shadows since it thinks you have 0. It will eventually just expire over time.

To fix this we will preserve the Utsusemi mod in case it does exist, then check to see if the stolen effect was copy images. If it is we will take the preserved mod value and set that to the player so that takeShadows can take these into account properly.

## Steps to test these changes

1. !changejob 6 99
2. Ensure you have 5/5 Aura Steal
3. !addeffect 66
4. !setmod 307 4
5. Steal
6. !reset if it misses