### PR TITLE
[cpp] Add lua binding to set a mob's list of stealable items

### DIFF
--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -865,6 +865,7 @@ public:
     uint32 getDropID();
     void   setDropID(uint32 dropID);
     void   addTreasure(uint16 itemID, sol::object const& arg1, sol::object const& arg2);
+    void   setStealItem(sol::object const& arg1);
     uint16 getStealItem();
     uint16 getDespoilItem();                // gets ItemID of droplist despoil item from mob (steal item if no despoil item)
     uint16 getDespoilDebuff(uint16 itemID); // gets the status effect id to apply to the mob on successful despoil


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Creates a new mob lua binding to set the stealable item. It's written in such a way that it could be easily extended to support passing a table, but only supports a single itemID for now.

`mob:setStealItem(xi.item.DANCESHROOM)` would
- Reset the mob's flag to be able to be stolen from
- loop through a mob's drop list, remove all stealable items, showing debug prints when it does
- insert the new stealable item

Error handling might be excessive, but exits early if:
- entity is not a mob
- droplist is null (i highly doubt we'd ever need this binding on a mob that has dropid 0)
- binding parameter doesn't map to a valid item

This binding is setting the framework for the steal patterns of WoTG funguar mobs, which have a steal item based on their animation sub

## Steps to test these changes

go to a mob:
- `!exec target:setStealItem(xi.item.DANCESHROOM)`
- `!changejob thf 99`
- `/ja steal` and `!reset` until you steal and item
- do steal a few more times to confirm it cannot be stolen from
- do binding again with a different item and see that you can now steal that item
