### PR TITLE
Movement speed adjustments

### DIFF
--- a/scripts/globals/job_utils/thief.lua
+++ b/scripts/globals/job_utils/thief.lua
@@ -261,7 +261,7 @@ xi.job_utils.thief.useFlee = function(player, target, ability)
         player:delStatusEffect(xi.effect.WEIGHT)
     end
 
-    player:addStatusEffect(xi.effect.FLEE, 100, 0, duration)
+    player:addStatusEffect(xi.effect.FLEE, 10000, 0, duration)
 end
 
 xi.job_utils.thief.useHide = function(player, target, ability)

--- a/scripts/items/bottle_of_sprinters_drink.lua
+++ b/scripts/items/bottle_of_sprinters_drink.lua
@@ -12,7 +12,7 @@ end
 
 itemObject.onItemUse = function(target)
     local effect = xi.effect.FLEE
-    local power = 100
+    local power = 7500
     local duration = 60
 
     xi.itemUtils.addItemEffect(target, effect, power, duration)

--- a/scripts/items/hermes_quencher.lua
+++ b/scripts/items/hermes_quencher.lua
@@ -16,7 +16,7 @@ end
 
 itemObject.onItemUse = function(target)
     target:delStatusEffect(xi.effect.FLEE)
-    target:addStatusEffect(xi.effect.FLEE, 100, 0, 30)
+    target:addStatusEffect(xi.effect.FLEE, 8750, 0, 30)
     target:messageBasic(xi.msg.basic.GAINS_EFFECT_OF_STATUS, xi.effect.FLEE)
     target:addStatusEffect(xi.effect.MEDICINE, 0, 0, 900)
 end

--- a/scripts/items/powder_boots.lua
+++ b/scripts/items/powder_boots.lua
@@ -12,7 +12,7 @@ end
 
 itemObject.onItemUse = function(target)
     target:delStatusEffect(xi.effect.FLEE)
-    target:addStatusEffect(xi.effect.FLEE, 100, 0, 30)
+    target:addStatusEffect(xi.effect.FLEE, 10000, 0, 30)
 end
 
 return itemObject

--- a/scripts/missions/amk/13_A_Challenge_You_Could_Be_a_Winner.lua
+++ b/scripts/missions/amk/13_A_Challenge_You_Could_Be_a_Winner.lua
@@ -231,7 +231,7 @@ mission.sections =
                         }
 
                         if option == 5 or option == 6 then
-                            player:addStatusEffect(xi.effect.FLEE, 100, 0, fleeDuration[option])
+                            player:addStatusEffect(xi.effect.FLEE, 10000, 0, fleeDuration[option])
                         end
                     end
                 end,

--- a/scripts/zones/AlTaieu/mobs/Jailer_of_Prudence.lua
+++ b/scripts/zones/AlTaieu/mobs/Jailer_of_Prudence.lua
@@ -40,14 +40,14 @@ entity.onMobSpawn = function(mob)
                 cooldown = 120, -- "Both can use Perfect Dodge multiple times, and will do so almost incessantly." (guessing a 2 minute cooldown)
                 hpp = 95,
                 endCode = function(mobArg)
-                    mobArg:addStatusEffectEx(xi.effect.FLEE, 0, 100, 0, 30) -- "Jailer of Prudence will however gain Flee speed during Perfect Dodge."
+                    mobArg:addStatusEffectEx(xi.effect.FLEE, 0, 10000, 0, 30) -- "Jailer of Prudence will however gain Flee speed during Perfect Dodge."
                 end,
             },
         },
     })
 
     mob:setAnimationSub(0) -- Mouth closed
