### PR TITLE
[Quest]20 in Pirate Years to IF

### DIFF
--- a/scripts/quests/outlands/NIN_AF1_Twenty_In_Pirate_Years.lua
+++ b/scripts/quests/outlands/NIN_AF1_Twenty_In_Pirate_Years.lua
@@ -1,0 +1,146 @@
+-----------------------------------
+-- Twenty in Pirate Years
+-----------------------------------
+-- Log ID: 5, Quest ID: 143
+-- Kagetora: !pos -95 -2.3 28 236
+-- qm2 Spiders: !pos 49 -7 400 114
+-- Ryoma: !pos -24 .5 -8.4 252
+-- Enetsu: !pos 33 -6 68 236
+-----------------------------------
+local eAltepaID = zones[xi.zone.EASTERN_ALTEPA_DESERT]
+-----------------------------------
+local quest = Quest:new(xi.questLog.OUTLANDS, xi.quest.id.outlands.TWENTY_IN_PIRATE_YEARS)
+local weaponsReward = { xi.item.ANJU,  xi.item.ZUSHIO }
+
+quest.reward =
+{
+    fameArea = xi.fameArea.NORG,
+    fame = 75,
+    item = weaponsReward,
+}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_AVAILABLE and
+            player:getMainJob() == xi.job.NIN and
+            player:getMainLvl() >= xi.settings.main.AF1_QUEST_LEVEL
+        end,
+
+        [xi.zone.NORG] =
+        {
+            ['Ryoma'] = quest:progressEvent(133),
+
+            onEventFinish =
+            {
+                [133] = function(player, csid, option, npc)
+                    quest:begin(player)
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_ACCEPTED
+        end,
+
+        [xi.zone.NORG] =
+        {
+            ['Ryoma'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:hasKeyItem(xi.ki.TRICK_BOX) then
+                        return quest:progressEvent(134)
+                    elseif quest:getVar(player, 'Prog') == 2 then
+                        return quest:progressEvent(804)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [134] = function(player, csid, option, npc)
+                    if quest:complete(player) then
+                        player:setLocalVar('Quest[5][144]mustZone', 1)
+                        player:delKeyItem(xi.ki.TRICK_BOX)
+                    end
+                end,
+            },
+        },
+
+        [xi.zone.PORT_BASTOK] =
+        {
+            ['Kagetora'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 0 then
+                        return quest:progressEvent(261)
+                    end
+                end,
+            },
+
+            ['Ensetsu'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 1 then
+                        return quest:progressEvent(262)
+                    elseif quest:getVar(player, 'Prog') == 3 then
+                        return quest:event(263)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [261] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 1)
+                end,
+
+                [262] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 2)
+                end,
+            },
+        },
+
+        [xi.zone.EASTERN_ALTEPA_DESERT] =
+        {
+            ['qm2'] =
+            {
+                onTrigger = function(player, npc)
+                    if
+                        quest:getVar(player, 'Prog') == 2 and
+                        quest:getVar(player, 'nmKilled') == 0 and
+                        quest:getLocalVar(player, 'nmPopped') == 0 and
+                        npcUtil.popFromQM(player, npc, { eAltepaID.mob.TSUCHIGUMO_OFFSET,
+                        eAltepaID.mob.TSUCHIGUMO_OFFSET + 1 }, { claim = false, hide = 0 })
+                    then
+                        quest:setLocalVar(player, 'nmPopped', 1) -- players can only pop once/zone
+                        return quest:messageSpecial(eAltepaID.text.HOSTILE_GAZE)
+                    elseif quest:getVar(player, 'nmKilled') == 1 then
+                        npcUtil.giveKeyItem(player, xi.ki.TRICK_BOX)
+                        quest:setVar(player, 'nmKilled', 0)
+                        quest:setVar(player, 'Prog', 3)
+                        return quest:noAction()
+                    end
+                end,
+            },
+
+            ['Tsuchigumo'] =
+            {
+                onMobDeath = function(mob, player, optParams)
+                    if
+                        quest:getVar(player, 'Prog') == 2 and
+                        GetMobByID(eAltepaID.mob.TSUCHIGUMO_OFFSET):isDead() and
+                        GetMobByID(eAltepaID.mob.TSUCHIGUMO_OFFSET + 1):isDead()
+                    then
+                        quest:setVar(player, 'nmKilled', 1) -- nm kill counts even after zone if didnt get KI
+                    end
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/zones/Eastern_Altepa_Desert/IDs.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/IDs.lua
@@ -27,6 +27,7 @@ zones[xi.zone.EASTERN_ALTEPA_DESERT] =
         FIND_NOTHING                  = 7580,  -- You dig and you dig, but find nothing.
         AMK_DIGGING_OFFSET            = 7646,  -- You spot some familiar footprints. You are convinced that your moogle friend has been digging in the immediate vicinity.
         ALREADY_OBTAINED_TELE         = 7674,  -- You already possess the gate crystal for this telepoint.
+        HOSTILE_GAZE                  = 7679,  -- You feel a hostile gaze upon you!
         GARRISON_BASE                 = 7701,  -- Hm? What is this? %? How do I know this is not some [San d'Orian/Bastokan/Windurstian] trick?
         PLAYER_OBTAINS_ITEM           = 7774,  -- <name> obtains <item>!
         UNABLE_TO_OBTAIN_ITEM         = 7775,  -- You were unable to obtain the item.

--- a/scripts/zones/Eastern_Altepa_Desert/mobs/Tsuchigumo.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/mobs/Tsuchigumo.lua
@@ -5,10 +5,32 @@
 -----------------------------------
 local entity = {}
 
-entity.onMobDeath = function(mob, player, optParams)
-    if player:getCharVar('twentyInPirateYearsCS') == 3 then
-        player:incrementCharVar('TsuchigumoKilled', 1)
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+    mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
+end
+
+entity.onMobSpawn = function(mob, target)
+    mob:setLocalVar('despawnTime', os.time() + 180)
+    mob:setMobMod(xi.mobMod.NO_LINK, 1)
+end
+
+entity.onAdditionalEffect = function(mob, target, damage)
+    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.POISON, { power = 20 })
+end
+
+entity.onMobRoam = function(mob)
+    local despawnTime = mob:getLocalVar('despawnTime')
+
+    if
+        despawnTime > 0 and
+        os.time() > despawnTime
+    then
+        DespawnMob(mob:getID())
     end
+end
+
+entity.onMobDeath = function(mob, player, optParams)
 end
 
 return entity

--- a/scripts/zones/Norg/npcs/Ryoma.lua
+++ b/scripts/zones/Norg/npcs/Ryoma.lua
@@ -4,8 +4,6 @@
 -- Start and Finish Quest: 20 in Pirate Years, I'll Take the Big Box, True Will, Bugi Soden
 -- !pos -23 0 -9 252
 -----------------------------------
-local ID = zones[xi.zone.NORG]
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
@@ -19,22 +17,11 @@ entity.onTrigger = function(player, npc)
     local mJob = player:getMainJob()
 
     if
-        twentyInPirateYears == xi.questStatus.QUEST_AVAILABLE and
-        mJob == xi.job.NIN and
-        mLvl >= 40
-    then
-        player:startEvent(133) -- Start Quest "20 in Pirate Years"
-    elseif
-        twentyInPirateYears == xi.questStatus.QUEST_ACCEPTED and
-        player:hasKeyItem(xi.ki.TRICK_BOX)
-    then
-        player:startEvent(134) -- Finish Quest "20 in Pirate Years"
-    elseif
         twentyInPirateYears == xi.questStatus.QUEST_COMPLETED and
         illTakeTheBigBox == xi.questStatus.QUEST_AVAILABLE and
         mJob == xi.job.NIN and
         mLvl >= 50 and
-        not player:needToZone()
+        player:getLocalVar('Quest[5][144]mustZone') == 0 -- temporary until i'll take the big box is converted to IF
     then
         player:startEvent(135) -- Start Quest "I'll Take the Big Box"
     elseif
@@ -53,24 +40,7 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    if csid == 133 then
-        player:addQuest(xi.questLog.OUTLANDS, xi.quest.id.outlands.TWENTY_IN_PIRATE_YEARS)
-        player:setCharVar('twentyInPirateYearsCS', 1)
-    elseif csid == 134 then
-        if player:getFreeSlotsCount() <= 1 then
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, xi.item.ANJU)
-        else
-            player:delKeyItem(xi.ki.TRICK_BOX)
-            player:addItem(xi.item.ANJU)
-            player:addItem(xi.item.ZUSHIO)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, xi.item.ANJU) -- Anju
-            player:messageSpecial(ID.text.ITEM_OBTAINED, xi.item.ZUSHIO) -- Zushio
-            player:needToZone()
-            player:setCharVar('twentyInPirateYearsCS', 0)
-            player:addFame(xi.fameArea.NORG, 30)
-            player:completeQuest(xi.questLog.OUTLANDS, xi.quest.id.outlands.TWENTY_IN_PIRATE_YEARS)
-        end
-    elseif csid == 135 then
+    if csid == 135 then
         player:addQuest(xi.questLog.OUTLANDS, xi.quest.id.outlands.I_LL_TAKE_THE_BIG_BOX)
     elseif csid == 136 then
         player:addQuest(xi.questLog.OUTLANDS, xi.quest.id.outlands.TRUE_WILL)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Converts the Outlands Quest Twenty in Pirate Years to Interaction Framework.
- Sets conditions for fight according to [capture](https://www.youtube.com/watch?v=gTytKWvZ0Ss)
    - NM's may only be spawned once per zone. Added localVar to account for that
    - Adjusted NM lua script to match capture listed above
    - Sets despawn time to 180 seconds.
    - Will only despawn if onMobRoam
 - Adjusted Ryoma's logic in lua file so it does not interfere with this quest.
     - Added next quest mustZone localVar.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Complete Ayame and Kaede
Obtain level 40
Complete quest.
Attempt to start next quest (once level 50) will not get next quest until zone.
Once this is merged, I will push the next quest, NIN_AF2_I_LL_TAKE_THE_BIG_BOX.
<!-- Clear and detailed steps to test your changes here -->
