### PR TITLE
Core: Long-distance/Chunked pathing support

### DIFF
--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -124,22 +124,11 @@ bool CPathFind::PathTo(const position_t& point, uint8 pathFlags, bool clear)
 
     if (isNavMeshEnabled())
     {
-        bool result = false;
-
-        if (m_pathFlags & PATHFLAG_WALLHACK)
-        {
-            result = FindClosestPath(m_POwner->loc.p, point);
-        }
-        else
-        {
-            result = FindPath(m_POwner->loc.p, point);
-        }
-
+        bool result = FindPath(m_POwner->loc.p, point, m_pathFlags & PATHFLAG_WALLHACK);
         if (!result)
         {
             Clear();
         }
-
         return result;
     }
     else
@@ -448,7 +437,7 @@ void CPathFind::StepTo(const position_t& pos, bool run)
     m_POwner->updatemask |= UPDATE_POS;
 }
 
-bool CPathFind::FindPath(const position_t& start, const position_t& end)
+bool CPathFind::FindPath(const position_t& start, const position_t& end, bool wallhack)
 {
     TracyZoneScoped;
 
@@ -466,6 +455,11 @@ bool CPathFind::FindPath(const position_t& start, const position_t& end)
 
     m_points       = std::move(points);
     m_currentPoint = 0;
+
+    if (result != CNavMesh::PathResult::Complete && wallhack)
+    {
+        m_points.emplace_back(pathpoint_t{ end, 0, false }); // this prevents exploits with navmesh / impassible terrain
+    }
 
     if (m_points.empty())
     {
@@ -525,39 +519,6 @@ bool CPathFind::FindRandomPath(const position_t& start, float maxRadius, uint8 m
     }
 
     return !m_points.empty();
-}
-
-bool CPathFind::FindClosestPath(const position_t& start, const position_t& end)
-{
-    TracyZoneScoped;
-
-    if (arePositionsClose(start, end))
-    {
-        return false;
-    }
-
-    if (!isNavMeshEnabled())
-    {
-        return false;
-    }
-
-    auto [result, points] = m_POwner->loc.zone->m_navMesh->findPath(start, end);
-
-    m_points       = std::move(points);
-    m_currentPoint = 0;
-
-    // TODO: This is just for testing, this wallhack behaviour is very important!
-    // m_points.emplace_back(pathpoint_t{ end, 0, false }); // this prevents exploits with navmesh / impassible terrain
-
-    /* this check requirement is never met as intended since m_points are never empty when mob has a path
-    if (m_points.empty())
-    {
-        // this is a trick to make mobs go up / down impassible terrain
-        m_points.emplace_back(end);
-    }
-*/
-
-    return true;
 }
 
 void CPathFind::LookAt(const position_t& point)

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -462,7 +462,9 @@ bool CPathFind::FindPath(const position_t& start, const position_t& end)
         return false;
     }
 
-    m_points       = m_POwner->loc.zone->m_navMesh->findPath(start, end);
+    auto [result, points] = m_POwner->loc.zone->m_navMesh->findPath(start, end);
+
+    m_points       = std::move(points);
     m_currentPoint = 0;
 
     if (m_points.empty())
@@ -516,7 +518,9 @@ bool CPathFind::FindRandomPath(const position_t& start, float maxRadius, uint8 m
     }
     if (m_turnPoints.size() > 0)
     {
-        m_points       = m_POwner->loc.zone->m_navMesh->findPath(start, m_turnPoints[0]);
+        auto [result, points] = m_POwner->loc.zone->m_navMesh->findPath(start, m_turnPoints[0]);
+
+        m_points       = std::move(points);
         m_currentPoint = 0;
     }
 
@@ -537,7 +541,9 @@ bool CPathFind::FindClosestPath(const position_t& start, const position_t& end)
         return false;
     }
 
