### PR TITLE
login: Add ACCOUNT_CHARACTER_LIMIT setting

### DIFF
--- a/settings/default/login.lua
+++ b/settings/default/login.lua
@@ -40,6 +40,10 @@ xi.settings.login =
     -- Number of simultaneous game sessions per IP (0 for no limit)
     LOGIN_LIMIT = 0,
 
+    -- Maximum number of characters per account (0 for no limit)
+    -- This is enforced through xi_connect and xiloader, you can bypass this if you create characters through other means
+    ACCOUNT_CHARACTER_LIMIT = 0,
+
     -- Expansion display on the client's login screen. This does NOT effect in game content whatsoever!
     RISE_OF_ZILART          = true,
     CHAINS_OF_PROMATHIA     = true,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [NOT YET LOL] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds this setting:
```lua
    -- Maximum number of characters per account (0 for no limit)
    -- This is enforced through xi_connect and xiloader, you can bypass this if you create characters through other means
    ACCOUNT_CHARACTER_LIMIT = 0,
```

And enforces it during attempted character creation