### PR TITLE
[LUA] Create Checks for obtaining Semih Lafihna Alter Ego

### DIFF
--- a/scripts/missions/bastok/2_3_2_The_Emissary_Windurst.lua
+++ b/scripts/missions/bastok/2_3_2_The_Emissary_Windurst.lua
@@ -66,15 +66,19 @@ mission.sections =
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
                     if missionStatus == 3 then
-                        local needsSemihTrust = (not player:hasSpell(xi.magic.spell.SEMIH_LAFIHNA) and not player:hasItem(xi.item.CIPHER_OF_SEMIHS_ALTER_EGO)) and 1 or 0
-                        local hasTrustQuest =
-                        (
-                            player:hasKeyItem(xi.ki.SAN_DORIA_TRUST_PERMIT) or
-                            player:hasKeyItem(xi.ki.BASTOK_TRUST_PERMIT) or
-                            player:hasKeyItem(xi.ki.WINDURST_TRUST_PERMIT)
-                        ) and 0 or 1
+                        if xi.settings.main.ENABLE_TRUST_QUESTS == 1 then
+                            local needsSemihTrust = (not player:hasSpell(xi.magic.spell.SEMIH_LAFIHNA) and not player:hasItem(xi.item.CIPHER_OF_SEMIHS_ALTER_EGO)) and 1 or 0
+                            local hasTrustQuest =
+                            (
+                                player:hasKeyItem(xi.ki.SAN_DORIA_TRUST_PERMIT) or
+                                player:hasKeyItem(xi.ki.BASTOK_TRUST_PERMIT) or
+                                player:hasKeyItem(xi.ki.WINDURST_TRUST_PERMIT)
+                            ) and 0 or 1
 
-                        return mission:progressEvent(239, 0, 0, 0, xi.nation.BASTOK, 0, hasTrustQuest, needsSemihTrust)
+                            return mission:progressEvent(239, 0, 0, 0, xi.nation.BASTOK, 0, hasTrustQuest, needsSemihTrust)
+                        else
+                            return mission:progressEvent(239)
+                        end
                     elseif missionStatus == 5 then
                         return mission:event(240)
                     elseif missionStatus == 6 then
@@ -112,6 +116,7 @@ mission.sections =
                     npcUtil.giveKeyItem(player, xi.ki.SWORD_OFFERING)
 
                     if
+                        xi.settings.main.ENABLE_TRUST_QUESTS == 1 and
                         not player:hasSpell(xi.magic.spell.SEMIH_LAFIHNA) and
                         not player:hasItem(xi.item.CIPHER_OF_SEMIHS_ALTER_EGO)
                     then

--- a/scripts/missions/sandoria/2_3_2_Journey_to_Windurst.lua
+++ b/scripts/missions/sandoria/2_3_2_Journey_to_Windurst.lua
@@ -50,9 +50,13 @@ mission.sections =
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
                     if missionStatus == 4 then
-                        local needsSemihTrust = (not player:hasSpell(xi.magic.spell.SEMIH_LAFIHNA) and not player:findItem(xi.item.CIPHER_OF_SEMIHS_ALTER_EGO)) and 1 or 0
+                        if xi.settings.main.ENABLE_TRUST_QUESTS == 1 then
+                            local needsSemihTrust = (not player:hasSpell(xi.magic.spell.SEMIH_LAFIHNA) and not player:findItem(xi.item.CIPHER_OF_SEMIHS_ALTER_EGO)) and 1 or 0
 
-                        return mission:progressEvent(238, 1, 1, 1, 1, xi.nation.SANDORIA, 0, 0, needsSemihTrust)
+                            return mission:progressEvent(238, 1, 1, 1, 1, xi.nation.SANDORIA, 0, 0, needsSemihTrust)
+                        else
+                            return mission:progressEvent(238)
+                        end
                     elseif missionStatus == 5 then
                         return mission:event(240)
                     elseif missionStatus == 6 then
