### PR TITLE
[CPP] info log DB name

### DIFF
--- a/src/common/sql.cpp
+++ b/src/common/sql.cpp
@@ -101,6 +101,11 @@ SqlConnection::~SqlConnection()
     }
 }
 
+std::string SqlConnection::GetDatabaseName()
+{
+    return fmt::format("database name: {}", settings::get<std::string>("network.SQL_DATABASE").c_str());
+}
+
 std::string SqlConnection::GetClientVersion()
 {
     return fmt::format("database client version: {}", MARIADB_PACKAGE_VERSION);

--- a/src/common/sql.h
+++ b/src/common/sql.h
@@ -86,6 +86,7 @@ public:
     SqlConnection(const char* user, const char* passwd, const char* host, uint16 port, const char* db);
     ~SqlConnection();
 
+    std::string GetDatabaseName();
     std::string GetClientVersion();
     std::string GetServerVersion();
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -217,6 +217,7 @@ int32 do_init(int32 argc, char** argv)
     ShowInfo("do_init: connecting to database");
     _sql = std::make_unique<SqlConnection>();
 
+    ShowInfo(_sql->GetDatabaseName().c_str());
     ShowInfo(_sql->GetClientVersion().c_str());
     ShowInfo(_sql->GetServerVersion().c_str());
     _sql->CheckCharset();


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds an info log which confirms the current db name. I found this helpful when debugging an issue where it appeared the wrong db was being loaded in.

## Steps to test these changes

rebuild + load up xi_map.exe
<img width="1178" alt="Screenshot 2024-05-17 at 3 54 12 PM" src="https://github.com/LandSandBoat/server/assets/33179100/acc5ac13-a842-4071-86d1-a45465d33e54">
