### PR TITLE
Enchantment coexist

### DIFF
--- a/scripts/items/acrobats_belt.lua
+++ b/scripts/items/acrobats_belt.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, item:getID())
 end
 

--- a/scripts/items/acrobats_belt.lua
+++ b/scripts/items/acrobats_belt.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 15866 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, 15866)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/armored_ring.lua
+++ b/scripts/items/armored_ring.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 

--- a/scripts/items/armored_ring.lua
+++ b/scripts/items/armored_ring.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 15783 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 15783)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/assailants_axe.lua
+++ b/scripts/items/assailants_axe.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 

--- a/scripts/items/assailants_axe.lua
+++ b/scripts/items/assailants_axe.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 18488 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 18488)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/assassins_ring.lua
+++ b/scripts/items/assassins_ring.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 14678 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 14678)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/assassins_ring.lua
+++ b/scripts/items/assassins_ring.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 

--- a/scripts/items/astral_pot.lua
+++ b/scripts/items/astral_pot.lua
@@ -6,20 +6,20 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
     local pet = target:getPet()
     if not pet then
         return xi.msg.basic.REQUIRES_A_PET, 0
-    elseif effect ~= nil and effect:getSubType() == 18243 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    elseif effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 300, 18243)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 300, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/astral_pot.lua
+++ b/scripts/items/astral_pot.lua
@@ -7,18 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
-    local effect = target:getItemEnchantmentEffect(item:getID())
-    local pet = target:getPet()
-    if not pet then
-        return xi.msg.basic.REQUIRES_A_PET, 0
-    elseif effect then
-        effect:delStatusEffect()
-    end
-
     return 0
 end
 
 itemObject.onItemUse = function(target, user, item)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
+    end
+
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 300, item:getID())
 end
 

--- a/scripts/items/augmenting_belt.lua
+++ b/scripts/items/augmenting_belt.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 

--- a/scripts/items/augmenting_belt.lua
+++ b/scripts/items/augmenting_belt.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 15889 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 15889)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/bag_of_wyvern_feed.lua
+++ b/scripts/items/bag_of_wyvern_feed.lua
@@ -7,18 +7,20 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
-    local effect = target:getItemEnchantmentEffect(item:getID())
     local pet = target:getPet()
     if not pet then
         return xi.msg.basic.REQUIRES_A_PET, 0
-    elseif effect then
-        effect:delStatusEffect()
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target, user, item)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
+    end
+
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 

--- a/scripts/items/bag_of_wyvern_feed.lua
+++ b/scripts/items/bag_of_wyvern_feed.lua
@@ -6,20 +6,20 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
     local pet = target:getPet()
     if not pet then
         return xi.msg.basic.REQUIRES_A_PET, 0
-    elseif effect ~= nil and effect:getSubType() == 18242 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    elseif effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 18242)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/bannaret_mail.lua
+++ b/scripts/items/bannaret_mail.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 

--- a/scripts/items/bannaret_mail.lua
+++ b/scripts/items/bannaret_mail.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 14531 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 14531)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/breath_mantle.lua
+++ b/scripts/items/breath_mantle.lua
@@ -6,15 +6,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 

--- a/scripts/items/breath_mantle.lua
+++ b/scripts/items/breath_mantle.lua
@@ -5,24 +5,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil then
-        if effect:getSubType() == 15486 then
-            target:delStatusEffect(xi.effect.ENCHANTMENT)
-        end
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    if target:hasStatusEffect(xi.effect.ENCHANTMENT) then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
-        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 15486)
-    else
-        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 15486)
-    end
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/counter_earring.lua
+++ b/scripts/items/counter_earring.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 14786 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 14786)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/counter_earring.lua
+++ b/scripts/items/counter_earring.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 

--- a/scripts/items/czars_belt.lua
+++ b/scripts/items/czars_belt.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, item:getID())
 end
 

--- a/scripts/items/czars_belt.lua
+++ b/scripts/items/czars_belt.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 15868 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, 15868)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/deadeye_earring.lua
+++ b/scripts/items/deadeye_earring.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 14787 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 14787)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/deadeye_earring.lua
+++ b/scripts/items/deadeye_earring.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 

