### PR TITLE
[LUA] Fix Rinpyotosha only affects caster

### DIFF
--- a/scripts/actions/mobskills/rinpyotosha.lua
+++ b/scripts/actions/mobskills/rinpyotosha.lua
@@ -13,7 +13,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.WARCRY, 25, 0, 180))
+    skill:setMsg(xi.mobskills.mobBuffMove(target, xi.effect.WARCRY, 25, 0, 180))
 
     return xi.effect.WARCRY
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes an issue with Rinpyotosha where it only affects the caster instead of the caster and it's allies.

## Steps to test these changes

1. Summon Gessho
2. !exec target:useMobAbility(3260)
