### PR TITLE
[blue] Fix magical blue spells damage error due to nil parameter

### DIFF
--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -425,7 +425,8 @@ xi.spells.blue.applySpellDamage = function(caster, target, spell, dmg, params, t
     dmg                 = dmg * xi.settings.main.BLUE_POWER
     local attackType    = params.attackType or xi.attackType.NONE
     local damageType    = params.damageType or xi.damageType.NONE
-    local extraTPGained = xi.combat.tp.calculateTPGainOnMagicalDamage(dmg, caster, target) * math.max(params.tphitslanded - 1, 0) -- Calculate extra TP gained from multihits. takeSpellDamage accounts for one already.
+    local tpHits        = params.tphitslanded or 0
+    local extraTPGained = xi.combat.tp.calculateTPGainOnMagicalDamage(dmg, caster, target) * math.max(tpHits - 1, 0) -- Calculate extra TP gained from multihits. takeSpellDamage accounts for one already.
 
     -- handle MDT, One For All, Liement
     if attackType == xi.attackType.MAGICAL then


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes an issue with tpHitsLanded being nil and having an arithmetic performed on them.
This, however, doesnt imply said parameter should ever be nil in the first place, but, for the time being, this allows magical spells to function.

Close #6289 

## Steps to test these changes

Cast blue magical spells. See things go bum.
