### PR TITLE
[SQL] Fixes rslotlook value for Opaline Dress and Wedding Dress

### DIFF
--- a/sql/item_equipment.sql
+++ b/sql/item_equipment.sql
@@ -4137,9 +4137,9 @@ INSERT INTO `item_equipment` VALUES (14380,'errant_hpl.',72,0,3850780,101,0,0,32
 INSERT INTO `item_equipment` VALUES (14381,'mahatma_hpl.',72,0,3850780,101,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (14382,'plastron',71,0,128,151,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (14383,'plastron_+1',71,0,128,151,0,0,32,0,0,0);
-INSERT INTO `item_equipment` VALUES (14384,'opaline_dress',40,0,4194303,116,0,0,32,64,0,0);
-INSERT INTO `item_equipment` VALUES (14385,'ceremonial_dress',40,0,4194303,116,0,0,32,64,0,0);
-INSERT INTO `item_equipment` VALUES (14386,'wedding_dress',20,0,4194303,116,0,0,32,64,0,0);
+INSERT INTO `item_equipment` VALUES (14384,'opaline_dress',40,0,4194303,116,0,0,32,64,116,0);
+INSERT INTO `item_equipment` VALUES (14385,'ceremonial_dress',40,0,4194303,116,0,0,32,64,116,0);
+INSERT INTO `item_equipment` VALUES (14386,'wedding_dress',20,0,4194303,116,0,0,32,64,116,0);
 INSERT INTO `item_equipment` VALUES (14387,'shura_togi',73,0,6146,106,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (14388,'shura_togi_+1',73,0,6146,106,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (14389,'dragon_harness',73,0,32,110,0,0,32,0,0,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
These body pieces also occupy the hands slot and currently display "default" hands while in a lockstyleset instead of the extended body piece look. This PR fixes the issue

## Steps to test these changes
Tested in-game by adding the Opaline Dress to `/lockstyleset 1`. After fix, I was able to see the correct "gloves".