### PR TITLE
[CPP/LUA] Add delallinventory and delcontaineritems commands

### DIFF
--- a/scripts/commands/delallinventory.lua
+++ b/scripts/commands/delallinventory.lua
@@ -1,0 +1,39 @@
+-----------------------------------
+-- func: delallinventory
+-- desc: Deletes all items in a player's inventory, if they have any.
+-----------------------------------
+local commandObj = {}
+
+commandObj.cmdprops =
+{
+    permission = 1,
+    parameters = 's'
+}
+
+local function error(player, msg)
+    player:printToPlayer(msg)
+    player:printToPlayer('!delallinventory (player)')
+end
+
+commandObj.onTrigger = function(player, target)
+    -- validate target
+    local targ
+    if target == nil then
+        targ = player:getCursorTarget()
+        if targ == nil or not targ:isPC() then
+            targ = player
+        end
+    else
+        targ = GetPlayerByName(target)
+        if targ == nil then
+            error(player, string.format('Player named "%s" not found!', target))
+            return
+        end
+    end
+
+    if targ:delContainerItems(xi.inv.INVENTORY) then
+        player:printToPlayer(string.format('Deleted entire inventory for %s.', targ:getName()))
+    end
+end
+
+return commandObj

--- a/scripts/commands/delcontaineritems.lua
+++ b/scripts/commands/delcontaineritems.lua
@@ -1,0 +1,67 @@
+-----------------------------------
+-- func: delcontaineritems
+-- desc: Deletes all items in a player's specified container, if they have any.
+-----------------------------------
+local commandObj = {}
+
+commandObj.cmdprops =
+{
+    permission = 1,
+    parameters = 'is'
+}
+
+local function error(player, msg)
+    player:printToPlayer(msg)
+    player:printToPlayer('!delcontaineritems <container> (player)')
+end
+
+local containerNames =
+{
+    [xi.inv.INVENTORY]  = 'Inventory',
+    [xi.inv.MOGSAFE]    = 'Mog Safe',
+    [xi.inv.STORAGE]    = 'Storage',
+    [xi.inv.TEMPITEMS]  = 'Temp. Items',
+    [xi.inv.MOGLOCKER]  = 'Mog Locker',
+    [xi.inv.MOGSATCHEL] = 'Mog Satchel',
+    [xi.inv.MOGSACK]    = 'Mog Sack',
+    [xi.inv.MOGCASE]    = 'Mog Case',
+    [xi.inv.WARDROBE]   = 'Mog Wardrobe 1',
+    [xi.inv.MOGSAFE2]   = 'Mog Safe 2',
+    [xi.inv.WARDROBE2]  = 'Mog Wardrobe 2',
+    [xi.inv.WARDROBE3]  = 'Mog Wardrobe 3',
+    [xi.inv.WARDROBE4]  = 'Mog Wardrobe 4',
+    [xi.inv.WARDROBE5]  = 'Mog Wardrobe 5',
+    [xi.inv.WARDROBE6]  = 'Mog Wardrobe 6',
+    [xi.inv.WARDROBE7]  = 'Mog Wardrobe 7',
+    [xi.inv.WARDROBE8]  = 'Mog Wardrobe 8',
+}
+
+commandObj.onTrigger = function(player, container, target)
+    -- validate target
+    local targ
+    if target == nil then
+        targ = player:getCursorTarget()
+        if targ == nil or not targ:isPC() then
+            targ = player
+        end
+    else
+        targ = GetPlayerByName(target)
+        if targ == nil then
+            error(player, string.format('Player named "%s" not found!', target))
+            return
+        end
+    end
+
+    -- validate container
+    local containerName = containerNames[container]
+    if containerName == nil then
+        error(player, 'Invalid container specified.')
+        return
+    end
+
+    if targ:delContainerItems(container) then
+        player:printToPlayer(string.format('Deleted all items in %s for %s.', containerName, targ:getName()))
+    end
+end
+
+return commandObj

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -3926,7 +3926,7 @@ bool CLuaBaseEntity::addItem(sol::variadic_args va)
  *  Function: delItem()
  *  Purpose : Deletes an item from a player's inventory
  *  Example : player:delItem(4102, 12)
