### PR TITLE
[Cleanup] Correct mobskill magical redundancies

### DIFF
--- a/scripts/actions/abilities/pets/aerial_blast.lua
+++ b/scripts/actions/abilities/pets/aerial_blast.lua
@@ -8,13 +8,10 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    local level = pet:getMainLvl()
-    local damage = 48 + (level * 8)
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(48 + pet:getMainLvl() * 8 + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WIND, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)

--- a/scripts/actions/abilities/pets/aero_ii.lua
+++ b/scripts/actions/abilities/pets/aero_ii.lua
@@ -8,13 +8,10 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp   = pet:getTP()
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    local damage = math.floor(45 + 0.025 * tp)
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(45 + 0.025 * pet:getTP() + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WIND, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)

--- a/scripts/actions/abilities/pets/aero_iv.lua
+++ b/scripts/actions/abilities/pets/aero_iv.lua
@@ -8,13 +8,10 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp   = pet:getTP()
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    local damage = math.floor(325 + 0.025 * tp)
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(325 + 0.025 * pet:getTP() + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WIND, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)

--- a/scripts/actions/abilities/pets/blizzard_ii.lua
+++ b/scripts/actions/abilities/pets/blizzard_ii.lua
@@ -8,13 +8,10 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp   = pet:getTP()
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    local damage = math.floor(45 + 0.025 * tp)
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(45 + 0.025 * pet:getTP() + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.ICE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.ICE, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.ICE, 1)

--- a/scripts/actions/abilities/pets/blizzard_iv.lua
+++ b/scripts/actions/abilities/pets/blizzard_iv.lua
@@ -8,13 +8,10 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp   = pet:getTP()
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    local damage = math.floor(325 + 0.025 * tp)
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(325 + 0.025 * pet:getTP() + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.ICE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.ICE, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.ICE, 1)

--- a/scripts/actions/abilities/pets/burning_strike.lua
+++ b/scripts/actions/abilities/pets/burning_strike.lua
@@ -1,5 +1,6 @@
 -----------------------------------
--- Burning Strike M = 6?
+-- Burning Strike
+-- Hybrid
 -----------------------------------
 local abilityObject = {}
 
@@ -8,24 +9,20 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local numhits = 1
-    local accmod = 1
-    local dmgmod = 6
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    local damage = xi.summon.avatarPhysicalMove(pet, target, petskill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
-    --get resist multiplier (1x if no resist)
-    local resist = xi.mobskills.applyPlayerResistance(pet, -1, target, pet:getStat(xi.mod.INT)-target:getStat(xi.mod.INT), xi.skill.ELEMENTAL_MAGIC, xi.element.FIRE)
-    --get the resisted damage
-    damage.dmg = damage.dmg * resist
-    --add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
-    damage.dmg = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.FIRE, petskill)
-    local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, petskill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
-    target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
-    target:updateEnmityFromDamage(pet, totaldamage)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, petskill, 1, 1, 6, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    damage       = math.floor(damage.dmg + pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
 
-    return totaldamage
+    -- Add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
+    damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.FIRE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.FIRE, petskill)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, 1)
+
+    target:takeDamage(damage, pet, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
+    target:updateEnmityFromDamage(pet, damage)
+
+    return damage
 end
 
 return abilityObject

--- a/scripts/actions/abilities/pets/clarsach_call.lua
+++ b/scripts/actions/abilities/pets/clarsach_call.lua
@@ -9,13 +9,10 @@ end
 
 -- https://www.bg-wiki.com/ffxi/Clarsach_Call
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local level = pet:getMainLvl()
-    local damage = 48 + (level * 8)
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(48 + pet:getMainLvl() * 8 + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WIND, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)

--- a/scripts/actions/abilities/pets/diamond_dust.lua
+++ b/scripts/actions/abilities/pets/diamond_dust.lua
@@ -8,13 +8,10 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    local level = pet:getMainLvl()
-    local damage = 48 + (level * 8)
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(48 + pet:getMainLvl() * 8 + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.ICE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.ICE, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.ICE, 1)

--- a/scripts/actions/abilities/pets/earthen_fury.lua
+++ b/scripts/actions/abilities/pets/earthen_fury.lua
@@ -8,13 +8,10 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    local level = pet:getMainLvl()
-    local damage = 48 + (level * 8)
-    damage = damage + (dINT * 1.5)
+    local damage = 48 + pet:getMainLvl() * 8 + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.EARTH, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.EARTH, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, 1)

--- a/scripts/actions/abilities/pets/fire_ii.lua
+++ b/scripts/actions/abilities/pets/fire_ii.lua
@@ -8,13 +8,10 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp   = pet:getTP()
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    local damage = math.floor(45 + 0.025 * tp)
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(45 + 0.025 * pet:getTP() + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.FIRE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.FIRE, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, 1)

--- a/scripts/actions/abilities/pets/fire_iv.lua
+++ b/scripts/actions/abilities/pets/fire_iv.lua
@@ -8,13 +8,10 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp   = pet:getTP()
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    local damage = math.floor(325 + 0.025 * tp)
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(325 + 0.025 * pet:getTP() + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.FIRE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.FIRE, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, 1)

