### PR TITLE
[cpp] Immanence logic cleanup

### DIFF
--- a/scripts/actions/abilities/immanence.lua
+++ b/scripts/actions/abilities/immanence.lua
@@ -7,11 +7,17 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
+    if player:hasStatusEffect(xi.effect.IMMANENCE) then
+        return xi.msg.basic.EFFECT_ALREADY_ACTIVE, 0
+    end
+
     return 0, 0
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
     player:addStatusEffect(xi.effect.IMMANENCE, 1, 0, 60)
+
+    return xi.effect.IMMANENCE
 end
 
 return abilityObject

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1131,70 +1131,69 @@ void CCharEntity::OnCastFinished(CMagicState& state, action_t& action)
                 StatusEffectContainer->DelStatusEffectSilent(EFFECT_CHAIN_AFFINITY);
             }
 
-            if (actionTarget.param > 0 &&
+            // Immanence will create or extend a skillchain for elemental spells
+            if (actionTarget.param >= 0 &&
                 PSpell->dealsDamage() &&
                 PSpell->getSpellGroup() == SPELLGROUP_BLACK &&
                 (StatusEffectContainer->HasStatusEffect(EFFECT_IMMANENCE)))
             {
-                SUBEFFECT effect = SUBEFFECT_NONE;
+                auto      immanenceApplies = true;
+                auto      isHelix          = false;
+                SUBEFFECT effect           = SUBEFFECT_NONE;
                 switch (PSpell->getSpellFamily())
                 {
-                    case SPELLFAMILY_STONE:
-                        effect = battleutils::GetSkillChainEffect(PTarget, 4, 0, 0);
-                        break;
                     case SPELLFAMILY_GEOHELIX:
-                        effect = battleutils::GetSkillChainEffect(PTarget, 4, 0, 0);
-                        break;
-                    case SPELLFAMILY_WATER:
-                        effect = battleutils::GetSkillChainEffect(PTarget, 5, 0, 0);
+                        isHelix = true;
+                        [[fallthrough]];
+                    case SPELLFAMILY_STONE:
+                        effect = battleutils::GetSkillChainEffect(PTarget, SKILLCHAIN_ELEMENT::SC_SCISSION, 0, 0);
                         break;
                     case SPELLFAMILY_HYDROHELIX:
-                        effect = battleutils::GetSkillChainEffect(PTarget, 5, 0, 0);
-                        break;
-                    case SPELLFAMILY_AERO:
-                        effect = battleutils::GetSkillChainEffect(PTarget, 6, 0, 0);
+                        isHelix = true;
+                        [[fallthrough]];
+                    case SPELLFAMILY_WATER:
+                        effect = battleutils::GetSkillChainEffect(PTarget, SKILLCHAIN_ELEMENT::SC_REVERBERATION, 0, 0);
                         break;
                     case SPELLFAMILY_ANEMOHELIX:
-                        effect = battleutils::GetSkillChainEffect(PTarget, 6, 0, 0);
-                        break;
-                    case SPELLFAMILY_FIRE:
-                        effect = battleutils::GetSkillChainEffect(PTarget, 3, 0, 0);
+                        isHelix = true;
+                        [[fallthrough]];
+                    case SPELLFAMILY_AERO:
+                        effect = battleutils::GetSkillChainEffect(PTarget, SKILLCHAIN_ELEMENT::SC_DETONATION, 0, 0);
                         break;
                     case SPELLFAMILY_PYROHELIX:
-                        effect = battleutils::GetSkillChainEffect(PTarget, 3, 0, 0);
-                        break;
-                    case SPELLFAMILY_BLIZZARD:
-                        effect = battleutils::GetSkillChainEffect(PTarget, 7, 0, 0);
+                        isHelix = true;
+                        [[fallthrough]];
+                    case SPELLFAMILY_FIRE:
+                        effect = battleutils::GetSkillChainEffect(PTarget, SKILLCHAIN_ELEMENT::SC_LIQUEFACTION, 0, 0);
                         break;
                     case SPELLFAMILY_CRYOHELIX:
-                        effect = battleutils::GetSkillChainEffect(PTarget, 7, 0, 0);
-                        break;
-                    case SPELLFAMILY_THUNDER:
-                        effect = battleutils::GetSkillChainEffect(PTarget, 8, 0, 0);
+                        isHelix = true;
+                        [[fallthrough]];
+                    case SPELLFAMILY_BLIZZARD:
+                        effect = battleutils::GetSkillChainEffect(PTarget, SKILLCHAIN_ELEMENT::SC_INDURATION, 0, 0);
                         break;
                     case SPELLFAMILY_IONOHELIX:
-                        effect = battleutils::GetSkillChainEffect(PTarget, 8, 0, 0);
-                        break;
-                    case SPELLFAMILY_LUMINOHELIX:
-                        effect = battleutils::GetSkillChainEffect(PTarget, 1, 0, 0);
+                        isHelix = true;
+                        [[fallthrough]];
+                    case SPELLFAMILY_THUNDER:
+                        effect = battleutils::GetSkillChainEffect(PTarget, SKILLCHAIN_ELEMENT::SC_IMPACTION, 0, 0);
                         break;
                     case SPELLFAMILY_NOCTOHELIX:
-                        effect = battleutils::GetSkillChainEffect(PTarget, 2, 0, 0);
+                        isHelix = true;
+                        effect  = battleutils::GetSkillChainEffect(PTarget, SKILLCHAIN_ELEMENT::SC_COMPRESSION, 0, 0);
+                        break;
+                    case SPELLFAMILY_LUMINOHELIX:
+                        isHelix = true;
+                        effect  = battleutils::GetSkillChainEffect(PTarget, SKILLCHAIN_ELEMENT::SC_TRANSFIXION, 0, 0);
                         break;
                     default:
+                        immanenceApplies = false;
                         break;
                 }
 
-                if (PSpell->getSpellFamily() >= SPELLFAMILY_FIRE &&
-                    PSpell->getSpellFamily() <= SPELLFAMILY_WATER)
+                if (immanenceApplies)
                 {
-                    StatusEffectContainer->DelStatusEffectSilent(EFFECT_IMMANENCE);
-                }
-
-                if (PSpell->getSpellFamily() >= SPELLFAMILY_GEOHELIX &&
-                    PSpell->getSpellFamily() <= SPELLFAMILY_LUMINOHELIX)
-                {
-                    StatusEffectContainer->DelStatusEffectSilent(EFFECT_IMMANENCE);
+                    StatusEffectContainer->DelStatusEffect(EFFECT_IMMANENCE);
                 }
 
                 if (effect != SUBEFFECT_NONE)
@@ -1212,6 +1211,13 @@ void CCharEntity::OnCastFinished(CMagicState& state, action_t& action)
                         actionTarget.addEffectMessage = 287 + effect;
                     }
                     actionTarget.additionalEffect = effect;
+
+                    // Closing a skillchain with an immanence Helix will make the magic burst window longer
+                    auto scEffect = PTarget->StatusEffectContainer->GetStatusEffect(EFFECT_SKILLCHAIN, 0);
+                    if (isHelix && scEffect)
+                    {
+                        scEffect->SetDuration(scEffect->GetDuration() + 2000);
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

![image](https://github.com/LandSandBoat/server/assets/131182600/3abf161c-6420-4715-b858-a05969988e62)

Apologies for the PR re-creation that will be happening, but any of my older PRs that need changes will have to be re-made as I've lost access to the source branches.

I will try to do my best to re-create the comments to avoid extra work on LSB's side.

(I won't be putting this disclaimer on every new PR, just a link to the old)

https://github.com/LandSandBoat/server/pull/5525

## Steps to test these changes
![image](https://github.com/LandSandBoat/server/assets/131182600/6a3e75fc-e8e4-41b8-8b45-ab3d6275efec)

Good call on extending the duration, as the skillchain tier does affect the remaining duration of the skillchain effect.

Same testing behavior is useful: add prints to `effects/skillchain.lua` to get the explicit start/stop of the effect (Note that the effect isn't removed when a skillchain is created, so this below screenshot is the logs from the above skillchains)
![image](https://github.com/LandSandBoat/server/assets/131182600/23d16daa-8307-4427-aa41-638078464334)

and helixes
![image](https://github.com/LandSandBoat/server/assets/131182600/babb0ff3-460e-425b-8cb5-a513d37ebdca)

![image](https://github.com/LandSandBoat/server/assets/131182600/5baaecba-28ed-4df4-a6bb-c42ae0b7b74b)

