### PR TITLE
[Quest] The Fanged One Interaction Framework

### DIFF
--- a/scripts/quests/windurst/The_Fanged_One.lua
+++ b/scripts/quests/windurst/The_Fanged_One.lua
@@ -1,0 +1,143 @@
+-----------------------------------
+-- The Fanged One
+-----------------------------------
+-- Log ID: 2, Quest ID: 31
+-- Perih Vashai: !pos 117 -3 92 241
+-- Tiger Bones: !pos 666 -8 -379 120
+-- Keeping Old Sabertooth and Tiger Bones in separate lua's due to special functions.
+-----------------------------------
+local windurstWoodsID = zones[xi.zone.WINDURST_WOODS]
+local sauromugueID = zones[xi.zone.SAUROMUGUE_CHAMPAIGN]
+-----------------------------------
+local quest = Quest:new(xi.questLog.WINDURST, xi.quest.id.windurst.THE_FANGED_ONE)
+
+quest.reward =
+{
+    fame     = 20,
+    fameArea = xi.fameArea.WINDURST,
+    item     = xi.item.RANGERS_NECKLACE,
+    title    = xi.title.THE_FANGED_ONE,
+}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_AVAILABLE and
+            player:getMainLvl() >= xi.settings.main.ADVANCED_JOB_LEVEL
+        end,
+
+        [xi.zone.WINDURST_WOODS] =
+        {
+            ['Perih_Vashai'] = quest:progressEvent(351),
+
+            onEventFinish =
+            {
+                [351] = function(player, csid, option, npc)
+                    quest:begin(player)
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_ACCEPTED
+        end,
+
+        [xi.zone.WINDURST_WOODS] =
+        {
+            ['Perih_Vashai'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 0 then
+                        return quest:event(352)
+                    elseif
+                        quest:getVar(player, 'Prog') == 1 and
+                        not player:hasKeyItem(xi.ki.OLD_TIGERS_FANG)
+                    then
+                        return quest:event(356)
+                    elseif player:hasKeyItem(xi.ki.OLD_TIGERS_FANG) then
+                        return quest:progressEvent(357)
+                    end
+                end,
+
+                onTrade = function(player, npc, trade)
+                    if npcUtil.tradeHasExactly(trade, xi.item.BLACK_TIGER_FANG) then
+                        return quest:event(356)
+                    end
+                end,
+            },
+
+            ['Kapeh_Myohrye'] =
+            {
+                onTrigger = function(player, npc)
+                    return quest:event(354)
+                end,
+            },
+
+            ['Muhk_Johldy'] =
+            {
+                onTrigger = function(player, npc)
+                    return quest:event(353)
+                end,
+            },
+
+            onEventFinish =
+            {
+                [356] = function(player, csid, option, npc)
+                    player:tradeComplete() -- capture shows taking black tiger fang if traded.
+                end,
+
+                [357] = function(player, csid, option, npc)
+                    if quest:complete(player) then
+                        player:delKeyItem(xi.ki.OLD_TIGERS_FANG)
+                        player:unlockJob(xi.job.RNG)
+                        npcUtil.giveKeyItem(xi.ki.JOB_GESTURE_RANGER)
+                        return quest:messageSpecial(windurstWoodsID.text.PERIH_VASHAI_DIALOG)
+                    end
+                end,
+            },
+        },
+
+        [xi.zone.SAUROMUGUE_CHAMPAIGN] =
+        -- The logic for this specific mechanic is unique. Therefore, the mob logic and onMobDeath
+        -- resides in the Old_Sabertooth.lua onMobSpawn, onMobFight, and onMobDeath.
+        -- Currently, unable to have the onMobDeath function load from this file due to enmity.
+        -- Issue was raised to LSB for consideration on how to adjust moving forward.
+        {
+            ['Tiger_Bones'] =
+            {
+                onTrigger = function(player, npc)
+                    if
+                        quest:getVar(player, 'Prog') == 0 and
+                        quest:getVar(player, 'Timer') <= os.time() and
+                        not GetMobByID(sauromugueID.mob.OLD_SABERTOOTH):isSpawned()
+                    then
+                        SpawnMob(sauromugueID.mob.OLD_SABERTOOTH):addStatusEffect(xi.effect.POISON, 10, 10, 240)
+                        return quest:messageSpecial(sauromugueID.text.OLD_SABERTOOTH_DIALOG_I)
+                    elseif
+                        quest:getVar(player, 'Prog') == 1 and -- listeners for damage and onMobDeath actions are in Old_Sabtertooth.lua
+                        not player:hasKeyItem(xi.ki.OLD_TIGERS_FANG)
+                    then
+                        npcUtil.giveKeyItem(player, xi.ki.OLD_TIGERS_FANG)
+                        return quest:noAction()
+                    end
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStaus.QUEST_COMPLETED
+        end,
+
+        [xi.zone.WINDURST_WOODS] =
+        {
+            ['Perih_Vashai'] = quest:event(348):replaceDefault(),
+        },
+    },
+}
+
+return quest

--- a/scripts/zones/Sauromugue_Champaign/DefaultActions.lua
+++ b/scripts/zones/Sauromugue_Champaign/DefaultActions.lua
@@ -1,11 +1,12 @@
 local ID = zones[xi.zone.SAUROMUGUE_CHAMPAIGN]
 
 return {
-    ['qm2']    = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
-    ['qm3']    = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
-    ['qm4']    = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
-    ['qm5']    = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
-    ['qm6']    = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
-    ['qm7']    = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
-    ['qm_maw'] = { messageSpecial = ID.text.NOTHING_HAPPENS },
+    ['qm2']         = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
+    ['qm3']         = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
+    ['qm4']         = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
+    ['qm5']         = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
+    ['qm6']         = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
+    ['qm7']         = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
+    ['qm_maw']      = { messageSpecial = ID.text.NOTHING_HAPPENS },
+    ['Tiger_Bones'] = { messageSpecial = ID.text.MANY_TIGER_BONES },
 }

--- a/scripts/zones/Sauromugue_Champaign/mobs/Old_Sabertooth.lua
+++ b/scripts/zones/Sauromugue_Champaign/mobs/Old_Sabertooth.lua
@@ -6,19 +6,61 @@
 -----------------------------------
 local entity = {}
 
+local pathNodes =
+{
+    { x = 675, y = -10, z = -362 },
+    { x = 674, y = -10, z = -368 },
+    { x = 672, y = -9.1, z = -372 },
+    { x = 668, y = -8.3, z = -376 },
+    { x = 674, y = -10, z = -366 },
+    { x = 675, y = -9.9, z = -361 },
+    { x = 674, y = -9.5, z = -357 },
+    { x = 673, y = -9.0, z = -352 },
+    { x = 671, y = -8.9, z = -347 },
+    { x = 668, y = -9.5, z = -341 },
+
+}
+
 entity.onMobSpawn = function(mob)
+    mob:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.STANDBACK))
+    mob:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.NO_TURN))
+    mob:setMobAbilityEnabled(false)
+    mob:setAutoAttackEnabled(false)
+    mob:setRoamFlags(256, 512)
+    mob:pathThrough(pathNodes, bit.bor(xi.path.flag.PATROL))
+
+    mob:addListener('TAKE_DAMAGE', 'PRIME_TAKE_DAMAGE', function(tiger, amount, attacker)
+        if attacker then
+            tiger:setLocalVar('tookDamage', 1)
+            tiger:setMobAbilityEnabled(true)
+            tiger:setAutoAttackEnabled(true)
+            tiger:setBehaviour(0)
+        end
+    end)
 end
 
