### PR TITLE
Z's Trident Latent

### DIFF
--- a/scripts/enum/latent.lua
+++ b/scripts/enum/latent.lua
@@ -42,7 +42,7 @@ xi.latent =
     JOB_MULTIPLE             = 38, -- PARAM: 0: ODD, 2: EVEN, 3-99: DIVISOR
     JOB_MULTIPLE_AT_NIGHT    = 39, -- PARAM: 0: ODD, 2: EVEN, 3-99: DIVISOR
     EQUIPPED_IN_SLOT         = 40, -- When item is equipped in the specified slot (e.g. Dweomer Knife, Erlking's Sword, etc.) PARAM: slotID
-    -- 41 free to use
+    DURING_WS                = 41, -- During Weaponskill
     -- 42 free to use
     WEAPON_DRAWN_HP_UNDER    = 43, -- PARAM: HP PERCENT
     NATION_CITIZEN           = 44, -- Triggered by player being citizen of nation matching param: 0 San d'Oria, 1 Bastok, 2 Windurst

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -2042,6 +2042,9 @@ INSERT INTO `item_latents` VALUES (18099,23,24,6,1000);  -- Attack+24 while TP <
 INSERT INTO `item_latents` VALUES (18099,25,5,6,1000);   -- Accuracy+5 while TP <100%
 INSERT INTO `item_latents` VALUES (18099,287,5,6,1000);  -- DMG+5 while TP <100%
 
+-- Z's Trident
+INSERT INTO `item_latents` VALUES (18101,8,12,41,0);     -- STR+12 during WS
+
 -- Leviathan's Couse
 -- TODO: INSERT INTO `item_latents` VALUES (18109,431,1,21,12); -- Additional effect: Water damage while you or a party member has Leviathan summoned
 

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1286,6 +1286,7 @@ void CCharEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& acti
     tp       = battleutils::CalculateWeaponSkillTP(this, PWeaponSkill, tp);
 
     PLatentEffectContainer->CheckLatentsTP();
+    PLatentEffectContainer->CheckLatentsWS(true);
 
     SLOTTYPE damslot    = SLOT_MAIN;
     bool     isRangedWS = (PWeaponSkill->getID() >= 192 && PWeaponSkill->getID() <= 218);
@@ -1455,6 +1456,8 @@ void CCharEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& acti
             actionTarget.speceffect = SPECEFFECT::BLOOD;
         }
     }
+
+    PLatentEffectContainer->CheckLatentsWS(false);
 }
 
 void CCharEntity::OnAbility(CAbilityState& state, action_t& action)

--- a/src/map/latent_effect.h
+++ b/src/map/latent_effect.h
@@ -70,7 +70,7 @@ enum class LATENT : uint16
     JOB_MULTIPLE           = 38, // PARAM: 0: ODD, 2: EVEN, 3-X: DIVISOR
     JOB_MULTIPLE_AT_NIGHT  = 39, // PARAM: 0: ODD, 2: EVEN, 3-X: DIVISOR
     EQUIPPED_IN_SLOT       = 40, // When item is equipped in the specified slot (e.g. Dweomer Knife, Erlking's Sword, etc.) PARAM: slotID
-    // 41 free to use
+    DURING_WS              = 41, // During WS
     // 42 free to use
     WEAPON_DRAWN_HP_UNDER = 43, // PARAM: HP PERCENT
     NATION_CITIZEN        = 44, // Triggered by player being citizen of nation matching param: 0 San d'Oria, 1 Bastok, 2 Windurst

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -168,6 +168,25 @@ void CLatentEffectContainer::CheckLatentsTP()
 
 /************************************************************************
 *                                                                       *
+* Checks all latents that are occur during WS and activates them        *
+*                                                                       *
+ ************************************************************************/
+void CLatentEffectContainer::CheckLatentsWS(bool isDuringWs)
+{
+    ProcessLatentEffects([this, isDuringWs](CLatentEffect& latentEffect) {
+        switch (latentEffect.GetConditionsID())
+        {
+            case LATENT::DURING_WS:
+                return ProcessLatentEffect(latentEffect, isDuringWs);
+            default:
+                break;
+        }
+        return false;
+    });
+}
+
+/************************************************************************
+*                                                                       *
  * Checks all latents that are affected by MP and activates them if     *
  * the conditions are met.                                              *
 *                                                                       *
@@ -686,7 +705,7 @@ void CLatentEffectContainer::ProcessLatentEffects(const std::function<bool(CLate
 
 // Processes a single CLatentEffect* and finds the expression to evaluate for
 // activation/deactivation and attempts to apply
-bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
+bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect, bool isDuringWs)
 {
     TracyZoneScoped;
     // Our default case un-finds our latent prevent us from toggling a latent we don't have programmed
@@ -1222,6 +1241,9 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
             break;
         case LATENT::EQUIPPED_IN_SLOT:
             expression = latentEffect.GetSlot() == latentEffect.GetConditionsValue();
+            break;
+        case LATENT::DURING_WS:
+            expression = isDuringWs;
             break;
         default:
             latentFound = false;

--- a/src/map/latent_effect_container.h
+++ b/src/map/latent_effect_container.h
@@ -42,6 +42,7 @@ class CLatentEffectContainer
 public:
     void CheckLatentsHP();
     void CheckLatentsTP();
+    void CheckLatentsWS(bool isDuringWs);
     void CheckLatentsMP();
     void CheckLatentsEquip(uint8 slot);
     void CheckLatentsWeaponDraw(bool drawn);
@@ -78,7 +79,7 @@ private:
     std::vector<CLatentEffect> m_LatentEffectList;
 
     void ProcessLatentEffects(const std::function<bool(CLatentEffect&)>& logic);
-    bool ProcessLatentEffect(CLatentEffect& latentEffect);
+    bool ProcessLatentEffect(CLatentEffect& latentEffect, bool isDuringWs = false);
     bool ApplyLatentEffect(CLatentEffect& effect, bool expression);
 };
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.
## Please enter a player-facing description

Latent effect was added to `Z's Trident`

## Source:

https://wiki-ffo-jp.translate.goog/html/3911.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en

![image](https://github.com/user-attachments/assets/ffd7f1f4-e646-42ca-809c-681c17f78083)

## What does this pull request do? (Please be technical)

This adds support for a `during WS` latent trigger. The existing one also applied when TP was less than 1000, which isn't what we wanted for `Z's Trident`.

Additionally, it adds the `STR+12` latent to Z's Trident to be active during Weapon Skills
![image](https://github.com/AirSkyBoat/AirSkyBoat/assets/43099213/d11f6fb5-dd8f-462f-b91b-b4c6c564da69)

## Steps to test these changes

You can add a `printf` in the `weaponskills.lua` to print player STR during WS, here is a screenshot of me doing that:

![image](https://github.com/AirSkyBoat/AirSkyBoat/assets/43099213/cdafb31e-d1fc-47a0-859b-f4c9f09c2df8)


## Special Deployment Considerations

* No new considerations for fresh installs
* The script will need to likely be run manually for pre-existing installs, unless there is a migration process or something I can update