### PR TITLE
[Cleanup] Shift-proof "C" Zones

### DIFF
--- a/scripts/zones/Caedarva_Mire/IDs.lua
+++ b/scripts/zones/Caedarva_Mire/IDs.lua
@@ -45,37 +45,29 @@ zones[xi.zone.CAEDARVA_MIRE] =
     },
     mob =
     {
+        AYNU_KAYSEY           = GetFirstID('Aynu-kaysey'),
+        CAEDARVA_TOAD         = GetFirstID('Caedarva_Toad'),
         CHIGOES =
         {
             ['Wild_Karakul'] = GetTableOfIDs('Chigoe', 5),
             ['Mosshorn']     = GetTableOfIDs('Chigoe', 5, 5),
         },
-        PEALLAIDH_PH =
-        {
-            [17100870] = 17101143, -- 333.885 -9.646 -447.557
-            [17100871] = 17101143, -- 309.638 -8.548 -447.557
-            [17100872] = 17101143, -- 307.320 -10.088 -451.786
-            [17100873] = 17101143, -- 295.122 -12.271 -414.418
-            [17100874] = 17101143, -- 287.607 -16.220 -387.671
-            [17100875] = 17101143, -- 315.793 -16.336 -402.407
-            [17100876] = 17101143, -- 321.809 -16.843 -373.780
-        },
-        AYNU_KAYSEY           = 17101099,
-        CAEDARVA_TOAD         = 17101145,
-        JAZARAAT              = 17101146,
-        LAMIA_NO27            = 17101148,
-        MOSHDAHN              = 17101149,
-        KHIMAIRA              = 17101197,
-        VERDELET              = 17101198,
-        TYGER                 = 17101199,
-        MAHJLAEF_THE_PAINTORN = 17101200,
-        EXPERIMENTAL_LAMIA    = 17101201,
+        EXPERIMENTAL_LAMIA    = GetFirstID('Experimental_Lamia'),
+        JAZARAAT              = GetFirstID('Jazaraat'),
+        KHIMAIRA              = GetFirstID('Khimaira'),
+        LAMIA_NO27            = GetFirstID('Lamia_No27'),
+        MAHJLAEF_THE_PAINTORN = GetFirstID('Mahjlaef_the_Paintorn'),
+        MOSHDAHN              = GetFirstID('Moshdahn'),
+        PEALLAIDH             = GetFirstID('Peallaidh'),
+        PEALLAIDH_PH_OFFSET   = GetFirstID('Wild_Karakul'), -- These are 270IDs away. Use offset in case of weird shift.
+        TYGER                 = GetFirstID('Tyger'),
+        VERDELET              = GetFirstID('Verdelet'),
     },
     npc =
     {
         LOGGING             = GetTableOfIDs('Logging_Point'),
-        RUNIC_PORTAL_AZOUPH = 17101319,
-        RUNIC_PORTAL_DVUCCA = 17101322,
+        RUNIC_PORTAL_AZOUPH = GetFirstID('Runic_Portal_Azouph'),
+        RUNIC_PORTAL_DVUCCA = GetFirstID('Runic_Portal_Dvucca'),
     },
 }
 

--- a/scripts/zones/Caedarva_Mire/mobs/Wild_Karakul.lua
+++ b/scripts/zones/Caedarva_Mire/mobs/Wild_Karakul.lua
@@ -8,11 +8,22 @@ local ID = zones[xi.zone.CAEDARVA_MIRE]
 -----------------------------------
 local entity = {}
 
+local peallaidhPHTable =
+{
+    [ID.mob.PEALLAIDH_PH_OFFSET]     = ID.mob.PEALLAIDH, -- 333.885 -9.646 -447.557
+    [ID.mob.PEALLAIDH_PH_OFFSET + 1] = ID.mob.PEALLAIDH, -- 309.638 -8.548 -447.557
+    [ID.mob.PEALLAIDH_PH_OFFSET + 2] = ID.mob.PEALLAIDH, -- 307.320 -10.088 -451.786
+    [ID.mob.PEALLAIDH_PH_OFFSET + 3] = ID.mob.PEALLAIDH, -- 295.122 -12.271 -414.418
+    [ID.mob.PEALLAIDH_PH_OFFSET + 4] = ID.mob.PEALLAIDH, -- 287.607 -16.220 -387.671
+    [ID.mob.PEALLAIDH_PH_OFFSET + 5] = ID.mob.PEALLAIDH, -- 315.793 -16.336 -402.407
+    [ID.mob.PEALLAIDH_PH_OFFSET + 6] = ID.mob.PEALLAIDH, -- 321.809 -16.843 -373.780
+}
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.PEALLAIDH_PH, 5, 3600) -- 1 hour
+    xi.mob.phOnDespawn(mob, peallaidhPHTable, 5, 3600) -- 1 hour
 end
 
 return entity

