### PR TITLE
[lua] Twinkbrix

### DIFF
--- a/scripts/enum/item.lua
+++ b/scripts/enum/item.lua
@@ -909,6 +909,7 @@ xi.item =
     POUCH_OF_PARRADAMO_STONES           = 1778,
     COTTON_POUCH                        = 1779,
     HANDFUL_OF_CHAMNAET_ICE             = 1780,
+    SYLVAN_STONE                        = 1781,
     FREE_CHOCOPASS                      = 1789,
     SUPERNAL_FRAGMENT                   = 1822,
     SHRIMP_LANTERN                      = 1823,

--- a/scripts/zones/Oldton_Movalpolos/npcs/Twinkbrix.lua
+++ b/scripts/zones/Oldton_Movalpolos/npcs/Twinkbrix.lua
@@ -4,48 +4,89 @@
 -- Type: Warp NPC
 -- !pos -292.779 6.999 -263.153 11
 -----------------------------------
+local ID = require("scripts/zones/Oldton_Movalpolos/IDs")
+require("scripts/globals/teleports")
+require("scripts/globals/npc_util")
+-----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
+    local operatingLeverCD = player:getCharVar("[ENM]OperatingLever")
+    local gateDialCD = player:getCharVar("[ENM]GateDial")
     local mineShaftWarpCost = 2000
     local tradeGil = trade:getGil()
 
     if
+        player:hasKeyItem(xi.ki.SHAFT_2716_OPERATING_LEVER) and
+        npcUtil.tradeHasExactly(trade, { { "gil", mineShaftWarpCost } })
+    then
+        player:startEvent(56, 1781, 23, 1757, 177552692, 8, 17407, 15, 0)
+
+    elseif
         player:hasKeyItem(xi.ki.SHAFT_GATE_OPERATING_DIAL) and
-        npcUtil.tradeHas(trade, { { 'gil', mineShaftWarpCost } })
+        npcUtil.tradeHasExactly(trade, { { "gil", mineShaftWarpCost } })
     then
         player:startEvent(56)
+
     elseif
         not player:hasKeyItem(xi.ki.SHAFT_GATE_OPERATING_DIAL) and
-        tradeGil > 0 and
-        tradeGil <= 10000 and
-        npcUtil.tradeHas(trade, { { 'gil', tradeGil } })
+        tradeGil > 0 and tradeGil <= 10000 and
+        npcUtil.tradeHasExactly(trade, { { "gil", tradeGil } }) and
+        gateDialCD < VanadielTime()
     then
         local maxRoll = tradeGil / 200
         local diceRoll = math.random(2, 100)
+        player:tradeComplete() -- Completing trade here prevents exploiting this system
         player:startEvent(55, tradeGil, maxRoll, diceRoll, mineShaftWarpCost)
+
+    elseif
+        trade:hasItemQty(1781, 1) and
+        trade:getItemCount() == 1 and
+        operatingLeverCD < VanadielTime()
+    then
+        player:startEvent(51, 1781)
     end
 end
 
 entity.onTrigger = function(player, npc)
-    if player:hasKeyItem(xi.ki.SHAFT_GATE_OPERATING_DIAL) then
+    local operatingLeverCD = player:getCharVar("[ENM]OperatingLever")
+    local gateDialCD = player:getCharVar("[ENM]GateDial")
+
+    if
+        player:hasKeyItem(xi.ki.SHAFT_GATE_OPERATING_DIAL) or
+        player:hasKeyItem(xi.ki.SHAFT_2716_OPERATING_LEVER)
+    then
         player:startEvent(50)
+
+    elseif operatingLeverCD > VanadielTime() then
+        player:startEvent(53, 1781, operatingLeverCD)
+
+    elseif gateDialCD > VanadielTime() then
+        player:startEvent(52, 1781, 432000, 10, gateDialCD, 2, 209, 209, 0)
+
     else
-        player:startEvent(52)
+        player:startEvent(52, 1781)
     end
 end
 
-entity.onEventUpdate = function(player, csid, option, npc)
+entity.onEventUpdate = function(player, csid, option)
 end
 
