### PR TITLE
Added ranged attack and ranged accuracy to attack and accuracy down.

### DIFF
--- a/scripts/effects/accuracy_down.lua
+++ b/scripts/effects/accuracy_down.lua
@@ -5,6 +5,7 @@ local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
     target:addMod(xi.mod.ACC, -effect:getPower())
+    target:addMod(xi.mod.RACC, -effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
@@ -13,6 +14,7 @@ effectObject.onEffectTick = function(target, effect)
     if downACCEffectSize > 0 then
         effect:setPower(downACCEffectSize - 1)
         target:delMod(xi.mod.ACC, -1)
+        target:delMod(xi.mod.RACC, -1)
     end
 end
 
@@ -20,6 +22,7 @@ effectObject.onEffectLose = function(target, effect)
     local downACCEffectSize = effect:getPower()
     if downACCEffectSize > 0 then
         target:delMod(xi.mod.ACC, -effect:getPower())
+        target:delMod(xi.mod.RACC, -effect:getPower())
     end
 end
 

--- a/scripts/effects/attack_down.lua
+++ b/scripts/effects/attack_down.lua
@@ -9,6 +9,7 @@ effectObject.onEffectGain = function(target, effect)
     end
 
     target:addMod(xi.mod.ATTP, -effect:getPower())
+    target:addMod(xi.mod.RATTP, -effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
@@ -16,6 +17,7 @@ end
 
 effectObject.onEffectLose = function(target, effect)
     target:delMod(xi.mod.ATTP, -effect:getPower())
+    target:delMod(xi.mod.RATTP, -effect:getPower())
 end
 
 return effectObject


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Applies a penalty to ranged attack and ranged accuracy, respectively, when Attack Down and Accuracy Down effects are applied.

**Captures**:
* <https://youtu.be/_tRCB-8Sc2g>
* <https://youtu.be/BlNjKljvYX4>

## Steps to test these changes

Fight something that applies the effects, doing `/checkparam` before and after. Compare.