### PR TITLE
[Module] Create module for quest workarounds

### DIFF
--- a/modules/custom/lua/quest_workarounds.lua
+++ b/modules/custom/lua/quest_workarounds.lua
@@ -1,0 +1,40 @@
+-----------------------------------
+-- This module is a compilation of overrides to temporarily fix
+-- parts of quests that are not currently fully functional due to something
+-- larger (like a system) not being implemented/operable.
+-----------------------------------
+-- Include the following:
+-- - Explanation of what quest(s) needs temporary fix
+-- - Link to issue reported on LSB
+-- - Explanation (if known) of how to fix
+-- - Include a TODO so it can be searched.
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('quest_workarounds')
+-----------------------------------
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    -- Bastok zones don't currently produce NONE weather, so we are adding SUNSHINE as an accepted weather so the quest becomes completable.
+    -- See: https://github.com/LandSandBoat/server/pull/5831
+    xi.module.modifyInteractionEntry('scripts/quests/bastok/Wish_Upon_a_Star', function(quest)
+        quest.sections[2][xi.zone.BASTOK_MARKETS]['Enu'].onTrade = function(player, npc, trade)
+        local isNight = VanadielTOTD() == xi.time.NIGHT or VanadielTOTD() == xi.time.MIDNIGHT
+            if npcUtil.tradeHasExactly(trade, xi.item.FALLEN_STAR) then
+                if
+                    player:getWeather() == xi.weather.NONE or
+                    player:getWeather() == xi.weather.SUNSHINE and
+                    isNight
+                then
+                    return quest:progressEvent(334)
+                else
+                    return quest:event(337)
+                end
+            end
+        end
+    end)
+end)
+
+return m


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Allows players to complete the quest Wish Upon a Star. Currently, Bastok does not have a "NONE" weather and therefore will never take the fallen star item. Adding sunshine (clear) remediates this.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Adds an or player:getWeather() == xi.weather.SUNSHINE
## Steps to test these changes
Run through the quest players will now be able to complete the quest.
<!-- Clear and detailed steps to test your changes here -->
