### PR TITLE
[Quest]RNG AF1-3 Series Conversion IF

### DIFF
--- a/scripts/actions/abilities/scavenge.lua
+++ b/scripts/actions/abilities/scavenge.lua
@@ -13,25 +13,18 @@ end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
     -- RNG AF2 quest check
-    local fireAndBrimstoneCS = player:getCharVar('fireAndBrimstone')
-    local oldEarring         = 1113 -- TODO: Use items file.
+    local oldEarring         = xi.item.OLD_EARRING
 
     if
-        player:getZoneID() == 151 and fireAndBrimstoneCS == 5 and-- zone + quest match
+        player:getZoneID() == xi.zone.CASTLE_OZTROJA and
+        player:getCharVar('Quest[2][73]Prog') == 4 and-- zone + quest match
         not player:hasItem(oldEarring) and -- make sure player doesn't already have the earring
         player:getYPos() > -43 and player:getYPos() < -38 and -- Y match
         player:getXPos() > -85 and player:getXPos() < -73 and -- X match
         player:getZPos() > -85 and player:getZPos() < -75 and -- Z match
         math.random(1, 100) <= 50
     then
-        if player:getFreeSlotsCount() == 0 then
-            player:messageSpecial(zones[player:getZoneID()].text.ITEM_CANNOT_BE_OBTAINED, oldEarring)
-            return
-        else
-            player:addItem(oldEarring)
-            player:messageSpecial(zones[player:getZoneID()].text.ITEM_OBTAINED, oldEarring)
-        end
-
+        npcUtil.giveItem(player, oldEarring)
     else
         local bonuses        = (player:getMod(xi.mod.SCAVENGE_EFFECT) + player:getMerit(xi.merit.SCAVENGE_EFFECT)) / 100
         local arrowsToReturn = math.floor(math.floor(player:getLocalVar('ArrowsUsed') % 10000) * (player:getMainLvl() / 200 + bonuses))

--- a/scripts/quests/windurst/RNG_AF1_Sin_Hunting.lua
+++ b/scripts/quests/windurst/RNG_AF1_Sin_Hunting.lua
@@ -1,0 +1,170 @@
+-----------------------------------
+-- Sin Hunting (RNG AF1)
+-----------------------------------
+-- Log ID: 2, Quest ID: 72
+-- Perih Vashai: !pos 117 -3 92 241
+-- Perchond: !pos -182.844 4 -164.948 166
+-- Alexis: !pos 105 1 382 104
+-- qm2: !pos -10.946 -1.000 313.810 104
+-----------------------------------
+
+local quest = Quest:new(xi.questLog.WINDURST, xi.quest.id.windurst.SIN_HUNTING)
+
+quest.reward =
+{
+    item     = xi.item.SNIPING_BOW,
+}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_AVAILABLE and
+            player:getMainLvl() >= xi.settings.main.AF1_QUEST_LEVEL and
+            player:getMainJob() == xi.job.RNG
+        end,
+
+        [xi.zone.WINDURST_WOODS] =
+        {
+            ['Perih_Vashai'] = quest:progressEvent(523),
+
+            onEventFinish =
+            {
+                [523] = function(player, csid, option, npc)
+                    quest:begin(player)
+                    npcUtil.giveKeyItem(player, xi.ki.CHIEFTAINNESSS_TWINSTONE_EARRING)
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_ACCEPTED
+        end,
+
+        [xi.zone.WINDURST_WOODS] =
+        {
+            ['Perih_Vashai'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') <= 3 then
+                        return quest:event(524)
+                    else
+                        return quest:progressEvent(527)
+                    end
+                end,
+            },
+
+            ['Kapeh_Myohrye'] = quest:event(526),
+
+            ['Muhk_Johldy'] = quest:event(525),
+
+            onEventFinish =
+            {
+                [527] = function(player, csid, option, npc)
+                    if quest:complete(player) then
+                        player:delKeyItem(xi.ki.PERCHONDS_ENVELOPE)
+                    end
+                end,
+            },
+        },
+
+        [xi.zone.RANGUEMONT_PASS] =
+        {
+            ['Perchond'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 0 then
+                        return quest:progressEvent(3, 0, xi.item.PINCH_OF_GLITTERSAND)
+                    elseif quest:getVar(player, 'Prog') == 2 then
+                        return quest:event(6)
+                    else
+                        return quest:event(4, 0, xi.item.PINCH_OF_GLITTERSAND)
+                    end
+                end,
+
+                onTrade = function(player, npc, trade)
+                    if
+                        npcUtil.tradeHasExactly(trade, xi.item.PINCH_OF_GLITTERSAND) and
+                        quest:getVar(player, 'Prog') == 1
+                    then
+                        return quest:progressEvent(5)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [3] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 1)
+                end,
+
+                [5] = function(player, csid, option, npc)
+                    player:tradeComplete()
+                    quest:setVar(player, 'Prog', 2)
+                    npcUtil.giveKeyItem(player, xi.ki.PERCHONDS_ENVELOPE)
+                end,
+            },
+        },
+
+        [xi.zone.JUGNER_FOREST] =
+        {
+            ['Alexius'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 2 then
+                        return quest:progressEvent(10)
+                    elseif quest:getVar(player, 'Prog') == 3 then
+                        return quest:event(11)
+                    elseif quest:getVar(player, 'Prog') == 4 then
+                        return quest:event(12)
+                    end
+                end,
+            },
+
+            ['qm2'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 3 then -- Full moon requirement removed.
+                        return quest:progressEvent(13, 0, xi.item.PINCH_OF_GLITTERSAND)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [10] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 3)
+                end,
+
+                [13] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 4)
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_COMPLETED
+        end,
+
+        [xi.zone.WINDURST_WOODS] =
+        {
+            ['Perih_Vashai'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.FIRE_AND_BRIMSTONE) == xi.questStatus.QUEST_AVAILABLE then
+                        return quest:event(528):replaceDefault()--dialog changes after each quest in the series is completed.
+                    end
+                end,
+            },
+
+            ['Kapeh_Myohrye'] = quest:event(530):replaceDefault(),
+            ['Muhk_Johldy']   = quest:event(529):replaceDefault(),
+        },
+    },
+}
+
+return quest

