### PR TITLE
[lua][chore] onBattlefieldWin Enums

### DIFF
--- a/scripts/missions/asa/04_Sugar-Coated_Directive.lua
+++ b/scripts/missions/asa/04_Sugar-Coated_Directive.lua
@@ -50,7 +50,7 @@ mission.sections =
                         return mission:messageSpecial(flamesID.text.POWER_STYMIES, xi.keyItem.DOMINAS_SCARLET_SEAL)
                     elseif
                         player:hasKeyItem(xi.ki.DOMINAS_SCARLET_SEAL) and
-                        player:getLocalVar('battlefieldWin') == 547
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.SUGAR_COATED_DIRECTIVE_CLOISTER_OF_FLAMES
                     then
                         return mission:progressEvent(2)
                     end
@@ -81,7 +81,7 @@ mission.sections =
                         return mission:messageSpecial(frostID.text.POWER_STYMIES, xi.keyItem.DOMINAS_AZURE_SEAL)
                     elseif
                         player:hasKeyItem(xi.ki.DOMINAS_AZURE_SEAL) and
-                        player:getLocalVar('battlefieldWin') == 484
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.SUGAR_COATED_DIRECTIVE_CLOISTER_OF_FROST
                     then
                         return mission:progressEvent(2)
                     end
@@ -112,7 +112,7 @@ mission.sections =
                         return mission:messageSpecial(galesID.text.POWER_STYMIES, xi.keyItem.DOMINAS_EMERALD_SEAL)
                     elseif
                         player:hasKeyItem(xi.ki.DOMINAS_EMERALD_SEAL) and
-                        player:getLocalVar('battlefieldWin') == 420
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.SUGAR_COATED_DIRECTIVE_CLOISTER_OF_GALES
                     then
                         return mission:progressEvent(2)
                     end
@@ -143,7 +143,7 @@ mission.sections =
                         return mission:messageSpecial(stormsID.text.POWER_STYMIES, xi.keyItem.DOMINAS_VIOLET_SEAL)
                     elseif
                         player:hasKeyItem(xi.ki.DOMINAS_VIOLET_SEAL) and
-                        player:getLocalVar('battlefieldWin') == 452
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.SUGAR_COATED_DIRECTIVE_CLOISTER_OF_STORMS
                     then
                         return mission:progressEvent(2)
                     end
@@ -174,7 +174,7 @@ mission.sections =
                         return mission:messageSpecial(tidesID.text.POWER_STYMIES, xi.keyItem.DOMINAS_CERULEAN_SEAL)
                     elseif
                         player:hasKeyItem(xi.ki.DOMINAS_CERULEAN_SEAL) and
-                        player:getLocalVar('battlefieldWin') == 611
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.SUGAR_COATED_DIRECTIVE_CLOISTER_OF_TIDES
                     then
                         return mission:progressEvent(2)
                     end
@@ -205,7 +205,7 @@ mission.sections =
                         return mission:messageSpecial(tremorsID.text.POWER_STYMIES, xi.keyItem.DOMINAS_AMBER_SEAL)
                     elseif
                         player:hasKeyItem(xi.ki.DOMINAS_AMBER_SEAL) and
-                        player:getLocalVar('battlefieldWin') == 580
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.SUGAR_COATED_DIRECTIVE_CLOISTER_OF_TREMORS
                     then
                         return mission:progressEvent(2)
                     end
@@ -312,7 +312,7 @@ mission.sections =
                         return mission:messageSpecial(flamesID.text.POWER_STYMIES, xi.keyItem.DOMINAS_SCARLET_SEAL)
                     elseif
                         player:hasKeyItem(xi.ki.DOMINAS_SCARLET_SEAL) and
-                        player:getLocalVar('battlefieldWin') == 547
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.SUGAR_COATED_DIRECTIVE_CLOISTER_OF_FLAMES
                     then
                         return mission:progressEvent(2)
                     end
@@ -343,7 +343,7 @@ mission.sections =
                         return mission:messageSpecial(frostID.text.POWER_STYMIES, xi.keyItem.DOMINAS_AZURE_SEAL)
                     elseif
                         player:hasKeyItem(xi.ki.DOMINAS_AZURE_SEAL) and
-                        player:getLocalVar('battlefieldWin') == 484
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.SUGAR_COATED_DIRECTIVE_CLOISTER_OF_FROST
                     then
                         return mission:progressEvent(2)
                     end
