### PR TITLE
[core] [zmq] Only kill pending zone sessions in MSG_KILL_SESSION

### DIFF
--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -838,7 +838,7 @@ namespace message
                     }
                 }
 
-                if (sessionToDelete)
+                if (sessionToDelete && sessionToDelete->blowfish.status == BLOWFISH_PENDING_ZONE)
                 {
                     DebugSockets(fmt::format("Closing session of charid {} on request of other process", charID));
                     map_close_session(server_clock::now(), sessionToDelete);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Only kill pending zone sessions in MSG_KILL_SESSION

## Steps to test these changes

Zone in on single session process and don't `delete` your PChar immediately