### PR TITLE
[cpp] Return exact gil amount when mob is set explicitly

### DIFF
--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -192,10 +192,10 @@ uint32 CMobEntity::GetRandomGil()
 
     if (min && max)
     {
-        // make sure divide won't crash server
+        // Assume we want this exact amount
         if (max <= min)
         {
-            max = min + 2;
+            return min;
         }
 
         if (max - min < 2)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

When mobmods for gil max and min are set to the same amount, the code was explicitly setting a range. There are quite a few mobs that have a particular amount of gil that they always drop, this allows you to set max and min to the same amount to get that amount.

## Steps to test these changes

`!setmobmod GIL_MIN 1000`
`!setmobmod GIL_MAX 1000`

kill mob

before this change, you'd get a small range of 2 gil variance, after this PR you always get 1000
![image](https://github.com/LandSandBoat/server/assets/131182600/b009941e-e044-4b26-8503-7cd145844bd6)

and of course previous mechanism still works:
![image](https://github.com/LandSandBoat/server/assets/131182600/c8f1e81c-f384-4ba5-88e9-3908ea75b3f2)

