### PR TITLE
[Digging] Part 2. Clean core and implement fatigue properly

### DIFF
--- a/scripts/globals/chocobo_digging.lua
+++ b/scripts/globals/chocobo_digging.lua
@@ -827,7 +827,7 @@ xi.chocoboDig.start = function(player)
         return false -- This means we do not send a digging animation.
     end
 
-    -- Handle  AMK mission 7 (index 6) exception.
+    -- Handle AMK mission 7 (index 6) exception.
     local zoneId = player:getZoneID()
     local text   = zones[zoneId].text
 
@@ -854,6 +854,25 @@ xi.chocoboDig.start = function(player)
 
         return true
     end
+
+    -- Handle auto-fail from position.
+    local currentX = player:getXPos()
+    local currentZ = player:getZPos()
+    local lastX    = player:getLocalVar('[DIG]LastXPos')
+    local lastZ    = player:getLocalVar('[DIG]LastZPos')
+
+    if
+        currentX >= lastX - 2 and currentX <= lastX + 2 and -- Check current X axis to see if you are too close to your last X.
+        currentZ >= lastZ - 2 and currentZ <= lastZ + 2     -- Check current Z axis to see if you are too close to your last Z.
+    then
+        player:messageText(player, text.FIND_NOTHING)
+        player:setLocalVar('[DIG]LastDigTime', os.time())
+
+        return true
+    end
+
+    player:setLocalVar('[DIG]LastXPos', currentX)
+    player:setLocalVar('[DIG]LastZPos', currentZ)
 
     -- Handel actual digging.
     local roll = math.random(0, 100)

--- a/scripts/globals/chocobo_digging.lua
+++ b/scripts/globals/chocobo_digging.lua
@@ -10,6 +10,69 @@ require('scripts/missions/amk/helpers')
 xi = xi or {}
 xi.chocoboDig = xi.chocoboDig or {}
 
+-- This contais all digging zones with the ones without loot tables defined commented out.
+local diggingZoneList =
+set{
+    xi.zone.CARPENTERS_LANDING,
+    xi.zone.BIBIKI_BAY,
+    -- xi.zone.ULEGUERAND_RANGE,
+    -- xi.zone.ATTOHWA_CHASM,
+    -- xi.zone.LUFAISE_MEADOWS,
+    -- xi.zone.MISAREAUX_COAST,
+    xi.zone.WAJAOM_WOODLANDS,
+    xi.zone.BHAFLAU_THICKETS,
+    -- xi.zone.CAEDARVA_MIRE,
+    -- xi.zone.EAST_RONFAURE_S,
+    -- xi.zone.JUGNER_FOREST_S,
+    -- xi.zone.VUNKERL_INLET_S,
+    -- xi.zone.BATALLIA_DOWNS_S,
+    -- xi.zone.NORTH_GUSTABERG_S,
+    -- xi.zone.GRAUBERG_S,
+    -- xi.zone.PASHHOW_MARSHLANDS_S,
+    -- xi.zone.ROLANBERRY_FIELDS_S,
+    -- xi.zone.WEST_SARUTABARUTA_S,
+    -- xi.zone.FORT_KARUGO_NARUGO_S,
+    -- xi.zone.MERIPHATAUD_MOUNTAINS_S,
+    -- xi.zone.SAUROMUGUE_CHAMPAIGN_S,
+    xi.zone.WEST_RONFAURE,
+    xi.zone.EAST_RONFAURE,
+    xi.zone.LA_THEINE_PLATEAU,
+    xi.zone.VALKURM_DUNES,
+    xi.zone.JUGNER_FOREST,
+    xi.zone.BATALLIA_DOWNS,
+    xi.zone.NORTH_GUSTABERG,
+    xi.zone.SOUTH_GUSTABERG,
+    xi.zone.KONSCHTAT_HIGHLANDS,
+    xi.zone.PASHHOW_MARSHLANDS,
+    xi.zone.ROLANBERRY_FIELDS,
+    -- xi.zone.BEAUCEDINE_GLACIER,
+    -- xi.zone.XARCABARD,
+    -- xi.zone.CAPE_TERIGGAN,
+    xi.zone.EASTERN_ALTEPA_DESERT,
+    xi.zone.WEST_SARUTABARUTA,
+    xi.zone.EAST_SARUTABARUTA,
+    xi.zone.TAHRONGI_CANYON,
+    xi.zone.BUBURIMU_PENINSULA,
+    xi.zone.MERIPHATAUD_MOUNTAINS,
+    xi.zone.SAUROMUGUE_CHAMPAIGN,
+    xi.zone.THE_SANCTUARY_OF_ZITAH,
+    xi.zone.YUHTUNGA_JUNGLE,
+    xi.zone.YHOATOR_JUNGLE,
+    xi.zone.WESTERN_ALTEPA_DESERT,
+    -- xi.zone.QUFIM_ISLAND,
+    -- xi.zone.BEHEMOTHS_DOMINION,
+    -- xi.zone.VALLEY_OF_SORROWS,
+    -- xi.zone.BEAUCEDINE_GLACIER_S,
+    -- xi.zone.XARCABARD_S,
+    -- xi.zone.YAHSE_HUNTING_GROUNDS,
+    -- xi.zone.CEIZAK_BATTLEGROUNDS,
+    -- xi.zone.FORET_DE_HENNETIEL,
+    -- xi.zone.YORCIA_WEALD,
+    -- xi.zone.MORIMAR_BASALT_FIELDS,
+    -- xi.zone.MARJAMI_RAVINE,
+    -- xi.zone.KAMIHR_DRIFTS,
+}
+
 local digReq =
 {
     NO_REQS = 0,
@@ -711,12 +774,20 @@ local function updateZoneDigCount(zoneId, increment)
 end
 ]]--
 
