### PR TITLE
Fix Food Mods on Roast Trout

### DIFF
--- a/scripts/items/roast_trout.lua
+++ b/scripts/items/roast_trout.lua
@@ -20,15 +20,15 @@ end
 itemObject.onEffectGain = function(target, effect)
     target:addMod(xi.mod.DEX, 3)
     target:addMod(xi.mod.MND, -1)
-    target:addMod(xi.mod.RATTP, 14)
-    target:addMod(xi.mod.RATT_CAP, 50)
+    target:addMod(xi.mod.FOOD_RATTP, 14)
+    target:addMod(xi.mod.FOOD_RATT_CAP, 50)
 end
 
 itemObject.onEffectLose = function(target, effect)
     target:delMod(xi.mod.DEX, 3)
     target:delMod(xi.mod.MND, -1)
-    target:delMod(xi.mod.RATTP, 14)
-    target:delMod(xi.mod.RATT_CAP, 50)
+    target:delMod(xi.mod.FOOD_RATTP, 14)
+    target:delMod(xi.mod.FOOD_RATT_CAP, 50)
 end
 
 return itemObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Roast Trout was throwing nil errors on Horizon on use and on effect wear off.
Upon further investigation - it was using the mods `RATTP` and `RATT_CAP` when it shoud be using `FOOD_RATTP` and `FOOD_RATT_CAP`.
`RATT_CAP` is not a defined mod, hence the nil error.

As a side effect - the RATT from this food was uncapped - making a great choice for mid 400 RATT.

## Steps to test these changes
1. Be a 75 Ranger with capped marksmanship, and equip a Culverin.
2. use `/checkparam <me>` and note your Ranged Attack
3. `!setmod RATT X` where X will get you to 500 Ranged Attack or more (for easy math)
4.  use `/checkparam <me>` and note your Ranged Attack of 500+
5. `!additem roast_trout 12`
6. eat a roast trout
7. use `/checkparam <me>` and note your Ranged Attack - the total gain should be `50` due to the cap
8. `!deleffect food` and note a reversion to step 4 values.
9.  `!setmod RATT 0` - this should bring your  RATT to the low 300s - ensure it is below 358 as 358 will hit the cap.
10. eat a roast trout - note that you gain 14% ranged attack