-entity.onMobDeath = function(mob, player, optParams)
-    if player == nil then
-        local players = mob:getZone():getPlayers()
+entity.onMobFight = function(mob)
+    if mob:getLocalVar('control') == 0 and mob:getLocalVar('tookDamage') == 0 then
+        mob:setLocalVar('control', 1)
+        mob:timer(15000, function(mobArg)
+            local pos = mob:getPos()
+            mob:pathTo(pos.x + math.random(-2, 2), pos.y, pos.z + math.random(-2, 2), 9)
+            mobArg:setLocalVar('control', 0)
+        end)
+    end
+end
 
+entity.onMobDeath = function(mob, player, optParams)-- TODO: We currently can't move old sabertooth logic from mob script to quest script due to how the quest works
+    local players = mob:getZone():getPlayers()
         for i, person in pairs(players) do -- can't use the variable name "player" because it's already being used
             if
                 person:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.THE_FANGED_ONE) == xi.questStatus.QUEST_ACCEPTED and
                 person:checkDistance(mob) < 32
-            then
-                person:setCharVar('TheFangedOneCS', 2)
+        then
+            if mob:getLocalVar('tookDamage') == 0 then
+                person:setCharVar('Quest[2][31]Prog', 1)
+            else
+                person:setCharVar('Quest[2][31]Timer', os.time() + 300)
             end
         end
     end

