### PR TITLE
[Core] Prevent players casting lots on items they can't obtain

### DIFF
--- a/src/map/treasure_pool.cpp
+++ b/src/map/treasure_pool.cpp
@@ -266,6 +266,22 @@ void CTreasurePool::LotItem(CCharEntity* PChar, uint8 SlotID, uint16 Lot)
         return;
     }
 
+    CItem* PItem = itemutils::GetItem(m_PoolItems[SlotID].ID);
+
+    // Cannot lot if player's inventory is full
+    if (PChar->getStorage(LOC_INVENTORY)->GetFreeSlotsCount() == 0)
+    {
+        ShowError(fmt::format("Player {} is trying to lot on item {} while full inventory (Packet injection)!", PChar->getName(), m_PoolItems[SlotID].ID));
+        return;
+    }
+
+    // Cannot lot if item is RARE and player already has it
+    if ((PItem->getFlag() & ITEM_FLAG_RARE) && charutils::HasItem(PChar, m_PoolItems[SlotID].ID))
+    {
+        ShowError(fmt::format("Player {} is trying to lot on item {} (Rare) while already holding one (Packet injection)! ", PChar->getName(), m_PoolItems[SlotID].ID));
+        return;
+    }
+
     LotInfo li;
     li.lot    = Lot;
     li.member = PChar;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
We shouldn't be trusting the client. Currently, you can cast lots on Rare items you already possess by sending a packet, for example by using certain Ashita plugins that can be configured to lot everything that drops. This change solves the issue.

## Steps to test these changes
Tested in game with a few characters using `!exec player:addTreasure(13014)`. Was not able to cast lot once already obtained, even by forcing a packet.
