### PR TITLE
[Bug Fix]Preserve m_PItem when copying/assigning latents.

### DIFF
--- a/src/map/latent_effect.h
+++ b/src/map/latent_effect.h
@@ -134,6 +134,7 @@ public:
     CLatentEffect(CLatentEffect&& o) noexcept
     {
         std::swap(m_POwner, o.m_POwner);
+        std::swap(m_PItem, o.m_PItem);
         std::swap(m_ConditionsID, o.m_ConditionsID);
         std::swap(m_ConditionsValue, o.m_ConditionsValue);
         std::swap(m_SlotID, o.m_SlotID);
@@ -144,6 +145,7 @@ public:
     CLatentEffect& operator=(CLatentEffect&& o) noexcept
     {
         std::swap(m_POwner, o.m_POwner);
+        std::swap(m_PItem, o.m_PItem);
         std::swap(m_ConditionsID, o.m_ConditionsID);
         std::swap(m_ConditionsValue, o.m_ConditionsValue);
         std::swap(m_SlotID, o.m_SlotID);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

When copying/assigning latent effects in the code base - the CItemEquipment m_PItem was getting left behind.

## Steps to test these changes

With this change m_PItem gets to join its friends m_POwner and others.