--- a/scripts/quests/windurst/RNG_AF2_Fire_and_Brimstone.lua
+++ b/scripts/quests/windurst/RNG_AF2_Fire_and_Brimstone.lua
@@ -1,0 +1,209 @@
+-----------------------------------
+-- Fire and Brimstone (RNG AF2)
+-----------------------------------
+-- Log ID: 2, Quest ID: 73
+-- Perih Vashai: !pos 117 -3 92 241
+-- Koh Lenbalalako: !pos -64.412 -17 29.213 249
+-- Gravestone: !pos 180 -32 -56 104
+-- Pool: !pos -79.0 -40.2 -76.3 151
+-----------------------------------
+local eldiemeID = zones[xi.zone.THE_ELDIEME_NECROPOLIS]
+-----------------------------------
+local quest = Quest:new(xi.questLog.WINDURST, xi.quest.id.windurst.FIRE_AND_BRIMSTONE)
+
+quest.reward =
+{
+    item     = xi.item.HUNTERS_BERET,
+}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_AVAILABLE and
+            player:getMainLvl() >= xi.settings.main.AF2_QUEST_LEVEL and
+            player:getMainJob() == xi.job.RNG and
+            player:hasCompletedQuest(xi.questLog.WINDURST, xi.quest.id.windurst.SIN_HUNTING)
+        end,
+
+        [xi.zone.WINDURST_WOODS] =
+        {
+            ['Perih_Vashai'] = quest:progressEvent(531),
+
+            onEventFinish =
+            {
+                [531] = function(player, csid, option, npc)
+                    quest:begin(player)
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_ACCEPTED
+        end,
+
+        [xi.zone.WINDURST_WOODS] =
+        {
+            ['Perih_Vashai'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') >= 0 and quest:getVar(player, 'Prog') < 3 then
+                        return quest:event(532) -- during RNG AF2
+                    elseif quest:getVar(player, 'Prog') == 3 then
+                        return quest:progressEvent(535, 0, xi.item.TWINSTONE_EARRING, xi.item.OLD_EARRING)
+                    elseif quest:getVar(player, 'Prog') == 4 then
+                        return quest:event(536, 0, xi.item.TWINSTONE_EARRING, xi.item.OLD_EARRING)
+                    end
+                end,
+
+                onTrade = function(player, npc, trade)
+                    if
+                        npcUtil.tradeHasExactly(trade, xi.item.OLD_EARRING) and
+                        quest:getVar(player, 'Prog') == 4
+                    then
+                        return quest:progressEvent(537, 0, xi.item.TWINSTONE_EARRING)
+                    end
+                end,
+            },
+
+            ['Kapeh_Myohrye'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') >= 2 then -- gives dialog after viewing cs about escaping prison.
+                        return quest:event(534)
+                    end
+                end,
+            },
+
+            ['Muhk_Johldy'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') >= 2 then -- gives dialog after viewing cs about escaping prison.
+                        return quest:event(533)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [535] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 4)
+                end,
+
+                [537] = function(player, csid, option, npc)
+                    if quest:complete(player) then
+                        player:tradeComplete()
+                        xi.quest.setMustZone(player, xi.questLog.WINDURST, xi.quest.id.windurst.UNBRIDLED_PASSION)
+                    end
+                end,
+            },
+        },
+
+        [xi.zone.MHAURA] =
+        {
+            ['Koh_Lenbalalako'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 0 then
+                        return quest:progressEvent(10007)
+                    elseif quest:getVar(player, 'Prog') == 2 then -- progress var so event wont trigger each time zoning into mhaura.
+                        return quest:event(323):oncePerZone()
+                    end
+                end,
+            },
+
+            onZoneIn =
+            {
+                function(player, prevZone)
+                    if quest:getVar(player, 'Prog') == 1 then
+                        return 10032
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [10007] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 1)
+                    player:setPos(-61.3135, -16.0000, 30.3377, 114, xi.zone.MHAURA)
+                end,
+
+                [10032] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 2)
+                end,
+            },
+        },
+
+        [xi.zone.THE_ELDIEME_NECROPOLIS] =
+        {
+            onZoneIn =
+            {
+                function(player, prevZone)
+                    if
+                        quest:getVar(player, 'Prog') == 2 and
+                        player:getPreviousZone() == xi.zone.BATALLIA_DOWNS
+                    then
+                        return 4
+                    end
+                end,
+            },
+
+            ['Gravestone'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 3 then
+                        if npc:getID() == eldiemeID.npc.GRAVESTONE_OFFSET then
+                            return quest:progressEvent(5)
+                        else
+                            player:messageSpecial(eldiemeID.text.NAMES_OF_DECEASED)
+                            return quest:messageSpecial(eldiemeID.text.SINNER_NOT_HERE)
+                        end
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [4] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 3)
+                end,
+
+                [5] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 4)
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_COMPLETED
+        end,
+
+        [xi.zone.WINDURST_WOODS] =
+        {
+            ['Gioh_Ajihri'] = quest:event(551, 0, xi.item.TWINSTONE_EARRING):importantOnce(),
+            ['Perih_Vashai'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.UNBRIDLED_PASSION) == xi.questStatus.QUEST_AVAILABLE then
+                        return quest:progressEvent(538):replaceDefault()
+                    end
+                end,
+            },
+
+            ['Muhk_Johldy'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.UNBRIDLED_PASSION) == xi.questStatus.QUEST_AVAILABLE then
+                        return quest:progressEvent(539):replaceDefault()
+                    end
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/quests/windurst/RNG_AF3_Unbridled_Passion.lua
+++ b/scripts/quests/windurst/RNG_AF3_Unbridled_Passion.lua
@@ -1,0 +1,204 @@
+-----------------------------------
+-- Unbridled Passion (RNG AF3)
+-----------------------------------
+-- Log ID: 2, Quest ID: 74
+-- Perih Vashai: !pos 117 -3 92 241
+-- Koh Lenbalalako: !pos -64.412 -17 29.213 249
+-- qm6: !pos -254.883 -17.003 -150.818 112
+-- qm7: !pos -295.065 -25.054 151.250 112
+-----------------------------------
+local ID = zones[xi.zone.XARCABARD]
+-----------------------------------
+local quest = Quest:new(xi.questLog.WINDURST, xi.quest.id.windurst.UNBRIDLED_PASSION)
+
+quest.reward =
+{
+    item     = xi.item.HUNTERS_SOCKS,
+    title    = xi.title.PARAGON_OF_RANGER_EXCELLENCE,
+}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_AVAILABLE and
+            player:getMainLvl() >= xi.settings.main.AF2_QUEST_LEVEL and
+            player:getMainJob() == xi.job.RNG and
+            player:hasCompletedQuest(xi.questLog.WINDURST, xi.quest.id.windurst.FIRE_AND_BRIMSTONE) and
+            not quest:getMustZone(player)
+        end,
+
+        [xi.zone.WINDURST_WOODS] =
+        {
+            ['Perih_Vashai'] = quest:progressEvent(541, 0, xi.item.TWINSTONE_EARRING),
+
+            onEventFinish =
+            {
+                [541] = function(player, csid, option, npc)
+                    quest:begin(player)
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_ACCEPTED
+        end,
+
+        [xi.zone.WINDURST_WOODS] =
+        {
+            ['Perih_Vashai'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') < 2 then
+                        return quest:event(542)-- Speak to Koh Lenbalalako
+                    elseif
+                        quest:getVar(player, 'Prog') >= 2 and
+                        quest:getVar(player, 'Prog') < 5
+                    then
+                        return quest:event(545)-- Follow to Northlands.
+                    elseif quest:getVar(player, 'Prog') >= 5 then
+                        return quest:progressEvent(546, 0, xi.item.HUNTERS_SOCKS) -- complete RNG AF3
+                    end
+                end,
+            },
+
+            ['Muhk_Johldy'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') < 5 then
+                        return quest:event(544)
+                    end
+                end,
+            },
+
+            ['Kapeh_Myohrye'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') < 5 then
+                        return quest:event(543)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [546] = function(player, csid, option, npc)
+                    quest:complete(player)
+                end,
+            },
+        },
+
+        [xi.zone.MHAURA] =
+        {
+            ['Koh_Lenbalalako'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 0 then
+                        return quest:progressEvent(10009, 0, xi.item.TWINSTONE_EARRING, xi.item.GOLD_EARRING)
+                    elseif quest:getVar(player, 'Prog') == 1 then
+                        return quest:event(10010, 0, 0, xi.item.GOLD_EARRING)
+                    elseif quest:getVar(player, 'Prog') == 2 then
+                        return quest:event(10012)
+                    end
+                end,
+
+                onTrade = function(player, npc, trade)
+                    if
+                        npcUtil.tradeHasExactly(trade, xi.item.GOLD_EARRING) and
+                        quest:getVar(player, 'Prog') == 1
+                    then
+                        return quest:progressEvent(10011)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [10009] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 1)
+                end,
+
+                [10011] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 2)
+                    npcUtil.giveKeyItem(player, xi.ki.KOHS_LETTER)
+                    player:tradeComplete()
+                end,
+            },
+        },
+
+        [xi.zone.XARCABARD] =
+        {
+            onZoneIn =
+            {
+                function(player, prevZone)
+                    if quest:getVar(player, 'Prog') == 2 then
+                        if player:getPreviousZone() == xi.zone.BEAUCEDINE_GLACIER then
+                            return 4
+                        else
+                            return 5
+                        end
+                    end
+                end,
+            },
+
+            ['qm6'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 4 then
+                        return quest:progressEvent(6, 0, xi.item.TWINSTONE_EARRING)
+                    elseif quest:getVar(player, 'Prog') == 5 then
+                        return quest:progressEvent(7)
+                    end
+                end,
+            },
+
+            ['qm7'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 3 then
+                        return quest:event(8)
+                    end
+                end,
+            },
+
+            ['Koenigstiger'] =
+            {
+                onMobDeath = function(mob, player, optParams)
+                    if quest:getVar(player, 'Prog') == 3 then
+                        quest:setVar(player, 'Prog', 4)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [4] = function(player, csid, option, npc) -- If entering from Beaucedine_Glacier
+                    quest:setVar(player, 'Prog', 3)
+                end,
+
+                [5] = function(player, csid, option, npc) -- If not entering from Beaucedine_Glacier
+                    quest:setVar(player, 'Prog', 3)
+                end,
+
+                [6] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 5)
+                end,
+
+                [7] = function(player, csid, option, npc)
+                    npcUtil.giveItem(player, { { xi.item.ICE_ARROW, 99 } })
+                    quest:setVar(player, 'Prog', 6) -- set var so players can't continue to get 99 arrows!
+                end,
+
+                [8] = function(player, csid, option, npc)
+                    if npcUtil.popFromQM(player, npc, ID.mob.KOENIGSTIGER, { claim = true, hide = 0 }) then
+                        return quest:messageSpecial(ID.text.MONSTER_DEEP_INSIDE)
+                    end
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/quests/windurst/The_Fanged_One.lua
+++ b/scripts/quests/windurst/The_Fanged_One.lua
@@ -130,12 +130,19 @@ quest.sections =
 
     {
         check = function(player, status, vars)
-            return status == xi.questStaus.QUEST_COMPLETED
+            return status == xi.questStatus.QUEST_COMPLETED
         end,
 
         [xi.zone.WINDURST_WOODS] =
         {
-            ['Perih_Vashai'] = quest:event(348):replaceDefault(),
+            ['Perih_Vashai'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.SIN_HUNTING) == xi.questStatus.QUEST_AVAILABLE then
+                        return quest:event(348):replaceDefault()--dialog changes after each quest in the series is completed.
+                    end
+                end,
+            },
         },
     },
 }

