### PR TITLE
[sql] Vasiliceratops

### DIFF
--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -12287,7 +12287,7 @@ INSERT INTO `mob_droplist` VALUES (1514,0,0,1000,842,390); -- Giant Bird Feather
 INSERT INTO `mob_droplist` VALUES (1514,0,0,1000,843,80);  -- Giant Bird Plume (8.0%)
 
 -- ZoneID:  88 - Lesser Wivre
-INSERT INTO `mob_droplist` VALUES (1515,0,0,1000,2427,30); -- Wivre Maul (3.0%)
+INSERT INTO `mob_droplist` VALUES (1515,0,0,1000,2427,@VRARE); -- Wivre Maul (Very Rare, 1%)
 
 -- ZoneID:  15 - Ley Clionid
 -- ZoneID:  15 - Ley Clionid
@@ -21861,13 +21861,13 @@ INSERT INTO `mob_droplist` VALUES (2663,0,0,1000,574,20); -- Bag Of Fruit Seeds 
 INSERT INTO `mob_droplist` VALUES (2663,4,0,1000,573,0);  -- Bag Of Vegetable Seeds (Despoil)
 
 -- ZoneID:  77 - Wivre
-INSERT INTO `mob_droplist` VALUES (2664,0,0,1000,2426,80);    -- Wivre Horn (8.0%)
-INSERT INTO `mob_droplist` VALUES (2664,0,0,1000,2428,80);    -- Wivre Hide (8.0%)
-INSERT INTO `mob_droplist` VALUES (2664,0,0,1000,2427,@RARE); -- Wivre Maul (Rare, 5%)
+INSERT INTO `mob_droplist` VALUES (2664,0,0,1000,2426,@RARE);   -- Wivre Horn (Rare, 5%)
+INSERT INTO `mob_droplist` VALUES (2664,0,0,1000,2428,@VRARE);  -- Wivre Hide (Very Rare, 1%)
+INSERT INTO `mob_droplist` VALUES (2664,0,0,1000,2427,@COMMON); -- Wivre Maul (Common, 15%)
 
 -- ZoneID:  89 - Wivre
-INSERT INTO `mob_droplist` VALUES (2665,0,0,1000,2427,280); -- Wivre Maul (28.0%)
-INSERT INTO `mob_droplist` VALUES (2665,0,0,1000,2426,80);  -- Wivre Horn (8.0%)
+INSERT INTO `mob_droplist` VALUES (2665,0,0,1000,2427,@COMMON); -- Wivre Maul (Common, 15%)
+INSERT INTO `mob_droplist` VALUES (2665,0,0,1000,2426,@RARE);   -- Wivre Horn (Rare, 5%)
 
 -- ZoneID: 124 - Woodland Sage
 INSERT INTO `mob_droplist` VALUES (2666,0,0,1000,701,530);  -- Rosewood Log (53.0%)
