### PR TITLE
[CPP] Fix party size latent effects should include trusts

### DIFF
--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -432,13 +432,15 @@ void CLatentEffectContainer::CheckLatentsHours()
 * activates them if the conditions are met.                             *
 *                                                                       *
  ************************************************************************/
-void CLatentEffectContainer::CheckLatentsPartyMembers(size_t members)
+void CLatentEffectContainer::CheckLatentsPartyMembers(size_t members, size_t trustCount)
 {
-    ProcessLatentEffects([this, members](CLatentEffect& latentEffect) {
+    ProcessLatentEffects([this, members, trustCount](CLatentEffect& latentEffect) {
+        size_t totalMembers = members + trustCount;
+
         switch (latentEffect.GetConditionsID())
         {
             case LATENT::PARTY_MEMBERS:
-                if (latentEffect.GetConditionsValue() <= members)
+                if (latentEffect.GetConditionsValue() <= totalMembers)
                 {
                     return latentEffect.Activate();
                 }
@@ -447,7 +449,7 @@ void CLatentEffectContainer::CheckLatentsPartyMembers(size_t members)
                     return latentEffect.Deactivate();
                 }
             case LATENT::PARTY_MEMBERS_IN_ZONE:
-                if (latentEffect.GetConditionsValue() <= members)
+                if (latentEffect.GetConditionsValue() <= totalMembers)
                 {
                     auto inZone = 0;
                     for (size_t m = 0; m < members; ++m)
@@ -457,6 +459,12 @@ void CLatentEffectContainer::CheckLatentsPartyMembers(size_t members)
                         {
                             inZone++;
                         }
+                    }
+
+                    auto* PLeader = (CCharEntity*)m_POwner->PParty->GetLeader();
+                    if (m_POwner->getZone() == PLeader->getZone())
+                    {
+                        inZone = inZone + static_cast<int>(trustCount);
                     }
 
                     if (inZone == latentEffect.GetConditionsValue())
@@ -775,8 +783,19 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
             expression = !m_POwner->StatusEffectContainer->HasStatusEffect(EFFECT_FOOD);
             break;
         case LATENT::PARTY_MEMBERS:
-            expression = m_POwner->PParty != nullptr && latentEffect.GetConditionsValue() <= m_POwner->PParty->members.size();
+        {
+            size_t partyCount = 0;
+            size_t trustCount = 0;
+            if (m_POwner->PParty != nullptr)
+            {
+                auto PLeader = (CCharEntity*)m_POwner->PParty->GetLeader();
+                trustCount = PLeader->PTrusts.size();
+                partyCount = m_POwner->PParty->members.size();
+            }
+
+            expression = latentEffect.GetConditionsValue() <= (partyCount + trustCount);
             break;
+        }
         case LATENT::PARTY_MEMBERS_IN_ZONE:
         {
             auto inZone = 0;
@@ -789,7 +808,14 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
                         ++inZone;
                     }
                 }
+                
+                auto PLeader = (CCharEntity*)m_POwner->PParty->GetLeader();
+                if (m_POwner->getZone() == PLeader->getZone())
+                {
+                    inZone = inZone + static_cast<int>(PLeader->PTrusts.size());
+                }
             }
+
             expression = latentEffect.GetConditionsValue() <= inZone;
             break;
         }
@@ -837,13 +863,14 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
                             break;
                         }
                     }
-                    for (auto* trust : static_cast<CCharEntity*>(member)->PTrusts)
+                }
+
+                for (auto* trust : static_cast<CCharEntity*>(m_POwner->PParty->GetLeader())->PTrusts)
+                {
+                    if (trust->GetMJob() == latentEffect.GetConditionsValue())
                     {
-                        if (trust->GetMJob() == latentEffect.GetConditionsValue())
-                        {
-                            expression = true;
-                            break;
-                        }
+                        expression = true;
+                        break;
                     }
                 }
             }

--- a/src/map/latent_effect_container.h
+++ b/src/map/latent_effect_container.h
@@ -52,7 +52,7 @@ public:
     void CheckLatentsMoonPhase();
     void CheckLatentsHours();
     void CheckLatentsWeekDay();
-    void CheckLatentsPartyMembers(size_t members);
+    void CheckLatentsPartyMembers(size_t members, size_t trustCount);
     void CheckLatentsPartyJobs();
     void CheckLatentsPartyAvatar();
     void CheckLatentsJobLevel();

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -132,7 +132,7 @@ void CParty::DisbandParty(bool playerInitiated)
 
             PChar->PParty = nullptr;
             PChar->PLatentEffectContainer->CheckLatentsPartyJobs();
-            PChar->PLatentEffectContainer->CheckLatentsPartyMembers(members.size());
+            PChar->PLatentEffectContainer->CheckLatentsPartyMembers(members.size(), 0);
             PChar->PLatentEffectContainer->CheckLatentsPartyAvatar();
             PChar->pushPacket(new CPartyMemberUpdatePacket(PChar, 0, 0, PChar->getZone()));
 
@@ -334,7 +334,9 @@ void CParty::RemoveMember(CBattleEntity* PEntity)
                         }
                     }
                 }
-                PChar->PLatentEffectContainer->CheckLatentsPartyMembers(members.size());
+
+                auto trustCount = static_cast<CCharEntity*>(m_PLeader)->PTrusts.size();
+                PChar->PLatentEffectContainer->CheckLatentsPartyMembers(members.size(), trustCount);
 
                 PChar->pushPacket(new CPartyDefinePacket(nullptr));
                 PChar->pushPacket(new CPartyMemberUpdatePacket(PChar, 0, 0, PChar->getZone()));
@@ -422,7 +424,7 @@ void CParty::DelMember(CBattleEntity* PEntity)
                         }
                     }
                 }
-                PChar->PLatentEffectContainer->CheckLatentsPartyMembers(members.size());
+                PChar->PLatentEffectContainer->CheckLatentsPartyMembers(members.size(), 0);
 
                 PChar->pushPacket(new CPartyDefinePacket(nullptr));
                 PChar->pushPacket(new CPartyMemberUpdatePacket(PChar, 0, 0, PChar->getZone()));
@@ -852,14 +854,16 @@ void CParty::ReloadParty()
     else
     {
         RefreshFlags(info);
-        CBattleEntity* PLeader = GetLeader();
+        CBattleEntity* PLeader    = GetLeader();
+        auto           trustCount = static_cast<CCharEntity*>(PLeader)->PTrusts.size();
+
         // regular party
         for (auto& member : members)
         {
             CCharEntity* PChar = (CCharEntity*)member;
 
             PChar->PLatentEffectContainer->CheckLatentsPartyJobs();
-            PChar->PLatentEffectContainer->CheckLatentsPartyMembers(members.size());
+            PChar->PLatentEffectContainer->CheckLatentsPartyMembers(members.size(), trustCount);
             PChar->PLatentEffectContainer->CheckLatentsPartyAvatar();
             PChar->ReloadPartyDec();
             PChar->pushPacket(new CPartyDefinePacket(this, PLeader && PChar->getZone() == PLeader->getZone()));


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Properly accounts for trusts in the party to activate party size related latent effects. Resolves https://github.com/LandSandBoat/server/issues/4861

## Steps to test these changes

1. !additem lyft_scimitar (or any other item with `LATENT::PARTY_MEMBERS` or `LATENT::PARTY_MEMBERS_IN_ZONE`)
2. Summon enough trusts to trigger the latent (for Lyft items it's 3 minimum)
3. Latent effect should apply
