### PR TITLE
Remove unnecessary Lua returns

### DIFF
--- a/scripts/zones/AlTaieu/mobs/Absolute_Virtue.lua
+++ b/scripts/zones/AlTaieu/mobs/Absolute_Virtue.lua
@@ -46,8 +46,6 @@ entity.onMagicHit = function(caster, target, spell)
             target:addMod(xi.mod.REGEN, -2)
         end
     end
-
-    return 1
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Bhaflau_Thickets/npcs/Hamta-Iramta.lua
+++ b/scripts/zones/Bhaflau_Thickets/npcs/Hamta-Iramta.lua
@@ -14,7 +14,6 @@ entity.onTrade = function(player, npc, trade)
         player:tradeComplete()
         player:setPos(-458, -16, 0, 189) -- using the pos method until the problem below is fixed
         -- player:startEvent(135) -- << this CS goes black at the end, never fades in
-        return 1
     end
 end
 

--- a/scripts/zones/Bhaflau_Thickets/npcs/_1g0.lua
+++ b/scripts/zones/Bhaflau_Thickets/npcs/_1g0.lua
@@ -10,7 +10,6 @@ end
 
 entity.onTrigger = function(player, npc)
     player:startEvent(502)
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Castle_Oztroja/npcs/_470.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_470.lua
@@ -11,7 +11,6 @@ local entity = {}
 entity.onTrigger = function(player, npc)
     if npc:getAnimation() == xi.anim.CLOSE_DOOR then
         player:messageSpecial(ID.text.ITS_LOCKED)
-        return 1
     end
 end
 

--- a/scripts/zones/Castle_Oztroja/npcs/_471.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_471.lua
@@ -11,7 +11,6 @@ local entity = {}
 entity.onTrigger = function(player, npc)
     if npc:getAnimation() == xi.anim.CLOSE_DOOR then
         player:messageSpecial(ID.text.ITS_LOCKED)
-        return 1
     end
 end
 

--- a/scripts/zones/Castle_Oztroja/npcs/_474.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_474.lua
@@ -11,7 +11,6 @@ local entity = {}
 entity.onTrigger = function(player, npc)
     if npc:getAnimation() == xi.anim.CLOSE_DOOR then
         player:messageSpecial(ID.text.ITS_LOCKED)
-        return 1
     end
 end
 

--- a/scripts/zones/Castle_Oztroja/npcs/_475.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_475.lua
@@ -11,7 +11,6 @@ local entity = {}
 entity.onTrigger = function(player, npc)
     if npc:getAnimation() == xi.anim.CLOSE_DOOR then
         player:messageSpecial(ID.text.ITS_LOCKED)
-        return 1
     end
 end
 

--- a/scripts/zones/Castle_Oztroja/npcs/_477.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_477.lua
@@ -11,7 +11,6 @@ local entity = {}
 entity.onTrigger = function(player, npc)
     if npc:getAnimation() == xi.anim.CLOSE_DOOR then
         player:messageSpecial(ID.text.ITS_LOCKED)
-        return 1
     end
 end
 

--- a/scripts/zones/Castle_Oztroja/npcs/_479.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_479.lua
@@ -26,7 +26,6 @@ end
 entity.onTrigger = function(player, npc)
     if npc:getAnimation() == xi.anim.CLOSE_DOOR then
         player:messageSpecial(ID.text.ITS_LOCKED)
-        return 1
     end
 end
 

--- a/scripts/zones/Castle_Zvahl_Keep/npcs/_4i5.lua
+++ b/scripts/zones/Castle_Zvahl_Keep/npcs/_4i5.lua
@@ -24,7 +24,6 @@ end
 
 entity.onTrigger = function(player, npc)
     player:startEvent(9)
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_0y0.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_0y0.lua
@@ -10,7 +10,6 @@ end
 
 entity.onTrigger = function(player, npc)
     player:startEvent(173)
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iyc.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iyc.lua
@@ -10,7 +10,6 @@ end
 
 entity.onTrigger = function(player, npc)
     player:startEvent(172)
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Heavens_Tower/npcs/_6q1.lua
+++ b/scripts/zones/Heavens_Tower/npcs/_6q1.lua
@@ -24,8 +24,6 @@ entity.onTrigger = function(player, npc)
     else
         player:messageSpecial(ID.text.STAIRWAY_ONLY_CITIZENS)
     end