@@ -24128,9 +24128,9 @@ INSERT INTO `mob_droplist` VALUES (2950,0,0,1000,17854,133); -- Cradle Horn (13.
 INSERT INTO `mob_droplist` VALUES (2951,0,0,1000,11409,167); -- Aoides Pumps (16.7%)
 
 -- ZoneID:  52 - Wivre
-INSERT INTO `mob_droplist` VALUES (2952,0,0,1000,2427,205);   -- Wivre Maul (20.5%)
-INSERT INTO `mob_droplist` VALUES (2952,0,0,1000,2426,60);    -- Wivre Horn (6.0%)
-INSERT INTO `mob_droplist` VALUES (2952,0,0,1000,2428,@RARE); -- Wivre Hide (Rare, 5%)
+INSERT INTO `mob_droplist` VALUES (2952,0,0,1000,2427,@COMMON); -- Wivre Maul (Common, 15%)
+INSERT INTO `mob_droplist` VALUES (2952,0,0,1000,2426,@RARE);   -- Wivre Horn (Rare, 5%)
+INSERT INTO `mob_droplist` VALUES (2952,0,0,1000,2428,@VRARE);  -- Wivre Hide (Very Rare, 1%)
 
 -- ZoneID:   7 - Sekhmet
 INSERT INTO `mob_droplist` VALUES (2953,0,0,1000,16374,140); -- Layqa Seraweels (14.0%)
@@ -26810,6 +26810,9 @@ INSERT INTO `mob_droplist` VALUES (3296,0,0,1000,2850,@UNCOMMON); -- Ingot of Sa
 
 -- ZoneID:  91 - Erle
 INSERT INTO `mob_droplist` VALUES (3297,0,0,1000,19122,@UNCOMMON); -- Courser's Pugio (Uncommon, 10%)
+
+-- ZoneID:  89 - Vasiliceratops
+INSERT INTO `mob_droplist` VALUES (3299,0,0,1000,18508,@UNCOMMON); -- Lyft Voulge (Uncommon, 10%)
 
 /*!40000 ALTER TABLE `mob_droplist` ENABLE KEYS */;
 UNLOCK TABLES;

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -5461,7 +5461,7 @@ INSERT INTO `mob_groups` VALUES (17,1638,89,'Goblin_Blastmaster',330,0,1024,0,0,
 INSERT INTO `mob_groups` VALUES (18,3912,89,'Thunder_Elemental',330,4,2410,0,0,75,75,0);
 INSERT INTO `mob_groups` VALUES (19,6312,89,'Chigoe',330,0,466,0,0,43,46,0);
 INSERT INTO `mob_groups` VALUES (20,4883,89,'Sarcopsylla',7200,0,3085,7860,7000,72,72,0);
-INSERT INTO `mob_groups` VALUES (21,0,89,'Vasiliceratops',0,32,0,0,0,0,0,0);
+INSERT INTO `mob_groups` VALUES (21,7073,89,'Vasiliceratops',0,32,3299,18750,0,88,89,0);
 INSERT INTO `mob_groups` VALUES (22,6473,89,'Vampire_Bat',330,2,80,0,0,40,45,0);
 INSERT INTO `mob_groups` VALUES (23,6238,89,'Onyx_Quadav',330,0,1862,0,0,61,64,0);
 INSERT INTO `mob_groups` VALUES (24,6236,89,'Young_Quadav',330,0,2786,0,0,61,63,0);

--- a/sql/mob_pools.sql
+++ b/sql/mob_pools.sql
@@ -7147,6 +7147,10 @@ INSERT INTO `mob_pools` VALUES (7071,'Garrison','Garrison',145,0x0000B7040000000
 
 -- Magicked Bones with a Dagger Inner Horutoto Ruins
 INSERT INTO `mob_pools` VALUES (7072,'Magicked_Bones_dagger','Magicked_Bones_dagger',227,0x0000480400000000000000000000000000000000,1,1,5,240,100,0,1,0,0,0,0,0,714,129,0,0,0,0,0,227,227);
+
+-- Missing NM mob_pools
+INSERT INTO `mob_pools` VALUES (7073,'Vasiliceratops','Vasiliceratops',257,0x0000B90800000000000000000000000000000000,1,1,5,240,100,1024,0,0,0,2,0,0,7,131,0,0,0,0,0,257,257);
+
 -- ------------------------------------------------------------
 -- Start of Ambuscade section
 -- NOTE: The mobs are changed every update in the DATs, so using out-of-date

--- a/sql/nm_spawn_points.sql
+++ b/sql/nm_spawn_points.sql
@@ -910,6 +910,7 @@ INSERT INTO `nm_spawn_points` VALUES (17125452,0,137.606,3.346,-279.050); -- Ash
 INSERT INTO `nm_spawn_points` VALUES (17137005,0,678.599,-10.219,532.811);
 INSERT INTO `nm_spawn_points` VALUES (17137705,0,678.599,-10.219,532.811); -- Ankabut
 INSERT INTO `nm_spawn_points` VALUES (17137821,0,49.650,1.692,630.371); -- Gloomanita
+INSERT INTO `nm_spawn_points` VALUES (17141885,0,276.142,25.332,-453.541); -- Vasiliceratops
 INSERT INTO `nm_spawn_points` VALUES (17141962,0,-23.892,-24.139,327.721); -- Kotan-kor Kamuy
 INSERT INTO `nm_spawn_points` VALUES (17141979,0,-140.354,-92.095,39.459); -- Scitalis
 INSERT INTO `nm_spawn_points` VALUES (17145867,0,-416.496,24.110,-441.589); -- Sugaar


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements the core data for [Vasiliceratops](https://www.bg-wiki.com/ffxi/Vasiliceratops).

A lot of diffs and a new drop pool, so doing the sql changes as a separate PR

- Drop lists for many wivre mob groups updated to match retail more closely
- mob pool and groups defined to allow NM to spawn and with proper stats
- nm spawn point added to suppress `phOnMobDespawn` warning

## Steps to test these changes

Go to grauberg, `!gotoname Vasiliceratops`, then use the console output to spawn that ID. Kill to see drop (repeat many times to get drop :) )