### PR TITLE
[LUA] Fix entering mog house doesn't clear some status effects

### DIFF
--- a/scripts/globals/moghouse.lua
+++ b/scripts/globals/moghouse.lua
@@ -111,6 +111,11 @@ xi.moghouse.onMoghouseZoneIn = function(player, prevZone)
     local cs = -1
 
     player:eraseAllStatusEffect()
+    player:delStatusEffectSilent(xi.effect.POISON)
+    player:delStatusEffectSilent(xi.effect.BLINDNESS)
+    player:delStatusEffectSilent(xi.effect.PARALYSIS)
+    player:delStatusEffectSilent(xi.effect.SILENCE)
+
     player:setPos(0, 0, 0, 192)
 
     -- Moghouse data (bit-packed)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Currently when you zone into a mog house it runs `eraseAllStatusEffect` which removes _most_ status effects but only those that can be removed with Erase. This skips several statuses that can be removed with -na spells. So, we'll silently remove these additional status effects on zone in as well.

https://wiki.ffo.jp/html/22.html

I couldn't find specifics or captures with exact status effects that it does clear so may require some retail verification. I believe virus and curse should not be cleared as it only applies to "minor abnormal conditions". Petrification also doesn't really make sense to add here since you wouldn't be able to get in anyway.

## Steps to test these changes

1. !addeffect poison / silence / blind / paralysis
2. Zone into a mog house
