### PR TITLE
[cpp] Ensure player is booted from failed instance cleanly

### DIFF
--- a/scripts/globals/instance.lua
+++ b/scripts/globals/instance.lua
@@ -441,12 +441,12 @@ xi.instance.onInstanceCreatedCallback = function(player, instance)
                     -- this makes the animation trigger reliably
                     v:release()
                     v:startEvent(unpack(lookupEntry[4]))
-                end
 
-                v:setInstance(instance)
-                local npc = player:getEventTarget()
-                if npc ~= nil then
-                    v:instanceEntry(npc, 4)
+                    v:setInstance(instance)
+                    local npc = player:getEventTarget()
+                    if npc ~= nil then
+                        v:instanceEntry(npc, 4)
+                    end
                 end
 
                 v:timer(35000, function(playerArg)

--- a/src/map/zone_instance.cpp
+++ b/src/map/zone_instance.cpp
@@ -25,6 +25,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "entities/charentity.h"
 #include "lua/luautils.h"
 #include "status_effect_container.h"
+#include "utils/charutils.h"
 #include "utils/zoneutils.h"
 
 CZoneInstance::CZoneInstance(ZONEID ZoneID, REGION_TYPE RegionID, CONTINENT_TYPE ContinentID, uint8 levelRestriction)
@@ -249,19 +250,30 @@ void CZoneInstance::IncreaseZoneCounter(CCharEntity* PChar)
                         .c_str());
 
         // instance no longer exists: put them outside (at exit)
-        PChar->loc.prevzone = GetID();
-
         uint16 zoneid = luautils::OnInstanceLoadFailed(this);
 
         CZone* PZone = zoneutils::GetZone(zoneid);
+        // At this stage, can only send the player to a zone on this map server
+        // reset position in the case of a zone crash while in an instance
+        PChar->loc.p.x = 0;
+        PChar->loc.p.y = 0;
+        PChar->loc.p.z = 0;
         if (PZone)
         {
             PZone->IncreaseZoneCounter(PChar);
         }
         else
         {
-            zoneutils::GetZone(PChar->loc.prevzone)->IncreaseZoneCounter(PChar);
+            // if we can't get the instance failed destination zone, get their previous zone
+            zoneid = PChar->loc.prevzone;
+            zoneutils::GetZone(zoneid)->IncreaseZoneCounter(PChar);
         }
+
+        // They are properly sent to zone, but bypassed the onZoneIn position fixup, do that now
+        PChar->loc.prevzone = GetID();
+        PChar->loc.destination = zoneid;
+        luautils::OnZoneIn(PChar);
+        charutils::SaveCharPosition(PChar);
     }
 }
 

--- a/src/map/zone_instance.cpp
+++ b/src/map/zone_instance.cpp
@@ -270,7 +270,7 @@ void CZoneInstance::IncreaseZoneCounter(CCharEntity* PChar)
         }
 
         // They are properly sent to zone, but bypassed the onZoneIn position fixup, do that now
-        PChar->loc.prevzone = GetID();
+        PChar->loc.prevzone    = GetID();
         PChar->loc.destination = zoneid;
         luautils::OnZoneIn(PChar);
         charutils::SaveCharPosition(PChar);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Previous PR to squash black-screen conditions for instance entry is working great, but there's one scenario that seems to still cause issues.

Unsure of the underlying cause, but it's possible for a group to enter an instance, be set and transported, but then fail to be mapped properly. This is shown in the map log:

![image](https://github.com/LandSandBoat/server/assets/131182600/07045849-38d2-4123-b361-e0fa8e925011)

The logic for handling this scenario is mostly good, but it fails to fix the player's position. When being sent to a zone via `!zone` or via the instance lua utils, the player's position is set to 0,0,0. This is never fixed when the player is booted from the instance

Also, the logic to failback to player's previous zone when `luautils::OnInstanceLoadFailed` returns a zone not within the map server was bad, moved the `PChar->loc.prevzone = GetID();` past the failback logic

Finally, a small oversight in my previous instance entry cleanup is corrected. The goal is the set the commander first, set all other members, push them into instance entry cutscene, then push the commander. Accidentally some logic in the main loop such that the commander would still get started into the event early which I believe would sometimes cause black screens still (confirmed to still work reliably with 2 players entering an instance)

## Steps to test these changes

Start up the map server with nyzul and whitegate as the only zones active on the port. `!zone 77` and see that you get properly sent back to whitegate, and not at 0,0,0

Start up the map server with alzadaal undersea ruins and nyzul active, `!zone 77` and see that you get booted into the ruins properly.

I'm unsure how to reliably trigger this failure condition (I suspect if we could, it would probably lead to a fix that makes it happen less often), but there's two very contrived ways (that both reliably reset the player into a valid position):
- if you set the player to release the event early, and set the isntance to fail as the fallback setPos is called... we can emulate this failure. 
- Crash the map server while in nyzul, and log back in

for the first:
- make instance.lua look like this:
![image](https://github.com/LandSandBoat/server/assets/131182600/afd6c4d6-5edb-4446-bd42-f3f0cf77bb49)
- Then `!addkeyitem nyzul_isle_assault_orders` 
- Try to enter nyzul normally
- You'll also get booted back to the ruins and not at 0,0,0. The map server log will look like this:
![image](https://github.com/LandSandBoat/server/assets/131182600/4ea0ef6f-6b44-4736-82d5-319969302f02)
