### PR TITLE
Lua: Align Soultrapper onItemCheck params with Core

### DIFF
--- a/scripts/globals/znm.lua
+++ b/scripts/globals/znm.lua
@@ -20,18 +20,18 @@ xi.znm = xi.znm or {}
 -----------------------------------
 xi.znm.soultrapper = xi.znm.soultrapper or {}
 
-xi.znm.soultrapper.onItemCheck = function(target, user)
+xi.znm.soultrapper.onItemCheck = function(target, item, param, caster)
     -- Target checks.
     if
         target == nil or -- Players can use a macro to bypass the client side targeting restriction.
         not target:isMob() or
-        not user:isFacing(target)
+        not caster:isFacing(target)
     then
         return xi.msg.basic.ITEM_UNABLE_TO_USE
     end
 
     -- Equipment checks.
-    local id = user:getEquipID(xi.slot.AMMO)
+    local id = caster:getEquipID(xi.slot.AMMO)
     if
         id ~= xi.item.BLANK_SOUL_PLATE and
         id ~= xi.item.BLANK_HIGH_SPEED_SOUL_PLATE
@@ -40,7 +40,7 @@ xi.znm.soultrapper.onItemCheck = function(target, user)
     end
 
     -- Inventory checks.
-    if user:getFreeSlotsCount() == 0 then
+    if caster:getFreeSlotsCount() == 0 then
         return xi.msg.basic.FULL_INVENTORY
     end
 

--- a/scripts/items/soultrapper.lua
+++ b/scripts/items/soultrapper.lua
@@ -3,8 +3,8 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target, user)
-    return xi.znm.soultrapper.onItemCheck(target, user)
+itemObject.onItemCheck = function(target, item, param, caster)
+    return xi.znm.soultrapper.onItemCheck(target, item, param, caster)
 end
 
 itemObject.onItemUse = function(target, user, item)

--- a/scripts/items/soultrapper_2000.lua
+++ b/scripts/items/soultrapper_2000.lua
@@ -3,8 +3,8 @@
 -----------------------------------
 local itemObject = {}
 
-itemObject.onItemCheck = function(target, user)
-    return xi.znm.soultrapper.onItemCheck(target, user)
+itemObject.onItemCheck = function(target, item, param, caster)
+    return xi.znm.soultrapper.onItemCheck(target, item, param, caster)
 end
 
 itemObject.onItemUse = function(target, user, item)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes args that were maybe not updated with the mass replacement that happened recently?

Closes https://github.com/LandSandBoat/server/issues/5946

## Steps to test these changes

Use Soultrapper, no errors