--- This function handles cooldowns before digging can be attempted, and by extension, before any animation is sent.
+-- This function handles zone and cooldown checks before digging can be attempted, before any animation is sent.
 local function checkDiggingCooldowns(player)
-    local currentTime = os.time()
-    local skillRank   = player:getSkillRank(xi.skill.DIG)
+    -- Check if current zone has digging enabled.
+    local isAllowedZone = diggingZoneList[player:getZoneID()] or false
+
+    if not isAllowedZone then
+        player:messageBasic(xi.msg.basic.WAIT_LONGER, 0, 0)
+
+        return false
+    end
 
     -- Check digging cooldowns.
+    local currentTime  = os.time()
+    local skillRank    = player:getSkillRank(xi.skill.DIG)
     local zoneCooldown = player:getLocalVar('ZoneInTime') + utils.clamp(60 - skillRank * 5, 10, 60)
     local digCooldown  = player:getLocalVar('[DIG]LastDigTime') + utils.clamp(15 - skillRank * 5, 3, 16)
 

--- a/scripts/zones/Batallia_Downs/Zone.lua
+++ b/scripts/zones/Batallia_Downs/Zone.lua
@@ -7,8 +7,8 @@ require('scripts/quests/i_can_hear_a_rainbow')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player, precheck)
-    return xi.chocoboDig.start(player, precheck)
+zoneObject.onChocoboDig = function(player)
+    return xi.chocoboDig.start(player)
 end
 
 local function registerRegionAroundNPC(zone, NPCID, zoneID)

--- a/scripts/zones/Batallia_Downs/Zone.lua
+++ b/scripts/zones/Batallia_Downs/Zone.lua
@@ -7,10 +7,6 @@ require('scripts/quests/i_can_hear_a_rainbow')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player)
-    return xi.chocoboDig.start(player)
-end
-
 local function registerRegionAroundNPC(zone, NPCID, zoneID)
     local npc      = GetNPCByID(NPCID)
     local x        = npc:getXPos()

--- a/scripts/zones/Bhaflau_Thickets/Zone.lua
+++ b/scripts/zones/Bhaflau_Thickets/Zone.lua
@@ -5,10 +5,6 @@ local ID = zones[xi.zone.BHAFLAU_THICKETS]
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player)
-    return xi.chocoboDig.start(player)
-end
-
 zoneObject.onInitialize = function(zone)
     UpdateNMSpawnPoint(ID.mob.HARVESTMAN)
     GetMobByID(ID.mob.HARVESTMAN):setRespawnTime(math.random(900, 10800))

--- a/scripts/zones/Bhaflau_Thickets/Zone.lua
+++ b/scripts/zones/Bhaflau_Thickets/Zone.lua
@@ -5,8 +5,8 @@ local ID = zones[xi.zone.BHAFLAU_THICKETS]
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player, precheck)
-    return xi.chocoboDig.start(player, precheck)
+zoneObject.onChocoboDig = function(player)
+    return xi.chocoboDig.start(player)
 end
 
 zoneObject.onInitialize = function(zone)

--- a/scripts/zones/Bibiki_Bay/Zone.lua
+++ b/scripts/zones/Bibiki_Bay/Zone.lua
@@ -3,10 +3,6 @@
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player)
-    return xi.chocoboDig.start(player)
-end
-
 zoneObject.onInitialize = function(zone)
     zone:registerTriggerArea(1,  474, -10,  667,  511, 10,  708) -- Manaclipper while docked at Sunset Docks
     zone:registerTriggerArea(2, -410, -10, -385, -371, 10, -343) -- Manaclipper while docked at Purgonorgo Isle

