### PR TITLE
[core] Add wardrobe bits at 0x5C to S2C 0x037

### DIFF
--- a/src/map/packets/char_update.cpp
+++ b/src/map/packets/char_update.cpp
@@ -368,4 +368,15 @@ CCharUpdatePacket::CCharUpdatePacket(CCharEntity* PChar)
     packet.Flags6 = flags6;
 
     std::memcpy(&data[0], &packet, sizeof(packet));
+
+    // Mog wardrobe enabled bits (apparently used by windower in get_bag_info(N).enabled):
+    // 0x01 = Wardrobe 3
+    // 0x02 = Wardrobe 4
+    // 0x04 = Unknown (not set in retail?)
+    // 0x08 = Wardrobe 5
+    // 0x10 = Wardrobe 6
+    // 0x20 = Wardrobe 7
+    // 0x40 = Wardrobe 8
+    ref<uint8>(0x5C) = 0x7B;
+    // This field is probably deprecated because the client reads it in and doesn't use it.
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes https://github.com/Windower/Lua/issues/2340
This fixes a windower bug, and is likely deprecated by the client. If something in the future uses this area, it's safe to remove.

Tested at https://github.com/LandSandBoat/server/discussions/5611#discussioncomment-9323006

## Steps to test these changes

see https://github.com/LandSandBoat/server/discussions/5611