### PR TITLE
[lua] Scitalis NM

### DIFF
--- a/scripts/zones/Grauberg_[S]/mobs/Ajattara.lua
+++ b/scripts/zones/Grauberg_[S]/mobs/Ajattara.lua
@@ -9,16 +9,14 @@ local entity = {}
 
 local scitalisPHTable =
 {
-    [ID.mob.SCITALIS - 2] = ID.mob.SCITALIS,
     [ID.mob.SCITALIS - 1] = ID.mob.SCITALIS,
-    [ID.mob.SCITALIS + 2] = ID.mob.SCITALIS,
 }
 
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, scitalisPHTable, 5, 3600) -- 1 hour
+    xi.mob.phOnDespawn(mob, scitalisPHTable, 10, 3600) -- 1 hour
 end
 
 return entity

--- a/scripts/zones/Grauberg_[S]/mobs/Scitalis.lua
+++ b/scripts/zones/Grauberg_[S]/mobs/Scitalis.lua
@@ -1,8 +1,25 @@
 -----------------------------------
 -- Area: Grauberg [S]
 --   NM: Scitalis
+-- https://www.bg-wiki.com/ffxi/Scitalis
 -----------------------------------
 local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:addImmunity(xi.immunity.GRAVITY)
+    mob:addImmunity(xi.immunity.SILENCE)
+    mob:addImmunity(xi.immunity.SLOW)
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.PETRIFY)
+
+    mob:setMod(xi.mod.DOUBLE_ATTACK, 50)
+    mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
+end
+
+entity.onAdditionalEffect = function(mob, target, damage)
+    -- Captures show unresisted damage between 120 and 200. TODO find what causes full power AE to vary so greatly
+    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENAERO, { power = math.random(165, 190) })
+end
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 503)

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -5473,7 +5473,7 @@ INSERT INTO `mob_groups` VALUES (29,71,89,'Air_Elemental',330,4,38,0,0,75,75,0);
 INSERT INTO `mob_groups` VALUES (30,1793,89,'Grauberg_Hippogryph',330,0,1219,0,0,73,75,0);
 INSERT INTO `mob_groups` VALUES (31,4869,89,'Kotan-kor_Kamuy',0,32,2950,13000,0,80,80,0);
 INSERT INTO `mob_groups` VALUES (32,74,89,'Ajattara',330,0,42,0,0,79,83,0);
-INSERT INTO `mob_groups` VALUES (33,3501,89,'Scitalis',0,32,2182,0,0,80,82,0);
+INSERT INTO `mob_groups` VALUES (33,3501,89,'Scitalis',0,32,2182,10800,0,83,83,0);
 INSERT INTO `mob_groups` VALUES (34,3617,89,'Sidhe',330,0,2001,0,0,75,77,0);
 INSERT INTO `mob_groups` VALUES (35,523,89,'Brasscap',330,0,346,0,0,59,61,0);
 INSERT INTO `mob_groups` VALUES (36,3114,89,'Peiste',330,0,1986,0,0,66,70,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements [Scitalis](https://www.bg-wiki.com/ffxi/Scitalis)

Most data in sql was fine, so leaving it as one commit.

Simple NM with _brutal_ AE damage

## Steps to test these changes

Adjust PH's lua to have
`xi.mob.phOnDespawn(mob, scitalisPHTable, 100, 3600, {immediate=true}) -- 1 hour`

kill it and see NM spawn immediately.

![image](https://github.com/LandSandBoat/server/assets/131182600/fd98cded-dc5f-4355-9211-4aa61b9d1b98)

