### PR TITLE
[lua] BCNM content.loot variable rename

### DIFF
--- a/scripts/battlefields/Horlais_Peak/double_dragonian.lua
+++ b/scripts/battlefields/Horlais_Peak/double_dragonian.lua
@@ -22,68 +22,68 @@ content:addEssentialMobs({ 'Dragonian_Berzerker', 'Dragonian_Minstrel' })
 content.loot =
 {
     {
-        { itemid = xi.item.SUBDUER,        droprate = 222 }, -- Subduer
-        { itemid = xi.item.DISSECTOR,      droprate = 302 }, -- Dissector
-        { itemid = xi.item.DESTROYERS,     droprate = 245 }, -- Destroyers
-        { itemid = xi.item.HEART_SNATCHER, droprate = 208 }, -- Heart Snatcher
+        { item = xi.item.SUBDUER,        weight = 222 }, -- Subduer
+        { item = xi.item.DISSECTOR,      weight = 302 }, -- Dissector
+        { item = xi.item.DESTROYERS,     weight = 245 }, -- Destroyers
+        { item = xi.item.HEART_SNATCHER, weight = 208 }, -- Heart Snatcher
     },
 
     {
         quantity = 2,
-        { itemid = xi.item.NONE,                 droprate = 638 }, -- Nothing
-        { itemid = xi.item.VIAL_OF_DRAGON_BLOOD, droprate =  10 }, -- Vial Of Dragon Blood
-        { itemid = xi.item.DRAGON_HEART,         droprate = 176 }, -- Dragon Heart
-        { itemid = xi.item.SLICE_OF_DRAGON_MEAT, droprate = 176 }, -- Slice Of Dragon Meat
+        { item = xi.item.NONE,                 weight = 638 }, -- Nothing
+        { item = xi.item.VIAL_OF_DRAGON_BLOOD, weight =  10 }, -- Vial Of Dragon Blood
+        { item = xi.item.DRAGON_HEART,         weight = 176 }, -- Dragon Heart
+        { item = xi.item.SLICE_OF_DRAGON_MEAT, weight = 176 }, -- Slice Of Dragon Meat
     },
 
     {
-        { itemid = xi.item.NONE,        droprate = 392 }, -- Nothing
-        { itemid = xi.item.SPEAR_STRAP, droprate = 354 }, -- Spear Strap
-        { itemid = xi.item.SWORD_STRAP, droprate = 165 }, -- Sword Strap
-        { itemid = xi.item.POLE_GRIP,   droprate =  89 }, -- Pole Grip
+        { item = xi.item.NONE,        weight = 392 }, -- Nothing
+        { item = xi.item.SPEAR_STRAP, weight = 354 }, -- Spear Strap
+        { item = xi.item.SWORD_STRAP, weight = 165 }, -- Sword Strap
+        { item = xi.item.POLE_GRIP,   weight =  89 }, -- Pole Grip
     },
 
     {
-        { itemid = xi.item.MINUET_EARRING,   droprate = 586 }, -- Minuet Earring
-        { itemid = xi.item.ADAMAN_INGOT,     droprate = 184 }, -- Adaman Ingot
-        { itemid = xi.item.ORICHALCUM_INGOT, droprate = 207 }, -- Orichalcum Ingot
+        { item = xi.item.MINUET_EARRING,   weight = 586 }, -- Minuet Earring
+        { item = xi.item.ADAMAN_INGOT,     weight = 184 }, -- Adaman Ingot
+        { item = xi.item.ORICHALCUM_INGOT, weight = 207 }, -- Orichalcum Ingot
     },
 
     {
-        { itemid = xi.item.SORROWFUL_HARP,  droprate = 238 }, -- Sorrowful Harp
-        { itemid = xi.item.ATTILAS_EARRING, droprate = 250 }, -- Attilas Earring
-        { itemid = xi.item.DURANDAL,        droprate = 225 }, -- Durandal
-        { itemid = xi.item.HOPLITES_HARPE,  droprate = 275 }, -- Hoplites Harpe
+        { item = xi.item.SORROWFUL_HARP,  weight = 238 }, -- Sorrowful Harp
+        { item = xi.item.ATTILAS_EARRING, weight = 250 }, -- Attilas Earring
+        { item = xi.item.DURANDAL,        weight = 225 }, -- Durandal
+        { item = xi.item.HOPLITES_HARPE,  weight = 275 }, -- Hoplites Harpe
     },
 
     {
-        { itemid = xi.item.CHUNK_OF_GOLD_ORE,        droprate = 122 }, -- Chunk Of Gold Ore
-        { itemid = xi.item.RERAISER,                 droprate =  54 }, -- Reraiser
-        { itemid = xi.item.CHUNK_OF_MYTHRIL_ORE,     droprate =  41 }, -- Chunk Of Mythril Ore
-        { itemid = xi.item.DEMON_HORN,               droprate =  81 }, -- Demon Horn
-        { itemid = xi.item.EBONY_LOG,                droprate = 149 }, -- Ebony Log
-        { itemid = xi.item.HANDFUL_OF_WYVERN_SCALES, droprate =  54 }, -- Handful Of Wyvern Scales
-        { itemid = xi.item.VILE_ELIXIR_P1,           droprate =  27 }, -- Vile Elixir +1
-        { itemid = xi.item.MAHOGANY_LOG,             droprate =  41 }, -- Mahogany Log
-        { itemid = xi.item.CORAL_FRAGMENT,           droprate =  95 }, -- Coral Fragment
-        { itemid = xi.item.PETRIFIED_LOG,            droprate = 108 }, -- Petrified Log
-        { itemid = xi.item.PHOENIX_FEATHER,          droprate = 135 }, -- Phoenix Feather
-        { itemid = xi.item.CHUNK_OF_PLATINUM_ORE,    droprate =  54 }, -- Chunk Of Platinum Ore
-        { itemid = xi.item.RAM_HORN,                 droprate =  14 }, -- Ram Horn
-        { itemid = xi.item.SQUARE_OF_RAINBOW_CLOTH,  droprate =  14 }, -- Square Of Rainbow Cloth
-        { itemid = xi.item.CHUNK_OF_DARKSTEEL_ORE,   droprate =  68 }, -- Chunk Of Darksteel Ore
-        { itemid = xi.item.HI_RERAISER,              droprate =  14 }, -- Hi-reraiser
-        { itemid = xi.item.SQUARE_OF_RAXA,           droprate = 135 }, -- Square Of Raxa
+        { item = xi.item.CHUNK_OF_GOLD_ORE,        weight = 122 }, -- Chunk Of Gold Ore
+        { item = xi.item.RERAISER,                 weight =  54 }, -- Reraiser
+        { item = xi.item.CHUNK_OF_MYTHRIL_ORE,     weight =  41 }, -- Chunk Of Mythril Ore
+        { item = xi.item.DEMON_HORN,               weight =  81 }, -- Demon Horn
+        { item = xi.item.EBONY_LOG,                weight = 149 }, -- Ebony Log
+        { item = xi.item.HANDFUL_OF_WYVERN_SCALES, weight =  54 }, -- Handful Of Wyvern Scales
+        { item = xi.item.VILE_ELIXIR_P1,           weight =  27 }, -- Vile Elixir +1
+        { item = xi.item.MAHOGANY_LOG,             weight =  41 }, -- Mahogany Log
+        { item = xi.item.CORAL_FRAGMENT,           weight =  95 }, -- Coral Fragment
+        { item = xi.item.PETRIFIED_LOG,            weight = 108 }, -- Petrified Log
+        { item = xi.item.PHOENIX_FEATHER,          weight = 135 }, -- Phoenix Feather
+        { item = xi.item.CHUNK_OF_PLATINUM_ORE,    weight =  54 }, -- Chunk Of Platinum Ore
+        { item = xi.item.RAM_HORN,                 weight =  14 }, -- Ram Horn
+        { item = xi.item.SQUARE_OF_RAINBOW_CLOTH,  weight =  14 }, -- Square Of Rainbow Cloth
+        { item = xi.item.CHUNK_OF_DARKSTEEL_ORE,   weight =  68 }, -- Chunk Of Darksteel Ore
+        { item = xi.item.HI_RERAISER,              weight =  14 }, -- Hi-reraiser
+        { item = xi.item.SQUARE_OF_RAXA,           weight = 135 }, -- Square Of Raxa
     },
 
     {
-        { itemid = xi.item.SQUARE_OF_DAMASCENE_CLOTH,  droprate =  96 }, -- Square Of Damascene Cloth
-        { itemid = xi.item.DAMASCUS_INGOT,             droprate =  27 }, -- Damascus Ingot
-        { itemid = xi.item.PHILOSOPHERS_STONE,         droprate = 164 }, -- Philosophers Stone
-        { itemid = xi.item.PHOENIX_FEATHER,            droprate = 260 }, -- Phoenix Feather
-        { itemid = xi.item.SPOOL_OF_MALBORO_FIBER,     droprate =  96 }, -- Spool Of Malboro Fiber
-        { itemid = xi.item.SQUARE_OF_RAXA,             droprate = 288 }, -- Square Of Raxa
-        { itemid = xi.item.VIAL_OF_BLACK_BEETLE_BLOOD, droprate =  41 }, -- Vial Of Black Beetle Blood
+        { item = xi.item.SQUARE_OF_DAMASCENE_CLOTH,  weight =  96 }, -- Square Of Damascene Cloth
+        { item = xi.item.DAMASCUS_INGOT,             weight =  27 }, -- Damascus Ingot
+        { item = xi.item.PHILOSOPHERS_STONE,         weight = 164 }, -- Philosophers Stone
+        { item = xi.item.PHOENIX_FEATHER,            weight = 260 }, -- Phoenix Feather
+        { item = xi.item.SPOOL_OF_MALBORO_FIBER,     weight =  96 }, -- Spool Of Malboro Fiber
+        { item = xi.item.SQUARE_OF_RAXA,             weight = 288 }, -- Square Of Raxa
+        { item = xi.item.VIAL_OF_BLACK_BEETLE_BLOOD, weight =  41 }, -- Vial Of Black Beetle Blood
     },
 }
 

