### PR TITLE
Add nullptr check for Party Leader in RemoveEntity

### DIFF
--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -867,7 +867,15 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
                     }
                 }
 
-                for (auto* trust : static_cast<CCharEntity*>(m_POwner->PParty->GetLeader())->PTrusts)
+                auto leader = (CCharEntity*)m_POwner->PParty->GetLeader();
+
+                if (leader == nullptr)
+                {
+                    expression = false;
+                    break;
+                }
+
+                for (auto* trust : leader->PTrusts)
                 {
                     if (trust->GetMJob() == latentEffect.GetConditionsValue())
                     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Safeley handles effect container logic if party leader is null. closes #5943 

## Steps to test these changes
Map server will no longer crash when hitting this condition.
