### PR TITLE
[LUA] Refactor ship time tracking messages

### DIFF
--- a/scripts/globals/transport.lua
+++ b/scripts/globals/transport.lua
@@ -94,6 +94,72 @@ xi.transport.pos =
     }
 }
 
+xi.transport.actions =
+{
+    ARRIVE = 0,
+    DEPART = 1,
+}
+
+xi.transport.destinations =
+{
+    SELBINA  = 0,
+    AL_ZAHBI = 1,
+}
+
+xi.transport.routes =
+{
+    SELBINA_MHAURA          = 0,
+    OPEN_SEA                = 1,
+    SILVER_SEA              = 2,
+    SELBINA_MHAURA_OPEN_SEA = 3,
+}
+
+xi.transport.schedules =
+{
+    [xi.transport.routes.SELBINA_MHAURA] = -- Ship bound for [Mhaura/Selbina]
+    {
+        { time =    0, action = xi.transport.actions.DEPART }, -- 00:00
+        { time =  400, action = xi.transport.actions.ARRIVE }, -- 06:40
+        { time =  480, action = xi.transport.actions.DEPART }, -- 08:00
+        { time =  880, action = xi.transport.actions.ARRIVE }, -- 14:40
+        { time =  960, action = xi.transport.actions.DEPART }, -- 16:00
+        { time = 1360, action = xi.transport.actions.ARRIVE }, -- 22:40
+    },
+    [xi.transport.routes.OPEN_SEA] = -- Open sea route to [Al Zahbi/Mhaura]
+    {
+        { time =  160, action = xi.transport.actions.ARRIVE }, -- 02:40
+        { time =  240, action = xi.transport.actions.DEPART }, -- 04:00
+        { time =  640, action = xi.transport.actions.ARRIVE }, -- 10:40
+        { time =  720, action = xi.transport.actions.DEPART }, -- 12:00
+        { time = 1120, action = xi.transport.actions.ARRIVE }, -- 18:40
+        { time = 1200, action = xi.transport.actions.DEPART }, -- 20:00
+    },
+    [xi.transport.routes.SILVER_SEA] = -- Silver Sea route to [Al Zahbi/Nashmau]
+    {
+        { time =    0, action = xi.transport.actions.DEPART }, -- 00:00
+        { time =  300, action = xi.transport.actions.ARRIVE }, -- 05:00
+        { time =  480, action = xi.transport.actions.DEPART }, -- 08:00
+        { time =  780, action = xi.transport.actions.ARRIVE }, -- 13:00
+        { time =  960, action = xi.transport.actions.DEPART }, -- 16:00
+        { time = 1260, action = xi.transport.actions.ARRIVE }, -- 21:00
+    },
+    [xi.transport.routes.SELBINA_MHAURA_OPEN_SEA] = -- Combination of Ship bound for [Mhaura/Selbina] and Open sea route to [Al Zahbi/Mhaura] used by Dieh Yamilsiah
+    {
+        { time =    0, action = xi.transport.actions.DEPART, destination = xi.transport.destinations.SELBINA },  -- 00:00
+        { time =  160, action = xi.transport.actions.ARRIVE, destination = xi.transport.destinations.AL_ZAHBI }, -- 02:40
+        { time =  240, action = xi.transport.actions.DEPART, destination = xi.transport.destinations.AL_ZAHBI }, -- 04:00
+        { time =  400, action = xi.transport.actions.ARRIVE, destination = xi.transport.destinations.SELBINA },  -- 06:40
+        { time =  480, action = xi.transport.actions.DEPART, destination = xi.transport.destinations.SELBINA },  -- 08:00
+        { time =  640, action = xi.transport.actions.ARRIVE, destination = xi.transport.destinations.AL_ZAHBI }, -- 10:40
+        { time =  720, action = xi.transport.actions.DEPART, destination = xi.transport.destinations.AL_ZAHBI }, -- 12:00
+        { time =  880, action = xi.transport.actions.ARRIVE, destination = xi.transport.destinations.SELBINA },  -- 14:40
+        { time =  960, action = xi.transport.actions.DEPART, destination = xi.transport.destinations.SELBINA },  -- 16:00
+        { time = 1120, action = xi.transport.actions.ARRIVE, destination = xi.transport.destinations.AL_ZAHBI }, -- 18:40
+        { time = 1200, action = xi.transport.actions.DEPART, destination = xi.transport.destinations.AL_ZAHBI }, -- 20:00
+        { time = 1360, action = xi.transport.actions.ARRIVE, destination = xi.transport.destinations.SELBINA },  -- 22:40
+    }
+}
+
 -----------------------------------
 -- public functions
 -----------------------------------
