### PR TITLE
[Crafting] Clean craft container on invalid recipe

### DIFF
--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -828,6 +828,8 @@ namespace synthutils
 
         if (!isRightRecipe(PChar))
         {
+            PChar->CraftContainer->Clean();
+
             return 0;
         }
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Handles edge case where craft container isnt cleaned if recipe isnt valid.

## Steps to test these changes

Try to craft using an invalid item combination and have npcs be responsive after that.