--- a/scripts/zones/Jugner_Forest/DefaultActions.lua
+++ b/scripts/zones/Jugner_Forest/DefaultActions.lua
@@ -2,4 +2,5 @@ local ID = zones[xi.zone.JUGNER_FOREST]
 
 return {
     ['Metallic_Hodgepodge'] = { ID.text.NOTHING_OUT_OF_ORDINARY },
+    ['qm2']                 = { messageSpecial = ID.text.DETECTS_DUST },
 }

--- a/scripts/zones/Jugner_Forest/IDs.lua
+++ b/scripts/zones/Jugner_Forest/IDs.lua
@@ -27,6 +27,7 @@ zones[xi.zone.JUGNER_FOREST] =
         AMK_DIGGING_OFFSET            = 7800,  -- You spot some familiar footprints. You are convinced that your moogle friend has been digging in the immediate vicinity.
         LOGGING_IS_POSSIBLE_HERE      = 7912,  -- Logging is possible here if you have <item>.
         VOIDWALKER_OBTAIN_KI          = 7919,  -- Obtained key item: <keyitem>!
+        DETECTS_DUST                  = 7943,  -- You detect a hint of sparkling dust on the tree.
         CONQUEST                      = 8063,  -- You've earned conquest points!
         GARRISON_BASE                 = 8431,  -- Hm? What is this? %? How do I know this is not some [San d'Orian/Bastokan/Windurstian] trick?
         PLAYER_OBTAINS_ITEM           = 8654,  -- <name> obtains <item>!

--- a/scripts/zones/Jugner_Forest/npcs/Alexius.lua
+++ b/scripts/zones/Jugner_Forest/npcs/Alexius.lua
@@ -14,8 +14,6 @@ end
 entity.onTrigger = function(player, npc)
     if player:hasKeyItem(xi.ki.WEAPONS_ORDER) then
         player:startEvent(5)
-    elseif player:getCharVar('sinHunting') == 3 then
-        player:startEvent(10)
     end
 end
 
@@ -27,8 +25,6 @@ entity.onEventFinish = function(player, csid, option, npc)
         player:delKeyItem(xi.ki.WEAPONS_ORDER)
         player:addKeyItem(xi.ki.WEAPONS_RECEIPT)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.WEAPONS_RECEIPT)
