### PR TITLE
[Quest] Convert Mihgo's Amigo to IF

### DIFF
--- a/scripts/quests/windurst/Mihgo_s_Amigo.lua
+++ b/scripts/quests/windurst/Mihgo_s_Amigo.lua
@@ -1,0 +1,152 @@
+-----------------------------------
+-- Mihgo's Amigo
+-----------------------------------
+-- Log ID: 2, Quest ID: 25
+-- Nanaa Mihgo       : !pos 62 -4 240 241
+-- Cha Lebagta       : !pos 58 -6 216 241
+-- Bopa Greso        : !pos 59 -6 216 241
+-- Mheca Khetashipah : !pos 66 -6 185 241
+-- Gioh Ajihri       : !pos 108 -5 176 241
+-- Wani Casdohry     : !pos 104 -5 176 241
+-----------------------------------
+
+local quest = Quest:new(xi.questLog.WINDURST, xi.quest.id.windurst.MIHGO_S_AMIGO)
+
+local gilPerTrade = 200
+
+quest.reward =
+{
+    fame     = 60, -- 16 era based on 212 Yagudo Necklaces for 4 Norg fame
+    fameArea = xi.fameArea.NORG,
+    title    = xi.title.CAT_BURGLAR_GROUPIE,
+}
+
+quest.sections =
+{
+    {
+        -- QUEST AVAILABLE
+        check = function(player, status, vars)
+            local lostForWords = player:getMissionStatus(xi.mission.log_id.WINDURST, xi.mission.id.windurst.LOST_FOR_WORDS)
+            return status == xi.questStatus.QUEST_AVAILABLE and
+                player:getFameLevel(xi.fameArea.NORG) >= 1 and
+                player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.THE_TENSHODO_SHOWDOWN) ~= xi.questStatus.QUEST_ACCEPTED and
+                player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.AS_THICK_AS_THIEVES) ~= xi.questStatus.QUEST_ACCEPTED and
+                lostForWords == 0 and -- Player cannot accept quest during Lost For Words Mission
+                not player:hasItem(xi.item.MARAUDERS_KNIFE)
+        end,
+
+        [xi.zone.WINDURST_WOODS] =
+        {
+            ['Nanaa_Mihgo'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.CRYING_OVER_ONIONS) == xi.questStatus.QUEST_ACCEPTED then
+                        return quest:progressEvent(81) -- come to apologize
+                    else
+                        return quest:progressEvent(80)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [80] = function(player, csid, option, npc)
+                    return quest:begin(player)
+                end,
+
+                [81] = function(player, csid, option, npc)
+                    quest:setVar(player, 'CryingforOnions', 1)
+                    return quest:begin(player)
+                end,
+            },
+        },
+    },
+
+    {
+        -- QUEST ACCEPTED
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_ACCEPTED
+        end,
+
+        [xi.zone.WINDURST_WOODS] =
+        {
+            ['Bopa_Greso'] = quest:event(84, 0, xi.item.YAGUDO_BEAD_NECKLACE), -- Migho's Amigo hint dialog
+
+            ['Cha_Lebagta'] = quest:event(85, 0, xi.item.YAGUDO_BEAD_NECKLACE), -- Migho's Amigo hint dialog
+
+            ['Gioh_Ajihri'] = quest:event(87),
+
+            ['Mheca_Khetashipah'] = quest:event(83),
+
+            ['Nanaa_Mihgo'] =
+            {
+                onTrade = function(player, npc, trade)
+                    if npcUtil.tradeHasExactly(trade, { { xi.item.YAGUDO_BEAD_NECKLACE, 4 } }) then
+                        if quest:getVar(player, 'CryingforOnions') == 1 then
+                            return quest:progressEvent(92, { [0] = xi.settings.main.GIL_RATE * gilPerTrade }) -- apology accepted
+                        else
+                            return quest:progressEvent(88, { [0] = xi.settings.main.GIL_RATE * gilPerTrade })
+                        end
+                    end
+                end,
+
+                onTrigger = function(player, npc)
+                    return quest:event(82)
+                end,
+            },
+
+            ['Wani_Casdohry'] = quest:event(86, 0, xi.item.YAGUDO_BEAD_NECKLACE), -- Migho's Amigo hint dialog
+
+            onEventFinish =
+            {
+                [88] = function(player, csid, option, npc)
+                    if quest:complete(player) then
+                        player:confirmTrade()
+                        player:addGil(xi.settings.main.GIL_RATE * gilPerTrade)
+                        xi.quest.setMustZone(player, xi.questLog.WINDURST, xi.quest.id.windurst.ROCK_RACKETEER)
+                    end
+                end,
+            },
+        },
+    },
+
+    -- QUEST COMPLETE
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_COMPLETED
+        end,
+
+        [xi.zone.WINDURST_WOODS] =
+        {
+
+            ['Bopa_Greso'] = quest:event(90, 0, xi.item.YAGUDO_BEAD_NECKLACE), -- New standard dialog after Mihgo's Amigo completion
+            ['Cha_Lebagta'] = quest:event(91, 0, xi.item.YAGUDO_BEAD_NECKLACE), -- New standard dialog after Mihgo's Amigo completion
+
+            ['Nanaa_Mihgo'] =
+            {
+                onTrade = function(player, npc, trade)
+                    if npcUtil.tradeHasExactly(trade, { { xi.item.YAGUDO_BEAD_NECKLACE, 4 } }) then
+                        return quest:progressEvent(494, { [0] = xi.settings.main.GIL_RATE * gilPerTrade })
+                    end
+                end,
+
+                onTrigger = function(player, npc)
+                    if player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.ROCK_RACKETEER) < xi.questStatus.QUEST_ACCEPTED then
+                        return quest:event(89):replaceDefault()
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [494] = function(player, csid, option, npc)
+                    player:confirmTrade()
+                    player:addGil(xi.settings.main.GIL_RATE * gilPerTrade)
+                    player:addFame(xi.fameArea.NORG, 30) -- 16 era based on 212 Yagudo Necklaces for 4 Norg fame
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/zones/Windurst_Woods/DefaultActions.lua
+++ b/scripts/zones/Windurst_Woods/DefaultActions.lua
@@ -1,16 +1,17 @@
 -- local ID = zones[xi.zone.WINDURST_WOODS]
 
 return {
-    ['An_Polaali']    = { event = 44 },
-    ['An_Shanaa']     = { event = 45 },
-    ['Apururu']       = { event = 274 },
-    ['Bopa_Greso']    = { event = 77 },
-    ['Cha_Lebagta']   = { event = 78 },
-    ['Hae_Jakkya']    = { event = 41 },
-    ['Kapeh_Myohrye'] = { event = 340 },-- There is at current an unknown mission/quest/status that alters their dialog. Windurst citizens get something different than other nations.
-    ['Kototo']        = { event = 410 },
-    ['Mourices']      = { event = 441 },
-    ['Muhk_Johldy']   = { event = 339 },-- There is at current an unknown mission/quest/status that alters their dialog. Windurst citizens get something different than other nations.
-    ['Perih_Vashai']  = { event = 338 },
-    ['Roberta']       = { event = 436 },
+    ['An_Polaali']        = { event = 44 },
+    ['An_Shanaa']         = { event = 45 },
+    ['Apururu']           = { event = 274 },
+    ['Bopa_Greso']        = { event = 77 },
+    ['Cha_Lebagta']       = { event = 78 },
+    ['Hae_Jakkya']        = { event = 41 },
+    ['Kapeh_Myohrye']     = { event = 340 }, -- There is at current an unknown mission/quest/status that alters their dialog. Windurst citizens get something different than other nations.
+    ['Kototo']            = { event = 410 },
+    ['Mheca_Khetashipah'] = { event = 423 }, -- Possibly not their default dialogue. Event #79 witnessed in capture. Leaving for now until verified.
+    ['Mourices']          = { event = 441 },
+    ['Muhk_Johldy']       = { event = 339 }, -- There is at current an unknown mission/quest/status that alters their dialog. Windurst citizens get something different than other nations.
+    ['Perih_Vashai']      = { event = 338 },
+    ['Roberta']           = { event = 436 },
 }

--- a/scripts/zones/Windurst_Woods/npcs/Bopa_Greso.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Bopa_Greso.lua
@@ -9,9 +9,6 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.MIHGO_S_AMIGO) == xi.questStatus.QUEST_ACCEPTED then
-        player:startEvent(84)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Windurst_Woods/npcs/Cha_Lebagta.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Cha_Lebagta.lua
@@ -10,13 +10,6 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local mihgosAmigo = player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.MIHGO_S_AMIGO)
-
-    if mihgosAmigo == xi.questStatus.QUEST_ACCEPTED then
-        player:startEvent(85, 0, 498) -- Migho's Amigo hint dialog
-    elseif mihgosAmigo == xi.questStatus.QUEST_COMPLETED then
-        player:startEvent(91, 0, 498) -- New standard dialog after Mihgo's Amigo completion
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Windurst_Woods/npcs/Gioh_Ajihri.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Gioh_Ajihri.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Area: Windurst Woods
---  NPC: Gioh Ajihri
+-- NPC: Gioh Ajihri
 -- Starts & Finishes Repeatable Quest: Twinstone Bonding
 -----------------------------------
 local entity = {}

