### PR TITLE
[LUA] Fix typeless magic damage causes error in calculateResistRate

### DIFF
--- a/scripts/globals/combat/magic_hit_rate.lua
+++ b/scripts/globals/combat/magic_hit_rate.lua
@@ -390,7 +390,11 @@ end
 
 xi.combat.magicHitRate.calculateResistRate = function(actor, target, skillType, spellElement, magicHitRate, rankModifier)
     local targetResistRate = 0 -- The variable we return.
-    local targetResistRank = target:getMod(xi.combat.element.resistRankMod[spellElement])
+    local targetResistRank = 0
+
+    if spellElement ~= nil and spellElement ~= xi.element.NONE then
+        targetResistRank = target:getMod(xi.combat.element.resistRankMod[spellElement])
+    end
 
     ----------------------------------------
     -- Handle 'Magic Shield' status effect.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

When using blue magic that does not have an elemental nature (physical for example) currently will throw an error in `xi.combat.magicHitRate.calculateResistRate` due to the element being nil when matching. To handle this we will default `targetResistRank` to 0 and only set it if the element is available. Example error log:

```
[05/09/24 18:33:06:346][map][error] luautils::onSpellCast: stack index 2, expected number, received nil: not a numeric type (bad argument into 'short(unsigned short)')
stack traceback:
	[C]: in function 'getMod'
	.\scripts/globals/combat/magic_hit_rate.lua:393: in function 'applyResistanceEffect'
	./scripts/globals/bluemagic.lua:556: in function 'usePhysicalSpellAddedEffect'
	./scripts/actions/spells/blue/disseverment.lua:55: in function <./scripts/actions/spells/blue/disseverment.lua:21> (luautils::OnSpellCast:2751)
```

## Steps to test these changes

1. !changejob 16 99
2. !addallspells
3. Set Disseverment in Blue Magic
4. Use Disseverment on a mob
