### PR TITLE
Qiqirn Family Skills

### DIFF
--- a/scripts/actions/mobskills/cutpurse.lua
+++ b/scripts/actions/mobskills/cutpurse.lua
@@ -1,0 +1,41 @@
+-----------------------------------
+--  Cutpurse
+--  Description: Unequips a random piece of equipment.
+--  Type: Enfeebling
+--  Ignore Shadows, Single target
+--  Note: If it takes off main weapon, anything held in Sub slot is unequipped as well.
+-----------------------------------
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    if not target:isPC() then
+        skill:setMsg(xi.msg.basic.SKILL_NO_EFFECT)
+        return
+    end
+
+    local slots = {}
+    for slot = xi.slot.MAIN, xi.slot.BACK do
+        table.insert(slots, slot)
+    end
+
+    slots = utils.shuffle(slots)
+    for _, slot in pairs(slots) do
+        if target:hasSlotEquipped(slot) then
+            target:unequipItem(slot)
+            if slot == xi.slot.MAIN then
+                target:unequipItem(xi.slot.SUB)
+            end
+
+            skill:setMsg(xi.msg.basic.USES)
+            return
+        end
+    end
+
+    skill:setMsg(xi.msg.basic.SKILL_NO_EFFECT)
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/faze.lua
+++ b/scripts/actions/mobskills/faze.lua
@@ -14,7 +14,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.TERROR, 1, 0, 5))
+    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.TERROR, 1, 0, 10))
 
     return xi.effect.TERROR
 end

--- a/scripts/actions/mobskills/sandspray.lua
+++ b/scripts/actions/mobskills/sandspray.lua
@@ -14,7 +14,7 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local power = 25
-    local duration = 90
+    local duration = 150
 
     skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, power, 0, duration))
 

--- a/scripts/actions/mobskills/strap_cutter.lua
+++ b/scripts/actions/mobskills/strap_cutter.lua
@@ -9,10 +9,48 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
--- todo make a random for which gear to remove and how many pieces
-    local remove = 0xFFFF
+    if not target:isPC() then
+        skill:setMsg(xi.msg.basic.SKILL_NO_EFFECT)
+        return
+    end
 
-    target:addStatusEffectEx(xi.effect.ENCUMBRANCE_I, xi.effect.ENCUMBRANCE_I, remove, 0, 60)
+    local slots = {}
+    for slot = xi.slot.MAIN, xi.slot.BACK do
+        table.insert(slots, slot)
+    end
+
+    local total = math.random(3, 5)
+    local amount = 0
+    local power = 0
+    slots = utils.shuffle(slots)
+    for _, slot in pairs(slots) do
+        if target:hasSlotEquipped(slot) then
+            target:unequipItem(slot)
+            if slot == xi.slot.MAIN then
+                target:unequipItem(xi.slot.SUB)
+            end
+
+            power = bit.bor(power, bit.lshift(1, slot))
+            amount = amount + 1
+            if amount >= total then
+                break
+            end
+        end
+    end
+
+    if amount == 0 then
+        skill:setMsg(xi.msg.basic.SKILL_NO_EFFECT)
+        return
+    end
+
+    local encumbrance = target:getStatusEffect(xi.effect.ENCUMBRANCE_I)
+    if encumbrance then
+        power = bit.bor(encumbrance:getPower(), power)
+        target:delStatusEffectSilent(xi.effect.ENCUMBRANCE_I)
+    end
+
+    target:addStatusEffectEx(xi.effect.ENCUMBRANCE_I, xi.effect.ENCUMBRANCE_I, power, 0, 60)
+    skill:setMsg(xi.msg.basic.USES)
 end
 
 return mobskillObject

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -862,7 +862,7 @@ INSERT INTO `mob_skill_lists` VALUES ('Puk',198,1720);
 INSERT INTO `mob_skill_lists` VALUES ('Puk',198,1721);
 INSERT INTO `mob_skill_lists` VALUES ('Puk',198,1722);
 INSERT INTO `mob_skill_lists` VALUES ('Qiqirn',199,1725);
