### PR TITLE
[Cleanup] Shift-proof "R" Zones

### DIFF
--- a/scripts/missions/bastok/7_1_The_Final_Image.lua
+++ b/scripts/missions/bastok/7_1_The_Final_Image.lua
@@ -134,7 +134,7 @@ mission.sections =
                             return mission:keyItem(xi.ki.REINFORCED_CERMET)
                         elseif
                             -- TODO: xi.settings default (300s) is used to hide this QM on spawn.  Verify if this is accurate since we're moving the QM
-                            npcUtil.popFromQM(player, npc, { romaeveID.mob.MOKKURKALFI_I, romaeveID.mob.MOKKURKALFI_II }, { claim = false, look = true, radius = 2 })
+                            npcUtil.popFromQM(player, npc, { romaeveID.mob.MOKKURKALFI, romaeveID.mob.MOKKURKALFI + 1 }, { claim = false, look = true, radius = 2 })
                         then
                             local newPosition = npcUtil.pickNewPosition(npc:getID(), romaeveID.npc.BASTOK_7_1_QM_POS, true)
                             npcUtil.queueMove(npc, newPosition)

--- a/scripts/zones/Rala_Waterways_U/IDs.lua
+++ b/scripts/zones/Rala_Waterways_U/IDs.lua
@@ -18,7 +18,7 @@ zones[xi.zone.RALA_WATERWAYS_U] =
     },
     mob =
     {
-        ARCIELA_BTS = 17838146, -- Arciela (Behind the Sluices)
+        ARCIELA_BTS = GetFirstID('Arciela'), -- Behind the Sluices
     },
     npc =
     {

--- a/scripts/zones/Ranguemont_Pass/IDs.lua
+++ b/scripts/zones/Ranguemont_Pass/IDs.lua
@@ -31,18 +31,15 @@ zones[xi.zone.RANGUEMONT_PASS] =
     },
     mob =
     {
-        GLOOM_EYE_PH =
-        {
-            [17457200] = 17457204,
-        },
+        GLOOM_EYE    = GetFirstID('Gloom_Eye'),
         TAISAIJIN_PH =
         {
             17457213, -- -18.325 1.830 -114.932
             17457214, -- -5.188 11.730 -141.503
             17457215, -- 59.15 -120 50
         },
-        TAISAIJIN    = 17457216,
-        TROS         = 17457309,
+        TAISAIJIN    = GetFirstID('Taisaijin'),
+        TROS         = GetFirstID('Tros'),
     },
     npc =
     {

--- a/scripts/zones/Ranguemont_Pass/mobs/Seeker_Bats.lua
+++ b/scripts/zones/Ranguemont_Pass/mobs/Seeker_Bats.lua
@@ -7,12 +7,17 @@ local ID = zones[xi.zone.RANGUEMONT_PASS]
 -----------------------------------
 local entity = {}
 
+local gloomEyePHTable =
+{
+    [ID.mob.GLOOM_EYE - 4] = ID.mob.GLOOM_EYE,
+}
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 603, 1, xi.regime.type.GROUNDS)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.GLOOM_EYE_PH, 10, 3600) -- 1 hour
+    xi.mob.phOnDespawn(mob, gloomEyePHTable, 10, 3600) -- 1 hour
 end
 
 return entity

--- a/scripts/zones/Riverne-Site_A01/IDs.lua
+++ b/scripts/zones/Riverne-Site_A01/IDs.lua
@@ -29,21 +29,13 @@ zones[xi.zone.RIVERNE_SITE_A01] =
     },
     mob =
     {
-        HELIODROMOS_PH_OFFSET    = 16900107,
-        HELIODROMOS_OFFSET       = 16900110,
-        CARMINE_DOBSONFLY_OFFSET = 16900230,
+        HELIODROMOS_OFFSET       = GetFirstID('Heliodromos'),
+        CARMINE_DOBSONFLY_OFFSET = GetFirstID('Carmine_Dobsonfly'),
+        AIATAR                   = GetFirstID('Aiatar'),
     },
     npc =
     {
-        DISPLACEMENT_OFFSET = 16900335,
-    },
-    AIATAR_PH =
-    {
-        [16900301] = 16900306,
-        [16900302] = 16900306,
-        [16900303] = 16900306,
-        [16900304] = 16900306,
-        [16900305] = 16900306,
+        DISPLACEMENT_OFFSET = GetFirstID('Spatial_Displacement'),
     },
 }
 

