### PR TITLE
[LUA] Create Checks for obtaining Halver Alter Ego

### DIFF
--- a/scripts/missions/bastok/2_3_1_The_Emissary_Sandoria.lua
+++ b/scripts/missions/bastok/2_3_1_The_Emissary_Sandoria.lua
@@ -30,9 +30,13 @@ mission.sections =
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
                     if missionStatus == 3 then
-                        local needsHalverTrust = (not player:hasSpell(xi.magic.spell.HALVER) and not player:findItem(xi.item.CIPHER_OF_HALVERS_ALTER_EGO)) and 1 or 0
+                        if xi.settings.main.ENABLE_TRUST_QUESTS == 1 then
+                            local needsHalverTrust = (not player:hasSpell(xi.magic.spell.HALVER) and not player:findItem(xi.item.CIPHER_OF_HALVERS_ALTER_EGO)) and 1 or 0
 
-                        return mission:progressEvent(501, { [7] = needsHalverTrust })
+                            return mission:progressEvent(501, { [7] = needsHalverTrust })
+                        else
+                            return mission:progressEvent(501)
+                        end
                     elseif missionStatus > 3 then
                         return mission:messageText(chateauID.text.HALVER_OFFSET + 266)
                     end
@@ -45,6 +49,7 @@ mission.sections =
                     player:setMissionStatus(mission.areaId, 4)
 
                     if
+                        xi.settings.main.ENABLE_TRUST_QUESTS == 1 and
                         not player:hasSpell(xi.magic.spell.HALVER) and
                         not player:findItem(xi.item.CIPHER_OF_HALVERS_ALTER_EGO)
                     then

--- a/scripts/missions/sandoria/2_3_0_Journey_Abroad.lua
+++ b/scripts/missions/sandoria/2_3_0_Journey_Abroad.lua
@@ -111,9 +111,13 @@ mission.sections =
                     if missionStatus == 11 then
                         return mission:progressEvent(507)
                     elseif missionStatus == 0 then
-                        local needsHalverTrust = (not player:hasSpell(xi.magic.spell.HALVER) and not player:findItem(xi.item.CIPHER_OF_HALVERS_ALTER_EGO)) and 1 or 0
+                        if xi.settings.main.ENABLE_TRUST_QUESTS == 1 then
+                            local needsHalverTrust = (not player:hasSpell(xi.magic.spell.HALVER) and not player:findItem(xi.item.CIPHER_OF_HALVERS_ALTER_EGO)) and 1 or 0
 
-                        return mission:progressEvent(505, { [7] = needsHalverTrust })
+                            return mission:progressEvent(505, { [7] = needsHalverTrust })
+                        else
+                            return mission:progressEvent(505)
+                        end
                     else
                         return mission:progressEvent(532)
                     end
@@ -127,6 +131,7 @@ mission.sections =
                     npcUtil.giveKeyItem(player, xi.ki.LETTER_TO_THE_CONSULS_SANDORIA)
 
                     if
+                        xi.settings.main.ENABLE_TRUST_QUESTS == 1 and
                         not player:hasSpell(xi.magic.spell.HALVER) and
                         not player:findItem(xi.item.CIPHER_OF_HALVERS_ALTER_EGO)
                     then

--- a/scripts/missions/windurst/2_3_1_The_Three_Kingdoms_Sandoria.lua
+++ b/scripts/missions/windurst/2_3_1_The_Three_Kingdoms_Sandoria.lua
@@ -30,9 +30,13 @@ mission.sections =
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
                     if missionStatus == 3 then
-                        local needsHalverTrust = (not player:hasSpell(xi.magic.spell.HALVER) and not player:findItem(xi.item.CIPHER_OF_HALVERS_ALTER_EGO)) and 1 or 0
+                        if xi.settings.main.ENABLE_TRUST_QUESTS == 1 then
+                            local needsHalverTrust = (not player:hasSpell(xi.magic.spell.HALVER) and not player:findItem(xi.item.CIPHER_OF_HALVERS_ALTER_EGO)) and 1 or 0
 
-                        return mission:progressEvent(502, { [7] = needsHalverTrust })
+                            return mission:progressEvent(502, { [7] = needsHalverTrust })
+                        else
+                            return mission:progressEvent(502)
+                        end
                     else
                         return mission:messageText(chateauID.text.HALVER_OFFSET + 279)
                     end
@@ -45,6 +49,7 @@ mission.sections =
                     player:setMissionStatus(mission.areaId, 4)
 
                     if
+                        xi.settings.main.ENABLE_TRUST_QUESTS == 1 and
                         not player:hasSpell(xi.magic.spell.HALVER) and
                         not player:findItem(xi.item.CIPHER_OF_HALVERS_ALTER_EGO)
                     then

--- a/scripts/missions/windurst/2_3_3_The_Three_Kingdoms_Sandoria2.lua
+++ b/scripts/missions/windurst/2_3_3_The_Three_Kingdoms_Sandoria2.lua
@@ -29,9 +29,13 @@ mission.sections =
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
                     if missionStatus == 8 then
-                        local needsHalverTrust = (not player:hasSpell(xi.magic.spell.HALVER) and not player:findItem(xi.item.CIPHER_OF_HALVERS_ALTER_EGO)) and 1 or 0
+                        if xi.settings.main.ENABLE_TRUST_QUESTS == 1 then
+                            local needsHalverTrust = (not player:hasSpell(xi.magic.spell.HALVER) and not player:findItem(xi.item.CIPHER_OF_HALVERS_ALTER_EGO)) and 1 or 0
 
-                        return mission:progressEvent(504, { [7] = needsHalverTrust })
+                            return mission:progressEvent(504, { [7] = needsHalverTrust })
+                        else
+                            return mission:progressEvent(504)
+                        end
                     else
                         return mission:messageText(chateauID.text.HALVER_OFFSET + 279)
                     end
@@ -44,6 +48,7 @@ mission.sections =
                     player:setMissionStatus(mission.areaId, 9)
 
                     if
+                        xi.settings.main.ENABLE_TRUST_QUESTS == 1 and
                         not player:hasSpell(xi.magic.spell.HALVER) and
                         not player:findItem(xi.item.CIPHER_OF_HALVERS_ALTER_EGO)
                     then

--- a/scripts/quests/hiddenQuests/Trust_Halver.lua
+++ b/scripts/quests/hiddenQuests/Trust_Halver.lua
@@ -8,7 +8,8 @@ quest.sections =
 {
     {
         check = function(player, questVars, vars)
-            return not player:hasSpell(xi.magic.spell.HALVER) and
+            return xi.settings.main.ENABLE_TRUST_QUESTS == 1 and
+                not player:hasSpell(xi.magic.spell.HALVER) and
                 not player:findItem(xi.item.CIPHER_OF_HALVERS_ALTER_EGO) and
                 player:hasCompletedMission(xi.mission.log_id.ROV, xi.mission.id.rov.THE_PATH_UNTRAVELED)
         end,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Implements a check established in `xi.settings.main.ENABLE_TRUST_QUESTS` for obtaining all instances of `Cipher_Of_Halvers_Trust_Alter_Ego`

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Checks for  `xi.settings.main.ENABLE_TRUST_QUESTS 1|0` 
## Steps to test these changes
Pick a nation and add mission 2-3. 
Speak with NPC's at consulate and then talk to Halver. 
If  `xi.settings.main.ENABLE_TRUST_QUESTS`  is 1 player will receive scroll.
if  `xi.settings.main.ENABLE_TRUST_QUESTS`  is 0 players will not receive scroll.
<!-- Clear and detailed steps to test your changes here -->