-entity.onEventFinish = function(player, csid, option, npc)
-    if csid == 55 and option == 1 then
+entity.onEventFinish = function(player, csid, option)
+    print(option)
+
+    if csid == 51 then
+        player:setCharVar("[ENM]OperatingLever", VanadielTime() + (xi.settings.main.ENM_COOLDOWN * 3600))
+        npcUtil.giveKeyItem(player, xi.ki.SHAFT_2716_OPERATING_LEVER)
+        player:tradeComplete()
+
+    elseif csid == 55 and option == 1 then
+        player:setCharVar("[ENM]GateDial", VanadielTime() + (xi.settings.main.ENM_COOLDOWN * 3600))
         npcUtil.giveKeyItem(player, xi.ki.SHAFT_GATE_OPERATING_DIAL)
-        player:confirmTrade()
-    elseif csid == 55 and option == 0 then
-        player:confirmTrade()
+
     elseif csid == 56 and option == 1 then
-        player:confirmTrade()
+        player:delKeyItem(xi.ki.SHAFT_2716_OPERATING_LEVER)
+        player:tradeComplete()
         xi.teleport.to(player, xi.teleport.id.MINESHAFT)
     end
 end

--- a/scripts/zones/Oldton_Movalpolos/npcs/Twinkbrix.lua
+++ b/scripts/zones/Oldton_Movalpolos/npcs/Twinkbrix.lua
@@ -4,68 +4,96 @@
 -- Type: Warp NPC
 -- !pos -292.779 6.999 -263.153 11
 -----------------------------------
-local ID = require("scripts/zones/Oldton_Movalpolos/IDs")
-require("scripts/globals/teleports")
-require("scripts/globals/npc_util")
------------------------------------
 local entity = {}
 
+entity.onTrigger = function(player, npc)
+    -- Trigger is only ever informative events about key item and cooldown status
+    local operatingLeverCD = player:getCharVar('[ENM]OperatingLever')
+    local operatingLeverWaiting = operatingLeverCD > VanadielTime()
+    local operatingLeverHas = player:hasKeyItem(xi.ki.SHAFT_2716_OPERATING_LEVER)
+
+    local gateDialCD = player:getCharVar('[ENM]GateDial')
+    local gateDialWaiting = gateDialCD > VanadielTime()
+    local gateDialHas = player:hasKeyItem(xi.ki.SHAFT_GATE_OPERATING_DIAL)
+
+    if
+        operatingLeverHas and
+        gateDialHas
+    then
+        player:startEvent(50)
+
+    -- lever on cooldown
+    else
+        -- generic messages about how to obtain both items
+        -- player:startEvent(52, xi.item.SYLVAN_STONE)
+
+        local eventID = (gateDialHas and operatingLeverWaiting) and 53 or 52
+        local operatingLeverParam = operatingLeverWaiting and operatingLeverCD or 432000
+        local gateDialParam = gateDialWaiting and gateDialCD or 432000
+        local keyItemFlag = 0 -- This event param passes whether the player has/can get both key items
+        keyItemFlag = utils.mask.setBit(keyItemFlag, 0, operatingLeverWaiting)
+        keyItemFlag = utils.mask.setBit(keyItemFlag, 1, gateDialWaiting)
+        keyItemFlag = utils.mask.setBit(keyItemFlag, 2, operatingLeverHas)
+        keyItemFlag = utils.mask.setBit(keyItemFlag, 3, gateDialHas)
+
+        player:startEvent(eventID, xi.item.SYLVAN_STONE, operatingLeverParam, 2964, gateDialParam, keyItemFlag)
+    end
+end
+
 entity.onTrade = function(player, npc, trade)
-    local operatingLeverCD = player:getCharVar("[ENM]OperatingLever")
-    local gateDialCD = player:getCharVar("[ENM]GateDial")
+    local operatingLeverCD = player:getCharVar('[ENM]OperatingLever')
+    local gateDialCD = player:getCharVar('[ENM]GateDial')
+    local specialGilTrade = 2716
     local mineShaftWarpCost = 2000
     local tradeGil = trade:getGil()
 
     if
