### PR TITLE
resolve error: call to non-'constexpr' function

### DIFF
--- a/src/login/auth_session.cpp
+++ b/src/login/auth_session.cpp
@@ -51,7 +51,7 @@ namespace
 
     constexpr bool isBcryptHash(const std::string& passHash)
     {
-        return passHash.length() == 60 &&
+        return std::size(passHash) == 60 &&
                passHash[0] == '$' &&
                passHash[1] == '2' &&
                (passHash[2] == 'a' || passHash[2] == 'b' || passHash[2] == 'y' || passHash[2] == 'x') && // bcrypt hash versions


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
This resolves an error message encountered when building:
```
/server/src/login/auth_session.cpp: In function 'constexpr bool {anonymous}::isBcryptHash(const string&)':
/server/src/login/auth_session.cpp:54:32: error: call to non-'constexpr' function 'std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::length() const [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type = long unsigned int]'
   54 |         return (passHash.length() == 60 &&
      |                 ~~~~~~~~~~~~~~~^~
In file included from /usr/include/c++/11/string:55,
                 from /server/docker_build/_deps/asio-src/asio/include/asio/ssl/context.hpp:20,
                 from /server/docker_build/_deps/asio-src/asio/include/asio/ssl.hpp:18,
                 from /server/src/login/auth_session.h:24,
                 from /server/src/login/auth_session.cpp:22:
/usr/include/c++/11/bits/basic_string.h:926:7: note: 'std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::length() const [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type = long unsigned int]' declared here
  926 |       length() const _GLIBCXX_NOEXCEPT
      |       ^~~~~~
```
By using the constexpr function ``std::size()`` instead of ``std::string.length()``
## Steps to test these changes
<!-- Clear and detailed steps to test your changes here -->
Build successfully