### PR TITLE
[core] Always store pet ID when saving pet info

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -464,6 +464,7 @@ void CCharEntity::setPetZoningInfo()
     {
         return;
     }
+    petZoningInfo.petID = PPetEntity->m_PetID;
 
     switch (PPetEntity->getPetType())
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Apparently zoning with an automaton caused a fire elemental to appear because it's pet ID was set to zero.

## Steps to test these changes

Zone with an automaton and keep the automaton.
