### PR TITLE
Fix storage related integer overflow

### DIFF
--- a/src/map/item_container.cpp
+++ b/src/map/item_container.cpp
@@ -74,7 +74,7 @@ uint16 CItemContainer::GetBuff() const
 uint8 CItemContainer::AddBuff(int8 buff)
 {
     m_buff += buff;
-    return SetSize(std::clamp<uint8>((uint8)m_buff, 0, 80)); // Limit in 0-80 cells for character
+    return SetSize(std::clamp<int>(m_buff, 0, 80)); // Limit in 0-80 cells for character
 }
 
 /************************************************************************


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This pull request fixes an interger overflow which can occur when a player accumulates a high amount (>255) of storage in their mog house.

When a player reaches >255 - they will overflow the variables resulting in their total storage size getting capped at an unxpectedly low value.

Why does this happen?
The previous code `std::clamp<uint8>((uint8)m_buff, 0, 80)` was first casting m_buff to uint8, then applying the clamp.  When m_buff exceeds the limits of a uint8, it would first overflow, then be clamped.

The fix:
Since the clamp is forcing values between 0 and 80 there is no explicit need (at this time) to cast downwards, I have removed the inner cast to unit8 and changed the clamp type to int.  Note that clamp type of unit8 will cause a cast _prior ro clamping_ and result in the same integer overlow.

## Steps to test these changes

**Prior to bug fix:**
1.  Add a few large storage items - wells will work as each has 80 storage `!additem well` 
2. Add a few smaller storage items - red_jar has 7, bookshelf has 20 and some aquariums at 1 are what I used.
3. Add storage giving items to MogSafe1, and Layout all the items.  Ensure that the total storage of all items is >255.  Ideally around 265.
4. Add a single item to storage.  This is not required to trigger the bug but helps clearly identify exactly when it occurs.
5. Log out and Log back in (this gives a clear state).
6. If you set your total storage to be around 265 - you will now have ~1/10 storage.
7. Attempting to remove a storage item from being laid out will be blocked by the UX if the result would put the total storage below the item count (1 in this case).  Therefore you could remove a red_jar, but not a bookcase or a well.

**With the bug fix:**
At step 6 - you will have 1/80 storage.  This will continue until enough items are removed to pull the total storage below 80.
