### PR TITLE
[core, lua] Rename isJugPet to hasJugPet to improve clarity

### DIFF
--- a/scripts/effects/level_restriction.lua
+++ b/scripts/effects/level_restriction.lua
@@ -16,7 +16,7 @@ effectObject.onEffectGain = function(target, effect)
             if
                 pet and
                 pet:getObjType() == xi.objType.PET and
-                target:isJugPet() and -- isJugPet checks m_PBaseEntity->PPet's check type, not the target's pet type.
+                target:hasJugPet() and -- hasJugPet checks m_PBaseEntity->PPet's check type, not the target's pet type.
                 masterLevel < pet:getMinimumPetLevel()
             then
                 target:despawnPet()

--- a/scripts/effects/level_sync.lua
+++ b/scripts/effects/level_sync.lua
@@ -16,7 +16,7 @@ effectObject.onEffectGain = function(target, effect)
             if
                 pet and
                 pet:getObjType() == xi.objType.PET and
-                target:isJugPet() and -- isJugPet checks m_PBaseEntity->PPet's check type, not the target's pet type.
+                target:hasJugPet() and -- hasJugPet checks m_PBaseEntity->PPet's check type, not the target's pet type.
                 masterLevel < pet:getMinimumPetLevel()
             then
                 target:despawnPet()

--- a/scripts/globals/job_utils/beastmaster.lua
+++ b/scripts/globals/job_utils/beastmaster.lua
@@ -105,7 +105,7 @@ xi.job_utils.beastmaster.onAbilityCheckFamiliar = function(player, target, abili
     if not pet then
         return xi.msg.basic.REQUIRES_A_PET, 0
     elseif
-        (not player:isJugPet() and pet:getObjType() ~= xi.objType.MOB) or
+        (not player:hasJugPet() and pet:getObjType() ~= xi.objType.MOB) or
         pet:getLocalVar('ReceivedFamiliar') == 1
     then
         return xi.msg.basic.NO_EFFECT_ON_PET, 0
@@ -252,7 +252,7 @@ xi.job_utils.beastmaster.onAbilityCheckReward = function(player, target, ability
     if not pet then
         return xi.msg.basic.REQUIRES_A_PET, 0 --TODO this currently will not hit this function. Returns You cannot attack that target. Targetfind.cpp line 564
     elseif
-        not player:isJugPet() and
+        not player:hasJugPet() and
         pet:getObjType() ~= xi.objType.MOB
     then
         return xi.msg.basic.NO_EFFECT_ON_PET, 0
@@ -421,7 +421,7 @@ xi.job_utils.beastmaster.onAbilityCheckNilPet = function(player, target, ability
     local pet = player:getPet()
 
     if
-        player:isJugPet() or
+        player:hasJugPet() or
         pet:getObjType() == xi.objType.MOB
     then
         if player:getPet() == nil then
@@ -444,7 +444,7 @@ xi.job_utils.beastmaster.onAbilityCheckSnarl = function(player, target, ability)
     else
         if
             player:getPet():getTarget() ~= nil and
-            player:isJugPet()
+            player:hasJugPet()
         then
             return 0, 0
         else

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -14482,25 +14482,6 @@ void CLuaBaseEntity::despawnPet()
 }
 
 /************************************************************************
- *  Function: isJugPet()
- *  Purpose : Returns true if the entity crawled out of a jug after birth
- *  Example : if pet:isJugPet() then
- *  Notes   :
- ************************************************************************/
-
-bool CLuaBaseEntity::isJugPet()
-{
-    auto* PBattle = static_cast<CBattleEntity*>(m_PBaseEntity);
-
-    if (PBattle->PPet)
-    {
-        return static_cast<CPetEntity*>(PBattle->PPet)->getPetType() == PET_TYPE::JUG_PET;
-    }
-
-    return false;
-}
-
-/************************************************************************
  *  Function: hasValidJugPetItem()
  *  Purpose : Returns true if subSkill Type is of sufficient value
  *  Example : if player:hasValidJugPetItem() then
@@ -14543,6 +14524,31 @@ bool CLuaBaseEntity::hasPet()
     auto* PTarget = static_cast<CBattleEntity*>(m_PBaseEntity);
 
     return PTarget->PPet != nullptr && PTarget->PPet->status != STATUS_TYPE::DISAPPEAR;
+}
+
+/************************************************************************
+ *  Function: hasJugPet()
+ *  Purpose : Returns true if player has a jug pet
+ *  Example : if player:hasJugPet() then
+ *  Notes   :
+ ************************************************************************/
+
+bool CLuaBaseEntity::hasJugPet()
+{
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid Entity (%s) calling function.", m_PBaseEntity->getName());
+        return false;
+    }
+
+    auto* PBattle = static_cast<CBattleEntity*>(m_PBaseEntity);
+
+    if (hasPet())
+    {
+        return static_cast<CPetEntity*>(PBattle->PPet)->getPetType() == PET_TYPE::JUG_PET;
+    }
+
+    return false;
 }
 
 /************************************************************************
@@ -18080,10 +18086,10 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("spawnPet", CLuaBaseEntity::spawnPet);
     SOL_REGISTER("despawnPet", CLuaBaseEntity::despawnPet);
 
-    SOL_REGISTER("isJugPet", CLuaBaseEntity::isJugPet);
     SOL_REGISTER("hasValidJugPetItem", CLuaBaseEntity::hasValidJugPetItem);
 
     SOL_REGISTER("hasPet", CLuaBaseEntity::hasPet);
+    SOL_REGISTER("hasJugPet", CLuaBaseEntity::hasJugPet);
     SOL_REGISTER("getPet", CLuaBaseEntity::getPet);
     SOL_REGISTER("getPetID", CLuaBaseEntity::getPetID);
     SOL_REGISTER("isAutomaton", CLuaBaseEntity::isAutomaton);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -734,10 +734,10 @@ public:
     void   removeAllSimpleGambits();
     void   setTrustTPSkillSettings(uint16 trigger, uint16 select, sol::object const& value);
 
-    bool isJugPet();
     bool hasValidJugPetItem();
 
     bool   hasPet();
+    bool   hasJugPet();
     auto   getPet() -> std::optional<CLuaBaseEntity>;
     uint32 getPetID();
     bool   isAutomaton();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR renames isJugPet to hasJugPet as the function actually checks if the entity has a pet that is a jug pet (rather than checking if an entity actually is a jug pet). Also the PR moves the function to a more logical location in the lua_baseentity file. Thus this improves clarity for devs.

## Steps to test these changes
Can try using the function with !exec with and without a jug pet