-
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Ilrusi_Atoll/npcs/Rune_of_Release.lua
+++ b/scripts/zones/Ilrusi_Atoll/npcs/Rune_of_Release.lua
@@ -14,8 +14,6 @@ entity.onTrigger = function(player, npc)
     if instance:completed() then
         player:startEvent(100, 4)
     end
-
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Inner_Horutoto_Ruins/DefaultActions.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/DefaultActions.lua
@@ -3,6 +3,12 @@ local ID = zones[xi.zone.INNER_HORUTOTO_RUINS]
 return {
     ['_5ca'] = { event = 44 },
     ['_5cb'] = { messageSpecial = ID.text.DOOR_FIRMLY_CLOSED },
+    ['_5cc'] = { messageSpecial = ID.text.DOOR_FIRMLY_CLOSED },
+    ['_5cd'] = { messageSpecial = ID.text.DOOR_FIRMLY_CLOSED },
+    ['_5ce'] = { messageSpecial = ID.text.DOOR_FIRMLY_CLOSED },
+    ['_5cf'] = { messageSpecial = ID.text.DOOR_FIRMLY_CLOSED },
+    ['_5cg'] = { messageSpecial = ID.text.DOOR_FIRMLY_CLOSED },
+    ['_5ch'] = { messageSpecial = ID.text.DOOR_FIRMLY_CLOSED },
     ['_5ci'] = { messageSpecial = ID.text.DOOR_FIRMLY_CLOSED },
     ['_5c5'] = { messageSpecial = ID.text.DOOR_FIRMLY_CLOSED },
 }

--- a/scripts/zones/Inner_Horutoto_Ruins/npcs/_5ca.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/npcs/_5ca.lua
@@ -26,8 +26,6 @@ entity.onTrigger = function(player, npc)
         player:messageSpecial(ID.text.CAT_BURGLARS_HIDEOUT, 1, xi.ki.WINDURST_WOODS_SCOOP) -- Confirm Story
         player:setCharVar('QuestMakingHeadlines_var', utils.mask.setBit(prog, 4, true))
     end
-
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Inner_Horutoto_Ruins/npcs/_5cc.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/npcs/_5cc.lua
@@ -3,16 +3,12 @@
 --  NPC: _5cc (Gate of Ice)
 -- !pos -228 0 99 192
 -----------------------------------
-local ID = zones[xi.zone.INNER_HORUTOTO_RUINS]
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:messageSpecial(ID.text.DOOR_FIRMLY_CLOSED)
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Inner_Horutoto_Ruins/npcs/_5cd.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/npcs/_5cd.lua
@@ -3,16 +3,12 @@
 --  NPC: _5cd (Gate of Water)
 -- !pos -228 0 140 192
 -----------------------------------
-local ID = zones[xi.zone.INNER_HORUTOTO_RUINS]
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:messageSpecial(ID.text.DOOR_FIRMLY_CLOSED)
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Inner_Horutoto_Ruins/npcs/_5ce.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/npcs/_5ce.lua
@@ -3,16 +3,12 @@
 --  NPC: _5ce (Gate of Earth)
 -- !pos -228 0 140 192
 -----------------------------------
-local ID = zones[xi.zone.INNER_HORUTOTO_RUINS]
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:messageSpecial(ID.text.DOOR_FIRMLY_CLOSED)
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Inner_Horutoto_Ruins/npcs/_5cf.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/npcs/_5cf.lua
@@ -3,16 +3,12 @@
 --  NPC: _5cf (Gate of Wind)
 -- !pos -332 0 99 192
 -----------------------------------
-local ID = zones[xi.zone.INNER_HORUTOTO_RUINS]
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:messageSpecial(ID.text.DOOR_FIRMLY_CLOSED)
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Inner_Horutoto_Ruins/npcs/_5cg.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/npcs/_5cg.lua
@@ -3,16 +3,12 @@
 --  NPC: _5cg (Gate of Fire)
 -- !pos -332 0 99 192
 -----------------------------------
