### PR TITLE
Core: Check player meets skill requirement to use weaponskills

### DIFF
--- a/src/map/ai/controllers/player_controller.cpp
+++ b/src/map/ai/controllers/player_controller.cpp
@@ -197,7 +197,7 @@ bool CPlayerController::WeaponSkill(uint16 targid, uint16 wsid)
             return false;
         }
 
-        if (!charutils::hasWeaponSkill(PChar, PWeaponSkill->getID()))
+        if (!charutils::hasWeaponSkill(PChar, PWeaponSkill->getID()) || !charutils::canUseWeaponSkill(PChar, wsid))
         {
             PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_CANNOT_USE_WS));
             return false;

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3829,6 +3829,12 @@ namespace charutils
         return delBit(WeaponSkillID, PChar->m_WeaponSkills, sizeof(PChar->m_WeaponSkills));
     }
 
+    bool canUseWeaponSkill(CCharEntity* PChar, uint16 wsid)
+    {
+        CWeaponSkill* PWeaponSkill = battleutils::GetWeaponSkill(wsid);
+        return PChar->GetSkill(PWeaponSkill->getType()) >= PWeaponSkill->getSkillLevel();
+    }
+
     /************************************************************************
      *                                                                       *
      *  Trait Functions                                                      *

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -171,6 +171,7 @@ namespace charutils
     int32 addWeaponSkill(CCharEntity* PChar, uint16 WeaponSkillID); // declaration of function to add weapon skill
     int32 hasWeaponSkill(CCharEntity* PChar, uint16 WeaponSkillID); // declaration of function to check for weapon skill
     int32 delWeaponSkill(CCharEntity* PChar, uint16 WeaponSkillID); // declaration of function to delete weapon skill
+    bool  canUseWeaponSkill(CCharEntity* PChar, uint16 wsid);
 
     void SaveCharJob(CCharEntity* PChar, JOBTYPE job); // save the level for the selected character's jobs
     void SaveCharExp(CCharEntity* PChar, JOBTYPE job); // save experience for the selected character’s chosen job


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Currently if a player can use a weaponskill from the menu, the server just allows it without checking their skill level. In certain cases where the menu isn't refreshed, this allows players to use weaponskills without meeting the requirements (And presumably could be completely bypassed with packet injection).

## Steps to test these changes
```
!changejob war 76
!additem fortitude_torque
```
Without Fortitude Torque, you will not have access to Fell Cleave (Without merits). Once Fortitude Torque is equipped, you will be able to use Fell Cleave. Currently, you can remove the Torque and continue to use Fell Cleave. With this fix, you can no longer continue to use it once the requirements are no longer met.