--- a/scripts/zones/Bibiki_Bay/Zone.lua
+++ b/scripts/zones/Bibiki_Bay/Zone.lua
@@ -3,8 +3,8 @@
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player, precheck)
-    return xi.chocoboDig.start(player, precheck)
+zoneObject.onChocoboDig = function(player)
+    return xi.chocoboDig.start(player)
 end
 
 zoneObject.onInitialize = function(zone)

--- a/scripts/zones/Buburimu_Peninsula/Zone.lua
+++ b/scripts/zones/Buburimu_Peninsula/Zone.lua
@@ -7,10 +7,6 @@ require('scripts/missions/amk/helpers')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player)
-    return xi.chocoboDig.start(player)
-end
-
 zoneObject.onInitialize = function(zone)
     local hour = VanadielHour()
 

--- a/scripts/zones/Buburimu_Peninsula/Zone.lua
+++ b/scripts/zones/Buburimu_Peninsula/Zone.lua
@@ -7,8 +7,8 @@ require('scripts/missions/amk/helpers')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player, precheck)
-    return xi.chocoboDig.start(player, precheck)
+zoneObject.onChocoboDig = function(player)
+    return xi.chocoboDig.start(player)
 end
 
 zoneObject.onInitialize = function(zone)

--- a/scripts/zones/Carpenters_Landing/Zone.lua
+++ b/scripts/zones/Carpenters_Landing/Zone.lua
@@ -6,10 +6,6 @@ local ID = zones[xi.zone.CARPENTERS_LANDING]
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player)
-    return xi.chocoboDig.start(player)
-end
-
 zoneObject.onInitialize = function(zone)
     UpdateNMSpawnPoint(ID.mob.TEMPEST_TIGON)
     GetMobByID(ID.mob.TEMPEST_TIGON):setRespawnTime(math.random(900, 10800))

--- a/scripts/zones/Carpenters_Landing/Zone.lua
+++ b/scripts/zones/Carpenters_Landing/Zone.lua
@@ -6,8 +6,8 @@ local ID = zones[xi.zone.CARPENTERS_LANDING]
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player, precheck)
-    return xi.chocoboDig.start(player, precheck)
+zoneObject.onChocoboDig = function(player)
+    return xi.chocoboDig.start(player)
 end
 
 zoneObject.onInitialize = function(zone)

--- a/scripts/zones/East_Ronfaure/Zone.lua
+++ b/scripts/zones/East_Ronfaure/Zone.lua
@@ -5,10 +5,6 @@ require('scripts/quests/i_can_hear_a_rainbow')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player)
-    return xi.chocoboDig.start(player)
-end
-
 zoneObject.onInitialize = function(zone)
     xi.helm.initZone(zone, xi.helmType.LOGGING)
 end

--- a/scripts/zones/East_Ronfaure/Zone.lua
+++ b/scripts/zones/East_Ronfaure/Zone.lua
@@ -5,8 +5,8 @@ require('scripts/quests/i_can_hear_a_rainbow')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player, precheck)
-    return xi.chocoboDig.start(player, precheck)
+zoneObject.onChocoboDig = function(player)
+    return xi.chocoboDig.start(player)
 end
 
 zoneObject.onInitialize = function(zone)

--- a/scripts/zones/East_Sarutabaruta/Zone.lua
+++ b/scripts/zones/East_Sarutabaruta/Zone.lua
@@ -6,10 +6,6 @@ require('scripts/quests/i_can_hear_a_rainbow')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player)
-    return xi.chocoboDig.start(player)
-end
-
 zoneObject.onInitialize = function(zone)
     UpdateNMSpawnPoint(ID.mob.DUKE_DECAPOD)
     GetMobByID(ID.mob.DUKE_DECAPOD):setRespawnTime(math.random(3600, 4200))

--- a/scripts/zones/East_Sarutabaruta/Zone.lua
+++ b/scripts/zones/East_Sarutabaruta/Zone.lua
@@ -6,8 +6,8 @@ require('scripts/quests/i_can_hear_a_rainbow')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player, precheck)
-    return xi.chocoboDig.start(player, precheck)
+zoneObject.onChocoboDig = function(player)
+    return xi.chocoboDig.start(player)
 end
 
 zoneObject.onInitialize = function(zone)

--- a/scripts/zones/Eastern_Altepa_Desert/Zone.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/Zone.lua
@@ -7,10 +7,6 @@ require('scripts/missions/amk/helpers')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player)
-    return xi.chocoboDig.start(player)
-end
-
 zoneObject.onInitialize = function(zone)
     UpdateNMSpawnPoint(ID.mob.NANDI)
     GetMobByID(ID.mob.NANDI):setRespawnTime(math.random(3600, 4200))

