### PR TITLE
[lua] Enforce unlocks on homepoint teleports

### DIFF
--- a/scripts/globals/homepoint.lua
+++ b/scripts/globals/homepoint.lua
@@ -201,7 +201,6 @@ xi.homepoint.onEventUpdate = function(player, csid, option, npc)
 
     if xi.settings.main.HOMEPOINT_TELEPORT == 1 then
         if choice >= selection.SET_LAYOUT and choice <= selection.REP_FAVORITE then
-
             local index = bit.rshift(bit.lshift(option, 8), 24) -- Ret HP #
 
             if choice == selection.ADD_FAVORITE then
@@ -230,6 +229,14 @@ xi.homepoint.onEventUpdate = function(player, csid, option, npc)
             end
 
             player:setTeleportMenu(xi.teleport.type.HOMEPOINT, favs)
+        elseif choice == selection.TELEPORT then
+            local hpIndex = bit.rshift(option, 16)
+            local origin  = player:getLocalVar('originIndex')
+
+            if not player:hasTeleport(xi.teleport.type.HOMEPOINT, hpIndex, math.floor(origin / 32)) then
+                print(string.format("Player %s tried to teleport to an HP without it's destination being unlocked", player:getName()))
+                player:release()
+            end
         end
 
         for x = 1, 3 do -- Condense arrays for event params


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Enforce unlocks on homepoint teleports

Note: this is NOT retail accurate. I did NOT inject a packet to cap this. I do not know what happens when you try to cheat this blatantly.

## Steps to test these changes

Try to teleport to a homepoint you don't have unlocked and get "Event skipped"
