### PR TITLE
[core] Attempt to improve session cleanup logic

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -189,7 +189,10 @@ int32 do_init(int32 argc, char** argv)
 #endif // TRACY_ENABLE
 
     ShowInfo("do_init: begin server initialization");
+
+    // These aren't set unless --ip or --port is set, respectively.
     map_ip.s_addr = 0;
+    map_port      = 0;
 
     for (int i = 1; i < argc; i++)
     {
@@ -568,11 +571,13 @@ int32 do_sockets(fd_set* rfd, duration next)
                 }
             }
 
-            map_session_data->last_update = time(nullptr);
-            size_t size                   = ret;
+            size_t size = ret;
 
             if (recv_parse(g_PBuff, &size, &from, map_session_data) != -1)
             {
+                // Update the time we last got a valid packet
+                map_session_data->last_update = time(nullptr);
+
                 // If the previous package was lost, then we do not collect a new one,
                 // and send the previous packet again
                 if (!parse(g_PBuff, &size, &from, map_session_data))
@@ -588,6 +593,7 @@ int32 do_sockets(fd_set* rfd, duration next)
                 map_session_data->server_packet_data = data;
                 map_session_data->server_packet_size = size;
             }
+
             if (map_session_data->shuttingDown > 0)
             {
                 map_close_session(server_clock::now(), map_session_data);
@@ -637,7 +643,7 @@ int32 map_decipher_packet(int8* buff, size_t size, sockaddr_in* from, map_sessio
         return 0;
     }
 
-    ShowError(fmt::format("map_encipher_packet: bad packet from <{}>", ip2str(ip)));
+    ShowError(fmt::format("map_decipher_packet: bad packet from <{}>", ip2str(ip)));
     return -1;
 }
 
@@ -694,7 +700,8 @@ int32 recv_parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_da
                 db::extractFromBlob(rset, "session_key", map_session_data->blowfish.key);
             }
 
-            map_session_data->PChar = charutils::LoadChar(CharID);
+            map_session_data->PChar  = charutils::LoadChar(CharID);
+            map_session_data->charID = CharID;
         }
         map_session_data->client_packet_id = 0;
         map_session_data->server_packet_id = 0;
@@ -1040,7 +1047,7 @@ int32 map_close_session(time_point tick, map_session_data_t* map_session_data)
         // clear accounts_sessions if character is logging out (not when zoning)
         if (map_session_data->shuttingDown == 1)
         {
-            _sql->Query("DELETE FROM accounts_sessions WHERE charid = %u", map_session_data->PChar->id);
+            _sql->Query("DELETE FROM accounts_sessions WHERE charid = %u", map_session_data->charID);
         }
 
         uint64 port64 = map_session_data->client_port;
@@ -1082,7 +1089,7 @@ int32 map_cleanup(time_point tick, CTaskMgr::CTask* PTask)
         {
             if (PChar != nullptr && !PChar->isLinkDead)
             {
-                _sql->Query("UPDATE char_flags SET disconnecting = 1 WHERE charid = %u", PChar->id);
+                _sql->Query("UPDATE char_flags SET disconnecting = 1 WHERE charid = %u", map_session_data->charID);
 
                 PChar->isLinkDead = true;
                 PChar->updatemask |= UPDATE_HP;
@@ -1093,35 +1100,36 @@ int32 map_cleanup(time_point tick, CTaskMgr::CTask* PTask)
                     PChar->loc.zone->SpawnPCs(PChar);
                 }
             }
