### PR TITLE
[core] Add utility method to get highest job level of char

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -2442,6 +2442,21 @@ int32 CCharEntity::GetTimeCreated()
     return 0;
 }
 
+uint8 CCharEntity::getHighestJobLevel()
+{
+    uint8 maxJobLevel = 0;
+
+    for (uint8 jobId = 0; jobId < MAX_JOBTYPE; jobId++)
+    {
+        if (jobs.job[jobId] > maxJobLevel)
+        {
+            maxJobLevel = jobs.job[jobId];
+        }
+    }
+
+    return maxJobLevel;
+}
+
 bool CCharEntity::hasMoghancement(uint16 moghancementID) const
 {
     return m_moghancementID == moghancementID;

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -564,6 +564,7 @@ public:
     int32 GetTimeRemainingUntilDeathHomepoint() const;
 
     int32 GetTimeCreated();
+    uint8 getHighestJobLevel();
 
     bool isInEvent();
     bool isNpcLocked();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR adds a utility function to get the highest level of all jobs of a char. This is useful for implementing retail logic such as fishing fatigue being different if chars highest level is less than 20 (see [retail patch notes](http://forum.square-enix.com/ffxi/threads/41117)). This is also useful for private servers that can use the function to implement restrictions to avoid spammers and bots. For example Horizon implements a min highest level of 20 for using yell and for fishing.

## Steps to test these changes
There is no user facing LSB implementation as of yet (as fishing data for example is not fully known). Thus one way to test is to add code to like zoning logic that prints to the player their highest level, the test by zoning.