### PR TITLE
[Magic] Add safety check and non elemental magic resistance bypass

### DIFF
--- a/scripts/globals/combat/magic_hit_rate.lua
+++ b/scripts/globals/combat/magic_hit_rate.lua
@@ -389,24 +389,34 @@ end
 -----------------------------------
 
 xi.combat.magicHitRate.calculateResistRate = function(actor, target, skillType, spellElement, magicHitRate, rankModifier)
-    local targetResistRate = 0 -- The variable we return.
-    local targetResistRank = target:getMod(xi.combat.element.resistRankMod[spellElement])
+    local targetResistRate = 1 -- The variable we return.
 
     ----------------------------------------
     -- Handle 'Magic Shield' status effect.
     ----------------------------------------
     if target:hasStatusEffect(xi.effect.MAGIC_SHIELD, 0) then
+        return 0
+    end
+
+    ----------------------------------------
+    -- Handle non elemental magic or user error.
+    ----------------------------------------
+    if
+        not spellElement or                -- You shouldnt be using this function.
+        spellElement <= xi.element.NONE or -- Non elemental magic (ex. Player Meteor) cannot be resisted.
+        spellElement > xi.element.DARK     -- That's not even an element.
+    then
         return targetResistRate
     end
 
     ----------------------------------------
     -- Handle target resistance rank.
     ----------------------------------------
+    local targetResistRank = target:getMod(xi.combat.element.resistRankMod[spellElement]) or 0
+
     -- Elemental resistance rank.
-    if spellElement ~= xi.element.NONE then
-        if targetResistRank > 4 then
-            targetResistRank = utils.clamp(targetResistRank - rankModifier, 4, 11)
-        end
+    if targetResistRank > 4 then
+        targetResistRank = utils.clamp(targetResistRank - rankModifier, 4, 11)
     end
 
     -- Skillchains lowers target resistance rank by 1.


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds logic for non-elemental magic to bypass resistance checks.
- Adds safety for incorrect element value.

## Steps to test these changes

None