### PR TITLE
[login] [core] Improve robustness of zoning

### DIFF
--- a/src/common/blowfish.h
+++ b/src/common/blowfish.h
@@ -29,6 +29,7 @@ enum BLOWFISH
     BLOWFISH_WAITING,
     BLOWFISH_SENT,
     BLOWFISH_ACCEPTED,
+    BLOWFISH_PENDING_ZONE,
 };
 
 struct blowfish_t

--- a/src/common/mmo.h
+++ b/src/common/mmo.h
@@ -57,6 +57,9 @@ enum MSGSERVTYPE : uint8
     MSG_LUA_FUNCTION,
     MSG_CHARVAR_UPDATE,
 
+    // Login/session related
+    MSG_KILL_SESSION, // Kill session on processes that receive this. Intended to delete sessions ahead of map cleanup
+
     // conquest, besieged, campaign..
     MSG_WORLD2MAP_REGIONAL_EVENT,
     MSG_MAP2WORLD_REGIONAL_EVENT,
@@ -163,6 +166,8 @@ constexpr auto msgTypeToStr = [](uint8 msgtype)
             return "MSG_RPC_RECV";
         case MSG_WORLD2MAP_REGIONAL_EVENT:
             return "MSG_WORLD2MAP_REGIONAL_EVENT";
+        case MSG_KILL_SESSION:
+            return "MSG_KILL_SESSION";
         default:
             return "Unknown";
     };

--- a/src/login/data_session.cpp
+++ b/src/login/data_session.cpp
@@ -241,7 +241,6 @@ void data_session::read_func()
             // Some kind of magic regarding the blowfish keys
             uint8 key3[20] = {};
             std::memcpy(key3, data_ + 1, sizeof(key3));
-            key3[16] -= 2;
 
             // https://github.com/atom0s/XiPackets/blob/main/lobby/S2C_0x000B_ResponseNextLogin.md
             lpkt_next_login characterSelectionResponse = {};

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -2459,8 +2459,12 @@ void CLuaBaseEntity::leaveGame()
         return;
     }
 
-    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
-    charutils::ForceLogout(PChar);
+    auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity);
+    if (PChar)
+    {
+        // Because we can't detect if this is happening in the middle of an effect wearing off or not, this can be processed after player tick in CZoneEntities::ZoneServer
+        PChar->status = STATUS_TYPE::SHUTDOWN;
+    }
 }
 
 /************************************************************************

--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -823,6 +823,28 @@ namespace message
 
                 break;
             }
+            case MSG_KILL_SESSION:
+            {
+                uint32 charID = ref<uint32>((uint8*)extra.data(), 0);
+
+                map_session_data_t* sessionToDelete = nullptr;
+                for (auto mapSession : map_session_list)
+                {
+                    auto session = mapSession.second;
+                    if (session->charID == charID)
+                    {
+                        sessionToDelete = session;
+                        break;
+                    }
+                }
+
+                if (sessionToDelete)
+                {
+                    DebugSockets(fmt::format("Closing session of charid {} on request of other process", charID));
+                    map_close_session(server_clock::now(), sessionToDelete);
+                }
+                break;
+            }
             default:
             {
                 ShowWarning("Message: unhandled message type %d", type);

--- a/src/map/packets/server_ip.cpp
+++ b/src/map/packets/server_ip.cpp
@@ -30,6 +30,10 @@ CServerIPPacket::CServerIPPacket(CCharEntity* PChar, uint8 type, uint64 ipp)
     this->setType(0x0B);
     this->setSize(0x1C);
 
+    // Store inputs to reconstruct later in map.cpp in case we detect the player needs the packet again
+    this->type = type;
+    this->ipp  = ipp;
+
     ref<uint8>(0x04)  = type;
     ref<uint32>(0x08) = (uint32)ipp;
     ref<uint16>(0x0C) = (uint16)(ipp >> 32);

--- a/src/map/packets/server_ip.h
+++ b/src/map/packets/server_ip.h
@@ -32,6 +32,9 @@ class CServerIPPacket : public CBasicPacket
 {
 public:
     CServerIPPacket(CCharEntity* PChar, uint8 type, uint64 ipp);
+
+    uint8  type;
+    uint64 ipp;
 };
 
 #endif

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -281,6 +281,8 @@ namespace charutils
     uint32 getCharIdFromName(std::string const& name);
 
     void forceSynthCritFail(std::string sourceFunction, CCharEntity* PChar);
+
+    void removeCharFromZone(CCharEntity* PChar);
 }; // namespace charutils
 
 #endif // _CHARUTILS_H

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -1695,6 +1695,8 @@ void CZoneEntities::ZoneServer(time_point tick)
         ++it;
     }
 
+    std::vector<CCharEntity*> charsToLogout = {};
+
     for (EntityList_t::const_iterator it = m_charList.begin(); it != m_charList.end(); ++it)
     {
         CCharEntity* PChar = (CCharEntity*)it->second;
@@ -1713,6 +1715,18 @@ void CZoneEntities::ZoneServer(time_point tick)
             PChar->PAI->Tick(tick);
             PChar->PTreasurePool->CheckItems(tick);
         }
+
+        // EFFECT_LEAVEGAME effect wore off or char got SHUTDOWN from some other location
+        if (PChar->status == STATUS_TYPE::SHUTDOWN)
+        {
+            charsToLogout.emplace_back(PChar);
+        }
+    }
+
+    // forceLogout eventually removes the char from m_charList -- so we must remove them here
+    for (auto PChar : charsToLogout)
+    {
+        charutils::ForceLogout(PChar);
     }
 
     if (tick > m_EffectCheckTime)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This commit attempts to improve retail accuracy where retail recovers from packet loss of you never recieving 0x00B As well as the server not caring if 0x00D is sent or not. We predictably know when the key should be incremented, and while not an ideal solution, seems to work

## Steps to test these changes

uhhh zone a lot and log in a lot I guess, there's a ton of scenarios like warping, teleporting !zone, /shutdown, etc
create char after logging in normally then logging out
create char right away after logging in

It is very important to test /logout and /shutdown without a GM character

The main one is this:
[1725996787757.webm](https://github.com/user-attachments/assets/e397720d-0f18-4019-a453-39ba673e21ff)
