### PR TITLE
[lua, core] Apply subtle blow, inhibit tp, dAGI, store tp to spells

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -476,11 +476,6 @@ function finalMagicAdjustments(caster, target, spell, dmg)
 
         -- Handle Enmity.
         target:updateEnmityFromDamage(caster, dmg)
-
-        -- Only add TP if the target is a mob
-        if target:getObjType() ~= xi.objType.PC and dmg > 0 then
-            target:addTP(100)
-        end
     end
 
     return dmg

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -1044,11 +1044,6 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
         -- Handle Enmity.
         target:updateEnmityFromDamage(caster, finalDamage)
 
-        -- Only add TP if the target is a mob and if the spell actually does damage.
-        if target:getObjType() ~= xi.objType.PC and finalDamage > 0 then
-            target:addTP(100)
-        end
-
         -- Add "Magic Burst!" message
         if magicBurst > 1 then
             spell:setMsg(xi.msg.basic.MAGIC_BURST_DAMAGE)

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2559,7 +2559,7 @@ namespace battleutils
         PDefender->takeDamage(damage, PAttacker, attackType, damageType);
 
         // Remove effects from damage
-        if (PSpell->canTargetEnemy() && damage > 0 && PSpell->dealsDamage())
+        if (PSpell->canTargetEnemy() && damage > 0)
         {
             PDefender->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DAMAGE);
 
@@ -2570,9 +2570,12 @@ namespace battleutils
             int16 tp = battleutils::CalculateSpellTP(PAttacker, PSpell);
             PAttacker->addTP(tp);
 
-            // Targets of damaging spells gain 50 tp + store tp bonus
-            float storeTPMultiplier = 1.0f + 0.01f * static_cast<float>(PDefender->getMod(Mod::STORETP) + getStoreTPbonusFromMerit(PDefender));
-            PDefender->addTP(static_cast<int16>(50 * storeTPMultiplier));
+            // Targets of damaging spells gain TP
+            auto tpGainFunc = lua["xi"]["combat"]["tp"]["calculateTPGainOnMagicalDamage"];
+            if (tpGainFunc.valid())
+            {
+                PDefender->addTP(tpGainFunc(damage, CLuaBaseEntity(PAttacker), CLuaBaseEntity(PDefender)));
+            }
         }
 
         return damage;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Apply subtle blow, inhibit tp, dAGI, store tp to spells

## Steps to test these changes

Test players and mobs getting correct modifiers for spells e.g.

mobs get 100 * dagi * subtle blow * store tp * inhibit TP gain on getting nuked
players get 50 * dagi * subtle blow * store tp * inhibit TP gain on getting nuked

test includes:
Spells, blue magic, dia and bio