### PR TITLE
modules: Add more error handling to startup

### DIFF
--- a/src/map/utils/moduleutils.cpp
+++ b/src/map/utils/moduleutils.cpp
@@ -192,10 +192,16 @@ namespace moduleutils
                     continue;
                 }
 
-                // Check the file is a valid module
+                if (!res.valid() || res.get_type() != sol::type::table)
+                {
+                    ShowError("Failed to load module: Invalid object returned from: %s", filename);
+                    continue;
+                }
+
+                // We've confirmed this is a table, treat it as such from now on
                 sol::table table = res;
 
-                // Check the file is a valid command
+                // Check the table is a valid command
                 if (table["cmdprops"].valid() && table["onTrigger"].valid())
                 {
                     auto commandName = path.filename().replace_extension("").generic_string();
@@ -204,10 +210,14 @@ namespace moduleutils
                     continue;
                 }
 
+                // Check table was created with Module:new() (or manually with the right fields)
                 if (table["overrides"].valid())
                 {
-                    auto moduleName = table.get_or("name", std::string());
+                    bool skipOverrideCheck = false;
+                    auto moduleName        = table.get_or("name", std::string());
+
                     ShowInfo(fmt::format("=== Module: {} ===", moduleName));
+
                     for (auto& override : table.get_or("overrides", std::vector<sol::table>()))
                     {
                         std::string name = override["name"];
@@ -231,13 +241,30 @@ namespace moduleutils
                             if (ret != SQL_ERROR && _sql->NumRows() == 0)
                             {
                                 DebugModules(fmt::format("{} does not appear to exist on this process.", zoneName));
+                                skipOverrideCheck = true;
                                 continue;
                             }
                         }
 
                         overrides.emplace_back(Override{ filename, name, parts, func, false });
                     }
+
+                    if (!skipOverrideCheck && overrides.empty())
+                    {
+                        ShowError("No overrides found in module: %s", filename);
+                    }
+
+                    // NOTE: This continue is for the expandedList loop
+                    // TODO: Flatten all of this surrounding logic so it's less fragile
+                    continue;
                 }
+
+                // TODO: Come up with a way to differentiate if the user has sent in an invalid table, malformed module (command or overrides),
+                //     : or whether they've just got a data-only table file in their modules directory.
+
+                // If we get here, we haven't managaed to look up (cmdprops + onTrigger) or (overrides) on the table we
+                // got back from the module, so something is wrong with the module.
+                // ShowError("Failed to find valid table fields in module: %s", filename);
             }
         }
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes https://github.com/LandSandBoat/server/issues/6241

Time before my lunchbreak ends. Explanation is in the linked issue, and well documented in the code.

### Tested with:

- Making module `test_npcs_in_gm_home` return `nil`
- Making module `test_npcs_in_gm_home` return `{}`

All result in error logging and server staying up. As with our other error handing in modules, we don't exit if we encounter an error, but we continue loading. Make sure you watch your logs for errors.

### NOT handled:

- Removing all overrides from `test_npcs_in_gm_home`

Because the dynamic renamer module has a Lua file kicking around that just returns a data table, it's harder to check the validity of the contents of a table. So, we're going to skip that error condition for now.

## Steps to test these changes

As above.