### PR TITLE
[Quest] Move The Tenshodo Showdown mob steal code to IF file

### DIFF
--- a/scripts/commands/checkinteraction.lua
+++ b/scripts/commands/checkinteraction.lua
@@ -95,6 +95,7 @@ commandObj.onTrigger = function(player, handlerName)
         return handlers
     end
 
+    local onSteals = gatherHandlers('onSteal')
     local onTriggers = gatherHandlers('onTrigger')
     local onTrades = gatherHandlers('onTrade')
 
@@ -113,6 +114,7 @@ commandObj.onTrigger = function(player, handlerName)
     end
 
     cmdPrint('Handlers for "%s":', handlerName)
+    printHandlers('Steal', onSteals)
     printHandlers('Trigger', onTriggers)
     printHandlers('Trade', onTrades)
 end

--- a/scripts/globals/interaction/interaction_global.lua
+++ b/scripts/globals/interaction/interaction_global.lua
@@ -103,6 +103,10 @@ function InteractionGlobal.afterZoneIn(player, fallbackFn)
     return InteractionGlobal.lookup:afterZoneIn(player, fallbackFn)
 end
 
+function InteractionGlobal.onSteal(player, mob, ability, action, fallbackFn)
+    return InteractionGlobal.lookup:onSteal(player, mob, ability, action, fallbackFn)
+end
+
 function InteractionGlobal.onTrigger(player, npc, fallbackFn)
     return InteractionGlobal.lookup:onTrigger(player, npc, fallbackFn)
 end

--- a/scripts/globals/interaction/interaction_lookup.lua
+++ b/scripts/globals/interaction/interaction_lookup.lua
@@ -413,6 +413,7 @@ local function onHandler(data, secondLevelKey, thirdLevelKey, args, fallbackHand
     -- except those that should only perform one action at a time, like onTrigger and onTrade
     if
         fallbackHandler and
+        thirdLevelKey ~= 'onSteal' and
         thirdLevelKey ~= 'onTrigger' and
         thirdLevelKey ~= 'onTrade'
     then
@@ -458,6 +459,10 @@ end
 
 function InteractionLookup:afterZoneIn(player, fallbackFn)
     return onHandler(self.data, 'afterZoneIn', 1, { player }, fallbackFn)
+end
+
+function InteractionLookup:onSteal(player, mob, ability, action, fallbackFn)
+    return onHandler(self.data, mob:getName(), 'onSteal', { player, mob, ability, action }, fallbackFn)
 end
 
 function InteractionLookup:onTrigger(player, npc, fallbackFn)

--- a/scripts/quests/windurst/THF_AF1_The_Tenshodo_Showdown.lua
+++ b/scripts/quests/windurst/THF_AF1_The_Tenshodo_Showdown.lua
@@ -1,6 +1,7 @@
 -----------------------------------
 -- The Tenshodo Showdown
 -----------------------------------
+-- Log ID: 2, Quest ID: 69
 -- !addquest 2 69
 -- Nanaa Mihgo : !pos 62 -4 240 241
 -- Harnek      : !pos 44 0 -19 245
@@ -127,6 +128,45 @@ quest.sections =
                 end,
             },
         },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_ACCEPTED and
+                not player:hasItem(xi.item.BOWL_OF_QUADAV_STEW)
+        end,
+
+        [xi.zone.BEADEAUX] =
+        {
+            ['Bronze_Quadav'] =
+            {
+                onSteal = function(player, target, ability, action)
+                    return xi.item.BOWL_OF_QUADAV_STEW
+                end
+            },
+
+            ['Garnet_Quadav'] =
+            {
+                onSteal = function(player, target, ability, action)
+                    return xi.item.BOWL_OF_QUADAV_STEW
+                end
+            },
+
+            ['Silver_Quadav'] =
+            {
+                onSteal = function(player, target, ability, action)
+                    return xi.item.BOWL_OF_QUADAV_STEW
+                end
+            },
+
+            ['Zircon_Quadav'] =
+            {
+                onSteal = function(player, target, ability, action)
+                    return xi.item.BOWL_OF_QUADAV_STEW
+                end
+            }
+        },
+
     },
 
     {

--- a/scripts/zones/Beadeaux/mobs/Bronze_Quadav.lua
+++ b/scripts/zones/Beadeaux/mobs/Bronze_Quadav.lua
@@ -1,22 +1,11 @@
 -----------------------------------
--- Area: Beadeaux (254)
+-- Area: Beadeaux (147)
 --  Mob: Bronze Quadav
 -- Notes: Bowl of Quadav Stew is a guaranteed steal with
 --  Quest THE_TENSHODO_SHOWDOWN active
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
-
-entity.onSteal = function(player, target, ability, action)
-    if
-        player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.THE_TENSHODO_SHOWDOWN) == xi.questStatus.QUEST_ACCEPTED and
-        not player:hasItem(xi.item.BOWL_OF_QUADAV_STEW)
-    then
-        return xi.item.BOWL_OF_QUADAV_STEW
-    else
-        return 0
-    end
-end
 
 entity.onMobDeath = function(mob, player, optParams)
 end

