### PR TITLE
[lua] Add new WSC entry if WSC mod is nil for WS boosting items

### DIFF
--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -486,7 +486,11 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
 
     for parameterName, modList in pairs(modParameters) do
         if attacker:getMod(modList[2]) > 0 then
-            wsParams[parameterName] = wsParams[parameterName] + (attacker:getMod(modList[2]) / 100)
+            if wsParams[parameterName] then
+                wsParams[parameterName] = wsParams[parameterName] + (attacker:getMod(modList[2]) / 100)
+            else
+                wsParams[parameterName] = attacker:getMod(modList[2]) / 100
+            end
         end
     end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes #6082

## Steps to test these changes

Equip Utu grip, use a WS that _does not already have a DEX mod_, see no errors.