### PR TITLE
[lua] mobMagicalMove 0 damage fix

### DIFF
--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -269,7 +269,7 @@ end
 xi.mobskills.mobMagicalMove = function(actor, target, action, baseDamage, actionElement, damageModifier, tpEffect, tpMultiplier)
     local returnInfo = {} -- TODO: Destroy
 
-    local finalDamage = 0
+    local finalDamage = baseDamage
 
     -- Base damage
     if tpEffect == xi.mobskills.magicalTpBonus.DMG_BONUS then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Closes: https://github.com/LandSandBoat/server/issues/5845

baseDamage was not being fed into mobMagicalMove  after the changes implemented in https://github.com/LandSandBoat/server/pull/5821 causing magical mobskills and avatar bloodpacts to do 0 damage. This simply sets the inital finalDamage variable value to use the mobskill's baseDamage so there is something to calculate.

Note: Have not fully tested any other changes relating to https://github.com/LandSandBoat/server/pull/5821 besides this.

## Steps to test these changes

1. Find a mob. Aggro it.
2. !exec target:useMobAbility(367) -- Lizard magical mobskill "Fireball"
3. See that the skill now does damage.

Alternate:

1. Summon an avatar.
2. Use a magical offensive blooc pact.
3. See that it does damage.

<!-- Clear and detailed steps to test your changes here -->
