### PR TITLE
[Core] [Lua] Rework TH effect on drop rates

### DIFF
--- a/scripts/globals/combat/treasure_hunter.lua
+++ b/scripts/globals/combat/treasure_hunter.lua
@@ -3,7 +3,7 @@ xi.combat = xi.combat or {}
 xi.combat.treasureHunter = xi.combat.treasureHunter or {}
 
 -- https://forum.square-enix.com/ffxi/threads/56550
-local treasureHunterTable =
+xi.combat.treasureHunter.treasureHunterTable =
 {
 -- TH lvl    VC    C     UC    R     VR    SR   UR
     [ 0] = { 2400, 1500, 1000,  500,  100,  50,  10 },
@@ -23,7 +23,7 @@ local treasureHunterTable =
     [14] = { 8000, 7000, 3250, 2000, 1000, 500, 150 },
 }
 
-local thBracketTable =
+xi.combat.treasureHunter.dropBracketTable =
 {
     [1] = { 2400 },
     [2] = { 1500 },
@@ -53,7 +53,7 @@ xi.combat.treasureHunter.getDropRate = function(thLevel, dropRate)
     local thBracket = 0
 
     for i = 1, 7 do
-        if thDropRate >= thBracketTable[i][1] then
+        if thDropRate >= xi.combat.treasureHunter.dropBracketTable[i][1] then
             thBracket = i
 
             break
@@ -61,7 +61,7 @@ xi.combat.treasureHunter.getDropRate = function(thLevel, dropRate)
     end
 
     -- Calculate TH drop rate
-    local newDropRate = treasureHunterTable[thTier][thBracket]
+    local newDropRate = xi.combat.treasureHunter.treasureHunterTable[thTier][thBracket]
 
     return newDropRate
 end

--- a/scripts/globals/combat/treasure_hunter.lua
+++ b/scripts/globals/combat/treasure_hunter.lua
@@ -1,0 +1,67 @@
+xi = xi or {}
+xi.combat = xi.combat or {}
+xi.combat.treasureHunter = xi.combat.treasureHunter or {}
+
+-- https://forum.square-enix.com/ffxi/threads/56550
+local treasureHunterTable =
+{
+-- TH lvl    VC    C     UC    R     VR    SR   UR
+    [ 0] = { 2400, 1500, 1000,  500,  100,  50,  10 },
+    [ 1] = { 4800, 3000, 1200,  600,  150,  75,  20 },
+    [ 2] = { 5600, 4000, 1500,  700,  200, 100,  30 },
+    [ 3] = { 6000, 4250, 1650,  750,  225, 120,  35 },
+    [ 4] = { 6400, 4500, 1800,  800,  250, 140,  40 },
+    [ 5] = { 6666, 4750, 1900,  850,  300, 160,  45 },
+    [ 6] = { 6800, 5000, 2000,  900,  350, 180,  50 },
+    [ 7] = { 6900, 5250, 2100,  950,  400, 200,  60 },
+    [ 8] = { 7050, 5500, 2250, 1050,  475, 230,  70 },
+    [ 9] = { 7200, 5750, 2400, 1150,  550, 260,  80 },
+    [10] = { 7350, 6000, 2650, 1250,  650, 300,  90 },
+    [11] = { 7400, 6250, 2800, 1350,  750, 350, 100 },
+    [12] = { 7600, 6500, 2950, 1550,  825, 400, 115 },
+    [13] = { 7800, 6750, 3100, 1750,  900, 450, 130 },
+    [14] = { 8000, 7000, 3250, 2000, 1000, 500, 150 },
+}
+
+local thBracketTable =
+{
+    [1] = { 2400 },
+    [2] = { 1500 },
+    [3] = { 1000 },
+    [4] = {  500 },
+    [5] = {  100 },
+    [6] = {   50 },
+    [7] = {    0 }, -- Set to 0, for weird cases in DB.
+}
+
+xi.combat.treasureHunter.getDropRate = function(thLevel, dropRate)
+    -- Sanitize parameters
+    local thTier     = thLevel or 0
+    local thDropRate = dropRate or 0
+
+    thTier     = utils.clamp(thTier, 0, 14)
+    thDropRate = utils.clamp(thDropRate, 0, 10000)
+
+    -- Early returns: Drop is guaranteed or non-existant.
+    if thDropRate == 10000 then
+        return 10000
+    elseif thDropRate == 0 then
+        return 0
+    end
+
+    -- Calculate original drop rate bracket.
+    local thBracket = 0
+
+    for i = 1, 7 do
+        if thDropRate >= thBracketTable[i][1] then
+            thBracket = i
+
+            break
+        end
+    end
+
+    -- Calculate TH drop rate
+    local newDropRate = treasureHunterTable[thTier][thBracket]
+
+    return newDropRate
+end

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -698,9 +698,8 @@ void CMobEntity::DropItems(CCharEntity* PChar)
 
     if (!getMobMod(MOBMOD_NO_DROPS) && dropList != nullptr && (!dropList->Items.empty() || !dropList->Groups.empty() || PAI->EventHandler.hasListener("ITEM_DROPS")))
     {
-        // THLvl is the number of 'extra chances' at an item. If the item is obtained, then break out.
-        int16 maxRolls = 1 + (m_THLvl > 2 ? 2 : m_THLvl);
-        int16 bonus    = (m_THLvl > 2 ? (m_THLvl - 2) * 10 : 0);
+        // THLvl determines the drop rate. If the item is obtained, then break out.
+        int16 bonus = (m_THLvl > 2 ? (m_THLvl - 2) * 10 : 0);
 
         LootContainer loot(dropList);
 
@@ -715,50 +714,39 @@ void CMobEntity::DropItems(CCharEntity* PChar)
                 total += item.DropRate;
             }
 
-            // NOTE: When switching over to the correct TH table method fixed rate means to not use the TH table
-            int16 rolls = group.hasFixedRate ? 1 : maxRolls;
-
-            for (int16 roll = 0; roll < rolls; ++roll)
+            // Determine if this group should drop an item
+            if (group.GroupRate > 0 && xirand::GetRandomNumber(1000) < group.GroupRate * settings::get<float>("map.DROP_RATE_MULTIPLIER") + bonus)
             {
-                // Determine if this group should drop an item
-                if (group.GroupRate > 0 && xirand::GetRandomNumber(1000) < group.GroupRate * settings::get<float>("map.DROP_RATE_MULTIPLIER") + bonus)
+                // Each item in the group is given its own weight range which is the previous value to the previous value + item.DropRate
+                // Such as 2 items with drop rates of 200 and 800 would be 0-199 and 200-999 respectively
+                uint16 previousRateValue = 0;
+                uint16 itemRoll          = xirand::GetRandomNumber(total);
+                for (const DropItem_t& item : group.Items)
                 {
-                    // Each item in the group is given its own weight range which is the previous value to the previous value + item.DropRate
-                    // Such as 2 items with drop rates of 200 and 800 would be 0-199 and 200-999 respectively
-                    uint16 previousRateValue = 0;
-                    uint16 itemRoll          = xirand::GetRandomNumber(total);
-                    for (const DropItem_t& item : group.Items)
+                    if (previousRateValue + item.DropRate > itemRoll)
                     {
-                        if (previousRateValue + item.DropRate > itemRoll)
+                        if (AddItemToPool(item.ItemID, ++dropCount))
                         {
-                            if (AddItemToPool(item.ItemID, ++dropCount))
-                            {
-                                return;
-                            }
-                            break;
+                            return;
                         }
-                        previousRateValue += item.DropRate;
+                        break;
                     }
-                    break;
+                    previousRateValue += item.DropRate;
                 }
+                break;
             }
         });
 
         loot.ForEachItem([&](const DropItem_t& item)
         {
             // NOTE: When switching over to the correct TH table method fixed rate means to not use the TH table
-            int16 rolls = item.hasFixedRate ? 1 : maxRolls;
-
-            for (int16 roll = 0; roll < rolls; ++roll)
+            if (item.DropRate > 0 && xirand::GetRandomNumber(1000) < item.DropRate * settings::get<float>("map.DROP_RATE_MULTIPLIER") + bonus)
             {
-                if (item.DropRate > 0 && xirand::GetRandomNumber(1000) < item.DropRate * settings::get<float>("map.DROP_RATE_MULTIPLIER") + bonus)
+                if (AddItemToPool(item.ItemID, ++dropCount))
                 {
-                    if (AddItemToPool(item.ItemID, ++dropCount))
-                    {
-                        return;
-                    }
-                    break;
+                    return;
                 }
+                break;
             }
         });
         // clang-format on

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -4086,28 +4086,21 @@ namespace charutils
         }
     }
 
