### PR TITLE
Remove invalid pets in zone petList

### DIFF
--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -1595,6 +1595,15 @@ void CZoneEntities::ZoneServer(time_point tick)
         //     : this way, but we need to do this to keep allies working (for now).
         if (auto* PPet = static_cast<CPetEntity*>(it->second))
         {
+            if (PPet->m_PetID > PETID::MAX_PETID)
+            {
+                // Automatons don't get destroyed in this loop, clean up invalid pointer to avoid crashes
+                // static_cast seemingly makes up properties for this PPet object
+                ShowDebug("CZoneEntities::ZoneServer: Pet: Removing stale Automaton from petlist");
+                m_petList.erase(it++);
+                continue;
+            }
+
             ShowTrace(fmt::format("CZoneEntities::ZoneServer: Pet: {} ({})", PPet->getName(), PPet->id).c_str());
 
             /*


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Resolves the crash condition to close https://github.com/LandSandBoat/server/issues/5439 .

The issue seems to lie in deactivating a pet tearing down the pet entity without removing it from the zone's petlist

The steps are reproducible with this macro:
![image](https://github.com/LandSandBoat/server/assets/131182600/a3e6b4c0-0a4c-4e31-8368-e6059169ca1a)

This PR seems to fully resolve the crash condition, but there's still the situation with spawning automatons too quickly leaving grey names around. I believe it's due to the same underlying issue, so perhaps someone more knowledgeable can help me update this PR (or make a new one and close this) to fix both.

Pets aren't removed from the player's `SpawnPETList` unless the it can be found via `((CPetEntity*)it->second)->id`, which as we see in this PR's solution, is bunk data.

## Steps to test these changes

- go into nyzul
- use macro above to spawn/despawn automatons
- go back to alz undersea ruins before the next zone tick: `!pos 131 0 20 72`

see these entries instead of a zone crash:
![image](https://github.com/LandSandBoat/server/assets/131182600/0fb6658c-2a98-4f93-9ea9-25ecb54f5088)
