### PR TITLE
Add getfishers command to get info about all recent fishers

### DIFF
--- a/scripts/commands/getfishers.lua
+++ b/scripts/commands/getfishers.lua
@@ -1,0 +1,43 @@
+-----------------------------------
+-- func: getfishers <MinutesToLookback>
+-- desc: Returns a list of all players who have recently fished.
+--       The default period to look back is 5 minutes but command
+--       accepts parameter between 1 and 60 minutes
+-----------------------------------
+local commandObj = {}
+
+commandObj.cmdprops =
+{
+    permission = 1,
+    parameters = 'i'
+}
+
+local function error(player, msg)
+    player:printToPlayer(msg)
+    player:printToPlayer('!getfishers <MinutesToLookback>')
+end
+
+commandObj.onTrigger = function(player, minutes)
+    -- default look back period is 5 minutes
+    if minutes == nil then
+        minutes = 5
+    elseif minutes < 1 or minutes > 60 then
+        error(player, 'The specified look back period must be between 1 and 60 minutes.')
+        return
+    end
+
+    local fishers = GetRecentFishers(minutes)
+
+    if #fishers == 0 then
+        player:printToPlayer(string.format('No active fishers in past %i minutes.', minutes), xi.msg.channel.SYSTEM_3)
+        return
+    end
+
+    player:printToPlayer(string.format('Active fishers in past %i minutes:', minutes), xi.msg.channel.SYSTEM_3)
+    for _, fisher in pairs(fishers) do
+        player:printToPlayer(string.format('Name: %s, Zone: %s, JobLevel: %d, Skill: %d',
+        fisher.playerName, fisher.zoneName, fisher.jobLevel, fisher.skill), xi.msg.channel.SYSTEM_3)
+    end
+end
+
+return commandObj

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -214,6 +214,7 @@ namespace luautils
         lua.set_function("GetMobRespawnTime", &luautils::GetMobRespawnTime);
         lua.set_function("DisallowRespawn", &luautils::DisallowRespawn);
         lua.set_function("UpdateNMSpawnPoint", &luautils::UpdateNMSpawnPoint);
+        lua.set_function("GetRecentFishers", &luautils::GetRecentFishers);
         lua.set_function("NearLocation", &luautils::NearLocation);
         lua.set_function("GetFurthestValidPosition", &luautils::GetFurthestValidPosition);
         lua.set_function("Terminate", &luautils::Terminate);
@@ -5080,6 +5081,45 @@ namespace luautils
 
         ShowError("luautils::GetMobAction: mob <%u> was not found", mobid);
         return 0;
+    }
+
+    /************************************************************************
+     *   Gets a list of players that have fished in the last specified mins *
+     *   where the specified param is between 1 and 60 mins                 *
+     ************************************************************************/
+
+    sol::table GetRecentFishers(uint16 minutes)
+    {
+        // limit the lookback time to prevent huge queries
+        uint16 lookbackTime = std::clamp<uint32>(minutes, 1, 60);
+
+        sol::table  fishers = lua.create_table();
+        const char* Query   = "SELECT cv.charid, c.charname, stats.mlvl, z.name, COALESCE(cs.value, 0) / 10 as skill "
+                              "FROM char_vars cv "
+                              "LEFT JOIN chars c ON c.charid  = cv.charid "
+                              "LEFT JOIN char_skills cs ON cs.charid = cv.charid AND cs.skillid = 48 "
+                              "INNER JOIN char_stats stats ON stats.charid = c.charid "
+                              "INNER JOIN zone_settings z ON z.zoneid = c.pos_zone "
+                              "WHERE "
+                              "varname = '[Fish]LastCastTime' AND "
+                              "FROM_UNIXTIME(cv.value) > NOW() - INTERVAL %u MINUTE "
+                              "ORDER BY z.name, z.name, stats.mlvl, skill";
+
+        if (_sql->Query(Query, lookbackTime) != SQL_ERROR && _sql->NumRows() != 0)
+        {
+            while (_sql->NextRow() == SQL_SUCCESS)
+            {
+                auto fisher          = lua.create_table();
+                auto charId          = _sql->GetUIntData(0);
+                fisher["playerName"] = _sql->GetStringData(1);
+                fisher["jobLevel"]   = _sql->GetUIntData(2);
+                fisher["zoneName"]   = _sql->GetStringData(3);
+                fisher["skill"]      = _sql->GetUIntData(4);
+                fishers[charId]      = fisher;
+            }
+        }
+
+        return fishers;
     }
 
     std::string GetServerMessage(uint8 language)

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -328,7 +328,8 @@ namespace luautils
     void   DisallowRespawn(uint32 mobid, bool allowRespawn);
     void   UpdateNMSpawnPoint(uint32 mobid);
 
-    std::string GetServerMessage(uint8 language); // Get the message to be delivered to player on first zone in of a session
+    std::string GetServerMessage(uint8 language);               // Get the message to be delivered to player on first zone in of a session
+    auto        GetRecentFishers(uint16 minutes) -> sol::table; // returns a list of recently active fishers (that fished in the last specified minutes)
 
     int32 OnAdditionalEffect(CBattleEntity* PAttacker, CBattleEntity* PDefender, actionTarget_t* Action, int32 damage);                                      // for mobs with additional effects
     int32 OnSpikesDamage(CBattleEntity* PDefender, CBattleEntity* PAttacker, actionTarget_t* Action, int32 damage);                                          // for mobs with spikes

--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -1950,6 +1950,8 @@ namespace fishingutils
         }
         else
         {
+            auto secs = std::chrono::duration_cast<std::chrono::seconds>(server_clock::now().time_since_epoch());
+            PChar->setCharVar("[Fish]LastCastTime", secs.count());
             PChar->lastCastTime = vanaTime;
             PChar->nextFishTime = PChar->lastCastTime + 5;
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR adds a GM command called !getfishers <lookbackPeriodMinutes> that displays to the GM a list of all fishers active in the last few minutes (default of 5 minutes but the lookback period can be specified between 1 min to 60 min). The list shown to the GM includes the fishers name, zone, joblevel, and fishing skill. The max of 60 mins is just reasonable limit to avoid overly long results returned.

Normally, such a command could just be a module however because it interacts with fishing it requires some core code. Also it has proven to be popular with Horizon GMs for tracking fish botting, thus it is potentially useful generally given that fish botting is common on servers.

Note that the most recent fishing time for a player is tracked via a char variable that is set when the player starts fishing. Thus the player even returns players that are no longer logged in at the time the GM runs the command.

## Steps to test these changes
Have players fish at different times and then use the !getfishers command with different lookback periods to test.
