### PR TITLE
[cpp]lua] Init mob positions on startup

### DIFF
--- a/scripts/commands/gotoid.lua
+++ b/scripts/commands/gotoid.lua
@@ -57,9 +57,9 @@ commandObj.onTrigger = function(player, target)
 
         -- display message
         if isUp then
-            player:printToPlayer(string.format('Going to %s (%i).', targ:getName(), targ:getID()))
+            player:printToPlayer(string.format('Going to %s (%i) in %s.', targ:getName(), targ:getID(), targ:getZoneName()))
         else
-            player:printToPlayer(string.format('%s (%i) is not currently up. Going to last known coordinates.', targ:getName(), targ:getID()))
+            player:printToPlayer(string.format('%s (%i) is not currently up in %s. Going to last known coordinates.', targ:getName(), targ:getID(), targ:getZoneName()))
         end
 
         -- half a second later, go.  this delay gives time for previous message to appear

--- a/scripts/commands/gotoname.lua
+++ b/scripts/commands/gotoname.lua
@@ -46,7 +46,11 @@ local goToEntity = function(player, entity)
     end
 
     -- display message
-    player:printToPlayer(string.format('Going to %s %s (%i).', entity:getName(), entity:getZoneName(), entity:getID()))
+    if entity:isSpawned() then
+        player:printToPlayer(string.format('Going to %s (%i).', entity:getName(), entity:getID()))
+    else
+        player:printToPlayer(string.format('%s (%i) is not currently up. Going to last known coordinates.', entity:getName(), entity:getID()))
+    end
 
     -- half a second later, go.  this delay gives time for previous message to appear
     player:timer(500, function(playerArg)

--- a/src/map/instance_loader.cpp
+++ b/src/map/instance_loader.cpp
@@ -102,6 +102,7 @@ CInstance* CInstanceLoader::LoadInstance()
             PMob->m_SpawnPoint.x        = _sql->GetFloatData(3);
             PMob->m_SpawnPoint.y        = _sql->GetFloatData(4);
             PMob->m_SpawnPoint.z        = _sql->GetFloatData(5);
+            PMob->loc.p                 = PMob->m_SpawnPoint;
 
             PMob->m_RespawnTime = _sql->GetUIntData(6) * 1000;
             PMob->m_SpawnType   = (SPAWNTYPE)_sql->GetUIntData(7);

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -440,6 +440,7 @@ namespace zoneutils
                                 PMob->m_SpawnPoint.x        = sql->GetFloatData(4);
                                 PMob->m_SpawnPoint.y        = sql->GetFloatData(5);
                                 PMob->m_SpawnPoint.z        = sql->GetFloatData(6);
+                                PMob->loc.p                 = PMob->m_SpawnPoint;
 
                                 PMob->m_RespawnTime = sql->GetUIntData(7) * 1000;
                                 PMob->m_SpawnType   = (SPAWNTYPE)sql->GetUIntData(8);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

`!gotoid` and `!gotoname` have the ability to send you to a mob not currently spawned, but when a zone starts up the mob's position isn't initialized until a mob spawns. The cpp changes fixes that

Also, cleaned up the wording of both functions since `!gotname` can't send you to another zone and cloned the wording from `!gotoid` into `!gotoname` to indicate if a mob is up or not

This was especially frustrating for me when coding ixion, as when you start up a zone, spawn ixion, then move him to the next zone... you couldn't use `!gotoname` until he spawned

## Steps to test these changes

![image](https://github.com/LandSandBoat/server/assets/131182600/6ca8e751-060a-4dd4-846a-90fab2e52ac7)