--- a/scripts/battlefields/Waughroon_Shrine/final_bout.lua
+++ b/scripts/battlefields/Waughroon_Shrine/final_bout.lua
@@ -26,43 +26,43 @@ content.loot =
 {
     {
         quantity = 2,
-        { itemid = xi.item.BAG_OF_TREE_CUTTINGS, droprate = 1000 }, -- bag_of_tree_cuttings
+        { item = xi.item.BAG_OF_TREE_CUTTINGS, weight = 1000 }, -- bag_of_tree_cuttings
     },
 
     {
-        { itemid = xi.item.CLUMP_OF_BOYAHDA_MOSS, droprate = 1000 }, -- clump_of_boyahda_moss
+        { item = xi.item.CLUMP_OF_BOYAHDA_MOSS, weight = 1000 }, -- clump_of_boyahda_moss
     },
 
     {
-        { itemid = xi.item.SCROLL_OF_QUAKE,          droprate = 100 }, -- scroll_of_quake
-        { itemid = xi.item.PIECE_OF_WISTERIA_LUMBER, droprate = 100 }, -- piece_of_wisteria_lumber
-        { itemid = xi.item.MAHOGANY_LOG,             droprate = 100 }, -- mahogany_log
-        { itemid = xi.item.EBONY_LOG,                droprate = 100 }, -- ebony_log
-        { itemid = xi.item.SCROLL_OF_FREEZE,         droprate = 100 }, -- scroll_of_freeze
-        { itemid = xi.item.DARKSTEEL_INGOT,          droprate = 100 }, -- darksteel_ingot
-        { itemid = xi.item.SCROLL_OF_RAISE_II,       droprate = 100 }, -- scroll_of_raise_ii
-        { itemid = xi.item.PETRIFIED_LOG,            droprate = 100 }, -- petrified_log
-        { itemid = xi.item.GOLD_INGOT,               droprate = 100 }, -- gold_ingot
-        { itemid = xi.item.CORAL_FRAGMENT,           droprate = 100 }, -- coral_fragment
+        { item = xi.item.SCROLL_OF_QUAKE,          weight = 100 }, -- scroll_of_quake
+        { item = xi.item.PIECE_OF_WISTERIA_LUMBER, weight = 100 }, -- piece_of_wisteria_lumber
+        { item = xi.item.MAHOGANY_LOG,             weight = 100 }, -- mahogany_log
+        { item = xi.item.EBONY_LOG,                weight = 100 }, -- ebony_log
+        { item = xi.item.SCROLL_OF_FREEZE,         weight = 100 }, -- scroll_of_freeze
+        { item = xi.item.DARKSTEEL_INGOT,          weight = 100 }, -- darksteel_ingot
+        { item = xi.item.SCROLL_OF_RAISE_II,       weight = 100 }, -- scroll_of_raise_ii
+        { item = xi.item.PETRIFIED_LOG,            weight = 100 }, -- petrified_log
+        { item = xi.item.GOLD_INGOT,               weight = 100 }, -- gold_ingot
+        { item = xi.item.CORAL_FRAGMENT,           weight = 100 }, -- coral_fragment
     },
 
     {
-        { itemid = xi.item.SHOCK_MASK,              droprate = 62 }, -- shock_mask
-        { itemid = xi.item.SUPER_RIBBON,            droprate = 62 }, -- super_ribbon
-        { itemid = xi.item.RIVAL_RIBBON,            droprate = 62 }, -- rival_ribbon
-        { itemid = xi.item.IVORY_MITTS,             droprate = 62 }, -- ivory_mitts
-        { itemid = xi.item.SPIKED_FINGER_GAUNTLETS, droprate = 70 }, -- spiked_finger_gauntlets
-        { itemid = xi.item.SLY_GAUNTLETS,           droprate = 62 }, -- sly_gauntlets
-        { itemid = xi.item.RUSH_GLOVES,             droprate = 62 }, -- rush_gloves
-        { itemid = xi.item.MANA_CIRCLET,            droprate = 62 }, -- mana_circlet
-        { itemid = xi.item.HATEFUL_COLLAR,          droprate = 62 }, -- hateful_collar
-        { itemid = xi.item.ESOTERIC_MANTLE,         droprate = 62 }, -- esoteric_mantle
-        { itemid = xi.item.TEMPLARS_MANTLE,         droprate = 62 }, -- templars_mantle
-        { itemid = xi.item.HEAVY_MANTLE,            droprate = 62 }, -- heavy_mantle
-        { itemid = xi.item.INTELLECT_TORQUE,        droprate = 62 }, -- intellect_torque
-        { itemid = xi.item.STORM_GORGET,            droprate = 62 }, -- storm_gorget
-        { itemid = xi.item.BENIGN_NECKLACE,         droprate = 62 }, -- benign_necklace
-        { itemid = xi.item.SNIPERS_MANTLE,          droprate = 62 }, -- snipers_mantle
+        { item = xi.item.SHOCK_MASK,              weight = 62 }, -- shock_mask
+        { item = xi.item.SUPER_RIBBON,            weight = 62 }, -- super_ribbon
+        { item = xi.item.RIVAL_RIBBON,            weight = 62 }, -- rival_ribbon
+        { item = xi.item.IVORY_MITTS,             weight = 62 }, -- ivory_mitts
+        { item = xi.item.SPIKED_FINGER_GAUNTLETS, weight = 70 }, -- spiked_finger_gauntlets
+        { item = xi.item.SLY_GAUNTLETS,           weight = 62 }, -- sly_gauntlets
+        { item = xi.item.RUSH_GLOVES,             weight = 62 }, -- rush_gloves
+        { item = xi.item.MANA_CIRCLET,            weight = 62 }, -- mana_circlet
+        { item = xi.item.HATEFUL_COLLAR,          weight = 62 }, -- hateful_collar
+        { item = xi.item.ESOTERIC_MANTLE,         weight = 62 }, -- esoteric_mantle
+        { item = xi.item.TEMPLARS_MANTLE,         weight = 62 }, -- templars_mantle
+        { item = xi.item.HEAVY_MANTLE,            weight = 62 }, -- heavy_mantle
+        { item = xi.item.INTELLECT_TORQUE,        weight = 62 }, -- intellect_torque
+        { item = xi.item.STORM_GORGET,            weight = 62 }, -- storm_gorget
+        { item = xi.item.BENIGN_NECKLACE,         weight = 62 }, -- benign_necklace
+        { item = xi.item.SNIPERS_MANTLE,          weight = 62 }, -- snipers_mantle
     },
 }
 

