### PR TITLE
[Core] Adds missing quantity count to charutils getItemCount

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1387,7 +1387,7 @@ namespace charutils
             {
                 if (PItem->getID() == ItemID)
                 {
-                    itemCount++;
+                    itemCount += PItem->getQuantity();
                 }
             });
             // clang-format on


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
`getItemCount` isn't factoring in quantity, eg. `player:getItemCount(1455)` returns 1 if a player has 1 Byne Bill x99.
This change fixes the issue.

## Steps to test these changes
Tested with stacking and non-stacking items and if player has no matching items.