-        player:hasKeyItem(xi.ki.SHAFT_2716_OPERATING_LEVER) and
-        npcUtil.tradeHasExactly(trade, { { "gil", mineShaftWarpCost } })
-    then
-        player:startEvent(56, 1781, 23, 1757, 177552692, 8, 17407, 15, 0)
-
-    elseif
         player:hasKeyItem(xi.ki.SHAFT_GATE_OPERATING_DIAL) and
-        npcUtil.tradeHasExactly(trade, { { "gil", mineShaftWarpCost } })
+        npcUtil.tradeHasExactly(trade, { { 'gil', mineShaftWarpCost } })
     then
-        player:startEvent(56)
+        -- teleport for mineShaftWarpCost relies on having SHAFT_GATE_OPERATING_DIAL
+        -- but consumes SHAFT_2716_OPERATING_LEVER (after confirming with you)
+        if player:hasKeyItem(xi.ki.SHAFT_2716_OPERATING_LEVER) then
+            player:startEvent(56, xi.item.SYLVAN_STONE, 23) -- capture contained these additional, unimportant items:, 1757, 177552692, 8, 17407, 15, 0)
+        else
+            player:startEvent(56)
+        end
 
     elseif
         not player:hasKeyItem(xi.ki.SHAFT_GATE_OPERATING_DIAL) and
         tradeGil > 0 and tradeGil <= 10000 and
-        npcUtil.tradeHasExactly(trade, { { "gil", tradeGil } }) and
-        gateDialCD < VanadielTime()
+        gateDialCD < VanadielTime() and
+        npcUtil.tradeHasExactly(trade, { { 'gil', tradeGil } })
     then
