### PR TITLE
[Fix] Correct immunity enum after update

### DIFF
--- a/scripts/zones/Grauberg_[S]/mobs/Sarcopsylla.lua
+++ b/scripts/zones/Grauberg_[S]/mobs/Sarcopsylla.lua
@@ -8,14 +8,18 @@ mixins = { require('scripts/mixins/families/chigoe_nm') }
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:addImmunity(xi.IMMUNITY.IMMUNITY_LIGHT_SLEEP)
-    mob:addImmunity(xi.IMMUNITY.IMMUNITY_DARK_SLEEP)
-    mob:addImmunity(xi.IMMUNITY.IMMUNITY_GRAVITY)
-    mob:addImmunity(xi.IMMUNITY.IMMUNITY_BIND)
-    mob:addImmunity(xi.IMMUNITY.IMMUNITY_SILENCE)
-    mob:addImmunity(xi.IMMUNITY.IMMUNITY_PETRIFY)
+    -- Set immunities.
+    mob:addImmunity(xi.immunity.GRAVITY)
+    mob:addImmunity(xi.immunity.BIND)
+    mob:addImmunity(xi.immunity.SILENCE)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.PETRIFY)
 
+    -- Set modifiers.
     mob:setMod(xi.mod.TRIPLE_ATTACK, 100)
+
+    -- Set mob modifiers.
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
 end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Replaces the enum for immunities with the new one.

## Steps to test these changes

Have the mob be immune to this effects and not error on server startup.
