### PR TITLE
[CPP] Update useMobAbility to check distance

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -16587,15 +16587,32 @@ void CLuaBaseEntity::useMobAbility(sol::variadic_args va)
     // clang-format off
     m_PBaseEntity->PAI->QueueAction(queueAction_t(0ms, true, [PTarget, skillid, PMobSkill](auto PEntity)
     {
-        if (PTarget)
+        auto mobObj = dynamic_cast<CMobEntity*>(PEntity);
+
+        // has both a valid target (specified by user and mob)
+        if (PTarget && mobObj)
         {
-            PEntity->PAI->MobSkill(PTarget->targid, skillid);
+            float currentDistance = distance(mobObj->loc.p, PTarget->loc.p);
+            if (currentDistance <= PMobSkill->getDistance())
+            {
+                PEntity->PAI->MobSkill(PTarget->targid, skillid);
+            }
         }
-        else if (dynamic_cast<CMobEntity*>(PEntity))
+        // does not have a specified target so default to current battle target
+        else if (mobObj)
         {
             if (PMobSkill->getValidTargets() & TARGET_ENEMY)
             {
-                PEntity->PAI->MobSkill(static_cast<CMobEntity*>(PEntity)->GetBattleTargetID(), skillid);
+                auto defaultTarget = mobObj->GetBattleTarget();
+                if (defaultTarget)
+                {
+                    // check distance from player or mob will use TP move and 'lock' itself
+                    float currentDistance = distance(mobObj->loc.p, defaultTarget->loc.p);
+                    if (currentDistance <= PMobSkill->getDistance())
+                    {
+                        PEntity->PAI->MobSkill(defaultTarget->targid, skillid);
+                    }
+                }
             }
             else if (PMobSkill->getValidTargets() & TARGET_SELF)
             {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
This resolves an edge-case where if a mob is issued the command `mob:useMobAbility(####)`, no distance check is performed on the ability being used.  This can cause the mob to ready a skill while the player is already out of range and results in the mob pseudo-stunning itself.  In cases where a mob may be issued multiple calls to `useMobAbility(####)` in quick succession, the mob becomes locked in place preventing it from moving or performing any other actions.

The function itself, in its current iteration, provides no guarantee that the mob will successfully use the ability specified as an argument unless distance checks are performed within that same mob script.  This update does not change this consideration, but rather instead of the mob stunning itself for 3s, it will fail the distance check and just continue without performing the skill.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
** Before Rebuilding **
1 - Move a character to any zone with mobs
2 - Find a mob and engage combat with it.
3 - Use `!exec target:useMobAbility(470)`  (or any mob skill)
4 - Update your movement speed `!speed 200`
5 - Run away from the mob and issue `!exec target:useMobAbility(470)` while you are out of range (15y+)
6 - Note that the mob will still "Ready" the skill.
7 - Repeatedly issue the `useMobAbility` command and note that the mob becomes stunlocked.

** After Rebuilding **
 - Repeat the steps as listed above
 - After reaching Step 5, note that the mob no longer attempts to "Ready" the skill if you are out of range
 - After reaching Step 7, note that the mob no longer becomes stun locked -- It instead will continue pathing to the target.
 
 Special Thanks to @TracentEden for helping me develop/update this.