### PR TITLE
[CPP] Fix possessive messages for players

### DIFF
--- a/src/map/packets/char_update.cpp
+++ b/src/map/packets/char_update.cpp
@@ -290,7 +290,7 @@ CCharUpdatePacket::CCharUpdatePacket(CCharEntity* PChar)
     charUpateFlags::flags2_t flags2 = {};
 
     flags2.NamedFlag       = false; // disable "The"
-    flags2.SingleFlag      = true;  // singular entity
+    flags2.SingleFlag      = false; // singular entity
     flags2.AutoPartyFlag   = false; // Not implemented.
     flags2.MotStopFlag     = PChar->StatusEffectContainer->HasStatusEffect(EFFECT_TERROR);
     flags2.CliPriorityFlag = PChar->priorityRender;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes an issue where messages relating to the player were not possessive. Resolves https://github.com/LandSandBoat/server/issues/5600.

## Steps to test these changes

1. Give yourself paralyze (!exec target:addStatusEffect(xi.effect.PARALYSIS, 100, 0, 90))
2. Attack a mob
3. Alternatively use an ability on yourself or ready a weaponskill or let an effect fall off

![image](https://github.com/LandSandBoat/server/assets/166072302/514b039a-c2d3-44c6-8f0a-27a52270cde4)
![image](https://github.com/LandSandBoat/server/assets/166072302/6c00a35b-0244-45ef-a37c-8cfd9188a9d8)
![image](https://github.com/LandSandBoat/server/assets/166072302/ec8f4ca6-306a-43ef-8277-6b2e2c58102e)
![image](https://github.com/LandSandBoat/server/assets/166072302/c58f54ab-0cfb-4c7d-92a8-bef02ce6afe4)
