### PR TITLE
[BCNM] Implement BCNM20 Shooting Fish

### DIFF
--- a/scripts/actions/mobskills/aqua_ball_knockback.lua
+++ b/scripts/actions/mobskills/aqua_ball_knockback.lua
@@ -1,0 +1,31 @@
+-----------------------------------
+-- Aqua Ball
+-- Deals ranged water damage that causes knockback.
+-- Used by pugils in BCNM: Shooting Fish
+-----------------------------------
+require('scripts/globals/mobskills')
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    local damage   = mob:getWeaponDmg() * 3
+    local power    = 20
+    local tick     = 3
+    local duration = power * tick
+
+    damage = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.WATER, 1, xi.mobskills.magicalTpBonus.MAB_BONUS, 1.5)
+    damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
+
+    target:takeDamage(damage, mob, xi.attackType.MAGICAL, xi.damageType.WATER)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STR_DOWN, power, tick, duration)
+    skill:setMsg(xi.msg.basic.HIT_DMG)
+
+    return damage
+end
+
+return mobskillObject

--- a/scripts/battlefields/Horlais_Peak/shooting_fish.lua
+++ b/scripts/battlefields/Horlais_Peak/shooting_fish.lua
@@ -16,8 +16,6 @@ local content = Battlefield:new({
     entryNpc         = 'BC_Entrance',
     exitNpc          = 'Burning_Circle',
     requiredItems    = { xi.item.CLOUDY_ORB, wearMessage = horlaisID.text.A_CRACK_HAS_FORMED, wornMessage = horlaisID.text.ORB_IS_CRACKED },
-
-    experimental = true,
 })
 
 content:addEssentialMobs({ 'Sniper_Pugil', 'Archer_Pugil' })

--- a/scripts/zones/Horlais_Peak/mobs/Archer_Pugil.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Archer_Pugil.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- Area: Horlais Peak
+--  Mob: Archer Pugil
+-- BCNM: Shooting Fish
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    mob:setMobSkillAttack(2014) -- Aquaball Knockback AA Skill
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+end
+
+return entity

--- a/scripts/zones/Horlais_Peak/mobs/Sniper_Pugil.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Sniper_Pugil.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- Area: Horlais Peak
+--  Mob: Sniper Pugil
+-- BCNM: Shooting Fish
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    mob:setMobSkillAttack(2014) -- Aquaball Knockback AA Skill
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+end
+
+return entity

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -3911,7 +3911,9 @@ INSERT INTO `mob_skill_lists` VALUES ('Avatar_Ifrit_WTB',2013,844); -- Waking th
 INSERT INTO `mob_skill_lists` VALUES ('Avatar_Ifrit_WTB',2013,845); -- Waking the Beast, fire iv
 INSERT INTO `mob_skill_lists` VALUES ('Avatar_Ifrit_WTB',2013,847); -- Waking the Beast, meteor_strike
 
--- Next available ID: 2014
+INSERT INTO `mob_skill_lists` VALUES ('Shooting_Fish',2014,313); -- knockback aquaball - BCNM20 Shooting Fish
+
+-- Next available ID: 2015
 
 -- ------------------------------------------------------------
 -- Start of Ambuscade section

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -326,7 +326,7 @@ INSERT INTO `mob_skills` VALUES (309,53,'spore',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (310,54,'queasyshroom',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (311,55,'numbshroom',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (312,56,'shakeshroom',0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (313,57,'counterspore',0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (313,201,'aqua_ball_knockback',0,14.0,2000,0,4,0,0,7,0,0,0);
 INSERT INTO `mob_skills` VALUES (314,58,'silence_gas',4,13.5,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (315,59,'dark_spore',4,13.5,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (316,60,'impale',0,7.0,2000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements the Aqua Ball Mechanic for BCNM20 shooting fish.

Basis and evidence for following changes:
https://youtu.be/V0Qp99O1AkA
https://drive.google.com/open?id=1ZpZ9FEQ3TYeCc9lPig-y2p6pCRLNkdyF
https://ffxiclopedia.fandom.com/wiki/Shooting_Fish

![image](https://github.com/user-attachments/assets/bd20afd7-59ba-4b35-a447-e7ea9464ea9f)

Ability 313 it is - renamed from counterspore for clarity

## Steps to test these changes

Enter BCNM20 shooting fish and see the mobs properly only use their knockback aquaball as a auto-attack.
