### PR TITLE
[Quest] Her Majesty's Garden to IF

### DIFF
--- a/scripts/quests/sandoria/Her_Majesty_S_Garden.lua
+++ b/scripts/quests/sandoria/Her_Majesty_S_Garden.lua
@@ -1,0 +1,96 @@
+-----------------------------------
+-- Her Majestys Garden
+-----------------------------------
+-- Log ID: 0, Quest ID: 62
+-- Chalvatot : !pos -105 0.1 72 233
+-- Reward : Map of the Northlands
+-----------------------------------
+
+local quest = Quest:new(xi.questLog.SANDORIA, xi.quest.id.sandoria.HER_MAJESTY_S_GARDEN)
+
+quest.reward =
+{
+    fame     = 30,
+    fameArea = xi.fameArea.SANDORIA,
+    keyItem  = xi.ki.MAP_OF_THE_NORTHLANDS_AREA,
+    gil      = 2000,
+    xp       = 2000,
+}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_AVAILABLE and
+            player:getFameLevel(xi.fameArea.SANDORIA) >= 4
+        end,
+
+        [xi.zone.CHATEAU_DORAGUILLE] =
+        {
+            ['Chalvatot'] =
+            {
+                onTrigger = function(player, npc)
+                    local questProgress = quest:getVar(player, 'Prog')
+
+                    if questProgress == 0 then
+                        if  player:getNation() ~= xi.nation.SANDORIA then -- Non sandy folk gets a CS prior to getting acceptance
+                            return quest:progressEvent(538)
+                        else -- Sandy folks go directly to CS acceptance
+                            return quest:progressEvent(84)
+                        end
+                    elseif questProgress == 1 then
+                        return quest:progressEvent(84)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [538] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 1)
+                end,
+
+                [84] = function(player, csid, option, npc)
+                    if option == 1 then
+                        quest:begin(player)
+                        quest:setVar(player, 'Prog', 0)
+                    end
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_ACCEPTED
+        end,
+
+        [xi.zone.CHATEAU_DORAGUILLE] =
+        {
+            ['Chalvatot'] =
+            {
+                onTrigger = function(player, npc)
+                    return quest:event(82)
+                end,
+
+                onTrade = function(player, npc, trade)
+                    if npcUtil.tradeHasExactly(trade, { xi.item.CHUNK_OF_DERFLAND_HUMUS }) then
+                        return quest:progressEvent(83)
+                    end
+                end,
+
+            },
+
+            onEventFinish =
+            {
+                [83] = function(player, csid, option, npc)
+                    if quest:complete(player) then
+                        player:confirmTrade()
+                    end
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/zones/Chateau_dOraguille/DefaultActions.lua
+++ b/scripts/zones/Chateau_dOraguille/DefaultActions.lua
@@ -5,6 +5,7 @@ return {
     ['_6h4']        = { text = ID.text.ITS_LOCKED_TIGHT },
     ['Arsha']       = { event = 513 },
     ['Chaphoire']   = { event = 512 },
+    ['Chalvatot']   = { event = 531 },
     ['Chupaile']    = { event = 514 },
     ['Ferdechiond'] = { event = 511 },
     ['Halver']      = { text = ID.text.HALVER_OFFSET + 1092 },

--- a/scripts/zones/Chateau_dOraguille/npcs/Chalvatot.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/Chalvatot.lua
@@ -11,16 +11,6 @@ local ID = zones[xi.zone.CHATEAU_DORAGUILLE]
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local herMajestysGarden = player:getQuestStatus(xi.questLog.SANDORIA, xi.quest.id.sandoria.HER_MAJESTY_S_GARDEN)
-
-    -- HER MAJESTY'S GARDEN (derfland humus)
-    if
-        herMajestysGarden == xi.questStatus.QUEST_ACCEPTED and
-        trade:hasItemQty(xi.item.CHUNK_OF_DERFLAND_HUMUS, 1) and
-        trade:getItemCount() == 1
-    then
-        player:startEvent(83)
-    end
 end
 
 entity.onTrigger = function(player, npc)
@@ -28,7 +18,6 @@ entity.onTrigger = function(player, npc)
     local circleProgress = player:getCharVar('circleTime')
     local lureOfTheWildcat = player:getQuestStatus(xi.questLog.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT)
     local wildcatSandy = player:getCharVar('WildcatSandy')
-    local herMajestysGarden = player:getQuestStatus(xi.questLog.SANDORIA, xi.quest.id.sandoria.HER_MAJESTY_S_GARDEN)
 
     -- CIRCLE OF TIME (Bard AF3)
     if circleOfTime == xi.questStatus.QUEST_ACCEPTED then
@@ -48,19 +37,6 @@ entity.onTrigger = function(player, npc)
         not utils.mask.getBit(wildcatSandy, 19)
     then
         player:startEvent(561)
-
-    -- HER MAJESTY'S GARDEN
-    elseif
-        herMajestysGarden == xi.questStatus.QUEST_AVAILABLE and
-        player:getFameLevel(xi.fameArea.SANDORIA) >= 4
-    then
-        player:startEvent(84)
-    elseif herMajestysGarden == xi.questStatus.QUEST_ACCEPTED then
-        player:startEvent(82)
-
-    -- DEFAULT DIALOG
-    else
-        player:startEvent(531)
     end
 end
 
@@ -89,16 +65,6 @@ entity.onEventFinish = function(player, csid, option, npc)
     -- LURE OF THE WILDCAT
     elseif csid == 561 then
         player:setCharVar('WildcatSandy', utils.mask.setBit(player:getCharVar('WildcatSandy'), 19, true))
-
-    -- HER MAJESTY'S GARDEN
-    elseif csid == 84 and option == 1 then
-        player:addQuest(xi.questLog.SANDORIA, xi.quest.id.sandoria.HER_MAJESTY_S_GARDEN)
-    elseif csid == 83 then
-        player:tradeComplete()
-        player:addKeyItem(xi.ki.MAP_OF_THE_NORTHLANDS_AREA)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.MAP_OF_THE_NORTHLANDS_AREA)
-        player:addFame(xi.fameArea.SANDORIA, 30)
-        player:completeQuest(xi.questLog.SANDORIA, xi.quest.id.sandoria.HER_MAJESTY_S_GARDEN)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR converts the Sandoria Quest Her Majesty's Garden to Interaction Framework.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Speak with Chalvatot:

Have fame at level 4 or higher and access to Chateau d Oraguille. 
If NOT Sandoria Citizen, player will receive a "pre cutscene". After the cutscene, the quest will continue as normal.
If Sandorian citizen, player will not receive the "pre cutscene" and go directly to the cutscene to accept or decline the quest.

Chalvatot will ask for a Chunk of Derfland Humus. 
Trade Chalvatot a Chunk of Derfland Humus.
Player will receive a KI Map of the Northlands
2000 Gil 
2000 Exp. 

[
<!-- Clear and detailed steps to test your changes here -->
Speak with Chalvatot with Fame 4 or greater. Trade Derfland Humus and get Map of Northlands, 2k Gil and 2k Exp.
If already have the map, player will still get 2k Gil and 2k EXP.

[Capture #1](https://www.youtube.com/watch?v=KPooIRDJbMY)
[Capture #2 ](https://www.youtube.com/watch?v=NIrSZ7VccvQ)