### PR TITLE
[core, lua] Give mobs guard skill and prevent some mobs from guarding

### DIFF
--- a/scripts/enum/mob_mod.lua
+++ b/scripts/enum/mob_mod.lua
@@ -87,4 +87,5 @@ xi.mobMod =
     NO_WIDESCAN            = 76, -- Disables widescan for a specific mob
     TRUST_DISTANCE         = 77, -- TRUSTS ONLY: Set movement type/distance. See trust.lua for details.
     STANDBACK_RANGE        = 78, -- Applies a specific standback range for the mob
+    CANNOT_GUARD           = 79, -- Check if the mob does not guard (despite being a MNK or PUP mob)
 }

--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -774,7 +774,7 @@ xi.combat.physical.canGuard = function(defender, attacker)
             defender:isPet() or
             defender:isTrust()
         then
-            canGuard = defender:getMainJob() == xi.job.MNK or defender:getMainJob() == xi.job.PUP
+            canGuard = (defender:getMainJob() == xi.job.MNK or defender:getMainJob() == xi.job.PUP) and defender:getMobMod(xi.mobMod.CANNOT_GUARD) == 0
         end
     end
 
@@ -789,10 +789,7 @@ xi.combat.physical.calculateGuardRate = function(defender, attacker)
 
     -- non-players do not have guard skill set on creation
     -- so use max skill at the level for the job
-    if
-        defender:isMob() or
-        defender:isPet()
-    then
+    if defender:isPet() then
         guardSkill = defender:getMaxSkillLevel(defender:getMainLvl(), defender:getMainJob(), xi.skill.GUARD)
     elseif defender:isTrust() then
         -- TODO: check trust type for ilvl > 99 when implemented

--- a/scripts/zones/Apollyon/mobs/Proto-Omega.lua
+++ b/scripts/zones/Apollyon/mobs/Proto-Omega.lua
@@ -41,6 +41,7 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
+    mob:setMobMod(xi.mobMod.CANNOT_GUARD, 1)
     mob:setMod(xi.mod.COUNTER, 10)
     mob:setMod(xi.mod.REGAIN, 50)
     mob:setMod(xi.mod.REGEN, 25)

--- a/scripts/zones/Dynamis-Xarcabard/mobs/Kindred_Monk.lua
+++ b/scripts/zones/Dynamis-Xarcabard/mobs/Kindred_Monk.lua
@@ -11,6 +11,10 @@ local ID = zones[xi.zone.DYNAMIS_XARCABARD]
 -----------------------------------
 local entity = {}
 
+entity.onMobSpawn = function(mob)
+    mob:setMobMod(xi.mobMod.CANNOT_GUARD, 1)
+end
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 

--- a/scripts/zones/Jugner_Forest/mobs/King_Arthro.lua
+++ b/scripts/zones/Jugner_Forest/mobs/King_Arthro.lua
@@ -16,6 +16,7 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
+    mob:setMobMod(xi.mobMod.CANNOT_GUARD, 1)
     local kingArthroID = mob:getID()
 
     -- Use King Arthro ID to determine Knight Crab Id's, then set their respawn to 0 so they don't spawn while KA is up

--- a/scripts/zones/RuAun_Gardens/mobs/Seiryu.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Seiryu.lua
@@ -8,6 +8,7 @@ mixins = { require('scripts/mixins/job_special') }
 local entity = {}
 
 entity.onMobSpawn = function(mob, target)
+    mob:setMobMod(xi.mobMod.CANNOT_GUARD, 1)
     GetNPCByID(ID.npc.PORTAL_OFFSET + 2):setAnimation(xi.anim.CLOSE_DOOR)
 end
 

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Seiryu.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Seiryu.lua
@@ -4,6 +4,10 @@
 -----------------------------------
 local entity = {}
 
+entity.onMobSpawn = function(mob)
+    mob:setMobMod(xi.mobMod.CANNOT_GUARD, 1)
+end
+
 entity.onMobMagicPrepare = function(mob, target, spellId)
     if not mob:hasStatusEffect(xi.effect.HUNDRED_FISTS, 0) then
         local rnd = math.random()

--- a/sql/mob_pool_mods.sql
+++ b/sql/mob_pool_mods.sql
@@ -470,9 +470,6 @@ INSERT INTO `mob_pool_mods` VALUES (4148,75,3,1); -- CAN_PARRY: 3
 -- Vanguard_Footsoldier
 INSERT INTO `mob_pool_mods` VALUES (4150,75,3,1); -- CAN_PARRY: 3
 
--- Vanguard_Grappler
-INSERT INTO `mob_pool_mods` VALUES (4151,75,3,1); -- CAN_PARRY: 3
-
 -- Vanguard_Gutslasher
 INSERT INTO `mob_pool_mods` VALUES (4152,75,3,1); -- CAN_PARRY: 3
 

--- a/src/map/mob_modifier.h
+++ b/src/map/mob_modifier.h
@@ -107,6 +107,7 @@ enum MOBMODIFIER : int
     MOBMOD_NO_WIDESCAN            = 76, // Disables widescan for a specific mob
     MOBMOD_TRUST_DISTANCE         = 77, // TRUSTS ONLY: Set movement type/distance. See trust.lua for details.
     MOBMOD_STANDBACK_RANGE        = 78, // Applies a specific standback range for the mob