@@ -112,4 +178,61 @@ xi.transport.dockMessage = function(npc, triggerID, messages, dock)
     else
         npc:pathThrough(xi.transport.pos[dock].DEPARTING, bit.bor(xi.path.flag.PATROL, xi.path.flag.WALLHACK))
     end
+end
+
+xi.transport.onBoatTimekeeperTrigger = function(player, route, travelMessage, arrivingMessage)
+    local schedule = xi.transport.schedules[route]
+
+    if schedule then
+        local nextEvent = xi.transport.getNextEvent(schedule, route)
+
+        local message = travelMessage
+        if nextEvent.gameMins < 30 then
+            message = arrivingMessage
+        end
+
+        player:messageSpecial(message, nextEvent.earthMins, nextEvent.gameHours)
+    else
+        printf('[warning] bad location %i in xi.transport.onBoatTimekeeperTrigger', route)
+    end
+end
+
+xi.transport.onDockTimekeeperTrigger = function(player, route, event)
+    local schedule = xi.transport.schedules[route]
+
+    if schedule then
+        local nextEvent = xi.transport.getNextEvent(schedule, route)
+
+        if route == xi.transport.routes.SELBINA_MHAURA_OPEN_SEA then
+            player:startEvent(event, nextEvent.earthSecs, nextEvent.action, 0, nextEvent.destination)
+        else
+            player:startEvent(event, nextEvent.earthSecs, nextEvent.action)
+        end
+    else
+        printf('[warning] bad location %i in xi.transport.onDockTimekeeperTrigger', route)
+    end
+end
+
+xi.transport.getNextEvent = function(schedule, route)
+    local currentTime = VanadielHour() * 60 + VanadielMinute()
+    local nextEvent = nil
+
+    for i = 1, #xi.transport.schedules[route] do
+        if schedule[i].time > currentTime then
+            nextEvent = schedule[i]
+            break
+        end
+    end
+
+    if nextEvent == nil then
+        nextEvent = schedule[1]
+        nextEvent.time = nextEvent.time + 1440 -- next day
+    end
+
+    nextEvent.gameMins = nextEvent.time - currentTime
+    nextEvent.earthSecs = nextEvent.gameMins * 60 / 25 -- one earth second is 25 game seconds
+    nextEvent.earthMins = math.ceil(nextEvent.earthSecs / 60)
+    nextEvent.gameHours = math.floor(nextEvent.gameMins / 60)
+
+    return nextEvent
 end

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Baya_Hiramayuh.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Baya_Hiramayuh.lua
@@ -1,6 +1,7 @@
 -----------------------------------
 -- Area: Aht Urhgan Whitegate
 --  NPC: Baya Hiramayuh
+-- !pos -12.08 2 -143.37 50
 -----------------------------------
 local entity = {}
 
