### PR TITLE
[SQL] Fix Mujin Obi missing enhance avatar attack

### DIFF
--- a/sql/item_mods_pet.sql
+++ b/sql/item_mods_pet.sql
@@ -173,6 +173,9 @@ INSERT INTO `item_mods_pet` VALUES (11619,368,25,1); -- Avatar - REGAIN: 25
 -- Ferine Earring
 INSERT INTO `item_mods_pet` VALUES (11711,25,3,0); -- All Pets - ACC: 3
 
+-- Mujin Obi
+INSERT INTO `item_mods_pet` VALUES (11776,23,10,1); -- Avatar - ATT: 10
+
 -- Cirque Earring
 INSERT INTO `item_mods_pet` VALUES (11720,23,2,3); -- Automaton - ATT: 2
 INSERT INTO `item_mods_pet` VALUES (11720,24,3,3); -- Automaton - RATT: 3


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

https://www.bg-wiki.com/ffxi/Mujin_Obi

Mujin Obi is currently missing a pet mod to enhance avatar attack by +10.

## Steps to test these changes

1. !changejob 15 99
2. !addallspells
3. !additem 11776
4. Summon an avatar
5. Avatar attack should be +10 with Obi equipped
