### PR TITLE
[Proposal] Create mobskill enum file

### DIFF
--- a/scripts/enum/mob_skills.lua
+++ b/scripts/enum/mob_skills.lua
@@ -1,0 +1,87 @@
+xi = xi or {}
+
+xi.mobSkill =
+{
+    FOOT_KICK_1       =  257,
+    DUST_CLOUD_1      =  258,
+    WHIRL_CLAWS_1     =  259,
+    LAMB_CHOP_1       =  260,
+    RAGE_1            =  261,
+    SHEEP_CHARGE_1    =  262,
+    SHEEP_BLEAT_1     =  263,
+    SHEEP_SONG_1      =  264,
+    RAGE_2            =  265,
+    RAM_CHARGE        =  266,
+    RUMBLE            =  267,
+    GREAT_BLEAT       =  268,
+    PETRIBREATH       =  269,
+    ROAR_1            =  270,
+    RAZOR_FANG_1      =  271,
+    RANGED_ATTACK_1   =  272,
+    CLAW_CYCLONE_1    =  273,
+    SHEEP_CHARGE_2    =  274,
+    SANDBLAST_1       =  275,
+    SANDPIT_1         =  276,
+    VENOM_SPRAY_1     =  277,
+    PIT_AMBUSH_1      =  278,
+    MANDIBULAR_BITE_1 =  279,
+
+    RANGED_ATTACK_2   =  412,
+
+    RANGED_ATTACK_3   = 1154,
+
+    RANGED_ATTACK_4   = 1202,
+    RANGED_ATTACK_5   = 1203,
+    RANGED_ATTACK_6   = 1204,
+    RANGED_ATTACK_7   = 1205,
+    RANGED_ATTACK_8   = 1206,
+
+    RANGED_ATTACK_9   = 1209,
+    RANGED_ATTACK_10  = 1210,
+    RANGED_ATTACK_11  = 1211,
+    RANGED_ATTACK_12  = 1212,
+    RANGED_ATTACK_13  = 1213,
+    RANGED_ATTACK_14  = 1214,
+
+    FOOT_KICK_2       = 1567,
+    DUST_CLOUD_2      = 1568,
+    WHIRL_CLAWS_2     = 1569,
+
+    SHEEP_BLEAT_2     = 1633,
+    SHEEP_SONG_2      = 1634,
+    SHEEP_CHARGE_3    = 1635,
+
+    ROAR_2            = 1677,
+    RAZOR_FANG_2      = 1678,
+    CLAW_CYCLONE_2    = 1679,
+
+    SANDBLAST_2       = 1841,
+    SANDPIT_2         = 1842,
+    VENOM_SPRAY_2     = 1843,
+    PIT_AMBUSH_2      = 1844,
+    MANDIBULAR_BITE_2 = 1845,
+
+    RANGED_ATTACK_15  = 1949,
+
+    ROAR_3            = 2406,
+
+    SHEEP_SONG_3      = 3433,
+
+    FOOT_KICK_3       = 3840,
+    DUST_CLOUD_3      = 3841,
+    WHIRL_CLAWS_3     = 3842,
+
+    ROAR_4            = 3848,
+    RAZOR_FANG_3      = 3849,
+    CLAW_CYCLONE_3    = 3850,
+
+    LAMB_CHOP_2       = 3857,
+    RAGE_3            = 3858,
+    SHEEP_CHARGE_4    = 3859,
+    SHEEP_SONG_4      = 3860,
+
+    SANDBLAST_3       = 3882,
+    SANDPIT_3         = 3883,
+    VENOM_SPRAY_3     = 3884,
+    MANDIBULAR_BITE_3 = 3885,
+}


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Proposes the creation of an enum file with all mobskill IDs

This PR contains all entries of "foot kick", "sheep song", etc... among others

I could have added more, however, I rather know everyones opinion before commiting to add 4000 entries by hand.
This gives a clear example of what the file would look like and allows for certain patterns to be recognized.

Its use would be to be able to have tables with mobskill info, like we do for spells, for instance. Or at least to not use raw IDs in mob family scripts and such.

## Steps to test these changes

None
