### PR TITLE
Fix EFFECT_TELEPORT crash

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -219,6 +219,8 @@ CCharEntity::CCharEntity()
     PRecastContainer       = std::make_unique<CCharRecastContainer>(this);
     PLatentEffectContainer = new CLatentEffectContainer(this);
 
+    requestedWarp = false;
+
     retriggerLatents = false;
 
     resetPetZoningInfo();
@@ -2204,7 +2206,7 @@ void CCharEntity::OnDeathTimer()
 {
     TracyZoneScoped;
     charutils::SetCharVar(this, "expLost", 0);
-    charutils::HomePoint(this);
+    charutils::HomePoint(this, true);
 }
 
 void CCharEntity::OnRaise()

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -219,7 +219,8 @@ CCharEntity::CCharEntity()
     PRecastContainer       = std::make_unique<CCharRecastContainer>(this);
     PLatentEffectContainer = new CLatentEffectContainer(this);
 
-    requestedWarp = false;
+    requestedWarp       = false;
+    requestedZoneChange = false;
 
     retriggerLatents = false;
 

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -408,7 +408,8 @@ public:
     // currency_t        m_currency;                 // conquest points, imperial standing points etc
     teleport_t teleport; // Outposts, Runic Portals, Homepoints, Survival Guides, Maws, etc.
 
-    bool requestedWarp = false; // used in CLuaBaseEntity::warp(). This will be processed after the player's tick to warp.
+    bool requestedWarp       = false; // used in CLuaBaseEntity::warp(). This will be processed after the player's tick to warp.
+    bool requestedZoneChange = false; // used in CLueBaseEntity::setPos(). This will be processed after the player's tick to change zones.
 
     uint8 GetGender();
 

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -408,6 +408,8 @@ public:
     // currency_t        m_currency;                 // conquest points, imperial standing points etc
     teleport_t teleport; // Outposts, Runic Portals, Homepoints, Survival Guides, Maws, etc.
 
+    bool requestedWarp = false; // used in CLuaBaseEntity::warp(). This will be processed after the player's tick to warp.
+
     uint8 GetGender();
 
     void          clearPacketList();

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -3022,12 +3022,11 @@ void CLuaBaseEntity::setPos(sol::variadic_args va)
                 return;
             }
 
-            PChar->loc.destination = zoneid;
-            PChar->status          = STATUS_TYPE::DISAPPEAR;
-            PChar->loc.boundary    = 0;
-            PChar->m_moghouseID    = 0;
-            PChar->clearPacketList();
-            charutils::SendToZone(PChar, 2, ipp);
+            PChar->loc.destination     = zoneid;
+            PChar->status              = STATUS_TYPE::DISAPPEAR;
+            PChar->loc.boundary        = 0;
+            PChar->m_moghouseID        = 0;
+            PChar->requestedZoneChange = true;
         }
         else if (PChar->status != STATUS_TYPE::DISAPPEAR)
         {

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -3051,18 +3051,10 @@ void CLuaBaseEntity::warp()
         return;
     }
 
