### PR TITLE
[core] Move some character cleanup from zone into char destructor

### DIFF
--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -1126,49 +1126,6 @@ void CZone::CharZoneOut(CCharEntity* PChar)
     moduleutils::OnCharZoneOut(PChar);
     luautils::OnZoneOut(PChar);
 
-    if (PChar->m_LevelRestriction != 0)
-    {
-        if (PChar->PParty)
-        {
-            if (PChar->PParty->GetSyncTarget() == PChar || PChar->PParty->GetLeader() == PChar)
-            {
-                PChar->PParty->SetSyncTarget("", 551);
-            }
-            if (PChar->PParty->GetSyncTarget() != nullptr)
-            {
-                uint8 count = 0;
-                for (uint32 i = 0; i < PChar->PParty->members.size(); ++i)
-                {
-                    if (PChar->PParty->members.at(i) != PChar && PChar->PParty->members.at(i)->getZone() == PChar->PParty->GetSyncTarget()->getZone())
-                    {
-                        count++;
-                    }
-                }
-                if (count < 2) // 3, because one is zoning out - thus at least 2 will be left
-                {
-                    PChar->PParty->SetSyncTarget("", 552);
-                }
-            }
-        }
-        PChar->StatusEffectContainer->DelStatusEffectSilent(EFFECT_LEVEL_SYNC);
-        PChar->StatusEffectContainer->DelStatusEffectSilent(EFFECT_LEVEL_RESTRICTION);
-    }
-
-    if (PChar->PLinkshell1 != nullptr)
-    {
-        PChar->PLinkshell1->DelMember(PChar);
-    }
-
-    if (PChar->PLinkshell2 != nullptr)
-    {
-        PChar->PLinkshell2->DelMember(PChar);
-    }
-
-    if (PChar->PUnityChat != nullptr)
-    {
-        PChar->PUnityChat->DelMember(PChar);
-    }
-
     if (PChar->PTreasurePool != nullptr) // TODO: Condition for eliminating problems with MobHouse, we need to solve it once and for all!
     {
         PChar->PTreasurePool->DelMember(PChar);
@@ -1182,13 +1139,6 @@ void CZone::CharZoneOut(CCharEntity* PChar)
         m_TreasurePool = new CTreasurePool(TREASUREPOOL_ZONE);
     }
 
-    PChar->ClearTrusts(); // trusts don't survive zone lines
-
-    if (PChar->isDead())
-    {
-        charutils::SaveDeathTime(PChar);
-    }
-
     PChar->loc.zone = nullptr;
 
     if (PChar->status == STATUS_TYPE::SHUTDOWN)
@@ -1199,40 +1149,6 @@ void CZone::CharZoneOut(CCharEntity* PChar)
     {
         PChar->loc.prevzone = m_zoneID;
     }
-
-    PChar->SpawnPCList.clear();
-    PChar->SpawnNPCList.clear();
-    PChar->SpawnMOBList.clear();
-    PChar->SpawnPETList.clear();
-    PChar->SpawnTRUSTList.clear();
-
-    if (PChar->PParty && PChar->loc.destination != 0 && PChar->m_moghouseID == 0)
-    {
-        uint8 data[4]{};
-
-        if (PChar->PParty->m_PAlliance)
-        {
-            ref<uint32>(data, 0) = PChar->PParty->m_PAlliance->m_AllianceID;
-            message::send(MSG_ALLIANCE_RELOAD, data, sizeof data, nullptr);
-        }
-        else
-        {
-            ref<uint32>(data, 0) = PChar->PParty->GetPartyID();
-            message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
-        }
-    }
-
-    if (PChar->PParty)
-    {
-        PChar->PParty->PopMember(PChar);
-    }
-
-    if (PChar->PAutomaton)
-    {
-        PChar->PAutomaton->PMaster = nullptr;
-    }
-
-    charutils::WriteHistory(PChar);
 }
 
 bool CZone::IsZoneActive() const


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Move some character cleanup that was in CZone for some reason into CCharEntity's destructor
This also fixes a rare corner case crash wherein a char was not inserted into a zone but had linkshells/unity chat etc

## Steps to test these changes

Zone in/out, with and without a party, with and without a pet, as PUP or not PUP, with and without level sync, etc and see no new issues
