### PR TITLE
[core] More memory leak fixes

### DIFF
--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -832,14 +832,14 @@ namespace message
 
     void send_charvar_update(uint32 charId, std::string const& varName, uint32 value, uint32 expiry)
     {
-        uint32 size = sizeof(uint32) + sizeof(uint32) + sizeof(uint32) + sizeof(uint8) + static_cast<uint32>(varName.size());
-        char*  buf  = new char[size];
+        const uint32 size      = sizeof(uint32) + sizeof(uint32) + sizeof(uint32) + sizeof(uint8) + 256;
+        char         buf[size] = {};
         memset(&buf[0], 0, size);
 
         ref<uint32>(buf, 0) = charId;
         ref<int32>(buf, 4)  = value;
         ref<uint32>(buf, 8) = expiry;
-        ref<uint8>(buf, 12) = (uint8)varName.size();
+        ref<uint8>(buf, 12) = static_cast<uint8>(std::min<size_t>(varName.size(), 255));
         memcpy(buf + 13, varName.c_str(), varName.size());
 
         message::send(MSG_CHARVAR_UPDATE, buf, size, nullptr);

--- a/src/map/trait.cpp
+++ b/src/map/trait.cpp
@@ -115,9 +115,9 @@ namespace traits
         // Manually cleanup traits list
         for (auto jobTraitList : PTraitsList)
         {
-            for (auto traitList : jobTraitList)
+            for (auto trait : jobTraitList)
             {
-                destroy(traitList);
+                destroy(trait);
             }
             jobTraitList.clear();
         }

--- a/src/map/trait.h
+++ b/src/map/trait.h
@@ -165,6 +165,7 @@ class CTrait
 {
 public:
     CTrait(uint16 id);
+    virtual ~CTrait() = default;
 
     uint16 getID() const
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fix memory leak on BLU trait cleanup when deleted from trait.cpp. CTrait wasn't polymorphic so `destroy` deleted all the data as if it were CTraits.

Fix memory leak in send_charvar_update, adjusting the function be statically sized instead of dynamic.

## Steps to test these changes

use `!exec SetCharVar(ID, 'var', 1)` with an ID where its not a logged on player and see it work
