### PR TITLE
[LUA] Fix Guild master rank 100 quest cannot progress

### DIFF
--- a/scripts/globals/crafting/crafting_guild_master.lua
+++ b/scripts/globals/crafting/crafting_guild_master.lua
@@ -210,12 +210,12 @@ xi.crafting.guildMasterOnEventFinish = function(player, csid, option, npc)
         -- Expert quest: Start.
         elseif option == 2 then
             if xi.crafting.hasJoinedGuild(player, guildId) then
-                player:setCharVar('FishingExpertQuest', 1)
+                player:setCharVar(npcTable[npcName][6], 1)
             end
 
         -- Expert quest fish (after getting KI)
         elseif option == 3 then
-            player:setCharVar('FishingExpertQuest', 2)
+            player:setCharVar(npcTable[npcName][6], 2)
 
         -- Rank renouncement.
         elseif


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes an issue where the rank 100 quest will not progress past the prompt to take it.

## Steps to test these changes

1. !setskill x 100
2. !setcraftrank 9
3. !addkeyitem way_of_the_craft
4. Talk to the guild master
