### PR TITLE
[core] Fix behavior of multiple char update packets in single tick

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -425,11 +425,12 @@ void SmallPacket0x00A(map_session_data_t* const PSession, CCharEntity* const PCh
     }
 }
 
+// https://github.com/atom0s/XiPackets/tree/main/world/client/0x001A
 /************************************************************************
  *                                                                       *
- *  Character Information Request                                        *
- *  Occurs while player is zoning or entering the game.                  *
- *                                                                       *
+ *  GP_CLI_COMMAND_GAMEOK                                                *
+ *  Client is ready to receive packets from the server.                  *
+ *  Before this packet is sent, all commands are blocked locally.        *
  ************************************************************************/
 
 void SmallPacket0x00C(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket& data)
@@ -1153,7 +1154,7 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
             PChar->updatemask |= UPDATE_HP;
             PChar->StatusEffectContainer->DelStatusEffectSilent(EFFECT_MOUNTED);
             // Workaround for a bug where dismounting out of update range would cause the character to stop rendering.
-            PChar->loc.zone->PushPacket(PChar, CHAR_INZONE, new CCharPacket(PChar, ENTITY_UPDATE, UPDATE_HP));
+            PChar->loc.zone->UpdateCharPacket(PChar, ENTITY_UPDATE, UPDATE_HP);
         }
         break;
         case 0x13: // tractor menu

--- a/src/map/packets/char.cpp
+++ b/src/map/packets/char.cpp
@@ -29,184 +29,14 @@
 #include "status_effect_container.h"
 #include "utils/itemutils.h"
 
