### PR TITLE
[LUA] Fix Temenos North avatars should not start spawned, error in Astral Flow

### DIFF
--- a/scripts/battlefields/Temenos/temenos_northern_tower.lua
+++ b/scripts/battlefields/Temenos/temenos_northern_tower.lua
@@ -224,11 +224,13 @@ content.groups =
     },
 
     {
-        mobs =
-        {
-            'Kindreds_Elemental',
-            'Kindreds_Avatar',
-        }
+        mobs    = { 'Kindreds_Avatar' },
+        mixins  = { require('scripts/mixins/families/avatar') },
+        spawned = false,
+    },
+
+    {
+        mobs = { 'Kindreds_Elemental' },
     },
 
     -- Floor 5
@@ -258,10 +260,15 @@ content.groups =
     },
 
     {
+        mobs    = { 'Tonberrys_Avatar' },
+        mixins  = { require('scripts/mixins/families/avatar') },
+        spawned = false,
+    },
+
+    {
         mobs =
         {
             'Tonberrys_Elemental',
-            'Tonberrys_Avatar',
         },
     },
 

--- a/scripts/mixins/families/avatar.lua
+++ b/scripts/mixins/families/avatar.lua
@@ -27,7 +27,13 @@ g_mixins.families.avatar = function(avatarMob)
 
         -- When GM is enabled, mobs will not automatically engage.  Update Enmity one more
         -- time to ensure that the listener will actually be triggered.
-        mob:updateEnmity()
+        local master = mob:getMaster()
+        if master ~= nil then
+            local target = master:getTarget()
+            if target ~= nil then
+                mob:updateEnmity(target)
+            end
+        end
 
         -- If something goes wrong, the avatar will clean itself up in 5s
         mob:timer(5000, function(mobArg)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Currently in Temenos North there's SMN avatars just hanging out doing nothing. After reviewing a capture video it appears they should only spawn when a SMN uses Astral Flow. To resolve this we will set them to not be spawned initially and add the avatar mixin similar to other Temenos battlefields. Additionally there is an error when Astral Flow is used currently due to `updateEnmity` not being passed anything so we will update the logic to check for a master and master's target to use in this call to resolve the error currently occuring.

https://www.youtube.com/watch?v=k7yx2lykDjM

Here is a capture where you can see the avatars only appear after a SMN uses Astral Flow. Elementals do appear already spawned in.

## Steps to test these changes

1. !pos 580.000 -2.375 104.000 37
2. !addkeyitem white_card
3. !addkeyitem cosmo_cleanse
4. Enter and go down a couple floors until you're either at Kindreds or Cryptonberrys
5. Whack on a SMN until they use Astral Flow (!togglegm to test that they still target you even with GM on)
