### PR TITLE
[core] new luautil function: getEntitiesInRange()

### DIFF
--- a/scripts/enum/aoe_radius.lua
+++ b/scripts/enum/aoe_radius.lua
@@ -1,0 +1,11 @@
+-----------------------------------
+-- AOE_RADIUS enum
+-- Defines the origin (center) of the AoE
+-----------------------------------
+xi = xi or {}
+
+xi.aoeRadius =
+{
+    ATTACKER = 1,
+    TARGET   = 2,
+}

--- a/scripts/enum/aoe_type.lua
+++ b/scripts/enum/aoe_type.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- AOE_TYPE enum
+-----------------------------------
+xi = xi or {}
+
+xi.aoeType =
+{
+    NONE      = 0,
+    ROUND     = 1,  -- Normal AoE type
+    CONE      = 2,  -- Forward conal AoE
+    REAR_CONE = 4,  -- conal AoE behind the source
+}

--- a/scripts/enum/find_flag.lua
+++ b/scripts/enum/find_flag.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- FINDFLAGS enum
+-- determines which targets to attempt to add to targetfind (will check for valid target before entry)
+-----------------------------------
+xi = xi or {}
+
+xi.findFlag =
+{
+    NONE            = 0,
+    DEAD            = 1,  -- target dead
+    ALLIANCE        = 2,  -- force target alliance
+    PET             = 4,  -- force target pet
+    UNLIMITED       = 8,  -- unlimited distance
+    HIT_ALL         = 16, -- hit all targets, regardless of party
+    IGNORE_BATTLEID = 32, -- ignore battle id check
+}

