### PR TITLE
[dbtool] Add migration to verify/fix char_flags count

### DIFF
--- a/tools/migrations/040_verify_char_flags.py
+++ b/tools/migrations/040_verify_char_flags.py
@@ -1,0 +1,33 @@
+import mariadb
+
+
+def migration_name():
+    return "Verifying char_flags row count is equal to chars"
+
+
+def check_preconditions(cur):
+    return
+
+
+def needs_to_run(cur):
+    # Ensure chatfilters column exists in chars
+    cur.execute("SELECT COUNT(*) as num_chars FROM chars;")
+    char_count = cur.fetchone()[0]
+
+    cur.execute("SELECT COUNT(*) as num_char_flags FROM char_flags;")
+    char_flags_count = cur.fetchone()[0]
+
+    if char_flags_count < char_count:
+        return True
+    return False
+
+
+def migrate(cur, db):
+    try:
+        # Add default row for each character into new char_flags table, on duplicate do nothing.
+        cur.execute("INSERT INTO char_flags (charid) SELECT charid FROM chars ON DUPLICATE KEY UPDATE char_flags.disconnecting = char_flags.disconnecting;");
+        print("If this (char_flags) migration is running repeatedly, there is probably a bug somewhere. Please report this.")
+        db.commit()
+
+    except mariadb.Error as err:
+        print("Something went wrong: {}".format(err))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes root cause of #5663 
If char_flags row count is less than char row count, that means the previous migration (or some other anomaly) failed before this PR to fix the previous migration fix #5647

The query it runs is safe to repeatedly run.

## Steps to test these changes

run `dbtool.py migrate`, see it work if you need it, and to skip if you don't.

