### PR TITLE
[core, lua] Improve draw-in specification to fix some issues

### DIFF
--- a/scripts/battlefields/Apollyon/sw_apollyon.lua
+++ b/scripts/battlefields/Apollyon/sw_apollyon.lua
@@ -351,10 +351,10 @@ content.groups =
         mobs    = { 'Armoury_Crate_Mimic' },
         mobMods =
         {
-            [xi.mobMod.DRAW_IN   ] = 1,
-            [xi.mobMod.NO_MOVE   ] = 1,
-            [xi.mobMod.NO_DESPAWN] = 1,
-            [xi.mobMod.NO_AGGRO  ] = 1,
+            [xi.mobMod.DRAW_IN_BITMASK ] = xi.drawin.NORMAL,
+            [xi.mobMod.NO_MOVE   ]       = 1,
+            [xi.mobMod.NO_DESPAWN]       = 1,
+            [xi.mobMod.NO_AGGRO  ]       = 1,
         },
 
         setup = function(battlefield, mobs)

--- a/scripts/enum/drawin.lua
+++ b/scripts/enum/drawin.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Drawin bits
+-----------------------------------
+xi = xi or {}
+
+xi.drawin =
+{
+    NONE             = 0x000, -- no draw-in (mob can only draw-in by explictly calling the lua drawin function)
+    NORMAL           = 0x001, -- basic draw-in where mob will draw-in battle target when target some distance from mob
+    TO_FRONT_OF_MOB  = 0x002, -- determines if draw-in to the center of mob (bit not set) or front of mob (bit set)
+    INCLUDE_ALLIANCE = 0x004, -- determines if draw-in includes just the battle target (bit not set) or entire alliance (bit set)
+}

--- a/scripts/enum/mob_mod.lua
+++ b/scripts/enum/mob_mod.lua
@@ -20,7 +20,7 @@ xi.mobMod =
     HP_HEAL_CHANCE         = 9,  -- can cast cures below this HP %
     SUBLINK                = 10, -- sub link group
     LINK_RADIUS            = 11, -- link radius
-    DRAW_IN                = 12, -- 1 - player draw in, 2 - alliance draw in -- only add as a spawn mod!
+    DRAW_IN_BITMASK        = 12, -- bitmask with different binary options for draw-in (see DRAWIN enum for options)
     SEVERE_SPELL_CHANCE    = 13, -- % chance to use a severe spell like death or impact
     SKILL_LIST             = 14, -- uses given mob skill list
     MUG_GIL                = 15, -- amount gil carried for mugging
@@ -90,4 +90,6 @@ xi.mobMod =
     CANNOT_GUARD           = 79, -- Check if the mob does not guard (despite being a MNK or PUP mob)
     SKIP_ALLEGIANCE_CHECK  = 80, -- Skip the allegiance check for valid target (allows for example a mob to cast a TARGET_ENEMY spell on itself)
     ABILITY_RESPONSE       = 81, -- Mob can respond to player ability use with onPlayerAbilityUse()
+    DRAW_IN_TRIGGER_DIST   = 82, -- Distance to trigger a draw-in (overrides a default of 2 * melee dist)
+    DRAW_IN_MAX_RANGE      = 83, -- Max range to draw-in an entity (overrides a default of entire zone)
 }

--- a/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
@@ -15,7 +15,8 @@ end
 
 entity.onMobInitialize = function(mob)
     mob:setCarefulPathing(true)
-    mob:setMobMod(xi.mobMod.DRAW_IN, 8)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NORMAL)
+    mob:setMobMod(xi.mobMod.DRAW_IN_TRIGGER_DIST, 8)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/Balgas_Dais/mobs/Black_Dragon.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Black_Dragon.lua
@@ -7,7 +7,7 @@
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.DRAW_IN, 1)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NORMAL)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Balgas_Dais/mobs/Large_Box.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Large_Box.lua
@@ -22,7 +22,7 @@ entity.onMobEngage = function(mob, target)
     then
         small:setLocalVar('engaged', 1)
 
-        mob:setMobMod(xi.mobMod.DRAW_IN, 1)
+        mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NORMAL)
         DespawnMob(mobId - 2)
         DespawnMob(mobId - 1)
 

