### PR TITLE
[core] Force crit fail on synth if player zones for any reason

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -553,18 +553,6 @@ void SmallPacket0x00D(map_session_data_t* const PSession, CCharEntity* const PCh
         PSession->shuttingDown = 2;
         _sql->Query("UPDATE char_stats SET zoning = 1 WHERE charid = %u", PChar->id);
         charutils::CheckEquipLogic(PChar, SCRIPT_CHANGEZONE, PChar->getZone());
-
-        if (PChar->CraftContainer->getItemsCount() > 0 && PChar->animation == ANIMATION_SYNTH)
-        {
-            // NOTE:
-            // Supposed non-losable items are reportely lost if this condition is met:
-            // https://ffxiclopedia.fandom.com/wiki/Lu_Shang%27s_Fishing_Rod
-            // The broken rod can never be lost in a normal failed synth. It will only be lost if the synth is
-            // interrupted in some way, such as by being attacked or moving to another area (e.g. ship docking).
-
-            ShowWarning("SmallPacket0x00D: %s attempting to zone in the middle of a synth, failing their synth!", PChar->getName());
-            synthutils::doSynthFail(PChar);
-        }
     }
 
     if (PChar->loc.zone != nullptr)

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -279,6 +279,8 @@ namespace charutils
     bool hasEntitySpawned(CCharEntity* PChar, CBaseEntity* entity);
 
     uint32 getCharIdFromName(std::string const& name);
+
+    void forceSynthCritFail(std::string sourceFunction, CCharEntity* PChar);
 }; // namespace charutils
 
 #endif // _CHARUTILS_H

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -485,6 +485,12 @@ void CZoneEntities::DecreaseZoneCounter(CCharEntity* PChar)
         }
     }
 
+    // Duplicated from charUtils, it is theoretically possible through d/c magic to hit this block and not sendToZone
+    if (PChar->CraftContainer && PChar->CraftContainer->getItemsCount() > 0)
+    {
+        charutils::forceSynthCritFail("DecreaseZoneCounter", PChar);
+    }
+
     if (PChar->animation == ANIMATION_SYNTH)
     {
         PChar->CraftContainer->setQuantity(0, synthutils::SYNTHESIS_FAIL);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Force crit fail on synth if player zones for any reason

## Steps to test these changes
!zone after starting synth and crit fail