### PR TITLE
[Magic] Fix duplicate message on death spell AND enemy Death spell not landing ever

### DIFF
--- a/scripts/actions/spells/black/death.lua
+++ b/scripts/actions/spells/black/death.lua
@@ -35,7 +35,6 @@ spellObject.onSpellCast = function(caster, target, spell)
         end
 
         if instaDeath then
-            spell:setMsg(xi.msg.basic.FALL_TO_GROUND)
             target:setHP(0)
         else
             spell:setMsg(xi.msg.basic.MAGIC_DMG)
@@ -49,8 +48,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
     -- Not-player spell.
     else
-        if math.random(1, 100) <= target:getMod(xi.mod.DEATHRES) then
-            spell:setMsg(xi.msg.basic.FALL_TO_GROUND)
+        if math.random(1, 100) > target:getMod(xi.mod.DEATHRES) then
             target:setHP(0)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes mob death not ever working. Fuck you players.
Fixes duplicate "Falls to the ground" message when death lands.

## Steps to test these changes

Get a mob to cast death on you.
Actually die.
