### PR TITLE
Fix invalid table reference for Waughroon Rank 2 Battlefield

### DIFF
--- a/scripts/battlefields/Waughroon_Shrine/rank_2_mission.lua
+++ b/scripts/battlefields/Waughroon_Shrine/rank_2_mission.lua
@@ -29,7 +29,7 @@ end
 
 function content:checkSkipCutscene(player)
     return player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_THREE_KINGDOMS_BASTOK2) or
-        player:hasCompletedMission(xi.mission.log_id.SANDORIA, xi.mission.id.bastok.JOURNEY_TO_BASTOK2) or
+        player:hasCompletedMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.JOURNEY_TO_BASTOK2) or
         (player:getMissionStatus(player:getNation()) > 9 and
         (
             player:getCurrentMission(xi.mission.log_id.WINDURST) == xi.mission.id.windurst.THE_THREE_KINGDOMS_BASTOK2 or


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes #5605 

Corrects table reference for required entry missions
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Enter battlefield, checks should not error
<!-- Clear and detailed steps to test your changes here -->
