### PR TITLE
Add nullptr check for PLeader in Latent Effect Container (2)

### DIFF
--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -788,9 +788,9 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
         {
             size_t partyCount = 0;
             size_t trustCount = 0;
-            if (m_POwner->PParty != nullptr)
+            auto* PLeader = m_POwner->PParty != nullptr ? dynamic_cast<CCharEntity*>(m_POwner->PParty->GetLeader()) : nullptr;
+            if (PLeader)
             {
-                auto PLeader = (CCharEntity*)m_POwner->PParty->GetLeader();
                 trustCount = PLeader->PTrusts.size();
                 partyCount = m_POwner->PParty->members.size();
             }
@@ -801,7 +801,7 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
         case LATENT::PARTY_MEMBERS_IN_ZONE:
         {
             auto inZone = 0;
-            if (m_POwner->PParty != nullptr)
+            if (m_POwner->PParty && dynamic_cast<CCharEntity*>(m_POwner->PParty->GetLeader()))
             {
                 for (auto* member : m_POwner->PParty->members)
                 {
@@ -810,7 +810,7 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
                         ++inZone;
                     }
                 }
-                
+
                 auto PLeader = (CCharEntity*)m_POwner->PParty->GetLeader();
                 if (m_POwner->getZone() == PLeader->getZone())
                 {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds a nullptr check to PLeader in latent effect container.
![image](https://github.com/LandSandBoat/server/assets/65316697/06654282-2130-444c-ab3d-88842b1a352e)


## Steps to test these changes
If PLeader is in another map server instance the value can be null.
