### PR TITLE
New TARGETTYPE flag for wotg-style mobskills

### DIFF
--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -654,7 +654,7 @@ INSERT INTO `mob_skills` VALUES (636,380,'flame_arrow',0,0.0,10.0,2000,1500,4,0,
 INSERT INTO `mob_skills` VALUES (637,381,'firebomb',4,0.0,9.5,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (638,382,'blastbomb',2,0.0,13.5,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (639,383,'fountain',4,0.0,9.5,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (640,384,'touchdown',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+-- INSERT INTO `mob_skills` VALUES (640,384,'touchdown',0,0.0,7.0,2000,1500,2049,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (641,973,'recoil_dive',4,0.0,9.5,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (642,386,'flame_breath',4,0.0,12.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (643,387,'poison_breath',4,0.0,12.0,2000,1500,4,0,0,0,0,0,0);
@@ -968,7 +968,7 @@ INSERT INTO `mob_skills` VALUES (950,652,'flame_blast_alt',0,0.0,18.0,2000,0,4,4
 INSERT INTO `mob_skills` VALUES (951,653,'hurricane_wing',1,0.0,30.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (952,654,'spike_flail',1,0.0,23.0,2000,2000,4,0,0,0,0,0,0); -- Alliance only targeting version of spike flail
 INSERT INTO `mob_skills` VALUES (953,655,'dragon_breath',4,0.0,18.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (954,656,'touchdown',1,0.0,30.0,2000,0,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (954,656,'touchdown',1,0.0,30.0,2000,0,2049,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (955,657,'flame_blast',1,0.0,30.0,2000,1500,4,0,0,0,0,0,0); -- KS99_Wyrm airborne fire AoE
 INSERT INTO `mob_skills` VALUES (956,658,'hurricane_wing_flying',1,0.0,30.0,2000,1500,4,0,0,0,0,0,0); -- KS99_Wyrm airborne Hurricane Wing
 INSERT INTO `mob_skills` VALUES (957,659,'absolute_terror',0,0.0,18.0,4000,1500,4,0,0,0,0,0,0);
@@ -1296,7 +1296,7 @@ INSERT INTO `mob_skills` VALUES (1278,652,'inferno_blast_alt',0,0.0,18.0,2000,0,
 INSERT INTO `mob_skills` VALUES (1279,653,'tebbad_wing',1,0.0,30.0,2000,1500,4,8,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1280,654,'spike_flail',1,0.0,23.0,2000,2000,4,8,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1281,655,'fiery_breath',4,0.0,18.0,2000,1500,4,8,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1282,656,'touchdown',1,0.0,6.0,2000,0,4,8,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1282,656,'touchdown',1,0.0,6.0,2000,0,2049,8,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1283,657,'inferno_blast',1,0.0,23.0,2000,2000,4,8,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1284,658,'tebbad_wing_air',1,0.0,30.0,2000,1500,4,8,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1285,659,'absolute_terror',0,0.0,18.0,2000,1500,4,8,0,0,0,0,0);
@@ -1306,7 +1306,7 @@ INSERT INTO `mob_skills` VALUES (1288,963,'sleet_blast_alt',0,0.0,18.0,2000,0,4,
 INSERT INTO `mob_skills` VALUES (1289,653,'gregale_wing',1,0.0,30.0,2000,1500,4,8,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1290,654,'spike_flail',1,0.0,23.0,2000,2000,4,8,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1291,962,'glacial_breath',4,0.0,18.0,2000,1500,4,8,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1292,656,'touchdown',1,0.0,6.0,2000,0,4,8,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1292,656,'touchdown',1,0.0,6.0,2000,0,2049,8,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1293,964,'sleet_blast',1,0.0,23.0,2000,2000,4,8,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1294,658,'gregale_wing_air',1,0.0,30.0,2000,1500,4,8,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1295,659,'absolute_terror',0,0.0,18.0,4000,1500,4,8,0,0,0,0,0);
@@ -1316,7 +1316,7 @@ INSERT INTO `mob_skills` VALUES (1298,966,'ochre_blast_alt',0,0.0,18.0,2000,0,4,
 INSERT INTO `mob_skills` VALUES (1299,653,'typhoon_wing',1,0.0,30.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1300,654,'spike_flail',1,0.0,23.0,2000,2000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1301,965,'geotic_breath',4,0.0,18.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1302,656,'touchdown',1,0.0,30.0,2000,0,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1302,656,'touchdown',1,0.0,30.0,2000,0,2049,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1303,967,'ochre_blast',1,0.0,23.0,2000,2000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1304,658,'bai_wing',1,0.0,30.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1305,659,'absolute_terror',1,0.0,18.0,4000,1500,4,0,0,0,0,0,0);
@@ -1326,7 +1326,7 @@ INSERT INTO `mob_skills` VALUES (1306,660,'horrid_roar_3',0,0.0,18.0,4000,1500,4
 INSERT INTO `mob_skills` VALUES (1309,653,'cyclone_wing',1,0.0,30.0,2000,1500,4,8,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1310,654,'spike_flail',1,0.0,23.0,2000,2000,4,8,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1311,968,'sable_breath',4,0.0,18.0,2000,1500,4,8,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1312,1056,'touchdown',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+-- INSERT INTO `mob_skills` VALUES (1312,1056,'touchdown',0,0.0,7.0,2000,1500,2049,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1313,1057,'dark_matter_blast',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1314,1058,'cyclone_wing',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1315,659,'absolute_terror',0,0.0,18.0,4000,1500,4,8,0,0,0,0,0);
@@ -1423,7 +1423,7 @@ INSERT INTO `mob_skills` VALUES (1399,1035,'cosmic_elucidation',0,0.0,15.0,2000,
 -- INSERT INTO `mob_skills` VALUES (1406,653,'typhoon_wing',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1407,654,'spike_flail',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1408,965,'geotic_breath',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1409,656,'touchdown',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+-- INSERT INTO `mob_skills` VALUES (1409,656,'touchdown',0,0.0,7.0,2000,1500,2049,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1410,967,'ocher_blast',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1411,658,'bai_wing',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1412,1156,'absolute_terror',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
@@ -1558,7 +1558,7 @@ INSERT INTO `mob_skills` VALUES (1540,1081,'citadel_buster',2,0.0,20.0,2000,1500
 -- INSERT INTO `mob_skills` VALUES (1541,1285,'blighted_gloom',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1542,1133,'trample',1,0.0,15.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1543,1134,'tempest_wing',4,0.0,15.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1544,1139,'touchdown_bahamut',1,0.0,15.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1544,1139,'touchdown_bahamut',1,0.0,15.0,2000,1500,2049,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1545,1135,'sweeping_flail',1,0.0,20.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1546,1140,'prodigious_spike',0,0.0,15.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1547,1141,'impulsion',0,0.0,15.0,2000,1500,4,0,0,0,0,0,0);

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -357,11 +357,11 @@ bool CMobController::MobSkill(int wsList)
                 continue;
             }
 
-            if (PMobSkill->getValidTargets() == TARGET_ENEMY) // enemy
+            if (PMobSkill->getValidTargets() & TARGET_ENEMY) // enemy
             {
                 PActionTarget = PTarget;
             }
-            else if (PMobSkill->getValidTargets() == TARGET_SELF) // self
+            else if (PMobSkill->getValidTargets() & TARGET_SELF) // self
             {
                 PActionTarget = PMob;
             }

--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -148,7 +148,7 @@ void CTargetFind::findWithinArea(CBattleEntity* PTarget, AOE_RADIUS radiusType, 
     else
     {
         // handle this as a mob
-        if (m_targetFlags & TARGET_MOB_AND_PLAYER)
+        if (m_targetFlags & TARGET_ANY_ALLEGIANCE)
         {
             m_findType = FIND_TYPE::MONSTER_PLAYER;
             if ((m_targetFlags & TARGET_SELF) && m_PBattleEntity->GetBattleTarget())
@@ -470,19 +470,19 @@ bool CTargetFind::validEntity(CBattleEntity* PTarget)
     }
 
     // short-circuit allegiance checks for aoe skills/abilities/spells that can hit players and mobs simultaneously
-    if (m_targetFlags & TARGET_MOB_AND_PLAYER)
+    if (m_targetFlags & TARGET_ANY_ALLEGIANCE)
     {
         if (m_targetFlags & TARGET_SELF)
         {
             if (m_PBattleEntity->allegiance == PTarget->allegiance)
             {
-                // TARGET_MOB_AND_PLAYER with TARGET_SELF means it should behave like TARGET_ENEMY
+                // TARGET_ANY_ALLEGIANCE with TARGET_SELF means it should behave like TARGET_ENEMY
                 return false;
             }
         }
         else if (m_PBattleEntity == PTarget)
         {
-            // Don't erroneously include self when using TARGET_MOB_AND_PLAYER
+            // Don't erroneously include self when using TARGET_ANY_ALLEGIANCE
             return false;
         }
     }

--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -148,7 +148,17 @@ void CTargetFind::findWithinArea(CBattleEntity* PTarget, AOE_RADIUS radiusType, 
     else
     {
         // handle this as a mob
-        if (m_PMasterTarget->objtype == TYPE_PC || m_PBattleEntity->allegiance == ALLEGIANCE_TYPE::PLAYER)
+        if (m_targetFlags & TARGET_MOB_AND_PLAYER)
+        {
+            m_findType = FIND_TYPE::MONSTER_PLAYER;
+            if ((m_targetFlags & TARGET_SELF) && m_PBattleEntity->GetBattleTarget())
+            {
+                // This ability targets self for aoe skills (such as Frozen Mist)
+                // We must update the base target for allegiance checks
+                m_PMasterTarget = findMaster(m_PBattleEntity->GetBattleTarget());
+            }
+        }
+        else if (m_PMasterTarget->objtype == TYPE_PC || m_PBattleEntity->allegiance == ALLEGIANCE_TYPE::PLAYER)
         {
             m_findType = FIND_TYPE::MONSTER_PLAYER;
         }
@@ -459,39 +469,59 @@ bool CTargetFind::validEntity(CBattleEntity* PTarget)
         return true;
     }
 
-    if (m_PTarget->allegiance != PTarget->allegiance)
+    // short-circuit allegiance checks for aoe skills/abilities/spells that can hit players and mobs simultaneously
+    if (m_targetFlags & TARGET_MOB_AND_PLAYER)
     {
-        return false;
-    }
-
-    // If offensive, don't target other entities with same allegiance
-    // Cures can be AoE with Accession and Majesty, ideally we would use SPELLGROUP or some other mechanism, but TargetFind wasn't designed with that in mind
-    if ((m_targetFlags & TARGET_ENEMY) && !(m_targetFlags & TARGET_PLAYER_PARTY) &&
-        m_PBattleEntity->allegiance == PTarget->allegiance)
-    {
-        return false;
-    }
-
-    // shouldn't add if target is charmed by the enemy
-    if (PTarget->PMaster != nullptr)
-    {
-        if (m_findType == FIND_TYPE::MONSTER_PLAYER)
+        if (m_targetFlags & TARGET_SELF)
         {
-            if (PTarget->PMaster->objtype == TYPE_MOB)
+            if (m_PBattleEntity->allegiance == PTarget->allegiance)
             {
+                // TARGET_MOB_AND_PLAYER with TARGET_SELF means it should behave like TARGET_ENEMY
                 return false;
             }
         }
-        else if (m_findType == FIND_TYPE::PLAYER_MONSTER)
+        else if (m_PBattleEntity == PTarget)
         {
-            if (PTarget->PMaster->objtype == TYPE_PC)
-            {
-                return false;
-            }
+            // Don't erroneously include self when using TARGET_MOB_AND_PLAYER
+            return false;
         }
-        else if (m_findType == FIND_TYPE::MONSTER_MONSTER || m_findType == FIND_TYPE::PLAYER_PLAYER)
+    }
+    else
+    {
+        if (m_PTarget->allegiance != PTarget->allegiance)
         {
-            return PTarget->objtype == TYPE_TRUST;
+            return false;
+        }
+
+        // If offensive, don't target other entities with same allegiance
+        // Cures can be AoE with Accession and Majesty, ideally we would use SPELLGROUP or some other mechanism, but TargetFind wasn't designed with that in mind
+        if ((m_targetFlags & TARGET_ENEMY) && !(m_targetFlags & TARGET_PLAYER_PARTY) &&
+            m_PBattleEntity->allegiance == PTarget->allegiance)
+        {
+            return false;
+        }
+
+        // shouldn't add if target is charmed by the enemy
+        if (PTarget->PMaster != nullptr)
+        {
+            if (m_findType == FIND_TYPE::MONSTER_PLAYER)
+            {
+                if (PTarget->PMaster->objtype == TYPE_MOB)
+                {
+                    return false;
+                }
+            }
+            else if (m_findType == FIND_TYPE::PLAYER_MONSTER)
+            {
+                if (PTarget->PMaster->objtype == TYPE_PC)
+                {
+                    return false;
+                }
+            }
+            else if (m_findType == FIND_TYPE::MONSTER_MONSTER || m_findType == FIND_TYPE::PLAYER_PLAYER)
+            {
+                return PTarget->objtype == TYPE_TRUST;
+            }
         }
     }
 

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -79,6 +79,13 @@ CMobSkillState::CMobSkillState(CBattleEntity* PEntity, uint16 targid, uint16 wsi
         actionTarget.animation  = 0;
         actionTarget.param      = m_PSkill->getID();
         actionTarget.messageID  = 43;
+
+        if ((m_PSkill->getValidTargets() & TARGET_MOB_AND_PLAYER) && (m_PSkill->getValidTargets() & TARGET_SELF))
+        {
+            // This ability targets self for aoe skills (such as Frozen Mist)
+            action.actiontype         = ACTION_WEAPONSKILL_START;
+            actionList.ActionTargetID = action.id;
+        }
         m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
 
         // face toward target // TODO : add force param to turnTowardsTarget on certain TP moves like Petro Eyes

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -80,7 +80,7 @@ CMobSkillState::CMobSkillState(CBattleEntity* PEntity, uint16 targid, uint16 wsi
         actionTarget.param      = m_PSkill->getID();
         actionTarget.messageID  = 43;
 
-        if ((m_PSkill->getValidTargets() & TARGET_MOB_AND_PLAYER) && (m_PSkill->getValidTargets() & TARGET_SELF))
+        if ((m_PSkill->getValidTargets() & TARGET_ANY_ALLEGIANCE) && (m_PSkill->getValidTargets() & TARGET_SELF))
         {
             // This ability targets self for aoe skills (such as Frozen Mist)
             action.actiontype         = ACTION_WEAPONSKILL_START;

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2131,7 +2131,19 @@ void CBattleEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
         return;
     }
 
-    uint16 targets = static_cast<uint16>(PAI->TargetFind->m_targets.size());
+    uint16 targets  = static_cast<uint16>(PAI->TargetFind->m_targets.size());
+    auto   skipSelf = false;
+
+    if ((PSkill->getValidTargets() & TARGET_MOB_AND_PLAYER) && (PSkill->getValidTargets() & TARGET_SELF))
+    {
+        // This ability targets self for aoe skills (such as Frozen Mist)
+        // Should be impossible for self to not be in target list, but just in case
+        if (targets > 0)
+        {
+            targets -= 1;
+        }
+        skipSelf = true;
+    }
 
     // No targets, perhaps something like Super Jump or otherwise untargetable
     if (targets == 0)
@@ -2161,6 +2173,14 @@ void CBattleEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
     bool first{ true };
     for (auto&& PTargetFound : PAI->TargetFind->m_targets)
     {
+        if (PTarget == PTargetFound && skipSelf)
+        {
+            // This ability targets self for aoe skills (such as Frozen Mist)
+            // Ignore self completely
+
+            continue;
+        }
+
         actionList_t& list = action.getNewActionList();
 
         list.ActionTargetID = PTargetFound->id;

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2134,7 +2134,7 @@ void CBattleEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
     uint16 targets  = static_cast<uint16>(PAI->TargetFind->m_targets.size());
     auto   skipSelf = false;
 
-    if ((PSkill->getValidTargets() & TARGET_MOB_AND_PLAYER) && (PSkill->getValidTargets() & TARGET_SELF))
+    if ((PSkill->getValidTargets() & TARGET_ANY_ALLEGIANCE) && (PSkill->getValidTargets() & TARGET_SELF))
     {
         // This ability targets self for aoe skills (such as Frozen Mist)
         // Should be impossible for self to not be in target list, but just in case
@@ -2152,6 +2152,7 @@ void CBattleEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
         actionList.ActionTargetID = id;
 
         actionTarget_t& actionTarget = actionList.getNewActionTarget();
+        actionTarget.messageID       = 0;
 
         if (skipSelf)
         {
@@ -2159,7 +2160,6 @@ void CBattleEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
             // And it found no valid targets in range, the skill and animation should still trigger
             // action.actiontype unchanged
             actionTarget.animation  = PSkill->getAnimationID();
-            actionTarget.messageID  = 0;
             actionTarget.reaction   = REACTION::MISS | REACTION::HIT | REACTION::GUARDED;
             actionTarget.speceffect = SPECEFFECT::SELFAOE_MISS;
         }
@@ -2168,7 +2168,6 @@ void CBattleEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
             action.actiontype      = ACTION_MOBABILITY_INTERRUPT;
             action.actionid        = 28787; // Some hardcoded magic for interrupts
             actionTarget.animation = 0x1FC; // Hardcoded magic sent from the server
-            actionTarget.messageID = 0;
             actionTarget.reaction  = REACTION::ABILITY | REACTION::HIT;
         }
 

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2148,15 +2148,29 @@ void CBattleEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
     // No targets, perhaps something like Super Jump or otherwise untargetable
     if (targets == 0)
     {
-        action.actiontype         = ACTION_MOBABILITY_INTERRUPT;
-        action.actionid           = 28787; // Some hardcoded magic for interrupts
         actionList_t& actionList  = action.getNewActionList();
         actionList.ActionTargetID = id;
 
         actionTarget_t& actionTarget = actionList.getNewActionTarget();
-        actionTarget.animation       = 0x1FC; // Hardcoded magic sent from the server
-        actionTarget.messageID       = 0;
-        actionTarget.reaction        = REACTION::ABILITY | REACTION::HIT;
+
+        if (skipSelf)
+        {
+            // This ability targets self for aoe skills (such as Frozen Mist)
+            // And it found no valid targets in range, the skill and animation should still trigger
+            // action.actiontype unchanged
+            actionTarget.animation  = PSkill->getAnimationID();
+            actionTarget.messageID  = 0;
+            actionTarget.reaction   = REACTION::MISS | REACTION::HIT | REACTION::GUARDED;
+            actionTarget.speceffect = SPECEFFECT::SELFAOE_MISS;
+        }
+        else
+        {
+            action.actiontype      = ACTION_MOBABILITY_INTERRUPT;
+            action.actionid        = 28787; // Some hardcoded magic for interrupts
+            actionTarget.animation = 0x1FC; // Hardcoded magic sent from the server
+            actionTarget.messageID = 0;
+            actionTarget.reaction  = REACTION::ABILITY | REACTION::HIT;
+        }
 
         return;
     }

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -316,6 +316,7 @@ enum class SPECEFFECT : uint8
 {
     NONE         = 0x00,
     BLOOD        = 0x02,
+    SELFAOE_MISS = 0x04,
     HIT          = 0x10,
     RAISE        = 0x11,
     RECOIL       = 0x20,

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -427,7 +427,7 @@ enum TARGETTYPE : uint16
     TARGET_PET                     = 0x0100,
     TARGET_PLAYER_PARTY_ENTRUST    = 0x0200,
     TARGET_IGNORE_BATTLEID         = 0x0400, // Can hit targets that do not have the same battle ID
-    TARGET_MOB_AND_PLAYER          = 0x0800, // Can hit targets from any allegiance simultaneously.
+    TARGET_ANY_ALLEGIANCE          = 0x0800, // Can hit targets from any allegiance simultaneously. To be used with other flags above and only makes sense for non-single-target skills
 };
 DECLARE_FORMAT_AS_UNDERLYING(TARGETTYPE);
 

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -426,6 +426,7 @@ enum TARGETTYPE : uint16
     TARGET_PET                     = 0x0100,
     TARGET_PLAYER_PARTY_ENTRUST    = 0x0200,
     TARGET_IGNORE_BATTLEID         = 0x0400, // Can hit targets that do not have the same battle ID
+    TARGET_MOB_AND_PLAYER          = 0x0800, // Can hit targets from any allegiance simultaneously.
 };
 DECLARE_FORMAT_AS_UNDERLYING(TARGETTYPE);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes https://github.com/LandSandBoat/server/issues/4695 .

Adds a new valid target flag to allow aoe or conal mobskills to hit all entities in range
- When combined with `TARGET_SELF`
  - mob will target itself, then include all enemies in range based on skillflag
  - This allows a skill to not rely in the primary target staying in range
- When combined with `TARGET_ENEMY`
  - Mob will target its battle target, then include all _entities_ in range (mobs and players)
- skillflag 8 includes all entities (mobs and players), new logic handles allegiance filtering based on above choice
- skillflag 0 includes only includes party/alliance/enmity entities, so it doesn't quite work for the `TARGET_ENEMY` option

I was careful to leave all behavior unaffected if the validTargets flag doesn't contain the new flag, `2048`.

Examples from retail:
Ruszor family targets itself so skills can't be out-ranged, the readying action type is different and actiontarget is itself:
![image](https://github.com/LandSandBoat/server/assets/131182600/f0968877-3426-4097-9fc8-d6c87d1eb85d)
and of course it doesn't target itself when the mobskill completes
![image](https://github.com/LandSandBoat/server/assets/131182600/8a54c7b9-ecf1-4e7f-89fc-3585dbb2c998)

combat log of some Ruszor skills being used
![image](https://github.com/LandSandBoat/server/assets/131182600/f8d3b9cb-9cab-4c5e-835c-65f7b6bd76fa)
![image](https://github.com/LandSandBoat/server/assets/131182600/4adbd14f-acb2-408d-857f-be81dee5279a)


Dark Ixion as well:
![image](https://github.com/LandSandBoat/server/assets/131182600/62b37b7f-e5c7-4caa-b03f-0a8d17d2d61e)

Finally, Rafflesia have skills that can hit all mobs/players in range:
![image](https://github.com/LandSandBoat/server/assets/131182600/1611c3d8-f94c-4ded-8e2a-a17eb8a9fdef)

Basically, WoTG mobs have wacky targetfinding for aoe and conals, but it all seems to boil down to either:
- ability targets self to not allow player 1 running away and saving player 2 still in range. But self is excluded from processing the actual ability (mobs don't hit themselves with their offensive abilities)
- ability targets mobs and players in range

In both cases, the targetfinding is mixing allegiances of found targets, hence calling the new flag `TARGET_MOB_AND_PLAYER`

## Steps to test these changes

Give a mobskill's `mob_skill_flag` a value of 8 and `mob_valid_targets` either 2049 (ruszor style) or 2052 (Rafflesia style)

Examples from LSB:
Updated some mobskills with completely fake options to show the new behavior
![image](https://github.com/LandSandBoat/server/assets/131182600/6791bb9d-5c09-43a0-860d-d6d80dd50a08)

![image](https://github.com/LandSandBoat/server/assets/131182600/c7d0ceee-fc8c-4759-9e01-b8794cb3b4a6)
With the above settings, diamondhide only hits player's partymembers

![image](https://github.com/LandSandBoat/server/assets/131182600/f6c34f53-08d6-484c-bee8-46f8b05d9c10)
Hard to tell what's going on, but Hydro wave was used with a target out of range, it still went off and hit "Mowtwo" close to it

![image](https://github.com/LandSandBoat/server/assets/131182600/7fbc300a-168a-4149-9a00-1902958f4cf6)
Floral bouquet hitting the players and mobs in range
(Note Floral Bouquet is supposed to "charm" Bees, but I adjusted for testing this PR)

