### PR TITLE
Add CI check for missing listener docs

### DIFF
--- a/tools/ci/cpp.sh
+++ b/tools/ci/cpp.sh
@@ -57,6 +57,20 @@ def contains_delete(line):
 def contains_relative_include(line):
     return "#include \"../" in line
 
+def load_documented_events(file_path):
+    with open(file_path, 'r') as file:
+        return {line.split(' - ')[0].strip() for line in file.readlines()}
+
+documented_events = load_documented_events('documentation/AI_Events.txt')
+
+def contains_undocumented_listener(line):
+    import re
+    match = re.search(r'\.triggerListener\("([^"]+)"', line)
+    if match:
+        listener = match.group(1)
+        return listener not in documented_events
+    return False
+
 def check(name):
     if os.path.isfile(name):
         with open(name) as f:
@@ -67,7 +81,10 @@ def check(name):
                     print(f"{name}:{counter}: Found naked delete. Please use destroy(ptr) or destroy_arr(ptr).")
                     print(line)
                 if contains_relative_include(line):
-                    print(f"{name}:{counter}: Found relative include. Please non-relative paths.")
+                    print(f"{name}:{counter}: Found relative include. Please use non-relative paths.")
+                    print(line)
+                if contains_undocumented_listener(line):
+                    print(f"{name}:{counter}: Found undocumented listener. Please document this in AI_Events.txt.")
                     print(line)
 
 if target == 'src':


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a job to scan for undocumented listeners so stuff like #5961 is unnecessary.

## Steps to test these changes

```
$ bash tools/ci/cpp.sh src/map/ai/controllers/mob_controller.cpp 2>> cpp_checks.txt
src/map/ai/controllers/mob_controller.cpp:1002: Found undocumented listener. Please document this in AI_Events.txt.
                    PMob->PAI->EventHandler.triggerListener("ROAM_ACTION", CLuaBaseEntity(PMob));

src/map/ai/controllers/mob_controller.cpp:1100: Found undocumented listener. Please document this in AI_Events.txt.
            PMob->PAI->EventHandler.triggerListener("PATH", CLuaBaseEntity(PMob));

src/map/ai/controllers/mob_controller.cpp:1134: Found undocumented listener. Please document this in AI_Events.txt.
        PMob->PAI->EventHandler.triggerListener("WEAPONSKILL_BEFORE_USE", PMob, wsid);
```