### PR TITLE
Marid Tusk Breaking

### DIFF
--- a/scripts/mixins/families/marid.lua
+++ b/scripts/mixins/families/marid.lua
@@ -1,0 +1,29 @@
+require('scripts/globals/mixins')
+
+g_mixins = g_mixins or {}
+g_mixins.families = g_mixins.families or {}
+
+g_mixins.families.marid = function(maridMob)
+    -- 20% chance to break tusk on critical hit
+    maridMob:addListener('CRITICAL_TAKE', 'MARID_CRITICAL_TAKE', function(mob)
+        if not utils.chance(20) then
+            return
+        end
+
+        local broken = mob:getAnimationSub()
+        if broken >= 2 then
+            return
+        end
+
+        mob:setAnimationSub(broken + 1)
+    end)
+
+    maridMob:addListener('ITEM_DROPS', 'MARID_ITEM_DROPS', function(mob, loot)
+        local broken = mob:getAnimationSub()
+        for _ = 1, broken do
+            loot:addItem(xi.item.MARID_TUSK, xi.drop_rate.GUARANTEED)
+        end
+    end)
+end
+
+return g_mixins.families.marid

--- a/scripts/zones/Bhaflau_Thickets/mobs/Grand_Marid.lua
+++ b/scripts/zones/Bhaflau_Thickets/mobs/Grand_Marid.lua
@@ -2,7 +2,7 @@
 -- Area: Bhaflau Thickets
 --  Mob: Grand Marid
 -----------------------------------
-mixins = { require('scripts/mixins/families/chigoe_pet') }
+mixins = { require('scripts/mixins/families/marid'), require('scripts/mixins/families/chigoe_pet') }
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Bhaflau_Thickets/mobs/Marid.lua
+++ b/scripts/zones/Bhaflau_Thickets/mobs/Marid.lua
@@ -3,7 +3,7 @@
 --  Mob: Marid
 -- Note: Place holder Mahishasura
 -----------------------------------
-mixins = { require('scripts/mixins/families/chigoe_pet') }
+mixins = { require('scripts/mixins/families/marid'), require('scripts/mixins/families/chigoe_pet') }
 local ID = zones[xi.zone.BHAFLAU_THICKETS]
 -----------------------------------
 local entity = {}

--- a/scripts/zones/Nyzul_Isle/mobs/Marid.lua
+++ b/scripts/zones/Nyzul_Isle/mobs/Marid.lua
@@ -2,6 +2,8 @@
 --  MOB: Marid
 -- Area: Nyzul Isle
 -----------------------------------
+mixins = { require('scripts/mixins/families/marid') }
+-----------------------------------
 local entity = {}
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/Wajaom_Woodlands/mobs/Grand_Marid.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Grand_Marid.lua
@@ -2,7 +2,7 @@
 -- Area: Wajaom Woodlands
 --  Mob: Grand Marid
 -----------------------------------
-mixins = { require('scripts/mixins/families/chigoe_pet') }
+mixins = { require('scripts/mixins/families/marid'), require('scripts/mixins/families/chigoe_pet') }
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Wajaom_Woodlands/mobs/Marid.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Marid.lua
@@ -2,7 +2,7 @@
 -- Area: Wajaom Woodlands
 --  Mob: Marid
 -----------------------------------
-mixins = { require('scripts/mixins/families/chigoe_pet') }
+mixins = { require('scripts/mixins/families/marid'), require('scripts/mixins/families/chigoe_pet') }
 -----------------------------------
 local entity = {}
 

--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -10038,7 +10038,6 @@ INSERT INTO `mob_droplist` VALUES (1213,0,0,1000,886,@RARE);       -- Demon Skul
 -- ZoneID:  52 - Grand Marid
 INSERT INTO `mob_droplist` VALUES (1214,0,0,1000,2151,210);       -- Marid Hide (21.0%)
 INSERT INTO `mob_droplist` VALUES (1214,0,0,1000,2166,@UNCOMMON); -- Lock Of Marid Hair (Uncommon, 10%)
-INSERT INTO `mob_droplist` VALUES (1214,0,0,1000,2147,30);        -- Marid Tusk (3.0%)
 INSERT INTO `mob_droplist` VALUES (1214,2,0,1000,2155,0);         -- Lesser Chigoe (Steal)
 
 -- ZoneID: 215 - Granite Borer
@@ -12948,15 +12947,11 @@ INSERT INTO `mob_droplist` VALUES (1616,0,0,1000,940,@VRARE);   -- Revival Tree 
 -- ZoneID:  51 - Marid
 INSERT INTO `mob_droplist` VALUES (1617,0,0,1000,2151,220);    -- Marid Hide (22.0%)
 INSERT INTO `mob_droplist` VALUES (1617,0,0,1000,2166,80);     -- Lock Of Marid Hair (8.0%)
-INSERT INTO `mob_droplist` VALUES (1617,0,0,1000,2147,20);     -- Marid Tusk (2.0%)
-INSERT INTO `mob_droplist` VALUES (1617,0,0,1000,2147,@VRARE); -- Marid Tusk (Very Rare, 1%)
 INSERT INTO `mob_droplist` VALUES (1617,2,0,1000,2155,0);      -- Lesser Chigoe (Steal)
 
 -- ZoneID:  77 - Marid
 INSERT INTO `mob_droplist` VALUES (1618,0,0,1000,2151,210);       -- Marid Hide (21.0%)
 INSERT INTO `mob_droplist` VALUES (1618,0,0,1000,2166,@UNCOMMON); -- Lock Of Marid Hair (Uncommon, 10%)
-INSERT INTO `mob_droplist` VALUES (1618,0,0,1000,2147,30);        -- Marid Tusk (3.0%)
-INSERT INTO `mob_droplist` VALUES (1618,0,0,1000,2147,20);        -- Marid Tusk (2.0%)
 INSERT INTO `mob_droplist` VALUES (1618,2,0,1000,2155,0);         -- Lesser Chigoe (Steal)
 
 -- ZoneID:  85 - Mariehene


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This implements the family logic for Marids to has their tusks broken and drop as loot. Marid's can have their tusks broken at a 20% chance per critical hit (similar to Imps and their horns). Whenever this happens the Marid animation changes to reflect this. Additionally, whenever the Marid dies it will drop Marid Tusks equal to the number broken.

This is logic I originally implemented for Eden years ago. Here is the capture I used thanks to @Wiggo32: https://www.youtube.com/watch?v=UEwacJNiyoU

## Steps to test these changes

1. Go fight a Marid `!gotoid 16986144`
2. Hit it with critical attacks to see its tusks break
3. Kill it with varying number of broken tusks to see that the number of tusks dropped are the same as the broken tusks
