### PR TITLE
[SQL] Level correct Gyre-Carlin

### DIFF
--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -429,7 +429,7 @@ INSERT INTO `mob_groups` VALUES (52,3992,9,'Treasure_Chest',0,128,0,0,0,55,60,0)
 INSERT INTO `mob_groups` VALUES (53,6387,9,'Gazer',924,0,315,0,0,42,44,0);
 INSERT INTO `mob_groups` VALUES (54,1040,9,'Diremite',924,0,657,0,0,42,46,0);
 INSERT INTO `mob_groups` VALUES (55,3685,9,'Snowball',924,0,2286,0,0,43,46,0);
-INSERT INTO `mob_groups` VALUES (56,6963,9,'Gyre-Carlin',0,32,1260,0,0,75,80,0);
+INSERT INTO `mob_groups` VALUES (56,6963,9,'Gyre-Carlin',0,32,1260,4883,0,50,50,0);
 INSERT INTO `mob_groups` VALUES (57,2922,9,'Nunyunuwi',0,128,0,3500,0,56,58,0);
 INSERT INTO `mob_groups` VALUES (58,292,9,'Avalanche',960,0,30,0,0,75,75,0);
 INSERT INTO `mob_groups` VALUES (59,3231,9,'Purgatory_Bat',960,0,234,0,0,72,76,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

[Gyre-Carlin](https://www.bg-wiki.com/ffxi/Gyre-Carlin) is currently set the same min/max as the Nyzul version which isn't appropriate for Pso'Xja. The wiki lists his level as 50, and a capture video also shows the same so. Referencing a similar NM in the same zone ([Nunyunuwi](https://www.bg-wiki.com/ffxi/Nunyunuwi)) we'll tweak the min to 56 and max to 58. HP is estimated to 5883 in the capture. Resolves https://github.com/LandSandBoat/server/issues/5700

https://www.bg-wiki.com/ffxi/Gyre-Carlin
https://www.youtube.com/watch?v=UYTrBzyYaXI

I am not entirely how to glean the real level from captures (if that's even possible). If there is a way please let me know!

## Steps to test these changes

1. !zone Pso'Xja
2. !mobhere 16814331