### PR TITLE
[Lua] Add player parrying, guarding, and blocking of physical (non-ranged) mobskills

### DIFF
--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -110,6 +110,25 @@ xi.mobskills.mobRangedMove = function(mob, target, skill, numberofhits, accmod, 
     return xi.mobskills.mobPhysicalMove(mob, target, skill, numberofhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.RANGED)
 end
 
+-- helper function to handle a single hit and check for parrying, guarding, and blocking
+local function handleSinglePhysicalHit(mob, target, hitdamage, hitslanded, finaldmg, tpEffect, minRatio, maxRatio)
+    -- if a non-ranged physical mobskill then can parry or guard
+    if
+        tpEffect == xi.mobskills.magicalTpBonus.RANGED or
+        (not xi.combat.physical.isParried(target, mob) and
+        not xi.combat.physical.isGuarded(target, mob))
+    then
+        local pdif = math.random((minRatio * 1000), (maxRatio * 1000)) --generate random PDIF
+        pdif = pdif / 1000 --multiplier set.
+        finaldmg = finaldmg + hitdamage * pdif
+        -- also handle blocking
+        finaldmg = xi.combat.physical.handleBlock(target, mob, finaldmg)
+        hitslanded = hitslanded + 1
+    end
+
+    return hitslanded, finaldmg
+end
+
 -----------------------------------
 -- Mob Physical Abilities
 -- accMod   : linear multiplier for accuracy (1 default)
@@ -202,21 +221,14 @@ xi.mobskills.mobPhysicalMove = function(mob, target, skill, numHits, accMod, dmg
 
     firstHitChance = utils.clamp(firstHitChance, 35, 95)
 
-    --Applying pDIF
-    local pdif
     if (math.random() * 100) <= firstHitChance then
-        pdif = math.random((minRatio * 1000), (maxRatio * 1000)) --generate random PDIF
-        pdif = pdif / 1000 --multiplier set.
-        finaldmg = finaldmg + hitdamage * pdif
-        hitslanded = hitslanded + 1
+        -- use helper function check for parry guard and blocking and handle the hit
+        hitslanded, finaldmg = handleSinglePhysicalHit(mob, target, hitdamage, hitslanded, finaldmg, tpEffect, minRatio, maxRatio)
     end
 
     while hitsdone < numHits do
         if (math.random() * 100) <= hitrate then --it hit
-            pdif       = math.random(minRatio * 1000, maxRatio * 1000) --generate random PDIF
-            pdif       = pdif / 1000 --multiplier set.
-            finaldmg   = finaldmg + hitdamage * pdif
-            hitslanded = hitslanded + 1
+            hitslanded, finaldmg = handleSinglePhysicalHit(mob, target, hitdamage, hitslanded, finaldmg, tpEffect, minRatio, maxRatio)
         end
 
         hitsdone = hitsdone + 1


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR adds player parrying, guarding, and blocking of physical (non-ranged) mobskills. This is done by leveraging the functions from the previous [PR](https://github.com/LandSandBoat/server/pull/5873) that added monster parrying, guarding, and blocking of player weaponskills. When a player guards or parries a physical mobskill hit the hit simply misses (though in contrast to a normal miss there is the possibility of a guard or parry skillup), see this [source](https://genomeffxi.livejournal.com/18269.html) for evidence for guard for example.

Closes https://github.com/LandSandBoat/server/issues/836

## Steps to test these changes
Fight mobs and notice that they miss physical mobskills more (due to guarding and parrying) and that you can get parrying and guarding skillups during these. Also similar for blocking.