### PR TITLE
[Fix] Magical mobskills doing 0 damage

### DIFF
--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -267,11 +267,11 @@ end
 -- xi.mobskills.magicalTpBonus.DMG_BONUS and TP = 200, tpvalue = 2, assume V=150  --> damage is now 150*(TP*2) / 100 = 600
 
 xi.mobskills.mobMagicalMove = function(actor, target, action, baseDamage, actionElement, damageModifier, tpEffect, tpMultiplier)
-    local finalDamage = 0
+    local finalDamage = baseDamage
 
     -- Base damage
     if tpEffect == xi.mobskills.magicalTpBonus.DMG_BONUS then
-        finalDamage = math.floor(baseDamage * action:getTP() * tpMultiplier / 1000)
+        finalDamage = math.floor(finalDamage * action:getTP() * tpMultiplier / 1000)
     end
 
     -- Get bonus macc.


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes an oversight on my end when changing this function to not return a table, were base damage was not properly set.
Close #6049 

## Steps to test these changes
Use shantotto II and watch her atacks do damage. Same for any other mob.
