### PR TITLE
Add Battlefield rule to allow trust casting

### DIFF
--- a/scripts/battlefields/Balgas_Dais/beyond_infinity.lua
+++ b/scripts/battlefields/Balgas_Dais/beyond_infinity.lua
@@ -6,15 +6,16 @@ local balgasID = zones[xi.zone.BALGAS_DAIS]
 -----------------------------------
 
 local content = BattlefieldQuest:new({
-    zoneId           = xi.zone.BALGAS_DAIS,
-    battlefieldId    = xi.battlefield.id.BEYOND_INFINITY_BALGAS_DAIS,
-    canLoseExp       = false,
-    maxPlayers       = 6,
-    levelCap         = 99,
-    timeLimit        = utils.minutes(10),
-    index            = 20,
-    entryNpc         = 'BC_Entrance',
-    exitNpc          = 'Burning_Circle',
+    zoneId        = xi.zone.BALGAS_DAIS,
+    battlefieldId = xi.battlefield.id.BEYOND_INFINITY_BALGAS_DAIS,
+    canLoseExp    = false,
+    allowTrusts   = true,
+    maxPlayers    = 6,
+    levelCap      = 99,
+    timeLimit     = utils.minutes(10),
+    index         = 20,
+    entryNpc      = 'BC_Entrance',
+    exitNpc       = 'Burning_Circle',
 
     questArea = xi.questLog.JEUNO,
     quest     = xi.quest.id.jeuno.BEYOND_INFINITY,

--- a/scripts/battlefields/Balgas_Dais/rank_2_mission.lua
+++ b/scripts/battlefields/Balgas_Dais/rank_2_mission.lua
@@ -11,6 +11,7 @@ local content = Battlefield:new({
     battlefieldId = xi.battlefield.id.RANK_2_MISSION,
     canLoseExp    = false,
     isMission     = true,
+    allowTrusts   = true,
     maxPlayers    = 6,
     levelCap      = 25,
     timeLimit     = utils.minutes(30),

--- a/scripts/battlefields/Balgas_Dais/saintly_invitation.lua
+++ b/scripts/battlefields/Balgas_Dais/saintly_invitation.lua
@@ -11,6 +11,7 @@ local content = BattlefieldMission:new({
     battlefieldId         = xi.battlefield.id.SAINTLY_INVITATION,
     canLoseExp            = false,
     isMission             = true,
+    allowTrusts           = true,
     maxPlayers            = 6,
     levelCap              = 75,
     timeLimit             = utils.minutes(30),

--- a/scripts/battlefields/Boneyard_Gully/head_wind.lua
+++ b/scripts/battlefields/Boneyard_Gully/head_wind.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId = xi.battlefield.id.HEAD_WIND,
     canLoseExp    = false,
     isMission     = true,
+    allowTrusts   = true,
     maxPlayers    = 6,
     levelCap      = 50,
     timeLimit     = utils.minutes(30),

--- a/scripts/battlefields/Chamber_of_Oracles/through_the_quicksand_caves.lua
+++ b/scripts/battlefields/Chamber_of_Oracles/through_the_quicksand_caves.lua
@@ -11,6 +11,7 @@ local content = BattlefieldMission:new({
     battlefieldId         = xi.battlefield.id.THROUGH_THE_QUICKSAND_CAVES,
     canLoseExp            = false,
     isMission             = true,
+    allowTrusts           = true,
     maxPlayers            = 6,
     levelCap              = 75,
     timeLimit             = utils.minutes(30),

--- a/scripts/battlefields/Cloister_of_Flames/sugar-coated_directive.lua
+++ b/scripts/battlefields/Cloister_of_Flames/sugar-coated_directive.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId = xi.battlefield.id.SUGAR_COATED_DIRECTIVE_CLOISTER_OF_FLAMES,
     canLoseExp    = false,
     isMission     = true,
+    allowTrusts   = true,
     maxPlayers    = 6,
     levelCap      = 99,
     timeLimit     = utils.minutes(30),

--- a/scripts/battlefields/Cloister_of_Frost/sugar-coated_directive.lua
+++ b/scripts/battlefields/Cloister_of_Frost/sugar-coated_directive.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId = xi.battlefield.id.SUGAR_COATED_DIRECTIVE_CLOISTER_OF_FROST,
     canLoseExp    = false,
     isMission     = true,
+    allowTrusts   = true,
     maxPlayers    = 6,
     levelCap      = 99,
     timeLimit     = utils.minutes(30),

--- a/scripts/battlefields/Cloister_of_Gales/sugar-coated_directive.lua
+++ b/scripts/battlefields/Cloister_of_Gales/sugar-coated_directive.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId = xi.battlefield.id.SUGAR_COATED_DIRECTIVE_CLOISTER_OF_GALES,
     canLoseExp    = false,
     isMission     = true,
+    allowTrusts   = true,
     maxPlayers    = 6,
     levelCap      = 99,
     timeLimit     = utils.minutes(30),

--- a/scripts/battlefields/Cloister_of_Storms/sugar-coated_directive.lua
+++ b/scripts/battlefields/Cloister_of_Storms/sugar-coated_directive.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId = xi.battlefield.id.SUGAR_COATED_DIRECTIVE_CLOISTER_OF_STORMS,
     canLoseExp    = false,
     isMission     = true,
+    allowTrusts   = true,
     maxPlayers    = 6,
     levelCap      = 99,
     timeLimit     = utils.minutes(30),

--- a/scripts/battlefields/Cloister_of_Tides/sugar-coated_directive.lua
+++ b/scripts/battlefields/Cloister_of_Tides/sugar-coated_directive.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId = xi.battlefield.id.SUGAR_COATED_DIRECTIVE_CLOISTER_OF_TIDES,
     canLoseExp    = false,
     isMission     = true,
+    allowTrusts   = true,
     maxPlayers    = 6,
     levelCap      = 99,
     timeLimit     = utils.minutes(30),

--- a/scripts/battlefields/Cloister_of_Tremors/sugar-coated_directive.lua
+++ b/scripts/battlefields/Cloister_of_Tremors/sugar-coated_directive.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId = xi.battlefield.id.SUGAR_COATED_DIRECTIVE_CLOISTER_OF_TREMORS,
     canLoseExp    = false,
     isMission     = true,
+    allowTrusts   = true,
     maxPlayers    = 6,
     levelCap      = 99,
     timeLimit     = utils.minutes(30),

--- a/scripts/battlefields/Empyreal_Paradox/apocalypse_nigh.lua
+++ b/scripts/battlefields/Empyreal_Paradox/apocalypse_nigh.lua
@@ -8,6 +8,7 @@ local empyrealParadoxID = zones[xi.zone.EMPYREAL_PARADOX]
 local content = BattlefieldQuest:new({
     zoneId        = xi.zone.EMPYREAL_PARADOX,
     battlefieldId = xi.battlefield.id.APOCALYPSE_NIGH,
+    allowTrusts   = true,
     maxPlayers    = 6,
     timeLimit     = utils.minutes(30),
     index         = 1,

--- a/scripts/battlefields/Empyreal_Paradox/dawn.lua
+++ b/scripts/battlefields/Empyreal_Paradox/dawn.lua
@@ -13,6 +13,7 @@ local content = BattlefieldMission:new({
     battlefieldId = xi.battlefield.id.DAWN,
     canLoseExp    = false,
     isMission     = true,
+    allowTrusts   = true,
     maxPlayers    = 6,
     levelCap      = 75,
     timeLimit     = utils.minutes(30),

--- a/scripts/battlefields/Full_Moon_Fountain/moon_reading.lua
+++ b/scripts/battlefields/Full_Moon_Fountain/moon_reading.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId         = xi.battlefield.id.MOON_READING,
     canLoseExp            = false,
     isMission             = true,
+    allowTrusts           = true,
     maxPlayers            = 6,
     levelCap              = 75,
     timeLimit             = utils.minutes(30),

--- a/scripts/battlefields/Ghelsba_Outpost/save_the_children.lua
+++ b/scripts/battlefields/Ghelsba_Outpost/save_the_children.lua
@@ -11,6 +11,7 @@ local content = BattlefieldMission:new({
     battlefieldId         = xi.battlefield.id.SAVE_THE_CHILDREN,
     canLoseExp            = false,
     isMission             = true,
+    allowTrusts           = true,
     maxPlayers            = 6,
     levelCap              = 99,
     timeLimit             = utils.minutes(10),

--- a/scripts/battlefields/Horlais_Peak/beyond_infinity.lua
+++ b/scripts/battlefields/Horlais_Peak/beyond_infinity.lua
@@ -6,15 +6,16 @@ local horlaisID = zones[xi.zone.HORLAIS_PEAK]
 -----------------------------------
 
 local content = BattlefieldQuest:new({
-    zoneId           = xi.zone.HORLAIS_PEAK,
-    battlefieldId    = xi.battlefield.id.BEYOND_INFINITY_HORLAIS_PEAK,
-    canLoseExp       = false,
-    maxPlayers       = 6,
-    levelCap         = 99,
-    timeLimit        = utils.minutes(10),
-    index            = 20,
-    entryNpc         = 'BC_Entrance',
-    exitNpc          = 'Burning_Circle',
+    zoneId        = xi.zone.HORLAIS_PEAK,
+    battlefieldId = xi.battlefield.id.BEYOND_INFINITY_HORLAIS_PEAK,
+    canLoseExp    = false,
+    allowTrusts   = true,
+    maxPlayers    = 6,
+    levelCap      = 99,
+    timeLimit     = utils.minutes(10),
+    index         = 20,
+    entryNpc      = 'BC_Entrance',
+    exitNpc       = 'Burning_Circle',
 
     questArea = xi.questLog.JEUNO,
     quest     = xi.quest.id.jeuno.BEYOND_INFINITY,

--- a/scripts/battlefields/Horlais_Peak/rank_2_mission.lua
+++ b/scripts/battlefields/Horlais_Peak/rank_2_mission.lua
@@ -10,6 +10,7 @@ local content = Battlefield:new({
     battlefieldId = xi.battlefield.id.RANK_2_MISSION_1,
     canLoseExp    = false,
     isMission     = true,
+    allowTrusts   = true,
     maxPlayers    = 6,
     levelCap      = 25,
     timeLimit     = utils.minutes(30),

--- a/scripts/battlefields/Horlais_Peak/the_secret_weapon.lua
+++ b/scripts/battlefields/Horlais_Peak/the_secret_weapon.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId         = xi.battlefield.id.THE_SECRET_WEAPON,
     canLoseExp            = false,
     isMission             = true,
+    allowTrusts           = true,
     maxPlayers            = 6,
     levelCap              = 75,
     timeLimit             = utils.minutes(30),

--- a/scripts/battlefields/Jade_Sepulcher/puppet_in_peril.lua
+++ b/scripts/battlefields/Jade_Sepulcher/puppet_in_peril.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId         = xi.battlefield.id.PUPPET_IN_PERIL,
     canLoseExp            = false,
     isMission             = true,
+    allowTrusts           = true,
     maxPlayers            = 6,
     levelCap              = 99,
     timeLimit             = utils.minutes(30),

--- a/scripts/battlefields/LaLoff_Amphitheater/ark_angels_1.lua
+++ b/scripts/battlefields/LaLoff_Amphitheater/ark_angels_1.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId         = xi.battlefield.id.ARK_ANGELS_1,
     canLoseExp            = false,
     isMission             = true,
+    allowTrusts           = true,
     maxPlayers            = 6,
     levelCap              = 75,
     timeLimit             = utils.minutes(30),

--- a/scripts/battlefields/LaLoff_Amphitheater/ark_angels_2.lua
+++ b/scripts/battlefields/LaLoff_Amphitheater/ark_angels_2.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId         = xi.battlefield.id.ARK_ANGELS_2,
     canLoseExp            = false,
     isMission             = true,
+    allowTrusts           = true,
     maxPlayers            = 6,
     levelCap              = 75,
     timeLimit             = utils.minutes(30),

--- a/scripts/battlefields/LaLoff_Amphitheater/ark_angels_3.lua
+++ b/scripts/battlefields/LaLoff_Amphitheater/ark_angels_3.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId         = xi.battlefield.id.ARK_ANGELS_3,
     canLoseExp            = false,
     isMission             = true,
+    allowTrusts           = true,
     maxPlayers            = 6,
     levelCap              = 75,
     timeLimit             = utils.minutes(30),

--- a/scripts/battlefields/LaLoff_Amphitheater/ark_angels_4.lua
+++ b/scripts/battlefields/LaLoff_Amphitheater/ark_angels_4.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId         = xi.battlefield.id.ARK_ANGELS_4,
     canLoseExp            = false,
     isMission             = true,
+    allowTrusts           = true,
     maxPlayers            = 6,
     levelCap              = 75,
     timeLimit             = utils.minutes(30),

--- a/scripts/battlefields/LaLoff_Amphitheater/ark_angels_5.lua
+++ b/scripts/battlefields/LaLoff_Amphitheater/ark_angels_5.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId         = xi.battlefield.id.ARK_ANGELS_5,
     canLoseExp            = false,
     isMission             = true,
+    allowTrusts           = true,
     maxPlayers            = 6,
     levelCap              = 75,
     timeLimit             = utils.minutes(30),

--- a/scripts/battlefields/LaLoff_Amphitheater/divine_might.lua
+++ b/scripts/battlefields/LaLoff_Amphitheater/divine_might.lua
@@ -9,6 +9,7 @@ local content = Battlefield:new({
     zoneId        = xi.zone.LALOFF_AMPHITHEATER,
     battlefieldId = xi.battlefield.id.DIVINE_MIGHT,
     canLoseExp    = false,
+    allowTrusts   = true,
     maxPlayers    = 18,
     levelCap      = 99,
     timeLimit     = utils.minutes(30),

--- a/scripts/battlefields/La_Vaule_[S]/purple_the_new_black.lua
+++ b/scripts/battlefields/La_Vaule_[S]/purple_the_new_black.lua
@@ -11,6 +11,7 @@ local content = BattlefieldMission:new({
     battlefieldId         = xi.battlefield.id.PURPLE_THE_NEW_BLACK,
     canLoseExp            = false,
     isMission             = true,
+    allowTrusts           = true,
     maxPlayers            = 6,
     timeLimit             = utils.minutes(30),
     index                 = 1,

--- a/scripts/battlefields/Mine_Shaft_2716/century_of_hardship.lua
+++ b/scripts/battlefields/Mine_Shaft_2716/century_of_hardship.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId         = xi.battlefield.id.CENTURY_OF_HARDSHIP,
     canLoseExp            = false,
     isMission             = true,
+    allowTrusts           = true,
     maxPlayers            = 6,
     levelCap              = 60,
     timeLimit             = utils.minutes(30),

--- a/scripts/battlefields/Monarch_Linn/ancient_vows.lua
+++ b/scripts/battlefields/Monarch_Linn/ancient_vows.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId = xi.battlefield.id.ANCIENT_VOWS,
     canLoseExp    = false,
     isMission     = true,
+    allowTrusts   = true,
     maxPlayers    = 6,
     levelCap      = 40,
     timeLimit     = utils.minutes(30),

--- a/scripts/battlefields/Monarch_Linn/savage.lua
+++ b/scripts/battlefields/Monarch_Linn/savage.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId = xi.battlefield.id.SAVAGE,
     canLoseExp    = false,
     isMission     = true,
+    allowTrusts   = true,
     maxPlayers    = 6,
     levelCap      = 50,
     timeLimit     = utils.minutes(30),

--- a/scripts/battlefields/Navukgo_Execution_Chamber/shield_of_diplomacy.lua
+++ b/scripts/battlefields/Navukgo_Execution_Chamber/shield_of_diplomacy.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId         = xi.battlefield.id.SHIELD_OF_DIPLOMACY,
     canLoseExp            = false,
     isMission             = true,
+    allowTrusts           = true,
     maxPlayers            = 6,
     levelCap              = 99,
     timeLimit             = utils.minutes(30),

--- a/scripts/battlefields/QuBia_Arena/beyond_infinity.lua
+++ b/scripts/battlefields/QuBia_Arena/beyond_infinity.lua
@@ -6,15 +6,16 @@ local qubiaID = zones[xi.zone.QUBIA_ARENA]
 -----------------------------------
 
 local content = BattlefieldQuest:new({
-    zoneId           = xi.zone.QUBIA_ARENA,
-    battlefieldId    = xi.battlefield.id.BEYOND_INFINITY,
-    canLoseExp       = false,
-    maxPlayers       = 6,
-    levelCap         = 99,
-    timeLimit        = utils.minutes(10),
-    index            = 21,
-    entryNpc         = 'BC_Entrance',
-    exitNpc          = 'Burning_Circle',
+    zoneId        = xi.zone.QUBIA_ARENA,
+    battlefieldId = xi.battlefield.id.BEYOND_INFINITY,
+    canLoseExp    = false,
+    allowTrusts   = true,
+    maxPlayers    = 6,
+    levelCap      = 99,
+    timeLimit     = utils.minutes(10),
+    index         = 21,
+    entryNpc      = 'BC_Entrance',
+    exitNpc       = 'Burning_Circle',
 
     questArea = xi.questLog.JEUNO,
     quest     = xi.quest.id.jeuno.BEYOND_INFINITY,

--- a/scripts/battlefields/QuBia_Arena/heir_to_the_light.lua
+++ b/scripts/battlefields/QuBia_Arena/heir_to_the_light.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId         = xi.battlefield.id.HEIR_TO_THE_LIGHT,
     canLoseExp            = false,
     isMission             = true,
+    allowTrusts           = true,
     maxPlayers            = 6,
     levelCap              = 75,
     timeLimit             = utils.minutes(30),

--- a/scripts/battlefields/QuBia_Arena/rank_5_mission.lua
+++ b/scripts/battlefields/QuBia_Arena/rank_5_mission.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId         = xi.battlefield.id.RANK_5_MISSION,
     canLoseExp            = false,
     isMission             = true,
+    allowTrusts           = true,
     maxPlayers            = 6,
     levelCap              = 50,
     timeLimit             = utils.minutes(30),

--- a/scripts/battlefields/QuBia_Arena/those_who_lurk_in_shadows.lua
+++ b/scripts/battlefields/QuBia_Arena/those_who_lurk_in_shadows.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId         = xi.battlefield.id.THOSE_WHO_LURK_IN_SHADOWS,
     canLoseExp            = false,
     isMission             = true,
+    allowTrusts           = true,
     maxPlayers            = 6,
     levelCap              = 99,
     timeLimit             = utils.minutes(30),

--- a/scripts/battlefields/Riverne_Site_B01/storms_of_fate.lua
+++ b/scripts/battlefields/Riverne_Site_B01/storms_of_fate.lua
@@ -9,6 +9,7 @@ local riverneID = zones[xi.zone.RIVERNE_SITE_B01]
 local content = BattlefieldQuest:new({
     zoneId        = xi.zone.RIVERNE_SITE_B01,
     battlefieldId = xi.battlefield.id.STORMS_OF_FATE,
+    allowTrusts   = true,
     maxPlayers    = 18,
     timeLimit     = utils.minutes(30),
     index         = 0,

--- a/scripts/battlefields/Sacrificial_Chamber/temple_of_uggalepih.lua
+++ b/scripts/battlefields/Sacrificial_Chamber/temple_of_uggalepih.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId         = xi.battlefield.id.TEMPLE_OF_UGGALEPIH,
     canLoseExp            = false,
     isMission             = true,
+    allowTrusts           = true,
     maxPlayers            = 6,
     levelCap              = 75,
     timeLimit             = utils.minutes(30),

--- a/scripts/battlefields/Sealions_Den/one_to_be_feared.lua
+++ b/scripts/battlefields/Sealions_Den/one_to_be_feared.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId = xi.battlefield.id.ONE_TO_BE_FEARED,
     canLoseExp    = false,
     isMission     = true,
+    allowTrusts   = true,
     maxPlayers    = 6,
     levelCap      = 75,
     timeLimit     = utils.minutes(45),

--- a/scripts/battlefields/Sealions_Den/warriors_path.lua
+++ b/scripts/battlefields/Sealions_Den/warriors_path.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId = xi.battlefield.id.WARRIORS_PATH,
     canLoseExp    = false,
     isMission     = true,
+    allowTrusts   = true,
     maxPlayers    = 6,
     levelCap      = 75,
     timeLimit     = utils.minutes(30),

--- a/scripts/battlefields/Spire_of_Dem/ancient_flames_beckon.lua
+++ b/scripts/battlefields/Spire_of_Dem/ancient_flames_beckon.lua
@@ -11,6 +11,7 @@ local content = Battlefield:new({
     battlefieldId = xi.battlefield.id.ANCIENT_FLAMES_BECKON_SPIRE_OF_DEM,
     canLoseExp    = false,
     isMission     = true,
+    allowTrusts   = true,
     maxPlayers    = 6,
     levelCap      = 30,
     timeLimit     = utils.minutes(30),

--- a/scripts/battlefields/Spire_of_Holla/ancient_flames_beckon.lua
+++ b/scripts/battlefields/Spire_of_Holla/ancient_flames_beckon.lua
@@ -11,6 +11,7 @@ local content = Battlefield:new({
     battlefieldId = xi.battlefield.id.ANCIENT_FLAMES_BECKON_SPIRE_OF_HOLLA,
     canLoseExp    = false,
     isMission     = true,
+    allowTrusts   = true,
     maxPlayers    = 6,
     levelCap      = 30,
     timeLimit     = utils.minutes(30),

--- a/scripts/battlefields/Spire_of_Mea/ancient_flames_beckon.lua
+++ b/scripts/battlefields/Spire_of_Mea/ancient_flames_beckon.lua
@@ -11,6 +11,7 @@ local content = Battlefield:new({
     battlefieldId = xi.battlefield.id.ANCIENT_FLAMES_BECKON_SPIRE_OF_MEA,
     canLoseExp    = false,
     isMission     = true,
+    allowTrusts   = true,
     maxPlayers    = 6,
     levelCap      = 30,
     timeLimit     = utils.minutes(30),

--- a/scripts/battlefields/Spire_of_Vahzl/desires_of_emptiness.lua
+++ b/scripts/battlefields/Spire_of_Vahzl/desires_of_emptiness.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId         = xi.battlefield.id.DESIRES_OF_EMPTINESS,
     canLoseExp            = false,
     isMission             = true,
+    allowTrusts           = true,
     maxPlayers            = 6,
     levelCap              = 50,
     timeLimit             = utils.minutes(30),

--- a/scripts/battlefields/Stellar_Fulcrum/return_to_delkfutts_tower.lua
+++ b/scripts/battlefields/Stellar_Fulcrum/return_to_delkfutts_tower.lua
@@ -11,6 +11,7 @@ local content = BattlefieldMission:new({
     battlefieldId         = xi.battlefield.id.RETURN_TO_DELKFUTTS_TOWER,
     canLoseExp            = false,
     isMission             = true,
+    allowTrusts           = true,
     maxPlayers            = 6,
     levelCap              = 75,
     timeLimit             = utils.minutes(30),

--- a/scripts/battlefields/Talacca_Cove/legacy_of_the_lost.lua
+++ b/scripts/battlefields/Talacca_Cove/legacy_of_the_lost.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId         = xi.battlefield.id.LEGACY_OF_THE_LOST,
     canLoseExp            = false,
     isMission             = true,
+    allowTrusts           = true,
     maxPlayers            = 6,
     levelCap              = 99,
     timeLimit             = utils.minutes(30),

--- a/scripts/battlefields/The_Celestial_Nexus/celestial_nexus.lua
+++ b/scripts/battlefields/The_Celestial_Nexus/celestial_nexus.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId = xi.battlefield.id.CELESTIAL_NEXUS,
     canLoseExp    = false,
     isMission     = true,
+    allowTrusts   = true,
     maxPlayers    = 6,
     levelCap      = 75,
     timeLimit     = utils.minutes(30),

--- a/scripts/battlefields/The_Garden_of_RuHmet/when_angels_fall.lua
+++ b/scripts/battlefields/The_Garden_of_RuHmet/when_angels_fall.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId = xi.battlefield.id.WHEN_ANGELS_FALL,
     canLoseExp    = false,
     isMission     = true,
+    allowTrusts   = true,
     maxPlayers    = 6,
     levelCap      = 75,
     timeLimit     = utils.minutes(30),

--- a/scripts/battlefields/The_Shrouded_Maw/darkness_named.lua
+++ b/scripts/battlefields/The_Shrouded_Maw/darkness_named.lua
@@ -10,6 +10,7 @@ local content = BattlefieldMission:new({
     battlefieldId = xi.battlefield.id.DARKNESS_NAMED,
     canLoseExp    = false,
     isMission     = true,
+    allowTrusts   = true,
     maxPlayers    = 6,
     levelCap      = 40,
     timeLimit     = utils.minutes(30),

--- a/scripts/battlefields/Throne_Room/shadow_lord_battle.lua
+++ b/scripts/battlefields/Throne_Room/shadow_lord_battle.lua
@@ -11,6 +11,7 @@ local content = BattlefieldMission:new({
     battlefieldId = xi.battlefield.id.SHADOW_LORD_BATTLE,
     canLoseExp    = false,
     isMission     = true,
+    allowTrusts   = true,
     maxPlayers    = 6,
     levelCap      = 75,
     timeLimit     = utils.minutes(30),

--- a/scripts/battlefields/Waughroon_Shrine/beyond_infinity.lua
+++ b/scripts/battlefields/Waughroon_Shrine/beyond_infinity.lua
@@ -6,15 +6,16 @@ local waughroonID = zones[xi.zone.WAUGHROON_SHRINE]
 -----------------------------------
 
 local content = BattlefieldQuest:new({
-    zoneId           = xi.zone.WAUGHROON_SHRINE,
-    battlefieldId    = xi.battlefield.id.BEYOND_INFINITY_WAUGHROON_SHRINE,
-    canLoseExp       = false,
-    maxPlayers       = 6,
-    levelCap         = 99,
-    timeLimit        = utils.minutes(10),
-    index            = 21,
-    entryNpc         = 'BC_Entrance',
-    exitNpc          = 'Burning_Circle',
+    zoneId        = xi.zone.WAUGHROON_SHRINE,
+    battlefieldId = xi.battlefield.id.BEYOND_INFINITY_WAUGHROON_SHRINE,
+    canLoseExp    = false,
+    allowTrusts   = true,
+    maxPlayers    = 6,
+    levelCap      = 99,
+    timeLimit     = utils.minutes(10),
+    index         = 21,
+    entryNpc      = 'BC_Entrance',
+    exitNpc       = 'Burning_Circle',
 
     questArea = xi.questLog.JEUNO,
     quest     = xi.quest.id.jeuno.BEYOND_INFINITY,

--- a/scripts/battlefields/Waughroon_Shrine/on_my_way.lua
+++ b/scripts/battlefields/Waughroon_Shrine/on_my_way.lua
@@ -11,6 +11,7 @@ local content = BattlefieldMission:new({
     battlefieldId         = xi.battlefield.id.ON_MY_WAY,
     canLoseExp            = false,
     isMission             = true,
+    allowTrusts           = true,
     maxPlayers            = 6,
     levelCap              = 75,
     timeLimit             = utils.minutes(30),

--- a/scripts/battlefields/Waughroon_Shrine/rank_2_mission.lua
+++ b/scripts/battlefields/Waughroon_Shrine/rank_2_mission.lua
@@ -11,6 +11,7 @@ local content = Battlefield:new({
     battlefieldId = xi.battlefield.id.RANK_2_MISSION_2,
     canLoseExp    = false,
     isMission     = true,
+    allowTrusts   = true,
     maxPlayers    = 6,
     levelCap      = 25,
     timeLimit     = utils.minutes(30),

--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -434,6 +434,7 @@ function Battlefield:new(data)
     obj.grantXP          = data.grantXP
     obj.levelCap         = data.levelCap or 0
     obj.allowSubjob      = (data.allowSubjob == nil or data.allowSubjob) or false
+    obj.allowTrusts      = data.allowTrusts and data.allowTrusts or false
     obj.hasWipeGrace     = (data.hasWipeGrace == nil or data.hasWipeGrace) or false
     obj.isMission        = data.isMission and data.isMission or false
     obj.canLoseExp       = (data.canLoseExp == nil or data.canLoseExp) or false

--- a/scripts/globals/trust.lua
+++ b/scripts/globals/trust.lua
@@ -199,6 +199,17 @@ xi.trust.checkBattlefieldTrustCount = function(caster)
         local numPlayers       = battlefield:getPlayerCount()
         local numTrusts        = 0
 
+        -- RoV KI Battlefields are limited to LB5 fights which are restricted to
+        -- one participant which would cause the return to fail.  In this case,
+        -- set the maxParticipants value to 6 to allow summoning.
+
+        if
+            rovKIBattlefieldIDs[battlefield:getID()] and
+            caster:hasKeyItem(xi.ki.RHAPSODY_IN_UMBER)
+        then
+            maxParticipants = 6
+        end
+
         for _, entity in ipairs(participants) do
             local objType = entity:getObjType()
 
@@ -353,11 +364,17 @@ xi.trust.canCast = function(caster, spell, notAllowedTrustIds)
         return -1
     end
 
-    -- Some battlefields allow trusts after you get this ROV Key Item
+    -- Some battlefields allow trusts after you get this ROV Key Item, and this
+    -- rule should take precedence.  If it is not one of these, then fall back
+    -- to checking the battlefield's definitions.
     local casterBattlefieldID = caster:getBattlefieldID()
-    if
-        rovKIBattlefieldIDs[casterBattlefieldID] and
-        not caster:hasKeyItem(xi.ki.RHAPSODY_IN_UMBER)
+    if rovKIBattlefieldIDs[casterBattlefieldID] then
+        if not caster:hasKeyItem(xi.ki.RHAPSODY_IN_UMBER) then
+            return xi.msg.basic.TRUST_NO_CAST_TRUST
+        end
+    elseif
+        xi.battlefield.contents[casterBattlefieldID] and
+        not xi.battlefield.contents[casterBattlefieldID].allowTrusts
     then
         return xi.msg.basic.TRUST_NO_CAST_TRUST
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
* Adds bool value to battlefield constructor to allow summoning of trusts (`allowTrusts`, Default: False)
* Updates mission and quest battlefields specified in https://www.bg-wiki.com/ffxi/Category:Trust#Available_Battle_Content to allow summoning of trusts
* Adjusts `xi.trust.checkBattlefieldTrustCount()` in cases of LB5 fights where battlefield participant count is restricted to 1, which should allow trusts with the Rhapsody in Umber KI

NOTE: rovKIBattlefields (LB5 fights) will obey the Rhapsody KI check and ignore allowTrusts by design.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
1. _ENSURE GM IS TOGGLED OFF_
2. Enter Shattering Stars battlefield without Rhapsody in Umber and attempt to summon trust (Should be rejected)
3. Enter Shattering Stars battlefield with Rhapsody in Umber KI and summon trusts to maximum count (Note: canCast takes priority, so without all appropriate KIs, you will still be restricted by that)
4. Enter mission battlefield and summon trusts where `allowTrusts` is set to True.
5. Enter battlefield and attempt to summon trusts where allowTrusts is False or Undefined (rejected)

<!-- Clear and detailed steps to test your changes here -->