@@ -374,7 +374,7 @@ mission.sections =
                         return mission:messageSpecial(galesID.text.POWER_STYMIES, xi.keyItem.DOMINAS_EMERALD_SEAL)
                     elseif
                         player:hasKeyItem(xi.ki.DOMINAS_EMERALD_SEAL) and
-                        player:getLocalVar('battlefieldWin') == 420
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.SUGAR_COATED_DIRECTIVE_CLOISTER_OF_GALES
                     then
                         return mission:progressEvent(2)
                     end
@@ -405,7 +405,7 @@ mission.sections =
                         return mission:messageSpecial(stormsID.text.POWER_STYMIES, xi.keyItem.DOMINAS_VIOLET_SEAL)
                     elseif
                         player:hasKeyItem(xi.ki.DOMINAS_VIOLET_SEAL) and
-                        player:getLocalVar('battlefieldWin') == 452
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.SUGAR_COATED_DIRECTIVE_CLOISTER_OF_STORMS
                     then
                         return mission:progressEvent(2)
                     end
@@ -436,7 +436,7 @@ mission.sections =
                         return mission:messageSpecial(tidesID.text.POWER_STYMIES, xi.keyItem.DOMINAS_CERULEAN_SEAL)
                     elseif
                         player:hasKeyItem(xi.ki.DOMINAS_CERULEAN_SEAL) and
-                        player:getLocalVar('battlefieldWin') == 611
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.SUGAR_COATED_DIRECTIVE_CLOISTER_OF_TIDES
                     then
                         return mission:progressEvent(2)
                     end
@@ -467,7 +467,7 @@ mission.sections =
                         return mission:messageSpecial(tremorsID.text.POWER_STYMIES, xi.keyItem.DOMINAS_AMBER_SEAL)
                     elseif
                         player:hasKeyItem(xi.ki.DOMINAS_AMBER_SEAL) and
-                        player:getLocalVar('battlefieldWin') == 580
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.SUGAR_COATED_DIRECTIVE_CLOISTER_OF_TREMORS
                     then
                         return mission:progressEvent(2)
                     end

--- a/scripts/missions/bastok/2_3_3_The_Emissary_Sandoria2.lua
+++ b/scripts/missions/bastok/2_3_3_The_Emissary_Sandoria2.lua
@@ -61,7 +61,7 @@ mission.sections =
                 [32001] = function(player, csid, option, npc)
                     if
                         player:getMissionStatus(mission.areaId) == 9 and
-                        player:getLocalVar('battlefieldWin') == 0
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.RANK_2_MISSION_1
                     then
                         npcUtil.giveKeyItem(player, xi.ki.KINDRED_CREST)
                         player:setMissionStatus(mission.areaId, 10)

--- a/scripts/missions/bastok/2_3_4_The_Emissary_Windurst2.lua
+++ b/scripts/missions/bastok/2_3_4_The_Emissary_Windurst2.lua
@@ -27,7 +27,7 @@ mission.sections =
                 [32001] = function(player, csid, option, npc)
                     if
                         player:getMissionStatus(mission.areaId) == 8 and
-                        player:getLocalVar('battlefieldWin') == 96
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.RANK_2_MISSION
                     then
                         npcUtil.giveKeyItem(player, xi.ki.KINDRED_CREST)
                         player:delKeyItem(xi.ki.DARK_KEY)

--- a/scripts/missions/bastok/5_1_Darkness_Rising.lua
+++ b/scripts/missions/bastok/5_1_Darkness_Rising.lua
@@ -199,7 +199,7 @@ mission.sections =
                 [32001] = function(player, csid, option, npc)
                     if
                         player:getMissionStatus(mission.areaId) == 11 and
-                        player:getLocalVar('battlefieldWin') == 512
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.RANK_5_MISSION
                     then
                         npcUtil.giveKeyItem(player, xi.ki.BURNT_SEAL)
                         player:setMissionStatus(mission.areaId, 12)

--- a/scripts/missions/bastok/5_2_Xarcabard_Land_of_Truths.lua
+++ b/scripts/missions/bastok/5_2_Xarcabard_Land_of_Truths.lua
@@ -144,7 +144,7 @@ mission.sections =
                 [32001] = function(player, csid, option, npc)
                     if
                         player:getMissionStatus(mission.areaId) == 3 and
-                        player:getLocalVar('battlefieldWin') == 160
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.SHADOW_LORD_BATTLE
                     then
                         if
                             player:getCurrentMission(xi.mission.log_id.ZILART) ~= xi.mission.id.zilart.THE_NEW_FRONTIER and

