### PR TITLE
[Lua] Add ZNM NPC to unique_event

### DIFF
--- a/scripts/enum/unique_event.lua
+++ b/scripts/enum/unique_event.lua
@@ -14,4 +14,5 @@ xi.uniqueEvent =
 {
     EKOKOKO_INTRODUCTION = 0,
     RECEIVED_NEXUS_CAPE  = 1,
+    SANRAKU_INTRODUCTION = 2,
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Place holder for ZNM NPC's Sanraku and Ryo in unique_event. Will determine which dialog players will get upon talking to either NPC.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
None at this time.
<!-- Clear and detailed steps to test your changes here -->
