### PR TITLE
[LUA]Fix typo in Beastmaster JobUtil Gauge

### DIFF
--- a/scripts/globals/job_utils/beastmaster.lua
+++ b/scripts/globals/job_utils/beastmaster.lua
@@ -171,7 +171,7 @@ xi.job_utils.beastmaster.onAbilityCheckGauge = function(player, target, ability)
 end
 
 -- On Ability Use Gauge
-xi.job_utils.beastmaster.onUseAbilityGuage = function(player, target, ability)
+xi.job_utils.beastmaster.onUseAbilityGauge = function(player, target, ability)
     local charmChance = player:getCharmChance(target, false)
 
     if charmChance >= 75 then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Corrects a type in jobUtils/Beastmaster.lua onUseAbilityGauge. 
Wasn't allowing players to use Gauge due to typo. 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Spelled Gauge correctly. 
Use gauge ability.
Verified no other instances of guage throughout repo. 
<!-- Clear and detailed steps to test your changes here -->
