### PR TITLE
Only check parry rate once per attack swing

### DIFF
--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -190,13 +190,21 @@ bool CAttack::IsBlocked() const
     return m_isBlocked;
 }
 
-bool CAttack::IsParried()
+bool CAttack::IsParried() const
+{
+    return m_isParried;
+}
+
+bool CAttack::CheckParried()
 {
     if (m_attackType != PHYSICAL_ATTACK_TYPE::DAKEN)
     {
-        return attackutils::IsParried(m_attacker, m_victim);
+        if (attackutils::IsParried(m_attacker, m_victim))
+        {
+            m_isParried = true;
+        }
     }
-    return false;
+    return m_isParried;
 }
 
 bool CAttack::IsAnticipated() const

--- a/src/map/attack.h
+++ b/src/map/attack.h
@@ -86,7 +86,8 @@ public:
     bool                      IsEvaded() const;                     // Gets the evaded flag.
     void                      SetEvaded(bool value);                // Sets the evaded flag.
     bool                      IsBlocked() const;                    // Returns the blocked flag.
-    bool                      IsParried();
+    bool                      IsParried() const;
+    bool                      CheckParried();
     bool                      IsAnticipated() const;
     bool                      CheckAnticipated();
     bool                      IsCountered() const;
@@ -106,6 +107,7 @@ private:
     uint8                     m_hitRate{ 0 };        // This attack's hitrate.
     bool                      m_isCritical{ false }; // Flag: Is this attack a critical attack?
     bool                      m_isGuarded{ false };  // Flag: Is this attack guarded by the victim?
+    bool                      m_isParried{ false };  // Flag: Is this attack parried by the victim?
     bool                      m_isBlocked{ false };  // Flag: Is this attack blocked by the victim?
     bool                      m_isEvaded{ false };   // Flag: Is this attack evaded by the victim?
     bool                      m_isCountered{ false };

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2187,7 +2187,7 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                  !PTarget->StatusEffectContainer->HasStatusEffect(EFFECT_ALL_MISS))
         {
             // Check parry.
-            if (attack.IsParried())
+            if (attack.CheckParried())
             {
                 actionTarget.messageID  = 70;
                 actionTarget.reaction   = REACTION::PARRY | REACTION::HIT;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Was looking into a wildly-lucky string of parrys to see if maybe petrification changes the rate or something

I don't believe it was (I'm not convinced the issue in this PR wasn't somehow double dipping parry rate)... but the chance of this is so crazy (lvl 72 mob and lvl 75 blu):
![image](https://github.com/LandSandBoat/server/assets/131182600/c63d5627-c1eb-43d7-9d7e-0fc89aa216c8)

At any rate, I found that the function `CAttack::IsParried()` was checking the rate each time

It's only called in a few places, basically:
- attack checks if it should be parried after not being evaded
- later checked if it's parried to try to skillup
- then checked if it wasn't parried to try an eva skillup

This PR adjusts the logic to follow the style of the other reaction checks. `CAttack::IsParried()` is only ever called after `CAttack::CheckParried()`, which sets the bool. This means that `CAttack::IsParried()` now reflects if an attack parried, not "let's check our parry rate to see if we _should_ parry"

We then replace the first call of `CAttack:IsParried()` with the new function:
![image](https://github.com/LandSandBoat/server/assets/131182600/51b62e26-3601-4c05-b019-dd0019af5539)

Other than code cleanliness/consistency, this means that eva skillups will no longer happen on a parried attack. And to those that use the old style parry skillup, this fixes a situation where you could skillup even if you didn't parry.

## Steps to test these changes

Fight a mob and see that you can still parry, messages are fine, and you can skillup 

![image](https://github.com/LandSandBoat/server/assets/131182600/255cc336-1ab3-49f2-a063-21e050c1da62)
