### PR TITLE
[CPP] Refactor IsRateLimitedPacket method to use milliseconds

### DIFF
--- a/src/map/packet_guard.cpp
+++ b/src/map/packet_guard.cpp
@@ -56,9 +56,9 @@ namespace PacketGuard
         // NOTE: You should rate limit any packet that a player can
         //       send at will that results in an immediate database hit
         // ratelimitList[0x03B] = 1; // Mannequin Equip
-        ratelimitList[0x05D] = 2; // Emotes
-        ratelimitList[0x11B] = 2; // Set Job Master Display
-        ratelimitList[0x11D] = 2; // Jump
+        ratelimitList[0x05D] = 2000; // Emotes
+        ratelimitList[0x11B] = 2000; // Set Job Master Display
+        ratelimitList[0x11D] = 2000; // Jump
     }
 
     bool PacketIsValidForPlayerState(CCharEntity* PChar, uint16 SmallPD_Type)
@@ -86,17 +86,17 @@ namespace PacketGuard
         TracyZoneScoped;
         using namespace std::chrono;
         uint32 lastPacketRecievedTime = PChar->m_PacketRecievedTimestamps[SmallPD_Type];
-        uint32 timeNowSeconds         = static_cast<uint32>(time_point_cast<seconds>(server_clock::now()).time_since_epoch().count());
+        uint32 timeNowMilliseconds    = static_cast<uint32>(time_point_cast<milliseconds>(server_clock::now()).time_since_epoch().count());
         uint32 ratelimitTime          = ratelimitList[SmallPD_Type];
 
-        PChar->m_PacketRecievedTimestamps[SmallPD_Type] = timeNowSeconds;
+        PChar->m_PacketRecievedTimestamps[SmallPD_Type] = timeNowMilliseconds;
 
         if (lastPacketRecievedTime == 0 || ratelimitTime == 0)
         {
             return false;
         }
 
-        return timeNowSeconds - lastPacketRecievedTime < ratelimitList[SmallPD_Type];
+        return timeNowMilliseconds - lastPacketRecievedTime < ratelimitList[SmallPD_Type];
     }
 
     void PrintPacketList(CCharEntity* PChar)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Updates `PacketGuard.IsRateLimitedPacket` to use milliseconds instead of seconds. Allows rate limiting to use fractions of a second. Resolves https://github.com/LandSandBoat/server/issues/430

## Steps to test these changes

1. Login 
2. Do some stuff
3. ???
4. Things don't break