-    void DistributeItem(CCharEntity* PChar, CBaseEntity* PEntity, uint16 itemid, uint16 droprate)
+    void DistributeItem(CCharEntity* PChar, CBaseEntity* PEntity, uint16 itemid, uint16 dropRate)
     {
         TracyZoneScoped;
 
-        uint8 tries    = 0;
-        uint8 maxTries = 1;
-        uint8 bonus    = 0;
+        auto   thDropRateFunction = lua["xi"]["combat"]["treasureHunter"]["getDropRate"];
+        uint16 thDropRate         = dropRate * 10;
+
         if (auto* PMob = dynamic_cast<CMobEntity*>(PEntity))
         {
-            // THLvl is the number of 'extra chances' at an item. If the item is obtained, then break out.
-            tries    = 0;
-            maxTries = 1 + (PMob->m_THLvl > 2 ? 2 : PMob->m_THLvl);
-            bonus    = (PMob->m_THLvl > 2 ? (PMob->m_THLvl - 2) * 10 : 0);
+            thDropRate = thDropRateFunction(PMob->m_THLvl, thDropRate);
         }
-        while (tries < maxTries)
+
+        if (thDropRate > 0 && xirand::GetRandomNumber(1, 10000) <= thDropRate * settings::get<float>("map.DROP_RATE_MULTIPLIER"))
         {
-            if (droprate > 0 && xirand::GetRandomNumber(1000) < droprate * settings::get<float>("map.DROP_RATE_MULTIPLIER") + bonus)
-            {
-                PChar->PTreasurePool->AddItem(itemid, PEntity);
-                break;
-            }
-            tries++;
+            PChar->PTreasurePool->AddItem(itemid, PEntity);
         }
     }
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Applies the TH chart to treasure hunter. This means, no multiple rolls and instead following the chart provided by retail.
- Removes multiple rolls. That's not how TH works.
- Define the chart in lua and calculate new drop rate in there while we are at it.
- Enforce the brackets no matter what the drop rate in the database is.
- Ensure fixed drop rates for items and groups are both unaffected by TH and by the pre-defined brackets.

Notes:
- Drop rates in core STILL need a major cleanup.
- TH triggering still needs to be coded.
- Drop rates had to be multiplied by 10 here. drop/1000 just didnt cut it, considering the chart 0.01 precision.

![imagen](https://github.com/user-attachments/assets/fe25277f-6ae9-4d02-ae4b-503a2fe963ad)

## Steps to test these changes

Kill mobs and get drops without the server creating a singularity in the space/time continuum.

Review by commit. It really helps to see the changes made, specially because of the removal of loops for multiple rolls.

