### PR TITLE
Core: Additional checks in TreasurePoll

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -2311,7 +2311,6 @@ void SmallPacket0x03D(map_session_data_t* const PSession, CCharEntity* const PCh
 void SmallPacket0x041(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket& data)
 {
     TracyZoneScoped;
-    PrintPacket(data);
 
     uint8 SlotID = data.ref<uint8>(0x04);
 
@@ -2339,7 +2338,6 @@ void SmallPacket0x041(map_session_data_t* const PSession, CCharEntity* const PCh
 void SmallPacket0x042(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket& data)
 {
     TracyZoneScoped;
-    PrintPacket(data);
 
     uint8 SlotID = data.ref<uint8>(0x04);
 
@@ -8228,7 +8226,6 @@ void SmallPacket0x112(map_session_data_t* const PSession, CCharEntity* const PCh
 void SmallPacket0x113(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket& data)
 {
     TracyZoneScoped;
-    PrintPacket(data);
 
     if (PChar->status != STATUS_TYPE::NORMAL)
     {

--- a/src/map/treasure_pool.cpp
+++ b/src/map/treasure_pool.cpp
@@ -267,6 +267,11 @@ void CTreasurePool::LotItem(CCharEntity* PChar, uint8 SlotID, uint16 Lot)
     }
 
     CItem* PItem = itemutils::GetItem(m_PoolItems[SlotID].ID);
+    if (PItem == nullptr)
+    {
+        ShowWarning(fmt::format("Player {} is trying to lot on an item that doesn't exist (PItem was nullptr) (Packet injection?)!", PChar->getName()).c_str());
+        return;
+    }
 
     // Cannot lot if player's inventory is full
     if (PChar->getStorage(LOC_INVENTORY)->GetFreeSlotsCount() == 0)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Matches a call to `GetItem` with a `nullptr` check
