### PR TITLE
[LUA] Add Prester latent effect functionality

### DIFF
--- a/scripts/enum/item.lua
+++ b/scripts/enum/item.lua
@@ -6171,6 +6171,7 @@ xi.item =
     DORJE                               = 18594,
     KEBBIE                              = 18596,
     CATALYST                            = 18597,
+    PRESTER                             = 18598,
     RAM_STAFF                           = 18612,
     SAMUDRA                             = 18618,
     SPHARAI_85                          = 18637,

--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -233,10 +233,11 @@ xi.combat.physical.calculateFTP = function(actor, tpFactor)
     local scProp1, scProp2, scProp3 = actor:getWSSkillchainProp()
     local dayElement                = VanadielDayElement() + 1
 
-    local neckFtpBonus  = 0
-    local waistFtpBonus = 0
-    local headFtpBonus  = 0
-    local handsFtpBonus = 0
+    local neckFtpBonus   = 0
+    local waistFtpBonus  = 0
+    local headFtpBonus   = 0
+    local handsFtpBonus  = 0
+    local weaponFtpBonus = 0
 
     if actor:getObjType() == xi.objType.PC then
         -- Calculate Neck fTP bonus.
@@ -315,10 +316,22 @@ xi.combat.physical.calculateFTP = function(actor, tpFactor)
                 handsFtpBonus = 0.06
             end
         end
+
+        -- Calculate Weapon fTP bonus.
+        local weaponItem = actor:getEquipID(xi.slot.MAIN)
+
+        if
+            weaponItem == xi.item.PRESTER and
+            (wsElementalProperties[scProp1][xi.element.WIND] == 1 or
+            wsElementalProperties[scProp2][xi.element.WIND] == 1 or
+            wsElementalProperties[scProp3][xi.element.WIND] == 1)
+        then
+            weaponFtpBonus = 0.1
+        end
     end
 
     -- Add all bonuses and return.
-    fTP = fTP + neckFtpBonus + waistFtpBonus + headFtpBonus + handsFtpBonus
+    fTP = fTP + neckFtpBonus + waistFtpBonus + headFtpBonus + handsFtpBonus + weaponFtpBonus
 
     return fTP
 end

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -1261,6 +1261,7 @@ xi.weaponskills.handleWSGorgetBelt = function(attacker)
 
         local neck                      = attacker:getEquipID(xi.slot.NECK)
         local belt                      = attacker:getEquipID(xi.slot.WAIST)
+        local weapon                    = attacker:getEquipID(xi.slot.MAIN)
         local scProp1, scProp2, scProp3 = attacker:getWSSkillchainProp()
 
         for i, v in ipairs(elementalGorget) do
@@ -1300,6 +1301,15 @@ xi.weaponskills.handleWSGorgetBelt = function(attacker)
 
         if belt == xi.item.FOTIA_BELT then -- Fotia Belt
             accBonus = accBonus + 10
+            ftpBonus = ftpBonus + 0.1
+        end
+
+        if
+            weapon == xi.item.PRESTER and
+            (xi.magicburst.doesElementMatchWeaponskill(xi.element.WIND, scProp1) or
+            xi.magicburst.doesElementMatchWeaponskill(xi.element.WIND, scProp2) or
+            xi.magicburst.doesElementMatchWeaponskill(xi.element.WIND, scProp3))
+        then -- Prester
             ftpBonus = ftpBonus + 0.1
         end
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds Prester's latent effect functionality. Prester works identically to Breeze Gorget/Belt so we simply add the proper checks for the weapon and wind element on the weaponskill then add the 0.1 fTP bonus if everything matches up.

https://www.bg-wiki.com/ffxi/Prester

## Steps to test these changes

1. !addallweaponskills
2. !additem 18598
3. !immortal a mob
4. !setmod regain 3000 or !godmode
5. Use a Fragmentation or Detonation weaponskill