-        local maxRoll = tradeGil / 200
-        local diceRoll = math.random(2, 100)
+        local maxToWin = math.floor(tradeGil / 200)
+        local maxRoll = 100
+        -- SE unveiled that trading a specific amount of gil on a specific day will improve chances of a win.
+        -- This number has been proven to be 2,716 (referring to Mine Shaft #2716), as the dialogue will change
+        -- and the correct day is Lightsday ('confirmed' via player reports).
+        if
+            tradeGil == specialGilTrade and
+            VanadielDayElement() == xi.element.LIGHT
+        then
+            -- trading 2716 gives a special message in the client, but
+            -- specifically for Lightsday we change the max random number to heavily weight winning the roll
+            maxRoll = 20 -- TODO confirm this value via a lot of data
+        end
+
+        local diceRoll = math.random(2, maxRoll)
         player:tradeComplete() -- Completing trade here prevents exploiting this system
-        player:startEvent(55, tradeGil, maxRoll, diceRoll, mineShaftWarpCost)
+        player:startEvent(55, tradeGil, maxToWin, diceRoll, mineShaftWarpCost)
 
     elseif
-        trade:hasItemQty(1781, 1) and
-        trade:getItemCount() == 1 and
-        operatingLeverCD < VanadielTime()
+        operatingLeverCD < VanadielTime() and
+        npcUtil.tradeHasExactly(trade, { xi.item.SYLVAN_STONE })
     then
-        player:startEvent(51, 1781)
-    end
-end
-
-entity.onTrigger = function(player, npc)
-    local operatingLeverCD = player:getCharVar("[ENM]OperatingLever")
-    local gateDialCD = player:getCharVar("[ENM]GateDial")
-
-    if
-        player:hasKeyItem(xi.ki.SHAFT_GATE_OPERATING_DIAL) or
-        player:hasKeyItem(xi.ki.SHAFT_2716_OPERATING_LEVER)
+        player:startEvent(51, xi.item.SYLVAN_STONE)
+    elseif
+        (tradeGil > 0 and tradeGil <= 10000) or
+        trade:hasItemQty(xi.item.SYLVAN_STONE, 1)
     then
-        player:startEvent(50)
-
-    elseif operatingLeverCD > VanadielTime() then
-        player:startEvent(53, 1781, operatingLeverCD)
-
-    elseif gateDialCD > VanadielTime() then
-        player:startEvent(52, 1781, 432000, 10, gateDialCD, 2, 209, 209, 0)
-
-    else
-        player:startEvent(52, 1781)
+        -- Trying to trade for a key item, but didn't match anything above. Give generic onTrigger message from logic above
+        entity.onTrigger(player, npc)
     end
 end
 
@@ -73,15 +101,15 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    print(option)
-
     if csid == 51 then
-        player:setCharVar("[ENM]OperatingLever", VanadielTime() + (xi.settings.main.ENM_COOLDOWN * 3600))
+        -- TODO entering battle sets the cooldown (extra important here as using the teleport consumes this key item, and it should be possible to immediately get another)
+        player:setCharVar('[ENM]OperatingLever', VanadielTime() + (xi.settings.main.ENM_COOLDOWN * 3600))
         npcUtil.giveKeyItem(player, xi.ki.SHAFT_2716_OPERATING_LEVER)
         player:tradeComplete()
 
     elseif csid == 55 and option == 1 then
-        player:setCharVar("[ENM]GateDial", VanadielTime() + (xi.settings.main.ENM_COOLDOWN * 3600))
+        -- TODO entering battle sets the cooldown
+        player:setCharVar('[ENM]GateDial', VanadielTime() + (xi.settings.main.ENM_COOLDOWN * 3600))
         npcUtil.giveKeyItem(player, xi.ki.SHAFT_GATE_OPERATING_DIAL)
 
     elseif csid == 56 and option == 1 then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Cleans up the logic for [Twinkbrix](https://www.bg-wiki.com/ffxi/Twinkbrix). Started with a cherry-pick from ASB then fell down the rabbit hole of getting retail captures and changed basically everything

- The logic of giving key items based on event id is unchanged from ASB (in `onEventFinish`)
  - Note that the cooldown technically needs to be started when the battle is entered, but afaik all other ENMs do it in the npc lua so that is left as a TODO (esp. since the fights aren't implemented yet)
- The trade logic was mostly correct except that trading 2k gil should only teleport you if you have the gate dial.
  - sub logic exists that if you have the operating lever, prompt if you are sure:
  - ![image](https://github.com/LandSandBoat/server/assets/131182600/252db5a0-bacd-464d-a9ab-0d17830a1e53)
- A message is added to the trade logic to revert to the `onTrigger` informational event if you trade the requirements for either key item
- The onTrigger function only ever gives information about the two ENM key items: `SHAFT_GATE_OPERATING_DIAL` and `SHAFT_2716_OPERATING_LEVER`
  - logic has so many possible combinations it felt impossible but after many captures I noticed the pattern
  - Event ID 50 is a generic "you got what you need" message
  - Event ID 53 is a generic "you can't get the operating lever until X time"
  - Event ID 52 has many possible combinations that vary depending on which key items you have/are on cooldown

Final note about trading 2716 gil:
- SE unveiled on a stream that this NPC had a special combination of gil and day to get a higher chance of winning. 
  - It is assumed to be 2716 on lightsday, due to the special message for trading 2716
  - It is highly likely the day is lightsday, due to player reports of winning often. Takes a bit more testing but we've yet to trade 2716 on lightsday and not win (current code in this PR makes the winning number <=13 in the range 2-20 so decent chance of losing still)
  - The 2716 on lightsday still says you need to roll between 2 and 13 so the higher chance is given (in this code) by changing the range of the random number. This matches what we've seen on retail:
    - ![image](https://github.com/LandSandBoat/server/assets/131182600/891b5855-a5bd-44e1-b900-3c172102b268)
    - ![image](https://github.com/LandSandBoat/server/assets/131182600/a8fc849a-ccb9-4465-a6e9-de0575b367eb)


## Steps to test these changes

trade the following things and notice the behavior depending on if you have the right key item/the ENM cooldown is in the future 
- 2k gil
  - if you have the key item: 
![image](https://github.com/LandSandBoat/server/assets/131182600/3181585a-ca60-428f-86ba-cffc6fc89ad0)

- 2716 gil
  - if you don't have key item and aren't on cooldown:  
![image](https://github.com/LandSandBoat/server/assets/131182600/7f5b95d3-5b2b-44d9-b066-2b0d1381920b)

- between 1k and 10k gil
  - same as above, without the special message
- Sylvan Stone item
  - if you don't have key item and aren't on cooldown:
![image](https://github.com/LandSandBoat/server/assets/131182600/a7044d12-1b17-4c17-82a8-dbf42f759fa0)

