### PR TITLE
[LUA] Add Frozen Mist and Hydro Wave mobskills

### DIFF
--- a/scripts/actions/mobskills/frozen_mist.lua
+++ b/scripts/actions/mobskills/frozen_mist.lua
@@ -1,0 +1,28 @@
+-----------------------------------
+--  Frozen Mist
+--  Description: Deals ice damage to enemies around the caster. Additional effect: Terror
+--  Type: Magical (Ice)
+-----------------------------------
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    local power    = 30
+    local resist   = xi.mobskills.applyPlayerResistance(mob, xi.effect.TERROR, target, mob:getStat(xi.mod.INT) - target:getStat(xi.mod.INT), 0, 0)
+    local duration = 30 * resist
+
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.TERROR, power, 0, duration)
+
+    local dmgmod = 1.5
+    local info   = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg(), xi.element.ICE, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    local dmg    = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.ICE, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
+
+    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.ICE)
+
+    return dmg
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/hydro_wave.lua
+++ b/scripts/actions/mobskills/hydro_wave.lua
@@ -1,0 +1,30 @@
+-----------------------------------
+--  Hydro Wave
+--  Description: Deals water damage to enemies around the caster.
+--  Type: Magical (Water)
+-----------------------------------
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    local power    = math.random(1, 16)
+    local resist   = xi.mobskills.applyPlayerResistance(mob, xi.effect.ENCUMBRANCE_II, target, mob:getStat(xi.mod.INT) - target:getStat(xi.mod.INT), 0, 0)
+    local duration = 30 * resist
+
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ENCUMBRANCE_II, power, 0, duration)
+
+    local dmgmod = 2.5
+    local info   = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg(), xi.element.WATER, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    local dmg    = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
+
+    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.WATER)
+
+    mob:addStatusEffect(xi.effect.STONESKIN, 0, 0, 180, 2, 1500)
+
+    return dmg
+end
+
+return mobskillObject

--- a/scripts/effects/encumbrance.lua
+++ b/scripts/effects/encumbrance.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- xi.effect.ENCUMBERANCE
+-- xi.effect.ENCUMBRANCE
 -----------------------------------
 local effectObject = {}
 

--- a/scripts/mixins/families/ruszor.lua
+++ b/scripts/mixins/families/ruszor.lua
@@ -3,9 +3,28 @@ require('scripts/globals/mixins')
 g_mixins = g_mixins or {}
 
 g_mixins.ruszor = function(ruszorMob)
+    ruszorMob:addListener('WEAPONSKILL_USE', 'AURA', function(mob, target, actionId, tp, action)
+        local frozenMist = 2438
+        local hydroWave  = 2439
+
+        -- Ruszor gain a temporary icy aura following the use of Frozen Mist.
+        if actionId == frozenMist then
+            mob:setAnimationSub(1)
+            mob:setMod(xi.mod.WATER_ABSORB, 0)
+            mob:setMod(xi.mod.ICE_ABSORB, 100)
+            -- Ruszor gain a temporary water aura following the use of Hydro Wave.
+        elseif actionId == hydroWave then
+            mob:setAnimationSub(2)
+            mob:setMod(xi.mod.ICE_ABSORB, 0)
+            mob:setMod(xi.mod.WATER_ABSORB, 100)
+        end
+    end)
+
     ruszorMob:addListener('EFFECT_LOSE', 'STONESKIN', function(mob, effect)
         if effect:getEffectType() == xi.effect.STONESKIN then
             mob:setAnimationSub(0)
+            mob:setMod(xi.mod.ICE_ABSORB, 0)
+            mob:setMod(xi.mod.WATER_ABSORB, 0)
         end
     end)
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds Frozen Mist and Hydro Wave mobskills. Requires implementing some unique types of Stoneskin, one which absorbs only physical and the other which only absorbs magic, breath, and non-elemental damage (to be done in https://github.com/LandSandBoat/server/pull/5734) Resolves https://github.com/LandSandBoat/server/issues/201

## Steps to test these changes

https://www.bg-wiki.com/ffxi/Category:Ruszor

1. !zone Beaucedine Glacier [S]
2. !mobhere 17334289

**Frozen Mist** - https://wiki.ffo.jp/html/21510.html

1. !exec target:useMobAbility(2438)
2. !getmod ICE_ABSORB
3. Effect should absorb 1000 physical damage, while active mob will absorb Ice damage (JP wiki says 1000, bg-wiki says 1500) - will be implemented in https://github.com/LandSandBoat/server/pull/5734

**Hydro Wave** - https://wiki.ffo.jp/html/24705.html

1. !exec target:useMobAbility(2439)
2. !getmod WATER_ABSORB
3. Effect should absorb 1500 magic, breath, and non-elemental damage, while active mob will absorb Water damage - will be implemented in https://github.com/LandSandBoat/server/pull/5734