### PR TITLE
[login] Add keepalives to TCP sockets

### DIFF
--- a/src/login/handler_session.cpp
+++ b/src/login/handler_session.cpp
@@ -39,6 +39,18 @@ void handler_session::start()
 {
     if (socket_.lowest_layer().is_open())
     {
+        // Enable keepalives for long sessions (view_session in particular)
+        socket_.lowest_layer().set_option(asio::socket_base::keep_alive(true));
+
+        socket_.lowest_layer().set_option(asio::detail::socket_option::integer<IPPROTO_TCP, TCP_KEEPINTVL>(5 * 60)); // interval between keepalive
+        socket_.lowest_layer().set_option(asio::detail::socket_option::integer<IPPROTO_TCP, TCP_KEEPCNT>(10));       // failed keepalives before declaring dead
+
+#ifdef __APPLE__
+        socket_.lowest_layer().set_option(asio::detail::socket_option::integer<IPPROTO_TCP, TCP_KEEPALIVE>(5 * 60)); // secs before keepalive probes
+#else
+        socket_.lowest_layer().set_option(asio::detail::socket_option::integer<IPPROTO_TCP, TCP_KEEPIDLE>(5 * 60)); // secs before keepalive probes
+#endif
+
         do_read();
     }
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Add keepalives to TCP sockets. This could help long-term connections staying connected to the view session, which FFXI expects to stay open if you ever /logout.

## Steps to test these changes

Login, look on wireshark/tcpdump for 0  length ACKs to port 54230 between login and your client every 5 minutes