-    elseif csid == 10 then
-        player:setCharVar('sinHunting', 4)
     end
 end
 

--- a/scripts/zones/Jugner_Forest/npcs/qm2.lua
+++ b/scripts/zones/Jugner_Forest/npcs/qm2.lua
@@ -10,18 +10,12 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if player:getCharVar('sinHunting') == 4 then
-        player:startEvent(13, 0, 1107)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    if csid == 13 then
-        player:setCharVar('sinHunting', 5)
-    end
 end
 
 return entity

--- a/scripts/zones/Mhaura/DefaultActions.lua
+++ b/scripts/zones/Mhaura/DefaultActions.lua
@@ -5,6 +5,7 @@ return {
     ['Itzha_Delavhitta'] = { event = 900 },
     ['Jikka-Abukka']     = { event = 850 },
     ['Kotan-Purutan']    = { event = 140 },
+    ['Koh_Lenbalalako']  = { event = 10008 },
     ['Kupupu']           = { event = 800 },
     ['Lacia']            = { event = 10021 },
     ['Lakom-Lukom']      = { event = 600 },

--- a/scripts/zones/Mhaura/npcs/Koh_Lenbalalako.lua
+++ b/scripts/zones/Mhaura/npcs/Koh_Lenbalalako.lua
@@ -3,55 +3,18 @@
 --  NPC: Koh Lenbalalako
 -- !pos -64.412 -17 29.213 249
 -----------------------------------
-local ID = zones[xi.zone.MHAURA]
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if trade:hasItemQty(xi.item.GOLD_EARRING, 1) and trade:getItemCount() == 1 then -- Trade gold earring (during Rng AF3 quest)
-        local unbridledPassionCS = player:getCharVar('unbridledPassion')
-        if unbridledPassionCS == 2 then
-            player:startEvent(10011)
-        end
-    end
 end
 
 entity.onTrigger = function(player, npc)
-    local fireAndBrimstoneCS = player:getCharVar('fireAndBrimstone')
-    local unbridledPassionCS = player:getCharVar('unbridledPassion')
-
-    -- during RNG af2
-    if fireAndBrimstoneCS == 1 then
-        player:startEvent(10007)
-
-    -- during RNG af3
-    elseif unbridledPassionCS == 1 then
-        player:startEvent(10009, 0, 13360, xi.item.GOLD_EARRING)
-    elseif unbridledPassionCS == 2 then
-        player:startEvent(10010, 0, 0, xi.item.GOLD_EARRING)
-    elseif unbridledPassionCS == 3 then
-        player:startEvent(10012)
-
-    else
-        player:startEvent(10013)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    if csid == 10007 then
-        player:startEvent(10032)
-        player:setCharVar('fireAndBrimstone', 2)
-    elseif csid == 10009 then
-        player:setCharVar('unbridledPassion', 2)
-    elseif csid == 10011 then
-        player:addKeyItem(xi.ki.KOHS_LETTER)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.KOHS_LETTER)
-        player:tradeComplete()
-        player:setCharVar('unbridledPassion', 3)
-    end
 end
 
 return entity

