### PR TITLE
[AMK, Lua] Fix: corrected helmtype in amk helpers.lua

### DIFF
--- a/scripts/missions/amk/helpers.lua
+++ b/scripts/missions/amk/helpers.lua
@@ -35,9 +35,9 @@ xi.amk.helpers.helmTrade = function(player, helmType, broke)
     local regionId = player:getCurrentRegion()
     local helmMapping =
     {
-        [xi.helm.type.MINING] = xi.ki.STURDY_METAL_STRIP,
-        [xi.helm.type.LOGGING] = xi.ki.PIECE_OF_RUGGED_TREE_BARK,
-        [xi.helm.type.HARVESTING] = xi.ki.SAVORY_LAMB_ROAST,
+        [xi.helmType.MINING] = xi.ki.STURDY_METAL_STRIP,
+        [xi.helmType.LOGGING] = xi.ki.PIECE_OF_RUGGED_TREE_BARK,
+        [xi.helmType.HARVESTING] = xi.ki.SAVORY_LAMB_ROAST,
     }
 
     if


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes helm enums in amk helpers.lua for mission 4

## Steps to test these changes

!addmission 10 4
/item sickle <harvesting_point