-    mob:addStatusEffectEx(xi.effect.FLEE, 0, 100, 0, 60)
+    mob:addStatusEffectEx(xi.effect.FLEE, 0, 10000, 0, 60)
     mob:setMod(xi.mod.TRIPLE_ATTACK, 20)
     mob:setMod(xi.mod.REGEN, 10)
     mob:addMod(xi.mod.BIND_MEVA, 30)

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -2821,6 +2821,10 @@ INSERT INTO `item_latents` VALUES (27367,399,16,52,5);   -- Pedagogy Loafers+1: 
 INSERT INTO `item_latents` VALUES (27367,399,16,52,6);   -- Pedagogy Loafers+1: Weather: Enhances Celerity and Alacrity Effect +16% (THUNDER)
 INSERT INTO `item_latents` VALUES (27367,399,16,52,7);   -- Pedagogy Loafers+1: Weather: Enhances Celerity and Alacrity Effect +16% (LIGHT)
 INSERT INTO `item_latents` VALUES (27367,399,16,52,8);   -- Pedagogy Loafers+1: Weather: Enhances Celerity and Alacrity Effect +16% (DARK)
+
+-- Councilor's Garb
+INSERT INTO `item_latents` VALUES (27923,76,24,63,0);   -- While in Adoulin: MOVE_SPEED_GEAR_BONUS +25% (retail testing shows +24%)
+
 INSERT INTO `item_latents` VALUES (28235,76,24,26,2);   -- Hachiya Kyahan: Dusk to dawn: MOVE_SPEED_GEAR_BONUS+25% (retail testing shows +24%)
 INSERT INTO `item_latents` VALUES (28256,76,24,26,2);   -- Hachiya Kyahan +1: Dusk to dawn: MOVE_SPEED_GEAR_BONUS+25% (retail testing shows +24%)
 INSERT INTO `item_latents` VALUES (28445,23,10,14,0);   -- Shetal Stone ATT +10 No Food Active

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -785,7 +785,7 @@ INSERT INTO `item_latents` VALUES (14085,369,1,26,0);    -- Daytime: Adds "Refre
 INSERT INTO `item_latents` VALUES (14085,370,1,26,1);    -- Nighttime: Adds "Regen" effect
 
 -- Ninja Kyahan
-INSERT INTO `item_latents` VALUES (14101,76,25,26,1);   -- MOVE_SPEED_GEAR_BONUS %25 during nighttime
+INSERT INTO `item_latents` VALUES (14101,76,24,26,1);   -- MOVE_SPEED_GEAR_BONUS %25 during nighttime (retail testing shows +24%)
 
 INSERT INTO `item_latents` VALUES (14122,68,8,52,6);     -- Kyahan: Evasion +8 in Water weather
 
@@ -1210,7 +1210,7 @@ INSERT INTO `item_latents` VALUES (15318,68,2,29,0);
 INSERT INTO `item_latents` VALUES (15318,68,2,31,0);
 
 -- Caitiff's Socks
--- INSERT INTO `item_latents` VALUES (15324,???,1,2,25); -- Flee when HP <25% and TP <100%
+-- INSERT INTO `item_latents` VALUES (15324,???,1,2,25); -- ~10% chance of 100% Flee effect when taking phys dmg while HP <25% and TP <100%
 
 INSERT INTO `item_latents` VALUES (15328,370,2,13,11);
 
@@ -1224,7 +1224,7 @@ INSERT INTO `item_latents` VALUES (15345,384,300,1,75);  -- Haste+3% when HP > 7
 INSERT INTO `item_latents` VALUES (15346,384,400,1,75);  -- Haste+4% when HP > 75%
 
 -- Ninja Kyahan +1
-INSERT INTO `item_latents` VALUES (15364,76,25,26,2);   -- Dusk - Dawn: MOVE_SPEED_GEAR_BONUS +25%
+INSERT INTO `item_latents` VALUES (15364,76,24,26,2);   -- Dusk - Dawn: MOVE_SPEED_GEAR_BONUS +25% (retail testing shows +24%)
 
 -- Hachiman Hakama
 INSERT INTO `item_latents` VALUES (15392,24,7,7,1000);   -- Ranged Attack+7 while TP >=100%