--- a/scripts/enum/target_type.lua
+++ b/scripts/enum/target_type.lua
@@ -1,0 +1,21 @@
+-----------------------------------
+-- TARGETTYPE enum
+-- used to determine if a pending target is valid based on comparison to "attacker" entity
+-----------------------------------
+xi = xi or {}
+
+xi.targetType =
+{
+    NONE                    = 0x00,
+    SELF                    = 0x01,
+    PLAYER_PARTY            = 0x02,
+    ENEMY                   = 0x04,
+    PLAYER_ALLIANCE         = 0x08,
+    PLAYER                  = 0x10,
+    PLAYER_DEAD             = 0x20,
+    NPC                     = 0x40, -- an npc is a mob that looks like an npc and fights on the side of the character
+    PLAYER_PARTY_PIANISSIMO = 0x80,
+    PET                     = 0x100,
+    PLAYER_PARTY_ENTRUST    = 0x200,
+    IGNORE_BATTLEID         = 0x400, -- Can hit targets that do not have the same battle ID
+}

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -10237,6 +10237,100 @@ void CLuaBaseEntity::recalculateAbilitiesTable()
 }
 
 /************************************************************************
+ *  Function: getEntitiesInRange()
+ *  Purpose : Returns a Lua table of entities within range of the base entity
+ *  Example : local players = npc:getEntitiesInRange(target, aoeType, radiusOrigin, distance, findFlags, validTargets)
+ *
+ *  WARNING : APART FROM THIS ONE EXCEPTION, ALL TARGET AND PATH FINDING SHOULD BE DONE EXCLUSIVELY IN CORE
+ *
+ *  Notes   : This is primarily made for Dark Ixion's trample, but there may be valid uses for other mob sequences
+ *               IN GENERAL, this function should not be used in persistent on-tick logic
+ *            if the passed distance is nil or 0 (as well as many other combinations), empty table will be returned
+ *            examples
+ *      mob:getEntitiesInRange(nearbyPlayer, xi.aoeType.ROUND, xi.aoeRadius.ATTACKER, trampleRange, xi.findFlag.HIT_ALL, xi.targetType.PLAYER + xi.targetType.PLAYER_PARTY)
+ *              The parameters should all be enums from xi.aoeType, xi.aoeRadius, xi.findFlag, and xi.targetType
+ ************************************************************************/
+
+auto CLuaBaseEntity::getEntitiesInRange(CLuaBaseEntity* PLuaEntityTarget, sol::variadic_args va) -> sol::table
+{
+    auto* baseEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
+    auto  entities   = lua.create_table();
+    if (!baseEntity || !baseEntity->PAI || !baseEntity->PAI->TargetFind)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->getName());
+        return entities;
+    }
+
+    auto* PTarget = dynamic_cast<CBattleEntity*>(PLuaEntityTarget->GetBaseEntity());
+    if (!PTarget)
+    {
+        ShowWarning("Invalid target entity in function (%s).", m_PBaseEntity->getName());
+        return entities;
+    }
+
+    // Reset targetfind
+    baseEntity->PAI->TargetFind->reset();
+
+    // Standard targetfind call: AOE_RADIUS::TARGET, distance, flags, PSpell->getValidTarget()
+    auto distance = va[2].is<float>() ? va[2].as<float>() : 0;
+    if (distance < 0)
+    {
+        ShowWarning("Invalid distance in function call (%s).", m_PBaseEntity->getName());
+        return entities;
+    }
+
+    auto findFlags    = va[3].is<uint8>() ? va[3].as<uint8>() : 0;
+    auto validTargets = va[4].is<uint16>() ? va[4].as<uint16>() : 0;
+
+    // Mob buff abilities also hit monster's pets
+    if (validTargets & TARGET_SELF)
+    {
+        findFlags |= FINDFLAGS_PET;
+    }
+
+    if ((validTargets & TARGET_IGNORE_BATTLEID) == TARGET_IGNORE_BATTLEID)
+    {
+        findFlags |= FINDFLAGS_IGNORE_BATTLEID;
+    }
+
+    auto aoeType      = va[0].is<uint16>() ? va[0].as<uint16>() : 0;
+    auto radiusOrigin = static_cast<AOE_RADIUS>(va[1].is<uint8>() ? va[1].as<uint8>() : 0);
+    // Targetfind always adds the primary target, ensure that is valid
+    if (radiusOrigin == AOE_RADIUS::TARGET || baseEntity->PAI->TargetFind->isWithinRange(&PTarget->loc.p, distance))
+    {
+        if (aoeType == AOE_TYPE::ROUND)
+        {
+            baseEntity->PAI->TargetFind->findWithinArea(PTarget, radiusOrigin, distance, findFlags, validTargets);
+        }
+        else if (aoeType == AOE_TYPE::ROUND || aoeType == AOE_TYPE::CONE)
+        {
+            float angle = 45.0f;
+            baseEntity->PAI->TargetFind->findWithinCone(PTarget, distance, angle, findFlags, validTargets, aoeType);
+        }
+        else
+        {
+            if (baseEntity->objtype == TYPE_MOB && PTarget->objtype == TYPE_PC)
+            {
+                CBattleEntity* PCoverAbilityUser = battleutils::GetCoverAbilityUser(PTarget, baseEntity);
+                if (PCoverAbilityUser != nullptr)
+                {
+                    PTarget = PCoverAbilityUser;
+                }
+            }
+
+            baseEntity->PAI->TargetFind->findSingleTarget(PTarget, findFlags, validTargets);
+        }
+    }
+
+    for (auto&& PTargetFound : baseEntity->PAI->TargetFind->m_targets)
+    {
+        entities.add(CLuaBaseEntity(PTargetFound));
+    }
+
+    return entities;
+}
+
+/************************************************************************
  *  Function: getParty()
  *  Purpose : Returns a Lua table of party member Entity objects
  *  Example : local party = player:getParty()
@@ -17899,6 +17993,7 @@ void CLuaBaseEntity::Register()
 
     SOL_REGISTER("recalculateSkillsTable", CLuaBaseEntity::recalculateSkillsTable);
     SOL_REGISTER("recalculateAbilitiesTable", CLuaBaseEntity::recalculateAbilitiesTable);
+    SOL_REGISTER("getEntitiesInRange", CLuaBaseEntity::getEntitiesInRange);
 
     // Parties and Alliances
     SOL_REGISTER("getParty", CLuaBaseEntity::getParty);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -516,6 +516,7 @@ public:
 
     void recalculateSkillsTable();
     void recalculateAbilitiesTable();
+    auto getEntitiesInRange(CLuaBaseEntity* PLuaEntityTarget, sol::variadic_args va) -> sol::table;
 
     // Parties and Alliances
     auto   getParty() -> sol::table;

--- a/src/map/mobskill.h
+++ b/src/map/mobskill.h
@@ -37,6 +37,14 @@ enum SKILLFLAG
     SKILLFLAG_BLOODPACT_WARD = 0x080,
 };
 
+enum AOE_TYPE
+{
+    NONE      = 0,
+    ROUND     = 1, // Normal AoE type
+    CONE      = 4, // Forward conal AoE
+    REAR_CONE = 8, // conal AoE behind the source
+};
+
 #define MAX_MOBSKILL_ID 4262
 
 class CMobSkill


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Sparked by [this comment](https://github.com/LandSandBoat/server/pull/4868#discussion_r1440575060), I've created a more generic binding for finding entities in range of an entity, using the existing `CTargetFind` class.

I'm putting this in draft mode while I test it, but preliminary testing seems to work (the benefits of using pre-existing systems)

This PR lays some groundwork:
- Creates a missing enum essential to skills/abilities: AOE_TYPE
- Copies all targetfind enums into lua space, with some comments about their caveats

The PR's main change: `getEntitiesInRange()`
- This binding first does basic checks and returns an empty table if anything essential is missing with the parameters
- It then calls a `PAI->Targetfind` flow similar to spells or mobskills
- the return is always a table, empty if no targets were found within the given targetfind parameters

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
