### PR TITLE
[cpp/lua] Sacrifice Torque

### DIFF
--- a/scripts/items/sacrifice_torque.lua
+++ b/scripts/items/sacrifice_torque.lua
@@ -19,7 +19,7 @@ end
 
 itemObject.onItemEquip  = function(user, item)
     local listenerName = fmt('{}_{}', listenerPrefix, item:getID())
-    if user:allLatentsActive(xi.slot.NECK) then
+    if user:hasAllLatentsActive(xi.slot.NECK) then
         user:setLocalVar(listenerName, 1)
         xi.itemUtils.handlePetLatentMods(user, latentPetId, latentMods, true)
     end
@@ -38,6 +38,7 @@ itemObject.onItemUnequip = function(user, item)
         xi.itemUtils.handlePetLatentMods(user, latentPetId, latentMods, false)
     end
 
+    user:setLocalVar(listenerName, 0)
     user:removeListener(listenerName)
 end
 

--- a/scripts/items/sacrifice_torque.lua
+++ b/scripts/items/sacrifice_torque.lua
@@ -1,14 +1,16 @@
 -----------------------------------
--- ID: 11675
--- Fervor Ring
+-- ID: 15528
+-- Sacrifice Torque
 -- Pet mod via latent effect
+-- Latents are added to player before OnItemEquip is called
+-- Latents are removed from player before OnItemUnequip is called
 -----------------------------------
 local itemObject = {}
 local listenerPrefix = 'PET_MOD_LATENT'
-local latentPetId = xi.petId.IFRIT
+local latentPetId = nil
 local latentMods =
 {
-    { xi.mod.MATT, 2 },
+    { xi.mod.ATT, 3 },
 }
 
 itemObject.onItemCheck = function(target)
@@ -17,10 +19,14 @@ end
 
 itemObject.onItemEquip  = function(user, item)
     local listenerName = fmt('{}_{}', listenerPrefix, item:getID())
-    xi.itemUtils.handlePetLatentMods(user, latentPetId, latentMods, true)
+    if user:allLatentsActive(xi.slot.NECK) then
+        user:setLocalVar(listenerName, 1)
+        xi.itemUtils.handlePetLatentMods(user, latentPetId, latentMods, true)
+    end
 
     user:addListener('MAGIC_STATE_EXIT', listenerName, function(player, spell)
         if spell:getSpellGroup() == xi.magic.spellGroup.SUMMONING then
+            player:setLocalVar(listenerName, 1)
             xi.itemUtils.handlePetLatentMods(user, latentPetId, latentMods, true)
         end
     end)
@@ -28,7 +34,9 @@ end
 
 itemObject.onItemUnequip = function(user, item)
     local listenerName = fmt('{}_{}', listenerPrefix, item:getID())
-    xi.itemUtils.handlePetLatentMods(user, latentPetId, latentMods, false)
+    if user:getLocalVar(listenerName) == 1 then
+        xi.itemUtils.handlePetLatentMods(user, latentPetId, latentMods, false)
+    end
 
     user:removeListener(listenerName)
 end

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -157,6 +157,8 @@ INSERT INTO `item_latents` VALUES (11667,369,1,57,0);    -- Rollers Ring Refresh
 -- Oneiros Ring
 INSERT INTO `item_latents` VALUES (11671,302,2,55,100);  -- Triple Attack +2% when mp is greater than or equal to 100
 
+-- Fervor Ring (pet latent via item lua)
+
 -- Flock Ring
 INSERT INTO `item_latents` VALUES (11676,26,1,16,3);
 INSERT INTO `item_latents` VALUES (11676,26,1,16,4);
@@ -1246,10 +1248,9 @@ INSERT INTO `item_latents` VALUES (15516,26,-16,52,8);   -- cumulative ranged ac
 INSERT INTO `item_latents` VALUES (15519,370,1,58,0);    -- storm muffler regen +1
 INSERT INTO `item_latents` VALUES (15520,68,7,58,0);     -- storm torque eva +7
 
--- Sacrifice Torque
+-- Sacrifice Torque (pet latent via item lua)
 INSERT INTO `item_latents` VALUES (15528,369,-3,21,21); -- AVATAR_IN_PARTY: 21 - REFRESH: -3
 INSERT INTO `item_latents` VALUES (15528,370,-8,21,21); -- AVATAR_IN_PARTY: 21 - REGEN:   -8
--- TODO: INSERT INTO `item_latents` VALUES (15528,??,3,21,21); -- AVATAR_IN_PARTY: 21 - Avatar ATT: 3
 
 -- Ace's Locket
 INSERT INTO `item_latents` VALUES (15529,291,5,0,25); -- HP_UNDER_PERCENT: 25 - COUNTER: 5

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -77,7 +77,7 @@ void CLatentEffectContainer::DelLatentEffects(uint8 reqLvl, uint8 slot)
 *                                                                       *
  ************************************************************************/
 