--- a/scripts/zones/Cape_Teriggan/IDs.lua
+++ b/scripts/zones/Cape_Teriggan/IDs.lua
@@ -46,16 +46,10 @@ zones[xi.zone.CAPE_TERIGGAN] =
     },
     mob =
     {
-        FROSTMANE_PH           =
-        {
-            [17240374] = 17240376, -- -283.874 -0.660 485.504
-            [17240372] = 17240376, -- -272.224 -0.942 461.321
-            [17240373] = 17240376, -- -268.000 -0.558 440.000
-            [17240371] = 17240376, -- -262.000 -0.700 442.000
-        },
-        KREUTZET               = 17240413,
-        AXESARION_THE_WANDERER = 17240414,
-        STOLAS                 = 17240424,
+        FROSTMANE              = GetFirstID('Frostmane'),
+        KREUTZET               = GetFirstID('Kreutzet'),
+        AXESARION_THE_WANDERER = GetFirstID('Axesarion_the_Wanderer'),
+        STOLAS                 = GetFirstID('Stolas'),
         ZMEY_GORYNYCH          = GetFirstID('Zmey_Gorynych')
     },
     npc =

--- a/scripts/zones/Cape_Teriggan/mobs/Greater_Manticore.lua
+++ b/scripts/zones/Cape_Teriggan/mobs/Greater_Manticore.lua
@@ -7,12 +7,20 @@ local ID = zones[xi.zone.CAPE_TERIGGAN]
 -----------------------------------
 local entity = {}
 
+local frostmanePHTable =
+{
+    [ID.mob.FROSTMANE - 5] = ID.mob.FROSTMANE, -- -262.000 -0.700 442.000
+    [ID.mob.FROSTMANE - 4] = ID.mob.FROSTMANE, -- -272.224 -0.942 461.321
+    [ID.mob.FROSTMANE - 3] = ID.mob.FROSTMANE, -- -268.000 -0.558 440.000
+    [ID.mob.FROSTMANE - 2] = ID.mob.FROSTMANE, -- -283.874 -0.660 485.504
+}
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 108, 2, xi.regime.type.FIELDS)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.FROSTMANE_PH, 5, math.random(3600, 21600)) -- 1 to 6 hours
+    xi.mob.phOnDespawn(mob, frostmanePHTable, 5, math.random(3600, 21600)) -- 1 to 6 hours
 end
 
 return entity

--- a/scripts/zones/Carpenters_Landing/IDs.lua
+++ b/scripts/zones/Carpenters_Landing/IDs.lua
@@ -38,29 +38,17 @@ zones[xi.zone.CARPENTERS_LANDING] =
     },
     mob =
     {
-        ORCTRAP_PH            =
-        {
-            [16785675] = 16785676, -- 181.819 -5.887 -524.872
-        },
-        TEMPEST_TIGON         = 16785593,
-        OVERGROWN_IVY         = 16785709,
-        CRYPTONBERRY_EXECUTOR = 16785710,
-        MYCOPHILE             = 16785722,
-        HERCULES_BEETLE       = 16785723,
+        ORCTRAP               = GetFirstID('Orctrap'),
+        TEMPEST_TIGON         = GetFirstID('Tempest_Tigon'),
+        OVERGROWN_IVY         = GetFirstID('Overgrown_Ivy'),
+        CRYPTONBERRY_EXECUTOR = GetFirstID('Cryptonberry_Executor'),
+        MYCOPHILE             = GetFirstID('Mycophile'),
+        HERCULES_BEETLE       = GetFirstID('Hercules_Beetle'),
     },
     npc =
     {
-        HERCULES_BEETLE_TREES =
-        {
-            16785730,
-            16785731,
-            16785732,
-            16785733,
-            16785734,
-            16785735,
-        },
-
-        LOGGING = GetTableOfIDs('Logging_Point'),
+        HERCULES_BEETLE_TREES = GetTableOfIDs('qm_hercules_beetle'),
+        LOGGING               = GetTableOfIDs('Logging_Point'),
     },
 }
 

--- a/scripts/zones/Carpenters_Landing/mobs/Birdtrap.lua
+++ b/scripts/zones/Carpenters_Landing/mobs/Birdtrap.lua
@@ -7,11 +7,16 @@ local ID = zones[xi.zone.CARPENTERS_LANDING]
 -----------------------------------
 local entity = {}
 
+local orctrapPHTable =
+{
+    [ID.mob.ORCTRAP - 1] = ID.mob.ORCTRAP, -- 181.819 -5.887 -524.872
+}
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.ORCTRAP_PH, 10, 3600) -- 1 hour minimum
+    xi.mob.phOnDespawn(mob, orctrapPHTable, 10, 3600) -- 1 hour minimum
 end
 
 return entity

