### PR TITLE
[SQL] Fix She-Slime Shield missing HP mod, correct DEF mod value

### DIFF
--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -84052,7 +84052,8 @@ INSERT INTO `item_mods` VALUES (28649,109,112);  -- SHIELD: 112
 INSERT INTO `item_mods` VALUES (28649,160,-500); -- DMG: -500
 
 -- She-Slime Shield
-INSERT INTO `item_mods` VALUES (28650,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (28650,1,1); -- DEF: 1
+INSERT INTO `item_mods` VALUES (28650,2,2); -- HP: 2
 
 -- Metal Slime Shield
 INSERT INTO `item_mods` VALUES (28651,1,3); -- DEF: 3


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

She-Slime Shield is missing its HP mod. The DEF mod should also be 1 instead of 2.

https://www.bg-wiki.com/ffxi/She-Slime_Shield

## Steps to test these changes

1. !additem 28650
2. Equip the shield
3. HP should go up by 2
