### PR TITLE
[core] PARTY_MEMBERS_IN_ZONE: Ensure that PMember is not nullptr in Latent Effect Container (3)

### DIFF
--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -454,15 +454,15 @@ void CLatentEffectContainer::CheckLatentsPartyMembers(size_t members, size_t tru
                     auto inZone = 0;
                     for (size_t m = 0; m < members; ++m)
                     {
-                        auto* PMember = (CCharEntity*)m_POwner->PParty->members.at(m);
-                        if (PMember->getZone() == m_POwner->getZone())
+                        auto* PMember = dynamic_cast<CCharEntity*>(m_POwner->PParty->members.at(m));
+                        if (PMember != nullptr && PMember->getZone() == m_POwner->getZone())
                         {
                             inZone++;
                         }
                     }
 
-                    auto* PLeader = (CCharEntity*)m_POwner->PParty->GetLeader();
-                    if (m_POwner->getZone() == PLeader->getZone())
+                    auto* PLeader = dynamic_cast<CCharEntity*>(m_POwner->PParty->GetLeader());
+                    if (PLeader != nullptr && m_POwner->getZone() == PLeader->getZone())
                     {
                         inZone = inZone + static_cast<int>(trustCount);
                     }
@@ -810,7 +810,7 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
                         ++inZone;
                     }
                 }
-                
+
                 auto PLeader = (CCharEntity*)m_POwner->PParty->GetLeader();
                 if (m_POwner->getZone() == PLeader->getZone())
                 {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Handles an edge case where calling `getZone()` may result in retrieving a nullptr.
![image](https://github.com/user-attachments/assets/9a4145f8-7cab-41c5-ab6e-f6cff43e8d33)

## Steps to test these changes
Not entirely sure how to reproduce this reliably.