--- a/scripts/items/deductive_brocade_obi.lua
+++ b/scripts/items/deductive_brocade_obi.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 

--- a/scripts/items/deductive_brocade_obi.lua
+++ b/scripts/items/deductive_brocade_obi.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 15861 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 15861)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/dhalmel_whistle.lua
+++ b/scripts/items/dhalmel_whistle.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 15505 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 15505)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/dhalmel_whistle.lua
+++ b/scripts/items/dhalmel_whistle.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 

--- a/scripts/items/eldritch_bone_hairpin.lua
+++ b/scripts/items/eldritch_bone_hairpin.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 

--- a/scripts/items/eldritch_bone_hairpin.lua
+++ b/scripts/items/eldritch_bone_hairpin.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 15268 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 15268)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/eldritch_horn_hairpin.lua
+++ b/scripts/items/eldritch_horn_hairpin.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 

--- a/scripts/items/eldritch_horn_hairpin.lua
+++ b/scripts/items/eldritch_horn_hairpin.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 15269 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 15269)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/enthralling_brocade_obi.lua
+++ b/scripts/items/enthralling_brocade_obi.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 15862 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 15862)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/enthralling_brocade_obi.lua
+++ b/scripts/items/enthralling_brocade_obi.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 

--- a/scripts/items/flexible_pole.lua
+++ b/scripts/items/flexible_pole.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 

--- a/scripts/items/flexible_pole.lua
+++ b/scripts/items/flexible_pole.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 18586 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 18586)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/gamushara_earring.lua
+++ b/scripts/items/gamushara_earring.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 14788 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 14788)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/gamushara_earring.lua
+++ b/scripts/items/gamushara_earring.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 

--- a/scripts/items/getsul_ring.lua
+++ b/scripts/items/getsul_ring.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 14681 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 14681)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/getsul_ring.lua
+++ b/scripts/items/getsul_ring.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 

--- a/scripts/items/gimlet_spear.lua
+++ b/scripts/items/gimlet_spear.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 

--- a/scripts/items/gimlet_spear.lua
+++ b/scripts/items/gimlet_spear.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 18117 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 18117)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/haste_belt.lua
+++ b/scripts/items/haste_belt.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffectEx(xi.effect.ENCHANTMENT, xi.effect.HASTE, 0, 0, 180, item:getID())
 end
 

--- a/scripts/items/haste_belt.lua
+++ b/scripts/items/haste_belt.lua
@@ -1,11 +1,17 @@
 -----------------------------------
 -- ID: 15290
 -- Item: Haste Belt
--- Item Effect: 10% haste
+-- Item Effect: 10% haste, stacks with haste
+-- Notes: must remain equipped to keep the effect, overwrites existing haste enchantment
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
+    end
+
     return 0
 end
 

--- a/scripts/items/healing_feather.lua
+++ b/scripts/items/healing_feather.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 18239 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 18239)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/healing_feather.lua
+++ b/scripts/items/healing_feather.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 

--- a/scripts/items/high_breath_mantle.lua
+++ b/scripts/items/high_breath_mantle.lua
@@ -6,15 +6,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 

--- a/scripts/items/high_breath_mantle.lua
+++ b/scripts/items/high_breath_mantle.lua
@@ -5,24 +5,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil then
-        if effect:getSubType() == 15487 then
-            target:delStatusEffect(xi.effect.ENCHANTMENT)
-        end
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    if target:hasStatusEffect(xi.effect.ENCHANTMENT) then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
-        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 15487)
-    else
-        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 15487)
-    end
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/high_mana_wand.lua
+++ b/scripts/items/high_mana_wand.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 

--- a/scripts/items/high_mana_wand.lua
+++ b/scripts/items/high_mana_wand.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 18403 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 18403)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/hydra_harness.lua
+++ b/scripts/items/hydra_harness.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 14516 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 14516)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/hydra_harness.lua
+++ b/scripts/items/hydra_harness.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 

--- a/scripts/items/hydra_mittens.lua
+++ b/scripts/items/hydra_mittens.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 14925 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 14925)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/hydra_mittens.lua
+++ b/scripts/items/hydra_mittens.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 

--- a/scripts/items/hydra_spats.lua
+++ b/scripts/items/hydra_spats.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1200, item:getID())
 end
 

