### PR TITLE
[cpp/lua] Luaeffect improvements

### DIFF
--- a/scripts/globals/job_utils/rune_fencer.lua
+++ b/scripts/globals/job_utils/rune_fencer.lua
@@ -296,8 +296,7 @@ local function applyVallationValianceSDTMods(target, SDTTypes, power, effect, du
         local newEffect = target:getStatusEffect(effect)
 
         for _, SDT in ipairs(SDTTypes) do
-            target:addMod(SDT, power)
-            newEffect:addMod(SDT, power) -- due to order of events, this only adds mods to the container, not to the owner of the effect.
+            newEffect:addMod(SDT, power)
         end
     end
 end
@@ -309,8 +308,7 @@ local function applyGambitSDTMods(target, SDTTypes, power, effect, duration) -- 
         local newEffect = target:getStatusEffect(effect)
 
         for _, SDT in ipairs(SDTTypes) do
-            target:addMod(SDT, power)
-            newEffect:addMod(SDT, power) -- due to order of events, this only adds mods to the container, not to the owner of the effect.
+            newEffect:addMod(SDT, power)
         end
     end
 end
@@ -695,7 +693,7 @@ local function addPflugResistType(type, effect, power)
 
     local resistTypes = pflugResistTypes[type]
 
-    for _, resistMod in pairs(resistTypes) do -- store mod in effect, this function is triggered from event onEffectGain so it adds to the player automatically.
+    for _, resistMod in pairs(resistTypes) do
         effect:addMod(resistMod, power)
     end
 end
@@ -782,7 +780,6 @@ xi.job_utils.rune_fencer.useRayke = function(player, target, ability, action)
             local element    = getRaykeElement(rune)
 
             raykeElements = raykeElements + bit.lshift(element, 4 * i) -- pack 4 bit damage type into 16 bit int
-            target:addMod(resRankMod, -1)
             effect:addMod(resRankMod, -1) -- Status effect handles removing the mods
 
             i = i + 1

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -12644,7 +12644,9 @@ std::optional<CLuaStatusEffect> CLuaBaseEntity::getStatusEffect(uint16 StatusID,
 
     if (PStatusEffect)
     {
-        return std::optional<CLuaStatusEffect>(PStatusEffect);
+        auto PLuaStatusEffect = std::optional<CLuaStatusEffect>(PStatusEffect);
+        PLuaStatusEffect->SetBaseEntity(m_PBaseEntity);
+        return PLuaStatusEffect;
     }
 
     return std::nullopt;
@@ -12674,9 +12676,11 @@ sol::table CLuaBaseEntity::getStatusEffects()
     auto table = lua.create_table();
     // clang-format off
     static_cast<CBattleEntity*>(m_PBaseEntity)->StatusEffectContainer->ForEachEffect(
-    [&table](CStatusEffect* PEffect)
+    [&table, &PBattleEntity](CStatusEffect* PEffect)
     {
-        table.add(CLuaStatusEffect(PEffect));
+        auto PLuaStatusEffect = std::optional<CLuaStatusEffect>(PEffect);
+        PLuaStatusEffect->SetBaseEntity(PBattleEntity);
+        table.add(PLuaStatusEffect);
     });
     // clang-format on
 

--- a/src/map/lua/lua_statuseffect.cpp
+++ b/src/map/lua/lua_statuseffect.cpp
@@ -23,7 +23,10 @@
 #include "common/timer.h"
 
 #include "lua_statuseffect.h"
+#include "status_effect_container.h"
 #include "status_effect.h"
+
+#include "entities/battleentity.h"
 
 //======================================================//
 
@@ -34,6 +37,18 @@ CLuaStatusEffect::CLuaStatusEffect(CStatusEffect* StatusEffect)
     {
         ShowError("CLuaStatusEffect created with nullptr instead of valid CStatusEffect*!");
     }
+
+    m_PBaseEntity = nullptr;
+}
+
+void CLuaStatusEffect::SetBaseEntity(CBaseEntity* BaseEntity)
+{
+    if (BaseEntity == nullptr)
+    {
+        ShowError("CLuaStatusEffect trying to map to a nullptr CBaseEntity*!");
+    }
+
+    m_PBaseEntity = BaseEntity;
 }
 
 //======================================================//
@@ -221,6 +236,28 @@ bool CLuaStatusEffect::hasEffectFlag(uint32 flag)
     return m_PLuaStatusEffect->HasEffectFlag(flag);
 }
 
