### PR TITLE
[CPP] Fix costume effect not lost on zone

### DIFF
--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -1032,10 +1032,9 @@ void CZone::CharZoneIn(CCharEntity* PChar)
         PChar->StatusEffectContainer->DelStatusEffectSilent(EFFECT_MOUNTED);
     }
 
-    if (PChar->m_Costume != 0)
+    if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_COSTUME))
     {
-        PChar->m_Costume = 0;
-        PChar->StatusEffectContainer->DelStatusEffect(EFFECT_COSTUME);
+        PChar->StatusEffectContainer->DelStatusEffectSilent(EFFECT_COSTUME);
     }
 
     PChar->ReloadPartyInc();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

![image](https://github.com/LandSandBoat/server/assets/166072302/eeea832e-700c-449b-a3de-5baacb6c7500)

Currently if you zone you lose the visible costume but the costume status effect remains. This is due to the check for removing the effect coming after the costume has already been removed resulting in it never reaching that code since `m_Costume` is always 0. Instead we'll check if the player has the effect and if they do remove it.

## Steps to test these changes

1. !addeffect 127 644 1000
2. Zone or log out and back in