--- a/scripts/actions/abilities/pets/flaming_crush.lua
+++ b/scripts/actions/abilities/pets/flaming_crush.lua
@@ -1,5 +1,6 @@
 -----------------------------------
--- Flaming Crush M=10, 2, 2? (STILL don't know)
+-- Flaming Crush
+-- Hybrid
 -----------------------------------
 local abilityObject = {}
 
@@ -8,25 +9,20 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local numhits = 3
-    local accmod = 1
-    local dmgmod = 10
-    local dmgmodsubsequent = 1
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    local damage = xi.summon.avatarPhysicalMove(pet, target, petskill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
-    --get resist multiplier (1x if no resist)
-    local resist = xi.mobskills.applyPlayerResistance(pet, -1, target, pet:getStat(xi.mod.INT)-target:getStat(xi.mod.INT), xi.skill.ELEMENTAL_MAGIC, xi.element.FIRE)
-    --get the resisted damage
-    damage.dmg = damage.dmg * resist
-    --add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
-    damage.dmg = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.FIRE, petskill)
-    local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, petskill, target, xi.attackType.PHYSICAL, xi.damageType.FIRE, numhits)
-    target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.FIRE)
-    target:updateEnmityFromDamage(pet, totaldamage)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, petskill, 2, 1, 10, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    damage       = math.floor(damage.dmg + pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
 
-    return totaldamage
+    -- Add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
+    damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.FIRE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.FIRE, petskill)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, 3)
+
+    target:takeDamage(damage, pet, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
+    target:updateEnmityFromDamage(pet, damage)
+
+    return damage
 end
 
 return abilityObject

--- a/scripts/actions/abilities/pets/geocrush.lua
+++ b/scripts/actions/abilities/pets/geocrush.lua
@@ -8,24 +8,22 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT   = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp     = pet:getTP() / 10
-    local merits = 0
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    if summoner ~= nil and summoner:isPC() then
+    local tp = pet:getTP()
+
+    -- Merit TP bonus.
+    local merits = 0
+
+    if summoner and summoner:isPC() then
         merits = summoner:getMerit(xi.merit.GEOCRUSH)
     end
 
-    tp = tp + (merits - 40)
-    if tp > 300 then
-        tp = 300
-    end
+    tp = utils.clamp(tp + merits - 400, 0, 3000)
 
     --note: this formula is only accurate for level 75 - 76+ may have a different intercept and/or slope
-    local damage = math.floor(512 + 1.72 * (tp + 1))
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(512 + 0.172 * tp + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.EARTH, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.EARTH, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, 1)

--- a/scripts/actions/abilities/pets/grand_fall.lua
+++ b/scripts/actions/abilities/pets/grand_fall.lua
@@ -8,25 +8,22 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT   = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp     = pet:getTP() / 10
-    local master = pet:getMaster()
-    local merits = 0
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    if master ~= nil and master:isPC() then
-        merits = master:getMerit(xi.merit.GRANDFALL)
+    local tp = pet:getTP()
+
+    -- Merit TP bonus.
+    local merits = 0
+
+    if summoner and summoner:isPC() then
+        merits = summoner:getMerit(xi.merit.GRANDFALL)
     end
 
-    tp = tp + (merits - 40)
-    if tp > 300 then
-        tp = 300
-    end
+    tp = utils.clamp(tp + merits - 400, 0, 3000)
 
     --note: this formula is only accurate for level 75 - 76+ may have a different intercept and/or slope
-    local damage = math.floor(512 + 1.72 * (tp + 1))
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(512 + 0.172 * tp + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.WATER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WATER, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.WATER, 1)

--- a/scripts/actions/abilities/pets/heavenly_strike.lua
+++ b/scripts/actions/abilities/pets/heavenly_strike.lua
@@ -8,24 +8,22 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT   = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp     = pet:getTP() / 10
-    local merits = 0
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    if summoner ~= nil and summoner:isPC() then
+    local tp = pet:getTP()
+
+    -- Merit TP bonus.
+    local merits = 0
+
+    if summoner and summoner:isPC() then
         merits = summoner:getMerit(xi.merit.HEAVENLY_STRIKE)
     end
 
-    tp = tp + (merits - 40)
-    if tp > 300 then
-        tp = 300
-    end
+    tp = utils.clamp(tp + merits - 400, 0, 3000)
 
     --note: this formula is only accurate for level 75 - 76+ may have a different intercept and/or slope
-    local damage = math.floor(512 + 1.72 * (tp + 1))
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(512 + 0.172 * tp + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.ICE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.ICE, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.ICE, 1)

--- a/scripts/actions/abilities/pets/howling_moon.lua
+++ b/scripts/actions/abilities/pets/howling_moon.lua
@@ -8,13 +8,10 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    local level = pet:getMainLvl()
-    local damage = 48 + (level * 8)
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(48 + pet:getMainLvl() * 8 + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.DARK, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.DARK, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.DARK, 1)

--- a/scripts/actions/abilities/pets/inferno.lua
+++ b/scripts/actions/abilities/pets/inferno.lua
@@ -8,13 +8,10 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    local level = pet:getMainLvl()
-    local damage = 48 + (level * 8)
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(48 + pet:getMainLvl() * 8 + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.FIRE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.FIRE, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, 1)

--- a/scripts/actions/abilities/pets/judgment_bolt.lua
+++ b/scripts/actions/abilities/pets/judgment_bolt.lua
@@ -8,13 +8,10 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    local level = pet:getMainLvl()
-    local damage = 48 + (level * 8)
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(48 + pet:getMainLvl() * 8 + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.THUNDER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.THUNDER, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.THUNDER, 1)

--- a/scripts/actions/abilities/pets/level_X_holy.lua
+++ b/scripts/actions/abilities/pets/level_X_holy.lua
@@ -9,38 +9,37 @@ end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
+    local damage            = 0
     local holyRollOneAnimID = 164
-    local primaryTargetID = action:getPrimaryTargetID()
+    local primaryTargetID   = action:getPrimaryTargetID()
 
     -- If primary target, roll for power by setting random animation.
+    -- We do this so the animation is random, but only rolled for once. (AKA: The same for all targets)
     if primaryTargetID == target:getID() then
         action:setAnimation(primaryTargetID, holyRollOneAnimID + math.random(0, 5))
     else
         action:setAnimation(target:getID(), action:getAnimation(primaryTargetID))
     end
 
-    local power = action:getAnimation(target:getID()) - holyRollOneAnimID + 1
-    local dMND = math.floor(pet:getStat(xi.mod.MND) - target:getStat(xi.mod.MND))
-    local ele = xi.element.LIGHT
-    local dmg = 0
+    local power = action:getAnimation(target:getID()) - 163
 
-    local dmgmod = 1
-    local basedmg = pet:getMainLvl() * power + (dMND * 1.5)
     -- Only have an effect if target's level is divisible by die roll
     if target:getMainLvl() % power == 0 then
-        local info = xi.mobskills.mobMagicalMove(pet, target, petskill, basedmg, ele, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT, 10)
-        dmg = xi.mobskills.mobAddBonuses(pet, target, info.dmg, ele, petskill)
-        dmg = xi.summon.avatarFinalAdjustments(dmg, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.LIGHT, 1)
+        damage = math.floor(pet:getMainLvl() * power + (pet:getStat(xi.mod.MND) - target:getStat(xi.mod.MND)) * 1.5)
+
+        damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.LIGHT, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 10)
+        damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.LIGHT, petskill)
+        damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.LIGHT, 1)
 
         -- TODO: Magic burst?
 
