### PR TITLE
DNC job ability: Contradance

### DIFF
--- a/scripts/actions/abilities/healing_waltz.lua
+++ b/scripts/actions/abilities/healing_waltz.lua
@@ -9,14 +9,16 @@ local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
     local waltzCost = 200 - player:getMod(xi.mod.WALTZ_COST) * 10
+    local returnCode = 0
+    local canUseAbility = false
     if target:getHP() == 0 then
-        return xi.msg.basic.CANNOT_ON_THAT_TARG, 0
+        returnCode = xi.msg.basic.CANNOT_ON_THAT_TARG
     elseif player:hasStatusEffect(xi.effect.SABER_DANCE) then
-        return xi.msg.basic.UNABLE_TO_USE_JA2, 0
+        returnCode = xi.msg.basic.UNABLE_TO_USE_JA2
     elseif player:hasStatusEffect(xi.effect.TRANCE) then
-        return 0, 0
+        canUseAbility = true
     elseif player:getTP() < waltzCost then
-        return xi.msg.basic.NOT_ENOUGH_TP, 0
+        returnCode = xi.msg.basic.NOT_ENOUGH_TP
     else
         --[[ Apply "Waltz Ability Delay" reduction
             1 modifier = 1 second]]
@@ -35,14 +37,28 @@ abilityObject.onAbilityCheck = function(player, target, ability)
             end
         end
 
-        return 0, 0
+        canUseAbility = true
     end
+
+    if
+        canUseAbility and
+        player:getStatusEffect(xi.effect.CONTRADANCE)
+    then
+        ability:setAOE(1)
+        ability:setRange(10)
+        player:delStatusEffect(xi.effect.CONTRADANCE)
+    end
+
+    return returnCode, 0
 end
 
-abilityObject.onUseAbility = function(player, target, ability)
+abilityObject.onUseAbility = function(player, target, ability, action)
     local waltzCost = 200 - player:getMod(xi.mod.WALTZ_COST) * 10
     -- Only remove TP if the player doesn't have Trance.
-    if not player:hasStatusEffect(xi.effect.TRANCE) then
+    if
+        not player:hasStatusEffect(xi.effect.TRANCE) and
+        action:getPrimaryTargetID() == target:getID()
+    then
         player:delTP(waltzCost)
     end
 

--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -470,9 +470,8 @@ xi.job_utils.dancer.useWildFlourishAbility = function(player, target, ability, a
     return 0
 end
 
--- TODO: Implement Contradance status effect.
 xi.job_utils.dancer.useContradanceAbility = function(player, target, ability)
-    -- player:addStatusEffect(xi.effect.CONTRADANCE, 19, 1, 60)
+    player:addStatusEffect(xi.effect.CONTRADANCE, 19, 1, 60)
 end
 
 xi.job_utils.dancer.useWaltzAbility = function(player, target, ability, action)
@@ -503,6 +502,13 @@ xi.job_utils.dancer.useWaltzAbility = function(player, target, ability, action)
     amtCured = (target:getStat(xi.mod.VIT) + player:getStat(xi.mod.CHR)) * statMultiplier + waltzInfo[3]
     amtCured = math.floor(amtCured * (1.0 + (math.min(50, player:getMod(xi.mod.WALTZ_POTENCY)) / 100)))
     -- TODO: Account for Waltz Potency Received
+    local contradance = player:getStatusEffect(xi.effect.CONTRADANCE)
+    if contradance then
+        amtCured = amtCured * 2
+        -- slight delay to allow the effect to apply to all targets of divine waltz, then fall off immediately after action target loop
+        -- TODO: Remove this workaround via something in cpp core
+        contradance:setDuration(1)
+    end
 
     amtCured = amtCured * xi.settings.main.CURE_POWER
     amtCured = math.min(amtCured, target:getMaxHP() - target:getHP())

--- a/sql/abilities.sql
+++ b/sql/abilities.sql
@@ -388,7 +388,7 @@ INSERT INTO `abilities` VALUES (380,'effusion',22,1,1,0,143,0,0,0,2000,0,6,0.0,0
 INSERT INTO `abilities` VALUES (381,'chocobo_jig_ii',19,70,1,60,218,126,0,13,2000,0,14,10.0,1,1,300,0,0,'SOA');
 INSERT INTO `abilities` VALUES (382,'relinquish',23,1,1,60,253,0,0,312,0,0,6,0.0,0,0,0,0,0,NULL);
 INSERT INTO `abilities` VALUES (383,'vivacious_pulse',22,65,1,60,242,102,0,327,2000,0,6,0.0,0,0,0,0,0,'SOA');
-INSERT INTO `abilities` VALUES (384,'contradance',19,50,1,300,229,0,0,329,2000,0,6,0.0,0,0,0,0,0,NULL); -- check animation
+INSERT INTO `abilities` VALUES (384,'contradance',19,50,1,300,229,0,0,81,2000,0,6,0.0,0,0,0,0,0,NULL);
 INSERT INTO `abilities` VALUES (385,'apogee',15,70,1,180,108,100,0,94,2000,0,6,0.0,0,1,80,0,0,'SOA');
 INSERT INTO `abilities` VALUES (386,'entrust',21,75,1,600,93,100,0,332,2000,0,6,0.0,0,1,300,0,0,'SOA');
 INSERT INTO `abilities` VALUES (387,'bestial_loyalty',9,23,1,1200,94,100,0,83,2000,0,6,18.0,0,1,0,900,0,'SOA');

--- a/src/map/lua/lua_ability.cpp
+++ b/src/map/lua/lua_ability.cpp
@@ -111,6 +111,11 @@ void CLuaAbility::setRange(float range)
     m_PLuaAbility->setRange(range);
 }
 
+void CLuaAbility::setAOE(uint8 aoe)
+{
+    m_PLuaAbility->setAOE(aoe);
+}
+
 //==========================================================//
 
 void CLuaAbility::Register()
@@ -132,6 +137,7 @@ void CLuaAbility::Register()
     SOL_REGISTER("getVE", CLuaAbility::getVE);
     SOL_REGISTER("setVE", CLuaAbility::setVE);
     SOL_REGISTER("setRange", CLuaAbility::setRange);
+    SOL_REGISTER("setAOE", CLuaAbility::setAOE);
 }
 
 std::ostream& operator<<(std::ostream& os, const CLuaAbility& ability)

--- a/src/map/lua/lua_ability.h
+++ b/src/map/lua/lua_ability.h
@@ -58,6 +58,7 @@ public:
     uint16 getVE();
     void   setVE(uint16 ve);
     void   setRange(float range);
+    void   setAOE(uint8 aoe);
 
     bool operator==(const CLuaAbility& other) const
     {


### PR DESCRIPTION
- Doubles curing power of next waltz
- Converts Healing Waltz to AoE

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Re-opening https://github.com/LandSandBoat/server/pull/4791 with a branch I have access to.

The previous comments seemed to all be resolved except the timer I had for removing the contradance effect. I think `setDuration(1)` is a much cleaner way to ensure the effect falls off as soon as the loop finishes. I believe claywar had another idea as well. Open to an even cleaner solution

## Steps to test these changes

Use the contradance ability, test 
- waltzes for bonus healing 
- that the effect wears on use
- that contradance bonus healing applies to all targets of Divine Waltz
- healing waltz becomes aoe