### PR TITLE
Add null check to charutils::canUseWeaponSkill()

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3823,6 +3823,13 @@ namespace charutils
     bool canUseWeaponSkill(CCharEntity* PChar, uint16 wsid)
     {
         CWeaponSkill* PWeaponSkill = battleutils::GetWeaponSkill(wsid);
+
+        if (PWeaponSkill == nullptr)
+        {
+            ShowError("Invalid Weaponskill ID passed to function.");
+            return false;
+        }
+
         return PChar->GetSkill(PWeaponSkill->getType()) >= PWeaponSkill->getSkillLevel();
     }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
`battleutils::GetWeaponSkill()` can potentially return null if an invalid wsid is passed to it.  Adds additional null check to `charutils::canUseWeaponskill()` and logs if this is hit as well (returns false in this case).
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Pass invalid WS to canUseWeaponskill, see multiple errors logged but no crash.
<!-- Clear and detailed steps to test your changes here -->