--- a/scripts/missions/bastok/9_2_Where_Two_Paths_Converge.lua
+++ b/scripts/missions/bastok/9_2_Where_Two_Paths_Converge.lua
@@ -134,7 +134,7 @@ mission.sections =
                 [32001] = function(player, csid, option, npc)
                     if
                         player:getMissionStatus(mission.areaId) == 1 and
-                        player:getLocalVar('battlefieldWin') == 161
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.WHERE_TWO_PATHS_CONVERGE
                     then
                         player:setMissionStatus(mission.areaId, 2)
                     end

--- a/scripts/missions/cop/2_5_Ancient_Vows.lua
+++ b/scripts/missions/cop/2_5_Ancient_Vows.lua
@@ -70,7 +70,7 @@ mission.sections =
                 [32001] = function(player, csid, option, npc)
                     if
                         mission:getVar(player, 'Status') == 2 and
-                        player:getLocalVar('battlefieldWin') == 960
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.ANCIENT_VOWS
                     then
                         mission:complete(player)
                         player:setPos(694, -5.5, -619, 74, 107) -- South Gustaberg

--- a/scripts/missions/cop/3_5_Darkness_Named.lua
+++ b/scripts/missions/cop/3_5_Darkness_Named.lua
@@ -148,7 +148,7 @@ mission.sections =
 
                 [32001] = function(player, csid, option, npc)
                     if
-                        player:getLocalVar('battlefieldWin') == 704 and
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.DARKNESS_NAMED and
                         mission:getVar(player, 'Status') == 4
                     then
                         player:addTitle(xi.title.TRANSIENT_DREAMER)