-        target:takeDamage(dmg, pet, xi.attackType.MAGICAL, ele)
-        target:updateEnmityFromDamage(pet, dmg)
+        target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.element.LIGHT)
+        target:updateEnmityFromDamage(pet, damage)
     else
         petskill:setMsg(xi.msg.basic.JA_NO_EFFECT_2)
     end
 
-    return dmg
+    return damage
 end
 
 return abilityObject

--- a/scripts/actions/abilities/pets/meteor_strike.lua
+++ b/scripts/actions/abilities/pets/meteor_strike.lua
@@ -8,24 +8,22 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT   = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp     = pet:getTP() / 10
-    local merits = 0
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    if summoner ~= nil and summoner:isPC() then
+    local tp = pet:getTP()
+
+    -- Merit TP bonus.
+    local merits = 0
+
+    if summoner and summoner:isPC() then
         merits = summoner:getMerit(xi.merit.METEOR_STRIKE)
     end
 
-    tp = tp + (merits - 40)
-    if tp > 300 then
-        tp = 300
-    end
+    tp = utils.clamp(tp + merits - 400, 0, 3000)
 
     --note: this formula is only accurate for level 75 - 76+ may have a different intercept and/or slope
-    local damage = math.floor(512 + 1.72 * (tp + 1))
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(512 + 0.172 * tp + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.FIRE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.FIRE, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, 1)

--- a/scripts/actions/abilities/pets/nether_blast.lua
+++ b/scripts/actions/abilities/pets/nether_blast.lua
@@ -9,8 +9,9 @@ end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
-    local level = pet:getMainLvl()
-    local damage = 5 * level + 10
+
+    local damage = math.floor(10 + 5 * pet:getMainLvl())
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.DARK, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.DARK, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.DARK, 1)

--- a/scripts/actions/abilities/pets/searing_light.lua
+++ b/scripts/actions/abilities/pets/searing_light.lua
@@ -8,13 +8,10 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local level = pet:getMainLvl()
-    local damage = 26 + (level * 6)
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(26 + pet:getMainLvl() * 6 + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.LIGHT, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.LIGHT, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.LIGHT, 1)

--- a/scripts/actions/abilities/pets/somnolence.lua
+++ b/scripts/actions/abilities/pets/somnolence.lua
@@ -9,25 +9,24 @@ end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
-    local dmg = 10 + pet:getMainLvl() * 2
-    local resist = xi.mobskills.applyPlayerResistance(pet, -1, target, 0, xi.skill.ELEMENTAL_MAGIC, xi.element.DARK)
-    local duration = 120
 
