### PR TITLE
Fix zone definition for Maat fights in Waughroon Shrine

### DIFF
--- a/scripts/battlefields/Waughroon_Shrine/shattering_stars_bst.lua
+++ b/scripts/battlefields/Waughroon_Shrine/shattering_stars_bst.lua
@@ -6,7 +6,7 @@ local waughroonID = zones[xi.zone.WAUGHROON_SHRINE]
 -----------------------------------
 
 local content = Battlefield:new({
-    zoneId        = xi.zone.HORLAIS_PEAK,
+    zoneId        = xi.zone.WAUGHROON_SHRINE,
     battlefieldId = xi.battlefield.id.SHATTERING_STARS_BST,
     maxPlayers    = 1,
     levelCap      = 99,

--- a/scripts/battlefields/Waughroon_Shrine/shattering_stars_rdm.lua
+++ b/scripts/battlefields/Waughroon_Shrine/shattering_stars_rdm.lua
@@ -6,7 +6,7 @@ local waughroonID = zones[xi.zone.WAUGHROON_SHRINE]
 -----------------------------------
 
 local content = Battlefield:new({
-    zoneId        = xi.zone.HORLAIS_PEAK,
+    zoneId        = xi.zone.WAUGHROON_SHRINE,
     battlefieldId = xi.battlefield.id.SHATTERING_STARS_RDM,
     maxPlayers    = 1,
     levelCap      = 99,

--- a/scripts/battlefields/Waughroon_Shrine/shattering_stars_thf.lua
+++ b/scripts/battlefields/Waughroon_Shrine/shattering_stars_thf.lua
@@ -6,7 +6,7 @@ local waughroonID = zones[xi.zone.WAUGHROON_SHRINE]
 -----------------------------------
 
 local content = Battlefield:new({
-    zoneId        = xi.zone.HORLAIS_PEAK,
+    zoneId        = xi.zone.WAUGHROON_SHRINE,
     battlefieldId = xi.battlefield.id.SHATTERING_STARS_THF,
     maxPlayers    = 1,
     levelCap      = 99,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Sets the correct zone for the Maat fights in Waughroon Shrine

## Steps to test these changes

!addquest JEUNO SHATTERING_STARS
!changejob RDM 99
!additem RED_MAGES_TESTIMONY
trade the test:

![image](https://github.com/LandSandBoat/server/assets/65316697/a5115ec3-dd2b-486c-930c-c622dabb068f)