--- a/scripts/zones/Eastern_Altepa_Desert/Zone.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/Zone.lua
@@ -7,8 +7,8 @@ require('scripts/missions/amk/helpers')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player, precheck)
-    return xi.chocoboDig.start(player, precheck)
+zoneObject.onChocoboDig = function(player)
+    return xi.chocoboDig.start(player)
 end
 
 zoneObject.onInitialize = function(zone)

--- a/scripts/zones/Jugner_Forest/Zone.lua
+++ b/scripts/zones/Jugner_Forest/Zone.lua
@@ -7,10 +7,6 @@ require('scripts/missions/amk/helpers')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player)
-    return xi.chocoboDig.start(player)
-end
-
 zoneObject.onInitialize = function(zone)
     zone:registerTriggerArea(1, -484, 10, 292, 0, 0, 0) -- Sets Mark for "Under Oath" Quest cutscene.
 

--- a/scripts/zones/Jugner_Forest/Zone.lua
+++ b/scripts/zones/Jugner_Forest/Zone.lua
@@ -7,8 +7,8 @@ require('scripts/missions/amk/helpers')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player, precheck)
-    return xi.chocoboDig.start(player, precheck)
+zoneObject.onChocoboDig = function(player)
+    return xi.chocoboDig.start(player)
 end
 
 zoneObject.onInitialize = function(zone)

--- a/scripts/zones/Konschtat_Highlands/Zone.lua
+++ b/scripts/zones/Konschtat_Highlands/Zone.lua
@@ -7,10 +7,6 @@ require('scripts/missions/amk/helpers')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player)
-    return xi.chocoboDig.start(player)
-end
-
 zoneObject.onInitialize = function(zone)
     xi.chocobo.initZone(zone)
     xi.voidwalker.zoneOnInit(zone)

--- a/scripts/zones/Konschtat_Highlands/Zone.lua
+++ b/scripts/zones/Konschtat_Highlands/Zone.lua
@@ -7,8 +7,8 @@ require('scripts/missions/amk/helpers')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player, precheck)
-    return xi.chocoboDig.start(player, precheck)
+zoneObject.onChocoboDig = function(player)
+    return xi.chocoboDig.start(player)
 end
 
 zoneObject.onInitialize = function(zone)

--- a/scripts/zones/La_Theine_Plateau/Zone.lua
+++ b/scripts/zones/La_Theine_Plateau/Zone.lua
@@ -7,8 +7,8 @@ require('scripts/quests/i_can_hear_a_rainbow')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player, precheck)
-    return xi.chocoboDig.start(player, precheck)
+zoneObject.onChocoboDig = function(player)
+    return xi.chocoboDig.start(player)
 end
 
 zoneObject.onInitialize = function(zone)

--- a/scripts/zones/La_Theine_Plateau/Zone.lua
+++ b/scripts/zones/La_Theine_Plateau/Zone.lua
@@ -7,10 +7,6 @@ require('scripts/quests/i_can_hear_a_rainbow')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player)
-    return xi.chocoboDig.start(player)
-end
-
 zoneObject.onInitialize = function(zone)
     laTheineGlobal.moveFallenEgg()
     xi.chocobo.initZone(zone)

--- a/scripts/zones/Meriphataud_Mountains/Zone.lua
+++ b/scripts/zones/Meriphataud_Mountains/Zone.lua
@@ -7,10 +7,6 @@ require('scripts/missions/amk/helpers')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player)
-    return xi.chocoboDig.start(player)
-end
-
 zoneObject.onInitialize = function(zone)
     UpdateNMSpawnPoint(ID.mob.WARAXE_BEAK)
     GetMobByID(ID.mob.WARAXE_BEAK):setRespawnTime(math.random(900, 10800))

--- a/scripts/zones/Meriphataud_Mountains/Zone.lua
+++ b/scripts/zones/Meriphataud_Mountains/Zone.lua
@@ -7,8 +7,8 @@ require('scripts/missions/amk/helpers')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player, precheck)
-    return xi.chocoboDig.start(player, precheck)
+zoneObject.onChocoboDig = function(player)
+    return xi.chocoboDig.start(player)
 end
 
 zoneObject.onInitialize = function(zone)

--- a/scripts/zones/North_Gustaberg/Zone.lua
+++ b/scripts/zones/North_Gustaberg/Zone.lua
@@ -5,10 +5,6 @@ require('scripts/quests/i_can_hear_a_rainbow')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player)
-    return xi.chocoboDig.start(player)
-end
-
 zoneObject.onInitialize = function(zone)
     xi.conq.setRegionalConquestOverseers(zone:getRegionID())
     xi.voidwalker.zoneOnInit(zone)

