### PR TITLE
Rename duplicate Tombstone NPCs in King Ranperre's Tomb

### DIFF
--- a/scripts/missions/sandoria/1_2_Bat_Hunt.lua
+++ b/scripts/missions/sandoria/1_2_Bat_Hunt.lua
@@ -94,15 +94,10 @@ mission.sections =
 
         [xi.zone.KING_RANPERRES_TOMB] =
         {
-            ['Tombstone'] =
+            ['Tombstone_Upper'] =
             {
                 onTrigger = function(player, npc)
-                    local xPos = npc:getXPos()
-                    local zPos = npc:getZPos()
-
-                    if xPos >= -1 and xPos <= 1 and zPos >= -106 and zPos <= -102 then
-                        return mission:progressEvent(4)
-                    end
+                    return mission:progressEvent(4)
                 end,
             },
 

--- a/scripts/missions/sandoria/6_2_Ranperres_Final_Rest.lua
+++ b/scripts/missions/sandoria/6_2_Ranperres_Final_Rest.lua
@@ -178,12 +178,10 @@ mission.sections =
                 end,
             },
 
-            -- TODO: This is another duplicate NPC in the database, separate these eventually
-            ['Tombstone'] =
+            ['Tombstone_Lower'] =
             {
                 onTrigger = function(player, npc)
                     if
-                        npc:getZPos() > 0 and
                         player:getMissionStatus(mission.areaId) == 3 and
                         not player:hasKeyItem(xi.ki.ANCIENT_SAN_DORIAN_BOOK)
                     then

--- a/scripts/zones/King_Ranperres_Tomb/npcs/Tombstone_Upper.lua
+++ b/scripts/zones/King_Ranperres_Tomb/npcs/Tombstone_Upper.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Area: King Ranperre's Tomb
---  NPC: Tombstone
+--  NPC: Tombstone (Upper)
 -- Involved in Quest: Grave Concerns
 -- !pos 1 0.1 -101 190
 -----------------------------------
@@ -16,12 +16,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local xPos = npc:getXPos()
-    local zPos = npc:getZPos()
-
-    if xPos >= -1 and xPos <= 1 and zPos >= -106 and zPos <= -102 then
-        player:startEvent(2)
-    end
+    player:startEvent(2)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Separates the Tombstone NPCs in King Ranperre's Tomb to Tombstone_Upper and Lower along with updating references to these NPCs.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No changes to gameplay should be observed
<!-- Clear and detailed steps to test your changes here -->
