### PR TITLE
[Guild] Account for settings when renouncing craft rank

### DIFF
--- a/scripts/globals/crafting/crafting_guild_master.lua
+++ b/scripts/globals/crafting/crafting_guild_master.lua
@@ -173,18 +173,20 @@ xi.crafting.guildMasterOnTrigger = function(player, npc)
                 end
             end
 
+            local rankFromSetting = math.floor(xi.settings.map.CRAFT_COMMON_CAP / 100) -- If 700, it will return rank 7 (Artisan)
+
             -- Params 7 and 8.
             for skillChecked = xi.skill.WOODWORKING, xi.skill.COOKING do
                 rankChecked = player:getSkillRank(skillChecked)
 
                 -- Param 7: Count crafts over craftsman rank.
-                if rankChecked >= xi.craftRank.ARTISAN then
+                if rankChecked >= rankFromSetting then
                     artisanCount = artisanCount + 1
                 end
 
                 -- Param 8: Full mask except craft ids that CAN be renounced.
                 if
-                    rankChecked < xi.craftRank.ARTISAN or
+                    rankChecked < rankFromSetting or
                     skillChecked == highestSkillId
                 then
                     artisanBitmask = bit.bor(artisanBitmask, bit.lshift(1, skillChecked - 48))
@@ -238,8 +240,11 @@ xi.crafting.guildMasterOnEventFinish = function(player, csid, option, npc)
             option >= xi.skill.WOODWORKING and
             option <= xi.skill.COOKING
         then
-            player:setSkillRank(option, xi.craftRank.CRAFTSMAN)
-            player:setSkillLevel(option, 700)
+            local rankFromSetting = math.floor(xi.settings.map.CRAFT_COMMON_CAP / 100) - 1  -- If 700, it will return rank 6 (Craftsman)
+
+            player:setSkillRank(option, rankFromSetting)
+            player:setSkillLevel(option, xi.settings.map.CRAFT_COMMON_CAP)
+
             player:messageSpecial(ID.text.RENOUNCE_CRAFTSMAN, 0, option - 49)
         end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The setting `CRAFT_COMMON_CAP` already exists. It determines what is the skill cap before the "specialization points" start counting and it can also be used to know what is the level and rank you should be set to when renouncing at the guilds.

If the setting is used properly, that is.

- This changes allows the guilds to be in line with the existing setting, instead of forcing a concrete level and rank.

## Steps to test these changes

Confirmed working properly for both retail and era values (700 and 600 respectively)

1. Change the setting to a normal, sane, not-made-to-break-the-system value and then level 2 crafts over the limit you defined.
2. Then interact with a guild master. You will be given the option to renounce ONE of the 2 you leveled.
3. Select it. Check you are set to the level and associated rank you defined.