### PR TITLE
Tem. N fix to equalize chameleon yarn and scarlet odoshi drops

### DIFF
--- a/scripts/battlefields/Temenos/temenos_northern_tower.lua
+++ b/scripts/battlefields/Temenos/temenos_northern_tower.lua
@@ -348,7 +348,7 @@ content.loot =
         {
             { item = xi.item.NONE,                     weight = xi.loot.weight.VERY_HIGH },
             { item = xi.item.CHUNK_OF_SNOWY_CERMET,    weight = xi.loot.weight.LOW       },
-            { item = xi.item.SPOOL_OF_CHAMELEON_YARN,  weight = xi.loot.weight.LOW       },
+            { item = xi.item.SPOOL_OF_SCARLET_ODOSHI,  weight = xi.loot.weight.LOW       },
             { item = xi.item.SPOOL_OF_GLITTERING_YARN, weight = xi.loot.weight.LOW       },
             { item = xi.item.SQUARE_OF_BRILLIANTINE,   weight = xi.loot.weight.LOW       },
         },


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Limbus AF+1 drops are completely made-up on LSB and each item is intended to have one Normal drop chance and one Low drop chance per zone. The image below shows the current drop rates, and note that Chameleon Yarn has 3 entries and Scarlet Odoshi has 1 entry. This PR switches the Low drop chance for Chameleon Yarn on floor 2 to Scarlet Odoshi instead.

![temn](https://github.com/user-attachments/assets/33a0ecc4-6ef5-4fb2-9719-0f413dd423be)

## Steps to test these changes

Kill the three center Gigas in Tem N and keep opening chests until odoshi drops