### PR TITLE
[Quest]Distant Loyalties and associated quests

### DIFF
--- a/scripts/quests/bastok/Father_Figure.lua
+++ b/scripts/quests/bastok/Father_Figure.lua
@@ -20,7 +20,9 @@ quest.sections =
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_AVAILABLE and
                 player:hasCompletedQuest(xi.questLog.BASTOK, xi.quest.id.bastok.THE_ELVAAN_GOLDSMITH) and
-                player:getFameLevel(xi.fameArea.BASTOK) >= 2
+                player:getFameLevel(xi.fameArea.BASTOK) >= 2 and
+                player:getQuestStatus(xi.questLog.SANDORIA, xi.quest.id.sandoria.DISTANT_LOYALTIES) ~= xi.questStatus.QUEST_ACCEPTED
+                -- quest is blocked if Distant Loyalties is active.
         end,
 
         [xi.zone.BASTOK_MARKETS] =

--- a/scripts/quests/bastok/The_Elvaan_Goldsmith.lua
+++ b/scripts/quests/bastok/The_Elvaan_Goldsmith.lua
@@ -18,7 +18,9 @@ quest.sections =
 {
     {
         check = function(player, status, vars)
-            return status == xi.questStatus.QUEST_AVAILABLE
+            return status == xi.questStatus.QUEST_AVAILABLE and
+            player:getQuestStatus(xi.questLog.SANDORIA, xi.quest.id.sandoria.DISTANT_LOYALTIES) ~= xi.questStatus.QUEST_ACCEPTED
+            --quest is blocked if Distant Loyalties is started
         end,
 
         [xi.zone.BASTOK_MARKETS] =
@@ -40,7 +42,8 @@ quest.sections =
                 (
                     status == xi.questStatus.QUEST_COMPLETED and
                     player:getFameLevel(xi.fameArea.BASTOK) == 1 and
-                    not quest:getMustZone(player)
+                    not quest:getMustZone(player) or
+                    (player:hasCompletedQuest(xi.questLog.BASTOK, xi.quest.id.bastok.THE_RETURN_OF_THE_ADVENTURER)) -- allows repeat only after this quest is completed.
                 )
         end,
 

--- a/scripts/quests/sandoria/Distant_Loyalties.lua
+++ b/scripts/quests/sandoria/Distant_Loyalties.lua
@@ -1,0 +1,159 @@
+-----------------------------------
+-- Distant Loyalties
+-----------------------------------
+-- !addquest 0 74
+-- Femitte: !gotoid 17719491
+-- Michea: !gotoid 17739820
+-----------------------------------
+
+local quest = Quest:new(xi.questLog.SANDORIA, xi.quest.id.sandoria.DISTANT_LOYALTIES)
+
+quest.reward =
+{
+    fame     = 30,
+    fameArea = xi.fameArea.SANDORIA,
+    item     = xi.item.WHITE_CAPE,
+}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_AVAILABLE and
+                player:getFameLevel(xi.fameArea.SANDORIA) >= 4
+        end,
+
+        [xi.zone.SOUTHERN_SAN_DORIA] =
+        {
+            ['Femitte'] = quest:progressEvent(663),
+
+            onEventFinish =
+            {
+                [663] = function(player, csid, option, npc)
+                    if option == 0 then
+                        quest:begin(player)
+                        npcUtil.giveKeyItem(player, xi.ki.GOLDSMITHING_ORDER)
+                    end
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_ACCEPTED
+        end,
+
+        [xi.zone.SOUTHERN_SAN_DORIA] =
+        {
+            ['Femitte'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:hasKeyItem(xi.ki.GOLDSMITHING_ORDER) then
+                        return quest:event(661)
+                    elseif
+                        quest:getVar(player, 'Prog') == 3 and
+                        player:hasKeyItem(xi.ki.MYTHRIL_HEARTS)
+                    then
+                        return quest:progressEvent(665)
+                    end
+                end,
+            },
+            ['Rouva'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:hasKeyItem(xi.ki.GOLDSMITHING_ORDER) then
+                        return quest:event(664)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [665] = function(player, csid, option, npc)
+                    if quest:complete(player) then
+                        quest:setVar(player, 'finalCS', 1)
+                        player:delKeyItem(xi.ki.MYTHRIL_HEARTS)
+                    end
+                end,
+            },
+        },
+
+        [xi.zone.BASTOK_MARKETS] =
+        {
+            ['Michea'] =
+            {
+                onTrade = function(player, npc, trade)
+                    if
+                        npcUtil.tradeHasExactly(trade, xi.item.MYTHRIL_INGOT) and
+                        quest:getVar(player, 'Prog') == 1
+                    then
+                        return quest:progressEvent(317)
+                    end
+                end,
+
+                onTrigger = function(player, npc)
+                    local questProgress = quest:getVar(player, 'Prog')
+
+                    if player:hasKeyItem(xi.ki.GOLDSMITHING_ORDER) then
+                        return quest:progressEvent(315)
+                    elseif questProgress == 1 then
+                        return quest:event(316)
+                    elseif
+                        questProgress == 2 and
+                        not player:needToZone()
+                    then
+                        return quest:progressEvent(318)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [315] = function(player, csid, option, npc)
+                    player:delKeyItem(xi.ki.GOLDSMITHING_ORDER)
+                    quest:setVar(player, 'Prog', 1)
+                end,
+
+                [317] = function(player, csid, option, npc)
+                    player:confirmTrade()
+                    quest:setVar(player, 'Prog', 2)
+                    quest:setMustZone(player)
+                end,
+
+                [318] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 3)
+                    npcUtil.giveKeyItem(player, xi.ki.MYTHRIL_HEARTS)
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_COMPLETED
+        end,
+
+        [xi.zone.BASTOK_MARKETS] =
+        {
+            ['Michea'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'finalCS') == 1 then
+                        return quest:progressEvent(319)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [319] = function(player, csid, option, npc)
+                    player:delKeyItem(xi.ki.GOLDSMITHING_ORDER)
+                    quest:setVar(player, 'finalCS', 0)
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/zones/Bastok_Markets/npcs/Michea.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Michea.lua
@@ -8,59 +8,15 @@
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local distantLoyalties = player:getQuestStatus(xi.questLog.SANDORIA, xi.quest.id.sandoria.DISTANT_LOYALTIES)
-
-    -- DISTANT LOYALTIES
-    if
-        distantLoyalties == xi.questStatus.QUEST_ACCEPTED and
-        player:getCharVar('DistantLoyaltiesProgress') == 2 and
-        npcUtil.tradeHas(trade, xi.item.MYTHRIL_INGOT)
-    then
-        player:startEvent(317)
-    end
 end
 
 entity.onTrigger = function(player, npc)
-    local distantLoyalties = player:getQuestStatus(xi.questLog.SANDORIA, xi.quest.id.sandoria.DISTANT_LOYALTIES)
-    local distantLoyaltiesProgress = player:getCharVar('DistantLoyaltiesProgress')
-
-    -- DISTANT LOYALTIES
-    if
-        distantLoyalties == xi.questStatus.QUEST_ACCEPTED and
-        distantLoyaltiesProgress >= 1 and
-        distantLoyaltiesProgress <= 3
-    then
-        if
-            distantLoyaltiesProgress == 1 and
-            player:hasKeyItem(xi.ki.GOLDSMITHING_ORDER)
-        then
-            player:startEvent(315)
-        elseif distantLoyaltiesProgress == 2 then
-            player:startEvent(316)
-        elseif distantLoyaltiesProgress == 3 and player:needToZone() then
-            player:startEvent(317)
-        elseif distantLoyaltiesProgress == 3 and not player:needToZone() then
-            player:startEvent(318)
-        end
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    -- DISTANT LOYALTIES
-    if csid == 315 then
-        player:delKeyItem(xi.ki.GOLDSMITHING_ORDER)
-        player:setCharVar('DistantLoyaltiesProgress', 2)
-    elseif csid == 317 then
-        player:confirmTrade()
-        player:setCharVar('DistantLoyaltiesProgress', 3)
-        player:needToZone(true)
-    elseif csid == 318 then
-        player:setCharVar('DistantLoyaltiesProgress', 4)
-        npcUtil.giveKeyItem(player, xi.ki.MYTHRIL_HEARTS)
-    end
 end
 
 return entity

--- a/scripts/zones/Southern_San_dOria/DefaultActions.lua
+++ b/scripts/zones/Southern_San_dOria/DefaultActions.lua
@@ -8,6 +8,7 @@ return {
     ['Cahaurme']    = { text = ID.text.NOTHING_TO_REPORT },
     ['Hae_Jakhya']  = { event = 610 },
     ['Rosel']       = { text = ID.text.ROSEL_GREETINGS },
+    ['HRouva']      = { event = 662 },
     ['Sobane']      = { text = ID.text.SOBANE_DIALOG },
     ['Valderotaux'] = { event = 58 },
 }

--- a/scripts/zones/Southern_San_dOria/npcs/Femitte.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Femitte.lua
@@ -4,16 +4,12 @@
 -- Involved in Quest: Lure of the Wildcat (San d'Oria), Distant Loyalties
 -- !pos -17 2 10 230
 -----------------------------------
-local ID = zones[xi.zone.SOUTHERN_SAN_DORIA]
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local distantLoyaltiesProgress = player:getCharVar('DistantLoyaltiesProgress')
-    local distantLoyalties = player:getQuestStatus(xi.questLog.SANDORIA, xi.quest.id.sandoria.DISTANT_LOYALTIES)
     local wildcatSandy = player:getCharVar('WildcatSandy')
 
     if
@@ -21,21 +17,6 @@ entity.onTrigger = function(player, npc)
         not utils.mask.getBit(wildcatSandy, 3)
     then
         player:startEvent(807)
-    elseif
-        player:getFameLevel(xi.fameArea.SANDORIA) >= 4 and
-        distantLoyalties == 0
-    then
-        player:startEvent(663)
-    elseif distantLoyalties == 1 and distantLoyaltiesProgress == 1 then
-        player:startEvent(664)
-    elseif
-        distantLoyalties == 1 and
-        distantLoyaltiesProgress == 4 and
-        player:hasKeyItem(xi.ki.MYTHRIL_HEARTS)
-    then
-        player:startEvent(665)
-    else
-        player:startEvent(661)
     end
 end
 
@@ -45,21 +26,6 @@ end
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 807 then
         player:setCharVar('WildcatSandy', utils.mask.setBit(player:getCharVar('WildcatSandy'), 3, true))
-    elseif csid == 663 and option == 0 then
-        player:addKeyItem(xi.ki.GOLDSMITHING_ORDER)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.GOLDSMITHING_ORDER)
-        player:addQuest(xi.questLog.SANDORIA, xi.quest.id.sandoria.DISTANT_LOYALTIES)
-        player:setCharVar('DistantLoyaltiesProgress', 1)
-    elseif csid == 665 then
-        if player:getFreeSlotsCount() == 0 then
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, xi.item.WHITE_CAPE)
-        else
-            player:delKeyItem(xi.ki.MYTHRIL_HEARTS)
-            player:addItem(xi.item.WHITE_CAPE, 1)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, xi.item.WHITE_CAPE)
-            player:setCharVar('DistantLoyaltiesProgress', 0)
-            player:completeQuest(xi.questLog.SANDORIA, xi.quest.id.sandoria.DISTANT_LOYALTIES)
-        end
     end
 end
 

--- a/scripts/zones/Southern_San_dOria/npcs/Rouva.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Rouva.lua
@@ -17,8 +17,6 @@ entity.onTrigger = function(player, npc)
         not utils.mask.getBit(wildcatSandy, 2)
     then
         player:startEvent(808)
-    else
-        player:startEvent(664)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Implements sandy quest Distant Loyalties
- adds checks to quests involving NPC's for distant loyalties (blocks other quests from being accepted if on distant loyalties)
- The Elvaan Goldsmith, Father Figure.
- adds default dialog to sandy NPC
- Removes npc lua functions associated.
- Added check for repeat of The Elvaan Goldsmith once  The Return of the Adventurer is completed.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
[Capture](https://www.youtube.com/watch?v=JC94ODejPmc)
## Steps to test these changes
Get Fame 4 in sandy. Speak with Femitte accept quest. Travel to Bastok Markets, NPC Michea will not give Father Figure or The Elvaan Goldsmith until completed. 
Complete quest and then can accept The elvaan goldsmith and father figure. 

<!-- Clear and detailed steps to test your changes here -->