--- a/scripts/zones/Ranguemont_Pass/DefaultActions.lua
+++ b/scripts/zones/Ranguemont_Pass/DefaultActions.lua
@@ -1,0 +1,6 @@
+local ID = zones[xi.zone.RANGUEMONT_PASS]
+
+return {
+    ['Perchond']           = { event = 2 },
+    ['Waters_of_Oblivion'] = { messageSpecial = ID.text.WATERS_OF_OBLIVION },
+}

--- a/scripts/zones/Ranguemont_Pass/IDs.lua
+++ b/scripts/zones/Ranguemont_Pass/IDs.lua
@@ -21,6 +21,7 @@ zones[xi.zone.RANGUEMONT_PASS] =
         MEMBERS_LEVELS_ARE_RESTRICTED = 7023,  -- Your party is unable to participate because certain members' levels are restricted.
         CONQUEST_BASE                 = 7064,  -- Tallying conquest results...
         FISHING_MESSAGE_OFFSET        = 7223,  -- You can't fish here.
+        WATERS_OF_OBLIVION            = 7365,  -- You behold the Waters of Oblivion.
         REGIME_REGISTERED             = 9533,  -- New training regime registered!
         PLAYER_OBTAINS_ITEM           = 10585, -- <name> obtains <item>!
         UNABLE_TO_OBTAIN_ITEM         = 10586, -- You were unable to obtain the item.

--- a/scripts/zones/Ranguemont_Pass/npcs/Perchond.lua
+++ b/scripts/zones/Ranguemont_Pass/npcs/Perchond.lua
@@ -3,45 +3,18 @@
 --  NPC: Perchond
 -- !pos -182.844 4 -164.948 166
 -----------------------------------
