### PR TITLE
Updates httplib dependency to 0.15.3

### DIFF
--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -137,7 +137,7 @@ CPMAddPackage(
 CPMAddPackage(
     NAME cpp-httplib
     GITHUB_REPOSITORY yhirose/cpp-httplib
-    GIT_TAG v0.11.3
+    GIT_TAG v0.15.3
 ) # defines: httplib::httplib
 
 CPMAddPackage(

--- a/src/world/http_server.cpp
+++ b/src/world/http_server.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
 Copyright (c) 2022 LandSandBoat Dev Teams
@@ -141,7 +141,7 @@ HTTPServer::HTTPServer()
         m_httpServer.set_error_handler([](httplib::Request const& /*req*/, httplib::Response& res)
         {
             auto str = fmt::format("<p>Error Status: <span style='color:red;'>{} ({})</span></p>",
-                res.status, httplib::detail::status_message(res.status));
+                res.status, httplib::status_message(res.status));
 
             for (auto const& [key, val] : res.headers)
             {
@@ -156,12 +156,12 @@ HTTPServer::HTTPServer()
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
             if (res.status >= 500)
             {
-                ShowError(fmt::format("Server Error: {} ({})", res.status, httplib::detail::status_message(res.status)));
+                ShowError(fmt::format("Server Error: {} ({})", res.status, httplib::status_message(res.status)));
                 return;
             }
             else if (res.status >= 400)
             {
-                ShowError(fmt::format("Client Error: {} ({})", res.status, httplib::detail::status_message(res.status)));
+                ShowError(fmt::format("Client Error: {} ({})", res.status, httplib::status_message(res.status)));
                 return;
             }
         });


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Updates the `yhirose/cpp-httplib` dependency to the most recent release.

## Steps to test these changes

Enable the world HTTP server in `network.lua`, start the world server, hit the endpoints provided and make sure everything works as expected.
* `/api`
* `/api/zones`
* `/api/zones/230`
* `/api/settings`
* `/api/bad_endpoint` (should throw 404)