### PR TITLE
Fix craft container check

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -5034,7 +5034,7 @@ void SmallPacket0x085(map_session_data_t* const PSession, CCharEntity* const PCh
 
     if (PItem != nullptr && (gil != nullptr && gil->isType(ITEM_CURRENCY)))
     {
-        if (PChar->CraftContainer)
+        if (PChar->animation == ANIMATION_SYNTH || (PChar->CraftContainer && PChar->CraftContainer->getItemsCount() > 0))
         {
             ShowWarning("SmallPacket0x085: Player %s trying to sell while in the middle of a synth!", PChar->getName());
             return;


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Even though I copy/pasted the same line wherever SYNTH_ANIMATION was used in the packet system file (save for 2 cases), this check got reverted to that. I even have the line properly in my own server.

I probably had an issue when I rebased the PR.

The PR: #6203 

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
