### PR TITLE
[core, lua] Implement NIN subtle blow merits

### DIFF
--- a/scripts/globals/combat/tp.lua
+++ b/scripts/globals/combat/tp.lua
@@ -128,11 +128,12 @@ xi.combat.tp.calculateTPGainOnPhysicalDamage = function(totalDamage, delay, acto
         local attackOutput       = xi.combat.tp.getModifiedDelayAndCanZanshin(actor, delay)
         local baseTPGain         = xi.combat.tp.calculateTPReturn(target, attackOutput.modifiedDelay)
         local dAGI               = actor:getMod(xi.mod.AGI) - target:getMod(xi.mod.AGI)
-        local inhibitTPModifier  = (100 - target:getMod(xi.mod.INHIBIT_TP)) / 100         -- no known cap: https://www.bg-wiki.com/ffxi/Monster_TP_gain#Inhibit_TP
-        local dAGIModifier       = utils.clamp(200 - (dAGI + 30) / 200, 1.0, 0.5)           -- 50% reduction at +70 dAGI: https://www.bg-wiki.com/ffxi/Monster_TP_gain
-        local subtleBlowI        = math.min(actor:getMod(xi.mod.SUBTLE_BLOW), 50)        -- cap of 50% https://www.bg-wiki.com/ffxi/Subtle_Blow
-        local subtleBlowII       = actor:getMod(xi.mod.SUBTLE_BLOW_II)                   -- no known cap
-        local subtleBlowModifier = math.max((100 - subtleBlowI + subtleBlowII) / 100, 0.25) -- combined cap of 75% reduction: https://www.bg-wiki.com/ffxi/Subtle_Blow
+        local inhibitTPModifier  = (100 - target:getMod(xi.mod.INHIBIT_TP)) / 100                    -- no known cap: https://www.bg-wiki.com/ffxi/Monster_TP_gain#Inhibit_TP
+        local dAGIModifier       = utils.clamp(200 - (dAGI + 30) / 200, 1.0, 0.5)                    -- 50% reduction at +70 dAGI: https://www.bg-wiki.com/ffxi/Monster_TP_gain
+        local subtleBlowMerits   = actor:getMerit(xi.merit.SUBTLE_BLOW_EFFECT)
+        local subtleBlowI        = math.min(actor:getMod(xi.mod.SUBTLE_BLOW) + subtleBlowMerits, 50) -- cap of 50% https://www.bg-wiki.com/ffxi/Subtle_Blow
+        local subtleBlowII       = actor:getMod(xi.mod.SUBTLE_BLOW_II)                               -- no known cap
+        local subtleBlowModifier = math.max((100 - subtleBlowI + subtleBlowII) / 100, 0.25)          -- combined cap of 75% reduction: https://www.bg-wiki.com/ffxi/Subtle_Blow
         local storeTPModifier    = (100 + target:getMod(xi.mod.STORETP)) / 100
 
         -- TODO: unknown where/how many floor steps there are. Napkin math seems to be a single floor step, but given x/256 it's hard to tell
@@ -159,11 +160,12 @@ xi.combat.tp.calculateTPGainOnMagicalDamage = function(totalDamage, actor, targe
     -- TODO: does dAGI penalty work against/for Trusts/Pets? Nothing is documented for this. Currently assuming mob only.
     if totalDamage > 0 and target and actor then
         local dAGI               = actor:getMod(xi.mod.AGI) - target:getMod(xi.mod.AGI)
-        local inhibitTPModifier  = (100 - target:getMod(xi.mod.INHIBIT_TP)) / 100         -- no known cap: https://www.bg-wiki.com/ffxi/Monster_TP_gain#Inhibit_TP
-        local dAGIModifier       = utils.clamp(200 - (dAGI + 30) / 200, 1.0, 0.5)           -- 50% reduction at +70 dAGI: https://www.bg-wiki.com/ffxi/Monster_TP_gain
-        local subtleBlowI        = math.min(actor:getMod(xi.mod.SUBTLE_BLOW), 50)        -- cap of 50% https://www.bg-wiki.com/ffxi/Subtle_Blow
-        local subtleBlowII       = actor:getMod(xi.mod.SUBTLE_BLOW_II)                   -- no known cap
-        local subtleBlowModifier = math.max((100 - subtleBlowI + subtleBlowII) / 100, 0.25) -- combined cap of 75% reduction: https://www.bg-wiki.com/ffxi/Subtle_Blow
+        local inhibitTPModifier  = (100 - target:getMod(xi.mod.INHIBIT_TP)) / 100                    -- no known cap: https://www.bg-wiki.com/ffxi/Monster_TP_gain#Inhibit_TP
+        local dAGIModifier       = utils.clamp(200 - (dAGI + 30) / 200, 1.0, 0.5)                    -- 50% reduction at +70 dAGI: https://www.bg-wiki.com/ffxi/Monster_TP_gain
+        local subtleBlowMerits   = actor:getMerit(xi.merit.SUBTLE_BLOW_EFFECT)
+        local subtleBlowI        = math.min(actor:getMod(xi.mod.SUBTLE_BLOW) + subtleBlowMerits, 50) -- cap of 50% https://www.bg-wiki.com/ffxi/Subtle_Blow
+        local subtleBlowII       = actor:getMod(xi.mod.SUBTLE_BLOW_II)                               -- no known cap
+        local subtleBlowModifier = math.max((100 - subtleBlowI + subtleBlowII) / 100, 0.25)          -- combined cap of 75% reduction: https://www.bg-wiki.com/ffxi/Subtle_Blow
         local storeTPModifier    = (100 + target:getMod(xi.mod.STORETP)) / 100
 
         -- Similar caveats to above for physical damage, unknown where/how many floors but seems to be one.

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2348,8 +2348,14 @@ namespace battleutils
 
             if (giveTPtoVictim)
             {
+                uint32 sBlowMerit = 0;
+                if (CCharEntity* PChar = dynamic_cast<CCharEntity*>(PAttacker))
+                {
+                    sBlowMerit = PChar->PMeritPoints->GetMeritValue(MERIT_TYPE::MERIT_SUBTLE_BLOW_EFFECT, PChar);
+                }
+
                 // account for attacker's subtle blow which reduces the baseTP gain for the defender
-                float sBlow1    = std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW), -50.0f, 50.0f);
+                float sBlow1    = std::clamp((float)(PAttacker->getMod(Mod::SUBTLE_BLOW) + sBlowMerit), -50.0f, 50.0f);
                 float sBlow2    = std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW_II), -50.0f, 50.0f);
                 float sBlowMult = ((100.0f - std::clamp(sBlow1 + sBlow2, -75.0f, 75.0f)) / 100.0f);
 
