### PR TITLE
[core] Fix ammo weapon damage (shurikens)

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -562,10 +562,14 @@ uint16 CBattleEntity::GetSubWeaponRank()
 
 uint16 CBattleEntity::GetRangedWeaponRank()
 {
-    if (auto* weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_RANGED]))
+    // Check ranged slot first, otherwise use ammo if it's null
+    CItemEquipment* item = m_Weapons[SLOT_RANGED] ? m_Weapons[SLOT_RANGED] : m_Weapons[SLOT_AMMO];
+
+    if (auto* weapon = dynamic_cast<CItemWeapon*>(item))
     {
         return (weapon->getDamage() + getMod(Mod::RANGED_DMG_RANK)) / 9;
     }
+
     return 0;
 }
 

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -3044,7 +3044,7 @@ namespace battleutils
             fstr = static_cast<int32>((dif + 13) / 2);
         }
 
-        if (SlotID == SLOT_RANGED)
+        if (SlotID == SLOT_RANGED || SlotID == SLOT_AMMO)
         {
             rank = PAttacker->GetRangedWeaponRank();
             // Different caps than melee weapons


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

FSTR2 and weapon rank were not being used correctly on ammo-only weapons such as shurikens.

## Steps to test these changes

/ra a shuriken as NIN99/whm 1

Per Spensa:

``` Fuma damage: 72, weapon rank: 8, fSTR2 cap = 32, pDIF cap = 3.25 + 0.1 = 3.35. Damage = (72 + 32) * 3.35 = 348. Crit damage = 348 * 1.25 = 435.```

Ranged attacks
![image](https://github.com/user-attachments/assets/e8818a5e-1fb5-434b-ad00-60046fd0631e)
And Daken:
![image](https://github.com/user-attachments/assets/0e3f5f47-ca4d-4a8b-afe1-ca79b42c006f)

