### PR TITLE
Fix Treasure Chest NPC ID reference in Pso'Xja IDs

### DIFF
--- a/scripts/zones/PsoXja/IDs.lua
+++ b/scripts/zones/PsoXja/IDs.lua
@@ -41,7 +41,7 @@ zones[xi.zone.PSOXJA] =
     npc =
     {
         STONE_DOOR_OFFSET       = GetFirstID('_090'),
-        TREASURE_CHEST          = GetFirstID('Treasure_Chest'),
+        TREASURE_CHEST          = GetTableOfIDs('Treasure_Chest')[7],
     },
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
![image](https://github.com/LandSandBoat/server/assets/81713309/71868d30-103c-4970-8293-eb868d0c9364)


Pso'Xja has 6 mobs named treasure chest, and the 7th and last one is the NPC, in which GetFirstID would return the first mob.  Pulls the entire table and sets to the last value for the expected NPC value, and to resolve the startup warning
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No warning, treasure chest NPC appears and works as expected
<!-- Clear and detailed steps to test your changes here -->
