### PR TITLE
[MISSION]Correct pickaxes given in Sandy 2-3

### DIFF
--- a/scripts/missions/sandoria/2_3_1_Journey_to_Bastok.lua
+++ b/scripts/missions/sandoria/2_3_1_Journey_to_Bastok.lua
@@ -78,7 +78,7 @@ mission.sections =
                 end,
 
                 [423] = function(player, csid, option, npc)
-                    if not npcUtil.giveItem(player, { { xi.item.PICKAXE, 5 } }) then
+                    if not npcUtil.giveItem(player, { { xi.item.PICKAXE, 3 } }) then
                         mission:setVar(player, 'Option', 1)
                     else
                         player:setMissionStatus(mission.areaId, 5)
@@ -86,7 +86,7 @@ mission.sections =
                 end,
 
                 [425] = function(player, csid, option, npc)
-                    if npcUtil.giveItem(player, { { xi.item.PICKAXE, 5 } }) then
+                    if npcUtil.giveItem(player, { { xi.item.PICKAXE, 3 } }) then
                         player:setMissionStatus(mission.areaId, 5)
                         mission:setVar(player, 'Option', 0)
                     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Corrects NPC Grohm to give correct amount of pickaxes during Sandy mission 2-3. 

[Capture](https://www.youtube.com/watch?v=e6lRLlRIal4) 4:32
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Corrects NPC giving more pickaxes than intended.
## Steps to test these changes
!addmission 0 6 
Talk to Halver in Chateau (or !setmissionstatus [NAME] 1 0
Talk to Grohm
Get 3 pickaxes. (No freebies around here, have you see the price of wood lately)?

<!-- Clear and detailed steps to test your changes here -->
