### PR TITLE
[Quest] Fear of the Dark to IF

### DIFF
--- a/scripts/quests/sandoria/Fear_of_the_Dark.lua
+++ b/scripts/quests/sandoria/Fear_of_the_Dark.lua
@@ -1,0 +1,78 @@
+-----------------------------------
+-- Fear of the Dark
+-----------------------------------
+-- Log ID: 0, Quest ID: 78
+-- Secodiand : !pos -160 -0 137 231
+-----------------------------------
+
+local quest = Quest:new(xi.questLog.SANDORIA, xi.quest.id.sandoria.FEAR_OF_THE_DARK)
+
+quest.reward =
+{
+    gil      = 200 * xi.settings.main.GIL_RATE,
+}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_AVAILABLE
+        end,
+
+        [xi.zone.NORTHERN_SAN_DORIA] =
+        {
+            ['Secodiand'] =
+            {
+                onTrigger = function(player, npc)
+                    return quest:progressEvent(19)
+                end,
+            },
+
+            onEventFinish =
+            {
+                [19] = function(player, csid, option, npc)
+                    if option == 1 then
+                        quest:begin(player)
+                    end
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status >= xi.questStatus.QUEST_ACCEPTED
+        end,
+
+        [xi.zone.NORTHERN_SAN_DORIA] =
+        {
+            ['Secodiand'] =
+            {
+                onTrade = function(player, npc, trade)
+                    if npcUtil.tradeHasExactly(trade, { { xi.item.BAT_WING, 2 } }) then
+                        return quest:progressEvent(18)
+                    end
+                end,
+
+                onTrigger = function(player, npc)
+                    return quest:event(17)
+                end,
+            },
+
+            onEventFinish =
+            {
+                [18] = function(player, csid, option, npc)
+                    player:tradeComplete()
+                        if player:getQuestStatus(quest.areaId, quest.questId) == xi.questStatus.QUEST_ACCEPTED then
+                            player:addFame(xi.fameArea.SANDORIA, 30)
+                        else
+                            player:addFame(xi.fameArea.SANDORIA, 5)
+                        end
+                    quest:complete(player)
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/zones/Northern_San_dOria/npcs/Secodiand.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Secodiand.lua
@@ -7,39 +7,15 @@
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if player:getQuestStatus(xi.questLog.SANDORIA, xi.quest.id.sandoria.FEAR_OF_THE_DARK) ~= xi.questStatus.QUEST_AVAILABLE then
-        if trade:hasItemQty(xi.item.BAT_WING, 2) and trade:getItemCount() == 2 then
-            player:startEvent(18)
-        end
-    end
 end
 
 entity.onTrigger = function(player, npc)
-    local fearOfTheDark = player:getQuestStatus(xi.questLog.SANDORIA, xi.quest.id.sandoria.FEAR_OF_THE_DARK)
-
-    if fearOfTheDark == xi.questStatus.QUEST_AVAILABLE then
-        player:startEvent(19)
-    else
-        player:startEvent(17)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    if csid == 19 and option == 1 then
-        player:addQuest(xi.questLog.SANDORIA, xi.quest.id.sandoria.FEAR_OF_THE_DARK)
-    elseif csid == 18 then
-        player:tradeComplete()
-        npcUtil.giveCurrency(player, 'gil', 200)
-        if player:getQuestStatus(xi.questLog.SANDORIA, xi.quest.id.sandoria.FEAR_OF_THE_DARK) == xi.questStatus.QUEST_ACCEPTED then
-            player:addFame(xi.fameArea.SANDORIA, 30)
-            player:completeQuest(xi.questLog.SANDORIA, xi.quest.id.sandoria.FEAR_OF_THE_DARK)
-        else
-            player:addFame(xi.fameArea.SANDORIA, 5)
-        end
-    end
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Converts the Sandoria Quest Fear of the Dark to Interaction Framework. 
[Capture](https://www.youtube.com/watch?v=7CsT5n9rxZQ)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Removes NPC Dialog from NPC file (Port Sandoria/Secodiand.lua)
## Steps to test these changes
Speak to Secodiand
Accept or decline.
Accepted, trade 2x Bat Wings (!additem 922 2)
On first completion, player will receive 30 Fame:
![fear_of_the_dark_Fame_pre_quest](https://github.com/user-attachments/assets/15419bcf-7211-4d21-ad79-885362d3d601)
![fear_of_the_dark_Fame_1st](https://github.com/user-attachments/assets/8bee0445-c8f8-4492-9e56-0542b4287e62)
Then after the first player will receive 5 Fame:
![fear_of_the_dark_Fame_after1st](https://github.com/user-attachments/assets/10ef0af5-139c-4610-8638-f69ecdb7862d)
<!-- Clear and detailed steps to test your changes here -->
Speak to Secodiand and follow the quest line to trade 2x bat wings.