### PR TITLE
Login: Update SUPPORTED_XILOADER_VERSION checks

### DIFF
--- a/src/login/auth_session.cpp
+++ b/src/login/auth_session.cpp
@@ -125,7 +125,11 @@ void auth_session::read_func()
     std::string username(usernameBuffer, 16);
     std::string password(passwordBuffer, 32);
 
-    if (strncmp(version.c_str(), SUPPORTED_XILOADER_VERSION, 5) != 0)
+    // Only match on the first 3 characters of the version string
+    // ie. 1.1.1 -> 1.1.x
+    // Major.Minor.Patch
+    // Major and minor version changes should be breaking, patch should not.
+    if (strncmp(version.c_str(), SUPPORTED_XILOADER_VERSION, 3) != 0)
     {
         ref<uint8>(data_, 0) = LOGIN_ERROR_VERSION_UNSUPPORTED;
 

--- a/src/login/auth_session.h
+++ b/src/login/auth_session.h
@@ -49,7 +49,11 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #define LOGIN_ERROR_ALREADY_LOGGED_IN   0x0A
 #define LOGIN_ERROR_VERSION_UNSUPPORTED 0x0B
 
-#define SUPPORTED_XILOADER_VERSION "1.0.0"
+// Only the first 3 characters of the version string are matched
+// ie. 1.1.1 -> 1.1.x
+// Major.Minor.Patch
+// Major and minor version changes should be breaking, patch should not.
+#define SUPPORTED_XILOADER_VERSION "1.1.x"
 
 // NOTE: This collection of flags is 64-bits wide!
 enum AUTH_COMPONENTS

--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -280,7 +280,7 @@ def fetch_credentials():
         os.getenv("XI_NETWORK_SQL_DATABASE") or settings["network"]["SQL_DATABASE"]
     )
     host = os.getenv("XI_NETWORK_SQL_HOST") or settings["network"]["SQL_HOST"]
-    port = os.getenv("XI_NETWORK_SQL_PORT") or int(settings["network"]["SQL_PORT"])
+    port = int(os.getenv("XI_NETWORK_SQL_PORT")) or int(settings["network"]["SQL_PORT"])
     login = os.getenv("XI_NETWORK_SQL_LOGIN") or settings["network"]["SQL_LOGIN"]
     password = (
         os.getenv("XI_NETWORK_SQL_PASSWORD") or settings["network"]["SQL_PASSWORD"]

--- a/tools/headlessxi/hxiclient.py
+++ b/tools/headlessxi/hxiclient.py
@@ -17,7 +17,7 @@ class HXIClient:
         self.server = server
         self.slot = slot
         self.debug_packets = debug_packets
-        self.xiloaderVersionNumber = "1.0.0" # compatible xiloader version
+        self.xiloaderVersionNumber = "1.1.1"  # compatible xiloader version
 
         # Read from version.conf default
         if client_str == "":
@@ -60,7 +60,7 @@ class HXIClient:
 
         data[0x39] = 0x10  # Auto-login
 
-	# 17 bytes of reserved space starting at 0x50
+        # 17 bytes of reserved space starting at 0x50
         util.memcpy(self.password, 0, data, 0x30, len(self.password))
 
         util.memcpy(self.xiloaderVersionNumber, 0, data, 0x61, 5)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Changes `SUPPORTED_XILOADER_VERSION` to `1.1.x`, and changes the check against it to only match the first 3 chars against the version. This means that we can update the patch version as we like (as long as it isn't a breaking change, then we should bump the minor version).

Tested with xiloader 1.1.1 - lets me in, changed SUPPORTED_XILOADER_VERSION to 1.2.1 and with xiloader 1.1.1 -> rejects me saying "version mismatch, check with your provider"