--- a/scripts/zones/Sauromugue_Champaign/npcs/Tiger_Bones.lua
+++ b/scripts/zones/Sauromugue_Champaign/npcs/Tiger_Bones.lua
@@ -4,38 +4,13 @@
 -- Involed in Quest: The Fanged One
 -- !pos 666 -8 -379 120
 -----------------------------------
-local ID = zones[xi.zone.SAUROMUGUE_CHAMPAIGN]
------------------------------------
+
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local fangedOne = player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.THE_FANGED_ONE)
-    local fangedOneCS = player:getCharVar('TheFangedOneCS')
-
-    -- THE FANGED ONE
-    if
-        fangedOne == xi.questStatus.QUEST_ACCEPTED and
-        fangedOneCS == 1 and
-        not GetMobByID(ID.mob.OLD_SABERTOOTH):isSpawned()
-    then
-        SpawnMob(ID.mob.OLD_SABERTOOTH):addStatusEffect(xi.effect.POISON, 40, 10, 210)
-        player:messageSpecial(ID.text.OLD_SABERTOOTH_DIALOG_I)
-    elseif
-        fangedOne == xi.questStatus.QUEST_ACCEPTED and
-        fangedOneCS == 2 and
-        not player:hasKeyItem(xi.ki.OLD_TIGERS_FANG)
-    then
-        player:addKeyItem(xi.ki.OLD_TIGERS_FANG)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.OLD_TIGERS_FANG)
-        player:setCharVar('TheFangedOneCS', 0)
-
-    -- DEFAULT DIALOG
-    else
-        player:messageSpecial(ID.text.NOTHING_HAPPENS)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Windurst_Woods/DefaultActions.lua
+++ b/scripts/zones/Windurst_Woods/DefaultActions.lua
@@ -1,14 +1,16 @@
 -- local ID = zones[xi.zone.WINDURST_WOODS]
 
 return {
-    ['An_Polaali']   = { event = 44 },
-    ['An_Shanaa']    = { event = 45 },
-    ['Apururu']      = { event = 274 },
-    ['Bopa_Greso']   = { event = 77 },
-    ['Cha_Lebagta']  = { event = 78 },
-    ['Hae_Jakkya']   = { event = 41 },
-    ['Kototo']       = { event = 410 },
-    ['Mourices']     = { event = 441 },
-    ['Perih_Vashai'] = { event = 338 },
-    ['Roberta']      = { event = 436 },
+    ['An_Polaali']    = { event = 44 },
+    ['An_Shanaa']     = { event = 45 },
+    ['Apururu']       = { event = 274 },
+    ['Bopa_Greso']    = { event = 77 },
+    ['Cha_Lebagta']   = { event = 78 },
+    ['Hae_Jakkya']    = { event = 41 },
+    ['Kapeh_Myohrye'] = { event = 340 },-- There is at current an unknown mission/quest/status that alters their dialog. Windurst citizens get something different than other nations.
+    ['Kototo']        = { event = 410 },
+    ['Mourices']      = { event = 441 },
+    ['Muhk_Johldy']   = { event = 339 },-- There is at current an unknown mission/quest/status that alters their dialog. Windurst citizens get something different than other nations.
+    ['Perih_Vashai']  = { event = 338 },
+    ['Roberta']       = { event = 436 },
 }

