### PR TITLE
[SQL/LUA] Improve Gration Spawn and Correct Drop Rate

### DIFF
--- a/scripts/enum/item.lua
+++ b/scripts/enum/item.lua
@@ -4053,6 +4053,7 @@ xi.item =
     ASTRAL_SHIELD                       = 12351,
     VIKING_SHIELD                       = 12356,
     HICKORY_SHIELD                      = 12359,
+    TATAMI_SHIELD                       = 12360,
     PATRIARCH_PROTECTORS_SHIELD         = 12363,
     NYMPH_SHIELD                        = 12364,
     PICAROONS_SHIELD                    = 12370,

--- a/scripts/zones/Misareaux_Coast/mobs/Gration.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Gration.lua
@@ -9,6 +9,11 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 900)
+    mob:setMobMod(xi.mobMod.GIL_MIN, 18000)
+    mob:setMobMod(xi.mobMod.GIL_MAX, 18000)
+    mob:addListener('ITEM_DROPS', 'ITEM_DROPS_GRATION', function(mobArg, loot)
+        loot:addItemFixed(xi.item.TATAMI_SHIELD, mob:getLocalVar('DropRate'))
+    end)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/Misareaux_Coast/npcs/qm_gration.lua
+++ b/scripts/zones/Misareaux_Coast/npcs/qm_gration.lua
@@ -9,11 +9,19 @@ local ID = zones[xi.zone.MISAREAUX_COAST]
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
+    local shieldChance = 0
+    if npcUtil.tradeHasExactly(trade, xi.item.HICKORY_SHIELD) then
+        shieldChance = 500
+    elseif npcUtil.tradeHasExactly(trade, xi.item.PICAROONS_SHIELD) then
+        shieldChance = 1000
+    end
+
     if
-        (npcUtil.tradeHas(trade, xi.item.PICAROONS_SHIELD) or npcUtil.tradeHas(trade, xi.item.HICKORY_SHIELD)) and
+        shieldChance > 0 and
         npcUtil.popFromQM(player, npc, ID.mob.GRATION)
     then
         player:confirmTrade()
+        GetMobByID(ID.mob.GRATION):setLocalVar('DropRate', shieldChance)
     end
 end
 

--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -10066,8 +10066,7 @@ INSERT INTO `mob_droplist` VALUES (1217,0,0,1000,4374,500); -- Sleepshroom (50.0
 INSERT INTO `mob_droplist` VALUES (1217,0,0,1000,4374,250); -- Sleepshroom (25.0%)
 INSERT INTO `mob_droplist` VALUES (1217,2,0,1000,4374,0);   -- Sleepshroom (Steal)
 
--- ZoneID:  25 - Gration
-INSERT INTO `mob_droplist` VALUES (1218,0,0,1000,12360,500); -- Tatami Shield (50.0%)
+-- 1218 Available
 
 -- ZoneID:  89 - Grauberg Hippogryph
 INSERT INTO `mob_droplist` VALUES (1219,0,0,1000,1690,230); -- Hippogryph Tailfeather (23.0%)

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -1008,7 +1008,7 @@ INSERT INTO `mob_groups` VALUES (54,4293,25,'Warder_Thalia',0,128,0,5000,0,62,63
 INSERT INTO `mob_groups` VALUES (55,466,25,'Bloody_Coffin',0,128,0,0,0,50,52,0);
 INSERT INTO `mob_groups` VALUES (56,484,25,'Boggelmann',0,128,0,7600,0,70,70,0);
 INSERT INTO `mob_groups` VALUES (57,98,25,'Alsha',0,128,0,0,0,60,60,0);
-INSERT INTO `mob_groups` VALUES (58,1792,25,'Gration',0,128,1218,30000,0,79,79,0);
+INSERT INTO `mob_groups` VALUES (58,1792,25,'Gration',0,128,0,30000,0,79,79,0);
 INSERT INTO `mob_groups` VALUES (59,4505,25,'Ziphius',0,128,2801,0,0,60,62,0);
 INSERT INTO `mob_groups` VALUES (60,6739,25,'Tsui-Goab',0,128,0,0,0,65,65,0);
 INSERT INTO `mob_groups` VALUES (61,6740,25,'Bloodswiller_Fly',0,128,0,0,0,0,0,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Improves the trade function for Gration and sets the drop rate in the lua depending on the item traded. Previously no matter which was traded to spawn the drop rate in mob_droplist.sql was set to 50%. This then was also being reduced to 24% from the recent Treasure Hunter merge (#6141).
- Removes the droplist from the mob_group.
- Adds the missing gil drop.
- Adds the Tatami Shield drop to scripts\enum.

## Steps to test these changes

- Spawn Gration with the Hickory Shield, and get no drop. Spawn it again with a Hickory Shield and get a drop.
- Spawn Gration with the Picaroon's Shield and get a drop.
- Success
