### PR TITLE
[Lua] Change bind to use retail accurate random duration

### DIFF
--- a/scripts/globals/spells/enfeebling_spell.lua
+++ b/scripts/globals/spells/enfeebling_spell.lua
@@ -265,6 +265,13 @@ end
 xi.spells.enfeebling.calculateDuration = function(caster, target, spellId, spellEffect, skillType)
     local duration = pTable[spellId][7] -- Get base duration.
 
+    -- BIND spells have a special random duration the follows a normal distribution with mean=30 and std=12
+    if spellEffect == xi.effect.BIND then
+        -- Use the Box-Muller transform to change uniform dist sample to the normal dist sample
+        local z0 = math.sqrt(-2 * math.log(math.random())) * math.cos(2 * math.pi * math.random())
+        duration = utils.clamp(math.floor(30 + z0 * 12), 1, duration)
+    end
+
     -- Additions to base duration.
     if
         spellEffect == xi.effect.BURN or


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR changes the duration of the spell bind and bindga to have a random duration (as on retail). I performed retail testing/captures that is summarized [here](https://docs.google.com/spreadsheets/d/1-e6p6Y73h4mrn6rqPcGZa6E-y7pbFWM1tkOKl2L_8WI/pubhtml) for both player->mob and mob->player. Essentially, after discussing with some magic people, the current best estimation is bind duration is drawn from a normal distribution with mean of 30s, std. dev. of 12 seconds, min of 1 sec, and max of 60 seconds. The random nature of bind duration (along with the max duration) is further supported by JP wiki [here](https://wiki.ffo.jp/html/836.html).

## Steps to test these changes
Bind mobs and watch the duration.
