### PR TITLE
[Magic] Add non-elemental safety checks to damage_spell.lua and add Rayke to nuke wall calculations

### DIFF
--- a/scripts/globals/job_utils/rune_fencer.lua
+++ b/scripts/globals/job_utils/rune_fencer.lua
@@ -800,26 +800,6 @@ xi.job_utils.rune_fencer.useRayke = function(player, target, ability, action)
     return xi.effect.RAYKE -- Rayke doesn't seem to inform you if it had no effect? -- TODO: double check
 end
 
--- Used for nuke wall reduction of Rayke
-xi.job_utils.rune_fencer.isRaykeReducingElement = function(actor, element)
-    local effect = actor:getStatusEffect(xi.effect.RAYKE)
-
-    if effect then
-        local subpower = effect:getSubPower()
-
-        -- current bit size of subPower is 16 bits, 4*4 = 16
-        -- Step from 0 to 16 in increments of 4...
-        for i = 0, 16, 4 do
-            -- If element is bitpacked into rayke subeffect...
-            if bit.band(bit.rshift(subpower, i), 0xF) == element then
-                return true
-            end
-        end
-    end
-
-    return false
-end
-
 -- see https://www.bg-wiki.com/ffxi/One_for_All
 xi.job_utils.rune_fencer.useOneForAll = function(player, target, ability, action)
     local duration = 30 + player:getJobPointLevel(xi.jp.ONE_FOR_ALL_DURATION)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- As title sais.
- Fixes nuke wall wrong check.
- Add Rayke effect to nuke wall.

Close #5900 

## Steps to test these changes

Review by commit.

- Use Shantotto II without errors.
- Chainspell spells of the same element against a NM. See dmg reduced.
