### PR TITLE
Make seigan benefit require a 2 handed weapon.

### DIFF
--- a/scripts/actions/abilities/third_eye.lua
+++ b/scripts/actions/abilities/third_eye.lua
@@ -8,7 +8,10 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    if player:hasStatusEffect(xi.effect.SEIGAN) then
+    if
+        player:hasStatusEffect(xi.effect.SEIGAN) and
+        player:isWeaponTwoHanded()
+    then
         ability:setRecast(ability:getRecast() / 2)
     end
 

--- a/scripts/effects/seigan.lua
+++ b/scripts/effects/seigan.lua
@@ -4,6 +4,7 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
+    -- TODO: confirm if this def bonus is only active with 2hander equipped and either follow the pattern currently in hasso/desperate blows or consider a latent sytle effect
     local jpValue = target:getJobPointLevel(xi.jp.SEIGAN_EFFECT)
 
     target:addMod(xi.mod.DEF, jpValue * 3)

--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -393,16 +393,17 @@ bool CAttack::CheckAnticipated()
         m_victim->StatusEffectContainer->DelStatusEffect(EFFECT_THIRD_EYE);
         return false;
     }
+    auto* weapon             = dynamic_cast<CItemWeapon*>(m_victim->m_Weapons[SLOT_MAIN]);
+    bool  isValid2HandWeapon = weapon && weapon->isTwoHanded();
+    bool  hasValidSeigan     = isValid2HandWeapon && m_victim->StatusEffectContainer->HasStatusEffect(EFFECT_SEIGAN, 0);
 
-    bool hasSeigan = m_victim->StatusEffectContainer->HasStatusEffect(EFFECT_SEIGAN, 0);
-
-    if (!hasSeigan && pastAnticipations == 0)
+    if (!hasValidSeigan && pastAnticipations == 0)
     {
         m_victim->StatusEffectContainer->DelStatusEffect(EFFECT_THIRD_EYE);
         m_anticipated = true;
         return true;
     }