--- a/scripts/zones/North_Gustaberg/Zone.lua
+++ b/scripts/zones/North_Gustaberg/Zone.lua
@@ -5,8 +5,8 @@ require('scripts/quests/i_can_hear_a_rainbow')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player, precheck)
-    return xi.chocoboDig.start(player, precheck)
+zoneObject.onChocoboDig = function(player)
+    return xi.chocoboDig.start(player)
 end
 
 zoneObject.onInitialize = function(zone)

--- a/scripts/zones/Pashhow_Marshlands/Zone.lua
+++ b/scripts/zones/Pashhow_Marshlands/Zone.lua
@@ -7,10 +7,6 @@ require('scripts/missions/amk/helpers')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player)
-    return xi.chocoboDig.start(player)
-end
-
 zoneObject.onInitialize = function(zone)
     UpdateNMSpawnPoint(ID.mob.BOWHO_WARMONGER)
     GetMobByID(ID.mob.BOWHO_WARMONGER):setRespawnTime(75600 + math.random(600, 900)) -- 21 hours, plus 10 to 15 min

--- a/scripts/zones/Pashhow_Marshlands/Zone.lua
+++ b/scripts/zones/Pashhow_Marshlands/Zone.lua
@@ -7,8 +7,8 @@ require('scripts/missions/amk/helpers')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player, precheck)
-    return xi.chocoboDig.start(player, precheck)
+zoneObject.onChocoboDig = function(player)
+    return xi.chocoboDig.start(player)
 end
 
 zoneObject.onInitialize = function(zone)

--- a/scripts/zones/Rolanberry_Fields/Zone.lua
+++ b/scripts/zones/Rolanberry_Fields/Zone.lua
@@ -6,8 +6,8 @@ require('scripts/quests/i_can_hear_a_rainbow')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player, precheck)
-    return xi.chocoboDig.start(player, precheck)
+zoneObject.onChocoboDig = function(player)
+    return xi.chocoboDig.start(player)
 end
 
 zoneObject.onInitialize = function(zone)

--- a/scripts/zones/Rolanberry_Fields/Zone.lua
+++ b/scripts/zones/Rolanberry_Fields/Zone.lua
@@ -6,10 +6,6 @@ require('scripts/quests/i_can_hear_a_rainbow')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player)
-    return xi.chocoboDig.start(player)
-end
-
 zoneObject.onInitialize = function(zone)
     UpdateNMSpawnPoint(ID.mob.SIMURGH)
     GetMobByID(ID.mob.SIMURGH):setRespawnTime(math.random(900, 7200))

--- a/scripts/zones/Sauromugue_Champaign/Zone.lua
+++ b/scripts/zones/Sauromugue_Champaign/Zone.lua
@@ -6,8 +6,8 @@ require('scripts/quests/i_can_hear_a_rainbow')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player, precheck)
-    return xi.chocoboDig.start(player, precheck)
+zoneObject.onChocoboDig = function(player)
+    return xi.chocoboDig.start(player)
 end
 
 zoneObject.onInitialize = function(zone)

--- a/scripts/zones/Sauromugue_Champaign/Zone.lua
+++ b/scripts/zones/Sauromugue_Champaign/Zone.lua
@@ -6,10 +6,6 @@ require('scripts/quests/i_can_hear_a_rainbow')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player)
-    return xi.chocoboDig.start(player)
-end
-
 zoneObject.onInitialize = function(zone)
     UpdateNMSpawnPoint(ID.mob.ROC)
     GetMobByID(ID.mob.ROC):setRespawnTime(math.random(900, 10800))

--- a/scripts/zones/South_Gustaberg/Zone.lua
+++ b/scripts/zones/South_Gustaberg/Zone.lua
@@ -5,8 +5,8 @@ require('scripts/quests/i_can_hear_a_rainbow')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player, precheck)
-    return xi.chocoboDig.start(player, precheck)
+zoneObject.onChocoboDig = function(player)
+    return xi.chocoboDig.start(player)
 end
 
 zoneObject.onInitialize = function(zone)

--- a/scripts/zones/South_Gustaberg/Zone.lua
+++ b/scripts/zones/South_Gustaberg/Zone.lua
@@ -5,10 +5,6 @@ require('scripts/quests/i_can_hear_a_rainbow')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player)
-    return xi.chocoboDig.start(player)
-end
-
 zoneObject.onInitialize = function(zone)
 end
 

