### PR TITLE
[Synth] Adds "Reraise Earring" Desynth

### DIFF
--- a/sql/synth_recipes.sql
+++ b/sql/synth_recipes.sql
@@ -4756,9 +4756,9 @@ INSERT INTO `synth_recipes` VALUES (75531,0,0,0,0,0,0,0,0,10,0,4099,4241,2773,27
 INSERT INTO `synth_recipes` VALUES (75532,1,0,0,0,0,0,34,0,0,0,4100,4242,12994,0,0,0,0,0,0,0,818,818,848,848,2,3,1,2,'Shoes (desynth)');
 INSERT INTO `synth_recipes` VALUES (75533,1,0,0,0,0,25,0,0,0,0,4100,4242,12722,0,0,0,0,0,0,0,834,819,819,819,2,5,6,7,'Bracers (desynth)'); -- FFXIclopedia
 INSERT INTO `synth_recipes` VALUES (75534,1,0,0,0,57,0,0,0,0,0,4100,4242,14018,0,0,0,0,0,0,0,653,653,745,745,1,2,1,1,'Gigas Bracelets (desynth)');
-
 INSERT INTO `synth_recipes` VALUES (75535,1,0,0,0,69,0,0,0,0,0,4100,4242,16514,0,0,0,0,0,0,0,744,744,651,745,1,1,1,1,'Mailbreaker (desynth)');
 INSERT INTO `synth_recipes` VALUES (75536,1,0,0,0,69,0,0,0,0,0,4100,4242,16618,0,0,0,0,0,0,0,744,744,651,745,1,1,1,1,'Mailbreaker +1 (desynth)');
+INSERT INTO `synth_recipes` VALUES (75537,1,0,0,0,45,0,0,0,0,0,4100,4242,14790,0,0,0,0,0,0,0,653,653,653,653,1,2,2,2,'Reraise Earring (desynth)'); -- FFXIclopedia.
 -- -----------
 -- RECIPES END
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Rescues change from PR #5903
Adds desynth for "Reraise earring". Data from xiclopedia. Contrasted with original (synth) recipe from JP wiki and BG wiki for level.

Closes #5903 

## Steps to test these changes
lightining crystal + reraise earring at lvl 45 goldsmithing
