### PR TITLE
Core: Adds region check for Ionis and fixes conquest latent error

### DIFF
--- a/src/map/conquest_data.cpp
+++ b/src/map/conquest_data.cpp
@@ -90,7 +90,12 @@ uint8 ConquestData::getRegionOwner(REGION_TYPE region) const
         return regionControls[regionNum].current;
     }
 
-    ShowError(fmt::format("Invalid conquest region passed to function ({})", regionNum));
+    // This can be called for Latent effects that work outside of conquest areas eg. Dynamis/Limbus
+    if (regionNum > (uint8)REGION_TYPE::LIMBUS)
+    {
+        ShowError(fmt::format("Invalid conquest region passed to function ({})", regionNum));
+    }
+
     return 0;
 }
 

--- a/src/map/conquest_data.cpp
+++ b/src/map/conquest_data.cpp
@@ -85,17 +85,28 @@ uint8 ConquestData::getRegionOwner(REGION_TYPE region) const
 {
     uint8 regionNum = static_cast<uint8>(region);
 
-    if (regionNum < regionControls.size())
+    // Handle some conquest regions that don't have conquest info as non-error
+    // TODO: Do Sandoria/Bastok/Windurst count as "owned by" themselves, no one, or some other state where latents don't work?
+    switch (region)
     {
-        return regionControls[regionNum].current;
+        case REGION_TYPE::SANDORIA:
+        case REGION_TYPE::BASTOK:
+        case REGION_TYPE::WINDURST:
+        case REGION_TYPE::JEUNO:
+        case REGION_TYPE::DYNAMIS:
+        case REGION_TYPE::TAVNAZIAN_MARQ:
+        case REGION_TYPE::PROMYVION:
+        case REGION_TYPE::LUMORIA:
+        case REGION_TYPE::LIMBUS:
+            return NATION_TYPE::NATION_BEASTMEN;
+        default:
+            if (regionNum < regionControls.size())
+            {
+                return regionControls[regionNum].current;
+            }
     }
 
-    // This can be called for Latent effects that work outside of conquest areas eg. Dynamis/Limbus
-    if (regionNum > (uint8)REGION_TYPE::LIMBUS)
-    {
-        ShowError(fmt::format("Invalid conquest region passed to function ({})", regionNum));
-    }
-
+    ShowError(fmt::format("Invalid conquest region passed to function ({})", regionNum));
     return 0;
 }
 

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -997,6 +997,7 @@ void CMobEntity::DropItems(CCharEntity* PChar)
         if (m_Element > 0)
         {
             REGION_TYPE regionID = PChar->loc.zone->GetRegionID();
+
             switch (regionID)
             {
                 // Sanction Regions
@@ -1006,6 +1007,7 @@ void CMobEntity::DropItems(CCharEntity* PChar)
                 case REGION_TYPE::ARRAPAGO:
                     effect = 2;
                     break;
+
                 // Sigil Regions
                 case REGION_TYPE::RONFAURE_FRONT:
                 case REGION_TYPE::NORVALLEN_FRONT:
@@ -1017,12 +1019,20 @@ void CMobEntity::DropItems(CCharEntity* PChar)
                 case REGION_TYPE::VALDEAUNIA_FRONT:
                     effect = 3;
                     break;
+
+                // Ionis Regions
+                case REGION_TYPE::ADOULIN_ISLANDS:
+                case REGION_TYPE::EAST_ULBUKA:
+                    effect = 4;
+                    break;
+
                 // Signet Regions
                 default:
-                    effect = (conquest::GetRegionOwner(PChar->loc.zone->GetRegionID()) <= 2) ? 1 : 0;
+                    effect = (regionID < REGION_TYPE::TAVNAZIA && conquest::GetRegionOwner(regionID) <= 2) ? 1 : 0;
                     break;
             }
         }
+
         uint8 crystalRolls = 0;
         // clang-format off
         PChar->ForParty([this, &crystalRolls, &effect](CBattleEntity* PMember)
@@ -1045,6 +1055,13 @@ void CMobEntity::DropItems(CCharEntity* PChar)
                     break;
                 case 3:
                     if (PMember->StatusEffectContainer->HasStatusEffect(EFFECT_SIGIL) && PMember->getZone() == getZone() &&
+                        distance(PMember->loc.p, loc.p) < 100)
+                    {
+                        crystalRolls++;
+                    }
+                    break;
+                case 4:
+                    if (PMember->StatusEffectContainer->HasStatusEffect(EFFECT_IONIS) && PMember->getZone() == getZone() &&
                         distance(PMember->loc.p, loc.p) < 100)
                     {
                         crystalRolls++;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Currently, logs are spammed with the error `Invalid conquest region passed to function` under the following conditions:
* Any mob killed in Adoulin regions, regardless of status effects
* When "conquest" latent effects activate outside the regular Conquest areas eg. Dynamis

Items with the "In areas outside own nation's control" latent  effect should trigger (And currently do) in certain regions even though they are not subject to conquest, but it still produces an error.

This PR fixes the issues by changing the following:
* Region ID must be outside of valid latent areas before `getRegionOwner` produces the error message (Extra permitted areas will simply return 0 - No owner)
* Adds a check for Conquest regions before simply passing off any mob kill to Signet (Which will produce errors in unhandled regions)
* Implemented Ionis effect requirement to receive crystals in Adoulin regions
* Added some extra padding and reuse variable to reduce extra lookups

## Steps to test these changes
Tested in-game using multiple different region types and conditions. Conquest area with/without control, Lumoria, Adoulin areas with/without Ionis, etc. Re-tested with Winter's rewrite of `ConquestData::getRegionOwner`