### PR TITLE
[LUA] Fix Avatar Blood Pacts eats actions when avatar is asleep, stunned, petrified, or already acting

### DIFF
--- a/scripts/globals/job_utils/summoner.lua
+++ b/scripts/globals/job_utils/summoner.lua
@@ -175,6 +175,18 @@ xi.job_utils.summoner.canUseBloodPact = function(player, pet, target, petAbility
             return xi.msg.basic.TARG_OUT_OF_RANGE, 0
         end
 
+        local petAction = pet:getCurrentAction()
+
+        -- check if avatar is under status effect
+        if petAction == xi.action.SLEEP or petAction == xi.action.STUN then
+            return xi.msg.basic.PET_CANNOT_DO_ACTION, 0 -- TODO: verify exact message in packet.
+        end
+
+        -- check if avatar is using a move already
+        if petAction == xi.action.PET_MOBABILITY_FINISH then
+            return xi.msg.basic.PET_CANNOT_DO_ACTION, 0 -- TODO: verify exact message in packet.
+        end
+
         local baseMPCost = getBaseMPCost(player, petAbility)
 
         if player:getMP() < baseMPCost then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Currently when a SMN attempts to quickly use 2 Blood Pacts (with Apogee or one Rage and one Ward) the second action will get eaten, the Rage/Ward will go on cooldown, and MP will be consumed. This change will add checks to ensure the avatar is not under a status effect that would prevent them from acting or already using an action in canUseBloodPact to prevent the second action from getting eaten.

Definitely requires retail verification, also quite a few TODOs for the message verification in canUseBloodPact.

## Steps to test these changes

Action
1. !changejob 15 99
2. Summon an Avatar
3. Use Apogee
4. Try to use 2 BPs in quick succession

Status effects
1. !changejob 15 99
2. Summon an Avatar
3. Target the avatar and !exec target:addStatusEffect(2, 1, 0, 100)
4. Try to use a BP

Petrify - 7
Sleep 1 - 2
Sleep 2 - 19
Lullaby - 193
Stun - 10