### PR TITLE
[Fix] Correct Promyvion-Mea event IDs. Correct Mea and Dem's map messages

### DIFF
--- a/scripts/zones/Promyvion-Dem/IDs.lua
+++ b/scripts/zones/Promyvion-Dem/IDs.lua
@@ -18,6 +18,8 @@ zones[xi.zone.PROMYVION_DEM] =
         LOGIN_NUMBER                  = 7003, -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.
         MEMBERS_LEVELS_ARE_RESTRICTED = 7023, -- Your party is unable to participate because certain members' levels are restricted.
         BARRIER_WOVEN                 = 7223, -- It appears to be a barrier woven from the energy of overflowing memories...
+        NOTHING_OUT_OF_ORDINARY_MAP   = 7224, -- There is nothing out of the ordinary here.
+        EERIE_GREEN_GLOW              = 7225, -- The sphere is emitting an eerie green glow.
     },
     mob =
     {

--- a/scripts/zones/Promyvion-Dem/npcs/qm_map.lua
+++ b/scripts/zones/Promyvion-Dem/npcs/qm_map.lua
@@ -10,12 +10,6 @@ local ID = zones[xi.zone.PROMYVION_DEM]
 -----------------------------------
 local entity = {}
 
-entity.onTrigger = function(player, npc)
-    player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)
-    -- TODO: The sphere is emitting an erie green glow. occurred when in posession of item, but not
-    -- with map, with map received nothing out of the ordinary.  Assumption: Glow is present until obtaining.
-end
-
 entity.onTrade = function(player, npc, trade)
     if
         npcUtil.tradeHas(trade, xi.item.BERYL_MEMOSPHERE) and
@@ -24,6 +18,14 @@ entity.onTrade = function(player, npc, trade)
         player:startEvent(49)
     else
         player:messageSpecial(ID.text.NOTHING_HAPPENS)
+    end
+end
+
+entity.onTrigger = function(player, npc)
+    if not player:hasKeyItem(xi.ki.MAP_OF_PROMYVION_DEM) then
+        player:messageSpecial(ID.text.EERIE_GREEN_GLOW)
+    else
+        player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY_MAP)
     end
 end
 

--- a/scripts/zones/Promyvion-Mea/IDs.lua
+++ b/scripts/zones/Promyvion-Mea/IDs.lua
@@ -18,6 +18,8 @@ zones[xi.zone.PROMYVION_MEA] =
         LOGIN_NUMBER                  = 7003, -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.
         MEMBERS_LEVELS_ARE_RESTRICTED = 7023, -- Your party is unable to participate because certain members' levels are restricted.
         BARRIER_WOVEN                 = 7223, -- It appears to be a barrier woven from the energy of overflowing memories...
