### PR TITLE
Fix underflow for slow mobs and negative mobspeedmod

### DIFF
--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -112,7 +112,7 @@ xi.settings.map =
     -- Note retail treats the mounted speed as double what it actually is.
     MOUNT_SPEED_MOD = 0,
 
-    -- Modifier to apply to agro'd monster speed. 0 is the retail accurate default. Negative numbers will reduce it.
+    -- This is an integer percentage. Modifier to apply to agro'd monster speed (i.e. while engaged in combat). 0 is the retail accurate default. Negative numbers will reduce ALL mobs's speed.
     MOB_SPEED_MOD = 0,
 
     -- Allows you to manipulate the constant multiplier in the skill-up rate formulas, having a potent effect on skill-up rates.

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -580,7 +580,13 @@ float CPathFind::GetRealSpeed()
         }
         else if (m_POwner->animation == ANIMATION_ATTACK)
         {
-            realSpeed = realSpeed + settings::get<int8>("map.MOB_SPEED_MOD");
+            auto speedMod = settings::get<int8>("map.MOB_SPEED_MOD");
+            if (speedMod < -90)
+            {
+                speedMod = -90;
+            }
+
+            realSpeed *= 1.0f + speedMod / 100.0f;
         }
     }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Troubleshooting Royal Jelly, i ran across a pretty silly bug. My local has `MOB_SPEED_MOD = -10` and the princess jellies have speed of 2... so they were underflow zooming to the center

## Steps to test these changes

Set map setting for mob_speed_mod negative, give a mob a speed such that this would be negative.

before:
https://imgur.com/f5eao3Q

after:
https://imgur.com/OmgTfXv