--- a/scripts/battlefields/Waughroon_Shrine/prehistoric_pigeons.lua
+++ b/scripts/battlefields/Waughroon_Shrine/prehistoric_pigeons.lua
@@ -24,56 +24,56 @@ content:addEssentialMobs({ 'Titanis_Max', 'Titanis_Jax', 'Titanis_Xax', 'Titanis
 content.loot =
 {
     {
-        { itemid = xi.item.MICHISHIBA_NO_TSUYU, droprate = 217 }, -- Michishiba-no-tsuyu
-        { itemid = xi.item.DISSECTOR,           droprate = 174 }, -- Dissector
-        { itemid = xi.item.COFFINMAKER,         droprate = 333 }, -- Coffinmaker
-        { itemid = xi.item.GRAVEDIGGER,         droprate = 174 }, -- Gravedigger
+        { item = xi.item.MICHISHIBA_NO_TSUYU, weight = 217 }, -- Michishiba-no-tsuyu
+        { item = xi.item.DISSECTOR,           weight = 174 }, -- Dissector
+        { item = xi.item.COFFINMAKER,         weight = 333 }, -- Coffinmaker
+        { item = xi.item.GRAVEDIGGER,         weight = 174 }, -- Gravedigger
     },
 
     {
-        { itemid = xi.item.CLAYMORE_GRIP,    droprate = 144 }, -- Claymore Grip
-        { itemid = xi.item.DAMASCUS_INGOT,   droprate = 275 }, -- Damascus Ingot
-        { itemid = xi.item.GIANT_BIRD_PLUME, droprate = 275 }, -- Giant Bird Plume
-        { itemid = xi.item.POLE_GRIP,        droprate = 203 }, -- Pole Grip
-        { itemid = xi.item.SPEAR_STRAP,      droprate = 116 }, -- Spear Strap
+        { item = xi.item.CLAYMORE_GRIP,    weight = 144 }, -- Claymore Grip
+        { item = xi.item.DAMASCUS_INGOT,   weight = 275 }, -- Damascus Ingot
+        { item = xi.item.GIANT_BIRD_PLUME, weight = 275 }, -- Giant Bird Plume
+        { item = xi.item.POLE_GRIP,        weight = 203 }, -- Pole Grip
+        { item = xi.item.SPEAR_STRAP,      weight = 116 }, -- Spear Strap
     },
 
     {
-        { itemid = xi.item.ADAMAN_INGOT,     droprate = 159 }, -- Adaman Ingot
-        { itemid = xi.item.ORICHALCUM_INGOT, droprate = 290 }, -- Orichalcum Ingot
-        { itemid = xi.item.TITANIS_EARRING,  droprate = 406 }, -- Titanis Earring
+        { item = xi.item.ADAMAN_INGOT,     weight = 159 }, -- Adaman Ingot
+        { item = xi.item.ORICHALCUM_INGOT, weight = 290 }, -- Orichalcum Ingot
+        { item = xi.item.TITANIS_EARRING,  weight = 406 }, -- Titanis Earring
     },
 
     {
-        { itemid = xi.item.EVOKERS_BOOTS,  droprate = 159 }, -- Evokers Boots
-        { itemid = xi.item.OSTREGER_MITTS, droprate = 217 }, -- Ostreger Mitts
-        { itemid = xi.item.PINEAL_HAT,     droprate = 145 }, -- Pineal Hat
-        { itemid = xi.item.TRACKERS_KECKS, droprate = 159 }, -- Trackers Kecks
+        { item = xi.item.EVOKERS_BOOTS,  weight = 159 }, -- Evokers Boots
+        { item = xi.item.OSTREGER_MITTS, weight = 217 }, -- Ostreger Mitts
+        { item = xi.item.PINEAL_HAT,     weight = 145 }, -- Pineal Hat
+        { item = xi.item.TRACKERS_KECKS, weight = 159 }, -- Trackers Kecks
     },
 
     {
-        { itemid = xi.item.CORAL_FRAGMENT,          droprate = 101 }, -- Coral Fragment
-        { itemid = xi.item.CHUNK_OF_DARKSTEEL_ORE,  droprate =  29 }, -- Chunk Of Darksteel Ore
-        { itemid = xi.item.DEMON_HORN,              droprate =  29 }, -- Demon Horn
-        { itemid = xi.item.EBONY_LOG,               droprate =  29 }, -- Ebony Log
-        { itemid = xi.item.GOLD_INGOT,              droprate = 101 }, -- Gold Ingot
-        { itemid = xi.item.SPOOL_OF_GOLD_THREAD,    droprate =  29 }, -- Spool Of Gold Thread
-        { itemid = xi.item.CHUNK_OF_MYTHRIL_ORE,    droprate =  29 }, -- Chunk Of Mythril Ore
-        { itemid = xi.item.PETRIFIED_LOG,           droprate =  58 }, -- Petrified Log
-        { itemid = xi.item.CHUNK_OF_PLATINUM_ORE,   droprate =  14 }, -- Chunk Of Platinum Ore
-        { itemid = xi.item.SQUARE_OF_RAINBOW_CLOTH, droprate =  58 }, -- Square Of Rainbow Cloth
-        { itemid = xi.item.RAM_HORN,                droprate =  14 }, -- Ram Horn
-        { itemid = xi.item.SQUARE_OF_RAXA,          droprate = 159 }, -- Square Of Raxa
-        { itemid = xi.item.SPOOL_OF_MALBORO_FIBER,  droprate =  72 }, -- Spool Of Malboro Fiber
+        { item = xi.item.CORAL_FRAGMENT,          weight = 101 }, -- Coral Fragment
+        { item = xi.item.CHUNK_OF_DARKSTEEL_ORE,  weight =  29 }, -- Chunk Of Darksteel Ore
+        { item = xi.item.DEMON_HORN,              weight =  29 }, -- Demon Horn
+        { item = xi.item.EBONY_LOG,               weight =  29 }, -- Ebony Log
+        { item = xi.item.GOLD_INGOT,              weight = 101 }, -- Gold Ingot
+        { item = xi.item.SPOOL_OF_GOLD_THREAD,    weight =  29 }, -- Spool Of Gold Thread
+        { item = xi.item.CHUNK_OF_MYTHRIL_ORE,    weight =  29 }, -- Chunk Of Mythril Ore
+        { item = xi.item.PETRIFIED_LOG,           weight =  58 }, -- Petrified Log
+        { item = xi.item.CHUNK_OF_PLATINUM_ORE,   weight =  14 }, -- Chunk Of Platinum Ore
+        { item = xi.item.SQUARE_OF_RAINBOW_CLOTH, weight =  58 }, -- Square Of Rainbow Cloth
+        { item = xi.item.RAM_HORN,                weight =  14 }, -- Ram Horn
+        { item = xi.item.SQUARE_OF_RAXA,          weight = 159 }, -- Square Of Raxa
+        { item = xi.item.SPOOL_OF_MALBORO_FIBER,  weight =  72 }, -- Spool Of Malboro Fiber
     },
 
     {
-        { itemid = xi.item.VIAL_OF_BLACK_BEETLE_BLOOD, droprate =  87 }, -- Vial Of Black Beetle Blood
-        { itemid = xi.item.DAMASCUS_INGOT,             droprate =  14 }, -- Damascus Ingot
-        { itemid = xi.item.SQUARE_OF_DAMASCENE_CLOTH,  droprate =  29 }, -- Square Of Damascene Cloth
-        { itemid = xi.item.PHILOSOPHERS_STONE,         droprate = 174 }, -- Philosophers Stone
-        { itemid = xi.item.PHOENIX_FEATHER,            droprate = 246 }, -- Phoenix Feather
-        { itemid = xi.item.SQUARE_OF_RAXA,             droprate = 159 }, -- Square Of Raxa
+        { item = xi.item.VIAL_OF_BLACK_BEETLE_BLOOD, weight =  87 }, -- Vial Of Black Beetle Blood
+        { item = xi.item.DAMASCUS_INGOT,             weight =  14 }, -- Damascus Ingot
+        { item = xi.item.SQUARE_OF_DAMASCENE_CLOTH,  weight =  29 }, -- Square Of Damascene Cloth
+        { item = xi.item.PHILOSOPHERS_STONE,         weight = 174 }, -- Philosophers Stone
+        { item = xi.item.PHOENIX_FEATHER,            weight = 246 }, -- Phoenix Feather
+        { item = xi.item.SQUARE_OF_RAXA,             weight = 159 }, -- Square Of Raxa
     },
 }
 


### PR DESCRIPTION
Loot tables were using old naming convention. Have been renamed correctly so that the chest will open and players can obtain items.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Renames itemid and droprate in content.loot tables to use item/weight instead. This aligns with the rest of the BCNMs using the newer battlefield framework and allows the player to open the armory crates/obtain items without errors.

## Steps to test these changes

1. Turn !togglegm on. Enter BCNM.
2. Kill mobs.
3. Open Armory Crate. Observe no errors in log. Items now drop into treasure.

<!-- Clear and detailed steps to test your changes here -->
