### PR TITLE
Fix race specific equipment and sexchange issue

### DIFF
--- a/scripts/enum/mod.lua
+++ b/scripts/enum/mod.lua
@@ -708,6 +708,8 @@ xi.mod =
     EAT_RAW_MEAT                    = 413, -- Without this, only Galka can eat raw meat (item cannot be used)
     DRINK_DISTILLED                 = 159, -- Without this, Distilled Water cannot be consumed (item can still be used)
 
+    EQUIPMENT_ONLY_RACE             = 276, -- An 8-bit flag that denotes that only a certain race(s) can use this equipment (0 means all races can use)
+
     ENHANCES_CURSNA_RCVD            = 67,   -- Potency of "Cursna" effects received
     ENHANCES_CURSNA                 = 310,  -- Raises success rate of Cursna when removing effect (like Doom) that are not 100% chance to remove
     ENHANCES_HOLYWATER              = 495,  -- Used by gear with the "Enhances Holy Water" or "Holy Water+" attribute

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -36,16 +36,20 @@ LOCK TABLES `item_mods` WRITE;
 INSERT INTO `item_mods` VALUES (10250,1,1); -- DEF: 1
 
 -- Decennial Coat
-INSERT INTO `item_mods` VALUES (10251,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (10251,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (10251,276,149); -- RSE (race specific equip)
 
 -- Decennial Dress
-INSERT INTO `item_mods` VALUES (10252,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (10252,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (10252,276,106); -- RSE (race specific equip)
 
 -- Decennial Coat +1
-INSERT INTO `item_mods` VALUES (10253,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (10253,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (10253,276,149); -- RSE (race specific equip)
 
 -- Decennial Dress +1
-INSERT INTO `item_mods` VALUES (10254,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (10254,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (10254,276,106); -- RSE (race specific equip)
 
 -- Matanca Harness
 INSERT INTO `item_mods` VALUES (10255,1,77);    -- DEF: 77
@@ -57,52 +61,68 @@ INSERT INTO `item_mods` VALUES (10255,23,22);   -- ATT: 22
 INSERT INTO `item_mods` VALUES (10255,384,300); -- HASTE_GEAR: 300
 
 -- Marine Gilet
-INSERT INTO `item_mods` VALUES (10256,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (10256,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (10256,276,1); -- RSE (race specific equip)
 
 -- Marine Top
-INSERT INTO `item_mods` VALUES (10257,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (10257,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (10257,276,2); -- RSE (race specific equip)
 
 -- Woodsy Gilet
-INSERT INTO `item_mods` VALUES (10258,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (10258,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (10258,276,4); -- RSE (race specific equip)
 
 -- Woodsy Top
-INSERT INTO `item_mods` VALUES (10259,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (10259,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (10259,276,8); -- RSE (race specific equip)
 
 -- Creek Maillot
-INSERT INTO `item_mods` VALUES (10260,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (10260,1,1);    -- DEF: 1
+INSERT INTO `item_mods` VALUES (10260,276,16); -- RSE (race specific equip)
 
 -- Creek Top
-INSERT INTO `item_mods` VALUES (10261,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (10261,1,1);    -- DEF: 1
+INSERT INTO `item_mods` VALUES (10261,276,32); -- RSE (race specific equip)
 
 -- River Top
-INSERT INTO `item_mods` VALUES (10262,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (10262,1,1);    -- DEF: 1
+INSERT INTO `item_mods` VALUES (10262,276,64); -- RSE (race specific equip)
 
 -- Dune Gilet
-INSERT INTO `item_mods` VALUES (10263,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (10263,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (10263,276,128); -- RSE (race specific equip)
 
 -- Marine Gilet +1
-INSERT INTO `item_mods` VALUES (10264,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (10264,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (10264,276,1); -- RSE (race specific equip)
 
 -- Marine Top +1
-INSERT INTO `item_mods` VALUES (10265,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (10265,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (10265,276,2); -- RSE (race specific equip)
 
 -- Woodsy Gilet +1
-INSERT INTO `item_mods` VALUES (10266,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (10266,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (10266,276,4); -- RSE (race specific equip)
 
 -- Woodsy Top +1
-INSERT INTO `item_mods` VALUES (10267,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (10267,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (10267,276,8); -- RSE (race specific equip)
 
 -- Creek Maillot +1
-INSERT INTO `item_mods` VALUES (10268,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (10268,1,2);    -- DEF: 2
+INSERT INTO `item_mods` VALUES (10268,276,16); -- RSE (race specific equip)
 
 -- Creek Top +1
-INSERT INTO `item_mods` VALUES (10269,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (10269,1,2);    -- DEF: 2
+INSERT INTO `item_mods` VALUES (10269,276,32); -- RSE (race specific equip)
 
 -- River Top +1
-INSERT INTO `item_mods` VALUES (10270,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (10270,1,2);    -- DEF: 2
+INSERT INTO `item_mods` VALUES (10270,276,64); -- RSE (race specific equip)
 
 -- Dune Gilet +1
-INSERT INTO `item_mods` VALUES (10271,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (10271,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (10271,276,128); -- RSE (race specific equip)
 
 -- Dux Scale Mail
 INSERT INTO `item_mods` VALUES (10272,1,68);     -- DEF: 68
@@ -466,52 +486,68 @@ INSERT INTO `item_mods` VALUES (10329,567,15); -- BARSPELL_AMOUNT: 15
 INSERT INTO `item_mods` VALUES (10329,832,1);  -- AQUAVEIL_COUNT: 1
 
 -- Marine Boxers
-INSERT INTO `item_mods` VALUES (10330,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (10330,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (10330,276,1); -- RSE (race specific equip)
 
 -- Marine Shorts
-INSERT INTO `item_mods` VALUES (10331,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (10331,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (10331,276,2); -- RSE (race specific equip)
 
 -- Woodsy Boxers
-INSERT INTO `item_mods` VALUES (10332,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (10332,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (10332,276,4); -- RSE (race specific equip)
 
 -- Woodsy Shorts
-INSERT INTO `item_mods` VALUES (10333,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (10333,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (10333,276,8); -- RSE (race specific equip)
 
 -- Creek Boxers
-INSERT INTO `item_mods` VALUES (10334,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (10334,1,1);    -- DEF: 1
+INSERT INTO `item_mods` VALUES (10334,276,16); -- RSE (race specific equip)
 
 -- Creek Shorts
-INSERT INTO `item_mods` VALUES (10335,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (10335,1,1);    -- DEF: 1
+INSERT INTO `item_mods` VALUES (10335,276,32); -- RSE (race specific equip)
 
 -- River Shorts
-INSERT INTO `item_mods` VALUES (10336,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (10336,1,1);    -- DEF: 1
+INSERT INTO `item_mods` VALUES (10336,276,64); -- RSE (race specific equip)
 
 -- Dune Boxers
-INSERT INTO `item_mods` VALUES (10337,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (10337,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (10337,276,128); -- RSE (race specific equip)
 
 -- Marine Boxers +1
-INSERT INTO `item_mods` VALUES (10338,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (10338,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (10338,276,1); -- RSE (race specific equip)
 
 -- Marine Shorts +1
-INSERT INTO `item_mods` VALUES (10339,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (10339,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (10339,276,2); -- RSE (race specific equip)
 
 -- Woodsy Boxers +1
-INSERT INTO `item_mods` VALUES (10340,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (10340,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (10340,276,4); -- RSE (race specific equip)
 
 -- Woodsy Shorts +1
-INSERT INTO `item_mods` VALUES (10341,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (10341,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (10341,276,8); -- RSE (race specific equip)
 
 -- Creek Boxers +1
-INSERT INTO `item_mods` VALUES (10342,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (10342,1,2);    -- DEF: 2
+INSERT INTO `item_mods` VALUES (10342,276,16); -- RSE (race specific equip)
 
 -- Creek Shorts +1
-INSERT INTO `item_mods` VALUES (10343,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (10343,1,2);    -- DEF: 2
+INSERT INTO `item_mods` VALUES (10343,276,32); -- RSE (race specific equip)
 
 -- River Shorts +1
-INSERT INTO `item_mods` VALUES (10344,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (10344,1,2);    -- DEF: 2
+INSERT INTO `item_mods` VALUES (10344,276,64); -- RSE (race specific equip)
 
 -- Dune Boxers +1
-INSERT INTO `item_mods` VALUES (10345,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (10345,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (10345,276,128); -- RSE (race specific equip)
 
 -- Dux Cuisses
 INSERT INTO `item_mods` VALUES (10346,1,55);     -- DEF: 55
@@ -861,16 +897,20 @@ INSERT INTO `item_mods` VALUES (10418,30,6); -- MACC: 6
 INSERT INTO `item_mods` VALUES (10429,1,1); -- DEF: 1
 
 -- Decennial Crown
-INSERT INTO `item_mods` VALUES (10430,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (10430,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (10430,276,149); -- RSE (race specific equip)
 
 -- Decennial Tiara
-INSERT INTO `item_mods` VALUES (10431,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (10431,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (10431,276,106); -- RSE (race specific equip)
 
 -- Decennial Crown +1
-INSERT INTO `item_mods` VALUES (10432,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (10432,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (10432,276,149); -- RSE (race specific equip)
 
 -- Decennial Tiara +1
-INSERT INTO `item_mods` VALUES (10433,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (10433,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (10433,276,106); -- RSE (race specific equip)
 
 -- Dux Visor
 INSERT INTO `item_mods` VALUES (10434,1,40);     -- DEF: 40
@@ -1965,16 +2005,20 @@ INSERT INTO `item_mods` VALUES (10582,289,5);   -- SUBTLE_BLOW: 5
 INSERT INTO `item_mods` VALUES (10582,384,400); -- HASTE_GEAR: 400
 
 -- Decennial Tights
-INSERT INTO `item_mods` VALUES (10593,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (10593,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (10593,276,149); -- RSE (race specific equip)
 
 -- Decennial Hose
-INSERT INTO `item_mods` VALUES (10594,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (10594,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (10594,276,106); -- RSE (race specific equip)
 
 -- Decennial Tights +1
-INSERT INTO `item_mods` VALUES (10595,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (10595,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (10595,276,149); -- RSE (race specific equip)
 
 -- Decennial Hose +1
-INSERT INTO `item_mods` VALUES (10596,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (10596,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (10596,276,106); -- RSE (race specific equip)
 
 -- Akasha Chaps
 INSERT INTO `item_mods` VALUES (10597,1,38);  -- DEF: 38
@@ -5998,52 +6042,68 @@ INSERT INTO `item_mods` VALUES (11263,12,6);  -- INT: 6
 INSERT INTO `item_mods` VALUES (11263,115,7); -- ELEM: 7
 
 -- Custom Gilet
-INSERT INTO `item_mods` VALUES (11265,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (11265,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (11265,276,1); -- RSE (race specific equip)
 
 -- Custom Top
-INSERT INTO `item_mods` VALUES (11266,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (11266,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (11266,276,2); -- RSE (race specific equip)
 
 -- Magna Gilet
-INSERT INTO `item_mods` VALUES (11267,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (11267,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (11267,276,4); -- RSE (race specific equip)
 
 -- Magna Top
-INSERT INTO `item_mods` VALUES (11268,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (11268,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (11268,276,8); -- RSE (race specific equip)
 
 -- Wonder Maillot
-INSERT INTO `item_mods` VALUES (11269,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (11269,1,1);    -- DEF: 1
+INSERT INTO `item_mods` VALUES (11269,276,16); -- RSE (race specific equip)
 
 -- Wonder Top
-INSERT INTO `item_mods` VALUES (11270,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (11270,1,1);    -- DEF: 1
+INSERT INTO `item_mods` VALUES (11270,276,32); -- RSE (race specific equip)
 
 -- Savage Top
-INSERT INTO `item_mods` VALUES (11271,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (11271,1,1);    -- DEF: 1
+INSERT INTO `item_mods` VALUES (11271,276,64); -- RSE (race specific equip)
 
 -- Elder Gilet
-INSERT INTO `item_mods` VALUES (11272,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (11272,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (11272,276,128); -- RSE (race specific equip)
 
 -- Custom Gilet +1
-INSERT INTO `item_mods` VALUES (11273,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (11273,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (11273,276,1); -- RSE (race specific equip)
 
 -- Custom Top +1
-INSERT INTO `item_mods` VALUES (11274,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (11274,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (11274,276,2); -- RSE (race specific equip)
 
 -- Magna Gilet +1
-INSERT INTO `item_mods` VALUES (11275,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (11275,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (11275,276,4); -- RSE (race specific equip)
 
 -- Magna Top +1
-INSERT INTO `item_mods` VALUES (11276,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (11276,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (11276,276,8); -- RSE (race specific equip)
 
 -- Wonder Maillot +1
-INSERT INTO `item_mods` VALUES (11277,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (11277,1,2);    -- DEF: 2
+INSERT INTO `item_mods` VALUES (11277,276,16); -- RSE (race specific equip)
 
 -- Wonder Top +1
-INSERT INTO `item_mods` VALUES (11278,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (11278,1,2);    -- DEF: 2
+INSERT INTO `item_mods` VALUES (11278,276,32); -- RSE (race specific equip)
 
 -- Savage Top +1
-INSERT INTO `item_mods` VALUES (11279,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (11279,1,2);    -- DEF: 2
+INSERT INTO `item_mods` VALUES (11279,276,64); -- RSE (race specific equip)
 
 -- Elder Gilet +1
-INSERT INTO `item_mods` VALUES (11280,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (11280,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (11280,276,128); -- RSE (race specific equip)
 
 -- Hachiryu Haramaki
 INSERT INTO `item_mods` VALUES (11281,1,52);  -- DEF: 52
@@ -6192,20 +6252,22 @@ INSERT INTO `item_mods` VALUES (11300,1,2); -- DEF: 2
 INSERT INTO `item_mods` VALUES (11301,1,3); -- DEF: 3
 
 -- Dancers Casaque +1
-INSERT INTO `item_mods` VALUES (11302,1,39);   -- DEF: 39
-INSERT INTO `item_mods` VALUES (11302,2,25);   -- HP: 25
-INSERT INTO `item_mods` VALUES (11302,8,5);    -- STR: 5
-INSERT INTO `item_mods` VALUES (11302,9,5);    -- DEX: 5
-INSERT INTO `item_mods` VALUES (11302,27,-2);  -- ENMITY: -2
-INSERT INTO `item_mods` VALUES (11302,491,10); -- WALTZ_POTENCY: 10
+INSERT INTO `item_mods` VALUES (11302,1,39);    -- DEF: 39
+INSERT INTO `item_mods` VALUES (11302,2,25);    -- HP: 25
+INSERT INTO `item_mods` VALUES (11302,8,5);     -- STR: 5
+INSERT INTO `item_mods` VALUES (11302,9,5);     -- DEX: 5
+INSERT INTO `item_mods` VALUES (11302,27,-2);   -- ENMITY: -2
+INSERT INTO `item_mods` VALUES (11302,276,149); -- RSE (race specific equip)
+INSERT INTO `item_mods` VALUES (11302,491,10);  -- WALTZ_POTENCY: 10
 
 -- Dancers Casaque +1
-INSERT INTO `item_mods` VALUES (11303,1,39);   -- DEF: 39
-INSERT INTO `item_mods` VALUES (11303,2,25);   -- HP: 25
-INSERT INTO `item_mods` VALUES (11303,8,5);    -- STR: 5
-INSERT INTO `item_mods` VALUES (11303,9,5);    -- DEX: 5
-INSERT INTO `item_mods` VALUES (11303,27,-2);  -- ENMITY: -2
-INSERT INTO `item_mods` VALUES (11303,491,10); -- WALTZ_POTENCY: 10
+INSERT INTO `item_mods` VALUES (11303,1,39);    -- DEF: 39
+INSERT INTO `item_mods` VALUES (11303,2,25);    -- HP: 25
+INSERT INTO `item_mods` VALUES (11303,8,5);     -- STR: 5
+INSERT INTO `item_mods` VALUES (11303,9,5);     -- DEX: 5
+INSERT INTO `item_mods` VALUES (11303,27,-2);   -- ENMITY: -2
+INSERT INTO `item_mods` VALUES (11303,276,106); -- RSE (race specific equip)
+INSERT INTO `item_mods` VALUES (11303,491,10);  -- WALTZ_POTENCY: 10
 
 -- Scholars Gown +1
 INSERT INTO `item_mods` VALUES (11304,1,39);   -- DEF: 39
@@ -6246,16 +6308,19 @@ INSERT INTO `item_mods` VALUES (11308,113,7); -- ENHANCE: 7
 INSERT INTO `item_mods` VALUES (11308,401,1); -- SUBLIMATION_BONUS: 1
 
 -- Benedight Coat
-INSERT INTO `item_mods` VALUES (11309,1,4);   -- DEF: 4
-INSERT INTO `item_mods` VALUES (11309,21,15); -- LIGHT_RES: 15
+INSERT INTO `item_mods` VALUES (11309,1,4);     -- DEF: 4
+INSERT INTO `item_mods` VALUES (11309,21,15);   -- LIGHT_RES: 15
+INSERT INTO `item_mods` VALUES (11309,276,149); -- RSE (race specific equip)
 
 -- Argent Coat
-INSERT INTO `item_mods` VALUES (11310,1,5);  -- DEF: 5
-INSERT INTO `item_mods` VALUES (11310,14,1); -- CHR: 1
+INSERT INTO `item_mods` VALUES (11310,1,5);     -- DEF: 5
+INSERT INTO `item_mods` VALUES (11310,14,1);    -- CHR: 1
+INSERT INTO `item_mods` VALUES (11310,276,149); -- RSE (race specific equip)
 
 -- Platino Coat
-INSERT INTO `item_mods` VALUES (11311,1,5);  -- DEF: 5
-INSERT INTO `item_mods` VALUES (11311,14,3); -- CHR: 3
+INSERT INTO `item_mods` VALUES (11311,1,5);     -- DEF: 5
+INSERT INTO `item_mods` VALUES (11311,14,3);    -- CHR: 3
+INSERT INTO `item_mods` VALUES (11311,276,149); -- RSE (race specific equip)
 
 -- Ramblers Cloak
 INSERT INTO `item_mods` VALUES (11312,1,3); -- DEF: 3
@@ -6283,16 +6348,20 @@ INSERT INTO `item_mods` VALUES (11315,13,5); -- MND: 5
 INSERT INTO `item_mods` VALUES (11315,14,5); -- CHR: 5
 
 -- Otokogusa Yukata
-INSERT INTO `item_mods` VALUES (11316,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (11316,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (11316,276,149); -- RSE (race specific equip)
 
 -- Onnagusa Yukata
-INSERT INTO `item_mods` VALUES (11317,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (11317,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (11317,276,106); -- RSE (race specific equip)
 
 -- Otokoeshi Yukata
-INSERT INTO `item_mods` VALUES (11318,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (11318,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (11318,276,149); -- RSE (race specific equip)
 
 -- Ominaeshi Yukata
-INSERT INTO `item_mods` VALUES (11319,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (11319,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (11319,276,106); -- RSE (race specific equip)
 
 -- Orange Racing Silks
 INSERT INTO `item_mods` VALUES (11321,1,2);    -- DEF: 2
@@ -6709,22 +6778,24 @@ INSERT INTO `item_mods` VALUES (11392,500,0);  -- ITEM_ADDEFFECT_DMG: 0
 INSERT INTO `item_mods` VALUES (11392,501,20); -- ITEM_ADDEFFECT_CHANCE: 20
 
 -- Dancers Toe Shoes +1
-INSERT INTO `item_mods` VALUES (11393,1,15);   -- DEF: 15
-INSERT INTO `item_mods` VALUES (11393,2,12);   -- HP: 12
-INSERT INTO `item_mods` VALUES (11393,8,3);    -- STR: 3
-INSERT INTO `item_mods` VALUES (11393,11,3);   -- AGI: 3
-INSERT INTO `item_mods` VALUES (11393,23,5);   -- ATT: 5
-INSERT INTO `item_mods` VALUES (11393,68,5);   -- EVA: 5
-INSERT INTO `item_mods` VALUES (11393,492,25); -- JIG_DURATION: 25
+INSERT INTO `item_mods` VALUES (11393,1,15);    -- DEF: 15
+INSERT INTO `item_mods` VALUES (11393,2,12);    -- HP: 12
+INSERT INTO `item_mods` VALUES (11393,8,3);     -- STR: 3
+INSERT INTO `item_mods` VALUES (11393,11,3);    -- AGI: 3
+INSERT INTO `item_mods` VALUES (11393,23,5);    -- ATT: 5
+INSERT INTO `item_mods` VALUES (11393,68,5);    -- EVA: 5
+INSERT INTO `item_mods` VALUES (11393,276,149); -- RSE (race specific equip)
+INSERT INTO `item_mods` VALUES (11393,492,25);  -- JIG_DURATION: 25
 
 -- Dancers Toe Shoes +1
-INSERT INTO `item_mods` VALUES (11394,1,15);   -- DEF: 15
-INSERT INTO `item_mods` VALUES (11394,2,12);   -- HP: 12
-INSERT INTO `item_mods` VALUES (11394,8,3);    -- STR: 3
-INSERT INTO `item_mods` VALUES (11394,11,3);   -- AGI: 3
-INSERT INTO `item_mods` VALUES (11394,23,5);   -- ATT: 5
-INSERT INTO `item_mods` VALUES (11394,68,5);   -- EVA: 5
-INSERT INTO `item_mods` VALUES (11394,492,25); -- JIG_DURATION: 25
+INSERT INTO `item_mods` VALUES (11394,1,15);    -- DEF: 15
+INSERT INTO `item_mods` VALUES (11394,2,12);    -- HP: 12
+INSERT INTO `item_mods` VALUES (11394,8,3);     -- STR: 3
+INSERT INTO `item_mods` VALUES (11394,11,3);    -- AGI: 3
+INSERT INTO `item_mods` VALUES (11394,23,5);    -- ATT: 5
+INSERT INTO `item_mods` VALUES (11394,68,5);    -- EVA: 5
+INSERT INTO `item_mods` VALUES (11394,276,106); -- RSE (race specific equip)
+INSERT INTO `item_mods` VALUES (11394,492,25);  -- JIG_DURATION: 25
 
 -- Scholars Loafers +1
 INSERT INTO `item_mods` VALUES (11395,1,11);   -- DEF: 11
@@ -7211,20 +7282,22 @@ INSERT INTO `item_mods` VALUES (11473,71,3);  -- MPHEAL: 3
 INSERT INTO `item_mods` VALUES (11474,1,25); -- DEF: 25
 
 -- Dancers Tiara +1
-INSERT INTO `item_mods` VALUES (11475,1,19);   -- DEF: 19
-INSERT INTO `item_mods` VALUES (11475,2,15);   -- HP: 15
-INSERT INTO `item_mods` VALUES (11475,9,4);    -- DEX: 4
-INSERT INTO `item_mods` VALUES (11475,14,4);   -- CHR: 4
-INSERT INTO `item_mods` VALUES (11475,27,-2);  -- ENMITY: -2
-INSERT INTO `item_mods` VALUES (11475,490,30); -- SAMBA_DURATION: 30
+INSERT INTO `item_mods` VALUES (11475,1,19);    -- DEF: 19
+INSERT INTO `item_mods` VALUES (11475,2,15);    -- HP: 15
+INSERT INTO `item_mods` VALUES (11475,9,4);     -- DEX: 4
+INSERT INTO `item_mods` VALUES (11475,14,4);    -- CHR: 4
+INSERT INTO `item_mods` VALUES (11475,27,-2);   -- ENMITY: -2
+INSERT INTO `item_mods` VALUES (11475,276,149); -- RSE (race specific equip)
+INSERT INTO `item_mods` VALUES (11475,490,30);  -- SAMBA_DURATION: 30
 
 -- Dancers Tiara +1
-INSERT INTO `item_mods` VALUES (11476,1,19);   -- DEF: 19
-INSERT INTO `item_mods` VALUES (11476,2,15);   -- HP: 15
-INSERT INTO `item_mods` VALUES (11476,9,4);    -- DEX: 4
-INSERT INTO `item_mods` VALUES (11476,14,4);   -- CHR: 4
-INSERT INTO `item_mods` VALUES (11476,27,-2);  -- ENMITY: -2
-INSERT INTO `item_mods` VALUES (11476,490,30); -- SAMBA_DURATION: 30
+INSERT INTO `item_mods` VALUES (11476,1,19);    -- DEF: 19
+INSERT INTO `item_mods` VALUES (11476,2,15);    -- HP: 15
+INSERT INTO `item_mods` VALUES (11476,9,4);     -- DEX: 4
+INSERT INTO `item_mods` VALUES (11476,14,4);    -- CHR: 4
+INSERT INTO `item_mods` VALUES (11476,27,-2);   -- ENMITY: -2
+INSERT INTO `item_mods` VALUES (11476,276,106); -- RSE (race specific equip)
+INSERT INTO `item_mods` VALUES (11476,490,30);  -- SAMBA_DURATION: 30
 
 -- Scholars Mortarboard +1
 INSERT INTO `item_mods` VALUES (11477,1,16);  -- DEF: 16
@@ -9104,14 +9177,16 @@ INSERT INTO `item_mods` VALUES (11852,115,10); -- ELEM: 10
 INSERT INTO `item_mods` VALUES (11852,117,10); -- SUMMONING: 10
 
 -- Novennial Coat
-INSERT INTO `item_mods` VALUES (11853,1,1);  -- DEF: 1
-INSERT INTO `item_mods` VALUES (11853,2,9);  -- HP: 9
-INSERT INTO `item_mods` VALUES (11853,21,9); -- LIGHT_RES: 9
+INSERT INTO `item_mods` VALUES (11853,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (11853,2,9);     -- HP: 9
+INSERT INTO `item_mods` VALUES (11853,21,9);    -- LIGHT_RES: 9
+INSERT INTO `item_mods` VALUES (11853,276,149); -- RSE (race specific equip)
 
 -- Novennial Dress
-INSERT INTO `item_mods` VALUES (11854,1,1);  -- DEF: 1
-INSERT INTO `item_mods` VALUES (11854,2,9);  -- HP: 9
-INSERT INTO `item_mods` VALUES (11854,21,9); -- LIGHT_RES: 9
+INSERT INTO `item_mods` VALUES (11854,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (11854,2,9);     -- HP: 9
+INSERT INTO `item_mods` VALUES (11854,21,9);    -- LIGHT_RES: 9
+INSERT INTO `item_mods` VALUES (11854,276,106); -- RSE (race specific equip)
 
 -- Mextli Harness
 INSERT INTO `item_mods` VALUES (11855,1,57);  -- DEF: 57
@@ -9165,10 +9240,12 @@ INSERT INTO `item_mods` VALUES (11860,115,11); -- ELEM: 11
 INSERT INTO `item_mods` VALUES (11860,117,11); -- SUMMONING: 11
 
 -- Hikogami Yukata
-INSERT INTO `item_mods` VALUES (11861,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (11861,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (11861,276,149); -- RSE (race specific equip)
 
 -- Himegami Yukata
-INSERT INTO `item_mods` VALUES (11862,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (11862,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (11862,276,106); -- RSE (race specific equip)
 
 -- Ocelomeh Harness
 INSERT INTO `item_mods` VALUES (11863,1,58);  -- DEF: 58
@@ -9400,34 +9477,39 @@ INSERT INTO `item_mods` VALUES (11898,5,-40); -- MP: -40
 INSERT INTO `item_mods` VALUES (11898,8,5);   -- STR: 5
 INSERT INTO `item_mods` VALUES (11898,9,-5);  -- DEX: -5
 INSERT INTO `item_mods` VALUES (11898,11,5);  -- AGI: 5
+INSERT INTO `item_mods` VALUES (11898,276,3); -- RSE (race specific equip)
 
 -- Weald Gages
-INSERT INTO `item_mods` VALUES (11899,1,16);  -- DEF: 16
-INSERT INTO `item_mods` VALUES (11899,2,-50); -- HP: -50
-INSERT INTO `item_mods` VALUES (11899,5,80);  -- MP: 80
-INSERT INTO `item_mods` VALUES (11899,12,7);  -- INT: 7
-INSERT INTO `item_mods` VALUES (11899,13,-4); -- MND: -4
+INSERT INTO `item_mods` VALUES (11899,1,16);   -- DEF: 16
+INSERT INTO `item_mods` VALUES (11899,2,-50);  -- HP: -50
+INSERT INTO `item_mods` VALUES (11899,5,80);   -- MP: 80
+INSERT INTO `item_mods` VALUES (11899,12,7);   -- INT: 7
+INSERT INTO `item_mods` VALUES (11899,13,-4);  -- MND: -4
+INSERT INTO `item_mods` VALUES (11899,276,12); -- RSE (race specific equip)
 
 -- Savanna Gages
-INSERT INTO `item_mods` VALUES (11900,1,16);  -- DEF: 16
-INSERT INTO `item_mods` VALUES (11900,2,100); -- HP: 100
-INSERT INTO `item_mods` VALUES (11900,5,-80); -- MP: -80
-INSERT INTO `item_mods` VALUES (11900,8,7);   -- STR: 7
-INSERT INTO `item_mods` VALUES (11900,9,-4);  -- DEX: -4
+INSERT INTO `item_mods` VALUES (11900,1,16);   -- DEF: 16
+INSERT INTO `item_mods` VALUES (11900,2,100);  -- HP: 100
+INSERT INTO `item_mods` VALUES (11900,5,-80);  -- MP: -80
+INSERT INTO `item_mods` VALUES (11900,8,7);    -- STR: 7
+INSERT INTO `item_mods` VALUES (11900,9,-4);   -- DEX: -4
+INSERT INTO `item_mods` VALUES (11900,276,48); -- RSE (race specific equip)
 
 -- Tropic Gages
-INSERT INTO `item_mods` VALUES (11901,1,16);  -- DEF: 16
-INSERT INTO `item_mods` VALUES (11901,2,-40); -- HP: -40
-INSERT INTO `item_mods` VALUES (11901,5,50);  -- MP: 50
-INSERT INTO `item_mods` VALUES (11901,12,-4); -- INT: -4
-INSERT INTO `item_mods` VALUES (11901,13,7);  -- MND: 7
+INSERT INTO `item_mods` VALUES (11901,1,16);   -- DEF: 16
+INSERT INTO `item_mods` VALUES (11901,2,-40);  -- HP: -40
+INSERT INTO `item_mods` VALUES (11901,5,50);   -- MP: 50
+INSERT INTO `item_mods` VALUES (11901,12,-4);  -- INT: -4
+INSERT INTO `item_mods` VALUES (11901,13,7);   -- MND: 7
+INSERT INTO `item_mods` VALUES (11901,276,64); -- RSE (race specific equip)
 
 -- Strand Gages
-INSERT INTO `item_mods` VALUES (11902,1,16);  -- DEF: 16
-INSERT INTO `item_mods` VALUES (11902,2,-80); -- HP: -80
-INSERT INTO `item_mods` VALUES (11902,5,100); -- MP: 100
-INSERT INTO `item_mods` VALUES (11902,12,-4); -- INT: -4
-INSERT INTO `item_mods` VALUES (11902,13,7);  -- MND: 7
+INSERT INTO `item_mods` VALUES (11902,1,16);    -- DEF: 16
+INSERT INTO `item_mods` VALUES (11902,2,-80);   -- HP: -80
+INSERT INTO `item_mods` VALUES (11902,5,100);   -- MP: 100
+INSERT INTO `item_mods` VALUES (11902,12,-4);   -- INT: -4
+INSERT INTO `item_mods` VALUES (11902,13,7);    -- MND: 7
+INSERT INTO `item_mods` VALUES (11902,276,128); -- RSE (race specific equip)
 
 -- Tide Gages
 INSERT INTO `item_mods` VALUES (11903,1,16);  -- DEF: 16
@@ -9436,34 +9518,39 @@ INSERT INTO `item_mods` VALUES (11903,5,50);  -- MP: 50
 INSERT INTO `item_mods` VALUES (11903,10,-5); -- VIT: -5
 INSERT INTO `item_mods` VALUES (11903,12,5);  -- INT: 5
 INSERT INTO `item_mods` VALUES (11903,13,5);  -- MND: 5
+INSERT INTO `item_mods` VALUES (11903,276,3); -- RSE (race specific equip)
 
 -- Thicket Gages
-INSERT INTO `item_mods` VALUES (11904,1,16);  -- DEF: 16
-INSERT INTO `item_mods` VALUES (11904,2,80);  -- HP: 80
-INSERT INTO `item_mods` VALUES (11904,5,-50); -- MP: -50
-INSERT INTO `item_mods` VALUES (11904,8,7);   -- STR: 7
-INSERT INTO `item_mods` VALUES (11904,9,-4);  -- DEX: -4
+INSERT INTO `item_mods` VALUES (11904,1,16);   -- DEF: 16
+INSERT INTO `item_mods` VALUES (11904,2,80);   -- HP: 80
+INSERT INTO `item_mods` VALUES (11904,5,-50);  -- MP: -50
+INSERT INTO `item_mods` VALUES (11904,8,7);    -- STR: 7
+INSERT INTO `item_mods` VALUES (11904,9,-4);   -- DEX: -4
+INSERT INTO `item_mods` VALUES (11904,276,12); -- RSE (race specific equip)
 
 -- Brook Gages
-INSERT INTO `item_mods` VALUES (11905,1,16);  -- DEF: 16
-INSERT INTO `item_mods` VALUES (11905,2,-80); -- HP: -80
-INSERT INTO `item_mods` VALUES (11905,5,100); -- MP: 100
-INSERT INTO `item_mods` VALUES (11905,12,7);  -- INT: 7
-INSERT INTO `item_mods` VALUES (11905,13,-4); -- MND: -4
+INSERT INTO `item_mods` VALUES (11905,1,16);   -- DEF: 16
+INSERT INTO `item_mods` VALUES (11905,2,-80);  -- HP: -80
+INSERT INTO `item_mods` VALUES (11905,5,100);  -- MP: 100
+INSERT INTO `item_mods` VALUES (11905,12,7);   -- INT: 7
+INSERT INTO `item_mods` VALUES (11905,13,-4);  -- MND: -4
+INSERT INTO `item_mods` VALUES (11905,276,48); -- RSE (race specific equip)
 
 -- Wild Gages
-INSERT INTO `item_mods` VALUES (11906,1,16);  -- DEF: 16
-INSERT INTO `item_mods` VALUES (11906,2,50);  -- HP: 50
-INSERT INTO `item_mods` VALUES (11906,5,-40); -- MP: -40
-INSERT INTO `item_mods` VALUES (11906,8,-4);  -- STR: -4
-INSERT INTO `item_mods` VALUES (11906,9,7);   -- DEX: 7
+INSERT INTO `item_mods` VALUES (11906,1,16);   -- DEF: 16
+INSERT INTO `item_mods` VALUES (11906,2,50);   -- HP: 50
+INSERT INTO `item_mods` VALUES (11906,5,-40);  -- MP: -40
+INSERT INTO `item_mods` VALUES (11906,8,-4);   -- STR: -4
+INSERT INTO `item_mods` VALUES (11906,9,7);    -- DEX: 7
+INSERT INTO `item_mods` VALUES (11906,276,64); -- RSE (race specific equip)
 
 -- Torrid Gages
-INSERT INTO `item_mods` VALUES (11907,1,16);  -- DEF: 16
-INSERT INTO `item_mods` VALUES (11907,2,100); -- HP: 100
-INSERT INTO `item_mods` VALUES (11907,5,80);  -- MP: 80
-INSERT INTO `item_mods` VALUES (11907,10,7);  -- VIT: 7
-INSERT INTO `item_mods` VALUES (11907,11,-4); -- AGI: -4
+INSERT INTO `item_mods` VALUES (11907,1,16);    -- DEF: 16
+INSERT INTO `item_mods` VALUES (11907,2,100);   -- HP: 100
+INSERT INTO `item_mods` VALUES (11907,5,80);    -- MP: 80
+INSERT INTO `item_mods` VALUES (11907,10,7);    -- VIT: 7
+INSERT INTO `item_mods` VALUES (11907,11,-4);   -- AGI: -4
+INSERT INTO `item_mods` VALUES (11907,276,128); -- RSE (race specific equip)
 
 -- Brute Gauntlets
 INSERT INTO `item_mods` VALUES (11908,1,23);   -- DEF: 23
@@ -9768,14 +9855,16 @@ INSERT INTO `item_mods` VALUES (11955,30,5);  -- MACC: 5
 INSERT INTO `item_mods` VALUES (11955,170,2); -- FASTCAST: 2
 
 -- Novennial Hose
-INSERT INTO `item_mods` VALUES (11956,1,1);  -- DEF: 1
-INSERT INTO `item_mods` VALUES (11956,5,9);  -- MP: 9
-INSERT INTO `item_mods` VALUES (11956,22,9); -- DARK_RES: 9
+INSERT INTO `item_mods` VALUES (11956,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (11956,5,9);     -- MP: 9
+INSERT INTO `item_mods` VALUES (11956,22,9);    -- DARK_RES: 9
+INSERT INTO `item_mods` VALUES (11956,276,149); -- RSE (race specific equip)
 
 -- Novennial Thigh Boots
-INSERT INTO `item_mods` VALUES (11957,1,1);  -- DEF: 1
-INSERT INTO `item_mods` VALUES (11957,5,9);  -- MP: 9
-INSERT INTO `item_mods` VALUES (11957,22,9); -- DARK_RES: 9
+INSERT INTO `item_mods` VALUES (11957,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (11957,5,9);     -- MP: 9
+INSERT INTO `item_mods` VALUES (11957,22,9);    -- DARK_RES: 9
+INSERT INTO `item_mods` VALUES (11957,276,106); -- RSE (race specific equip)
 
 -- Calmecac Trousers
 INSERT INTO `item_mods` VALUES (11958,1,46);    -- DEF: 46
@@ -9826,16 +9915,20 @@ INSERT INTO `item_mods` VALUES (11964,15,20);  -- FIRE_RES: 20
 INSERT INTO `item_mods` VALUES (11964,288,3);  -- DOUBLE_ATTACK: 3
 
 -- Dream Trousers
-INSERT INTO `item_mods` VALUES (11965,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (11965,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (11965,276,149); -- RSE (race specific equip)
 
 -- Dream Trousers +1
-INSERT INTO `item_mods` VALUES (11966,1,3); -- DEF: 3
+INSERT INTO `item_mods` VALUES (11966,1,3);     -- DEF: 3
+INSERT INTO `item_mods` VALUES (11966,276,149); -- RSE (race specific equip)
 
 -- Dream Pants
-INSERT INTO `item_mods` VALUES (11967,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (11967,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (11967,276,106); -- RSE (race specific equip)
 
 -- Dream Pants +1
-INSERT INTO `item_mods` VALUES (11968,1,3); -- DEF: 3
+INSERT INTO `item_mods` VALUES (11968,1,3);     -- DEF: 3
+INSERT INTO `item_mods` VALUES (11968,276,106); -- RSE (race specific equip)
 
 -- Ogiers Breeches
 INSERT INTO `item_mods` VALUES (11969,1,55);     -- DEF: 55
@@ -13197,25 +13290,32 @@ INSERT INTO `item_mods` VALUES (12630,1,10); -- DEF: 10
 INSERT INTO `item_mods` VALUES (12630,16,5); -- ICE_RES: 5
 
 -- Hume Tunic
-INSERT INTO `item_mods` VALUES (12631,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (12631,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (12631,276,1); -- RSE (race specific equip)
 
 -- Hume Vest
-INSERT INTO `item_mods` VALUES (12632,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (12632,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (12632,276,2); -- RSE (race specific equip)
 
 -- Elvaan Jerkin
-INSERT INTO `item_mods` VALUES (12633,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (12633,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (12633,276,4); -- RSE (race specific equip)
 
 -- Elvaan Bodice
-INSERT INTO `item_mods` VALUES (12634,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (12634,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (12634,276,8); -- RSE (race specific equip)
 
 -- Tarutaru Kaftan
-INSERT INTO `item_mods` VALUES (12635,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (12635,1,2);    -- DEF: 2
+INSERT INTO `item_mods` VALUES (12635,276,48); -- RSE (race specific equip)
 
 -- Mithran Separates
-INSERT INTO `item_mods` VALUES (12636,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (12636,1,2);    -- DEF: 2
+INSERT INTO `item_mods` VALUES (12636,276,64); -- RSE (race specific equip)
 
 -- Galkan Surcoat
-INSERT INTO `item_mods` VALUES (12637,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (12637,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (12637,276,128); -- RSE (race specific equip)
 
 -- Fighters Lorica
 INSERT INTO `item_mods` VALUES (12638,1,47);  -- DEF: 47
@@ -13323,6 +13423,7 @@ INSERT INTO `item_mods` VALUES (12654,2,32);  -- HP: 32
 INSERT INTO `item_mods` VALUES (12654,10,3);  -- VIT: 3
 INSERT INTO `item_mods` VALUES (12654,12,-1); -- INT: -1
 INSERT INTO `item_mods` VALUES (12654,14,1);  -- CHR: 1
+INSERT INTO `item_mods` VALUES (12654,276,1); -- RSE (race specific equip)
 
 -- Custom Vest
 INSERT INTO `item_mods` VALUES (12655,1,18);  -- DEF: 18
@@ -13330,39 +13431,45 @@ INSERT INTO `item_mods` VALUES (12655,2,32);  -- HP: 32
 INSERT INTO `item_mods` VALUES (12655,10,3);  -- VIT: 3
 INSERT INTO `item_mods` VALUES (12655,12,-1); -- INT: -1
 INSERT INTO `item_mods` VALUES (12655,14,1);  -- CHR: 1
+INSERT INTO `item_mods` VALUES (12655,276,2); -- RSE (race specific equip)
 
 -- Magna Jerkin
-INSERT INTO `item_mods` VALUES (12656,1,18); -- DEF: 18
-INSERT INTO `item_mods` VALUES (12656,2,24); -- HP: 24
-INSERT INTO `item_mods` VALUES (12656,5,4);  -- MP: 4
-INSERT INTO `item_mods` VALUES (12656,9,1);  -- DEX: 1
-INSERT INTO `item_mods` VALUES (12656,12,1); -- INT: 1
+INSERT INTO `item_mods` VALUES (12656,1,18);  -- DEF: 18
+INSERT INTO `item_mods` VALUES (12656,2,24);  -- HP: 24
+INSERT INTO `item_mods` VALUES (12656,5,4);   -- MP: 4
+INSERT INTO `item_mods` VALUES (12656,9,1);   -- DEX: 1
+INSERT INTO `item_mods` VALUES (12656,12,1);  -- INT: 1
+INSERT INTO `item_mods` VALUES (12656,276,4); -- RSE (race specific equip)
 
 -- Magna Bodice
-INSERT INTO `item_mods` VALUES (12657,1,18); -- DEF: 18
-INSERT INTO `item_mods` VALUES (12657,2,24); -- HP: 24
-INSERT INTO `item_mods` VALUES (12657,5,4);  -- MP: 4
-INSERT INTO `item_mods` VALUES (12657,9,1);  -- DEX: 1
-INSERT INTO `item_mods` VALUES (12657,12,1); -- INT: 1
+INSERT INTO `item_mods` VALUES (12657,1,18);  -- DEF: 18
+INSERT INTO `item_mods` VALUES (12657,2,24);  -- HP: 24
+INSERT INTO `item_mods` VALUES (12657,5,4);   -- MP: 4
+INSERT INTO `item_mods` VALUES (12657,9,1);   -- DEX: 1
+INSERT INTO `item_mods` VALUES (12657,12,1);  -- INT: 1
+INSERT INTO `item_mods` VALUES (12657,276,8); -- RSE (race specific equip)
 
 -- Wonder Kaftan
-INSERT INTO `item_mods` VALUES (12658,1,18); -- DEF: 18
-INSERT INTO `item_mods` VALUES (12658,2,36); -- HP: 36
-INSERT INTO `item_mods` VALUES (12658,8,1);  -- STR: 1
-INSERT INTO `item_mods` VALUES (12658,10,2); -- VIT: 2
-INSERT INTO `item_mods` VALUES (12658,13,1); -- MND: 1
+INSERT INTO `item_mods` VALUES (12658,1,18);   -- DEF: 18
+INSERT INTO `item_mods` VALUES (12658,2,36);   -- HP: 36
+INSERT INTO `item_mods` VALUES (12658,8,1);    -- STR: 1
+INSERT INTO `item_mods` VALUES (12658,10,2);   -- VIT: 2
+INSERT INTO `item_mods` VALUES (12658,13,1);   -- MND: 1
+INSERT INTO `item_mods` VALUES (12658,276,48); -- RSE (race specific equip)
 
 -- Savage Separates
-INSERT INTO `item_mods` VALUES (12659,1,18); -- DEF: 18
-INSERT INTO `item_mods` VALUES (12659,2,32); -- HP: 32
-INSERT INTO `item_mods` VALUES (12659,8,1);  -- STR: 1
-INSERT INTO `item_mods` VALUES (12659,14,1); -- CHR: 1
+INSERT INTO `item_mods` VALUES (12659,1,18);   -- DEF: 18
+INSERT INTO `item_mods` VALUES (12659,2,32);   -- HP: 32
+INSERT INTO `item_mods` VALUES (12659,8,1);    -- STR: 1
+INSERT INTO `item_mods` VALUES (12659,14,1);   -- CHR: 1
+INSERT INTO `item_mods` VALUES (12659,276,64); -- RSE (race specific equip)
 
 -- Elders Surcoat
-INSERT INTO `item_mods` VALUES (12660,1,18); -- DEF: 18
-INSERT INTO `item_mods` VALUES (12660,5,32); -- MP: 32
-INSERT INTO `item_mods` VALUES (12660,12,1); -- INT: 1
-INSERT INTO `item_mods` VALUES (12660,14,1); -- CHR: 1
+INSERT INTO `item_mods` VALUES (12660,1,18);    -- DEF: 18
+INSERT INTO `item_mods` VALUES (12660,5,32);    -- MP: 32
+INSERT INTO `item_mods` VALUES (12660,12,1);    -- INT: 1
+INSERT INTO `item_mods` VALUES (12660,14,1);    -- CHR: 1
+INSERT INTO `item_mods` VALUES (12660,276,128); -- RSE (race specific equip)
 
 -- Solid Mail
 INSERT INTO `item_mods` VALUES (12661,1,12); -- DEF: 12
@@ -13750,25 +13857,32 @@ INSERT INTO `item_mods` VALUES (12753,1,3);  -- DEF: 3
 INSERT INTO `item_mods` VALUES (12753,23,3); -- ATT: 3
 
 -- Hume M Gloves
-INSERT INTO `item_mods` VALUES (12754,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (12754,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (12754,276,1); -- RSE (race specific equip)
 
 -- Elvaan Gloves
-INSERT INTO `item_mods` VALUES (12755,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (12755,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (12755,276,4); -- RSE (race specific equip)
 
 -- Tarutaru Mitts
-INSERT INTO `item_mods` VALUES (12756,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (12756,1,1);    -- DEF: 1
+INSERT INTO `item_mods` VALUES (12756,276,48); -- RSE (race specific equip)
 
 -- Mithran Gauntlets
-INSERT INTO `item_mods` VALUES (12757,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (12757,1,1);    -- DEF: 1
+INSERT INTO `item_mods` VALUES (12757,276,64); -- RSE (race specific equip)
 
 -- Galkan Bracers
-INSERT INTO `item_mods` VALUES (12758,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (12758,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (12758,276,128); -- RSE (race specific equip)
 
 -- Elvaan Gauntlets
-INSERT INTO `item_mods` VALUES (12759,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (12759,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (12759,276,8); -- RSE (race specific equip)
 
 -- Hume F Gloves
-INSERT INTO `item_mods` VALUES (12760,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (12760,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (12760,276,2); -- RSE (race specific equip)
 
 -- Custom M Gloves
 INSERT INTO `item_mods` VALUES (12761,1,6);   -- DEF: 6
@@ -13778,6 +13892,7 @@ INSERT INTO `item_mods` VALUES (12761,8,3);   -- STR: 3
 INSERT INTO `item_mods` VALUES (12761,9,3);   -- DEX: 3
 INSERT INTO `item_mods` VALUES (12761,10,-1); -- VIT: -1
 INSERT INTO `item_mods` VALUES (12761,11,-1); -- AGI: -1
+INSERT INTO `item_mods` VALUES (12761,276,1); -- RSE (race specific equip)
 
 -- Custom F Gloves
 INSERT INTO `item_mods` VALUES (12762,1,6);   -- DEF: 6
@@ -13787,34 +13902,40 @@ INSERT INTO `item_mods` VALUES (12762,8,3);   -- STR: 3
 INSERT INTO `item_mods` VALUES (12762,9,3);   -- DEX: 3
 INSERT INTO `item_mods` VALUES (12762,10,-1); -- VIT: -1
 INSERT INTO `item_mods` VALUES (12762,11,-1); -- AGI: -1
+INSERT INTO `item_mods` VALUES (12762,276,2); -- RSE (race specific equip)
 
 -- Magna Gauntlets
-INSERT INTO `item_mods` VALUES (12763,1,6);  -- DEF: 6
-INSERT INTO `item_mods` VALUES (12763,5,24); -- MP: 24
-INSERT INTO `item_mods` VALUES (12763,9,2);  -- DEX: 2
-INSERT INTO `item_mods` VALUES (12763,12,1); -- INT: 1
+INSERT INTO `item_mods` VALUES (12763,1,6);   -- DEF: 6
+INSERT INTO `item_mods` VALUES (12763,5,24);  -- MP: 24
+INSERT INTO `item_mods` VALUES (12763,9,2);   -- DEX: 2
+INSERT INTO `item_mods` VALUES (12763,12,1);  -- INT: 1
+INSERT INTO `item_mods` VALUES (12763,276,4); -- RSE (race specific equip)
 
 -- Magna Gloves
-INSERT INTO `item_mods` VALUES (12764,1,6);  -- DEF: 6
-INSERT INTO `item_mods` VALUES (12764,5,24); -- MP: 24
-INSERT INTO `item_mods` VALUES (12764,9,2);  -- DEX: 2
-INSERT INTO `item_mods` VALUES (12764,12,1); -- INT: 1
+INSERT INTO `item_mods` VALUES (12764,1,6);   -- DEF: 6
+INSERT INTO `item_mods` VALUES (12764,5,24);  -- MP: 24
+INSERT INTO `item_mods` VALUES (12764,9,2);   -- DEX: 2
+INSERT INTO `item_mods` VALUES (12764,12,1);  -- INT: 1
+INSERT INTO `item_mods` VALUES (12764,276,8); -- RSE (race specific equip)
 
 -- Wonder Mitts
-INSERT INTO `item_mods` VALUES (12765,1,6);  -- DEF: 6
-INSERT INTO `item_mods` VALUES (12765,2,12); -- HP: 12
-INSERT INTO `item_mods` VALUES (12765,8,3);  -- STR: 3
+INSERT INTO `item_mods` VALUES (12765,1,6);    -- DEF: 6
+INSERT INTO `item_mods` VALUES (12765,2,12);   -- HP: 12
+INSERT INTO `item_mods` VALUES (12765,8,3);    -- STR: 3
+INSERT INTO `item_mods` VALUES (12765,276,48); -- RSE (race specific equip)
 
 -- Savage Gauntlets
-INSERT INTO `item_mods` VALUES (12766,1,6);  -- DEF: 6
-INSERT INTO `item_mods` VALUES (12766,5,16); -- MP: 16
-INSERT INTO `item_mods` VALUES (12766,10,4); -- VIT: 4
-INSERT INTO `item_mods` VALUES (12766,13,2); -- MND: 2
+INSERT INTO `item_mods` VALUES (12766,1,6);    -- DEF: 6
+INSERT INTO `item_mods` VALUES (12766,5,16);   -- MP: 16
+INSERT INTO `item_mods` VALUES (12766,10,4);   -- VIT: 4
+INSERT INTO `item_mods` VALUES (12766,13,2);   -- MND: 2
+INSERT INTO `item_mods` VALUES (12766,276,64); -- RSE (race specific equip)
 
 -- Elders Bracers
-INSERT INTO `item_mods` VALUES (12767,1,6);  -- DEF: 6
-INSERT INTO `item_mods` VALUES (12767,5,32); -- MP: 32
-INSERT INTO `item_mods` VALUES (12767,12,2); -- INT: 2
+INSERT INTO `item_mods` VALUES (12767,1,6);     -- DEF: 6
+INSERT INTO `item_mods` VALUES (12767,5,32);    -- MP: 32
+INSERT INTO `item_mods` VALUES (12767,12,2);    -- INT: 2
+INSERT INTO `item_mods` VALUES (12767,276,128); -- RSE (race specific equip)
 
 -- Solid Finger Gauntlets
 INSERT INTO `item_mods` VALUES (12768,1,4); -- DEF: 4
@@ -14233,52 +14354,59 @@ INSERT INTO `item_mods` VALUES (12870,1,17); -- DEF: 17
 INSERT INTO `item_mods` VALUES (12870,68,5); -- EVA: 5
 
 -- Custom Slacks
-INSERT INTO `item_mods` VALUES (12871,1,12); -- DEF: 12
-INSERT INTO `item_mods` VALUES (12871,5,32); -- MP: 32
-INSERT INTO `item_mods` VALUES (12871,8,-1); -- STR: -1
-INSERT INTO `item_mods` VALUES (12871,13,3); -- MND: 3
-INSERT INTO `item_mods` VALUES (12871,14,1); -- CHR: 1
+INSERT INTO `item_mods` VALUES (12871,1,12);  -- DEF: 12
+INSERT INTO `item_mods` VALUES (12871,5,32);  -- MP: 32
+INSERT INTO `item_mods` VALUES (12871,8,-1);  -- STR: -1
+INSERT INTO `item_mods` VALUES (12871,13,3);  -- MND: 3
+INSERT INTO `item_mods` VALUES (12871,14,1);  -- CHR: 1
+INSERT INTO `item_mods` VALUES (12871,276,1); -- RSE (race specific equip)
 
 -- Custom Pants
-INSERT INTO `item_mods` VALUES (12872,1,12); -- DEF: 12
-INSERT INTO `item_mods` VALUES (12872,5,32); -- MP: 32
-INSERT INTO `item_mods` VALUES (12872,8,-1); -- STR: -1
-INSERT INTO `item_mods` VALUES (12872,13,3); -- MND: 3
-INSERT INTO `item_mods` VALUES (12872,14,1); -- CHR: 1
+INSERT INTO `item_mods` VALUES (12872,1,12);  -- DEF: 12
+INSERT INTO `item_mods` VALUES (12872,5,32);  -- MP: 32
+INSERT INTO `item_mods` VALUES (12872,8,-1);  -- STR: -1
+INSERT INTO `item_mods` VALUES (12872,13,3);  -- MND: 3
+INSERT INTO `item_mods` VALUES (12872,14,1);  -- CHR: 1
+INSERT INTO `item_mods` VALUES (12872,276,2); -- RSE (race specific equip)
 
 -- Magna M Chausses
-INSERT INTO `item_mods` VALUES (12873,1,12); -- DEF: 12
-INSERT INTO `item_mods` VALUES (12873,2,12); -- HP: 12
-INSERT INTO `item_mods` VALUES (12873,5,12); -- MP: 12
-INSERT INTO `item_mods` VALUES (12873,9,2);  -- DEX: 2
-INSERT INTO `item_mods` VALUES (12873,11,2); -- AGI: 2
+INSERT INTO `item_mods` VALUES (12873,1,12);  -- DEF: 12
+INSERT INTO `item_mods` VALUES (12873,2,12);  -- HP: 12
+INSERT INTO `item_mods` VALUES (12873,5,12);  -- MP: 12
+INSERT INTO `item_mods` VALUES (12873,9,2);   -- DEX: 2
+INSERT INTO `item_mods` VALUES (12873,11,2);  -- AGI: 2
+INSERT INTO `item_mods` VALUES (12873,276,4); -- RSE (race specific equip)
 
 -- Magna F Chausses
-INSERT INTO `item_mods` VALUES (12874,1,12); -- DEF: 12
-INSERT INTO `item_mods` VALUES (12874,2,12); -- HP: 12
-INSERT INTO `item_mods` VALUES (12874,5,12); -- MP: 12
-INSERT INTO `item_mods` VALUES (12874,9,2);  -- DEX: 2
-INSERT INTO `item_mods` VALUES (12874,11,2); -- AGI: 2
+INSERT INTO `item_mods` VALUES (12874,1,12);  -- DEF: 12
+INSERT INTO `item_mods` VALUES (12874,2,12);  -- HP: 12
+INSERT INTO `item_mods` VALUES (12874,5,12);  -- MP: 12
+INSERT INTO `item_mods` VALUES (12874,9,2);   -- DEX: 2
+INSERT INTO `item_mods` VALUES (12874,11,2);  -- AGI: 2
+INSERT INTO `item_mods` VALUES (12874,276,8); -- RSE (race specific equip)
 
 -- Wonder Braccae
-INSERT INTO `item_mods` VALUES (12875,1,12); -- DEF: 12
-INSERT INTO `item_mods` VALUES (12875,2,21); -- HP: 21
-INSERT INTO `item_mods` VALUES (12875,8,1);  -- STR: 1
-INSERT INTO `item_mods` VALUES (12875,10,2); -- VIT: 2
-INSERT INTO `item_mods` VALUES (12875,13,2); -- MND: 2
+INSERT INTO `item_mods` VALUES (12875,1,12);   -- DEF: 12
+INSERT INTO `item_mods` VALUES (12875,2,21);   -- HP: 21
+INSERT INTO `item_mods` VALUES (12875,8,1);    -- STR: 1
+INSERT INTO `item_mods` VALUES (12875,10,2);   -- VIT: 2
+INSERT INTO `item_mods` VALUES (12875,13,2);   -- MND: 2
+INSERT INTO `item_mods` VALUES (12875,276,48); -- RSE (race specific equip)
 
 -- Savage Loincloth
-INSERT INTO `item_mods` VALUES (12876,1,12); -- DEF: 12
-INSERT INTO `item_mods` VALUES (12876,5,32); -- MP: 32
-INSERT INTO `item_mods` VALUES (12876,10,1); -- VIT: 1
-INSERT INTO `item_mods` VALUES (12876,13,1); -- MND: 1
+INSERT INTO `item_mods` VALUES (12876,1,12);   -- DEF: 12
+INSERT INTO `item_mods` VALUES (12876,5,32);   -- MP: 32
+INSERT INTO `item_mods` VALUES (12876,10,1);   -- VIT: 1
+INSERT INTO `item_mods` VALUES (12876,13,1);   -- MND: 1
+INSERT INTO `item_mods` VALUES (12876,276,64); -- RSE (race specific equip)
 
 -- Elders Braguette
-INSERT INTO `item_mods` VALUES (12877,1,12); -- DEF: 12
-INSERT INTO `item_mods` VALUES (12877,5,20); -- MP: 20
-INSERT INTO `item_mods` VALUES (12877,11,2); -- AGI: 2
-INSERT INTO `item_mods` VALUES (12877,12,1); -- INT: 1
-INSERT INTO `item_mods` VALUES (12877,14,2); -- CHR: 2
+INSERT INTO `item_mods` VALUES (12877,1,12);    -- DEF: 12
+INSERT INTO `item_mods` VALUES (12877,5,20);    -- MP: 20
+INSERT INTO `item_mods` VALUES (12877,11,2);    -- AGI: 2
+INSERT INTO `item_mods` VALUES (12877,12,1);    -- INT: 1
+INSERT INTO `item_mods` VALUES (12877,14,2);    -- CHR: 2
+INSERT INTO `item_mods` VALUES (12877,276,128); -- RSE (race specific equip)
 
 -- Coral Subligar
 INSERT INTO `item_mods` VALUES (12878,1,29);     -- DEF: 29
@@ -14312,25 +14440,32 @@ INSERT INTO `item_mods` VALUES (12882,1,12); -- DEF: 12
 INSERT INTO `item_mods` VALUES (12882,10,1); -- VIT: 1
 
 -- Hume Slacks
-INSERT INTO `item_mods` VALUES (12883,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (12883,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (12883,276,1); -- RSE (race specific equip)
 
 -- Hume Pants
-INSERT INTO `item_mods` VALUES (12884,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (12884,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (12884,276,2); -- RSE (race specific equip)
 
 -- Elvaan M Chausses
-INSERT INTO `item_mods` VALUES (12885,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (12885,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (12885,276,4); -- RSE (race specific equip)
 
 -- Tarutaru Braccae
-INSERT INTO `item_mods` VALUES (12886,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (12886,1,2);    -- DEF: 2
+INSERT INTO `item_mods` VALUES (12886,276,48); -- RSE (race specific equip)
 
 -- Mithran Loincloth
-INSERT INTO `item_mods` VALUES (12887,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (12887,1,2);    -- DEF: 2
+INSERT INTO `item_mods` VALUES (12887,276,64); -- RSE (race specific equip)
 
 -- Galkan Braguette
-INSERT INTO `item_mods` VALUES (12888,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (12888,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (12888,276,128); -- RSE (race specific equip)
 
 -- Elvaan F Chausses
-INSERT INTO `item_mods` VALUES (12889,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (12889,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (12889,276,8); -- RSE (race specific equip)
 
 -- Chain Hose +1
 INSERT INTO `item_mods` VALUES (12890,1,17); -- DEF: 17
@@ -14817,25 +14952,32 @@ INSERT INTO `item_mods` VALUES (13004,15,3); -- FIRE_RES: 3
 INSERT INTO `item_mods` VALUES (13004,16,3); -- ICE_RES: 3
 
 -- Hume M Boots
-INSERT INTO `item_mods` VALUES (13005,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (13005,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (13005,276,1); -- RSE (race specific equip)
 
 -- Elvaan M Ledelsens
-INSERT INTO `item_mods` VALUES (13006,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (13006,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (13006,276,4); -- RSE (race specific equip)
 
 -- Tarutaru Clomps
-INSERT INTO `item_mods` VALUES (13007,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (13007,1,1);    -- DEF: 1
+INSERT INTO `item_mods` VALUES (13007,276,48); -- RSE (race specific equip)
 
 -- Mithran Gaiters
-INSERT INTO `item_mods` VALUES (13008,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (13008,1,1);    -- DEF: 1
+INSERT INTO `item_mods` VALUES (13008,276,64); -- RSE (race specific equip)
 
 -- Galkan Sandals
-INSERT INTO `item_mods` VALUES (13009,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (13009,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (13009,276,128); -- RSE (race specific equip)
 
 -- Hume F Boots
-INSERT INTO `item_mods` VALUES (13010,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (13010,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (13010,276,2); -- RSE (race specific equip)
 
 -- Elvaan F Ledelsens
-INSERT INTO `item_mods` VALUES (13011,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (13011,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (13011,276,8); -- RSE (race specific equip)
 
 -- Power Sandals
 INSERT INTO `item_mods` VALUES (13012,1,3);  -- DEF: 3
@@ -14860,6 +15002,7 @@ INSERT INTO `item_mods` VALUES (13015,9,-1);  -- DEX: -1
 INSERT INTO `item_mods` VALUES (13015,11,3);  -- AGI: 3
 INSERT INTO `item_mods` VALUES (13015,12,3);  -- INT: 3
 INSERT INTO `item_mods` VALUES (13015,13,-1); -- MND: -1
+INSERT INTO `item_mods` VALUES (13015,276,1); -- RSE (race specific equip)
 
 -- Custom F Boots
 INSERT INTO `item_mods` VALUES (13016,1,5);   -- DEF: 5
@@ -14869,35 +15012,41 @@ INSERT INTO `item_mods` VALUES (13016,9,-1);  -- DEX: -1
 INSERT INTO `item_mods` VALUES (13016,11,3);  -- AGI: 3
 INSERT INTO `item_mods` VALUES (13016,12,3);  -- INT: 3
 INSERT INTO `item_mods` VALUES (13016,13,-1); -- MND: -1
+INSERT INTO `item_mods` VALUES (13016,276,2); -- RSE (race specific equip)
 
 -- Magna M Ledelsens
-INSERT INTO `item_mods` VALUES (13017,1,5);  -- DEF: 5
-INSERT INTO `item_mods` VALUES (13017,5,20); -- MP: 20
-INSERT INTO `item_mods` VALUES (13017,11,3); -- AGI: 3
-INSERT INTO `item_mods` VALUES (13017,12,2); -- INT: 2
+INSERT INTO `item_mods` VALUES (13017,1,5);   -- DEF: 5
+INSERT INTO `item_mods` VALUES (13017,5,20);  -- MP: 20
+INSERT INTO `item_mods` VALUES (13017,11,3);  -- AGI: 3
+INSERT INTO `item_mods` VALUES (13017,12,2);  -- INT: 2
+INSERT INTO `item_mods` VALUES (13017,276,4); -- RSE (race specific equip)
 
 -- Magna F Ledelsens
-INSERT INTO `item_mods` VALUES (13018,1,5);  -- DEF: 5
-INSERT INTO `item_mods` VALUES (13018,5,20); -- MP: 20
-INSERT INTO `item_mods` VALUES (13018,11,3); -- AGI: 3
-INSERT INTO `item_mods` VALUES (13018,12,2); -- INT: 2
+INSERT INTO `item_mods` VALUES (13018,1,5);   -- DEF: 5
+INSERT INTO `item_mods` VALUES (13018,5,20);  -- MP: 20
+INSERT INTO `item_mods` VALUES (13018,11,3);  -- AGI: 3
+INSERT INTO `item_mods` VALUES (13018,12,2);  -- INT: 2
+INSERT INTO `item_mods` VALUES (13018,276,8); -- RSE (race specific equip)
 
 -- Wonder Clomps
-INSERT INTO `item_mods` VALUES (13019,1,5);  -- DEF: 5
-INSERT INTO `item_mods` VALUES (13019,2,20); -- HP: 20
-INSERT INTO `item_mods` VALUES (13019,8,2);  -- STR: 2
+INSERT INTO `item_mods` VALUES (13019,1,5);    -- DEF: 5
+INSERT INTO `item_mods` VALUES (13019,2,20);   -- HP: 20
+INSERT INTO `item_mods` VALUES (13019,8,2);    -- STR: 2
+INSERT INTO `item_mods` VALUES (13019,276,48); -- RSE (race specific equip)
 
 -- Savage Gaiters
-INSERT INTO `item_mods` VALUES (13020,1,5);  -- DEF: 5
-INSERT INTO `item_mods` VALUES (13020,2,16); -- HP: 16
-INSERT INTO `item_mods` VALUES (13020,8,3);  -- STR: 3
-INSERT INTO `item_mods` VALUES (13020,14,2); -- CHR: 2
+INSERT INTO `item_mods` VALUES (13020,1,5);    -- DEF: 5
+INSERT INTO `item_mods` VALUES (13020,2,16);   -- HP: 16
+INSERT INTO `item_mods` VALUES (13020,8,3);    -- STR: 3
+INSERT INTO `item_mods` VALUES (13020,14,2);   -- CHR: 2
+INSERT INTO `item_mods` VALUES (13020,276,64); -- RSE (race specific equip)
 
 -- Elders Sandals
-INSERT INTO `item_mods` VALUES (13021,1,5);  -- DEF: 5
-INSERT INTO `item_mods` VALUES (13021,5,12); -- MP: 12
-INSERT INTO `item_mods` VALUES (13021,11,3); -- AGI: 3
-INSERT INTO `item_mods` VALUES (13021,12,2); -- INT: 2
+INSERT INTO `item_mods` VALUES (13021,1,5);     -- DEF: 5
+INSERT INTO `item_mods` VALUES (13021,5,12);    -- MP: 12
+INSERT INTO `item_mods` VALUES (13021,11,3);    -- AGI: 3
+INSERT INTO `item_mods` VALUES (13021,12,2);    -- INT: 2
+INSERT INTO `item_mods` VALUES (13021,276,128); -- RSE (race specific equip)
 
 -- Chestnut Sabots +1
 INSERT INTO `item_mods` VALUES (13022,1,6); -- DEF: 6
@@ -15822,129 +15971,149 @@ INSERT INTO `item_mods` VALUES (13251,2,30);  -- HP: 30
 INSERT INTO `item_mods` VALUES (13251,8,3);   -- STR: 3
 INSERT INTO `item_mods` VALUES (13251,9,2);   -- DEX: 2
 INSERT INTO `item_mods` VALUES (13251,12,-5); -- INT: -5
+INSERT INTO `item_mods` VALUES (13251,276,3); -- RSE (race specific equip)
 
 -- Forest Belt
-INSERT INTO `item_mods` VALUES (13252,1,5);   -- DEF: 5
-INSERT INTO `item_mods` VALUES (13252,2,20);  -- HP: 20
-INSERT INTO `item_mods` VALUES (13252,9,3);   -- DEX: 3
-INSERT INTO `item_mods` VALUES (13252,11,2);  -- AGI: 2
-INSERT INTO `item_mods` VALUES (13252,13,-5); -- MND: -5
+INSERT INTO `item_mods` VALUES (13252,1,5);    -- DEF: 5
+INSERT INTO `item_mods` VALUES (13252,2,20);   -- HP: 20
+INSERT INTO `item_mods` VALUES (13252,9,3);    -- DEX: 3
+INSERT INTO `item_mods` VALUES (13252,11,2);   -- AGI: 2
+INSERT INTO `item_mods` VALUES (13252,13,-5);  -- MND: -5
+INSERT INTO `item_mods` VALUES (13252,276,12); -- RSE (race specific equip)
 
 -- Steppe Belt
-INSERT INTO `item_mods` VALUES (13253,1,3);   -- DEF: 3
-INSERT INTO `item_mods` VALUES (13253,2,40);  -- HP: 40
-INSERT INTO `item_mods` VALUES (13253,8,2);   -- STR: 2
-INSERT INTO `item_mods` VALUES (13253,10,3);  -- VIT: 3
-INSERT INTO `item_mods` VALUES (13253,12,-5); -- INT: -5
+INSERT INTO `item_mods` VALUES (13253,1,3);    -- DEF: 3
+INSERT INTO `item_mods` VALUES (13253,2,40);   -- HP: 40
+INSERT INTO `item_mods` VALUES (13253,8,2);    -- STR: 2
+INSERT INTO `item_mods` VALUES (13253,10,3);   -- VIT: 3
+INSERT INTO `item_mods` VALUES (13253,12,-5);  -- INT: -5
+INSERT INTO `item_mods` VALUES (13253,276,48); -- RSE (race specific equip)
 
 -- Jungle Belt
-INSERT INTO `item_mods` VALUES (13254,1,4);   -- DEF: 4
-INSERT INTO `item_mods` VALUES (13254,2,30);  -- HP: 30
-INSERT INTO `item_mods` VALUES (13254,8,3);   -- STR: 3
-INSERT INTO `item_mods` VALUES (13254,10,2);  -- VIT: 2
-INSERT INTO `item_mods` VALUES (13254,12,-5); -- INT: -5
+INSERT INTO `item_mods` VALUES (13254,1,4);    -- DEF: 4
+INSERT INTO `item_mods` VALUES (13254,2,30);   -- HP: 30
+INSERT INTO `item_mods` VALUES (13254,8,3);    -- STR: 3
+INSERT INTO `item_mods` VALUES (13254,10,2);   -- VIT: 2
+INSERT INTO `item_mods` VALUES (13254,12,-5);  -- INT: -5
+INSERT INTO `item_mods` VALUES (13254,276,64); -- RSE (race specific equip)
 
 -- Desert Belt
-INSERT INTO `item_mods` VALUES (13255,1,5);   -- DEF: 5
-INSERT INTO `item_mods` VALUES (13255,2,20);  -- HP: 20
-INSERT INTO `item_mods` VALUES (13255,8,2);   -- STR: 2
-INSERT INTO `item_mods` VALUES (13255,11,3);  -- AGI: 3
-INSERT INTO `item_mods` VALUES (13255,12,-5); -- INT: -5
+INSERT INTO `item_mods` VALUES (13255,1,5);     -- DEF: 5
+INSERT INTO `item_mods` VALUES (13255,2,20);    -- HP: 20
+INSERT INTO `item_mods` VALUES (13255,8,2);     -- STR: 2
+INSERT INTO `item_mods` VALUES (13255,11,3);    -- AGI: 3
+INSERT INTO `item_mods` VALUES (13255,12,-5);   -- INT: -5
+INSERT INTO `item_mods` VALUES (13255,276,128); -- RSE (race specific equip)
 
 -- Ocean Stone
-INSERT INTO `item_mods` VALUES (13256,1,2);  -- DEF: 2
-INSERT INTO `item_mods` VALUES (13256,5,30); -- MP: 30
-INSERT INTO `item_mods` VALUES (13256,8,-5); -- STR: -5
-INSERT INTO `item_mods` VALUES (13256,12,3); -- INT: 3
-INSERT INTO `item_mods` VALUES (13256,13,2); -- MND: 2
+INSERT INTO `item_mods` VALUES (13256,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (13256,5,30);  -- MP: 30
+INSERT INTO `item_mods` VALUES (13256,8,-5);  -- STR: -5
+INSERT INTO `item_mods` VALUES (13256,12,3);  -- INT: 3
+INSERT INTO `item_mods` VALUES (13256,13,2);  -- MND: 2
+INSERT INTO `item_mods` VALUES (13256,276,3); -- RSE (race specific equip)
 
 -- Forest Stone
-INSERT INTO `item_mods` VALUES (13257,1,1);  -- DEF: 1
-INSERT INTO `item_mods` VALUES (13257,5,40); -- MP: 40
-INSERT INTO `item_mods` VALUES (13257,9,-5); -- DEX: -5
-INSERT INTO `item_mods` VALUES (13257,11,2); -- AGI: 2
-INSERT INTO `item_mods` VALUES (13257,12,3); -- INT: 3
+INSERT INTO `item_mods` VALUES (13257,1,1);    -- DEF: 1
+INSERT INTO `item_mods` VALUES (13257,5,40);   -- MP: 40
+INSERT INTO `item_mods` VALUES (13257,9,-5);   -- DEX: -5
+INSERT INTO `item_mods` VALUES (13257,11,2);   -- AGI: 2
+INSERT INTO `item_mods` VALUES (13257,12,3);   -- INT: 3
+INSERT INTO `item_mods` VALUES (13257,276,12); -- RSE (race specific equip)
 
 -- Steppe Stone
-INSERT INTO `item_mods` VALUES (13258,1,3);  -- DEF: 3
-INSERT INTO `item_mods` VALUES (13258,5,20); -- MP: 20
-INSERT INTO `item_mods` VALUES (13258,8,-5); -- STR: -5
-INSERT INTO `item_mods` VALUES (13258,10,2); -- VIT: 2
-INSERT INTO `item_mods` VALUES (13258,13,3); -- MND: 3
+INSERT INTO `item_mods` VALUES (13258,1,3);    -- DEF: 3
+INSERT INTO `item_mods` VALUES (13258,5,20);   -- MP: 20
+INSERT INTO `item_mods` VALUES (13258,8,-5);   -- STR: -5
+INSERT INTO `item_mods` VALUES (13258,10,2);   -- VIT: 2
+INSERT INTO `item_mods` VALUES (13258,13,3);   -- MND: 3
+INSERT INTO `item_mods` VALUES (13258,276,48); -- RSE (race specific equip)
 
 -- Jungle Stone
-INSERT INTO `item_mods` VALUES (13259,1,2);   -- DEF: 2
-INSERT INTO `item_mods` VALUES (13259,5,30);  -- MP: 30
-INSERT INTO `item_mods` VALUES (13259,11,-5); -- AGI: -5
-INSERT INTO `item_mods` VALUES (13259,12,2);  -- INT: 2
-INSERT INTO `item_mods` VALUES (13259,13,3);  -- MND: 3
+INSERT INTO `item_mods` VALUES (13259,1,2);    -- DEF: 2
+INSERT INTO `item_mods` VALUES (13259,5,30);   -- MP: 30
+INSERT INTO `item_mods` VALUES (13259,11,-5);  -- AGI: -5
+INSERT INTO `item_mods` VALUES (13259,12,2);   -- INT: 2
+INSERT INTO `item_mods` VALUES (13259,13,3);   -- MND: 3
+INSERT INTO `item_mods` VALUES (13259,276,64); -- RSE (race specific equip)
 
 -- Desert Stone
-INSERT INTO `item_mods` VALUES (13260,1,1);  -- DEF: 1
-INSERT INTO `item_mods` VALUES (13260,5,40); -- MP: 40
-INSERT INTO `item_mods` VALUES (13260,9,-5); -- DEX: -5
-INSERT INTO `item_mods` VALUES (13260,12,3); -- INT: 3
-INSERT INTO `item_mods` VALUES (13260,14,2); -- CHR: 2
+INSERT INTO `item_mods` VALUES (13260,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (13260,5,40);    -- MP: 40
+INSERT INTO `item_mods` VALUES (13260,9,-5);    -- DEX: -5
+INSERT INTO `item_mods` VALUES (13260,12,3);    -- INT: 3
+INSERT INTO `item_mods` VALUES (13260,14,2);    -- CHR: 2
+INSERT INTO `item_mods` VALUES (13260,276,128); -- RSE (race specific equip)
 
 -- Ocean Sash
 INSERT INTO `item_mods` VALUES (13261,1,6);   -- DEF: 6
 INSERT INTO `item_mods` VALUES (13261,2,45);  -- HP: 45
 INSERT INTO `item_mods` VALUES (13261,8,4);   -- STR: 4
 INSERT INTO `item_mods` VALUES (13261,12,-4); -- INT: -4
+INSERT INTO `item_mods` VALUES (13261,276,3); -- RSE (race specific equip)
 
 -- Forest Sash
-INSERT INTO `item_mods` VALUES (13262,1,7);   -- DEF: 7
-INSERT INTO `item_mods` VALUES (13262,2,30);  -- HP: 30
-INSERT INTO `item_mods` VALUES (13262,9,4);   -- DEX: 4
-INSERT INTO `item_mods` VALUES (13262,12,-4); -- INT: -4
+INSERT INTO `item_mods` VALUES (13262,1,7);    -- DEF: 7
+INSERT INTO `item_mods` VALUES (13262,2,30);   -- HP: 30
+INSERT INTO `item_mods` VALUES (13262,9,4);    -- DEX: 4
+INSERT INTO `item_mods` VALUES (13262,12,-4);  -- INT: -4
+INSERT INTO `item_mods` VALUES (13262,276,12); -- RSE (race specific equip)
 
 -- Steppe Sash
-INSERT INTO `item_mods` VALUES (13263,1,5);   -- DEF: 5
-INSERT INTO `item_mods` VALUES (13263,2,60);  -- HP: 60
-INSERT INTO `item_mods` VALUES (13263,10,4);  -- VIT: 4
-INSERT INTO `item_mods` VALUES (13263,13,-4); -- MND: -4
+INSERT INTO `item_mods` VALUES (13263,1,5);    -- DEF: 5
+INSERT INTO `item_mods` VALUES (13263,2,60);   -- HP: 60
+INSERT INTO `item_mods` VALUES (13263,10,4);   -- VIT: 4
+INSERT INTO `item_mods` VALUES (13263,13,-4);  -- MND: -4
+INSERT INTO `item_mods` VALUES (13263,276,48); -- RSE (race specific equip)
 
 -- Jungle Sash
-INSERT INTO `item_mods` VALUES (13264,1,6);   -- DEF: 6
-INSERT INTO `item_mods` VALUES (13264,2,45);  -- HP: 45
-INSERT INTO `item_mods` VALUES (13264,8,4);   -- STR: 4
-INSERT INTO `item_mods` VALUES (13264,13,-4); -- MND: -4
+INSERT INTO `item_mods` VALUES (13264,1,6);    -- DEF: 6
+INSERT INTO `item_mods` VALUES (13264,2,45);   -- HP: 45
+INSERT INTO `item_mods` VALUES (13264,8,4);    -- STR: 4
+INSERT INTO `item_mods` VALUES (13264,13,-4);  -- MND: -4
+INSERT INTO `item_mods` VALUES (13264,276,64); -- RSE (race specific equip)
 
 -- Desert Sash
-INSERT INTO `item_mods` VALUES (13265,1,7);   -- DEF: 7
-INSERT INTO `item_mods` VALUES (13265,2,30);  -- HP: 30
-INSERT INTO `item_mods` VALUES (13265,11,4);  -- AGI: 4
-INSERT INTO `item_mods` VALUES (13265,12,-4); -- INT: -4
+INSERT INTO `item_mods` VALUES (13265,1,7);     -- DEF: 7
+INSERT INTO `item_mods` VALUES (13265,2,30);    -- HP: 30
+INSERT INTO `item_mods` VALUES (13265,11,4);    -- AGI: 4
+INSERT INTO `item_mods` VALUES (13265,12,-4);   -- INT: -4
+INSERT INTO `item_mods` VALUES (13265,276,128); -- RSE (race specific equip)
 
 -- Ocean Rope
-INSERT INTO `item_mods` VALUES (13266,1,4);  -- DEF: 4
-INSERT INTO `item_mods` VALUES (13266,5,45); -- MP: 45
-INSERT INTO `item_mods` VALUES (13266,8,-4); -- STR: -4
-INSERT INTO `item_mods` VALUES (13266,12,4); -- INT: 4
+INSERT INTO `item_mods` VALUES (13266,1,4);   -- DEF: 4
+INSERT INTO `item_mods` VALUES (13266,5,45);  -- MP: 45
+INSERT INTO `item_mods` VALUES (13266,8,-4);  -- STR: -4
+INSERT INTO `item_mods` VALUES (13266,12,4);  -- INT: 4
+INSERT INTO `item_mods` VALUES (13266,276,3); -- RSE (race specific equip)
 
 -- Forest Rope
-INSERT INTO `item_mods` VALUES (13267,1,3);  -- DEF: 3
-INSERT INTO `item_mods` VALUES (13267,5,60); -- MP: 60
-INSERT INTO `item_mods` VALUES (13267,9,-4); -- DEX: -4
-INSERT INTO `item_mods` VALUES (13267,12,4); -- INT: 4
+INSERT INTO `item_mods` VALUES (13267,1,3);    -- DEF: 3
+INSERT INTO `item_mods` VALUES (13267,5,60);   -- MP: 60
+INSERT INTO `item_mods` VALUES (13267,9,-4);   -- DEX: -4
+INSERT INTO `item_mods` VALUES (13267,12,4);   -- INT: 4
+INSERT INTO `item_mods` VALUES (13267,276,12); -- RSE (race specific equip)
 
 -- Steppe Rope
-INSERT INTO `item_mods` VALUES (13268,1,5);  -- DEF: 5
-INSERT INTO `item_mods` VALUES (13268,5,30); -- MP: 30
-INSERT INTO `item_mods` VALUES (13268,8,-4); -- STR: -4
-INSERT INTO `item_mods` VALUES (13268,13,4); -- MND: 4
+INSERT INTO `item_mods` VALUES (13268,1,5);    -- DEF: 5
+INSERT INTO `item_mods` VALUES (13268,5,30);   -- MP: 30
+INSERT INTO `item_mods` VALUES (13268,8,-4);   -- STR: -4
+INSERT INTO `item_mods` VALUES (13268,13,4);   -- MND: 4
+INSERT INTO `item_mods` VALUES (13268,276,48); -- RSE (race specific equip)
 
 -- Jungle Rope
-INSERT INTO `item_mods` VALUES (13269,1,4);  -- DEF: 4
-INSERT INTO `item_mods` VALUES (13269,5,45); -- MP: 45
-INSERT INTO `item_mods` VALUES (13269,9,-4); -- DEX: -4
-INSERT INTO `item_mods` VALUES (13269,12,4); -- INT: 4
+INSERT INTO `item_mods` VALUES (13269,1,4);    -- DEF: 4
+INSERT INTO `item_mods` VALUES (13269,5,45);   -- MP: 45
+INSERT INTO `item_mods` VALUES (13269,9,-4);   -- DEX: -4
+INSERT INTO `item_mods` VALUES (13269,12,4);   -- INT: 4
+INSERT INTO `item_mods` VALUES (13269,276,64); -- RSE (race specific equip)
 
 -- Desert Rope
-INSERT INTO `item_mods` VALUES (13270,1,3);   -- DEF: 3
-INSERT INTO `item_mods` VALUES (13270,5,60);  -- MP: 60
-INSERT INTO `item_mods` VALUES (13270,10,-4); -- VIT: -4
-INSERT INTO `item_mods` VALUES (13270,12,4);  -- INT: 4
+INSERT INTO `item_mods` VALUES (13270,1,3);     -- DEF: 3
+INSERT INTO `item_mods` VALUES (13270,5,60);    -- MP: 60
+INSERT INTO `item_mods` VALUES (13270,10,-4);   -- VIT: -4
+INSERT INTO `item_mods` VALUES (13270,12,4);    -- INT: 4
+INSERT INTO `item_mods` VALUES (13270,276,128); -- RSE (race specific equip)
 
 -- Corsette
 INSERT INTO `item_mods` VALUES (13271,1,4);   -- DEF: 4
@@ -18414,16 +18583,20 @@ INSERT INTO `item_mods` VALUES (13818,9,1);  -- DEX: 1
 INSERT INTO `item_mods` VALUES (13818,14,1); -- CHR: 1
 
 -- Onoko Yukata
-INSERT INTO `item_mods` VALUES (13819,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (13819,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (13819,276,149); -- RSE (race specific equip)
 
 -- Omina Yukata
-INSERT INTO `item_mods` VALUES (13820,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (13820,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (13820,276,106); -- RSE (race specific equip)
 
 -- Lords Yukata
-INSERT INTO `item_mods` VALUES (13821,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (13821,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (13821,276,149); -- RSE (race specific equip)
 
 -- Ladys Yukata
-INSERT INTO `item_mods` VALUES (13822,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (13822,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (13822,276,106); -- RSE (race specific equip)
 
 -- Regen Cuirass
 INSERT INTO `item_mods` VALUES (13823,1,49); -- DEF: 49
@@ -19018,15 +19191,18 @@ INSERT INTO `item_mods` VALUES (13930,14,4);  -- CHR: 4
 INSERT INTO `item_mods` VALUES (13930,27,-6); -- ENMITY: -6
 
 -- Lilac Corsage
-INSERT INTO `item_mods` VALUES (13931,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (13931,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (13931,276,106); -- RSE (race specific equip)
 
 -- Gala Corsage
-INSERT INTO `item_mods` VALUES (13932,1,2);  -- DEF: 2
-INSERT INTO `item_mods` VALUES (13932,14,1); -- CHR: 1
+INSERT INTO `item_mods` VALUES (13932,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (13932,14,1);    -- CHR: 1
+INSERT INTO `item_mods` VALUES (13932,276,106); -- RSE (race specific equip)
 
 -- Bridal Corsage
-INSERT INTO `item_mods` VALUES (13933,1,1);  -- DEF: 1
-INSERT INTO `item_mods` VALUES (13933,21,5); -- LIGHT_RES: 5
+INSERT INTO `item_mods` VALUES (13933,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (13933,21,5);    -- LIGHT_RES: 5
+INSERT INTO `item_mods` VALUES (13933,276,106); -- RSE (race specific equip)
 
 -- Shura Zunari Kabuto
 INSERT INTO `item_mods` VALUES (13934,1,20);  -- DEF: 20
@@ -20024,7 +20200,8 @@ INSERT INTO `item_mods` VALUES (14115,21,4);  -- LIGHT_RES: 4
 INSERT INTO `item_mods` VALUES (14115,22,-2); -- DARK_RES: -2
 
 -- Opaline Boots
-INSERT INTO `item_mods` VALUES (14116,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (14116,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (14116,276,106); -- RSE (race specific equip)
 
 -- Iron Greaves
 INSERT INTO `item_mods` VALUES (14118,1,8); -- DEF: 8
@@ -20054,12 +20231,14 @@ INSERT INTO `item_mods` VALUES (14124,12,3); -- INT: 3
 INSERT INTO `item_mods` VALUES (14124,14,3); -- CHR: 3
 
 -- Ceremonial Boots
-INSERT INTO `item_mods` VALUES (14125,1,2);  -- DEF: 2
-INSERT INTO `item_mods` VALUES (14125,14,1); -- CHR: 1
+INSERT INTO `item_mods` VALUES (14125,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (14125,14,1);    -- CHR: 1
+INSERT INTO `item_mods` VALUES (14125,276,106); -- RSE (race specific equip)
 
 -- Wedding Boots
-INSERT INTO `item_mods` VALUES (14126,1,1);  -- DEF: 1
-INSERT INTO `item_mods` VALUES (14126,21,5); -- LIGHT_RES: 5
+INSERT INTO `item_mods` VALUES (14126,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (14126,21,5);    -- LIGHT_RES: 5
+INSERT INTO `item_mods` VALUES (14126,276,106); -- RSE (race specific equip)
 
 -- Thick Sollerets +1
 INSERT INTO `item_mods` VALUES (14127,1,13);  -- DEF: 13
@@ -20466,6 +20645,7 @@ INSERT INTO `item_mods` VALUES (14198,11,2);  -- AGI: 2
 INSERT INTO `item_mods` VALUES (14198,12,-3); -- INT: -3
 INSERT INTO `item_mods` VALUES (14198,13,-3); -- MND: -3
 INSERT INTO `item_mods` VALUES (14198,14,-3); -- CHR: -3
+INSERT INTO `item_mods` VALUES (14198,276,1); -- RSE (race specific equip)
 
 -- Marine F Boots
 INSERT INTO `item_mods` VALUES (14199,1,9);   -- DEF: 9
@@ -20477,50 +20657,57 @@ INSERT INTO `item_mods` VALUES (14199,11,2);  -- AGI: 2
 INSERT INTO `item_mods` VALUES (14199,12,-3); -- INT: -3
 INSERT INTO `item_mods` VALUES (14199,13,-3); -- MND: -3
 INSERT INTO `item_mods` VALUES (14199,14,-3); -- CHR: -3
+INSERT INTO `item_mods` VALUES (14199,276,2); -- RSE (race specific equip)
 
 -- Wood M Ledelsens
-INSERT INTO `item_mods` VALUES (14200,1,9);  -- DEF: 9
-INSERT INTO `item_mods` VALUES (14200,5,30); -- MP: 30
-INSERT INTO `item_mods` VALUES (14200,8,-3); -- STR: -3
-INSERT INTO `item_mods` VALUES (14200,11,6); -- AGI: 6
-INSERT INTO `item_mods` VALUES (14200,12,3); -- INT: 3
+INSERT INTO `item_mods` VALUES (14200,1,9);   -- DEF: 9
+INSERT INTO `item_mods` VALUES (14200,5,30);  -- MP: 30
+INSERT INTO `item_mods` VALUES (14200,8,-3);  -- STR: -3
+INSERT INTO `item_mods` VALUES (14200,11,6);  -- AGI: 6
+INSERT INTO `item_mods` VALUES (14200,12,3);  -- INT: 3
+INSERT INTO `item_mods` VALUES (14200,276,4); -- RSE (race specific equip)
 
 -- Wood F Ledelsens
-INSERT INTO `item_mods` VALUES (14201,1,9);  -- DEF: 9
-INSERT INTO `item_mods` VALUES (14201,5,30); -- MP: 30
-INSERT INTO `item_mods` VALUES (14201,8,-3); -- STR: -3
-INSERT INTO `item_mods` VALUES (14201,11,6); -- AGI: 6
-INSERT INTO `item_mods` VALUES (14201,12,3); -- INT: 3
+INSERT INTO `item_mods` VALUES (14201,1,9);   -- DEF: 9
+INSERT INTO `item_mods` VALUES (14201,5,30);  -- MP: 30
+INSERT INTO `item_mods` VALUES (14201,8,-3);  -- STR: -3
+INSERT INTO `item_mods` VALUES (14201,11,6);  -- AGI: 6
+INSERT INTO `item_mods` VALUES (14201,12,3);  -- INT: 3
+INSERT INTO `item_mods` VALUES (14201,276,8); -- RSE (race specific equip)
 
 -- Creek M Clomps
-INSERT INTO `item_mods` VALUES (14202,1,9);   -- DEF: 9
-INSERT INTO `item_mods` VALUES (14202,2,35);  -- HP: 35
-INSERT INTO `item_mods` VALUES (14202,5,-35); -- MP: -35
-INSERT INTO `item_mods` VALUES (14202,8,4);   -- STR: 4
-INSERT INTO `item_mods` VALUES (14202,10,4);  -- VIT: 4
-INSERT INTO `item_mods` VALUES (14202,12,-3); -- INT: -3
+INSERT INTO `item_mods` VALUES (14202,1,9);    -- DEF: 9
+INSERT INTO `item_mods` VALUES (14202,2,35);   -- HP: 35
+INSERT INTO `item_mods` VALUES (14202,5,-35);  -- MP: -35
+INSERT INTO `item_mods` VALUES (14202,8,4);    -- STR: 4
+INSERT INTO `item_mods` VALUES (14202,10,4);   -- VIT: 4
+INSERT INTO `item_mods` VALUES (14202,12,-3);  -- INT: -3
+INSERT INTO `item_mods` VALUES (14202,276,16); -- RSE (race specific equip)
 
 -- Creek F Clomps
-INSERT INTO `item_mods` VALUES (14203,1,9);   -- DEF: 9
-INSERT INTO `item_mods` VALUES (14203,2,35);  -- HP: 35
-INSERT INTO `item_mods` VALUES (14203,5,-35); -- MP: -35
-INSERT INTO `item_mods` VALUES (14203,8,4);   -- STR: 4
-INSERT INTO `item_mods` VALUES (14203,10,4);  -- VIT: 4
-INSERT INTO `item_mods` VALUES (14203,12,-3); -- INT: -3
+INSERT INTO `item_mods` VALUES (14203,1,9);    -- DEF: 9
+INSERT INTO `item_mods` VALUES (14203,2,35);   -- HP: 35
+INSERT INTO `item_mods` VALUES (14203,5,-35);  -- MP: -35
+INSERT INTO `item_mods` VALUES (14203,8,4);    -- STR: 4
+INSERT INTO `item_mods` VALUES (14203,10,4);   -- VIT: 4
+INSERT INTO `item_mods` VALUES (14203,12,-3);  -- INT: -3
+INSERT INTO `item_mods` VALUES (14203,276,32); -- RSE (race specific equip)
 
 -- River Gaiters
-INSERT INTO `item_mods` VALUES (14204,1,9);  -- DEF: 9
-INSERT INTO `item_mods` VALUES (14204,5,35); -- MP: 35
-INSERT INTO `item_mods` VALUES (14204,9,-3); -- DEX: -3
-INSERT INTO `item_mods` VALUES (14204,12,4); -- INT: 4
-INSERT INTO `item_mods` VALUES (14204,13,4); -- MND: 4
+INSERT INTO `item_mods` VALUES (14204,1,9);    -- DEF: 9
+INSERT INTO `item_mods` VALUES (14204,5,35);   -- MP: 35
+INSERT INTO `item_mods` VALUES (14204,9,-3);   -- DEX: -3
+INSERT INTO `item_mods` VALUES (14204,12,4);   -- INT: 4
+INSERT INTO `item_mods` VALUES (14204,13,4);   -- MND: 4
+INSERT INTO `item_mods` VALUES (14204,276,64); -- RSE (race specific equip)
 
 -- Dune Sandals
-INSERT INTO `item_mods` VALUES (14205,1,9);   -- DEF: 9
-INSERT INTO `item_mods` VALUES (14205,2,-20); -- HP: -20
-INSERT INTO `item_mods` VALUES (14205,5,45);  -- MP: 45
-INSERT INTO `item_mods` VALUES (14205,10,-3); -- VIT: -3
-INSERT INTO `item_mods` VALUES (14205,14,4);  -- CHR: 4
+INSERT INTO `item_mods` VALUES (14205,1,9);     -- DEF: 9
+INSERT INTO `item_mods` VALUES (14205,2,-20);   -- HP: -20
+INSERT INTO `item_mods` VALUES (14205,5,45);    -- MP: 45
+INSERT INTO `item_mods` VALUES (14205,10,-3);   -- VIT: -3
+INSERT INTO `item_mods` VALUES (14205,14,4);    -- CHR: 4
+INSERT INTO `item_mods` VALUES (14205,276,128); -- RSE (race specific equip)
 
 -- Garrison Boots
 INSERT INTO `item_mods` VALUES (14206,1,4);  -- DEF: 4
@@ -20779,15 +20966,18 @@ INSERT INTO `item_mods` VALUES (14248,14,5);  -- CHR: 5
 INSERT INTO `item_mods` VALUES (14248,68,-4); -- EVA: -4
 
 -- Opaline Hose
-INSERT INTO `item_mods` VALUES (14249,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (14249,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (14249,276,106); -- RSE (race specific equip)
 
 -- Ceremonial Hose
-INSERT INTO `item_mods` VALUES (14250,1,2);  -- DEF: 2
-INSERT INTO `item_mods` VALUES (14250,14,1); -- CHR: 1
+INSERT INTO `item_mods` VALUES (14250,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (14250,14,1);    -- CHR: 1
+INSERT INTO `item_mods` VALUES (14250,276,106); -- RSE (race specific equip)
 
 -- Wedding Hose
-INSERT INTO `item_mods` VALUES (14251,1,1);  -- DEF: 1
-INSERT INTO `item_mods` VALUES (14251,21,5); -- LIGHT_RES: 5
+INSERT INTO `item_mods` VALUES (14251,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (14251,21,5);    -- LIGHT_RES: 5
+INSERT INTO `item_mods` VALUES (14251,276,106); -- RSE (race specific equip)
 
 -- Thick Breeches +1
 INSERT INTO `item_mods` VALUES (14252,1,32);  -- DEF: 32
@@ -21572,16 +21762,19 @@ INSERT INTO `item_mods` VALUES (14383,160,1500); -- DMG: 1500
 INSERT INTO `item_mods` VALUES (14383,369,1);    -- REFRESH: 1
 
 -- Opaline Dress
-INSERT INTO `item_mods` VALUES (14384,1,3);  -- DEF: 3
-INSERT INTO `item_mods` VALUES (14384,14,1); -- CHR: 1
+INSERT INTO `item_mods` VALUES (14384,1,3);     -- DEF: 3
+INSERT INTO `item_mods` VALUES (14384,14,1);    -- CHR: 1
+INSERT INTO `item_mods` VALUES (14384,276,106); -- RSE (race specific equip)
 
 -- Ceremonial Dress
-INSERT INTO `item_mods` VALUES (14385,1,3);  -- DEF: 3
-INSERT INTO `item_mods` VALUES (14385,14,2); -- CHR: 2
+INSERT INTO `item_mods` VALUES (14385,1,3);     -- DEF: 3
+INSERT INTO `item_mods` VALUES (14385,14,2);    -- CHR: 2
+INSERT INTO `item_mods` VALUES (14385,276,106); -- RSE (race specific equip)
 
 -- Wedding Dress
-INSERT INTO `item_mods` VALUES (14386,1,3);   -- DEF: 3
-INSERT INTO `item_mods` VALUES (14386,21,10); -- LIGHT_RES: 10
+INSERT INTO `item_mods` VALUES (14386,1,3);     -- DEF: 3
+INSERT INTO `item_mods` VALUES (14386,21,10);   -- LIGHT_RES: 10
+INSERT INTO `item_mods` VALUES (14386,276,106); -- RSE (race specific equip)
 
 -- Shura Togi
 INSERT INTO `item_mods` VALUES (14387,1,40);  -- DEF: 40
@@ -21922,53 +22115,67 @@ INSERT INTO `item_mods` VALUES (14449,2,52);  -- HP: 52
 INSERT INTO `item_mods` VALUES (14449,370,1); -- REGEN: 1
 
 -- Hume Gilet
-INSERT INTO `item_mods` VALUES (14450,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (14450,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (14450,276,1); -- RSE (race specific equip)
 
 -- Hume Top
-INSERT INTO `item_mods` VALUES (14451,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (14451,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (14451,276,2); -- RSE (race specific equip)
 
 -- Elvaan Gilet
-INSERT INTO `item_mods` VALUES (14452,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (14452,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (14452,276,4); -- RSE (race specific equip)
 
 -- Elvaan Top
-INSERT INTO `item_mods` VALUES (14453,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (14453,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (14453,276,8); -- RSE (race specific equip)
 
 -- Tarutaru Maillot
-INSERT INTO `item_mods` VALUES (14454,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (14454,1,1);    -- DEF: 1
+INSERT INTO `item_mods` VALUES (14454,276,16); -- RSE (race specific equip)
 
 -- Mithra Top
-INSERT INTO `item_mods` VALUES (14455,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (14455,1,1);    -- DEF: 1
+INSERT INTO `item_mods` VALUES (14455,276,64); -- RSE (race specific equip)
 
 -- Galka Gilet
-INSERT INTO `item_mods` VALUES (14456,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (14456,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (14456,276,128); -- RSE (race specific equip)
 
 -- Hume Gilet +1
 INSERT INTO `item_mods` VALUES (14457,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (14457,276,1); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (14457,510,1); -- CLAMMING_REDUCED_INCIDENTS: 1
 
 -- Hume Top +1
 INSERT INTO `item_mods` VALUES (14458,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (14458,276,2); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (14458,510,1); -- CLAMMING_REDUCED_INCIDENTS: 1
 
 -- Elvaan Gilet +1
 INSERT INTO `item_mods` VALUES (14459,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (14459,276,4); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (14459,510,1); -- CLAMMING_REDUCED_INCIDENTS: 1
 
 -- Elvaan Top +1
 INSERT INTO `item_mods` VALUES (14460,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (14460,276,8); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (14460,510,1); -- CLAMMING_REDUCED_INCIDENTS: 1
 
 -- Tarutaru Maillot +1
-INSERT INTO `item_mods` VALUES (14461,1,2);   -- DEF: 2
-INSERT INTO `item_mods` VALUES (14461,510,1); -- CLAMMING_REDUCED_INCIDENTS: 1
+INSERT INTO `item_mods` VALUES (14461,1,2);    -- DEF: 2
+INSERT INTO `item_mods` VALUES (14461,276,16); -- RSE (race specific equip)
+INSERT INTO `item_mods` VALUES (14461,510,1);  -- CLAMMING_REDUCED_INCIDENTS: 1
 
 -- Mithra Top +1
-INSERT INTO `item_mods` VALUES (14462,1,2);   -- DEF: 2
-INSERT INTO `item_mods` VALUES (14462,510,1); -- CLAMMING_REDUCED_INCIDENTS: 1
+INSERT INTO `item_mods` VALUES (14462,1,2);    -- DEF: 2
+INSERT INTO `item_mods` VALUES (14462,276,64); -- RSE (race specific equip)
+INSERT INTO `item_mods` VALUES (14462,510,1);  -- CLAMMING_REDUCED_INCIDENTS: 1
 
 -- Galka Gilet +1
-INSERT INTO `item_mods` VALUES (14463,1,2);   -- DEF: 2
-INSERT INTO `item_mods` VALUES (14463,510,1); -- CLAMMING_REDUCED_INCIDENTS: 1
+INSERT INTO `item_mods` VALUES (14463,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (14463,276,128); -- RSE (race specific equip)
+INSERT INTO `item_mods` VALUES (14463,510,1);   -- CLAMMING_REDUCED_INCIDENTS: 1
 
 -- Trailers Tunica
 INSERT INTO `item_mods` VALUES (14464,1,14); -- DEF: 14
@@ -22018,11 +22225,13 @@ INSERT INTO `item_mods` VALUES (14470,21,15); -- LIGHT_RES: 15
 INSERT INTO `item_mods` VALUES (14470,22,15); -- DARK_RES: 15
 
 -- Tarutaru Top
-INSERT INTO `item_mods` VALUES (14471,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (14471,1,1);    -- DEF: 1
+INSERT INTO `item_mods` VALUES (14471,276,32); -- RSE (race specific equip)
 
 -- Tarutaru Top +1
-INSERT INTO `item_mods` VALUES (14472,1,2);   -- DEF: 2
-INSERT INTO `item_mods` VALUES (14472,510,1); -- CLAMMING_REDUCED_INCIDENTS: 1
+INSERT INTO `item_mods` VALUES (14472,1,2);    -- DEF: 2
+INSERT INTO `item_mods` VALUES (14472,276,32); -- RSE (race specific equip)
+INSERT INTO `item_mods` VALUES (14472,510,1);  -- CLAMMING_REDUCED_INCIDENTS: 1
 
 -- Fighters Lorica +1
 INSERT INTO `item_mods` VALUES (14473,1,50);  -- DEF: 50
@@ -22404,16 +22613,20 @@ INSERT INTO `item_mods` VALUES (14530,165,1); -- CRITHITRATE: 1
 INSERT INTO `item_mods` VALUES (14531,1,21); -- DEF: 21
 
 -- Otoko Yukata
-INSERT INTO `item_mods` VALUES (14532,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (14532,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (14532,276,149); -- RSE (race specific equip)
 
 -- Onago Yukata
-INSERT INTO `item_mods` VALUES (14533,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (14533,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (14533,276,106); -- RSE (race specific equip)
 
 -- Otokogimi Yukata
-INSERT INTO `item_mods` VALUES (14534,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (14534,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (14534,276,149); -- RSE (race specific equip)
 
 -- Onnagimi Yukata
-INSERT INTO `item_mods` VALUES (14535,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (14535,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (14535,276,106); -- RSE (race specific equip)
 
 -- Arakan Samue
 INSERT INTO `item_mods` VALUES (14536,1,50);  -- DEF: 50
@@ -22710,20 +22923,22 @@ INSERT INTO `item_mods` VALUES (14577,160,-500); -- DMG: -500
 INSERT INTO `item_mods` VALUES (14577,384,-500); -- HASTE_GEAR: -500
 
 -- Dancers Casaque
-INSERT INTO `item_mods` VALUES (14578,1,38);   -- DEF: 38
-INSERT INTO `item_mods` VALUES (14578,2,20);   -- HP: 20
-INSERT INTO `item_mods` VALUES (14578,8,2);    -- STR: 2
-INSERT INTO `item_mods` VALUES (14578,9,2);    -- DEX: 2
-INSERT INTO `item_mods` VALUES (14578,27,-2);  -- ENMITY: -2
-INSERT INTO `item_mods` VALUES (14578,491,10); -- WALTZ_POTENCY: 10
+INSERT INTO `item_mods` VALUES (14578,1,38);    -- DEF: 38
+INSERT INTO `item_mods` VALUES (14578,2,20);    -- HP: 20
+INSERT INTO `item_mods` VALUES (14578,8,2);     -- STR: 2
+INSERT INTO `item_mods` VALUES (14578,9,2);     -- DEX: 2
+INSERT INTO `item_mods` VALUES (14578,27,-2);   -- ENMITY: -2
+INSERT INTO `item_mods` VALUES (14578,276,149); -- RSE (race specific equip)
+INSERT INTO `item_mods` VALUES (14578,491,10);  -- WALTZ_POTENCY: 10
 
 -- Dancers Casaque
-INSERT INTO `item_mods` VALUES (14579,1,38);   -- DEF: 38
-INSERT INTO `item_mods` VALUES (14579,2,20);   -- HP: 20
-INSERT INTO `item_mods` VALUES (14579,8,2);    -- STR: 2
-INSERT INTO `item_mods` VALUES (14579,9,2);    -- DEX: 2
-INSERT INTO `item_mods` VALUES (14579,27,-2);  -- ENMITY: -2
-INSERT INTO `item_mods` VALUES (14579,491,10); -- WALTZ_POTENCY: 10
+INSERT INTO `item_mods` VALUES (14579,1,38);    -- DEF: 38
+INSERT INTO `item_mods` VALUES (14579,2,20);    -- HP: 20
+INSERT INTO `item_mods` VALUES (14579,8,2);     -- STR: 2
+INSERT INTO `item_mods` VALUES (14579,9,2);     -- DEX: 2
+INSERT INTO `item_mods` VALUES (14579,27,-2);   -- ENMITY: -2
+INSERT INTO `item_mods` VALUES (14579,276,106); -- RSE (race specific equip)
+INSERT INTO `item_mods` VALUES (14579,491,10);  -- WALTZ_POTENCY: 10
 
 -- Scholars Gown
 INSERT INTO `item_mods` VALUES (14580,1,38);   -- DEF: 38
@@ -23522,44 +23737,54 @@ INSERT INTO `item_mods` VALUES (14791,72,4); -- HPHEAL: 4
 INSERT INTO `item_mods` VALUES (14792,71,2); -- MPHEAL: 2
 
 -- Belinkys Earring
-INSERT INTO `item_mods` VALUES (14793,2,10); -- HP: 10
-INSERT INTO `item_mods` VALUES (14793,9,1);  -- DEX: 1
-INSERT INTO `item_mods` VALUES (14793,10,1); -- VIT: 1
+INSERT INTO `item_mods` VALUES (14793,2,10);  -- HP: 10
+INSERT INTO `item_mods` VALUES (14793,9,1);   -- DEX: 1
+INSERT INTO `item_mods` VALUES (14793,10,1);  -- VIT: 1
+INSERT INTO `item_mods` VALUES (14793,276,3); -- RSE (race specific equip)
 
 -- Quantzs Earring
-INSERT INTO `item_mods` VALUES (14794,5,10); -- MP: 10
-INSERT INTO `item_mods` VALUES (14794,12,1); -- INT: 1
-INSERT INTO `item_mods` VALUES (14794,13,1); -- MND: 1
+INSERT INTO `item_mods` VALUES (14794,5,10);  -- MP: 10
+INSERT INTO `item_mods` VALUES (14794,12,1);  -- INT: 1
+INSERT INTO `item_mods` VALUES (14794,13,1);  -- MND: 1
+INSERT INTO `item_mods` VALUES (14794,276,3); -- RSE (race specific equip)
 
 -- Desamilions Earring
-INSERT INTO `item_mods` VALUES (14795,5,15); -- MP: 15
-INSERT INTO `item_mods` VALUES (14795,12,2); -- INT: 2
+INSERT INTO `item_mods` VALUES (14795,5,15);   -- MP: 15
+INSERT INTO `item_mods` VALUES (14795,12,2);   -- INT: 2
+INSERT INTO `item_mods` VALUES (14795,276,12); -- RSE (race specific equip)
 
 -- Melninas Earring
-INSERT INTO `item_mods` VALUES (14796,9,2);  -- DEX: 2
-INSERT INTO `item_mods` VALUES (14796,11,1); -- AGI: 1
+INSERT INTO `item_mods` VALUES (14796,9,2);    -- DEX: 2
+INSERT INTO `item_mods` VALUES (14796,11,1);   -- AGI: 1
+INSERT INTO `item_mods` VALUES (14796,276,12); -- RSE (race specific equip)
 
 -- Waetotos Earring
-INSERT INTO `item_mods` VALUES (14797,8,2);  -- STR: 2
-INSERT INTO `item_mods` VALUES (14797,10,1); -- VIT: 1
+INSERT INTO `item_mods` VALUES (14797,8,2);    -- STR: 2
+INSERT INTO `item_mods` VALUES (14797,10,1);   -- VIT: 1
+INSERT INTO `item_mods` VALUES (14797,276,48); -- RSE (race specific equip)
 
 -- Morukakas Earring
-INSERT INTO `item_mods` VALUES (14798,2,35); -- HP: 35
+INSERT INTO `item_mods` VALUES (14798,2,35);   -- HP: 35
+INSERT INTO `item_mods` VALUES (14798,276,48); -- RSE (race specific equip)
 
 -- Ryakhos Earring
-INSERT INTO `item_mods` VALUES (14799,2,10); -- HP: 10
-INSERT INTO `item_mods` VALUES (14799,13,2); -- MND: 2
+INSERT INTO `item_mods` VALUES (14799,2,10);   -- HP: 10
+INSERT INTO `item_mods` VALUES (14799,13,2);   -- MND: 2
+INSERT INTO `item_mods` VALUES (14799,276,64); -- RSE (race specific equip)
 
 -- Feyuhs Earring
-INSERT INTO `item_mods` VALUES (14800,8,1);  -- STR: 1
-INSERT INTO `item_mods` VALUES (14800,10,2); -- VIT: 2
+INSERT INTO `item_mods` VALUES (14800,8,1);    -- STR: 1
+INSERT INTO `item_mods` VALUES (14800,10,2);   -- VIT: 2
+INSERT INTO `item_mods` VALUES (14800,276,64); -- RSE (race specific equip)
 
 -- Zedomas Earring
-INSERT INTO `item_mods` VALUES (14801,5,30); -- MP: 30
+INSERT INTO `item_mods` VALUES (14801,5,30);    -- MP: 30
+INSERT INTO `item_mods` VALUES (14801,276,128); -- RSE (race specific equip)
 
 -- Gayanjs Earring
-INSERT INTO `item_mods` VALUES (14802,5,10); -- MP: 10
-INSERT INTO `item_mods` VALUES (14802,12,2); -- INT: 2
+INSERT INTO `item_mods` VALUES (14802,5,10);    -- MP: 10
+INSERT INTO `item_mods` VALUES (14802,12,2);    -- INT: 2
+INSERT INTO `item_mods` VALUES (14802,276,128); -- RSE (race specific equip)
 
 -- Optical Earring
 INSERT INTO `item_mods` VALUES (14803,1,1);   -- DEF: 1
@@ -23720,6 +23945,7 @@ INSERT INTO `item_mods` VALUES (14833,11,-3); -- AGI: -3
 INSERT INTO `item_mods` VALUES (14833,12,4);  -- INT: 4
 INSERT INTO `item_mods` VALUES (14833,13,4);  -- MND: 4
 INSERT INTO `item_mods` VALUES (14833,14,3);  -- CHR: 3
+INSERT INTO `item_mods` VALUES (14833,276,1); -- RSE (race specific equip)
 
 -- Marine F Gloves
 INSERT INTO `item_mods` VALUES (14834,1,11);  -- DEF: 11
@@ -23729,6 +23955,7 @@ INSERT INTO `item_mods` VALUES (14834,11,-3); -- AGI: -3
 INSERT INTO `item_mods` VALUES (14834,12,4);  -- INT: 4
 INSERT INTO `item_mods` VALUES (14834,13,4);  -- MND: 4
 INSERT INTO `item_mods` VALUES (14834,14,3);  -- CHR: 3
+INSERT INTO `item_mods` VALUES (14834,276,2); -- RSE (race specific equip)
 
 -- Wood Gauntlets
 INSERT INTO `item_mods` VALUES (14835,1,11);  -- DEF: 11
@@ -23737,6 +23964,7 @@ INSERT INTO `item_mods` VALUES (14835,5,55);  -- MP: 55
 INSERT INTO `item_mods` VALUES (14835,9,4);   -- DEX: 4
 INSERT INTO `item_mods` VALUES (14835,10,-3); -- VIT: -3
 INSERT INTO `item_mods` VALUES (14835,12,4);  -- INT: 4
+INSERT INTO `item_mods` VALUES (14835,276,4); -- RSE (race specific equip)
 
 -- Wood Gloves
 INSERT INTO `item_mods` VALUES (14836,1,11);  -- DEF: 11
@@ -23745,35 +23973,40 @@ INSERT INTO `item_mods` VALUES (14836,5,55);  -- MP: 55
 INSERT INTO `item_mods` VALUES (14836,9,4);   -- DEX: 4
 INSERT INTO `item_mods` VALUES (14836,10,-3); -- VIT: -3
 INSERT INTO `item_mods` VALUES (14836,12,4);  -- INT: 4
+INSERT INTO `item_mods` VALUES (14836,276,8); -- RSE (race specific equip)
 
 -- Creek M Mitts
-INSERT INTO `item_mods` VALUES (14837,1,11);  -- DEF: 11
-INSERT INTO `item_mods` VALUES (14837,2,65);  -- HP: 65
-INSERT INTO `item_mods` VALUES (14837,8,6);   -- STR: 6
-INSERT INTO `item_mods` VALUES (14837,10,2);  -- VIT: 2
-INSERT INTO `item_mods` VALUES (14837,11,-3); -- AGI: -3
+INSERT INTO `item_mods` VALUES (14837,1,11);   -- DEF: 11
+INSERT INTO `item_mods` VALUES (14837,2,65);   -- HP: 65
+INSERT INTO `item_mods` VALUES (14837,8,6);    -- STR: 6
+INSERT INTO `item_mods` VALUES (14837,10,2);   -- VIT: 2
+INSERT INTO `item_mods` VALUES (14837,11,-3);  -- AGI: -3
+INSERT INTO `item_mods` VALUES (14837,276,16); -- RSE (race specific equip)
 
 -- Creek F Mitts
-INSERT INTO `item_mods` VALUES (14838,1,11);  -- DEF: 11
-INSERT INTO `item_mods` VALUES (14838,2,65);  -- HP: 65
-INSERT INTO `item_mods` VALUES (14838,8,6);   -- STR: 6
-INSERT INTO `item_mods` VALUES (14838,10,2);  -- VIT: 2
-INSERT INTO `item_mods` VALUES (14838,11,-3); -- AGI: -3
+INSERT INTO `item_mods` VALUES (14838,1,11);   -- DEF: 11
+INSERT INTO `item_mods` VALUES (14838,2,65);   -- HP: 65
+INSERT INTO `item_mods` VALUES (14838,8,6);    -- STR: 6
+INSERT INTO `item_mods` VALUES (14838,10,2);   -- VIT: 2
+INSERT INTO `item_mods` VALUES (14838,11,-3);  -- AGI: -3
+INSERT INTO `item_mods` VALUES (14838,276,32); -- RSE (race specific equip)
 
 -- River Gauntlets
-INSERT INTO `item_mods` VALUES (14839,1,11);  -- DEF: 11
-INSERT INTO `item_mods` VALUES (14839,2,60);  -- HP: 60
-INSERT INTO `item_mods` VALUES (14839,10,6);  -- VIT: 6
-INSERT INTO `item_mods` VALUES (14839,11,-5); -- AGI: -5
-INSERT INTO `item_mods` VALUES (14839,13,1);  -- MND: 1
+INSERT INTO `item_mods` VALUES (14839,1,11);   -- DEF: 11
+INSERT INTO `item_mods` VALUES (14839,2,60);   -- HP: 60
+INSERT INTO `item_mods` VALUES (14839,10,6);   -- VIT: 6
+INSERT INTO `item_mods` VALUES (14839,11,-5);  -- AGI: -5
+INSERT INTO `item_mods` VALUES (14839,13,1);   -- MND: 1
+INSERT INTO `item_mods` VALUES (14839,276,64); -- RSE (race specific equip)
 
 -- Dune Bracers
-INSERT INTO `item_mods` VALUES (14840,1,11);  -- DEF: 11
-INSERT INTO `item_mods` VALUES (14840,2,-35); -- HP: -35
-INSERT INTO `item_mods` VALUES (14840,5,65);  -- MP: 65
-INSERT INTO `item_mods` VALUES (14840,10,-5); -- VIT: -5
-INSERT INTO `item_mods` VALUES (14840,12,2);  -- INT: 2
-INSERT INTO `item_mods` VALUES (14840,13,2);  -- MND: 2
+INSERT INTO `item_mods` VALUES (14840,1,11);    -- DEF: 11
+INSERT INTO `item_mods` VALUES (14840,2,-35);   -- HP: -35
+INSERT INTO `item_mods` VALUES (14840,5,65);    -- MP: 65
+INSERT INTO `item_mods` VALUES (14840,10,-5);   -- VIT: -5
+INSERT INTO `item_mods` VALUES (14840,12,2);    -- INT: 2
+INSERT INTO `item_mods` VALUES (14840,13,2);    -- MND: 2
+INSERT INTO `item_mods` VALUES (14840,276,128); -- RSE (race specific equip)
 
 -- Garrison Gloves
 INSERT INTO `item_mods` VALUES (14841,1,4);  -- DEF: 4
@@ -24733,18 +24966,20 @@ INSERT INTO `item_mods` VALUES (15001,25,4);  -- ACC: 4
 INSERT INTO `item_mods` VALUES (15001,27,-4); -- ENMITY: -4
 
 -- Dancers Bangles
-INSERT INTO `item_mods` VALUES (15002,1,15);   -- DEF: 15
-INSERT INTO `item_mods` VALUES (15002,2,12);   -- HP: 12
-INSERT INTO `item_mods` VALUES (15002,9,2);    -- DEX: 2
-INSERT INTO `item_mods` VALUES (15002,11,2);   -- AGI: 2
-INSERT INTO `item_mods` VALUES (15002,403,10); -- STEP_ACCURACY: 10
+INSERT INTO `item_mods` VALUES (15002,1,15);    -- DEF: 15
+INSERT INTO `item_mods` VALUES (15002,2,12);    -- HP: 12
+INSERT INTO `item_mods` VALUES (15002,9,2);     -- DEX: 2
+INSERT INTO `item_mods` VALUES (15002,11,2);    -- AGI: 2
+INSERT INTO `item_mods` VALUES (15002,276,149); -- RSE (race specific equip)
+INSERT INTO `item_mods` VALUES (15002,403,10);  -- STEP_ACCURACY: 10
 
 -- Dancers Bangles
-INSERT INTO `item_mods` VALUES (15003,1,15);   -- DEF: 15
-INSERT INTO `item_mods` VALUES (15003,2,12);   -- HP: 12
-INSERT INTO `item_mods` VALUES (15003,9,2);    -- DEX: 2
-INSERT INTO `item_mods` VALUES (15003,11,2);   -- AGI: 2
-INSERT INTO `item_mods` VALUES (15003,403,10); -- STEP_ACCURACY: 10
+INSERT INTO `item_mods` VALUES (15003,1,15);    -- DEF: 15
+INSERT INTO `item_mods` VALUES (15003,2,12);    -- HP: 12
+INSERT INTO `item_mods` VALUES (15003,9,2);     -- DEX: 2
+INSERT INTO `item_mods` VALUES (15003,11,2);    -- AGI: 2
+INSERT INTO `item_mods` VALUES (15003,276,106); -- RSE (race specific equip)
+INSERT INTO `item_mods` VALUES (15003,403,10);  -- STEP_ACCURACY: 10
 
 -- Scholars Bracers
 INSERT INTO `item_mods` VALUES (15004,1,13);   -- DEF: 13
@@ -24936,20 +25171,22 @@ INSERT INTO `item_mods` VALUES (15034,18,20);  -- EARTH_RES: 20
 INSERT INTO `item_mods` VALUES (15034,539,30); -- STONESKIN_BONUS_HP: 30
 
 -- Dancers Bangles +1
-INSERT INTO `item_mods` VALUES (15035,1,16);   -- DEF: 16
-INSERT INTO `item_mods` VALUES (15035,2,17);   -- HP: 17
-INSERT INTO `item_mods` VALUES (15035,9,4);    -- DEX: 4
-INSERT INTO `item_mods` VALUES (15035,11,4);   -- AGI: 4
-INSERT INTO `item_mods` VALUES (15035,23,5);   -- ATT: 5
-INSERT INTO `item_mods` VALUES (15035,403,10); -- STEP_ACCURACY: 10
+INSERT INTO `item_mods` VALUES (15035,1,16);    -- DEF: 16
+INSERT INTO `item_mods` VALUES (15035,2,17);    -- HP: 17
+INSERT INTO `item_mods` VALUES (15035,9,4);     -- DEX: 4
+INSERT INTO `item_mods` VALUES (15035,11,4);    -- AGI: 4
+INSERT INTO `item_mods` VALUES (15035,23,5);    -- ATT: 5
+INSERT INTO `item_mods` VALUES (15035,276,149); -- RSE (race specific equip)
+INSERT INTO `item_mods` VALUES (15035,403,10);  -- STEP_ACCURACY: 10
 
 -- Dancers Bangles +1
-INSERT INTO `item_mods` VALUES (15036,1,16);   -- DEF: 16
-INSERT INTO `item_mods` VALUES (15036,2,17);   -- HP: 17
-INSERT INTO `item_mods` VALUES (15036,9,4);    -- DEX: 4
-INSERT INTO `item_mods` VALUES (15036,11,4);   -- AGI: 4
-INSERT INTO `item_mods` VALUES (15036,23,5);   -- ATT: 5
-INSERT INTO `item_mods` VALUES (15036,403,10); -- STEP_ACCURACY: 10
+INSERT INTO `item_mods` VALUES (15036,1,16);    -- DEF: 16
+INSERT INTO `item_mods` VALUES (15036,2,17);    -- HP: 17
+INSERT INTO `item_mods` VALUES (15036,9,4);     -- DEX: 4
+INSERT INTO `item_mods` VALUES (15036,11,4);    -- AGI: 4
+INSERT INTO `item_mods` VALUES (15036,23,5);    -- ATT: 5
+INSERT INTO `item_mods` VALUES (15036,276,106); -- RSE (race specific equip)
+INSERT INTO `item_mods` VALUES (15036,403,10);  -- STEP_ACCURACY: 10
 
 -- Scholars Bracers +1
 INSERT INTO `item_mods` VALUES (15037,1,14);   -- DEF: 14
@@ -26924,12 +27161,14 @@ INSERT INTO `item_mods` VALUES (15388,1,23); -- DEF: 23
 INSERT INTO `item_mods` VALUES (15388,14,1); -- CHR: 1
 
 -- Vir Subligar
-INSERT INTO `item_mods` VALUES (15389,1,30); -- DEF: 30
-INSERT INTO `item_mods` VALUES (15389,21,9); -- LIGHT_RES: 9
+INSERT INTO `item_mods` VALUES (15389,1,30);    -- DEF: 30
+INSERT INTO `item_mods` VALUES (15389,21,9);    -- LIGHT_RES: 9
+INSERT INTO `item_mods` VALUES (15389,276,149); -- RSE (race specific equip)
 
 -- Femina Subligar
-INSERT INTO `item_mods` VALUES (15390,1,30); -- DEF: 30
-INSERT INTO `item_mods` VALUES (15390,21,9); -- LIGHT_RES: 9
+INSERT INTO `item_mods` VALUES (15390,1,30);    -- DEF: 30
+INSERT INTO `item_mods` VALUES (15390,21,9);    -- LIGHT_RES: 9
+INSERT INTO `item_mods` VALUES (15390,276,106); -- RSE (race specific equip)
 
 -- Blessed Trousers
 INSERT INTO `item_mods` VALUES (15391,1,32);    -- DEF: 32
@@ -27033,53 +27272,67 @@ INSERT INTO `item_mods` VALUES (15407,2,46); -- HP: 46
 INSERT INTO `item_mods` VALUES (15407,9,5);  -- DEX: 5
 
 -- Hume Trunks
-INSERT INTO `item_mods` VALUES (15408,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (15408,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (15408,276,1); -- RSE (race specific equip)
 
 -- Hume Shorts
-INSERT INTO `item_mods` VALUES (15409,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (15409,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (15409,276,2); -- RSE (race specific equip)
 
 -- Elvaan Trunks
-INSERT INTO `item_mods` VALUES (15410,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (15410,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (15410,276,4); -- RSE (race specific equip)
 
 -- Elvaan Shorts
-INSERT INTO `item_mods` VALUES (15411,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (15411,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (15411,276,8); -- RSE (race specific equip)
 
 -- Tarutaru Trunks
-INSERT INTO `item_mods` VALUES (15412,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (15412,1,1);    -- DEF: 1
+INSERT INTO `item_mods` VALUES (15412,276,16); -- RSE (race specific equip)
 
 -- Mithra Shorts
-INSERT INTO `item_mods` VALUES (15413,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (15413,1,1);    -- DEF: 1
+INSERT INTO `item_mods` VALUES (15413,276,64); -- RSE (race specific equip)
 
 -- Galka Trunks
-INSERT INTO `item_mods` VALUES (15414,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (15414,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (15414,276,128); -- RSE (race specific equip)
 
 -- Hume Trunks +1
 INSERT INTO `item_mods` VALUES (15415,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (15415,276,1); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (15415,509,1); -- CLAMMING_IMPROVED_RESULTS: 1
 
 -- Hume Shorts +1
 INSERT INTO `item_mods` VALUES (15416,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (15416,276,2); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (15416,509,1); -- CLAMMING_IMPROVED_RESULTS: 1
 
 -- Elvaan Trunks +1
 INSERT INTO `item_mods` VALUES (15417,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (15417,276,4); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (15417,509,1); -- CLAMMING_IMPROVED_RESULTS: 1
 
 -- Elvaan Shorts +1
 INSERT INTO `item_mods` VALUES (15418,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (15418,276,8); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (15418,509,1); -- CLAMMING_IMPROVED_RESULTS: 1
 
 -- Tarutaru Trunks +1
-INSERT INTO `item_mods` VALUES (15419,1,2);   -- DEF: 2
-INSERT INTO `item_mods` VALUES (15419,509,1); -- CLAMMING_IMPROVED_RESULTS: 1
+INSERT INTO `item_mods` VALUES (15419,1,2);    -- DEF: 2
+INSERT INTO `item_mods` VALUES (15419,276,16); -- RSE (race specific equip)
+INSERT INTO `item_mods` VALUES (15419,509,1);  -- CLAMMING_IMPROVED_RESULTS: 1
 
 -- Mithra Shorts +1
-INSERT INTO `item_mods` VALUES (15420,1,2);   -- DEF: 2
-INSERT INTO `item_mods` VALUES (15420,509,1); -- CLAMMING_IMPROVED_RESULTS: 1
+INSERT INTO `item_mods` VALUES (15420,1,2);    -- DEF: 2
+INSERT INTO `item_mods` VALUES (15420,276,64); -- RSE (race specific equip)
+INSERT INTO `item_mods` VALUES (15420,509,1);  -- CLAMMING_IMPROVED_RESULTS: 1
 
 -- Galka Trunks +1
-INSERT INTO `item_mods` VALUES (15421,1,2);   -- DEF: 2
-INSERT INTO `item_mods` VALUES (15421,509,1); -- CLAMMING_IMPROVED_RESULTS: 1
+INSERT INTO `item_mods` VALUES (15421,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (15421,276,128); -- RSE (race specific equip)
+INSERT INTO `item_mods` VALUES (15421,509,1);   -- CLAMMING_IMPROVED_RESULTS: 1
 
 -- Black Hose
 INSERT INTO `item_mods` VALUES (15422,1,16); -- DEF: 16
@@ -27087,11 +27340,13 @@ INSERT INTO `item_mods` VALUES (15422,8,1);  -- STR: 1
 INSERT INTO `item_mods` VALUES (15422,27,1); -- ENMITY: 1
 
 -- Tarutaru Shorts
-INSERT INTO `item_mods` VALUES (15423,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (15423,1,1);    -- DEF: 1
+INSERT INTO `item_mods` VALUES (15423,276,32); -- RSE (race specific equip)
 
 -- Tarutaru Shorts +1
-INSERT INTO `item_mods` VALUES (15424,1,2);   -- DEF: 2
-INSERT INTO `item_mods` VALUES (15424,509,1); -- CLAMMING_IMPROVED_RESULTS: 1
+INSERT INTO `item_mods` VALUES (15424,1,2);    -- DEF: 2
+INSERT INTO `item_mods` VALUES (15424,276,32); -- RSE (race specific equip)
+INSERT INTO `item_mods` VALUES (15424,509,1);  -- CLAMMING_IMPROVED_RESULTS: 1
 
 -- Galliard Trousers
 INSERT INTO `item_mods` VALUES (15425,1,30);  -- DEF: 30
@@ -28221,18 +28476,20 @@ INSERT INTO `item_mods` VALUES (15658,30,5);    -- MACC: 5
 INSERT INTO `item_mods` VALUES (15658,160,500); -- DMG: 500
 
 -- Dancers Tights
-INSERT INTO `item_mods` VALUES (15659,1,28);  -- DEF: 28
-INSERT INTO `item_mods` VALUES (15659,2,10);  -- HP: 10
-INSERT INTO `item_mods` VALUES (15659,14,3);  -- CHR: 3
-INSERT INTO `item_mods` VALUES (15659,25,3);  -- ACC: 3
-INSERT INTO `item_mods` VALUES (15659,27,-1); -- ENMITY: -1
+INSERT INTO `item_mods` VALUES (15659,1,28);    -- DEF: 28
+INSERT INTO `item_mods` VALUES (15659,2,10);    -- HP: 10
+INSERT INTO `item_mods` VALUES (15659,14,3);    -- CHR: 3
+INSERT INTO `item_mods` VALUES (15659,25,3);    -- ACC: 3
+INSERT INTO `item_mods` VALUES (15659,276,149); -- RSE (race specific equip)
+INSERT INTO `item_mods` VALUES (15659,27,-1);   -- ENMITY: -1
 
 -- Dancers Tights
-INSERT INTO `item_mods` VALUES (15660,1,28);  -- DEF: 28
-INSERT INTO `item_mods` VALUES (15660,2,10);  -- HP: 10
-INSERT INTO `item_mods` VALUES (15660,14,3);  -- CHR: 3
-INSERT INTO `item_mods` VALUES (15660,25,3);  -- ACC: 3
-INSERT INTO `item_mods` VALUES (15660,27,-1); -- ENMITY: -1
+INSERT INTO `item_mods` VALUES (15660,1,28);    -- DEF: 28
+INSERT INTO `item_mods` VALUES (15660,2,10);    -- HP: 10
+INSERT INTO `item_mods` VALUES (15660,14,3);    -- CHR: 3
+INSERT INTO `item_mods` VALUES (15660,25,3);    -- ACC: 3
+INSERT INTO `item_mods` VALUES (15660,27,-1);   -- ENMITY: -1
+INSERT INTO `item_mods` VALUES (15660,276,106); -- RSE (race specific equip)
 
 -- Homam Gambieras
 INSERT INTO `item_mods` VALUES (15661,1,16);    -- DEF: 16
@@ -28770,18 +29027,20 @@ INSERT INTO `item_mods` VALUES (15745,17,15);   -- WIND_RES: 15
 INSERT INTO `item_mods` VALUES (15745,384,100); -- HASTE_GEAR: 100
 
 -- Dancers Toe Shoes
-INSERT INTO `item_mods` VALUES (15746,1,14);   -- DEF: 14
-INSERT INTO `item_mods` VALUES (15746,2,7);    -- HP: 7
-INSERT INTO `item_mods` VALUES (15746,23,5);   -- ATT: 5
-INSERT INTO `item_mods` VALUES (15746,68,5);   -- EVA: 5
-INSERT INTO `item_mods` VALUES (15746,492,25); -- JIG_DURATION: 25
+INSERT INTO `item_mods` VALUES (15746,1,14);    -- DEF: 14
+INSERT INTO `item_mods` VALUES (15746,2,7);     -- HP: 7
+INSERT INTO `item_mods` VALUES (15746,23,5);    -- ATT: 5
+INSERT INTO `item_mods` VALUES (15746,68,5);    -- EVA: 5
+INSERT INTO `item_mods` VALUES (15746,276,149); -- RSE (race specific equip)
+INSERT INTO `item_mods` VALUES (15746,492,25);  -- JIG_DURATION: 25
 
 -- Dancers Toe Shoes
-INSERT INTO `item_mods` VALUES (15747,1,14);   -- DEF: 14
-INSERT INTO `item_mods` VALUES (15747,2,7);    -- HP: 7
-INSERT INTO `item_mods` VALUES (15747,23,5);   -- ATT: 5
-INSERT INTO `item_mods` VALUES (15747,68,5);   -- EVA: 5
-INSERT INTO `item_mods` VALUES (15747,492,25); -- JIG_DURATION: 25
+INSERT INTO `item_mods` VALUES (15747,1,14);    -- DEF: 14
+INSERT INTO `item_mods` VALUES (15747,2,7);     -- HP: 7
+INSERT INTO `item_mods` VALUES (15747,23,5);    -- ATT: 5
+INSERT INTO `item_mods` VALUES (15747,68,5);    -- EVA: 5
+INSERT INTO `item_mods` VALUES (15747,276,106); -- RSE (race specific equip)
+INSERT INTO `item_mods` VALUES (15747,492,25);  -- JIG_DURATION: 25
 
 -- Scholars Loafers
 INSERT INTO `item_mods` VALUES (15748,1,10);   -- DEF: 10
@@ -29106,6 +29365,12 @@ INSERT INTO `item_mods` VALUES (15839,122,2); -- BLUE: 2
 
 -- Patronus Ring
 INSERT INTO `item_mods` VALUES (15844,161,-200); -- DMGPHYS: -200
+
+-- Matrimony Ring
+INSERT INTO `item_mods` VALUES (15847,276,149); -- RSE (race specific equip)
+
+-- Matrimony Band
+INSERT INTO `item_mods` VALUES (15848,276,106); -- RSE (race specific equip)
 
 -- Krousis Ring
 INSERT INTO `item_mods` VALUES (15849,1,15); -- DEF: 15
@@ -30233,18 +30498,20 @@ INSERT INTO `item_mods` VALUES (16136,1,21); -- DEF: 21
 INSERT INTO `item_mods` VALUES (16137,1,21); -- DEF: 21
 
 -- Dancers Tiara
-INSERT INTO `item_mods` VALUES (16138,1,18);   -- DEF: 18
-INSERT INTO `item_mods` VALUES (16138,2,10);   -- HP: 10
-INSERT INTO `item_mods` VALUES (16138,14,4);   -- CHR: 4
-INSERT INTO `item_mods` VALUES (16138,27,-2);  -- ENMITY: -2
-INSERT INTO `item_mods` VALUES (16138,490,30); -- SAMBA_DURATION: 30
+INSERT INTO `item_mods` VALUES (16138,1,18);    -- DEF: 18
+INSERT INTO `item_mods` VALUES (16138,2,10);    -- HP: 10
+INSERT INTO `item_mods` VALUES (16138,14,4);    -- CHR: 4
+INSERT INTO `item_mods` VALUES (16138,27,-2);   -- ENMITY: -2
+INSERT INTO `item_mods` VALUES (16138,276,149); -- RSE (race specific equip)
+INSERT INTO `item_mods` VALUES (16138,490,30);  -- SAMBA_DURATION: 30
 
 -- Dancers Tiara
-INSERT INTO `item_mods` VALUES (16139,1,18);   -- DEF: 18
-INSERT INTO `item_mods` VALUES (16139,2,10);   -- HP: 10
-INSERT INTO `item_mods` VALUES (16139,14,4);   -- CHR: 4
-INSERT INTO `item_mods` VALUES (16139,27,-2);  -- ENMITY: -2
-INSERT INTO `item_mods` VALUES (16139,490,30); -- SAMBA_DURATION: 30
+INSERT INTO `item_mods` VALUES (16139,1,18);    -- DEF: 18
+INSERT INTO `item_mods` VALUES (16139,2,10);    -- HP: 10
+INSERT INTO `item_mods` VALUES (16139,14,4);    -- CHR: 4
+INSERT INTO `item_mods` VALUES (16139,27,-2);   -- ENMITY: -2
+INSERT INTO `item_mods` VALUES (16139,276,106); -- RSE (race specific equip)
+INSERT INTO `item_mods` VALUES (16139,490,30);  -- SAMBA_DURATION: 30
 
 -- Scholars Mortarboard
 INSERT INTO `item_mods` VALUES (16140,1,15);  -- DEF: 15
@@ -31069,52 +31336,68 @@ INSERT INTO `item_mods` VALUES (16320,9,5);  -- DEX: 5
 INSERT INTO `item_mods` VALUES (16320,10,5); -- VIT: 5
 
 -- Custom Trunks
-INSERT INTO `item_mods` VALUES (16321,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (16321,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (16321,276,1); -- RSE (race specific equip)
 
 -- Custom Shorts
-INSERT INTO `item_mods` VALUES (16322,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (16322,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (16322,276,2); -- RSE (race specific equip)
 
 -- Magna Trunks
-INSERT INTO `item_mods` VALUES (16323,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (16323,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (16323,276,4); -- RSE (race specific equip)
 
 -- Magna Shorts
-INSERT INTO `item_mods` VALUES (16324,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (16324,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (16324,276,8); -- RSE (race specific equip)
 
 -- Wonder Trunks
-INSERT INTO `item_mods` VALUES (16325,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (16325,1,1);    -- DEF: 1
+INSERT INTO `item_mods` VALUES (16325,276,16); -- RSE (race specific equip)
 
 -- Wonder Shorts
-INSERT INTO `item_mods` VALUES (16326,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (16326,1,1);    -- DEF: 1
+INSERT INTO `item_mods` VALUES (16326,276,32); -- RSE (race specific equip)
 
 -- Savage Shorts
-INSERT INTO `item_mods` VALUES (16327,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (16327,1,1);    -- DEF: 1
+INSERT INTO `item_mods` VALUES (16327,276,64); -- RSE (race specific equip)
 
 -- Elder Trunks
-INSERT INTO `item_mods` VALUES (16328,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (16328,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (16328,276,128); -- RSE (race specific equip)
 
 -- Custom Trunks +1
-INSERT INTO `item_mods` VALUES (16329,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (16329,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (16329,276,1); -- RSE (race specific equip)
 
 -- Custom Shorts +1
-INSERT INTO `item_mods` VALUES (16330,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (16330,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (16330,276,2); -- RSE (race specific equip)
 
 -- Magna Trunks +1
-INSERT INTO `item_mods` VALUES (16331,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (16331,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (16331,276,4); -- RSE (race specific equip)
 
 -- Magna Shorts +1
-INSERT INTO `item_mods` VALUES (16332,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (16332,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (16332,276,8); -- RSE (race specific equip)
 
 -- Wonder Trunks +1
-INSERT INTO `item_mods` VALUES (16333,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (16333,1,2);    -- DEF: 2
+INSERT INTO `item_mods` VALUES (16333,276,16); -- RSE (race specific equip)
 
 -- Wonder Shorts +1
-INSERT INTO `item_mods` VALUES (16334,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (16334,1,2);    -- DEF: 2
+INSERT INTO `item_mods` VALUES (16334,276,32); -- RSE (race specific equip)
 
 -- Savage Shorts +1
-INSERT INTO `item_mods` VALUES (16335,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (16335,1,2);    -- DEF: 2
+INSERT INTO `item_mods` VALUES (16335,276,64); -- RSE (race specific equip)
 
 -- Elder Trunks +1
-INSERT INTO `item_mods` VALUES (16336,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (16336,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (16336,276,128); -- RSE (race specific equip)
 
 -- Hachiryu Haidate
 INSERT INTO `item_mods` VALUES (16337,1,42);  -- DEF: 42
@@ -31249,22 +31532,24 @@ INSERT INTO `item_mods` VALUES (16356,23,4);  -- ATT: 4
 INSERT INTO `item_mods` VALUES (16356,28,4);  -- MATT: 4
 
 -- Dancers Tights +1
-INSERT INTO `item_mods` VALUES (16357,1,29);  -- DEF: 29
-INSERT INTO `item_mods` VALUES (16357,2,15);  -- HP: 15
-INSERT INTO `item_mods` VALUES (16357,10,5);  -- VIT: 5
-INSERT INTO `item_mods` VALUES (16357,14,5);  -- CHR: 5
-INSERT INTO `item_mods` VALUES (16357,23,5);  -- ATT: 5
-INSERT INTO `item_mods` VALUES (16357,25,5);  -- ACC: 5
-INSERT INTO `item_mods` VALUES (16357,27,-1); -- ENMITY: -1
+INSERT INTO `item_mods` VALUES (16357,1,29);    -- DEF: 29
+INSERT INTO `item_mods` VALUES (16357,2,15);    -- HP: 15
+INSERT INTO `item_mods` VALUES (16357,10,5);    -- VIT: 5
+INSERT INTO `item_mods` VALUES (16357,14,5);    -- CHR: 5
+INSERT INTO `item_mods` VALUES (16357,23,5);    -- ATT: 5
+INSERT INTO `item_mods` VALUES (16357,25,5);    -- ACC: 5
+INSERT INTO `item_mods` VALUES (16357,276,149); -- RSE (race specific equip)
+INSERT INTO `item_mods` VALUES (16357,27,-1);   -- ENMITY: -1
 
 -- Dancers Tights +1
-INSERT INTO `item_mods` VALUES (16358,1,29);  -- DEF: 29
-INSERT INTO `item_mods` VALUES (16358,2,15);  -- HP: 15
-INSERT INTO `item_mods` VALUES (16358,10,5);  -- VIT: 5
-INSERT INTO `item_mods` VALUES (16358,14,5);  -- CHR: 5
-INSERT INTO `item_mods` VALUES (16358,23,5);  -- ATT: 5
-INSERT INTO `item_mods` VALUES (16358,25,5);  -- ACC: 5
-INSERT INTO `item_mods` VALUES (16358,27,-1); -- ENMITY: -1
+INSERT INTO `item_mods` VALUES (16358,1,29);    -- DEF: 29
+INSERT INTO `item_mods` VALUES (16358,2,15);    -- HP: 15
+INSERT INTO `item_mods` VALUES (16358,10,5);    -- VIT: 5
+INSERT INTO `item_mods` VALUES (16358,14,5);    -- CHR: 5
+INSERT INTO `item_mods` VALUES (16358,23,5);    -- ATT: 5
+INSERT INTO `item_mods` VALUES (16358,25,5);    -- ACC: 5
+INSERT INTO `item_mods` VALUES (16358,27,-1);   -- ENMITY: -1
+INSERT INTO `item_mods` VALUES (16358,276,106); -- RSE (race specific equip)
 
 -- Scholars Pants +1
 INSERT INTO `item_mods` VALUES (16359,1,28);   -- DEF: 28
@@ -31305,15 +31590,18 @@ INSERT INTO `item_mods` VALUES (16363,27,-3); -- ENMITY: -3
 INSERT INTO `item_mods` VALUES (16363,116,7); -- DARK: 7
 
 -- Benedight Hose
-INSERT INTO `item_mods` VALUES (16364,1,2);   -- DEF: 2
-INSERT INTO `item_mods` VALUES (16364,21,10); -- LIGHT_RES: 10
+INSERT INTO `item_mods` VALUES (16364,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (16364,21,10);   -- LIGHT_RES: 10
+INSERT INTO `item_mods` VALUES (16364,276,149); -- RSE (race specific equip)
 
 -- Argent Hose
-INSERT INTO `item_mods` VALUES (16365,1,4); -- DEF: 4
+INSERT INTO `item_mods` VALUES (16365,1,4);     -- DEF: 4
+INSERT INTO `item_mods` VALUES (16365,276,149); -- RSE (race specific equip)
 
 -- Platino Hose
-INSERT INTO `item_mods` VALUES (16366,1,4);  -- DEF: 4
-INSERT INTO `item_mods` VALUES (16366,14,2); -- CHR: 2
+INSERT INTO `item_mods` VALUES (16366,1,4);     -- DEF: 4
+INSERT INTO `item_mods` VALUES (16366,14,2);    -- CHR: 2
+INSERT INTO `item_mods` VALUES (16366,276,149); -- RSE (race specific equip)
 
 -- Phlegethons Trousers
 INSERT INTO `item_mods` VALUES (16367,1,10); -- DEF: 10
@@ -36465,28 +36753,35 @@ INSERT INTO `item_mods` VALUES (18245,30,8); -- MACC: 8
 INSERT INTO `item_mods` VALUES (18246,11,1); -- AGI: 1
 
 -- Balm Sachet
-INSERT INTO `item_mods` VALUES (18247,8,1);  -- STR: 1
-INSERT INTO `item_mods` VALUES (18247,12,1); -- INT: 1
+INSERT INTO `item_mods` VALUES (18247,8,1);   -- STR: 1
+INSERT INTO `item_mods` VALUES (18247,12,1);  -- INT: 1
+INSERT INTO `item_mods` VALUES (18247,276,1); -- RSE (race specific equip)
 
 -- Millefleurs Sachet
-INSERT INTO `item_mods` VALUES (18248,8,1);  -- STR: 1
-INSERT INTO `item_mods` VALUES (18248,12,1); -- INT: 1
+INSERT INTO `item_mods` VALUES (18248,8,1);   -- STR: 1
+INSERT INTO `item_mods` VALUES (18248,12,1);  -- INT: 1
+INSERT INTO `item_mods` VALUES (18248,276,2); -- RSE (race specific equip)
 
 -- Olibanum Sachet
-INSERT INTO `item_mods` VALUES (18249,8,2); -- STR: 2
+INSERT INTO `item_mods` VALUES (18249,8,2);   -- STR: 2
+INSERT INTO `item_mods` VALUES (18249,276,4); -- RSE (race specific equip)
 
 -- Attar Sachet
-INSERT INTO `item_mods` VALUES (18250,8,2); -- STR: 2
+INSERT INTO `item_mods` VALUES (18250,8,2);   -- STR: 2
+INSERT INTO `item_mods` VALUES (18250,276,8); -- RSE (race specific equip)
 
 -- Sweet Sachet
-INSERT INTO `item_mods` VALUES (18251,12,2); -- INT: 2
+INSERT INTO `item_mods` VALUES (18251,12,2);   -- INT: 2
+INSERT INTO `item_mods` VALUES (18251,276,48); -- RSE (race specific equip)
 
 -- Civet Sachet
-INSERT INTO `item_mods` VALUES (18252,9,1);  -- DEX: 1
-INSERT INTO `item_mods` VALUES (18252,11,1); -- AGI: 1
+INSERT INTO `item_mods` VALUES (18252,9,1);    -- DEX: 1
+INSERT INTO `item_mods` VALUES (18252,11,1);   -- AGI: 1
+INSERT INTO `item_mods` VALUES (18252,276,64); -- RSE (race specific equip)
 
 -- Musk Sachet
-INSERT INTO `item_mods` VALUES (18253,10,2); -- VIT: 2
+INSERT INTO `item_mods` VALUES (18253,10,2);    -- VIT: 2
+INSERT INTO `item_mods` VALUES (18253,276,128); -- RSE (race specific equip)
 
 -- Tiphia Sting
 INSERT INTO `item_mods` VALUES (18254,2,-25); -- HP: -25
@@ -46835,6 +47130,7 @@ INSERT INTO `item_mods` VALUES (23058,29,2);    -- MDEF: 2
 INSERT INTO `item_mods` VALUES (23058,31,63);   -- MEVA: 63
 INSERT INTO `item_mods` VALUES (23058,68,64);   -- EVA: 64
 INSERT INTO `item_mods` VALUES (23058,259,4);   -- DUAL_WIELD: 4
+INSERT INTO `item_mods` VALUES (23058,276,149); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (23058,384,800); -- HASTE_GEAR: 800
 INSERT INTO `item_mods` VALUES (23058,403,25);  -- STEP_ACCURACY: 25
 INSERT INTO `item_mods` VALUES (23058,490,45);  -- SAMBA_DURATION: 45
@@ -46855,6 +47151,7 @@ INSERT INTO `item_mods` VALUES (23059,29,2);    -- MDEF: 2
 INSERT INTO `item_mods` VALUES (23059,31,63);   -- MEVA: 63
 INSERT INTO `item_mods` VALUES (23059,68,64);   -- EVA: 64
 INSERT INTO `item_mods` VALUES (23059,259,4);   -- DUAL_WIELD: 4
+INSERT INTO `item_mods` VALUES (23059,276,106); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (23059,384,800); -- HASTE_GEAR: 800
 INSERT INTO `item_mods` VALUES (23059,403,25);  -- STEP_ACCURACY: 25
 INSERT INTO `item_mods` VALUES (23059,490,45);  -- SAMBA_DURATION: 45
@@ -48239,6 +48536,7 @@ INSERT INTO `item_mods` VALUES (23125,25,46);   -- ACC: 46
 INSERT INTO `item_mods` VALUES (23125,29,6);    -- MDEF: 6
 INSERT INTO `item_mods` VALUES (23125,31,74);   -- MEVA: 74
 INSERT INTO `item_mods` VALUES (23125,68,69);   -- EVA: 69
+INSERT INTO `item_mods` VALUES (23125,276,149); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (23125,384,400); -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (23125,491,17);  -- WALTZ_POTENCY: 17
 
@@ -48258,6 +48556,7 @@ INSERT INTO `item_mods` VALUES (23126,25,46);   -- ACC: 46
 INSERT INTO `item_mods` VALUES (23126,29,6);    -- MDEF: 6
 INSERT INTO `item_mods` VALUES (23126,31,74);   -- MEVA: 74
 INSERT INTO `item_mods` VALUES (23126,68,69);   -- EVA: 69
+INSERT INTO `item_mods` VALUES (23126,276,106); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (23126,384,400); -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (23126,491,17);  -- WALTZ_POTENCY: 17
 
@@ -49647,6 +49946,7 @@ INSERT INTO `item_mods` VALUES (23192,25,38);   -- ACC: 38
 INSERT INTO `item_mods` VALUES (23192,29,2);    -- MDEF: 2
 INSERT INTO `item_mods` VALUES (23192,31,47);   -- MEVA: 47
 INSERT INTO `item_mods` VALUES (23192,68,44);   -- EVA: 44
+INSERT INTO `item_mods` VALUES (23192,276,149); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (23192,384,500); -- HASTE_GEAR: 500
 INSERT INTO `item_mods` VALUES (23192,403,30);  -- STEP_ACCURACY: 30
 INSERT INTO `item_mods` VALUES (23192,841,5);   -- ALL_WSDMG_FIRST_HIT: 5
@@ -49666,6 +49966,7 @@ INSERT INTO `item_mods` VALUES (23193,25,38);   -- ACC: 38
 INSERT INTO `item_mods` VALUES (23193,29,2);    -- MDEF: 2
 INSERT INTO `item_mods` VALUES (23193,31,47);   -- MEVA: 47
 INSERT INTO `item_mods` VALUES (23193,68,44);   -- EVA: 44
+INSERT INTO `item_mods` VALUES (23193,276,106); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (23193,384,500); -- HASTE_GEAR: 500
 INSERT INTO `item_mods` VALUES (23193,403,30);  -- STEP_ACCURACY: 30
 INSERT INTO `item_mods` VALUES (23193,841,5);   -- ALL_WSDMG_FIRST_HIT: 5
@@ -51017,6 +51318,7 @@ INSERT INTO `item_mods` VALUES (23259,25,46);   -- ACC: 46
 INSERT INTO `item_mods` VALUES (23259,29,5);    -- MDEF: 5
 INSERT INTO `item_mods` VALUES (23259,31,79);   -- MEVA: 79
 INSERT INTO `item_mods` VALUES (23259,68,68);   -- EVA: 68
+INSERT INTO `item_mods` VALUES (23259,276,149); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (23259,175,14);  -- SKILLCHAINDMG: 14
 INSERT INTO `item_mods` VALUES (23259,384,600); -- HASTE_GEAR: 600
 
@@ -51034,6 +51336,7 @@ INSERT INTO `item_mods` VALUES (23260,25,46);   -- ACC: 46
 INSERT INTO `item_mods` VALUES (23260,29,5);    -- MDEF: 5
 INSERT INTO `item_mods` VALUES (23260,31,79);   -- MEVA: 79
 INSERT INTO `item_mods` VALUES (23260,68,68);   -- EVA: 68
+INSERT INTO `item_mods` VALUES (23260,276,106); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (23260,175,14);  -- SKILLCHAINDMG: 14
 INSERT INTO `item_mods` VALUES (23260,384,600); -- HASTE_GEAR: 600
 
@@ -52341,6 +52644,7 @@ INSERT INTO `item_mods` VALUES (23326,25,36);   -- ACC: 36
 INSERT INTO `item_mods` VALUES (23326,29,5);    -- MDEF: 5
 INSERT INTO `item_mods` VALUES (23326,31,79);   -- MEVA: 79
 INSERT INTO `item_mods` VALUES (23326,68,92);   -- EVA: 92
+INSERT INTO `item_mods` VALUES (23326,276,149); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (23326,384,400); -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (23326,491,12);  -- WALTZ_POTENCY: 12
 INSERT INTO `item_mods` VALUES (23326,492,45);  -- JIG_DURATION: 45
@@ -52359,6 +52663,7 @@ INSERT INTO `item_mods` VALUES (23327,25,36);   -- ACC: 36
 INSERT INTO `item_mods` VALUES (23327,29,5);    -- MDEF: 5
 INSERT INTO `item_mods` VALUES (23327,31,79);   -- MEVA: 79
 INSERT INTO `item_mods` VALUES (23327,68,92);   -- EVA: 92
+INSERT INTO `item_mods` VALUES (23327,276,106); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (23327,384,400); -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (23327,491,12);  -- WALTZ_POTENCY: 12
 INSERT INTO `item_mods` VALUES (23327,492,45);  -- JIG_DURATION: 45
@@ -53690,6 +53995,7 @@ INSERT INTO `item_mods` VALUES (23393,25,47);   -- ACC: 47
 INSERT INTO `item_mods` VALUES (23393,29,3);    -- MDEF: 3
 INSERT INTO `item_mods` VALUES (23393,31,73);   -- MEVA: 73
 INSERT INTO `item_mods` VALUES (23393,68,74);   -- EVA: 74
+INSERT INTO `item_mods` VALUES (23393,276,149); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (23393,259,8);   -- DUAL_WIELD: 8
 INSERT INTO `item_mods` VALUES (23393,384,800); -- HASTE_GEAR: 800
 INSERT INTO `item_mods` VALUES (23393,403,35);  -- STEP_ACCURACY: 35
@@ -53710,6 +54016,7 @@ INSERT INTO `item_mods` VALUES (23394,25,47);   -- ACC: 47
 INSERT INTO `item_mods` VALUES (23394,29,3);    -- MDEF: 3
 INSERT INTO `item_mods` VALUES (23394,31,73);   -- MEVA: 73
 INSERT INTO `item_mods` VALUES (23394,68,74);   -- EVA: 74
+INSERT INTO `item_mods` VALUES (23394,276,106); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (23394,259,8);   -- DUAL_WIELD: 8
 INSERT INTO `item_mods` VALUES (23394,384,800); -- HASTE_GEAR: 800
 INSERT INTO `item_mods` VALUES (23394,403,35);  -- STEP_ACCURACY: 35
@@ -54298,6 +54605,7 @@ INSERT INTO `item_mods` VALUES (23460,25,56);   -- ACC: 56
 INSERT INTO `item_mods` VALUES (23460,29,7);    -- MDEF: 7
 INSERT INTO `item_mods` VALUES (23460,31,84);   -- MEVA: 84
 INSERT INTO `item_mods` VALUES (23460,68,79);   -- EVA: 79
+INSERT INTO `item_mods` VALUES (23460,276,149); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (23460,384,400); -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (23460,491,19);  -- WALTZ_POTENCY: 19
 
@@ -54317,6 +54625,7 @@ INSERT INTO `item_mods` VALUES (23461,25,56);   -- ACC: 56
 INSERT INTO `item_mods` VALUES (23461,29,7);    -- MDEF: 7
 INSERT INTO `item_mods` VALUES (23461,31,84);   -- MEVA: 84
 INSERT INTO `item_mods` VALUES (23461,68,79);   -- EVA: 79
+INSERT INTO `item_mods` VALUES (23461,276,106); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (23461,384,400); -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (23461,491,19);  -- WALTZ_POTENCY: 19
 
@@ -54771,6 +55080,7 @@ INSERT INTO `item_mods` VALUES (23527,25,48);   -- ACC: 48
 INSERT INTO `item_mods` VALUES (23527,29,3);    -- MDEF: 3
 INSERT INTO `item_mods` VALUES (23527,31,57);   -- MEVA: 57
 INSERT INTO `item_mods` VALUES (23527,68,54);   -- EVA: 54
+INSERT INTO `item_mods` VALUES (23527,276,149); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (23527,384,500); -- HASTE_GEAR: 500
 INSERT INTO `item_mods` VALUES (23527,403,40);  -- STEP_ACCURACY: 40
 INSERT INTO `item_mods` VALUES (23527,841,10);  -- ALL_WSDMG_FIRST_HIT: 10
@@ -54790,6 +55100,7 @@ INSERT INTO `item_mods` VALUES (23528,25,48);   -- ACC: 48
 INSERT INTO `item_mods` VALUES (23528,29,3);    -- MDEF: 3
 INSERT INTO `item_mods` VALUES (23528,31,57);   -- MEVA: 57
 INSERT INTO `item_mods` VALUES (23528,68,54);   -- EVA: 54
+INSERT INTO `item_mods` VALUES (23528,276,106); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (23528,384,500); -- HASTE_GEAR: 500
 INSERT INTO `item_mods` VALUES (23528,403,40);  -- STEP_ACCURACY: 40
 INSERT INTO `item_mods` VALUES (23528,841,10);  -- ALL_WSDMG_FIRST_HIT: 10
@@ -55251,6 +55562,7 @@ INSERT INTO `item_mods` VALUES (23594,25,56);   -- ACC: 56
 INSERT INTO `item_mods` VALUES (23594,29,6);    -- MDEF: 6
 INSERT INTO `item_mods` VALUES (23594,31,89);   -- MEVA: 89
 INSERT INTO `item_mods` VALUES (23594,68,78);   -- EVA: 78
+INSERT INTO `item_mods` VALUES (23594,276,149); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (23594,175,16);  -- SKILLCHAINDMG: 16
 INSERT INTO `item_mods` VALUES (23594,384,600); -- HASTE_GEAR: 600
 
@@ -55268,6 +55580,7 @@ INSERT INTO `item_mods` VALUES (23595,25,56);   -- ACC: 56
 INSERT INTO `item_mods` VALUES (23595,29,6);    -- MDEF: 6
 INSERT INTO `item_mods` VALUES (23595,31,89);   -- MEVA: 89
 INSERT INTO `item_mods` VALUES (23595,68,78);   -- EVA: 78
+INSERT INTO `item_mods` VALUES (23595,276,106); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (23595,175,16);  -- SKILLCHAINDMG: 16
 INSERT INTO `item_mods` VALUES (23595,384,600); -- HASTE_GEAR: 600
 
@@ -55731,6 +56044,7 @@ INSERT INTO `item_mods` VALUES (23661,25,46);   -- ACC: 46
 INSERT INTO `item_mods` VALUES (23661,29,6);    -- MDEF: 6
 INSERT INTO `item_mods` VALUES (23661,31,89);   -- MEVA: 89
 INSERT INTO `item_mods` VALUES (23661,68,102);  -- EVA: 102
+INSERT INTO `item_mods` VALUES (23661,276,149); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (23661,384,400); -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (23661,491,14);  -- WALTZ_POTENCY: 14
 INSERT INTO `item_mods` VALUES (23661,492,50);  -- JIG_DURATION: 50
@@ -55749,6 +56063,7 @@ INSERT INTO `item_mods` VALUES (23662,25,46);   -- ACC: 46
 INSERT INTO `item_mods` VALUES (23662,29,6);    -- MDEF: 6
 INSERT INTO `item_mods` VALUES (23662,31,89);   -- MEVA: 89
 INSERT INTO `item_mods` VALUES (23662,68,102);  -- EVA: 102
+INSERT INTO `item_mods` VALUES (23662,276,106); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (23662,384,400); -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (23662,491,14);  -- WALTZ_POTENCY: 14
 INSERT INTO `item_mods` VALUES (23662,492,50);  -- JIG_DURATION: 50
@@ -58671,6 +58986,12 @@ INSERT INTO `item_mods` VALUES (25600,62,33);   -- ATTP: 33
 INSERT INTO `item_mods` VALUES (25600,68,33);   -- EVA: 33
 INSERT INTO `item_mods` VALUES (25600,306,5);   -- ZANSHIN: 5
 INSERT INTO `item_mods` VALUES (25600,384,700); -- HASTE_GEAR: 700
+
+-- Agent Hood
+INSERT INTO `item_mods` VALUES (25606,276,149); -- RSE (race specific equip)
+
+-- Starlet Flower
+INSERT INTO `item_mods` VALUES (25607,276,106); -- RSE (race specific equip)
 
 -- Emicho Coronet
 INSERT INTO `item_mods` VALUES (25609,1,115);   -- DEF: 115
@@ -65967,6 +66288,18 @@ INSERT INTO `item_mods` VALUES (26963,288,10);    -- DOUBLE_ATTACK: 10
 INSERT INTO `item_mods` VALUES (26963,384,1600);  -- HASTE_GEAR: 1600
 INSERT INTO `item_mods` VALUES (26963,413,1);     -- EAT_RAW_MEAT: 1
 
+-- Ta Moko
+INSERT INTO `item_mods` VALUES (26965,276,149); -- RSE (race specific equip)
+
+-- Ta Moko +1
+INSERT INTO `item_mods` VALUES (26966,276,149); -- RSE (race specific equip)
+
+-- Cossie Top
+INSERT INTO `item_mods` VALUES (26967,276,106); -- RSE (race specific equip)
+
+-- Cossie Top +1
+INSERT INTO `item_mods` VALUES (26968,276,106); -- RSE (race specific equip)
+
 -- Vrikodara Jupon
 INSERT INTO `item_mods` VALUES (26969,1,135);   -- DEF: 135
 INSERT INTO `item_mods` VALUES (26969,2,54);    -- HP: 54
@@ -66029,6 +66362,12 @@ INSERT INTO `item_mods` VALUES (26971,905,3);    -- SHIELD_DEF_BONUS: 3
 
 -- Samnuha Coat
 INSERT INTO `item_mods` VALUES (26973,255,15); -- DEATHRES: 15
+
+-- Agent Coat
+INSERT INTO `item_mods` VALUES (26974,276,149); -- RSE (race specific equip)
+
+-- Starlet Jabot
+INSERT INTO `item_mods` VALUES (26975,276,106); -- RSE (race specific equip)
 
 -- Agoge Mufflers
 INSERT INTO `item_mods` VALUES (26976,1,70);     -- DEF: 70
@@ -67894,6 +68233,12 @@ INSERT INTO `item_mods` VALUES (27109,29,3);    -- MDEF: 3
 INSERT INTO `item_mods` VALUES (27109,384,300); -- HASTE_GEAR: 300
 INSERT INTO `item_mods` VALUES (27109,117,21);  -- SUMMONING: 21
 INSERT INTO `item_mods` VALUES (27109,1042,1);  -- CAIT_SITH_LVL_BONUS: 1
+
+-- Agent Cuffs
+INSERT INTO `item_mods` VALUES (27111,276,149); -- RSE (race specific equip)
+
+-- Starlet Gloves
+INSERT INTO `item_mods` VALUES (27112,276,106); -- RSE (race specific equip)
 
 -- Emicho Gauntlets
 INSERT INTO `item_mods` VALUES (27113,1,103);   -- DEF: 103
@@ -69985,6 +70330,18 @@ INSERT INTO `item_mods` VALUES (27289,384,500); -- HASTE_GEAR: 500
 INSERT INTO `item_mods` VALUES (27289,455,6);   -- SONG_SPELLCASTING_TIME: 6
 INSERT INTO `item_mods` VALUES (27289,519,15);  -- CURE_CAST_TIME: 15
 
+-- Swimming Togs
+INSERT INTO `item_mods` VALUES (27291,276,149); -- RSE (race specific equip)
+
+-- Swimming Togs +1
+INSERT INTO `item_mods` VALUES (27292,276,149); -- RSE (race specific equip)
+
+-- Cossie Bottom
+INSERT INTO `item_mods` VALUES (27293,276,106); -- RSE (race specific equip)
+
+-- Cossie Bottom +1
+INSERT INTO `item_mods` VALUES (27294,276,106); -- RSE (race specific equip)
+
 -- Samnuha Tights
 INSERT INTO `item_mods` VALUES (27295,1,116);   -- DEF: 116
 INSERT INTO `item_mods` VALUES (27295,2,41);    -- HP: 41
@@ -70002,6 +70359,12 @@ INSERT INTO `item_mods` VALUES (27295,31,75);   -- MEVA: 75
 INSERT INTO `item_mods` VALUES (27295,68,41);   -- EVA: 41
 INSERT INTO `item_mods` VALUES (27295,73,7);    -- STORETP: 7
 INSERT INTO `item_mods` VALUES (27295,384,600); -- HASTE_GEAR: 600
+
+-- Agent Pants
+INSERT INTO `item_mods` VALUES (27296,276,149); -- RSE (race specific equip)
+
+-- Starlet Skirt
+INSERT INTO `item_mods` VALUES (27297,276,106); -- RSE (race specific equip)
 
 -- Emicho Hose
 INSERT INTO `item_mods` VALUES (27298,1,129);   -- DEF: 129
@@ -72136,6 +72499,12 @@ INSERT INTO `item_mods` VALUES (27466,161,-400); -- DMGPHYS: -400
 INSERT INTO `item_mods` VALUES (27466,240,15);   -- SLEEPRES: 15
 INSERT INTO `item_mods` VALUES (27466,384,300);  -- HASTE_GEAR: 300
 
+-- Agent Boots
+INSERT INTO `item_mods` VALUES (27467,276,149); -- RSE (race specific equip)
+
+-- Starlet Boots
+INSERT INTO `item_mods` VALUES (27468,276,106); -- RSE (race specific equip)
+
 -- Emicho Gambieras
 INSERT INTO `item_mods` VALUES (27469,1,87);    -- DEF: 87
 INSERT INTO `item_mods` VALUES (27469,2,22);    -- HP: 22
@@ -73197,6 +73566,7 @@ INSERT INTO `item_mods` VALUES (27681,14,18);   -- CHR: 18
 INSERT INTO `item_mods` VALUES (27681,29,1);    -- MDEF: 1
 INSERT INTO `item_mods` VALUES (27681,31,36);   -- MEVA: 36
 INSERT INTO `item_mods` VALUES (27681,68,20);   -- EVA: 20
+INSERT INTO `item_mods` VALUES (27681,276,149); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (27681,384,700); -- HASTE_GEAR: 700
 INSERT INTO `item_mods` VALUES (27681,403,10);  -- STEP_ACCURACY: 10
 INSERT INTO `item_mods` VALUES (27681,498,45);  -- SAMBA_PDURATION: 45
@@ -73215,6 +73585,7 @@ INSERT INTO `item_mods` VALUES (27682,14,18);   -- CHR: 18
 INSERT INTO `item_mods` VALUES (27682,29,1);    -- MDEF: 1
 INSERT INTO `item_mods` VALUES (27682,31,36);   -- MEVA: 36
 INSERT INTO `item_mods` VALUES (27682,68,20);   -- EVA: 20
+INSERT INTO `item_mods` VALUES (27682,276,106); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (27682,384,700); -- HASTE_GEAR: 700
 INSERT INTO `item_mods` VALUES (27682,403,10);  -- STEP_ACCURACY: 10
 INSERT INTO `item_mods` VALUES (27682,498,45);  -- SAMBA_PDURATION: 45
@@ -73579,6 +73950,7 @@ INSERT INTO `item_mods` VALUES (27702,14,24);   -- CHR: 24
 INSERT INTO `item_mods` VALUES (27702,29,2);    -- MDEF: 2
 INSERT INTO `item_mods` VALUES (27702,31,53);   -- MEVA: 53
 INSERT INTO `item_mods` VALUES (27702,68,44);   -- EVA: 44
+INSERT INTO `item_mods` VALUES (27702,276,149); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (27702,384,800); -- HASTE_GEAR: 800
 INSERT INTO `item_mods` VALUES (27702,403,10);  -- STEP_ACCURACY: 10
 INSERT INTO `item_mods` VALUES (27702,498,45);  -- SAMBA_PDURATION: 45
@@ -73597,6 +73969,7 @@ INSERT INTO `item_mods` VALUES (27703,14,24);   -- CHR: 24
 INSERT INTO `item_mods` VALUES (27703,29,2);    -- MDEF: 2
 INSERT INTO `item_mods` VALUES (27703,31,53);   -- MEVA: 53
 INSERT INTO `item_mods` VALUES (27703,68,44);   -- EVA: 44
+INSERT INTO `item_mods` VALUES (27703,276,106); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (27703,384,800); -- HASTE_GEAR: 800
 INSERT INTO `item_mods` VALUES (27703,403,10);  -- STEP_ACCURACY: 10
 INSERT INTO `item_mods` VALUES (27703,498,45);  -- SAMBA_PDURATION: 45
@@ -73927,6 +74300,9 @@ INSERT INTO `item_mods` VALUES (27732,29,5);    -- MDEF: 5
 INSERT INTO `item_mods` VALUES (27732,31,75);   -- MEVA: 75
 INSERT INTO `item_mods` VALUES (27732,68,36);   -- EVA: 36
 INSERT INTO `item_mods` VALUES (27732,384,600); -- HASTE_GEAR: 600
+
+-- Straw Hat
+INSERT INTO `item_mods` VALUES (27733,276,149); -- RSE (race specific equip)
 
 -- Enedron Glasses
 INSERT INTO `item_mods` VALUES (27735,1,50);    -- DEF: 50
@@ -74754,6 +75130,18 @@ INSERT INTO `item_mods` VALUES (27802,30,2);  -- MACC: 2
 INSERT INTO `item_mods` VALUES (27802,113,2); -- ENHANCE: 2
 INSERT INTO `item_mods` VALUES (27802,114,2); -- ENFEEBLE: 2
 
+-- Rustic Maillot
+INSERT INTO `item_mods` VALUES (27803,276,149); -- RSE (race specific equip)
+
+-- Shoal Maillot
+INSERT INTO `item_mods` VALUES (27804,276,106); -- RSE (race specific equip)
+
+-- Rustic Maillot +1
+INSERT INTO `item_mods` VALUES (27805,276,149); -- RSE (race specific equip)
+
+-- Shoal Maillot +1
+INSERT INTO `item_mods` VALUES (27806,276,106); -- RSE (race specific equip)
+
 -- Pummelers Lorica
 INSERT INTO `item_mods` VALUES (27807,1,102);   -- DEF: 102
 INSERT INTO `item_mods` VALUES (27807,2,29);    -- HP: 29
@@ -75111,6 +75499,7 @@ INSERT INTO `item_mods` VALUES (27825,25,13);   -- ACC: 13
 INSERT INTO `item_mods` VALUES (27825,29,3);    -- MDEF: 3
 INSERT INTO `item_mods` VALUES (27825,31,43);   -- MEVA: 43
 INSERT INTO `item_mods` VALUES (27825,68,23);   -- EVA: 23
+INSERT INTO `item_mods` VALUES (27825,276,149); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (27825,384,400); -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (27825,491,15);  -- WALTZ_POTENCY: 15
 
@@ -75130,6 +75519,7 @@ INSERT INTO `item_mods` VALUES (27826,25,13);   -- ACC: 13
 INSERT INTO `item_mods` VALUES (27826,29,3);    -- MDEF: 3
 INSERT INTO `item_mods` VALUES (27826,31,43);   -- MEVA: 43
 INSERT INTO `item_mods` VALUES (27826,68,23);   -- EVA: 23
+INSERT INTO `item_mods` VALUES (27826,276,106); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (27826,384,400); -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (27826,491,15);  -- WALTZ_POTENCY: 15
 
@@ -75508,6 +75898,7 @@ INSERT INTO `item_mods` VALUES (27846,25,13);   -- ACC: 13
 INSERT INTO `item_mods` VALUES (27846,29,6);    -- MDEF: 6
 INSERT INTO `item_mods` VALUES (27846,31,64);   -- MEVA: 64
 INSERT INTO `item_mods` VALUES (27846,68,49);   -- EVA: 49
+INSERT INTO `item_mods` VALUES (27846,276,149); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (27846,384,400); -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (27846,491,15);  -- WALTZ_POTENCY: 15
 
@@ -75527,6 +75918,7 @@ INSERT INTO `item_mods` VALUES (27847,25,13);   -- ACC: 13
 INSERT INTO `item_mods` VALUES (27847,29,6);    -- MDEF: 6
 INSERT INTO `item_mods` VALUES (27847,31,64);   -- MEVA: 64
 INSERT INTO `item_mods` VALUES (27847,68,49);   -- EVA: 49
+INSERT INTO `item_mods` VALUES (27847,276,106); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (27847,384,400); -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (27847,491,15);  -- WALTZ_POTENCY: 15
 
@@ -75632,6 +76024,12 @@ INSERT INTO `item_mods` VALUES (27858,170,7);   -- FASTCAST: 7
 INSERT INTO `item_mods` VALUES (27858,288,2);   -- DOUBLE_ATTACK: 2
 INSERT INTO `item_mods` VALUES (27858,384,400); -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (27858,835,1);   -- MUG_EFFECT: 1
+
+-- Kengyu Happi
+INSERT INTO `item_mods` VALUES (27859,276,149); -- RSE (race specific equip)
+
+-- Shokujo Happi
+INSERT INTO `item_mods` VALUES (27860,276,106); -- RSE (race specific equip)
 
 -- Karmesin Vest
 INSERT INTO `item_mods` VALUES (27861,1,132);   -- DEF: 132
@@ -75880,6 +76278,12 @@ INSERT INTO `item_mods` VALUES (27878,31,80);   -- MEVA: 80
 INSERT INTO `item_mods` VALUES (27878,68,41);   -- EVA: 41
 INSERT INTO `item_mods` VALUES (27878,369,20);  -- REFRESH: 20
 INSERT INTO `item_mods` VALUES (27878,384,300); -- HASTE_GEAR: 300
+
+-- Overalls
+INSERT INTO `item_mods` VALUES (27879,276,149); -- RSE (race specific equip)
+
+-- Overalls
+INSERT INTO `item_mods` VALUES (27880,276,106); -- RSE (race specific equip)
 
 -- Outrider Mail
 INSERT INTO `item_mods` VALUES (27881,1,133);   -- DEF: 133
@@ -76155,6 +76559,12 @@ INSERT INTO `item_mods` VALUES (27897,14,20); -- CHR: 20
 INSERT INTO `item_mods` VALUES (27897,27,-5); -- ENMITY: -5
 INSERT INTO `item_mods` VALUES (27897,31,54); -- MEVA: 54
 INSERT INTO `item_mods` VALUES (27897,369,3); -- REFRESH: 3
+
+-- Morass Tunic
+INSERT INTO `item_mods` VALUES (27904,276,149); -- RSE (race specific equip)
+
+-- Woodland Tunic
+INSERT INTO `item_mods` VALUES (27905,276,106); -- RSE (race specific equip)
 
 -- Gorney Haubert
 INSERT INTO `item_mods` VALUES (27907,1,90);    -- DEF: 90
@@ -76925,6 +77335,7 @@ INSERT INTO `item_mods` VALUES (27961,23,15);   -- ATT: 15
 INSERT INTO `item_mods` VALUES (27961,29,1);    -- MDEF: 1
 INSERT INTO `item_mods` VALUES (27961,31,25);   -- MEVA: 25
 INSERT INTO `item_mods` VALUES (27961,68,11);   -- EVA: 11
+INSERT INTO `item_mods` VALUES (27961,276,149); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (27961,384,400); -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (27961,403,10);  -- STEP_ACCURACY: 10
 
@@ -76942,6 +77353,7 @@ INSERT INTO `item_mods` VALUES (27962,23,15);   -- ATT: 15
 INSERT INTO `item_mods` VALUES (27962,29,1);    -- MDEF: 1
 INSERT INTO `item_mods` VALUES (27962,31,25);   -- MEVA: 25
 INSERT INTO `item_mods` VALUES (27962,68,11);   -- EVA: 11
+INSERT INTO `item_mods` VALUES (27962,276,106); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (27962,384,400); -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (27962,403,10);  -- STEP_ACCURACY: 10
 
@@ -77295,6 +77707,7 @@ INSERT INTO `item_mods` VALUES (27982,23,15);   -- ATT: 15
 INSERT INTO `item_mods` VALUES (27982,29,2);    -- MDEF: 2
 INSERT INTO `item_mods` VALUES (27982,31,37);   -- MEVA: 37
 INSERT INTO `item_mods` VALUES (27982,68,24);   -- EVA: 24
+INSERT INTO `item_mods` VALUES (27982,276,149); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (27982,384,500); -- HASTE_GEAR: 500
 INSERT INTO `item_mods` VALUES (27982,403,20);  -- STEP_ACCURACY: 20
 
@@ -77312,6 +77725,7 @@ INSERT INTO `item_mods` VALUES (27983,23,15);   -- ATT: 15
 INSERT INTO `item_mods` VALUES (27983,29,2);    -- MDEF: 2
 INSERT INTO `item_mods` VALUES (27983,31,37);   -- MEVA: 37
 INSERT INTO `item_mods` VALUES (27983,68,24);   -- EVA: 24
+INSERT INTO `item_mods` VALUES (27983,276,106); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (27983,384,500); -- HASTE_GEAR: 500
 INSERT INTO `item_mods` VALUES (27983,403,20);  -- STEP_ACCURACY: 20
 
@@ -77741,6 +78155,12 @@ INSERT INTO `item_mods` VALUES (28022,29,3);    -- MDEF: 3
 INSERT INTO `item_mods` VALUES (28022,30,20);   -- MACC: 20
 INSERT INTO `item_mods` VALUES (28022,68,37);   -- EVA: 37
 INSERT INTO `item_mods` VALUES (28022,384,300); -- HASTE_GEAR: 300
+
+-- Work Gloves
+INSERT INTO `item_mods` VALUES (28023,276,149); -- RSE (race specific equip)
+
+-- Work Gloves
+INSERT INTO `item_mods` VALUES (28024,276,106); -- RSE (race specific equip)
 
 -- Regimen Mittens
 INSERT INTO `item_mods` VALUES (28025,1,90);    -- DEF: 90
@@ -78434,6 +78854,18 @@ INSERT INTO `item_mods` VALUES (28085,5,8);   -- MP: 8
 INSERT INTO `item_mods` VALUES (28085,13,2);  -- MND: 2
 INSERT INTO `item_mods` VALUES (28085,170,1); -- FASTCAST: 1
 
+-- Rustic Trunks
+INSERT INTO `item_mods` VALUES (28086,276,149); -- RSE (race specific equip)
+
+-- Shoal Trunks
+INSERT INTO `item_mods` VALUES (28087,276,106); -- RSE (race specific equip)
+
+-- Rustic Trunks +1
+INSERT INTO `item_mods` VALUES (28088,276,149); -- RSE (race specific equip)
+
+-- Shoal Trunks +1
+INSERT INTO `item_mods` VALUES (28089,276,106); -- RSE (race specific equip)
+
 -- Pummelers Cuisses
 INSERT INTO `item_mods` VALUES (28090,1,89);    -- DEF: 89
 INSERT INTO `item_mods` VALUES (28090,2,23);    -- HP: 23
@@ -78761,6 +79193,7 @@ INSERT INTO `item_mods` VALUES (28108,25,15);   -- ACC: 15
 INSERT INTO `item_mods` VALUES (28108,29,2);    -- MDEF: 2
 INSERT INTO `item_mods` VALUES (28108,31,47);   -- MEVA: 47
 INSERT INTO `item_mods` VALUES (28108,68,27);   -- EVA: 27
+INSERT INTO `item_mods` VALUES (28108,276,149); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (28108,175,10);  -- SKILLCHAINDMG: 10
 INSERT INTO `item_mods` VALUES (28108,384,600); -- HASTE_GEAR: 600
 
@@ -78779,6 +79212,7 @@ INSERT INTO `item_mods` VALUES (28109,29,2);    -- MDEF: 2
 INSERT INTO `item_mods` VALUES (28109,31,47);   -- MEVA: 47
 INSERT INTO `item_mods` VALUES (28109,68,27);   -- EVA: 27
 INSERT INTO `item_mods` VALUES (28109,175,10);  -- SKILLCHAINDMG: 10
+INSERT INTO `item_mods` VALUES (28109,276,106); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (28109,384,600); -- HASTE_GEAR: 600
 
 -- Academics Pants
@@ -79127,6 +79561,7 @@ INSERT INTO `item_mods` VALUES (28129,29,5);    -- MDEF: 5
 INSERT INTO `item_mods` VALUES (28129,31,69);   -- MEVA: 69
 INSERT INTO `item_mods` VALUES (28129,68,48);   -- EVA: 48
 INSERT INTO `item_mods` VALUES (28129,175,12);  -- SKILLCHAINDMG: 12
+INSERT INTO `item_mods` VALUES (28129,276,149); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (28129,384,600); -- HASTE_GEAR: 600
 
 -- Maxixi Tights +1
@@ -79144,6 +79579,7 @@ INSERT INTO `item_mods` VALUES (28130,29,5);    -- MDEF: 5
 INSERT INTO `item_mods` VALUES (28130,31,69);   -- MEVA: 69
 INSERT INTO `item_mods` VALUES (28130,68,48);   -- EVA: 48
 INSERT INTO `item_mods` VALUES (28130,175,12);  -- SKILLCHAINDMG: 12
+INSERT INTO `item_mods` VALUES (28130,276,106); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (28130,384,600); -- HASTE_GEAR: 600
 
 -- Academics Pants +1
@@ -79301,6 +79737,12 @@ INSERT INTO `item_mods` VALUES (28148,31,107);  -- MEVA: 107
 INSERT INTO `item_mods` VALUES (28148,68,27);   -- EVA: 27
 INSERT INTO `item_mods` VALUES (28148,384,500); -- HASTE_GEAR: 500
 INSERT INTO `item_mods` VALUES (28148,902,30);  -- OCCULT_ACUMEN: 30
+
+-- Kengyu Hanmomohiki
+INSERT INTO `item_mods` VALUES (28149,276,149); -- RSE (race specific equip)
+
+-- Shokujo Hanmomohiki
+INSERT INTO `item_mods` VALUES (28150,276,106); -- RSE (race specific equip)
 
 -- Sifahir Slacks
 INSERT INTO `item_mods` VALUES (28151,1,106);   -- DEF: 106
@@ -79807,6 +80249,12 @@ INSERT INTO `item_mods` VALUES (28184,31,73);   -- MEVA: 73
 INSERT INTO `item_mods` VALUES (28184,68,12);   -- EVA: 12
 INSERT INTO `item_mods` VALUES (28184,170,5);   -- FASTCAST: 5
 INSERT INTO `item_mods` VALUES (28184,384,100); -- HASTE_GEAR: 100
+
+-- Morass Pants
+INSERT INTO `item_mods` VALUES (28186,276,149); -- RSE (race specific equip)
+
+-- Woodland Pants
+INSERT INTO `item_mods` VALUES (28187,276,106); -- RSE (race specific equip)
 
 -- Gorney Brayettes
 INSERT INTO `item_mods` VALUES (28188,1,78);    -- DEF: 78
@@ -80565,6 +81013,7 @@ INSERT INTO `item_mods` VALUES (28241,23,10);   -- ATT: 10
 INSERT INTO `item_mods` VALUES (28241,29,2);    -- MDEF: 2
 INSERT INTO `item_mods` VALUES (28241,31,47);   -- MEVA: 47
 INSERT INTO `item_mods` VALUES (28241,68,33);   -- EVA: 33
+INSERT INTO `item_mods` VALUES (28241,276,149); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (28241,384,400); -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (28241,491,10);  -- WALTZ_POTENCY: 10
 INSERT INTO `item_mods` VALUES (28241,492,35);  -- JIG_DURATION: 35
@@ -80582,6 +81031,7 @@ INSERT INTO `item_mods` VALUES (28242,23,10);   -- ATT: 10
 INSERT INTO `item_mods` VALUES (28242,29,2);    -- MDEF: 2
 INSERT INTO `item_mods` VALUES (28242,31,47);   -- MEVA: 47
 INSERT INTO `item_mods` VALUES (28242,68,33);   -- EVA: 33
+INSERT INTO `item_mods` VALUES (28242,276,106); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (28242,384,400); -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (28242,491,10);  -- WALTZ_POTENCY: 10
 INSERT INTO `item_mods` VALUES (28242,492,35);  -- JIG_DURATION: 35
@@ -80933,6 +81383,7 @@ INSERT INTO `item_mods` VALUES (28262,23,10);   -- ATT: 10
 INSERT INTO `item_mods` VALUES (28262,29,5);    -- MDEF: 5
 INSERT INTO `item_mods` VALUES (28262,31,69);   -- MEVA: 69
 INSERT INTO `item_mods` VALUES (28262,68,72);   -- EVA: 72
+INSERT INTO `item_mods` VALUES (28262,276,149); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (28262,384,400); -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (28262,491,10);  -- WALTZ_POTENCY: 10
 INSERT INTO `item_mods` VALUES (28262,492,40);  -- JIG_DURATION: 40
@@ -80950,6 +81401,7 @@ INSERT INTO `item_mods` VALUES (28263,23,10);   -- ATT: 10
 INSERT INTO `item_mods` VALUES (28263,29,5);    -- MDEF: 5
 INSERT INTO `item_mods` VALUES (28263,31,69);   -- MEVA: 69
 INSERT INTO `item_mods` VALUES (28263,68,72);   -- EVA: 72
+INSERT INTO `item_mods` VALUES (28263,276,106); -- RSE (race specific equip)
 INSERT INTO `item_mods` VALUES (28263,384,400); -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (28263,491,10);  -- WALTZ_POTENCY: 10
 INSERT INTO `item_mods` VALUES (28263,492,40);  -- JIG_DURATION: 40
@@ -81476,10 +81928,12 @@ INSERT INTO `item_mods` VALUES (28301,384,400); -- HASTE_GEAR: 400
 -- Thatch Boots
 INSERT INTO `item_mods` VALUES (28302,1,1);  -- DEF: 1
 INSERT INTO `item_mods` VALUES (28302,20,3); -- WATER_RES: 3
+INSERT INTO `item_mods` VALUES (28302,276,149); -- RSE (race specific equip)
 
 -- Thatch Boots
 INSERT INTO `item_mods` VALUES (28303,1,1);  -- DEF: 1
 INSERT INTO `item_mods` VALUES (28303,20,3); -- WATER_RES: 3
+INSERT INTO `item_mods` VALUES (28303,276,106); -- RSE (race specific equip)
 
 -- Litany Clogs
 INSERT INTO `item_mods` VALUES (28304,1,40);    -- DEF: 40
@@ -81815,10 +82269,12 @@ INSERT INTO `item_mods` VALUES (28323,384,400); -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (28324,1,1); -- DEF: 1
 
 -- Morass Boots
-INSERT INTO `item_mods` VALUES (28325,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (28325,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (28325,276,149); -- RSE (race specific equip)
 
 -- Woodland Boots
-INSERT INTO `item_mods` VALUES (28326,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (28326,1,1);     -- DEF: 1
+INSERT INTO `item_mods` VALUES (28326,276,106); -- RSE (race specific equip)
 
 -- Gorney Sollerets
 INSERT INTO `item_mods` VALUES (28327,1,52);     -- DEF: 52

--- a/src/map/items/item_equipment.cpp
+++ b/src/map/items/item_equipment.cpp
@@ -132,6 +132,27 @@ void CItemEquipment::setSuperiorLevel(uint8 level)
     m_superiorLevel = level;
 }
 
+bool CItemEquipment::isEquippableByRace(uint8 race) const
+{
+    // first note that a single race actually represents a race and sex combination (for example hume-male)
+    // the EQUIPEMENT_ONLY_RACE mod is a multi-bit flag (where each set bit denotes that a specific race can use that equip)
+    // this is needed because many equips allow a subset of races
+    // for example Steppe Belt allows both taru-male and taru-female
+    // also note the default mod value of 0 denotes all races can wear
+    auto raceMod      = getModifier(Mod::EQUIPMENT_ONLY_RACE);
+    bool isEquippable = true;
+
+    // if a positive mod (so some race restriction(s) exist) then check against the char race
+    // do so by converting the race flag of a character (which is a value between 1 and 8)
+    // to a multi-bit style flag and then compare
+    if (raceMod > 0 && (raceMod & (1 << (race - 1))) == 0)
+    {
+        isEquippable = false;
+    }
+
+    return isEquippable;
+}
+
 // percentage of damage blocked by shield
 uint8 CItemEquipment::getShieldAbsorption() const
 {

--- a/src/map/items/item_equipment.h
+++ b/src/map/items/item_equipment.h
@@ -82,6 +82,7 @@ public:
     uint8  getSuperiorLevel();
 
     bool IsShield() const;
+    bool isEquippableByRace(uint8 race) const;
 
     void setReqLvl(uint8 lvl);
     void setILvl(uint8 lvl);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -4561,6 +4561,10 @@ bool CLuaBaseEntity::canEquipItem(uint16 itemID, sol::object const& chkLevel)
     {
         return false;
     }
+    if (!PItem->isEquippableByRace(PChar->look.race))
+    {
+        return false;
+    }
     if (checkLevel && (PItem->getReqLvl() > PChar->GetMLevel()))
     {
         return false;

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -872,6 +872,8 @@ enum class Mod
     EAT_RAW_MEAT    = 413, // Without this, only Galka can eat raw meat (item cannot be used)
     DRINK_DISTILLED = 159, // Without this, Distilled Water cannot be consumed (item can still be used)
 
+    EQUIPMENT_ONLY_RACE = 276, // An 8-bit flag that denotes that only a certain race(s) can use this equipment (0 means all races can use)
+
     ENHANCES_CURSNA_RCVD     = 67,   // Potency of "Cursna" effects received
     ENHANCES_CURSNA          = 310,  // Used by gear with the "Enhances Cursna" or "Cursna+" attribute
     ENHANCES_HOLYWATER       = 495,  // Used by gear with the "Enhances Holy Water" or "Holy Water+" attribute
@@ -1015,7 +1017,7 @@ enum class Mod
     //
     // SPARE IDs:
     // 221 to 222
-    // 274 to 276
+    // 274 to 275
     //
     // SPARE = 1082 and onward
 };

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1880,7 +1880,8 @@ namespace charutils
 
         if ((PChar->m_EquipBlock & (1 << equipSlotID)) || !(PItem->getJobs() & (1 << (PChar->GetMJob() - 1))) ||
             (PItem->getSuperiorLevel() > PChar->getMod(Mod::SUPERIOR_LEVEL)) ||
-            (PItem->getReqLvl() > (settings::get<bool>("map.DISABLE_GEAR_SCALING") ? PChar->GetMLevel() : PChar->jobs.job[PChar->GetMJob()])))
+            (PItem->getReqLvl() > (settings::get<bool>("map.DISABLE_GEAR_SCALING") ? PChar->GetMLevel() : PChar->jobs.job[PChar->GetMJob()])) ||
+            !PItem->isEquippableByRace(PChar->look.race))
         {
             return false;
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR prevents players that use the sexchange addon from equipping gear they should not be able to equip (such as RSE gear of different races). This is done by adding a mod that stores the valid races for any RSE gear and then checking this mod server side when players change gear (thus preventing the change). The mod stores a multi-bit flag similar to how the jobs flag works.

Fixes https://github.com/LandSandBoat/server/issues/1147

## Steps to test these changes
Try to equip different RSE gear after using the sexchange addon to change your race on the client side. Notice that you are no longer able to equip RSE gear of the race you changed to. 
