### PR TITLE
CI: Use macos-13 and windows-2022 instead of *-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -345,8 +345,8 @@ jobs:
 
   MacOS_64bit:
     needs: Sanity_Checks
-    # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md
-    runs-on: macos-latest
+    # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -279,7 +279,7 @@ jobs:
 
   Windows_64bit_Debug:
     needs: Sanity_Checks
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       MSBUILD_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\
     steps:
@@ -312,7 +312,7 @@ jobs:
 
   Windows_64bit_Release_Tracy_Modules:
     needs: Sanity_Checks
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       MSBUILD_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\
     steps:
@@ -640,7 +640,7 @@ jobs:
         fi
 
   Full_Startup_Checks_Windows:
-    runs-on: windows-latest
+    runs-on: windows-2022
     needs: Windows_64bit_Debug
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -353,13 +353,7 @@ jobs:
           fetch-depth: 1
       - name: Install Dependencies (Brew)
         run: |
-          brew install mariadb zeromq zmq
-      - name: Install Dependencies (LuaJIT)
-        run: |
-          git clone https://github.com/LuaJIT/LuaJIT.git
-          cd LuaJIT
-          sudo make install MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion) -j $(sysctl -n hw.physicalcpu)
-          sudo ln -sf luajit-2.1.0-beta3 /usr/local/bin/luajit
+          brew install mariadb zeromq zmq luajit
       - name: Configure CMake
         run: |
           mkdir -p build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -360,11 +360,6 @@ jobs:
           cd LuaJIT
           sudo make install MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion) -j $(sysctl -n hw.physicalcpu)
           sudo ln -sf luajit-2.1.0-beta3 /usr/local/bin/luajit
-      - name: Cache 'build' folder
-        uses: actions/cache@v3
-        with:
-          path: build
-          key: ${{ runner.os }}-osx
       - name: Configure CMake
         run: |
           mkdir -p build


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Pinning to `latest` is normally a bad idea, I assume this is why the OSX build has been failing recently.

https://github.com/actions/runner-images/tree/main