### PR TITLE
Wivre Family Improvements

### DIFF
--- a/scripts/actions/mobskills/boiling_blood.lua
+++ b/scripts/actions/mobskills/boiling_blood.lua
@@ -2,8 +2,6 @@
 -- Boiling Blood
 -- Description: Boiling Blood
 -- Foe gains Haste +25% and Berserk +50%
--- TODO: Verify ability duration
--- https://www.bg-wiki.com/ffxi/Locus_Wivre
 -----------------------------------
 local mobskillObject = {}
 
@@ -12,8 +10,8 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    xi.mobskills.mobBuffMove(mob, xi.effect.HASTE, 2500, 0, 60)
-    xi.mobskills.mobBuffMove(mob, xi.effect.BERSERK, 50, 0, 60)
+    xi.mobskills.mobBuffMove(mob, xi.effect.HASTE, 2500, 0, 180)
+    xi.mobskills.mobBuffMove(mob, xi.effect.BERSERK, 50, 0, 180)
     skill:setMsg(xi.msg.basic.NONE)
     return 0
 end

--- a/scripts/actions/mobskills/clobber.lua
+++ b/scripts/actions/mobskills/clobber.lua
@@ -1,6 +1,6 @@
 -----------------------------------
---  Batterhorn
---  Description: Inflicts damage in a frontal area of effect. Additional effect: Knockback.
+--  Clobber
+--  Description: Only used when targets behind it gets hate.
 --  Type: Physical
 --  Utsusemi/Blink absorb: 2-3 shadows
 --  Range: Melee
@@ -8,7 +8,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if target:isInfront(mob) then
+    if target:isBehind(mob) then
         return 0
     end
 

--- a/scripts/actions/mobskills/crippling_slam.lua
+++ b/scripts/actions/mobskills/crippling_slam.lua
@@ -1,8 +1,8 @@
 -----------------------------------
---  Batterhorn
---  Description: Inflicts damage in a frontal area of effect. Additional effect: Knockback.
+--  Crippling Slam
+--  Description: Deals severe damage to targets in front of it by slamming into them. Additional effect: Paralysis.
 --  Type: Physical
---  Utsusemi/Blink absorb: 2-3 shadows
+--  Utsusemi/Blink absorb: Wipes Shadows
 --  Range: Melee
 -----------------------------------
 local mobskillObject = {}
@@ -16,12 +16,16 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local numhits = 3
+    local numhits = 1
     local accmod = 1
-    local dmgmod = .8
+    local dmgmod = 4
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
-    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
+    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
+
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 30, 60)
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 50, 0, duration))
+
     return dmg
 end
 

--- a/scripts/actions/mobskills/demoralizing_roar.lua
+++ b/scripts/actions/mobskills/demoralizing_roar.lua
@@ -1,7 +1,6 @@
 -----------------------------------
 -- Demoralizing Roar
 -- Description: Inflicts Attack Down (-50%) to players within a 10' area of effect
--- https://www.bg-wiki.com/ffxi/Locus_Wivre
 -----------------------------------
 local mobskillObject = {}
 
@@ -15,7 +14,7 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local power = 500
-    local duration = 30
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 30, 90)
 
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ATTACK_DOWN, power, 0, duration)
 end

--- a/scripts/actions/mobskills/granite_skin.lua
+++ b/scripts/actions/mobskills/granite_skin.lua
@@ -1,9 +1,6 @@
 -----------------------------------
 -- Granite Skin
--- Description: Physical Shield
--- TODO: This is a buff that makes target in front of target deal 0 physical damage.
--- This will need a new effect and some kind of check to zero it properly.
--- https://www.bg-wiki.com/ffxi/Locus_Wivre
+-- Description: Enhances defense and guarding skill (nullifies all physical damage from the front).
 -----------------------------------
 local mobskillObject = {}
 
