### PR TITLE
Remove duplicate mobIds declaration in 'Thief in Norg' declaration.

### DIFF
--- a/scripts/battlefields/Waughroon_Shrine/thief_in_norg.lua
+++ b/scripts/battlefields/Waughroon_Shrine/thief_in_norg.lua
@@ -55,15 +55,6 @@ content.groups =
             battlefield:setStatus(xi.battlefield.status.WON)
         end,
     },
-
-    {
-        mobIds =
-        {
-            { waughroonID.mob.GAKI + 4  },
-            { waughroonID.mob.GAKI + 9  },
-            { waughroonID.mob.GAKI + 14 },
-        },
-    },
 }
 
 return content:register()


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Currently the battlefield will not complete as expected when all mobs are dead. I believe this is due to the duplicate declaration of mobIds in the content table. Removing it allows the battlefield to complete successfully.

## Steps to test these changes
!zone Waughroon Shrine
!togglegm
Select "a Thief in Norg"
Kill mobs -- see that battlefield will not end.
Remove "duplicate" mobIds section in table, and try again, Battlefield will complete this time.
