### PR TITLE
[core] Session cleanup and improvements

### DIFF
--- a/src/common/mmo.h
+++ b/src/common/mmo.h
@@ -665,4 +665,26 @@ public:
     ~char_mini(){};
 };
 
+// https://github.com/atom0s/XiPackets/tree/main/world/client/0x000A
+// Defined here for use in both map.cpp and packet_system.cpp
+struct GP_CLI_LOGIN
+{
+    uint16_t id : 9;
+    uint16_t size : 7;
+    uint16_t sync;
+    uint8_t  LoginPacketCheck; // PS2: LoginPacketCheck
+    uint8_t  padding00;        // PS2: dam__
+    uint16_t unknown00;        // PS2: MyPort
+    uint32_t unknown01;        // PS2: MyIP
+    uint32_t UniqueNo;         // PS2: UniqueNo
+    uint16_t GrapIDTbl[9];     // PS2: GrapIDTbl
+    char     sName[15];        // PS2: sName
+    char     sAccunt[15];      // PS2: sAccunt
+    uint8_t  Ticket[16];       // PS2: Ticket
+    uint32_t Ver;              // PS2: Ver
+    uint8_t  sPlatform[4];     // PS2: sPlatform
+    uint16_t uCliLang;         // PS2: uCliLang
+    uint16_t dammyArea;        // PS2: dammyArea
+};
+
 #endif // _MMO_H

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -723,18 +723,18 @@ int32 recv_parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_da
 
     if (checksumResult == 0)
     {
-        // We can only get here if an 0x00A (not encrypted) packet was here.
-        // If we were pending zones, delete our old char
-        if (map_session_data->blowfish.status == BLOWFISH_PENDING_ZONE)
-        {
-            destroy(map_session_data->PChar);
-        }
-
         uint16 packetID = ref<uint16>(buff, FFXI_HEADER_SIZE) & 0x1FF;
 
         if (packetID != 0x00A)
         {
             return -1;
+        }
+
+        // We can only get here if an 0x00A (not encrypted) packet was here.
+        // If we were pending zones, delete our old char
+        if (map_session_data->blowfish.status == BLOWFISH_PENDING_ZONE)
+        {
+            destroy(map_session_data->PChar);
         }
 
         if (map_session_data->PChar == nullptr)

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -597,9 +597,6 @@ int32 do_sockets(fd_set* rfd, duration next)
             int32 decryptCount = recv_parse(g_PBuff, &size, &from, map_session_data);
             if (decryptCount != -1)
             {
-                // Update the time we last got a valid packet
-                map_session_data->last_update = time(nullptr);
-
                 // DecryptCount of 0 means the main key decrypted the packet
                 if (decryptCount == 0)
                 {
@@ -875,6 +872,12 @@ int32 parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_data_t*
             {
                 DebugPackets("parse: %03hX | %04hX %04hX %02hX from user: %s",
                              SmallPD_Type, ref<uint16>(SmallPD_ptr, 2), ref<uint16>(buff, 2), SmallPD_Size, PChar->getName());
+            }
+            else
+            {
+                // Update the time we last got a char sync packet
+                // The client can spam some other packets when trying to zone, preventing timely session deletions
+                map_session_data->last_update = time(nullptr);
             }
 
             if (settings::get<bool>("map.PACKETGUARD_ENABLED") && PacketGuard::IsRateLimitedPacket(PChar, SmallPD_Type))

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1192,6 +1192,12 @@ int32 map_close_session(time_point tick, map_session_data_t* map_session_data)
         destroy_arr(map_session_data->server_packet_data);
         if (map_session_data->PChar)
         {
+            CZone* PZone = map_session_data->PChar->loc.zone;
+            if (PZone)
+            {
+                // This should already be done in removeCharFromZone, but just to be safe...
+                PZone->DecreaseZoneCounter(map_session_data->PChar);
+            }
             destroy(map_session_data->PChar);
         }
         destroy(map_session_data);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

When you login, the server pulls a charid from your login packet, but due to the robust login packet changes, sometimes there's junk data that looks decryptable but isn't
This should severely limit any junk making it across as charid

Cleanup session immediately instead of deffering cleanup to a secondary cleanup if session timed out.
Remove accounts_session immediately on timeout

Remove a bunch of excess/copy pasted code from session cleanup
## Steps to test these changes

Login as normal when zoning,

Disconnect with the following methods
* standard force d/c
* /logout
* /shutdown
* block outgoing C2S packets after casting warp/teleports/etc