### PR TITLE
[Quest]Correct NPC location

### DIFF
--- a/scripts/quests/bastok/Smoke_on_the_Mountain.lua
+++ b/scripts/quests/bastok/Smoke_on_the_Mountain.lua
@@ -3,6 +3,8 @@
 -----------------------------------
 -- Log ID: 1, Quest ID: 15
 -- Hungry Wolf : !pos -25.861 -11 -30.172 237
+-- Offa: !pos -283-6 -15.9 -140.3 235
+-- ??? (Campfire) !pos 461.8 -20.9 -578.5 107
 -----------------------------------
 local southGustabergID = zones[xi.zone.SOUTH_GUSTABERG]
 -----------------------------------
@@ -53,8 +55,6 @@ quest.sections =
                 end,
             },
 
-            ['Offa'] = quest:event(222),
-
             onEventFinish =
             {
                 [429] = function(player, csid, option, npc)
@@ -67,6 +67,11 @@ quest.sections =
                     quest:complete(player)
                 end,
             },
+        },
+
+        [xi.zone.BASTOK_MARKETS] =
+        {
+            ['Offa'] = quest:event(222),
         },
 
         [xi.zone.SOUTH_GUSTABERG] =


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes NPC Offa location. Offa is located in Bastok Markets not Metalworks.
Added Locations for each NPC in comments.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Offa is option but after speaking with Hungry Wolf, he directs you to his friend Offa. Offa gives the clue to making galkan sausage. 

<!-- Clear and detailed steps to test your changes here -->
