### PR TITLE
[core] Look up automaton correctly if automaton is in an instance

### DIFF
--- a/src/map/utils/puppetutils.cpp
+++ b/src/map/utils/puppetutils.cpp
@@ -23,6 +23,7 @@
 #include "battleutils.h"
 #include "charutils.h"
 #include "entities/automatonentity.h"
+#include "instance.h"
 #include "itemutils.h"
 #include "job_points.h"
 #include "lua/luautils.h"
@@ -51,14 +52,33 @@ namespace puppetutils
             {
                 // Make sure we don't delete a pet that is active
                 auto* PZone = zoneutils::GetZone(PChar->PAutomaton->getZone());
-                if (PZone == nullptr || PZone->GetEntity(PChar->PAutomaton->targid, TYPE_PET) == nullptr)
+                if (PZone == nullptr)
                 {
                     destroy(PChar->PAutomaton);
                 }
                 else
                 {
-                    PChar->PAutomaton->PMaster = nullptr;
+                    if (PChar->PAutomaton->PInstance)
+                    {
+                        if (PChar->PAutomaton->PInstance->GetEntity(PChar->PAutomaton->targid, TYPE_PET) == nullptr)
+                        {
+                            destroy(PChar->PAutomaton);
+                        }
+                        else
+                        {
+                            PChar->PAutomaton->PMaster = nullptr;
+                        }
+                    }
+                    else if (PZone->GetEntity(PChar->PAutomaton->targid, TYPE_PET) == nullptr)
+                    {
+                        destroy(PChar->PAutomaton);
+                    }
+                    else
+                    {
+                        PChar->PAutomaton->PMaster = nullptr;
+                    }
                 }
+
                 PChar->PPet       = nullptr;
                 PChar->PAutomaton = nullptr;
             }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Apparently GetEntity in a CInstanceZone fails to look up non-PCs. So bypass that problem(? if it even IS one) for now and just directly look up the PInstance in load automaton.
Fixes #5439

Obsoletes/fixes root cause of #5508
## Steps to test these changes

See #5439