--- a/scripts/zones/Tahrongi_Canyon/Zone.lua
+++ b/scripts/zones/Tahrongi_Canyon/Zone.lua
@@ -7,8 +7,8 @@ require('scripts/missions/amk/helpers')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player, precheck)
-    return xi.chocoboDig.start(player, precheck)
+zoneObject.onChocoboDig = function(player)
+    return xi.chocoboDig.start(player)
 end
 
 zoneObject.onInitialize = function(zone)

--- a/scripts/zones/Tahrongi_Canyon/Zone.lua
+++ b/scripts/zones/Tahrongi_Canyon/Zone.lua
@@ -7,10 +7,6 @@ require('scripts/missions/amk/helpers')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player)
-    return xi.chocoboDig.start(player)
-end
-
 zoneObject.onInitialize = function(zone)
     xi.helm.initZone(zone, xi.helmType.EXCAVATION)
     xi.chocobo.initZone(zone)

--- a/scripts/zones/The_Sanctuary_of_ZiTah/Zone.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/Zone.lua
@@ -7,10 +7,6 @@ require('scripts/missions/amk/helpers')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player)
-    return xi.chocoboDig.start(player)
-end
-
 zoneObject.onInitialize = function(zone)
     GetMobByID(ID.mob.NOBLE_MOLD):setLocalVar('pop', os.time() + math.random(43200, 57600)) -- 12 to 16 hr
 

--- a/scripts/zones/The_Sanctuary_of_ZiTah/Zone.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/Zone.lua
@@ -7,8 +7,8 @@ require('scripts/missions/amk/helpers')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player, precheck)
-    return xi.chocoboDig.start(player, precheck)
+zoneObject.onChocoboDig = function(player)
+    return xi.chocoboDig.start(player)
 end
 
 zoneObject.onInitialize = function(zone)

--- a/scripts/zones/Valkurm_Dunes/Zone.lua
+++ b/scripts/zones/Valkurm_Dunes/Zone.lua
@@ -7,10 +7,6 @@ require('scripts/missions/amk/helpers')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player)
-    return xi.chocoboDig.start(player)
-end
-
 zoneObject.onInitialize = function(zone)
     xi.conq.setRegionalConquestOverseers(zone:getRegionID())
     xi.mogTablet.onZoneInitialize(zone)

--- a/scripts/zones/Valkurm_Dunes/Zone.lua
+++ b/scripts/zones/Valkurm_Dunes/Zone.lua
@@ -7,8 +7,8 @@ require('scripts/missions/amk/helpers')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player, precheck)
-    return xi.chocoboDig.start(player, precheck)
+zoneObject.onChocoboDig = function(player)
+    return xi.chocoboDig.start(player)
 end
 
 zoneObject.onInitialize = function(zone)

--- a/scripts/zones/Wajaom_Woodlands/Zone.lua
+++ b/scripts/zones/Wajaom_Woodlands/Zone.lua
@@ -3,10 +3,6 @@
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player)
-    return xi.chocoboDig.start(player)
-end
-
 zoneObject.onInitialize = function(zone)
     xi.helm.initZone(zone, xi.helmType.HARVESTING)
     xi.chocobo.initZone(zone)

--- a/scripts/zones/Wajaom_Woodlands/Zone.lua
+++ b/scripts/zones/Wajaom_Woodlands/Zone.lua
@@ -3,8 +3,8 @@
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player, precheck)
-    return xi.chocoboDig.start(player, precheck)
+zoneObject.onChocoboDig = function(player)
+    return xi.chocoboDig.start(player)
 end
 
 zoneObject.onInitialize = function(zone)

--- a/scripts/zones/West_Ronfaure/Zone.lua
+++ b/scripts/zones/West_Ronfaure/Zone.lua
@@ -5,10 +5,6 @@ require('scripts/quests/i_can_hear_a_rainbow')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player)
-    return xi.chocoboDig.start(player)
-end
-
 zoneObject.onInitialize = function(zone)
     xi.conq.setRegionalConquestOverseers(zone:getRegionID())
 end

--- a/scripts/zones/West_Ronfaure/Zone.lua
+++ b/scripts/zones/West_Ronfaure/Zone.lua
@@ -5,8 +5,8 @@ require('scripts/quests/i_can_hear_a_rainbow')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player, precheck)
-    return xi.chocoboDig.start(player, precheck)
+zoneObject.onChocoboDig = function(player)
+    return xi.chocoboDig.start(player)
 end
 
 zoneObject.onInitialize = function(zone)

--- a/scripts/zones/West_Sarutabaruta/Zone.lua
+++ b/scripts/zones/West_Sarutabaruta/Zone.lua
@@ -5,10 +5,6 @@ require('scripts/quests/i_can_hear_a_rainbow')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player)
-    return xi.chocoboDig.start(player)
-end
-
 zoneObject.onInitialize = function(zone)
     xi.conq.setRegionalConquestOverseers(zone:getRegionID())
 

