### PR TITLE
[lua] Fixes duration of crafting belts

### DIFF
--- a/scripts/items/alchemists_belt.lua
+++ b/scripts/items/alchemists_belt.lua
@@ -2,10 +2,10 @@
 -- ID: 15450
 -- Item: Alchemist's belt
 -- Enchantment: Synthesis image support
--- 2Min, All Races
+-- 8Min, All Races
 -----------------------------------
 -- Enchantment: Synthesis image support
--- Duration: 2Min
+-- Duration: 8Min
 -- Alchemy Skill +3
 -----------------------------------
 local itemObject = {}
@@ -20,7 +20,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ALCHEMY_IMAGERY, 3, 0, 120)
+    target:addStatusEffect(xi.effect.ALCHEMY_IMAGERY, 3, 0, 480)
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/blacksmiths_belt.lua
+++ b/scripts/items/blacksmiths_belt.lua
@@ -2,10 +2,10 @@
 -- ID: 15445
 -- Item: Blacksmith's Belt
 -- Enchantment: Synthesis image support
--- 2Min, All Races
+-- 8Min, All Races
 -----------------------------------
 -- Enchantment: Synthesis image support
--- Duration: 2Min
+-- Duration: 8Min
 -- Smithing Skill +3
 -----------------------------------
 local itemObject = {}
@@ -20,7 +20,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.SMITHING_IMAGERY, 3, 0, 120)
+    target:addStatusEffect(xi.effect.SMITHING_IMAGERY, 3, 0, 480)
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/boneworkers_belt.lua
+++ b/scripts/items/boneworkers_belt.lua
@@ -2,10 +2,10 @@
 -- ID: 15449
 -- Item: Boneworker's belt
 -- Enchantment: Synthesis image support
--- 2Min, All Races
+-- 8Min, All Races
 -----------------------------------
 -- Enchantment: Synthesis image support
--- Duration: 2Min
+-- Duration: 8Min
 -- Bonecraft Skill +3
 -----------------------------------
 local itemObject = {}
@@ -20,7 +20,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.BONECRAFT_IMAGERY, 3, 0, 120)
+    target:addStatusEffect(xi.effect.BONECRAFT_IMAGERY, 3, 0, 480)
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/carpenters_belt.lua
+++ b/scripts/items/carpenters_belt.lua
@@ -2,10 +2,10 @@
 -- ID: 15444
 -- Item: Carpenter's belt
 -- Enchantment: Synthesis image support
--- 2Min, All Races
+-- 8Min, All Races
 -----------------------------------
 -- Enchantment: Synthesis image support
--- Duration: 2Min
+-- Duration: 8Min
 -- Woodworking Skill +3
 -----------------------------------
 local itemObject = {}
@@ -20,7 +20,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.WOODWORKING_IMAGERY, 3, 0, 120)
+    target:addStatusEffect(xi.effect.WOODWORKING_IMAGERY, 3, 0, 480)
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/culinarians_belt.lua
+++ b/scripts/items/culinarians_belt.lua
@@ -2,10 +2,10 @@
 -- ID: 15451
 -- Item: Culinarian's Belt
 -- Enchantment: Synthesis image support
--- 2Min, All Races
+-- 8Min, All Races
 -----------------------------------
 -- Enchantment: Synthesis image support
--- Duration: 2Min
+-- Duration: 8Min
 -- Alchemy Skill +3
 -----------------------------------
 local itemObject = {}
@@ -20,7 +20,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.COOKING_IMAGERY, 3, 0, 120)
+    target:addStatusEffect(xi.effect.COOKING_IMAGERY, 3, 0, 480)
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/goldsmiths_belt.lua
+++ b/scripts/items/goldsmiths_belt.lua
@@ -2,10 +2,10 @@
 -- ID: 15446
 -- Item: Goldsmith's Belt
 -- Enchantment: Synthesis image support
--- 2Min, All Races
+-- 8Min, All Races
 -----------------------------------
 -- Enchantment: Synthesis image support
--- Duration: 2Min
+-- Duration: 8Min
 -- Goldsmithing Skill +3
 -----------------------------------
 local itemObject = {}
@@ -20,7 +20,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.GOLDSMITHING_IMAGERY, 3, 0, 120)
+    target:addStatusEffect(xi.effect.GOLDSMITHING_IMAGERY, 3, 0, 480)
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/tanners_belt.lua
+++ b/scripts/items/tanners_belt.lua
@@ -2,10 +2,10 @@
 -- ID: 15448
 -- Item: Tanners belt
 -- Enchantment: Synthesis image support
--- 2Min, All Races
+-- 8Min, All Races
 -----------------------------------
 -- Enchantment: Synthesis image support
--- Duration: 2Min
+-- Duration: 8Min
 -- Leathercraft Skill +3
 -----------------------------------
 local itemObject = {}
@@ -20,7 +20,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.LEATHERCRAFT_IMAGERY, 3, 0, 120)
+    target:addStatusEffect(xi.effect.LEATHERCRAFT_IMAGERY, 3, 0, 480)
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/items/weavers_belt.lua
+++ b/scripts/items/weavers_belt.lua
@@ -2,10 +2,10 @@
 -- ID: 15447
 -- Item: Weaver's Belt
 -- Enchantment: Synthesis image support
--- 2Min, All Races
+-- 8Min, All Races
 -----------------------------------
 -- Enchantment: Synthesis image support
--- Duration: 2Min
+-- Duration: 8Min
 -- Clothcraft Skill +3
 -----------------------------------
 local itemObject = {}
@@ -20,7 +20,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.CLOTHCRAFT_IMAGERY, 3, 0, 120)
+    target:addStatusEffect(xi.effect.CLOTHCRAFT_IMAGERY, 3, 0, 480)
 end
 
 itemObject.onEffectGain = function(target, effect)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Changes the duration of crafting belts that give Advanced Synth Support 8 minute duration instead of 2 minutes

https://www.bg-wiki.com/ffxi/Category:Advanced_Synthesis_Image_Support
Support provided by both of these NPCs lasts for eight minutes

https://ffxiclopedia.fandom.com/wiki/Synthesis_Image_Support
Guild-obtained image synthesis support belts give the equivalent bonus to craft skill as Advanced synthesis image support for that guild.


<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!additem 15447
Use the belt
<!-- Clear and detailed steps to test your changes here -->
