### PR TITLE
[core] Rotate towards targets in ability/mobskill states that are non-instant

### DIFF
--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -73,6 +73,10 @@ CMobSkillState::CMobSkillState(CBattleEntity* PEntity, uint16 targid, uint16 wsi
         actionTarget.param      = m_PSkill->getID();
         actionTarget.messageID  = 43;
         m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+
+        // face toward target
+        m_PEntity->loc.p.rotation = worldAngle(m_PEntity->loc.p, PTarget->loc.p);
+        m_PEntity->loc.zone->UpdateEntityPacket(m_PEntity, ENTITY_UPDATE, UPDATE_POS);
     }
     m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_STATE_ENTER", CLuaBaseEntity(m_PEntity), m_PSkill->getID());
     SpendCost();
@@ -109,6 +113,17 @@ void CMobSkillState::SpendCost()
 
 bool CMobSkillState::Update(time_point tick)
 {
+    // Rotate towards target during ability
+    if (m_castTime > 0s && tick < GetEntryTime() + m_castTime)
+    {
+        CBaseEntity* PTarget = GetTarget();
+        if (PTarget)
+        {
+            m_PEntity->loc.p.rotation = worldAngle(m_PEntity->loc.p, PTarget->loc.p);
+            m_PEntity->loc.zone->UpdateEntityPacket(m_PEntity, ENTITY_UPDATE, UPDATE_POS);
+        }
+    }
+
     if (m_PEntity && m_PEntity->isAlive() && (tick > GetEntryTime() + m_castTime && !IsCompleted()))
     {
         action_t action;

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1957,11 +1957,6 @@ void CBattleEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
         {
             PET_TYPE petType = static_cast<CPetEntity*>(this)->getPetType();
 
-            if (static_cast<CPetEntity*>(this)->getPetType() == PET_TYPE::AVATAR || static_cast<CPetEntity*>(this)->getPetType() == PET_TYPE::WYVERN)
-            {
-                target.animation = PSkill->getPetAnimationID();
-            }
-
             if (petType == PET_TYPE::AUTOMATON)
             {
                 damage = luautils::OnAutomatonAbility(PTargetFound, this, PSkill, PMaster, &action);

--- a/src/map/mobskill.cpp
+++ b/src/map/mobskill.cpp
@@ -173,17 +173,6 @@ uint16 CMobSkill::getAnimationID() const
     return m_AnimID;
 }
 
-uint16 CMobSkill::getPetAnimationID() const
-{
-    // wyvern
-    if (m_AnimID >= 621 && m_AnimID <= 632)
-    {
-        return m_AnimID - 493;
-    }
-
-    return m_AnimID;
-}
-
 int16 CMobSkill::getTP() const
 {
     return m_TP;

--- a/src/map/mobskill.h
+++ b/src/map/mobskill.h
@@ -55,7 +55,6 @@ public:
 
     uint16 getID() const;
     uint16 getAnimationID() const;
-    uint16 getPetAnimationID() const;
     uint8  getAoe() const;
     float  getDistance() const;
     uint8  getFlag() const;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Rotate towards targets in ability/mobskill states that are non-instant, just like retail

## Steps to test these changes

Use Restoring Breath/Smiting Breath and see the wyvern rotate towards you
give mobs 3k tp and watch them rotate towards their target when readying the tp move
