### PR TITLE
[Lua] Drop message when avatar is already using a move

### DIFF
--- a/scripts/globals/job_utils/summoner.lua
+++ b/scripts/globals/job_utils/summoner.lua
@@ -204,7 +204,7 @@ xi.job_utils.summoner.canUseBloodPact = function(player, pet, target, petAbility
 
         -- check if avatar is using a move already
         if petAction == xi.action.PET_MOBABILITY_FINISH then
-            return xi.msg.basic.PET_CANNOT_DO_ACTION, 0 -- TODO: verify exact message in packet.
+            return 0, 0
         end
 
         local baseMPCost = getBaseMPCost(player, petAbility)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

https://github.com/LandSandBoat/server/commit/e8e69f5e7bbae677f6696b043894ba9a48bd0fd5

@ShiyoKozuki confirmed that there is no message when an avatar is already using an ability in retail so we'll remove the message currently occurring in that case.

## Steps to test these changes

1. !changejob 15 99
2. !addallspells
3. Summon an avatar
4. Use Apogee
5. Try to use 2 BPs in quick succession
