### PR TITLE
[BugFix]Prevent invalid lua onEquip calls

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -2729,6 +2729,9 @@ namespace charutils
                     PChar->PLatentEffectContainer->CheckLatentsEquip(equipSlotID);
                     PChar->addPetModifiers(&PItem->petModList);
 
+                    // Only call the lua onEquip if its a valid equip - e.g. has passed EquipArmor and other checks above
+                    luautils::OnItemEquip(PChar, PItem);
+
                     PChar->pushPacket(new CEquipPacket(slotID, equipSlotID, containerID));
                     PChar->pushPacket(new CInventoryAssignPacket(PItem, INV_NODROP));
                 }
@@ -2752,11 +2755,6 @@ namespace charutils
 
             BuildingCharWeaponSkills(PChar);
             PChar->pushPacket(new CCharAbilitiesPacket(PChar));
-        }
-
-        if (PItem != nullptr)
-        {
-            luautils::OnItemEquip(PChar, PItem);
         }
 
         charutils::BuildingCharSkillsTable(PChar);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Moves the calling of `luautils::OnItemEquip` into the code block gated by `EquipArmor` - ensuring that a lua file's `onItemEquip` is only invoked if the equipment is _actually_ equipped.

Prior to this change, by using tools like LegacyAC it is possible to cause the `onItemEquip` lua clause to be trigged, granting the effect of the armor on characters that cannot wear the equipment.  Due to never actually being equipped, the lua `onItemUnequip` is never called.

For example - here is a level 55 Galka Blm, using legacyAC to gain the spell Impact from `Twilight Cloak`.

![image](https://github.com/user-attachments/assets/fe591f7e-6cf4-465b-ac7a-280946e4b9f6)

**Is this a major issue?**  no.  
For LSB all equipment (outside Twilight Cloak) that could be impacted by this are also gated by latent effects which would not be present on the player or in the case of the Tredecim Scythe a validation that the scythe is equipped and ex data on the item itself.
Technically I suppose someone could cheese the Drk Unlock quests :joy:.
However if a down stream did something like say, put a stat addition directly on an `onItemEquip` well that would cause all sorts of hilarity, wouldnt it?

## Steps to test these changes

1. Be on a job that should not be able to equip a `Twilight Cloak`
2. Setup Legacy AC, and have the below file loaded on the character
3. For fun, put a `printf("Twilight onItemEquip")` in `onItemEquip` and a  `printf("Twilight onItemUnequip")` in `onItemUnequip`
4. Engage a mob on the character
5. Without this fix: Note the system console outputs _Twilight onItemEquip_ every few seconds and never _Twilight onItemUnequip_.  Disengage and check spell list (ctrl+m).  You now have Impact.
6. With this fix - no console outputs at all.  No impact.

### LegacyAC File for testing purposes
```xml
<ashitacast>
	<settings>
		<buffupdate>false</buffupdate>
		<statusupdate>false</statusupdate>
		<hpupdate>false</hpupdate>
		<autoupdate>true</autoupdate>
	</settings>
	<sets>
		<set name="TP">
			<body>Twilight Cloak</body>
		</set>
		<include>
		</include>
	</sets>
	<variables>
	</variables>
	<inputcommands>
	</inputcommands>
	<idlegear>
		<if p_status="engaged">
            <equip set="TP" />
        </if>
	</idlegear>
	<preranged>
	</preranged>
	<midranged>
	</midranged>
	<premagic>
	</premagic>
	<midmagic>
	</midmagic>
	<jobability>
	</jobability>
	<weaponskill>
	</weaponskill>
</ashitacast>
```