### PR TITLE
[lua] Recalculate stats after player calcs gear set mods

### DIFF
--- a/scripts/globals/gear_sets.lua
+++ b/scripts/globals/gear_sets.lua
@@ -2597,4 +2597,6 @@ xi.gear_sets.checkForGearSet = function(player)
             end
         end
     end
+
+    player:recalculateStats()
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes https://github.com/LandSandBoat/server/issues/5741 .

## Steps to test these changes

Equip 2 or more items that create a set bonus with base stats (str, hp/mp, magic skill), zone and see that the mod is applied but player doesn't have the stats

Apply this PR and see that you do get updated stats immediately after zoning