### PR TITLE
[core] Clear zone wide treasure pool when last player leaves zone

### DIFF
--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -1174,6 +1174,14 @@ void CZone::CharZoneOut(CCharEntity* PChar)
         PChar->PTreasurePool->DelMember(PChar);
     }
 
+    // If zone-wide treasure pool but no players in zone then destroy current pool and create new pool
+    // this prevents loot from staying in zone pool after the last player leaves the zone
+    if (m_TreasurePool && m_TreasurePool->GetPoolType() == TREASUREPOOL_ZONE && m_zoneEntities->CharListEmpty())
+    {
+        destroy(m_TreasurePool);
+        m_TreasurePool = new CTreasurePool(TREASUREPOOL_ZONE);
+    }
+
     PChar->ClearTrusts(); // trusts don't survive zone lines
 
     if (PChar->isDead())


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR clears the zone wide treasure pool when the last player leaves the zone. This prevents situations where, for example, a group exits dyna (or is kicked) with treasure still in pool and the next group enters and can lot that treasure.

## Steps to test these changes
Set a zone to have zone wide treasure pool and then get items in pool and do !goto playerName and see that the treasure is gone after zoning back in