+
             if ((time(nullptr) - map_session_data->last_update) > settings::get<uint16>("map.MAX_TIME_LASTUPDATE"))
             {
+                bool otherMap = false;
+
+                // check if session is attached to a different map server...
+                const char* fmtQuery = "select server_addr, server_port from accounts_sessions WHERE charid = %u";
+                _sql->Query(fmtQuery, map_session_data->charID);
+                if (_sql->NextRow() == SQL_SUCCESS)
+                {
+                    uint32 server_addr = _sql->GetUIntData(0);
+                    uint32 server_port = _sql->GetUIntData(1);
+
+                    // s_addr of 0 is single process map server without IP address set explicitly in commandline
+                    // map_port is 0 without the port being explicitly set in commandline
+                    if ((map_ip.s_addr != 0 && server_addr != map_ip.s_addr) || (map_port != 0 && server_port != map_port))
+                    {
+                        otherMap = true;
+                    }
+                }
+
                 if (PChar != nullptr)
                 {
                     // Check if the PChar current zone is on this server
-                    CZone* PZone    = nullptr;
-                    bool   otherMap = false;
+                    CZone* PZone = nullptr;
 
                     // Get zone if available
                     if (PChar->loc.zone && PChar->loc.zone->GetID() && (g_PZoneList.find(PChar->loc.zone->GetID()) != g_PZoneList.end()))
                     {
                         PZone = PChar->loc.zone;
-                    }
-
-                    // if PChar->loc.zone != null, maybe we didn't receive 0x00D, check accounts_sessions
-                    if (PZone)
-                    {
-                        const char* fmtQuery = "select server_addr, server_port from accounts_sessions WHERE charid = %u";
-                        _sql->Query(fmtQuery, PChar->id);
-                        if (_sql->NextRow() == SQL_SUCCESS)
-                        {
-                            uint32 server_addr = _sql->GetUIntData(0);
-                            uint32 server_port = _sql->GetUIntData(1);
-
-                            if (server_addr != PZone->GetIP() || server_port != PZone->GetPort())
-                            {
-                                otherMap = true;
-                            }
-                        }
                     }
 
                     if (map_session_data->shuttingDown == 0)
@@ -1184,7 +1192,7 @@ int32 map_cleanup(time_point tick, CTaskMgr::CTask* PTask)
                         {
                             // Player session is attached to this map process and has stopped responding.
                             map_session_data->PChar->StatusEffectContainer->SaveStatusEffects(true);
-                            _sql->Query("DELETE FROM accounts_sessions WHERE charid = %u", map_session_data->PChar->id);
+                            _sql->Query("DELETE FROM accounts_sessions WHERE charid = %u", map_session_data->charID);
                         }
 
                         ShowDebug(fmt::format("Clearing map server session for player: {} in zone: {} (On other map server = {})", PChar->name, PChar->loc.zone ? PChar->loc.zone->getName() : "None", otherMap ? "Yes" : "No"));
@@ -1202,13 +1210,14 @@ int32 map_cleanup(time_point tick, CTaskMgr::CTask* PTask)
                         continue;
                     }
                 }
-                else if (map_session_data->shuttingDown == 0)
+                else
                 {
-                    ShowWarning("map_cleanup: WHITHOUT CHAR timed out, session closed");
-
-                    const char* Query = "DELETE FROM accounts_sessions WHERE client_addr = %u AND client_port = %u";
-                    _sql->Query(Query, map_session_data->client_addr, map_session_data->client_port);
-
+                    ShowWarning("map_cleanup: WITHOUT CHAR timed out, session closed on this process");
+                    if (!otherMap)
+                    {
+                        const char* Query = "DELETE FROM accounts_sessions WHERE charid = %u";
+                        _sql->Query(Query, map_session_data->charID);
+                    }
                     destroy_arr(map_session_data->server_packet_data);
                     map_session_list.erase(it++);
                     destroy(map_session_data);
@@ -1218,7 +1227,7 @@ int32 map_cleanup(time_point tick, CTaskMgr::CTask* PTask)
         }
         else if (PChar != nullptr && PChar->isLinkDead)
         {
-            _sql->Query("UPDATE char_flags SET disconnecting = 0 WHERE charid = %u", PChar->id);
+            _sql->Query("UPDATE char_flags SET disconnecting = 0 WHERE charid = %u", map_session_data->charID);
 
             PChar->isLinkDead = false;
             PChar->updatemask |= UPDATE_HP;

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -56,6 +56,7 @@ struct map_session_data_t
     blowfish_t   blowfish           = {};      // unique decypher keys
     CCharEntity* PChar              = nullptr; // game char
     uint8        shuttingDown       = 0;       // prevents double session closing
+    uint32       charID             = 0;
 };
 
 extern uint32 map_amntplayers;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Attempts to fix #6106 
Shifts some logic around and stores charID in session instead of on PChar to make most logic similar.
Removes some weird `zoning == 0` check for session cleanup. Doesn't make sense especially if PChar is null.

## Steps to test these changes

See #6106 
Logout, login, force d/c, /terminate, etc etc and see sessions still get cleaned up