-    dmg = dmg * resist
-    dmg = xi.mobskills.mobAddBonuses(pet, target, dmg, xi.element.DARK, petskill)
-    dmg = xi.summon.avatarFinalAdjustments(dmg, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.DARK, 1)
+    -- Damage
+    local damage = 10 + pet:getMainLvl() * 2
 
-    if resist < 0.15 then  --the gravity effect from this ability is more likely to land than Tail Whip
-        resist = 0
+    damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage.dmg, xi.element.FIRE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.DARK, petskill)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.DARK, 1)
+
+    -- Effect
+    if not target:hasStatusEffect(xi.effect.WEIGHT) then
+        local resist = xi.mobskills.applyPlayerResistance(pet, -1, target, 0, xi.skill.ELEMENTAL_MAGIC, xi.element.DARK)
+
+        if resist >= 0.15 then
+            target:addStatusEffect(xi.effect.WEIGHT, 50, 0, 120 * resist)
+        end
     end
 
-    duration = duration * resist
-
-    if duration > 0 and not target:hasStatusEffect(xi.effect.WEIGHT) then
-        target:addStatusEffect(xi.effect.WEIGHT, 50, 0, duration)
-    end
-
-    return dmg
+    return damage
 end
 
 return abilityObject

--- a/scripts/actions/abilities/pets/sonic_buffet.lua
+++ b/scripts/actions/abilities/pets/sonic_buffet.lua
@@ -9,14 +9,12 @@ end
 
 -- http://wiki.ffo.jp/html/37931.html
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp   = pet:getTP()
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    -- TODO: upon smn BP damage rewrite, the base damage & mods etc need to be re-evaluated. These are eyeballed and guesstimated to fit what damage looks like on retail.
-    local damage = math.floor(37.5 * (2.0 + 0.1 * tp / 150)) -- fTP starts at 2.0 and scales every 150 tp by .1 for a range of 2.0 to 4.0. Base value ballparked from retail.
-    damage = damage + (dINT * 1.5)
+    -- TODO: upon smn BP damage rewrite, the base damage & mods etc need to be re-evaluated.
+    -- fTP starts at 2.0 and scales every 150 tp by .1 for a range of 2.0 to 4.0. Base value ballparked from retail.
+    local damage = math.floor(37.5 * (2 + 0.1 * pet:getTP() / 150) + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WIND, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)

--- a/scripts/actions/abilities/pets/stone_ii.lua
+++ b/scripts/actions/abilities/pets/stone_ii.lua
@@ -8,13 +8,10 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp = pet:getTP()
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    local damage = math.floor(45 + 0.025 * tp)
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(45 + 0.025 * pet:getTP() + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.EARTH, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.EARTH, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, 1)

--- a/scripts/actions/abilities/pets/stone_iv.lua
+++ b/scripts/actions/abilities/pets/stone_iv.lua
@@ -8,13 +8,10 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT   = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp     = pet:getTP()
-    local damage = math.floor(325 + 0.025 * tp)
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(325 + 0.025 * pet:getTP() + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.EARTH, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.EARTH, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, 1)

--- a/scripts/actions/abilities/pets/thunder_ii.lua
+++ b/scripts/actions/abilities/pets/thunder_ii.lua
@@ -8,13 +8,10 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp   = pet:getTP()
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    local damage = math.floor(45 + 0.025 * tp)
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(45 + 0.025 * pet:getTP() + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.THUNDER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.THUNDER, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.THUNDER, 1)

--- a/scripts/actions/abilities/pets/thunder_iv.lua
+++ b/scripts/actions/abilities/pets/thunder_iv.lua
@@ -8,13 +8,10 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp   = pet:getTP()
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    local damage = math.floor(325 + 0.025 * tp)
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(325 + 0.025 * pet:getTP() + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.THUNDER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.THUNDER, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.THUNDER, 1)

--- a/scripts/actions/abilities/pets/thunderspark.lua
+++ b/scripts/actions/abilities/pets/thunderspark.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Thunderspark M=whatever
+-- Thunderspark
 -----------------------------------
 local abilityObject = {}
 
@@ -8,33 +8,21 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local numhits = 1
-    local accmod = 1
-    local dmgmod = 2
-    local dmgmodsubsequent = 1 -- ??
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    local damage = xi.summon.avatarPhysicalMove(pet, target, petskill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
-    --get resist multiplier (1x if no resist)
-    local resist = xi.mobskills.applyPlayerResistance(pet, -1, target, pet:getStat(xi.mod.INT)-target:getStat(xi.mod.INT), xi.skill.ELEMENTAL_MAGIC, xi.element.THUNDER)
-    --get the resisted damage
-    damage.dmg = damage.dmg * resist
-    --add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
-    damage.dmg = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.THUNDER, petskill)
+    local damage = math.floor(275 + pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
 
-    local tp = pet:getTP()
-    if tp < 1000 then
-        tp = 1000
-    end
+    -- Add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
+    damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage.dmg, xi.element.THUNDER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.THUNDER, petskill)
+    damage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.THUNDER, 1)
 
