### PR TITLE
Login: Check multiple bcrypt hash versions

### DIFF
--- a/src/login/auth_session.cpp
+++ b/src/login/auth_session.cpp
@@ -48,6 +48,15 @@ namespace
 
         return year;
     }
+
+    constexpr bool isBcryptHash(const std::string& passHash)
+    {
+        return passHash.length() == 60 &&
+               passHash[0] == '$' &&
+               passHash[1] == '2' &&
+               (passHash[2] == 'a' || passHash[2] == 'b' || passHash[2] == 'y' || passHash[2] == 'x') && // bcrypt hash versions
+               passHash[3] == '$';
+    }
 } // namespace
 
 void auth_session::start()
@@ -185,8 +194,7 @@ void auth_session::read_func()
             // OLD PASSWORD HASH MIGRATION
             static_assert(currentYear() <= 2024, "Migration period for old password hashes has expired. Please simplify this code after 2024-12-31 or open an issue upstream to do so.");
 
-            // Is passHash a BCrypt hash?
-            if (passHash.length() == 60 && passHash[0] == '$' && passHash[1] == '2' && passHash[2] == 'a' && passHash[3] == '$')
+            if (isBcryptHash(passHash))
             {
                 // It's a BCrypt hash, so we can validate it.
                 if (!BCrypt::validatePassword(password, passHash))
@@ -411,8 +419,7 @@ void auth_session::read_func()
             // OLD PASSWORD HASH MIGRATION
             static_assert(currentYear() <= 2024, "Migration period for old password hashes has expired. Please simplify this code after 2024-12-31 or open an issue upstream to do so.");
 
-            // Is passHash a BCrypt hash?
-            if (passHash.length() == 60 && passHash[0] == '$' && passHash[1] == '2' && passHash[2] == 'a' && passHash[3] == '$')
+            if (isBcryptHash(passHash))
             {
                 // It's a BCrypt hash, so we can validate it.
                 if (!BCrypt::validatePassword(password, passHash))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

If you produce bcrypt hashes for your users from outside (like a website) you might have newer versions of bcrypt, which produce the same hashes, but have different preambles. We now handle those different preambles.

## Steps to test these changes

Login as normal