-local ID = zones[xi.zone.RANGUEMONT_PASS]
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if
-        trade:hasItemQty(xi.item.PINCH_OF_GLITTERSAND, 1) and
-        trade:getItemCount() == 1
-    then
-        local sinHunting = player:getCharVar('sinHunting')    -- RNG AF1
-
-        if sinHunting == 2 then
-            player:startEvent(5)
-        end
-    end
 end
 
 entity.onTrigger = function(player, npc)
-    local sinHunting = player:getCharVar('sinHunting')    -- RNG AF1
-
-    if sinHunting == 1 then
-        player:startEvent(3, 0, xi.item.PINCH_OF_GLITTERSAND)
-    else
-        player:startEvent(2)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    if csid == 3 then
-        player:setCharVar('sinHunting', 2)
-    elseif csid == 5 then
-        player:tradeComplete()
-        player:addKeyItem(xi.ki.PERCHONDS_ENVELOPE)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.PERCHONDS_ENVELOPE)
-        player:setCharVar('sinHunting', 3)
-    end
 end
 
 return entity

--- a/scripts/zones/Ranguemont_Pass/npcs/Waters_of_Oblivion.lua
+++ b/scripts/zones/Ranguemont_Pass/npcs/Waters_of_Oblivion.lua
@@ -23,8 +23,6 @@ entity.onTrigger = function(player, npc)
         SpawnMob(ID.mob.TROS):updateClaim(player)
     elseif player:hasKeyItem(xi.ki.MERTAIRES_BRACELET) and trosKilled == 1 then
         player:startEvent(8) -- Finish Quest 'Painful Memory'
-    else
-        player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)
     end
 end
 

--- a/scripts/zones/The_Eldieme_Necropolis/DefaultActions.lua
+++ b/scripts/zones/The_Eldieme_Necropolis/DefaultActions.lua
@@ -3,5 +3,6 @@ local ID = zones[xi.zone.THE_ELDIEME_NECROPOLIS]
 return {
     ['qm1']        = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
     ['Brazier']    = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
+    ['Gravestone'] = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
     ['Hume_Bones'] = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
 }

--- a/scripts/zones/The_Eldieme_Necropolis/IDs.lua
+++ b/scripts/zones/The_Eldieme_Necropolis/IDs.lua
@@ -45,6 +45,8 @@ zones[xi.zone.THE_ELDIEME_NECROPOLIS] =
         CHEST_UNLOCKED                   = 7417,  -- You unlock the chest!
         SPIRIT_INCENSE_EMITS_PUTRID_ODOR = 7427,  -- The <item> emits a putrid odor and burns up. Your attempt this time has failed...
         SARCOPHAGUS_CANNOT_BE_OPENED     = 7444,  -- It is a stone sarcophagus with the lid sealed tight. It cannot be opened.
+        NAMES_OF_DECEASED                = 7455,  -- The names of the deceased are carved upon the stone.
+        SINNER_NOT_HERE                  = 7456,  -- ...The name of the sinner's daughter is not here.
         SEEMS_TO_BE_THE_END              = 7572,  -- That seems to be the end of it.
         GIRL_BACK_TO_JEUNO               = 7584,  -- I'll take the little girl back to Jeuno. Take care.
         NOT_TIME_TO_SEARCH               = 7596,  -- Now doesn't seem to be the time to search here.
@@ -73,12 +75,13 @@ zones[xi.zone.THE_ELDIEME_NECROPOLIS] =
     },
     npc =
     {
-        GATE_OFFSET        = GetFirstID('_5f1'),
         BRAZIER            = GetFirstID('Brazier'),
+        CANDLE_OFFSET      = GetFirstID('_5fu'),
+        GATE_OFFSET        = GetFirstID('_5f1'),
+        GRAVESTONE_OFFSET  = GetFirstID('Gravestone'),
+        SARCOPHAGUS_OFFSET = GetFirstID('Sarcophagus'),
         TREASURE_CHEST     = GetFirstID('Treasure_Chest'),
         TREASURE_COFFER    = GetFirstID('Treasure_Coffer'),
-        SARCOPHAGUS_OFFSET = GetFirstID('Sarcophagus'),
-        CANDLE_OFFSET      = GetFirstID('_5fu'),
     },
 }
 

--- a/scripts/zones/The_Eldieme_Necropolis/npcs/Gravestone.lua
+++ b/scripts/zones/The_Eldieme_Necropolis/npcs/Gravestone.lua
@@ -10,18 +10,12 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if player:getCharVar('fireAndBrimstone') == 3 then
-        player:startEvent(5)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    if csid == 5 then
-        player:setCharVar('fireAndBrimstone', 4)
-    end
 end
 
 return entity

--- a/scripts/zones/Windurst_Woods/npcs/Perih_Vashai.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Perih_Vashai.lua
@@ -7,108 +7,12 @@
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    -- FIRE AND BRIMSTONE
-    if
-        player:getCharVar('fireAndBrimstone') == 5 and
-        npcUtil.tradeHas(trade, xi.item.OLD_EARRING)
-    then
-        -- old earring
-        player:startEvent(537, 0, 13360)
-    end
 end
 
 entity.onTrigger = function(player, npc)
