### PR TITLE
[lua] BCNM Royal Jelly - Do not spawn queen jelly at start

### DIFF
--- a/scripts/battlefields/Waughroon_Shrine/royal_jelly.lua
+++ b/scripts/battlefields/Waughroon_Shrine/royal_jelly.lua
@@ -20,7 +20,11 @@ local content = Battlefield:new({
     experimental = true,
 })
 
-content:addEssentialMobs({ 'Queen_Jelly', 'Princess_Jelly' })
+-- base queens that must be dead to get win, but doesn't start spawned
+content:addEssentialMobs({ 'Queen_Jelly' })
+content.groups[1].spawned = false
+
+content:addEssentialMobs({ 'Princess_Jelly' })
 
 content.loot =
 {

--- a/scripts/zones/Waughroon_Shrine/IDs.lua
+++ b/scripts/zones/Waughroon_Shrine/IDs.lua
@@ -61,6 +61,7 @@ zones[xi.zone.WAUGHROON_SHRINE] =
         MAAT              = GetFirstID('Maat'),
         PLATOON_SCORPION  = GetFirstID('Platoon_Scorpion'),
         YOBHU_HIDEOUSMASK = GetFirstID('YoBhu_Hideousmask'),
+        QUEEN_JELLY       = GetFirstID('Queen_Jelly'),
     },
 
     npc =

--- a/scripts/zones/Waughroon_Shrine/mobs/Princess_Jelly.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Princess_Jelly.lua
@@ -3,6 +3,8 @@
 -- Mob: Princess Jelly
 -- BCNM: Royal Jelly
 -----------------------------------
+local waughroonID = zones[xi.zone.WAUGHROON_SHRINE]
+-----------------------------------
 local elementalSpells =
 {
     { xi.magic.spell.BURN,  xi.magic.spell.FIRE },
@@ -46,6 +48,10 @@ entity.onMobSpawn = function(mob)
     mob:addMod(mevaList[mob:getLocalVar('mobElement')][2], 1000)
 end
 
+local function getQueenJellyID(bfNum)
+    return waughroonID.mob.QUEEN_JELLY + (bfNum - 1) * 10
+end
+
 local function getDistanceFromCenter(bfNum, mob)
     local pos = mob:getPos()
 
@@ -60,7 +66,7 @@ local function allJellysInCenter(bfNum, zone)
     local totalMobsAlive = 0
     local totalInCenter = 0
     for i = 1, 8 do
-        local princess = GetMobByID(zone:queryEntitiesByName('Queen_Jelly')[bfNum]:getID() + i)
+        local princess = GetMobByID(getQueenJellyID(bfNum) + i)
         if getDistanceFromCenter(bfNum, princess) <= 0.5 then
             totalInCenter = totalInCenter + 1
         end
@@ -82,7 +88,7 @@ local function princessesTotalHP(bfNum, zone)
     local totalHP = 0
 
     for i = 1, 8 do
-        local princess = GetMobByID(zone:queryEntitiesByName('Queen_Jelly')[bfNum]:getID() + i)
+        local princess = GetMobByID(getQueenJellyID(bfNum) + i)
         if princess:isAlive() then
             totalHP = totalHP + princess:getHP()
         end
@@ -92,10 +98,10 @@ local function princessesTotalHP(bfNum, zone)
 end
 
 local function spawnQueenJelly(bfNum, target, zone)
-    local queen = zone:queryEntitiesByName('Queen_Jelly')[bfNum]
+    local queen = GetMobByID(getQueenJellyID(bfNum))
 
     if not queen:isSpawned() then
-        SpawnMob(zone:queryEntitiesByName('Queen_Jelly')[bfNum]:getID())
+        SpawnMob(queen:getID())
         queen:setHP(princessesTotalHP(bfNum, zone))
         queen:setPos(centers[bfNum][1], centers[bfNum][2], centers[bfNum][3], 0)
         queen:setLocalVar('target', target:getID())
@@ -128,7 +134,7 @@ end
 
 entity.onMobFight = function(mob, target)
     local bfNum = mob:getBattlefield():getArea()
-    local queen = mob:getZone():queryEntitiesByName('Queen_Jelly')[bfNum]
+    local queen = GetMobByID(getQueenJellyID(bfNum))
     local center = centers[bfNum]
 
     mob:pathThrough(center, xi.path.flag.SCRIPT)
@@ -147,19 +153,12 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onMobEngage = function(mob, target)
-    local bfNum = mob:getBattlefield():getArea()
-
-    for i = 1, 8 do
-        local princess = GetMobByID(mob:getZone():queryEntitiesByName('Queen_Jelly')[bfNum]:getID() + i)
-        if not princess:isDead() then
-            princess:updateEnmity(target)
-        end
-    end
+    -- battlefield has superlink
 end
 
 entity.onMobDeath = function(mob, player, optParams)
     local bfNum = mob:getBattlefield():getArea()
-    local queen = mob:getZone():queryEntitiesByName('Queen_Jelly')[bfNum]
+    local queen = GetMobByID(getQueenJellyID(bfNum))
 
     if not queen:isSpawned() and allJellysInCenter(bfNum, mob:getZone()) then
         spawnQueenJelly(bfNum, player, mob:getZone())


### PR DESCRIPTION
princess jelly code cleanup

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The Queen Jelly should not spawn when the battlefield starts. Before this PR if you kill the queen, the princesses go to the middle, then spawn a the queen again.

After _that_ queen dies, no chest would spawn

This PR also cleans up a whole lot of extraneous calls to queryZoneEntities

Did the battlefield simulatenous with two solo players as well to confirm that works

## Steps to test these changes

zone to waughroon
`!togglegm`
enter Royal Jelly
do fight, see that you can win by killing all the princesses, or `!exec target:setSpeed(60)` (to get them to the center faster) and see that they merge properly and you get armory crate when queen dies