### PR TITLE
[sql] Shadow ring has 25% deathres

### DIFF
--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -23062,7 +23062,7 @@ INSERT INTO `item_mods` VALUES (14645,5,30);   -- MP: 30
 INSERT INTO `item_mods` VALUES (14645,21,-30); -- LIGHT_RES: -30
 
 -- Shadow Ring
-INSERT INTO `item_mods` VALUES (14646,255,5);  -- DEATHRES: 5
+INSERT INTO `item_mods` VALUES (14646,255,20); -- DEATHRES: 20
 INSERT INTO `item_mods` VALUES (14646,476,13); -- MAGIC_NULL: 13
 
 -- Telluric Ring


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Perhaps the units of `DEATHRES` used to be a different scale, but currently it's only used [here](https://github.com/search?q=repo%3ALandSandBoat%2Fserver%20deathres&type=code), the rate is out of 100, and [the rate](https://www.bg-wiki.com/ffxi/Shadow_Ring) is well-known to be 25%

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