+void CLuaStatusEffect::delStatusEffect()
+{
+    auto* PBattleEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
+    if (!PBattleEntity || !PBattleEntity->StatusEffectContainer)
+    {
+        return;
+    }
+
+    PBattleEntity->StatusEffectContainer->RemoveStatusEffect(m_PLuaStatusEffect);
+}
+
+void CLuaStatusEffect::delStatusEffectSilent()
+{
+    auto* PBattleEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
+    if (!PBattleEntity || !PBattleEntity->StatusEffectContainer)
+    {
+        return;
+    }
+
+    PBattleEntity->StatusEffectContainer->RemoveStatusEffect(m_PLuaStatusEffect, true);
+}
+
 uint16 CLuaStatusEffect::getIcon()
 {
     return m_PLuaStatusEffect->GetIcon();
@@ -256,6 +293,8 @@ void CLuaStatusEffect::Register()
     SOL_REGISTER("addEffectFlag", CLuaStatusEffect::addEffectFlag);
     SOL_REGISTER("delEffectFlag", CLuaStatusEffect::delEffectFlag);
     SOL_REGISTER("hasEffectFlag", CLuaStatusEffect::hasEffectFlag);
+    SOL_REGISTER("delStatusEffect", CLuaStatusEffect::delStatusEffect);
+    SOL_REGISTER("delStatusEffectSilent", CLuaStatusEffect::delStatusEffectSilent);
     SOL_REGISTER("getIcon", CLuaStatusEffect::getIcon);
 }
 

--- a/src/map/lua/lua_statuseffect.cpp
+++ b/src/map/lua/lua_statuseffect.cpp
@@ -23,8 +23,8 @@
 #include "common/timer.h"
 
 #include "lua_statuseffect.h"
-#include "status_effect_container.h"
 #include "status_effect.h"
+#include "status_effect_container.h"
 
 #include "entities/battleentity.h"
 
@@ -207,6 +207,14 @@ void CLuaStatusEffect::setStartTime(uint32 time)
 void CLuaStatusEffect::addMod(uint16 mod, int16 amount)
 {
     m_PLuaStatusEffect->addMod(static_cast<Mod>(mod), amount);
+
+    // Since an effect's mod list is only applied to entity when adding the effect
+    // we need to add the mod to the entity manually if the effect is already applied
+    auto* PBattleEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
+    if (PBattleEntity)
+    {
+        PBattleEntity->addModifier(static_cast<Mod>(mod), amount);
+    }
 }
 
 //======================================================//