--- a/scripts/zones/West_Sarutabaruta/Zone.lua
+++ b/scripts/zones/West_Sarutabaruta/Zone.lua
@@ -5,8 +5,8 @@ require('scripts/quests/i_can_hear_a_rainbow')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player, precheck)
-    return xi.chocoboDig.start(player, precheck)
+zoneObject.onChocoboDig = function(player)
+    return xi.chocoboDig.start(player)
 end
 
 zoneObject.onInitialize = function(zone)

--- a/scripts/zones/Western_Altepa_Desert/Zone.lua
+++ b/scripts/zones/Western_Altepa_Desert/Zone.lua
@@ -7,10 +7,6 @@ require('scripts/missions/amk/helpers')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player)
-    return xi.chocoboDig.start(player)
-end
-
 zoneObject.onInitialize = function(zone)
     UpdateNMSpawnPoint(ID.mob.KING_VINEGARROON)
     GetMobByID(ID.mob.KING_VINEGARROON):setRespawnTime(math.random(900, 10800))

--- a/scripts/zones/Western_Altepa_Desert/Zone.lua
+++ b/scripts/zones/Western_Altepa_Desert/Zone.lua
@@ -7,8 +7,8 @@ require('scripts/missions/amk/helpers')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player, precheck)
-    return xi.chocoboDig.start(player, precheck)
+zoneObject.onChocoboDig = function(player)
+    return xi.chocoboDig.start(player)
 end
 
 zoneObject.onInitialize = function(zone)

--- a/scripts/zones/Yhoator_Jungle/Zone.lua
+++ b/scripts/zones/Yhoator_Jungle/Zone.lua
@@ -7,10 +7,6 @@ require('scripts/missions/amk/helpers')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player)
-    return xi.chocoboDig.start(player)
-end
-
 zoneObject.onInitialize = function(zone)
     UpdateNMSpawnPoint(ID.mob.WOODLAND_SAGE)
     GetMobByID(ID.mob.WOODLAND_SAGE):setRespawnTime(math.random(900, 10800))

--- a/scripts/zones/Yhoator_Jungle/Zone.lua
+++ b/scripts/zones/Yhoator_Jungle/Zone.lua
@@ -7,8 +7,8 @@ require('scripts/missions/amk/helpers')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player, precheck)
-    return xi.chocoboDig.start(player, precheck)
+zoneObject.onChocoboDig = function(player)
+    return xi.chocoboDig.start(player)
 end
 
 zoneObject.onInitialize = function(zone)

--- a/scripts/zones/Yuhtunga_Jungle/Zone.lua
+++ b/scripts/zones/Yuhtunga_Jungle/Zone.lua
@@ -7,10 +7,6 @@ require('scripts/missions/amk/helpers')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player)
-    return xi.chocoboDig.start(player)
-end
-
 zoneObject.onInitialize = function(zone)
     xi.conq.setRegionalConquestOverseers(zone:getRegionID())
 

--- a/scripts/zones/Yuhtunga_Jungle/Zone.lua
+++ b/scripts/zones/Yuhtunga_Jungle/Zone.lua
@@ -7,8 +7,8 @@ require('scripts/missions/amk/helpers')
 -----------------------------------
 local zoneObject = {}
 
-zoneObject.onChocoboDig = function(player, precheck)
-    return xi.chocoboDig.start(player, precheck)
+zoneObject.onChocoboDig = function(player)
+    return xi.chocoboDig.start(player)
 end
 
 zoneObject.onInitialize = function(zone)

--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -291,7 +291,7 @@ xi.settings.main =
     NUMBER_OF_DM_EARRINGS        = 1,     -- Number of earrings players can simultaneously own from Divine Might before scripts start blocking them (Default: 1)
     HOMEPOINT_TELEPORT           = 1,     -- Enables the homepoint teleport system
     DIG_ABUNDANCE_BONUS          = 0,     -- Increase chance of digging up an item (450  = item digup chance +45)
-    DIG_FATIGUE                  = 1,     -- Set to 0 to disable Dig Fatigue
+    DIG_FATIGUE                  = 100,   -- Allowed succesful digs per day. Set to 0 to disable Dig Fatigue
     DIG_GRANT_BURROW             = 0,     -- Set to 1 to grant burrow ability
     DIG_GRANT_BORE               = 0,     -- Set to 1 to grant bore ability
     ENM_COOLDOWN                 = 120,   -- Number of hours before a player can obtain same KI for ENMs (default: 5 days)

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -5316,20 +5316,22 @@ namespace luautils
         }
     }
 
