### PR TITLE
[LUA] Fix Geocolure spells shouldn't be castable with GEO sub

### DIFF
--- a/scripts/globals/job_utils/geomancer.lua
+++ b/scripts/globals/job_utils/geomancer.lua
@@ -337,6 +337,9 @@ xi.job_utils.geomancer.geoOnMagicCastingCheck = function(caster, target, spell)
         return xi.msg.basic.ALREADY_HAS_A_PET
     elseif not caster:canUseMisc(xi.zoneMisc.PET) then
         return xi.msg.basic.CANT_BE_USED_IN_AREA
+    elseif caster:getMainJob() ~= xi.job.GEO then
+        -- wikis are incorrect, does not require handbell
+        return xi.msg.basic.MAGIC_CANNOT_CAST
     else
         return 0
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Prevents players who are sub GEO from casting Geocolure spells.

From Xaver: 
> went to retail to check. It seems #shitwikisais strikes again:
> 
> Main-job GEO can use Geo-spells with no handbell.
> Sub-job GEO can't because the spell doesn't even appear on the spell list at all.

## Steps to test these changes

1. !changejob 1 99
2. !changesjob 21 99
3. Attempt to cast a Geocolure spell either through text or a macro (it won't display them in the magic menu)

![image](https://github.com/LandSandBoat/server/assets/166072302/d4feb67a-19be-4a64-a8f7-0d16c50aa81d)