--- a/scripts/zones/Balgas_Dais/mobs/Medium_Box.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Medium_Box.lua
@@ -16,7 +16,7 @@ entity.onMobEngage = function(mob, target)
     then
         small:setLocalVar('engaged', 1)
 
-        mob:setMobMod(xi.mobMod.DRAW_IN, 1)
+        mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NORMAL)
         DespawnMob(mobId - 1)
         DespawnMob(mobId + 1)
 

--- a/scripts/zones/Balgas_Dais/mobs/Small_Box.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Small_Box.lua
@@ -18,7 +18,7 @@ entity.onMobEngage = function(mob, target)
     if mob:getLocalVar('engaged') == 0 then
         mob:setLocalVar('engaged', 1)
 
-        mob:setMobMod(xi.mobMod.DRAW_IN, 1)
+        mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NORMAL)
         DespawnMob(mobId + 1)
         DespawnMob(mobId + 2)
 

--- a/scripts/zones/Balgas_Dais/mobs/Wyrm.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Wyrm.lua
@@ -11,7 +11,7 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setMobMod(xi.mobMod.DRAW_IN, 1) -- has a bug during flight, like Tiamat
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NORMAL) -- has a bug during flight, like Tiamat
     mob:setTP(3000) -- opens fight with a skill
 end
 

--- a/scripts/zones/Behemoths_Dominion/mobs/King_Behemoth.lua
+++ b/scripts/zones/Behemoths_Dominion/mobs/King_Behemoth.lua
@@ -14,6 +14,8 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NORMAL)
+    mob:setMobMod(xi.mobMod.DRAW_IN_TRIGGER_DIST, 25)
     mob:setLocalVar('[rage]timer', 3600) -- 60 minutes
 
     -- Despawn the ???

--- a/scripts/zones/Dragons_Aery/mobs/Fafnir.lua
+++ b/scripts/zones/Dragons_Aery/mobs/Fafnir.lua
@@ -9,6 +9,8 @@ mixins = { require('scripts/mixins/rage') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NORMAL)
+    mob:setMobMod(xi.mobMod.DRAW_IN_TRIGGER_DIST, 20)
     mob:setLocalVar('[rage]timer', 3600) -- 60 minutes
     mob:setMobMod(xi.mobMod.WEAPON_BONUS, 50) -- Level 90 + 50 = 140 Base Weapon Damage
 

--- a/scripts/zones/FeiYin/mobs/Capricious_Cassie.lua
+++ b/scripts/zones/FeiYin/mobs/Capricious_Cassie.lua
@@ -8,7 +8,7 @@ mixins = { require('scripts/mixins/rage') }
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.DRAW_IN, 2)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, bit.bor(xi.drawin.NORMAL, xi.drawin.INCLUDE_ALLIANCE))
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Garlaige_Citadel/mobs/Serket.lua
+++ b/scripts/zones/Garlaige_Citadel/mobs/Serket.lua
@@ -8,7 +8,7 @@ mixins = { require('scripts/mixins/rage') }
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.DRAW_IN, 1)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NORMAL)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Queen.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Queen.lua
@@ -9,7 +9,7 @@ local entity = {}
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
     mob:setMobMod(xi.mobMod.HP_STANDBACK, -1)
-    mob:setMobMod(xi.mobMod.DRAW_IN, 1)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NORMAL)
     mob:setMod(xi.mod.STUN_MEVA, 50)
 end
 

--- a/scripts/zones/King_Ranperres_Tomb/mobs/Cemetery_Cherry.lua
+++ b/scripts/zones/King_Ranperres_Tomb/mobs/Cemetery_Cherry.lua
@@ -20,7 +20,7 @@ end
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
-    mob:setMobMod(xi.mobMod.DRAW_IN, 1)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NORMAL)
 
     local saplingsRespawn = math.random(1800, 3600) -- 30 to 60 minutes
     mob:timer(saplingsRespawn * 1000, function(mobArg)

--- a/scripts/zones/Konschtat_Highlands/mobs/Steelfleece_Baldarich.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Steelfleece_Baldarich.lua
@@ -10,7 +10,7 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ALWAYS_AGGRO, 1)
-    mob:setMobMod(xi.mobMod.DRAW_IN, 1)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NORMAL)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/La_Theine_Plateau/mobs/Bloodtear_Baldurf.lua
+++ b/scripts/zones/La_Theine_Plateau/mobs/Bloodtear_Baldurf.lua
@@ -10,7 +10,7 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ALWAYS_AGGRO, 1)
-    mob:setMobMod(xi.mobMod.DRAW_IN, 1)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NORMAL)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/Labyrinth_of_Onzozo/mobs/Lord_of_Onzozo.lua
+++ b/scripts/zones/Labyrinth_of_Onzozo/mobs/Lord_of_Onzozo.lua
@@ -8,7 +8,7 @@ mixins = { require('scripts/mixins/rage') }
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.DRAW_IN, 1)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NORMAL)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Mamook/mobs/Gulool_Ja_Ja.lua
+++ b/scripts/zones/Mamook/mobs/Gulool_Ja_Ja.lua
@@ -10,7 +10,7 @@ local entity = {}
 
 entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.DOUBLE_ATTACK, 20)
