### PR TITLE
[cpp] Update petskill hasMissMsg to include JA miss msg ID

### DIFF
--- a/src/map/petskill.cpp
+++ b/src/map/petskill.cpp
@@ -47,7 +47,7 @@ CPetSkill::CPetSkill(uint16 id)
 
 bool CPetSkill::hasMissMsg() const
 {
-    return m_Message == 158 || m_Message == 188 || m_Message == 31 || m_Message == 30;
+    return m_Message == 324 || m_Message == 158 || m_Message == 188 || m_Message == 31 || m_Message == 30;
 }
 
 bool CPetSkill::isAoE() const


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The recent [PR](https://github.com/LandSandBoat/server/pull/5458) to update avatar petskill miss messages used the proper miss message for petskills/job abilities, this is not listed in the `hasMissMsg()` function and resulted in the same dang issue that the previous PR was trying to fix:

![image](https://github.com/LandSandBoat/server/assets/131182600/03d849c8-915f-422a-a123-cfc67987b323)

The updated coded properly matches that this is a miss in the code after petskill finishes to not allow skillchaining:

![image](https://github.com/LandSandBoat/server/assets/131182600/328767ac-6ac2-47ea-acd4-b3eb2ad20128)

skillchain of course still works when not missing:

![image](https://github.com/LandSandBoat/server/assets/131182600/3c5b7813-9944-4a97-8bba-3b98b0b1cf11)


## Steps to test these changes

Give an avatar -1000 acc, give mob +1000 eva, use punch > burning strike and see they both miss and it doesn't skillchain