### PR TITLE
[Lua] Adds missing quantity to Ugrihd message

### DIFF
--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ugrihd.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ugrihd.lua
@@ -83,7 +83,7 @@ entity.onEventFinish = function(player, csid, option, npc)
 
         player:delCurrency('imperial_standing', quantity * price)
         npc:showText(npc, ID.text.UGRIHD_PURCHASE_DIALOGUE)
-        player:messageSpecial(ID.text.ITEM_OBTAINED, item)
+        player:messageSpecial(ID.text.ITEM_OBTAINED + 9, item, quantity)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Ugrihd doesn't currently print the quantity the player obtains after purchasing coins with Imperial Standing. This PR fixes the issue.

## Steps to test these changes
Add Imperial Standing and speak to Ugrihd to see the new message.