- *  Notes   : Can specify contianer using third variable
+ *  Notes   : Can specify container using third variable
  ************************************************************************/
 
 bool CLuaBaseEntity::delItem(uint16 itemID, int32 quantity, sol::object const& containerID)
@@ -3956,6 +3956,49 @@ bool CLuaBaseEntity::delItem(uint16 itemID, int32 quantity, sol::object const& c
     }
 
     return false;
+}
+
+/************************************************************************
+ *  Function: delContainerItems()
+ *  Purpose : Deletes all items from a specific player's container
+ *  Example : player:delContainerItems(xi.inv.INVENTORY)
+ *  Notes   : Used in delinventory command
+ ************************************************************************/
+
+bool CLuaBaseEntity::delContainerItems(sol::object const& containerID)
+{
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->getName());
+        return false;
+    }
+
+    uint8 location = containerID.get_type() == sol::type::number ? containerID.as<uint8>() : 0;
+
+    if (location >= CONTAINER_ID::MAX_CONTAINER_ID)
+    {
+        ShowWarning("Lua::delContainerItems: Attempting to delete items from an invalid container. Defaulting to main inventory.");
+        return false;
+    }
+
+    auto* PChar          = static_cast<CCharEntity*>(m_PBaseEntity);
+    auto* PItemContainer = PChar->getStorage(location);
+    uint8 containerSize  = PItemContainer->GetSize();
+
+    for (uint8 i = 1; i <= containerSize; ++i)
+    {
+        auto* PItem = PItemContainer->GetItem(i);
+
+        if (PItem != nullptr)
+        {
+            int32 quantity = PItem->getQuantity();
+
+            charutils::UpdateItem(PChar, location, i, -quantity);
+        }
+    }
+
+    PChar->pushPacket(new CInventoryFinishPacket());
+    return true;
 }
 
 /************************************************************************
@@ -17590,6 +17633,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("getItemCount", CLuaBaseEntity::getItemCount);
     SOL_REGISTER("addItem", CLuaBaseEntity::addItem);
     SOL_REGISTER("delItem", CLuaBaseEntity::delItem);
+    SOL_REGISTER("delContainerItems", CLuaBaseEntity::delContainerItems);
     SOL_REGISTER("addUsedItem", CLuaBaseEntity::addUsedItem);
     SOL_REGISTER("addTempItem", CLuaBaseEntity::addTempItem);
     SOL_REGISTER("getWornUses", CLuaBaseEntity::getWornUses);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -222,6 +222,7 @@ public:
     uint32 getItemCount(uint16 itemID);
     bool   addItem(sol::variadic_args va);
     bool   delItem(uint16 itemID, int32 quantity, sol::object const& containerID);
+    bool   delContainerItems(sol::object const& containerID);
     bool   addUsedItem(uint16 itemID);
     bool   addTempItem(uint16 itemID, sol::object const& arg1);
     uint8  getWornUses(uint16 itemID);                                                      // Check if the item is already worn

--- a/tools/ci/lua_stylecheck.py
+++ b/tools/ci/lua_stylecheck.py
@@ -57,6 +57,7 @@ disallowed_numeric_parameters = {
     "addUsedItem"             : [ 0 ],
     "canLearnSpell"           : [ 0 ],
     "delItem"                 : [ 0 ],
+    "delContainerItems"       : [ 0 ],
     "delKeyItem"              : [ 0 ],
     "delSpell"                : [ 0 ],
     "delStatusEffect"         : [ 0 ],


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds commands to quickly delete a user's entire inventory or specified containers. Useful when testing and you don't want to throw away every item in your current inventory/container which can be very tedious.

## Steps to test these changes

1. Fill your inventory with items
2. Run !delinventory
3. Inventory should be empty

1. Fill a container with items
2. Run !delcontaineritems (you'll need to provide the container's id)
3. Container should be empty
