### PR TITLE
[lua] Aftermath effect cleanup

### DIFF
--- a/scripts/effects/aftermath.lua
+++ b/scripts/effects/aftermath.lua
@@ -11,7 +11,6 @@ effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    xi.aftermath.onEffectLose(target, effect)
 end
 
 return effectObject

--- a/scripts/globals/aftermath.lua
+++ b/scripts/globals/aftermath.lua
@@ -632,16 +632,19 @@ xi.aftermath.onEffectGain = function(target, effect)
     {
         -- Relic
         [1] = function(x)
-            local pet = nil
-            if aftermath.includePets then
-                pet = target:getPet()
+            local pet = target:getPet()
+            if
+                pet and
+                aftermath.includePets
+            then
+                -- pets gain same mods as the player, so give them the effect without a loss message
+                pet:delStatusEffectSilent(xi.effect.AFTERMATH)
+                pet:addStatusEffect(xi.effect.AFTERMATH, effect:getPower(), 0, effect:getDuration(), 0, effect:getSubPower(), effect:getTier())
+                pet:getStatusEffect(xi.effect.AFTERMATH):addEffectFlag(xi.effectFlag.NO_LOSS_MESSAGE)
             end
 
             for i = 1, #aftermath.mods, 2 do
                 target:addMod(aftermath.mods[i], aftermath.mods[i + 1])
-                if pet then
-                    pet:addMod(aftermath.mods[i], aftermath.mods[i + 1])
-                end
             end
         end,
 
@@ -650,11 +653,15 @@ xi.aftermath.onEffectGain = function(target, effect)
             local tp = effect:getSubPower()
             local mods = aftermath.mods[math.floor(tp / 1000)]
             local pet = target:getPet()
+            if pet then
+                -- pets gain same mods as the player, so give them the effect without a loss message
+                pet:delStatusEffectSilent(xi.effect.AFTERMATH)
+                pet:addStatusEffect(xi.effect.AFTERMATH, effect:getPower(), 0, effect:getDuration(), 0, effect:getSubPower(), effect:getTier())
+                pet:getStatusEffect(xi.effect.AFTERMATH):addEffectFlag(xi.effectFlag.NO_LOSS_MESSAGE)
+            end
+
             for i = 1, #mods, 2 do
                 target:addMod(mods[i], mods[i + 1](tp))
-                if pet then
-                    pet:addMod(mods[i], mods[i + 1](tp))
-                end
             end
         end,
 
@@ -678,9 +685,6 @@ xi.aftermath.onEffectLose = function(target, effect)
 
             for i = 1, #aftermath.mods, 2 do
                 target:delMod(aftermath.mods[i], aftermath.mods[i + 1])
-                if pet then
-                    pet:delMod(aftermath.mods[i], aftermath.mods[i + 1])
-                end
             end
         end,
 
@@ -688,12 +692,8 @@ xi.aftermath.onEffectLose = function(target, effect)
         [2] = function(x)
             local tp = effect:getSubPower()
             local mods = aftermath.mods[math.floor(tp / 1000)]
-            local pet = target:getPet()
             for i = 1, #mods, 2 do
                 target:delMod(mods[i], mods[i + 1](tp))
-                if pet then
-                    pet:delMod(mods[i], mods[i + 1](tp))
-                end
             end
         end,
 

--- a/scripts/globals/aftermath.lua
+++ b/scripts/globals/aftermath.lua
@@ -644,7 +644,7 @@ xi.aftermath.onEffectGain = function(target, effect)
             end
 
             for i = 1, #aftermath.mods, 2 do
-                target:addMod(aftermath.mods[i], aftermath.mods[i + 1])
+                effect:addMod(aftermath.mods[i], aftermath.mods[i + 1])
             end
         end,
 
@@ -661,45 +661,13 @@ xi.aftermath.onEffectGain = function(target, effect)
             end
 
             for i = 1, #mods, 2 do
-                target:addMod(mods[i], mods[i + 1](tp))
+                effect:addMod(mods[i], mods[i + 1](tp))
             end
         end,
 
         -- Empyrean
         [3] = function(x)
-            target:addMod(aftermath.mod, aftermath.power[math.floor(effect:getSubPower() / 1000)])
-        end
-    }
-end
-
-xi.aftermath.onEffectLose = function(target, effect)
-    local aftermath = xi.aftermath.effects[effect:getPower()]
-    switch (effect:getTier()) : caseof
-    {
-        -- Relic
-        [1] = function(x)
-            local pet = nil
-            if aftermath.includePets then
-                pet = target:getPet()
-            end
-
-            for i = 1, #aftermath.mods, 2 do
-                target:delMod(aftermath.mods[i], aftermath.mods[i + 1])
-            end
-        end,
-
-        -- Mythic
-        [2] = function(x)
-            local tp = effect:getSubPower()
-            local mods = aftermath.mods[math.floor(tp / 1000)]
-            for i = 1, #mods, 2 do
-                target:delMod(mods[i], mods[i + 1](tp))
-            end
-        end,
-
-        -- Empyrean
-        [3] = function(x)
-            target:delMod(aftermath.mod, aftermath.power[math.floor(effect:getSubPower() / 1000)])
+            effect:addMod(aftermath.mod, aftermath.power[math.floor(effect:getSubPower() / 1000)])
         end
     }
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes https://github.com/LandSandBoat/server/issues/5231 .

Changes aftermath to encode the aftermath effect the same way on a pet:
- ensure we always give the effect to the pet with the same power/subpower/tier/duration

This then allows us to simplify the `onEffectGain`/`onEffectLose` functions to just stack mods on the effect

## Steps to test these changes

see that pet gets the mods just like before
![image](https://github.com/LandSandBoat/server/assets/131182600/5f96e7c1-9ea0-4683-8a2c-db92eeb7bb6c)

and also that aftermath functions the same for player as well:
![image](https://github.com/LandSandBoat/server/assets/131182600/020b7ffa-dbd9-4044-a589-17c27fb671bf)

and just to be sure here's spharai:
![image](https://github.com/LandSandBoat/server/assets/131182600/12ffab0b-50d5-4f07-a3cf-aeba865a2a8a)
![image](https://github.com/LandSandBoat/server/assets/131182600/f2e76231-749e-4e71-a1cd-11f7de667f23)


and of course there are no errors in map server console