### PR TITLE
[LUA/SQL] Add Quadav Belt costume

### DIFF
--- a/scripts/items/quadav_belt.lua
+++ b/scripts/items/quadav_belt.lua
@@ -1,0 +1,20 @@
+-----------------------------------
+-- ID: 10848
+-- Quadav Belt
+-- Enchantment: 60Min, Costume - Quadav
+-----------------------------------
+local itemObject = {}
+
+itemObject.onItemCheck = function(target)
+    if not target:canUseMisc(xi.zoneMisc.COSTUME) then
+        return xi.msg.basic.CANT_BE_USED_IN_AREA
+    end
+
+    return 0
+end
+
+itemObject.onItemUse = function(target)
+    target:addStatusEffect(xi.effect.COSTUME, 644, 0, 3600)
+end
+
+return itemObject

--- a/sql/item_usable.sql
+++ b/sql/item_usable.sql
@@ -1980,6 +1980,7 @@ INSERT INTO `item_usable` VALUES (10293,'chocobo_shirt',1,8,0,0,1,30,72000,0);
 INSERT INTO `item_usable` VALUES (10383,'dream_mittens_+1',1,6,24,0,1,30,7200,0);
 INSERT INTO `item_usable` VALUES (10796,'decennial_ring',1,3,76,0,10,15,3600,0);
 INSERT INTO `item_usable` VALUES (10812,'chocobo_shield_+1',1,8,0,0,1,30,86400,0);
+INSERT INTO `item_usable` VALUES (10848,'quadav_belt',1,1,0,0,1,30,3600,0);
 INSERT INTO `item_usable` VALUES (10875,'snowman_cap',1,1,0,0,1,30,3600,0);
 INSERT INTO `item_usable` VALUES (11002,'dragon_tank',1,1,55,0,5,30,60,0);
 INSERT INTO `item_usable` VALUES (11273,'custom_gilet_+1',1,8,0,0,1,30,72000,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds the costume effect for Quadav Belt and makes it usable. Verified in retail the model although I could not get the capture addon to actually run a capture.

![image](https://github.com/LandSandBoat/server/assets/166072302/5b1bf8de-747b-4fc8-a089-b272ddfe1d98)
![image](https://github.com/LandSandBoat/server/assets/166072302/db1da057-5a38-41a9-81c8-37fd764e0f95)

## Steps to test these changes

1. !additem quadav_belt
2. Equip the item
3. Use it