-    m_points       = m_POwner->loc.zone->m_navMesh->findPath(start, end);
+    auto [result, points] = m_POwner->loc.zone->m_navMesh->findPath(start, end);
+
+    m_points       = std::move(points);
     m_currentPoint = 0;
 
     // TODO: This is just for testing, this wallhack behaviour is very important!

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -105,6 +105,9 @@ bool CPathFind::RoamAround(const position_t& point, float maxRadius, uint8 maxTu
 bool CPathFind::PathTo(const position_t& point, uint8 pathFlags, bool clear)
 {
     TracyZoneScoped;
+
+    DebugNavmesh("%s (%d) PathTo: %f %f %f", m_POwner->getName(), m_POwner->id, point.x, point.y, point.z);
+
     // don't follow a new path if the current path has script flag and new path doesn't
     if (IsFollowingPath() && (m_pathFlags & PATHFLAG_SCRIPT) && !(pathFlags & PATHFLAG_SCRIPT))
     {
@@ -116,7 +119,8 @@ bool CPathFind::PathTo(const position_t& point, uint8 pathFlags, bool clear)
         Clear();
     }
 
-    m_pathFlags = pathFlags;
+    m_destinationPoint = point;
+    m_pathFlags        = pathFlags;
 
     if (isNavMeshEnabled())
     {
@@ -535,7 +539,9 @@ bool CPathFind::FindClosestPath(const position_t& start, const position_t& end)
 
     m_points       = m_POwner->loc.zone->m_navMesh->findPath(start, end);
     m_currentPoint = 0;
-    m_points.emplace_back(pathpoint_t{ end, 0, false }); // this prevents exploits with navmesh / impassible terrain
+
+    // TODO: This is just for testing, this wallhack behaviour is very important!
+    // m_points.emplace_back(pathpoint_t{ end, 0, false }); // this prevents exploits with navmesh / impassible terrain
 
     /* this check requirement is never met as intended since m_points are never empty when mob has a path
     if (m_points.empty())
@@ -697,6 +703,9 @@ void CPathFind::Clear()
 
     m_currentTurn = 0;
     m_turnPoints.clear();
+
+    // TODO: Clear m_destinationPoint, should this be optional<>?
+    // m_destinationPoint
 }
 
 void CPathFind::AddPoints(std::vector<pathpoint_t>&& points, bool reverse)
@@ -748,8 +757,16 @@ void CPathFind::FinishedPath()
         m_currentPoint = 0;
         m_currentTurn  = 0;
     }
-    else
+    else // TODO: Is this always right?
     {
-        Clear();
+        // If we're not there yet, keep pathing until we are
+        if (distance(m_POwner->loc.p, m_destinationPoint) > 10.0f)
+        {
+            PathTo(m_destinationPoint, m_pathFlags);
+        }
+        else
+        {
+            Clear();
+        }
     }
 }

--- a/src/map/ai/helpers/pathfind.h
+++ b/src/map/ai/helpers/pathfind.h
@@ -144,6 +144,7 @@ private:
     std::vector<pathpoint_t> m_patrol;
     std::vector<position_t>  m_turnPoints;
     position_t               m_originalPoint;
+    position_t               m_destinationPoint; // TODO: optional<>?
     float                    m_distanceFromPoint;
 
     uint8  m_pathFlags;

--- a/src/map/ai/helpers/pathfind.h
+++ b/src/map/ai/helpers/pathfind.h
@@ -60,6 +60,7 @@ public:
 
     // find and walk to the given point
     bool PathTo(const position_t& point, uint8 pathFlags = 0, bool clear = true);
+
     // walk to the given point until in range
     bool PathInRange(const position_t& point, float range, uint8 pathFlags = 0, bool clear = true);
 
@@ -126,11 +127,7 @@ public:
 
 private:
     // find a valid path using polys
-    bool FindPath(const position_t& start, const position_t& end);
-
-    // cut some corners and find the fastest path
-    // this will make the mob run down cliffs
-    bool FindClosestPath(const position_t& start, const position_t& end);
+    bool FindPath(const position_t& start, const position_t& end, bool wallhack);
 
     // finds a random path around the given point
     bool FindRandomPath(const position_t& start, float maxRadius, uint8 maxTurns, uint16 roamFlags);

--- a/src/map/navmesh.h
+++ b/src/map/navmesh.h
@@ -73,7 +73,7 @@ public:
     void reload();
     void unload();
 
-    std::vector<pathpoint_t>     findPath(const position_t& start, const position_t& end);
+    std::vector<pathpoint_t>     findPath(const position_t& start, const position_t& end); // TODO: Return a status of whether or not the path return is complete or not
     std::pair<int16, position_t> findRandomPosition(const position_t& start, float maxRadius);
 
     // Returns true if the point is in water
@@ -93,40 +93,75 @@ public:
     // Like validPosition(), but will also set the given position to the valid position that it finds.
     void snapToValidPosition(position_t& position);
 
-    static inline void outputError(uint32 status)
+    // High level status.
+    static const unsigned int DT_FAILURE     = 1u << 31; // Operation failed.
+    static const unsigned int DT_SUCCESS     = 1u << 30; // Operation succeed.
+    static const unsigned int DT_IN_PROGRESS = 1u << 29; // Operation still in progress.
+
+    // Detail information for status.
+    static const unsigned int DT_STATUS_DETAIL_MASK = 0x0ffffff;
+    static const unsigned int DT_WRONG_MAGIC        = 1 << 0; // Input data is not recognized.
+    static const unsigned int DT_WRONG_VERSION      = 1 << 1; // Input data is in wrong version.
+    static const unsigned int DT_OUT_OF_MEMORY      = 1 << 2; // Operation ran out of memory.
+    static const unsigned int DT_INVALID_PARAM      = 1 << 3; // An input parameter was invalid.
+    static const unsigned int DT_BUFFER_TOO_SMALL   = 1 << 4; // Result buffer for the query was too small to store all results.
+    static const unsigned int DT_OUT_OF_NODES       = 1 << 5; // Query ran out of nodes during search.
+    static const unsigned int DT_PARTIAL_RESULT     = 1 << 6; // Query did not reach the end location, returning best guess.
+    static const unsigned int DT_ALREADY_OCCUPIED   = 1 << 7; // A tile has already been assigned to the given x,y coordinate
+
+    [[nodiscard]] static inline auto detourStatusString(uint32 status) -> std::string
     {
+        std::string outStr;
+
+        // High level status.
+        if (status & DT_FAILURE)
+        {
+            outStr += "DT_FAILURE: Operation failed. ";
+        }
+        if (status & DT_SUCCESS)
+        {
+            outStr += "DT_SUCCESS: Operation succeeded. ";
+        }
+        if (status & DT_IN_PROGRESS)
+        {
+            outStr += "DT_IN_PROGRESS: Operation still in progress. ";
+        }
+
+        // Detail information for status.
         if (status & DT_WRONG_MAGIC)
         {
-            ShowError("Detour: Input data is not recognized.");
+            outStr += "DT_WRONG_MAGIC: Input data is not recognized. ";
         }
-        else if (status & DT_WRONG_VERSION)
+        if (status & DT_WRONG_VERSION)
         {
-            ShowError("Detour: Input data is in wrong version.");
+            outStr += "DT_WRONG_VERSION: Input data is in wrong version. ";
         }
-        else if (status & DT_OUT_OF_MEMORY)
+        if (status & DT_OUT_OF_MEMORY)
         {
-            ShowError("Detour: Operation ran out of memory.");
+            outStr += "DT_OUT_OF_MEMORY: Operation ran out of memory. ";
         }
-        else if (status & DT_INVALID_PARAM)
+        if (status & DT_INVALID_PARAM)
         {
-            ShowError("Detour: An input parameter was invalid.");
+            outStr += "DT_INVALID_PARAM: An input parameter was invalid. ";
         }
-        else if (status & DT_BUFFER_TOO_SMALL)
+        if (status & DT_BUFFER_TOO_SMALL)
         {
-            ShowError("Detour: Result buffer for the query was too small to store all results.");
+            outStr += "DT_BUFFER_TOO_SMALL: Result buffer for the query was too small to store all results. ";
         }
-        else if (status & DT_OUT_OF_NODES)
+        if (status & DT_OUT_OF_NODES)
         {
-            ShowError("Detour: Query ran out of nodes during search.");
+            outStr += "DT_OUT_OF_NODES: Query ran out of nodes during search. ";
         }
-        else if (status & DT_PARTIAL_RESULT)
+        if (status & DT_PARTIAL_RESULT)
         {
-            ShowError("Detour: Query did not reach the end location, returning best guess.");
+            outStr += "DT_PARTIAL_RESULT: Query did not reach the end location, returning best guess. ";
         }
-        else if (status & DT_ALREADY_OCCUPIED)
+        if (status & DT_ALREADY_OCCUPIED)
         {
-            ShowError("Detour: A tile has already been assigned to the given x,y coordinate");
+            outStr += "DT_ALREADY_OCCUPIED: A tile has already been assigned to the given x, y coordinate. ";
         }
+
+        return outStr;
     }
 
 private:

--- a/src/map/navmesh.h
+++ b/src/map/navmesh.h
@@ -34,8 +34,6 @@ The NavMesh class will load and find paths given a start point and end point.
 #include <memory>
 #include <vector>
 
-#define MAX_NAV_POLYS 256
-
 static const int NAVMESHSET_MAGIC   = 'M' << 24 | 'S' << 16 | 'E' << 8 | 'T'; // 'MSET'
 static const int NAVMESHSET_VERSION = 1;
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes https://github.com/LandSandBoat/server/issues/3522

Allows mobs to navigate a zone's entire length from a single, non-specialised call to our existing pathing functions - without tanking performance and without them resorting to wallhacking. For use in Besieged, Campaign, etc.

### Work

- [x] Fafnir can long-distance path the whole length of Bhaflau Thickets without resorting to wallhacking or getting trapped in the tunnel local minima.
- [x] Improve Tracy plumbing for more data: https://github.com/LandSandBoat/server/pull/6118
- [ ] Lots of testing on all types of mobs and path, and NPC pathing
- [ ] Abuse testing
- [ ] Enhance the debug logging in PathFind and NavMesh
- [ ] Performance profiling of different poly buffer sizes and overall load of chunking (if chunking even kicks in during regular use)
- [ ] Before/after performance profiling of regular use (The Kuftal Tunnel chase, etc.)
- [ ] New/before/after performance profiling of spawning 32 mobs, and sending them on long-distance pathing
- [ ] Audit the logic in PathFind
- [ ] Explain about the problem with local minima
- [ ] Explain about the problems with the logic in PathFind (when "wallhack" kicks in)
- [ ] Explain about "chunking" in Detour
- [ ] Explain about the cost of the poly buffer in NavMesh
- [ ] Explain about the final "bogus" point in an incomplete path
- [ ] Explain about incomplete paths
- [ ] Make the internals of pathfind and navmesh as const as possible
- [ ] Play with reducing poly search extents to as small as possible
- [x] Remove all allocations possible inside pathing routines
- [ ] Address all TODOs in code and PR
- [ ] Keep a list of waypoints, so you can manually define waypoints for a mob to navigate around/between
- [ ] Lots of mobs are trying to path from their valid start position to (0,0,0) and this causes a failure, what's going on here?
- [ ] The Debug logging for navmesh takes up a lot of time, how can I ask Tracy to ignore that specific line/symbol?
- [x] Move cpp members in navmesh into CNavmesh class, so they're not shared between instances (protecting against future threading issues)
- [ ] The logic inside FindPath should be: If I've requested a path and it's incomplete or invalid and the wallhack flag is on, that's when I should wallhack to my destination - to go after people who aren't on-mesh. If I have a complete or a partial path, then I should just follow that. This will need careful testing!

Notes:
```
My long-distance pathing work has ballooned out into changing the pathing->wallhacking logic

The current logic (if the wallhack flag is on):
I will try ask the navmesh a single time for for directions to my destination. I will put that destination as the last point of my directions so I will always wallhack there. If I got back no points, I will wallhack straight away.

The new logic:
I will ask the navmesh for directions. If I get back points I will follow them. If I reach the end of my points I will ask the navmesh again and follow them. Repeat. If I'm at my destination: success! If I asked the navmesh for more points, I got none back, and I'm not yet at my destination: I will wallhack the rest of the way to my destination.
 
It's also possible to look up why a mob might be wallhacking to go off-mesh
We can make the mob produce logs saying "I'm going off-mesh to chase after player X. Navmesh says that player X is n distance away from the nearest navmesh poly (x, y, z, zoneId)" 

That then produces logs that can be used to find broken/abuse points
```
<img width="827" alt="image" src="https://github.com/user-attachments/assets/dbff9102-1d1c-4e6f-b82f-0a0ab1e439bc">


```
1. Start Point
2. Local Minima Point
3. End Point
```

## Steps to test these changes

```
Info: Bhaflau Thickets
Start Point (Zone In): 383.7, -10.1, 10.0
End Point (North of the map): 70.5, -32.2, 643.5
```

- Truncate `mob_spawn_points` so the server is empty of anything that might try to path
- Enable `DEBUG_NAVMESH` in Logging
- `!zone {Bha` -> `{Bhaflau Thickets}`
- `!togglegm` (So you don't get aggro'd)
- `!fafnir`
- `!exec target:pathTo(70.5, -32.2, 643.5)`
- `/follow` Fafnir
- Observe Fafnir's path
- Observe the debug logging about the navmesh/pathing
