### PR TITLE
Fix a logical error in !yell command

### DIFF
--- a/scripts/commands/yell.lua
+++ b/scripts/commands/yell.lua
@@ -18,10 +18,10 @@ end
 commandObj.onTrigger = function(player, value, target, days)
     -- validate value
     if
-        value ~= 'ban' or
+        value ~= 'ban' and
         value ~= 'unban'
     then
-        error(player)
+        error(player, 'Parameter not specified <ban/unban>')
         return
     end
 
@@ -48,8 +48,6 @@ commandObj.onTrigger = function(player, value, target, days)
 
         target:setCharVar('[YELL]Banned', 1, os.time() + utils.days(days))
         player:printToPlayer(string.format('%s has been banned from using the /yell command.', target:getName()))
-    else
-        error(player, 'Invalid value specified.')
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Corrects a logical error in the !yell command.
Properly passed `msg` to `error` function.

## Steps to test these changes

!yell ban Player 365
