### PR TITLE
[Magic] Fix Haste and Flurry stacking

### DIFF
--- a/scripts/effects/flurry.lua
+++ b/scripts/effects/flurry.lua
@@ -4,14 +4,16 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.SNAP_SHOT, effect:getPower())
+    -- Overwrites regular Haste Effect
+    target:delStatusEffect(xi.effect.HASTE)
+
+    effect:addMod(xi.mod.SNAP_SHOT, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.SNAP_SHOT, effect:getPower())
 end
 
 return effectObject

--- a/scripts/effects/flurry_ii.lua
+++ b/scripts/effects/flurry_ii.lua
@@ -4,14 +4,16 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.SNAP_SHOT, effect:getPower())
+    -- Overwrites regular Haste Effect
+    target:delStatusEffect(xi.effect.HASTE)
+
+    effect:addMod(xi.mod.SNAP_SHOT, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.SNAP_SHOT, effect:getPower())
 end
 
 return effectObject

--- a/scripts/effects/haste.lua
+++ b/scripts/effects/haste.lua
@@ -4,14 +4,16 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.HASTE_MAGIC, effect:getPower())
+    -- Overwrites regular Flurry Effect
+    target:delStatusEffect(xi.effect.FLURRY_II)
+
+    effect:addMod(xi.mod.HASTE_MAGIC, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.HASTE_MAGIC, effect:getPower())
 end
 
 return effectObject

--- a/scripts/globals/spells/enhancing_spell.lua
+++ b/scripts/globals/spells/enhancing_spell.lua
@@ -95,8 +95,9 @@ local pTable =
     [xi.magic.spell.ENWATER_II   ] = { 2, xi.effect.ENWATER_II,    60,    0,  180, true,  false, 0 },
 
     -- Flurry
-    [xi.magic.spell.FLURRY       ] = { 1, xi.effect.FLURRY,        48,   15,  180, true,  false, 0 },
-    [xi.magic.spell.FLURRY_II    ] = { 2, xi.effect.FLURRY_II,     96,   30,  180, true,  false, 0 },
+    [xi.magic.spell.FLURRY       ] = { 1, xi.effect.FLURRY_II,     48,   15,  180, true,  false, 0 }, -- Thats the actual effect. Not a typo.
+    [xi.magic.spell.FLURRY_II    ] = { 2, xi.effect.FLURRY_II,     96,   30,  180, true,  false, 0 }, -- Thats the actual effect. Not a typo.
+
     -- Foil
     [xi.magic.spell.FOIL         ] = { 1, xi.effect.FOIL,          58,  150,   30, true,  false, 3 },
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Fixes incorrect effect being applied by Flurry (I) spell
- Fixes haste and Flurry stacking with each other (The effects should now cancel/overwrite each other)

This is a capture of me casting Flurry (lvl 1) with haste applied
![imagen](https://github.com/user-attachments/assets/fb5a2076-214d-49ab-ba12-9621e641f831)

Closes #5697 

Sorry it took so long, Amp

## Steps to test these changes

Cast flurry and flurry II. See how they dont stack
Cast haste, then flurry/II and see haste dissapear.