--- a/scripts/zones/Windurst_Woods/npcs/Mheca_Khetashipah.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Mheca_Khetashipah.lua
@@ -9,15 +9,6 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local starStatus = player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.MIHGO_S_AMIGO)
-
-    if starStatus == xi.questStatus.QUEST_ACCEPTED then
-        player:startEvent(83)
-    else
-        -- Possibly not their default dialogue. Event #79 witnessed in capture. Leaving for now until
-        -- verified.
-        player:startEvent(426)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Windurst_Woods/npcs/Nanaa_Mihgo.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Nanaa_Mihgo.lua
@@ -46,15 +46,6 @@ local trustMemory = function(player)
 end
 
 entity.onTrade = function(player, npc, trade)
-    if npcUtil.tradeHas(trade, { { 498, 4 } }) then -- Yagudo Necklace x4
-        local mihgosAmigo = player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.MIHGO_S_AMIGO)
-
-        if mihgosAmigo == xi.questStatus.QUEST_ACCEPTED then
-            player:startEvent(88, xi.settings.main.GIL_RATE * 200)
-        elseif mihgosAmigo == xi.questStatus.QUEST_COMPLETED then
-            player:startEvent(494, xi.settings.main.GIL_RATE * 200)
-        end
-    end
 end
 
 entity.onTrigger = function(player, npc)