--- a/src/map/lua/lua_statuseffect.h
+++ b/src/map/lua/lua_statuseffect.h
@@ -29,9 +29,11 @@ class CStatusEffect;
 class CLuaStatusEffect
 {
     CStatusEffect* m_PLuaStatusEffect;
+    CBaseEntity*   m_PBaseEntity;
 
 public:
     CLuaStatusEffect(CStatusEffect*);
+    void SetBaseEntity(CBaseEntity* entity);
 
     CStatusEffect* GetStatusEffect() const
     {
@@ -69,6 +71,8 @@ public:
     void   addEffectFlag(uint32 flag);
     void   delEffectFlag(uint32 flag);
     bool   hasEffectFlag(uint32 flag);
+    void   delStatusEffect();
+    void   delStatusEffectSilent();
 
     bool operator==(const CLuaStatusEffect& other) const
     {

--- a/src/map/status_effect_container.h
+++ b/src/map/status_effect_container.h
@@ -49,8 +49,9 @@ public:
     bool DelStatusEffect(EFFECT StatusID);
     bool DelStatusEffectSilent(EFFECT StatusID);
     bool DelStatusEffect(EFFECT StatusID, uint16 SubID);
-    void DelStatusEffectsByFlag(uint32 flag, bool silent = false); // Remove all the status effects with the specified type
-    void DelStatusEffectsByIcon(uint16 IconID);                    // Remove all effects with the specified icon
+    void RemoveStatusEffect(CStatusEffect* PEffect, bool silent = false); // Remove a single status effect by pointer
+    void DelStatusEffectsByFlag(uint32 flag, bool silent = false);        // Remove all the status effects with the specified type
+    void DelStatusEffectsByIcon(uint16 IconID);                           // Remove all effects with the specified icon
     void DelStatusEffectsByType(uint16 Type);
     bool DelStatusEffectByTier(EFFECT StatusID, uint16 power);
     void KillAllStatusEffect();
@@ -133,7 +134,6 @@ private:
 
     // void ReplaceStatusEffect(EFFECT effect); //this needs to be implemented
     void RemoveStatusEffect(uint32 id, bool silent = false);              // We remove the effect by its number in the container
-    void RemoveStatusEffect(CStatusEffect* PEffect, bool silent = false); // We remove the effect by its number in the container
     void DeleteStatusEffects();
     void SetEffectParams(CStatusEffect* StatusEffect); // We set the effect of the effect
     void HandleAura(CStatusEffect* PStatusEffect);

--- a/src/map/status_effect_container.h
+++ b/src/map/status_effect_container.h
@@ -133,7 +133,7 @@ private:
     CBattleEntity* m_POwner = nullptr;
 
     // void ReplaceStatusEffect(EFFECT effect); //this needs to be implemented
-    void RemoveStatusEffect(uint32 id, bool silent = false);              // We remove the effect by its number in the container
+    void RemoveStatusEffect(uint32 id, bool silent = false); // We remove the effect by its number in the container
     void DeleteStatusEffects();
     void SetEffectParams(CStatusEffect* StatusEffect); // We set the effect of the effect
     void HandleAura(CStatusEffect* PStatusEffect);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Meta: 
- gives `CLuaStatusEffect` a pointer to track the owner of a status effect
- sets this pointer when using `entity:getStatusEffect(` or `entity:getStatusEffects(`
- Moves `CStatusEffectContainer::RemoveStatusEffect(*pointer)` function to public so it can be used by the new lua binding

Simplifies the item lua logic for https://github.com/LandSandBoat/server/pull/5726 for deleting effects by being able to do it directly via the object

Also, fixes a small oversight with existing `effect:addMod` logic in that it only gives the entity mod values if it was used within `onEffectGain` (and cleans up the few instances in the code that worked around this limitation, found via command below):
```
/mnt/c/VSCode/LSBserver/scripts$ grep :addMod -R | grep -v ^effects | grep -v pet:addMod | grep -v target:addMod | grep -v mob:addMod | grep -v player:addMod
battlefields/Apollyon/nw_apollyon.lua:    boss:addMod(xi.mod.ATTP, 100)
battlefields/Apollyon/nw_apollyon.lua:    boss:addMod(xi.mod.ACC, 50)
battlefields/Temenos/central_temenos_3rd_floor.lua:            boss:addMod(bonusMod, amount)
globals/job_utils/dragoon.lua:            wyvern:addMod(xi.mod.ACC, 6 * numLevelUps)
globals/job_utils/dragoon.lua:            wyvern:addMod(xi.mod.HPP, 6 * numLevelUps)
globals/job_utils/dragoon.lua:            wyvern:addMod(xi.mod.ATTP, 5 * numLevelUps)
globals/job_utils/geomancer.lua:    luopan:addMod(xi.mod.REGEN_DOWN, math.floor(luopan:getMainLvl() / 4) - bolsterValue)
globals/job_utils/geomancer.lua:    luopan:addMod(xi.mod.DMG, -5000)
globals/job_utils/rune_fencer.lua:            newEffect:addMod(SDT, power)
globals/job_utils/rune_fencer.lua:            newEffect:addMod(SDT, power)
globals/job_utils/rune_fencer.lua:    effect:addMod(xi.mod.INQUARTATA, effect:getPower())
globals/job_utils/rune_fencer.lua:        effect:addMod(xi.mod.PARRY_SPIKES, spikesType)
globals/job_utils/rune_fencer.lua:        effect:addMod(xi.mod.PARRY_SPIKES_DMG, effect:getSubPower())
globals/job_utils/rune_fencer.lua:        effect:addMod(resistMod, power)
globals/weaponskills.lua:        attacker:addMod(xi.mod.ACC, 40 + flourishEffect:getSubPower() * 2)
globals/weaponskills.lua:        attacker:addMod(xi.mod.ATTP, 25 + flourishEffect:getSubPower())
zones/AlTaieu/mobs/Jailer_of_Prudence.lua:        secondPrudence:addMod(xi.mod.ATTP, 100)
zones/AlTaieu/mobs/Jailer_of_Prudence.lua:        firstPrudence:addMod(xi.mod.ATTP, 100)
zones/Horlais_Peak/mobs/Dragonian_Berzerker.lua:                    mobArg:addMod(xi.mod.ATT, 200)
zones/Horlais_Peak/mobs/Dragonian_Minstrel.lua:                    mobArg:addMod(xi.mod.ATT, 200)
zones/La_Vaule_[S]/mobs/Draketrader_Zlodgodd.lua:            mobArg:addMod(xi.mod.ATT, 100)
zones/Nyzul_Isle/mobs/Raubahn.lua:                    mobArg:addMod(xi.mod.UDMGMAGIC, -10000)
zones/Nyzul_Isle/mobs/Raubahn.lua:                    mobArg:addMod(xi.mod.UDMGRANGE, -10000)
```


## Steps to test these changes

Execute `!exec player:getStatusEffect(xi.effect.REGEN)` or `!exec player:getStatusEffects()` and see it still works as it did before

see that this bit of lua removes all effects from a player:
```
itemObject.onItemUnequip = function(target, item)
    for _, itemEffect in pairs(target:getStatusEffects()) do
        print(itemEffect)
        itemEffect:delStatusEffect()
    end
end
```

Testing the `addMod` extension:
- give yourself any effect, then stack mods on it and see the mod is on your char then removed with effect goes away
  - `!addeffect regen`
  - `!exec player:getStatusEffect(xi.effect.REGEN):addMod(xi.mod.STR, 5)`
  - see that you have +5 str in equipment menu
  - cancel the effect
  - see that the +5 str goes away