--- a/scripts/zones/Castle_Oztroja/IDs.lua
+++ b/scripts/zones/Castle_Oztroja/IDs.lua
@@ -42,54 +42,24 @@ zones[xi.zone.CASTLE_OZTROJA] =
     },
     mob =
     {
-        MEE_DEGGI_THE_PUNISHER_PH  =
-        {
-            [17395798] = 17395800, -- -207.840 -0.498 109.939
-            [17395766] = 17395800, -- -178.119 -0.644 153.039
-            [17395769] = 17395800, -- -188.253 -0.087 158.955
-            [17395783] = 17395800, -- -233.116 -0.741 172.067
-            [17395784] = 17395800, -- -254.302 -0.057 163.759
-            [17395799] = 17395800, -- -227.415 -4.340 145.213
-            [17395761] = 17395800, -- -207.370 -0.056 106.537
-            [17395775] = 17395800, -- -235.639 -0.063 103.280
-        },
-        MOO_OUZI_THE_SWIFTBLADE_PH =
-        {
-            [17395809] = 17395816, -- -18.415 -0.075 -92.889
-            [17395813] = 17395816, -- -38.689 0.191 -101.068
-        },
-        QUU_DOMI_THE_GALLANT_PH    =
-        {
-            [17395844] = 17395870, -- 103.948 -1.250 -189.869
-            [17395845] = 17395870, -- 67.103 -0.079 -176.981
-            [17395853] = 17395870, -- 99.000 -0.181 -149.000
-            [17395831] = 17395870, -- 46.861 0.343 -176.989
-            [17395868] = 17395870, -- 35.847 -0.500 -101.685
-            [17395867] = 17395870, -- 59.000 -4.000 -131.000
-            [17395829] = 17395870, -- 33.832 -0.068 -176.627
-            [17395837] = 17395870, -- 18.545 -0.056 -120.283
-        },
-        YAA_HAQA_THE_PROFANE_PH    =
-        {
-            [17395950] = 17395954, -- -24.719 -16.250 -139.678
-            [17395951] = 17395954, -- -22.395 -16.250 -139.341
-            [17395952] = 17395954, -- -25.044 -16.250 -141.534
-            [17395953] = 17395954, -- -32.302 -16.250 -139.169
-        },
-        YAGUDO_AVATAR              = 17396134,
-        HUU_XALMO_THE_SAVAGE       = 17396140,
-        MIMIC                      = 17396144,
+        MEE_DEGGI_THE_PUNISHER  = GetFirstID('Mee_Deggi_the_Punisher'),
+        MOO_OUZI_THE_SWIFTBLADE = GetFirstID('Moo_Ouzi_the_Swiftblade'),
+        QUU_DOMI_THE_GALLANT    = GetFirstID('Quu_Domi_the_Gallant'),
+        YAA_HAQA_THE_PROFANE    = GetFirstID('Yaa_Haqa_the_Profane'),
+        YAGUDO_AVATAR           = GetFirstID('Yagudo_Avatar'),
+        HUU_XALMO_THE_SAVAGE    = GetFirstID('Huu_Xalmo_the_Savage'),
+        MIMIC                   = GetFirstID('Mimic'),
     },
     npc =
     {
-        HANDLE_DOOR_FLOOR_2    = 17396161,
-        FIRST_PASSWORD_STATUE  = 17396169,
-        SECOND_PASSWORD_STATUE = 17396174,
-        THIRD_PASSWORD_STATUE  = 17396179,
-        BRASS_DOOR_FLOOR_4_H7  = 17396186,
-        TRAP_DOOR_FLOOR_4      = 17396192,
-        FINAL_PASSWORD_STATUE  = 17396193,
-        HINT_HANDLE_OFFSET     = 17396197,
+        HANDLE_DOOR_FLOOR_2    = GetFirstID('_471'),
+        FIRST_PASSWORD_STATUE  = GetTableOfIDs('Brass_Statue')[1],
+        SECOND_PASSWORD_STATUE = GetTableOfIDs('Brass_Statue')[2],
+        THIRD_PASSWORD_STATUE  = GetTableOfIDs('Brass_Statue')[3],
+        FINAL_PASSWORD_STATUE  = GetTableOfIDs('Brass_Statue')[4],
+        BRASS_DOOR_FLOOR_4_H7  = GetFirstID('_477'),
+        TRAP_DOOR_FLOOR_4      = GetFirstID('_478'),
+        HINT_HANDLE_OFFSET     = GetFirstID('_47q'),
         TREASURE_CHEST         = GetFirstID('Treasure_Chest'),
         TREASURE_COFFER        = GetFirstID('Treasure_Coffer'),
     },

--- a/scripts/zones/Castle_Oztroja/mobs/Yagudo_Conquistador.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Yagudo_Conquistador.lua
@@ -7,11 +7,16 @@ local ID = zones[xi.zone.CASTLE_OZTROJA]
 -----------------------------------
 local entity = {}
 
+local yaaHaqaPHTable =
+{
+    [ID.mob.YAA_HAQA_THE_PROFANE - 3] = ID.mob.YAA_HAQA_THE_PROFANE, -- -22.395 -16.250 -139.341
+}
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.YAA_HAQA_THE_PROFANE_PH, 5, 3600) -- 1 hour
+    xi.mob.phOnDespawn(mob, yaaHaqaPHTable, 5, 3600) -- 1 hour
 end
 
 return entity

