### PR TITLE
[cpp] Allow LoadAutomaton to run on zone in and persist other pet

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -844,10 +844,7 @@ namespace charutils
         BuildingCharTraitsTable(PChar);
 
         // Order matters as this uses merits and JP gifts.
-        if (PChar->petZoningInfo.petID >= PETID_HARLEQUINFRAME && PChar->petZoningInfo.petID <= PETID_STORMWAKERFRAME)
-        {
-            puppetutils::LoadAutomaton(PChar);
-        }
+        puppetutils::LoadAutomaton(PChar); // Take care not to reset petZoningInfo with this call
 
         PChar->animation = (HP == 0 ? ANIMATION_DEATH : ANIMATION_NONE);
 

--- a/src/map/utils/puppetutils.cpp
+++ b/src/map/utils/puppetutils.cpp
@@ -566,6 +566,8 @@ namespace puppetutils
 
     void LoadAutomatonStats(CCharEntity* PChar)
     {
+        // Save this since LoadPet() below changes it, but we don't want this changed
+        auto origPetID = PChar->petZoningInfo.petID;
         switch (PChar->PAutomaton->getFrame())
         {
             default: // case FRAME_HARLEQUIN:
@@ -584,7 +586,8 @@ namespace puppetutils
                 petutils::LoadPet(PChar, PETID_STORMWAKERFRAME, false);
                 break;
         }
-        PChar->PPet = nullptr; // already saved as PAutomaton, don't need it twice unless it's summoned
+        PChar->PPet                = nullptr; // already saved as PAutomaton, don't need it twice unless it's summoned
+        PChar->petZoningInfo.petID = origPetID;
     }
 
     void TrySkillUP(CAutomatonEntity* PAutomaton, SKILLTYPE SkillID, uint8 lvl)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

[This commit](https://github.com/LandSandBoat/server/pull/5473/commits/22350f5fa771a0e05d3727a98a164ab7ca6c6fdc) made LoadAutomaton conditional, but that function is essential to populating pup equipment menu as described in [this issue](https://github.com/LandSandBoat/server/issues/5516)

This PR closes https://github.com/LandSandBoat/server/issues/5516 .

The `LoadAutomaton` function nests a call to `LoadPet(`, but then sets `PChar->PPet` to null. This PR preserves the original petzoninginfo.petID and sets it after the automaton is initialized for the player

## Steps to test these changes

https://imgur.com/SXTu3rC