-    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
-
-    PChar->loc.boundary    = 0;
-    PChar->m_moghouseID    = 0;
-    PChar->loc.p           = PChar->profile.home_point.p;
-    PChar->loc.destination = PChar->profile.home_point.destination;
-
-    PChar->status    = STATUS_TYPE::DISAPPEAR;
-    PChar->animation = ANIMATION_NONE;
-
-    PChar->clearPacketList();
-    charutils::SendToZone(PChar, 2, zoneutils::GetZoneIPP(m_PBaseEntity->loc.destination));
+    if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
+    {
+        PChar->requestedWarp = true;
+    }
 }
 
 /************************************************************************

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -886,7 +886,11 @@ int32 parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_data_t*
 
             if (PChar->loc.zone == nullptr && SmallPD_Type != 0x0A)
             {
-                ShowWarning("This packet is unexpected from %s - Received %03hX earlier without matching 0x0A", PChar->getName(), SmallPD_Type);
+                // Packets aren't unexpected from the old key under BLOWFISH_PENDING_ZONE
+                if (map_session_data->blowfish.status != BLOWFISH_PENDING_ZONE)
+                {
+                    ShowWarning("This packet is unexpected from %s - Received %03hX earlier without matching 0x0A", PChar->getName(), SmallPD_Type);
+                }
             }
             else
             {

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -292,7 +292,7 @@ void SmallPacket0x00A(map_session_data_t* const PSession, CCharEntity* const PCh
             // TODO: work out how to drop player in moghouse that exits them to the zone they were in before this happened, like we used to.
             ShowWarning("packet_system::SmallPacket0x00A player tried to enter zone that was invalid or out of range");
             ShowWarning("packet_system::SmallPacket0x00A dumping player `%s` to homepoint!", PChar->getName());
-            charutils::HomePoint(PChar);
+            charutils::HomePoint(PChar, true);
             return;
         }
 
@@ -943,7 +943,7 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
             }
 
             PChar->setCharVar("expLost", 0);
-            charutils::HomePoint(PChar);
+            charutils::HomePoint(PChar, true);
         }
         break;
         case 0x0C: // assist

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -6551,18 +6551,22 @@ namespace charutils
         SendToZone(PChar, 2, zoneutils::GetZoneIPP(PChar->loc.destination));
     }
 
-    void HomePoint(CCharEntity* PChar)
+    void HomePoint(CCharEntity* PChar, bool resetHPMP)
     {
         TracyZoneScoped;
 
-        // remove weakness on homepoint
-        PChar->StatusEffectContainer->DelStatusEffectSilent(EFFECT_WEAKNESS);
-        PChar->StatusEffectContainer->DelStatusEffectSilent(EFFECT_LEVEL_SYNC);
+        // player initiated warp/warp 2 or otherwise
+        if (resetHPMP)
+        {
+            // remove weakness on homepoint
+            PChar->StatusEffectContainer->DelStatusEffectSilent(EFFECT_WEAKNESS);
+            PChar->StatusEffectContainer->DelStatusEffectSilent(EFFECT_LEVEL_SYNC);
 
-        PChar->SetDeathTimestamp(0);
+            PChar->SetDeathTimestamp(0);
 
-        PChar->health.hp = PChar->GetMaxHP();
-        PChar->health.mp = PChar->GetMaxMP();
+            PChar->health.hp = PChar->GetMaxHP();
+            PChar->health.mp = PChar->GetMaxMP();
+        }
 
         PChar->loc.boundary    = 0;
         PChar->loc.p           = PChar->profile.home_point.p;

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -240,7 +240,7 @@ namespace charutils
     void  SendToZone(CCharEntity* PChar, uint8 type, uint64 ipp);
     void  ForceLogout(CCharEntity* PChar);
     void  ForceRezone(CCharEntity* PChar);
-    void  HomePoint(CCharEntity* PChar);
+    void  HomePoint(CCharEntity* PChar, bool resetHPMP);
     bool  AddWeaponSkillPoints(CCharEntity*, SLOTTYPE, int);
 
     int32 GetCharVar(CCharEntity* PChar, std::string const& var);

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -1717,20 +1717,17 @@ void CZoneEntities::ZoneServer(time_point tick)
             PChar->PTreasurePool->CheckItems(tick);
         }
 
-        // EFFECT_LEAVEGAME effect wore off or char got SHUTDOWN from some other location
-        if (PChar->status == STATUS_TYPE::SHUTDOWN)
+        // Else-if chain so only one end-result can be processed.
+        // This is done to prevent multiple-deletion of PChar
+        if (PChar->status == STATUS_TYPE::SHUTDOWN) // EFFECT_LEAVEGAME effect wore off or char got SHUTDOWN from some other location
         {
             charsToLogout.emplace_back(PChar);
         }
-
-        // EFFECT_TELEPORT can request players to warp
-        if (PChar->requestedWarp)
+        else if (PChar->requestedWarp) // EFFECT_TELEPORT can request players to warp
         {
             charsToWarp.emplace_back(PChar);
         }
-
-        // EFFECT_TELEPORT can request players to change zones
-        if (PChar->requestedZoneChange)
+        else if (PChar->requestedZoneChange) // EFFECT_TELEPORT can request players to change zones
         {
             charsToChangeZone.emplace_back(PChar);
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes #6264 

Does what it says on the tin -- fixes teleport/warp crash.

This moves warp/zoning logic to post-tick processing so PChar isn't deleted from under the the zone server's feet.

Also removes a noisy, pointless warning on zone that that is incorrect (clients DO send packets when they are requested to zone)

## Steps to test these changes

/logout and /shutdown without issue
Perform all warps here with no error/crash

```
effectObject.onEffectLose = function(target, effect)
    local destination = effect:getPower()

    if target:isMob() then
        DespawnMob(target:getID())
    elseif destination == xi.teleport.id.WARP then
        target:warp()
    elseif destination == xi.teleport.id.ESCAPE then
        xi.teleport.escape(target)
    elseif destination == xi.teleport.id.OUTPOST then
        local region = effect:getSubPower()
        xi.teleport.toOutpost(target, region)
    elseif destination == xi.teleport.id.LEADER then
        xi.teleport.toLeader(target)
    elseif destination == xi.teleport.id.HOME_NATION then
        xi.teleport.toHomeNation(target)
    elseif destination == xi.teleport.id.RETRACE then
        xi.teleport.toAlliedNation(target)
    elseif destination == xi.teleport.id.TIDAL_TALISMAN then
        xi.teleport.tidalTeleport(target)
    else
        xi.teleport.to(target, destination)
    end
end
```