--- a/scripts/zones/Castle_Oztroja/mobs/Yagudo_Drummer.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Yagudo_Drummer.lua
@@ -7,11 +7,19 @@ local ID = zones[xi.zone.CASTLE_OZTROJA]
 -----------------------------------
 local entity = {}
 
+local meeDeggiPHTable =
+{
+    [ID.mob.MEE_DEGGI_THE_PUNISHER - 34] = ID.mob.MEE_DEGGI_THE_PUNISHER, -- -178.119 -0.644 153.039
+    [ID.mob.MEE_DEGGI_THE_PUNISHER - 25] = ID.mob.MEE_DEGGI_THE_PUNISHER, -- -235.639 -0.063 103.280
+    [ID.mob.MEE_DEGGI_THE_PUNISHER - 17] = ID.mob.MEE_DEGGI_THE_PUNISHER, -- -233.116 -0.741 172.067
+    [ID.mob.MEE_DEGGI_THE_PUNISHER - 2]  = ID.mob.MEE_DEGGI_THE_PUNISHER, -- -207.840 -0.498 109.939
+}
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.MEE_DEGGI_THE_PUNISHER_PH, 5, 3000) -- 50 minutes
+    xi.mob.phOnDespawn(mob, meeDeggiPHTable, 5, 3000) -- 50 minutes
 end
 
 return entity

--- a/scripts/zones/Castle_Oztroja/mobs/Yagudo_Herald.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Yagudo_Herald.lua
@@ -7,11 +7,19 @@ local ID = zones[xi.zone.CASTLE_OZTROJA]
 -----------------------------------
 local entity = {}
 
+local quuDomiPHTable =
+{
+    [ID.mob.QUU_DOMI_THE_GALLANT - 41] = ID.mob.QUU_DOMI_THE_GALLANT, -- 33.832 -0.068 -176.627
+    [ID.mob.QUU_DOMI_THE_GALLANT - 33] = ID.mob.QUU_DOMI_THE_GALLANT, -- 18.545 -0.056 -120.283
+    [ID.mob.QUU_DOMI_THE_GALLANT - 26] = ID.mob.QUU_DOMI_THE_GALLANT, -- 103.948 -1.250 -189.869
+    [ID.mob.QUU_DOMI_THE_GALLANT - 3]  = ID.mob.QUU_DOMI_THE_GALLANT, -- 59.000 -4.000 -131.000
+}
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.QUU_DOMI_THE_GALLANT_PH, 5, 3600) -- 1 hour
+    xi.mob.phOnDespawn(mob, quuDomiPHTable, 5, 3600) -- 1 hour
 end
 
 return entity

--- a/scripts/zones/Castle_Oztroja/mobs/Yagudo_Interrogator.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Yagudo_Interrogator.lua
@@ -7,11 +7,19 @@ local ID = zones[xi.zone.CASTLE_OZTROJA]
 -----------------------------------
 local entity = {}
 
+local meeDeggiPHTable =
+{
+    [ID.mob.MEE_DEGGI_THE_PUNISHER - 39] = ID.mob.MEE_DEGGI_THE_PUNISHER, -- -207.370 -0.056 106.537
+    [ID.mob.MEE_DEGGI_THE_PUNISHER - 31] = ID.mob.MEE_DEGGI_THE_PUNISHER, -- -188.253 -0.087 158.955
+    [ID.mob.MEE_DEGGI_THE_PUNISHER - 16] = ID.mob.MEE_DEGGI_THE_PUNISHER, -- -254.302 -0.057 163.759
+    [ID.mob.MEE_DEGGI_THE_PUNISHER - 1]  = ID.mob.MEE_DEGGI_THE_PUNISHER, -- -227.415 -4.340 145.213
+}
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.MEE_DEGGI_THE_PUNISHER_PH, 5, 3000) -- 50 minutes
+    xi.mob.phOnDespawn(mob, meeDeggiPHTable, 5, 3000) -- 50 minutes
 end
 
 return entity

--- a/scripts/zones/Castle_Oztroja/mobs/Yagudo_Lutenist.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Yagudo_Lutenist.lua
@@ -7,11 +7,16 @@ local ID = zones[xi.zone.CASTLE_OZTROJA]
 -----------------------------------
 local entity = {}
 
+local yaaHaqaPHTable =
+{
+    [ID.mob.YAA_HAQA_THE_PROFANE - 2] = ID.mob.YAA_HAQA_THE_PROFANE, -- -25.044 -16.250 -141.534
+}
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.YAA_HAQA_THE_PROFANE_PH, 5, 3600) -- 1 hour
+    xi.mob.phOnDespawn(mob, yaaHaqaPHTable, 5, 3600) -- 1 hour
 end
 
 return entity

--- a/scripts/zones/Castle_Oztroja/mobs/Yagudo_Oracle.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Yagudo_Oracle.lua
@@ -7,11 +7,19 @@ local ID = zones[xi.zone.CASTLE_OZTROJA]
 -----------------------------------
 local entity = {}
 
