### PR TITLE
[LUA] Add Fuscous Ooze's encumbrance effect

### DIFF
--- a/scripts/actions/mobskills/fuscous_ooze.lua
+++ b/scripts/actions/mobskills/fuscous_ooze.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 --  Fuscous Ooze
 --  Family: Slugs
---  Description: A dusky slime inflicts encumberance and weight.
+--  Description: A dusky slime inflicts encumbrance and weight.
 --  Type: Magical
 --  Utsusemi/Blink absorb: Ignores shadows
 --  Range: Cone
@@ -13,8 +13,11 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    -- TODO: Encumberance seems to do nothing?
-    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.WEIGHT, 50, 0, 45)
+    local power    = math.random(1, 16)
+    local duration = math.random(30, 45)
+
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ENCUMBRANCE_II, power, 0, duration)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.WEIGHT, 50, 0, duration)
 
     local dmgmod = 1
     local baseDamage = mob:getWeaponDmg() * 3.7


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds the encumbrance effect to Fuscous Ooze. Duration seems like it should be random between 30 and 45 seconds according to https://wiki.ffo.jp/html/24648.html, not much other information available.

## Steps to test these changes

1. !zone Pashhow Marshlands [S]
2. !mobhere 17145979
3. !exec target:useMobAbility(2183)