### PR TITLE
[LUA] Fix ??? Footwear shouldn't reward Leaping Boots

### DIFF
--- a/scripts/enum/item.lua
+++ b/scripts/enum/item.lua
@@ -5074,6 +5074,7 @@ xi.item =
     SCOUTERS_ROPE                       = 15302,
     EVOKERS_BOOTS                       = 15325,
     FUMA_SUNE_ATE                       = 15327,
+    BOUNDING_BOOTS                      = 15351,
     FIGHTERS_CALLIGAE_P1                = 15352,
     TEMPLE_GAITERS_P1                   = 15353,
     HEALERS_DUCKBILLS_P1                = 15354,

--- a/scripts/globals/appraisal.lua
+++ b/scripts/globals/appraisal.lua
@@ -708,7 +708,7 @@ xi.appraisal.appraisalItems =
             items =
             {
                 { 95, xi.item.LEATHER_HIGHBOOTS },
-                {  5, xi.item.LEAPING_BOOTS     },
+                {  5, xi.item.BOUNDING_BOOTS    },
             },
         },
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

https://wiki.ffo.jp/html/6853.html

Appraised items should always reward the rare/ex version of the rare item they can appraise to. For example, ??? Headgear can reward Empress Hairpin which is the rare/ex version of Emperor Hairpin. Currently ??? Footwear can reward Leaping Boots but should reward Bounding Boots so we'll swap it.

## Steps to test these changes

1. !pos -42.739 -1 -45.987 48
2. !exec player:addItem({ id = 2196, appraisal = 107 })
3. /item "??? Footwear" <t> (optionally tweak the rarity in scripts\globals\appraisal.lua to make it guaranteed)
