### PR TITLE
Fix cruor table reference for non-visions Cruor Prospectors

### DIFF
--- a/scripts/zones/Abyssea-Altepa/npcs/Cruor_Prospector.lua
+++ b/scripts/zones/Abyssea-Altepa/npcs/Cruor_Prospector.lua
@@ -185,7 +185,7 @@ entity.onEventFinish = function(player, csid, option, npc)
     elseif itemCategory == itemType.ENHANCEMENT then
         local enhanceData = prospectorItems[itemCategory][itemSelected]
 
-        if enhanceData <= cruorTotal then
+        if enhanceData[2] <= cruorTotal then
             for _, v in ipairs(enhanceData[1]) do
                 player:addStatusEffectEx(v[1], v[2], v[3] + xi.abyssea.getAbyssiteTotal(player, v[4]) * v[5])
 

--- a/scripts/zones/Abyssea-Attohwa/npcs/Cruor_Prospector.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/Cruor_Prospector.lua
@@ -183,7 +183,7 @@ entity.onEventFinish = function(player, csid, option, npc)
     elseif itemCategory == itemType.ENHANCEMENT then
         local enhanceData = prospectorItems[itemCategory][itemSelected]
 
-        if enhanceData <= cruorTotal then
+        if enhanceData[2] <= cruorTotal then
             for _, v in ipairs(enhanceData[1]) do
                 player:addStatusEffectEx(v[1], v[2], v[3] + xi.abyssea.getAbyssiteTotal(player, v[4]) * v[5])
 

--- a/scripts/zones/Abyssea-Grauberg/npcs/Cruor_Prospector.lua
+++ b/scripts/zones/Abyssea-Grauberg/npcs/Cruor_Prospector.lua
@@ -188,7 +188,7 @@ entity.onEventFinish = function(player, csid, option, npc)
     elseif itemCategory == itemType.ENHANCEMENT then
         local enhanceData = prospectorItems[itemCategory][itemSelected]
 
-        if enhanceData <= cruorTotal then
+        if enhanceData[2] <= cruorTotal then
             for _, v in ipairs(enhanceData[1]) do
                 player:addStatusEffectEx(v[1], v[2], v[3] + xi.abyssea.getAbyssiteTotal(player, v[4]) * v[5])
 

--- a/scripts/zones/Abyssea-Misareaux/npcs/Cruor_Prospector.lua
+++ b/scripts/zones/Abyssea-Misareaux/npcs/Cruor_Prospector.lua
@@ -182,7 +182,7 @@ entity.onEventFinish = function(player, csid, option, npc)
     elseif itemCategory == itemType.ENHANCEMENT then
         local enhanceData = prospectorItems[itemCategory][itemSelected]
 
-        if enhanceData <= cruorTotal then
+        if enhanceData[2] <= cruorTotal then
             for _, v in ipairs(enhanceData[1]) do
                 player:addStatusEffectEx(v[1], v[2], v[3] + xi.abyssea.getAbyssiteTotal(player, v[4]) * v[5])
 

--- a/scripts/zones/Abyssea-Uleguerand/npcs/Cruor_Prospector.lua
+++ b/scripts/zones/Abyssea-Uleguerand/npcs/Cruor_Prospector.lua
@@ -184,7 +184,7 @@ entity.onEventFinish = function(player, csid, option, npc)
     elseif itemCategory == itemType.ENHANCEMENT then
         local enhanceData = prospectorItems[itemCategory][itemSelected]
 
-        if enhanceData <= cruorTotal then
+        if enhanceData[2] <= cruorTotal then
             for _, v in ipairs(enhanceData[1]) do
                 player:addStatusEffectEx(v[1], v[2], v[3] + xi.abyssea.getAbyssiteTotal(player, v[4]) * v[5])
 

--- a/scripts/zones/Abyssea-Vunkerl/npcs/Cruor_Prospector.lua
+++ b/scripts/zones/Abyssea-Vunkerl/npcs/Cruor_Prospector.lua
@@ -186,7 +186,7 @@ entity.onEventFinish = function(player, csid, option, npc)
     elseif itemCategory == itemType.ENHANCEMENT then
         local enhanceData = prospectorItems[itemCategory][itemSelected]
 
-        if enhanceData <= cruorTotal then
+        if enhanceData[2] <= cruorTotal then
             for _, v in ipairs(enhanceData[1]) do
                 player:addStatusEffectEx(v[1], v[2], v[3] + xi.abyssea.getAbyssiteTotal(player, v[4]) * v[5])
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Non-visions (globaled) Cruor Prospectors were trying to compare a table as int for Enhancement buffs.  Corrects the comparison to use index 2 of the table (cruor cost)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Enter non-visions Abyssea area and receive any enhancement from the NPC
<!-- Clear and detailed steps to test your changes here -->