--- a/scripts/zones/Riverne-Site_A01/mobs/Flamedrake.lua
+++ b/scripts/zones/Riverne-Site_A01/mobs/Flamedrake.lua
@@ -6,11 +6,20 @@ local ID = zones[xi.zone.RIVERNE_SITE_A01]
 -----------------------------------
 local entity = {}
 
+local aiatarPHTable =
+{
+    [ID.mob.AIATAR - 5] = ID.mob.AIATAR,
+    [ID.mob.AIATAR - 4] = ID.mob.AIATAR,
+    [ID.mob.AIATAR - 3] = ID.mob.AIATAR,
+    [ID.mob.AIATAR - 2] = ID.mob.AIATAR,
+    [ID.mob.AIATAR - 1] = ID.mob.AIATAR,
+}
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.AIATAR_PH, 10, 75600) -- 50 minutes
+    xi.mob.phOnDespawn(mob, aiatarPHTable, 10, 75600) -- 50 minutes
 end
 
 return entity

--- a/scripts/zones/Riverne-Site_A01/mobs/Heliodromos.lua
+++ b/scripts/zones/Riverne-Site_A01/mobs/Heliodromos.lua
@@ -25,7 +25,7 @@ entity.onMobRoam = function(mob)
         end
 
         -- allow placeholders to respawn
-        for i = ID.mob.HELIODROMOS_PH_OFFSET, ID.mob.HELIODROMOS_PH_OFFSET + 2 do
+        for i = ID.mob.HELIODROMOS_OFFSET - 3, ID.mob.HELIODROMOS_OFFSET - 1 do
             local ph = GetMobByID(i)
             DisallowRespawn(i, false)
             ph:setRespawnTime(GetMobRespawnTime(ph:getID()))
@@ -53,7 +53,7 @@ entity.onMobDespawn = function(mob)
         SetServerVariable('Heliodromos_ToD', os.time() + math.random(43200, 54000)) -- 12 to 15 hours
 
         -- allow placeholders to respawn
-        for i = ID.mob.HELIODROMOS_PH_OFFSET, ID.mob.HELIODROMOS_PH_OFFSET + 2 do
+        for i = ID.mob.HELIODROMOS_OFFSET - 3, ID.mob.HELIODROMOS_OFFSET - 1 do
             local ph = GetMobByID(i)
             DisallowRespawn(i, false)
             ph:setRespawnTime(GetMobRespawnTime(ph:getID()))

--- a/scripts/zones/Riverne-Site_A01/mobs/Hippogryph.lua
+++ b/scripts/zones/Riverne-Site_A01/mobs/Hippogryph.lua
@@ -8,7 +8,7 @@ local ID = zones[xi.zone.RIVERNE_SITE_A01]
 local entity = {}
 
 local function disturbMob(mob)
-    local offset = mob:getID() - ID.mob.HELIODROMOS_PH_OFFSET
+    local offset = mob:getID() - ID.mob.HELIODROMOS_OFFSET - 3
     if offset >= 0 and offset <= 2 then
         SetServerVariable('Heliodromos_ToD', os.time() + math.random(43200, 54000)) -- 12 to 15 hours
     end
@@ -38,7 +38,7 @@ entity.onMobRoam = function(mob)
 
         if noHeliodromosSpawned then
             -- despawn placeholders
-            for i = ID.mob.HELIODROMOS_PH_OFFSET, ID.mob.HELIODROMOS_PH_OFFSET + 2 do
+            for i = ID.mob.HELIODROMOS_OFFSET - 3, ID.mob.HELIODROMOS_OFFSET - 1 do
                 DisallowRespawn(i, true)
                 DespawnMob(i)
             end

