### PR TITLE
[LUA] Hybrid Weaponskill Damage is Incorrect

### DIFF
--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -374,28 +374,6 @@ local function getSingleHitDamage(attacker, target, dmg, ftp, wsParams, calcPara
         hitDamage = hitDamage - xi.combat.physical.getDamageReductionForBlock(target, attacker, hitDamage)
     end
 
-    -- Duplicate the first hit with an added magical component for hybrid WSes
-    if calcParams.hybridHit then
-        -- Calculate magical bonuses and reductions
-        local magicdmg = addBonusesAbility(attacker, wsParams.ele, target, hitDamage, wsParams)
-
-        magicdmg = magicdmg * applyResistanceAbility(attacker, target, wsParams.ele, wsParams.skill, calcParams.bonusAcc)
-        magicdmg = target:magicDmgTaken(magicdmg, wsParams.ele)
-
-        if magicdmg > 0 then
-            magicdmg = magicdmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, wsParams.ele) -- this may absorb or nullify
-        end
-
-        if magicdmg > 0 then -- handle nonzero damage if previous function does not absorb or nullify
-            magicdmg = magicdmg - target:getMod(xi.mod.PHALANX)
-            magicdmg = utils.clamp(magicdmg, 0, 99999)
-            magicdmg = utils.oneforall(target, magicdmg)
-            magicdmg = utils.stoneskin(target, magicdmg)
-        end
-
-        hitDamage = hitDamage + magicdmg
-    end
-
     calcParams.hitsLanded = calcParams.hitsLanded + 1
 
     return hitDamage, calcParams
@@ -463,6 +441,37 @@ local function calculateWsMods(attacker, calcParams, wsParams)
     return wsMods * calcParams.alpha + calcParams.fSTR
 end
 
+-- Compute magic damage component of hybrid weaponskill
+-- https://wiki.ffo.jp/html/1261.html
+-- https://www.ffxiah.com/forum/topic/33470/the-sealed-dagger-a-ninja-guide/151/#3420836
+-- https://www.ffxiah.com/forum/topic/49614/blade-chi-damage-formula/2/#3171538
+local function calculateHybridMagicDamage(tp, physicaldmg, attacker, target, wsParams, calcParams, wsID)
+    local ftp = xi.weaponskills.fTP(tp, wsParams.ftpMod)
+    local magicdmg = physicaldmg * ftp + attacker:getMod(xi.mod.MAGIC_DAMAGE)
+    local wsd = attacker:getMod(xi.mod.ALL_WSDMG_ALL_HITS)
+    if attacker:getMod(xi.mod.WEAPONSKILL_DAMAGE_BASE + wsID) > 0 then
+        wsd = wsd + attacker:getMod(xi.mod.WEAPONSKILL_DAMAGE_BASE + wsID)
+    end
+    magicdmg = magicdmg * (100 + wsd) / 100
+    magicdmg = addBonusesAbility(attacker, wsParams.ele, target, magicdmg, wsParams)
+    magicdmg = magicdmg + calcParams.bonusfTP * physicaldmg
+    magicdmg = magicdmg * applyResistanceAbility(attacker, target, wsParams.ele, wsParams.skill, calcParams.bonusAcc)
+    magicdmg = target:magicDmgTaken(magicdmg, wsParams.ele)
+
+    if magicdmg > 0 then
+        magicdmg = magicdmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, wsParams.ele)
+    end
+
+    if magicdmg > 0 then                                           -- handle nonzero damage if previous function does not absorb or nullify
+        magicdmg = magicdmg - target:getMod(xi.mod.PHALANX)
+        magicdmg = utils.clamp(magicdmg, 0, 99999)
+        magicdmg = utils.oneforall(target, magicdmg)
+        magicdmg = utils.stoneskin(target, magicdmg)
+    end
+
+    return math.floor(magicdmg)
+end
+
 -- Calculates the raw damage for a weaponskill, used by both xi.weaponskills.doPhysicalWeaponskill and xi.weaponskills.doRangedWeaponskill.
 -- Behavior of damage calculations can vary based on the passed in calcParams, which are determined by the calling function
 -- depending on the type of weaponskill being done, and any special cases for that weaponskill
@@ -501,6 +510,9 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
 
     -- Calculate fTP multiplier
     local ftp = xi.weaponskills.fTP(tp, wsParams.ftpMod) + calcParams.bonusfTP
+    if calcParams.hybridHit then
+        ftp = 1 + calcParams.bonusfTP
+    end
 
     -- Calculate critrates
     -- TODO: calc per-hit with weapon crit+% on each hand (if dual wielding)
@@ -575,9 +587,8 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
         end
     end
 
-    -- We've now accounted for any crit from SA/TA, or damage bonus for a Hybrid WS, so nullify them
+    -- We've now accounted for any crit from SA/TA, so nullify them
     calcParams.forcedFirstCrit = false
-    calcParams.hybridHit       = false
 
     -- For items that apply bonus damage to the first hit of a weaponskill (but not later hits),
     -- store bonus damage for first hit, for use after other calculations are done
@@ -822,7 +833,13 @@ xi.weaponskills.doPhysicalWeaponskill = function(attacker, target, wsID, wsParam
 
     -- Send our wsParams off to calculate our raw WS damage, hits landed, and shadows absorbed
     calcParams     = xi.weaponskills.calculateRawWSDmg(attacker, target, wsID, tp, action, wsParams, calcParams)
-    local finaldmg = calcParams.finalDmg
+    local finaldmg = math.floor(calcParams.finalDmg)
+
+    -- Add in magic damage for hybrid weaponskills
+    -- Only procs if the mob still has HP remaining
+    if wsParams.hybridWS and target:getHP() > finaldmg then
+        finaldmg = finaldmg + calculateHybridMagicDamage(tp, finaldmg, attacker, target, wsParams, calcParams, wsID)
+    end
 
     -- Delete statuses that may have been spent by the WS
     attacker:delStatusEffectsByFlag(xi.effectFlag.DETECTABLE)
@@ -895,6 +912,13 @@ xi.weaponskills.doRangedWeaponskill = function(attacker, target, wsID, wsParams,
     -- Calculate reductions
     finaldmg = target:rangedDmgTaken(finaldmg)
     finaldmg = finaldmg * target:getMod(xi.mod.PIERCE_SDT) / 1000
+    finaldmg = math.floor(finaldmg)
+
+    -- Add in magic damage for hybrid weaponskills
+    -- Only procs if the mob still has HP remaining
+    if wsParams.hybridWS and target:getHP() > finaldmg then
+        finaldmg = finaldmg + calculateHybridMagicDamage(tp, finaldmg, attacker, target, wsParams, calcParams, wsID)
+    end
 
     finaldmg            = finaldmg * xi.settings.main.WEAPON_SKILL_POWER -- Add server bonus
     calcParams.finalDmg = finaldmg


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Hybrid weaponskill base physical damage and bonus magic damage is now computed according to the following references.

## Steps to test these changes

Use Piercing Arrow at 3000 TP and record the damage. Then use Flaming Arrow at 3000 TP and verify that you get something close to the following.

Physical Hit - Same as Flaming Arrow

Magic Base = Physical Hit * fTP

Modifier = 0.2 if using gorget/belt, 0.1 if using gorget or belt, 0 otherwise. 

Magical Hit = ((Magic Base + mDMG) * MAB * (1/MDB)* Affinity * Day/Weather * SDT * TMDA * WSD + Physical Hit * Modifier