+local quuDomiPHTable =
+{
+    [ID.mob.QUU_DOMI_THE_GALLANT - 39] = ID.mob.QUU_DOMI_THE_GALLANT, -- 46.861 0.343 -176.989
+    [ID.mob.QUU_DOMI_THE_GALLANT - 25] = ID.mob.QUU_DOMI_THE_GALLANT, -- 67.103 -0.079 -176.981
+    [ID.mob.QUU_DOMI_THE_GALLANT - 17] = ID.mob.QUU_DOMI_THE_GALLANT, -- 99.000 -0.181 -149.000
+    [ID.mob.QUU_DOMI_THE_GALLANT - 2]  = ID.mob.QUU_DOMI_THE_GALLANT, -- 35.847 -0.500 -101.685
+}
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.QUU_DOMI_THE_GALLANT_PH, 5, 3600) -- 1 hour
+    xi.mob.phOnDespawn(mob, quuDomiPHTable, 5, 3600) -- 1 hour
 end
 
 return entity

--- a/scripts/zones/Castle_Oztroja/mobs/Yagudo_Prior.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Yagudo_Prior.lua
@@ -7,11 +7,16 @@ local ID = zones[xi.zone.CASTLE_OZTROJA]
 -----------------------------------
 local entity = {}
 
+local yaaHaqaPHTable =
+{
+    [ID.mob.YAA_HAQA_THE_PROFANE - 1] = ID.mob.YAA_HAQA_THE_PROFANE, -- -32.302 -16.250 -139.169
+}
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.YAA_HAQA_THE_PROFANE_PH, 5, 3600) -- 1 hour
+    xi.mob.phOnDespawn(mob, yaaHaqaPHTable, 5, 3600) -- 1 hour
 end
 
 return entity

--- a/scripts/zones/Castle_Oztroja/mobs/Yagudo_Theologist.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Yagudo_Theologist.lua
@@ -7,11 +7,17 @@ local ID = zones[xi.zone.CASTLE_OZTROJA]
 -----------------------------------
 local entity = {}
 
+local mooQuziPHTable =
+{
+    [ID.mob.MOO_OUZI_THE_SWIFTBLADE - 7] = ID.mob.MOO_OUZI_THE_SWIFTBLADE, -- -18.415 -0.075 -92.889
+    [ID.mob.MOO_OUZI_THE_SWIFTBLADE - 3] = ID.mob.MOO_OUZI_THE_SWIFTBLADE, -- -38.689 0.191 -101.068
+}
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.MOO_OUZI_THE_SWIFTBLADE_PH, 5, 3600) -- 1 hour
+    xi.mob.phOnDespawn(mob, mooQuziPHTable, 5, 3600) -- 1 hour
 end
 
 return entity

--- a/scripts/zones/Castle_Oztroja/mobs/Yagudo_Zealot.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Yagudo_Zealot.lua
@@ -7,11 +7,16 @@ local ID = zones[xi.zone.CASTLE_OZTROJA]
 -----------------------------------
 local entity = {}
 
+local yaaHaqaPHTable =
+{
+    [ID.mob.YAA_HAQA_THE_PROFANE - 4] = ID.mob.YAA_HAQA_THE_PROFANE, -- -24.719 -16.250 -139.678
+}
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.YAA_HAQA_THE_PROFANE_PH, 5, 3600) -- 1 hours
+    xi.mob.phOnDespawn(mob, yaaHaqaPHTable, 5, 3600) -- 1 hours
 end
 
 return entity

