### PR TITLE
[LUA] Fix Divine Might (repeat) trade for Moonlight Ore error

### DIFF
--- a/scripts/quests/outlands/Divine_Might_Repeat.lua
+++ b/scripts/quests/outlands/Divine_Might_Repeat.lua
@@ -141,7 +141,7 @@ quest.sections =
                 end,
 
                 [8] = function(player, csid, option, npc)
-                    npcUtil.giveKeyItem(xi.ki.MOONLIGHT_ORE)
+                    npcUtil.giveKeyItem(player, xi.ki.MOONLIGHT_ORE)
                     player:confirmTrade()
                 end,
             },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes an error when attempting to trade Light Ore for the Moonlight Ore for Divine Might (repeat).

## Steps to test these changes

1. To avoid waiting for a full moon and night change line 120-121 to true
2. Trade a Light Ore to the Qu'Hau Spring
3. You should receive the Moonlight Ore KI
