### PR TITLE
Fixed level check for pet spells

### DIFF
--- a/src/map/spell.cpp
+++ b/src/map/spell.cpp
@@ -679,36 +679,26 @@ namespace spell
     // Check If user can cast spell
     bool CanUseSpell(CBattleEntity* PCaster, CSpell* spell)
     {
-        bool usable = false;
-
-        if (spell != nullptr)
+        if (spell == nullptr)
         {
-            uint8 JobMLVL      = spell->getJob(PCaster->GetMJob());
-            uint8 JobSLVL      = spell->getJob(PCaster->GetSJob());
-            uint8 requirements = spell->getRequirements();
+            return false;
+        }
 
-            if (PCaster->objtype == TYPE_MOB || (PCaster->objtype == TYPE_PET && static_cast<CPetEntity*>(PCaster)->getPetType() != PET_TYPE::ADVENTURING_FELLOW) ||
-                PCaster->objtype == TYPE_TRUST)
-            {
-                // cant cast cause im hidden or untargetable
+        bool  usable = false;
+        uint8 requirements;
+
+        switch (PCaster->objtype)
+        {
+            case TYPE_MOB:
+                // Unable to cast because caster is hidden or untargetable
                 if (PCaster->IsNameHidden() || static_cast<CMobEntity*>(PCaster)->GetUntargetable())
                 {
                     return false;
                 }
-
-                // Ensure pet or trust is level appropriate
-                if (((PCaster->objtype == TYPE_PET && static_cast<CPetEntity*>(PCaster)->getPetType() != PET_TYPE::AUTOMATON) || PCaster->objtype == TYPE_TRUST) &&
-                    PCaster->GetMLevel() < static_cast<CMobEntity*>(PCaster)->m_SpellListContainer->GetSpellMinLevel(spell->getID()))
-                {
-                    return false;
-                }
-
                 // Mobs can cast any non-given char spell
                 return true;
-            }
 
-            if (PCaster->objtype == TYPE_PC)
-            {
+            case TYPE_PC:
                 if (spell->getSpellGroup() == SPELLGROUP_TRUST)
                 {
                     return true; // every PC can use trusts
@@ -717,35 +707,88 @@ namespace spell
                 {
                     return true;
                 }
-            }
+                [[fallthrough]];
+            case TYPE_FELLOW:
+            case TYPE_NPC:
+                requirements = spell->getRequirements();
 
-            if (PCaster->GetMLevel() >= JobMLVL)
-            {
-                usable = true;
-                if (requirements & SPELLREQ_TABULA_RASA)
+                // Make sure caster has the right main job and level
+                if (PCaster->GetMLevel() >= spell->getJob(PCaster->GetMJob()))
                 {
-                    if (!PCaster->StatusEffectContainer->HasStatusEffect(EFFECT_TABULA_RASA))
+                    usable = true;
+                    if (requirements & SPELLREQ_TABULA_RASA)
                     {
-                        usable = false;
+                        if (!PCaster->StatusEffectContainer->HasStatusEffect(EFFECT_TABULA_RASA))
+                        {
+                            usable = false;
+                        }
+                    }
+                    if (PCaster->GetMJob() == JOB_SCH)
+                    {
+                        if (requirements & SPELLREQ_ADDENDUM_BLACK)
+                        {
+                            if (!PCaster->StatusEffectContainer->HasStatusEffect({ EFFECT_ADDENDUM_BLACK, EFFECT_ENLIGHTENMENT }))
+                            {
+                                usable = false;
+                            }
+                        }
+                        else if (requirements & SPELLREQ_ADDENDUM_WHITE)
+                        {
+                            if (!PCaster->StatusEffectContainer->HasStatusEffect({ EFFECT_ADDENDUM_WHITE, EFFECT_ENLIGHTENMENT }))
+                            {
+                                usable = false;
+                            }
+                        }
+                    }
+                    if (spell->getSpellGroup() == SPELLGROUP_BLUE && PCaster->objtype == TYPE_PC)
+                    {
+                        if (requirements & SPELLREQ_UNBRIDLED_LEARNING)
+                        {
+                            if (!PCaster->StatusEffectContainer->HasStatusEffect({ EFFECT_UNBRIDLED_LEARNING, EFFECT_UNBRIDLED_WISDOM }))
+                            {
+                                usable = false;
+                            }
+                        }
+                        else if (!blueutils::IsSpellSet((CCharEntity*)PCaster, (CBlueSpell*)spell))
+                        {
+                            usable = false;
+                        }
+                    }
+                    if (usable)
+                    {
+                        return true;
                     }
                 }
-                if (requirements & SPELLREQ_ADDENDUM_BLACK && PCaster->GetMJob() == JOB_SCH)
+
+                // Make sure caster has the right sub job and level
+                if (PCaster->GetSLevel() >= spell->getJob(PCaster->GetSJob()) && !(requirements & SPELLREQ_MAIN_JOB_ONLY))
                 {
-                    if (!PCaster->StatusEffectContainer->HasStatusEffect({ EFFECT_ADDENDUM_BLACK, EFFECT_ENLIGHTENMENT }))
+                    usable = true;
+                    if (requirements & SPELLREQ_TABULA_RASA)
                     {
-                        usable = false;
+                        if (!PCaster->StatusEffectContainer->HasStatusEffect(EFFECT_TABULA_RASA))
+                        {
+                            usable = false;
+                        }
                     }
-                }
-                else if (requirements & SPELLREQ_ADDENDUM_WHITE && PCaster->GetMJob() == JOB_SCH)
-                {
-                    if (!PCaster->StatusEffectContainer->HasStatusEffect({ EFFECT_ADDENDUM_WHITE, EFFECT_ENLIGHTENMENT }))
+                    if (PCaster->GetSJob() == JOB_SCH)
                     {
-                        usable = false;
+                        if (requirements & SPELLREQ_ADDENDUM_BLACK)
+                        {
+                            if (!PCaster->StatusEffectContainer->HasStatusEffect({ EFFECT_ADDENDUM_BLACK, EFFECT_ENLIGHTENMENT }))
+                            {
+                                usable = false;
+                            }
+                        }
+                        else if (requirements & SPELLREQ_ADDENDUM_WHITE)
+                        {
+                            if (!PCaster->StatusEffectContainer->HasStatusEffect({ EFFECT_ADDENDUM_WHITE, EFFECT_ENLIGHTENMENT }))
+                            {
+                                usable = false;
+                            }
+                        }
                     }
-                }
-                else if (spell->getSpellGroup() == SPELLGROUP_BLUE)
-                {
-                    if (PCaster->objtype == TYPE_PC)
+                    if (spell->getSpellGroup() == SPELLGROUP_BLUE && PCaster->objtype == TYPE_PC)
                     {
                         if (requirements & SPELLREQ_UNBRIDLED_LEARNING)
                         {
@@ -760,55 +803,37 @@ namespace spell
                         }
                     }
                 }
+                return usable;
+
+            case TYPE_PET:
+                if (static_cast<CPetEntity*>(PCaster)->getPetType() == PET_TYPE::AUTOMATON)
+                {
+                    usable = true;
+                }
+                [[fallthrough]];
+            case TYPE_TRUST:
+                // Unable to cast because caster is hidden or untargetable
+                if (PCaster->IsNameHidden() || static_cast<CMobEntity*>(PCaster)->GetUntargetable())
+                {
+                    return false;
+                }
+
                 if (usable)
                 {
                     return true;
                 }
-            }
-            if (PCaster->GetSLevel() >= JobSLVL && !(requirements & SPELLREQ_MAIN_JOB_ONLY))
-            {
-                usable = true;
-                if (requirements & SPELLREQ_TABULA_RASA)
+
+                // Ensure pet or trust is level appropriate
+                if (PCaster->GetMLevel() < static_cast<CMobEntity*>(PCaster)->m_SpellListContainer->GetSpellMinLevel(spell->getID()))
                 {
-                    if (!PCaster->StatusEffectContainer->HasStatusEffect(EFFECT_TABULA_RASA))
-                    {
-                        usable = false;
-                    }
+                    return false;
                 }
-                if (requirements & SPELLREQ_ADDENDUM_BLACK && PCaster->GetSJob() == JOB_SCH)
-                {
-                    if (!PCaster->StatusEffectContainer->HasStatusEffect({ EFFECT_ADDENDUM_BLACK, EFFECT_ENLIGHTENMENT }))
-                    {
-                        usable = false;
-                    }
-                }
-                else if (requirements & SPELLREQ_ADDENDUM_WHITE && PCaster->GetSJob() == JOB_SCH)
-                {
-                    if (!PCaster->StatusEffectContainer->HasStatusEffect({ EFFECT_ADDENDUM_WHITE, EFFECT_ENLIGHTENMENT }))
-                    {
-                        usable = false;
-                    }
-                }
-                else if (spell->getSpellGroup() == SPELLGROUP_BLUE)
-                {
-                    if (PCaster->objtype == TYPE_PC)
-                    {
-                        if (requirements & SPELLREQ_UNBRIDLED_LEARNING)
-                        {
-                            if (!PCaster->StatusEffectContainer->HasStatusEffect({ EFFECT_UNBRIDLED_LEARNING, EFFECT_UNBRIDLED_WISDOM }))
-                            {
-                                usable = false;
-                            }
-                        }
-                        else if (!blueutils::IsSpellSet((CCharEntity*)PCaster, (CBlueSpell*)spell))
-                        {
-                            usable = false;
-                        }
-                    }
-                }
-            }
+                return true;
+
+            default:
+                break;
         }
-        return usable;
+        return false;
     }
 
     // This is a utility method for mobutils, when we want to work out if we can give monsters a spell

--- a/src/map/spell.cpp
+++ b/src/map/spell.cpp
@@ -687,7 +687,7 @@ namespace spell
             uint8 JobSLVL      = spell->getJob(PCaster->GetSJob());
             uint8 requirements = spell->getRequirements();
 
-            if (PCaster->objtype == TYPE_MOB || (PCaster->objtype == TYPE_PET && static_cast<CPetEntity*>(PCaster)->getPetType() == PET_TYPE::AUTOMATON) ||
+            if (PCaster->objtype == TYPE_MOB || (PCaster->objtype == TYPE_PET && static_cast<CPetEntity*>(PCaster)->getPetType() != PET_TYPE::ADVENTURING_FELLOW) ||
                 PCaster->objtype == TYPE_TRUST)
             {
                 // cant cast cause im hidden or untargetable
@@ -696,8 +696,9 @@ namespace spell
                     return false;
                 }
 
-                // ensure trust level is appropriate+
-                if (PCaster->objtype == TYPE_TRUST && PCaster->GetMLevel() < static_cast<CMobEntity*>(PCaster)->m_SpellListContainer->GetSpellMinLevel(spell->getID()))
+                // Ensure pet or trust is level appropriate
+                if (((PCaster->objtype == TYPE_PET && static_cast<CPetEntity*>(PCaster)->getPetType() != PET_TYPE::AUTOMATON) || PCaster->objtype == TYPE_TRUST) &&
+                    PCaster->GetMLevel() < static_cast<CMobEntity*>(PCaster)->m_SpellListContainer->GetSpellMinLevel(spell->getID()))
                 {
                     return false;
                 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Fixes issue #5318 by changing the level check for pets casting spells to check the `min_level` value from `mob_spell_lists.sql` instead of checking if a player of the pet's job and level can cast the spell.
Fully optimizes `CanUseSpell()` by converting `PCaster->objtype` if statements to `switch(PCaster->objtype)`, removing no longer needed variables, and moving all function calls to their relevant cases.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Summoned Light Spirit at various levels in Cape Teriggan and let it go through it's spell list multiple times while fighting things, before and after recompiling the server with the changes. Before it would stop casting Banish after level 90, and it was able to cast Banish IV (non-player spell on it's spell list) after.
Tested every possible case I could think of covered by the optimization to ensure everything is working properly.