--- INSERT INTO `mob_skill_lists` VALUES ('Qiqirn',199,1726);
+INSERT INTO `mob_skill_lists` VALUES ('Qiqirn',199,1726);
 INSERT INTO `mob_skill_lists` VALUES ('Qiqirn',199,1727);
 INSERT INTO `mob_skill_lists` VALUES ('Qiqirn',199,1728);
 INSERT INTO `mob_skill_lists` VALUES ('Quadav',200,611);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -4785,6 +4785,25 @@ void CLuaBaseEntity::unlockEquipSlot(uint8 slot)
 }
 
 /************************************************************************
+ *  Function: hasSlotEquipped()
+ *  Purpose : Returns true if a player has an item equipped in the slot
+ *  Example : if player:hasSlotEquipped(xi.slot.RING1) then
+ *  Notes   :
+ ************************************************************************/
+
+bool CLuaBaseEntity::hasSlotEquipped(uint8 slot)
+{
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Attempt to check item slot for a non-player (%s).", m_PBaseEntity->getName());
+        return false;
+    }
+
+    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
+    return charutils::hasSlotEquipped(PChar, slot);
+}
+
+/************************************************************************
  *  Function: getShieldSize()
  *  Purpose : Return the shield size of the equipped shield
  *  Example : player:getShieldSize()
@@ -17924,6 +17943,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("setEquipBlock", CLuaBaseEntity::setEquipBlock);
     SOL_REGISTER("lockEquipSlot", CLuaBaseEntity::lockEquipSlot);
     SOL_REGISTER("unlockEquipSlot", CLuaBaseEntity::unlockEquipSlot);
+    SOL_REGISTER("hasSlotEquipped", CLuaBaseEntity::hasSlotEquipped);
 
     SOL_REGISTER("getShieldSize", CLuaBaseEntity::getShieldSize);
     SOL_REGISTER("getShieldDefense", CLuaBaseEntity::getShieldDefense);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -255,6 +255,7 @@ public:
     void setEquipBlock(uint16 equipBlock);
     void lockEquipSlot(uint8 slot);
     void unlockEquipSlot(uint8 slot);
+    bool hasSlotEquipped(uint8 slot);
 
     int8  getShieldSize();
     int16 getShieldDefense();

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1851,6 +1851,12 @@ namespace charutils
         }
     }
 
+    bool hasSlotEquipped(CCharEntity* PChar, uint8 equipSlotID)
+    {
+        CItem* PItem = PChar->getEquip((SLOTTYPE)equipSlotID);
+        return PItem != nullptr && PItem->isType(ITEM_EQUIPMENT);
+    }
+
     void RemoveSub(CCharEntity* PChar)
     {
         CItemEquipment* PItem = PChar->getEquip(SLOT_SUB);

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -121,6 +121,7 @@ namespace charutils
     void   EquipItem(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 containerID);
     void   UnequipItem(CCharEntity* PChar, uint8 equipSlotID,
                        bool update = true); // call with update == false to prevent calls to UpdateHealth() - used for correct handling of stats on armor swaps
+    bool   hasSlotEquipped(CCharEntity* PChar, uint8 equipSlotID);
     void   RemoveSub(CCharEntity* PChar);
     bool   EquipArmor(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 containerID);
     void   CheckUnarmedWeapon(CCharEntity* PChar);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This adds a new function called `hasSlotEquipped` making it possible to query if an item is equipped in a specific slot. This is then used in the Cutpurse and Strap Cutter mob skills that randomly remove pieces of equipment. Additionally I adjusted the duration of some of the status effects applied from Faze and Kibosh. All of these changes are in response to observed behavior from retail. I have video capture of all of these except Strap Cutter.

## Steps to test these changes

1. Use `!gotoid 17072134` and give `!tp 3000` to observe the various mob skills
2. Use `!gotoid 17072172` then `!spawnmob 17072172` and finally `!tp 3000` to see Strap Cutter in action.
