### PR TITLE
[Fix] Alchemy and Goldsmith advanced support npc messages.

### DIFF
--- a/scripts/globals/crafting/crafting_utils.lua
+++ b/scripts/globals/crafting/crafting_utils.lua
@@ -6,6 +6,25 @@ require('scripts/globals/utils')
 xi = xi or {}
 xi.crafting = xi.crafting or {}
 -----------------------------------
+-- Document the "Guild_Member" bitmask.
+-- Bit  0: Has joined Fishing guild.
+-- Bit  1: Has joined Woodworking guild.
+-- Bit  2: Has joined Smithing guild.
+-- Bit  3: Has joined Goldsmithing guild.
+-- Bit  4: Has joined Clothcraft guild.
+-- Bit  5: Has joined Leathercraft guild.
+-- Bit  6: Has joined Bonecraft guild.
+-- Bit  7: Has joined Alchemy guild.
+-- Bit  8: Has joined Cooking guild.
+
+-- Bit 24: Has spoken to "Fatimah" after joining Goldsmithing guild.
+-- Bit 25: Has spoken to "Azima" afer joining Alchemy guild.
+
+-- Bit 27: Unknown, but this bits are used. Captured them on a lvl 110 Alchemist with a stage 2 Escutcheon completed.
+-- Bit 28: Unknown, but this bits are used. Captured them on a lvl 110 Alchemist with a stage 2 Escutcheon completed.
+-- Bit 29: Unknown, but this bits are used. Captured them on a lvl 110 Alchemist with a stage 2 Escutcheon completed.
+-- Bit 30: Unknown, but this bits are used. Captured them on a lvl 110 Alchemist with a stage 2 Escutcheon completed.
+
 xi.crafting.guildTable =
 {
     --           [guild ID] = { skill used,            'currency used'      },


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Fixes special cases with alchemy and goldsmithing advanced image support NPCs.
- Documents bitmask used in most guild events (guilds joined, npc conversations and unknowns)
- Discovered what first parameter in aht uhrgan image support npcs actually does (menu options displayed). Adjust accordingly.

## Steps to test these changes

Speak with those npcs after joining their guilds. Be able to get image support after the first try.
