### PR TITLE
[LUA] Fix Quick Draw improperly calculating resistance

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -522,23 +522,23 @@ function applyResistanceEffect(caster, target, spell, params)
         percentBonus = percentBonus - xi.magic.getEffectResistance(target, effect)
     end
 
-    local p = getMagicHitRate(caster, target, skill, element, percentBonus, magicaccbonus)
+    local magicHitRate = getMagicHitRate(caster, target, skill, element, percentBonus, magicaccbonus)
 
-    return getMagicResist(p)
+    return getMagicResist(caster, target, skill, element, magicHitRate)
 end
 
 -- Applies resistance for things that may not be spells - ie. Quick Draw
 function applyResistanceAbility(player, target, element, skill, bonus)
-    local p = getMagicHitRate(player, target, skill, element, 0, bonus)
+    local magicHitRate = getMagicHitRate(player, target, skill, element, 0, bonus)
 
-    return getMagicResist(p)
+    return getMagicResist(player, target, skill, element, magicHitRate)
 end
 
 -- Applies resistance for additional effects
 function applyResistanceAddEffect(player, target, element, bonus)
-    local p = getMagicHitRate(player, target, 0, element, 0, bonus)
+    local magicHitRate = getMagicHitRate(player, target, 0, element, 0, bonus)
 
-    return getMagicResist(p)
+    return getMagicResist(player, target, xi.skill.NONE, element, magicHitRate)
 end
 
 function getMagicHitRate(caster, target, skillType, element, percentBonus, bonusAcc)
@@ -593,29 +593,8 @@ function getMagicHitRate(caster, target, skillType, element, percentBonus, bonus
 end
 
 -- Returns resistance value from given magic hit rate (p)
-function getMagicResist(magicHitRate)
-    local p = magicHitRate / 100
-    local resist = 1.0
-
-    -- Resistance thresholds based on p.  A higher p leads to lower resist rates, and a lower p leads to higher resist rates.
-    local half      = (1 - p)
-    local quart     = ((1 - p)^2)
-    local eighth    = ((1 - p)^3)
-    local sixteenth = ((1 - p)^4)
-    local resvar    = math.random()
-
-    -- Determine final resist based on which thresholds have been crossed.
-    if resvar <= sixteenth then
-        resist = 0.0625
-    elseif resvar <= eighth then
-        resist = 0.125
-    elseif resvar <= quart then
-        resist = 0.25
-    elseif resvar <= half then
-        resist = 0.5
-    end
-
-    return resist
+function getMagicResist(caster, target, skill, element, magicHitRate)
+    return xi.combat.magicHitRate.calculateResistRate(caster, target, skill, element, magicHitRate, 0)
 end
 
 -- Returns the amount of resistance the target has to the given effect


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Currently Quick Draw elemental shots (and other magical abilities) do not properly calculate a mob's resistance. For example, if you use Fire Shot on a Fire Elemental it will deal full damage, the same damage as any other elemental shot, and the resist value will be 1. To resolve this we will reuse the xi.combat.magicHitRate.calculateResistRate which does properly account for mob's resistances.

There's a decent amount of code duplication that exists between scripts/globals/combat/magic_hit_rate.lua and scripts/globals/magic.lua, but I have left that for now as this minor change resolves resistances flat out not working.

## Steps to test these changes

1. !changejob 17 99
2. !additem 2974 99
3. !additem 21278
4. !additem 18235 99
5. Equip the gun and bullets
6. Find a mob with elemental resistances (Elementals in Sky for example !pos 397 -24 -2 130)
7. !immortal the mob
8. Use Quick Draw with a shot the mob is resistance to (Fire Elemental is resistant to Fire and Ice)
9. Shots that the mob are resistant to should now deal significantly less damage
10. !reset if necessary

![image](https://github.com/LandSandBoat/server/assets/166072302/446fb638-7d2c-40e9-bbf8-0c06fc115724)