### PR TITLE
Fix units of spell interruption check

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1786,6 +1786,7 @@ namespace battleutils
         float chance = xirand::GetRandomNumber<float>(1.0f);
 
         // caps, always give a 1% chance of interrupt // TODO: verify, perhaps there is a breakpoint where this no longer happens.
+        check /= 100.0f;
         if (check < 0.01)
         {
             check = 0.01;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Spell Interruption units for the check are out of 100, then the final comparison assumes it's float from 0 to 1

This PR fixes the units to be able to avoid spell interruption again

## Steps to test these changes

Before change:
![image](https://github.com/LandSandBoat/server/assets/131182600/974d95a1-ae90-4683-be1a-49a01ca31cdd)


After change (with `!setmod spellinterrupt 50`):
an interrupt
![image](https://github.com/LandSandBoat/server/assets/131182600/fda80101-53e9-4b23-acd9-3bf6674ad47a)

also getting hit it's possible to not be interrupted