### PR TITLE
[Quest]Chocobo on the loose auto flag

### DIFF
--- a/scripts/quests/jeuno/Chocobos_Wounds.lua
+++ b/scripts/quests/jeuno/Chocobos_Wounds.lua
@@ -72,8 +72,10 @@ quest.sections =
                     if option == 1 then
                         quest:begin(player)
                         quest:setVar(player, 'Prog', 1)
-                        -- This quest is automatically flagged during this interaction.
-                        player:addQuest(xi.questLog.JEUNO, xi.quest.id.jeuno.CHOCOBO_ON_THE_LOOSE)
+                        if xi.settings.main.ENABLE_TOAU == 1 then
+                            -- This quest is automatically flagged during this interaction.
+                            player:addQuest(xi.questLog.JEUNO, xi.quest.id.jeuno.CHOCOBO_ON_THE_LOOSE)
+                        end
                     else
                         -- Dialogue changes if the player fails to choose the correct option.
                         quest:setVar(player, 'Declined', 1)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Checks to see if TOAU is enable prior to flagging Chocobo's on the loose quest.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Disable TOAU - and complete chocobo wounds - Player should not flag Chocobos on the loose quest.
Enable TOAU - Chocobos on the loose will flag automatically. 
<!-- Clear and detailed steps to test your changes here -->