--- a/scripts/missions/cop/4_2_The_Savage.lua
+++ b/scripts/missions/cop/4_2_The_Savage.lua
@@ -50,7 +50,7 @@ mission.sections =
             {
                 [32001] = function(player, csid, option, npc)
                     if
-                        player:getLocalVar('battlefieldWin') == 961 and
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.SAVAGE and
                         mission:getVar(player, 'Status') == 1
                     then
                         mission:setVar(player, 'Status', 2)

--- a/scripts/missions/cop/5_2_Desires_of_Emptiness.lua
+++ b/scripts/missions/cop/5_2_Desires_of_Emptiness.lua
@@ -204,7 +204,7 @@ mission.sections =
 
                 [32001] = function(player, csid, option, npc)
                     if
-                        player:getLocalVar('battlefieldWin') == 864 and
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.DESIRES_OF_EMPTINESS and
                         mission:getVar(player, 'Status') == 2
                     then
                         mission:setVar(player, 'Status', 3)

--- a/scripts/missions/cop/5_3_Three_Paths.lua
+++ b/scripts/missions/cop/5_3_Three_Paths.lua
@@ -240,7 +240,7 @@ mission.sections =
 
                 [32001] = function(player, csid, option, npc)
                     if
-                        player:getLocalVar('battlefieldWin') == 736 and
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.CENTURY_OF_HARDSHIP and
                         player:getMissionStatus(mission.areaId, xi.mission.status.COP.LOUVERANCE) == 8
                     then
                         player:setMissionStatus(mission.areaId, 9, xi.mission.status.COP.LOUVERANCE)
@@ -643,7 +643,7 @@ mission.sections =
             {
                 [32001] = function(player, csid, option, npc)
                     if
-                        player:getLocalVar('battlefieldWin') == 640 and
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.FLAMES_FOR_THE_DEAD and
                         player:getMissionStatus(mission.areaId, xi.mission.status.COP.ULMIA) == 8
                     then
                         player:setMissionStatus(mission.areaId, 9, xi.mission.status.COP.ULMIA)

--- a/scripts/missions/cop/6_4_One_to_be_Feared.lua
+++ b/scripts/missions/cop/6_4_One_to_be_Feared.lua
@@ -106,7 +106,7 @@ mission.sections =
 
                 [32001] = function(player, csid, option, npc)
                     if
-                        player:getLocalVar('battlefieldWin') == 992 and
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.ONE_TO_BE_FEARED and
                         mission:getVar(player, 'Status') == 3
                     then
                         -- While we could queue this, any disconnect would cause the player to have to

--- a/scripts/missions/cop/7_5_The_Warriors_Path.lua
+++ b/scripts/missions/cop/7_5_The_Warriors_Path.lua
@@ -83,7 +83,7 @@ mission.sections =
                 [32001] = function(player, csid, option, npc)
                     if
                         mission:getVar(player, 'Status') == 1 and
-                        player:getLocalVar('battlefieldWin') == 993
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.WARRIORS_PATH
                     then
                         mission:setVar(player, 'Status', 2)
                         player:setPos(612.057, 132.664, 776.920, 188, xi.zone.SEALIONS_DEN)

--- a/scripts/missions/rotz/04_The_Temple_of_Uggalepih.lua
+++ b/scripts/missions/rotz/04_The_Temple_of_Uggalepih.lua
@@ -69,7 +69,7 @@ mission.sections =
             onEventFinish =
             {
                 [32001] = function(player, csid, option, npc)
-                    if player:getLocalVar('battlefieldWin') == 128 then
+                    if player:getLocalVar('battlefieldWin') == xi.battlefield.id.TEMPLE_OF_UGGALEPIH then
                         player:setMissionStatus(mission.areaId, 1)
                         player:setPos(-329.762, -0.015, -300.172, 127, xi.zone.SACRIFICIAL_CHAMBER)
                     end
@@ -100,7 +100,7 @@ mission.sections =
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission ~= mission.missionId and
-                player:getLocalVar('battlefieldWin') == 128
+                player:getLocalVar('battlefieldWin') == xi.battlefield.id.TEMPLE_OF_UGGALEPIH
         end,
 
         [xi.zone.SACRIFICIAL_CHAMBER] =

--- a/scripts/missions/rotz/08_Return_to_Delkfutts_Tower.lua
+++ b/scripts/missions/rotz/08_Return_to_Delkfutts_Tower.lua
@@ -133,7 +133,7 @@ mission.sections =
                 end,
 
                 [32001] = function(player, csid, option, npc)
-                    if player:getLocalVar('battlefieldWin') == 256 then
+                    if player:getLocalVar('battlefieldWin') == xi.battlefield.id.RETURN_TO_DELKFUTTS_TOWER then
                         player:setMissionStatus(mission.areaId, 3)
                         player:setPos(-519.99, 1.076, -19.943, 64, xi.zone.STELLAR_FULCRUM)
                     end

--- a/scripts/missions/rotz/16_The_Celestial_Nexus.lua
+++ b/scripts/missions/rotz/16_The_Celestial_Nexus.lua
@@ -32,7 +32,7 @@ mission.sections =
             onEventFinish =
             {
                 [32001] = function(player, csid, option, npc)
-                    if player:getLocalVar('battlefieldWin') == 320 then
+                    if player:getLocalVar('battlefieldWin') == xi.battlefield.id.CELESTIAL_NEXUS then
                         mission:complete(player)
                     end
 

--- a/scripts/missions/sandoria/2_3_3_Journey_to_Bastok2.lua
+++ b/scripts/missions/sandoria/2_3_3_Journey_to_Bastok2.lua
@@ -119,7 +119,7 @@ mission.sections =
                 [32001] = function(player, csid, option, npc)
                     if
                         player:getMissionStatus(mission.areaId) == 10 and
-                        player:getLocalVar('battlefieldWin') == 64
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.RANK_2_MISSION_2
                     then
                         npcUtil.giveKeyItem(player, xi.ki.KINDRED_CREST)
                         player:delKeyItem(xi.ki.DARK_KEY)

--- a/scripts/missions/sandoria/2_3_4_Journey_to_Windurst2.lua
+++ b/scripts/missions/sandoria/2_3_4_Journey_to_Windurst2.lua
@@ -25,7 +25,7 @@ mission.sections =
                 [32001] = function(player, csid, option, npc)
                     if
                         player:getMissionStatus(mission.areaId) == 8 and
-                        player:getLocalVar('battlefieldWin') == 96
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.RANK_2_MISSION
                     then
                         npcUtil.giveKeyItem(player, xi.ki.KINDRED_CREST)
                         player:delKeyItem(xi.ki.DARK_KEY)

--- a/scripts/missions/sandoria/5_1_The_Ruins_of_FeiYin.lua
+++ b/scripts/missions/sandoria/5_1_The_Ruins_of_FeiYin.lua
@@ -182,7 +182,7 @@ mission.sections =
                 [32001] = function(player, csid, option, npc)
                     if
                         player:getMissionStatus(mission.areaId) == 11 and
-                        player:getLocalVar('battlefieldWin') == 512
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.RANK_5_MISSION
                     then
                         npcUtil.giveKeyItem(player, xi.ki.BURNT_SEAL)
                         player:setMissionStatus(mission.areaId, 12)

--- a/scripts/missions/sandoria/5_2_The_Shadow_Lord.lua
+++ b/scripts/missions/sandoria/5_2_The_Shadow_Lord.lua
@@ -126,7 +126,7 @@ mission.sections =
                 [32001] = function(player, csid, option, npc)
                     if
                         player:getMissionStatus(mission.areaId) == 3 and
-                        player:getLocalVar('battlefieldWin') == 160
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.SHADOW_LORD_BATTLE
                     then
                         if
                             player:getCurrentMission(xi.mission.log_id.ZILART) ~= xi.mission.id.zilart.THE_NEW_FRONTIER and

--- a/scripts/missions/sandoria/7_2_The_Secret_Weapon.lua
+++ b/scripts/missions/sandoria/7_2_The_Secret_Weapon.lua
@@ -132,7 +132,7 @@ mission.sections =
                 [32001] = function(player, csid, option, npc)
                     if
                         player:getMissionStatus(mission.areaId) == 2 and
-                        player:getLocalVar('battlefieldWin') == 3
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.THE_SECRET_WEAPON
                     then
                         npcUtil.giveKeyItem(player, xi.ki.CRYSTAL_DOWSER)
                         player:setMissionStatus(mission.areaId, 3)

--- a/scripts/missions/toau/22_Shield_of_Diplomacy.lua
+++ b/scripts/missions/toau/22_Shield_of_Diplomacy.lua
@@ -52,7 +52,7 @@ mission.sections =
                 end,
 
                 [32001] = function(player, csid, option, npc)
-                    if player:getLocalVar('battlefieldWin') == 1124 then
+                    if player:getLocalVar('battlefieldWin') == xi.battlefield.id.SHIELD_OF_DIPLOMACY then
                         mission:complete(player)
                     end
                 end,

--- a/scripts/missions/toau/35_Legacy_of_the_Lost.lua
+++ b/scripts/missions/toau/35_Legacy_of_the_Lost.lua
@@ -25,7 +25,7 @@ mission.sections =
             onEventFinish =
             {
                 [32001] = function(player, csid, option, npc)
-                    if player:getLocalVar('battlefieldWin') == 1092 then
+                    if player:getLocalVar('battlefieldWin') == xi.battlefield.id.LEGACY_OF_THE_LOST then
                         mission:complete(player)
                     end
                 end,

--- a/scripts/missions/windurst/2_3_3_The_Three_Kingdoms_Sandoria2.lua
+++ b/scripts/missions/windurst/2_3_3_The_Three_Kingdoms_Sandoria2.lua
@@ -65,7 +65,7 @@ mission.sections =
                 [32001] = function(player, csid, option, npc)
                     if
                         player:getMissionStatus(mission.areaId) == 9 and
-                        player:getLocalVar('battlefieldWin') == 0
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.RANK_2_MISSION_1
                     then
                         npcUtil.giveKeyItem(player, xi.ki.KINDRED_CREST)
                         player:delKeyItem(xi.ki.DARK_KEY)

--- a/scripts/missions/windurst/2_3_4_The_Three_Kingdoms_Bastok2.lua
+++ b/scripts/missions/windurst/2_3_4_The_Three_Kingdoms_Bastok2.lua
@@ -86,7 +86,7 @@ mission.sections =
                 [32001] = function(player, csid, option, npc)
                     if
                         player:getMissionStatus(mission.areaId) == 10 and
-                        player:getLocalVar('battlefieldWin') == 64
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.RANK_2_MISSION_2
                     then
                         npcUtil.giveKeyItem(player, xi.ki.KINDRED_CREST)
                         player:delKeyItem(xi.ki.DARK_KEY)

--- a/scripts/missions/windurst/5_1_The_Final_Seal.lua
+++ b/scripts/missions/windurst/5_1_The_Final_Seal.lua
@@ -159,7 +159,7 @@ mission.sections =
                 [32001] = function(player, csid, option, npc)
                     if
                         player:getMissionStatus(mission.areaId) == 11 and
-                        player:getLocalVar('battlefieldWin') == 512
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.RANK_5_MISSION
                     then
                         npcUtil.giveKeyItem(player, xi.ki.BURNT_SEAL)
                         player:setMissionStatus(mission.areaId, 12)

--- a/scripts/missions/windurst/5_2_The_Shadow_Awaits.lua
+++ b/scripts/missions/windurst/5_2_The_Shadow_Awaits.lua
@@ -132,7 +132,7 @@ mission.sections =
                 [32001] = function(player, csid, option, npc)
                     if
                         player:getMissionStatus(mission.areaId) == 3 and
-                        player:getLocalVar('battlefieldWin') == 160
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.SHADOW_LORD_BATTLE
                     then
                         if
                             player:getCurrentMission(xi.mission.log_id.ZILART) ~= xi.mission.id.zilart.THE_NEW_FRONTIER and

--- a/scripts/missions/windurst/6_2_Saintly_Invitation.lua
+++ b/scripts/missions/windurst/6_2_Saintly_Invitation.lua
@@ -110,7 +110,7 @@ mission.sections =
                 [32001] = function(player, csid, option, npc)
                     if
                         player:getMissionStatus(mission.areaId) == 1 and
-                        player:getLocalVar('battlefieldWin') == 99
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.SAINTLY_INVITATION
                     then
                         player:addTitle(xi.title.VICTOR_OF_THE_BALGA_CONTEST)
                         npcUtil.giveKeyItem(player, xi.ki.BALGA_CHAMPION_CERTIFICATE)

--- a/scripts/missions/windurst/9_2_Moon_Reading.lua
+++ b/scripts/missions/windurst/9_2_Moon_Reading.lua
@@ -106,7 +106,7 @@ mission.sections =
                 [32001] = function(player, csid, option, npc)
                     if
                         player:getMissionStatus(mission.areaId) == 2 and
-                        player:getLocalVar('battlefieldWin') == 225
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.MOON_READING
                     then
                         player:setMissionStatus(mission.areaId, 3)
                     end

--- a/scripts/missions/wotg/37_Darkness_Descends.lua
+++ b/scripts/missions/wotg/37_Darkness_Descends.lua
@@ -68,7 +68,7 @@ mission.sections =
                     -- in various missions.
 
                     if
-                        player:getLocalVar('battlefieldWin') == 353 and
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.DARKNESS_DESCENDS and
                         mission:getVar(player, 'Status') == 1
                     then
                         mission:setVar(player, 'Status', 2)

--- a/scripts/quests/ahtUrhgan/BLU_AF2_Omens.lua
+++ b/scripts/quests/ahtUrhgan/BLU_AF2_Omens.lua
@@ -146,7 +146,7 @@ quest.sections =
             {
                 [32001] = function(player, csid, option, npc)
                     if
-                        player:getLocalVar('battlefieldWin') == 1122 and
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.OMENS and
                         quest:getVar(player, 'Prog') == 0
                     then
                         quest:setVar(player, 'Prog', 1)

--- a/scripts/quests/bastok/Trial_Size_Trial_by_Earth.lua
+++ b/scripts/quests/bastok/Trial_Size_Trial_by_Earth.lua
@@ -95,7 +95,7 @@ quest.sections =
             onEventFinish =
             {
                 [32001] = function(player, csid, option, npc)
-                    if player:getLocalVar('battlefieldWin') == 578 then
+                    if player:getLocalVar('battlefieldWin') == xi.battlefield.id.TRIAL_SIZE_TRIAL_BY_EARTH then
                         if not player:hasSpell(xi.magic.spell.TITAN) then
                             player:addSpell(xi.magic.spell.TITAN)
                             player:messageSpecial(tremorsID.text.TITAN_UNLOCKED, 0, 0, 1)

--- a/scripts/quests/bastok/Trial_by_Earth.lua
+++ b/scripts/quests/bastok/Trial_by_Earth.lua
@@ -123,7 +123,7 @@ quest.sections =
             onEventFinish =
             {
                 [32001] = function(player, csid, option, npc)
-                    if player:getLocalVar('battlefieldWin') == 576 then
+                    if player:getLocalVar('battlefieldWin') == xi.battlefield.id.TRIAL_BY_EARTH then
                         npcUtil.giveKeyItem(player, xi.ki.WHISPER_OF_TREMORS)
                         player:addTitle(xi.title.HEIR_OF_THE_GREAT_EARTH)
                     end

--- a/scripts/quests/windurst/SMN_AF1_The_Puppet_Master.lua
+++ b/scripts/quests/windurst/SMN_AF1_The_Puppet_Master.lua
@@ -118,7 +118,7 @@ quest.sections =
             {
                 [32001] = function(player, csid, option, npc)
                     if
-                        player:getLocalVar('battlefieldWin') == 577 and
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.PUPPET_MASTER and
                         quest:getVar(player, 'Prog') == 1
                     then
                         quest:setVar(player, 'Prog', 2)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?


Replaces raw battlefield ID numbers with enums from battlefield.lua.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Try battlefields, see that they can be entered.
<!-- Clear and detailed steps to test your changes here -->
