### PR TITLE
[sql] Update Ungur Boomerang to have Piercing damage type

### DIFF
--- a/sql/item_weapon.sql
+++ b/sql/item_weapon.sql
@@ -1775,7 +1775,7 @@ INSERT INTO `item_weapon` VALUES (18137,'holy_ampulla',0,0,0,0,0,0,1,999,0,0);
 INSERT INTO `item_weapon` VALUES (18138,'bailathorn',0,0,0,0,0,0,1,999,0,0);
 INSERT INTO `item_weapon` VALUES (18139,'bomb_core',0,0,0,0,0,0,1,999,0,0);
 INSERT INTO `item_weapon` VALUES (18140,'phtm._tathlum',0,0,0,0,0,0,1,999,0,0);
-INSERT INTO `item_weapon` VALUES (18141,'ungur_boomerang',27,0,0,0,0,0,1,220,30,0);
+INSERT INTO `item_weapon` VALUES (18141,'ungur_boomerang',27,0,0,0,0,1,1,220,30,0);
 INSERT INTO `item_weapon` VALUES (18142,'shigeto_bow',25,0,0,0,0,1,1,600,75,0);
 INSERT INTO `item_weapon` VALUES (18143,'shigeto_bow_+1',25,0,0,0,0,1,1,582,76,0);
 INSERT INTO `item_weapon` VALUES (18144,'bow_of_trials',25,0,0,0,0,1,1,360,39,300);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Update Ungur Boomerang to have Piercing damage type, apparently it was "NONE" before.

## Steps to test these changes
Use Ungur Boomerange vs elementals or things weak to piercing and see the damage weakened/boosted as expected
