### PR TITLE
Add safety for CItemFish cast in CatchFish

### DIFF
--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -1496,7 +1496,7 @@ namespace fishingutils
 
         if (PChar->getStorage(LOC_INVENTORY)->GetFreeSlotsCount() != 0)
         {
-            CItemFish* Fish = static_cast<CItemFish*>(itemutils::GetItem(FishID));
+            CItemFish* Fish = dynamic_cast<CItemFish*>(itemutils::GetItem(FishID));
 
             if (Fish == nullptr)
             {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Null check occurs after a static cast from CItem* to CItemFish (which inherits CItem).  Use dynamic_cast for safety

![image](https://github.com/LandSandBoat/server/assets/81713309/65b58558-1eda-42ad-baf8-ed840e079917)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
