### PR TITLE
Add Move Speed latent as Item Mod

### DIFF
--- a/src/map/latent_effect.cpp
+++ b/src/map/latent_effect.cpp
@@ -114,7 +114,8 @@ bool CLatentEffect::ModOnItemOnly(Mod modID)
         modID == Mod::ITEM_ADDEFFECT_ELEMENT ||
         modID == Mod::ITEM_ADDEFFECT_STATUS ||
         modID == Mod::ITEM_ADDEFFECT_POWER ||
-        modID == Mod::ITEM_ADDEFFECT_DURATION)
+        modID == Mod::ITEM_ADDEFFECT_DURATION ||
+        modID == Mod::MOVE_SPEED_GEAR_BONUS)
     {
         return true;
     }

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -523,6 +523,8 @@ void CLatentEffectContainer::CheckLatentsJobLevel()
         {
             case LATENT::JOB_MULTIPLE:
             case LATENT::JOB_MULTIPLE_AT_NIGHT:
+            case LATENT::JOB_LEVEL_BELOW:
+            case LATENT::JOB_LEVEL_ABOVE:
                 return ProcessLatentEffect(latentEffect);
                 break;
             default:

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -5934,8 +5934,10 @@ void CLuaBaseEntity::changeJob(uint8 newJob)
 
         PChar->resetPetZoningInfo();
 
+        charutils::RemoveAllEquipMods(PChar);
         PChar->jobs.unlocked |= (1 << newJob);
         PChar->SetMJob(newJob);
+        charutils::ApplyAllEquipMods(PChar);
 
         if (newJob == JOB_BLU)
         {
@@ -6228,10 +6230,12 @@ void CLuaBaseEntity::setLevel(uint8 level)
 
     if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
     {
+        charutils::RemoveAllEquipMods(PChar);
         PChar->SetMLevel(level);
         PChar->jobs.job[PChar->GetMJob()] = level;
         PChar->SetSLevel(PChar->jobs.job[PChar->GetSJob()]);
         PChar->jobs.exp[PChar->GetMJob()] = charutils::GetExpNEXTLevel(PChar->jobs.job[PChar->GetMJob()]) - 1;
+        charutils::ApplyAllEquipMods(PChar);
 
         charutils::SetStyleLock(PChar, false);
         blueutils::ValidateBlueSpells(PChar);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds `Mod::MOVE_SPEED_GEAR_BONUS` to list of mods that should apply to the item instead of the player. 

Fixes #4766
Fixes #5810

Under 31:
![image](https://github.com/LandSandBoat/server/assets/2593549/705684ed-d320-468a-a552-542348ef3ca4)
Over 30:
![image](https://github.com/LandSandBoat/server/assets/2593549/a6335f15-e3a3-44a9-b074-019aa13f6488)


## Steps to test these changes

```
!additem 11811
!changejob war 30
/equip head "Destrier beret"
!changejob war 31
```