### PR TITLE
[LUA]Clears enmity when using Staging Point doors.

### DIFF
--- a/scripts/zones/Arrapago_Reef/npcs/_jib.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/_jib.lua
@@ -15,7 +15,7 @@ entity.onTrigger = function(player, npc)
         if player:getXPos() < 8 then
             player:messageSpecial(ID.text.STAGING_GATE_ILRUSI)
             player:messageSpecial(ID.text.STAGING_GATE_INTERACT)
-            player:startEvent(106)
+            player:startOptionalCutscene(106)
         elseif not player:hasKeyItem(xi.ki.ILRUSI_ASSAULT_ORDERS) then
             player:messageSpecial(ID.text.STAGING_GATE_ILRUSI)
             player:messageSpecial(ID.text.STAGING_GATE_INTERACT)

--- a/scripts/zones/Bhaflau_Thickets/npcs/_1g1.lua
+++ b/scripts/zones/Bhaflau_Thickets/npcs/_1g1.lua
@@ -15,7 +15,7 @@ entity.onTrigger = function(player, npc)
         if player:getZPos() > -761 then
             player:messageSpecial(ID.text.STAGING_GATE_MAMOOL)
             player:messageSpecial(ID.text.STAGING_GATE_INTERACT)
-            player:startEvent(106)
+            player:startOptionalCutscene(106)
         elseif not player:hasKeyItem(xi.ki.MAMOOL_JA_ASSAULT_ORDERS) then
             player:messageSpecial(ID.text.STAGING_GATE_MAMOOL)
             player:messageSpecial(ID.text.STAGING_GATE_INTERACT)

--- a/scripts/zones/Caedarva_Mire/npcs/_270.lua
+++ b/scripts/zones/Caedarva_Mire/npcs/_270.lua
@@ -15,7 +15,7 @@ entity.onTrigger = function(player, npc)
         if player:getZPos() > -438 then
             player:messageSpecial(ID.text.STAGING_GATE_AZOUPH)
             player:messageSpecial(ID.text.STAGING_GATE_INTERACT)
-            player:startEvent(120)
+            player:startOptionalCutscene(120)
         elseif not player:hasKeyItem(xi.ki.LEUJAOAM_ASSAULT_ORDERS) then
             player:messageSpecial(ID.text.STAGING_GATE_AZOUPH)
             player:messageSpecial(ID.text.STAGING_GATE_INTERACT)

--- a/scripts/zones/Caedarva_Mire/npcs/_271.lua
+++ b/scripts/zones/Caedarva_Mire/npcs/_271.lua
@@ -15,7 +15,7 @@ entity.onTrigger = function(player, npc)
         if player:getZPos() < -78 then
             player:messageSpecial(ID.text.STAGING_GATE_DVUCCA)
             player:messageSpecial(ID.text.STAGING_GATE_INTERACT)
-            player:startEvent(122)
+            player:startOptionalCutscene(122)
         elseif not player:hasKeyItem(xi.ki.PERIQIA_ASSAULT_ORDERS) then
             player:messageSpecial(ID.text.STAGING_GATE_DVUCCA)
             player:messageSpecial(ID.text.STAGING_GATE_INTERACT)

--- a/scripts/zones/Mount_Zhayolm/npcs/_1p0.lua
+++ b/scripts/zones/Mount_Zhayolm/npcs/_1p0.lua
@@ -15,7 +15,7 @@ entity.onTrigger = function(player, npc)
         if player:getZPos() < 332 then
             player:messageSpecial(ID.text.STAGING_GATE_HALVUNG)
             player:messageSpecial(ID.text.STAGING_GATE_INTERACT)
-            player:startEvent(106)
+            player:startOptionalCutscene(106)
         elseif not player:hasKeyItem(xi.ki.LEBROS_ASSAULT_ORDERS) then
             player:messageSpecial(ID.text.STAGING_GATE_HALVUNG)
             player:messageSpecial(ID.text.STAGING_GATE_INTERACT)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Changed startEvent() to startOptionalEvent() which will clear enmity.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Mob should not follow you into staging point. 
Go to staging point, aggro a mob, reenter staging point via door. Enmity will be lost for player and pet as per retail (No mobs in the champagne room!)
<!-- Clear and detailed steps to test your changes here -->
