### PR TITLE
[lua] Fixes to chigoe mixins

### DIFF
--- a/scripts/mixins/families/chigoe.lua
+++ b/scripts/mixins/families/chigoe.lua
@@ -37,12 +37,14 @@ g_mixins.families.chigoe = function(chigoeMob)
 
     chigoeMob:addListener('CRITICAL_TAKE', 'CHIGOE_CRITICAL_TAKE', function(mob)
         mob:setMobMod(xi.mobMod.EXP_BONUS, -100)
+        mob:setMobMod(xi.mobMod.NO_DROPS, 1)
         mob:setHP(0)
     end)
 
     chigoeMob:addListener('WEAPONSKILL_TAKE', 'CHIGOE_WEAPONSKILL_TAKE', function(mob, wsid)
         if wsid then
             mob:setMobMod(xi.mobMod.EXP_BONUS, -100)
+            mob:setMobMod(xi.mobMod.NO_DROPS, 1)
             mob:setHP(0)
         end
     end)
@@ -50,6 +52,7 @@ g_mixins.families.chigoe = function(chigoeMob)
     chigoeMob:addListener('ABILITY_TAKE', 'CHIGOE_ABILITY_TAKE', function(mob, user, ability)
         if jobAbilities[ability:getID()] then
             mob:setMobMod(xi.mobMod.EXP_BONUS, -100)
+            mob:setMobMod(xi.mobMod.NO_DROPS, 1)
             mob:setHP(0)
         end
     end)

--- a/scripts/mixins/families/chigoe_pet.lua
+++ b/scripts/mixins/families/chigoe_pet.lua
@@ -5,26 +5,13 @@ require('scripts/globals/mixins')
 g_mixins = g_mixins or {}
 g_mixins.families = g_mixins.families or {}
 
-local jobAbilities = set{
-    xi.jobAbility.SHIELD_BASH,
-    xi.jobAbility.JUMP,
-    xi.jobAbility.HIGH_JUMP,
-    xi.jobAbility.WEAPON_BASH,
-    xi.jobAbility.CHI_BLAST,
-    xi.jobAbility.TOMAHAWK,
-    xi.jobAbility.ANGON,
-    xi.jobAbility.QUICKSTEP,
-    xi.jobAbility.BOXSTEP,
-    xi.jobAbility.STUTTER_STEP,
-    xi.jobAbility.FEATHER_STEP,
-}
-
 g_mixins.families.chigoe_pet = function(hostMob)
     local ID = zones[hostMob:getZoneID()]
 
-    hostMob:addListener('WEAPONSKILL_USE', 'MOB_SPAWN_CHIGOE', function(mob)
+    hostMob:addListener('WEAPONSKILL_USE', 'MOB_SPAWN_CHIGOE', function(mob, target)
         local mobName = mob:getName()
 
+        -- Requires a Chigoe.lua with the chigoe mixin for this to work
         if ID.mob.CHIGOES[mobName] == nil then
             return
         end
@@ -35,30 +22,13 @@ g_mixins.families.chigoe_pet = function(hostMob)
             if not chigoe:isSpawned() then
                 chigoe:setSpawn(hostMob:getXPos() + math.random(-2, 2), hostMob:getYPos() + math.random(-2, 2), hostMob:getZPos() + math.random(-2, 2), hostMob:getRotPos())
                 chigoe:spawn()
+                if target then
+                    chigoe:updateEnmity(target)
+                end
 
-                chigoe:addListener('CRITICAL_TAKE', 'CHIGOE_CRITICAL_TAKE', function(chigoeMob)
-                    chigoeMob:setMobMod(xi.mobMod.EXP_BONUS, -100)
-                    chigoeMob:setHP(0)
-                end)
-
-                chigoe:addListener('WEAPONSKILL_TAKE', 'CHIGOE_WEAPONSKILL_TAKE', function(chigoeMob, wsid)
-                    if wsid then
-                        chigoeMob:setMobMod(xi.mobMod.EXP_BONUS, -100)
-                        chigoeMob:setHP(0)
-                    end
-                end)
-
-                chigoe:addListener('ABILITY_TAKE', 'CHIGOE_ABILITY_TAKE', function(chigoeMob, user, ability, action)
-                    if jobAbilities[ability:getID()] then
-                        chigoeMob:setMobMod(xi.mobMod.EXP_BONUS, -100)
-                        chigoeMob:setHP(0)
-                    end
-                end)
-
-                chigoe:addListener('DEATH', 'CHIGOE_DEATH', function(chigoeMob)
-                    chigoeMob:removeListener('CHIGOE_CRITICAL_TAKE')
-                    chigoeMob:removeListener('CHIGOE_WEAPONSKILL_TAKE')
-                    chigoeMob:removeListener('CHIGOE_ABILITY_TAKE')
+                chigoe:addListener('DISENGAGE', 'CHIGOE_DISENGAGE', function(mobArg)
+                    DespawnMob(mobArg:getID())
+                    mobArg:removeListener('CHIGOE_DISENGAGE')
                 end)
 
                 return


### PR DESCRIPTION
spawn on mobskill behavior in various zones
do not drop loot when instagib happens

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The chigoe mixin for spawning chigoe pets on Marid mobskills had a few issues:
- they didn't spawn engaged
- they never went away
- they had duplicate code (every instance of a chigoe being spawned by this `chigoe_pet` mixin already has a `Chigoe.lua` that defines the instagib behavior)

This PR resolves those

Separately, the `chigoe` mixin did not properly set no_drop on the mobs when they are set to not give xp

## Steps to test these changes

Go to the zones that have chigoe_pet mixin mobs (no idea why that diremite has the mixin, afaict it isn't supposed to spawn chigoes on mobskills?).
![image](https://github.com/LandSandBoat/server/assets/131182600/5b69de24-937f-4b83-bcb9-9bdc5d89c3e7)

Confirm when they mobskill a chigoe spawns and immediately aggros/has proper chigoe behavior

https://imgur.com/nxVM12q
