### PR TITLE
[lua] Move trigger area after wider trigger area in Alz Undersea Ruins

### DIFF
--- a/scripts/zones/Alzadaal_Undersea_Ruins/Zone.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/Zone.lua
@@ -13,7 +13,6 @@ zoneObject.onInitialize = function(zone)
     zone:registerTriggerArea(7, -208, -2, -556, -202, 0, -551)  -- map 5 porter (white)
     zone:registerTriggerArea(8,  323, -2, 591, 329, 0, 598)     -- map 6 east porter (white)
     zone:registerTriggerArea(9,  270, -2, 591, 276, 0, 598)     -- map 6 west porter (blue)
-    zone:registerTriggerArea(10, 442, -2, -557, 450, 0, -550)   -- map 7 porter (white)
     zone:registerTriggerArea(11, -63, -10,  56, -57, -8,  62)   -- map 8 NW/Arrapago porter
     zone:registerTriggerArea(12,  17, -6,  56,  23, -4,  62)    -- map 8 NE/Silver Sea/Khim porter
     zone:registerTriggerArea(13, -63, -10, -23, -57, -8, -16)   -- map 8 SW/Zhayolm/bird camp porter
@@ -29,6 +28,7 @@ zoneObject.onInitialize = function(zone)
     zone:registerTriggerArea(23, 394, -1, -619, 487, 1, -540)   -- map 7, Whole zone right before the door (as per BG-Wiki). https://www.bg-wiki.com/ffxi/Aht_Urhgan_Mission_9. ToAU mission 9.
     zone:registerTriggerArea(24,  52, -1, 774, 67, 1, 778)      -- transformations (quest)
     zone:registerTriggerArea(25, 134, -1, -584, 146, 1, -577)   -- transformations (quest)
+    zone:registerTriggerArea(26, 442, -2, -557, 450, 0, -550)   -- map 7 porter (white) (moved after region 23 to avoid spamming events)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)
@@ -95,7 +95,7 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
             player:startEvent(201)
         end,
 
-        [10] = function(x)
+        [26] = function(x)
             player:startEvent(213)
         end,
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes #3976 .

A player can only be within one region at any given time. Once they enter that region, they're marked as in it and cannot trigger the `onTriggerAreaEnter`. The linked issue was caused by entering the teleporter region, then being entered into the bigger mission region. Reversing the order makes the teleporter work properly. Also confirmed that the mission region can still trigger.

## Steps to test these changes

`!pos 436.414 0.05 -552.659 72`, walk onto platform, hit no and see that the message doesn't come back up

confirm mission works
- `!addmission toau 8`
- `!zone 50`
- `!gotoname Naja_Salaheem`
- interact for the cutscene telling you to investigate 
- `!pos 436.414 0.05 -552.659 72`
- Run out door and go back in to trigger cutscene
  - Note that this puts you _inside_ the mission region, which was changed to not trigger the logic on zone-in.
  - Under normal circumstances, you'd enter this zone via a teleporter and the event would trigger normally