### PR TITLE
[Quest] Convert Say it with Flowers to IF

### DIFF
--- a/scripts/quests/windurst/Say_it_With_Flowers.lua
+++ b/scripts/quests/windurst/Say_it_With_Flowers.lua
@@ -1,0 +1,323 @@
+-----------------------------------
+-- Say It With Flowers
+-----------------------------------
+-- Log ID: 2, Quest ID: 50
+-- Moari-Kaaori   : !pos -253 -5 -227 238
+-- Kenapa-Keppa   : !pos 27 -6 -199 238
+-- Ohbiru-Dohbiru : !pos 23 -5 -193 238
+-- Tahrongi Cacti : !pos -308 7 264 117
+-----------------------------------
+local windurstWatersIDs = zones[xi.zone.WINDURST_WATERS]
+local tahrongiID = zones[xi.zone.TAHRONGI_CANYON]
+-----------------------------------
+
+local quest = Quest:new(xi.questLog.WINDURST, xi.quest.id.windurst.SAY_IT_WITH_FLOWERS)
+
+quest.reward = { }
+
+local flowerList =
+{
+    [0] = { itemId = xi.item.CARNATION,  cost = 300 },
+    [1] = { itemId = xi.item.RED_ROSE,   cost = 200 },
+    [2] = { itemId = xi.item.RAIN_LILY,  cost = 250 },
+    [3] = { itemId = xi.item.LILAC,      cost = 150 },
+    [4] = { itemId = xi.item.AMARYLLIS,  cost = 200 },
+    [5] = { itemId = xi.item.MARGUERITE, cost = 100 },
+}
+
+local function ohbiruFlowerHelp(player, option)
+    if option < 7 then
+        local choice = flowerList[option]
+        if
+            choice and
+            player:getGil() >= choice.cost
+        then
+            if npcUtil.giveItem(player, choice.itemId) then -- Sells player wrong flower
+                player:delGil(choice.cost)
+            else
+                player:messageSpecial(windurstWatersIDs.text.ITEM_CANNOT_BE_OBTAINED, choice.itemId)
+            end
+        else
+            player:messageSpecial(windurstWatersIDs.text.NOT_HAVE_ENOUGH_GIL)
+        end
+    elseif option == 7 then -- Cactus Message
+        quest:setVar(player, 'CactusHint', 1)
+    end
+
+    quest:incrementVar(player, 'Prog', 1)
+end
+
+local function completeQuest(player, fame, title, gil)
+    player:tradeComplete()
+    quest.reward =
+    {
+        fame     = fame,
+        fameArea = xi.fameArea.WINDURST,
+        title    = title,
+    }
+    player:addGil(gil) -- gil reward is silent on first runthrough/handled by CS during repeats
+    quest:complete(player)
+    quest:setMustZone(player)
+end
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return player:getFameLevel(xi.fameArea.WINDURST) >= 2 and
+                status == xi.questStatus.QUEST_AVAILABLE
+        end,
+
+        [xi.zone.WINDURST_WATERS] =
+        {
+            ['Moari-Kaaori'] = quest:progressEvent(514),
+
+            onEventFinish =
+            {
+                [514] = function(player, csid, option, npc)
+                    if option == 1 then
+                        quest:begin(player)
+                        quest:setVar(player, 'CactusAvailable', 1)
+                    end
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_ACCEPTED
+        end,
+
+        [xi.zone.WINDURST_WATERS] =
+        {
+            ['Moari-Kaaori'] =
+            {
+                onTrade = function(player, npc, trade) -- player can turn in at any time after starting
+                    local flowers = {
+                        xi.item.CARNATION, xi.item.RED_ROSE, xi.item.RAIN_LILY,
+                        xi.item.LILAC, xi.item.AMARYLLIS, xi.item.MARGUERITE,
+                    }
+                    if npcUtil.tradeHasExactly(trade, { xi.item.TAHRONGI_CACTUS }) then
+                        return quest:progressEvent(520)
+                    elseif
+                        trade:getItemCount() == 1 and
+                        npcUtil.tradeSetInList(trade, flowers)
+                    then
+                        player:startEvent(522) -- Brought wrong flowers.
+                    end
+                end,
+
+                onTrigger = quest:event(515),
+            },
+
+            onEventFinish =
+            {
+                [520] = function(player, csid, option, npc) -- Right flower, full reward
+                    if npcUtil.giveItem(player, xi.item.IRON_SWORD) then
+                        completeQuest(player, 30, xi.title.CUPIDS_FLORIST, xi.settings.main.GIL_RATE * 400)
+                    end
+                end,
+
+                [522] = function(player, csid, option, npc) -- Wrong flower, smaller reward
+                    completeQuest(player, 10, nil, xi.settings.main.GIL_RATE * 100)
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_ACCEPTED and
+                quest:getVar(player, 'Prog') == 0
+        end,
+
+        [xi.zone.WINDURST_WATERS] =
+        {
+            ['Ohbiru-Dohbiru'] = quest:progressEvent(516, { [4] = xi.item.TAHRONGI_CACTUS }),
+
+            onEventFinish =
+            {
+                [516] = function(player, csid, option, npc)
+                    ohbiruFlowerHelp(player, option) -- only offered once per runthrough
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_ACCEPTED and
+                quest:getVar(player, 'Prog') ~= 0
+        end,
+
+        [xi.zone.WINDURST_WATERS] =
+        {
+            ['Kenapa-Keppa'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'CactusHint') == 1 then
+                        return quest:progressEvent(519)
+                    end
+                end
+            },
+
+            ['Ohbiru-Dohbiru'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'CactusHint') == 1 then
+                        return quest:progressEvent(517, { [4] = xi.item.TAHRONGI_CACTUS })
+                    else
+                        return quest:progressEvent(518)
+                    end
+                end
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_COMPLETED and
+                quest:getMustZone(player)
+        end,
+
+        [xi.zone.WINDURST_WATERS] =
+        {
+            ['Moari-Kaaori'] = quest:progressEvent(521),
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_COMPLETED and
+                quest:getVar(player, 'Prog') == 0 and
+                not quest:getMustZone(player)
+        end,
+
+        [xi.zone.WINDURST_WATERS] =
+        {
+            ['Moari-Kaaori'] = quest:progressEvent(685, 0, xi.item.TAHRONGI_CACTUS),
+
+            onEventFinish =
+            {
+                [685] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 1)
+                    quest:setVar(player, 'CactusAvailable', 1)
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_COMPLETED and
+                quest:getVar(player, 'Prog') ~= 0
+        end,
+
+        [xi.zone.WINDURST_WATERS] =
+        {
+            ['Moari-Kaaori'] =
+            {
+                onTrade = function(player, npc, trade) -- player can turn in at any time after starting
+                    local flowers = {
+                        xi.item.CARNATION, xi.item.RED_ROSE, xi.item.RAIN_LILY,
+                        xi.item.LILAC, xi.item.AMARYLLIS, xi.item.MARGUERITE,
+                    }
+                    if npcUtil.tradeHasExactly(trade, { xi.item.TAHRONGI_CACTUS }) then
+                        return quest:progressEvent(525, xi.settings.main.GIL_RATE * 400)
+                    elseif
+                        trade:getItemCount() == 1 and
+                        npcUtil.tradeSetInList(trade, flowers)
+                    then
+                        player:startEvent(522, xi.settings.main.GIL_RATE * 100) -- Brought wrong flowers.
+                    end
+                end,
+
+                onTrigger = quest:event(515),
+            },
+
+            onEventFinish =
+            {
+                [522] = function(player, csid, option, npc) -- Wrong flower, smaller reward
+                    completeQuest(player, 10, nil, xi.settings.main.GIL_RATE * 100)
+                end,
+
+                [525] = function(player, csid, option, npc) -- Repeatable rewards
+                    completeQuest(player, 30, xi.title.CUPIDS_FLORIST, xi.settings.main.GIL_RATE * 400)
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_COMPLETED and
+                quest:getVar(player, 'Prog') == 1
+        end,
+
+        [xi.zone.WINDURST_WATERS] =
+        {
+            ['Ohbiru-Dohbiru'] = quest:progressEvent(516, { [4] = xi.item.TAHRONGI_CACTUS }),
+
+            onEventFinish =
+            {
+                [516] = function(player, csid, option, npc)
+                    ohbiruFlowerHelp(player, option) -- only offered once per runthrough
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_COMPLETED and
+                quest:getVar(player, 'Prog') > 1
+        end,
+
+        [xi.zone.WINDURST_WATERS] =
+        {
+            ['Kenapa-Keppa'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'CactusHint') == 1 then
+                        quest:progressEvent(519)
+                    end
+                end
+            },
+
+            ['Ohbiru-Dohbiru'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'CactusHint') == 1 then
+                        quest:progressEvent(517, { [4] = xi.item.TAHRONGI_CACTUS })
+                    else
+                        quest:progressEvent(518)
+                    end
+                end
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status >= xi.questStatus.QUEST_ACCEPTED and
+                quest:getVar(player, 'CactusAvailable') == 1
+        end,
+
+        [xi.zone.TAHRONGI_CANYON] =
+        {
+            ['Tahrongi_Cacti'] =
+            {
+                onTrigger = function(player, npc)
+                    if not player:hasItem(xi.item.TAHRONGI_CACTUS) then
+                        npcUtil.giveItem(player, xi.item.TAHRONGI_CACTUS)
+                    else
+                        player:messageSpecial(tahrongiID.text.CANT_TAKE_ANY_MORE)
+                    end
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/zones/Tahrongi_Canyon/DefaultActions.lua
+++ b/scripts/zones/Tahrongi_Canyon/DefaultActions.lua
@@ -2,4 +2,5 @@ local ID = zones[xi.zone.TAHRONGI_CANYON]
 
 return {
     ['Shattered_Telepoint'] = { messageSpecial = ID.text.TELEPOINT_HAS_BEEN_SHATTERED },
+    ['Tahrongi_Cactus']     = { messageSpecial = ID.text.POISONOUS_LOOKING_BUDS }
 }

--- a/scripts/zones/Tahrongi_Canyon/npcs/Tahrongi_Cacti.lua
+++ b/scripts/zones/Tahrongi_Canyon/npcs/Tahrongi_Cacti.lua
@@ -4,27 +4,9 @@
 -- Involved in Quest: Say It with Flowers
 -- !pos -308.721 7.477 264.454
 -----------------------------------
-local ID = zones[xi.zone.TAHRONGI_CANYON]
------------------------------------
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    if
-        player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.SAY_IT_WITH_FLOWERS) > xi.questStatus.QUEST_AVAILABLE and
-        player:getCharVar('FLOWER_PROGRESS') == 3
-    then
-        if
-            player:getFreeSlotsCount() > 0 and
-            not player:hasItem(xi.item.TAHRONGI_CACTUS)
-        then
-            player:addItem(xi.item.TAHRONGI_CACTUS)
-            player:messageSpecial(ID.text.BUD_BREAKS_OFF, 0, xi.item.TAHRONGI_CACTUS)
-        else
-            player:messageSpecial(ID.text.CANT_TAKE_ANY_MORE)
-        end
-    else
-        player:messageSpecial(ID.text.POISONOUS_LOOKING_BUDS)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Windurst_Waters/DefaultActions.lua
+++ b/scripts/zones/Windurst_Waters/DefaultActions.lua
@@ -17,6 +17,7 @@ return {
     ['Library_book2']   = { event = 368 },
     ['Mashuu-Ajuu']     = { event = 429 },
     ['Mimomo']          = { event = 436 },
+    ['Moari-Kaaori']    = { event = 512 },
     ['Ohbiru-Dohbiru']  = { event = 344 },
     ['Orn']             = { event = 652 },
     ['Paku-Nakku']      = { event = 431 },

--- a/scripts/zones/Windurst_Waters/npcs/Kenapa-Keppa.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Kenapa-Keppa.lua
@@ -4,34 +4,16 @@
 -- Involved in Quest: Food For Thought, Hat in Hand
 -- !pos 27 -6 -199 238
 -----------------------------------
-local ID = zones[xi.zone.WINDURST_WATERS]
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local sayItWithFlowers = player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.SAY_IT_WITH_FLOWERS)
-    local flowerProgress = player:getCharVar('FLOWER_PROGRESS') -- progress of Say It with Flowers
-
-    if
-        player:hasKeyItem(xi.ki.NEW_MODEL_HAT) and
-        not utils.mask.getBit(player:getCharVar('QuestHatInHand_var'), 2)
-    then
-        player:messageSpecial(ID.text.YOU_SHOW_OFF_THE, 0, xi.ki.NEW_MODEL_HAT)
-        player:startEvent(56)
-    elseif
-        (sayItWithFlowers == xi.questStatus.QUEST_ACCEPTED or sayItWithFlowers == xi.questStatus.QUEST_COMPLETED) and
-        flowerProgress == 2
-    then
-        player:startEvent(519)
+    if math.random(1, 2) == 1 then
+        player:startEvent(302) -- Standard converstation
     else
-        if math.random(1, 2) == 1 then
-            player:startEvent(302) -- Standard converstation
-        else
-            player:startEvent(303) -- Standard converstation
-        end
+        player:startEvent(303) -- Standard converstation
     end
 end
 
@@ -42,8 +24,6 @@ entity.onEventFinish = function(player, csid, option, npc)
     if csid == 56 then
         player:setCharVar('QuestHatInHand_var', utils.mask.setBit(player:getCharVar('QuestHatInHand_var'), 2, true))
         player:incrementCharVar('QuestHatInHand_count', 1)
-    elseif csid == 519 then
-        player:setCharVar('FLOWER_PROGRESS', 3)
     end
 end
 

--- a/scripts/zones/Windurst_Waters/npcs/Moari-Kaaori.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Moari-Kaaori.lua
@@ -2,100 +2,18 @@
 -- Area: Windurst Waters
 --  NPC: Moari-Kaaori
 -----------------------------------
-local ID = zones[xi.zone.WINDURST_WATERS]
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local sayFlowers = player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.SAY_IT_WITH_FLOWERS)
-    local flowerProgress = player:getCharVar('FLOWER_PROGRESS')
-    local offer = trade:getItemId()
-
-    if flowerProgress == 3 then
-        if
-            trade:hasItemQty(xi.item.TAHRONGI_CACTUS, 1) and
-            trade:getItemCount() == 1
-        then
-            if sayFlowers == xi.questStatus.QUEST_COMPLETED then
-                player:startEvent(525, xi.settings.main.GIL_RATE * 400)
-            else
-                player:startEvent(520)
-            end
-        elseif
-            offer == 941 or
-            offer == 948 or
-            offer == 949 or
-            offer == 956 or
-            offer == 957 or
-            offer == 958
-        then
-            player:startEvent(522) -- Brought wrong flowers.
-        end
-    end
 end
 
 entity.onTrigger = function(player, npc)
-    local sayFlowers = player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.SAY_IT_WITH_FLOWERS)
-    local flowerProgress = player:getCharVar('FLOWER_PROGRESS')
-    local needToZone = player:needToZone()
-
-    if
-        sayFlowers == xi.questStatus.QUEST_AVAILABLE and
-        player:getFameLevel(xi.fameArea.WINDURST) >= 2
-    then
-        player:startEvent(514) -- Begin Say It with Flowers.
-    elseif flowerProgress == 3 or flowerProgress == 1 then
-        player:startEvent(515) -- Waiting for trade.
-    elseif
-        sayFlowers == xi.questStatus.QUEST_COMPLETED and
-        needToZone and
-        flowerProgress == 0
-    then -- Must zone to retry quest.
-        player:startEvent(521)
-    elseif sayFlowers == xi.questStatus.QUEST_COMPLETED and flowerProgress == 0 then
-        player:startEvent(523) -- Repeat Say It with Flowers.
-    else
-        player:startEvent(512)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    if csid == 514 and option == 1 then
-        player:setCharVar('FLOWER_PROGRESS', 1)
-        player:addQuest(xi.questLog.WINDURST, xi.quest.id.windurst.SAY_IT_WITH_FLOWERS)
-    elseif csid == 520 then -- First completion, Iron Sword awarded.
-        if player:getFreeSlotsCount() > 0 then
-            player:tradeComplete()
-            player:addItem(xi.item.IRON_SWORD)
-            player:completeQuest(xi.questLog.WINDURST, xi.quest.id.windurst.SAY_IT_WITH_FLOWERS)
-            player:addFame(xi.fameArea.WINDURST, 30)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, xi.item.IRON_SWORD)
-            player:setCharVar('FLOWER_PROGRESS', 0)
-            player:needToZone(true)
-            player:setTitle(xi.title.CUPIDS_FLORIST)
-        else
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, xi.item.IRON_SWORD)
-        end
-    elseif csid == 522 then -- Wrong flowers so complete quest, but smaller reward/fame and no title.
-        player:completeQuest(xi.questLog.WINDURST, xi.quest.id.windurst.SAY_IT_WITH_FLOWERS)
-        player:tradeComplete()
-        npcUtil.giveCurrency(player, 'gil', 100)
-        player:addFame(xi.fameArea.WINDURST, 10)
-        player:needToZone(true)
-        player:setCharVar('FLOWER_PROGRESS', 0)
-    elseif csid == 523 then
-        player:setCharVar('FLOWER_PROGRESS', 1)
-    elseif csid == 525 then -- Repeatable quest rewards.
-        player:tradeComplete()
-        player:addFame(xi.fameArea.WINDURST, 30)
-        player:addGil(xi.settings.main.GIL_RATE * 400)
-        player:setCharVar('FLOWER_PROGRESS', 0)
-        player:needToZone(true)
-        player:setTitle(xi.title.CUPIDS_FLORIST)
-    end
 end
 
 return entity

--- a/scripts/zones/Windurst_Waters/npcs/Ohbiru-Dohbiru.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Ohbiru-Dohbiru.lua
@@ -5,65 +5,18 @@
 --  Starts and finishes quest: Toraimarai Turmoil
 -- !pos 23 -5 -193 238
 -----------------------------------
-local ID = zones[xi.zone.WINDURST_WATERS]
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local needToZone = player:needToZone()
-    local sayFlowers = player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.SAY_IT_WITH_FLOWERS)
-    local flowerProgress = player:getCharVar('FLOWER_PROGRESS')
-
-    if
-        (sayFlowers == xi.questStatus.QUEST_ACCEPTED or sayFlowers == xi.questStatus.QUEST_COMPLETED) and
-        flowerProgress == 1
-    then
-        if needToZone then
-            player:startEvent(518)
-        elseif player:getCharVar('FLOWER_PROGRESS') == 2 then
-            player:startEvent(517, 0, 0, 0, 0, 950)
-        else
-            player:startEvent(516, 0, 0, 0, 0, 950)
-        end
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    local flowerList =
-    {
-        [0] = { itemid = 948, gil = 300 }, -- Carnation
-        [1] = { itemid = 941, gil = 200 }, -- Red Rose
-        [2] = { itemid = 949, gil = 250 }, -- Rain Lily
-        [3] = { itemid = 956, gil = 150 }, -- Lilac
-        [4] = { itemid = 957, gil = 200 }, -- Amaryllis
-        [5] = { itemid = 958, gil = 100 }  -- Marguerite
-    }
-
-    if csid == 516 then
-        if option < 7 then
-            local choice = flowerList[option]
-            if choice and player:getGil() >= choice.gil then
-                if player:getFreeSlotsCount() > 0 then
-                    player:addItem(choice.itemid)
-                    player:messageSpecial(ID.text.ITEM_OBTAINED, choice.itemid)
-                    player:delGil(choice.gil)
-                    player:needToZone(true)
-                else
-                    player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, choice.itemid)
-                end
-            else
-                player:messageSpecial(ID.text.NOT_HAVE_ENOUGH_GIL)
-            end
-        elseif option == 7 then
-            player:setCharVar('FLOWER_PROGRESS', 2)
-        end
-    end
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Converts quest `Say it with Flowers` to IF
Fixes quest progression sequence based on capture
Fixes quest dialog based on capture
Fixes quest repeat based on capture

[Capture (First Completion)](https://www.youtube.com/watch?v=yTeWqRTB1w0)
[Capture (Repeat)](https://www.youtube.com/watch?v=_fwotoTPC4s)

## Steps to test these changes

Pre-Reqs:
Windurst fame > 2

Quest:
Speak to `Moari-Kaaori` (!pos -253 -5 -227 238) to begin quest
Trade `Moari-Kaaori` a `Tahrongi Cactus` (!additem 950) or a wrong flower (`Carnation`(948), `Red Rose`(941), `Rain Lily`(949), `Lilac`(956), `Amaryllis`(957), `Marguerite`(958))
