### PR TITLE
[core] Move usercheck() after settings init

### DIFF
--- a/src/common/kernel.cpp
+++ b/src/common/kernel.cpp
@@ -231,12 +231,12 @@ int main(int argc, char** argv)
 
     log_init(argc, argv);
     set_socket_type();
-    usercheck();
     signals_init();
     timer_init();
 
     lua_init();
     settings::init();
+    usercheck();
 
     socket_init();
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This allows the message to be correctly printed inside usercheck()
Fixes #6103 

## Steps to test these changes

`sudo ./xi_map`, get complaint you shouldn't be using root instead of warning about a missing setting
