### PR TITLE
[Fix] Add ranged attack effects to Last Resort

### DIFF
--- a/scripts/effects/last_resort.lua
+++ b/scripts/effects/last_resort.lua
@@ -5,10 +5,19 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    effect:addMod(xi.mod.ATT, 2 * target:getJobPointLevel(xi.jp.LAST_RESORT_EFFECT))
-    effect:addMod(xi.mod.ATTP, 25 + target:getMerit(xi.merit.LAST_RESORT_EFFECT))
+    local targetMerit     = target:getMerit(xi.merit.LAST_RESORT_EFFECT)
+    local targetJobPoints = target:getJobPointLevel(xi.jp.LAST_RESORT_EFFECT)
+
+    -- Job point effect
+    effect:addMod(xi.mod.ATT, 2 * targetJobPoints)
+    effect:addMod(xi.mod.RATT, 2 * targetJobPoints)
+
+    -- Merit effect
+    effect:addMod(xi.mod.ATTP, 25 + targetMerit)
+    effect:addMod(xi.mod.RATTP, 25 + targetMerit)
+    effect:addMod(xi.mod.DEFP, -25 - targetMerit)
+
     effect:addMod(xi.mod.TWOHAND_HASTE_ABILITY, target:getMod(xi.mod.DESPERATE_BLOWS) + target:getMerit(xi.merit.DESPERATE_BLOWS))
-    effect:addMod(xi.mod.DEFP, -25 - target:getMerit(xi.merit.LAST_RESORT_EFFECT))
 end
 
 effectObject.onEffectTick = function(target, effect)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds missing ranged attack bonuses from merits and job points to last resort.

https://www.bg-wiki.com/ffxi/Last_Resort

![imagen](https://github.com/user-attachments/assets/195db708-f8f7-4373-bbb2-d4b1231e37e0)

## Steps to test these changes

Use /checkparam
Use last resort
Use /checkparam again

See the bonus to ranged attack
