### PR TITLE
[lua] Adjust accVaries to reduce accuracy not hitrate

### DIFF
--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -246,7 +246,7 @@ xi.job_utils.dancer.useStepAbility = function(player, target, ability, action, s
         player:delTP(100 + player:getMod(xi.mod.STEP_TP_CONSUMED))
     end
 
-    if math.random() <= xi.weaponskills.getHitRate(player, target, true, 10 + player:getMod(xi.mod.STEP_ACCURACY)) then
+    if math.random() <= xi.weaponskills.getHitRate(player, target, 10 + player:getMod(xi.mod.STEP_ACCURACY)) then
         local maxSteps         = player:getMainJob() == xi.job.DNC and 10 or 5
         local debuffEffect     = target:getStatusEffect(stepEffect)
         local origDebuffStacks = 0
@@ -360,7 +360,7 @@ xi.job_utils.dancer.useDesperateFlourishAbility = function(player, target, abili
     setFinishingMoves(player, numMoves - 1)
 
     if
-        math.random() <= xi.weaponskills.getHitRate(player, target, true, player:getJobPointLevel(xi.jp.FLOURISH_I_EFFECT)) or
+        math.random() <= xi.weaponskills.getHitRate(player, target, player:getJobPointLevel(xi.jp.FLOURISH_I_EFFECT)) or
         (player:hasStatusEffect(xi.effect.SNEAK_ATTACK) and player:isBehind(target))
     then
         local spell  = GetSpell(xi.magic.spell.GRAVITY)
@@ -397,7 +397,7 @@ xi.job_utils.dancer.useViolentFlourishAbility = function(player, target, ability
     setFinishingMoves(player, numMoves - 1)
 
     if
-        math.random() <= xi.weaponskills.getHitRate(player, target, true, 100) or
+        math.random() <= xi.weaponskills.getHitRate(player, target, 100) or
         (player:hasStatusEffect(xi.effect.SNEAK_ATTACK) and player:isBehind(target))
     then
         local hitType = 3


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

I know there are comments that accVaries is possibly not implemented properly, but the current intention of the param is to reduce accuracy by a percent based on TP:
![image](https://github.com/LandSandBoat/server/assets/131182600/cf6b035e-3b28-48e9-bb77-acb02c30ece7)

The current code reduces `hitRate` by the percent of `accuracy` (ranged or physical depending on the ws), but it ignores the evasion. I think someone was trying to be clever by utilizing the same divisor as the getHitRate functions `(acc - eva)/200`, but the result is that `hitRate` reduction is only a function of accuracy, meaning the explicit `hitRate` penalty is increased as player accuracy increases.

This PR rearranges the `accVaries` consideration to before `hitRate` is calculated and adjusts the `calcParams.bonusAcc` value.

Note that previous code had a param to not cap `hitRate` at 95% so `accVaries` could be considered later, then clamped `hitRate`. So this new code is functionally the same there.

## Steps to test these changes

Ensure dancer steps, desperate flourish, and violent flourish work, as they utilize `xi.weaponskills.getHitRate`

add a print in the `getRangedHitRate` and `xi.weaponskills.getHitRate` functions to view the hitrate and bonusacc to verify things are working as expected.

![image](https://github.com/LandSandBoat/server/assets/131182600/f3118bc9-f7d2-49bc-ae34-6dba2927ee0e)
^^ first is the physical first hit's hitrate due to +100 acc. Second is regular hitrate