### PR TITLE
Core: Improvements to Backtrace

### DIFF
--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -182,11 +182,6 @@ namespace logging
 
     void AddBacktrace(std::string const& str)
     {
-        if (BacktraceBuffer.is_full())
-        {
-            BacktraceBuffer.dequeue();
-        }
-
         BacktraceBuffer.enqueue(str);
     }
 
@@ -194,6 +189,7 @@ namespace logging
     {
         std::vector<std::string> backtrace;
 
+        // Emptying in this manner will mean the oldest is returned first, and the most recent is returned last
         while (!BacktraceBuffer.is_empty())
         {
             backtrace.push_back(BacktraceBuffer.dequeue());

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1836,6 +1836,8 @@ namespace luautils
         auto name     = PZone->getName();
         auto filename = fmt::format("./scripts/zones/{}/Zone.lua", name);
 
+        ShowTraceFmt("luautils::OnZoneInitialise: {}", name);
+
         CacheLuaObjectFromFile(filename);
 
         auto onInitialize = lua["xi"]["zones"][name]["Zone"]["onInitialize"];
@@ -1862,6 +1864,8 @@ namespace luautils
         auto name     = PZone->getName();
         auto filename = fmt::format("./scripts/zones/{}/Zone.lua", name);
 
+        ShowTraceFmt("luautils::OnZoneTick: {}", name);
+
         auto onZoneTick = GetCacheEntryFromFilename(filename)["onZoneTick"];
         if (!onZoneTick.valid())
         {
@@ -1879,6 +1883,8 @@ namespace luautils
     int32 OnGameIn(CCharEntity* PChar, bool zoning)
     {
         TracyZoneScoped;
+
+        ShowTraceFmt("luautils::OnGameIn: {}", PChar->getName());
 
         auto onGameIn = lua["xi"]["player"]["onGameIn"];
         if (!onGameIn.valid())
@@ -1910,8 +1916,17 @@ namespace luautils
             return;
         }
 
+        CZone*      prevZone    = zoneutils::GetZone(PChar->loc.prevzone);
+        std::string prevZoneStr = "Unknown";
+        if (prevZone)
+        {
+            prevZoneStr = prevZone->getName();
+        }
+
         auto name     = PChar->m_moghouseID ? "Residential_Area" : destinationZone->getName();
         auto filename = fmt::format("./scripts/zones/{}/Zone.lua", name);
+
+        ShowTraceFmt("luautils::OnZoneIn: {}: {} -> {}", PChar->getName(), prevZoneStr, name);
 
         auto onZoneInFramework = lua["InteractionGlobal"]["onZoneIn"];
         auto onZoneIn          = GetCacheEntryFromFilename(filename)["onZoneIn"];
@@ -1946,6 +1961,8 @@ namespace luautils
         auto name     = PChar->loc.zone->getName();
         auto filename = fmt::format("./scripts/zones/{}/Zone.lua", name);
 
+        ShowTraceFmt("luautils::AfterZoneIn: {} ({})", PChar->getName(), name);
+
         auto afterZoneInFramework = lua["InteractionGlobal"]["afterZoneIn"];
         auto afterZoneIn          = GetCacheEntryFromFilename(filename)["afterZoneIn"];
 
@@ -1964,6 +1981,8 @@ namespace luautils
 
         auto name     = PChar->loc.zone->getName();
         auto filename = fmt::format("./scripts/zones/{}/Zone.lua", name);
+
+        ShowTraceFmt("luautils::OnZoneOut: {} ({})", PChar->getName(), name);
 
         auto onZoneOutFramework = lua["InteractionGlobal"]["onZoneOut"];
         auto onZoneOut          = GetCacheEntryFromFilename(filename)["onZoneOut"];
@@ -2114,6 +2133,8 @@ namespace luautils
         }
         auto filename = fmt::format(fmt::runtime(pathFormat), zone, name);
 
+        ShowTraceFmt("luautils::OnTrigger: {} ({}) -> {}", name, zone, PNpc->getName());
+
         PChar->eventPreparation->targetEntity = PNpc;
         PChar->eventPreparation->scriptFile   = filename;
 
@@ -2135,6 +2156,9 @@ namespace luautils
     int32 OnEventUpdate(CCharEntity* PChar, uint16 eventID, uint32 result)
     {
         TracyZoneScoped;
+
+        ShowTraceFmt("luautils::OnEventUpdate: {} ({}), id: {}, result: {}",
+                     PChar->getName(), PChar->loc.zone->getName(), eventID, result);
 
         EventPrep* previousPrep = PChar->eventPreparation;
         PChar->eventPreparation = PChar->currentEvent;
@@ -2167,6 +2191,9 @@ namespace luautils
     {
         TracyZoneScoped;
 
+        ShowTrace("luautils::OnEventUpdate: {} ({}), string: {}",
+                  PChar->getName(), PChar->loc.zone->getName(), updateString);
+
         EventPrep* previousPrep = PChar->eventPreparation;
         PChar->eventPreparation = PChar->currentEvent;
 
@@ -2197,6 +2224,9 @@ namespace luautils
     int32 OnEventFinish(CCharEntity* PChar, uint16 eventID, uint32 result)
     {
         TracyZoneScoped;
+
+        ShowTraceFmt("luautils::OnEventFinish: {} ({}), id: {}, result: {}",
+                     PChar->getName(), PChar->loc.zone->getName(), eventID, result);
 
         EventPrep* previousPrep = PChar->eventPreparation;
         PChar->eventPreparation = PChar->currentEvent;
@@ -2245,6 +2275,8 @@ namespace luautils
         auto zone     = PChar->loc.zone->getName();
         auto name     = PNpc->getName();
         auto filename = fmt::format("./scripts/zones/{}/npcs/{}.lua", zone, name);
+
+        ShowTrace("luautils::OnTrade: {} ({}) -> {}", PChar->getName(), zone, name);
 
         PChar->eventPreparation->targetEntity = PNpc;
         PChar->eventPreparation->scriptFile   = filename;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Later commits in this PR will be adding more interesting/detailed logging for the backtrace - to encourage people to use it.

I'll also be taking a look at the crash handler in some common cases (null ptr deref, out of bounds access, access of garbage static_cast ptrs, etc.) to make sure the crash handler is engaged properly, and that the backtrace is populated.

I'll probably also add/update wiki articles to make sure it's beyond clear that "if crash" -> "go look at dmp folder"

I don't particularly want to add a double-click handler for Windows to determine if we should be adding a pause to terminal exit. There is a burden of competence that is undermined by doing too much hand-holding.