### PR TITLE
[CPP] Fix error on zone when naked

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1020,7 +1020,7 @@ namespace charutils
                             "WHERE charid = (?)";
 
         auto rset = db::preparedStmt(Query, PChar->id);
-        if (rset && rset->rowsCount())
+        if (rset)
         {
             // equipSlotData[equipSlotId] = { slotId, containerId }
             std::unordered_map<uint8, std::pair<uint8, uint8>> equipSlotData;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a check to prevent reporting an error if a character is naked and has no equipment to load. Resolves https://github.com/LandSandBoat/server/issues/5702

## Steps to test these changes

1. Unequip everything
2. Zone
3. Error shouldn't appear