--- a/scripts/zones/Windurst_Woods/npcs/Kapeh_Myohrye.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Kapeh_Myohrye.lua
@@ -8,7 +8,6 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(340)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Windurst_Woods/npcs/Muhk_Johldy.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Muhk_Johldy.lua
@@ -8,7 +8,6 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(339)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Windurst_Woods/npcs/Perih_Vashai.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Perih_Vashai.lua
@@ -4,8 +4,6 @@
 -- Starts and Finishes Quest: The Fanged One, From Saplings Grow
 -- !pos 117 -3 92 241
 -----------------------------------
-local ID = zones[xi.zone.WINDURST_WOODS]
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
@@ -20,8 +18,6 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local theFangedOne = player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.THE_FANGED_ONE) -- RNG flag quest
-    local theFangedOneCS = player:getCharVar('TheFangedOne_Event')
     local sinHunting = player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.SIN_HUNTING)-- RNG AF1
     local sinHuntingCS = player:getCharVar('sinHunting')
     local fireAndBrimstone = player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.FIRE_AND_BRIMSTONE)-- RNG AF2
@@ -31,24 +27,8 @@ entity.onTrigger = function(player, npc)
     local lvl = player:getMainLvl()
     local job = player:getMainJob()
 
-    -- THE FANGED ONE
-    if
-        theFangedOne == xi.questStatus.QUEST_AVAILABLE and
-        lvl >= xi.settings.main.ADVANCED_JOB_LEVEL
-    then
-        player:startEvent(351)
-    elseif
-        theFangedOne == xi.questStatus.QUEST_ACCEPTED and
-        not player:hasKeyItem(xi.ki.OLD_TIGERS_FANG)
-    then
-        player:startEvent(352)
-    elseif player:hasKeyItem(xi.ki.OLD_TIGERS_FANG) and theFangedOneCS ~= 1 then
-        player:startEvent(357)
-    elseif theFangedOneCS == 1 then
-        player:startEvent(358)
-
     -- SIN HUNTING
-    elseif
+    if
         sinHunting == xi.questStatus.QUEST_AVAILABLE and
         job == xi.job.RNG and
         lvl >= xi.settings.main.AF1_QUEST_LEVEL
@@ -92,20 +72,8 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    -- THE FANGED ONE
-    if csid == 351 then
-        player:addQuest(xi.questLog.WINDURST, xi.quest.id.windurst.THE_FANGED_ONE)
-        player:setCharVar('TheFangedOneCS', 1)
-    elseif
-        (csid == 357 or csid == 358) and
-        npcUtil.completeQuest(player, xi.questLog.WINDURST, xi.quest.id.windurst.THE_FANGED_ONE, { item = 13117, title = xi.title.THE_FANGED_ONE, var = { 'TheFangedOne_Event', 'TheFangedOneCS' } })
-    then
-        player:delKeyItem(xi.ki.OLD_TIGERS_FANG)
-        player:unlockJob(xi.job.RNG)
-        player:messageSpecial(ID.text.PERIH_VASHAI_DIALOG)
-
     -- SIN HUNTING
-    elseif csid == 523 then -- start quest RNG AF1
+    if csid == 523 then -- start quest RNG AF1
         player:addQuest(xi.questLog.WINDURST, xi.quest.id.windurst.SIN_HUNTING)
         npcUtil.giveKeyItem(player, xi.ki.CHIEFTAINNESSS_TWINSTONE_EARRING)
         player:setCharVar('sinHunting', 1)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Had an issue with my rebase - ended up closing https://github.com/LandSandBoat/server/pull/5381
and redoing it here.

Converts the quest The Fanged One (RNG Flag) to Interaction Framework

Adds functionality for Old Sabertooth to path in the hallway.
Adjusted the poison effect to ~2%/tic as per the capture.
Added listener to Old Sabertooth (in the mob lua file) to capture if players damaged the mob. If they do, they incur a 5 min wait timer to respawn.
Replaced NPC lua events into DefaultActions.lua
Capture shows black tiger fang being traded and taken during quest.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Be on any job 30+ and speak with Perih Vasha.

Capture located at
https://www.youtube.com/watch?v=FWtjEDaDG7s
<!-- Clear and detailed steps to test your changes here -->
