### PR TITLE
[core] Add blue capped text to craft on skillup to max of rank

### DIFF
--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -630,6 +630,12 @@ namespace synthutils
                 if ((charSkill / 10) < (charSkill + skillUpAmount) / 10)
                 {
                     PChar->WorkingSkills.skill[skillID] += 0x20;
+
+                    if (PChar->RealSkills.skill[skillID] >= maxSkill)
+                    {
+                        PChar->WorkingSkills.skill[skillID] |= 0x8000; // blue capped text
+                    }
+
                     PChar->pushPacket(new CCharSkillsPacket(PChar));
                     PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, skillID, (charSkill + skillUpAmount) / 10, 53));
                 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

When you cap your craft on skillup it will now appropriately cap the craft in the skill packet

![image](https://github.com/user-attachments/assets/82d1e630-c6ef-4200-a4b9-66885cd13578)

Rankup will un-cap as expected
![image](https://github.com/user-attachments/assets/74d89466-fb7c-4647-a714-3b063bf57ff4)

## Steps to test these changes

Craft until your skill cap, see blue capped text _without_ zoning