### PR TITLE
[LUA] Fix can't receive Power Sandals during Test My Mettle

### DIFF
--- a/scripts/enum/item.lua
+++ b/scripts/enum/item.lua
@@ -4153,6 +4153,7 @@ xi.item =
     GALKAN_SANDALS                      = 13009,
     HUME_F_BOOTS                        = 13010,
     ELVAAN_F_LEDELSENS                  = 13011,
+    POWER_SANDALS                       = 13012,
     STUMBLING_SANDALS                   = 13013,
     LEAPING_BOOTS                       = 13014,
     FUMA_KYAHAN                         = 13054,

--- a/scripts/quests/otherAreas/Test_My_Mettle.lua
+++ b/scripts/quests/otherAreas/Test_My_Mettle.lua
@@ -2,7 +2,7 @@
 -- Test My Mettle
 -----------------------------------
 -- Log ID: 4, Quest ID: 25
--- Devean : !pos -58 -10 6 248
+-- Devean : !pos 39.86 -14.56 40 248
 -- Jar    : !gotoname Jar
 -----------------------------------
 require('scripts/quests/otherAreas/helpers')


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Power Sandals are missing from the item enum at the moment causing Test My Mettle to function improperly. Also seems like the NPC was moved at some point so updated his pos comment.

## Steps to test these changes

1. !pos 39.86 -14.56 40 248
2. !zone Davoi
3. !gotoname Jar
4. Jar should give Power Sandals