### PR TITLE
[core] Camouflage Enhancements

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -2063,8 +2063,93 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
     }
     battleutils::ClaimMob(PTarget, this);
     battleutils::RemoveAmmo(this, ammoConsumed);
-    // only remove detectables
-    StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DETECTABLE);
+
+    // Handle Camouflage effects
+    if (this->StatusEffectContainer->HasStatusEffect(EFFECT_CAMOUFLAGE, 0))
+    {
+        int16 retainChance     = 40; // Estimate base ~40% chance to keep Camouflage on a ranged attack
+        uint8 rotAllowance     = 25; // Allow for some slight variance in direction faced to be "behind" or "beside" the mob
+        float distanceToTarget = distance(this->loc.p, PTarget->loc.p);
+        float meleeRange       = PTarget->GetMeleeRange();
+
+        if (isBarrage)
+        {
+            // Camouflage is never retained if Barrage is fired
+            retainChance = 0;
+        }
+        else if (behind(this->loc.p, PTarget->loc.p, rotAllowance))
+        {
+            // Max melee distance + .6 = safe
+            // Max melee distance + (.1~.5) = chance of deactivation
+            // Under max melee distance = certain deactivation
+            if (distanceToTarget > meleeRange + .6)
+            {
+                retainChance = 100;
+            }
+            else if (distanceToTarget > meleeRange + .1)
+            {
+                retainChance += 1.6 * distanceToTarget;
+            }
+            else
+            {
+                retainChance = 0;
+            }
+        }
+        else if (beside(this->loc.p, PTarget->loc.p, rotAllowance))
+        {
+            // Max melee distance + 5 yalms = safe
+            // (Max melee distance + 3.3) + (0.0~1.6) = chance of deactivation
+            // Under Max melee distance + 3.3 = certain deactivation
+            if (distanceToTarget > meleeRange + 5)
+            {
+                retainChance = 100;
+            }
+            else if (distanceToTarget > meleeRange + 3.3)
+            {
+                retainChance += 1.6 * distanceToTarget;
+            }
+            else
+            {
+                retainChance = 0;
+            }
+        }
+        else
+        {
+            // Max melee distance + 8.1 yalms = safe
+            // (Max melee distance + 7.1) + (0.0~.99) = chance of deactivation
+            // Under Max melee distance + 7.1 = certain deactivation
+            if (distanceToTarget > meleeRange + 8.1)
+            {
+                retainChance = 100;
+            }
+            else if (distanceToTarget > meleeRange + 7.1)
+            {
+                retainChance += 1.6 * distanceToTarget;
+            }
+            else
+            {
+                retainChance = 0;
+            }
+        }
+
+        if (xirand::GetRandomNumber(100) > retainChance)
+        {
+            // Camouflage was up, but is lost, so now all detectable effects must be dropped
+            StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DETECTABLE);
+        }
+        else
+        {
+            // Camouflage up, and retained, but all other effects must be dropped
+            StatusEffectContainer->DelStatusEffect(EFFECT_SNEAK);
+            StatusEffectContainer->DelStatusEffect(EFFECT_INVISIBLE);
+            StatusEffectContainer->DelStatusEffect(EFFECT_DEODORIZE);
+        }
+    }
+    else
+    {
+        // Camouflage not up, so remove all detectable status effects
+        StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DETECTABLE);
+    }
 }
 
 bool CCharEntity::IsMobOwner(CBattleEntity* PBattleTarget)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Updates the logic for Camouflage to determine when it should or should not fall off, based on recent captures.

## Capture Summary

![image](https://github.com/user-attachments/assets/4291ea3f-9cbe-4e27-9da3-6fdeee39ce68)

https://docs.google.com/spreadsheets/d/1EWNu3Z-qTJmVgYTmE4bHYavVPq7uGE6Vk30XHzl7Ebg

```
Crawlers were my initial target. They have a meleehit box of 3'6. When I tested back shots at 4'5 i had no breaks in camo.
When tried Gigas, I was losing camo on all shots at 4'5. Gigas had a melee hit box of 4'9. So I added 9, and tested at 5'8, and had no loss in camo. The minimum distance on a gigas I lost camo was 5'4, with many in the 4'9~5'3 range. Based on this, for back shots at least.. it might be that it's minimum melee hit box + '6 is the safe spot, with anything between melee and safe spot being having a chance to lose camo. It doesn't appear to be random in the sense that 1 out of 2 shots at 5'3 loses camo... more like one mob of the same size will let you pew-pew away at 5'3, but the next one you'll lose it - possibly mob-to-player level dependent.

Side shots also appear to have different distances dependent on mob size too. I just ended up adding .9 yalms to account for the size difference between the crawler and the gigas and I was able to maintain camo at 9.9 yalms. When testing minimum, the closest I lost it was 8.4 and farthest was 9.8.
```

**Speculated Formula by Capturer**

```
Back

Max melee distance + .6 = safe

Max melee distance + (.1~.5) = chance of deactivation

Under Max melee distance = certain deactivation
```

```
Side

Max melee distance + 5 yalms = safe 

(Max melee distance + 3.3) + (0.0~1.6) = chance of deactivation

Under Max melee distance + 3.3 = certain deactivation
```

```
Front

At melee distance + 8.1 yalms = safe 

(Max melee distance + 7.1) + (0.0~.99) = chance of deactivation

Under Max melee distance + 7.1 = certain deactivation
```



## What might be Missing

@Xaver-DaRed shared some helpful data below that implied mob levels might also have an impact on Camouflage retainability. The capturer also mentioned that mob level might play into some of the seemingly random cases where Camouflage fell off at specific distances. It might be prudent to go attempt some more tests with that in mind.

Additionally, the "chance of deactivation" percentage is currently estimated. I kept the existing estimation from work completed in ASB way before my time. Due to the nature of Camouflage being a 5 minute cooldown, it might take a long time to capture enough data if we think this is important. I would appreciate direction in how large of a sample size we'd need to be comfortable with a failure rate estimation.

~~I've started doing retail testing and can confirm barrage breaks the camouflage effect after fired. Once I gather enough data to be sure it is guaranteed and not a chance, I'll update my PR.~~

I've updated the PR to drop Camouflage if Barrage is active during the shot, to match retail behavior.

![image](https://github.com/user-attachments/assets/77e508e9-5602-4f15-bfb1-89fd995d3132)

## PR Testing Video (done on ASB, can re-record for LSB if needed):
https://beta.ffxivclock.com/camouflage_testing.mp4

## Steps to test these changes

```
!changejob rng 75
!additem loxley_bow
!additem kabura_arrow 99
Equip the Bow and Arrow
Use Camouflage
Shoot from various angles and distances
Use !reset to reset the Camouflage cooldown when needed
```
