### PR TITLE
[cpp/sql/lua] Add WEATHER_CONDITION for latents + sunlight pole latent effect

### DIFF
--- a/scripts/enum/latent.lua
+++ b/scripts/enum/latent.lua
@@ -43,7 +43,7 @@ xi.latent =
     JOB_MULTIPLE_AT_NIGHT    = 39, -- PARAM: 0: ODD, 2: EVEN, 3-99: DIVISOR
     EQUIPPED_IN_SLOT         = 40, -- When item is equipped in the specified slot (e.g. Dweomer Knife, Erlking's Sword, etc.) PARAM: slotID
     DURING_WS                = 41, -- During Weaponskill
-    -- 42 free to use
+    WEATHER_CONDITION        = 42, -- See weather.lua for xi.weather enum
     WEAPON_DRAWN_HP_UNDER    = 43, -- PARAM: HP PERCENT
     NATION_CITIZEN           = 44, -- Triggered by player being citizen of nation matching param: 0 San d'Oria, 1 Bastok, 2 Windurst
     MP_UNDER_VISIBLE_GEAR    = 45, -- mp less than or equal to %, calculated using MP bonuses from visible gear only

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -1765,6 +1765,9 @@ INSERT INTO `item_latents` VALUES (17527,5,-10,47,0);
 INSERT INTO `item_latents` VALUES (17527,15,-10,47,0);
 INSERT INTO `item_latents` VALUES (17527,21,-10,47,0);
 
+-- Sunlight Pole
+INSERT INTO `item_latents` VALUES (17529,370,1,42,1);     -- Regen Effect +1/tick in Sunny weather
+
 -- Musketeer's Pole +1/+2
 INSERT INTO `item_latents` VALUES (17539,2,10,53,1);     -- HP +10 in areas outside own nation's control
 INSERT INTO `item_latents` VALUES (17539,5,10,53,1);     -- MP +10 in areas outside own nation's control

--- a/src/map/latent_effect.h
+++ b/src/map/latent_effect.h
@@ -71,27 +71,27 @@ enum class LATENT : uint16
     JOB_MULTIPLE_AT_NIGHT  = 39, // PARAM: 0: ODD, 2: EVEN, 3-X: DIVISOR
     EQUIPPED_IN_SLOT       = 40, // When item is equipped in the specified slot (e.g. Dweomer Knife, Erlking's Sword, etc.) PARAM: slotID
     DURING_WS              = 41, // During WS
-    // 42 free to use
-    WEAPON_DRAWN_HP_UNDER = 43, // PARAM: HP PERCENT
-    NATION_CITIZEN        = 44, // Triggered by player being citizen of nation matching param: 0 San d'Oria, 1 Bastok, 2 Windurst
-    MP_UNDER_VISIBLE_GEAR = 45, // mp less than or equal to %, calculated using MP bonuses from visible gear only
-    HP_OVER_VISIBLE_GEAR  = 46, // hp more than or equal to %, calculated using HP bonuses from visible gear only
-    WEAPON_BROKEN         = 47, //
-    IN_DYNAMIS            = 48, //
-    FOOD_ACTIVE           = 49, // food effect (foodId) active - PARAM: FOOD ITEMID
-    JOB_LEVEL_BELOW       = 50, // PARAM: level
-    JOB_LEVEL_ABOVE       = 51, // PARAM: level
-    WEATHER_ELEMENT       = 52, // PARAM: 0: NONE, 1: FIRE, 2: ICE, 3: WIND 4: EARTH, 5: THUNDER, 6: WATER, 7: LIGHT, 8: DARK
-    NATION_CONTROL        = 53, // checks if player region is under nation's control - PARAM: 0: Under own nation's control, 1: Outside own nation's control
-    ZONE_HOME_NATION      = 54, // in zone and citizen of nation (aketons)
-    MP_OVER               = 55, // mp greater than # - PARAM: MP #
-    WEAPON_DRAWN_MP_OVER  = 56, // while weapon is drawn and mp greater than # - PARAM: MP #
-    ELEVEN_ROLL_ACTIVE    = 57, // corsair roll of 11 active
-    IN_ASSAULT            = 58, // is in an Instance battle in a TOAU zone
-    VS_ECOSYSTEM          = 59, // Vs. Specific Ecosystem ID (e.g. Vs. Plantoid: Accuracy+3)
-    VS_FAMILY             = 60, // Vs. Specific Family ID (e.g. Vs. Korrigan: Accuracy+3)
-    VS_SUPERFAMILY        = 61, // Vs. Specific SuperFamily ID (e.g. Vs. Mandragora: Accuracy+3)
-    MAINJOB               = 62, // mainjob - PARAM: JOBTYPE
+    WEATHER_CONDITION      = 42, // See Weather.h for WEATHER enum
+    WEAPON_DRAWN_HP_UNDER  = 43, // PARAM: HP PERCENT
+    NATION_CITIZEN         = 44, // Triggered by player being citizen of nation matching param: 0 San d'Oria, 1 Bastok, 2 Windurst
+    MP_UNDER_VISIBLE_GEAR  = 45, // mp less than or equal to %, calculated using MP bonuses from visible gear only
+    HP_OVER_VISIBLE_GEAR   = 46, // hp more than or equal to %, calculated using HP bonuses from visible gear only
+    WEAPON_BROKEN          = 47, //
+    IN_DYNAMIS             = 48, //
+    FOOD_ACTIVE            = 49, // food effect (foodId) active - PARAM: FOOD ITEMID
+    JOB_LEVEL_BELOW        = 50, // PARAM: level
+    JOB_LEVEL_ABOVE        = 51, // PARAM: level
+    WEATHER_ELEMENT        = 52, // PARAM: 0: NONE, 1: FIRE, 2: ICE, 3: WIND 4: EARTH, 5: THUNDER, 6: WATER, 7: LIGHT, 8: DARK
+    NATION_CONTROL         = 53, // checks if player region is under nation's control - PARAM: 0: Under own nation's control, 1: Outside own nation's control
+    ZONE_HOME_NATION       = 54, // in zone and citizen of nation (aketons)
+    MP_OVER                = 55, // mp greater than # - PARAM: MP #
+    WEAPON_DRAWN_MP_OVER   = 56, // while weapon is drawn and mp greater than # - PARAM: MP #
+    ELEVEN_ROLL_ACTIVE     = 57, // corsair roll of 11 active
+    IN_ASSAULT             = 58, // is in an Instance battle in a TOAU zone
+    VS_ECOSYSTEM           = 59, // Vs. Specific Ecosystem ID (e.g. Vs. Plantoid: Accuracy+3)
+    VS_FAMILY              = 60, // Vs. Specific Family ID (e.g. Vs. Korrigan: Accuracy+3)
+    VS_SUPERFAMILY         = 61, // Vs. Specific SuperFamily ID (e.g. Vs. Mandragora: Accuracy+3)
+    MAINJOB                = 62, // mainjob - PARAM: JOBTYPE
 };
 
 #define MAX_LATENTEFFECTID 63

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -304,6 +304,7 @@ void CLatentEffectContainer::CheckLatentsStatusEffect()
         switch (latentEffect.GetConditionsID())
         {
             case LATENT::STATUS_EFFECT_ACTIVE:
+            case LATENT::WEATHER_CONDITION:
             case LATENT::WEATHER_ELEMENT:
             case LATENT::NATION_CONTROL:
                 return ProcessLatentEffect(latentEffect);
@@ -621,6 +622,7 @@ void CLatentEffectContainer::CheckLatentsZone()
             case LATENT::ZONE:
             case LATENT::IN_ASSAULT:
             case LATENT::IN_DYNAMIS:
+            case LATENT::WEATHER_CONDITION:
             case LATENT::WEATHER_ELEMENT:
             case LATENT::NATION_CONTROL:
             case LATENT::NATION_CITIZEN:
@@ -659,6 +661,11 @@ void CLatentEffectContainer::CheckLatentsWeather(uint16 weather)
         if (latent.GetConditionsID() == LATENT::WEATHER_ELEMENT)
         {
             auto element = zoneutils::GetWeatherElement(battleutils::GetWeather((CBattleEntity*)m_POwner, false, weather));
+            return ApplyLatentEffect(latent, latent.GetConditionsValue() == element);
+        }
+        else if (latent.GetConditionsID() == LATENT::WEATHER_CONDITION)
+        {
+            auto element = battleutils::GetWeather((CBattleEntity*)m_POwner, false, weather);
             return ApplyLatentEffect(latent, latent.GetConditionsValue() == element);
         }
         return false;
@@ -1147,6 +1154,9 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect, bo
             break;
         case LATENT::JOB_LEVEL_ABOVE:
             expression = m_POwner->GetMLevel() >= latentEffect.GetConditionsValue();
+            break;
+        case LATENT::WEATHER_CONDITION:
+            expression = latentEffect.GetConditionsValue() == battleutils::GetWeather((CBattleEntity*)m_POwner, false);
             break;
         case LATENT::WEATHER_ELEMENT:
             expression = latentEffect.GetConditionsValue() == zoneutils::GetWeatherElement(battleutils::GetWeather((CBattleEntity*)m_POwner, false));


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements a weather condition check during latent effect checks for NONE, SUNSHINE, CLOUDS, FOG
Updates Sunshine Pole latent effect with [1/tick regen during sunny weather](https://ffxiclopedia.fandom.com/wiki/Sunlight_Pole?oldid=1115539). 

## Steps to test these changes

Build map, update item_latents.sql with dbtool

!additem 17529 -- Sunlight Pole

!setweather 1 -- Sunshine
