### PR TITLE
[cpp] Adds standback range mod for mobs

### DIFF
--- a/scripts/enum/mob_mod.lua
+++ b/scripts/enum/mob_mod.lua
@@ -85,4 +85,5 @@ xi.mobMod =
     CAN_PARRY              = 75, -- Check if a mob is allowed to have parry rank (Rank Value 1-5)
     NO_WIDESCAN            = 76, -- Disables widescan for a specific mob
     TRUST_DISTANCE         = 77, -- TRUSTS ONLY: Set movement type/distance. See trust.lua for details.
+    STANDBACK_RANGE        = 78, -- Applies a specific standback range for the mob
 }

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -1339,6 +1339,11 @@ bool CMobController::CanMoveForward(float currentDistance)
 
     uint16 standbackRange = 20;
 
+    if (PMob->getMobMod(MOBMOD_STANDBACK_RANGE) > 0)
+    {
+        standbackRange = PMob->getMobMod(MOBMOD_STANDBACK_RANGE);
+    }
+
     if (PMob->m_Behaviour & BEHAVIOUR_STANDBACK && currentDistance < standbackRange && PMob->CanSeeTarget(PTarget))
     {
         return false;

--- a/src/map/mob_modifier.h
+++ b/src/map/mob_modifier.h
@@ -106,6 +106,7 @@ enum MOBMODIFIER : int
     MOBMOD_CAN_PARRY              = 75, // Check if a mob is allowed to have parry rank (Rank Value 1-5)
     MOBMOD_NO_WIDESCAN            = 76, // Disables widescan for a specific mob
     MOBMOD_TRUST_DISTANCE         = 77, // TRUSTS ONLY: Set movement type/distance. See trust.lua for details.
+    MOBMOD_STANDBACK_RANGE        = 78, // Applies a specific standback range for the mob
 };
 
 #endif


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Our standback range is hardcoded to 20 which is inaccurate. We need to gather more retail research on this but a lot of mobs have different standback ranges. This PR adds standback range mod for mobs.  This will allow us to apply the range needed for proper standback.

Example of Dynamis capture that needs this: https://www.youtube.com/watch?v=JriGL3j062c
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
You can use Vanguard Hitman as an example or any ranger/ninja mob you would like.
Apply the mod: `mob:setMobMod(xi.mobMod.STANDBACK_RANGE, 16)`
See the mob standback at 16
[Imgur](https://imgur.com/7je7YaN) (dont ask I am bringing it back a few years bc the gif was too large)
<!-- Clear and detailed steps to test your changes here -->
