### PR TITLE
Fix "A Thief in Norg?!" Entry Requirements

### DIFF
--- a/scripts/battlefields/Waughroon_Shrine/thief_in_norg.lua
+++ b/scripts/battlefields/Waughroon_Shrine/thief_in_norg.lua
@@ -16,13 +16,11 @@ local content = BattlefieldQuest:new({
     exitNpc          = 'Burning_Circle',
     requiredItems    = { xi.item.BANISHING_CHARM },
 
-    questArea = xi.questLog.OUTLANDS,
-    quest     = xi.quest.id.outlands.A_THIEF_IN_NORG,
+    questArea     = xi.questLog.OUTLANDS,
+    quest         = xi.quest.id.outlands.A_THIEF_IN_NORG,
+    requiredVar   = 'Quest[5][142]Prog',
+    requiredValue = 6,
 })
-
-function content:entryRequirement(player, npc, isRegistrant, trade)
-    return xi.quest.getVar(player, xi.questLog.OUTLANDS, xi.quest.id.outlands.A_THIEF_IN_NORG, 'Prog') == 6
-end
 
 content.groups =
 {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes entry requirements for non-registrants for the battlefield "A Thief in Norg?!"  entryRequirement() is required for all members, and was errantly requiring all members to have the required quest variable.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Enter BCNM with party where only the registrant is on the quest, but the remaining members have completed.
<!-- Clear and detailed steps to test your changes here -->