@@ -2503,8 +2509,14 @@ namespace battleutils
                                                (1.0f + 0.01f * (float)((PAttacker->getMod(Mod::STORETP) + getStoreTPbonusFromMerit(PAttacker))))));
             }
 
+            uint32 sBlowMerit = 0;
+            if (CCharEntity* PChar = dynamic_cast<CCharEntity*>(PAttacker))
+            {
+                sBlowMerit = PChar->PMeritPoints->GetMeritValue(MERIT_TYPE::MERIT_SUBTLE_BLOW_EFFECT, PChar);
+            }
+
             // account for attacker's subtle blow which reduces the baseTP gain for the defender
-            float sBlow1    = std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW), -50.0f, 50.0f);
+            float sBlow1    = std::clamp((float)(PAttacker->getMod(Mod::SUBTLE_BLOW) + sBlowMerit), -50.0f, 50.0f);
             float sBlow2    = std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW_II), -50.0f, 50.0f);
             float sBlowMult = (100.0f - std::clamp(sBlow1 + sBlow2, -75.0f, 75.0f)) / 100.0f;
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements Subtle Blow merits for NIN (yes, really.)

## Steps to test these changes
5/5 merits in subtle blow,
27 + 5 subtle blow so..
`100 * .5 * .68 = 34`
![image](https://github.com/user-attachments/assets/14495d72-e096-416d-9466-05bc98b6ad06)
Also test with auto attacks (you can just breakpoint np)