@@ -90,6 +94,7 @@ mission.sections =
                     npcUtil.giveKeyItem(player, xi.ki.SHIELD_OFFERING)
 
                     if
+                        xi.settings.main.ENABLE_TRUST_QUESTS == 1 and
                         not player:hasSpell(xi.magic.spell.SEMIH_LAFIHNA) and
                         not player:findItem(xi.item.CIPHER_OF_SEMIHS_ALTER_EGO)
                     then

--- a/scripts/missions/windurst/2_3_0_The_Three_Kingdoms.lua
+++ b/scripts/missions/windurst/2_3_0_The_Three_Kingdoms.lua
@@ -106,9 +106,13 @@ mission.sections =
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
                     if missionStatus == 0 then
-                        local needsSemihTrust = (not player:hasSpell(xi.magic.spell.SEMIH_LAFIHNA) and not player:findItem(xi.item.CIPHER_OF_SEMIHS_ALTER_EGO)) and 1 or 0
+                        if xi.settings.main.ENABLE_TRUST_QUESTS == 1 then
+                            local needsSemihTrust = (not player:hasSpell(xi.magic.spell.SEMIH_LAFIHNA) and not player:findItem(xi.item.CIPHER_OF_SEMIHS_ALTER_EGO)) and 1 or 0
 
-                        return mission:progressEvent(95, 0, 0, 0, xi.ki.LETTER_TO_THE_CONSULS_WINDURST, 0, 0, 0, needsSemihTrust)
+                            return mission:progressEvent(95, 0, 0, 0, xi.ki.LETTER_TO_THE_CONSULS_WINDURST, 0, 0, 0, needsSemihTrust)
+                        else
+                            return mission:progressEvent(95)
+                        end
                     elseif missionStatus == 11 then
                         return mission:progressEvent(101, 0, 0, xi.ki.ADVENTURERS_CERTIFICATE)
                     else
@@ -124,6 +128,7 @@ mission.sections =
                     npcUtil.giveKeyItem(player, xi.ki.LETTER_TO_THE_CONSULS_WINDURST)
 
                     if
+                        xi.settings.main.ENABLE_TRUST_QUESTS == 1 and
                         not player:hasSpell(xi.magic.spell.SEMIH_LAFIHNA) and
                         not player:findItem(xi.item.CIPHER_OF_SEMIHS_ALTER_EGO)
                     then

--- a/scripts/quests/hiddenQuests/Trust_Semih.lua
+++ b/scripts/quests/hiddenQuests/Trust_Semih.lua
@@ -8,7 +8,8 @@ quest.sections =
 {
     {
         check = function(player, questVars, vars)
-            return not player:hasSpell(xi.magic.spell.SEMIH_LAFIHNA) and
+            return xi.settings.main.ENABLE_TRUST_QUESTS == 1 and
+                not player:hasSpell(xi.magic.spell.SEMIH_LAFIHNA) and
                 not player:findItem(xi.item.CIPHER_OF_SEMIHS_ALTER_EGO) and
                 player:hasCompletedMission(xi.mission.log_id.ROV, xi.mission.id.rov.THE_PATH_UNTRAVELED)
         end,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Implements a check established in xi.settings.main.ENABLE_TRUST_QUESTS for obtaining all instances of Cipher_Of_SEMIH_LAFIHNA_Trust_Alter_Ego
Checks for xi.settings.main.ENABLE_TRUST_QUESTS 1|0
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Pick a nation and add mission 2-3.
Speak with NPC's at consulate and then talk to Semih Lafihna.
If xi.settings.main.ENABLE_TRUST_QUESTS is 1 player will receive scroll.
if xi.settings.main.ENABLE_TRUST_QUESTS is 0 players will not receive scroll.
Puts check in for hidden quest Trust_Semih
<!-- Clear and detailed steps to test your changes here -->
