### PR TITLE
[Lua] Fix traveling merchant conquest tie issue

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -614,11 +614,12 @@ xi.conquest.toggleRegionalNPCs = function(zone)
         end)
 
         local firstPlaceZone  = rankings[1][2]
-        local secondPlaceZone = rankings[2][2]
+        -- check if the first and second are both rank 1 (thus a tie)
+        local firstAndSecondTie = rankings[1][1] == rankings[2][1]
 
         if
             firstPlaceZone == id and
-            firstPlaceZone ~= secondPlaceZone
+            not firstAndSecondTie
         then
             print('Showing regional conquest NPCs in: ' .. zone:getName())
         else
@@ -637,7 +638,7 @@ xi.conquest.toggleRegionalNPCs = function(zone)
                     -- If there is a clear winner, and not a tie, show the NPCs
                     if
                         id == firstPlaceZone and
-                        firstPlaceZone ~= secondPlaceZone
+                        not firstAndSecondTie
                     then
                         entity:setStatus(xi.status.NORMAL)
                     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This fixes an issue where traveling merchants appear even when there is a tie at the top in conquest (two or three way). Specifically `conquest.lua` uses the incorrect logic of `firstPlaceZone ~= secondPlaceZone` which will always be true. This PR fixes this incorrect logic by checking the actual nation ranks rather than the zone IDs.

## Steps to test these changes
Change the conquest results in the DB and then using the `!updateconquest` command and check the traveling merchants.
