### PR TITLE
Update deeds field for RoeSparkUpdatePacket to uint16

### DIFF
--- a/src/map/packets/roe_sparkupdate.cpp
+++ b/src/map/packets/roe_sparkupdate.cpp
@@ -42,10 +42,8 @@ CRoeSparkUpdatePacket::CRoeSparkUpdatePacket(CCharEntity* PChar)
     if (ret != SQL_ERROR && _sql->NextRow() == SQL_SUCCESS)
     {
         ref<uint32>(0x04) = _sql->GetIntData(0);
-        ref<uint8>(0x08)  = _sql->GetIntData(1);
-
+        ref<uint16>(0x08) = _sql->GetIntData(1);
         ref<uint16>(0x0A) = _sql->GetIntData(2);
-
         ref<uint8>(0x0C)  = daysSinceEpoch % 6;  // Unity Shared Daily (0-5)
         ref<uint8>(0x0D)  = weeksSinceEpoch % 4; // Unity Leader Weekly (0-3)
         ref<uint16>(0x0E) = 0xFFFF;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Deeds field was mistakenly set as uint8 when it should be uint16.  Change made to align with packet expectations
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Set deeds to 300
<!-- Clear and detailed steps to test your changes here -->
