### PR TITLE
Fix Entry for BF: Puppet in Peril

### DIFF
--- a/scripts/battlefields/Jade_Sepulcher/puppet_in_peril.lua
+++ b/scripts/battlefields/Jade_Sepulcher/puppet_in_peril.lua
@@ -20,6 +20,7 @@ local content = BattlefieldMission:new({
     exitNpcs              = { '_1v1', '_1v2', '_1v3' },
     missionArea           = xi.mission.log_id.TOAU,
     mission               = xi.mission.id.toau.PUPPET_IN_PERIL,
+    missionStatusArea     = xi.mission.log_id.TOAU,
     requiredMissionStatus = 1,
 })
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This battlefield script appears to be missing a missionStatusArea declaration that prevents players from entering the battlefield

## Steps to test these changes
!addmission TOAU 28
!zone Jade Sepulcher
Examine the Ornamental Door for a cutscene.
Check the door again and select "Puppet in Peril" to enter the battlefield.