@@ -8,18 +9,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    -- Based on scripts/zones/Mhaura/Dieh_Yamilsiah.lua
-    local timer = 1152 - ((os.time() - 1009811376)%1152)
-    local direction = 0 -- Arrive, 1 for depart
-    local waiting = 195 -- Offset for Mhaura
-
-    if timer <= waiting then
-        direction = 1 -- Ship arrived, switch dialog from 'arrive' to 'depart'
-    else
-        timer = timer - waiting -- Ship hasn't arrived, subtract waiting time to get time to arrival
-    end
-
-    player:startEvent(232, timer, direction)
+    xi.transport.onDockTimekeeperTrigger(player, xi.transport.routes.OPEN_SEA, 232)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Kuhn_Tsahnpri.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Kuhn_Tsahnpri.lua
@@ -1,6 +1,7 @@
 -----------------------------------
 -- Area: Aht Urhgan Whitegate
 --  NPC: Kuhn Tsahnpri
+-- !pos 12.08 2 143.39 50
 -----------------------------------
 local entity = {}
 
@@ -8,18 +9,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    -- Based on scripts/zones/Mhaura/Dieh_Yamilsiah.lua
-    local timer = 1152 - ((os.time() - 1009810800)%1152)
-    local direction = 0 -- Arrive, 1 for depart
-    local waiting = 431 -- Offset for Nashmau
-
-    if timer <= waiting then
-        direction = 1 -- Ship arrived, switch dialog from 'arrive' to 'depart'
-    else
-        timer = timer - waiting -- Ship hasn't arrived, subtract waiting time to get time to arrival
-    end
-
-    player:startEvent(236, timer, direction)
+    xi.transport.onDockTimekeeperTrigger(player, xi.transport.routes.OPEN_SEA, 236)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Mhaura/npcs/Dieh_Yamilsiah.lua
+++ b/scripts/zones/Mhaura/npcs/Dieh_Yamilsiah.lua
@@ -41,28 +41,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    -- Each boat comes every 1152 seconds/8 game hours, 4 hour offset between Selbina and Aht Urghan
-    -- Original timer: local timer = 1152 - ((os.time() - 1009810584)%1152)
-    local timer = 1152 - ((os.time() - 1009810802)%1152)
-    local destination = 0 -- Selbina, set to 1 for Al Zhabi
-    local direction = 0 -- Arrive, 1 for depart
-    local waiting = 216 -- Offset for Selbina
-
-    -- Next ferry is Al Zhabi for higher values.
-    if timer >= 576 then
-        destination = 1
-        timer = timer - 576
-        waiting = 193
-    end
-
-    -- Logic to manipulate cutscene results.
-    if timer <= waiting then
-        direction = 1 -- Ship arrived, switch dialog from "arrive" to "depart"
-    else
-        timer = timer - waiting -- Ship hasn't arrived, subtract waiting time to get time to arrival
-    end
-
-    player:startEvent(231, timer, direction, 0, destination) -- timer arriving/departing ??? destination
+    xi.transport.onDockTimekeeperTrigger(player, xi.transport.routes.SELBINA_MHAURA_OPEN_SEA, 231)
 
     --[[Other cutscenes:
     233 "This ship is headed for Selbina."

--- a/scripts/zones/Nashmau/npcs/Yohj_Dukonlhy.lua
+++ b/scripts/zones/Nashmau/npcs/Yohj_Dukonlhy.lua
@@ -1,6 +1,7 @@
 -----------------------------------
 -- Area: Nashmau
 --  NPC: Yohj Dukonlhy
+-- !pos 10.05 2 -103.45 53
 -----------------------------------
 local entity = {}
 
@@ -8,18 +9,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    -- Based on scripts/zones/Mhaura/Dieh_Yamilsiah.lua
-    local timer = 1152 - ((os.time() - 1009810800) % 1152)
-    local direction = 0 -- Arrive, 1 for depart
-    local waiting = 431 -- Offset for Nashmau
-
-    if timer <= waiting then
-        direction = 1 -- Ship arrived, switch dialog from "arrive" to "depart"
-    else
-        timer = timer - waiting -- Ship hasn't arrived, subtract waiting time to get time to arrival
-    end
-
-    player:startEvent(231, timer, direction)
+    xi.transport.onDockTimekeeperTrigger(player, xi.transport.routes.SILVER_SEA, 231)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Open_sea_route_to_Al_Zahbi/IDs.lua
+++ b/scripts/zones/Open_sea_route_to_Al_Zahbi/IDs.lua
@@ -18,7 +18,9 @@ zones[xi.zone.OPEN_SEA_ROUTE_TO_AL_ZAHBI] =
         FISHING_MESSAGE_OFFSET        = 7064, -- You can't fish here.
         ON_WAY_TO_AL_ZAHBI            = 7323, -- We are on our way to Al Zahbi. We should arrive in [less than an hour/about 1 hour/about 2 hours/about 3 hours/about 4 hours/about 5 hours/about 6 hours/about 7 hours] (# [minute/minutes] in Earth time).
         DOCKING_IN_AL_ZAHBI           = 7324, -- We are now docking in Al Zahbi.
+        NEARING_AL_ZAHBI              = 7325, -- We are nearing Al Zahbi.
         CEHN_TEYOHNGO_SHOP_DIALOG     = 7327, -- If you're looking for fishing gear, you've come to the right place!
+        ARRIVING_SOON_AL_ZAHBI        = 7328, -- We are on our way to Al Zahbi. We will be arriving soon.
     },
     mob =
     {

--- a/scripts/zones/Open_sea_route_to_Al_Zahbi/npcs/Adeben.lua
+++ b/scripts/zones/Open_sea_route_to_Al_Zahbi/npcs/Adeben.lua
@@ -12,7 +12,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:messageSpecial(ID.text.ON_WAY_TO_AL_ZAHBI, 0, 0) -- Earth Time, Vana Hours. Needs a get-time function for boat?
+    xi.transport.onBoatTimekeeperTrigger(player, xi.transport.routes.OPEN_SEA, ID.text.ON_WAY_TO_AL_ZAHBI, ID.text.ARRIVING_SOON_AL_ZAHBI)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Open_sea_route_to_Mhaura/IDs.lua
+++ b/scripts/zones/Open_sea_route_to_Mhaura/IDs.lua
@@ -18,7 +18,9 @@ zones[xi.zone.OPEN_SEA_ROUTE_TO_MHAURA] =
         FISHING_MESSAGE_OFFSET        = 7064, -- You can't fish here.
         ON_WAY_TO_MHAURA              = 7323, -- We are on our way to Mhaura. We should arrive in [less than an hour/about 1 hour/about 2 hours/about 3 hours/about 4 hours/about 5 hours/about 6 hours/about 7 hours] (# [minute/minutes] in Earth time).
         DOCKING_IN_MHAURA             = 7324, -- We are now docking in Mhaura.
+        NEARING_MHAURA                = 7325, -- We are nearing Mhaura.
         PASHI_MACCALEH_SHOP_DIALOG    = 7327, -- Step right up for the best fishing gear in these parts!
+        ARRIVING_SOON_MHAURA          = 7328, -- We are on our way to Mhaura. We will be arriving soon.
     },
     mob =
     {

--- a/scripts/zones/Open_sea_route_to_Mhaura/npcs/Sheadon.lua
+++ b/scripts/zones/Open_sea_route_to_Mhaura/npcs/Sheadon.lua
@@ -12,7 +12,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:messageSpecial(ID.text.ON_WAY_TO_MHAURA, 0, 0) -- Earth Time, Vana Hours. Needs a get-time function for boat?
+    xi.transport.onBoatTimekeeperTrigger(player, xi.transport.routes.OPEN_SEA, ID.text.ON_WAY_TO_MHAURA, ID.text.ARRIVING_SOON_MHAURA)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Selbina/npcs/Humilitie.lua
+++ b/scripts/zones/Selbina/npcs/Humilitie.lua
@@ -32,18 +32,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    -- Based on scripts/zones/Mhaura/Dieh_Yamilsiah.lua
-    local timer = 1152 - ((os.time() - 1009810800) % 1152)
-    local direction = 0 -- Arrive, 1 for depart
-    local waiting = 216 -- Offset for Mhaura
-
-    if timer <= waiting then
-        direction = 1 -- Ship arrived, switch dialog from "arrive" to "depart"
-    else
-        timer = timer - waiting -- Ship hasn't arrived, subtract waiting time to get time to arrival
-    end
-
-    player:startEvent(231, timer, direction)
+    xi.transport.onDockTimekeeperTrigger(player, xi.transport.routes.SELBINA_MHAURA, 231)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Ship_bound_for_Mhaura/npcs/Sahn.lua
+++ b/scripts/zones/Ship_bound_for_Mhaura/npcs/Sahn.lua
@@ -12,36 +12,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local vHour = VanadielHour()
-    local vMin  = VanadielMinute()
-
-    while vHour >= 6 do
-        vHour = vHour - 8
-    end
-
-    vHour = vHour - (vHour - 3) * 2
-
-    if vHour == 8 and vMin <= 40 then
-        vHour = 0
-    end
-
-    local vMinutes = (vHour * 60) + 40 - vMin
-
-    vHour = math.floor(vMinutes / 60 + 0.5)
-
-    local message = ID.text.ON_WAY_TO_MHAURA
-
-    if vMinutes <= 30 then
-        message = ID.text.ARRIVING_SOON_MHAURA
-    elseif vMinutes < 60 then
-        vHour = 0
-    end
-
-    if vHour > 7 then -- Normal players can't be on the boat longer than 7 Vanadiel hours. This is for GMs.
-        vHour = 7
-    end
-
-    player:messageSpecial(message, math.abs(math.floor((2.4 * ((vHour * 60) + 40 - vMin)) / 60)), vHour)
+    xi.transport.onBoatTimekeeperTrigger(player, xi.transport.routes.SELBINA_MHAURA, ID.text.ON_WAY_TO_MHAURA, ID.text.ARRIVING_SOON_MHAURA)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Ship_bound_for_Mhaura_Pirates/npcs/Sahn.lua
+++ b/scripts/zones/Ship_bound_for_Mhaura_Pirates/npcs/Sahn.lua
@@ -12,36 +12,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local vHour = VanadielHour()
-    local vMin  = VanadielMinute()
-
-    while vHour >= 6 do
-        vHour = vHour - 8
-    end
-
-    vHour = vHour - (vHour - 3) * 2
-
-    if vHour == 8 and vMin <= 40 then
-        vHour = 0
-    end
-
-    local vMinutes = (vHour * 60) + 40 - vMin
-
-    vHour = math.floor(vMinutes / 60 + 0.5)
-
-    local message = ID.text.ON_WAY_TO_MHAURA
-
-    if vMinutes <= 30 then
-        message = ID.text.ARRIVING_SOON_MHAURA
-    elseif vMinutes < 60 then
-        vHour = 0
-    end
-
-    if vHour > 7 then -- Normal players can't be on the boat longer than 7 Vanadiel hours. This is for GMs.
-        vHour = 7
-    end
-
-    player:messageSpecial(message, math.abs(math.floor((2.4 * ((vHour * 60) + 40 - vMin)) / 60)), vHour)
+    xi.transport.onBoatTimekeeperTrigger(player, xi.transport.routes.SELBINA_MHAURA, ID.text.ON_WAY_TO_MHAURA, ID.text.ARRIVING_SOON_MHAURA)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Ship_bound_for_Selbina/npcs/Bhagirath.lua
+++ b/scripts/zones/Ship_bound_for_Selbina/npcs/Bhagirath.lua
@@ -12,36 +12,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local vHour = VanadielHour()
-    local vMin  = VanadielMinute()
-
-    while vHour >= 6 do
-        vHour = vHour - 8
-    end
-
-    vHour = vHour - (vHour - 3) * 2
-
-    if vHour == 8 and vMin <= 40 then
-        vHour = 0
-    end
-
-    local vMinutes = (vHour * 60) + 40 - vMin
-
-    vHour = math.floor(vMinutes / 60 + 0.5)
-
-    local message = ID.text.ON_WAY_TO_SELBINA
-
-    if vMinutes <= 30 then
-        message = ID.text.ARRIVING_SOON_SELBINA
-    elseif vMinutes < 60 then
-        vHour = 0
-    end
-
-    if vHour > 7 then -- Normal players can't be on the boat longer than 7 Vanadiel hours. This is for GMs.
-        vHour = 7
-    end
-
-    player:messageSpecial(message, math.abs(math.floor((2.4 * ((vHour * 60) + 40 - vMin)) / 60)), vHour)
+    xi.transport.onBoatTimekeeperTrigger(player, xi.transport.routes.SELBINA_MHAURA, ID.text.ON_WAY_TO_SELBINA, ID.text.ARRIVING_SOON_SELBINA)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Ship_bound_for_Selbina_Pirates/npcs/Bhagirath.lua
+++ b/scripts/zones/Ship_bound_for_Selbina_Pirates/npcs/Bhagirath.lua
@@ -12,36 +12,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local vHour = VanadielHour()
-    local vMin  = VanadielMinute()
-
-    while vHour >= 6 do
-        vHour = vHour - 8
-    end
-
-    vHour = vHour - (vHour - 3) * 2
-
-    if vHour == 8 and vMin <= 40 then
-        vHour = 0
-    end
-
-    local vMinutes = (vHour * 60) + 40 - vMin
-
-    vHour = math.floor(vMinutes / 60 + 0.5)
-
-    local message = ID.text.ON_WAY_TO_SELBINA
-
-    if vMinutes <= 30 then
-        message = ID.text.ARRIVING_SOON_SELBINA
-    elseif vMinutes < 60 then
-        vHour = 0
-    end
-
-    if vHour > 7 then -- Normal players can't be on the boat longer than 7 Vanadiel hours. This is for GMs.
-        vHour = 7
-    end
-
-    player:messageSpecial(message, math.abs(math.floor((2.4 * ((vHour * 60) + 40 - vMin)) / 60)), vHour)
+    xi.transport.onBoatTimekeeperTrigger(player, xi.transport.routes.SELBINA_MHAURA, ID.text.ON_WAY_TO_SELBINA, ID.text.ARRIVING_SOON_SELBINA)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Silver_Sea_route_to_Al_Zahbi/IDs.lua
+++ b/scripts/zones/Silver_Sea_route_to_Al_Zahbi/IDs.lua
@@ -16,10 +16,11 @@ zones[xi.zone.SILVER_SEA_ROUTE_TO_AL_ZAHBI] =
         LOGIN_NUMBER                  = 7003, -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.
         MEMBERS_LEVELS_ARE_RESTRICTED = 7023, -- Your party is unable to participate because certain members' levels are restricted.
         FISHING_MESSAGE_OFFSET        = 7061, -- You can't fish here.
+        ON_WAY_TO_AL_ZAHBI            = 7320, -- We are on our way to Al Zahbi. We should arrive in [less than an hour/about 1 hour/about 2 hours/about 3 hours/about 4 hours/about 5 hours/about 6 hours/about 7 hours] (# [minute/minutes] in Earth time).
         DOCKING_IN_AL_ZAHBI           = 7321, -- We are now docking in Al Zahbi.
         NEARING_AL_ZAHBI              = 7322, -- We are nearing Al Zahbi.
         YAHLIQ_SHOP_DIALOG            = 7324, -- You've picked the best place to shop for your items, guaranteed!
-        ON_WAY_TO_AL_ZAHBI            = 7325, -- We are on our way to Al Zahbi. We will be arriving soon.
+        ARRIVING_SOON_AL_ZAHBI        = 7325, -- We are on our way to Al Zahbi. We will be arriving soon.
     },
     mob =
     {

--- a/scripts/zones/Silver_Sea_route_to_Al_Zahbi/npcs/Shadeeu.lua
+++ b/scripts/zones/Silver_Sea_route_to_Al_Zahbi/npcs/Shadeeu.lua
@@ -27,7 +27,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:messageSpecial(ID.text.ON_WAY_TO_AL_ZAHBI, 0, 0) -- Earth Time, Vana Hours. Needs a get-time function for boat?
+    xi.transport.onBoatTimekeeperTrigger(player, xi.transport.routes.SILVER_SEA, ID.text.ON_WAY_TO_AL_ZAHBI, ID.text.ARRIVING_SOON_AL_ZAHBI)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Silver_Sea_route_to_Nashmau/IDs.lua
+++ b/scripts/zones/Silver_Sea_route_to_Nashmau/IDs.lua
@@ -16,10 +16,11 @@ zones[xi.zone.SILVER_SEA_ROUTE_TO_NASHMAU] =
         LOGIN_NUMBER                  = 7003, -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.
         MEMBERS_LEVELS_ARE_RESTRICTED = 7023, -- Your party is unable to participate because certain members' levels are restricted.
         FISHING_MESSAGE_OFFSET        = 7061, -- You can't fish here.
+        ON_WAY_TO_NASHMAU             = 7320, -- We are on our way to Nashmau. We should arrive in [less than an hour/about 1 hour/about 2 hours/about 3 hours/about 4 hours/about 5 hours/about 6 hours/about 7 hours] (# [minute/minutes] in Earth time).
         DOCKING_IN_NASHMAU            = 7321, -- We are now docking in Nashmau.
         NEARING_NASHMAU               = 7322, -- We are nearing Nashmau.
         JIDWAHN_SHOP_DIALOG           = 7324, -- Would you care for some items to use on your travels?
-        ON_WAY_TO_NASHMAU             = 7325, -- We are on our way to Nashmau. We will be arriving soon.
+        ARRIVING_SOON_NASHMAU         = 7325, -- We are on our way to Nashmau. We will be arriving soon.
     },
     mob =
     {

--- a/scripts/zones/Silver_Sea_route_to_Nashmau/npcs/Qudamahf.lua
+++ b/scripts/zones/Silver_Sea_route_to_Nashmau/npcs/Qudamahf.lua
@@ -27,7 +27,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:messageSpecial(ID.text.ON_WAY_TO_NASHMAU, 0, 0) -- Earth Time, Vana Hours. Needs a get-time function for boat?
+    xi.transport.onBoatTimekeeperTrigger(player, xi.transport.routes.SILVER_SEA, ID.text.ON_WAY_TO_NASHMAU, ID.text.ARRIVING_SOON_NASHMAU)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Refactors existing ship time tracking into a normalized function that can be reused across each ship type (excluding Manaclipper, but that could also be moved from there to here).

## Steps to test these changes

1. Talk to any of the ship time tracking NPCs
    - !pos -12.08 2 -143.37 50
    - !pos 12.08 2 143.39 50
    - !pos 10.05 2 -103.45 53
    - !pos 0.340 -12.232 -4.120 46
    - !pos 0.340 -12.232 -4.120 47
    - !pos 17.979 -2.39 -58.800 248
    - !pos 0.28 -14.0 -1.411 221
    - !pos 0.278 -14.707 -1.411 220
    - !pos 0.340 -12.232 -4.120 58
    - !pos 0.340 -12.232 -4.120 58
    - !pos 7.057 -2.364 2.489 249
2. They should report the correct times and whether or not the ship is arriving or departing, Dieh in Mhaura should also report the correct destinations since it varies
