### PR TITLE
[Lua] Corrected ph Ids for nm Bloodthirster Madkix

### DIFF
--- a/scripts/zones/Kuftal_Tunnel/mobs/Goblin_Mercenary.lua
+++ b/scripts/zones/Kuftal_Tunnel/mobs/Goblin_Mercenary.lua
@@ -10,8 +10,8 @@ local entity = {}
 
 local bloodthirsterPHTable =
 {
-    [ID.mob.BLOODTHIRSTER_MADKIX + 14] = ID.mob.BLOODTHIRSTER_MADKIX, -- 265.000 9.000 30.000
-    [ID.mob.BLOODTHIRSTER_MADKIX + 23] = ID.mob.BLOODTHIRSTER_MADKIX, -- 256.000 10.000 34.000
+    [ID.mob.BLOODTHIRSTER_MADKIX - 13] = ID.mob.BLOODTHIRSTER_MADKIX, -- 260.000 11.000 37.000
+    [ID.mob.BLOODTHIRSTER_MADKIX - 1] = ID.mob.BLOODTHIRSTER_MADKIX, -- 257.000 10.000 44.000
 }
 
 entity.onMobDeath = function(mob, player, optParams)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes PH ids for bloodthirster madkix nm in Kuftal Tunnel.  Fixes #6035 
Source:
[wiki](https://ffxiclopedia.fandom.com/wiki/Bloodthirster_Madkix)
[bg-wiki](https://www.bg-wiki.com/ffxi/Bloodthirster_Madkix)

## Steps to test these changes

Kill goblin mercenaries at M-8/M-9 of second map in kuftal til he pops (up spawn chance to speed up process)
