### PR TITLE
[lua] Antlion animations

### DIFF
--- a/scripts/actions/mobskills/pit_ambush.lua
+++ b/scripts/actions/mobskills/pit_ambush.lua
@@ -22,10 +22,6 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
 
-    -- These are here as it doesn't look right otherwise
-    mob:hideName(false)
-    mob:setUntargetable(false)
-    mob:setAnimationSub(1)
     mob:setLocalVar('AMBUSH', 1) -- Used it for the last time!
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)

--- a/scripts/mixins/families/antlion_ambush.lua
+++ b/scripts/mixins/families/antlion_ambush.lua
@@ -6,6 +6,8 @@ g_mixins = g_mixins or {}
 g_mixins.families = g_mixins.families or {}
 
 g_mixins.families.antlion_ambush = function(antlionAmbushMob)
+    local pitAmbush = 278
+
     antlionAmbushMob:addListener('SPAWN', 'ANTLION_AMBUSH_SPAWN', function(mob)
         mob:hideName(true)
         mob:setUntargetable(true)
@@ -14,8 +16,18 @@ g_mixins.families.antlion_ambush = function(antlionAmbushMob)
     end)
 
     antlionAmbushMob:addListener('ENGAGE', 'ANTLION_AMBUSH_ENGAGE', function(mob, target)
-        mob:useMobAbility(278) -- Pit Ambush
+        mob:useMobAbility(pitAmbush)
         mob:setMobMod(xi.mobMod.NO_MOVE, 0)
+    end)
+
+    -- Ensures an interupted pit ambush doesn't let the mob stay hidden underground
+    antlionAmbushMob:addListener('WEAPONSKILL_STATE_EXIT', 'ANTLION_AMBUSH_FINISH', function(mob, skillID)
+        if skillID == pitAmbush then
+            -- ensure name doesn't show up until mobskill completes
+            mob:setAnimationSub(1)
+            mob:hideName(false)
+            mob:setUntargetable(false)
+        end
     end)
 
     antlionAmbushMob:addListener('DISENGAGE', 'ANTLION_AMBUSH_DISENGAGE', function(mob)

--- a/scripts/mixins/families/antlion_ambush_noaggro.lua
+++ b/scripts/mixins/families/antlion_ambush_noaggro.lua
@@ -10,6 +10,8 @@ g_mixins = g_mixins or {}
 g_mixins.families = g_mixins.families or {}
 
 g_mixins.families.antlion_ambush_noaggro = function(antlionAmbushNoaggroMob)
+    local pitAmbush = 278
+
     antlionAmbushNoaggroMob:addListener('SPAWN', 'ANTLION_AMBUSH_NOAGGRO_SPAWN', function(mob)
         mob:hideName(true)
         mob:setUntargetable(true)
@@ -17,7 +19,17 @@ g_mixins.families.antlion_ambush_noaggro = function(antlionAmbushNoaggroMob)
     end)
 
     antlionAmbushNoaggroMob:addListener('ENGAGE', 'ANTLION_AMBUSH_NOAGGRO_ENGAGE', function(mob, target)
-        mob:useMobAbility(278) -- Pit Ambush
+        mob:useMobAbility(pitAmbush)
+    end)
+
+    -- Ensures an interupted pit ambush doesn't let the mob stay hidden underground
+    antlionAmbushNoaggroMob:addListener('WEAPONSKILL_STATE_EXIT', 'ANTLION_AMBUSH_FINISH', function(mob, skillID)
+        if skillID == pitAmbush then
+            -- ensure name doesn't show up until mobskill completes
+            mob:setAnimationSub(1)
+            mob:hideName(false)
+            mob:setUntargetable(false)
+        end
     end)
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR solves a few issues:
- Antlion ambush can sometimes leave a mob hidden (if the mobskill doesn't go off)
- Antlion ambush doesn't look like what it [should based on retail](https://youtu.be/6TYCqwkoxqE?t=224).
  - Before this PR, the mob gets out of the ground and immediately has a visible name. It also kinda pops out then blips and digs its way out due to the mobskill setting animationsub(1) before the mobskill animation goes off
- Finally, the Tuchulcha sandpit move allowed players to know his next location
  - the position is not sent to the client if status is set to `INVISIBLE`
  - confirmed via retail videos that he does, indeed disappear without animation after using sandpit, so this behavior is unchanged

## Steps to test these changes

Big thing to test is that the ENM "Sheep in antlion's clothing" functions properly:
- `!zone 8`
- `!togglegm` to get the enm option
- `!togglegm` again to be able to aggro the antlions
- search around and see that ambush still functions properly, Tuchulcha still uses sandpit and runs away, etc

Another place to test would be Attohwa Chasm:
- `!zone 7`
- `!gotoname Burrow_Antlion 1`

There's two mobs with the no_aggro version of the mixin, they are spawned during the Rostrum Pumps event:
- `!additem ANTLION_TRAP`
- `!gotoid 16806296`
- trade the trap and go through [the fight](https://www.bg-wiki.com/ffxi/Alastor_Antlion). See that Alastor and Executioner use pit ambush properly

Finally, here's a few videos showing off the various situations
https://imgur.com/a/XicUnSL