-    damage.dmg = damage.dmg * tp / 1000
-    local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.THUNDER, numhits)
+    target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.THUNDER)
+    target:updateEnmityFromDamage(pet, damage)
+
     target:addStatusEffect(xi.effect.PARALYSIS, 15, 0, 60)
-    target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.THUNDER)
-    target:updateEnmityFromDamage(pet, totaldamage)
 
-    return totaldamage
+    return damage
 end
 
 return abilityObject

--- a/scripts/actions/abilities/pets/thunderstorm.lua
+++ b/scripts/actions/abilities/pets/thunderstorm.lua
@@ -10,22 +10,20 @@ end
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    local dINT   = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp     = pet:getTP() / 10
+    local tp = pet:getTP()
+
+    -- Merit TP bonus.
     local merits = 0
 
-    if summoner ~= nil and summoner:isPC() then
+    if summoner and summoner:isPC() then
         merits = summoner:getMerit(xi.merit.THUNDERSTORM)
     end
 
-    tp = tp + (merits - 40)
-    if tp > 300 then
-        tp = 300
-    end
+    tp = utils.clamp(tp + merits - 400, 0, 3000)
 
     --note: this formula is only accurate for level 75 - 76+ may have a different intercept and/or slope
-    local damage = math.floor(512 + 1.72 * (tp + 1))
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(256 + 0.172 * tp + pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.THUNDER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.THUNDER, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.THUNDER, 1)

--- a/scripts/actions/abilities/pets/tidal_wave.lua
+++ b/scripts/actions/abilities/pets/tidal_wave.lua
@@ -8,13 +8,10 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    local level = pet:getMainLvl()
-    local damage = 48 + (level * 8)
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(48 + pet:getMainLvl() * 8 + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.WATER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WATER, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.WATER, 1)

--- a/scripts/actions/abilities/pets/tornado_ii.lua
+++ b/scripts/actions/abilities/pets/tornado_ii.lua
@@ -9,18 +9,11 @@ end
 
 -- Modeling this on the known formula for magical Merit BPs of the same level with a merit level of 0
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT   = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp     = pet:getTP() / 10
-
-    if tp > 300 then
-        tp = 300
-    end
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
     --note: this formula is only accurate for level 75 - 76+ may have a different intercept and/or slope
-    local damage = math.floor(512 + 1.72 * (tp + 1))
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(512 + 0.172 * pet:getTP() + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WIND, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)

--- a/scripts/actions/abilities/pets/water_ii.lua
+++ b/scripts/actions/abilities/pets/water_ii.lua
@@ -8,13 +8,10 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp   = pet:getTP()
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    local damage = math.floor(45 + 0.025 * tp)
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(45 + 0.025 * pet:getTP() + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.WATER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WATER, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.WATER, 1)

--- a/scripts/actions/abilities/pets/water_iv.lua
+++ b/scripts/actions/abilities/pets/water_iv.lua
@@ -8,13 +8,10 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT   = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp     = pet:getTP()
-    local damage = math.floor(325 + 0.025 * tp)
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(325 + 0.025 * pet:getTP() + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.WATER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WATER, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.WATER, 1)

--- a/scripts/actions/abilities/pets/wind_blade.lua
+++ b/scripts/actions/abilities/pets/wind_blade.lua
@@ -8,25 +8,22 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
-    local dINT   = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp     = pet:getTP() / 10
-    local master = pet:getMaster()
-    local merits = 0
-
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    if master ~= nil and master:isPC() then
-        merits = master:getMerit(xi.merit.WIND_BLADE)
+    local tp = pet:getTP()
+
+    -- Merit TP bonus.
+    local merits = 0
+
+    if summoner and summoner:isPC() then
+        merits = summoner:getMerit(xi.merit.WIND_BLADE)
     end
 
-    tp = tp + (merits - 40)
-    if tp > 300 then
-        tp = 300
-    end
+    tp = utils.clamp(tp + merits - 400, 0, 3000)
 
     --note: this formula is only accurate for level 75 - 76+ may have a different intercept and/or slope
-    local damage = math.floor(512 + 1.72 * (tp + 1))
-    damage = damage + (dINT * 1.5)
+    local damage = math.floor(512 + 0.172 * tp + (pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)) * 1.5)
+
     damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.element.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.element.WIND, petskill)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)

--- a/scripts/actions/abilities/pets/zantetsuken.lua
+++ b/scripts/actions/abilities/pets/zantetsuken.lua
@@ -1,18 +1,23 @@
 -----------------------------------
 -- Zantetsuken
+-- Wanna bet this is made up?
 -----------------------------------
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    return 0, 0
+    return xi.job_utils.summoner.canUseBloodPact(player, player:getPet(), target, ability)
 end
 
-abilityObject.onPetAbility = function(target, pet, skill, master)
-    local power = master:getMP() / master:getMaxMP()
-    master:setMP(0)
+abilityObject.onPetAbility = function(target, pet, skill, summoner, action)
+    local returnParam = 0
 