@@ -2766,7 +2766,7 @@ INSERT INTO `item_latents` VALUES (23298,291,16,13,420); -- Hattori Hakama +2: E
 -- TODO: INSERT INTO `item_latents` VALUES (23301,??,750,13,457); -- Hashishin Tayt +2: EFFECT_EFFLUX: TP Bonus +750
 
 -- Hachiya Kyahan +2
-INSERT INTO `item_latents` VALUES (23320,76,25,26,2);   -- Dusk to dawn: MOVE_SPEED_GEAR_BONUS+25%
+INSERT INTO `item_latents` VALUES (23320,76,24,26,2);   -- Dusk to dawn: MOVE_SPEED_GEAR_BONUS+25% (retail testing shows +24%)
 
 INSERT INTO `item_latents` VALUES (23338,63,10,13,64);   -- Fallen's sollerets +2: STATUS_EFFECT_ACTIVE: EFFECT_LAST_RESORT: DEFP: 10
 
@@ -2781,7 +2781,7 @@ INSERT INTO `item_latents` VALUES (23350,399,17,52,8);   -- Pedagogy Loafers+2: 
 
 INSERT INTO `item_latents` VALUES (23532,518,15,13,57); -- WAR AF2 119 +3 Hands Defender Shield Rate +15
 -- Hachiya Kyahan +3
-INSERT INTO `item_latents` VALUES (23655,76,25,26,2);   -- Dusk to dawn: MOVE_SPEED_GEAR_BONUS+25%
+INSERT INTO `item_latents` VALUES (23655,76,24,26,2);   -- Dusk to dawn: MOVE_SPEED_GEAR_BONUS+25% (retail testing shows +24%)
 
 INSERT INTO `item_latents` VALUES (23685,399,18,52,1);   -- Pedagogy Loafers+3: Weather: Enhances Celerity and Alacrity Effect +18% (FIRE)
 INSERT INTO `item_latents` VALUES (23685,399,18,52,2);   -- Pedagogy Loafers+3: Weather: Enhances Celerity and Alacrity Effect +18% (EARTH)
@@ -2821,8 +2821,8 @@ INSERT INTO `item_latents` VALUES (27367,399,16,52,5);   -- Pedagogy Loafers+1: 
 INSERT INTO `item_latents` VALUES (27367,399,16,52,6);   -- Pedagogy Loafers+1: Weather: Enhances Celerity and Alacrity Effect +16% (THUNDER)
 INSERT INTO `item_latents` VALUES (27367,399,16,52,7);   -- Pedagogy Loafers+1: Weather: Enhances Celerity and Alacrity Effect +16% (LIGHT)
 INSERT INTO `item_latents` VALUES (27367,399,16,52,8);   -- Pedagogy Loafers+1: Weather: Enhances Celerity and Alacrity Effect +16% (DARK)
-INSERT INTO `item_latents` VALUES (28235,76,25,26,2);   -- Hachiya Kyahan: Dusk to dawn: MOVE_SPEED_GEAR_BONUS+25%
-INSERT INTO `item_latents` VALUES (28256,76,25,26,2);   -- Hachiya Kyahan +1: Dusk to dawn: MOVE_SPEED_GEAR_BONUS+25%
+INSERT INTO `item_latents` VALUES (28235,76,24,26,2);   -- Hachiya Kyahan: Dusk to dawn: MOVE_SPEED_GEAR_BONUS+25% (retail testing shows +24%)
+INSERT INTO `item_latents` VALUES (28256,76,24,26,2);   -- Hachiya Kyahan +1: Dusk to dawn: MOVE_SPEED_GEAR_BONUS+25% (retail testing shows +24%)
 INSERT INTO `item_latents` VALUES (28445,23,10,14,0);   -- Shetal Stone ATT +10 No Food Active
 INSERT INTO `item_latents` VALUES (28445,68,10,14,0);   -- Shetal Stone EVA +10 No Food Active
 

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -35667,8 +35667,8 @@ INSERT INTO `item_mods` VALUES (17812,8,1);  -- STR: 1
 INSERT INTO `item_mods` VALUES (17812,11,1); -- AGI: 1
 
 -- Raikiri