-    bool OnChocoboDig(CCharEntity* PChar, bool pre)
+    bool OnChocoboDig(CCharEntity* PChar)
     {
         TracyZoneScoped;
 
-        auto name = PChar->loc.zone->getName();
-
+        // Check if zone can be digged in.
+        auto name         = PChar->loc.zone->getName();
         auto onChocoboDig = lua["xi"]["zones"][name]["Zone"]["onChocoboDig"];
+
         if (!onChocoboDig.valid())
         {
             ShowWarning("luautils::onChocoboDig");
             return false;
         }
 
-        auto result = onChocoboDig(CLuaBaseEntity(PChar), pre);
+        // Run lua-side chocobo digging.
+        auto result = onChocoboDig(CLuaBaseEntity(PChar));
         if (!result.valid())
         {
             sol::error err = result;

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -5320,10 +5320,9 @@ namespace luautils
     {
         TracyZoneScoped;
 
-        // Check if zone can be digged in.
-        auto name         = PChar->loc.zone->getName();
-        auto onChocoboDig = lua["xi"]["zones"][name]["Zone"]["onChocoboDig"];
+        auto onChocoboDig = lua["xi"]["chocoboDig"]["start"];
 
+        // Check that the function exists.
         if (!onChocoboDig.valid())
         {
             ShowWarning("luautils::onChocoboDig");

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -350,7 +350,7 @@ namespace luautils
     void OnPlayerEmote(CCharEntity* PChar, Emote EmoteID);
     void OnPlayerVolunteer(CCharEntity* PChar, std::string const& text);
 
-    bool OnChocoboDig(CCharEntity* PChar, bool pre); // chocobo digging, pre = check
+    bool OnChocoboDig(CCharEntity* PChar); // chocobo digging
 
     // Utility method: checks for and loads a lua function for events
     auto LoadEventScript(CCharEntity* PChar, const char* functionName) -> sol::function;

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -1110,37 +1110,26 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
         break;
         case 0x11: // chocobo digging
         {
+            // Mounted Check.
             if (!PChar->isMounted())
             {
                 return;
             }
 
-            // bunch of gysahl greens
+            // Gysahl Green Check.
             uint8 slotID = PChar->getStorage(LOC_INVENTORY)->SearchItem(4545);
-
-            if (slotID != ERROR_SLOTID)
+            if (slotID == ERROR_SLOTID)
             {
-                // attempt to dig
-                if (luautils::OnChocoboDig(PChar, true))
-                {
-                    charutils::UpdateItem(PChar, LOC_INVENTORY, slotID, -1);
-
-                    PChar->pushPacket(new CInventoryFinishPacket());
-                    PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CChocoboDiggingPacket(PChar));
-
-                    // dig is possible
-                    luautils::OnChocoboDig(PChar, false);
-                }
-                else
-                {
-                    // unable to dig yet
-                    PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_WAIT_LONGER));
-                }
-            }
-            else
-            {
-                // You don't have any gysahl greens
                 PChar->pushPacket(new CMessageSystemPacket(4545, 0, MsgStd::YouDontHaveAny));
+                return;
+            }
+
+            // Consume Gysahl Green and push animation on dig attempt.
+            if (luautils::OnChocoboDig(PChar))
+            {
+                charutils::UpdateItem(PChar, LOC_INVENTORY, slotID, -1);
+                PChar->pushPacket(new CInventoryFinishPacket());
+                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CChocoboDiggingPacket(PChar));
             }
         }
         break;


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Updates core logic so we dont have the need to hit the global file TWICE per digging attempt
- Implements the fatigue mechanic properly.
  - It now respects the value in stting instead of it being hardcoded
  - Uses an expirable variable to track daily digs
  - It now doesnt prevent you from digging when fatigued, as retail does.
- Implements positional check to prevent repeatedy digging without moving.

## Steps to test these changes

Dig normaly

To review:
- Review by commit

Commit 1:
- Ignore the zone files. That way its simpler.
- What was done is removing an extra parameter. The way it was coded, this was the workflow:
  - Call global lua function first time, with arg being true.
  - Call global lua function a second time, with arg being false, IF it returned `true` the first time
- This was... I dunnow, not very good. So the logic was changed so the global lua function is only called once per attempt.

Commit 2:
- Handles the main setting for fatigue. changing it from being used as a boolean to being a proper int defining max daily digs.
- Reorders code to hit as less code as necesary
- Compensates deleted code in core, adding some messages.

Commit 3:
- In retail you must move 2+ yalms to be able to dig successfully again. So this implements that.

Commit 4:
- Once again, ignore all zone files.
- We make a change in core to call the global function, that was being called in lua in all touched zone scripts, directly.
- We add a table of allowed zones to dig in and check first thing, to guarantee we wont dig in undefined zones.