### PR TITLE
Add player evasion skill up chance when evading an attack

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2392,6 +2392,12 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
 
             // Check & Handle Afflatus Misery Accuracy Bonus
             battleutils::HandleAfflatusMiseryAccuracyBonus(this);
+
+            // player should still be able to skill up evasion on an evaded attack
+            if (auto* PChar = dynamic_cast<CCharEntity*>(PTarget))
+            {
+                charutils::TrySkillUP(PChar, SKILL_EVASION, GetMLevel());
+            }
         }
 
         // If we didn't hit at all, set param to 0 if we didn't blink any shadows.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This adds the potential for an evasion skill up when evading an attack. See for example [here](https://www.bg-wiki.com/ffxi/Evasion_Skill).

## Steps to test these changes
Fight a mob and see that the player can get an evasion skill up on an evaded attack.