--- a/scripts/items/hydra_spats.lua
+++ b/scripts/items/hydra_spats.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 15681 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1200, 15681)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1200, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/hydra_tights.lua
+++ b/scripts/items/hydra_tights.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffectEx(xi.effect.ENCHANTMENT, xi.effect.HASTE, 0, 0, 180, item:getID())
 end
 

--- a/scripts/items/hydra_tights.lua
+++ b/scripts/items/hydra_tights.lua
@@ -1,6 +1,6 @@
 -----------------------------------
--- ID: 15290
--- Item: Haste Belt
+-- ID: 15596
+-- Item: Hydra Tights
 -- Item Effect: 10% haste, stacks with haste
 -- Notes: must remain equipped to keep the effect, overwrites existing haste enchantment
 -----------------------------------

--- a/scripts/items/janizary_earring.lua
+++ b/scripts/items/janizary_earring.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 14785 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 14785)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/janizary_earring.lua
+++ b/scripts/items/janizary_earring.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 

--- a/scripts/items/jolt_axe.lua
+++ b/scripts/items/jolt_axe.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 

--- a/scripts/items/jolt_axe.lua
+++ b/scripts/items/jolt_axe.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 17954 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 17954)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/maharajas_belt.lua
+++ b/scripts/items/maharajas_belt.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, item:getID())
 end
 

--- a/scripts/items/maharajas_belt.lua
+++ b/scripts/items/maharajas_belt.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 15870 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, 15870)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/mana_wand.lua
+++ b/scripts/items/mana_wand.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 

--- a/scripts/items/mana_wand.lua
+++ b/scripts/items/mana_wand.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 18402 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 18402)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/mighty_ring.lua
+++ b/scripts/items/mighty_ring.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 

--- a/scripts/items/mighty_ring.lua
+++ b/scripts/items/mighty_ring.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 15558 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 15558)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/naruko_earring.lua
+++ b/scripts/items/naruko_earring.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 14789 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 14789)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/naruko_earring.lua
+++ b/scripts/items/naruko_earring.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 

--- a/scripts/items/pacifist_ring.lua
+++ b/scripts/items/pacifist_ring.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 14680 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 14680)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/pacifist_ring.lua
+++ b/scripts/items/pacifist_ring.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 

--- a/scripts/items/pendragons_belt.lua
+++ b/scripts/items/pendragons_belt.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, item:getID())
 end
 

--- a/scripts/items/pendragons_belt.lua
+++ b/scripts/items/pendragons_belt.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 15869 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, 15869)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/piercing_dagger.lua
+++ b/scripts/items/piercing_dagger.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 

--- a/scripts/items/piercing_dagger.lua
+++ b/scripts/items/piercing_dagger.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 18029 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 18029)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/runners_belt.lua
+++ b/scripts/items/runners_belt.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 15865 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, 15865)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/runners_belt.lua
+++ b/scripts/items/runners_belt.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, item:getID())
 end
 

--- a/scripts/items/samsonian_belt.lua
+++ b/scripts/items/samsonian_belt.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, item:getID())
 end
 

--- a/scripts/items/samsonian_belt.lua
+++ b/scripts/items/samsonian_belt.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 15863 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, 15863)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/sanation_ring.lua
+++ b/scripts/items/sanation_ring.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 14677 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 15486)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/sanation_ring.lua
+++ b/scripts/items/sanation_ring.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 

--- a/scripts/items/smash_cesti.lua
+++ b/scripts/items/smash_cesti.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 

--- a/scripts/items/smash_cesti.lua
+++ b/scripts/items/smash_cesti.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 18747 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 18747)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/spirit_lantern.lua
+++ b/scripts/items/spirit_lantern.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 18240 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 18240)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/spirit_lantern.lua
+++ b/scripts/items/spirit_lantern.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, item:getID())
 end
 

--- a/scripts/items/sturdy_slacks.lua
+++ b/scripts/items/sturdy_slacks.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 

--- a/scripts/items/sturdy_slacks.lua
+++ b/scripts/items/sturdy_slacks.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 15611 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 15611)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/sturdy_trousers.lua
+++ b/scripts/items/sturdy_trousers.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 