--- a/scripts/zones/Beadeaux/mobs/Garnet_Quadav.lua
+++ b/scripts/zones/Beadeaux/mobs/Garnet_Quadav.lua
@@ -1,22 +1,11 @@
 -----------------------------------
--- Area: Beadeaux (254)
+-- Area: Beadeaux (147)
 --  Mob: Garnet Quadav
 -- Notes: Bowl of Quadav Stew is a guaranteed steal with
 --  Quest THE_TENSHODO_SHOWDOWN active
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
-
-entity.onSteal = function(player, target, ability, action)
-    if
-        player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.THE_TENSHODO_SHOWDOWN) == xi.questStatus.QUEST_ACCEPTED and
-        not player:hasItem(xi.item.BOWL_OF_QUADAV_STEW)
-    then
-        return xi.item.BOWL_OF_QUADAV_STEW
-    else
-        return 0
-    end
-end
 
 entity.onMobDeath = function(mob, player, optParams)
 end

--- a/scripts/zones/Beadeaux/mobs/Silver_Quadav.lua
+++ b/scripts/zones/Beadeaux/mobs/Silver_Quadav.lua
@@ -1,22 +1,11 @@
 -----------------------------------
--- Area: Beadeaux (254)
+-- Area: Beadeaux (147)
 --  Mob: Silver Quadav
 -- Notes: Bowl of Quadav Stew is a guaranteed steal with
 --  Quest THE_TENSHODO_SHOWDOWN active
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
-
-entity.onSteal = function(player, target, ability, action)
-    if
-        player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.THE_TENSHODO_SHOWDOWN) == xi.questStatus.QUEST_ACCEPTED and
-        not player:hasItem(xi.item.BOWL_OF_QUADAV_STEW)
-    then
-        return xi.item.BOWL_OF_QUADAV_STEW
-    else
-        return 0
-    end
-end
 
 entity.onMobDeath = function(mob, player, optParams)
 end

--- a/scripts/zones/Beadeaux/mobs/Zircon_Quadav.lua
+++ b/scripts/zones/Beadeaux/mobs/Zircon_Quadav.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Area: Beadeaux (254)
+-- Area: Beadeaux (147)
 --  Mob: Zircon Quadav
 -- Notes: PH for Zo'Khu Blackcloud
 --  Bowl of Quadav Stew is a guaranteed steal with
@@ -14,17 +14,6 @@ local zoKhuPHTable =
 {
     [ID.mob.ZO_KHU_BLACKCLOUD - 2] = ID.mob.ZO_KHU_BLACKCLOUD, -- -294.223 -3.504 -206.657
 }
-
-entity.onSteal = function(player, target, ability, action)
-    if
-        player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.THE_TENSHODO_SHOWDOWN) == xi.questStatus.QUEST_ACCEPTED and
-        not player:hasItem(xi.item.BOWL_OF_QUADAV_STEW)
-    then
-        return xi.item.BOWL_OF_QUADAV_STEW
-    else
-        return 0
-    end
-end
 
 entity.onMobDeath = function(mob, player, optParams)
 end

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -4237,13 +4237,16 @@ namespace luautils
             return 0;
         }
 
-        sol::function onSteal = getEntityCachedFunction(PMob, "onSteal");
-        if (!onSteal.valid())
-        {
-            return 0;
-        }
+        auto zone     = PChar->loc.zone->getName();
+        auto name     = PMob->getName();
+        auto filename = fmt::format("./scripts/zones/{}/mobs/{}.lua", zone, name);
 
-        auto result = onSteal(CLuaBaseEntity(PChar), CLuaBaseEntity(PMob), CLuaAbility(PAbility), CLuaAction(action));
+        ShowTrace("luautils::OnSteal: {} ({}) -> {}", PChar->getName(), zone, name);
+
+        auto onStealFramework = lua["InteractionGlobal"]["onSteal"];
+        auto onSteal          = GetCacheEntryFromFilename(filename)["onSteal"];
+
+        auto result = onStealFramework(CLuaBaseEntity(PChar), CLuaBaseEntity(PMob), CLuaAbility(PAbility), CLuaAction(action), onSteal);
         if (!result.valid())
         {
             sol::error err = result;

--- a/tools/ci/check_lua_binding_usage.py
+++ b/tools/ci/check_lua_binding_usage.py
@@ -57,6 +57,7 @@ def main():
     function_names.append("afterZoneIn")
     function_names.append("onTrigger")
     function_names.append("onTrade")
+    function_names.append("onSteal")
     function_names.append("onMobDeath")
     function_names.append("onZoneIn")
     function_names.append("noAction")


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds `onSteal` to IF
Moves npc code handling `onSteal` for the THF AF1 quest into the quest lua

## Steps to test these changes

Steal from Quadavs during THF AF1 quest, see unchanged results.

## Notes
Some players indicated they could steal the stew prior to flagging the quest:
[1](https://ffxi.allakhazam.com/db/quests.html?fquest=225#:~:text=1/1%20on%20a%20Silver%20Quadav%20pulled%20from%20the%20top%20%3A%20didn%27t%20have%20the%20quest%20started.%20Good%20luck%20to%20the%20rest%20of%20you!)
[2](https://ffxi.allakhazam.com/db/quests.html?fquest=225#:~:text=I%20would%20like,rolenberry%20for%20me.)