### PR TITLE
Cleanly fail the GetFirstID lookup

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -901,9 +901,18 @@ namespace luautils
 
         // Update GetFirstID to use this new lookup
         // clang-format off
-        lua.set_function("GetFirstID", [&](std::string const& name) -> uint32
+        lua.set_function("GetFirstID", [&](std::string const& name) -> std::optional<uint32>
         {
-            return lookup[name].front();
+            if (lookup.find(name) != lookup.end())
+            {
+                return lookup[name].front();
+            }
+            else
+            {
+                ShowWarning(fmt::format("GetFirstID({}) in zone {}: Returning nil", name, zoneName));
+
+                return std::nullopt;
+            }
         });
 
         std::unordered_map<std::string, sol::table> idLuaTables;
@@ -926,7 +935,7 @@ namespace luautils
                 // If we have no entries, bail out and return nil
                 if (lookup.find(name) == lookup.end())
                 {
-                    ShowWarning(fmt::format("GetTableOfIDs({}): Returning nil", name));
+                    ShowWarning(fmt::format("GetTableOfIDs({}) in zone {}: Returning nil", name, zoneName));
                     return sol::lua_nil;
                 }
 
@@ -934,7 +943,7 @@ namespace luautils
 
                 if (entriesVec.empty())
                 {
-                    ShowWarning(fmt::format("GetTableOfIDs({}): Returning empty table", name));
+                    ShowWarning(fmt::format("GetTableOfIDs({}) in zone {}: Returning empty table", name, zoneName));
                     return table;
                 }
 
@@ -964,7 +973,7 @@ namespace luautils
 
             if (table.empty())
             {
-                ShowWarning(fmt::format("Tried to look do ID lookup for {}, but found nothing.", name));
+                ShowWarning(fmt::format("GetTableOfIDs({}) in zone {}: Tried to look do ID lookup, but found nothing.", name, zoneName));
             }
 
             // Add to cache

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -909,7 +909,7 @@ namespace luautils
             }
             else
             {
-                ShowWarning(fmt::format("GetFirstID({}) in zone {}: Returning nil", name, zoneName));
+                ShowError(fmt::format("GetFirstID({}) in zone {}: Returning nil", name, zoneName));
 
                 return std::nullopt;
             }
@@ -935,7 +935,7 @@ namespace luautils
                 // If we have no entries, bail out and return nil
                 if (lookup.find(name) == lookup.end())
                 {
-                    ShowWarning(fmt::format("GetTableOfIDs({}) in zone {}: Returning nil", name, zoneName));
+                    ShowError(fmt::format("GetTableOfIDs({}) in zone {}: Returning nil", name, zoneName));
                     return sol::lua_nil;
                 }
 
@@ -943,7 +943,7 @@ namespace luautils
 
                 if (entriesVec.empty())
                 {
-                    ShowWarning(fmt::format("GetTableOfIDs({}) in zone {}: Returning empty table", name, zoneName));
+                    ShowError(fmt::format("GetTableOfIDs({}) in zone {}: Returning empty table", name, zoneName));
                     return table;
                 }
 
@@ -973,7 +973,7 @@ namespace luautils
 
             if (table.empty())
             {
-                ShowWarning(fmt::format("GetTableOfIDs({}) in zone {}: Tried to look do ID lookup, but found nothing.", name, zoneName));
+                ShowError(fmt::format("GetTableOfIDs({}) in zone {}: Tried to look do ID lookup, but found nothing.", name, zoneName));
             }
 
             // Add to cache


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes https://github.com/LandSandBoat/server/issues/5567 .

We cleanly exit and return 0 when the lookup doesn't exist in the `unordered_map`

## Steps to test these changes

Do the steps in the issue:
![image](https://github.com/LandSandBoat/server/assets/131182600/16f7524a-5a8d-477f-92e8-a0bbd0ba1d31)

the table's value ends up being zero:
![image](https://github.com/LandSandBoat/server/assets/131182600/920b053b-8d98-4791-b651-bf7fef17dd6f)

and if we do a name that has multiple entries, see we still return the first:
![image](https://github.com/LandSandBoat/server/assets/131182600/bf05ab19-f934-4a94-ac63-5dc41f2ace31)