-    mob:setMobMod(xi.mobMod.DRAW_IN, 2)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, bit.bor(xi.drawin.NORMAL, xi.drawin.INCLUDE_ALLIANCE))
 end
 
 entity.onMobEngage = function(mob, target)

--- a/scripts/zones/Meriphataud_Mountains/mobs/Waraxe_Beak.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Waraxe_Beak.lua
@@ -6,7 +6,7 @@
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.DRAW_IN, 1)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NORMAL)
     mob:setMobMod(xi.mobMod.HP_STANDBACK, -1)
 end
 

--- a/scripts/zones/Nyzul_Isle/mobs/Alexander.lua
+++ b/scripts/zones/Nyzul_Isle/mobs/Alexander.lua
@@ -10,7 +10,7 @@ local entity = {}
 entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.NO_MOVE, 1)
     -- 'Draw in' should only trigger when target is beyond 20' (out of Radiant_Sacrament range)
-    mob:setMobMod(xi.mobMod.DRAW_IN, 1)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NORMAL)
 
     mob:addListener('WEAPONSKILL_STATE_ENTER', 'WS_START_MSG', function(mobArg, skillID)
         -- Radiant Sacrament

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Minotaur.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Minotaur.lua
@@ -8,7 +8,8 @@ mixins = { require('scripts/mixins/fomor_hate') }
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.DRAW_IN, 15)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, bit.bor(xi.drawin.NORMAL, xi.drawin.INCLUDE_ALLIANCE))
+    mob:setMobMod(xi.mobMod.DRAW_IN_TRIGGER_DIST, 15)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/Riverne-Site_A01/mobs/Ouryu.lua
+++ b/scripts/zones/Riverne-Site_A01/mobs/Ouryu.lua
@@ -7,7 +7,8 @@
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.DRAW_IN, 15)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NORMAL)
+    mob:setMobMod(xi.mobMod.DRAW_IN_TRIGGER_DIST, 15)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/Riverne-Site_B01/mobs/Vrtra.lua
+++ b/scripts/zones/Riverne-Site_B01/mobs/Vrtra.lua
@@ -6,7 +6,8 @@
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.DRAW_IN, 15)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NORMAL)
+    mob:setMobMod(xi.mobMod.DRAW_IN_TRIGGER_DIST, 15)
 end
 
 return entity

--- a/scripts/zones/Temenos/mobs/Proto-Ultima.lua
+++ b/scripts/zones/Temenos/mobs/Proto-Ultima.lua
@@ -47,7 +47,7 @@ executeCitadelBusterState = function(mob)
         mob:setMagicCastingEnabled(true)
         mob:setAutoAttackEnabled(true)
         mob:setMobAbilityEnabled(true)
-        mob:setMobMod(xi.mobMod.DRAW_IN, 0)
+        mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NONE)
         -- Use Citadel Buster at a regular interval
         mob:setLocalVar('citadelBusterTime', os.time() + math.random(90, 100))
         return
@@ -64,7 +64,7 @@ entity.onMobSpawn = function(mob)
     mob:setMagicCastingEnabled(false)
     mob:setAutoAttackEnabled(true)
     mob:setMobAbilityEnabled(true)
-    mob:setMobMod(xi.mobMod.DRAW_IN, 0)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NONE)
     mob:setMobMod(xi.mobMod.SKILL_LIST, 729)
 end
 
@@ -99,7 +99,7 @@ entity.onMobFight = function(mob, target)
         mob:setMobAbilityEnabled(false)
         mob:setMagicCastingEnabled(false)
         mob:setAutoAttackEnabled(false)
