### PR TITLE
[LUA] Fix error in xi.mobskills.applyPlayerResistance

### DIFF
--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -340,9 +340,9 @@ xi.mobskills.applyPlayerResistance = function(mob, effect, target, diff, bonus, 
         percentBonus = percentBonus - xi.magic.getEffectResistance(target, effect)
     end
 
-    local p = getMagicHitRate(mob, target, 0, element, percentBonus, magicaccbonus)
+    local magicHitRate = getMagicHitRate(mob, target, 0, element, percentBonus, magicaccbonus)
 
-    return getMagicResist(p)
+    return getMagicResist(mob, target, xi.skill.NONE, element, magicHitRate)
 end
 
 xi.mobskills.mobAddBonuses = function(caster, target, dmg, ele, skill) -- used for SMN magical bloodpacts, despite the name.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Due to my recent refactor of getMagicResist there is currently an error when xi.mobskills.applyPlayerResistance runs since it's not using the updated parameters for the method. To fix this we'll just update the method to use the updated parameters.

```
[05/04/24 23:11:47:198][map][error] luautils::onMobWeaponSkill (mobskill) .\scripts/globals/combat/magic_hit_rate.lua:403: attempt to index local 'target' (a nil value)
stack traceback:
	.\scripts/globals/combat/magic_hit_rate.lua:403: in function 'applyPlayerResistance'
	.\scripts/globals/mobskills.lua:710: in function 'mobStatusEffectMove'
	./scripts/actions/mobskills/sonic_boom.lua:12: in function <./scripts/actions/mobskills/sonic_boom.lua:11> (luautils::OnMobWeaponSkill:3842)
```

## Steps to test these changes

1. Find a mob
2. !exec target:useMobAbility(393)
