### PR TITLE
Update Celestial Nexus mobs from March 2024 Shift

### DIFF
--- a/sql/bcnm_battlefield.sql
+++ b/sql/bcnm_battlefield.sql
@@ -720,15 +720,15 @@ INSERT INTO `bcnm_battlefield` VALUES (293,3,17514541,3);
 INSERT INTO `bcnm_battlefield` VALUES (293,3,17514542,3);
 INSERT INTO `bcnm_battlefield` VALUES (293,3,17514543,3);
 INSERT INTO `bcnm_battlefield` VALUES (293,3,17514544,3);
-INSERT INTO `bcnm_battlefield` VALUES (320,1,17518595,3); -- celestial_nexus
-INSERT INTO `bcnm_battlefield` VALUES (320,1,17518596,3);
-INSERT INTO `bcnm_battlefield` VALUES (320,1,17518597,2);
-INSERT INTO `bcnm_battlefield` VALUES (320,2,17518600,3);
+INSERT INTO `bcnm_battlefield` VALUES (320,1,17518596,3); -- celestial_nexus
+INSERT INTO `bcnm_battlefield` VALUES (320,1,17518597,3);
+INSERT INTO `bcnm_battlefield` VALUES (320,1,17518598,2);
 INSERT INTO `bcnm_battlefield` VALUES (320,2,17518601,3);
-INSERT INTO `bcnm_battlefield` VALUES (320,2,17518602,2);
-INSERT INTO `bcnm_battlefield` VALUES (320,3,17518605,3);
+INSERT INTO `bcnm_battlefield` VALUES (320,2,17518602,3);
+INSERT INTO `bcnm_battlefield` VALUES (320,2,17518603,2);
 INSERT INTO `bcnm_battlefield` VALUES (320,3,17518606,3);
-INSERT INTO `bcnm_battlefield` VALUES (320,3,17518607,2);
+INSERT INTO `bcnm_battlefield` VALUES (320,3,17518607,3);
+INSERT INTO `bcnm_battlefield` VALUES (320,3,17518608,2);
 INSERT INTO `bcnm_battlefield` VALUES (416,1,17600513,3); -- trial_by_wind
 INSERT INTO `bcnm_battlefield` VALUES (416,2,17600514,3);
 INSERT INTO `bcnm_battlefield` VALUES (416,3,17600515,3);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
All defined mobs shifted in the March Update from within Celestial Nexus.  This adjusts bcnm_battlefield and mob spawn points table to reflect the necessary changes.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Enter battlefield, and don't see this:
![image](https://github.com/LandSandBoat/server/assets/81713309/d51bb60e-5463-4c2e-bed5-0ab4c9924229)

<!-- Clear and detailed steps to test your changes here -->
