### PR TITLE
[LUA] Fix RSE ammo drop chances are incorrect

### DIFF
--- a/scripts/zones/Gusgen_Mines/npcs/qm1.lua
+++ b/scripts/zones/Gusgen_Mines/npcs/qm1.lua
@@ -27,7 +27,7 @@ entity.onTrigger = function(player, npc)
 
         local item = 18246 + playerRace - raceOffset
         GetMobByID(ID.mob.AROMA_FLY):addListener('ITEM_DROPS', 'ITEM_DROPS_RSE', function(mob, loot)
-            loot:addItemFixed(item, xi.drop_rate.UNCOMMON)
+            loot:addItem(item, xi.drop_rate.UNCOMMON)
         end)
 
         local newSpawn = math.random(1, 3) -- determine new spawn point for ???

--- a/scripts/zones/Maze_of_Shakhrami/npcs/qm1.lua
+++ b/scripts/zones/Maze_of_Shakhrami/npcs/qm1.lua
@@ -27,7 +27,7 @@ entity.onTrigger = function(player, npc)
 
         local item = 18246 + playerRace - raceOffset
         GetMobByID(ID.mob.AROMA_CRAWLER):addListener('ITEM_DROPS', 'ITEM_DROPS_RSE', function(mob, loot)
-            loot:addItemFixed(item, xi.drop_rate.UNCOMMON)
+            loot:addItem(item, xi.drop_rate.UNCOMMON)
         end)
 
         local newSpawn = math.random(1, 3) -- determine new spawn point for ???

--- a/scripts/zones/Ordelles_Caves/npcs/qm1.lua
+++ b/scripts/zones/Ordelles_Caves/npcs/qm1.lua
@@ -27,7 +27,7 @@ entity.onTrigger = function(player, npc)
 
         local item = 18246 + playerRace - raceOffset
         GetMobByID(ID.mob.AROMA_LEECH):addListener('ITEM_DROPS', 'ITEM_DROPS_RSE', function(mob, loot)
-            loot:addItemFixed(item, xi.drop_rate.UNCOMMON)
+            loot:addItem(item, xi.drop_rate.UNCOMMON)
         end)
 
         local newSpawn = math.random(1, 3) -- determine new spawn point for ???


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Currently the RSE ammo NMs are set with a drop rate of 5 (UNCOMMON in the drop_rate enum) but the method it's using to add the item to the pool is addItemFixed which should be using the values in RATE_PERCENTAGES (lua_loot.cpp). It's also noted in the example for the addItemFixed method: `loot:addItemFixed(xi.items.ANCIENT_BEASTCOIN, 500, 2);`.

## Steps to test these changes

1. Reference https://www.pyogenes.com/ffxi/timer/v2.html to figure out rotation
2. Login with the proper character race and gender
3. Zone into the proper RSE zone (Gusgen Mines, Maze of Shakhrami, or Ordelle's Caves)
4. !npchere (17580347 Mines, 17588711 Maze, 17568147 Caves)
5. Repeat as necessary or temporarily set the chance to 1000 (guaranteed)

If there's a better way to do this please let me know!

![image](https://github.com/LandSandBoat/server/assets/166072302/f6a480c0-3808-41c3-a326-f268ce6f7409)