-        mob:setMobMod(xi.mobMod.DRAW_IN, 1)
+        mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NORMAL)
         executeCitadelBusterState(mob)
     end
 end

--- a/scripts/zones/The_Boyahda_Tree/mobs/Ancient_Goobbue.lua
+++ b/scripts/zones/The_Boyahda_Tree/mobs/Ancient_Goobbue.lua
@@ -18,7 +18,7 @@ entity.onMobSpawn = function(mob)
             { id = xi.jsa.HUNDRED_FISTS, cooldown = 60, hpp = math.random(85, 95) },
         },
     })
-    mob:setMobMod(xi.mobMod.DRAW_IN, 1)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NORMAL)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/The_Boyahda_Tree/mobs/Voluptuous_Vivian.lua
+++ b/scripts/zones/The_Boyahda_Tree/mobs/Voluptuous_Vivian.lua
@@ -8,7 +8,7 @@ mixins = { require('scripts/mixins/job_special') }
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.DRAW_IN, 2)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, bit.bor(xi.drawin.NORMAL, xi.drawin.INCLUDE_ALLIANCE))
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
@@ -14,7 +14,8 @@ end
 
 entity.onMobInitialize = function(mob)
     mob:setCarefulPathing(true)
-    mob:setMobMod(xi.mobMod.DRAW_IN, 15)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NORMAL)
+    mob:setMobMod(xi.mobMod.DRAW_IN_TRIGGER_DIST, 15)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/Wajaom_Woodlands/mobs/Tinnin.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Tinnin.lua
@@ -18,7 +18,7 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.GIL_MIN, 12000)
     mob:setMobMod(xi.mobMod.GIL_MAX, 30000)
     mob:setMobMod(xi.mobMod.MUG_GIL, 8000)
-    mob:setMobMod(xi.mobMod.DRAW_IN, 1)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NORMAL)
     mob:setMod(xi.mod.UDMGBREATH, -10000) -- immune to breath damage
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 300)
 end

--- a/scripts/zones/Waughroon_Shrine/mobs/Dark_Dragon.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Dark_Dragon.lua
@@ -7,7 +7,8 @@
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.DRAW_IN, 1)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NORMAL)
+    mob:setMobMod(xi.mobMod.DRAW_IN_TRIGGER_DIST, 25)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Waughroon_Shrine/mobs/Flayer_Franz.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Flayer_Franz.lua
@@ -7,7 +7,7 @@
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setMobMod(xi.mobMod.DRAW_IN, 1)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NORMAL)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Western_Altepa_Desert/mobs/King_Vinegarroon.lua
+++ b/scripts/zones/Western_Altepa_Desert/mobs/King_Vinegarroon.lua
@@ -17,7 +17,8 @@ end
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
-    mob:setMobMod(xi.mobMod.DRAW_IN, 2)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, bit.bor(xi.drawin.NORMAL, xi.drawin.INCLUDE_ALLIANCE))
+    mob:setMobMod(xi.mobMod.DRAW_IN_TRIGGER_DIST, 15)
 end
 
 entity.onMobDrawIn = function(mob, target)

--- a/scripts/zones/Xarcabard/mobs/Boreal_Coeurl.lua
+++ b/scripts/zones/Xarcabard/mobs/Boreal_Coeurl.lua
@@ -86,6 +86,8 @@ entity.onMobEngage = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, bit.bor(xi.drawin.NORMAL, xi.drawin.INCLUDE_ALLIANCE))
+    mob:setMobMod(xi.mobMod.DRAW_IN_TRIGGER_DIST, 15)
     mob:setSpeed(baseSpeed)
     -- Failsafe to make sure NPC is down when NM is up
     if xi.settings.main.OLDSCHOOL_G2 then

--- a/scripts/zones/Xarcabard/mobs/Boreal_Hound.lua
+++ b/scripts/zones/Xarcabard/mobs/Boreal_Hound.lua
@@ -88,6 +88,8 @@ entity.onMobEngage = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, bit.bor(xi.drawin.NORMAL, xi.drawin.INCLUDE_ALLIANCE))
+    mob:setMobMod(xi.mobMod.DRAW_IN_TRIGGER_DIST, 15)
     mob:setSpeed(baseSpeed)
     -- Failsafe to make sure NPC is down when NM is up
     if xi.settings.main.OLDSCHOOL_G2 then

