### PR TITLE
[lua] Correct homepoint bit checking for teleport rejection

### DIFF
--- a/scripts/globals/homepoint.lua
+++ b/scripts/globals/homepoint.lua
@@ -230,10 +230,11 @@ xi.homepoint.onEventUpdate = function(player, csid, option, npc)
 
             player:setTeleportMenu(xi.teleport.type.HOMEPOINT, favs)
         elseif choice == selection.TELEPORT then
-            local hpIndex = bit.rshift(option, 16)
-            local origin  = player:getLocalVar('originIndex')
+            local index = bit.band(bit.rshift(option, 16), 0xFF)
+            local hpBit = index % 32
+            local hpSet = math.floor(index / 32)
 
-            if not player:hasTeleport(xi.teleport.type.HOMEPOINT, hpIndex, math.floor(origin / 32)) then
+            if not player:hasTeleport(xi.teleport.type.HOMEPOINT, hpBit, hpSet) then
                 print(string.format("Player %s tried to teleport to an HP without it's destination being unlocked", player:getName()))
                 player:release()
             end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Correct homepoint bit checking for teleport rejection

## Steps to test these changes

Teleport from Windurst Waters HP 4->3 and see it work (if you have it unlocked)