--- a/scripts/zones/Castle_Oztroja_[S]/IDs.lua
+++ b/scripts/zones/Castle_Oztroja_[S]/IDs.lua
@@ -22,24 +22,17 @@ zones[xi.zone.CASTLE_OZTROJA_S] =
     },
     mob =
     {
-        AA_XALMO_THE_SAVAGE_PH =
-        {
-            [17182827] = 17182843,
-            [17182838] = 17182843,
-        },
-        ZHUU_BUXU_THE_SILENT_PH =
-        {
-            [17182813] = 17182813,
-        },
-        DUU_MASA_THE_ONECUT    = 17182790,
-        DEE_ZELKO_THE_ESOTERIC = 17183031,
-        MARQUIS_FORNEUS        = 17183032,
-        LOO_KUTTO_THE_PENSIVE  = 17183033,
-        FLESHGNASHER           = 17183034,
-        VEE_LADU_THE_TITTERER  = 17183035,
-        MAA_ILLMU_THE_BESTOWER = 17183036,
-        ASTERION               = 17183037,
-        SUU_XICU_THE_CANTABILE = 17183038,
+        AA_XALMO_THE_SAVAGE    = GetFirstID('Aa_Xalmo_the_Savage'),
+        ZHUU_BUXU_THE_SILENT   = GetFirstID('Zhuu_Buxu_the_Silent'),
+        DUU_MASA_THE_ONECUT    = GetFirstID('Duu_Masa_the_Onecut'),
+        DEE_ZELKO_THE_ESOTERIC = GetFirstID('Dee_Zelko_the_Esoteric'),
+        MARQUIS_FORNEUS        = GetFirstID('Marquis_Forneus'),
+        LOO_KUTTO_THE_PENSIVE  = GetFirstID('Loo_Kutto_the_Pensive'),
+        FLESHGNASHER           = GetFirstID('Fleshgnasher'),
+        VEE_LADU_THE_TITTERER  = GetFirstID('Vee_Ladu_the_Titterer'),
+        MAA_ILLMU_THE_BESTOWER = GetFirstID('Maa_Illmu_the_Bestower'),
+        ASTERION               = GetFirstID('Asterion'),
+        SUU_XICU_THE_CANTABILE = GetFirstID('Suu_Xicu_the_Cantabile'),
     },
     npc =
     {

--- a/scripts/zones/Castle_Oztroja_[S]/mobs/Yagudo_Sentinel.lua
+++ b/scripts/zones/Castle_Oztroja_[S]/mobs/Yagudo_Sentinel.lua
@@ -7,12 +7,23 @@ local ID = zones[xi.zone.CASTLE_OZTROJA_S]
 -----------------------------------
 local entity = {}
 
+local aaXalmoPHTable =
+{
+    [ID.mob.AA_XALMO_THE_SAVAGE - 16] = ID.mob.AA_XALMO_THE_SAVAGE,
+    [ID.mob.AA_XALMO_THE_SAVAGE - 5]  = ID.mob.AA_XALMO_THE_SAVAGE,
+}
+
+local zhuuBuxuPHTable =
+{
+    [ID.mob.ZHUU_BUXU_THE_SILENT - 1] = ID.mob.ZHUU_BUXU_THE_SILENT,
+}
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.AA_XALMO_THE_SAVAGE_PH, 10, 7200) -- 2 hour
-    xi.mob.phOnDespawn(mob, ID.mob.ZHUU_BUXU_THE_SILENT_PH, 10, 7200) -- 2 hour
+    xi.mob.phOnDespawn(mob, aaXalmoPHTable, 10, 7200) -- 2 hour
+    xi.mob.phOnDespawn(mob, zhuuBuxuPHTable, 10, 7200) -- 2 hour
 end
 
 return entity

--- a/scripts/zones/Castle_Zvahl_Baileys/IDs.lua
+++ b/scripts/zones/Castle_Zvahl_Baileys/IDs.lua
@@ -24,22 +24,18 @@ zones[xi.zone.CASTLE_ZVAHL_BAILEYS] =
     },
     mob =
     {
-        MARQUIS_SABNOCK_PH =
-        {
-            [17436879] = 17436881,
-            [17436882] = 17436881,
-        },
-        LIKHO            = 17436714,
-        MARQUIS_ALLOCEN  = 17436913,
-        MARQUIS_AMON     = 17436918,
-        DUKE_HABORYM     = 17436923,
-        GRAND_DUKE_BATYM = 17436927,
-        DARK_SPARK       = 17436964,
-        MIMIC            = 17436965,
+        MARQUIS_SABNOCK  = GetFirstID('Marquis_Sabnock'),
+        LIKHO            = GetFirstID('Likho'),
+        MARQUIS_ALLOCEN  = GetFirstID('Marquis_Allocen'),
+        MARQUIS_AMON     = GetFirstID('Marquis_Amon'),
+        DUKE_HABORYM     = GetFirstID('Duke_Haborym'),
+        GRAND_DUKE_BATYM = GetFirstID('Grand_Duke_Batym'),
+        DARK_SPARK       = GetFirstID('Dark_Spark'),
+        MIMIC            = GetFirstID('Mimic'),
     },
     npc =
     {
-        TORCH_OFFSET    = 17436985,
+        TORCH_OFFSET    = GetFirstID('Torch'),
         TREASURE_CHEST  = GetFirstID('Treasure_Chest'),
         TREASURE_COFFER = GetFirstID('Treasure_Coffer'),
     },

--- a/scripts/zones/Castle_Zvahl_Baileys/mobs/Abyssal_Demon.lua
+++ b/scripts/zones/Castle_Zvahl_Baileys/mobs/Abyssal_Demon.lua
@@ -7,11 +7,16 @@ local ID = zones[xi.zone.CASTLE_ZVAHL_BAILEYS]
 -----------------------------------
 local entity = {}
 
+local marquisPHTable =
+{
+    [ID.mob.MARQUIS_SABNOCK - 2] = ID.mob.MARQUIS_SABNOCK,
+}
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.MARQUIS_SABNOCK_PH, 10, 7200) -- 2 hour
+    xi.mob.phOnDespawn(mob, marquisPHTable, 10, 7200) -- 2 hour
 end
 
 return entity

--- a/scripts/zones/Castle_Zvahl_Baileys/mobs/Doom_Demon.lua
+++ b/scripts/zones/Castle_Zvahl_Baileys/mobs/Doom_Demon.lua
@@ -7,11 +7,16 @@ local ID = zones[xi.zone.CASTLE_ZVAHL_BAILEYS]
 -----------------------------------
 local entity = {}
 
