### PR TITLE
[LUA] Fix Rank 2-3 mission BCNM doesn't award KI on win

### DIFF
--- a/scripts/missions/bastok/2_3_3_The_Emissary_Sandoria2.lua
+++ b/scripts/missions/bastok/2_3_3_The_Emissary_Sandoria2.lua
@@ -61,7 +61,7 @@ mission.sections =
                 [32001] = function(player, csid, option, npc)
                     if
                         player:getMissionStatus(mission.areaId) == 9 and
-                        player:getLocalVar('battlefieldWin') == 999
+                        player:getLocalVar('battlefieldWin') == 0
                     then
                         npcUtil.giveKeyItem(player, xi.ki.KINDRED_CREST)
                         player:setMissionStatus(mission.areaId, 10)

--- a/scripts/missions/windurst/2_3_3_The_Three_Kingdoms_Sandoria2.lua
+++ b/scripts/missions/windurst/2_3_3_The_Three_Kingdoms_Sandoria2.lua
@@ -65,7 +65,7 @@ mission.sections =
                 [32001] = function(player, csid, option, npc)
                     if
                         player:getMissionStatus(mission.areaId) == 9 and
-                        player:getLocalVar('battlefieldWin') == 999
+                        player:getLocalVar('battlefieldWin') == 0
                     then
                         npcUtil.giveKeyItem(player, xi.ki.KINDRED_CREST)
                         player:delKeyItem(xi.ki.DARK_KEY)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The recent BCNM rework missed a small edge case where the win var was changed to 999 instead of 0. As a result, when you win the Rank 2-3 mission BCNM you are not awarded the KI. It doesn't seem like this should cause any issues being 0, at least I did not run into any.

## Steps to test these changes

Bastok

1. !setnation 1
2. !addmission 1 8
3. !exec player:setMissionStatus(1, 9)
4. !zone Horlais Peak
5. Enter BCNM and win

Windurst

1. !setnation 1
2. !addmission 2 8
3. !exec player:setMissionStatus(2, 9)
4. !zone Horlais Peak
5. Enter BCNM and win

If you test both make sure you !completequest before changing over, also !delkeyitem KINDRED_CREST since they both award the same KI.