### PR TITLE
[sql] Add Gigas Bracelets Desynth

### DIFF
--- a/sql/synth_recipes.sql
+++ b/sql/synth_recipes.sql
@@ -4755,6 +4755,7 @@ INSERT INTO `synth_recipes` VALUES (75530,0,0,0,0,0,0,0,0,10,0,4099,4241,2773,27
 INSERT INTO `synth_recipes` VALUES (75531,0,0,0,0,0,0,0,0,10,0,4099,4241,2773,2773,2774,2774,2775,4161,0,0,2781,2781,2781,2781,1,1,1,1,'Enfeeb. Kit Sleep');
 INSERT INTO `synth_recipes` VALUES (75532,1,0,0,0,0,0,34,0,0,0,4100,4242,12994,0,0,0,0,0,0,0,818,818,848,848,2,3,1,2,'Shoes (desynth)');
 INSERT INTO `synth_recipes` VALUES (75533,1,0,0,0,0,25,0,0,0,0,4100,4242,12722,0,0,0,0,0,0,0,834,819,819,819,2,5,6,7,'Bracers (desynth)'); -- FFXIclopedia
+INSERT INTO `synth_recipes` VALUES (75534,1,0,0,0,57,0,0,0,0,0,4100,4242,14018,0,0,0,0,0,0,0,653,653,745,745,1,2,1,1,'Gigas Bracelets (desynth)');
 
 -- -----------
 -- RECIPES END


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Updated sql script to add desynthesis recipe for `Gigas Bracelets`

## Sources

- https://wiki.ffo.jp/html/7184.html
- https://ffxiclopedia.fandom.com/wiki/Gigas_Bracelets?oldid=319936

## Proof of level 57 Goldsmithing
I started a new character and leveled Goldsmithing 1 level at a time, attempting the synth with +3 Synth Support to find exactly what level it became synthable. Here are the last 2 videos showing it was not synthable at 29, but became synthable at 30, giving us the true level of the synth (57).

![image](https://github.com/user-attachments/assets/4ca4d080-f50b-43fa-b59e-3f23614332d0)

https://github.com/user-attachments/assets/72d7c3c9-2bda-4767-a2ba-dca94f369df0


https://github.com/user-attachments/assets/b49278af-0c3a-4c5c-a65f-f63ca685bc2e



## Steps to test these changes

- Be on a goldsmither 57+
- Use a lightning crystal on `Gigas Bracelets`

## Screenshots

![image](https://github.com/AirSkyBoat/AirSkyBoat/assets/43099213/3fdc00c8-9b86-4b6f-9580-bc1f72119c63)

![image](https://github.com/AirSkyBoat/AirSkyBoat/assets/43099213/a693313c-970f-4d4e-8301-f48686463aec)