+local marquisPHTable =
+{
+    [ID.mob.MARQUIS_SABNOCK + 1] = ID.mob.MARQUIS_SABNOCK,
+}
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.MARQUIS_SABNOCK_PH, 10, 7200) -- 2 hour
+    xi.mob.phOnDespawn(mob, marquisPHTable, 10, 7200) -- 2 hour
 end
 
 return entity

--- a/scripts/zones/Castle_Zvahl_Keep/IDs.lua
+++ b/scripts/zones/Castle_Zvahl_Keep/IDs.lua
@@ -25,24 +25,10 @@ zones[xi.zone.CASTLE_ZVAHL_KEEP] =
     },
     mob =
     {
-        BARON_VAPULA_PH   =
-        {
-            [17440962] = 17440963, -- -254.000 -52.125 86.000
-            [17440960] = 17440963, -- -227.007 -52.125 83.768
-        },
-        BARONET_ROMWE_PH  =
-        {
-            [17440985] = 17440986, -- -335.444 -52.125 15.148
-            [17440984] = 17440986, -- -317.070 -52.125 14.052
-        },
-        COUNT_BIFRONS_PH  =
-        {
-            [17440968] = 17440969, -- -204.000 -52.125 -95.000
-        },
-        VISCOUNT_MORAX_PH =
-        {
-            [17440973] = 17440975, -- -365.684 -52.125 -136.540
-        },
+        BARON_VAPULA   = GetFirstID('Baron_Vapula'),
+        BARONET_ROMWE  = GetFirstID('Baronet_Romwe'),
+        COUNT_BIFRONS  = GetFirstID('Count_Bifrons'),
+        VISCOUNT_MORAX = GetFirstID('Viscount_Morax'),
     },
     npc =
     {

--- a/scripts/zones/Castle_Zvahl_Keep/mobs/Demon_Knight.lua
+++ b/scripts/zones/Castle_Zvahl_Keep/mobs/Demon_Knight.lua
@@ -7,11 +7,16 @@ local ID = zones[xi.zone.CASTLE_ZVAHL_KEEP]
 -----------------------------------
 local entity = {}
 
+local bifronsPHTable =
+{
+    [ID.mob.COUNT_BIFRONS - 1] = ID.mob.COUNT_BIFRONS, -- -204.000 -52.125 -95.000
+}
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.COUNT_BIFRONS_PH, 10, math.random(3600, 28800)) -- 1 to 8 hours
+    xi.mob.phOnDespawn(mob, bifronsPHTable, 10, 3600) -- 1 hour
 end
 
 return entity

--- a/scripts/zones/Castle_Zvahl_Keep/mobs/Demon_Pawn.lua
+++ b/scripts/zones/Castle_Zvahl_Keep/mobs/Demon_Pawn.lua
@@ -7,11 +7,17 @@ local ID = zones[xi.zone.CASTLE_ZVAHL_KEEP]
 -----------------------------------
 local entity = {}
 
+local baronetPHTable =
+{
+    [ID.mob.BARONET_ROMWE - 2] = ID.mob.BARONET_ROMWE, -- -317.070 -52.125 14.052
+    [ID.mob.BARONET_ROMWE - 1] = ID.mob.BARONET_ROMWE, -- -335.444 -52.125 15.148
+}
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.BARONET_ROMWE_PH, 10, math.random(3600, 28800)) -- 1 to 8 hours
+    xi.mob.phOnDespawn(mob, baronetPHTable, 10, 3600) -- 1 hour
 end
 
 return entity

--- a/scripts/zones/Castle_Zvahl_Keep/mobs/Demon_Warlock.lua
+++ b/scripts/zones/Castle_Zvahl_Keep/mobs/Demon_Warlock.lua
@@ -7,11 +7,16 @@ local ID = zones[xi.zone.CASTLE_ZVAHL_KEEP]
 -----------------------------------
 local entity = {}
 
+local viscountPHTable =
+{
+    [ID.mob.VISCOUNT_MORAX - 2] = ID.mob.VISCOUNT_MORAX, -- -365.684 -52.125 -136.540
+}
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.VISCOUNT_MORAX_PH, 10, math.random(3600, 28800)) -- 1 to 8 hours
+    xi.mob.phOnDespawn(mob, viscountPHTable, 10, 3600) -- 1 hour
 end
 
 return entity

--- a/scripts/zones/Castle_Zvahl_Keep/mobs/Demon_Wizard.lua
+++ b/scripts/zones/Castle_Zvahl_Keep/mobs/Demon_Wizard.lua
@@ -7,11 +7,17 @@ local ID = zones[xi.zone.CASTLE_ZVAHL_KEEP]
 -----------------------------------
 local entity = {}
 
