### PR TITLE
Trusts: Iroha and Iroha II Spell Implementation

### DIFF
--- a/scripts/actions/spells/trust/iroha.lua
+++ b/scripts/actions/spells/trust/iroha.lua
@@ -13,6 +13,23 @@ end
 
 spellObject.onMobSpawn = function(mob)
     xi.trust.message(mob, xi.trust.messageOffset.SPAWN)
+
+    -- TODO: Weaponskills
+    --       - Uncomment entries in mob_pool_mods.sql
+    --       - Needs Self Skillchain logic - if Meditate and Hagakure are available and 2000 TP
+    --       - Self Skillchain = Hanadoki > Choun > Fuga > Gachirin > Gachirin
+    --       - Needs entries in mob_skill_lists.sql
+    --       - Needs skillchain properties in mob_skills.sql
+    --       - Needs Weaponskill LUAs
+    --       - Holds 2500 TP To close Skillchains
+    -- TODO: Abilities
+    -- mob:addSimpleGambit(ai.t.SELF, ai.c.TP_LT, 1000, ai.r.JA, ai.s.SPECIFIC, xi.ja.MEDITATE)
+    -- mob:addSimpleGambit(ai.t.SELF, ai.c.NOT_STATUS, xi.effect.HAGAKURE, ai.r.JA, ai.s.SPECIFIC, xi.ja.HAGAKURE)
+    -- mob:addSimpleGambit(ai.t.SELF, ai.c.NOT_STATUS, xi.effect.HASSO, ai.r.JA, ai.s.SPECIFIC, xi.ja.HASSO)
+    -- mob:addSimpleGambit(ai.t.SELF, ai.c.HAS_TOP_ENMITY, 0, ai.r.JA, ai.s.SPECIFIC, xi.ja.THIRD_EYE)
+
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.NOT_STATUS, xi.effect.PROTECT, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.PROTECTRA_V)
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.NOT_STATUS, xi.effect.SHELL, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.SHELLRA_V)
 end
 
 spellObject.onMobDespawn = function(mob)
@@ -21,6 +38,8 @@ end
 
 spellObject.onMobDeath = function(mob)
     xi.trust.message(mob, xi.trust.messageOffset.DEATH)
+
+    -- TODO: Blessing of Phoenix (One Time Reraise with full HP) needs to be Implemented
 end
 
 return spellObject

--- a/scripts/actions/spells/trust/iroha_ii.lua
+++ b/scripts/actions/spells/trust/iroha_ii.lua
@@ -13,6 +13,29 @@ end
 
 spellObject.onMobSpawn = function(mob)
     xi.trust.message(mob, xi.trust.messageOffset.SPAWN)
+
+    -- TODO: Weaponskills
+    --       - Uncomment entries in mob_pool_mods.sql
+    --       - Gains 205 TP per hit
+    --       - Needs Self Skillchain logic - if Meditate is up and 2000 TP
+    --       - 4 Step Double Light Self Skillchain
+    --       - Kyori > Hanadoki > Suien > Gachirin
+    --       - Needs entries in mob_skill_lists.sql
+    --       - Needs skillchain properties in mob_skills.sql
+    --       - Needs Weaponskill LUAs
+    --       - Holds TP To close Skillchains
+    --       - Rise from Ashes:
+    --           * Weaponskill that restores 25% HP of All Party, Restores MP, and 500HP Stoneskin
+    --           * Will use if 3 or more party are < 25% hp or if a party member is asleep
+    -- TODO: Abilities
+    -- mob:addSimpleGambit(ai.t.SELF, ai.c.TP_LT, 1000, ai.r.JA, ai.s.SPECIFIC, xi.ja.MEDITATE)
+    -- mob:addSimpleGambit(ai.t.SELF, ai.c.NOT_STATUS, xi.effect.HASSO, ai.r.JA, ai.s.SPECIFIC, xi.ja.HASSO)
+    -- mob:addSimpleGambit(ai.t.SELF, ai.c.HAS_TOP_ENMITY, 0, ai.r.JA, ai.s.SPECIFIC, xi.ja.THIRD_EYE)
+
+    mob:addSimpleGambit(ai.t.TARGET, ai.c.MB_AVAILABLE, 0, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.FLARE_II)
+
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.NOT_STATUS, xi.effect.PROTECT, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.PROTECTRA_V)
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.NOT_STATUS, xi.effect.SHELL, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.SHELLRA_V)
 end
 
 spellObject.onMobDespawn = function(mob)

--- a/sql/mob_pool_mods.sql
+++ b/sql/mob_pool_mods.sql
@@ -654,8 +654,18 @@ INSERT INTO `mob_pool_mods` VALUES (5932,6,250,0);    -- MPP: 250
 INSERT INTO `mob_pool_mods` VALUES (5944,3,-10,0);      -- HPP: -10
 INSERT INTO `mob_pool_mods` VALUES (5944,6,35,0);       -- MPP: 35
 