-local ID = zones[xi.zone.INNER_HORUTOTO_RUINS]
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:messageSpecial(ID.text.DOOR_FIRMLY_CLOSED)
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Inner_Horutoto_Ruins/npcs/_5ch.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/npcs/_5ch.lua
@@ -3,16 +3,12 @@
 --  NPC: _5ch (Gate of Thunder)
 -- !pos -331 0 139 192
 -----------------------------------
-local ID = zones[xi.zone.INNER_HORUTOTO_RUINS]
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:messageSpecial(ID.text.DOOR_FIRMLY_CLOSED)
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Lebros_Cavern/npcs/Rune_of_Release.lua
+++ b/scripts/zones/Lebros_Cavern/npcs/Rune_of_Release.lua
@@ -12,8 +12,6 @@ entity.onTrigger = function(player, npc)
     if instance:completed() then
         player:startEvent(100, 2)
     end
-
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Leujaoam_Sanctum/npcs/Rune_of_Release.lua
+++ b/scripts/zones/Leujaoam_Sanctum/npcs/Rune_of_Release.lua
@@ -13,8 +13,6 @@ entity.onTrigger = function(player, npc)
     if instance:completed() then
         player:startEvent(100, 0)
     end
-
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Mamook/mobs/Chamrosh.lua
+++ b/scripts/zones/Mamook/mobs/Chamrosh.lua
@@ -66,8 +66,6 @@ entity.onMagicHit = function(caster, target, spell)
         target:setLocalVar('COPY_SPELL', spell:getID())
         target:setLocalVar('LAST_CAST', target:getBattleTime())
     end
-
-    return 1
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Mamool_Ja_Training_Grounds/npcs/Rune_of_Release.lua
+++ b/scripts/zones/Mamool_Ja_Training_Grounds/npcs/Rune_of_Release.lua
@@ -12,8 +12,6 @@ entity.onTrigger = function(player, npc)
     if instance:completed() then
         player:startEvent(100, 1)
     end