+local baronPHTable =
+{
+    [ID.mob.BARON_VAPULA - 3] = ID.mob.BARON_VAPULA, -- -254.000 -52.125 86.000
+    [ID.mob.BARON_VAPULA - 1] = ID.mob.BARON_VAPULA, -- -227.007 -52.125 83.768
+}
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.BARON_VAPULA_PH, 10, math.random(3600, 28800)) -- 1 to 8 hours
+    xi.mob.phOnDespawn(mob, baronPHTable, 10, math.random(3600, 28800)) -- 1 to 8 hours
 end
 
 return entity

--- a/scripts/zones/Crawlers_Nest/IDs.lua
+++ b/scripts/zones/Crawlers_Nest/IDs.lua
@@ -41,18 +41,12 @@ zones[xi.zone.CRAWLERS_NEST] =
     },
     mob =
     {
-        DEMONIC_TIPHIA_PH =
-        {
-            [17584392] = 17584398, -- -103.000 -1.000 311.000
-            [17584395] = 17584398, -- -89.000 -1.000 301.000
-            [17584396] = 17584398, -- -75.000 -1.000 299.000
-            [17584391] = 17584398, -- -101.000 -1.000 285.000
-        },
-        AWD_GOGGIE          = 17584135,
-        DYNAST_BEETLE       = 17584312,
-        DREADBUG            = 17584425,
-        MIMIC               = 17584426,
-        APPARATUS_ELEMENTAL = 17584427,
+        DEMONIC_TIPHIA      = GetFirstID('Demonic_Tiphia'),
+        AWD_GOGGIE          = GetFirstID('Awd_Goggie'),
+        DYNAST_BEETLE       = GetFirstID('Dynast_Beetle'),
+        DREADBUG            = GetFirstID('Dreadbug'),
+        MIMIC               = GetFirstID('Mimic'),
+        APPARATUS_ELEMENTAL = GetTableOfIDs('Water_Elemental')[9], -- 9th Water Elemental
     },
     npc =
     {

--- a/scripts/zones/Crawlers_Nest/mobs/Wespe.lua
+++ b/scripts/zones/Crawlers_Nest/mobs/Wespe.lua
@@ -7,12 +7,20 @@ local ID = zones[xi.zone.CRAWLERS_NEST]
 -----------------------------------
 local entity = {}
 
+local tiphiaPHTable =
+{
+    [ID.mob.DEMONIC_TIPHIA - 7] = ID.mob.DEMONIC_TIPHIA, -- -101.000 -1.000 285.000
+    [ID.mob.DEMONIC_TIPHIA - 6] = ID.mob.DEMONIC_TIPHIA, -- -103.000 -1.000 311.000
+    [ID.mob.DEMONIC_TIPHIA - 3] = ID.mob.DEMONIC_TIPHIA, -- -89.000 -1.000 301.000
+    [ID.mob.DEMONIC_TIPHIA - 2] = ID.mob.DEMONIC_TIPHIA, -- -75.000 -1.000 299.000
+}
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 691, 2, xi.regime.type.GROUNDS)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.DEMONIC_TIPHIA_PH, 5, math.random(7200, 28800)) -- 2 to 8 hours
+    xi.mob.phOnDespawn(mob, tiphiaPHTable, 5, math.random(7200, 28800)) -- 2 to 8 hours
 end
 
 return entity

--- a/scripts/zones/Crawlers_Nest_[S]/IDs.lua
+++ b/scripts/zones/Crawlers_Nest_[S]/IDs.lua
@@ -21,10 +21,7 @@ zones[xi.zone.CRAWLERS_NEST_S] =
     },
     mob =
     {
-        MORILLE_MORTELLE_PH =
-        {
-            [17477636] = 17477640, -- 61 0 -4
-        },
+        MORILLE_MORTELLE = GetFirstID('Morille_Mortelle'),
     },
     npc =
     {

--- a/scripts/zones/Crawlers_Nest_[S]/mobs/Witch_Hazel.lua
+++ b/scripts/zones/Crawlers_Nest_[S]/mobs/Witch_Hazel.lua
@@ -7,11 +7,16 @@ local ID = zones[xi.zone.CRAWLERS_NEST_S]
 -----------------------------------
 local entity = {}
 
+local morillePHTable =
+{
+    [ID.mob.MORILLE_MORTELLE - 4] = ID.mob.MORILLE_MORTELLE, -- 61 0 -4
+}
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.MORILLE_MORTELLE_PH, 12, 18000) -- 5 hours
+    xi.mob.phOnDespawn(mob, morillePHTable, 12, 18000) -- 5 hours
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Shift proof
Crawlers Nest & [S]
Castle Zvahl Keep
Castle Zvahl Baileys
Castle Oztroja [S]
Castle Oztroja
Carpenters Landing
Cape Terriggan
Caedarva Mire

**Caedarva Mire**
I made a PEALLAIDH_PH_OFFSET call because the IDs were -270 which seemed weird to put there in case an ID shifts. I decided to make the offset the first wild kara which is the PH group instead.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Start server, lotto NMs
<!-- Clear and detailed steps to test your changes here -->
