### PR TITLE
[CPP] Fix map crash when counting trusts

### DIFF
--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -335,7 +335,12 @@ void CParty::RemoveMember(CBattleEntity* PEntity)
                     }
                 }
 
-                auto trustCount = static_cast<CCharEntity*>(m_PLeader)->PTrusts.size();
+                size_t trustCount = 0;
+                if (m_PLeader != nullptr)
+                {
+                    trustCount = static_cast<CCharEntity*>(m_PLeader)->PTrusts.size();
+                }
+
                 PChar->PLatentEffectContainer->CheckLatentsPartyMembers(members.size(), trustCount);
 
                 PChar->pushPacket(new CPartyDefinePacket(nullptr));
@@ -855,7 +860,12 @@ void CParty::ReloadParty()
     {
         RefreshFlags(info);
         CBattleEntity* PLeader    = GetLeader();
-        auto           trustCount = static_cast<CCharEntity*>(PLeader)->PTrusts.size();
+        size_t         trustCount = 0;
+
+        if (PLeader != nullptr)
+        {
+            trustCount = static_cast<CCharEntity*>(PLeader)->PTrusts.size();
+        }
 
         // regular party
         for (auto& member : members)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a map crash due to party leader being null when they are initially zoning. Resolves https://github.com/LandSandBoat/server/issues/5844

## Steps to test these changes

1. Make a group with 2 or more
2. Be in the same zone together and have the party leader zone out and in
