### PR TITLE
[core] Fix hp and mp visible gear latents

### DIFF
--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -279,7 +279,7 @@ INSERT INTO `item_latents` VALUES (13143,368,25,13,19);
 INSERT INTO `item_latents` VALUES (13143,368,25,13,193);
 
 -- Uggalepih Pendant
-INSERT INTO `item_latents` VALUES (13145,28,8,4,51);     -- "Magic Atk. Bonus" while MP <51%
+INSERT INTO `item_latents` VALUES (13145,28,8,45,51);     -- "Magic Atk. Bonus" while MP <51%
 
 -- Brisingamen +1
 INSERT INTO `item_latents` VALUES (13162,2,12,26,0);     -- Daytime: HP +12
@@ -1249,7 +1249,7 @@ INSERT INTO `item_latents` VALUES (15504,23,3,53,0);     -- ATK +3 in areas insi
 INSERT INTO `item_latents` VALUES (15504,25,3,53,0);     -- ACC +3 in areas inside own nation's control
 
 -- Parade Gorget
-INSERT INTO `item_latents` VALUES (15506,369,1,1,85);    -- Refresh when HP >=85%
+INSERT INTO `item_latents` VALUES (15506,369,1,46,85);    -- Refresh when HP >=85%
 
 -- Diabolos's Torque
 INSERT INTO `item_latents` VALUES (15516,24,7,52,8);     -- ranged acc+8 in Dark weather

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -713,6 +713,23 @@ CItemEquipment* CCharEntity::getEquip(SLOTTYPE slot)
     return item;
 }
 
