### PR TITLE
[LUA] Fix Ripper Fang doesn't match wikis

### DIFF
--- a/scripts/actions/mobskills/ripper_fang.lua
+++ b/scripts/actions/mobskills/ripper_fang.lua
@@ -1,7 +1,7 @@
 -----------------------------------
---  Sprout Smack
---  Description: Additional effect: Slow.  Duration of effect varies with TP.
---  Type: Physical (Blunt)
+--  Ripper Fang
+--  Description: Deals physical damage. Damage varies with TP.
+--  Type: Physical (Slashing)
 -----------------------------------
 local mobskillObject = {}
 
@@ -12,12 +12,11 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 1
     local accmod = 1
-    local dmgmod = 2.5
-    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
-    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, info.hitslanded)
+    local dmgmod = 1.5
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.ATK_VARIES, 1.3, 1.3, 1.3)
+    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.SLOW, 1250, 0, 120)
-    target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
+    target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
 
     return dmg
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Noticed some comment issues on Ripper Fang which led me down the rabbit hole. Wikis seems to have conflicting information but from what I can gather it should be closer to 200% modifier (JP wiki says 150%?) and slashing damage, the additional effect may no longer be a thing but would require retail verification so I've left it in for now.

https://www.bg-wiki.com/ffxi/Category:Raptor
https://www.bg-wiki.com/ffxi/Category:Jug_Pets
https://wiki.ffo.jp/html/23464.html

## Steps to test these changes

1. Find a mob
2. !exec target:useMobAbility(374)
