### PR TITLE
[core] Move SIRD interrupt reduction

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1782,14 +1782,19 @@ namespace battleutils
         }
 
         float interruptRate = ((100.0f - (meritReduction + (float)PDefender->getMod(Mod::SPELLINTERRUPT))) / 100.0f);
-        check *= interruptRate;
-        uint8 chance = xirand::GetRandomNumber(100);
 
-        // caps, always give a 1% chance of interrupt
-        if (check < 1)
+        float chance = xirand::GetRandomNumber<float>(1.0f);
+
+        // caps, always give a 1% chance of interrupt // TODO: verify, perhaps there is a breakpoint where this no longer happens.
+        if (check < 0.01)
         {
-            check = 0;
+            check = 0.01;
         }
+
+        // SIRD reduces the interrupt after all the calculations are done -- as evidenced by the infamous "102% SIRD" builds.
+        // Anything less than 102% interrupt results in the ability to be interrupted.
+        // Note: the 102% is probably an x/256 x/1024 nonsense -- sometimes 101% works.
+        check *= interruptRate;
 
         if (chance < check)
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Evidenced by the fact that you need exactly [102%](https://www.bg-wiki.com/ffxi/Spell_Interruption_Rate) SIRD to be truly immune to spell interrupts, the calculation for spell interrupt was slightly altered.

## Steps to test these changes
Get 100% spell interrupt and be uninterruptible.
