### PR TITLE
Correct size for 0x77 S->C Packet

### DIFF
--- a/src/map/packets/entity_enable_list.cpp
+++ b/src/map/packets/entity_enable_list.cpp
@@ -7,7 +7,7 @@
 CEntityEnableList::CEntityEnableList(const std::vector<uint32>& list)
 {
     this->setType(0x77);
-    this->setSize(0x110); // TODO: Verify
+    this->setSize(0x88);
 
     ref<uint32>(0x04) = 1;
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Corrects the size for 0x77 S->C packet from 0x110 to 0x88
![image](https://github.com/LandSandBoat/server/assets/81713309/79f73175-2b1c-406a-ba95-a80f60b566fe)


<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No changes should be observed (outside of the correct size being set)
<!-- Clear and detailed steps to test your changes here -->
