### PR TITLE
[lua] Update incorrect call to giveItem without a quantity

### DIFF
--- a/scripts/items/combat_casters_quiver.lua
+++ b/scripts/items/combat_casters_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    npcUtil.giveItem(target, { { xi.item.COMBAT_CASTERS_ARROW } })
+    npcUtil.giveItem(target, { { xi.item.COMBAT_CASTERS_ARROW, 1 } })
 end
 
 return itemObject

--- a/scripts/items/iron_musketeers_quiver.lua
+++ b/scripts/items/iron_musketeers_quiver.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    npcUtil.giveItem(target, { { xi.item.IRON_MUSKETEERS_BOLT } })
+    npcUtil.giveItem(target, { { xi.item.IRON_MUSKETEERS_BOLT, 1 } })
 end
 
 return itemObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Small oversight in the massive update to dispensing items from a few weeks ago. Only two items that have the oversight:

![image](https://github.com/LandSandBoat/server/assets/131182600/226d5b23-1d0c-4e07-bec6-0dc97d9207bf)


## Steps to test these changes

![image](https://github.com/LandSandBoat/server/assets/131182600/d6cafc47-6dbf-4790-9431-27cf05bc1264)

I'm not actually sure if this item should allow you to use it if npcUtil fails due to a rare/ex item, but the PR fixes the issue of the item doing nothing