--- a/scripts/zones/Xarcabard/mobs/Boreal_Tiger.lua
+++ b/scripts/zones/Xarcabard/mobs/Boreal_Tiger.lua
@@ -83,6 +83,8 @@ entity.onMobEngage = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, bit.bor(xi.drawin.NORMAL, xi.drawin.INCLUDE_ALLIANCE))
+    mob:setMobMod(xi.mobMod.DRAW_IN_TRIGGER_DIST, 15)
     mob:setSpeed(baseSpeed)
     -- Failsafe to make sure NPC is down when NM is up
     if xi.settings.main.OLDSCHOOL_G2 then

--- a/scripts/zones/Xarcabard_[S]/mobs/Zirnitra.lua
+++ b/scripts/zones/Xarcabard_[S]/mobs/Zirnitra.lua
@@ -14,7 +14,7 @@ entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.REGEN, 50)
     mob:setMod(xi.mod.REGAIN, 100)
     mob:setMod(xi.mod.WIND_ABSORB, 100)
-    mob:setMobMod(xi.mobMod.DRAW_IN, 1)
+    mob:setMobMod(xi.mobMod.DRAW_IN_BITMASK, xi.drawin.NORMAL)
 end
 
 entity.onMobEngage = function(mob)

--- a/sql/mob_pool_mods.sql
+++ b/sql/mob_pool_mods.sql
@@ -70,7 +70,7 @@ INSERT INTO `mob_pool_mods` VALUES (268,368,150,0); -- REGAIN: 150
 INSERT INTO `mob_pool_mods` VALUES (268,370,50,0);  -- REGEN: 50
 
 -- Athamas
-INSERT INTO `mob_pool_mods` VALUES (276,12,1,1); -- DRAW_IN: 1
+INSERT INTO `mob_pool_mods` VALUES (276,12,1,1); -- DRAW_IN_BITMASK: 1
 
 -- Aura Statue
 INSERT INTO `mob_pool_mods` VALUES (289,4,4,1); -- SIGHT_RANGE: 4
@@ -131,9 +131,6 @@ INSERT INTO `mob_pool_mods` VALUES (820,368,10,0); -- REGAIN: 10
 -- Darksteel Golem
 INSERT INTO `mob_pool_mods` VALUES (906,4,4,1); -- SIGHT_RANGE: 4
 
--- Dark Dragon
-INSERT INTO `mob_pool_mods` VALUES (912,12,25,1); -- DRAW_IN: 25
-
 -- Dea
 INSERT INTO `mob_pool_mods` VALUES (930,370,15,0); -- REGEN: 15
 
@@ -154,7 +151,7 @@ INSERT INTO `mob_pool_mods` VALUES (979,9,60,1); -- HP_HEAL_CHANCE: 60
 INSERT INTO `mob_pool_mods` VALUES (1013,28,-100,1); -- EXP_BONUS: -100
 
 -- Diabolos
-INSERT INTO `mob_pool_mods` VALUES (1027,12,1,1); -- DRAW_IN: 1
+INSERT INTO `mob_pool_mods` VALUES (1027,12,1,1); -- DRAW_IN_BITMASK: 1
 
 -- Effigy Prototype
 INSERT INTO `mob_pool_mods` VALUES (1178,163,-100,0); -- DMGMAGIC: -100
@@ -282,7 +279,7 @@ INSERT INTO `mob_pool_mods` VALUES (2643,160,-50,0); -- DMG: -50
 INSERT INTO `mob_pool_mods` VALUES (2647,160,-50,0); -- DMG: -50
 
 -- Mimic
-INSERT INTO `mob_pool_mods` VALUES (2664,12,1,1); -- DRAW_IN: 1
+INSERT INTO `mob_pool_mods` VALUES (2664,12,1,1); -- DRAW_IN_BITMASK: 1
 
 -- Minotaur
 INSERT INTO `mob_pool_mods` VALUES (2675,4,25,1); -- SIGHT_RANGE: 25

--- a/sql/mob_spawn_mods.sql
+++ b/sql/mob_spawn_mods.sql
@@ -332,15 +332,10 @@ INSERT INTO `mob_spawn_mods` VALUES (17235987,2,2765,1); -- GIL_MAX: 2765
 INSERT INTO `mob_spawn_mods` VALUES (17236201,55,180,1); -- IDLE_DESPAWN: 180
 
 -- Boreal Hound