+    MOBMOD_CANNOT_GUARD           = 79, // Check if the mob does not guard(despite being a MNK or PUP mob)
 };
 
 #endif

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2014,9 +2014,15 @@ namespace battleutils
             validWeapon = PDefender->GetMJob() == JOB_MNK || PDefender->GetMJob() == JOB_PUP;
         }
 
+        int16 cannotGuardMod = 0;
+        if (auto* PMob = dynamic_cast<CMobEntity*>(PDefender))
+        {
+            cannotGuardMod = PMob->getMobMod(MOBMOD_CANNOT_GUARD);
+        }
+
         bool hasGuardSkillRank = (GetSkillRank(SKILL_GUARD, PDefender->GetMJob()) > 0 || GetSkillRank(SKILL_GUARD, PDefender->GetSJob()) > 0);
 
-        if (validWeapon && hasGuardSkillRank && PDefender->PAI->IsEngaged())
+        if (validWeapon && cannotGuardMod == 0 && hasGuardSkillRank && PDefender->PAI->IsEngaged())
         {
             // assuming this is like parry
             float gbase = (float)PDefender->GetSkill(SKILL_GUARD) + PDefender->getMod(Mod::GUARD);

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -725,15 +725,20 @@ namespace mobutils
         PMob->addModifier(Mod::RATT, GetBaseSkill(PMob, PMob->attRank)); // Base Ranged Attack for all mobs is Rank A+ but pull from DB for specific cases
         PMob->addModifier(Mod::RACC, GetBaseSkill(PMob, PMob->accRank)); // Base Ranged Accuracy for all mobs is Rank A+ but pull from DB for specific cases
 
-        // Note: Known Base Parry for all mobs is Rank C
-        // MOBMOD_CAN_PARRY uses the mod value as the rank. It is unknown if mobs in current retail or somewhere else have a different parry rank
-        // Known mobs to have parry rating
-        // 1) Dynamis Mobs
-        // 2) ???
-        // 3) ???
+        // Known Base Parry for all mobs is Rank C
+        // MOBMOD_CAN_PARRY uses the mod value as the rank, unknown if mobs in current retail or somewhere else have a different parry rank
+        // Known mobs to have parry rating:
+        // Dynamis beastmen mobs
+        // Fantoccini (not yet coded)
         if (PMob->getMobMod(MOBMOD_CAN_PARRY) > 0)
         {
-            PMob->addModifier(Mod::PARRY, GetBaseSkill(PMob, PMob->getMobMod(MOBMOD_CAN_PARRY)));
+            PMob->WorkingSkills.skill[SKILL_PARRY] = GetBaseSkill(PMob, PMob->getMobMod(MOBMOD_CAN_PARRY));
+        }
+
+        // Assume base guard for MNK and PUP mobs is the same as parry (Rank C)
+        if ((PMob->GetMJob() == JOB_MNK || PMob->GetMJob() == JOB_PUP) && PMob->getMobMod(MOBMOD_CANNOT_GUARD) == 0)
+        {
+            PMob->WorkingSkills.skill[SKILL_GUARD] = GetBaseSkill(PMob, 3);
         }
 
         // natural magic evasion


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes several related issues:
1. On LSB currently MNK and PUP mobs do not have any guard skill. This results in the current guard formula using zero for the skill and thus guarding at a lower rate than intended. This is causing an inconsistency because the lua WS guarding code has a check for this lack of skill, while the normal c++ auto-attack code does not.

2. Currently on LSB all MNK and PUP mobs can guard, however captures show that there are a few MNK mobs that should not be able to guard.

3. On LSB Vanguard Grappler can currently erroneously parry and guard

This PR does the following to fix these issues:
1. Adds guard skill to all MNK and PUP mobs that can guard (similar to how LSB adds parry skills to mobs that can parry). The guard skill level is set to C (the same known level as mob parry skill). Also changes the parry skill code to add skill rather than PARRY mod as this is how all other skills are set in the code. Note that Siknoz and others are currently working to validate and check the guard formula itself through captures, however this requires further captures and thus changes will come in a later PR for brevity sake.

3. Retail [captures](https://discord.com/channels/443544205206355968/674750598939279400/1260007481741148240) by Siknoz of many different MNK and PUP mob types illustrate that most MNK and PUP mobs should guard (see listing below). Thus given the small number of MNK or PUP mobs that do not guard, a `CANNOT_GUARD` mob mod was added and applied to Kindred Monk, King Arthro, Proto-Omega, and Seiryu.

      The following were tested and shown to guard:
      Orcish Champion (Orc)
      Yagudo Initiate (Yag)
      Mandragora (Mandy)
      Fomor Monk (Fomor)
      Korrigan (Mandy)
      Arrapago Apkallu (Apkallu)
      Sabotender Corrido (Sabotender)
      Molech (Taurus)
      Hilltroll Puppetmaster (Troll)
      Bugbear Deathman (Bugbear)
      Eo'aern (mnk) (Aern)
      
      The following were also tested and did not guard:
      Sea Monks (probably wars with incorrect job on LSB)
      Ancient Goobbue (probably also war)
      Kindred Monk (dyna xarc, maybe using axe weapon?)
      King Arthro
      Proto-Omega
      Seiryu

4. Remove the CAN_PARRY mod from Vanguard Grappler so it can only guard

## Steps to test these changes
Fight MNK or PUP mobs and see that they guard WS and normal attacks at the same rate. Also see that for example Seiryu no longer guards, and that Vanguard Grappler does not parry but only guards.