@@ -12,9 +9,17 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    xi.mobskills.mobBuffMove(mob, xi.effect.PHYSICAL_SHIELD, 3, 0, 30)
-    skill:setMsg(xi.msg.basic.NONE)
-    return 0
+    -- This is a special case where the defense boost prevents damage
+    -- while the attacker is in front of the defender at the given subpower angle
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 60, 90)
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.DEFENSE_BOOST, 0, 0, duration))
+
+    if mob:hasStatusEffect(xi.effect.DEFENSE_BOOST) then
+        local effect = mob:getStatusEffect(xi.effect.DEFENSE_BOOST)
+        effect:setSubPower(90)
+    end
+
+    return xi.effect.DEFENSE_BOOST
 end
 
 return mobskillObject

--- a/scripts/effects/defense_boost.lua
+++ b/scripts/effects/defense_boost.lua
@@ -1,5 +1,7 @@
 -----------------------------------
 -- xi.effect.DEFENSE_BOOST
+-- When a subpower is provided this buff acts as a 100% physical damage negation
+-- While the attacker is in front within the angle of the subpower
 -----------------------------------
 local effectObject = {}
 

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -2602,10 +2602,10 @@ INSERT INTO `mob_skill_lists` VALUES ('Khimaira_13',779,2023); -- Thunderstrike:
 INSERT INTO `mob_skill_lists` VALUES ('Khimaira_13',779,2024); -- Tourbillion: AoE DMG + Knockback. Removes Utsusemi.
 INSERT INTO `mob_skill_lists` VALUES ('Khimaira_13',779,2025); -- Dreadstorm: AoE DMG + terrorize. Removes Utsusemi.
 INSERT INTO `mob_skill_lists` VALUES ('Lancelord_Gaheel_Ja',780,2094); -- Flame Angon - AoE fire damage (50-100)
+INSERT INTO `mob_skill_lists` VALUES ('Lancelord_Gaheel_Ja',780,2095); -- Batterhorn - 2-hit frontal AOE, absorbed by Utsusemi.
+INSERT INTO `mob_skill_lists` VALUES ('Lancelord_Gaheel_Ja',780,2096); -- Clobber - Targeted AoE physical damage
+INSERT INTO `mob_skill_lists` VALUES ('Lancelord_Gaheel_Ja',780,2097); -- Granite Skin - Parry/Guard skill increase, cannot be dispelled
 INSERT INTO `mob_skill_lists` VALUES ('Lancelord_Gaheel_Ja',780,2098); -- Blazing Angon - AoE fire damage (150-300)
