### PR TITLE
[Fix] "Ore Toss" incorrect damage multiplier

### DIFF
--- a/scripts/actions/mobskills/ore_toss.lua
+++ b/scripts/actions/mobskills/ore_toss.lua
@@ -14,11 +14,13 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 1
-    local accmod = 1
-    local dmgmod = math.random(3, 6)
-    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
-    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.RANGED, xi.damageType.BLUNT, xi.mobskills.shadowBehavior.NUMSHADOWS_1)
+    local accmod  = 1
+    local dmgmod  = 2
+    local info    = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
+    local dmg     = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.RANGED, xi.damageType.BLUNT, xi.mobskills.shadowBehavior.NUMSHADOWS_1)
+
     target:takeDamage(dmg, mob, xi.attackType.RANGED, xi.damageType.BLUNT)
+
     return dmg
 end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Data from Jimmayus spreadsheet
![imagen](https://github.com/LandSandBoat/server/assets/60053999/81de253f-6e5d-4076-902f-3c511f63397e)

## Steps to test these changes

Have a quadave toss you an ore.
Dont see this:
![imagen](https://github.com/LandSandBoat/server/assets/60053999/0cd93907-cddd-4c0e-9b72-96022ba862bc)

