### PR TITLE
[core] Small counter audit

### DIFF
--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -445,7 +445,8 @@ bool CAttack::CheckCounter()
         return false;
     }
 
-    if (!m_victim->PAI->IsEngaged())
+    // Don't counter if not engaged or stunned, slept, etc.
+    if (!m_victim->PAI->IsEngaged() || m_victim->StatusEffectContainer->HasPreventActionEffect(true))
     {
         m_isCountered = false;
         return m_isCountered;

--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -473,20 +473,25 @@ bool CAttack::CheckCounter()
         seiganChance = std::clamp<uint16>(seiganChance, 0, 100);
         seiganChance /= 4;
     }
-    if ((xirand::GetRandomNumber(100) < std::clamp<uint16>(m_victim->getMod(Mod::COUNTER) + meritCounter, 0, 80) ||
-         xirand::GetRandomNumber(100) < seiganChance) &&
-        facing(m_victim->loc.p, m_attacker->loc.p, 64) && xirand::GetRandomNumber(100) < battleutils::GetHitRate(m_victim, m_attacker))
-    {
-        m_isCountered = true;
-        m_isCritical  = (xirand::GetRandomNumber(100) < battleutils::GetCritHitRate(m_victim, m_attacker, false));
-    }
-    else if (m_victim->StatusEffectContainer->HasStatusEffect(EFFECT_PERFECT_COUNTER))
-    { // Perfect Counter only counters hits that normal counter misses, always critical, can counter 1-3 times before wearing
-        m_isCountered = true;
-        m_isCritical  = true;
 
-        // TODO: Implement VIT-based formula for Perfect Counter wearing off, and add JP bonus
-        m_victim->StatusEffectContainer->DelStatusEffect(EFFECT_PERFECT_COUNTER);
+    // Do not counter if PD is up
+    if (!m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_PERFECT_DODGE))
+    {
+        if ((xirand::GetRandomNumber(100) < std::clamp<uint16>(m_victim->getMod(Mod::COUNTER) + meritCounter, 0, 80) ||
+             xirand::GetRandomNumber(100) < seiganChance) &&
+            facing(m_victim->loc.p, m_attacker->loc.p, 64) && xirand::GetRandomNumber(100) < battleutils::GetHitRate(m_victim, m_attacker))
+        {
+            m_isCountered = true;
+            m_isCritical  = (xirand::GetRandomNumber(100) < battleutils::GetCritHitRate(m_victim, m_attacker, false));
+        }
+        else if (m_victim->StatusEffectContainer->HasStatusEffect(EFFECT_PERFECT_COUNTER))
+        { // Perfect Counter only counters hits that normal counter misses, always critical, can counter 1-3 times before wearing
+            m_isCountered = true;
+            m_isCritical  = true;
+
+            // TODO: Implement VIT-based formula for Perfect Counter wearing off, and add JP bonus
+            m_victim->StatusEffectContainer->DelStatusEffect(EFFECT_PERFECT_COUNTER);
+        }
     }
     return m_isCountered;
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Disable counter with PD up
Disable counter if the defender is stunned/slept etc

## Steps to test these changes

Use PD vs a mob with 100% counter and 9999 acc, see it not counter when you attack it
Stun a mob and see it not counter with the above conditions minus PD