### PR TITLE
[lua] Correct isValidEntry logic to trade for registration

### DIFF
--- a/scripts/battlefields/Apollyon/central_apollyon.lua
+++ b/scripts/battlefields/Apollyon/central_apollyon.lua
@@ -19,15 +19,11 @@ local content = Limbus:new({
     timeLimit        = utils.minutes(30),
     index            = 4,
     area             = 5,
-    entryNpc         = '_12i',
+    entryNpcs        = { '_12i', '_127' },
     requiredKeyItems = { xi.ki.COSMO_CLEANSE, { xi.ki.RED_CARD, xi.ki.BLACK_CARD }, message = ID.text.YOU_INSERT_THE_CARD_POLISHED },
     requiredItems    = { xi.item.SMALT_CHIP, xi.item.SMOKY_CHIP, xi.item.CHARCOAL_CHIP, xi.item.MAGENTA_CHIP },
     name             = 'CENTRAL_APOLLYON',
 })
-
-function content:isValidEntry(player, npc)
-    return self.entryNpc == '_12i' or self.entryNpc == '_127'
-end
 
 function content:onEntryEventUpdate(player, csid, option, npc)
     if Battlefield.onEntryEventUpdate(self, player, csid, option, npc) then

--- a/scripts/battlefields/Apollyon/cs_apollyon.lua
+++ b/scripts/battlefields/Apollyon/cs_apollyon.lua
@@ -16,16 +16,12 @@ local content = Limbus:new({
     timeLimit        = utils.minutes(20),
     index            = 5,
     area             = 6,
-    entryNpc         = '_12i',
+    entryNpcs        = { '_12i', '_127' },
     requiredKeyItems = { xi.ki.COSMO_CLEANSE, { xi.ki.RED_CARD, xi.ki.BLACK_CARD }, message = ID.text.YOU_INSERT_THE_CARD_POLISHED },
     requiredItems    = { xi.item.METAL_CHIP },
     name             = 'CS_APOLLYON',
     timeExtension    = 5,
 })
-
-function content:isValidEntry(player, npc)
-    return self.entryNpc == '_12i' or self.entryNpc == '_127'
-end
 
 function content:onEntryEventUpdate(player, csid, option, npc)
     if Battlefield.onEntryEventUpdate(self, player, csid, option, npc) then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes https://github.com/LandSandBoat/server/issues/5613 .

The `isValidEntry` logic was referencing the battlefield `entryNpc` value (which never explicitly gets set, it gets passed and used to build a table of one entry for `entryNpcs`) instead of the traded npc's name

## Steps to test these changes

Give yourself all the key items and items and trade the 4 chips to the swirling vortex