-    local sinHunting = player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.SIN_HUNTING)-- RNG AF1
-    local sinHuntingCS = player:getCharVar('sinHunting')
-    local fireAndBrimstone = player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.FIRE_AND_BRIMSTONE)-- RNG AF2
-    local fireAndBrimstoneCS = player:getCharVar('fireAndBrimstone')
-    local unbridledPassion = player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.UNBRIDLED_PASSION)-- RNG AF3
-    local unbridledPassionCS = player:getCharVar('unbridledPassion')
-    local lvl = player:getMainLvl()
-    local job = player:getMainJob()
-
-    -- SIN HUNTING
-    if
-        sinHunting == xi.questStatus.QUEST_AVAILABLE and
-        job == xi.job.RNG and
-        lvl >= xi.settings.main.AF1_QUEST_LEVEL
-    then
-        player:startEvent(523) -- start RNG AF1
-    elseif sinHuntingCS > 0 and sinHuntingCS < 5 then
-        player:startEvent(524) -- during quest RNG AF1
-    elseif sinHuntingCS == 5 then
-        player:startEvent(527) -- complete quest RNG AF1
-
-    -- FIRE AND BRIMSTONE
-    elseif
-        sinHunting == xi.questStatus.QUEST_COMPLETED and
-        job == xi.job.RNG and
-        lvl >= xi.settings.main.AF2_QUEST_LEVEL and
-        fireAndBrimstone == xi.questStatus.QUEST_AVAILABLE
-    then
-        player:startEvent(531) -- start RNG AF2
-    elseif fireAndBrimstoneCS > 0 and fireAndBrimstoneCS < 4 then
-        player:startEvent(532) -- during RNG AF2
-    elseif fireAndBrimstoneCS == 4 then
-        player:startEvent(535, 0, 13360, xi.item.OLD_EARRING) -- second part RNG AF2
-    elseif fireAndBrimstoneCS == 5 then
-        player:startEvent(536, 0, 13360, xi.item.OLD_EARRING) -- during second part RNG AF2
-
-    -- UNBRIDLED PASSION
-    elseif
-        fireAndBrimstone == xi.questStatus.QUEST_COMPLETED and
-        job == xi.job.RNG and
-        lvl >= xi.settings.main.AF3_QUEST_LEVEL and
-        unbridledPassion == xi.questStatus.QUEST_AVAILABLE
-    then
-        player:startEvent(541, 0, 13360) -- start RNG AF3
-    elseif unbridledPassionCS > 0 and unbridledPassionCS < 3 then
-        player:startEvent(542)-- during RNG AF3
-    elseif unbridledPassionCS < 7 then
-        player:startEvent(542)-- during RNG AF3
-    elseif unbridledPassionCS == 7 then
-        player:startEvent(546, 0, 14099) -- complete RNG AF3
-    end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    -- SIN HUNTING
-    if csid == 523 then -- start quest RNG AF1
-        player:addQuest(xi.questLog.WINDURST, xi.quest.id.windurst.SIN_HUNTING)
-        npcUtil.giveKeyItem(player, xi.ki.CHIEFTAINNESSS_TWINSTONE_EARRING)
-        player:setCharVar('sinHunting', 1)
-    elseif
-        csid == 527 and
-        npcUtil.completeQuest(player, xi.questLog.WINDURST, xi.quest.id.windurst.SIN_HUNTING, { item = 17188, var = 'sinHunting' })
-    then
-        -- complete quest RNG AF1
-        player:delKeyItem(xi.ki.CHIEFTAINNESSS_TWINSTONE_EARRING)
-        player:delKeyItem(xi.ki.PERCHONDS_ENVELOPE)
-
-    -- FIRE AND BRIMSTONE
-    elseif csid == 531 then -- start RNG AF2
-        player:addQuest(xi.questLog.WINDURST, xi.quest.id.windurst.FIRE_AND_BRIMSTONE)
-        player:setCharVar('fireAndBrimstone', 1)
-    elseif csid == 535 then -- start second part RNG AF2
-        player:setCharVar('fireAndBrimstone', 5)
-    elseif
-        csid == 537 and
-        npcUtil.completeQuest(player, xi.questLog.WINDURST, xi.quest.id.windurst.FIRE_AND_BRIMSTONE, { item = 12518, var = 'fireAndBrimstone' })
-    then
-        -- complete quest RNG AF2
-        player:confirmTrade()
-
-    -- UNBRIDLED PASSION
-    elseif csid == 541 then -- start RNG AF3
-        player:addQuest(xi.questLog.WINDURST, xi.quest.id.windurst.UNBRIDLED_PASSION)
-        player:setCharVar('unbridledPassion', 1)
-    elseif
-        csid == 546 and
-        npcUtil.completeQuest(player, xi.questLog.WINDURST, xi.quest.id.windurst.UNBRIDLED_PASSION, { item = 14099, var = 'unbridledPassion' })
-    then
-        -- complete quest RNG AF3
-        player:delKeyItem(xi.ki.KOHS_LETTER)
-    end
 end
 
 return entity

