### PR TITLE
Fix TOAU21, Apocalypse Nigh entry requirements

### DIFF
--- a/scripts/battlefields/Empyreal_Paradox/apocalypse_nigh.lua
+++ b/scripts/battlefields/Empyreal_Paradox/apocalypse_nigh.lua
@@ -15,8 +15,8 @@ local content = BattlefieldQuest:new({
     exitNpc       = 'Transcendental_Radiance',
     questArea     = xi.questLog.JEUNO,
     quest         = xi.quest.id.jeuno.APOCALYPSE_NIGH,
-    requiredVar   = 'ApocalypseNigh',
-    requiredValue = 4,
+    requiredVar   = 'Quest[3][89]Prog',
+    requiredValue = 3,
 })
 
 function content:onEventFinishWin(player, csid, option, npc)

--- a/scripts/battlefields/Navukgo_Execution_Chamber/shield_of_diplomacy.lua
+++ b/scripts/battlefields/Navukgo_Execution_Chamber/shield_of_diplomacy.lua
@@ -19,6 +19,7 @@ local content = BattlefieldMission:new({
     exitNpcs              = { '_1s1', '_1s2', '_1s3' },
     missionArea           = xi.mission.log_id.TOAU,
     mission               = xi.mission.id.toau.SHIELD_OF_DIPLOMACY,
+    missionStatusArea     = xi.mission.log_id.TOAU,
     requiredMissionStatus = 2,
 })
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes #5935 

TOAU21 was missing missionStatusArea and defaulting to checking missionStatus for the player's nation.  This resolves that issue, and also corrects the required variable for Apocalypse Nigh

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Run through the quest/mission and entry should be successful (quite unsure how Nigh worked for me yesterday without this change)

<!-- Clear and detailed steps to test your changes here -->
