### PR TITLE
[core, lua] Add zone uptime command

### DIFF
--- a/scripts/commands/uptime.lua
+++ b/scripts/commands/uptime.lua
@@ -1,0 +1,50 @@
+-----------------------------------
+-- func: uptime
+-- desc: prints zone uptime
+-----------------------------------
+local commandObj = {}
+
+commandObj.cmdprops =
+{
+    permission = 1,
+    parameters = ''
+}
+
+local function formatSeconds(seconds)
+    local days = math.floor(seconds / 86400)
+    seconds = seconds % 86400  -- Use modulo to get remaining seconds after days
+    local hours = math.floor(seconds / 3600)
+    seconds = seconds % 3600   -- Use modulo again for remaining seconds after hours
+    local minutes = math.floor(seconds / 60)
+    seconds = seconds % 60     -- And again for remaining seconds
+
+    local parts = {}
+
+    if days > 0 then
+        table.insert(parts, string.format('%d day%s', days, days > 1 and 's' or ''))
+    end
+
+    if hours > 0 then
+        table.insert(parts, string.format('%d hour%s', hours, hours > 1 and 's' or ''))
+    end
+
+    if minutes > 0 then
+        table.insert(parts, string.format('%d minute%s', minutes, minutes > 1 and 's' or ''))
+    end
+
+    if seconds > 0 or #parts == 0 then
+        table.insert(parts, string.format('%d second%s', seconds, seconds > 1 and 's' or ''))
+    end
+
+    return table.concat(parts, ' ')
+end
+
+commandObj.onTrigger = function(player)
+    local zone = player:getZone()
+    if zone then
+        local uptime = zone:getUptime()
+        player:printToPlayer('The zone has been up for ' .. formatSeconds(uptime), xi.msg.channel.SYSTEM_3)
+    end
+end
+
+return commandObj

--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -181,6 +181,16 @@ WEATHER CLuaZone::getWeather()
     return m_pLuaZone->GetWeather();
 }
 
+uint32 CLuaZone::getUptime()
+{
+    time_point currentTime   = std::chrono::system_clock::now(); // Gets the current time
+    time_point zoneStartTime = get_server_start_time();          // Gets the start time of the zone group (cluster)
+
+    long long uptime = std::chrono::duration_cast<std::chrono::seconds>(currentTime - zoneStartTime).count();
+    // returns the zone up time in seconds
+    return static_cast<uint32>(uptime);
+}
+
 void CLuaZone::reloadNavmesh()
 {
     if (m_pLuaZone->m_navMesh)
@@ -317,6 +327,7 @@ void CLuaZone::Register()
     SOL_REGISTER("getBattlefieldByInitiator", CLuaZone::getBattlefieldByInitiator);
     SOL_REGISTER("battlefieldsFull", CLuaZone::battlefieldsFull);
     SOL_REGISTER("getWeather", CLuaZone::getWeather);
+    SOL_REGISTER("getUptime", CLuaZone::getUptime);
     SOL_REGISTER("reloadNavmesh", CLuaZone::reloadNavmesh);
     SOL_REGISTER("isNavigablePoint", CLuaZone::isNavigablePoint);
     SOL_REGISTER("insertDynamicEntity", CLuaZone::insertDynamicEntity);

--- a/src/map/lua/lua_zone.h
+++ b/src/map/lua/lua_zone.h
@@ -56,6 +56,7 @@ public:
     auto               getBattlefieldByInitiator(uint32 charID) -> std::optional<CLuaBattlefield>;
     bool               battlefieldsFull(int battlefieldId);
     WEATHER            getWeather();
+    uint32             getUptime();
     void               reloadNavmesh();
     bool               isNavigablePoint(const sol::table& position);
     auto               insertDynamicEntity(sol::table table) -> std::optional<CLuaBaseEntity>;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR adds a command to display the uptime of the current zone to a GM (several private servers also expose such a command to normal players). This command is something specifically requested by Horizon GMs and very useful for investigating, for example, player reports of zone crashes and validating the zone actually crashed (rather than just player DC) when refunding pop items (like BCNM orbs).

## Steps to test these changes
Boot up a zone and use !uptime
