### PR TITLE
[LUA] Fix Stegotaur and Teratotaur resetting fomor hate

### DIFF
--- a/scripts/zones/Sacrarium/mobs/Stegotaur.lua
+++ b/scripts/zones/Sacrarium/mobs/Stegotaur.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -4)
+    mob:setLocalVar('fomorHateAdj', 4) -- treated as negative in fomor_hate mixin
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Sacrarium/mobs/Teratotaur.lua
+++ b/scripts/zones/Sacrarium/mobs/Teratotaur.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('fomorHateAdj', -4)
+    mob:setLocalVar('fomorHateAdj', 4) -- treated as negative in fomor_hate mixin
 end
 
 entity.onMobDeath = function(mob, player, optParams)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Local vars cannot be stored in negative numbers, -4 currently translates to 4294967292 when checked in the fomor hate mixin. The mixin handles non-family types and makes the adjustment negative already so we just need to remove the negative from the local var set on the Stegotaur and Teratotaur.

## Steps to test these changes

1. !pos 100 -2 -41 28
2. !setplayervar name FOMOR_HATE 60
3. Kill Teratotaur or Stegotaur
4. !checkvar FOMOR_HATE

![image](https://github.com/LandSandBoat/server/assets/166072302/be53c0e3-5a44-42f7-8da6-7dd3cecca95e)