--- a/scripts/zones/Xarcabard/IDs.lua
+++ b/scripts/zones/Xarcabard/IDs.lua
@@ -23,6 +23,7 @@ zones[xi.zone.XARCABARD] =
         BEASTMEN_BANNER                = 7156,  -- There was a curse on the beastmen's banner!
         ALREADY_OBTAINED_TELE          = 7386,  -- You already possess the gate crystal for this telepoint.
         CONQUEST                       = 7399,  -- You've earned conquest points!
+        MONSTER_DEEP_INSIDE            = 7240,  -- A monster appears from deep within the cave!
         ONLY_SHARDS                    = 7732,  -- Only shards of ice lie upon the ground.
         BLOCKS_OF_ICE                  = 7733,  -- You can hear blocks of ice moving from deep within the cave.
         PERENNIAL_SNOW_DEFAULT         = 7734,  -- How many millennia has this snow been here, hidden from the rays of the sun?

--- a/scripts/zones/Xarcabard/mobs/Koenigstiger.lua
+++ b/scripts/zones/Xarcabard/mobs/Koenigstiger.lua
@@ -6,9 +6,6 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    if player:getCharVar('unbridledPassion') == 4 then
-        player:setCharVar('unbridledPassion', 5)
-    end
 end
 
 return entity

--- a/scripts/zones/Xarcabard/npcs/qm6.lua
+++ b/scripts/zones/Xarcabard/npcs/qm6.lua
@@ -10,24 +10,12 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local unbridledPassionCS = player:getCharVar('unbridledPassion')
-
-    if unbridledPassionCS == 5 then
-        player:startEvent(6, 0, 13360)
-    elseif unbridledPassionCS == 6 then
-        player:startEvent(7)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    if csid == 6 then
-        player:setCharVar('unbridledPassion', 6)
-    elseif csid == 7 and npcUtil.giveItem(player, xi.item.ICE_ARROW) then
-        player:setCharVar('unbridledPassion', 7)
-    end
 end
 
 return entity

--- a/scripts/zones/Xarcabard/npcs/qm7.lua
+++ b/scripts/zones/Xarcabard/npcs/qm7.lua
@@ -4,29 +4,18 @@
 -- Involved in Quests: RNG AF3 quest - Unbridled Passion
 -- !pos -295.065 -25.054 151.250 112
 -----------------------------------
-local ID = zones[xi.zone.XARCABARD]
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if
-        player:getCharVar('unbridledPassion') == 4 and
-        not GetMobByID(ID.mob.KOENIGSTIGER):isSpawned()
-    then
-        player:startEvent(8)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    if csid == 8 then
-        SpawnMob(ID.mob.KOENIGSTIGER):updateClaim(player)
-    end
 end
 
 return entity


### PR DESCRIPTION
[Quest]RNG AF1-3 Series Conversion IF

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.
I realize this is a very large PR. My logic behind putting them all into one, besides it being a series, is the good chunk of the quests revolve around Perih Vashai, Koh Lenbalalako, Kapeh Myohrye, and Muhk Johldy. It seemed logical for testing to do them all at once.
## What does this pull request do?
Converts the RNG AF quests 1-3 series to Interaction Framework.

-Scavenge now uses Quest framework var format and enum'd zone and item.
    -Added a quest complete section and a check for next quest because the dialog changes on complete quest after each 
    one except for the last.
-Converts Sin Hunting (AF1) to IF.
    -Moves default dialog to DefaultActions where appropriate.
-Converts Fire and Brimstone (AF2) to IF
    -Adds dialogs to NPC's from near by NPC's that was previously not there.
    -Adds zoning requirement before next quest is available.
    -Players were previously able to select any Gravestone and complete that portion of the quest. They now will get correct 
    dialog if they chose the incorrect one. Only allowing the correct Gravestone to produce the progressing event.
    -Players must have zoned from Batallia Downs as per capture in order to get the cutscene.
-Converts Unbridled Passion (AF3)
    -Added dialog for different parts of mission based on progress.
    -Based on capture, depending on where player zoned in from, changes the cs but still progresses the same.
    -Allows players to still complete the quest even if they don't gather the 99 ice arrows that are optional.
-Adjusted The Fanged One to the correct dialog after quest complete but before accepting any other quest as the NPC 
    dialog changes based on progress in the quest series.
-Removed all NPC lua logic invovled with the quest series.

[Capture](https://www.youtube.com/watch?v=qPQwnp1gkMY&feature=youtu.be)
[Capture](https://www.youtube.com/watch?v=zSgfuHEfZ8g)
[Capture](https://www.youtube.com/watch?v=nmwUEdLbqdg)
[Capture](https://www.youtube.com/watch?v=pbowyq3ekHw)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Set job to RNG level 50 or higher and complete the quests. The info has all POS for particular points of interest.

One of these days I will be able to rebase without having some weird issues. 

Reference: https://github.com/LandSandBoat/server/pull/5822