### PR TITLE
[Fix] Add missing message ID in Aht Uhrgan Whitegate

### DIFF
--- a/scripts/zones/Aht_Urhgan_Whitegate/IDs.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/IDs.lua
@@ -44,6 +44,7 @@ zones[xi.zone.AHT_URHGAN_WHITEGATE] =
         ASSAULT_FAILED                = 5670,  -- Your mission was not successful; however, the Empire recognizes your contribution and has awarded you Assault Points.
         AUTOMATON_RENAME              = 5847,  -- Your automaton has a new name.
         YOU_CAN_BECOME_PUP            = 5850,  -- You can now become a puppetmaster!
+        NYZUL_FAIL                    = 6191,  -- Your mission was not successful. I regret to inform you that the Imperial Army does not officially recognize your efforts within this Assault area.
         BESIEGED_OFFSET               = 6832,  -- Your Imperial Standing has increased!
         PAY_DIVINATION                = 8784,  -- ou pay 1000 gil for the divination.
         MEMBER_OF_SALAHEEMS_SENTINELS = 9262,  -- You are now a member of Salaheem's Sentinels.


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds missing message ID, as title sais.

## Steps to test these changes

Message is used when being kicked from Nyzul via wipe or time-out... failing, in general and speaking with the assault npc
