### PR TITLE
Increases inventory storage ItemNum2 to uint16 to fix uint8 overflow

### DIFF
--- a/src/map/packets/inventory_size.cpp
+++ b/src/map/packets/inventory_size.cpp
@@ -58,22 +58,22 @@ CInventorySizePacket::CInventorySizePacket(CCharEntity* PChar)
     ref<uint8>(0x15) = 1 + PChar->getStorage(LOC_RECYCLEBIN)->GetSize();
 
     // These set the usable amount of the container. 0x00 disables the container.
-    ref<uint8>(0x24) = 1 + PChar->getStorage(LOC_INVENTORY)->GetBuff();
-    ref<uint8>(0x26) = 1 + PChar->getStorage(LOC_MOGSAFE)->GetBuff();
-    ref<uint8>(0x28) = 1 + PChar->getStorage(LOC_STORAGE)->GetBuff();
-    ref<uint8>(0x2A) = 1 + PChar->getStorage(LOC_TEMPITEMS)->GetBuff();
-    ref<uint8>(0x2C) = charutils::hasMogLockerAccess(PChar) ? 1 + PChar->getStorage(LOC_MOGLOCKER)->GetBuff() : 0x00;
-    ref<uint8>(0x2E) = 1 + PChar->getStorage(LOC_MOGSATCHEL)->GetBuff();
-    ref<uint8>(0x30) = 1 + PChar->getStorage(LOC_MOGSACK)->GetBuff();
-    ref<uint8>(0x32) = 1 + PChar->getStorage(LOC_MOGCASE)->GetBuff();
-    ref<uint8>(0x34) = 1 + PChar->getStorage(LOC_WARDROBE)->GetBuff();
-    ref<uint8>(0x36) = 1 + PChar->getStorage(LOC_MOGSAFE2)->GetBuff();
-    ref<uint8>(0x38) = 1 + PChar->getStorage(LOC_WARDROBE2)->GetBuff();
-    ref<uint8>(0x3A) = 1 + PChar->getStorage(LOC_WARDROBE3)->GetBuff();
-    ref<uint8>(0x3C) = 1 + PChar->getStorage(LOC_WARDROBE4)->GetBuff();
-    ref<uint8>(0x3E) = 1 + PChar->getStorage(LOC_WARDROBE5)->GetBuff();
-    ref<uint8>(0x40) = 1 + PChar->getStorage(LOC_WARDROBE6)->GetBuff();
-    ref<uint8>(0x42) = 1 + PChar->getStorage(LOC_WARDROBE7)->GetBuff();
-    ref<uint8>(0x44) = 1 + PChar->getStorage(LOC_WARDROBE8)->GetBuff();
-    ref<uint8>(0x46) = 1 + PChar->getStorage(LOC_RECYCLEBIN)->GetBuff();
+    ref<uint16>(0x24) = 1 + PChar->getStorage(LOC_INVENTORY)->GetBuff();
+    ref<uint16>(0x26) = 1 + PChar->getStorage(LOC_MOGSAFE)->GetBuff();
+    ref<uint16>(0x28) = 1 + PChar->getStorage(LOC_STORAGE)->GetBuff();
+    ref<uint16>(0x2A) = 1 + PChar->getStorage(LOC_TEMPITEMS)->GetBuff();
+    ref<uint16>(0x2C) = charutils::hasMogLockerAccess(PChar) ? 1 + PChar->getStorage(LOC_MOGLOCKER)->GetBuff() : 0x00;
+    ref<uint16>(0x2E) = 1 + PChar->getStorage(LOC_MOGSATCHEL)->GetBuff();
+    ref<uint16>(0x30) = 1 + PChar->getStorage(LOC_MOGSACK)->GetBuff();
+    ref<uint16>(0x32) = 1 + PChar->getStorage(LOC_MOGCASE)->GetBuff();
+    ref<uint16>(0x34) = 1 + PChar->getStorage(LOC_WARDROBE)->GetBuff();
+    ref<uint16>(0x36) = 1 + PChar->getStorage(LOC_MOGSAFE2)->GetBuff();
+    ref<uint16>(0x38) = 1 + PChar->getStorage(LOC_WARDROBE2)->GetBuff();
+    ref<uint16>(0x3A) = 1 + PChar->getStorage(LOC_WARDROBE3)->GetBuff();
+    ref<uint16>(0x3C) = 1 + PChar->getStorage(LOC_WARDROBE4)->GetBuff();
+    ref<uint16>(0x3E) = 1 + PChar->getStorage(LOC_WARDROBE5)->GetBuff();
+    ref<uint16>(0x40) = 1 + PChar->getStorage(LOC_WARDROBE6)->GetBuff();
+    ref<uint16>(0x42) = 1 + PChar->getStorage(LOC_WARDROBE7)->GetBuff();
+    ref<uint16>(0x44) = 1 + PChar->getStorage(LOC_WARDROBE8)->GetBuff();
+    ref<uint16>(0x46) = 1 + PChar->getStorage(LOC_RECYCLEBIN)->GetBuff();
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Per the information provided [here](https://github.com/atom0s/XiPackets/blob/024300c4ba710ad4417e442593d3626de42168b1/world/server/0x001C/README.md) and through some discussions with WinterSolstice - determined the underlying packets for inventory storage should be supporting `uint16` not `uint8`.

This matters for Mog House Storage which has a total storage size which can exceed 255.

In a previous [PR](https://github.com/LandSandBoat/server/pull/5616) I resolved the player's available storage space getting truncated to lower than expected values due to uint8 overflow internal to the server.  E.g. The player would expect to have 80 storage, and would only have say 10 accessable storage.

This PR ensures the correct values are also sent to the client - where the client uses the information to determine _if_ a player should be allowed to remove placed furniture.  When the values sent to the client overflow, players are unable to remove laid out furniture if the client believe the removal would orphan items in storage.  
E.g. The player has 266 storage, 4 wells (240), a bookshelf (20), and 6 Aquariums and has 7 items in storage.  When overflowing - the client will believe the player only has ~10 available storage space and will incorrectly prevent the removal of the bookshelf and the wells.

## Steps to test these changes

1. Have a player with 4 wells, a bookshelf, and 6 single storage furniture all laid out in their mog house.
2. They will display as 80 available storage slots.
3. Add 7 items to storage (and only 7)
4.  Attempt to remove (Layout > select furniture > remove) a well or a bookshelf.
5.  Note that despite having 266 storage - removal of the non-single item furnishings will be prevented

Post this PR
On step 4 - you can remove all large storage items, or all large storage items but 1 if you remove the single item furnishings.  Essentially `works as intended`