### PR TITLE
[cpp] Preserve ALL pet zoning info after loadautomaton

### DIFF
--- a/src/map/utils/puppetutils.cpp
+++ b/src/map/utils/puppetutils.cpp
@@ -566,8 +566,7 @@ namespace puppetutils
 
     void LoadAutomatonStats(CCharEntity* PChar)
     {
-        // Save this since LoadPet() below changes it, but we don't want this changed
-        auto origPetID = PChar->petZoningInfo.petID;
+        auto origPetZoningInfo = PChar->petZoningInfo;
         switch (PChar->PAutomaton->getFrame())
         {
             default: // case FRAME_HARLEQUIN:
@@ -586,8 +585,13 @@ namespace puppetutils
                 petutils::LoadPet(PChar, PETID_STORMWAKERFRAME, false);
                 break;
         }
-        PChar->PPet                = nullptr; // already saved as PAutomaton, don't need it twice unless it's summoned
-        PChar->petZoningInfo.petID = origPetID;
+        PChar->PPet = nullptr; // already saved as PAutomaton, don't need it twice unless it's summoned
+
+        // The above LoadPet() calls change PChar->petZoningInfo, so we need to restore it if the original zoned pet was not an automaton
+        if (origPetZoningInfo.respawnPet && origPetZoningInfo.petType != PET_TYPE::AUTOMATON)
+        {
+            PChar->petZoningInfo = origPetZoningInfo;
+        }
     }
 
     void TrySkillUP(CAutomatonEntity* PAutomaton, SKILLTYPE SkillID, uint8 lvl)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Continuation of [this PR](https://github.com/LandSandBoat/server/pull/5521).

After the second PR, zoning with an automaton would summon a fire spirit after going into the new zone. This would be in the log:

![image](https://github.com/LandSandBoat/server/assets/131182600/e66a07f6-d1ec-40a4-9ca5-68ad19b8528a)

I could have sworn i tested both permutations, but apparently not.

This new change only messes with the `petZoningInfo` if the pet type is not an automaton and the `petZoningInfo` was such that we needed to preserve the pet

I've tried smn/pup, pup/smn, drg/pup, pup/drg and zoning with and without a pet seems to all work like it should

Edit: changed to draft because i got a crash re-doing the steps below:

![image](https://github.com/LandSandBoat/server/assets/131182600/230addf3-78bc-4fc9-a007-e43932eb8d5d)

I'm guessing that's the wyvern listener... 

## Steps to test these changes

- change job to pup, zone and see that your automaton setup menu loads (no active pet)
- change sub job to smn, summon avatar, zone and see that your avatar persists
- change main job to drg, call wyvern, zone and see that your wyvern persists
- change subjob to pup, zone and see wyvern persists
  - (note that the automaton setup UI takes a few ticks to show up before zoning, as the changesjob lua binding doesn't immediately send the CCharJobsPacket... might need to open the equipment screen)
