### PR TITLE
[CPP] Fix non-equipment items can cause map crash

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -4557,6 +4557,11 @@ bool CLuaBaseEntity::canEquipItem(uint16 itemID, sol::object const& chkLevel)
         return false;
     }
 
+    if (!PItem->isType(ITEM_EQUIPMENT))
+    {
+        return false;
+    }
+
     if (!(PItem->getJobs() & (1 << (PChar->GetMJob() - 1))))
     {
         return false;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Currently since `CLuaBaseEntity::canEquipItem` only takes an item ID as a param then casts it, it will sometimes be a non-equipment item. With the addition of `isEquippableByRace` it attempts to check a modifier that doesn't exist on non-equipment items. To fix this we'll add a return false if the item is not equipment. Resolves https://github.com/LandSandBoat/server/issues/5703

## Steps to test these changes

1. Go to a conquest NPC
2. Keep opening the "Are you sure you want to purchase the X?" menu on a non-equipment item (Scroll of Instant Warp for example)
