### PR TITLE
[Magic] Add Shield Barrier trait functionality

### DIFF
--- a/scripts/enum/mod.lua
+++ b/scripts/enum/mod.lua
@@ -438,6 +438,7 @@ xi.mod =
     PALISADE_BLOCK_BONUS            = 1066, -- Increases base block rate while under the effects of Palisade (additive, not multiplicative)
     REPRISAL_BLOCK_BONUS            = 1067, -- Increases block rate while under the effects of Reprisal (multiplicative, not additive)
     REPRISAL_SPIKES_BONUS           = 1068, -- Increases Reprisal spikes damage by percentage (e.g. mod value of 50 will increase spikes damage by 50%)
+    SHIELD_BARRIER                  = 1082, -- Grants a bonus to Protect spells cast by self while a shield is equipped.
 
     -- Dark Knight
     ARCANE_CIRCLE_POTENCY           = 1069, -- Increases the potency of the Arcane Circle effect (e.g. mod value 2 = +2% Arcana Killer)

--- a/scripts/globals/spells/enhancing_spell.lua
+++ b/scripts/globals/spells/enhancing_spell.lua
@@ -318,6 +318,14 @@ xi.spells.enhancing.calculateEnhancingFinalPower = function(caster, target, spel
             finalPower = finalPower + (tier * 2)
         end
 
+        -- Handle "Shield Barrier" Job Trait.
+        if
+            caster:isPC() and
+            caster:getMod(xi.mod.SHIELD_BARRIER) > 0
+        then
+            finalPower = finalPower + caster:getShieldDefense()
+        end
+
     -- Refresh
     elseif spellEffect == xi.effect.REFRESH then
         finalPower = finalPower + caster:getMod(xi.mod.ENHANCES_REFRESH)

--- a/sql/traits.sql
+++ b/sql/traits.sql
@@ -742,6 +742,8 @@ INSERT INTO `traits` VALUES (134,'ws damage boost',14,75,4,840,16,'ROV',0);
 INSERT INTO `traits` VALUES (134,'ws damage boost',14,85,5,840,19,'ROV',0);
 INSERT INTO `traits` VALUES (134,'ws damage boost',14,95,6,840,21,'ROV',0);
 
+INSERT INTO `traits` VALUES (136,'shield barrier',7,70,1,1082,1,'ROV',0);
+
 INSERT INTO `traits` VALUES (137,'tandem strike',9,30,1,271,10,'ROV',0);
 INSERT INTO `traits` VALUES (137,'tandem strike',9,45,2,271,20,'ROV',0);
 INSERT INTO `traits` VALUES (137,'tandem strike',9,60,3,271,30,'ROV',0);

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -602,6 +602,18 @@ int8 CCharEntity::getShieldSize()
     return PItem->getShieldSize();
 }
 
+int16 CCharEntity::getShieldDefense()
+{
+    CItemEquipment* PItem = getEquip(SLOT_SUB);
+
+    if (PItem && PItem->IsShield())
+    {
+        return PItem->getModifier(Mod::DEF);
+    }
+
+    return 0;
+}
+
 bool CCharEntity::hasBazaar()
 {
     if (isSettingBazaarPrices)

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -493,8 +493,9 @@ public:
 
     CharHistory_t m_charHistory;
 
-    int8 getShieldSize();
-    bool hasBazaar();
+    int8  getShieldSize();
+    int16 getShieldDefense();
+    bool  hasBazaar();
 
     bool getStyleLocked() const;
     void setStyleLocked(bool isStyleLocked);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -4726,6 +4726,27 @@ int8 CLuaBaseEntity::getShieldSize()
 }
 
 /************************************************************************
+ *  Function: getShieldDefense()
+ *  Purpose : Return the defense of the equipped shield
+ *  Example : player:getShieldDefense()
+ *  Notes   : Returns 0 if player does not have shield equipped
+ ************************************************************************/
+
+int16 CLuaBaseEntity::getShieldDefense()
+{
+    if (m_PBaseEntity->objtype == TYPE_PC)
+    {
+        return static_cast<CCharEntity*>(m_PBaseEntity)->getShieldDefense();
+    }
+    else
+    {
+        ShowWarning("Entity is not a Player: (%s).", m_PBaseEntity->getName());
+    }
+
+    return 0;
+}
+
+/************************************************************************
  *  Function: addGearSetMod()
  *  Purpose : Need to research functionality more to provide description
  *  Example : player:addGearSetMod(setId, modId, modValue)
@@ -17611,6 +17632,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("unlockEquipSlot", CLuaBaseEntity::unlockEquipSlot);
 
     SOL_REGISTER("getShieldSize", CLuaBaseEntity::getShieldSize);
+    SOL_REGISTER("getShieldDefense", CLuaBaseEntity::getShieldDefense);
 
     SOL_REGISTER("addGearSetMod", CLuaBaseEntity::addGearSetMod);
     SOL_REGISTER("clearGearSetMods", CLuaBaseEntity::clearGearSetMods);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -253,7 +253,8 @@ public:
     void lockEquipSlot(uint8 slot);
     void unlockEquipSlot(uint8 slot);
 
-    int8 getShieldSize();
+    int8  getShieldSize();
+    int16 getShieldDefense();
 
     bool hasGearSetMod(uint8 modNameId);
     void addGearSetMod(uint8 modNameId, Mod modId, uint16 modValue);

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -466,6 +466,7 @@ enum class Mod
     PALISADE_BLOCK_BONUS   = 1066, // Increases base block rate while under the effects of Palisade (additive, not multiplicative)
     REPRISAL_BLOCK_BONUS   = 1067, // Increases block rate while under the effects of Reprisal (multiplicative, not additive)
     REPRISAL_SPIKES_BONUS  = 1068, // Increases Reprisal spikes damage by percentage (e.g. mod value 50 = +50% spikes damage)
+    SHIELD_BARRIER         = 1082, // Grants a bonus to Protect spells cast by self while a shield is equipped.
 
     // Dark Knight
     ARCANE_CIRCLE_DURATION = 858,  // Arcane Circle extended duration in seconds
@@ -1019,7 +1020,7 @@ enum class Mod
     // 221 to 222
     // 274 to 275
     //
-    // SPARE = 1082 and onward
+    // SPARE = 1083 and onward
 };
 
 // temporary workaround for using enum class as unordered_map key until compilers support it


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds functionality for the PLD Shield Barrier trait as described on the wiki. Adds the defense value of the equipped shield to the power of all Protect spells cast by self.

https://www.bg-wiki.com/ffxi/Shield_Barrier

## Steps to test these changes

1. !changejob 7 99
2. !getmod shield_barrier should be 1
3. !addallspells
4. !additem 15070
5. Cast Protect with shield on, bonus should apply
6. !changejob 7 69
7. !getmod shield_barrier should be 0
8. Cast Protect with shield on, bonus shouldn't apply

Protect base 20
Protect with shield 60
Protect II base 50
Protect II with shield 90
Protect III base 90
Protect III with shield 130
Protect IV base 140
Protect IV with shield 180
Protect V base 220
Protect V with shield 260