-INSERT INTO `item_mods` VALUES (17814,25,3);  -- ACC: 3
-INSERT INTO `item_mods` VALUES (17814,75,-5); -- MOVE_SPEED_STACKABLE: -5
+INSERT INTO `item_mods` VALUES (17814,25,3);   -- ACC: 3
+INSERT INTO `item_mods` VALUES (17814,75,-10); -- MOVE_SPEED_STACKABLE: -10
 
 -- Tachi Of Trials
 INSERT INTO `item_mods` VALUES (17815,2,20);  -- HP: 20

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -4149,6 +4149,7 @@ INSERT INTO `item_mods` VALUES (10961,2,50); -- HP: 50
 
 -- Lavalier +1
 INSERT INTO `item_mods` VALUES (10962,2,60); -- HP: 60
+-- INSERT INTO `item_mods` VALUES (10962,75,-10); -- MOVE_SPEED_STACKABLE: -10 (unconfirmed)
 
 -- Airmids Gorget
 INSERT INTO `item_mods` VALUES (10963,1,9);  -- DEF: 9
@@ -31448,7 +31449,7 @@ INSERT INTO `item_mods` VALUES (16344,9,5);   -- DEX: 5
 INSERT INTO `item_mods` VALUES (16344,11,5);  -- AGI: 5
 INSERT INTO `item_mods` VALUES (16344,25,5);  -- ACC: 5
 INSERT INTO `item_mods` VALUES (16344,26,5);  -- RACC: 5
-INSERT INTO `item_mods` VALUES (16344,75,-5); -- MOVE_SPEED_STACKABLE: -5
+INSERT INTO `item_mods` VALUES (16344,75,-4); -- MOVE_SPEED_STACKABLE: -4
 
 -- Magus Shalwar +1
 INSERT INTO `item_mods` VALUES (16345,1,34);   -- DEF: 34
@@ -37617,7 +37618,7 @@ INSERT INTO `item_mods` VALUES (18518,25,5); -- ACC: 5
 
 -- Oneiros Axe
 INSERT INTO `item_mods` VALUES (18519,73,-15); -- STORETP: -15
-INSERT INTO `item_mods` VALUES (18519,75,-5);  -- MOVE_SPEED_STACKABLE: -5
+INSERT INTO `item_mods` VALUES (18519,75,-10);  -- MOVE_SPEED_STACKABLE: -10
 
 -- Laceratrice
 INSERT INTO `item_mods` VALUES (18520,165,4); -- CRITHITRATE: 4

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -262,7 +262,7 @@ uint8 CBattleEntity::GetSpeed()
     float weightFactor = std::clamp<float>(1.0f - static_cast<float>(getMod(Mod::MOVE_SPEED_WEIGHT_PENALTY)) / 100.0f, 0.1f, 1.0f);
 
     // Flee.
-    float fleeFactor = std::clamp<float>(1.0f + static_cast<float>(getMod(Mod::MOVE_SPEED_FLEE)) / 100.0f, 1.0f, 2.0f);
+    float fleeFactor = std::clamp<float>(1.0f + static_cast<float>(getMod(Mod::MOVE_SPEED_FLEE)) / 10000.0f, 1.0f, 2.0f);
 
     // Cheer KI's
     float cheerFactor = (99.0f + static_cast<float>(getMod(Mod::MOVE_SPEED_CHEER))) / 99.0f;

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -126,6 +126,26 @@ bool CBattleEntity::isInAssault()
     {
         return loc.zone->GetTypeMask() & ZONE_TYPE::INSTANCED &&
                (loc.zone->GetRegionID() >= REGION_TYPE::WEST_AHT_URHGAN && loc.zone->GetRegionID() <= REGION_TYPE::ALZADAAL);
+    }
+    return false;
+}
+
+bool CBattleEntity::isInAdoulin()
+{
+    if (loc.zone != nullptr)
+    {
+        ZONEID zoneid = loc.zone->GetID();
+        switch (zoneid)
+        {
+            case ZONEID::ZONE_WESTERN_ADOULIN:
+            case ZONEID::ZONE_EASTERN_ADOULIN:
+            case ZONEID::ZONE_MOG_GARDEN:
+            case ZONEID::ZONE_SILVER_KNIFE:
+            case ZONEID::ZONE_CELENNIA_MEMORIAL_LIBRARY:
+                return true;
+            default:
+                break;
+        }
     }
     return false;
 }

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -567,6 +567,7 @@ public:
 
     bool isDead();
     bool isAlive();
