### PR TITLE
[core] Allow random deal to reset trust ability timers

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -13559,7 +13559,12 @@ bool CLuaBaseEntity::doRandomDeal(CLuaBaseEntity* PTarget)
         return false;
     }
 
-    return battleutils::DoRandomDealToEntity(static_cast<CCharEntity*>(m_PBaseEntity), static_cast<CCharEntity*>(PTarget->m_PBaseEntity));
+    if (auto PBattleTarget = dynamic_cast<CBattleEntity*>(PTarget->m_PBaseEntity))
+    {
+        return battleutils::DoRandomDealToEntity(static_cast<CCharEntity*>(m_PBaseEntity), PBattleTarget);
+    }
+
+    return false;
 }
 
 /************************************************************************

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -5983,7 +5983,7 @@ namespace battleutils
      *   Does the random deal effect to a specific character (reset ability) *
      *                                                                       *
      ************************************************************************/
-    bool DoRandomDealToEntity(CCharEntity* PChar, CCharEntity* PTarget)
+    bool DoRandomDealToEntity(CCharEntity* PChar, CBattleEntity* PTarget)
     {
         std::vector<uint16> resetCandidateList;
         std::vector<uint16> activeCooldownList;
@@ -6042,8 +6042,11 @@ namespace battleutils
                 }
                 if (PChar != PTarget)
                 {
-                    // Update target's recast state; caster's will be handled in CCharEntity::OnAbility.
-                    PTarget->pushPacket(new CCharRecastPacket(PTarget));
+                    if (auto PCharTarget = dynamic_cast<CCharEntity*>(PTarget))
+                    {
+                        // Update target's recast state; caster's will be handled in CCharEntity::OnAbility.
+                        PCharTarget->pushPacket(new CCharRecastPacket(PCharTarget));
+                    }
                 }
                 return true;
             }
@@ -6062,16 +6065,19 @@ namespace battleutils
             // Reset first ability (shuffled or only)
             PTarget->PRecastContainer->DeleteByIndex(RECAST_ABILITY, resetCandidateList.at(0));
 
-            // Reset 2 abilities by chance (could be 2 abilitie that don't need resets)
+            // Reset 2 abilities by chance (could be 2 abilities that don't need resets)
             if (resetCandidateList.size() > 1 && activeCooldownList.size() > 1 && resetTwoChance >= xirand::GetRandomNumber(1, 100))
             {
                 PTarget->PRecastContainer->DeleteByIndex(RECAST_ABILITY, resetCandidateList.at(1));
             }
 
-            if (PChar != PTarget && PTarget->objtype == TYPE_PC)
+            if (PChar != PTarget)
             {
-                // Update target's recast state; caster's will be handled in CCharEntity::OnAbility.
-                PTarget->pushPacket(new CCharRecastPacket(PTarget));
+                if (auto PCharTarget = dynamic_cast<CCharEntity*>(PTarget))
+                {
+                    // Update target's recast state; caster's will be handled in CCharEntity::OnAbility.
+                    PCharTarget->pushPacket(new CCharRecastPacket(PCharTarget));
+                }
             }
 
             return true;

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -251,7 +251,7 @@ namespace battleutils
     bool    WeatherMatchesElement(WEATHER weather, uint8 element);
     bool    DrawIn(CBattleEntity* PEntity, CMobEntity* PMob, float offset);
     void    DoWildCardToEntity(CCharEntity* PCaster, CCharEntity* PTarget, uint8 roll);
-    bool    DoRandomDealToEntity(CCharEntity* PChar, CCharEntity* PTarget);
+    bool    DoRandomDealToEntity(CCharEntity* PChar, CBattleEntity* PTarget);
 
     void turnTowardsTarget(CBaseEntity* PEntity, CBaseEntity* PTarget, bool force = false);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Allow random deal to reset trust ability timers
Also fixes a crash when trusts get hit with random deal

## Steps to test these changes

Random deal with trusts out and don't crash and have their CRecastContainer timer reset for 1 or 2 abilities
