### PR TITLE
[cpp] Allow isInDynamis() to return proper value while zoning

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -47,6 +47,7 @@
 #include "utils/battleutils.h"
 #include "utils/petutils.h"
 #include "utils/puppetutils.h"
+#include "utils/zoneutils.h"
 #include "weapon_skill.h"
 
 CBattleEntity::CBattleEntity()
@@ -111,9 +112,10 @@ bool CBattleEntity::isAlive()
 
 bool CBattleEntity::isInDynamis()
 {
-    if (loc.zone != nullptr)
+    auto* PZone = loc.zone == nullptr ? zoneutils::GetZone(loc.destination) : loc.zone;
+    if (PZone)
     {
-        return loc.zone->GetTypeMask() & ZONE_TYPE::DYNAMIS;
+        return PZone->GetTypeMask() & ZONE_TYPE::DYNAMIS;
     }
     return false;
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Original reported issue (to us) was that stage 3 relics didn't give the weaponskill unless weapons were switched after initial zone.

This function appears to only be used for 3 things:
- `ADDS_WEAPONSKILL_DYN`
- `LATENT::IN_DYNAMIS`
- various mob behavior

First 2 only are affected by this change, and confirmed they work with the updated change. This updated logic is used in a few places to resolve the real zone ID of a player into a zone pointer

## Steps to test these changes

Do this before and after compiling in these changes to see the different behavior
- equip `Batardeau` as a lvl 75 thf
- zone into dynamis
- look at ws list
- change ranged weapon
- look at ws list again

to confirm latents for isInDynamis
- do the same with `malefic_dagger`
- zone into dynamis
- run `!getstats` on the player
- see the main weapon damage is 23 and not 1