### PR TITLE
[MISSION]Adds completed section to CoP 1-3

### DIFF
--- a/scripts/missions/cop/1_3_The_Mothercrystals.lua
+++ b/scripts/missions/cop/1_3_The_Mothercrystals.lua
@@ -217,6 +217,54 @@ mission.sections =
             },
         },
     },
+
+    {
+        check = function(player, currentMission, missionStatus, vars)
+            return player:hasCompletedMission(mission.areaId, mission.missionId)
+        end,
+
+        [xi.zone.KONSCHTAT_HIGHLANDS] =
+        {
+            ['Shattered_Telepoint'] = mission:event(913):replaceDefault(),
+
+            onEventFinish =
+            {
+                [913] = function(player, csid, option, npc)
+                    if option == 0 then
+                        player:setPos(-267.194, -40.634, -280.019, 0, 14) -- To Hall of Transference (R)
+                    end
+                end,
+            },
+        },
+
+        [xi.zone.TAHRONGI_CANYON] =
+        {
+            ['Shattered_Telepoint'] = mission:event(913):replaceDefault(),
+
+            onEventFinish =
+            {
+                [913] = function(player, csid, option, npc)
+                    if option == 0 then
+                        player:setPos(280.066, -80.635, -67.096, 191, 14)
+                    end
+                end,
+            },
+        },
+
+        [xi.zone.LA_THEINE_PLATEAU] =
+        {
+            ['Shattered_Telepoint'] = mission:event(202):replaceDefault(),
+
+            onEventFinish =
+            {
+                [202] = function(player, csid, option, npc)
+                    if option == 0 then
+                        player:setPos(-266.76, -0.635, 280.058, 0, 14) -- To Hall of Transference (R)
+                    end
+                end,
+            },
+        },
+    },
 }
 
 return mission

--- a/scripts/zones/Konschtat_Highlands/npcs/Shattered_Telepoint.lua
+++ b/scripts/zones/Konschtat_Highlands/npcs/Shattered_Telepoint.lua
@@ -10,18 +10,12 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS) then
-        player:startEvent(913)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    if csid == 913 and option == 0 then
-        player:setPos(-267.194, -40.634, -280.019, 0, 14) -- To Hall of Transference (R)
-    end
 end
 
 return entity

--- a/scripts/zones/La_Theine_Plateau/npcs/Shattered_Telepoint.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/Shattered_Telepoint.lua
@@ -10,18 +10,12 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS) then
-        player:startEvent(202)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    if csid == 202 and option == 0 then
-        player:setPos(-266.76, -0.635, 280.058, 0, 14) -- To Hall of Transference (R)
-    end
 end
 
 return entity

--- a/scripts/zones/Tahrongi_Canyon/npcs/Shattered_Telepoint.lua
+++ b/scripts/zones/Tahrongi_Canyon/npcs/Shattered_Telepoint.lua
@@ -10,18 +10,12 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS) then
-        player:startEvent(913)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    if csid == 913 and option == 0 then
-        player:setPos(280.066, -80.635, -67.096, 191, 14)
-    end
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds a hasCompletedMission section to CoP 1-3 Mothercrystals mission. 
Removes logic from shattered_telepoint.lua for each of the zones:
Konschtat Highlands
La Theine Plateau
Tahrongi Canyon
Players will now not have to cycle through defaultAction message if completed and returning to the shattered telepoint.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Go to shattered teleport in any of the crag zones with a player not on or above Mothercrystals. Players will not be shown the option to enter the telepoint.
![image](https://github.com/user-attachments/assets/0200f872-9304-48a6-b252-fe6da122cb1d)

Be on  the mission or complete the mission to get the option to enter the telepoint, without having it cycle through default action.
![image](https://github.com/user-attachments/assets/0dcda6a0-a1e5-4f4a-914a-4f484ac16b4f)

<!-- Clear and detailed steps to test your changes here -->
