### PR TITLE
[core] Add Skilchain resistance rank reduction

### DIFF
--- a/scripts/globals/combat/magic_hit_rate.lua
+++ b/scripts/globals/combat/magic_hit_rate.lua
@@ -435,18 +435,12 @@ xi.combat.magicHitRate.calculateResistRate = function(actor, target, skillType, 
     ----------------------------------------
     -- Handle target resistance rank.
     ----------------------------------------
+    -- Skillchains lower target resistance rank by 1 (handled in EFFECT_SKILLCHAIN in battleutils.cpp)
     local targetResistRank = target:getMod(xi.combat.element.resistRankMod[spellElement]) or 0
 
     -- Elemental resistance rank.
     if targetResistRank > 4 then
         targetResistRank = utils.clamp(targetResistRank - rankModifier, 4, 11)
-    end
-
-    -- Skillchains lowers target resistance rank by 1.
-    local _, skillchainCount = xi.magicburst.formMagicBurst(spellElement, target)
-
-    if skillchainCount > 0 then
-        targetResistRank = targetResistRank - 1
     end
 
     -- TODO: Rayke logic might be needed here, depending on how it's implemented.

--- a/src/map/status_effect.cpp
+++ b/src/map/status_effect.cpp
@@ -225,3 +225,16 @@ void CStatusEffect::addMod(Mod modType, int16 amount)
     }
     modList.emplace_back(modType, amount);
 }
+
+void CStatusEffect::setMod(Mod modType, int16 value)
+{
+    for (auto& i : modList)
+    {
+        if (i.getModID() == modType)
+        {
+            i.setModAmount(value);
+            return;
+        }
+    }
+    modList.emplace_back(modType, value);
+}

--- a/src/map/status_effect.h
+++ b/src/map/status_effect.h
@@ -806,6 +806,7 @@ public:
     void SetStartTime(time_point StartTime);
 
     void addMod(Mod modType, int16 amount);
+    void setMod(Mod modType, int16 value);
 
     void SetEffectName(std::string name);
 

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -134,6 +134,7 @@ namespace battleutils
     uint8                GetSkillchainSubeffect(SKILLCHAIN_ELEMENT skillchain);
     int16                GetSkillchainMinimumResistance(SKILLCHAIN_ELEMENT element, CBattleEntity* PDefender, ELEMENT* appliedEle);
     std::vector<ELEMENT> GetSkillchainMagicElement(SKILLCHAIN_ELEMENT skillchain);
+    Mod                  GetResistanceRankModFromElement(ELEMENT& element);
 
     bool IsParalyzed(CBattleEntity* PAttacker);
     bool IsAbsorbByShadow(CBattleEntity* PDefender, CBattleEntity* PAttacker);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Per bg wiki https://www.bg-wiki.com/ffxi/Resist#Modifying_Resistance_Rank
skillchains should reduce resistance ranks by 1 rank.

## Steps to test these changes

!getmod WIND_RES_RANK and use Tachi Jinpu repeatedly to see it switch +/- 1 of the targets resistance rank when on Detonation/Scission or nothing.
