### PR TITLE
[ITEM]Creates useable item ccb_polymer_pump

### DIFF
--- a/scripts/items/ccb_polymer_pump.lua
+++ b/scripts/items/ccb_polymer_pump.lua
@@ -1,0 +1,29 @@
+-----------------------------------
+-- ID: 5268
+-- Item: CCB Polymer Pump
+-- Used during CoP 6-4 One To Be Feared on Ultima or Omega to inflict a 1 minute amnesia
+-----------------------------------
+local itemObject = {}
+
+itemObject.onItemCheck = function(target, player)
+    local result      = xi.msg.basic.ITEM_UNABLE_TO_USE
+    local battlefield = player:getBattlefieldID()
+
+    if
+        battlefield == xi.battlefield.id.ONE_TO_BE_FEARED and
+        (target:getName() == 'Omega' or target:getName() == 'Ultima') and
+        not target:hasStatusEffect(xi.effect.AMNESIA)
+    then
+        result = 0
+    elseif target:checkDistance(player) > 10 then
+        result = xi.msg.basic.TOO_FAR_AWAY
+    end
+
+    return result
+end
+
+itemObject.onItemUse = function(target)
+    target:addStatusEffect(xi.effect.AMNESIA, 1, 0, 60)
+end
+
+return itemObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Allows player to use CCB_Polymer_Pump to inflict amnesia on Ultima/Omega during COP 6-4 "One to be Feared".
Checks for battlefield One to be feared so it is unable to be used in other "Ultima/Omega" fights with same name.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Omega:
![image](https://github.com/LandSandBoat/server/assets/13935086/7f5ed5c8-89e5-4851-8c15-9044fb964b0c)
Ultima:
![image](https://github.com/LandSandBoat/server/assets/13935086/48c88209-9e11-4079-8da5-9488256d488c)



## Steps to test these changes
Enter One to be Feared battle. Use CCB on Ultima/Omega. Gives 1 min of Amnesia. 
<!-- Clear and detailed steps to test your changes here -->