--- a/scripts/items/sturdy_trousers.lua
+++ b/scripts/items/sturdy_trousers.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 15610 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 15610)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/sultans_belt.lua
+++ b/scripts/items/sultans_belt.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, item:getID())
 end
 

--- a/scripts/items/sultans_belt.lua
+++ b/scripts/items/sultans_belt.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 15867 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, 15867)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/tactical_ring.lua
+++ b/scripts/items/tactical_ring.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 120, item:getID())
 end
 

--- a/scripts/items/tactical_ring.lua
+++ b/scripts/items/tactical_ring.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 14679 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 120, 14679)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 120, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/taikyoku_kenpogi.lua
+++ b/scripts/items/taikyoku_kenpogi.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 

--- a/scripts/items/taikyoku_kenpogi.lua
+++ b/scripts/items/taikyoku_kenpogi.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 14541 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 14541)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/tough_belt.lua
+++ b/scripts/items/tough_belt.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 15864 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 600, 15864)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 600, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/tough_belt.lua
+++ b/scripts/items/tough_belt.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 600, item:getID())
 end
 

--- a/scripts/items/twicer.lua
+++ b/scripts/items/twicer.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 30, item:getID())
 end
 

--- a/scripts/items/twicer.lua
+++ b/scripts/items/twicer.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 18216 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 30, 18216)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 30, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/vial_of_refresh_musk.lua
+++ b/scripts/items/vial_of_refresh_musk.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffectEx(xi.effect.ENCHANTMENT, xi.effect.REFRESH, 0, 0, 30, item:getID())
 end
 

--- a/scripts/items/vial_of_refresh_musk.lua
+++ b/scripts/items/vial_of_refresh_musk.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 18241 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffectEx(xi.effect.ENCHANTMENT, xi.effect.REFRESH, 0, 0, 30, 18241)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffectEx(xi.effect.ENCHANTMENT, xi.effect.REFRESH, 0, 0, 30, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/vision_ring.lua
+++ b/scripts/items/vision_ring.lua
@@ -7,15 +7,15 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, user, item, param)
+    return 0
+end
+
+itemObject.onItemUse = function(target, user, item)
     local effect = target:getItemEnchantmentEffect(item:getID())
     if effect then
         effect:delStatusEffect()
     end
 
-    return 0
-end
-
-itemObject.onItemUse = function(target, user, item)
     target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 