-bool CLatentEffectContainer::AllLatentsActive(uint8 slot)
+bool CLatentEffectContainer::HasAllLatentsActive(uint8 slot)
 {
     auto allActive = true;
     for (auto iter = m_LatentEffectList.begin(); iter != m_LatentEffectList.end(); ++iter)

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -801,7 +801,10 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
                     if (member->PPet != nullptr)
                     {
                         auto* PPet = (CPetEntity*)member->PPet;
-                        if (PPet->m_PetID == latentEffect.GetConditionsValue() && PPet->PAI->IsSpawned())
+                        if (
+                                !PPet->isDead() && PPet->m_PetID < 21 && // is a live avatar
+                                (PPet->m_PetID == latentEffect.GetConditionsValue() || latentEffect.GetConditionsValue() == 21)
+                            )
                         {
                             expression = true;
                             break;
@@ -812,7 +815,10 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
             else if (m_POwner->PParty == nullptr && m_POwner->PPet != nullptr)
             {
                 auto* PPet = (CPetEntity*)m_POwner->PPet;
-                if (PPet->m_PetID == latentEffect.GetConditionsValue() && !PPet->isDead())
+                if (
+                        !PPet->isDead() && PPet->m_PetID < 21 && // is a live avatar
+                        (PPet->m_PetID == latentEffect.GetConditionsValue() || latentEffect.GetConditionsValue() == 21)
+                    )
                 {
                     expression = true;
                 }

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -71,6 +71,26 @@ void CLatentEffectContainer::DelLatentEffects(uint8 reqLvl, uint8 slot)
                              m_LatentEffectList.end());
 }
 
+/************************************************************************
+*                                                                       *
+* Returns true if no latents for slot are inactive                      *
+*                                                                       *
+ ************************************************************************/
+
+bool CLatentEffectContainer::AllLatentsActive(uint8 slot)
+{
+    auto allActive = true;
+    for (auto iter = m_LatentEffectList.begin(); iter != m_LatentEffectList.end(); ++iter)
+    {
+        CLatentEffect& latent = *iter;
+        if (!latent.IsActivated() && latent.GetSlot() == slot)
+        {
+            allActive = false;
+        }
+    }
+    return allActive;
+}
+
 void CLatentEffectContainer::AddLatentEffect(LATENT conditionID, uint16 conditionValue, Mod modID, int16 modValue)
 {
     m_LatentEffectList.emplace_back(m_POwner, conditionID, conditionValue, MAX_SLOTTYPE, modID, modValue);

--- a/src/map/latent_effect_container.h
+++ b/src/map/latent_effect_container.h
@@ -66,6 +66,7 @@ public:
 
     void AddLatentEffects(std::vector<CItemEquipment::itemLatent>& latentList, uint8 reqLvl, uint8 slot);
     void DelLatentEffects(uint8 reqLvl, uint8 slot);
+    bool AllLatentsActive(uint8 slot);
 
     void AddLatentEffect(LATENT conditionID, uint16 conditionValue, Mod modID, int16 modValue);
     bool DelLatentEffect(LATENT conditionID, uint16 conditionValue, Mod modID, int16 modValue);

--- a/src/map/latent_effect_container.h
+++ b/src/map/latent_effect_container.h
@@ -66,7 +66,7 @@ public:
 
     void AddLatentEffects(std::vector<CItemEquipment::itemLatent>& latentList, uint8 reqLvl, uint8 slot);
     void DelLatentEffects(uint8 reqLvl, uint8 slot);
-    bool AllLatentsActive(uint8 slot);
+    bool HasAllLatentsActive(uint8 slot);
 
     void AddLatentEffect(LATENT conditionID, uint16 conditionValue, Mod modID, int16 modValue);
     bool DelLatentEffect(LATENT conditionID, uint16 conditionValue, Mod modID, int16 modValue);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -13085,13 +13085,13 @@ bool CLuaBaseEntity::delLatent(uint16 condID, uint16 conditionValue, uint16 mID,
 }
 
 /************************************************************************
- *  Function: allLatentsActive()
+ *  Function: hasAllLatentsActive()
  *  Purpose : Returns false if any latents for the slot are not active
- *  Example : player:allLatentsActive(xi.slot.NECK)
+ *  Example : player:hasAllLatentsActive(xi.slot.NECK)
  *  Notes   :
  ************************************************************************/
 
-bool CLuaBaseEntity::allLatentsActive(uint8 slot)
+bool CLuaBaseEntity::hasAllLatentsActive(uint8 slot)
 {
     if (m_PBaseEntity->objtype != TYPE_PC)
     {
@@ -13099,7 +13099,7 @@ bool CLuaBaseEntity::allLatentsActive(uint8 slot)
         return false;
     }
 
-    return static_cast<CCharEntity*>(m_PBaseEntity)->PLatentEffectContainer->AllLatentsActive(slot);
+    return static_cast<CCharEntity*>(m_PBaseEntity)->PLatentEffectContainer->HasAllLatentsActive(slot);
 }
 
 /************************************************************************
@@ -17934,7 +17934,7 @@ void CLuaBaseEntity::Register()
 
     SOL_REGISTER("addLatent", CLuaBaseEntity::addLatent);
     SOL_REGISTER("delLatent", CLuaBaseEntity::delLatent);
-    SOL_REGISTER("allLatentsActive", CLuaBaseEntity::allLatentsActive);
+    SOL_REGISTER("hasAllLatentsActive", CLuaBaseEntity::hasAllLatentsActive);
 
     SOL_REGISTER("fold", CLuaBaseEntity::fold);
     SOL_REGISTER("doWildCard", CLuaBaseEntity::doWildCard);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -13085,6 +13085,24 @@ bool CLuaBaseEntity::delLatent(uint16 condID, uint16 conditionValue, uint16 mID,
 }
 
 /************************************************************************
+ *  Function: allLatentsActive()
+ *  Purpose : Returns false if any latents for the slot are not active
+ *  Example : player:allLatentsActive(xi.slot.NECK)
+ *  Notes   :
+ ************************************************************************/
+
+bool CLuaBaseEntity::allLatentsActive(uint8 slot)
+{
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->getName());
+        return false;
+    }
+
+    return static_cast<CCharEntity*>(m_PBaseEntity)->PLatentEffectContainer->AllLatentsActive(slot);
+}
+
+/************************************************************************
  *  Function: getMaxGearMod()
  *  Purpose : Returns the highest integer value of a specified Mod on all equiped items
  *  Example : local maxValue = player:getMaxGearMod(xi.mod.GEOMANCY_BONUS)
@@ -17916,6 +17934,7 @@ void CLuaBaseEntity::Register()
 
     SOL_REGISTER("addLatent", CLuaBaseEntity::addLatent);
     SOL_REGISTER("delLatent", CLuaBaseEntity::delLatent);
+    SOL_REGISTER("allLatentsActive", CLuaBaseEntity::allLatentsActive);
 
     SOL_REGISTER("fold", CLuaBaseEntity::fold);
     SOL_REGISTER("doWildCard", CLuaBaseEntity::doWildCard);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -660,6 +660,7 @@ public:
 
     void addLatent(uint16 condID, uint16 conditionValue, uint16 mID, int16 modValue);
     bool delLatent(uint16 condID, uint16 conditionValue, uint16 mID, int16 modValue);
+    bool allLatentsActive(uint8 slot);
 
     void   fold();
     void   doWildCard(CLuaBaseEntity* PEntity, uint8 total);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -660,7 +660,7 @@ public:
 
     void addLatent(uint16 condID, uint16 conditionValue, uint16 mID, int16 modValue);
     bool delLatent(uint16 condID, uint16 conditionValue, uint16 mID, int16 modValue);
-    bool allLatentsActive(uint8 slot);
+    bool hasAllLatentsActive(uint8 slot);
 
     void   fold();
     void   doWildCard(CLuaBaseEntity* PEntity, uint8 total);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR does 3 major things
- Adds a player lua binding to check if an item in a certain slot has its latents active
- Fixes the latent effect for "Avatar in the party" to properly understand latent condition 21 to mean _any_ smn pet
- Adds final Sacrifice Torque latent effect to follow logic from [this PR](https://github.com/LandSandBoat/server/pull/5487) for Ferver Ring
  - [Sacrifice torque](https://www.bg-wiki.com/ffxi/Sacrifice_Torque) already has the regen and refresh latents, which should stay as regular latents of course
  - the pet attack latent should be in lua as it only matters/applies if the smn has a pet out, which can only happen if they cast it

## Steps to test these changes

for testing the player binding, equip any item with a latent and check map server output from running: `!exec player:allLatentsActive(xi.slot.BLAH)`

here it is before and after summoning ifrit with the sacrifice torque: `!exec player:allLatentsActive(xi.slot.NECK)`
![image](https://github.com/LandSandBoat/server/assets/131182600/1bdf09c4-803b-48b8-8bfc-cb1e3bb3a846)

For testing the updated latent, again sacrifice torque is a simple way to go
![image](https://github.com/LandSandBoat/server/assets/131182600/e8d51d43-0055-415d-86c9-c3e696759eff)

and finally, testing this updated logic to add the last latent to sacrifice torque:
![image](https://github.com/LandSandBoat/server/assets/131182600/9f4a2585-bf73-4f62-8034-169e9fb18756)

