### PR TITLE
Modify Interaction to allow direct function definition for on/afterZone events

### DIFF
--- a/scripts/globals/interaction/actions/action.lua
+++ b/scripts/globals/interaction/actions/action.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 ----- Action base class
 -----------------------------------
----@class TInteractionAction
+---@class TAction
 Action = {}
 
 ---@enum Action.Priority
@@ -30,7 +30,7 @@ Action.Type =
 }
 
 ---@param type Action.Type
----@return TInteractionAction
+---@return TAction
 function Action:new(type)
     local obj = {}
     setmetatable(obj, self)
@@ -48,26 +48,26 @@ function Action:perform(player, targetEntity)
 end
 
 ---@param priorityArg Action.Priority|integer
----@return TInteractionAction
+---@return TAction
 function Action:setPriority(priorityArg)
     self.priority = priorityArg
     return self
 end
 
----@return TInteractionAction
+---@return TAction
 function Action:progress()
     -- Set highest priority for action
     return self:setPriority(Action.Priority.Progress)
 end
 
----@return TInteractionAction
+---@return TAction
 function Action:replaceDefault()
     -- Always prefer this over falling back to default in lua file
     return self:setPriority(Action.Priority.ReplaceDefault)
 end
 
 -- Perform the action as a Progress priority, and then default back to event
----@return TInteractionAction
+---@return TAction
 function Action:importantEvent()
     self.priority = Action.Priority.Progress
     self.secondaryPriority = Action.Priority.Event
@@ -75,7 +75,7 @@ function Action:importantEvent()
 end
 
 -- After the first time the action is performed, it will have a lower priority
----@return TInteractionAction
+---@return TAction
 function Action:importantOnce()
     self.priority = Action.Priority.Event
     self.secondaryPriority = Action.Priority.Default
@@ -83,19 +83,19 @@ function Action:importantOnce()
 end
 
 -- Only do this action once per zone, unless there's nothing else to do
----@return TInteractionAction
+---@return TAction
 function Action:oncePerZone()
     self.secondaryPriority = Action.Priority.Ignore
     return self
 end
 
----@return TInteractionAction
+---@return TAction
 function Action:openDoor()
     self.returnValue = -1
     return self
 end
 
----@return TInteractionAction
+---@return TAction
 function Action:open()
     return self:openDoor()
 end

--- a/scripts/globals/interaction/actions/event.lua
+++ b/scripts/globals/interaction/actions/event.lua
@@ -3,7 +3,7 @@
 -----------------------------------
 require('scripts/globals/interaction/actions/action')
 
----@class TInteractionEvent : TInteractionAction
+---@class TEvent : TAction
 ---@field id integer
 ---@field options integer[]|table[]
 Event = Action:new(Action.Type.Event)
@@ -33,7 +33,7 @@ function Event:perform(player, targetEntity)
     return self.returnValue
 end
 
----@return TInteractionEvent
+---@return TEvent
 function Event:cutscene()
     self.isCutscene = true
     return self

--- a/scripts/globals/interaction/actions/keyitem.lua
+++ b/scripts/globals/interaction/actions/keyitem.lua
@@ -3,12 +3,12 @@
 -----------------------------------
 require('scripts/globals/interaction/actions/action')
 
----@class TInteractionKeyItem : TInteractionAction
+---@class TKeyItem : TAction
 ---@field id integer
 KeyItemAction = Action:new(Action.Type.KeyItem)
 
 ---@param keyItemId xi.keyItem
----@return TInteractionKeyItem
+---@return TKeyItem
 function KeyItemAction:new(keyItemId)
     local obj = {}
     setmetatable(obj, self)

--- a/scripts/globals/interaction/actions/lambdaaction.lua
+++ b/scripts/globals/interaction/actions/lambdaaction.lua
@@ -3,7 +3,7 @@
 -----------------------------------
 require('scripts/globals/interaction/actions/action')
 
----@class TInteractionLambdaAction : TInteractionAction
+---@class TLambdaAction : TAction
 ---@field actionFunc function
 ---@field priority Action.Priority|integer
 LambdaAction = Action:new(Action.Type.LambdaAction)

--- a/scripts/globals/interaction/actions/message.lua
+++ b/scripts/globals/interaction/actions/message.lua
@@ -3,7 +3,7 @@
 -----------------------------------
 require('scripts/globals/interaction/actions/action')
 
----@class TInteractionMessage: TInteractionAction
+---@class TMessage: TAction
 ---@field messageType Message.type
 ---@field id integer
 ---@field npcId integer?
@@ -22,7 +22,7 @@ Message.Type =
 ---@param messageId integer
 ---@param messageType Message.type?
 ---@param ... integer?
----@return TInteractionMessage
+---@return TMessage
 function Message:new(messageId, messageType, ...)
     local obj = {}
     setmetatable(obj, self)

--- a/scripts/globals/interaction/actions/noaction.lua
+++ b/scripts/globals/interaction/actions/noaction.lua
@@ -6,7 +6,7 @@
 -----------------------------------
 require('scripts/globals/interaction/actions/action')
 
----@class TInteractionNoAction : TInteractionAction
+---@class TNoAction : TAction
 NoAction = Action:new(Action.Type.NoAction)
 
 function NoAction:new(prio)

--- a/scripts/globals/interaction/actions/sequence.lua
+++ b/scripts/globals/interaction/actions/sequence.lua
@@ -4,7 +4,7 @@
 require('scripts/globals/interaction/actions/action')
 require('scripts/globals/interaction/actions/message')
 
----@class TInteractionSequence : TInteractionAction
+---@class TSequence : TAction
 ---@field __nextAction any
 Sequence = Action:new(Action.Type.Sequence)
 
@@ -30,7 +30,7 @@ function Sequence:new(unparsedSequence)
     local id = nil
     for _, entry in ipairs(unparsedSequence) do
         if entry.text then
-            ---@type TInteractionMessage
+            ---@type TMessage
             local newLast = Message:new(entry.text)
             last.__nextAction = newLast
             last = newLast

--- a/scripts/globals/interaction/container.lua
+++ b/scripts/globals/interaction/container.lua
@@ -38,48 +38,48 @@ end
 
 ---@param eventid integer
 ---@param ... integer|table
----@return TInteractionEvent
+---@return TEvent
 function Container:event(eventid, ...)
     return Event:new(eventid, ...)
 end
 
 ---@param eventid integer
 ---@param ... integer|table
----@return TInteractionEvent
+---@return TEvent
 function Container:cutscene(eventid, ...)
     return Event:new(eventid, ...):cutscene()
 end
 
 ---@param eventid integer
 ---@param ... integer|table
----@return TInteractionEvent
+---@return TEvent
 function Container:progressEvent(eventid, ...)
     return Event:new(eventid, ...):progress()
 end
 
 ---@param eventid integer
 ---@param ... integer|table
----@return TInteractionEvent
+---@return TEvent
 function Container:priorityEvent(eventid, ...)
     return Event:new(eventid, ...):progress()
 end
 
 ---@param eventid integer
 ---@param ... integer|table
----@return TInteractionEvent
+---@return TEvent
 function Container:progressCutscene(eventid, ...)
     return Event:new(eventid, ...):cutscene():progress()
 end
 
 ---@param eventid integer
 ---@param ... integer|table
----@return TInteractionEvent
+---@return TEvent
 function Container:replaceEvent(eventid, ...)
     return Event:new(eventid, ...):replaceDefault()
 end
 
 ---@param keyItemId xi.keyItem
----@return TInteractionKeyItem
+---@return TKeyItem
 function Container:keyItem(keyItemId)
     return KeyItemAction:new(keyItemId)
 end
@@ -87,28 +87,28 @@ end
 ---@param messageId integer
 ---@param messageType integer?
 ---@param ... integer?
----@return TInteractionMessage
+---@return TMessage
 function Container:message(messageId, messageType, ...)
     return Message:new(messageId, messageType, ...)
 end
 
 ---@param messageId integer
 ---@param ... integer?
----@return TInteractionMessage
+---@return TMessage
 function Container:messageText(messageId, ...)
     return Message:new(messageId, Message.Type.Text, ...)
 end
 
 ---@param messageId integer
 ---@param ... integer?
----@return TInteractionMessage
+---@return TMessage
 function Container:messageSpecial(messageId, ...)
     return Message:new(messageId, Message.Type.Special, ...)
 end
 
 ---@param messageId integer
 ---@param ... integer?