--- a/scripts/items/vision_ring.lua
+++ b/scripts/items/vision_ring.lua
@@ -6,17 +6,17 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getSubType() == 15559 then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+itemObject.onItemCheck = function(target, user, item, param)
+    local effect = target:getItemEnchantmentEffect(item:getID())
+    if effect then
+        effect:delStatusEffect()
     end
 
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 15559)
+itemObject.onItemUse = function(target, user, item)
+    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, item:getID())
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/sql/status_effects.sql
+++ b/sql/status_effects.sql
@@ -196,7 +196,7 @@ INSERT INTO `status_effects` VALUES (158,'provoke',32,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (159,'penalty',32,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (160,'preparations',32,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (161,'sprint',32,0,0,0,0,0,0,0,0);
-INSERT INTO `status_effects` VALUES (162,'enchantment',32,0,0,0,0,0,0,0,0);
+INSERT INTO `status_effects` VALUES (162,'enchantment',32,0,0,4,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (163,'azure_lore',4194336,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (164,'chain_affinity',4194336,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (165,'burst_affinity',4194336,0,0,0,0,0,0,0,0);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -12651,6 +12651,18 @@ std::optional<CLuaStatusEffect> CLuaBaseEntity::getStatusEffect(uint16 StatusID,
 }
 
 /************************************************************************
+ *  Function: getItemEnchantmentEffect()
+ *  Purpose : Returns the ENCHANTMENT effect Object of a specified Item ID
+ *  Example : local hasteBeltEffect = target:getItemEnchantmentEffect(xi.item.HASTE_BELT)
+ *  Notes   :
+ ************************************************************************/
+
+std::optional<CLuaStatusEffect> CLuaBaseEntity::getItemEnchantmentEffect(sol::object const& ItemID)
+{
+    return getStatusEffect(EFFECT_ENCHANTMENT, ItemID);
+}
+
+/************************************************************************
  *  Function: getStatusEffects()
  *  Purpose : Returns a Lua table of all Status Effects an Entity has
  *  Example : local effects = caster:getStatusEffects() -- can iterate over table
@@ -17991,6 +18003,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("addStatusEffect", CLuaBaseEntity::addStatusEffect);
     SOL_REGISTER("addStatusEffectEx", CLuaBaseEntity::addStatusEffectEx);
     SOL_REGISTER("getStatusEffect", CLuaBaseEntity::getStatusEffect);
+    SOL_REGISTER("getItemEnchantmentEffect", CLuaBaseEntity::getItemEnchantmentEffect);
     SOL_REGISTER("getStatusEffects", CLuaBaseEntity::getStatusEffects);
     SOL_REGISTER("getStatusEffectElement", CLuaBaseEntity::getStatusEffectElement);
     SOL_REGISTER("canGainStatusEffect", CLuaBaseEntity::canGainStatusEffect);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -636,6 +636,7 @@ public:
     bool   addStatusEffect(sol::variadic_args va);
     bool   addStatusEffectEx(sol::variadic_args va);
     auto   getStatusEffect(uint16 StatusID, sol::object const& SubType) -> std::optional<CLuaStatusEffect>;
+    auto   getItemEnchantmentEffect(sol::object const& ItemID) -> std::optional<CLuaStatusEffect>;
     auto   getStatusEffects() -> sol::table;
     int16  getStatusEffectElement(uint16 statusId);
     bool   canGainStatusEffect(uint16 effect, sol::object const& powerObj);

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2590,7 +2590,7 @@ namespace luautils
             caster = CLuaBaseEntity(PCaster);
         }
 
-        auto result = onItemCheck(CLuaBaseEntity(PTarget), caster, static_cast<uint32>(param));
+        auto result = onItemCheck(CLuaBaseEntity(PTarget), caster, CLuaItem(PItem), static_cast<uint32>(param));
         if (!result.valid())
         {
             sol::error err = result;
@@ -2609,6 +2609,7 @@ namespace luautils
     // We use the subject. The return value is the message number or 0.
     // It is also necessary to somehow pass the message parameter (for example,
     // number of recovered MP)
+    // Note that effects with subtype > 0 and < 20000 will utilize itemObject.onEffectGain and itemObject.onEffectLose
     int32 OnItemUse(CBaseEntity* PUser, CBaseEntity* PTarget, CItem* PItem)
     {
         TracyZoneScoped;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

[This PR](https://github.com/LandSandBoat/server/pull/4816/files) discovered a pretty annoying oversight with `ENCHANTMENT` effects. They cannot co-exist at all.

First off, this adjusts slightly the `onItemCheck` parameters to put item after target and user. There isn't a single `onItemCheck` that has a third parameter currently, not sure if perhaps there's something in some other section of the code that i'm not seeing?

The commits are:
- update core to support these changes
  - don't overwrite `ENCHANTMENT` effects
  - pass `item` into the `onItemCheck` function
  - special binding to get an item's `ENCHANTMENT` effect
- Update all `onItemUse` functions that add `ENCHANTMENT` effects to use the new paradigm (not assuming there's only one `ENCHANTMENT` effect at a time)
- ~~Update all `onEffectLose` functions to stack mods on the effect instead of duplicating code in `onEffectLose`~~
  - nevermind, gonna leave that for another PR
- Confirmed with `haste_belt` that the previous enchantment isn't removed in `onItemCheck`, assuming this structure for all items and moved the enchantment removal to `onItemUse`

Note: adding any effect with a subtype between 0 and 20000 makes `CStatusEffectContainer::SetEffectParams` assume it's an item's effect, and uses `onEffectGain` and `onEffectLose` from the item's lua instead of the effect's lua (I added a note for that to help someone else going down the rabbit hole I went, lol). 

Note2: some items remove the effect on removing the item. Best I can tell _none_ of the items in lsb have this behavior. I will try to correct these as I find them while updating all `ENCHANTMENT` effects

Leaving as a draft until #5743 is merged

## Steps to test these changes

Example of using multiple items and having all the buffs

![image](https://github.com/LandSandBoat/server/assets/131182600/79559fa9-03a1-498d-922a-adb448318b74)

