### PR TITLE
Add `enc_temp_folder` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,7 @@ log/leaks.txt
 # Visual Studio
 **/*.vcxproj*
 **/*.sln
+enc_temp_folder
 
 # CMake files
 CMakeCache.txt


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
For some reason, VS2022 likes to cache everything modified while running in `enc_temp_folder` within the repo root.  Adds that to .gitignore
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Run server via VS2022 and make changes to any file, see only the changed file and not the stale backup
<!-- Clear and detailed steps to test your changes here -->