+    local power = summoner:getMP() / utils.clamp(summoner:getMaxMP(), 1, 9999)
+    summoner:setMP(0)
+
+    -- Damage
     if target:isNM() then
-        local dmg = 0.1 * target:getHP() + 0.1 * target:getHP() * power
+        local dmg = (target:getHP() + target:getHP() * power) / 10
+
         if dmg > 9999 then
             dmg = 9999
         end
@@ -20,20 +25,32 @@ abilityObject.onPetAbility = function(target, pet, skill, master)
         dmg = xi.mobskills.mobMagicalMove(pet, target, skill, dmg, xi.element.DARK, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
         dmg = xi.mobskills.mobAddBonuses(pet, target, dmg.dmg, xi.element.DARK, skill)
         dmg = xi.summon.avatarFinalAdjustments(dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, 1)
+
         target:takeDamage(dmg, pet, xi.attackType.MAGICAL, xi.damageType.DARK)
         target:updateEnmityFromDamage(pet, dmg)
-        return dmg
+
+        returnParam = dmg
+
+    -- Insta-kill: Highly innacurate against regular monsters.
     else
-        local chance = (100 * power) / skill:getTotalTargets()
-        if math.random(0, 99) < chance and target:getAnimation() ~= 33 then
+        local chance = 50 * power / utils.clamp(skill:getTotalTargets(), 1, 50)
+
+        if
+            math.random(1, 100) <= chance and
+            target:getAnimation() ~= 33
+        then
             skill:setMsg(xi.msg.basic.SKILL_ENFEEB_IS)
             target:takeDamage(target:getHP(), pet, xi.attackType.MAGICAL, xi.damageType.DARK)
-            return xi.effect.KO
+
+            returnParam = xi.effect.KO
         else
             skill:setMsg(xi.msg.basic.EVADES)
-            return 0
+
+            returnParam = 0
         end
     end
+
+    return returnParam
 end
 
 return abilityObject

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -7,6 +7,7 @@
 require('scripts/globals/combat/magic_hit_rate')
 require('scripts/globals/magicburst')
 require('scripts/globals/magic')
+require('scripts/globals/spells/damage_spell')
 require('scripts/globals/utils')
 -----------------------------------
 xi = xi or {}
@@ -265,59 +266,58 @@ end
 -- xi.mobskills.magicalTpBonus.DMG_BONUS and TP = 100, tpvalue = 2, assume V=150  --> damage is now 150*(TP*2) / 100 = 300
 -- xi.mobskills.magicalTpBonus.DMG_BONUS and TP = 200, tpvalue = 2, assume V=150  --> damage is now 150*(TP*2) / 100 = 600
 
-xi.mobskills.mobMagicalMove = function(mob, target, skill, damage, element, dmgmod, tpeffect, tpvalue)
-    local returninfo = {}
+xi.mobskills.mobMagicalMove = function(actor, target, action, baseDamage, actionElement, damageModifier, tpEffect, tpMultiplier)
+    local returnInfo = {} -- TODO: Destroy
 
-    local mdefBarBonus = 0
-    if
-        element >= xi.element.FIRE and
-        element <= xi.element.WATER and
-        target:hasStatusEffect(xi.magic.barSpell[element])
-    then -- bar- spell magic defense bonus
-        mdefBarBonus = target:getStatusEffect(xi.magic.barSpell[element]):getSubPower()
+    local finalDamage = 0
+
+    -- Base damage
+    if tpEffect == xi.mobskills.magicalTpBonus.DMG_BONUS then
+        finalDamage = math.floor(baseDamage * action:getTP() * tpMultiplier / 1000)
     end
 
-    -- plus 100 forces it to be a number
-    local mab = (100 + mob:getMod(xi.mod.MATT)) / (100 + target:getMod(xi.mod.MDEF) + mdefBarBonus)
-    mab = utils.clamp(mab, 0.7, 1.3)
-
-    if tpeffect == xi.mobskills.magicalTpBonus.DMG_BONUS then
-        damage = damage * (((skill:getTP() / 10) * tpvalue) / 100)
-    end
-
-    -- resistance is added last
-    local finaldmg = damage * mab * dmgmod
-
-    -- get resistance
+    -- Get bonus macc.
     local petAccBonus = 0
-    if mob:isPet() and mob:getMaster() ~= nil then
-        local master = mob:getMaster()
-        if mob:isAvatar() then
-            petAccBonus = utils.clamp(master:getSkillLevel(xi.skill.SUMMONING_MAGIC) - master:getMaxSkillLevel(mob:getMainLvl(), xi.job.SMN, xi.skill.SUMMONING_MAGIC), 0, 200)
+    if actor:isPet() and actor:getMaster() ~= nil then
+        local master = actor:getMaster()
+        if actor:isAvatar() then
+            petAccBonus = utils.clamp(master:getSkillLevel(xi.skill.SUMMONING_MAGIC) - master:getMaxSkillLevel(actor:getMainLvl(), xi.job.SMN, xi.skill.SUMMONING_MAGIC), 0, 200)
         end
 
-        local skillchainTier, _ = xi.magicburst.formMagicBurst(element, target)
+        local skillchainTier, _ = xi.magicburst.formMagicBurst(actionElement, target)
         if
-            mob:getPetID() > 0 and
+            actor:getPetID() > 0 and
             skillchainTier > 0
         then
             petAccBonus = petAccBonus + 25
         end
     end
 
-    local resist       = xi.mobskills.applyPlayerResistance(mob, nil, target, mob:getStat(xi.mod.INT)-target:getStat(xi.mod.INT), petAccBonus, element)
-    local magicDefense = getElementalDamageReduction(target, element)
+    -- Multipliers.
+    local sdt                         = xi.spells.damage.calculateSDT(target, actionElement)
+    local resist                      = xi.mobskills.applyPlayerResistance(actor, nil, target, actor:getStat(xi.mod.INT) - target:getStat(xi.mod.INT), petAccBonus, actionElement)
+    local dayAndWeather               = xi.spells.damage.calculateDayAndWeather(actor, 0, actionElement)
+    local magicBonusDiff              = xi.spells.damage.calculateMagicBonusDiff(actor, target, 0, 0, actionElement)
+    local targetMagicDamageAdjustment = xi.spells.damage.calculateTMDA(target, actionElement)
 
-    finaldmg       = finaldmg * resist * magicDefense
-    returninfo.dmg = finaldmg
+    -- Calculate final damage.
+    finalDamage = math.floor(finalDamage * sdt)
+    finalDamage = math.floor(finalDamage * resist)
+    finalDamage = math.floor(finalDamage * dayAndWeather)
+    finalDamage = math.floor(finalDamage * magicBonusDiff)
+    finalDamage = math.floor(finalDamage * targetMagicDamageAdjustment)
+    finalDamage = math.floor(finalDamage * damageModifier)
 
     -- magical mob skills are single hit so provide single Melee hit TP return if primary target
-    if finaldmg > 0 and skill:getPrimaryTargetID() == target:getID() then
-        local tpReturn = xi.combat.tp.getSingleMeleeHitTPReturn(mob, target)
-        mob:addTP(tpReturn)
+    -- TODO: This should probably be moved to AFTER all damage is calculated, since this is not the final step.
+    if finalDamage > 0 and action:getPrimaryTargetID() == target:getID() then
+        local tpReturn = xi.combat.tp.getSingleMeleeHitTPReturn(actor, target)
+        actor:addTP(tpReturn)
     end
 
-    return returninfo
+    returnInfo.dmg = finalDamage
+
+    return returnInfo
 end
 
 -- effect = xi.effect.WHATEVER if enfeeble
@@ -351,72 +351,20 @@ xi.mobskills.applyPlayerResistance = function(actor, effect, target, diff, bonus
     return resistRate
 end
 
-xi.mobskills.mobAddBonuses = function(caster, target, dmg, ele, skill) -- used for SMN magical bloodpacts, despite the name.
-    local magicDefense = getElementalDamageReduction(target, ele)
-    dmg = math.floor(dmg * magicDefense)
+xi.mobskills.mobAddBonuses = function(actor, target, damage, element, skill) -- used for SMN magical bloodpacts, despite the name.
+    local burst = calculateMobMagicBurst(actor, element, target)
 
-    local dayWeatherBonus = 1.00
-
-    if caster:getWeather() == xi.magic.singleWeatherStrong[ele] then
-        if math.random() < 0.33 then
-            dayWeatherBonus = dayWeatherBonus + 0.10
-        end
-    elseif caster:getWeather() == xi.magic.singleWeatherWeak[ele] then
-        if math.random() < 0.33 then
-            dayWeatherBonus = dayWeatherBonus - 0.10
-        end
-    elseif caster:getWeather() == xi.magic.doubleWeatherStrong[ele] then
-        if math.random() < 0.33 then
-            dayWeatherBonus = dayWeatherBonus + 0.25
-        end
-    elseif caster:getWeather() == xi.magic.doubleWeatherWeak[ele] then
-        if math.random() < 0.33 then
-            dayWeatherBonus = dayWeatherBonus - 0.25
-        end
-    end
-
-    if VanadielDayElement() == xi.magic.dayStrong[ele] then
-        if math.random() < 0.33 then
-            dayWeatherBonus = dayWeatherBonus + 0.10
-        end
-    elseif VanadielDayElement() == xi.magic.dayWeak[ele] then
-        if math.random() < 0.33 then
-            dayWeatherBonus = dayWeatherBonus - 0.10
-        end
-    end
-
-    dayWeatherBonus = math.min(1.35, dayWeatherBonus)
-    dmg             = math.floor(dmg * dayWeatherBonus)
-
-    local burst = calculateMobMagicBurst(caster, ele, target)
     if
         skill and
-        burst > 1.0 and
-        caster:getPetID() > 0 -- all pets except charmed pets can get magic burst message, but only with petskill action
+        burst > 1 and
+        actor:getPetID() > 0 -- all pets except charmed pets can get magic burst message, but only with petskill action
     then
         skill:setMsg(xi.msg.basic.JA_MAGIC_BURST)
     end
 
-    dmg         = math.floor(dmg * burst)
+    damage = math.floor(damage * burst)
 
-    local mdefBarBonus = 0
-    if
-        ele >= xi.element.FIRE and
-        ele <= xi.element.WATER and
-        target:hasStatusEffect(xi.magic.barSpell[ele])
-    then -- bar- spell magic defense bonus
-        mdefBarBonus = target:getStatusEffect(xi.magic.barSpell[ele]):getSubPower()
-    end
-
-    local mab = (100 + caster:getMod(xi.mod.MATT)) / (100 + target:getMod(xi.mod.MDEF) + mdefBarBonus)
-
-    dmg = math.floor(dmg * mab)
-
-    local magicDmgMod = (10000 + target:getMod(xi.mod.DMGMAGIC)) / 10000
-
-    dmg = math.floor(dmg * magicDmgMod)
-
-    return dmg
+    return damage
 end
 
 -- Calculates breath damage

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -133,7 +133,7 @@ xi.summon.avatarPhysicalMove = function(avatar, target, skill, numberofhits, acc
     -- Only bonuses are applied for avatar level correction
     if shouldApplyLevelCorrection then
         if levelDiff > 0 then
-            levelCorrection = math.max((levelDiff * 2), 0)
+            levelCorrection = math.max(levelDiff * 2, 0)
         end
     end
 
@@ -143,10 +143,10 @@ xi.summon.avatarPhysicalMove = function(avatar, target, skill, numberofhits, acc
     -- Normal hits computed first
     local hitrateSubsequent = 75 + dAcc + levelCorrection
     local hitrateFirst      = hitrateSubsequent + 50 -- First hit gets a +100 ACC bonus which translates to +50 hit
-    hitrateSubsequent = hitrateSubsequent / 100
-    hitrateFirst      = hitrateFirst / 100
-    hitrateSubsequent = utils.clamp(hitrateSubsequent, minHitRate, maxHitRate)
-    hitrateFirst      = utils.clamp(hitrateFirst, minHitRate, maxHitRate)
+    hitrateSubsequent       = hitrateSubsequent / 100
+    hitrateFirst            = hitrateFirst / 100
+    hitrateSubsequent       = utils.clamp(hitrateSubsequent, minHitRate, maxHitRate)
+    hitrateFirst            = utils.clamp(hitrateFirst, minHitRate, maxHitRate)
 
     -- Compute hits first so we can exit early
     local firstHitLanded   = false
@@ -231,7 +231,7 @@ xi.summon.avatarPhysicalMove = function(avatar, target, skill, numberofhits, acc
             end
 
             local qRatio = getRandRatio(wRatio)                  -- Get a random ratio from min and max.
-            local pDif   = qRatio * (1 + (math.random() * 0.05)) -- Final pDif is qRatio randomized with a 1-1.05 multiplier.
+            local pDif   = qRatio * (1 + math.random() * 0.05) -- Final pDif is qRatio randomized with a 1-1.05 multiplier.
 
             if isCrit then
                 pDif = pDif * critAttackBonus
@@ -348,27 +348,20 @@ xi.summon.avatarFinalAdjustments = function(dmg, mob, skill, target, skilltype, 
     end
 
     -- Calculate Blood Pact Damage before stoneskin
-    dmg = dmg + dmg * mob:getMod(xi.mod.BP_DAMAGE) / 100
+    dmg = math.floor(dmg + dmg * mob:getMod(xi.mod.BP_DAMAGE) / 100)
+
+    if dmg < 0 then
+        return dmg
+    end
 
     -- handle One For All, Liement
     if skilltype == xi.attackType.MAGICAL then
-        local targetMagicDamageAdjustment = xi.spells.damage.calculateTMDA(target, damagetype) -- Apply checks for Liement, MDT/MDTII/DT
-
-        dmg = math.floor(dmg * targetMagicDamageAdjustment)
-        if dmg < 0 then
-            return dmg
-        end
-
         dmg = utils.oneforall(target, dmg)
     end
 
     -- Handle Phalanx
     if dmg > 0 then
         dmg = utils.clamp(dmg - target:getMod(xi.mod.PHALANX), 0, 99999)
-    end
-
-    if skilltype == xi.attackType.MAGICAL then
-        dmg = utils.oneforall(target, dmg)
     end
 
     -- handling stoneskin


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Mobskill/Summon magical multipliers where stupidly divided among several functions, resulting in several multipliers being repeatedly applied, or not applied at all, depending on the amount of functions used.

This:
- Makes calculations used the magic rewrite new functions.
- Makes 1 function handle all multipliers, which is the function used for all magical skills, another the magic burst, which councidentally is the function used for the only skills that CAN magic burst, and the final one the final operations (phalanx, shadows, one for all, stoneaskin, etc)
- Audits several petskills. Including a magical petskill being treated as physical.

## Steps to test these changes

Play, summon, use magical skills and take cover

To review:
- The important changes are located in the global scripts. The individual skill scripts are mostly style and consistency