### PR TITLE
Fix RoE reward message ordering, use proper item messages

### DIFF
--- a/scripts/globals/roe.lua
+++ b/scripts/globals/roe.lua
@@ -183,7 +183,7 @@ local function completeRecord(player, record)
     local rewards = recordEntry.reward
 
     if not player:getEminenceCompleted(record) and rewards['item'] then
-        if not npcUtil.giveItem(player, rewards['item']) then
+        if not npcUtil.giveItem(player, rewards['item'], { silent = true }) then
             player:messageBasic(xi.msg.basic.ROE_UNABLE_BONUS_ITEM)
             return false
         end
@@ -203,6 +203,24 @@ local function completeRecord(player, record)
         end
     end
 
+    if rewards['xp'] ~= nil and type(rewards['xp']) == 'number' then
+        player:addExp(rewards['xp'] * xi.settings.main.ROE_EXP_RATE)
+    end
+
+    if rewards['capacity'] ~= nil and type(rewards['capacity']) == 'number' then
+        player:addCapacityPoints(rewards['capacity'])
+    end
+
+    -- NOTE: To preserve retail order, messaging is here, but item is given if able at the beginning of this
+    -- function, since if it fails, it will need to bail out.
+    if rewards['item'] then
+        local itemQty   = type(rewards['item'][1]) == 'table' and rewards['item'][1][2] or 1
+        local itemId    = type(rewards['item'][1]) == 'table' and rewards['item'][1][1] or rewards['item'][1]
+        local messageId = itemQty > 1 and xi.msg.basic.ROE_BONUS_ITEM_PLURAL or xi.msg.basic.ROE_BONUS_ITEM
+
+        player:messageBasic(messageId, itemId, itemQty)
+    end
+
     if recordFlags['repeat'] then
         if recordFlags['timed'] then
             player:messageBasic(xi.msg.basic.ROE_TIMED_CLEAR)
@@ -213,14 +231,6 @@ local function completeRecord(player, record)
         player:setEminenceCompleted(record, true)
     else
         player:setEminenceCompleted(record)
-    end
-
-    if rewards['xp'] ~= nil and type(rewards['xp']) == 'number' then
-        player:addExp(rewards['xp'] * xi.settings.main.ROE_EXP_RATE)
-    end
-
-    if rewards['capacity'] ~= nil and type(rewards['capacity']) == 'number' then
-        player:addCapacityPoints(rewards['capacity'])
     end
 
     if


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
* Adds RoE item reward messages as opposed to using npcUtil 'Obtained' message and reorders the displayed messages to align with retail.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Add/complete objectives that reward single and multiple items
<!-- Clear and detailed steps to test your changes here -->
