### PR TITLE
[lua] Mobskill animationsub changes

### DIFF
--- a/scripts/actions/mobskills/axe_throw.lua
+++ b/scripts/actions/mobskills/axe_throw.lua
@@ -1,11 +1,12 @@
 -----------------------------------
---  Axe Throw
+-- Axe Throw
 --
---  Description: Ranged attack with the equipped weapon, which is lost.
---  Type: Ranged
---  Utsusemi/Blink absorb: 1 shadow
---  Range: 7.0
---  Notes: Only used by armed BST Mamool Ja
+-- Description: Ranged attack with the equipped weapon, which is lost.
+-- Type: Ranged
+-- Utsusemi/Blink absorb: 1 shadow
+-- Range: 7.0
+-- Notes: Only used by armed BST Mamool Ja
+-- Animation sub is changed by the mixin: mobskill_animation_sub.lua
 -----------------------------------
 local mobskillObject = {}
 
@@ -18,8 +19,6 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    mob:setAnimationSub(1)
-
     local numhits = 1
     local accmod  = 1
     local dmgmod  = 3

--- a/scripts/actions/mobskills/bastion_of_twilight.lua
+++ b/scripts/actions/mobskills/bastion_of_twilight.lua
@@ -1,6 +1,7 @@
 -----------------------------------
 -- Bastion of Twilight
 -- Magic Shield Effect
+-- Animation sub is changed by the mixin: mobskill_animation_sub.lua
 -----------------------------------
 local ID = zones[xi.zone.EMPYREAL_PARADOX]
 -----------------------------------
@@ -20,7 +21,6 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     mob:addStatusEffect(xi.effect.MAGIC_SHIELD, 1, 0, 0)
-    mob:setAnimationSub(2)
 
     skill:setMsg(xi.msg.basic.SKILL_GAIN_EFFECT)
     return xi.effect.MAGIC_SHIELD

--- a/scripts/actions/mobskills/javelin_throw.lua
+++ b/scripts/actions/mobskills/javelin_throw.lua
@@ -1,11 +1,12 @@
 -----------------------------------
---  Javelin Throw
+-- Javelin Throw
 --
---  Description: Ranged attack with the equipped weapon, which is lost.
---  Type: Ranged
---  Utsusemi/Blink absorb: 1 shadow
---  Range: 7.0
---  Notes: Only used by armed DRG Mamool Ja
+-- Description: Ranged attack with the equipped weapon, which is lost.
+-- Type: Ranged
+-- Utsusemi/Blink absorb: 1 shadow
+-- Range: 7.0
+-- Notes: Only used by armed DRG Mamool Ja
+-- Animation sub is changed by the mixin: mobskill_animation_sub.lua
 -----------------------------------
 local mobskillObject = {}
 
@@ -18,7 +19,6 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    mob:setAnimationSub(1)
     local numhits = 1
     local accmod = 1
     local dmgmod = 3

--- a/scripts/actions/mobskills/luminous_lance.lua
+++ b/scripts/actions/mobskills/luminous_lance.lua
@@ -1,5 +1,6 @@
 -----------------------------------
---  Luminous Lance
+-- Luminous Lance
+-- Animation sub is changed by the mixin: mobskill_animation_sub.lua
 -----------------------------------
 local ID = zones[xi.zone.EMPYREAL_PARADOX]
 -----------------------------------
@@ -35,7 +36,6 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     mob:entityAnimationPacket('ids0')
     mob:setLocalVar('lanceTime', mob:getBattleTime())
     mob:setLocalVar('lanceOut', 0)
-    target:setAnimationSub(3)
 
     -- Cannot be resisted
     target:addStatusEffect(xi.effect.TERROR, 0, 0, 20)

--- a/scripts/actions/mobskills/numbshroom.lua
+++ b/scripts/actions/mobskills/numbshroom.lua
@@ -4,11 +4,12 @@
 -- Range is 14.7 yalms.
 -- Piercing damage Ranged Attack.
 -- Secondary modifiers: INT: 20%.
+-- Animation sub is changed by the mixin: mobskill_animation_sub.lua
 -----------------------------------
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getMobMod(xi.mobMod.VAR) == 1 then
+    if mob:getAnimationSub() == 1 then
         return 0
     end
 
@@ -16,7 +17,6 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    mob:setMobMod(xi.mobMod.VAR, 2)
     local numhits = 1
     local accmod = 1
     local dmgmod = 2

--- a/scripts/actions/mobskills/queasyshroom.lua
+++ b/scripts/actions/mobskills/queasyshroom.lua
@@ -7,11 +7,12 @@
 -- Additional Effect: Poison is 3 HP/tick.
 -- Poison effect may not always process.
 -- Removes all Shadow Images on the target.
