### PR TITLE
[LUA]Removes defaultAction for shattered teleporters

### DIFF
--- a/scripts/zones/Konschtat_Highlands/DefaultActions.lua
+++ b/scripts/zones/Konschtat_Highlands/DefaultActions.lua
@@ -3,6 +3,5 @@ local ID = zones[xi.zone.KONSCHTAT_HIGHLANDS]
 return {
     ['qm1']                 = { messageSpecial = ID.text.FIND_NOTHING },
     ['qm2']                 = { messageSpecial = ID.text.BLACKENED_SPOT_ON_GROUND },
-    ['Shattered_Telepoint'] = { messageSpecial = ID.text.TELEPOINT_HAS_BEEN_SHATTERED },
     ['Signpost']            = { messageSpecial = ID.text.SIGNPOST_DIALOG_1 },
 }

--- a/scripts/zones/Konschtat_Highlands/npcs/Shattered_Telepoint.lua
+++ b/scripts/zones/Konschtat_Highlands/npcs/Shattered_Telepoint.lua
@@ -3,6 +3,8 @@
 --  NPC: Shattered telepoint
 -- !pos 135 19 220 108
 -----------------------------------
+local ID = zones[xi.zone.KONSCHTAT_HIGHLANDS]
+-----------------------------------
 ---@type TNpcEntity
 local entity = {}
 
@@ -12,6 +14,8 @@ end
 entity.onTrigger = function(player, npc)
     if player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS) then
         player:startEvent(913)
+    else
+        player:messageSpecial(ID.text.TELEPOINT_HAS_BEEN_SHATTERED)
     end
 end
 

--- a/scripts/zones/La_Theine_Plateau/DefaultActions.lua
+++ b/scripts/zones/La_Theine_Plateau/DefaultActions.lua
@@ -9,7 +9,6 @@ return {
     ['Galaihaurat']         = { text = ID.text.RESCUE_DRILL },
     ['Laurisse']            = { text = ID.text.RESCUE_DRILL + 36 },
     ['Narvecaint']          = { text = ID.text.RESCUE_DRILL + 37 },
-    ['Shattered_Telepoint'] = { messageSpecial = ID.text.TELEPOINT_HAS_BEEN_SHATTERED },
     ['Vicorpasse']          = { text = ID.text.RESCUE_DRILL + 38 },
     ['Yaucevouchat']        = { text = ID.text.RESCUE_DRILL + 34 },
 }

--- a/scripts/zones/La_Theine_Plateau/npcs/Shattered_Telepoint.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/Shattered_Telepoint.lua
@@ -3,6 +3,8 @@
 --  NPC: Shattered Telepoint
 -- !pos 334 19 -60 102
 -----------------------------------
+local ID = zones[xi.zone.LA_THEINE_PLATEAU]
+-----------------------------------
 ---@type TNpcEntity
 local entity = {}
 
@@ -12,6 +14,8 @@ end
 entity.onTrigger = function(player, npc)
     if player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS) then
         player:startEvent(202)
+    else
+        player:messageSpecial(ID.text.TELEPOINT_HAS_BEEN_SHATTERED)
     end
 end
 

--- a/scripts/zones/Tahrongi_Canyon/npcs/Shattered_Telepoint.lua
+++ b/scripts/zones/Tahrongi_Canyon/npcs/Shattered_Telepoint.lua
@@ -3,6 +3,8 @@
 --  NPC: Shattered Telepoint
 -- !pos 179 35 255 117
 -----------------------------------
+local ID = zones[xi.zone.TAHRONGI_CANYON]
+-----------------------------------
 ---@type TNpcEntity
 local entity = {}
 
@@ -12,6 +14,8 @@ end
 entity.onTrigger = function(player, npc)
     if player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS) then
         player:startEvent(913)
+    else
+        player:messageSpecial(ID.text.TELEPOINT_HAS_BEEN_SHATTERED)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Currently, when a player interacts with the three Shattered Telepoints, it cycles between the default action and the proper cutscene to enter the Hall of Transference. 

Removes the two instances of default Actions in the zone and puts the "default message" into the npc script. 

Adds message special to each of the shattered_telepoint.lua 

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
If players have not completed The Mothercrystals, they will get the default message.
If players are on the mission or past it, they will get the cs option to investigate further and enter the Hall of Transference. 

<!-- Clear and detailed steps to test your changes here -->