-// Namespace to avoid compilation units using the same structs twice with different definitions
-namespace charflags
-{
-    // PS2: (Non-defined bitfield type.)
-    struct sendflags_t
-    {
-        uint8_t Position : 1;
-        uint8_t ClaimStatus : 1;
-        uint8_t General : 1;
-        uint8_t Name : 1;
-        uint8_t Model : 1;
-        uint8_t Despawn : 1;
-        uint8_t unused : 2;
-    };
-
-    // PS2: (Unnamed bitfield struct.)
-    struct flags0_t
-    {
-        uint32_t MovTime : 13;    // PS2: MovTime
-        uint32_t RunMode : 1;     // PS2: RunMode
-        uint32_t unknown_1_6 : 1; // PS2: TargetMode
-        uint32_t GroundFlag : 1;  // PS2: GroundFlag
-        uint32_t KingFlag : 1;    // PS2: KingFlag
-        uint32_t facetarget : 15; // PS2: facetarget
-    };
-
-    // PS2: (Unnamed bitfield struct.)
-    struct flags1_t
-    {
-        uint32_t MonsterFlag : 1;     // PS2: MonsterFlag
-        uint32_t HideFlag : 1;        // PS2: HideFlag
-        uint32_t SleepFlag : 1;       // PS2: SleepFlag
-        uint32_t unknown_0_3 : 1;     // PS2: MonStat
-        uint32_t unknown_0_4 : 1;     // PS2: (unknown)
-        uint32_t ChocoboIndex : 3;    // PS2: ChocoboIndex
-        uint32_t CliPosInitFlag : 1;  // PS2: CliPosInitFlag
-        uint32_t GraphSize : 2;       // PS2: GraphSize
-        uint32_t LfgFlag : 1;         // PS2: LfgFlag
-        uint32_t AnonymousFlag : 1;   // PS2: AnonymousFlag
-        uint32_t YellFlag : 1;        // PS2: YellFlag
-        uint32_t AwayFlag : 1;        // PS2: AwayFlag
-        uint32_t Gender : 1;          // PS2: Gender
-        uint32_t PlayOnelineFlag : 1; // PS2: PlayOnelineFlag
-        uint32_t LinkShellFlag : 1;   // PS2: LinkShellFlag
-        uint32_t LinkDeadFlag : 1;    // PS2: LinkDeadFlag
-        uint32_t TargetOffFlag : 1;   // PS2: TargetOffFlag
-        uint32_t TalkUcoffFlag : 1;   // PS2: TalkUcoffFlag
-        uint32_t unknown_2_5 : 1;     // PS2: PartyLeaderFlg
-        uint32_t unknown_2_6 : 1;     // PS2: AllianceLeaderFlg
-        uint32_t unknown_2_7 : 1;     // PS2: DebugClientFlg
-        uint32_t GmLevel : 3;         // PS2: GmLevel
-        uint32_t HackMove : 1;        // PS2: HackMove
-        uint32_t unknown_3_4 : 1;     // PS2: GMInvisFlag
-        uint32_t InvisFlag : 1;       // PS2: InvisFlag
-        uint32_t TurnFlag : 1;        // PS2: TurnFlag
-        uint32_t BazaarFlag : 1;      // PS2: BazaarFlag
-    };
-
-    // PS2: (Unnamed bitfield struct.)
-    struct flags2_t
-    {
-        uint32_t r : 8;             // PS2: r
-        uint32_t g : 8;             // PS2: g
-        uint32_t b : 8;             // PS2: b
-        uint32_t PvPFlag : 1;       // PS2: PvPFlag
-        uint32_t ShadowFlag : 1;    // PS2: ShadowFlag
-        uint32_t ShipStartMode : 1; // PS2: ShipStartMode
-        uint32_t CharmFlag : 1;     // PS2: CharmFlag
-        uint32_t GmIconFlag : 1;    // PS2: GmIconFlag
-        uint32_t NamedFlag : 1;     // PS2: NamedFlag
-        uint32_t SingleFlag : 1;    // PS2: SingleFlag
-        uint32_t AutoPartyFlag : 1; // PS2: AutoPartyFlag
-    };
-
-    // PS2: (Unnamed bitfield struct. This has been fully repurposed.)
-    struct flags3_t
-    {
-        uint32_t TrustFlag : 1;        // PS2: (New; replaced 'PetMode'.)
-        uint32_t LfgMasterFlag : 1;    // PS2: (New; replaced 'PetMode'.)
-        uint32_t PetNewFlag : 1;       // PS2: PetNewFlag
-        uint32_t unknown_0_3 : 1;      // PS2: PetKillFlag
-        uint32_t MotStopFlag : 1;      // PS2: MotStopFlag
-        uint32_t CliPriorityFlag : 1;  // PS2: CliPriorityFlag
-        uint32_t PetFlag : 1;          // PS2: NpcPetFlag
-        uint32_t OcclusionoffFlag : 1; // PS2: OcclusionoffFlag
-        uint32_t BallistaTeam : 8;     // PS2: (New; did not exist.)
-        uint32_t MonStat : 3;          // PS2: (New; did not exist.)
-        uint32_t unknown_2_3 : 1;      // PS2: (New; did not exist.)
-        uint32_t unknown_2_4 : 1;      // PS2: (New; did not exist.)
-        uint32_t SilenceFlag : 1;      // PS2: (New; did not exist.)
-        uint32_t unknown_2_6 : 1;      // PS2: (New; did not exist.)
-        uint32_t NewCharacterFlag : 1; // PS2: (New; did not exist.)
-        uint32_t MentorFlag : 1;       // PS2: (New; did not exist.)
-        uint32_t unknown_3_1 : 1;      // PS2: (New; did not exist.)
-        uint32_t unknown_3_2 : 1;      // PS2: (New; did not exist.)
-        uint32_t unknown_3_3 : 1;      // PS2: (New; did not exist.)
-        uint32_t unknown_3_4 : 1;      // PS2: (New; did not exist.)
-        uint32_t unknown_3_5 : 1;      // PS2: (New; did not exist.)
-        uint32_t unknown_3_6 : 1;      // PS2: (New; did not exist.)
-        uint32_t unknown_3_7 : 1;      // PS2: (New; did not exist.)
-    };
-
-    // PS2: (New; did not exist.)
-    struct flags4_t
-    {
-        uint8_t unknown_0_0 : 1;   // PS2: (New; did not exist.)
-        uint8_t TrialFlag : 1;     // PS2: (New; did not exist.)
-        uint8_t unknown_0_2 : 2;   // PS2: (New; did not exist.)
-        uint8_t unknown_0_4 : 2;   // PS2: (New; did not exist.)
-        uint8_t JobMasterFlag : 1; // PS2: (New; did not exist.)
-        uint8_t unknown_0_7 : 1;   // PS2: (New; did not exist.)
-    };
-
-    // PS2: (New; did not exist.)
-    struct flags5_t
-    {
-        uint8_t GeoIndiElement : 4; // PS2: (New; did not exist.)
-        uint8_t GeoIndiSize : 2;    // PS2: (New; did not exist.)
-        uint8_t GeoIndiFlag : 1;    // PS2: (New; did not exist.)
-        uint8_t unknown_0_7 : 1;    // PS2: (New; did not exist.)
-    };
-
-    // PS2: (New; did not exist.)
-    struct flags6_t
-    {
-        uint32_t GateId : 4;       // PS2: (New; did not exist.)
-        uint32_t MountIndex : 8;   // PS2: (New; did not exist.)
-        uint32_t unknown_1_3 : 20; // PS2: (New; did not exist.)
-    };
-} // namespace charflags
-
-// PS2: GP_SERV_CHAR_PC
-struct GP_SERV_CHAR_PC
-{
-    uint16_t id : 9;
-    uint16_t size : 7;
-    uint16_t sync;
-
-    // PS2: GP_SERV_POS_HEAD
-    uint32_t               UniqueNo;      // PS2: UniqueNo
-    uint16_t               ActIndex;      // PS2: ActIndex
-    charflags::sendflags_t SendFlg;       // PS2: SendFlg
-    uint8_t                dir;           // PS2: dir
-    float                  x;             // PS2: x
-    float                  z;             // PS2: z
-    float                  y;             // PS2: y
-    charflags::flags0_t    Flags0;        // PS2: <bits> (Nameless bitfield.)
-    uint8_t                Speed;         // PS2: Speed
-    uint8_t                SpeedBase;     // PS2: SpeedBase
-    uint8_t                Hpp;           // PS2: HpMax
-    uint8_t                server_status; // PS2: server_status
-    charflags::flags1_t    Flags1;        // PS2: <bits> (Nameless bitfield.)
-    charflags::flags2_t    Flags2;        // PS2: <bits> (Nameless bitfield.)
-    charflags::flags3_t    Flags3;        // PS2: <bits> (Nameless bitfield.)
-    uint32_t               BtTargetID;    // PS2: BtTargetID
-
-    // PS2: GP_SERV_CHAR_PC remaining fields.
-    uint16_t            CostumeId;           // PS2: (New; did not exist.)
-    uint8_t             BallistaInfo;        // PS2: (New; did not exist.)
-    charflags::flags4_t Flags4;              // PS2: (New; did not exist.)
-    uint32_t            CustomProperties[2]; // PS2: (New; did not exist.)
-    uint16_t            PetActIndex;         // PS2: (New; did not exist.)
-    uint16_t            MonstrosityFlags;    // PS2: (New; did not exist.)
-    uint8_t             MonstrosityNameId1;  // PS2: (New; did not exist.)
-    uint8_t             MonstrosityNameId2;  // PS2: (New; did not exist.)
-    charflags::flags5_t Flags5;              // PS2: (New; did not exist.)
-    uint8_t             ModelHitboxSize;     // PS2: (New; did not exist.)
-    charflags::flags6_t Flags6;              // PS2: (New; did not exist.)
-    uint16_t            GrapIDTbl[9];        // PS2: GrapIDTbl
-    uint8_t             name[16];            // PS2: name
-};
-
 constexpr uint32_t nonspecific_size = offsetof(GP_SERV_CHAR_PC, MonstrosityFlags);
 constexpr uint32_t general_size     = offsetof(GP_SERV_CHAR_PC, GrapIDTbl[0]);
 constexpr uint32_t model_size       = offsetof(GP_SERV_CHAR_PC, name[0]);
 constexpr uint32_t name_size        = offsetof(GP_SERV_CHAR_PC, name[0]);
 