-INSERT INTO `mob_spawn_mods` VALUES (17236202,12,15,1);  -- DRAW_IN: 15
 INSERT INTO `mob_spawn_mods` VALUES (17236202,160,50,0); -- DMG: 50
 
 -- Boreal Coeurl
-INSERT INTO `mob_spawn_mods` VALUES (17236203,12,15,1);  -- DRAW_IN: 15
 INSERT INTO `mob_spawn_mods` VALUES (17236203,23,8,1);   -- IMMUNITY: 8
-
--- Boreal Tiger
-INSERT INTO `mob_spawn_mods` VALUES (17236204,12,15,1);  -- DRAW_IN: 15
 
 -- Koenigstiger
 INSERT INTO `mob_spawn_mods` VALUES (17236205,55,240,1); -- IDLE_DESPAWN: 240
@@ -399,9 +394,6 @@ INSERT INTO `mob_spawn_mods` VALUES (17285545,55,300,1); -- IDLE_DESPAWN: 300
 -- Kappa Biwa
 INSERT INTO `mob_spawn_mods` VALUES (17285546,55,150,1); -- IDLE_DESPAWN: 150
 
--- King Vinegarroon
-INSERT INTO `mob_spawn_mods` VALUES (17289575,12,15,1); -- DRAW_IN: 15
-
 -- Eastern Sphinx
 INSERT INTO `mob_spawn_mods` VALUES (17289654,55,168,1); -- IDLE_DESPAWN: 168
 
@@ -411,9 +403,6 @@ INSERT INTO `mob_spawn_mods` VALUES (17289655,55,168,1); -- IDLE_DESPAWN: 168
 -- Kraken
 INSERT INTO `mob_spawn_mods` VALUES (17293486,31,5,1); -- ROAM_DISTANCE: 5
 INSERT INTO `mob_spawn_mods` VALUES (17293486,51,1,1); -- ROAM_TURNS: 1
-
--- King Behemoth
-INSERT INTO `mob_spawn_mods` VALUES (17297441,12,25,1); -- DRAW_IN: 25
 
 -- Picklix Longindex
 INSERT INTO `mob_spawn_mods` VALUES (17297446,55,180,1); -- IDLE_DESPAWN: 180
@@ -826,9 +815,6 @@ INSERT INTO `mob_spawn_mods` VALUES (17404337,55,288,1); -- IDLE_DESPAWN: 288
 
 -- Beet Leafhopper
 INSERT INTO `mob_spawn_mods` VALUES (17404338,55,120,1); -- IDLE_DESPAWN: 120
-
--- Fafnir
-INSERT INTO `mob_spawn_mods` VALUES (17408018,12,20,1); -- DRAW_IN: 20
 
 -- Gerwitz'S Scythe
 INSERT INTO `mob_spawn_mods` VALUES (17420629,55,300,1); -- IDLE_DESPAWN: 300

--- a/src/map/ai/controllers/mob_controller.h
+++ b/src/map/ai/controllers/mob_controller.h
@@ -85,6 +85,7 @@ protected:
     bool         CanMoveForward(float currentDistance);
     bool         IsSpecialSkillReady(float currentDistance);
     bool         IsSpellReady(float currentDistance);
+    bool         HandleDrawin(float currentDistance);
 
     CBattleEntity* PTarget{ nullptr };
 

--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -102,6 +102,14 @@ enum BEHAVIOUR : uint16
     BEHAVIOUR_NO_TURN      = 0x400  // mob does not turn to face target
 };
 
+enum DRAWIN : uint16
+{
+    DRAWIN_NONE             = 0x000, // no draw-in (mob can only draw-in by explictly calling the lua drawin function)
+    DRAWIN_NORMAL           = 0x001, // basic draw-in where mob will draw-in battle target when target some distance from mob
+    DRAWIN_TO_FRONT_OF_MOB  = 0x002, // determines if draw-in to the center of mob (bit not set) or front of mob (bit set)
+    DRAWIN_INCLUDE_ALLIANCE = 0x004, // determines if draw-in includes just the battle target (bit not set) or entire alliance (bit set)
+};
+
 class CMobSkillState;
 
 class CMobEntity : public CBattleEntity

