### PR TITLE
Update exit locations for promy holla and mea

### DIFF
--- a/scripts/zones/Spire_of_Holla/bcnms/ancient_flames_beckon.lua
+++ b/scripts/zones/Spire_of_Holla/bcnms/ancient_flames_beckon.lua
@@ -46,7 +46,7 @@ battlefieldObject.onEventFinish = function(player, csid, option, npc)
         player:getLocalVar('toLufaise') ~= 1
     then
         player:addExp(1500)
-        xi.teleport.to(player, xi.teleport.id.EXITPROMDEM)
+        xi.teleport.to(player, xi.teleport.id.EXITPROMHOLLA)
     end
 end
 

--- a/scripts/zones/Spire_of_Mea/bcnms/ancient_flames_beckon.lua
+++ b/scripts/zones/Spire_of_Mea/bcnms/ancient_flames_beckon.lua
@@ -46,7 +46,7 @@ battlefieldObject.onEventFinish = function(player, csid, option, npc)
         player:getLocalVar('toLufaise') ~= 1
     then
         player:addExp(1500)
-        xi.teleport.to(player, xi.teleport.id.EXITPROMDEM)
+        xi.teleport.to(player, xi.teleport.id.EXITPROMMEA)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Exit location when past the mothercyrstals mission should be the respective spire's crag, just like when completing it before your third:

> After defeating each boss once, you will be awarded with (Key Item [Light of Dem](https://www.bg-wiki.com/ffxi/Light_of_Dem), Key Item [Light of Holla](https://www.bg-wiki.com/ffxi/Light_of_Holla) and Key Item [Light of Mea](https://www.bg-wiki.com/ffxi/Light_of_Mea)) and be transported out to the area in which you entered.

## Steps to test these changes

There's a slight oversight with the bcnm completion logic so you need to be past the mothercrystals to properly test this change:
- `!addmission 6 AN_INVITATION_WEST`

Go into the 3 base spires, togglegm to get access to the mission, kill boss

you will get teleported to the base of the current crag instead of all 3 sending you to dem

![image](https://github.com/LandSandBoat/server/assets/131182600/4c842510-38e0-485f-b0e5-44a0ca6b2888)
