### PR TITLE
[LUA] Fix Tenshodo Coffer uses KI when reward is unobtainable

### DIFF
--- a/scripts/zones/Lower_Jeuno/npcs/Treasure_Coffer.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Treasure_Coffer.lua
@@ -1763,12 +1763,14 @@ local function givePrize(player, ki)
             end
 
             -- give prize
-            if player:getFreeSlotsCount() == 0 then
-                player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, prize.itemId)
-            else
+            if
+                player:getFreeSlotsCount() ~= 0 and
                 player:addItem(prize.itemId, 1, unpack(addAug))
+            then
                 player:messageSpecial(ID.text.ITEM_OBTAINED, prize.itemId)
                 player:delKeyItem(ki)
+            else
+                player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, prize.itemId)
             end
         end
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes an issue with the Tenshodo Coffer where the KI will be consumed even if a player cannot receive the current reward item. `player:addItem` returns whether or not it was successful so we just need to flip the if..then logic and add it there. Resolves https://github.com/LandSandBoat/server/issues/4727

## Steps to test these changes

1. !pos 41.169 3.899 -51.005 245
2. !addkeyitem 1184
3. !additem 4751
4. Open until you get a Scroll of Erase or your inventory is full