### PR TITLE
Wamouracampa Family

### DIFF
--- a/scripts/actions/mobskills/amber_scutum.lua
+++ b/scripts/actions/mobskills/amber_scutum.lua
@@ -13,15 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local status = mob:getStatusEffect(xi.effect.DEFENSE_BOOST)
-    local power  = 100
+    local power = 20
 
-    if status ~= nil then
-        -- This is as accurate as we get until effects applied by mob moves can use subpower..
-        power = status:getPower() * 2
-    end
-
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.DEFENSE_BOOST, power, 0, 60))
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.DEFENSE_BOOST, power, 0, 120))
 
     return xi.effect.DEFENSE_BOOST
 end

--- a/scripts/actions/mobskills/cannonball.lua
+++ b/scripts/actions/mobskills/cannonball.lua
@@ -20,7 +20,7 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits   = 1
     local accmod    = 1
-    local dmgmod    = 1.75
+    local dmgmod    = 1.5
     local offcratio = mob:getStat(xi.mod.DEF)
     local info      = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1.75, 2.125, 2.75, offcratio)
     local dmg       = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)

--- a/scripts/actions/mobskills/eclosion.lua
+++ b/scripts/actions/mobskills/eclosion.lua
@@ -1,0 +1,33 @@
+-----------------------------------
+-- Eclosion
+-- Morphs a Wamouracampa into a Wamoura
+-----------------------------------
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    mob:timer(4000, function(mobArg)
+        mobArg:setStatus(xi.status.INVISIBLE)
+        local mobID = mobArg:getID()
+        DespawnMob(mobID)
+        DisallowRespawn(mobID, true)
+
+        local wamoura = GetMobByID(mobID + 1)
+        wamoura:setSpawn(mobArg:getXPos(), mobArg:getYPos(), mobArg:getZPos())
+        SpawnMob(mobID + 1)
+
+        wamoura:addListener('DESPAWN', 'WAMOURA_DESPAWN', function(wamouraMob)
+            GetMobByID(mobID):setRespawnTime(GetMobRespawnTime(mobID))
+            DisallowRespawn(mobID, false)
+        end)
+    end)
+
+    skill:setMsg(xi.msg.basic.NONE)
+
+    return 0
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/heat_barrier.lua
+++ b/scripts/actions/mobskills/heat_barrier.lua
@@ -13,9 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    -- TODO: Enfire power, Blaze Spikes reduced power in Salvage zones
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.BLAZE_SPIKES, math.random(50, 67), 0, 180))
-    -- xi.mobskills.mobBuffMove(mob, xi.effect.ENFIRE, ???, 0, 180)
+    -- TODO: Blaze Spikes reduced power in Salvage zones
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.BLAZE_SPIKES, mob:getMainLvl() * 0.8, 0, 180))
+    xi.mobskills.mobBuffMove(mob, xi.effect.ENFIRE, mob:getMainLvl() * 0.4, 0, 300)
 
     return xi.effect.BLAZE_SPIKES
 end

--- a/scripts/actions/mobskills/thermal_pulse.lua
+++ b/scripts/actions/mobskills/thermal_pulse.lua
@@ -18,13 +18,15 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local damage = mob:getWeaponDmg() * 3
+    local damage = mob:getWeaponDmg() * 4.5
 
     damage = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.FIRE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT)
     damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 
     target:takeDamage(damage, mob, xi.attackType.MAGICAL, xi.damageType.FIRE)
-    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 20, 0, 60)
+
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 30, 90)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 100, 0, duration)
 
     return damage
 end

--- a/scripts/actions/mobskills/vitriolic_shower.lua
+++ b/scripts/actions/mobskills/vitriolic_shower.lua
@@ -13,9 +13,10 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local damage = math.floor(mob:getWeaponDmg() * 2.7)
+    damage = damage + math.random(0, 7.5 + math.max(mob:getStat(xi.mod.INT) - target:getStat(xi.mod.INT) * 4 / 3, 0))
 
     damage = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.FIRE, 2, xi.mobskills.magicalTpBonus.NO_EFFECT)
-    damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, nil, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
+    damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
 
     target:takeDamage(damage, mob, xi.attackType.MAGICAL, xi.damageType.FIRE)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BURN, math.random(15, 35), 3, 60)

--- a/scripts/actions/mobskills/vitriolic_spray.lua
+++ b/scripts/actions/mobskills/vitriolic_spray.lua
@@ -15,6 +15,7 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local damage = math.floor(mob:getWeaponDmg() * 2.7)
+    damage = damage + math.random(0, 4.5 + math.max(mob:getStat(xi.mod.INT) - target:getStat(xi.mod.INT), 0))
 
     damage = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.FIRE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT)
     damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, xi.mobskills.shadowBehavior.WIPE_SHADOWS)

