### PR TITLE
[Quest] Gate to Paradise to IF

### DIFF
--- a/scripts/quests/sandoria/Gates_to_Paradise.lua
+++ b/scripts/quests/sandoria/Gates_to_Paradise.lua
@@ -1,0 +1,115 @@
+-----------------------------------
+-- Gates to Paradise
+-----------------------------------
+-- !addquest 0 18
+-- Olbergieut: !pos 91 0 121 231
+-- Faurbellant !pos 484 24 -89 102
+-----------------------------------
+local northernSandyID = zones[xi.zone.NORTHERN_SAN_DORIA]
+local laTheineID = zones[xi.zone.LA_THEINE_PLATEAU]
+-----------------------------------
+local quest = Quest:new(xi.questLog.SANDORIA, xi.quest.id.sandoria.GATES_TO_PARADISE)
+
+quest.reward =
+{
+    fame = 30,
+    fameArea = xi.fameArea.SANDORIA,
+    item = xi.item.COTTON_CAPE,
+    title = xi.title.THE_PIOUS_ONE,
+}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_AVAILABLE and
+                player:getFameLevel(xi.fameArea.SANDORIA) >= 2
+        end,
+
+        [xi.zone.NORTHERN_SAN_DORIA] =
+        {
+            ['Olbergieut'] = quest:progressEvent(619),
+
+            onEventFinish =
+            {
+                [619] = function(player, csid, option, npc)
+                    if option == 0 then
+                        quest:begin(player)
+                        npcUtil.giveKeyItem(player, xi.ki.SCRIPTURE_OF_WIND)
+                    end
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_ACCEPTED
+        end,
+
+        [xi.zone.NORTHERN_SAN_DORIA] =
+        {
+            ['Olbergieut'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:hasKeyItem(xi.ki.SCRIPTURE_OF_WATER) then
+                        return quest:progressEvent(620)
+                    elseif player:hasKeyItem(xi.ki.SCRIPTURE_OF_WIND) then
+                        return quest:messageSpecial(northernSandyID.text.OLBERGIEUT_DIALOG, xi.ki.SCRIPTURE_OF_WIND)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [620] = function(player, csid, option, npc)
+                    if quest:complete(player) then
+                        player:delKeyItem(xi.ki.SCRIPTURE_OF_WATER)
+                    end
+                end
+            },
+        },
+
+        [xi.zone.LA_THEINE_PLATEAU] =
+        {
+            ['Faurbellant'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:hasKeyItem(xi.ki.SCRIPTURE_OF_WIND) then
+                        player:delKeyItem(xi.ki.SCRIPTURE_OF_WIND)
+                        npcUtil.giveKeyItem(player, xi.ki.SCRIPTURE_OF_WATER)
+                        return quest:messageSpecial(laTheineID.text.FAURBELLANT_2, 0, xi.ki.SCRIPTURE_OF_WIND)
+                    elseif player:hasKeyItem(xi.ki.SCRIPTURE_OF_WATER) then
+                        return quest:messageSpecial(laTheineID.text.FAURBELLANT_3, xi.ki.SCRIPTURE_OF_WATER):replaceDefault()
+                    end
+                end,
+            },
+        },
+    },
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_COMPLETED
+        end,
+
+        [xi.zone.LA_THEINE_PLATEAU] =
+        {
+            ['Faurbellant'] =
+            {
+                onTrigger = function(player, npc)
+                    return quest:messageSpecial(laTheineID.text.FAURBELLANT_4)
+                end,
+            },
+        },
+        [xi.zone.NORTHERN_SAN_DORIA] =
+        {
+            ['Olbergieut'] =
+            {
+                onTrigger = function(player, npc)
+                    return quest:messageSpecial(northernSandyID.text.OLBERGIEUT_DIALOG_II)
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/zones/La_Theine_Plateau/DefaultActions.lua
+++ b/scripts/zones/La_Theine_Plateau/DefaultActions.lua
@@ -6,6 +6,7 @@ return {
     ['Chocobo_Tracks']      = { messageSpecial = ID.text.CHOCOBO_TRACKS },
     ['Deaufrain']           = { text = ID.text.RESCUE_DRILL + 32 },
     ['Equesobillot']        = { text = ID.text.RESCUE_DRILL + 31 },
+    ['Faurbellan']          = { text = ID.text.FAURBELLANT_1 },
     ['Galaihaurat']         = { text = ID.text.RESCUE_DRILL },
     ['Laurisse']            = { text = ID.text.RESCUE_DRILL + 36 },
     ['Narvecaint']          = { text = ID.text.RESCUE_DRILL + 37 },

--- a/scripts/zones/La_Theine_Plateau/npcs/Faurbellant.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/Faurbellant.lua
@@ -5,29 +5,12 @@
 -- Involved in Quest: Gates of Paradise
 -- !pos 484 24 -89 102
 -----------------------------------
-local ID = zones[xi.zone.LA_THEINE_PLATEAU]
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local gates = player:getQuestStatus(xi.questLog.SANDORIA, xi.quest.id.sandoria.GATES_TO_PARADISE)
-    if gates == xi.questStatus.QUEST_COMPLETED then
-        player:showText(npc, ID.text.FAURBELLANT_4)
-    elseif gates == xi.questStatus.QUEST_ACCEPTED then
-        if player:hasKeyItem(xi.ki.SCRIPTURE_OF_WIND) then
-            player:showText(npc, ID.text.FAURBELLANT_2, 0, xi.ki.SCRIPTURE_OF_WIND)
-            player:delKeyItem(xi.ki.SCRIPTURE_OF_WIND)
-            player:addKeyItem(xi.ki.SCRIPTURE_OF_WATER)
-            player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.SCRIPTURE_OF_WATER)
-        else
-            player:showText(npc, ID.text.FAURBELLANT_3, xi.ki.SCRIPTURE_OF_WATER)
-        end
-    else
-        player:showText(npc, ID.text.FAURBELLANT_1)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Northern_San_dOria/DefaultActions.lua
+++ b/scripts/zones/Northern_San_dOria/DefaultActions.lua
@@ -24,6 +24,7 @@ return {
     ['Morjean']           = { event = 601 },
     ['Nouveil']           = { event = 574 },
     ['Odyssean_Passage']  = { messageSpecial = ID.text.NOTHING_HAPPENS },
+    ['Olbergieut']        = { event = 612 },
     ['Pellimie']          = { text = ID.text.PELLIMIE_DIALOG },
     ['Pepigort']          = { text = ID.text.PEPIGORT_DIALOG },
     ['Phaviane']          = { text = ID.text.PHAVIANE_DIALOG },

--- a/scripts/zones/Northern_San_dOria/IDs.lua
+++ b/scripts/zones/Northern_San_dOria/IDs.lua
@@ -53,6 +53,7 @@ zones[xi.zone.NORTHERN_SAN_DORIA] =
         COULLENE_DIALOG               = 11261, -- Goddess above, deliver us to Paradise!
         WILL_PROVIDE_PITTANCE         = 11277, -- I will provide you with <item> for a pittance of <number> gil.
         OLBERGIEUT_DIALOG             = 11303, -- Friar Faurbellant is on retreat at the Crag of Holla. Please give <item> to him.
+        OLBERGIEUT_DIALOG_II          = 11305, -- Friars spend every day in ascetic training. Greet them kindly; it will inspire them to strive ever harder.
         ABEAULE_DIALOG_HOME           = 11359, -- Amaura makes her home on Watchdog Alley. If you can't find her, ask someone along the way. I'll be waiting here!
         ABEAULE_DIALOG_THANKS         = 11361, -- You've been a great help, again. I don't know how to thank you!
         GUILERME_DIALOG               = 11375, -- Behold Chateau d'Oraguille, the greatest fortress in the realm!

--- a/scripts/zones/Northern_San_dOria/npcs/Olbergieut.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Olbergieut.lua
@@ -5,50 +5,18 @@
 -- !pos 91 0 121 231
 -- Starts and Finishes Quest: Gates of Paradise
 -----------------------------------
-local ID = zones[xi.zone.NORTHERN_SAN_DORIA]
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local gates = player:getQuestStatus(xi.questLog.SANDORIA, xi.quest.id.sandoria.GATES_TO_PARADISE)
-
-    if player:hasKeyItem(xi.ki.SCRIPTURE_OF_WATER) then
-        player:startEvent(620)
-    elseif gates == xi.questStatus.QUEST_ACCEPTED then
-        player:showText(npc, ID.text.OLBERGIEUT_DIALOG, xi.ki.SCRIPTURE_OF_WIND)
-    elseif
-        player:getFameLevel(xi.fameArea.SANDORIA) >= 2 and
-        gates == xi.questStatus.QUEST_AVAILABLE
-    then
-        player:startEvent(619)
-    else
-        player:startEvent(612)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    if csid == 619 and option == 0 then
-        player:addQuest(xi.questLog.SANDORIA, xi.quest.id.sandoria.GATES_TO_PARADISE)
-        player:addKeyItem(xi.ki.SCRIPTURE_OF_WIND)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.SCRIPTURE_OF_WIND)
-    elseif csid == 620 then
-        if player:getFreeSlotsCount() == 0 then
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, xi.item.COTTON_CAPE)
-        else
-            player:completeQuest(xi.questLog.SANDORIA, xi.quest.id.sandoria.GATES_TO_PARADISE)
-            player:addFame(xi.fameArea.SANDORIA, 30)
-            player:addTitle(xi.title.THE_PIOUS_ONE)
-            player:delKeyItem(xi.ki.SCRIPTURE_OF_WATER)
-            player:addItem(xi.item.COTTON_CAPE, 1)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, xi.item.COTTON_CAPE)
-        end
-    end
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Converts the Sandy quest Gates to Paradise to Interaction Framework.
[Capture](https://www.youtube.com/watch?v=k6ZiMxR-7GY)
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Removes all NPC related quest data from their individual LUA's
Adds defaultActions to associated NPCs
Moves quest Gates to Paradise to Interaction Framework.
Adds dialog for quest completion.
## Steps to test these changes
Have 2 Fame in Sandy. 
Speak with Olbergieut - Will give Key Item Scripture of Wind
Speak to Faurbellant who will take the Scripture of Wind and give you Scripture of Water.
Return to Oblergieut who will remove Scripture of Water and reward Cotton Cape.
Speak to both to get completed dialogs.
<!-- Clear and detailed steps to test your changes here -->