+-- Trust: Iroha
+INSERT INTO `mob_pool_mods` VALUES (5997,6,50,0);       -- MPP: 50
+-- INSERT INTO `mob_pool_mods` VALUES (5997,880,400,0); -- Save TP: 400
+
 -- Trust: Prishe II
 INSERT INTO `mob_pool_mods` VALUES (6011,165,25,0);     -- CRITHITRATE: 25
+
+-- Trust: Iroha II
+INSERT INTO `mob_pool_mods` VALUES (6018,6,250,0);      -- MPP: 250
+INSERT INTO `mob_pool_mods` VALUES (6018,395,-85,0);    -- BLACK_MAGIC_CAST: -85
+-- INSERT INTO `mob_pool_mods` VALUES (6018,3,-5,0);    -- HPP: -5
+-- INSERT INTO `mob_pool_mods` VALUES (6018,880,400,0); -- Save TP: 400
 
 -- Trust: Shantotto II
 INSERT INTO `mob_pool_mods` VALUES (6019,3,-10,0);      -- HPP: -10

--- a/sql/mob_spell_lists.sql
+++ b/sql/mob_spell_lists.sql
@@ -4200,15 +4200,7 @@ INSERT INTO `mob_spell_lists` VALUES ('TRUST_AATT',408,273,31,55);  -- sleepga (
 INSERT INTO `mob_spell_lists` VALUES ('TRUST_AATT',408,274,56,255); -- sleepga_ii (56~255)
 
 -- TRUST_Iroha (410)
-INSERT INTO `mob_spell_lists` VALUES ('TRUST_Iroha',410,125,7,255);  -- protectra (7~255)
-INSERT INTO `mob_spell_lists` VALUES ('TRUST_Iroha',410,126,27,255); -- protectra_ii (27~255)
-INSERT INTO `mob_spell_lists` VALUES ('TRUST_Iroha',410,127,47,255); -- protectra_iii (47~255)
-INSERT INTO `mob_spell_lists` VALUES ('TRUST_Iroha',410,128,63,255); -- protectra_iv (63~255)
 INSERT INTO `mob_spell_lists` VALUES ('TRUST_Iroha',410,129,75,255); -- protectra_v (75~255)
-INSERT INTO `mob_spell_lists` VALUES ('TRUST_Iroha',410,130,17,255); -- shellra (17~255)
-INSERT INTO `mob_spell_lists` VALUES ('TRUST_Iroha',410,131,37,255); -- shellra_ii (37~255)
-INSERT INTO `mob_spell_lists` VALUES ('TRUST_Iroha',410,132,57,255); -- shellra_iii (57~255)
-INSERT INTO `mob_spell_lists` VALUES ('TRUST_Iroha',410,133,68,255); -- shellra_iv (68~255)
 INSERT INTO `mob_spell_lists` VALUES ('TRUST_Iroha',410,134,75,255); -- shellra_v (75~255)
 
 -- TRUST_Ygnas (411)
@@ -4394,15 +4386,7 @@ INSERT INTO `mob_spell_lists` VALUES ('TRUST_Arciela_II',426,845,48,255); -- flu
 INSERT INTO `mob_spell_lists` VALUES ('TRUST_Arciela_II',426,846,96,255); -- flurry_ii (96~255)
 
 -- TRUST_Iroha_II (427)
-INSERT INTO `mob_spell_lists` VALUES ('TRUST_Iroha_II',427,125,7,255);  -- protectra (7~255)
-INSERT INTO `mob_spell_lists` VALUES ('TRUST_Iroha_II',427,126,27,255); -- protectra_ii (27~255)
-INSERT INTO `mob_spell_lists` VALUES ('TRUST_Iroha_II',427,127,47,255); -- protectra_iii (47~255)
-INSERT INTO `mob_spell_lists` VALUES ('TRUST_Iroha_II',427,128,63,255); -- protectra_iv (63~255)
 INSERT INTO `mob_spell_lists` VALUES ('TRUST_Iroha_II',427,129,75,255); -- protectra_v (75~255)
-INSERT INTO `mob_spell_lists` VALUES ('TRUST_Iroha_II',427,130,17,255); -- shellra (17~255)
-INSERT INTO `mob_spell_lists` VALUES ('TRUST_Iroha_II',427,131,37,255); -- shellra_ii (37~255)
-INSERT INTO `mob_spell_lists` VALUES ('TRUST_Iroha_II',427,132,57,255); -- shellra_iii (57~255)
-INSERT INTO `mob_spell_lists` VALUES ('TRUST_Iroha_II',427,133,68,255); -- shellra_iv (68~255)
 INSERT INTO `mob_spell_lists` VALUES ('TRUST_Iroha_II',427,134,75,255); -- shellra_v (75~255)
 INSERT INTO `mob_spell_lists` VALUES ('TRUST_Iroha_II',427,205,75,255); -- flare_ii (75~255)
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds spell gambits for Iroha and Iroha II.
Adds `MPP` mods for both, and gives Iroha II `BLACK_MAGIC_CAST` -85 for her "near instacast" Flare II.
Removes lower tier versions of Protectra and Shellra from both spell lists.
Adds TODO messages for everything that still needs to be implemented.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
I play tested the changes made to Iroha and Iroha II in a party with Fablinix and Moogle.