### PR TITLE
[lua] [food] Remove fake effect of Movalpolos Water

### DIFF
--- a/scripts/items/bottle_of_movalpolos_water.lua
+++ b/scripts/items/bottle_of_movalpolos_water.lua
@@ -1,31 +1,20 @@
 -----------------------------------
 -- ID: 5165
 -- Item: Bottle of Movalpolos Water
--- Item Effect: Refresh 2 MP 3/Tic under 85% MP.
--- Duration: 30 Mins
+-- Item Effect: Food Effect with no obvious effects.
+-- Duration: 30 Minutes
 -----------------------------------
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, item, param, caster)
-    return 0
+    return xi.itemUtils.foodOnItemCheck(target, xi.foodType.BASIC)
 end
 
+-- Previously, this item used to give a 2/tick refresh effect (not food effect with refresh) if used on lightsday.
+-- That was proven wrong simply by using a movalpolos water on lightsday. It gives a food effect just like JP wiki claims
+-- https://wiki.ffo.jp/html/1657.html
 itemObject.onItemUse = function(target)
-    local mMP = target:getMaxMP()
-    local cMP = target:getMP()
-    if VanadielDayOfTheWeek() == xi.day.LIGHTSDAY then
-        if cMP < (mMP * .85) then
-            if not target:hasStatusEffect(xi.effect.REFRESH) then
-                target:addStatusEffect(xi.effect.REFRESH, 2, 3, 1800)
-            else
-                target:messageBasic(xi.msg.basic.NO_EFFECT)
-            end
-        else
-            target:messageBasic(xi.msg.basic.NO_EFFECT)
-        end
-    else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
-    end
+    target:addStatusEffect(xi.effect.FOOD, 0, 0, 30 * 60, 5165)
 end
 
 return itemObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Removes the fake effect of movalpolos water that only ffxiclopedia claimed was "true".
Applies the real effect (apparently 30 minutes of food effect?...), JP wiki also claims this.

I never once got refresh on lightsday with 0 MP
![image](https://github.com/user-attachments/assets/d6e083d5-c98a-4fc4-a672-8934d6de2066)

Trying to use movalpolos water twice:
![image](https://github.com/user-attachments/assets/fc8272d5-7e9a-4506-928d-f8b4218bafbf)


yes I spent hours yesterday killing mobs with signet up on my ilvl blm to claim movalpolos just for this test...

## Steps to test these changes

Use movalpolos water, get food "effect". 
