### PR TITLE
[LUA/SQL] Update Aquaveil Logic

### DIFF
--- a/scripts/globals/spells/enhancing_spell.lua
+++ b/scripts/globals/spells/enhancing_spell.lua
@@ -187,8 +187,10 @@ xi.spells.enhancing.calculateEnhancingBasePower = function(caster, target, spell
     ------------------------------------------------------------
 
     -- Aquaveil
-    if spellEffect == xi.effect.AQUAVEIL then
-        if skillLevel >= 200 then -- Cutoff point is estimated. https://www.bg-wiki.com/bg/Aquaveil
+    if spellEffect == xi.effect.AQUAVEIL then -- Skill Breakpoints per BG Wiki (2024-06-27): https://www.bg-wiki.com/bg/Aquaveil
+        if skillLevel > 500 then -- 501+ Skill = 3 Interruptions
+            basePower = basePower + 2
+        elseif skillLevel > 300 then -- 301+ Skill = 2 Interruptions
             basePower = basePower + 1
         end
 
@@ -301,8 +303,12 @@ xi.spells.enhancing.calculateEnhancingFinalPower = function(caster, target, spel
 
     -- TODO: Find a way to replace big if/else chain and still make it look good.
 
+    -- Aquaveil
+    if spellEffect == xi.effect.AQUAVEIL then
+        finalPower = finalPower + caster:getMod(xi.mod.AQUAVEIL_COUNT) -- Aquaveil+ from gear applies during accession (https://www.bg-wiki.com/ffxi/Aquaveil)
+
     -- Bar-Element
-    if spellEffect >= xi.effect.BARFIRE and spellEffect <= xi.effect.BARWATER then
+    elseif spellEffect >= xi.effect.BARFIRE and spellEffect <= xi.effect.BARWATER then
         finalPower = finalPower + caster:getMerit(xi.merit.BAR_SPELL_EFFECT) + caster:getMod(xi.mod.BARSPELL_AMOUNT) + caster:getJobPointLevel(xi.jp.BAR_SPELL_EFFECT) * 2
 
     -- Bar-Status

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -45152,6 +45152,10 @@ INSERT INTO `item_mods` VALUES (21694,355,60);  -- ADDS_WEAPONSKILL: 60
 -- TODO: Aftermath
 -- TODO: Ultimate Skillchain
 
+-- Nibiru Faussar
+INSERT INTO `item_mods` VALUES (21699,832,1);  -- AQUAVEIL_COUNT: 1
+-- TODO: non-AQUAVEIL MODS
+
 -- Blurred Claymore
 INSERT INTO `item_mods` VALUES (21700,25,20); -- ACC: 20
 
@@ -59267,6 +59271,10 @@ INSERT INTO `item_mods` VALUES (25643,68,33);   -- EVA: 33
 INSERT INTO `item_mods` VALUES (25643,170,8);   -- FASTCAST: 8
 INSERT INTO `item_mods` VALUES (25643,384,600); -- HASTE_GEAR: 600
 
+-- Chironic Hat
+INSERT INTO `item_mods` VALUES (25644,832,1);  -- AQUAVEIL_COUNT: 1
+-- TODO: non-AQUAVEIL MODS
+
 -- Crab Cap
 INSERT INTO `item_mods` VALUES (25652,1,1); -- DEF: 1
 
@@ -60510,6 +60518,10 @@ INSERT INTO `item_mods` VALUES (25823,31,48);   -- MEVA: 48
 INSERT INTO `item_mods` VALUES (25823,68,19);   -- EVA: 19
 INSERT INTO `item_mods` VALUES (25823,311,49);  -- MAGIC_DAMAGE: 49
 INSERT INTO `item_mods` VALUES (25823,384,400); -- HASTE_GEAR: 400
+
+-- Regal Cuffs
+INSERT INTO `item_mods` VALUES (25827,832,2);  -- AQUAVEIL_COUNT: 2
+-- TODO: non-AQUAVEIL MODS
 
 -- Fancy Trunks
 INSERT INTO `item_mods` VALUES (25838,1,2); -- DEF: 2


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

[LUA] Updates Aquaveil Formula to account for known skill breaks 
[LUA] Adds step to apply `AQUAVEIL_COUNT` MODs
[SQL] Adds missing `AQUAVEIL_COUNT` MODs on a few items

## Steps to test these changes

### Base Logic
* Change Job to RDM 75
* add all spells
* cap all skills
* cast aquaveil 
* `player:getStatusEffect(xi.effect.AQUAVEIL):getPower()` should be 1

### Skill Logic
* On the same character, change Job to RDM 99
* cap all skills (again)
* cast aquaveil 
* `player:getStatusEffect(xi.effect.AQUAVEIL):getPower()` should be 2

### Item Mod + Skill Logic
* On the same character, `!additem 25644`
* equip Chironic Hat
* cast aquaveil 
* `player:getStatusEffect(xi.effect.AQUAVEIL):getPower()` should be 3
