### PR TITLE
Rework Battlefield Group Death Counter

### DIFF
--- a/src/map/battlefield.h
+++ b/src/map/battlefield.h
@@ -123,7 +123,6 @@ struct BattlefieldGroup
     sol::function       randomDeathCallback;
     sol::function       allDeathCallback;
     sol::function       setupCallback;
-    uint8               deathCount  = 0;
     uint32              randomMobId = 0;
 };
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Before this change it would track the number of mobs that have died in a battlefield group. Once all the mobs have died it would call the `allDeath` callback. This works fine for mobs that are spawned at the start of the battlefield and have to die. This does not work if not all mobs are spawned at the start and/or can be spawned multiple times and consequently the death count can reach the target amount without having all mobs dead.

This is fixed by tracking how many mobs are dead for the group when a mob dies.

## Steps to test these changes

I'm not sure if we have any battlefields that currently work like this but I have one in the works (Call To Arms ISNM) that does. You can cheat this though by going to a battlefield that does have an `allDeath` and respawn a mob after killing it to see that it doesn't work without this change and will work with this change.

Divine Punishers BCNM has allDeath
`!additem 1130`
`!zone Balgas Dias`
Enter Divine Punishers and go kill a mob with `!hp 0` after they despawn then respawn it. Kill the other mobs one by one and the bcnm should end with one mob remaining.