### PR TITLE
[LUA] Fix Atonement comment should be Burtgang

### DIFF
--- a/scripts/actions/weaponskills/atonement.lua
+++ b/scripts/actions/weaponskills/atonement.lua
@@ -3,7 +3,7 @@
 -- TODO: This needs to be reworked, as this weapon skill does damage based on current enmity, not based on stat modifiers. http://wiki.ffxiclopedia.org/wiki/Atonement    http://www.bg-wiki.com/bg/Atonement
 -- Sword weapon skill
 -- Skill Level: N/A
--- Delivers a Twofold attack. Damage varies with TP. Conqueror: Aftermath effect varies with TP.
+-- Delivers a Twofold attack. Enmity varies with TP. Burtgang: Aftermath effect varies with TP.
 -- Available only after completing the Unlocking a Myth (Paladin) quest.
 -- Aligned with the Aqua Gorget, Flame Gorget & Light Gorget.
 -- Aligned with the Aqua Belt, Flame Belt & Light Belt.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Corrects the comment in Atonement to Burtgang from Conqueror. Also changes "Damage varies with TP" to "Enmity varies with TP" to match wiki description. https://www.bg-wiki.com/ffxi/Atonement

## Steps to test these changes

No functional code has changed