### PR TITLE
[core] [sql] Fix a hung session bug

### DIFF
--- a/sql/accounts_sessions.sql
+++ b/sql/accounts_sessions.sql
@@ -33,6 +33,7 @@ CREATE TABLE `accounts_sessions` (
   `version_mismatch` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `seacom_type` TINYINT(1) unsigned NOT NULL DEFAULT '0',
   `seacom_message` TINYBLOB NULL DEFAULT NULL,
+  `last_zoneout_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`charid`),
   UNIQUE KEY `accid` (`accid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1057,6 +1057,11 @@ int32 map_close_session(time_point tick, map_session_data_t* map_session_data)
         {
             _sql->Query("DELETE FROM accounts_sessions WHERE charid = %u", map_session_data->charID);
         }
+        else
+        {
+            // Set client port to zero, indicating the client tried to zone out and no longer has a port until the next 0x00A
+            _sql->Query("UPDATE accounts_sessions SET client_port = 0, last_zoneout_time = NOW() WHERE charid = %u", map_session_data->charID);
+        }
 
         uint64 port64 = map_session_data->client_port;
         uint64 ipp    = map_session_data->client_addr;

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -314,7 +314,7 @@ void SmallPacket0x00A(map_session_data_t* const PSession, CCharEntity* const PCh
 
         PChar->m_ZonesList[PChar->getZone() >> 3] |= (1 << (PChar->getZone() % 8));
 
-        const char* fmtQuery = "UPDATE accounts_sessions SET targid = %u, session_key = x'%s', server_addr = %u, client_port = %u WHERE charid = %u";
+        const char* fmtQuery = "UPDATE accounts_sessions SET targid = %u, session_key = x'%s', server_addr = %u, client_port = %u, last_zoneout_time = 0 WHERE charid = %u";
 
         // Current zone could either be current zone or destination
         CZone* currentZone = zoneutils::GetZone(PChar->getZone());


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This fixes a hung session if you zone out but you never make it to the other zone on a different map server. 30 second wait time before you're allowed in in case of exploits
## Steps to test these changes

Create a setup with 2 map servers, on different ports
!hp 0 yourself, and zone after moving the zone .dat you're HPing to, this will kill your client

wait 30 seconds
log back in normally after fixing your client setup
Works best on linux, you can just rename the FFXI folder and you're done

Pre patch you'd be forever stuck not begin able to login without manually clearing the session