--- a/src/map/mob_modifier.h
+++ b/src/map/mob_modifier.h
@@ -40,7 +40,7 @@ enum MOBMODIFIER : int
     MOBMOD_HP_HEAL_CHANCE         = 9,  // can cast cures below this HP %
     MOBMOD_SUBLINK                = 10, // sub link group
     MOBMOD_LINK_RADIUS            = 11, // link radius
-    MOBMOD_DRAW_IN                = 12, // 1 - player draw in, 2 - alliance draw in -- only add as a spawn mod!
+    MOBMOD_DRAW_IN_BITMASK        = 12, // bitmask with different binary options for draw-in (see DRAWIN enum for options)
     MOBMOD_SEVERE_SPELL_CHANCE    = 13, // % chance to use a severe spell like death or impact
     MOBMOD_SKILL_LIST             = 14, // uses given mob skill list
     MOBMOD_MUG_GIL                = 15, // amount gil carried for mugging
@@ -110,6 +110,8 @@ enum MOBMODIFIER : int
     MOBMOD_CANNOT_GUARD           = 79, // Check if the mob does not guard(despite being a MNK or PUP mob)
     MOBMOD_SKIP_ALLEGIANCE_CHECK  = 80, // Skip the allegiance check for valid target (allows for example a mob to cast a TARGET_ENEMY spell on itself)
     MOBMOD_ABILITY_RESPONSE       = 81, // Mob can respond to player ability use with onPlayerAbilityUse()
+    MOBMOD_DRAW_IN_TRIGGER_DIST   = 82, // Distance to trigger a draw-in (overrides a default of 2 * melee dist)
+    MOBMOD_DRAW_IN_MAX_RANGE      = 83, // Max range to draw-in an entity (overrides a default of entire zone)
 };
 
 #endif

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -246,7 +246,7 @@ namespace battleutils
     WEATHER GetWeather(CBattleEntity* PEntity, bool ignoreScholar);
     WEATHER GetWeather(CBattleEntity* PEntity, bool ignoreScholar, uint16 zoneWeather);
     bool    WeatherMatchesElement(WEATHER weather, uint8 element);
-    bool    DrawIn(CBattleEntity* PEntity, CMobEntity* PMob, float offset);
+    bool    DrawIn(CBattleEntity* PEntity, CMobEntity* PMob, float offset, int16 maxDistance, bool includeAlli, bool toFrontOfMob);
     void    DoWildCardToEntity(CCharEntity* PCaster, CCharEntity* PTarget, uint8 roll);
     bool    DoRandomDealToEntity(CCharEntity* PChar, CBattleEntity* PTarget);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR changes the specification of draw-in functions in several places to support flexibility and the additional options needed for the draw-in logic of different mobs. 

Current LSB draw-in problems:
- The `DRAW_IN` mob mod is currently representing two different options that do not always occur together. Specifically, a `DRAW_IN > 1` indicates alliance draw-in and a `DRAW_IN > 1` also sets the draw-in trigger distance to the mob mod. Thus all mobs with a non-standard trigger distance are also forced to have alliance draw-in. This creates several draw-in bugs.
- No ability to draw-in to the front of the mob (as opposed to mob center)
- No ability to set a max draw-in distance (beyond which a player or alliance member will not be draw-in)
- The lua draw-in function (used for ad-hoc draw-ins in special case mobs) does not allow any options and does not allow overriding the mob or hard coded draw-in defaults.

Changes by this PR:
- Changes the `DRAW_IN` mob mod to be a bitmask mod that represents several different draw-in options including perform normal draw-in logic, include alliance members in draw-in, and draw-in to front of mob. Also adds mob mods MOBMOD_DRAW_IN_TRIGGER_DIST and MOBMOD_DRAW_IN_MAX_RANGE to allow specifying the draw-in trigger distance and the max draw-in range. The bitmask approach allows flexibility and easy future expansion to new draw-in types that LSB is still missing.
- Changes the lua draw-in function to allow options as parameters. The order of precedence is thus: specified function option -> mob mod(s) -> hardcoded default option
- Changes mobs with draw-in to use the new and updated draw-in mob mods

## Steps to test these changes
Fight mobs with draw-in and vary the draw-in mob mods to set different options, also test the lua drawIn function call with different parameters
