### PR TITLE
Steal All Status Effect Data

### DIFF
--- a/scripts/globals/job_utils/thief.lua
+++ b/scripts/globals/job_utils/thief.lua
@@ -301,8 +301,12 @@ xi.job_utils.thief.useLarceny = function(player, target, ability, action)
         local newPower    = effectStolen:getPower()
         local newTick     = effectStolen:getTick()
         local newDuration = effectStolen:getDuration() + jpValue
+        local newSubType  = effectStolen:getSubType()
+        local newSubPower = effectStolen:getSubPower()
+        local newTier     = effectStolen:getTier()
+        local newFlags    = effectStolen:getEffectFlags()
 
-        player:addStatusEffectEx(newID, newIcon, newPower, newTick, newDuration)
+        player:addStatusEffectEx(newID, newIcon, newPower, newTick, newDuration, newSubType, newSubPower, newTier, newFlags)
         target:delStatusEffect(newID)
 
         effectID = newID

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1316,7 +1316,8 @@ CStatusEffect* CStatusEffectContainer::StealStatusEffect(EFFECTFLAG flag)
 
         // make a copy
         CStatusEffect* EffectCopy = new CStatusEffect(oldEffect->GetStatusID(), oldEffect->GetIcon(), oldEffect->GetPower(), oldEffect->GetTickTime() / 1000,
-                                                      oldEffect->GetDuration() / 1000);
+                                                      oldEffect->GetDuration() / 1000, oldEffect->GetSubID(), oldEffect->GetSubPower(), oldEffect->GetTier(),
+                                                      oldEffect->GetEffectFlags());
 
         RemoveStatusEffect(oldEffect);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This change copies over all of the data associated with a stolen status effect. This came about directly from trying to test the Wivre PR I have up (#5993). Originally it was only copying the subpower but after further inspection I believe it makes sense to copy over all of this data. See discussion below.

## Steps to test these changes

Possibly the easiest way to test this is to apply this change on top of the Wivre PR I have up (#5993). With Granite Skin from that or another status that has a subpower, get the status effect on the mob and then use Larceny (THF99 has it). You should have the subpower of the stolen status effect.
