### PR TITLE
[cpp] Update pet buffs to set themselves as initial target for AoEs

### DIFF
--- a/src/map/entities/petentity.cpp
+++ b/src/map/entities/petentity.cpp
@@ -430,9 +430,13 @@ void CPetEntity::OnPetSkillFinished(CPetSkillState& state, action_t& action)
     */
 
     // Mob buff abilities also hit monster's pets
-    if (PSkill->getValidTargets() == TARGET_SELF)
+    if (PSkill->getValidTargets() & TARGET_SELF)
     {
         findFlags |= FINDFLAGS_PET;
+        if (PSkill->isAoE())
+        {
+            PTarget = this;
+        }
     }
 
     if ((PSkill->getValidTargets() & TARGET_IGNORE_BATTLEID) == TARGET_IGNORE_BATTLEID)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

AoE petskills weren't including the pet itself, this PR fixes that. Closes https://github.com/LandSandBoat/server/issues/4996 .

## Steps to test these changes

To show that it doesn't target party-member's pets:
https://imgur.com/G5TaRBE

and here's the message showing up properly like retail:
![image](https://github.com/LandSandBoat/server/assets/131182600/2fcbe49e-e396-4201-971c-f61e183fd61f)

Suspected the primary target message is what made the text color slightly different, confirmed:
![image](https://github.com/LandSandBoat/server/assets/131182600/cc86ee16-3137-4072-b7e3-e5eb1024513b)
