### PR TITLE
[QUEST]Foreman Best Friend xp OR map

### DIFF
--- a/scripts/quests/bastok/A_Foremans_Best_Friend.lua
+++ b/scripts/quests/bastok/A_Foremans_Best_Friend.lua
@@ -9,10 +9,8 @@ local quest = Quest:new(xi.questLog.BASTOK, xi.quest.id.bastok.A_FOREMANS_BEST_F
 
 quest.reward =
 {
-    exp      = 2000,
     fame     = 60,
     fameArea = xi.fameArea.BASTOK,
-    keyItem  = xi.ki.MAP_OF_THE_GUSGEN_MINES,
 }
 
 quest.sections =
@@ -58,6 +56,11 @@ quest.sections =
                 [112] = function(player, csid, option, npc)
                     if quest:complete(player) then
                         player:confirmTrade()
+                        if player:hasKeyItem(xi.ki.MAP_OF_THE_GUSGEN_MINES) then
+                            player:addExp(2000)
+                        else
+                            npcUtil.giveKeyItem(player, xi.ki.MAP_OF_THE_GUSGEN_MINES)
+                        end
                     end
                 end,
             },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Updates A foremans best friends quest in Bastok to give EITHER map of gusgen mines OR 2k exp if already has map.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!addquest 1 9
!giveitem dog_collar
If player doesnt have map then will give map. Otherwise will give 2k xp.
<!-- Clear and detailed steps to test your changes here -->