--- a/scripts/zones/Riverne-Site_B01/IDs.lua
+++ b/scripts/zones/Riverne-Site_B01/IDs.lua
@@ -30,20 +30,12 @@ zones[xi.zone.RIVERNE_SITE_B01] =
     },
     mob =
     {
-        IMDUGUD_PH       =
-        {
-            [16896101] = 16896107, -- 650.770 20.052 676.513
-            [16896102] = 16896107, -- 643.308 20.049 652.354
-            [16896103] = 16896107, -- 669.574 19.215 623.129
-            [16896104] = 16896107, -- 691.504 21.296 583.884
-            [16896105] = 16896107, -- 687.199 21.161 582.560
-            [16896106] = 16896107, -- 666.737 20.012 652.352
-        },
-        UNSTABLE_CLUSTER = 16896155,
+        IMDUGUD          = GetFirstID('Imdugud'),
+        UNSTABLE_CLUSTER = GetFirstID('Unstable_Cluster'),
     },
     npc =
     {
-        DISPLACEMENT_OFFSET = 16896184,
+        DISPLACEMENT_OFFSET = GetFirstID('Spatial_Displacement'),
     },
 }
 

--- a/scripts/zones/Riverne-Site_B01/mobs/Nimbus_Hippogryph.lua
+++ b/scripts/zones/Riverne-Site_B01/mobs/Nimbus_Hippogryph.lua
@@ -7,11 +7,21 @@ local ID = zones[xi.zone.RIVERNE_SITE_B01]
 -----------------------------------
 local entity = {}
 
+local imdugudPHTable =
+{
+    [ID.mob.IMDUGUD - 6] = ID.mob.IMDUGUD, -- 650.770 20.052 676.513
+    [ID.mob.IMDUGUD - 5] = ID.mob.IMDUGUD, -- 643.308 20.049 652.354
+    [ID.mob.IMDUGUD - 4] = ID.mob.IMDUGUD, -- 669.574 19.215 623.129
+    [ID.mob.IMDUGUD - 3] = ID.mob.IMDUGUD, -- 691.504 21.296 583.884
+    [ID.mob.IMDUGUD - 2] = ID.mob.IMDUGUD, -- 687.199 21.161 582.560
+    [ID.mob.IMDUGUD - 1] = ID.mob.IMDUGUD, -- 666.737 20.012 652.352
+}
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.IMDUGUD_PH, 10, 75600) -- 21 hours
+    xi.mob.phOnDespawn(mob, imdugudPHTable, 10, 75600) -- 21 hours
 end
 
 return entity

--- a/scripts/zones/RoMaeve/IDs.lua
+++ b/scripts/zones/RoMaeve/IDs.lua
@@ -35,19 +35,10 @@ zones[xi.zone.ROMAEVE] =
     },
     mob =
     {
-        NIGHTMARE_VASE_PH =
-        {
-            [17276981] = 17276982, -- -101.575 -6.099 -1.520 (west)
-            [17276987] = 17276992, -- 59.825 -5.760 25.123 (east)
-        },
-        ROGUE_RECEPTACLE_PH =
-        {
-            [17277075] = 17277079,
-            [17277078] = 17277079,
-        },
-        MOKKURKALFI_I     = 17276929,
-        MOKKURKALFI_II    = 17276930,
-        ELDHRIMNIR        = 17277126,
+        NIGHTMARE_VASE   = GetTableOfIDs('Nightmare_Vase'), -- 2 NMs
+        ROGUE_RECEPTACLE = GetFirstID('Rogue_Receptacle'),
+        ELDHRIMNIR       = GetFirstID('Eldhrimnir'),
+        MOKKURKALFI      = GetFirstID('Mokkurkalfi'),
     },
     npc =
     {
@@ -65,8 +56,8 @@ zones[xi.zone.ROMAEVE] =
             [10] = { -160.000, -6.000, -107.000 }, -- D-10
         },
 
-        MOONGATE_OFFSET = 17277196,
-        BASTOK_7_1_QM   = 17277208,
+        MOONGATE_OFFSET = GetFirstID('_3e0'),
+        BASTOK_7_1_QM   = GetFirstID('qm2'),
     },
 }
 

--- a/scripts/zones/RoMaeve/mobs/Magic_Flagon.lua
+++ b/scripts/zones/RoMaeve/mobs/Magic_Flagon.lua
@@ -7,13 +7,25 @@ local ID = zones[xi.zone.ROMAEVE]
 -----------------------------------
 local entity = {}
 