+std::vector<CItemEquipment*> CCharEntity::getVisibleEquip()
+{
+    std::vector<CItemEquipment*> visibleItems;
+    CItemEquipment*              item = nullptr;
+
+    for (SLOTTYPE slot : { SLOT_MAIN, SLOT_SUB, SLOT_RANGED, SLOT_AMMO, SLOT_BODY, SLOT_HANDS, SLOT_LEGS, SLOT_FEET })
+    {
+        item = getEquip(slot);
+        if (item != nullptr)
+        {
+            visibleItems.emplace_back(item);
+        }
+    }
+
+    return visibleItems;
+}
+
 void CCharEntity::ReloadPartyInc()
 {
     m_reloadParty = true;

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -520,7 +520,8 @@ public:
     void   SetPlayTime(uint32 playTime);        // Set playtime
     uint32 GetPlayTime(bool needUpdate = true); // Get playtime
 
-    CItemEquipment* getEquip(SLOTTYPE slot);
+    CItemEquipment*              getEquip(SLOTTYPE slot);
+    std::vector<CItemEquipment*> getVisibleEquip();
 
     CBasicPacket* PendingPositionPacket = nullptr;
 

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -1011,57 +1011,36 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
             expression = m_POwner->health.hp < latentEffect.GetConditionsValue() && m_POwner->animation == ANIMATION_ATTACK;
             break;
         case LATENT::MP_UNDER_VISIBLE_GEAR:
-            // TODO: figure out if this is actually right
-            // CItemEquipment* head = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_HEAD]));
-            // CItemEquipment* body = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_BODY]));
-            // CItemEquipment* hands = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_HANDS]));
-            // CItemEquipment* legs = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_LEGS]));
-            // CItemEquipment* feet = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_FEET]));
+        {
+            // Since equipment is fairly specific to a player, don't put this visible calculation in battleentity
+            std::vector<CItemEquipment*> visibleEquip = m_POwner->getVisibleEquip();
 
-            // int32 visibleMp = 0;
-            // visibleMp += (head ? head->getModifier(Mod::MP) : 0);
-            // visibleMp += (body ? body->getModifier(Mod::MP) : 0);
-            // visibleMp += (hands ? hands->getModifier(Mod::MP) : 0);
-            // visibleMp += (legs ? legs->getModifier(Mod::MP) : 0);
-            // visibleMp += (feet ? feet->getModifier(Mod::MP) : 0);
+            int32 visibleMP = m_POwner->health.maxmp;
 
-            // TODO: add mp percent too
-            // if ((float)( mp / ((m_POwner->health.mp - m_POwner->health.modmp) + (m_POwner->PMeritPoints->GetMerit(MERIT_MAX_MP)->count * 10 ) +
-            //    visibleMp) ) <= m_LatentEffectList.at(i)->GetConditionsValue())
-            //{
-            //    m_LatentEffectList.at(i)->Activate();
-            //}
-            // else
-            //{
-            //    m_LatentEffectList.at(i)->Deactivate();
-            //}
+            for (auto equip: visibleEquip)
+            {
+                visibleMP += equip->getModifier(Mod::MP);
+            }
+            
+            // there is evidence that 0/0 (e.g., 0/20 with uggalepih pendant) does not trigger this latent
+            expression = visibleMP > 0 && ((static_cast<float>(m_POwner->health.mp) / static_cast<float>(visibleMP)) * 100) <= latentEffect.GetConditionsValue();
             break;
+        }
         case LATENT::HP_OVER_VISIBLE_GEAR:
-            // TODO: figure out if this is actually right
-            // CItemEquipment* head = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_HEAD]));
-            // CItemEquipment* body = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_BODY]));
-            // CItemEquipment* hands = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_HANDS]));
-            // CItemEquipment* legs = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_LEGS]));
-            // CItemEquipment* feet = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_FEET]));
+        {
+            // Since equipment is fairly specific to a player, don't put this visible calculation in battleentity
+            std::vector<CItemEquipment*> visibleEquip = m_POwner->getVisibleEquip();
 
-            // int32 visibleHp = 0;
-            // visibleHp += (head ? head->getModifier(Mod::HP) : 0);
-            // visibleHp += (body ? body->getModifier(Mod::HP) : 0);
-            // visibleHp += (hands ? hands->getModifier(Mod::HP) : 0);
-            // visibleHp += (legs ? legs->getModifier(Mod::HP) : 0);
-            // visibleHp += (feet ? feet->getModifier(Mod::HP) : 0);
+            int32 visibleHP = m_POwner->health.maxhp;
 
-            // TODO: add mp percent too
-            // if ((float)( hp / ((m_POwner->health.hp - m_POwner->health.modhp) + (m_POwner->PMeritPoints->GetMerit(MERIT_MAX_HP)->count * 10 ) +
-            //    visibleHp) ) <= m_LatentEffectList.at(i)->GetConditionsValue())
-            //{
-            //    m_LatentEffectList.at(i)->Activate();
-            //}
-            // else
-            //{
-            //    m_LatentEffectList.at(i)->Deactivate();
-            //}
+            for (auto equip: visibleEquip)
+            {
+                visibleHP += equip->getModifier(Mod::HP);
+            }
+
+            expression = visibleHP > 0 && ((static_cast<float>(m_POwner->health.hp) / static_cast<float>(visibleHP)) * 100) >= latentEffect.GetConditionsValue();
             break;
+        }
         case LATENT::WEAPON_BROKEN:
         {
             auto  slot = latentEffect.GetSlot();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR adds the functionality for two rare types of latent gear. Specifically MP_UNDER_VISIBLE_GEAR and HP_OVER_VISIBLE_GEAR which are used by Uggalepih Pendant and Parade Gorget respectively. Retail testing can be see for example [here](https://github.com/AirSkyBoat/AirSkyBoat/pull/2099) and [JP Wiki](https://wiki.ffo.jp/html/2495.html).

Still in draft as I figure out how this will interact with another PR I am making to fix other latent and HP issues.

## Steps to test these changes
Calculate your HP or MP given only the +HP or +MP in the defined slots (SLOT_MAIN, SLOT_SUB, SLOT_RANGED, SLOT_AMMO, SLOT_BODY, SLOT_HANDS, SLOT_LEGS, SLOT_FEET) and then, with the pendant, for example, check your MATT at different MPs near 51%
