### PR TITLE
Mob Spell Casting Cooldown

### DIFF
--- a/src/map/ai/controllers/mob_controller.h
+++ b/src/map/ai/controllers/mob_controller.h
@@ -60,6 +60,8 @@ public:
     void         SetFollowTarget(CBaseEntity* PTarget, FollowType followType);
     void         ClearFollowTarget();
 
+    void OnCastStopped(CMagicState& state, action_t& action);
+
 protected:
     virtual bool TryDeaggro();
 
@@ -94,7 +96,7 @@ private:
     CMobEntity* const PMob;
 
     time_point m_LastActionTime;
-    time_point m_LastMagicTime;
+    time_point m_nextMagicTime;
     time_point m_LastMobSkillTime;
     time_point m_LastSpecialTime;
     time_point m_DeaggroTime;

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -1225,7 +1225,25 @@ void CMobEntity::OnCastFinished(CMagicState& state, action_t& action)
     TracyZoneScoped;
     CBattleEntity::OnCastFinished(state, action);
 
+    CMobController* mobController = dynamic_cast<CMobController*>(PAI->GetController());
+    if (mobController)
+    {
+        mobController->OnCastStopped(state, action);
+    }
+
     TapDeaggroTime();
+}
+
+void CMobEntity::OnCastInterrupted(CMagicState& state, action_t& action, MSGBASIC_ID msg, bool blockedCast)
+{
+    TracyZoneScoped;
+    CBattleEntity::OnCastInterrupted(state, action, msg, blockedCast);
+
+    CMobController* mobController = dynamic_cast<CMobController*>(PAI->GetController());
+    if (mobController)
+    {
+        mobController->OnCastStopped(state, action);
+    }
 }
 
 bool CMobEntity::OnAttack(CAttackState& state, action_t& action)

--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -165,6 +165,7 @@ public:
     virtual bool OnAttack(CAttackState&, action_t&) override;
     virtual bool CanAttack(CBattleEntity* PTarget, std::unique_ptr<CBasicPacket>& errMsg) override;
     virtual void OnCastFinished(CMagicState&, action_t&) override;
+    virtual void OnCastInterrupted(CMagicState&, action_t&, MSGBASIC_ID msg, bool blockedCast) override;
 
     virtual void OnDisengage(CAttackState&) override;
     virtual void OnDeathTimer() override;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This changes the when it calculates a mobs next spell can be casted. Before this change it was calculating it at the start of spell casting. The problem with this is that spells can have very different casting times so the cooldown would vary greatly. With this change it is now **after** finished casting to keep the cooldown much more consistent.

There is potentially a similar situation with automatons. I opted not to do this as it requires additional research and I wanted to keep this concise for the time being.

## Retail proof

Here is a capture video showing Flans casting many spells and always having a consistent cast cooldown
[Flan Capture](https://youtu.be/_JkMctGmfo0?t=305)

## Steps to test these changes

Go to a BLM mob such as the Flan up on Mount Zhayolm and see that their cast cooldowns are now consistent despite casting long casting spells such as Flare.
