### PR TITLE
[Core] Add Stoneskin subpower interactions for Ruszor mobskills

### DIFF
--- a/scripts/actions/abilities/blade_bash.lua
+++ b/scripts/actions/abilities/blade_bash.lua
@@ -26,7 +26,7 @@ abilityObject.onUseAbility = function(player, target, ability)
     local damage   = math.floor(player:getMod(xi.mod.WEAPON_BASH) + (jobLevel + 11) / 4)
 
     -- Calculating and applying Blade Bash damage
-    damage = utils.stoneskin(target, damage)
+    damage = utils.stoneskin(target, damage, xi.attackType.PHYSICAL)
     target:takeDamage(damage, player, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     target:updateEnmityFromDamage(player, damage)
 

--- a/scripts/actions/abilities/mijin_gakure.lua
+++ b/scripts/actions/abilities/mijin_gakure.lua
@@ -19,7 +19,7 @@ abilityObject.onUseAbility = function(player, target, ability)
     -- Job Point Bonus (3% per Level)
     dmg = dmg * (1 + (player:getJobPointLevel(xi.jp.MIJIN_GAKURE_EFFECT) * 0.03))
     dmg = dmg * resist
-    dmg = utils.stoneskin(target, dmg)
+    dmg = utils.stoneskin(target, dmg, xi.attackType.SPECIAL)
 
     target:takeDamage(dmg, player, xi.attackType.SPECIAL, xi.damageType.ELEMENTAL)
     player:setLocalVar('MijinGakure', 1)

--- a/scripts/actions/abilities/pets/automaton/shield_bash.lua
+++ b/scripts/actions/abilities/pets/automaton/shield_bash.lua
@@ -47,7 +47,7 @@ abilityObject.onAutomatonAbility = function(target, automaton, skill, master, ac
 
     damage = damage * (pdif / 1000)
 
-    damage = utils.stoneskin(target, damage)
+    damage = utils.stoneskin(target, damage, xi.attackType.PHYSICAL)
     target:takeDamage(damage, automaton, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     target:updateEnmityFromDamage(automaton, damage)
     target:addEnmity(automaton, 450, 900)

--- a/scripts/actions/abilities/pets/concentric_pulse.lua
+++ b/scripts/actions/abilities/pets/concentric_pulse.lua
@@ -24,7 +24,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
         dmg = dmg + (dmg * 0.01 * dmgBoost)
     end
 
-    dmg = utils.stoneskin(target, dmg)
+    dmg = utils.stoneskin(target, dmg, xi.attackType.MAGICAL)
 
     target:takeDamage(dmg, pet, xi.attackType.MAGICAL, xi.damageType.NONE)
 

--- a/scripts/actions/mobskills/spirits_within.lua
+++ b/scripts/actions/mobskills/spirits_within.lua
@@ -42,7 +42,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         return 0
     end
 
-    dmg = utils.stoneskin(target, dmg)
+    dmg = utils.stoneskin(target, dmg, xi.attackType.BREATH)
 
     if dmg > 0 then
         target:wakeUp()

--- a/scripts/effects/bio.lua
+++ b/scripts/effects/bio.lua
@@ -19,7 +19,7 @@ effectObject.onEffectTick = function(target, effect)
     -- handle diabolos nightmare bio damage explicitly
     if effect:getTier() > 0 then
         -- re-using logic from helix effect processing
-        local dmg = utils.stoneskin(target, effect:getPower())
+        local dmg = utils.stoneskin(target, effect:getPower(), xi.attackType.MAGICAL)
 
         if dmg > 0 then
             target:takeDamage(dmg, nil, nil, nil, { wakeUp = false, breakBind = false })

--- a/scripts/effects/helix.lua
+++ b/scripts/effects/helix.lua
@@ -7,7 +7,7 @@ effectObject.onEffectGain = function(target, effect)
 end
 
 effectObject.onEffectTick = function(target, effect)
-    local dmg = utils.stoneskin(target, effect:getPower())
+    local dmg = utils.stoneskin(target, effect:getPower(), xi.attackType.MAGICAL)
 
     if dmg > 0 then
         target:takeDamage(dmg)

--- a/scripts/globals/ability.lua
+++ b/scripts/globals/ability.lua
@@ -85,7 +85,7 @@ xi.ability.adjustDamage = function(dmg, mob, skill, target, skilltype, skillpara
         dmg = utils.oneforall(target, dmg)
     end
 
-    dmg = utils.stoneskin(target, dmg)
+    dmg = utils.stoneskin(target, dmg, skilltype)
 
     if dmg > 0 then
         target:wakeUp()

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -446,7 +446,7 @@ xi.spells.blue.applySpellDamage = function(caster, target, spell, dmg, params, t
     end
 
     -- handle stoneskin
-    dmg = utils.stoneskin(target, dmg)
+    dmg = utils.stoneskin(target, dmg, attackType)
 
     target:takeSpellDamage(caster, spell, dmg, attackType, damageType)
 

--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -427,7 +427,7 @@ xi.job_utils.dancer.useViolentFlourishAbility = function(player, target, ability
             ability:setMsg(xi.msg.basic.JA_DAMAGE)
         end
 
-        dmg = utils.stoneskin(target, dmg)
+        dmg = utils.stoneskin(target, dmg, xi.attackType.PHYSICAL)
         target:takeDamage(dmg, player, xi.attackType.PHYSICAL, player:getWeaponDamageType(xi.slot.MAIN))
         target:updateEnmityFromDamage(player, dmg)
 

--- a/scripts/globals/job_utils/paladin.lua
+++ b/scripts/globals/job_utils/paladin.lua
@@ -210,7 +210,7 @@ xi.job_utils.paladin.useShieldBash = function(player, target, ability)
     local randomizer = 1 + (math.random(1, 5) / 100)
 
     damage = damage * randomizer
-    damage = utils.stoneskin(target, damage)
+    damage = utils.stoneskin(target, damage, xi.attackType.PHYSICAL)
 
     target:takeDamage(damage, player, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     target:updateEnmityFromDamage(player, damage)

--- a/scripts/globals/job_utils/rune_fencer.lua
+++ b/scripts/globals/job_utils/rune_fencer.lua
@@ -522,7 +522,7 @@ local function calculateSwipeLungeDamage(player, target, skillModifier, gearBonu
 
     -- Handle Stoneskin
     if damage > 0 then
-        damage = utils.clamp(utils.stoneskin(target, damage), -99999, 99999)
+        damage = utils.clamp(utils.stoneskin(target, damage, xi.attackType.MAGICAL), -99999, 99999)
     end
 
     return damage

--- a/scripts/globals/job_utils/white_mage.lua
+++ b/scripts/globals/job_utils/white_mage.lua
@@ -110,12 +110,12 @@ xi.job_utils.white_mage.useDevotion = function(player, target, ability)
     local damageHP   = math.floor(player:getHP() * 0.25)
 
     -- If stoneskin is present, it should absorb damage
-    damageHP = utils.stoneskin(player, damageHP)
+    damageHP = utils.stoneskin(player, damageHP, xi.attackType.MAGICAL)
 
     local healMP = player:getHP() * mpPercent
     healMP = utils.clamp(healMP, 0, target:getMaxMP() - target:getMP())
 
-    damageHP = utils.stoneskin(player, damageHP)
+    damageHP = utils.stoneskin(player, damageHP, xi.attackType.MAGICAL)
     player:delHP(damageHP)
     target:addMP(healMP)
 
@@ -143,7 +143,7 @@ xi.job_utils.white_mage.useMartyr = function(player, target, ability)
     healHP = utils.clamp(healHP, 0, target:getMaxHP() - target:getHP())
 
     -- If stoneskin is present, it should absorb damage
-    damageHP = utils.stoneskin(player, damageHP)
+    damageHP = utils.stoneskin(player, damageHP, xi.attackType.MAGICAL)
     player:delHP(damageHP)
     target:addHP(healHP)
 

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -457,7 +457,7 @@ function finalMagicAdjustments(caster, target, spell, dmg)
     dmg = utils.oneforall(target, dmg)
 
     --handling stoneskin
-    dmg = utils.stoneskin(target, dmg)
+    dmg = utils.stoneskin(target, dmg, xi.attackType.MAGICAL)
     dmg = utils.clamp(dmg, -99999, 99999)
 
     if dmg < 0 then
@@ -490,7 +490,7 @@ function finalMagicNonSpellAdjustments(caster, target, ele, dmg)
     dmg = utils.oneforall(target, dmg)
 
     -- handling stoneskin
-    dmg = utils.stoneskin(target, dmg)
+    dmg = utils.stoneskin(target, dmg, xi.attackType.MAGICAL)
 
     dmg = utils.clamp(dmg, -99999, 99999)
 

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -471,7 +471,7 @@ xi.mobskills.mobBreathMove = function(mob, target, skill, percent, base, element
 
     -- Handle Stoneskin
     if damage > 0 then
-        damage = utils.clamp(utils.stoneskin(target, damage), -99999, 99999)
+        damage = utils.clamp(utils.stoneskin(target, damage, xi.attackType.BREATH), -99999, 99999)
     end
 
     -- breath mob skills are single hit so provide single Melee hit TP return if primary target
@@ -601,7 +601,7 @@ xi.mobskills.mobFinalAdjustments = function(dmg, mob, skill, target, attackType,
         end
     end
 
-    dmg = utils.stoneskin(target, dmg)
+    dmg = utils.stoneskin(target, dmg, attackType)
 
     if dmg > 0 then
         target:updateEnmityFromDamage(mob, dmg)

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -1001,7 +1001,7 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
 
     -- Handle Stoneskin
     if finalDamage > 0 then
-        finalDamage = utils.clamp(utils.stoneskin(target, finalDamage), -99999, 99999)
+        finalDamage = utils.clamp(utils.stoneskin(target, finalDamage, xi.attackType.MAGICAL), -99999, 99999)
     end
 
     -- Handle Magic Absorb

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -372,7 +372,7 @@ xi.summon.avatarFinalAdjustments = function(dmg, mob, skill, target, skilltype, 
     end
 
     -- handling stoneskin
-    dmg = utils.stoneskin(target, dmg)
+    dmg = utils.stoneskin(target, dmg, skilltype)
 
     return dmg
 end

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -92,7 +92,7 @@ local function souleaterBonus(attacker, wsParams)
         local bonusDamage       = math.floor(attacker:getHP() * (0.1 + souleaterEffect + souleaterEffectII))
 
         if bonusDamage >= 1 then
-            attacker:delHP(utils.stoneskin(attacker, bonusDamage * stalwartSoulBonus))
+            attacker:delHP(utils.stoneskin(attacker, bonusDamage * stalwartSoulBonus, xi.attackType.PHYSICAL))
 
             if attacker:getMainJob() ~= xi.job.DRK then
                 return math.floor(bonusDamage / 2)
@@ -349,7 +349,7 @@ local function getSingleHitDamage(attacker, target, dmg, ftp, wsParams, calcPara
                     magicdmg = magicdmg - target:getMod(xi.mod.PHALANX)
                     magicdmg = utils.clamp(magicdmg, 0, 99999)
                     magicdmg = utils.oneforall(target, magicdmg)
-                    magicdmg = utils.stoneskin(target, magicdmg)
+                    magicdmg = utils.stoneskin(target, magicdmg, xi.attackType.MAGICAL)
                 end
 
                 finaldmg = finaldmg + magicdmg
@@ -398,7 +398,7 @@ local function modifyMeleeHitDamage(attacker, target, attackTbl, wsParams, rawDa
         adjustedDamage = utils.clamp(adjustedDamage, 0, 99999)
     end
 
-    adjustedDamage = utils.stoneskin(target, adjustedDamage)
+    adjustedDamage = utils.stoneskin(target, adjustedDamage, xi.attackType.PHYSICAL)
 
     return adjustedDamage
 end
@@ -937,7 +937,7 @@ xi.weaponskills.doMagicWeaponskill = function(attacker, target, wsID, wsParams, 
         end
 
         dmg = utils.oneforall(target, dmg)
-        dmg = utils.stoneskin(target, dmg)
+        dmg = utils.stoneskin(target, dmg, xi.attackType.MAGICAL)
 
         dmg = dmg * xi.settings.main.WEAPON_SKILL_POWER -- Add server bonus
     else

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1941,7 +1941,7 @@ void CStatusEffectContainer::TickRegen(time_point tick)
 
         if (poison)
         {
-            int16 damage = battleutils::HandleStoneskin(m_POwner, poison);
+            int16 damage = battleutils::HandleStoneskin(m_POwner, poison, ATTACK_TYPE::MAGICAL);
 
             if (damage > 0)
             {

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -226,7 +226,8 @@ namespace battleutils
     void BindBreakCheck(CBattleEntity* PAttacker, CBattleEntity* PDefender);
 
     // returns damage taken
-    int32 HandleStoneskin(CBattleEntity* PDefender, int32 damage);
+    int32 HandleStoneskin(CBattleEntity* PDefender, int32 damage, ATTACK_TYPE attackType);
+    int32 HandleStoneskinSubPower(CBattleEntity* PDefender, CStatusEffect* effect, int32 damage, int16 skin);
     int32 HandleOneForAll(CBattleEntity* PDefender, int32 damage);
     int32 HandleFanDance(CBattleEntity* PDefender, int32 damage);
     void  HandleScarletDelirium(CBattleEntity* PDefender, int32 damage);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds Stoneskin subpower interactions support for some unique types of Stoneskin, one which absorbs only physical and the other which only absorbs magic, breath, and non-elemental damage.

## Steps to test these changes

https://www.bg-wiki.com/ffxi/Category:Ruszor

1. !zone Beaucedine Glacier [S]
2. !mobhere 17334289
3. !exec target:useMobAbility(2438) - Frozen Mist
5. Effect should absorb 1000 physical damage, while active mob will absorb Ice damage
6. !exec target:useMobAbility(2439) - Hydro Wave
8. Effect should absorb 1500 magic, breath, and non-elemental damage, while active mob will absorb Water damage