+-- Animation sub is changed by the mixin: mobskill_animation_sub.lua
 -----------------------------------
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getMobMod(xi.mobMod.VAR) == 0 then
+    if mob:getAnimationSub() == 0 then
         return 0
     end
 
@@ -19,7 +20,6 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    mob:setMobMod(xi.mobMod.VAR, 1)
     local numhits = 1
     local accmod = 1
     local dmgmod = 2

--- a/scripts/actions/mobskills/shakeshroom.lua
+++ b/scripts/actions/mobskills/shakeshroom.lua
@@ -4,11 +4,12 @@
 -- Range is 14.7 yalms.
 -- Piercing damage Ranged Attack.
 -- Secondary modifiers: INT: 20%.
+-- Animation sub is changed by the mixin: mobskill_animation_sub.lua
 -----------------------------------
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getMobMod(xi.mobMod.VAR) == 2 then
+    if mob:getAnimationSub() == 2 then
         return 0
     end
 
@@ -16,7 +17,6 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    mob:setMobMod(xi.mobMod.VAR, 3)
     local numhits = 1
     local accmod = 1
     local dmgmod = 2

--- a/scripts/actions/mobskills/stave_toss.lua
+++ b/scripts/actions/mobskills/stave_toss.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- Stave Toss (staff wielding Mamool Ja only!)
+-- Animation sub is changed by the mixin: mobskill_animation_sub.lua
 -----------------------------------
 local mobskillObject = {}
 
@@ -22,7 +23,6 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
 
-    mob:setAnimationSub(1) -- Mob loses Staff on using Stave Toss
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg
 end

--- a/scripts/actions/mobskills/touchdown.lua
+++ b/scripts/actions/mobskills/touchdown.lua
@@ -1,7 +1,8 @@
 -----------------------------------
---  Touchdown
---  Description: Deals magical damage to enemies in an area of effect upon landing.
---  Further Notes:
+-- Touchdown
+-- Description: Deals magical damage to enemies in an area of effect upon landing.
+-- Further Notes:
+-- Animation sub is changed by the mixin: mobskill_animation_sub.lua
 -----------------------------------
 local mobskillObject = {}
 
@@ -16,7 +17,6 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.NONE)
     mob:delStatusEffect(xi.effect.ALL_MISS)
     mob:setMobSkillAttack(0)
-    mob:setAnimationSub(2)
     return dmg
 end
 

--- a/scripts/actions/mobskills/wheel_of_impregnability.lua
+++ b/scripts/actions/mobskills/wheel_of_impregnability.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- Wheel of Impregnability
+-- Animation sub is changed by the mixin: mobskill_animation_sub.lua
 -----------------------------------
 local ID = zones[xi.zone.EMPYREAL_PARADOX]
 -----------------------------------
@@ -19,7 +20,6 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     mob:addStatusEffect(xi.effect.PHYSICAL_SHIELD, 1, 0, 0)
-    mob:setAnimationSub(1)
 
     skill:setMsg(xi.msg.basic.SKILL_GAIN_EFFECT)
     return xi.effect.PHYSICAL_SHIELD

--- a/scripts/mixins/mobskill_animation_sub.lua
+++ b/scripts/mixins/mobskill_animation_sub.lua
@@ -11,6 +11,10 @@ g_mixins.mobskillAnimationSub = function(mobObject)
         [310]  = 1, -- queasyshroom
         [311]  = 2, -- numbshroom
         [312]  = 3, -- shakeshroom
+        [954]  = 2, -- touchdown
+        [1282] = 2, -- touchdown
+        [1292] = 2, -- touchdown
+        [1302] = 2, -- touchdown
     }
 
     -- creates a listener to set the mob's animation sub after the skill completes

