### PR TITLE
[cpp] sum matching mods

### DIFF
--- a/src/map/items/item_equipment.cpp
+++ b/src/map/items/item_equipment.cpp
@@ -243,14 +243,15 @@ void CItemEquipment::addModifier(CModifier modifier)
 
 int16 CItemEquipment::getModifier(Mod mod) const
 {
-    for (auto& i : modList)
+    int16 totalAmount = 0;
+    for (const auto& i : modList)
     {
         if (i.getModID() == mod)
         {
-            return i.getModAmount();
+            totalAmount += i.getModAmount();
         }
     }
-    return 0;
+    return totalAmount;
 }
 
 void CItemEquipment::addPetModifier(CPetModifier modifier)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Sums all matching mods rather than returning early, this resulted in latent effects such as the `DMG: 46~54, increases by 2 for every person above 2 in party` to not properly take effect.

This meant latent effects were not properly applied for items that compound based on party size (with current latent implementation):

`Company Sword`
`Mensur Epee`
`Company Fleuret`

## Steps to test these changes

Equip the `Company Sword` with 2, 3, 4, 5 party members to see compounding take effect (dmg + 2 per party member over 2 total members).