-
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Metalworks/DefaultActions.lua
+++ b/scripts/zones/Metalworks/DefaultActions.lua
@@ -2,6 +2,7 @@ local ID = zones[xi.zone.METALWORKS]
 
 return {
     ['_6ld']        = { event = 604 },
+    ['_6le']        = { messageSpecial = ID.text.ITS_LOCKED },
     ['_6lg']        = { messageSpecial = ID.text.ITS_LOCKED },
     ['Alois']       = { event = 370 },
     ['Ayame']       = { event = 701 },

--- a/scripts/zones/Metalworks/npcs/_6le.lua
+++ b/scripts/zones/Metalworks/npcs/_6le.lua
@@ -3,16 +3,12 @@
 -- Door: _6le (Presidential Suite)
 -- !pos 113 -20 8 237
 -----------------------------------
-local ID = zones[xi.zone.METALWORKS]
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:messageSpecial(ID.text.ITS_LOCKED)
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Misareaux_Coast/npcs/_0p3.lua
+++ b/scripts/zones/Misareaux_Coast/npcs/_0p3.lua
@@ -10,7 +10,6 @@ end
 
 entity.onTrigger = function(player, npc)
     player:startEvent(553)
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Periqia/npcs/Rune_of_Release.lua
+++ b/scripts/zones/Periqia/npcs/Rune_of_Release.lua
@@ -14,8 +14,6 @@ entity.onTrigger = function(player, npc)
     if instance:completed() then
         player:startEvent(100, 3)
     end
-
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Port_Bastok/npcs/_6k9.lua
+++ b/scripts/zones/Port_Bastok/npcs/_6k9.lua
@@ -10,7 +10,6 @@ end
 
 entity.onTrigger = function(player, npc)
     player:startEvent(140)
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Port_Jeuno/npcs/_6u2.lua
+++ b/scripts/zones/Port_Jeuno/npcs/_6u2.lua
@@ -9,7 +9,6 @@ end
 
 entity.onTrigger = function(player, npc)
     player:startEvent(54)
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Port_Jeuno/npcs/_6u6.lua
+++ b/scripts/zones/Port_Jeuno/npcs/_6u6.lua
@@ -9,7 +9,6 @@ end
 
 entity.onTrigger = function(player, npc)
     player:startEvent(53)
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Port_Jeuno/npcs/_6uc.lua
+++ b/scripts/zones/Port_Jeuno/npcs/_6uc.lua
@@ -9,7 +9,6 @@ end
 
 entity.onTrigger = function(player, npc)
     player:startEvent(52)
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Port_Jeuno/npcs/_6ug.lua
+++ b/scripts/zones/Port_Jeuno/npcs/_6ug.lua
@@ -9,7 +9,6 @@ end
 
 entity.onTrigger = function(player, npc)
     player:startEvent(55)
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Port_San_dOria/npcs/_6g7.lua
+++ b/scripts/zones/Port_San_dOria/npcs/_6g7.lua
@@ -12,8 +12,6 @@ entity.onTrigger = function(player, npc)
     if player:getZPos() >= 12 then
         player:startEvent(518)
     end
-
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Port_Windurst/npcs/_6o7.lua
+++ b/scripts/zones/Port_Windurst/npcs/_6o7.lua
@@ -10,7 +10,6 @@ end
 
 entity.onTrigger = function(player, npc)
     player:startEvent(182)
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Qulun_Dome/npcs/_441.lua
+++ b/scripts/zones/Qulun_Dome/npcs/_441.lua
@@ -28,8 +28,6 @@ entity.onTrigger = function(player, npc)
             player:messageSpecial(ID.text.CANNOT_BE_OPENED_FROM_THIS_SIDE)
         end
     end
-
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Ranguemont_Pass/npcs/_4m0.lua
+++ b/scripts/zones/Ranguemont_Pass/npcs/_4m0.lua
@@ -7,7 +7,6 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    return 1
 end
 
 return entity

--- a/scripts/zones/Temple_of_Uggalepih/npcs/_mf1.lua
+++ b/scripts/zones/Temple_of_Uggalepih/npcs/_mf1.lua
@@ -21,8 +21,6 @@ entity.onTrigger = function(player, npc)
     if guardian ~= nil and guardian:getHP() > 0 and guardian:getTarget() == nil then
         guardian:updateClaim(player)
     end
-
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Temple_of_Uggalepih/npcs/_mf8.lua
+++ b/scripts/zones/Temple_of_Uggalepih/npcs/_mf8.lua
@@ -22,8 +22,6 @@ entity.onTrigger = function(player, npc)
     else
         npc:openDoor(11) -- retail timed
     end
-
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Temple_of_Uggalepih/npcs/_mf9.lua
+++ b/scripts/zones/Temple_of_Uggalepih/npcs/_mf9.lua
@@ -22,8 +22,6 @@ entity.onTrigger = function(player, npc)
     else
         npc:openDoor(11) -- retail timed
     end
-
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Upper_Delkfutts_Tower/npcs/_4e1.lua
+++ b/scripts/zones/Upper_Delkfutts_Tower/npcs/_4e1.lua
@@ -10,7 +10,6 @@ end
 
 entity.onTrigger = function(player, npc)
     player:startEvent(2)
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Wajaom_Woodlands/npcs/_1f0.lua
+++ b/scripts/zones/Wajaom_Woodlands/npcs/_1f0.lua
@@ -10,7 +10,6 @@ end
 
 entity.onTrigger = function(player, npc)
     player:startEvent(502)
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Windurst_Walls/npcs/_6n8.lua
+++ b/scripts/zones/Windurst_Walls/npcs/_6n8.lua
@@ -21,8 +21,6 @@ entity.onTrigger = function(player, npc)
     else
         player:startEvent(395)
     end
-
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Removes unnecessary returns in Lua scripts (primarily in onTrigger).  onTrigger defaults to 1 on a nil return, and the only specific check is for -1 (if it is a door).  This removes all `return 1` references except when -1 is returned in the same function.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No impact to gameplay should be observed
<!-- Clear and detailed steps to test your changes here -->
