### PR TITLE
Add the ability to parry, guard, or block a player WS (adds checks to lua)

### DIFF
--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -70,6 +70,16 @@ xi.combat.physical.pDifWeaponCapTable =
     [xi.skill.THROWING        ] = { 3.25 },
 }
 
+local shieldSizeToBlockRateTable =
+{
+    [1] = 55, -- Buckler
+    [2] = 40, -- Round
+    [3] = 45, -- Kite
+    [4] = 30, -- Tower
+    [5] = 50, -- Aegis and Srivatsa
+    [6] = 100, -- Ochain  https://www.bg-wiki.com/ffxi/Category:Shields
+}
+
 local elementalGorget = -- Ordered by element.
 {
     xi.item.FLAME_GORGET,
@@ -683,4 +693,286 @@ xi.combat.physical.calculateSecondaryHitCritical = function(actor, additionalPar
 end
 
 xi.combat.physical.calculateSecondaryHitDamage = function(actor, additionalParamsHere)
+end
+
+xi.combat.physical.canParry = function(defender, attacker)
+    local canParry = false
+
+    if
+        defender:isFacing(attacker) and
+        defender:isEngaged()
+    then
+        if defender:isPC() and defender:getSkillRank(xi.skill.PARRY) > 0 then
+            local mainWeapon = defender:getEquippedItem(xi.slot.MAIN)
+            if mainWeapon then
+                canParry = mainWeapon:getSkillType() ~= xi.skill.HAND_TO_HAND
+            end
+        elseif
+            defender:isMob() or
+            defender:isPet() or
+            defender:isTrust()
+        then
+            canParry = defender:getMobMod(xi.mobMod.CAN_PARRY) > 0
+        end
+    end
+
+    return canParry
+end
+
+xi.combat.physical.calculateParryRate = function(defender, attacker)
+    local parryRate = 0
+
+    -- http://wiki.ffxiclopedia.org/wiki/Talk:Parrying_Skill
+    -- {(Parry Skill x .125) + ([Player Agi - Enemy Dex] x .125)} x Diff
+
+    local parrySkill = defender:getSkillLevel(xi.skill.PARRY) + defender:getMod(xi.mod.PARRY)
+
+    if defender:isPC() then
+        parrySkill = parrySkill + defender:getILvlParry()
+    end
+
+    local levelDiffMult = 1 + (defender:getMainLvl() - attacker:getMainLvl()) / 15
+
+    -- two handed weapons get a bonus
+    if defender:isPC() and defender:isWeaponTwoHanded() then
+        levelDiffMult = levelDiffMult + 0.1
+    end
+
+    levelDiffMult = utils.clamp(levelDiffMult, 0.4, 1.4)
+
+    local attackerDex = attacker:getStat(xi.mod.DEX)
+    local defenderAgi = defender:getStat(xi.mod.AGI)
+
+    parryRate = utils.clamp(((parrySkill * 0.1 + (defenderAgi - attackerDex) * 0.125 + 10.0) * levelDiffMult), 5, 25)
+
+    -- Issekigan grants parry rate bonus
+    -- from best available data if you already capped out at 25% parry it grants another 25% bonus for ~50% parry rate
+    if defender:hasStatusEffect(xi.effect.ISSEKIGAN) then
+        parryRate = parryRate + defender:getStatusEffect(xi.effect.ISSEKIGAN):getPower()
+    end
+
+    -- Inquartata grants a flat parry rate bonus
+    parryRate = parryRate + defender:getMod(xi.mod.INQUARTATA)
+
+    return parryRate
+end
+
+xi.combat.physical.canGuard = function(defender, attacker)
+    local canGuard = false
+
+    -- per testing done by Genome guard can proc when petrified, stunned, or asleep
+    -- https://genomeffxi.livejournal.com/18269.html
+    if
+        defender:isFacing(attacker) and
+        defender:isEngaged()
+    then
+        if defender:isPC() and defender:getSkillRank(xi.skill.GUARD) > 0 then
+            local mainWeapon = defender:getEquippedItem(xi.slot.MAIN)
+            canGuard = (not mainWeapon) or mainWeapon:getSkillType() == xi.skill.HAND_TO_HAND
+        elseif
+            defender:isMob() or
+            defender:isPet() or
+            defender:isTrust()
+        then
+            canGuard = defender:getMainJob() == xi.job.MNK or defender:getMainJob() == xi.job.PUP
+        end
+    end
+
+    return canGuard
+end
+
+xi.combat.physical.calculateGuardRate = function(defender, attacker)
+    local guardRate = 0
+
+    -- default to using actual skill
+    local guardSkill = defender:getSkillLevel(xi.skill.GUARD)
+
+    -- non-players do not have guard skill set on creation
+    -- so use max skill at the level for the job
+    if
+        defender:isMob() or
+        defender:isPet()
+    then
+        guardSkill = defender:getMaxSkillLevel(defender:getMainLvl(), defender:getMainJob(), xi.skill.GUARD)
+    elseif defender:isTrust() then
+        -- TODO: check trust type for ilvl > 99 when implemented
+        guardSkill = defender:getMaxSkillLevel(math.min(defender:getMainLvl(), 99), defender:getMainJob(), xi.skill.GUARD)
+    end
+
+    guardSkill = guardSkill + defender:getMod(xi.mod.GUARD) + guardSkill * (defender:getMod(xi.mod.GUARD_PERCENT) / 100)
+
+    -- current assumption (from core) is that guard and parry Ilvl are the same
+    if defender:isPC() then
+        guardSkill = guardSkill + defender:getILvlParry()
+    end
+
+    local levelDiffMult = 1 + (defender:getMainLvl() - attacker:getMainLvl()) / 15
+    levelDiffMult = utils.clamp(levelDiffMult, 0.4, 1.4)
+
+    local attackerDex = attacker:getStat(xi.mod.DEX)
+    local defenderAgi = defender:getStat(xi.mod.AGI)
+
+    guardRate = utils.clamp(((guardSkill * 0.1 + (defenderAgi - attackerDex) * 0.125 + 10) * levelDiffMult), 5, 25)
+
+    return guardRate
+end
+
+xi.combat.physical.canBlock = function(defender, attacker)
+    local canBlock = false
+
+    if defender:isFacing(attacker) and not defender:hasPreventActionEffect() then
+        if defender:isPC() and defender:getSkillRank(xi.skill.SHIELD) > 0 then
+            local shield = defender:getEquippedItem(xi.slot.SUB)
+            if shield then
+                canBlock = shield:isShield()
+            end
+        elseif
+            defender:isMob() or
+            defender:isPet() or
+            defender:isTrust()
+        then
+            canBlock = defender:getMobMod(xi.mobMod.CAN_SHIELD_BLOCK) > 0
+        end
+    end
+
+    return canBlock
+end
+
+xi.combat.physical.calculateBlockRate = function(defender, attacker)
+    local blockRate = 0
+    local shieldSize = 3
+    local skillModifier = 0
+    local palisadeMod = defender:getMod(xi.mod.PALISADE_BLOCK_BONUS)
+    local reprisalMult = 1.0
+
+    -- assume bare hands case
+    local attackerSkillType = xi.skill.HAND_TO_HAND
+    if not attacker:isUsingH2H() then
+        attackerSkillType = attacker:getWeaponSkillType(xi.slot.MAIN)
+    end
+
+    local attackSkill = attacker:getSkillLevel(attackerSkillType)
+    local blockSkill = defender:getSkillLevel(xi.skill.SHIELD)
+
+    if defender:isPC() then
+        local shield = defender:getEquippedItem(xi.slot.SUB)
+        -- already checked in canBlock but check again here to make sure
+        if shield and shield:isShield() then
+            shieldSize = shield:getShieldSize()
+        else
+            return 0
+        end
+    elseif
+        defender:isMob() or
+        defender:isPet() or
+        defender:isTrust()
+    then
+        -- already checked in canBlock but check again here to make sure
+        if defender:getMobMod(xi.mobMod.CAN_SHIELD_BLOCK) > 0 then
+            blockRate = defender:getMod(xi.mod.SHIELDBLOCKRATE)
+            -- automations are a special case
+            if defender:isAutomaton() then
+                skillModifier = (defender:getSkillLevel(xi.skill.AUTOMATON_MELEE) - attackSkill) * 0.215
+                return math.max(0, blockRate + skillModifier)
+            -- mobs and trusts use max skill for job and level
+            elseif defender:isTrust() then
+                -- TODO: check trust type for ilvl > 99 when implemented
+                blockSkill = defender:getMaxSkillLevel(math.min(defender:getMainLvl(), 99), defender:getMainJob(), xi.skill.SHIELD)
+            else
+                blockSkill = defender:getMaxSkillLevel(defender:getMainLvl(), defender:getMainJob(), xi.skill.SHIELD)
+            end
+        else -- No block mobmod so zero rate
+            return 0
+        end
+    end
+
+    if defender:isPC() then
+        -- get blockrate from table and use default value of 0
+        blockRate = shieldSizeToBlockRateTable[shieldSize] or 0
+    end
+
+    -- Check for Reprisal and adjust skill and block rate bonus multiplier
+    if defender:hasStatusEffect(xi.effect.REPRISAL) then
+        blockSkill   = blockSkill * 1.15
+        reprisalMult = 1.5
+
+        -- Adamas and Priwen set the multiplier to 3.0x while equipped
+        if defender:getMod(xi.mod.REPRISAL_BLOCK_BONUS) > 0 then
+            reprisalMult = 3.0
+        end
+    end
+
+    skillModifier = (blockSkill - attackSkill) * 0.2325
+
+    -- Add skill and Palisade bonuses and multiply by Reprisals bonus
+    blockRate = (blockRate + skillModifier + palisadeMod) * reprisalMult
+
+    -- Apply the lower and upper caps
+    blockRate = utils.clamp(blockRate, 5, 100)
+
+    return blockRate
+end
+
+xi.combat.physical.handleBlock = function(defender, attacker, damage)
+    if
+        xi.combat.physical.canBlock(defender, attacker) and
+        xi.combat.physical.calculateBlockRate(defender, attacker) > math.random(100)
+    then
+        -- shield def bonus is a flat raw damage reduction that occurs before absorb
+        -- however do not reduce below 0 or if damage is negative
+        if damage > 0 then
+            damage = math.max(0, damage - defender:getMod(xi.mod.SHIELD_DEF_BONUS))
+        end
+
+        if defender:isPC() then
+            local shield = defender:getEquippedItem(xi.slot.SUB)
+            local absorb = 100
+            absorb = utils.clamp(absorb - shield:getShieldAbsorptionRate(), 0, 100)
+            damage = math.floor(damage * (absorb / 100))
+            defender:trySkillUp(xi.skill.SHIELD, attacker:getMainLvl())
+        else
+            damage = math.floor(damage * 0.5)
+        end
+    end
+
+    return damage
+end
+
+xi.combat.physical.isParried = function(defender, attacker)
+    local parried = false
+    if
+        xi.combat.physical.canParry(defender, attacker) and
+        xi.combat.physical.calculateParryRate(defender, attacker) > math.random(100)
+    then
+        parried = true
+        if defender:isPC() then
+            -- TODO: implement Turms mod here (when that mod is added to LSB)
+            defender:trySkillUp(xi.skill.PARRY, attacker:getMainLvl())
+            -- handle tactical parry
+            if defender:hasTrait(xi.trait.TACTICAL_PARRY) then
+                defender:addTP(defender:getMod(xi.mod.TACTICAL_PARRY))
+            end
+        end
+    end
+
+    return parried
+end
+
+xi.combat.physical.isGuarded = function(defender, attacker)
+    local guarded = false
+    if
+        xi.combat.physical.canGuard(defender, attacker) and
+        xi.combat.physical.calculateGuardRate(defender, attacker) > math.random(100)
+    then
+        guarded = true
+        if defender:isPC() then
+            defender:trySkillUp(xi.skill.GUARD, attacker:getMainLvl())
+            -- handle tactical guard
+            if defender:hasTrait(xi.trait.TACTICAL_GUARD) then
+                defender:addTP(defender:getMod(xi.mod.TACTICAL_GUARD))
+            end
+        end
+    end
+
+    return guarded
 end

--- a/sql/mob_pool_mods.sql
+++ b/sql/mob_pool_mods.sql
@@ -437,15 +437,6 @@ INSERT INTO `mob_pool_mods` VALUES (4082,4,4,1); -- SIGHT_RANGE: 4
 INSERT INTO `mob_pool_mods` VALUES (4083,368,30,0); -- REGAIN: 30
 INSERT INTO `mob_pool_mods` VALUES (4083,370,1,0);  -- REGEN: 1
 
--- Vanguard_Alchemist
-INSERT INTO `mob_pool_mods` VALUES (4133,75,3,1); -- CAN_PARRY: 3
-
--- Vanguard_Ambusher
-INSERT INTO `mob_pool_mods` VALUES (4134,75,3,1); -- CAN_PARRY: 3
-
--- Vanguard_Amputator
-INSERT INTO `mob_pool_mods` VALUES (4135,75,3,1); -- CAN_PARRY: 3
-
 -- Vanguard_Armorer
 INSERT INTO `mob_pool_mods` VALUES (4136,75,3,1); -- CAN_PARRY: 3
 
@@ -467,12 +458,6 @@ INSERT INTO `mob_pool_mods` VALUES (4141,75,3,1); -- CAN_PARRY: 3
 -- Vanguard_Defender
 INSERT INTO `mob_pool_mods` VALUES (4143,75,3,1); -- CAN_PARRY: 3
 
--- Vanguard_Dollmaster
-INSERT INTO `mob_pool_mods` VALUES (4144,75,3,1); -- CAN_PARRY: 3
-
--- Vanguard_Dragon
-INSERT INTO `mob_pool_mods` VALUES (4145,75,3,1); -- CAN_PARRY: 3
-
 -- Vanguard_Drakekeeper
 INSERT INTO `mob_pool_mods` VALUES (4146,75,3,1); -- CAN_PARRY: 3
 
@@ -481,9 +466,6 @@ INSERT INTO `mob_pool_mods` VALUES (4147,75,3,1); -- CAN_PARRY: 3
 
 -- Vanguard_Exemplar
 INSERT INTO `mob_pool_mods` VALUES (4148,75,3,1); -- CAN_PARRY: 3
-
--- Vanguard_Eye
-INSERT INTO `mob_pool_mods` VALUES (4149,75,3,1); -- CAN_PARRY: 3
 
 -- Vanguard_Footsoldier
 INSERT INTO `mob_pool_mods` VALUES (4150,75,3,1); -- CAN_PARRY: 3
@@ -518,26 +500,14 @@ INSERT INTO `mob_pool_mods` VALUES (4159,75,3,1); -- CAN_PARRY: 3
 -- Vanguard_Maestro
 INSERT INTO `mob_pool_mods` VALUES (4160,75,3,1); -- CAN_PARRY: 3
 
--- Vanguard_Mesmerizer
-INSERT INTO `mob_pool_mods` VALUES (4162,75,3,1); -- CAN_PARRY: 3
-
--- Vanguard_Militant
-INSERT INTO `mob_pool_mods` VALUES (4163,75,3,1); -- CAN_PARRY: 3
-
 -- Vanguard_Minstrel
 INSERT INTO `mob_pool_mods` VALUES (4164,75,3,1); -- CAN_PARRY: 3
 
 -- Vanguard_Neckchopper
 INSERT INTO `mob_pool_mods` VALUES (4165,75,3,1); -- CAN_PARRY: 3
 
--- Vanguard_Necromancer
-INSERT INTO `mob_pool_mods` VALUES (4166,75,3,1); -- CAN_PARRY: 3
-
 -- Vanguard_Ogresoother
 INSERT INTO `mob_pool_mods` VALUES (4167,75,3,1); -- CAN_PARRY: 3
-
--- Vanguard_Oracle
-INSERT INTO `mob_pool_mods` VALUES (4168,75,3,1); -- CAN_PARRY: 3
 
 -- Vanguard_Partisan
 INSERT INTO `mob_pool_mods` VALUES (4169,75,3,1); -- CAN_PARRY: 3
@@ -551,18 +521,6 @@ INSERT INTO `mob_pool_mods` VALUES (4171,75,3,1); -- CAN_PARRY: 3
 -- Vanguard_Pillager
 INSERT INTO `mob_pool_mods` VALUES (4172,75,3,1); -- CAN_PARRY: 3
 
--- Vanguard_Pitfighter
-INSERT INTO `mob_pool_mods` VALUES (4173,75,3,1); -- CAN_PARRY: 3
-
--- Vanguard_Predator
-INSERT INTO `mob_pool_mods` VALUES (4174,75,3,1); -- CAN_PARRY: 3
-
--- Vanguard_Prelate
-INSERT INTO `mob_pool_mods` VALUES (4175,75,3,1); -- CAN_PARRY: 3
-
--- Vanguard_Priest
-INSERT INTO `mob_pool_mods` VALUES (4176,75,3,1); -- CAN_PARRY: 3
-
 -- Vanguard_Protector
 INSERT INTO `mob_pool_mods` VALUES (4177,75,3,1); -- CAN_PARRY: 3
 
@@ -571,15 +529,6 @@ INSERT INTO `mob_pool_mods` VALUES (4178,75,3,1); -- CAN_PARRY: 3
 
 -- Vanguard_Ronin
 INSERT INTO `mob_pool_mods` VALUES (4179,75,3,1); -- CAN_PARRY: 3
-
--- Vanguard_Salvager
-INSERT INTO `mob_pool_mods` VALUES (4180,75,3,1); -- CAN_PARRY: 3
-
--- Vanguard_Sentinel
-INSERT INTO `mob_pool_mods` VALUES (4181,75,3,1); -- CAN_PARRY: 3
-
--- Vanguard_Shaman
-INSERT INTO `mob_pool_mods` VALUES (4182,75,3,1); -- CAN_PARRY: 3
 
 -- Vanguard_Skirmisher
 INSERT INTO `mob_pool_mods` VALUES (4183,75,3,1); -- CAN_PARRY: 3

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -13665,6 +13665,23 @@ uint16 CLuaBaseEntity::getILvlSkill()
 }
 
 /************************************************************************
+ *  Function: getILvlParry()
+ *  Purpose : Returns the parry skill Bonus value of an equipped Main Weapon
+ *  Example : player:getILvlParry()
+ *  Notes   : Value of m_iLvlParry (private member of CItemWeapon)
+ ************************************************************************/
+
+uint16 CLuaBaseEntity::getILvlParry()
+{
+    if (auto* weapon = dynamic_cast<CItemWeapon*>(static_cast<CBattleEntity*>(m_PBaseEntity)->m_Weapons[SLOT_MAIN]))
+    {
+        return weapon->getILvlParry();
+    }
+
+    return 0;
+}
+
+/************************************************************************
  *  Function: isSpellAoE()
  *  Purpose : Returns true if a specified spell is AoE
  *  Example : if caster:isSpellAoE(spell:getID()) then
@@ -18045,6 +18062,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("getRATT", CLuaBaseEntity::getRATT);
     SOL_REGISTER("getILvlMacc", CLuaBaseEntity::getILvlMacc);
     SOL_REGISTER("getILvlSkill", CLuaBaseEntity::getILvlSkill);
+    SOL_REGISTER("getILvlParry", CLuaBaseEntity::getILvlParry);
 
     SOL_REGISTER("isSpellAoE", CLuaBaseEntity::isSpellAoE);
 

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -689,6 +689,7 @@ public:
     uint16 getRATT();
     uint16 getILvlMacc();
     uint16 getILvlSkill();
+    uint16 getILvlParry();
     bool   isSpellAoE(uint16 spellId);
 
     int32 physicalDmgTaken(double damage, sol::variadic_args va);

--- a/src/map/lua/lua_item.cpp
+++ b/src/map/lua/lua_item.cpp
@@ -236,6 +236,48 @@ bool CLuaItem::isShield()
     return false;
 }
 
+uint8 CLuaItem::getShieldSize()
+{
+    if (CItemEquipment* PArmor = dynamic_cast<CItemEquipment*>(m_PLuaItem))
+    {
+        if (PArmor->IsShield())
+        {
+            return PArmor->getShieldSize();
+        }
+        else
+        {
+            ShowError("CLuaItem::getShieldSize - not a valid Shield.");
+        }
+    }
+    else
+    {
+        ShowError("CLuaItem::getShieldSize - not a valid Armor.");
+    }
+
+    return 0;
+}
+
+uint8 CLuaItem::getShieldAbsorptionRate()
+{
+    if (CItemEquipment* PArmor = dynamic_cast<CItemEquipment*>(m_PLuaItem))
+    {
+        if (PArmor->IsShield())
+        {
+            return PArmor->getShieldAbsorption();
+        }
+        else
+        {
+            ShowError("CLuaItem::getShieldSize - not a valid Shield.");
+        }
+    }
+    else
+    {
+        ShowError("CLuaItem::getShieldSize - not a valid Armor.");
+    }
+
+    return 0;
+}
+
 auto CLuaItem::getSignature() -> std::string
 {
     char signature[DecodeStringLength] = {};
@@ -360,6 +402,8 @@ void CLuaItem::Register()
     SOL_REGISTER("isTwoHanded", CLuaItem::isTwoHanded);
     SOL_REGISTER("isHandToHand", CLuaItem::isHandToHand);
     SOL_REGISTER("isShield", CLuaItem::isShield);
+    SOL_REGISTER("getShieldSize", CLuaItem::getShieldSize);
+    SOL_REGISTER("getShieldAbsorptionRate", CLuaItem::getShieldAbsorptionRate);
     SOL_REGISTER("getSignature", CLuaItem::getSignature);
     SOL_REGISTER("getAppraisalID", CLuaItem::getAppraisalID);
     SOL_REGISTER("setAppraisalID", CLuaItem::setAppraisalID);

--- a/src/map/lua/lua_item.h
+++ b/src/map/lua/lua_item.h
@@ -75,9 +75,11 @@ public:
     uint8  getSkillType();         // get skill type
     uint16 getWeaponskillPoints(); // get current ws points
 
-    bool isTwoHanded();  // is a two handed weapon
-    bool isHandToHand(); // is a hand to hand weapon (or unarmed H2H)
-    bool isShield();     // is a Shield
+    bool  isTwoHanded();             // is a two handed weapon
+    bool  isHandToHand();            // is a hand to hand weapon (or unarmed H2H)
+    bool  isShield();                // is a Shield
+    uint8 getShieldSize();           // get the shield size (used for block rate calculation)
+    uint8 getShieldAbsorptionRate(); // get the shield absorbtion rate (used for block rate calculation)
 
     auto getSignature() -> std::string;
 

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2130,13 +2130,20 @@ namespace battleutils
             if (isBlocked)
             {
                 uint8 absorb = 100;
+
+                // shield def bonus is a flat raw damage reduction that occurs before absorb
+                // however do not reduce below 0 or if damage is negative
+                if (damage > 0)
+                {
+                    damage = std::max(0, damage - PDefender->getMod(Mod::SHIELD_DEF_BONUS));
+                }
+
                 if (const auto PChar = dynamic_cast<CCharEntity*>(PDefender))
                 {
                     CItemEquipment* slotSub = PChar->getEquip(SLOT_SUB);
                     if (slotSub && slotSub->IsShield())
                     {
                         absorb = std::clamp(100 - slotSub->getShieldAbsorption(), 0, 100);
-                        absorb -= PDefender->getMod(Mod::SHIELD_DEF_BONUS); // Include Shield Defense Bonus in absorb amount
 
                         // Shield Mastery
                         if ((std::max(damage - (PDefender->getMod(Mod::PHALANX) + PDefender->getMod(Mod::STONESKIN)), 0) > 0) &&


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR makes adds the potential for parrying, guarding, or blocking a player weaponskill. This is done by adding lua logic for these cases to physical_utilities.lua and weaponskills.lua. The lua logic is based on the analogous core logic. 

The idea is that the logic is generic enough to be used also in the future for mobskills and eventually normal auto-attack logic once that is in lua. Though one question is weather is makes sense to try to already call up to these from within core (for auto-attacks)? I can try to do that if desired.

I made the PR draft for now to get comments on the above and from other people working on the battle system migration to lua.

Also a related bug fix, on LSB currently all dynamis beastmen can parry, however captures show that it should be only beastmen with jobs with native parry skill. Specifically I checked log of dyna farming capture by Siknoz and only saw monster parries from BRD, NIN, BST, DRG, DRK, WAR, SAM, and PLD, which aligns with most jobs that have natural parry skill. Furthermore, Eden also limited parry in the same way (see this fixed [bug report](https://github.com/EdenServer/community/issues/3321)). 

Finally, another bug fix is related to SHIELD_DEF_BONUS which should be a flat damage reduction that occurs before the absorb calculation rather than a percent reduction (see [here](https://wiki.ffo.jp/html/20048.html) and [here](https://www.bg-wiki.com/ffxi/Shield_Def._Bonus)), this was changed in both the lua and core code. The original incorrect implementation (from 6 years ago) has no source or info.

## Steps to test these changes
Perform WS on mobs/players that can parry, guard, and block
