### PR TITLE
[CPP] Fix manual sorting doesn't stack items

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -1499,6 +1499,29 @@ void SmallPacket0x029(map_session_data_t* const PSession, CCharEntity* const PCh
         if (ToSlotID < 82) // 80 + 1
         {
             ShowDebug("SmallPacket0x29: Trying to unite items", FromLocationID, FromSlotID);
+            CItem* PItem2 = PChar->getStorage(ToLocationID)->GetItem(ToSlotID);
+
+            if ((PItem2 != nullptr) && (PItem2->getID() == PItem->getID()) && (PItem2->getQuantity() < PItem2->getStackSize()) &&
+                !PItem2->isSubType(ITEM_LOCKED) && (PItem2->getReserve() == 0))
+            {
+                uint32 totalQty = PItem->getQuantity() + PItem2->getQuantity();
+                uint32 moveQty  = 0;
+
+                if (totalQty >= PItem2->getStackSize())
+                {
+                    moveQty = PItem2->getStackSize() - PItem2->getQuantity();
+                }
+                else
+                {
+                    moveQty = PItem->getQuantity();
+                }
+                if (moveQty > 0)
+                {
+                    charutils::UpdateItem(PChar, ToLocationID, ToSlotID, moveQty);
+                    charutils::UpdateItem(PChar, FromLocationID, FromSlotID, -(int32)moveQty);
+                }
+            }
+
             return;
         }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

When manually sorting stackable items it does not stack the items as expected. To fix this we'll expand upon `SmallPacket0x029` (item movement) and stacking logic similar to `SmallPacket0x03A` (sort inventory). Resolves https://github.com/LandSandBoat/server/issues/4929

## Steps to test these changes

1. Turn off auto sorting (Config > Gameplay > Inventory > Sort)
2. !additem gold_beastcoin 1
3. !additem gold_beastcoin 2
4. !additem gold_beastcoin 12
5. Attempt to manually sort the small stacks together, they should combine
6. Attempt to manually sort the combined small stack with the large stack, it should move but not stack over max stack size (12)