### PR TITLE
Fix enum references in PM8-1

### DIFF
--- a/scripts/missions/cop/8_1_Garden_of_Antiquity.lua
+++ b/scripts/missions/cop/8_1_Garden_of_Antiquity.lua
@@ -32,7 +32,7 @@ local towerOption =
 }
 
 local function setMissionStatusBit(player, bitNum)
-    local statusIndex   = bitNum == 0 and xi.mission.status.CID or xi.mission.status.RUBIOUS
+    local statusIndex   = bitNum == 0 and xi.mission.status.COP.CID or xi.mission.status.COP.RUBIOUS
     local adjustedBit   = bitNum == 0 and 3 or bitNum - 1
     local missionStatus = player:getMissionStatus(mission.areaId, statusIndex)
 
@@ -40,7 +40,7 @@ local function setMissionStatusBit(player, bitNum)
 end
 
 local function getMissionStatusBit(player, bitNum)
-    local statusIndex   = bitNum == 0 and xi.mission.status.CID or xi.mission.status.RUBIOUS
+    local statusIndex   = bitNum == 0 and xi.mission.status.COP.CID or xi.mission.status.COP.RUBIOUS
     local adjustedBit   = bitNum == 0 and 3 or bitNum - 1
     local missionStatus = player:getMissionStatus(mission.areaId, statusIndex)
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
get/set MissionStatusBit functions referenced the incorrect enum for statusIndex calculation.  Fixes reference.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
NMs spawn as expected
<!-- Clear and detailed steps to test your changes here -->