----@return TInteractionMessage
+---@return TMessage
 function Container:messageName(messageId, ...)
     return Message:new(messageId, Message.Type.Name, ...)
 end
@@ -119,7 +119,7 @@ function Container:replaceMessage(messageId, messageType, ...)
     return Message:new(messageId, messageType, ...):replaceDefault()
 end
 
----@return TInteractionSequence|TInteractionMessage?
+---@return TSequence|TMessage?
 function Container:sequence(...)
     if type(...) == 'number' then
         return Message:new(...)
@@ -128,7 +128,7 @@ function Container:sequence(...)
     end
 end
 
----@return TInteractionNoAction
+---@return TNoAction
 function Container:noAction(...)
     return NoAction:new(...)
 end

--- a/scripts/globals/interaction/interaction_lookup.lua
+++ b/scripts/globals/interaction/interaction_lookup.lua
@@ -100,7 +100,7 @@ local function addHandlers(secondLevel, lookupSecondLevel, checkFunc, container)
         for _, keyName in ipairs(wrappedDefinitions) do
             if
                 secondLevelKey == keyName and
-                type(thirdLevel) == "function"
+                type(thirdLevel) == 'function'
             then
                 thirdLevel = { thirdLevel }
             end

--- a/scripts/globals/interaction/interaction_lookup.lua
+++ b/scripts/globals/interaction/interaction_lookup.lua
@@ -87,6 +87,25 @@ local function addHandlers(secondLevel, lookupSecondLevel, checkFunc, container)
 
     -- Loop through the given second level table, and add them to lookup as needed
     for secondLevelKey, thirdLevel in pairs(secondLevel) do
+        -- The following keys are restricted in CI to function definitions, but to preserve
+        -- backwards-compatibility and ease of use in this system, wrap them in tables if
+        -- encountered.
+        local wrappedDefinitions =
+        {
+            'onZoneIn',
+            'onZoneOut',
+            'afterZoneIn',
+        }
+
+        for _, keyName in ipairs(wrappedDefinitions) do
+            if
+                secondLevelKey == keyName and
+                type(thirdLevel) == "function"
+            then
+                thirdLevel = { thirdLevel }
+            end
+        end
+
         lookupSecondLevel[secondLevelKey] = lookupSecondLevel[secondLevelKey] or {}
 
         -- If only given a function or an action definition as third level, that will default to be an onTrigger handler
@@ -196,6 +215,7 @@ function InteractionLookup:addContainer(container, validZoneTable)
         for zoneId, secondLevel in pairs(section) do
             if zoneId ~= 'check' and (validZoneTable == nil or validZoneTable[zoneId]) then
                 self.data[zoneId] = self.data[zoneId] or {}
+
                 addHandlers(secondLevel, self.data[zoneId], checkFunc, container)
             end
         end

--- a/scripts/globals/interaction/quest.lua
+++ b/scripts/globals/interaction/quest.lua
@@ -18,7 +18,7 @@ end
 ---@type rewardParam
 Quest.reward = {}
 
----@type TQuestSectionList
+---@type TQuestSection[]
 Quest.sections = {}
 
 ---@param areaId xi.questLog

