### PR TITLE
[LUA] Fix Despoil incorrect message on fail

### DIFF
--- a/scripts/globals/job_utils/thief.lua
+++ b/scripts/globals/job_utils/thief.lua
@@ -218,7 +218,7 @@ xi.job_utils.thief.useDespoil = function(player, target, ability, action)
     if
         target:isMob() and
         math.random(1, 100) <= despoilChance and
-        stolen
+        stolen ~= 0
     then
         if player:getObjType() == xi.objType.TRUST then
             player:getMaster():addItem(stolen)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Despoil currently gives an improper message when it fails due to a `stolen` always having a value. When a mob has no item to steal or it has already been stolen the `stolen` variable will be 0.

Before
![image](https://github.com/LandSandBoat/server/assets/166072302/1aba3185-5db9-4143-8f08-335cd6daccac)

After
![image](https://github.com/LandSandBoat/server/assets/166072302/51753035-c4b8-464b-bc19-d5f275af6fa9)

## Steps to test these changes

1. !changejob 6 99
2. Find a mob
3. Attempt to Despoil from it
