### PR TITLE
Fix invalid enum reference in 'Trial By Earth' battlefield scripts

### DIFF
--- a/scripts/battlefields/Cloister_of_Tremors/trial-size_trial_by_earth.lua
+++ b/scripts/battlefields/Cloister_of_Tremors/trial-size_trial_by_earth.lua
@@ -17,7 +17,7 @@ local content = BattlefieldQuest:new({
     requiredItems    = { xi.item.MINI_TUNING_FORK_OF_EARTH },
 
     questArea = xi.questLog.BASTOK,
-    quest     = xi.quest.id.outlands.TRIAL_SIZE_TRIAL_BY_EARTH,
+    quest     = xi.quest.id.bastok.TRIAL_SIZE_TRIAL_BY_EARTH,
 })
 
 function content:entryRequirement(player, npc, isRegistrant, trade)

--- a/scripts/battlefields/Cloister_of_Tremors/trial_by_earth.lua
+++ b/scripts/battlefields/Cloister_of_Tremors/trial_by_earth.lua
@@ -16,7 +16,7 @@ local content = BattlefieldQuest:new({
     requiredKeyItems = { xi.ki.TUNING_FORK_OF_EARTH },
 
     questArea = xi.questLog.BASTOK,
-    quest     = xi.quest.id.outlands.TRIAL_BY_EARTH,
+    quest     = xi.quest.id.bastok.TRIAL_BY_EARTH,
 })
 
 content.groups =


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Trial by earth is part of the Bastok quest log, not outlands.

## Steps to test these changes
1. Add key item
2. Add quest
3. Click proto crystal in Cloister of Tremors.
4. 
![image](https://github.com/LandSandBoat/server/assets/65316697/ec250460-7fc7-4c24-90e1-57e38ca48179)