### PR TITLE
[core] Fix mobs turning while casting with Manafont up

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -582,7 +582,7 @@ void CMobController::DoCombatTick(time_point tick)
         PMob->PAI->EventHandler.triggerListener("COMBAT_TICK", CLuaBaseEntity(PMob));
         luautils::OnMobFight(PMob, PTarget);
 
-        if (PMob->PAI->IsCurrentState<CInactiveState>())
+        if (PMob->PAI->IsCurrentState<CInactiveState>() || !PMob->PAI->CanChangeState())
         {
             return;
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes an issue where mobs will rotate when manafont is up while casting (which they shouldn't do)
[2024-05-08 19-51-22.webm](https://github.com/LandSandBoat/server/assets/60417494/2a6bb024-d7ce-4936-a48c-6f1849f820f8)


## Steps to test these changes

`!exec target:addEffect(xi.effect.MANAFONT, -1, -1, -1)`
spin a blm and see it not spin with you while its casting

Sidenote: chainspell/manafont isnt as brutal on retail. Mobs do not instantly start recasting as soon as possible. Other minor nitpick is that it seems our spellcasting state ends too late, and mobs should start to rotate sooner, but also stay in place.. so not sure what that's about.