### PR TITLE
[lua] Vasiliceratops

### DIFF
--- a/scripts/actions/mobskills/batterhorn.lua
+++ b/scripts/actions/mobskills/batterhorn.lua
@@ -14,7 +14,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local numhits = 1
+    local numhits = 3
     local accmod = 1
     local dmgmod = .8
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/zones/Grauberg_[S]/IDs.lua
+++ b/scripts/zones/Grauberg_[S]/IDs.lua
@@ -33,6 +33,7 @@ zones[xi.zone.GRAUBERG_S] =
         KOTAN_KOR_KAMUY      = GetFirstID('Kotan-kor_Kamuy'),
         SCITALIS             = GetFirstID('Scitalis'),
         MIGRATORY_HIPPOGRYPH = GetFirstID('Migratory_Hippogryph'),
+        VASILICERATOPS       = GetFirstID('Vasiliceratops'),
     },
     npc =
     {

--- a/scripts/zones/Grauberg_[S]/mobs/Vasiliceratops.lua
+++ b/scripts/zones/Grauberg_[S]/mobs/Vasiliceratops.lua
@@ -1,8 +1,24 @@
 -----------------------------------
 -- Area: Grauberg [S]
 --   NM: Vasiliceratops
+-- https://www.bg-wiki.com/ffxi/Vasiliceratops
 -----------------------------------
 local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:addImmunity(xi.immunity.BIND)
+    mob:addImmunity(xi.immunity.GRAVITY)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.PETRIFY)
+
+    mob:setMod(xi.mod.DOUBLE_ATTACK, 100)
+    mob:setSpeed(100)
+end
+
+entity.onMobWeaponSkillPrepare = function(mob, target)
+    return 2099 -- Batterhorn is only TP move
+end
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 505)

--- a/scripts/zones/Grauberg_[S]/mobs/Wivre.lua
+++ b/scripts/zones/Grauberg_[S]/mobs/Wivre.lua
@@ -1,0 +1,24 @@
+-----------------------------------
+-- Area: Grauberg [S]
+--  Mob: Wivre
+-- Note: PH for Vasiliceratops
+-----------------------------------
+local ID = zones[xi.zone.GRAUBERG_S]
+-----------------------------------
+local entity = {}
+
+local vasiliceratopsPHTable =
+{
+    [ID.mob.VASILICERATOPS - 3] = ID.mob.VASILICERATOPS,
+    -- [ID.mob.VASILICERATOPS - 67] = ID.mob.VASILICERATOPS,
+    -- TODO: Add shared spawning for the PH. Only one PH is alive at a time. Spawns in either spot.
+}
+
+entity.onMobDeath = function(mob, player, optParams)
+end
+
+entity.onMobDespawn = function(mob)
+    xi.mob.phOnDespawn(mob, vasiliceratopsPHTable, 10, 5400) -- 1.5 hour
+end
+
+return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements [Vasiliceratops](https://www.bg-wiki.com/ffxi/Vasiliceratops)

Partner PR to the sql side of this nm: https://github.com/LandSandBoat/server/pull/5781

(Note: my previous split PRs for NMs had the sql within the final lua PR, github UI doesn't update when a commit gets merged to `base`, so I'm not including it here to avoid having to close/re-open PR to fix the commit history.)

## Steps to test these changes

To test this, you will need to import the SQL from the [partner PR](https://github.com/LandSandBoat/server/pull/5781)

As with all ph-style NMs, best test is to update the PH lua `xi.mob.phOnDespawn` call to have 100% chance and spawn NM immediately, to ensure all metadata is accurate. I.E. 

- `!gotoname Vasiliceratops` and see that it is not spawned
- update `Wivre.lua` to have: `xi.mob.phOnDespawn(mob, vasiliceratopsPHTable, 100, 5400, {immediate=true}) -- 1.5 hour`
- `!gotoid 17141882`
- `!hp 0` the mob
- `!gotoname Vasiliceratops` and see that it is spawned now
- Fight and see that he has `NO_TURN` and only uses batterhorn

oh yea, here's the new fancy `!getstats` results too:
![image](https://github.com/LandSandBoat/server/assets/131182600/4bfc14f6-64cd-44f9-8849-6daa1d23f50f)