--- a/scripts/missions/acp/01_A_Crystalline_Prophecy.lua
+++ b/scripts/missions/acp/01_A_Crystalline_Prophecy.lua
@@ -23,12 +23,9 @@ mission.sections =
 
         [xi.zone.LOWER_JEUNO] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    return 10094
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                return 10094
+            end,
 
             onEventUpdate =
             {

--- a/scripts/missions/amk/12_Joy_Summoned_to_a_Fabulous_Fete.lua
+++ b/scripts/missions/amk/12_Joy_Summoned_to_a_Fabulous_Fete.lua
@@ -20,12 +20,9 @@ mission.sections =
 
         [xi.zone.CASTLE_ZVAHL_BAILEYS] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    return 88
-                end
-            },
+            onZoneIn = function(player, prevZone)
+                return 88
+            end,
 
             onEventFinish =
             {

--- a/scripts/missions/asa/01_A_Shantotto_Ascension.lua
+++ b/scripts/missions/asa/01_A_Shantotto_Ascension.lua
@@ -23,17 +23,14 @@ mission.sections =
 
         [xi.zone.WINDURST_WALLS] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if
-                        prevZone == xi.zone.WINDURST_WATERS or
-                        prevZone == xi.zone.WINDURST_WOODS
-                    then
-                        return 510
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if
+                    prevZone == xi.zone.WINDURST_WATERS or
+                    prevZone == xi.zone.WINDURST_WOODS
+                then
+                    return 510
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/missions/asa/02_Burgeoning_Dread.lua
+++ b/scripts/missions/asa/02_Burgeoning_Dread.lua
@@ -21,17 +21,14 @@ mission.sections =
 
         [xi.zone.EAST_SARUTABARUTA] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if
-                        prevZone == xi.zone.WINDURST_WOODS and
-                        not player:hasStatusEffect(xi.effect.MOUNTED)
-                    then
-                        return mission:event(71)
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if
+                    prevZone == xi.zone.WINDURST_WOODS and
+                    not player:hasStatusEffect(xi.effect.MOUNTED)
+                then
+                    return mission:event(71)
+                end
+            end,
 
             onEventUpdate =
             {
@@ -52,16 +49,13 @@ mission.sections =
 
         [xi.zone.WEST_SARUTABARUTA] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if prevZone == xi.zone.WINDURST_WATERS then
-                        return 62
-                    elseif prevZone == xi.zone.PORT_WINDURST then
-                        return 63
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if prevZone == xi.zone.WINDURST_WATERS then
+                    return 62
+                elseif prevZone == xi.zone.PORT_WINDURST then
+                    return 63
+                end
+            end,
 
             onEventUpdate =
             {

--- a/scripts/missions/bastok/2_3_2_The_Emissary_Windurst.lua
+++ b/scripts/missions/bastok/2_3_2_The_Emissary_Windurst.lua
@@ -87,14 +87,11 @@ mission.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if player:getMissionStatus(mission.areaId) == 2 then
-                        return 42
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if player:getMissionStatus(mission.areaId) == 2 then
+                    return 42
+                end
+            end,
 
             onEventUpdate =
             {

--- a/scripts/missions/bastok/3_1_The_Four_Musketeers.lua
+++ b/scripts/missions/bastok/3_1_The_Four_Musketeers.lua
@@ -141,14 +141,11 @@ mission.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if player:getMissionStatus(mission.areaId) == 1 then
-                        return 120
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if player:getMissionStatus(mission.areaId) == 1 then
+                    return 120
+                end
+            end,
 
             onEventFinish =
             {
@@ -161,23 +158,20 @@ mission.sections =
 
         [xi.zone.PASHHOW_MARSHLANDS] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if prevZone == xi.zone.BEADEAUX then
-                        local missionStatus = player:getMissionStatus(mission.areaId)
+            onZoneIn = function(player, prevZone)
+                if prevZone == xi.zone.BEADEAUX then
+                    local missionStatus = player:getMissionStatus(mission.areaId)
 
-                        if
-                            missionStatus > 1 and
-                            missionStatus < 22
-                        then
-                            return 10
-                        elseif missionStatus == 22 then
-                            return 11
-                        end
+                    if
+                        missionStatus > 1 and
+                        missionStatus < 22
+                    then
+                        return 10
+                    elseif missionStatus == 22 then
+                        return 11
                     end
-                end,
-            },
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/missions/bastok/4_1_Magicite.lua
+++ b/scripts/missions/bastok/4_1_Magicite.lua
@@ -277,14 +277,11 @@ mission.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if mission:getVar(player, 'Option') == 2 then -- Fickbix CS
-                        return 10000
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if mission:getVar(player, 'Option') == 2 then -- Fickbix CS
+                    return 10000
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/missions/bastok/5_1_Darkness_Rising.lua
+++ b/scripts/missions/bastok/5_1_Darkness_Rising.lua
@@ -175,14 +175,11 @@ mission.sections =
 
         [xi.zone.FEIYIN] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if player:getMissionStatus(mission.areaId) == 10 then
-                        return 1
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if player:getMissionStatus(mission.areaId) == 10 then
+                    return 1
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/missions/bastok/8_2_Enter_the_Talekeeper.lua
+++ b/scripts/missions/bastok/8_2_Enter_the_Talekeeper.lua
@@ -103,20 +103,17 @@ mission.sections =
         {
             ['Rashid'] = mission:messageSpecial(bastokMinesID.text.EXTENDED_MISSION_OFFSET + 12),
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    -- This is a continuation of event 204 from Zeruhn Mines.  Player is teleported
-                    -- here automatically, and this event will finish the sequence and complete the
-                    -- mission.
-                    if
-                        prevZone == xi.zone.ZERUHN_MINES and
-                        player:getMissionStatus(mission.areaId) == 5
-                    then
-                        return 176
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                -- This is a continuation of event 204 from Zeruhn Mines.  Player is teleported
+                -- here automatically, and this event will finish the sequence and complete the
+                -- mission.
+                if
+                    prevZone == xi.zone.ZERUHN_MINES and
+                    player:getMissionStatus(mission.areaId) == 5
+                then
+                    return 176
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/missions/cop/1_1_The_Rites_of_Life.lua
+++ b/scripts/missions/cop/1_1_The_Rites_of_Life.lua
@@ -27,14 +27,11 @@ mission.sections =
 
         [xi.zone.LOWER_DELKFUTTS_TOWER] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if prevZone == xi.zone.QUFIM_ISLAND then
-                        return 22
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if prevZone == xi.zone.QUFIM_ISLAND then
+                    return 22
+                end
+            end,
 
             onEventFinish =
             {
@@ -70,12 +67,9 @@ mission.sections =
 
         [xi.zone.UPPER_JEUNO] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    return 2
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                return 2
+            end,
 
             onEventFinish =
             {

--- a/scripts/missions/cop/1_2_Below_the_Arks.lua
+++ b/scripts/missions/cop/1_2_Below_the_Arks.lua
@@ -180,12 +180,9 @@ mission.sections =
                 onTrigger = largeApparatusOnTrigger,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    return 108
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                return 108
+            end,
 
             onEventFinish =
             {

--- a/scripts/missions/cop/1_3_The_Mothercrystals.lua
+++ b/scripts/missions/cop/1_3_The_Mothercrystals.lua
@@ -120,19 +120,16 @@ mission.sections =
                 onTrigger = largeApparatusOnTrigger,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if
-                        xi.cop.helpers.numPromyvionCompleted(player) == 2 and
-                        not xi.cop.helpers.hasCompletedPromyvion(player, prevZone) and
-                        mission:getVar(player, 'Status') == 0
-                    then
-                        player:setLocalVar('toPromyvion', xi.cop.helpers.shatteredTelepointInfo[prevZone][1])
-                        return 155
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if
+                    xi.cop.helpers.numPromyvionCompleted(player) == 2 and
+                    not xi.cop.helpers.hasCompletedPromyvion(player, prevZone) and
+                    mission:getVar(player, 'Status') == 0
+                then
+                    player:setLocalVar('toPromyvion', xi.cop.helpers.shatteredTelepointInfo[prevZone][1])
+                    return 155
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/missions/cop/2_1_An_Invitation_West.lua
+++ b/scripts/missions/cop/2_1_An_Invitation_West.lua
@@ -45,14 +45,11 @@ mission.sections =
 
         [xi.zone.TAVNAZIAN_SAFEHOLD] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if mission:getVar(player, 'Status') == 1 then
-                        return 101
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if mission:getVar(player, 'Status') == 1 then
+                    return 101
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/missions/cop/2_5_Ancient_Vows.lua
+++ b/scripts/missions/cop/2_5_Ancient_Vows.lua
@@ -46,14 +46,11 @@ mission.sections =
 
         [xi.zone.RIVERNE_SITE_A01] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if mission:getVar(player, 'Status') == 1 then
-                        return 100
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if mission:getVar(player, 'Status') == 1 then
+                    return 100
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/missions/cop/3_1_The_Call_of_the_Wyrmking.lua
+++ b/scripts/missions/cop/3_1_The_Call_of_the_Wyrmking.lua
@@ -23,14 +23,11 @@ mission.sections =
 
         [xi.zone.SOUTH_GUSTABERG] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if mission:getVar(player, 'Status') == 0 then
-                        return 906
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if mission:getVar(player, 'Status') == 0 then
+                    return 906
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/missions/cop/3_3_The_Road_Forks.lua
+++ b/scripts/missions/cop/3_3_The_Road_Forks.lua
@@ -102,14 +102,11 @@ mission.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if player:getMissionStatus(mission.areaId, xi.mission.status.COP.SANDORIA) == 0 then
-                        return 14
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if player:getMissionStatus(mission.areaId, xi.mission.status.COP.SANDORIA) == 0 then
+                    return 14
+                end
+            end,
 
             onEventFinish =
             {
@@ -253,14 +250,11 @@ mission.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if player:getMissionStatus(mission.areaId, xi.mission.status.COP.WINDURST) == 0 then
-                        return 871
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if player:getMissionStatus(mission.areaId, xi.mission.status.COP.WINDURST) == 0 then
+                    return 871
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/missions/cop/3_4_Tending_Aged_Wounds.lua
+++ b/scripts/missions/cop/3_4_Tending_Aged_Wounds.lua
@@ -37,14 +37,11 @@ mission.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if mission:getVar(player, 'Status') == 0 then
-                        return 70
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if mission:getVar(player, 'Status') == 0 then
+                    return 70
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/missions/cop/3_5_Darkness_Named.lua
+++ b/scripts/missions/cop/3_5_Darkness_Named.lua
@@ -131,14 +131,11 @@ mission.sections =
 
         [xi.zone.THE_SHROUDED_MAW] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if mission:getVar(player, 'Status') == 3 then
-                        return 2
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if mission:getVar(player, 'Status') == 3 then
+                    return 2
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/missions/cop/4_1_Sheltering_Doubt.lua
+++ b/scripts/missions/cop/4_1_Sheltering_Doubt.lua
@@ -48,14 +48,11 @@ mission.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if mission:getVar(player, 'Status') == 0 then
-                        return 107
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if mission:getVar(player, 'Status') == 0 then
+                    return 107
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/missions/cop/5_1_The_Enduring_Tumult_of_War.lua
+++ b/scripts/missions/cop/5_1_The_Enduring_Tumult_of_War.lua
@@ -102,14 +102,11 @@ mission.sections =
 
         [xi.zone.PORT_BASTOK] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if mission:getVar(player, 'Status') == 0 then
-                        return 306
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if mission:getVar(player, 'Status') == 0 then
+                    return 306
+                end
+            end,
 
             onEventFinish =
             {
@@ -184,18 +181,15 @@ mission.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if
-                        player:getXPos() == -300 and
-                        prevZone == xi.zone.BEAUCEDINE_GLACIER and
-                        mission:getVar(player, 'Status') == 2
-                    then
-                        return 1
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if
+                    player:getXPos() == -300 and
+                    prevZone == xi.zone.BEAUCEDINE_GLACIER and
+                    mission:getVar(player, 'Status') == 2
+                then
+                    return 1
+                end
+            end,
 
             onEventFinish =
             {
@@ -213,14 +207,11 @@ mission.sections =
 
         [xi.zone.PROMYVION_VAHZL] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if mission:getVar(player, 'Status') == 4 then
-                        return 50
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if mission:getVar(player, 'Status') == 4 then
+                    return 50
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/missions/cop/5_2_Desires_of_Emptiness.lua
+++ b/scripts/missions/cop/5_2_Desires_of_Emptiness.lua
@@ -179,18 +179,15 @@ mission.sections =
 
         [xi.zone.SPIRE_OF_VAHZL] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if mission:getVar(player, 'Status') == 1 then
-                        if bit.rshift(mission:getVar(player, 'Option'), 3) == 7 then
-                            return 20
-                        else
-                            return 21
-                        end
+            onZoneIn = function(player, prevZone)
+                if mission:getVar(player, 'Status') == 1 then
+                    if bit.rshift(mission:getVar(player, 'Option'), 3) == 7 then
+                        return 20
+                    else
+                        return 21
                     end
-                end,
-            },
+                end
+            end,
 
             onEventFinish =
             {
@@ -249,14 +246,11 @@ mission.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if mission:getVar(player, 'Status') == 3 then
-                        return 206
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if mission:getVar(player, 'Status') == 3 then
+                    return 206
+                end
+            end,
 
             onEventUpdate =
             {

--- a/scripts/missions/cop/5_3_Three_Paths.lua
+++ b/scripts/missions/cop/5_3_Three_Paths.lua
@@ -198,14 +198,11 @@ mission.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if player:getMissionStatus(mission.areaId, xi.mission.status.COP.LOUVERANCE) == 6 then
-                        return 1
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if player:getMissionStatus(mission.areaId, xi.mission.status.COP.LOUVERANCE) == 6 then
+                    return 1
+                end
+            end,
 
             onEventFinish =
             {
@@ -331,17 +328,14 @@ mission.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if
-                        player:getXPos() == 220 and
-                        player:getMissionStatus(mission.areaId, xi.mission.status.COP.TENZEN) == 9
-                    then
-                        return 4
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if
+                    player:getXPos() == 220 and
+                    player:getMissionStatus(mission.areaId, xi.mission.status.COP.TENZEN) == 9
+                then
+                    return 4
+                end
+            end,
 
             onEventFinish =
             {
@@ -536,14 +530,11 @@ mission.sections =
 
         [xi.zone.PORT_SAN_DORIA] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if player:getMissionStatus(mission.areaId, xi.mission.status.COP.ULMIA) == 2 then
-                        return 4
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if player:getMissionStatus(mission.areaId, xi.mission.status.COP.ULMIA) == 2 then
+                    return 4
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/missions/cop/6_1_For_Whom_the_Verse_is_Sung.lua
+++ b/scripts/missions/cop/6_1_For_Whom_the_Verse_is_Sung.lua
@@ -36,14 +36,11 @@ mission.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if mission:getVar(player, 'Status') == 2 then
-                        return 10047
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if mission:getVar(player, 'Status') == 2 then
+                    return 10047
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/missions/cop/6_4_One_to_be_Feared.lua
+++ b/scripts/missions/cop/6_4_One_to_be_Feared.lua
@@ -67,18 +67,15 @@ mission.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    local missionStatus = mission:getVar(player, 'Status')
+            onZoneIn = function(player, prevZone)
+                local missionStatus = mission:getVar(player, 'Status')
 
-                    if missionStatus == 1 then
-                        return 15
-                    elseif missionStatus == 4 then
-                        return 33
-                    end
-                end,
-            },
+                if missionStatus == 1 then
+                    return 15
+                elseif missionStatus == 4 then
+                    return 33
+                end
+            end,
 
             onEventUpdate =
             {

--- a/scripts/missions/cop/7_1_Chains_and_Bonds.lua
+++ b/scripts/missions/cop/7_1_Chains_and_Bonds.lua
@@ -23,14 +23,11 @@ mission.sections =
 
         [xi.zone.LUFAISE_MEADOWS] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if mission:getVar(player, 'Status') == 0 then
-                        return 111
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if mission:getVar(player, 'Status') == 0 then
+                    return 111
+                end
+            end,
 
             onEventUpdate =
             {
@@ -72,14 +69,11 @@ mission.sections =
             ['Despachiaire']     = mission:event(318),
             ['Justinius']        = mission:event(135),
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if mission:getVar(player, 'Status') == 1 then
-                        return 114
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if mission:getVar(player, 'Status') == 1 then
+                    return 114
+                end
+            end,
 
             onEventFinish =
             {
@@ -107,14 +101,11 @@ mission.sections =
 
         [xi.zone.SEALIONS_DEN] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if not mission:isVarBitsSet(player, 'Option', 2) then
-                        return 14
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if not mission:isVarBitsSet(player, 'Option', 2) then
+                    return 14
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/missions/cop/7_5_The_Warriors_Path.lua
+++ b/scripts/missions/cop/7_5_The_Warriors_Path.lua
@@ -51,14 +51,11 @@ mission.sections =
 
             ['Sueleen'] = mission:event(28),
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if mission:getVar(player, 'Status') == 2 then
-                        return 34
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if mission:getVar(player, 'Status') == 2 then
+                    return 34
+                end
+            end,
 
             onEventUpdate =
             {
@@ -94,16 +91,13 @@ mission.sections =
 
         [xi.zone.ALTAIEU] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if mission:getVar(player, 'Status') == 3 then
-                        -- NOTE: Event Options 1 and 2 come for update requests, no observed responses
-                        -- this may be related to RotZ progress, since Kam'Lanaut shows up as ???
-                        return 1
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if mission:getVar(player, 'Status') == 3 then
+                    -- NOTE: Event Options 1 and 2 come for update requests, no observed responses
+                    -- this may be related to RotZ progress, since Kam'Lanaut shows up as ???
+                    return 1
+                end
+            end,
 
             onEventFinish =
             {
@@ -140,14 +134,11 @@ mission.sections =
         {
             ['Sueleen'] = mission:event(12),
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if mission:getVar(player, 'Option') == 1 then
-                        return 18
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if mission:getVar(player, 'Option') == 1 then
+                    return 18
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/missions/cop/8_3_When_Angels_Fall.lua
+++ b/scripts/missions/cop/8_3_When_Angels_Fall.lua
@@ -66,14 +66,11 @@ mission.sections =
 
         [xi.zone.THE_GARDEN_OF_RUHMET] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if mission:getVar(player, 'Status') == 0 then
-                        return 201
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if mission:getVar(player, 'Status') == 0 then
+                    return 201
+                end
+            end,
 
             ['_iz2']              = ebonPanelOnTrigger,
             ['Ebon_Panel_Elvaan'] = ebonPanelOnTrigger,

--- a/scripts/missions/cop/helpers.lua
+++ b/scripts/missions/cop/helpers.lua
@@ -42,18 +42,15 @@ xi.cop.helpers.hasCompletedPromyvion = function(player, zoneId)
     return player:hasKeyItem(xi.cop.helpers.shatteredTelepointInfo[zoneId][5])
 end
 
-xi.cop.helpers.promyvionOnZoneIn =
-{
-    function(player, prevZone)
-        local missionOption = xi.mission.getVar(player, xi.mission.log_id.COP, player:getCurrentMission(xi.mission.log_id.COP), 'Option')
+xi.cop.helpers.promyvionOnZoneIn = function(player, prevZone)
+    local missionOption = xi.mission.getVar(player, xi.mission.log_id.COP, player:getCurrentMission(xi.mission.log_id.COP), 'Option')
 
-        if
-            missionOption == 0
-        then
-            return 50 + xi.cop.helpers.numPromyvionCompleted(player)
-        end
-    end,
-}
+    if
+        missionOption == 0
+    then
+        return 50 + xi.cop.helpers.numPromyvionCompleted(player)
+    end
+end
 
 xi.cop.helpers.sendToPromyvionZone = function(player, promyvionOffset)
     if promyvionOffset == xi.cop.helpers.promyvionCrags.HOLLA then

--- a/scripts/missions/wotg/42_Forget_Me_Not.lua
+++ b/scripts/missions/wotg/42_Forget_Me_Not.lua
@@ -21,14 +21,11 @@ mission.reward =
     nextMission = { xi.mission.log_id.WOTG, xi.mission.id.wotg.PILLAR_OF_HOPE },
 }
 
-local completeMissionOnZoneIn =
-{
-    function(player, prevZone)
-        if mission:complete(player) then
-            xi.wotg.helpers.removeMemoryFragments(player)
-        end
-    end,
-}
+local completeMissionOnZoneIn = function(player, prevZone)
+    if mission:complete(player) then
+        xi.wotg.helpers.removeMemoryFragments(player)
+    end
+end
 
 local mawOnEventFinish = function(player, csid, option, npc)
     mission:setVar(player, 'Status', 1)
@@ -118,14 +115,11 @@ mission.sections =
 
         [xi.zone.GRAUBERG_S] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if mission:getVar(player, 'Status') == 1 then
-                        return 33
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if mission:getVar(player, 'Status') == 1 then
+                    return 33
+                end
+            end,
 
             onEventUpdate =
             {

--- a/scripts/quests/abyssea/A_Beaked_Blusterer.lua
+++ b/scripts/quests/abyssea/A_Beaked_Blusterer.lua
@@ -43,12 +43,9 @@ quest.sections =
 
         [xi.zone.SOUTH_GUSTABERG] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    return 1
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                return 1
+            end,
 
             onEventUpdate =
             {

--- a/scripts/quests/abyssea/A_Goldstruck_Gigas.lua
+++ b/scripts/quests/abyssea/A_Goldstruck_Gigas.lua
@@ -43,12 +43,9 @@ quest.sections =
 
         [xi.zone.LA_THEINE_PLATEAU] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    return 10
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                return 10
+            end,
 
             onEventUpdate =
             {

--- a/scripts/quests/abyssea/A_Journey_Begins.lua
+++ b/scripts/quests/abyssea/A_Journey_Begins.lua
@@ -33,14 +33,11 @@ quest.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if quest:getVar(player, 'Prog') == 0 then
-                        return 324
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if quest:getVar(player, 'Prog') == 0 then
+                    return 324
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/quests/abyssea/Megadrile_Menace.lua
+++ b/scripts/quests/abyssea/Megadrile_Menace.lua
@@ -47,12 +47,9 @@ quest.sections =
 
         [xi.zone.LA_THEINE_PLATEAU] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    return 39
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                return 39
+            end,
 
             onEventUpdate =
             {

--- a/scripts/quests/abyssea/The_Truth_Beckons.lua
+++ b/scripts/quests/abyssea/The_Truth_Beckons.lua
@@ -47,47 +47,47 @@ quest.sections =
 
         [xi.zone.ABYSSEA_KONSCHTAT] =
         {
-            onZoneIn = { handleOnZoneIn },
+            onZoneIn = handleOnZoneIn,
         },
 
         [xi.zone.ABYSSEA_LA_THEINE] =
         {
-            onZoneIn = { handleOnZoneIn },
+            onZoneIn = handleOnZoneIn,
         },
 
         [xi.zone.ABYSSEA_TAHRONGI] =
         {
-            onZoneIn = { handleOnZoneIn },
+            onZoneIn = handleOnZoneIn,
         },
 
         [xi.zone.ABYSSEA_ATTOHWA] =
         {
-            onZoneIn = { handleOnZoneIn },
+            onZoneIn = handleOnZoneIn,
         },
 
         [xi.zone.ABYSSEA_MISAREAUX] =
         {
-            onZoneIn = { handleOnZoneIn },
+            onZoneIn = handleOnZoneIn,
         },
 
         [xi.zone.ABYSSEA_VUNKERL] =
         {
-            onZoneIn = { handleOnZoneIn },
+            onZoneIn = handleOnZoneIn,
         },
 
         [xi.zone.ABYSSEA_ALTEPA] =
         {
-            onZoneIn = { handleOnZoneIn },
+            onZoneIn = handleOnZoneIn,
         },
 
         [xi.zone.ABYSSEA_ULEGUERAND] =
         {
-            onZoneIn = { handleOnZoneIn },
+            onZoneIn = handleOnZoneIn,
         },
 
         [xi.zone.ABYSSEA_GRAUBERG]  =
         {
-            onZoneIn = { handleOnZoneIn },
+            onZoneIn = handleOnZoneIn,
         },
     },
 }

--- a/scripts/quests/abyssea/To_Paste_a_Peiste.lua
+++ b/scripts/quests/abyssea/To_Paste_a_Peiste.lua
@@ -43,12 +43,9 @@ quest.sections =
 
         [xi.zone.KONSCHTAT_HIGHLANDS] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    return 1
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                return 1
+            end,
 
             onEventUpdate =
             {

--- a/scripts/quests/ahtUrhgan/Saga_of_the_Skyserpent.lua
+++ b/scripts/quests/ahtUrhgan/Saga_of_the_Skyserpent.lua
@@ -87,14 +87,11 @@ quest.sections =
 
         [xi.zone.WAJAOM_WOODLANDS] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if quest:getVar(player, 'Prog') == 1 then
-                        return 12
-                    end
+            onZoneIn = function(player, prevZone)
+                if quest:getVar(player, 'Prog') == 1 then
+                    return 12
                 end
-            },
+            end,
 
             onEventFinish =
             {

--- a/scripts/quests/ahtUrhgan/Striking_a_Balance.lua
+++ b/scripts/quests/ahtUrhgan/Striking_a_Balance.lua
@@ -191,12 +191,9 @@ quest.sections =
 
         [xi.zone.AHT_URHGAN_WHITEGATE] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    return 695
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                return 695
+            end,
 
             onEventFinish =
             {

--- a/scripts/quests/ahtUrhgan/Such_Sweet_Sorrow.lua
+++ b/scripts/quests/ahtUrhgan/Such_Sweet_Sorrow.lua
@@ -24,14 +24,11 @@ quest.sections =
         {
             ['Dabhuh'] = quest:progressEvent(582, { text_table = 0 }),
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if quest:getVar(player, 'Option') == 2 then
-                        return { 956, 0 }
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if quest:getVar(player, 'Option') == 2 then
+                    return { 956, 0 }
+                end
+            end,
 
             onEventFinish =
             {
@@ -49,14 +46,11 @@ quest.sections =
 
         [xi.zone.CAEDARVA_MIRE] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if quest:getVar(player, 'Option') == 1 then
-                        return 29
-                    end
+            onZoneIn = function(player, prevZone)
+                if quest:getVar(player, 'Option') == 1 then
+                    return 29
                 end
-            },
+            end,
 
             onEventFinish =
             {

--- a/scripts/quests/ahtUrhgan/The_Prince_and_the_Hopper.lua
+++ b/scripts/quests/ahtUrhgan/The_Prince_and_the_Hopper.lua
@@ -58,25 +58,22 @@ quest.sections =
 
         [xi.zone.WAJAOM_WOODLANDS] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if quest:getVar(player, 'Prog') == 0 then
-                        local xPos = player:getXPos()
-                        local yPos = player:getYPos()
-                        local zPos = player:getZPos()
+            onZoneIn = function(player, prevZone)
+                if quest:getVar(player, 'Prog') == 0 then
+                    local xPos = player:getXPos()
+                    local yPos = player:getYPos()
+                    local zPos = player:getZPos()
 
-                        if
-                            xPos >= 680.0 and yPos >= -19.0 and zPos >= 218.0 and
-                            xPos <= 691.0 and yPos <= -14.0 and zPos <= 221.0
-                        then
-                            return 513
-                        end
-                    elseif quest:getVar(player, 'Prog') == 2 then
-                        return 20
+                    if
+                        xPos >= 680.0 and yPos >= -19.0 and zPos >= 218.0 and
+                        xPos <= 691.0 and yPos <= -14.0 and zPos <= 221.0
+                    then
+                        return 513
                     end
-                end,
-            },
+                elseif quest:getVar(player, 'Prog') == 2 then
+                    return 20
+                end
+            end,
 
             onEventFinish =
             {
@@ -134,14 +131,11 @@ quest.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if quest:getVar(player, 'Prog') == 3 then
-                        return 227
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if quest:getVar(player, 'Prog') == 3 then
+                    return 227
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/quests/ahtUrhgan/Three_Men_and_a_Closet.lua
+++ b/scripts/quests/ahtUrhgan/Three_Men_and_a_Closet.lua
@@ -118,17 +118,14 @@ quest.sections =
 
         [xi.zone.WAJAOM_WOODLANDS] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if
-                        prevZone == xi.zone.AHT_URHGAN_WHITEGATE and
-                        quest:getVar(player, 'Prog') == 0
-                    then
-                        return 510
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if
+                    prevZone == xi.zone.AHT_URHGAN_WHITEGATE and
+                    quest:getVar(player, 'Prog') == 0
+                then
+                    return 510
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/quests/bastok/Blade_of_Darkness.lua
+++ b/scripts/quests/bastok/Blade_of_Darkness.lua
@@ -46,18 +46,15 @@ quest.sections =
 
         [xi.zone.ZERUHN_MINES] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if prevZone == xi.zone.PALBOROUGH_MINES then
-                        if quest:getVar(player, 'Prog') == 0 then
-                            return 130
-                        elseif not player:hasItem(xi.item.CHAOSBRINGER) then
-                            return 131
-                        end
+            onZoneIn = function(player, prevZone)
+                if prevZone == xi.zone.PALBOROUGH_MINES then
+                    if quest:getVar(player, 'Prog') == 0 then
+                        return 130
+                    elseif not player:hasItem(xi.item.CHAOSBRINGER) then
+                        return 131
                     end
-                end,
-            },
+                end
+            end,
 
             onEventFinish =
             {
@@ -75,17 +72,14 @@ quest.sections =
 
         [xi.zone.BEADEAUX] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if
-                        prevZone == xi.zone.PASHHOW_MARSHLANDS and
-                        player:getCharVar('ChaosbringerKills') >= 100
-                    then
-                        return 121
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if
+                    prevZone == xi.zone.PASHHOW_MARSHLANDS and
+                    player:getCharVar('ChaosbringerKills') >= 100
+                then
+                    return 121
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/quests/bastok/Blade_of_Death.lua
+++ b/scripts/quests/bastok/Blade_of_Death.lua
@@ -47,17 +47,14 @@ quest.sections =
 
         [xi.zone.ZERUHN_MINES] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if
-                        prevZone == xi.zone.PALBOROUGH_MINES and
-                        not player:hasItem(xi.item.CHAOSBRINGER)
-                    then
-                        return 131
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if
+                    prevZone == xi.zone.PALBOROUGH_MINES and
+                    not player:hasItem(xi.item.CHAOSBRINGER)
+                then
+                    return 131
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/quests/bastok/DRK_AF2_Dark_Puppet.lua
+++ b/scripts/quests/bastok/DRK_AF2_Dark_Puppet.lua
@@ -101,14 +101,11 @@ quest.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if quest:getVar(player, 'Prog') == 0 then
-                        return 10
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if quest:getVar(player, 'Prog') == 0 then
+                    return 10
+                end
+            end,
 
             onEventFinish =
             {
@@ -120,14 +117,11 @@ quest.sections =
 
         [xi.zone.LA_THEINE_PLATEAU] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if quest:getVar(player, 'Prog') == 2 then
-                        return 122
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if quest:getVar(player, 'Prog') == 2 then
+                    return 122
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/quests/bastok/DRK_AF3_Blade_of_Evil.lua
+++ b/scripts/quests/bastok/DRK_AF3_Blade_of_Evil.lua
@@ -30,14 +30,11 @@ quest.sections =
 
         [xi.zone.BEADEAUX] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if prevZone == xi.zone.PASHHOW_MARSHLANDS then
-                        return 122
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if prevZone == xi.zone.PASHHOW_MARSHLANDS then
+                    return 122
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/quests/bastok/Lure_of_the_Wildcat_Bastok.lua
+++ b/scripts/quests/bastok/Lure_of_the_Wildcat_Bastok.lua
@@ -41,9 +41,6 @@ local wildcatNpcData =
     ['Vaghron']           = { 19, 503 }, -- !pos -39.162 -1 -92.147 234
 }
 
----@param player CBaseEntity
----@param npc CBaseEntity
----@return QuestReturnType?
 local wildcatOnTrigger = function(player, npc)
     local npcData = wildcatNpcData[npc:getName()]
 

--- a/scripts/quests/bastok/MNK_AF2_The_First_Meeting.lua
+++ b/scripts/quests/bastok/MNK_AF2_The_First_Meeting.lua
@@ -91,17 +91,14 @@ quest.sections =
 
         [xi.zone.FEIYIN] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if
-                        prevZone == xi.zone.QUBIA_ARENA and
-                        not player:hasKeyItem(xi.ki.LETTER_FROM_DALZAKK)
-                    then
-                        return 16
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if
+                    prevZone == xi.zone.QUBIA_ARENA and
+                    not player:hasKeyItem(xi.ki.LETTER_FROM_DALZAKK)
+                then
+                    return 16
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/quests/bastok/WAR_AF3_The_Talekeepers_Gift.lua
+++ b/scripts/quests/bastok/WAR_AF3_The_Talekeepers_Gift.lua
@@ -130,17 +130,14 @@ quest.sections =
 
         [xi.zone.QUFIM_ISLAND] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if
-                        prevZone == xi.zone.BEHEMOTHS_DOMINION and
-                        quest:getVar(player, 'Prog') == 7
-                    then
-                        return 100
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if
+                    prevZone == xi.zone.BEHEMOTHS_DOMINION and
+                    quest:getVar(player, 'Prog') == 7
+                then
+                    return 100
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/quests/crystalWar/Blood_of_Heroes.lua
+++ b/scripts/quests/crystalWar/Blood_of_Heroes.lua
@@ -97,14 +97,11 @@ quest.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if quest:getVar(player, 'Prog') == 4 then
-                        return 6
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if quest:getVar(player, 'Prog') == 4 then
+                    return 6
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/quests/crystalWar/Bonds_That_Never_Die.lua
+++ b/scripts/quests/crystalWar/Bonds_That_Never_Die.lua
@@ -95,14 +95,11 @@ quest.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if quest:getVar(player, 'Prog') == 4 then
-                        return 215
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if quest:getVar(player, 'Prog') == 4 then
+                    return 215
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/quests/crystalWar/Chasing_Shadows.lua
+++ b/scripts/quests/crystalWar/Chasing_Shadows.lua
@@ -86,17 +86,14 @@ quest.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if
-                        prevZone == xi.zone.BEAUCEDINE_GLACIER_S and
-                        quest:getVar(player, 'Prog') == 0
-                    then
-                        return 30
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if
+                    prevZone == xi.zone.BEAUCEDINE_GLACIER_S and
+                    quest:getVar(player, 'Prog') == 0
+                then
+                    return 30
+                end
+            end,
 
             onEventFinish =
             {
@@ -155,17 +152,14 @@ quest.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if
-                        prevZone == xi.zone.BEAUCEDINE_GLACIER_S and
-                        quest:getVar(player, 'Prog') == 5
-                    then
-                        return 114
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if
+                    prevZone == xi.zone.BEAUCEDINE_GLACIER_S and
+                    quest:getVar(player, 'Prog') == 5
+                then
+                    return 114
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/quests/crystalWar/Claws_of_the_Griffon.lua
+++ b/scripts/quests/crystalWar/Claws_of_the_Griffon.lua
@@ -114,17 +114,14 @@ quest.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if
-                        prevZone == xi.zone.EAST_RONFAURE_S and
-                        quest:getVar(player, 'Prog') == 1
-                    then
-                        return 200
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if
+                    prevZone == xi.zone.EAST_RONFAURE_S and
+                    quest:getVar(player, 'Prog') == 1
+                then
+                    return 200
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/quests/crystalWar/Face_of_the_Future.lua
+++ b/scripts/quests/crystalWar/Face_of_the_Future.lua
@@ -32,17 +32,14 @@ quest.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if
-                        prevZone == xi.zone.BATALLIA_DOWNS and
-                        quest:getVar(player, 'Prog') == 0
-                    then
-                        return 44
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if
+                    prevZone == xi.zone.BATALLIA_DOWNS and
+                    quest:getVar(player, 'Prog') == 0
+                then
+                    return 44
+                end
+            end,
 
             onEventFinish =
             {
@@ -67,14 +64,11 @@ quest.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if quest:getVar(player, 'Prog') == 2 then
-                        return 57
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if quest:getVar(player, 'Prog') == 2 then
+                    return 57
+                end
+            end,
 
             onEventFinish =
             {
@@ -98,14 +92,11 @@ quest.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if quest:getVar(player, 'Prog') == 5 then
-                        return quest:progressEvent(2)
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if quest:getVar(player, 'Prog') == 5 then
+                    return 2
+                end
+            end,
 
             onEventFinish =
             {
@@ -145,20 +136,17 @@ quest.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    local questProgress = quest:getVar(player, 'Prog')
+            onZoneIn = function(player, prevZone)
+                local questProgress = quest:getVar(player, 'Prog')
 
-                    if questProgress == 7 then
-                        return 505
-                    elseif questProgress == 9 then
-                        return 508
-                    elseif questProgress == 10 then
-                        return 507
-                    end
-                end,
-            },
+                if questProgress == 7 then
+                    return 505
+                elseif questProgress == 9 then
+                    return 508
+                elseif questProgress == 10 then
+                    return 507
+                end
+            end,
 
             onEventFinish =
             {
@@ -193,14 +181,11 @@ quest.sections =
 
         [xi.zone.XARCABARD_S] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if quest:getVar(player, 'Prog') == 8 then
-                        return 40
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if quest:getVar(player, 'Prog') == 8 then
+                    return 40
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/quests/crystalWar/Her_Memories_Carnelian_Footfalls.lua
+++ b/scripts/quests/crystalWar/Her_Memories_Carnelian_Footfalls.lua
@@ -38,17 +38,14 @@ quest.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if
-                        prevZone == xi.zone.EAST_RONFAURE_S and
-                        quest:getVar(player, 'Prog') == 0
-                    then
-                        return 170
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if
+                    prevZone == xi.zone.EAST_RONFAURE_S and
+                    quest:getVar(player, 'Prog') == 0
+                then
+                    return 170
+                end
+            end,
 
             onEventFinish =
             {
@@ -125,17 +122,14 @@ quest.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if
-                        prevZone == xi.zone.SOUTHERN_SAN_DORIA_S and
-                        quest:getVar(player, 'Prog') == 1
-                    then
-                        return 12
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if
+                    prevZone == xi.zone.SOUTHERN_SAN_DORIA_S and
+                    quest:getVar(player, 'Prog') == 1
+                then
+                    return 12
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/quests/crystalWar/Her_Memories_Homecoming_Queen.lua
+++ b/scripts/quests/crystalWar/Her_Memories_Homecoming_Queen.lua
@@ -65,14 +65,11 @@ quest.sections =
 
         [xi.zone.SOUTHERN_SAN_DORIA] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if prevZone == xi.zone.EAST_RONFAURE then
-                        return 957
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if prevZone == xi.zone.EAST_RONFAURE then
+                    return 957
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/quests/crystalWar/Her_Memories_Operation_Cupid.lua
+++ b/scripts/quests/crystalWar/Her_Memories_Operation_Cupid.lua
@@ -26,14 +26,11 @@ quest.sections =
 
         [xi.zone.BATALLIA_DOWNS_S] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if prevZone == xi.zone.JUGNER_FOREST_S then
-                        return 23
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if prevZone == xi.zone.JUGNER_FOREST_S then
+                    return 23
+                end
+            end,
 
             onEventFinish =
             {
@@ -113,17 +110,14 @@ quest.sections =
 
         [xi.zone.BATALLIA_DOWNS_S] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if
-                        prevZone == xi.zone.ROLANBERRY_FIELDS_S and
-                        quest:getVar(player, 'Prog') == 2
-                    then
-                        return 24
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if
+                    prevZone == xi.zone.ROLANBERRY_FIELDS_S and
+                    quest:getVar(player, 'Prog') == 2
+                then
+                    return 24
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/quests/crystalWar/In_a_Haze_of_Glory.lua
+++ b/scripts/quests/crystalWar/In_a_Haze_of_Glory.lua
@@ -79,14 +79,11 @@ quest.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if quest:getVar(player, 'Prog') == 2 then
-                        return 33
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if quest:getVar(player, 'Prog') == 2 then
+                    return 33
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/quests/crystalWar/Light_in_the_Darkness.lua
+++ b/scripts/quests/crystalWar/Light_in_the_Darkness.lua
@@ -150,14 +150,11 @@ quest.sections =
 
         [xi.zone.PASHHOW_MARSHLANDS_S] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if prevZone == xi.zone.GRAUBERG_S then
-                        return 901
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if prevZone == xi.zone.GRAUBERG_S then
+                    return 901
+                end
+            end,
 
             onEventFinish =
             {
@@ -203,12 +200,9 @@ quest.sections =
 
         [xi.zone.PASHHOW_MARSHLANDS_S] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    return 902
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                return 902
+            end,
 
             onEventFinish =
             {

--- a/scripts/quests/crystalWar/SCH_AF2_Downward_Helix.lua
+++ b/scripts/quests/crystalWar/SCH_AF2_Downward_Helix.lua
@@ -48,17 +48,14 @@ quest.sections =
 
         [xi.zone.SOUTHERN_SAN_DORIA_S] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if
-                        prevZone == xi.zone.EAST_RONFAURE_S and
-                        quest:getVar(player, 'Prog') == 0
-                    then
-                        return 65
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if
+                    prevZone == xi.zone.EAST_RONFAURE_S and
+                    quest:getVar(player, 'Prog') == 0
+                then
+                    return 65
+                end
+            end,
 
             onEventFinish =
             {
@@ -103,17 +100,14 @@ quest.sections =
 
         [xi.zone.SAUROMUGUE_CHAMPAIGN_S] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if
-                        prevZone == xi.zone.ROLANBERRY_FIELDS_S and
-                        quest:getVar(player, 'Prog') == 2
-                    then
-                        return 3
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if
+                    prevZone == xi.zone.ROLANBERRY_FIELDS_S and
+                    quest:getVar(player, 'Prog') == 2
+                then
+                    return 3
+                end
+            end,
 
             ['Indescript_Markings'] =
             {

--- a/scripts/quests/crystalWar/Songbirds_in_a_Snowstorm.lua
+++ b/scripts/quests/crystalWar/Songbirds_in_a_Snowstorm.lua
@@ -169,14 +169,11 @@ quest.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if quest:getVar(player, 'Prog') == 1 then
-                        return 1
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if quest:getVar(player, 'Prog') == 1 then
+                    return 1
+                end
+            end,
 
             onEventUpdate =
             {

--- a/scripts/quests/jeuno/Apocalypse_Nigh.lua
+++ b/scripts/quests/jeuno/Apocalypse_Nigh.lua
@@ -78,14 +78,11 @@ quest.sections =
 
         [xi.zone.SEALIONS_DEN] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if quest:getVar(player, 'Prog') == 0 then
-                        return 29
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if quest:getVar(player, 'Prog') == 0 then
+                    return 29
+                end
+            end,
 
             onEventUpdate =
             {
@@ -126,14 +123,11 @@ quest.sections =
 
         [xi.zone.EMPYREAL_PARADOX] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if quest:getVar(player, 'Prog') == 4 then
-                        return 7
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if quest:getVar(player, 'Prog') == 4 then
+                    return 7
+                end
+            end,
 
             ['TR_Entrance'] =
             {

--- a/scripts/quests/jeuno/DNC_AF2_The_Road_to_Divadom.lua
+++ b/scripts/quests/jeuno/DNC_AF2_The_Road_to_Divadom.lua
@@ -109,14 +109,11 @@ quest.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if quest:getVar(player, 'Prog') == 0 then
-                        return 105
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if quest:getVar(player, 'Prog') == 0 then
+                    return 105
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/quests/jeuno/DNC_AF3_Comeback_Queen.lua
+++ b/scripts/quests/jeuno/DNC_AF3_Comeback_Queen.lua
@@ -113,22 +113,19 @@ quest.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    local questProgress = quest:getVar(player, 'Prog')
+            onZoneIn = function(player, prevZone)
+                local questProgress = quest:getVar(player, 'Prog')
 
-                    if questProgress == 4 then
-                        return 10208
-                    elseif questProgress == 5 then
-                        return 10209
-                    elseif questProgress == 6 then
-                        return 10210
-                    elseif questProgress == 7 then
-                        return 10211
-                    end
-                end,
-            },
+                if questProgress == 4 then
+                    return 10208
+                elseif questProgress == 5 then
+                    return 10209
+                elseif questProgress == 6 then
+                    return 10210
+                elseif questProgress == 7 then
+                    return 10211
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/quests/jeuno/The_Road_to_Aht_Urhgan.lua
+++ b/scripts/quests/jeuno/The_Road_to_Aht_Urhgan.lua
@@ -223,21 +223,18 @@ quest.sections =
 
         [xi.zone.WAJAOM_WOODLANDS] =
         {
-            afterZoneIn =
-            {
-                function(player)
-                    -- Player won't see these messages due to teleporting at the
-                    -- end of the cutscene if awarded then. Display after they zone in.
-                    -- NOTE: Prog value of 4 is set immediately before teleporting the player.
-                    if
-                        quest:getVar(player, 'Prog') == 4
-                    then
-                        npcUtil.giveKeyItem(player, xi.ki.BOARDING_PERMIT)
-                        npcUtil.giveKeyItem(player, xi.ki.MAP_OF_WAJAOM_WOODLANDS)
-                        quest:setVar(player, 'Prog', 5)
-                    end
-                end,
-            },
+            afterZoneIn = function(player)
+                -- Player won't see these messages due to teleporting at the
+                -- end of the cutscene if awarded then. Display after they zone in.
+                -- NOTE: Prog value of 4 is set immediately before teleporting the player.
+                if
+                    quest:getVar(player, 'Prog') == 4
+                then
+                    npcUtil.giveKeyItem(player, xi.ki.BOARDING_PERMIT)
+                    npcUtil.giveKeyItem(player, xi.ki.MAP_OF_WAJAOM_WOODLANDS)
+                    quest:setVar(player, 'Prog', 5)
+                end
+            end,
         },
     },
 

--- a/scripts/quests/otherAreas/Give_a_Moogle_a_Break.lua
+++ b/scripts/quests/otherAreas/Give_a_Moogle_a_Break.lua
@@ -31,7 +31,7 @@ quest.sections[1] =
     end
 }
 
----@type TQuestZoneSection
+---@type ZoneSection
 local questAvailable =
 {
     ['Moogle'] =
@@ -60,7 +60,7 @@ quest.sections[2] =
     end
 }
 
----@type TQuestZoneSection
+---@type ZoneSection
 local questAccepted =
 {
     ['Moogle'] =

--- a/scripts/quests/otherAreas/Monstrosity.lua
+++ b/scripts/quests/otherAreas/Monstrosity.lua
@@ -166,12 +166,9 @@ quest.sections =
 
         [xi.zone.FERETORY] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    return 2
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                return 2
+            end,
 
             onEventUpdate =
             {

--- a/scripts/quests/otherAreas/Moogles_in_the_Wild.lua
+++ b/scripts/quests/otherAreas/Moogles_in_the_Wild.lua
@@ -32,7 +32,7 @@ quest.sections[1] =
     end
 }
 
----@type TQuestZoneSection
+---@type ZoneSection
 local questAvailable =
 {
     ['Moogle'] =
@@ -61,7 +61,7 @@ quest.sections[2] =
     end
 }
 
----@type TQuestZoneSection
+---@type ZoneSection
 local questAccepted =
 {
     ['Moogle'] =

--- a/scripts/quests/otherAreas/The_Moogles_Picnic.lua
+++ b/scripts/quests/otherAreas/The_Moogles_Picnic.lua
@@ -32,7 +32,7 @@ quest.sections[1] =
     end
 }
 
----@type TQuestZoneSection
+---@type ZoneSection
 local questAvailable =
 {
     ['Moogle'] =
@@ -61,7 +61,7 @@ quest.sections[2] =
     end
 }
 
----@type TQuestZoneSection
+---@type ZoneSection
 local questAccepted =
 {
     ['Moogle'] =

--- a/scripts/quests/outlands/SAM_AF3_A_Thief_in_Norg.lua
+++ b/scripts/quests/outlands/SAM_AF3_A_Thief_in_Norg.lua
@@ -187,14 +187,11 @@ quest.sections =
 
         [xi.zone.WAUGHROON_SHRINE] =
         {
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if quest:getVar(player, 'Prog') == 4 then
-                        return 2
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if quest:getVar(player, 'Prog') == 4 then
+                    return 2
+                end
+            end,
 
             onEventFinish =
             {

--- a/scripts/quests/sandoria/RDM_AF1_The_Crimson_Trial.lua
+++ b/scripts/quests/sandoria/RDM_AF1_The_Crimson_Trial.lua
@@ -104,17 +104,14 @@ quest.sections =
                 end,
             },
 
-            onZoneIn =
-            {
-                function(player, prevZone)
-                    if
-                        not player:hasKeyItem(xi.ki.ORCISH_DRIED_FOOD) and
-                        not GetMobByID(davoiID.mob.PURPLEFLASH_BRUKDOK):isSpawned()
-                    then
-                        SpawnMob(davoiID.mob.PURPLEFLASH_BRUKDOK) -- Spawned by Quest: The Crimson Trial upon entering the zone
-                    end
-                end,
-            },
+            onZoneIn = function(player, prevZone)
+                if
+                    not player:hasKeyItem(xi.ki.ORCISH_DRIED_FOOD) and
+                    not GetMobByID(davoiID.mob.PURPLEFLASH_BRUKDOK):isSpawned()
+                then
+                    SpawnMob(davoiID.mob.PURPLEFLASH_BRUKDOK) -- Spawned by Quest: The Crimson Trial upon entering the zone
+                end
+            end,
         },
 
         [xi.zone.SOUTHERN_SAN_DORIA] =

--- a/scripts/specs/types/Quest.lua
+++ b/scripts/specs/types/Quest.lua
@@ -4,39 +4,31 @@
 ---@meta
 
 -- Definitions for quest.sections{}
----@alias TQuestSectionList TQuestSection[]
-
 ---@class TQuestSection
 ---@field check fun(player: CBaseEntity, status: xi.questStatus, vars: { [string]: integer }): boolean
----@field [xi.zone] TQuestZoneSection
+---@field [xi.zone] ZoneSection
 
 -- TODO: Below here, we can most likely be generic and reuse these definitions for Hidden Quests, Missions,
 -- and perhaps Battlefields as well
----@class TQuestZoneSection
----@field onZoneIn? TQuestOnZoneIn
----@field onZoneOut? TQuestOnZoneFunction
----@field afterZoneIn? TQuestOnZoneFunction
----@field [string]? TQuestZoneEntity|QuestReturnType|fun(player: CBaseEntity, npc: CBaseEntity): QuestReturnType?
----@field onEventUpdate? TQuestEventSection
----@field onEventFinish? TQuestEventSection
----@field onTriggerAreaEnter? TQuestTriggerAreaSection
----@field onTriggerAreaLeave? TQuestTriggerAreaSection
+---@class ZoneSection
+---@field onZoneIn? fun(player: CBaseEntity, prevZone: xi.zone): integer|table<integer>?
+---@field onZoneOut? onZoneHandler
+---@field afterZoneIn? onZoneHandler
+---@field [string]? EntitySection|TAction|fun(player: CBaseEntity, npc: CBaseEntity): TAction?
+---@field onEventUpdate? onEventHandler
+---@field onEventFinish? onEventHandler
+---@field onTriggerAreaEnter? onTriggerAreaHandler
+---@field onTriggerAreaLeave? onTriggerAreaHandler
 
----@class TQuestOnZoneIn
----@field [integer] fun(player: CBaseEntity, prevZone: xi.zone): integer?
+---@alias onZoneHandler fun(player: CBaseEntity): TAction?
 
----@class TQuestOnZoneFunction
----@field [integer] fun(player: CBaseEntity): QuestReturnType?
+---@class onTriggerAreaHandler
+---@field [integer] fun(player: CBaseEntity, triggerArea: CTriggerArea): TAction?
 
----@class TQuestTriggerAreaSection
----@field [integer] fun(player: CBaseEntity, triggerArea: CTriggerArea): QuestReturnType?
-
----@class TQuestZoneEntity
----@field onTrade? QuestReturnType|fun(player: CBaseEntity, npc: CBaseEntity, trade: CTradeContainer): QuestReturnType?
----@field onTrigger? QuestReturnType|fun(player: CBaseEntity, npc: CBaseEntity): QuestReturnType?
+---@class EntitySection
+---@field onTrade? TAction|fun(player: CBaseEntity, npc: CBaseEntity, trade: CTradeContainer): TAction?
+---@field onTrigger? TAction|fun(player: CBaseEntity, npc: CBaseEntity): TAction?
 ---@field onMobDeath? fun(mob: CBaseEntity, player: CBaseEntity, optParams: { isKiller: boolean, noKiller: boolean, isWeaponSkillKill: boolean, weaponskillUsed: xi.weaponskill, weaponskillDamage: integer })
 
----@class TQuestEventSection
+---@class onEventHandler
 ---@field [integer] fun(player: CBaseEntity, csid: integer, option: integer, npc: CBaseEntity)
-
----@alias QuestReturnType TInteractionEvent|TInteractionKeyItem|TInteractionMessage|TInteractionSequence|TInteractionAction|TInteractionNoAction?


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
* Simplifies some of the language used for defining Interaction types for clarity
* Changes onZoneIn, onZoneOut, and afterZoneIn formats from table of a single function to function.  This is wrapped in a table behind the scenes, and is backwards compatible with the old method; however, CI will now fail if defining those as a table.
* Updates Quest/Mission scripts to use the above changes
* Fixes onZoneIn return type to allow for table (when text table needs to change in that event)
* Fixes additional issues reported by LLS due to onZone* functions now being checked properly
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
onZoneIn, onZoneOut, and afterZoneIn events defined in quest scripts should function as expected, no additional impact to gameplay, CI should pass.
<!-- Clear and detailed steps to test your changes here -->