-INSERT INTO `mob_skill_lists` VALUES ('Lancelord_Gaheel_Ja',780,2099); -- Batterhorn - 2-hit frontal AOE, absorbed by Utsusemi.
-INSERT INTO `mob_skill_lists` VALUES ('Lancelord_Gaheel_Ja',780,2100); -- Clobber - Targeted AoE physical damage
-INSERT INTO `mob_skill_lists` VALUES ('Lancelord_Gaheel_Ja',780,2103); -- Granite Skin - Parry/Guard skill increase, cannot be dispelled
 INSERT INTO `mob_skill_lists` VALUES ('Naja_Salaheem',781,165); -- Skullbreaker (Mission version uses skull
 INSERT INTO `mob_skill_lists` VALUES ('Naja_Salaheem',781,168); -- Hexa Strike
 INSERT INTO `mob_skill_lists` VALUES ('Naja_Salaheem',781,169); -- Black Halo

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -2108,16 +2108,16 @@ INSERT INTO `mob_skills` VALUES (2091,1430,'meteoric_impact',0,7.0,2000,1500,4,0
 INSERT INTO `mob_skills` VALUES (2092,1431,'scouring_bubbles',1,7.0,2000,1500,4,0,0,0,14,10,0);  -- Mihli
 -- INSERT INTO `mob_skills` VALUES (2093,1837,'.',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2094,1432,'fire_angon',0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (2095,1437,'batterhorn',0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (2096,1438,'clobber',0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (2097,1439,'granite_skin',0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (2095,1437,'batterhorn',4,16.0,2000,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (2096,1438,'clobber',8,16.0,2000,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (2097,1439,'granite_skin',0,7.0,2000,1500,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2098,1433,'blazing_angon',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2099,1437,'batterhorn',4,16.0,2000,1000,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (2100,1436,'clobber',4,16.0,2000,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (2100,1436,'clobber',8,16.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2101,1434,'demoralizing_roar',1,16.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2102,1435,'boiling_blood',0,7.0,2000,1000,1,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (2103,1439,'granite_skin',0,7.0,2000,1000,1,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (2104,1436,'crippling_slam',0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (2103,1439,'granite_skin',0,7.0,2000,1500,1,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (2104,1436,'crippling_slam',4,15.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (2105,1440,'mijin_gakure',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2106,1449,'bloodrake',0,7.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2107,1450,'decollation',0,7.0,2000,1000,4,0,0,0,0,0,0);

--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -212,6 +212,22 @@ bool CAttack::IsAnticipated() const
     return m_anticipated;
 }
 
+bool CAttack::IsDeflected() const
+{
+    if (!m_victim->StatusEffectContainer->HasStatusEffect(EFFECT_DEFENSE_BOOST))
+    {
+        return false;
+    }
+
+    uint16 subpower = m_victim->StatusEffectContainer->GetStatusEffect(EFFECT_DEFENSE_BOOST)->GetSubPower();
+    if (subpower == 0)
+    {
+        return false;
+    }
+
+    return infront(m_attacker->loc.p, m_victim->loc.p, subpower);
+}
+
 /************************************************************************
  *                                                                      *
  *  Returns the isFirstSwing flag.                                      *

--- a/src/map/attack.h
+++ b/src/map/attack.h
@@ -89,6 +89,7 @@ public:
     bool                      IsParried() const;
     bool                      CheckParried();
     bool                      IsAnticipated() const;
+    bool                      IsDeflected() const;
     bool                      CheckAnticipated();
     bool                      IsCountered() const;
     bool                      CheckCounter();

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2183,6 +2183,12 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
             actionTarget.reaction   = REACTION::EVADE;
             actionTarget.speceffect = SPECEFFECT::NONE;
         }
+        else if (attack.IsDeflected())
+        {
+            actionTarget.messageID  = 1;
+            actionTarget.reaction   = REACTION::PARRY | REACTION::HIT;
+            actionTarget.speceffect = SPECEFFECT::NONE;
+        }
         else if ((xirand::GetRandomNumber(100) < attack.GetHitRate() || attackRound.GetSATAOccured()) &&
                  !PTarget->StatusEffectContainer->HasStatusEffect(EFFECT_ALL_MISS))
         {

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2392,6 +2392,14 @@ namespace battleutils
         auto* weapon   = GetEntityWeapon(PAttacker, (SLOTTYPE)slot);
         bool  isRanged = (slot == SLOT_AMMO || slot == SLOT_RANGED);
 
+        if (attackType == ATTACK_TYPE::PHYSICAL &&
+            PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_DEFENSE_BOOST) &&
+            PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_DEFENSE_BOOST)->GetSubPower() != 0 &&
+            infront(PAttacker->loc.p, PDefender->loc.p, PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_DEFENSE_BOOST)->GetSubPower()))
+        {
+            damage = 0;
+        }
+
         if (damage > 0)
         {
             damage = std::max(damage - PDefender->getMod(Mod::PHALANX), 0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This focuses on improving the Wivre family to be more retail accurate. This is primarily focused on Wivre skills. All changes here are either directly taken from the [Monster Stats sheet](https://docs.google.com/spreadsheets/d/1YBoveP-weMdidrirY-vPDzHyxbEI2ryECINlfCnFkLI/edit?gid=57955395#gid=57955395) or from retail captures I did myself.

The biggest change revolves around the skill Granite Skin which provides immunity to physical attacks while the attacker is directly in front of the target. With Larceny I was able to verify the status effect is Defense Boost. I opted to use the unused subpower on this effect to act as an angle from the front that determines if the attack is negated or not. This may be unnecessary and the angle could possibly be hardcoded instead with the subpower simply indicating that this effect has this special case.

## Steps to test these changes

The usual - go to a Wivre, `!gotoid 17137983` and spam `!tp 3000` to see the various mob skills.