### PR TITLE
[core] Set capped skill bit when fishing skill maxes for rank

### DIFF
--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -1889,6 +1889,12 @@ namespace fishingutils
                 if ((charSkill / 10) < (charSkill + skillAmount) / 10)
                 {
                     PChar->WorkingSkills.skill[SKILL_FISHING] += 0x20;
+
+                    if (PChar->RealSkills.skill[SKILL_FISHING] >= maxSkill)
+                    {
+                        PChar->WorkingSkills.skill[SKILL_FISHING] |= 0x8000; // blue capped text
+                    }
+
                     PChar->pushPacket(new CCharSkillsPacket(PChar));
                     PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, SKILL_FISHING, (charSkill + skillAmount) / 10, 53));
                 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Set capped skill bit when fishing skill maxes for rank

## Steps to test these changes
Fish to cap, see blue text

![image](https://github.com/user-attachments/assets/f0f803c0-bda9-454c-b180-55abfc9c914a)

rank up and see it's uncapped
![image](https://github.com/user-attachments/assets/67fb17cd-81dc-4600-b3bc-9dfc88fa201c)
