### PR TITLE
Fixes error on startup with restrict content and extravaganza

### DIFF
--- a/scripts/globals/extravaganza.lua
+++ b/scripts/globals/extravaganza.lua
@@ -40,8 +40,9 @@ xi.extravaganza.shadowEraHide = function(npc)
     local active = xi.extravaganza.campaignActive()
 
     if
-        active == xi.extravaganza.campaign.NONE or
-        active == xi.extravaganza.campaign.SPRING_FALL
+        (active == xi.extravaganza.campaign.NONE or
+        active == xi.extravaganza.campaign.SPRING_FALL) and
+        xi.settings.main.ENABLE_WOTG == 1
     then
         GetNPCByID(npc):setStatus(xi.status.DISAPPEAR)
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Add WOTG setting check for extravaganza NPC loading.

The NPCs that use this function all have the content tag for WOTG. When restrict content is turned on and WOTG is not enabled this creates error inside the log because there is no NPC to actually set to `DISAPPEAR` because the NPC isn't loaded. This extra check should fix the errors. 

![image](https://github.com/LandSandBoat/server/assets/105882754/d01bea2c-be63-44b8-acce-5def62f9e49a)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Inside main.lua:
Set `RESTRICT_CONTENT = 1,`
Set `ENABLE_WOTG      = 0,`

See no errors on startup.
<!-- Clear and detailed steps to test your changes here -->