+    bool isInAdoulin();
     bool isInAssault();
     bool isInDynamis();
     bool isInMogHouse();

--- a/src/map/latent_effect.h
+++ b/src/map/latent_effect.h
@@ -92,9 +92,10 @@ enum class LATENT : uint16
     VS_FAMILY              = 60, // Vs. Specific Family ID (e.g. Vs. Korrigan: Accuracy+3)
     VS_SUPERFAMILY         = 61, // Vs. Specific SuperFamily ID (e.g. Vs. Mandragora: Accuracy+3)
     MAINJOB                = 62, // mainjob - PARAM: JOBTYPE
+    IN_ADOULIN             = 63, //
 };
 
-#define MAX_LATENTEFFECTID 63
+#define MAX_LATENTEFFECTID 64
 
 /************************************************************************
  *                                                                       *

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -622,6 +622,7 @@ void CLatentEffectContainer::CheckLatentsZone()
             case LATENT::ZONE:
             case LATENT::IN_ASSAULT:
             case LATENT::IN_DYNAMIS:
+            case LATENT::IN_ADOULIN:
             case LATENT::WEATHER_CONDITION:
             case LATENT::WEATHER_ELEMENT:
             case LATENT::NATION_CONTROL:
@@ -1144,6 +1145,9 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect, bo
             break;
         case LATENT::IN_ASSAULT:
             expression = m_POwner->isInAssault();
+            break;
+        case LATENT::IN_ADOULIN:
+            expression = m_POwner->isInAdoulin();
             break;
         case LATENT::FOOD_ACTIVE:
             expression = m_POwner->StatusEffectContainer->HasStatusEffect(EFFECT_FOOD) &&


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes some issues with various speed related things:

- Fix `MOVE_SPEED_STACKABLE` being cast as unsigned. Need this for gear reductions.
- Use signed int for intermediate calculations. Also bumped the size up so we can work with the full unsigned 8-bit range before clamping.
- Quickening effect should only apply if speed > 0 based on retail research.
- Adjust Flee mod for more precision. Hermes Quencher was found to be +87.5% flee effect through retail testing.
- Adjusts various speed related mods and latents based on retail testing. Councilor's Garb and Ninja Kyahan were found to be +24% movement speed, so I extrapolated that to all +25% gear.
- Add new latent for Councilor's Garb. This will likely need some kind of adjustment when Alliance Shirt +1 is implemented as that one doesn't work in Mog Garden.

## Steps to test these changes

You need an addon to either show your speed or capture and display incoming packet 0x037.

```
!changejob cor 99
!additem 5497
/item "Bolter's Die" <me>
/ja "Bolter's Roll" <me>
```

Note the increase in speed.

```
!changejob war 99
!changesjob thf 49
!additem 18519
!additem 11817
!additem 12573
!additem 12701
!additem 16344
!additem 10372
!additem 10980
```

Equip all of that gear. That should bring you to -4 speed, plus whatever that noted increase from Bolter's Roll was.

```
/ja Flee <me>
```

Note your speed should have decreased.

```
!additem 27923
!zone 256
```

Equip Councilor's Garb, note speed increase,