### PR TITLE
[cpp] Do not turn entities that have NO_TURN

### DIFF
--- a/src/map/ai/states/ability_state.cpp
+++ b/src/map/ai/states/ability_state.cpp
@@ -69,9 +69,13 @@ CAbilityState::CAbilityState(CBattleEntity* PEntity, uint16 targid, uint16 abili
         m_PEntity->PAI->EventHandler.triggerListener("ABILITY_START", CLuaBaseEntity(m_PEntity), CLuaAbility(PAbility));
 
         // face toward target
-        m_PEntity->loc.p.rotation = worldAngle(m_PEntity->loc.p, PTarget->loc.p);
-        m_PEntity->updatemask |= UPDATE_POS;
-        m_PEntity->loc.zone->UpdateEntityPacket(m_PEntity, ENTITY_UPDATE, UPDATE_POS);
+        auto* PMob = dynamic_cast<CMobEntity*>(m_PEntity);
+        if (!PMob || !(PMob->m_Behaviour & BEHAVIOUR_NO_TURN))
+        {
+            m_PEntity->loc.p.rotation = worldAngle(m_PEntity->loc.p, PTarget->loc.p);
+            m_PEntity->updatemask |= UPDATE_POS;
+            m_PEntity->loc.zone->UpdateEntityPacket(m_PEntity, ENTITY_UPDATE, UPDATE_POS);
+        }
     }
     else
     {
@@ -118,8 +122,13 @@ bool CAbilityState::Update(time_point tick)
         CBaseEntity* PTarget = GetTarget();
         if (PTarget)
         {
-            m_PEntity->loc.p.rotation = worldAngle(m_PEntity->loc.p, PTarget->loc.p);
-            m_PEntity->loc.zone->UpdateEntityPacket(m_PEntity, ENTITY_UPDATE, UPDATE_POS);
+            auto* PMob = dynamic_cast<CMobEntity*>(m_PEntity);
+            if (!PMob || !(PMob->m_Behaviour & BEHAVIOUR_NO_TURN))
+            {
+                m_PEntity->loc.p.rotation = worldAngle(m_PEntity->loc.p, PTarget->loc.p);
+                m_PEntity->updatemask |= UPDATE_POS;
+                m_PEntity->loc.zone->UpdateEntityPacket(m_PEntity, ENTITY_UPDATE, UPDATE_POS);
+            }
         }
     }
 

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -75,8 +75,13 @@ CMobSkillState::CMobSkillState(CBattleEntity* PEntity, uint16 targid, uint16 wsi
         m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
 
         // face toward target
-        m_PEntity->loc.p.rotation = worldAngle(m_PEntity->loc.p, PTarget->loc.p);
-        m_PEntity->loc.zone->UpdateEntityPacket(m_PEntity, ENTITY_UPDATE, UPDATE_POS);
+        auto* PMob = dynamic_cast<CMobEntity*>(m_PEntity);
+        if (!PMob || !(PMob->m_Behaviour & BEHAVIOUR_NO_TURN))
+        {
+            m_PEntity->loc.p.rotation = worldAngle(m_PEntity->loc.p, PTarget->loc.p);
+            m_PEntity->updatemask |= UPDATE_POS;
+            m_PEntity->loc.zone->UpdateEntityPacket(m_PEntity, ENTITY_UPDATE, UPDATE_POS);
+        }
     }
     m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_STATE_ENTER", CLuaBaseEntity(m_PEntity), m_PSkill->getID());
     SpendCost();
@@ -119,8 +124,13 @@ bool CMobSkillState::Update(time_point tick)
         CBaseEntity* PTarget = GetTarget();
         if (PTarget)
         {
-            m_PEntity->loc.p.rotation = worldAngle(m_PEntity->loc.p, PTarget->loc.p);
-            m_PEntity->loc.zone->UpdateEntityPacket(m_PEntity, ENTITY_UPDATE, UPDATE_POS);
+            auto* PMob = dynamic_cast<CMobEntity*>(m_PEntity);
+            if (!PMob || !(PMob->m_Behaviour & BEHAVIOUR_NO_TURN))
+            {
+                m_PEntity->loc.p.rotation = worldAngle(m_PEntity->loc.p, PTarget->loc.p);
+                m_PEntity->updatemask |= UPDATE_POS;
+                m_PEntity->loc.zone->UpdateEntityPacket(m_PEntity, ENTITY_UPDATE, UPDATE_POS);
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Recent change to make entities turn towards their target when readying a skill that has a readytime > 0 neglected to consider the mob behavior `NO_TURN`. Fafnir is a good example (funnier example is [Dark Ixion](https://github.com/LandSandBoat/server/pull/4868), where the logic turns him away to do a rear kick...)

This PR has no change if the entity performing a JA or mobskill is not a mob, and if it is a mob, make sure their behavior allows them to turn

## Steps to test these changes

Feed tp to fafnir and watch him not turn on mobskills

~~set a wyvern to behavior no turn `!exec target:setBehaviour(xi.behavior.NO_TURN)` and watch it _not_ turn doing breaths after a weaponskill~~

Wyvern can't have behavior set, and i can't find a way to make an ai-controlled entity use a job ability, but I assume it works just as well as the mobskill fix