### PR TITLE
[AMK, Lua] Loops fixed, formatting fixes, added comment

### DIFF
--- a/scripts/missions/amk/06_An_Errand_The_Professors_Price.lua
+++ b/scripts/missions/amk/06_An_Errand_The_Professors_Price.lua
@@ -89,8 +89,8 @@ mission.sections =
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission >= mission.missionId and
-            missionStatus == 0 and
-            not player:hasKeyItem(xi.ki.RIPE_STARFRUIT)
+                missionStatus == 0 and
+                not player:hasKeyItem(xi.ki.RIPE_STARFRUIT)
         end,
 
         [xi.zone.WINDURST_WALLS] =

--- a/scripts/missions/amk/09_Rescue_A_Moogles_Labor_of_Love.lua
+++ b/scripts/missions/amk/09_Rescue_A_Moogles_Labor_of_Love.lua
@@ -25,6 +25,10 @@ mission.reward =
     nextMission = { xi.mission.log_id.AMK, xi.mission.id.amk.ROAR_A_CAT_BURGLAR_BARES_HER_FANGS },
 }
 
+-- There are ten possible sets of QM locations that could be assigned to the player
+-- that give the stone KIs. The table below holds the 10 sets that can be
+-- randomly assigned, which stores the indices of the QM ids from a table
+-- that is pulled from the database
 local markerSets =
 {
     { 1, 2, 5, 7,  8,  11, 14, 19, 20 },
@@ -51,8 +55,8 @@ local getMarkerSet = function(player)
 end
 
 local hasAllStones = function(player)
-    for offset = 0, 8 do
-        if not player:hasKeyItem(xi.ki.STONE_OF_SURYA + offset) then
+    for keyItemId = xi.ki.STONE_OF_SURYA, xi.ki.STONE_OF_KETU do
+        if not player:hasKeyItem(keyItemId) then
             return false
         end
     end
@@ -66,7 +70,7 @@ mission.sections =
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission == mission.missionId and
-            player:getCharVar('Mission[10][8]progress') == 0
+                player:getCharVar('Mission[10][8]progress') == 0
         end,
 
         [xi.zone.QUICKSAND_CAVES] =
@@ -118,10 +122,9 @@ mission.sections =
 
                     -- Determine if QM triggered is in markerset
                     local keyItem = 0
-                    for setIndex = 1, 9 do
-                        local markerIdIndex = markerSets[amkMarkerSet][setIndex]
+                    for idx, markerIdIndex in ipairs(markerSets[amkMarkerSet]) do
                         if npc:getID() == ID.npc.QM_AMK[markerIdIndex] then
-                            keyItem = xi.ki.STONE_OF_SURYA + setIndex - 1
+                            keyItem = xi.ki.STONE_OF_SURYA + idx - 1
                         end
                     end
 
@@ -156,8 +159,8 @@ mission.sections =
             onEventFinish =
             {
                 [100] = function(player, csid, option, npc)
-                    for i = 0, 8 do
-                        player:delKeyItem(xi.ki.STONE_OF_SURYA + i)
+                    for keyItemId = xi.ki.STONE_OF_SURYA, xi.ki.STONE_OF_KETU do
+                        player:delKeyItem(keyItemId)
                     end
 
                     player:setCharVar('Mission[10][8]markerSet', 0)

--- a/scripts/missions/amk/13_A_Challenge_You_Could_Be_a_Winner.lua
+++ b/scripts/missions/amk/13_A_Challenge_You_Could_Be_a_Winner.lua
@@ -38,7 +38,7 @@ mission.sections =
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission >= mission.missionId and
-            not player:hasKeyItem(xi.ki.GAUNTLET_CHALLENGE_KUPON)
+                not player:hasKeyItem(xi.ki.GAUNTLET_CHALLENGE_KUPON)
         end,
 
         [xi.zone.CASTLE_ZVAHL_BAILEYS] =
@@ -65,11 +65,11 @@ mission.sections =
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission >= mission.missionId and
-            (mission:getVar(player, 'progress') == 1 or
-            currentMission > mission.missionId) and
-            not player:hasKeyItem(xi.ki.POCKET_MOGBOMB) and
-            not player:hasKeyItem(xi.ki.TRIVIA_CHALLENGE_KUPON) and
-            player:needToZone() == false
+                (mission:getVar(player, 'progress') == 1 or
+                currentMission > mission.missionId) and
+                not player:hasKeyItem(xi.ki.POCKET_MOGBOMB) and
+                not player:hasKeyItem(xi.ki.TRIVIA_CHALLENGE_KUPON) and
+                player:needToZone() == false
         end,
 
         [xi.zone.BEAUCEDINE_GLACIER] =
@@ -100,10 +100,10 @@ mission.sections =
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission >= mission.missionId and
-            mission:getVar(player, 'progress') == 1 and
-            not player:hasKeyItem(xi.ki.POCKET_MOGBOMB) and
-            not player:hasKeyItem(xi.ki.TRIVIA_CHALLENGE_KUPON) and
-            player:needToZone() == true
+                mission:getVar(player, 'progress') == 1 and
+                not player:hasKeyItem(xi.ki.POCKET_MOGBOMB) and
+                not player:hasKeyItem(xi.ki.TRIVIA_CHALLENGE_KUPON) and
+                player:needToZone() == true
         end,
 
         [xi.zone.BEAUCEDINE_GLACIER] =
@@ -248,8 +248,8 @@ mission.sections =
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission >= mission.missionId and
-            mission:getVar(player, 'progress') == 1 and
-            player:hasKeyItem(xi.ki.POCKET_MOGBOMB)
+                mission:getVar(player, 'progress') == 1 and
+                player:hasKeyItem(xi.ki.POCKET_MOGBOMB)
         end,
 
         [xi.zone.BEAUCEDINE_GLACIER] =
@@ -284,8 +284,8 @@ mission.sections =
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission >= mission.missionId and
-            mission:getVar(player, 'progress') == 2 and
-            player:hasKeyItem(xi.ki.TRIVIA_CHALLENGE_KUPON)
+                mission:getVar(player, 'progress') == 2 and
+                player:hasKeyItem(xi.ki.TRIVIA_CHALLENGE_KUPON)
         end,
 
         [xi.zone.BEAUCEDINE_GLACIER] =
@@ -342,8 +342,8 @@ mission.sections =
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission >= mission.missionId and
-            mission:getVar(player, 'progress') == 3 and
-            player:hasKeyItem(xi.ki.GAUNTLET_CHALLENGE_KUPON)
+                mission:getVar(player, 'progress') == 3 and
+                player:hasKeyItem(xi.ki.GAUNTLET_CHALLENGE_KUPON)
         end,
 
         [xi.zone.XARCABARD] =
@@ -445,8 +445,8 @@ mission.sections =
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission >= mission.missionId and
-            mission:getVar(player, 'progress') == 4 and
-            player:hasKeyItem(xi.ki.FESTIVAL_SOUVENIR_KUPON)
+                mission:getVar(player, 'progress') == 4 and
+                player:hasKeyItem(xi.ki.FESTIVAL_SOUVENIR_KUPON)
         end,
 
         [xi.zone.CASTLE_ZVAHL_BAILEYS] =


### PR DESCRIPTION
Added comment describing table in mission 9 (rescue) Changed loops to use enum values

**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Addresses comments in #5551 . Loops in mission 9 to use enum values, added comment to describe the markerset matrix, misc formatting.

## Steps to test these changes

!addmission 10 8
collect key items for navaratna talisman in quicksand caves