+// This packet should only be constructed in CCharEntity::updateCharPacket()!
 CCharPacket::CCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint8 updatemask)
+: packet{}
 {
     ref<uint32>(0x04) = PChar->id;
     updateWith(PChar, type, updatemask);
@@ -222,8 +52,6 @@ void CCharPacket::updateWith(CCharEntity* PChar, ENTITYUPDATE type, uint8 update
         return;
     }
     ref<uint32>(0x04) = PChar->id;
-
-    GP_SERV_CHAR_PC packet = {};
 
     packet.id       = 0x0D;
     packet.size     = roundUpToNearestFour(nonspecific_size) / 4; // Client recieves this and multiplies by 4
@@ -242,10 +70,17 @@ void CCharPacket::updateWith(CCharEntity* PChar, ENTITYUPDATE type, uint8 update
     {
         packet.SendFlg.Despawn = true;
     }
-    else
+    else // Update and OR the flags together
     {
-        // static_cast doesn't set the bits the way we need it to
-        std::memcpy(&packet.SendFlg, &updatemask, sizeof(charflags::sendflags_t));
+        // static_cast doesn't set the bits the way we need it to, so do some memcpy
+        uint8 tempSendFlg = {};
+        std::memcpy(&tempSendFlg, &packet.SendFlg, sizeof(charflags::sendflags_t));
+
+        // OR the update mask with the previously-calculated mask...
+        tempSendFlg |= updatemask;
+
+        // set the flags back
+        std::memcpy(&packet.SendFlg, &tempSendFlg, sizeof(charflags::sendflags_t));
     }
 
     if (packet.SendFlg.Position)

--- a/src/map/packets/char.h
+++ b/src/map/packets/char.h
@@ -28,11 +28,186 @@
 
 class CCharEntity;
 
+// Namespace to avoid compilation units using the same structs twice with different definitions
+namespace charflags
+{
+    // PS2: (Non-defined bitfield type.)
+    struct sendflags_t
+    {
+        uint8_t Position : 1;
+        uint8_t ClaimStatus : 1;
+        uint8_t General : 1;
+        uint8_t Name : 1;
+        uint8_t Model : 1;
+        uint8_t Despawn : 1;
+        uint8_t unused : 2;
+    };
+
+    // PS2: (Unnamed bitfield struct.)
+    struct flags0_t
+    {
+        uint32_t MovTime : 13;    // PS2: MovTime
+        uint32_t RunMode : 1;     // PS2: RunMode
+        uint32_t unknown_1_6 : 1; // PS2: TargetMode
+        uint32_t GroundFlag : 1;  // PS2: GroundFlag
+        uint32_t KingFlag : 1;    // PS2: KingFlag
+        uint32_t facetarget : 15; // PS2: facetarget
+    };
+
+    // PS2: (Unnamed bitfield struct.)
+    struct flags1_t
+    {
+        uint32_t MonsterFlag : 1;     // PS2: MonsterFlag
+        uint32_t HideFlag : 1;        // PS2: HideFlag
+        uint32_t SleepFlag : 1;       // PS2: SleepFlag
+        uint32_t unknown_0_3 : 1;     // PS2: MonStat
+        uint32_t unknown_0_4 : 1;     // PS2: (unknown)
+        uint32_t ChocoboIndex : 3;    // PS2: ChocoboIndex
+        uint32_t CliPosInitFlag : 1;  // PS2: CliPosInitFlag
+        uint32_t GraphSize : 2;       // PS2: GraphSize
+        uint32_t LfgFlag : 1;         // PS2: LfgFlag
+        uint32_t AnonymousFlag : 1;   // PS2: AnonymousFlag
+        uint32_t YellFlag : 1;        // PS2: YellFlag
+        uint32_t AwayFlag : 1;        // PS2: AwayFlag
+        uint32_t Gender : 1;          // PS2: Gender
+        uint32_t PlayOnelineFlag : 1; // PS2: PlayOnelineFlag
+        uint32_t LinkShellFlag : 1;   // PS2: LinkShellFlag
+        uint32_t LinkDeadFlag : 1;    // PS2: LinkDeadFlag
+        uint32_t TargetOffFlag : 1;   // PS2: TargetOffFlag
+        uint32_t TalkUcoffFlag : 1;   // PS2: TalkUcoffFlag
+        uint32_t unknown_2_5 : 1;     // PS2: PartyLeaderFlg
+        uint32_t unknown_2_6 : 1;     // PS2: AllianceLeaderFlg
+        uint32_t unknown_2_7 : 1;     // PS2: DebugClientFlg
+        uint32_t GmLevel : 3;         // PS2: GmLevel
+        uint32_t HackMove : 1;        // PS2: HackMove
+        uint32_t unknown_3_4 : 1;     // PS2: GMInvisFlag
+        uint32_t InvisFlag : 1;       // PS2: InvisFlag
+        uint32_t TurnFlag : 1;        // PS2: TurnFlag
+        uint32_t BazaarFlag : 1;      // PS2: BazaarFlag
+    };
+
+    // PS2: (Unnamed bitfield struct.)
+    struct flags2_t
+    {
+        uint32_t r : 8;             // PS2: r
+        uint32_t g : 8;             // PS2: g
+        uint32_t b : 8;             // PS2: b
+        uint32_t PvPFlag : 1;       // PS2: PvPFlag
+        uint32_t ShadowFlag : 1;    // PS2: ShadowFlag
+        uint32_t ShipStartMode : 1; // PS2: ShipStartMode
+        uint32_t CharmFlag : 1;     // PS2: CharmFlag
+        uint32_t GmIconFlag : 1;    // PS2: GmIconFlag
+        uint32_t NamedFlag : 1;     // PS2: NamedFlag
+        uint32_t SingleFlag : 1;    // PS2: SingleFlag
+        uint32_t AutoPartyFlag : 1; // PS2: AutoPartyFlag
+    };
+
+    // PS2: (Unnamed bitfield struct. This has been fully repurposed.)
+    struct flags3_t
+    {
+        uint32_t TrustFlag : 1;        // PS2: (New; replaced 'PetMode'.)
+        uint32_t LfgMasterFlag : 1;    // PS2: (New; replaced 'PetMode'.)
+        uint32_t PetNewFlag : 1;       // PS2: PetNewFlag
+        uint32_t unknown_0_3 : 1;      // PS2: PetKillFlag
+        uint32_t MotStopFlag : 1;      // PS2: MotStopFlag
+        uint32_t CliPriorityFlag : 1;  // PS2: CliPriorityFlag
+        uint32_t PetFlag : 1;          // PS2: NpcPetFlag
+        uint32_t OcclusionoffFlag : 1; // PS2: OcclusionoffFlag
+        uint32_t BallistaTeam : 8;     // PS2: (New; did not exist.)
+        uint32_t MonStat : 3;          // PS2: (New; did not exist.)
+        uint32_t unknown_2_3 : 1;      // PS2: (New; did not exist.)
+        uint32_t unknown_2_4 : 1;      // PS2: (New; did not exist.)
+        uint32_t SilenceFlag : 1;      // PS2: (New; did not exist.)
+        uint32_t unknown_2_6 : 1;      // PS2: (New; did not exist.)
+        uint32_t NewCharacterFlag : 1; // PS2: (New; did not exist.)
+        uint32_t MentorFlag : 1;       // PS2: (New; did not exist.)
+        uint32_t unknown_3_1 : 1;      // PS2: (New; did not exist.)
+        uint32_t unknown_3_2 : 1;      // PS2: (New; did not exist.)
+        uint32_t unknown_3_3 : 1;      // PS2: (New; did not exist.)
+        uint32_t unknown_3_4 : 1;      // PS2: (New; did not exist.)
+        uint32_t unknown_3_5 : 1;      // PS2: (New; did not exist.)
+        uint32_t unknown_3_6 : 1;      // PS2: (New; did not exist.)
+        uint32_t unknown_3_7 : 1;      // PS2: (New; did not exist.)
+    };
+
+    // PS2: (New; did not exist.)
+    struct flags4_t
+    {
+        uint8_t unknown_0_0 : 1;   // PS2: (New; did not exist.)
+        uint8_t TrialFlag : 1;     // PS2: (New; did not exist.)
+        uint8_t unknown_0_2 : 2;   // PS2: (New; did not exist.)
+        uint8_t unknown_0_4 : 2;   // PS2: (New; did not exist.)
+        uint8_t JobMasterFlag : 1; // PS2: (New; did not exist.)
+        uint8_t unknown_0_7 : 1;   // PS2: (New; did not exist.)
+    };
+
+    // PS2: (New; did not exist.)
+    struct flags5_t
+    {
+        uint8_t GeoIndiElement : 4; // PS2: (New; did not exist.)
+        uint8_t GeoIndiSize : 2;    // PS2: (New; did not exist.)
+        uint8_t GeoIndiFlag : 1;    // PS2: (New; did not exist.)
+        uint8_t unknown_0_7 : 1;    // PS2: (New; did not exist.)
+    };
+
+    // PS2: (New; did not exist.)
+    struct flags6_t
+    {
+        uint32_t GateId : 4;       // PS2: (New; did not exist.)
+        uint32_t MountIndex : 8;   // PS2: (New; did not exist.)
+        uint32_t unknown_1_3 : 20; // PS2: (New; did not exist.)
+    };
+} // namespace charflags
+
+// PS2: GP_SERV_CHAR_PC
+struct GP_SERV_CHAR_PC
+{
+    uint16_t id : 9;
+    uint16_t size : 7;
+    uint16_t sync;
+
+    // PS2: GP_SERV_POS_HEAD
+    uint32_t               UniqueNo;      // PS2: UniqueNo
+    uint16_t               ActIndex;      // PS2: ActIndex
+    charflags::sendflags_t SendFlg;       // PS2: SendFlg
+    uint8_t                dir;           // PS2: dir
+    float                  x;             // PS2: x
+    float                  z;             // PS2: z
+    float                  y;             // PS2: y
+    charflags::flags0_t    Flags0;        // PS2: <bits> (Nameless bitfield.)
+    uint8_t                Speed;         // PS2: Speed
+    uint8_t                SpeedBase;     // PS2: SpeedBase
+    uint8_t                Hpp;           // PS2: HpMax
+    uint8_t                server_status; // PS2: server_status
+    charflags::flags1_t    Flags1;        // PS2: <bits> (Nameless bitfield.)
+    charflags::flags2_t    Flags2;        // PS2: <bits> (Nameless bitfield.)
+    charflags::flags3_t    Flags3;        // PS2: <bits> (Nameless bitfield.)
+    uint32_t               BtTargetID;    // PS2: BtTargetID
+
+    // PS2: GP_SERV_CHAR_PC remaining fields.
+    uint16_t            CostumeId;           // PS2: (New; did not exist.)
+    uint8_t             BallistaInfo;        // PS2: (New; did not exist.)
+    charflags::flags4_t Flags4;              // PS2: (New; did not exist.)
+    uint32_t            CustomProperties[2]; // PS2: (New; did not exist.)
+    uint16_t            PetActIndex;         // PS2: (New; did not exist.)
+    uint16_t            MonstrosityFlags;    // PS2: (New; did not exist.)
+    uint8_t             MonstrosityNameId1;  // PS2: (New; did not exist.)
+    uint8_t             MonstrosityNameId2;  // PS2: (New; did not exist.)
+    charflags::flags5_t Flags5;              // PS2: (New; did not exist.)
+    uint8_t             ModelHitboxSize;     // PS2: (New; did not exist.)
+    charflags::flags6_t Flags6;              // PS2: (New; did not exist.)
+    uint16_t            GrapIDTbl[9];        // PS2: GrapIDTbl
+    uint8_t             name[16];            // PS2: name
+};
+
 class CCharPacket : public CBasicPacket
 {
 public:
     CCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint8 updatemask);
     void updateWith(CCharEntity* PChar, ENTITYUPDATE type, uint8 updatemask);
+
+private:
+    GP_SERV_CHAR_PC packet;
 };
 
 #endif


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

After the 0x00D/0x037 overhaul, the logic to update a char update packet broke. This fixes it.
Fixes #5519 

## Steps to test these changes

See #5519