+        NOTHING_OUT_OF_ORDINARY_MAP   = 7224, -- There is nothing out of the ordinary here.
+        EERIE_GREEN_GLOW              = 7225, -- The sphere is emitting an eerie green glow.
     },
     mob =
     {
@@ -42,22 +44,26 @@ zones[xi.zone.PROMYVION_MEA] =
     {
         MEMORY_STREAMS =
         {
-            [11]        = { -122, -4,  197, -117, 4,  202, { 46 } },     -- floor 1 return
-            [21]        = {   -1, -4, -121,    2, 4, -118, { 41 } },     -- floor 2 return
-            [31]        = { -161, -4,  158, -157, 4,  161, { 30 } },     -- floor 3 return
-            [32]        = {  158, -4, -281,  161, 4, -278, { 30 } },     -- floor 3 return
-            [41]        = {  -82, -4,  358,  -78, 4,  361, { 33 } },     -- floor 4 return
-            [16859483]  = { -283, -4,  237, -276, 4,  242, { 30 } },     -- floor 1 MR1
-            [16859486]  = {  -82, -4,  -42,  -78, 4,  -38, { 33, 37 } }, -- floor 2 MR1
-            [16859490]  = { -322, -4, -361, -318, 4, -357, { 33, 37 } }, -- floor 2 MR2
-            [16859491]  = {  -42, -4, -321,  -37, 4, -317, { 33, 37 } }, -- floor 2 MR3
-            [16859492]  = {   77, -4, -241,   81, 4, -238, { 33, 37 } }, -- floor 2 MR4
-            [16859484]  = { -321, -4,  -42, -318, 4,  -38, { 31 } },     -- floor 3 MR1
-            [16859485]  = { -241, -4,  -42, -238, 4,  -37, { 31 } },     -- floor 3 MR2
-            [16859487]  = {  -42, -4,   -2,  -38, 4,    2, { 31 } },     -- floor 3 MR3
-            [16859488]  = {  198, -4,   -2,  201, 4,    2, { 31 } },     -- floor 3 MR4
-            [16859489]  = {  358, -4,  -41,  362, 4,  -38, { 31 } },     -- floor 3 MR5
-            [16859493]  = {  240, -4, -322,  244, 4, -317, { 31 } },     -- floor 3 MR6
+            [11]       = { -122, -4,  197, -117, 4,  202, { 46 } }, -- Floor 1 return
+            [21]       = {   -1, -4, -121,    2, 4, -118, { 41 } }, -- Floor 2 return
+            [31]       = { -161, -4,  158, -157, 4,  161, { 42 } }, -- Floor 3 (West) return
+            [32]       = {  158, -4, -281,  161, 4, -278, { 43 } }, -- Floor 3 (East) return
+            [41]       = {  -82, -4,  358,  -78, 4,  361, { 33 } }, -- Floor 4 return
+            -- TODO: Cleanup promyvions. It knows where you came from and will only return the apropiate event acordingly.
+            -- Event 44 -> Return to floor 3 West
+            -- Event 45 -> Return to floor 3 East
+
+            [16859483] = { -283, -4,  237, -276, 4,  242, { 30 } }, -- Floor 1 MR
+            [16859486] = {  -82, -4,  -42,  -78, 4,  -38, { 33 } }, -- Floor 2 MR N  - Destination: East
+            [16859490] = { -322, -4, -361, -318, 4, -357, { 37 } }, -- Floor 2 MR SW - Destination: West
+            [16859491] = {  -42, -4, -321,  -37, 4, -317, { 38 } }, -- Floor 2 MR S  - Destination: West
+            [16859492] = {   77, -4, -241,   81, 4, -238, { 39 } }, -- Floor 2 MR SE - Destination: East
+            [16859484] = { -321, -4,  -42, -318, 4,  -38, { 31 } }, -- Floor 3 (West) MR SW
+            [16859485] = { -241, -4,  -42, -238, 4,  -37, { 32 } }, -- Floor 3 (West) MR S
+            [16859487] = {  -42, -4,   -2,  -38, 4,    2, { 34 } }, -- Floor 3 (West) MR SE
+            [16859488] = {  198, -4,   -2,  201, 4,    2, { 35 } }, -- Floor 3 (East) MR NW
+            [16859489] = {  358, -4,  -41,  362, 4,  -38, { 36 } }, -- Floor 3 (East) MR NE
+            [16859493] = {  240, -4, -322,  244, 4, -317, { 40 } }, -- Floor 3 (East) MR SW
         },
     },
 }

--- a/scripts/zones/Promyvion-Mea/npcs/qm_map.lua
+++ b/scripts/zones/Promyvion-Mea/npcs/qm_map.lua
@@ -10,10 +10,6 @@ local ID = zones[xi.zone.PROMYVION_MEA]
 -----------------------------------
 local entity = {}
 
-entity.onTrigger = function(player, npc)
-    player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)
-end
-
 entity.onTrade = function(player, npc, trade)
     if
         npcUtil.tradeHas(trade, xi.item.INDIGO_MEMOSPHERE) and
@@ -22,6 +18,14 @@ entity.onTrade = function(player, npc, trade)
         player:startEvent(49)
     else
         player:messageSpecial(ID.text.NOTHING_HAPPENS)
+    end
+end
+
+entity.onTrigger = function(player, npc)
+    if not player:hasKeyItem(xi.ki.MAP_OF_PROMYVION_MEA) then
+        player:messageSpecial(ID.text.EERIE_GREEN_GLOW)
+    else
+        player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY_MAP)
     end
 end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Corrects event IDs used by portals in promyvion Mea.
- Corrects messages used in Mea and Dem when triggering map npcs

## Steps to test these changes

I would like to thank whoever originally coded Promyvions via making up the events used instead of taking a capture, for making me waste the whole day.
