### PR TITLE
Fix exp ring recharge CP cost logic

### DIFF
--- a/src/map/lua/lua_item.cpp
+++ b/src/map/lua/lua_item.cpp
@@ -252,6 +252,16 @@ auto CLuaItem::getSignature() -> std::string
     return signature;
 }
 
+uint8 CLuaItem::getCurrentCharges()
+{
+    if (auto* PUsableItem = dynamic_cast<CItemUsable*>(m_PLuaItem))
+    {
+        return PUsableItem->getCurrentCharges();
+    }
+
+    return 0;
+}
+
 uint8 CLuaItem::getAppraisalID()
 {
     return m_PLuaItem->m_extra[0x16];
@@ -353,6 +363,7 @@ void CLuaItem::Register()
     SOL_REGISTER("getSignature", CLuaItem::getSignature);
     SOL_REGISTER("getAppraisalID", CLuaItem::getAppraisalID);
     SOL_REGISTER("setAppraisalID", CLuaItem::setAppraisalID);
+    SOL_REGISTER("getCurrentCharges", CLuaItem::getCurrentCharges);
     SOL_REGISTER("isInstalled", CLuaItem::isInstalled);
     SOL_REGISTER("setSoulPlateData", CLuaItem::setSoulPlateData);
     SOL_REGISTER("getSoulPlateData", CLuaItem::getSoulPlateData);

--- a/src/map/lua/lua_item.h
+++ b/src/map/lua/lua_item.h
@@ -84,6 +84,8 @@ public:
     uint8 getAppraisalID();         // get an appraisal ID
     void  setAppraisalID(uint8 id); // set an appraisal ID
 
+    uint8 getCurrentCharges(); // Get remaining charges
+
     bool isInstalled();
 
     void setSoulPlateData(std::string const& name, uint16 mobFamily, uint8 zeni, uint16 skillIndex, uint8 fp);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes the EXP ring recharge logic so that partial recharging only costs CP proportionate to the used charges (see [retail video](https://youtu.be/ZoWM8nQpXbY) by Siknoz). Also it implements the correct logic when trading a fully charged ring to the NPC (see [retail video](https://youtu.be/m-QFW08fOHc) by Sylvebits). Also the retail text for trading when already traded during this conquest period was verified on retail by Tracent.

## Steps to test these changes
Try different scenarios for recharging the exp rings such as trading when already fully charged, partially charged, or empty.
