### PR TITLE
[LUA] Fix Shattering Stars BCNMs should restrict subjob

### DIFF
--- a/scripts/battlefields/Balgas_Dais/shattering_stars_mnk.lua
+++ b/scripts/battlefields/Balgas_Dais/shattering_stars_mnk.lua
@@ -10,6 +10,7 @@ local content = Battlefield:new({
     battlefieldId = xi.battlefield.id.SHATTERING_STARS_MNK,
     maxPlayers    = 1,
     levelCap      = 99,
+    allowSubjob   = false,
     timeLimit     = utils.minutes(10),
     index         = 5,
     entryNpc      = 'BC_Entrance',

--- a/scripts/battlefields/Balgas_Dais/shattering_stars_smn.lua
+++ b/scripts/battlefields/Balgas_Dais/shattering_stars_smn.lua
@@ -10,6 +10,7 @@ local content = Battlefield:new({
     battlefieldId = xi.battlefield.id.SHATTERING_STARS_SMN,
     maxPlayers    = 1,
     levelCap      = 99,
+    allowSubjob   = false,
     timeLimit     = utils.minutes(10),
     index         = 7,
     entryNpc      = 'BC_Entrance',

--- a/scripts/battlefields/Balgas_Dais/shattering_stars_whm.lua
+++ b/scripts/battlefields/Balgas_Dais/shattering_stars_whm.lua
@@ -10,6 +10,7 @@ local content = Battlefield:new({
     battlefieldId = xi.battlefield.id.SHATTERING_STARS_WHM,
     maxPlayers    = 1,
     levelCap      = 99,
+    allowSubjob   = false,
     timeLimit     = utils.minutes(10),
     index         = 6,
     entryNpc      = 'BC_Entrance',

--- a/scripts/battlefields/Horlais_Peak/shattering_stars_blm.lua
+++ b/scripts/battlefields/Horlais_Peak/shattering_stars_blm.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Area: Balga's Dais
+-- Area: Horlais Peak
 -- Name: Shattering stars - Maat Fight (BLM)
 -----------------------------------
 local horlaisID = zones[xi.zone.HORLAIS_PEAK]
@@ -10,6 +10,7 @@ local content = Battlefield:new({
     battlefieldId = xi.battlefield.id.SHATTERING_STARS_BLM,
     maxPlayers    = 1,
     levelCap      = 99,
+    allowSubjob   = false,
     timeLimit     = utils.minutes(10),
     index         = 6,
     entryNpc      = 'BC_Entrance',

--- a/scripts/battlefields/Horlais_Peak/shattering_stars_rng.lua
+++ b/scripts/battlefields/Horlais_Peak/shattering_stars_rng.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Area: Balga's Dais
+-- Area: Horlais Peak
 -- Name: Shattering stars - Maat Fight (RNG)
 -----------------------------------
 local horlaisID = zones[xi.zone.HORLAIS_PEAK]
@@ -10,6 +10,7 @@ local content = Battlefield:new({
     battlefieldId = xi.battlefield.id.SHATTERING_STARS_RNG,
     maxPlayers    = 1,
     levelCap      = 99,
+    allowSubjob   = false,
     timeLimit     = utils.minutes(10),
     index         = 7,
     entryNpc      = 'BC_Entrance',

--- a/scripts/battlefields/Horlais_Peak/shattering_stars_war.lua
+++ b/scripts/battlefields/Horlais_Peak/shattering_stars_war.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Area: Balga's Dais
+-- Area: Horlais Peak
 -- Name: Shattering stars - Maat Fight (WAR)
 -----------------------------------
 local horlaisID = zones[xi.zone.HORLAIS_PEAK]
@@ -10,6 +10,7 @@ local content = Battlefield:new({
     battlefieldId = xi.battlefield.id.SHATTERING_STARS_WAR,
     maxPlayers    = 1,
     levelCap      = 99,
+    allowSubjob   = false,
     timeLimit     = utils.minutes(10),
     index         = 5,
     entryNpc      = 'BC_Entrance',

--- a/scripts/battlefields/Waughroon_Shrine/shattering_stars_bst.lua
+++ b/scripts/battlefields/Waughroon_Shrine/shattering_stars_bst.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Area: Balga's Dais
+-- Area: Waughroon Shrine
 -- Name: Shattering stars - Maat Fight (BST)
 -----------------------------------
 local waughroonID = zones[xi.zone.WAUGHROON_SHRINE]
@@ -10,6 +10,7 @@ local content = Battlefield:new({
     battlefieldId = xi.battlefield.id.SHATTERING_STARS_BST,
     maxPlayers    = 1,
     levelCap      = 99,
+    allowSubjob   = false,
     timeLimit     = utils.minutes(10),
     index         = 8,
     entryNpc      = 'BC_Entrance',

--- a/scripts/battlefields/Waughroon_Shrine/shattering_stars_rdm.lua
+++ b/scripts/battlefields/Waughroon_Shrine/shattering_stars_rdm.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Area: Balga's Dais
+-- Area: Waughroon Shrine
 -- Name: Shattering stars - Maat Fight (RDM)
 -----------------------------------
 local waughroonID = zones[xi.zone.WAUGHROON_SHRINE]
@@ -10,6 +10,7 @@ local content = Battlefield:new({
     battlefieldId = xi.battlefield.id.SHATTERING_STARS_RDM,
     maxPlayers    = 1,
     levelCap      = 99,
+    allowSubjob   = false,
     timeLimit     = utils.minutes(10),
     index         = 6,
     entryNpc      = 'BC_Entrance',

--- a/scripts/battlefields/Waughroon_Shrine/shattering_stars_thf.lua
+++ b/scripts/battlefields/Waughroon_Shrine/shattering_stars_thf.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Area: Balga's Dais
+-- Area: Waughroon Shrine
 -- Name: Shattering stars - Maat Fight (THF)
 -----------------------------------
 local waughroonID = zones[xi.zone.WAUGHROON_SHRINE]
@@ -10,6 +10,7 @@ local content = Battlefield:new({
     battlefieldId = xi.battlefield.id.SHATTERING_STARS_THF,
     maxPlayers    = 1,
     levelCap      = 99,
+    allowSubjob   = false,
     timeLimit     = utils.minutes(10),
     index         = 7,
     entryNpc      = 'BC_Entrance',


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The Shattering Stars BCNMs are currently being converted into the new battlefield framework but are missing the parameter to disable subjobs. This causes players to be able to use their subjob during the BCNM which should not be possible.

## Steps to test these changes

1. !changejob 11 99
2. !additem 1436
3. !zone Horlais Peak
4. Trade the testimony to the Burning Circle