-    else if (!hasSeigan)
+    else if (!hasValidSeigan)
     {
         m_victim->StatusEffectContainer->DelStatusEffect(EFFECT_THIRD_EYE);
         return false;
@@ -461,8 +462,12 @@ bool CAttack::CheckCounter()
 
     // counter check (rate AND your hit rate makes it land, else its just a regular hit)
     // having seigan active gives chance to counter at 25% of the zanshin proc rate
-    uint16 seiganChance = 0;
-    if (m_victim->objtype == TYPE_PC && m_victim->StatusEffectContainer->HasStatusEffect(EFFECT_SEIGAN))
+    uint16 seiganChance       = 0;
+    auto*  weapon             = dynamic_cast<CItemWeapon*>(m_victim->m_Weapons[SLOT_MAIN]);
+    bool   isValid2HandWeapon = weapon && weapon->isTwoHanded();
+    bool   hasValidSeigan     = isValid2HandWeapon && m_victim->StatusEffectContainer->HasStatusEffect(EFFECT_SEIGAN, 0);
+
+    if (m_victim->objtype == TYPE_PC && hasValidSeigan)
     {
         seiganChance = m_victim->getMod(Mod::ZANSHIN) + ((CCharEntity*)m_victim)->PMeritPoints->GetMeritValue(MERIT_ZASHIN_ATTACK_RATE, (CCharEntity*)m_victim);
         seiganChance = std::clamp<uint16>(seiganChance, 0, 100);

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1968,8 +1968,6 @@ namespace charutils
             {
                 case SLOT_MAIN:
                 {
-                    CItemWeapon* weapon = dynamic_cast<CItemWeapon*>(PChar->getEquip(SLOT_MAIN));
-
                     if (PItem->isType(ITEM_WEAPON))
                     {
                         switch (static_cast<CItemWeapon*>(PItem)->getSkillType())
@@ -2014,11 +2012,6 @@ namespace charutils
                             }
                         }
                         PChar->m_Weapons[SLOT_MAIN] = PItem;
-
-                        if (weapon && weapon->isTwoHanded())
-                        {
-                            PChar->StatusEffectContainer->DelStatusEffect(EFFECT_SEIGAN); // TODO: make seigan-specific effects not function without a 2H weapon so it doesn't have to be deleted if a weapon is removed
-                        }
                     }
                     PChar->look.main = PItem->getModelId();
                     UpdateWeaponStyle(PChar, equipSlotID, (CItemWeapon*)PItem);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Discovered an issue on Horizon where changing weapons from a 2 hander to a not 2 hander did not cause the removal of hasso and seigan.
This same bug is present in LSB.
Instead of fixing the bug directly, I've removed the workaround of deleting the seigan effect and updated seigan to require a 2 handed weapon.

### The bug/RCA
We expect to cancel seigan when the weapon being replaced on equip is a two hander.
On [this line](https://github.com/LandSandBoat/server/blob/436bc759586dfd66ed2fd573df616f8dc5e7cc75/src/map/utils/charutils.cpp#L1971) we dynamically cast from CItemEquipment to CItemWeapon.  This is a valid downcast however - earlier on in the function [here](https://github.com/LandSandBoat/server/blob/436bc759586dfd66ed2fd573df616f8dc5e7cc75/src/map/utils/charutils.cpp#L1919) we unequip the existing weapon since a new weapon is coming in.
This results in us never having an acutal weapon equipped when we pull the equip from the MAIN slot - and always having a nullptr.
[Later on](https://github.com/LandSandBoat/server/blob/436bc759586dfd66ed2fd573df616f8dc5e7cc75/src/map/utils/charutils.cpp#L2018) we are checking to ensure the pointer is non-null before accessing it, but it is always null, so we never progress to checking if it was a 2 hander or not and we thereforenever remove seigan.

### Fixing the workaround (not reccomended)
The original work around, while better than not having the work around, did not close all edge cases.  
Canceling seigan in the way the work around did is incomplete as there is no accounting for just unequipping a 2 hander on say mnk/sam and having full fledged seigan and increased counter rate while bare handed.
It also left the end user with the problematic case of seigan being removed if they were to swap from a 2 handed weapon to another 2 handed weapon.

However if we wanted to maintain the workaround, a quick fix would be to replace the line performing the dynamis cast from 
```cpp
CItemWeapon* weapon = dynamic_cast<CItemWeapon*>(PChar->getEquip(SLOT_MAIN));
```
to
```cpp
CItemWeapon* weapon = dynamic_cast<CItemWeapon*>(PChar->getEquip(oldItem));
```
`oldItem` is referenced [earlier](https://github.com/LandSandBoat/server/blob/436bc759586dfd66ed2fd573df616f8dc5e7cc75/src/map/utils/charutils.cpp#L1889) in the function and would provide valid access to the piece being replaced.

### A better approach
In this PR, I've tracked down all the places I could think of when considering the benefits of seigan.
For each instance of benefit, I've tightly coupled needing a 2 hander to gain the benefit.
I've added a todo on the JobPoint benefits of the siegan defense bonus as I am not aware if that should be resticted to 2 hander or not.

## Steps to test these changes

### Retaining Seigan
1. Be a Sam or /Sam - equip a 2 handed weapon.  e.g. Mnk/Sam with Mekki Shakki.
2. Use Seigan - Recieve the buff.
3. Equip a warp cudgel or similar 1 hander - keep the seigan buff.
4. Attempt to reapply Seigan with the 1 hander - recieve an error message that JA activation requires a 2 handed weaopn.
5. Requip the Mekki Shakki, reapply Seigan.
6. Repeat steps 3 & 4 with HtH e.g. Destroyers.

### Verify existing seigan functionality
1. Be a job with no native counter - eg Warror. and equip a 2 hander (Mekki Shakki)
2. Apply Seigan and Third Eye - note that Seigan could be used and Third Eye recast was 30s.
3. Engage a mob that has reasonably high relative accuracy e.g. Epharim Shades near the Cutter in Arapago Reef vs a 75 War with agressor up.
4. Allowing for a relatively reasonable sample size - maintain Seigan use Third Eye and note the number of anitcipates and counters.  2+ combined anticipates and counters per third eye should be common.

### Verify loss of seigan functionality with a one hander
1. Be a job with no native counter - eg Warror. and equip a 2 hander (Mekki Shakki)
2. Apply Seigan and third eye with the 2 hander equipped.
3. Swap to a 1 hander - note that the first anticipate causes loss of thrid eye.  note that no counter occured.
4. Swap back to a 2 hander and third eye, and return to 1 hander to repeat step 3 multiple times.
5. `!mobstun 15` can be useful for ensuring that incoming auto attacks are not recieved while the 2 hander is equipped.
6. No longer swap back to the 2 hander - but trigger third eye while seigan is still active and a 1 hander is equipped - note that the first anticipate causes loss of thrid eye.  note that no counter occurs.

## Conversation Point/Question
I noticed that Hasso (and Desperate Blows) have specific 2 hander mods implemented - which is what allowed this PR to be done with relatively small changes.  
I was curious why that approach was chosen over creating a new latent parameter, TWO_HANDER_REQUIRED - and applying the latent effects on effect recieved.  
Was the rationale that latents incurr more overall processing cost, as they are processed at multiple points?