### PR TITLE
[cpp] Better skillup handling with sch arts active

### DIFF
--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -97,6 +97,7 @@ namespace charutils
     void   DistributeCapacityPoints(CCharEntity* PChar, CMobEntity* PMob);
 
     void TrySkillUP(CCharEntity* PChar, SKILLTYPE SkillID, uint8 lvl, bool forceSkillUp = false, bool useSubSkill = false);
+    bool ArtsBonusActive(CCharEntity* PChar, SKILLTYPE SkillID);
     void BuildingCharSkillsTable(CCharEntity* PChar);
     void BuildingCharWeaponSkills(CCharEntity* PChar);
     void BuildingCharAbilityTable(CCharEntity* PChar);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes #1981 .

## Steps to test these changes

at 0 skill enf with dark arts was at 246, skilled up and it stayed the same:
![image](https://github.com/LandSandBoat/server/assets/131182600/a85e3ba4-69a1-4bd0-b005-14a194e2c0f7)

at 200 real skill, dark arts put me to 246. Skillup put me to 247:
![image](https://github.com/LandSandBoat/server/assets/131182600/bf18b9ac-6856-42b2-a7af-e7234f39d040)

![image](https://github.com/LandSandBoat/server/assets/131182600/23952dff-9e53-416f-882b-e2f7badc1fa5)