--- a/scripts/mixins/mobskill_animation_sub.lua
+++ b/scripts/mixins/mobskill_animation_sub.lua
@@ -1,0 +1,39 @@
+-- Mixin to handle Animation Sub updates for mob skill completions
+
+require('scripts/globals/mixins')
+
+g_mixins = g_mixins or {}
+
+g_mixins.mobskillAnimationSub = function(mobObject)
+    -- SELECT CONCAT("[",mob_skill_id,"] = X, -- ",mob_skill_name) FROM mob_skills WHERE mob_skill_name IN ("axe_throw"...
+    local mobskillAnimationSubs =
+    {
+        [310]  = 1, -- queasyshroom
+        [311]  = 2, -- numbshroom
+        [312]  = 3, -- shakeshroom
+    }
+
+    -- creates a listener to set the mob's animation sub after the skill completes
+    -- Only changes the animation sub if the move completed successfully
+    local localVarName = 'MOBSKILL_LANDED'
+    mobObject:addListener('WEAPONSKILL_STATE_EXIT', 'MOBSKILL_ANIMATION_SUB_WS_EXIT', function(mob, skillID)
+        local newAnimationSub = mobskillAnimationSubs[skillID]
+        if
+            newAnimationSub and
+            mob:getLocalVar(localVarName) == 1 and
+            mob:getAnimationSub() ~= newAnimationSub
+        then
+            mob:setAnimationSub(newAnimationSub)
+        end
+
+        mob:setLocalVar(localVarName, 0)
+    end)
+
+    -- creates a listener to indicate that the mobskill completed on a target
+    -- this listener is not called if a move readies but doesn't complete
+    mobObject:addListener('WEAPONSKILL_USE', 'MOBSKILL_ANIMATION_SUB_WS_LANDED', function(mob)
+        mob:setLocalVar(localVarName, 1)
+    end)
+end
+
+return g_mixins.mobskillAnimationSub

--- a/scripts/mixins/mobskill_animation_sub.lua
+++ b/scripts/mixins/mobskill_animation_sub.lua
@@ -15,6 +15,10 @@ g_mixins.mobskillAnimationSub = function(mobObject)
         [1282] = 2, -- touchdown
         [1292] = 2, -- touchdown
         [1302] = 2, -- touchdown
+        [1504] = 1, -- wheel_of_impregnability
+        [1505] = 2, -- bastion_of_twilight
+        [1508] = 3, -- luminous_lance
+        [3621] = 3, -- luminous_lance
     }
 
     -- creates a listener to set the mob's animation sub after the skill completes

--- a/scripts/mixins/mobskill_animation_sub.lua
+++ b/scripts/mixins/mobskill_animation_sub.lua
@@ -6,6 +6,7 @@ g_mixins = g_mixins or {}
 
 g_mixins.mobskillAnimationSub = function(mobObject)
     -- SELECT CONCAT("[",mob_skill_id,"] = X, -- ",mob_skill_name) FROM mob_skills WHERE mob_skill_name IN ("axe_throw"...
+    -- Typically "Weapon throw" mobskills change the mob's animation sub to 2, and animation sub 1 is used for weapon breaks
     local mobskillAnimationSubs =
     {
         [310]  = 1, -- queasyshroom
@@ -18,6 +19,10 @@ g_mixins.mobskillAnimationSub = function(mobObject)
         [1504] = 1, -- wheel_of_impregnability
         [1505] = 2, -- bastion_of_twilight
         [1508] = 3, -- luminous_lance
+        [1735] = 2, -- javelin_throw
+        [1736] = 2, -- axe_throw
+        [1925] = 2, -- stave_toss
+        [2361] = 2, -- stave_toss
         [3621] = 3, -- luminous_lance
     }
 

--- a/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Myxomycete.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Myxomycete.lua
@@ -5,6 +5,8 @@
 -----------------------------------
 local ID = zones[xi.zone.THE_SANCTUARY_OF_ZITAH]
 -----------------------------------
+mixins = { require('scripts/mixins/mobskill_animation_sub') }
+-----------------------------------
 local entity = {}
 
 local nobleMoldPHTable =


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Working on #5788 I noticed that the three funguar mobskills that remove bulbs from the head were not calling `setAnimationSub`. This causes an inconsistency in a player rendering the mob:
- When a funguar animates an `Xshroom` mobskill, the client handles cleanly removing the bulb and sending it to the target
- as long as the player stays in range of the funguar, the model of the funguar is kept consistent, but if you log or go out of range it resets back to animationSub 0 

This PR resolves the situation by creating a generic mixin that can be added to any mob's lua that should get these updates.
- A mixin was chosen as Xaver requested it for consistency
  - Action scripts handle damage, messages, etc
  - Effect scripts handle stats, mods, etc
  - Mixins handle generic mob things: animations, aggro, etc
- This PR is being submitted not as a draft because:
  - while it isn't a complete solution for all mobskills that change animation sub (it is actually a regression for all but the funguar skills, which already didn't update animationSub), the scope of adding a mixin to every mob that uses the 15 mobskills is massive. I would like to create a PR per mob type that relies on this PR as a guide/framework

Note: the PR is split into 4 commits to make reviewing easier. Seeing what changes in mobskills were reflected in the mixin was a bit confusing without the separation.

## Steps to test these changes

for funguars
https://imgur.com/a/vr3UtC5