+local nightmarePHTable =
+{
+    [ID.mob.NIGHTMARE_VASE[1] - 1] = ID.mob.NIGHTMARE_VASE[1], -- -101.575 -6.099 -1.520 (west)
+    [ID.mob.NIGHTMARE_VASE[2] - 5] = ID.mob.NIGHTMARE_VASE[2], -- 59.825 -5.760 25.123 (east) (Needs Audit)
+}
+
+local roguePHTable =
+{
+    [ID.mob.ROGUE_RECEPTACLE - 4] = ID.mob.ROGUE_RECEPTACLE,
+    [ID.mob.ROGUE_RECEPTACLE - 1] = ID.mob.ROGUE_RECEPTACLE,
+}
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 120, 1, xi.regime.type.FIELDS)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.NIGHTMARE_VASE_PH, 10, 3600) -- 1 hour
-    xi.mob.phOnDespawn(mob, ID.mob.ROGUE_RECEPTACLE_PH, 10, 7200) -- 2 hour
+    xi.mob.phOnDespawn(mob, nightmarePHTable, 10, 3600) -- 1 hour
+    xi.mob.phOnDespawn(mob, roguePHTable, 10, 7200) -- 2 hour
 end
 
 return entity

--- a/scripts/zones/Rolanberry_Fields/IDs.lua
+++ b/scripts/zones/Rolanberry_Fields/IDs.lua
@@ -49,27 +49,12 @@ zones[xi.zone.ROLANBERRY_FIELDS] =
 
     mob =
     {
-        BLACK_TRIPLE_STARS_PH =
-        {
-            [17227968] = 17227972, -- 4 -16 -119 (north)
-            [17227988] = 17227992, -- 76 -15 -209 (south)
-        },
-
-        DROOLING_DAISY_PH =
-        {
-            [17228235] = 17228236, -- -691.786 -34.802 -335.763
-        },
-
-        ELDRITCH_EDGE_PH  =
-        {
-            [17228152] = 17228150, -- 440 -28 -44
-            [17228148] = 17228150, -- 396.992 -24.01 -152.613
-            [17228149] = 17228150, -- 395 -24 -147
-        },
-
-        SILK_CATERPILLAR  = 17227782,
-        SIMURGH           = 17228242,
-        CHUGLIX_BERRYPAWS = 17228249,
+        BLACK_TRIPLE_STARS = GetTableOfIDs('Black_Triple_Stars'), -- 2 NMs
+        DROOLING_DAISY     = GetFirstID('Drooling_Daisy'),
+        ELDRITCH_EDGE      = GetFirstID('Eldritch_Edge'),
+        SILK_CATERPILLAR   = GetFirstID('Silk_Caterpillar'),
+        SIMURGH            = GetFirstID('Simurgh'),
+        CHUGLIX_BERRYPAWS  = GetFirstID('Chuglix_Berrypaws'),
 
         VOIDWALKER =
         {

--- a/scripts/zones/Rolanberry_Fields/mobs/Evil_Weapon.lua
+++ b/scripts/zones/Rolanberry_Fields/mobs/Evil_Weapon.lua
@@ -7,11 +7,18 @@ local ID = zones[xi.zone.ROLANBERRY_FIELDS]
 -----------------------------------
 local entity = {}
 
+local eldritchPHTable =
+{
+    [ID.mob.ELDRITCH_EDGE + 2] = ID.mob.ELDRITCH_EDGE, -- 440 -28 -44
+    [ID.mob.ELDRITCH_EDGE - 2] = ID.mob.ELDRITCH_EDGE, -- 396.992 -24.01 -152.613
+    [ID.mob.ELDRITCH_EDGE - 1] = ID.mob.ELDRITCH_EDGE, -- 395 -24 -147
+}
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.ELDRITCH_EDGE_PH, 20, math.random(5400, 7200)) -- 90 to 120 minutes
+    xi.mob.phOnDespawn(mob, eldritchPHTable, 20, math.random(5400, 7200)) -- 90 to 120 minutes
 end
 
 return entity

--- a/scripts/zones/Rolanberry_Fields/mobs/Midnight_Wings.lua
+++ b/scripts/zones/Rolanberry_Fields/mobs/Midnight_Wings.lua
@@ -7,11 +7,17 @@ local ID = zones[xi.zone.ROLANBERRY_FIELDS]
 -----------------------------------
 local entity = {}
 
+local tripleStardPHTable =
+{
+    [ID.mob.BLACK_TRIPLE_STARS[1] - 4] = ID.mob.BLACK_TRIPLE_STARS[1], -- 4 -16 -119 (north)
+    [ID.mob.BLACK_TRIPLE_STARS[2] - 4] = ID.mob.BLACK_TRIPLE_STARS[2], -- 76 -15 -209 (south)
+}
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.BLACK_TRIPLE_STARS_PH, 10, 3600) -- 1 hour
+    xi.mob.phOnDespawn(mob, tripleStardPHTable, 10, 3600) -- 1 hour
 end
 
 return entity

