### PR TITLE
Wamoura Family Mobskills

### DIFF
--- a/scripts/actions/mobskills/erosion_dust.lua
+++ b/scripts/actions/mobskills/erosion_dust.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+--  Erosion Dust
+--  Description: Spreads eroding dust particles on targets in an area of effect, dealing Light damage and inflicting Dia.
+--  Type: Magical
+--  Utsusemi/Blink absorb: Wipes shadows
+-----------------------------------
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    local damage = mob:getWeaponDmg() * 3.3
+
+    damage = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.LIGHT, 1, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHT, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
+    target:takeDamage(damage, mob, xi.attackType.MAGICAL, xi.damageType.LIGHT)
+
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 10, 30)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.DIA, 3, 3, duration)
+
+    return damage
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/erratic_flutter.lua
+++ b/scripts/actions/mobskills/erratic_flutter.lua
@@ -23,13 +23,13 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local damage = mob:getWeaponDmg() * 1.5
+    local damage = mob:getWeaponDmg() * 2.75
 
     damage = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.FIRE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT)
     damage = xi.mobskills.mobFinalAdjustments(damage , mob, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 
     target:takeDamage(damage, mob, xi.attackType.MAGICAL, xi.damageType.FIRE)
-    xi.mobskills.mobBuffMove(mob, xi.effect.HASTE, 2998, 0, 300) -- There is no message for the self buff aspect, only dmg.
+    xi.mobskills.mobBuffMove(mob, xi.effect.HASTE, 4500, 0, 180) -- There is no message for the self buff aspect, only dmg.
 
     return damage
 end

--- a/scripts/actions/mobskills/exuviation.lua
+++ b/scripts/actions/mobskills/exuviation.lua
@@ -12,8 +12,6 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local baseHeal = 500
-    local statusHeal = 300
     local effectCount = 0
     local dispel = mob:eraseStatusEffect()
 
@@ -24,7 +22,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     end
 
     skill:setMsg(xi.msg.basic.SELF_HEAL)
-    return xi.mobskills.mobHealMove(mob, statusHeal * effectCount + baseHeal)
+    return xi.mobskills.mobHealMove(mob, (699 + (mob:getMainLvl() - 70) * 10) * effectCount)
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/magma_fan.lua
+++ b/scripts/actions/mobskills/magma_fan.lua
@@ -1,5 +1,5 @@
 -----------------------------------
---  Magma_Fan
+--  Magma Fan
 --  Description: Deals Fire damage to enemies within a fan-shaped area originating from the caster.
 --  Type: Magical Fire (Element)
 -----------------------------------
@@ -10,7 +10,8 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.5, 1.25, xi.element.FIRE, 600)
+    -- Breath damage is HP * 1/12
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.0833, 1, xi.element.FIRE, 600)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.FIRE)

--- a/scripts/actions/mobskills/proboscis.lua
+++ b/scripts/actions/mobskills/proboscis.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Proboscis
+-- Steals MP and dispels one beneficial status effect from targets in front.
+-- Type: Magical
+-- Utsusemi/Blink absorb: ignore shadow
+-----------------------------------
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    local damage = mob:getWeaponDmg()
+
+    target:dispelStatusEffect()
+
+    damage = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.DARK, 1, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)
+    damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
+
+    skill:setMsg(xi.mobskills.mobPhysicalDrainMove(mob, target, skill, xi.mobskills.drainType.MP, damage))
+
+    return damage
+end
+
+return mobskillObject

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -2988,7 +2988,7 @@ INSERT INTO `mob_groups` VALUES (21,4247,61,'Volcanic_Leech',330,0,0,0,0,72,75,0
 INSERT INTO `mob_groups` VALUES (22,1953,61,'Hilltroll_Red_Mage',330,0,1312,0,0,79,83,0);
 INSERT INTO `mob_groups` VALUES (23,1950,61,'Hilltroll_Paladin',330,0,1310,0,0,79,82,0);
 INSERT INTO `mob_groups` VALUES (24,4282,61,'Wamoura_Prince',330,0,2611,0,0,79,81,0);
-INSERT INTO `mob_groups` VALUES (25,4280,61,'Wamoura',0,128,2608,0,0,80,82,0);
+INSERT INTO `mob_groups` VALUES (25,4280,61,'Wamoura',330,0,2608,0,0,80,82,0);
 INSERT INTO `mob_groups` VALUES (26,3825,61,'Sweeping_Cluster',330,0,2367,0,0,73,78,0);
 INSERT INTO `mob_groups` VALUES (27,4501,61,'Zhayolm_Apkallu',330,0,1447,0,0,70,74,0);
 INSERT INTO `mob_groups` VALUES (28,5190,61,'Chary_Apkallu',0,0,3287,0,0,76,77,0);
@@ -3023,6 +3023,7 @@ INSERT INTO `mob_groups` VALUES (56,6751,61,'Elders_Imp',0,128,0,0,0,99,99,0);
 INSERT INTO `mob_groups` VALUES (57,6752,61,'Grand_Grenade',0,128,0,0,0,99,99,0);
 INSERT INTO `mob_groups` VALUES (58,6753,61,'Sarama',0,128,0,0,0,99,99,0);
 INSERT INTO `mob_groups` VALUES (59,6750,61,'Fahrafahr_the_Bloodied',0,32,3259,0,0,80,80,0);
+INSERT INTO `mob_groups` VALUES (60,4280,61,'Wamoura',0,128,2608,0,0,80,82,0);
 
 -- ------------------------------------------------------------
 -- Halvung (Zone 62)

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -1096,7 +1096,6 @@ INSERT INTO `mob_skill_lists` VALUES ('Wamoura',253,1952);
 INSERT INTO `mob_skill_lists` VALUES ('Wamoura',253,1953);
 INSERT INTO `mob_skill_lists` VALUES ('Wamoura',253,1954);
 INSERT INTO `mob_skill_lists` VALUES ('Wamoura',253,1955);
--- INSERT INTO `mob_skill_lists` VALUES ('Wamoura',253,1956);
 INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa_strech',254,1815);
 INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa_strech',254,1816);
 INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa_strech',254,1817);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

These changes are focused on improving Wamora mobskills. This primarily involves incorporating data collected by Jimmayus. Two additional changes include

1. Implemented the missing mobskills Erosion Dust and Proboscis
2. Added a new mob group for Wamoura that spawn from eclosion and changed the other Wamoura group to spawn normally. 

## Retail Proof
https://ffxiclopedia.fandom.com/wiki/Category:Wamoura
[Jimmayus' Mob Sheet](https://docs.google.com/spreadsheets/d/1YBoveP-weMdidrirY-vPDzHyxbEI2ryECINlfCnFkLI/edit?gid=57955395#gid=57955395)

## Steps to test these changes

`!gotoid 17027421`
`!exec target:useMobAbility(1951)`
`!exec target:useMobAbility(1952)`
`!exec target:useMobAbility(1953)`
`!exec target:useMobAbility(1954)`
`!exec target:useMobAbility(1955)`