@@ -100,17 +91,6 @@ entity.onTrigger = function(player, npc)
         player:startEvent(95) -- not sold reminder
     elseif rockRacketeer == xi.questStatus.QUEST_ACCEPTED then
         player:startEvent(94) -- quest reminder
-
-    -- MIHGO'S AMIGO
-    elseif mihgosAmigo == xi.questStatus.QUEST_AVAILABLE then
-        if player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.CRYING_OVER_ONIONS) == xi.questStatus.QUEST_AVAILABLE then
-            player:startEvent(81) -- Start Quest "Mihgo's Amigo" with quest "Crying Over Onions" Activated
-        else
-            player:startEvent(80) -- Start Quest "Mihgo's Amigo"
-        end
-    elseif mihgosAmigo == xi.questStatus.QUEST_ACCEPTED then
-        player:startEvent(82)
-
     -- STANDARD DIALOG
     elseif rockRacketeer == xi.questStatus.QUEST_COMPLETED then
         player:startEvent(99) -- new dialog after Rock Racketeer
@@ -137,21 +117,7 @@ entity.onEventFinish = function(player, csid, option, npc)
         player:delGil(10 * xi.settings.main.GIL_RATE)
         player:setCharVar('rockracketeer_sold', 3)
 
-    -- MIHGO'S AMIGO
-    elseif csid == 80 or csid == 81 then
-        player:addQuest(xi.questLog.WINDURST, xi.quest.id.windurst.MIHGO_S_AMIGO)
-    elseif csid == 88 then
-        player:confirmTrade()
-        player:completeQuest(xi.questLog.WINDURST, xi.quest.id.windurst.MIHGO_S_AMIGO)
-        player:addTitle(xi.title.CAT_BURGLAR_GROUPIE)
-        player:addGil(xi.settings.main.GIL_RATE * 200)
-        player:addFame(xi.fameArea.NORG, 60)
-        player:needToZone(true)
-    elseif csid == 494 then
-        player:confirmTrade()
-        player:addTitle(xi.title.CAT_BURGLAR_GROUPIE)
-        player:addGil(xi.settings.main.GIL_RATE * 200)
-        player:addFame(xi.fameArea.NORG, 30)
+    -- TRUST
     elseif csid == 865 and option == 2 then
         player:addSpell(xi.magic.spell.NANAA_MIHGO, true, true)
         player:messageSpecial(ID.text.YOU_LEARNED_TRUST, 0, xi.magic.spell.NANAA_MIHGO)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Converts `Mihgo's Amigo` to IF + adds missing dialog

## Steps to test these changes

Pre-Reqs:
Quests `The Tenshodo Showdown` and `As Thick as Thieves` can not be active.
Mission `Lost For Words` can not be active.
Item `Marauder's Knife` can not be in inventory

Quest:
Speak to `Nanaa Mihgo` with at least 1 Norg fame to flag quest.
Optional -- Speak to other NPCs in area for quest dialog
Trade 4 `Yagudo Bead Necklace`s to Nanaa Mihgo