--- a/scripts/zones/Rolanberry_Fields/mobs/Ochu.lua
+++ b/scripts/zones/Rolanberry_Fields/mobs/Ochu.lua
@@ -7,12 +7,17 @@ local ID = zones[xi.zone.ROLANBERRY_FIELDS]
 -----------------------------------
 local entity = {}
 
+local droolingPHTable =
+{
+    [ID.mob.DROOLING_DAISY - 1] = ID.mob.DROOLING_DAISY, -- -691.786 -34.802 -335.763
+}
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 88, 1, xi.regime.type.FIELDS)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.DROOLING_DAISY_PH, 10, 3600) -- 1 hour
+    xi.mob.phOnDespawn(mob, droolingPHTable, 10, 3600) -- 1 hour
 end
 
 return entity

--- a/scripts/zones/Rolanberry_Fields_[S]/IDs.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/IDs.lua
@@ -32,14 +32,9 @@ zones[xi.zone.ROLANBERRY_FIELDS_S] =
     },
     mob =
     {
-        DELICIEUSE_DELPHINE_PH =
-        {
-            [17150279] = 17150280, -- -484.535 -23.756 -467.462
-        },
-
-        ERLE = GetFirstID('Erle'), -- PH at -341 4 6
-
-        DYINYINGA = GetFirstID('Dyinyinga'), -- PH at 170 -31.8 -170
+        DELICIEUSE_DELPHINE_PH = GetFirstID('Delicieuse_Delphine'),
+        ERLE                   = GetFirstID('Erle'), -- PH at -341 4 6
+        DYINYINGA              = GetFirstID('Dyinyinga'), -- PH at 170 -31.8 -170
 
         VOIDWALKER =
         {

--- a/scripts/zones/Rolanberry_Fields_[S]/mobs/Ochu.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/mobs/Ochu.lua
@@ -7,11 +7,16 @@ local ID = zones[xi.zone.ROLANBERRY_FIELDS_S]
 -----------------------------------
 local entity = {}
 
+local delicieusePHTable =
+{
+    [ID.mob.DELICIEUSE_DELPHINE_PH - 1] = ID.mob.DELICIEUSE_DELPHINE_PH, -- -484.535 -23.756 -467.462
+}
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.DELICIEUSE_DELPHINE_PH, 10, 5400) -- 1.5 hours
+    xi.mob.phOnDespawn(mob, delicieusePHTable, 10, 5400) -- 1.5 hours
 end
 
 return entity

--- a/scripts/zones/Ruhotz_Silvermines/IDs.lua
+++ b/scripts/zones/Ruhotz_Silvermines/IDs.lua
@@ -18,7 +18,7 @@ zones[xi.zone.RUHOTZ_SILVERMINES] =
     },
     mob =
     {
-        SAPPHIRINE_QUADAV_OFFSET = 17158192,
+        SAPPHIRINE_QUADAV_OFFSET = GetFirstID('Sapphirine_Quadav'),
     },
     npc =
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Shift-proof the following zones:
Ruhotz Silvermines 
Rolanberry Fields and [S]
Riverne Site A 01 and B 01
Ranguemont Pass
Rala Waterways U
RoMaeve
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
All lotto NMs, one ID change to a quest.
<!-- Clear and detailed steps to test your changes here -->
