### PR TITLE
Add support for experimental BCNM flag

### DIFF
--- a/scripts/battlefields/Balgas_Dais/early_bird_catches_the_wyrm.lua
+++ b/scripts/battlefields/Balgas_Dais/early_bird_catches_the_wyrm.lua
@@ -15,6 +15,8 @@ local content = Battlefield:new({
     entryNpc         = 'BC_Entrance',
     exitNpc          = 'Burning_Circle',
     requiredItems    = { xi.item.THEMIS_ORB, wearMessage = balgasID.text.A_CRACK_HAS_FORMED, wornMessage = balgasID.text.ORB_IS_CRACKED },
+
+    experimental = true,
 })
 
 content:addEssentialMobs({ 'Wyrm' })

--- a/scripts/battlefields/Horlais_Peak/horns_of_war.lua
+++ b/scripts/battlefields/Horlais_Peak/horns_of_war.lua
@@ -15,6 +15,8 @@ local content = Battlefield:new({
     entryNpc         = 'BC_Entrance',
     exitNpc          = 'Burning_Circle',
     requiredItems    = { xi.item.THEMIS_ORB, wearMessage = horlaisID.text.A_CRACK_HAS_FORMED, wornMessage = horlaisID.text.ORB_IS_CRACKED },
+
+    experimental = true,
 })
 
 content:addEssentialMobs({ 'Chlevnik' })

--- a/scripts/battlefields/Horlais_Peak/shooting_fish.lua
+++ b/scripts/battlefields/Horlais_Peak/shooting_fish.lua
@@ -16,6 +16,8 @@ local content = Battlefield:new({
     entryNpc         = 'BC_Entrance',
     exitNpc          = 'Burning_Circle',
     requiredItems    = { xi.item.CLOUDY_ORB, wearMessage = horlaisID.text.A_CRACK_HAS_FORMED, wornMessage = horlaisID.text.ORB_IS_CRACKED },
+
+    experimental = true,
 })
 
 content:addEssentialMobs({ 'Sniper_Pugil', 'Archer_Pugil' })

--- a/scripts/battlefields/Horlais_Peak/shots_in_the_dark.lua
+++ b/scripts/battlefields/Horlais_Peak/shots_in_the_dark.lua
@@ -16,6 +16,8 @@ local content = Battlefield:new({
     entryNpc         = 'BC_Entrance',
     exitNpc          = 'Burning_Circle',
     requiredItems    = { xi.item.MOON_ORB, wearMessage = horlaisID.text.A_CRACK_HAS_FORMED, wornMessage = horlaisID.text.ORB_IS_CRACKED },
+
+    experimental = true,
 })
 
 content:addEssentialMobs({ 'Orcish_Onager' })

--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -225,6 +225,9 @@ xi.settings.map =
     -- Enable/disable level cap of mission battlefields stored in database.
     LV_CAP_MISSION_BCNM = false,
 
+    -- Allow players to enter BCNMs which are flagged as experimental
+    BCNM_ENABLE_EXPERIMENTAL = true,
+
     -- Max allowed merits points players can hold
     -- 10 classic
     -- 30 abyssea


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
* Adds an `experimental` boolean to battlefield constructor which increases mob levels by 100%, prints a warning on entry, and adds a setting to disallow entry to experimental BCNMs
* Adds experimental flag to previously disabled BCNMs in Horlais Peak and Balga's Dais
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
* Enter a BCNM with experimental, disable experimental, disable experimental setting

![image](https://github.com/LandSandBoat/server/assets/81713309/ff94aed4-33ec-4b48-837c-eb5d17263e51)

<!-- Clear and detailed steps to test your changes here -->