--- a/scripts/enum/mob_skills.lua
+++ b/scripts/enum/mob_skills.lua
@@ -63,6 +63,8 @@ xi.mobSkill =
 
     RANGED_ATTACK_15  = 1949,
 
+    ECLOSION          = 1970,
+
     ROAR_3            = 2406,
 
     SHEEP_SONG_3      = 3433,

--- a/scripts/zones/Halvung/IDs.lua
+++ b/scripts/zones/Halvung/IDs.lua
@@ -32,6 +32,7 @@ zones[xi.zone.HALVUNG] =
     },
     mob =
     {
+        WAMOURA_OFFSET         = GetTableOfIDs('Wamoura'),
         BIG_BOMB               = GetFirstID('Big_Bomb'),
         GURFURLUR_THE_MENACING = GetFirstID('Gurfurlur_the_Menacing'),
         DEXTROSE               = GetFirstID('Dextrose'),

--- a/scripts/zones/Halvung/mobs/Wamouracampa.lua
+++ b/scripts/zones/Halvung/mobs/Wamouracampa.lua
@@ -1,7 +1,6 @@
 -----------------------------------
 -- Area: Halvung
 --  Mob: Wamouracampa
--- TODO: Damage resistances in streched and curled stances. Halting movement during stance change. Morph into Wamoura.
 -----------------------------------
 mixins = { require('scripts/mixins/families/wamouracampa') }
 -----------------------------------

--- a/scripts/zones/Lebros_Cavern/IDs.lua
+++ b/scripts/zones/Lebros_Cavern/IDs.lua
@@ -34,6 +34,7 @@ zones[xi.zone.LEBROS_CAVERN] =
 
     mob =
     {
+        WAMOURA_OFFSET = GetTableOfIDs('Ranch_Wamoura'),
         [xi.assault.mission.EXCAVATION_DUTY] =
         {
             MOBS_START =

--- a/scripts/zones/Lebros_Cavern/mobs/Ranch_Wamoura.lua
+++ b/scripts/zones/Lebros_Cavern/mobs/Ranch_Wamoura.lua
@@ -1,0 +1,18 @@
+-----------------------------------
+-- Area: Lebros Cavern (Wamoura Farm Raid)
+--  Mob: Ranch Wamoura
+-----------------------------------
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+end
+
+entity.onMobDespawn = function(mob)
+    local instance = mob:getInstance()
+    instance:setProgress(instance:getProgress() + 1)
+end
+
+return entity

--- a/scripts/zones/Lebros_Cavern/mobs/Ranch_Wamouracampa.lua
+++ b/scripts/zones/Lebros_Cavern/mobs/Ranch_Wamouracampa.lua
@@ -2,15 +2,40 @@
 -- Area: Lebros Cavern (Wamoura Farm Raid)
 --  Mob: Ranch Wamouracampa
 -----------------------------------
+mixins = { require('scripts/mixins/families/wamouracampa') }
+-----------------------------------
 local entity = {}
 
+entity.onMobSpawn = function(mob)
+    -- Eclosion should be between 10-20 minutes
+    if mob:getLocalVar('eclosionTime') ~= 0 then
+        mob:setLocalVar('eclosionTime', os.time() + math.random(600, 1200))
+    end
+end
+
 entity.onMobEngage = function(mob, target)
+end
+
+entity.onMobDisengage = function(mob)
+    if mob:getLocalVar('eclosionTime') ~= 0 then
+        mob:setLocalVar('eclosionTime', os.time() + math.random(600, 1200))
+    end
 end
 
 entity.onMobDeath = function(mob, player, optParams)
 end
 
+entity.onMobWeaponSkill = function(target, mob, skill)
+    if skill:getID() == 1970 then
+        mob:setLocalVar('usedEclosion', 1)
+    end
+end
+
 entity.onMobDespawn = function(mob)
+    if mob:getLocalVar('usedEclosion') ~= 0 then
+        return
+    end
+
     local instance = mob:getInstance()
     instance:setProgress(instance:getProgress() + 1)
 end

--- a/scripts/zones/Mount_Zhayolm/IDs.lua
+++ b/scripts/zones/Mount_Zhayolm/IDs.lua
@@ -41,6 +41,7 @@ zones[xi.zone.MOUNT_ZHAYOLM] =
     },
     mob =
     {
+        WAMOURA_OFFSET        = GetTableOfIDs('Wamoura'),
         ENERGETIC_ERUCA       = GetFirstID('Energetic_Eruca'),
         IGNAMOTH              = GetFirstID('Ignamoth'),
         CERBERUS              = GetFirstID('Cerberus'),

--- a/scripts/zones/Mount_Zhayolm/mobs/Wamoura_Prince.lua
+++ b/scripts/zones/Mount_Zhayolm/mobs/Wamoura_Prince.lua
@@ -1,7 +1,6 @@
 -----------------------------------
 -- Area: Mount Zhayolm
 --   NM: Wamoura Prince
--- TODO: Damage resistances in streched and curled stances. Halting movement during stance change. Morph into Wamoura.
 -----------------------------------
 mixins = { require('scripts/mixins/families/wamouracampa') }
 -----------------------------------

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -3050,7 +3050,7 @@ INSERT INTO `mob_groups` VALUES (19,2686,62,'Moblin_Billionaire',960,0,1704,0,0,
 INSERT INTO `mob_groups` VALUES (20,1341,62,'Fire_Elemental',960,4,831,0,0,74,75,0);
 INSERT INTO `mob_groups` VALUES (21,1426,62,'Friars_Lantern',960,0,908,0,0,72,76,0);
 INSERT INTO `mob_groups` VALUES (22,5210,62,'Flammeri',0,128,0,22500,5000,79,80,0);
-INSERT INTO `mob_groups` VALUES (23,4280,62,'Wamoura',960,0,2608,0,0,81,82,0);
+INSERT INTO `mob_groups` VALUES (23,4280,62,'Wamoura',960,128,2608,0,0,81,82,0);
 -- zone 62 group 24: free
 INSERT INTO `mob_groups` VALUES (25,4009,62,'Troll_Artilleryman',960,0,2473,0,0,78,83,0);
 INSERT INTO `mob_groups` VALUES (26,4012,62,'Troll_Combatant',960,0,2475,0,0,78,83,0);

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1983,7 +1983,7 @@ INSERT INTO `mob_skills` VALUES (1966,1330,'mind_purge',0,7.0,2000,1000,4,0,0,0,
 INSERT INTO `mob_skills` VALUES (1967,1331,'tribulation',1,15.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1968,1332,'immortal_anathema',1,15.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1969,1333,'reprobation',1,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1970,1714,'eclosion',0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1970,1344,'eclosion',0,7.0,4000,0,1,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1971,1715,'.',0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1972,1716,'.',0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1973,1717,'.',0,7.0,2000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

These changes focus on the Wamouracampa family introduced in the highly acclaimed expansion Treasures of Aht Urhgan released in 2006.

The first set of changes revolve around improving Wamouracampa mobskills.

The other changes implement the logic for Wamouracampa to evolve into Wamoura via eclosion. How this works is that we get all of the Wamoura in each zone that they are in and then in the wamouracampa family mixin the code looks to see if the mob is followed by a Wamoura. If it is then that means that the Wamouracampa can evolve into the Wamoura after being left alone for some amount of time. This works by the mob using the mobskill 'eclosion' which plays an animation and despawns the Wamouracampa and then spawns the Wamoura in its place.

## Retail Proof

[Jimmayus' Mob Sheet](https://docs.google.com/spreadsheets/d/1YBoveP-weMdidrirY-vPDzHyxbEI2ryECINlfCnFkLI/edit?gid=57955395#gid=57955395)
[Amber Scutum potency and duration capture](bd1f79e63e433162fcfd2a07538eee8290773656)
[Eclosion capture](https://discord.com/channels/443544205206355968/485290259404292096/1130203312516509727)

## Steps to test these changes

**NOTE:** Changes with Ranch Wamouracampa and Ranch Wamoura in Wamoura Farm Raid are untested since that assault is not fully implemented from what I can tell.

### Testing mobskills
`!gotoid 17027197`
`!exec target:useMobAbility(1815)`
`!exec target:useMobAbility(1816)`
`!exec target:useMobAbility(1817)`
`!exec target:useMobAbility(1818)`
`!exec target:useMobAbility(1819)`
`!exec target:useMobAbility(1820)`

### Testing Eclosion
`!gotoid 17027197`
Do not engage.
`!exec target:useMobAbility(1970)`
In order to test it naturally evolving you need to wait for 40-50 minutes or change the code to have a shorter eclosion time.
After the evolved Wamoura dies (`!hp 0`) the original Wamouracampa will respawn after about 6 minutes.