### PR TITLE
Trial By Lightning: Typo in keyItem enum

### DIFF
--- a/scripts/battlefields/Cloister_of_Storms/trial_by_lightning.lua
+++ b/scripts/battlefields/Cloister_of_Storms/trial_by_lightning.lua
@@ -14,7 +14,7 @@ local content = BattlefieldQuest:new({
     index            = 0,
     entryNpc         = 'LP_Entrance',
     exitNpc          = 'Lightning_Protocrystal',
-    requiredKeyItems = { xi.ki.TUNING_FORK_OF_LIGHTING },
+    requiredKeyItems = { xi.ki.TUNING_FORK_OF_LIGHTNING },
 
     questArea = xi.questLog.OTHER_AREAS,
     quest     = xi.quest.id.otherAreas.TRIAL_BY_LIGHTNING,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Key item is never consumed in Trial by Lightning as the enum in the battlefield script contains a typo

## Steps to test these changes
Enter the battlefield, confirm that the keyitem was consumed.

