### PR TITLE
[core] Add mob mod to skip allegiance check (for healing with damage spells)

### DIFF
--- a/scripts/enum/mob_mod.lua
+++ b/scripts/enum/mob_mod.lua
@@ -88,4 +88,5 @@ xi.mobMod =
     TRUST_DISTANCE         = 77, -- TRUSTS ONLY: Set movement type/distance. See trust.lua for details.
     STANDBACK_RANGE        = 78, -- Applies a specific standback range for the mob
     CANNOT_GUARD           = 79, -- Check if the mob does not guard (despite being a MNK or PUP mob)
+    SKIP_ALLEGIANCE_CHECK  = 80, -- Skip the allegiance check for valid target (allows for example a mob to cast a TARGET_ENEMY spell on itself)
 }

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1501,7 +1501,19 @@ bool CBattleEntity::ValidTarget(CBattleEntity* PInitiator, uint16 targetFlags)
             // PVE
             if (allegiance <= ALLEGIANCE_TYPE::PLAYER && PInitiator->allegiance <= ALLEGIANCE_TYPE::PLAYER)
             {
-                return allegiance != PInitiator->allegiance;
+                bool haveDiffAllegiances = allegiance != PInitiator->allegiance;
+
+                if (haveDiffAllegiances)
+                {
+                    return true;
+                }
+                // if seems like an invalid target due to allegiances then check for special mob mod
+                // this is needed for mobs that heal themselves with TARGET_ENEMY spells
+                // like fire-absorbing mobs casting Fire IV on themselves
+                else if (auto* PMobInitiator = dynamic_cast<CMobEntity*>(PInitiator))
+                {
+                    return PMobInitiator->getMobMod(MOBMODIFIER::MOBMOD_SKIP_ALLEGIANCE_CHECK) == 1;
+                }
             }
 
             return false;

--- a/src/map/mob_modifier.h
+++ b/src/map/mob_modifier.h
@@ -108,6 +108,7 @@ enum MOBMODIFIER : int
     MOBMOD_TRUST_DISTANCE         = 77, // TRUSTS ONLY: Set movement type/distance. See trust.lua for details.
     MOBMOD_STANDBACK_RANGE        = 78, // Applies a specific standback range for the mob
     MOBMOD_CANNOT_GUARD           = 79, // Check if the mob does not guard(despite being a MNK or PUP mob)
+    MOBMOD_SKIP_ALLEGIANCE_CHECK  = 80, // Skip the allegiance check for valid target (allows for example a mob to cast a TARGET_ENEMY spell on itself)
 };
 
 #endif


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR adds a new mod mob (`SKIP_ALLEGIANCE_CHECK`) that allows skipping the allegiance check in the `CBattleEntity::ValidTarget` method. This is needed because some mobs use damaging spells (with `TARGET_ENEMY` as the validTargets flag) to heal themselves. Specifically, for example, the elementals in Waking the Beast heal both themselves and the avatars by casting T4 spells on themselves that they absorb. Thus this PR is helping to lay the ground work for WTB implementation (that will come in another PR). 

Unfortunately, this cannot be done by changing the flag on the spell object validTargets because `CBattleEntity::ValidTarget` is called before any available lua hook (such as the mobs `onSpellPrecast`) and thus would require a new hook or reordering of existing hooks. Therefore, I think this PR is the cleanest solution at the moment.

## Steps to test these changes
Find a casting mob and target it
Use !exec target:castSpell(144,target) and see no casting of Fire on itself
Use !exec target:addMobMod(79,1) to add the mob mod
Use !exec target:castSpell(144,target) and see the mob cast Fire on itself