### PR TITLE
Fix relic ws add effect durations

### DIFF
--- a/scripts/actions/weaponskills/gate_of_tartarus.lua
+++ b/scripts/actions/weaponskills/gate_of_tartarus.lua
@@ -33,7 +33,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     if damage > 0 then
         if not target:hasStatusEffect(xi.effect.ATTACK_DOWN) then
-            local duration = tp / 1000 * 3 * applyResistanceAddEffect(player, target, xi.element.WATER, 0)
+            local duration = 120 * applyResistanceAddEffect(player, target, xi.element.WATER, 0)
             target:addStatusEffect(xi.effect.ATTACK_DOWN, 20, 0, duration)
         end
     end

--- a/scripts/actions/weaponskills/metatron_torment.lua
+++ b/scripts/actions/weaponskills/metatron_torment.lua
@@ -35,7 +35,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
     if damage > 0 then
-        local duration = tp / 1000 * 20 * applyResistanceAddEffect(player, target, xi.element.WIND, 0)
+        local duration = 120 * applyResistanceAddEffect(player, target, xi.element.WIND, 0)
         target:addStatusEffect(xi.effect.DEFENSE_DOWN, 19, 0, duration)
     end
 

--- a/scripts/actions/weaponskills/onslaught.lua
+++ b/scripts/actions/weaponskills/onslaught.lua
@@ -33,8 +33,8 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
     if damage > 0 then
         if not target:hasStatusEffect(xi.effect.ACCURACY_DOWN) then
-            local duration = tp / 1000 * 20 * applyResistanceAddEffect(player, target, xi.element.EARTH, 0)
-            target:addStatusEffect(xi.effect.ACCURACY_DOWN, 20, 0, duration)
+            local duration = 120 * applyResistanceAddEffect(player, target, xi.element.EARTH, 0)
+            target:addStatusEffect(xi.effect.ACCURACY_DOWN, 30, 0, duration)
         end
     end
 

--- a/scripts/actions/weaponskills/randgrith.lua
+++ b/scripts/actions/weaponskills/randgrith.lua
@@ -31,7 +31,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     if damage > 0 then
         if not target:hasStatusEffect(xi.effect.EVASION_DOWN) then
-            local duration = tp / 1000 * 20 * applyResistanceAddEffect(player, target, xi.element.ICE, 0)
+            local duration = 120 * applyResistanceAddEffect(player, target, xi.element.ICE, 0)
             target:addStatusEffect(xi.effect.EVASION_DOWN, 32, 0, duration)
         end
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adjusts relic WS add effect durations to 120s (note: currently no proof for Randgrith's add effect but what was there was almost certainly more wrong. I don't see why it would't be 120s like the rest.

Commits have proof where available (all but Randgrith)

Apparently Onslaught's acc down was too low as well.
## Steps to test these changes

Use WS, see longer add effect durations if they land, etc
