### PR TITLE
[Magic] Retire some functions and skip certain damage multipliers when absorbing magic

### DIFF
--- a/scripts/actions/abilities/earth_shot.lua
+++ b/scripts/actions/abilities/earth_shot.lua
@@ -37,7 +37,7 @@ abilityObject.onUseAbility = function(player, target, ability, action)
 
     local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
     dmg            = dmg * applyResistanceAbility(player, target, xi.element.EARTH, xi.skill.NONE, bonusAcc)
-    dmg            = adjustForTarget(target, dmg, xi.element.EARTH)
+    dmg            = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.EARTH)
 
     params.targetTPMult = 0 -- Quick Draw does not feed TP
     dmg = xi.ability.takeDamage(target, player, params, true, dmg, xi.attackType.MAGICAL, xi.damageType.EARTH, xi.slot.RANGED, 1, 0, 0, 0, action, nil)

--- a/scripts/actions/abilities/fire_shot.lua
+++ b/scripts/actions/abilities/fire_shot.lua
@@ -37,7 +37,7 @@ abilityObject.onUseAbility = function(player, target, ability, action)
 
     local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
     dmg            = dmg * applyResistanceAbility(player, target, xi.element.FIRE, xi.skill.NONE, bonusAcc)
-    dmg            = adjustForTarget(target, dmg, xi.element.FIRE)
+    dmg            = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.FIRE)
 
     params.targetTPMult = 0 -- Quick Draw does not feed TP
     dmg                 = xi.ability.takeDamage(target, player, params, true, dmg, xi.attackType.MAGICAL, xi.damageType.FIRE, xi.slot.RANGED, 1, 0, 0, 0, action, nil)

--- a/scripts/actions/abilities/ice_shot.lua
+++ b/scripts/actions/abilities/ice_shot.lua
@@ -37,7 +37,7 @@ abilityObject.onUseAbility = function(player, target, ability, action)
 
     local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
     dmg            = dmg * applyResistanceAbility(player, target, xi.element.ICE, xi.skill.NONE, bonusAcc)
-    dmg            = adjustForTarget(target, dmg, xi.element.ICE)
+    dmg            = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.ICE)
 
     params.targetTPMult = 0 -- Quick Draw does not feed TP
     dmg                 = xi.ability.takeDamage(target, player, params, true, dmg, xi.attackType.MAGICAL, xi.damageType.ICE, xi.slot.RANGED, 1, 0, 0, 0, action, nil)

--- a/scripts/actions/abilities/thunder_shot.lua
+++ b/scripts/actions/abilities/thunder_shot.lua
@@ -37,7 +37,7 @@ abilityObject.onUseAbility = function(player, target, ability, action)
 
     local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
     dmg            = dmg * applyResistanceAbility(player, target, xi.element.THUNDER, xi.skill.NONE, bonusAcc)
-    dmg            = adjustForTarget(target, dmg, xi.element.THUNDER)
+    dmg            = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.THUNDER)
 
     params.targetTPMult = 0 -- Quick Draw does not feed TP
     dmg                 = xi.ability.takeDamage(target, player, params, true, dmg, xi.attackType.MAGICAL, xi.damageType.THUNDER, xi.slot.RANGED, 1, 0, 0, 0, action, nil)

--- a/scripts/actions/abilities/water_shot.lua
+++ b/scripts/actions/abilities/water_shot.lua
@@ -37,7 +37,7 @@ abilityObject.onUseAbility = function(player, target, ability, action)
 
     local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
     dmg            = dmg * applyResistanceAbility(player, target, xi.element.WATER, xi.skill.NONE, bonusAcc)
-    dmg            = adjustForTarget(target, dmg, xi.element.WATER)
+    dmg            = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.WATER)
 
     params.targetTPMult = 0 -- Quick Draw does not feed TP
     dmg                 = xi.ability.takeDamage(target, player, params, true, dmg, xi.attackType.MAGICAL, xi.damageType.WATER, xi.slot.RANGED, 1, 0, 0, 0, action, nil)

--- a/scripts/actions/abilities/wind_shot.lua
+++ b/scripts/actions/abilities/wind_shot.lua
@@ -37,7 +37,7 @@ abilityObject.onUseAbility = function(player, target, ability, action)
 
     local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
     dmg            = dmg * applyResistanceAbility(player, target, xi.element.WIND, xi.skill.NONE, bonusAcc)
-    dmg            = adjustForTarget(target, dmg, xi.element.WIND)
+    dmg            = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.WIND)
 
     params.targetTPMult = 0 -- Quick Draw does not feed TP
     dmg                 = xi.ability.takeDamage(target, player, params, true, dmg, xi.attackType.MAGICAL, xi.damageType.WIND, xi.slot.RANGED, 1, 0, 0, 0, action, nil)

--- a/scripts/actions/mobskills/gravitic_horn.lua
+++ b/scripts/actions/mobskills/gravitic_horn.lua
@@ -24,7 +24,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         damage = math.floor(damage * 0.95)
     end
 
-    damage = math.floor(damage * getElementalDamageReduction(target, xi.element.WIND))
+    damage = math.floor(damage * xi.spells.damage.calculateSDT(target, xi.element.WIND))
     damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
 
     target:takeDamage(damage, mob, xi.attackType.MAGICAL, xi.damageType.WIND)

--- a/scripts/actions/spells/black/absorb-tp.lua
+++ b/scripts/actions/spells/black/absorb-tp.lua
@@ -26,7 +26,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     dmg = addBonuses(caster, spell, target, dmg)
 
     --add in target adjustment
-    dmg = adjustForTarget(target, dmg, spell:getElement())
+    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, spell:getElement())
 
     --add in final adjustments
     if resist <= 0.125 then

--- a/scripts/actions/spells/black/aspir.lua
+++ b/scripts/actions/spells/black/aspir.lua
@@ -30,7 +30,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     --add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
     dmg = addBonuses(caster, spell, target, dmg)
     --add in target adjustment
-    dmg = adjustForTarget(target, dmg, spell:getElement())
+    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, spell:getElement())
     --add in final adjustments
 
     dmg = dmg * xi.settings.main.DARK_POWER

--- a/scripts/actions/spells/black/aspir_ii.lua
+++ b/scripts/actions/spells/black/aspir_ii.lua
@@ -28,7 +28,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     --add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
     dmg = addBonuses(caster, spell, target, dmg)
     --add in target adjustment
-    dmg = adjustForTarget(target, dmg, spell:getElement())
+    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, spell:getElement())
     --add in final adjustments
 
     dmg = dmg * xi.settings.main.DARK_POWER

--- a/scripts/actions/spells/black/bio.lua
+++ b/scripts/actions/spells/black/bio.lua
@@ -32,7 +32,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     -- Add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
     dmg = addBonuses(caster, spell, target, dmg)
     -- Add in target adjustment
-    dmg = adjustForTarget(target, dmg, spell:getElement())
+    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, spell:getElement())
     -- Add in final adjustments including the actual damage dealt
     local final = finalMagicAdjustments(caster, target, spell, dmg)
 

--- a/scripts/actions/spells/black/bio_ii.lua
+++ b/scripts/actions/spells/black/bio_ii.lua
@@ -32,7 +32,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     -- Add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
     dmg = addBonuses(caster, spell, target, dmg)
     -- Add in target adjustment
-    dmg = adjustForTarget(target, dmg, spell:getElement())
+    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, spell:getElement())
     -- Add in final adjustments including the actual damage dealt
     local final = finalMagicAdjustments(caster, target, spell, dmg)
 

--- a/scripts/actions/spells/black/bio_iii.lua
+++ b/scripts/actions/spells/black/bio_iii.lua
@@ -32,7 +32,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     -- Add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
     dmg = addBonuses(caster, spell, target, dmg)
     -- Add in target adjustment
-    dmg = adjustForTarget(target, dmg, spell:getElement())
+    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, spell:getElement())
     -- Add in final adjustments including the actual damage dealt
     local final = finalMagicAdjustments(caster, target, spell, dmg)
 

--- a/scripts/actions/spells/black/bio_iv.lua
+++ b/scripts/actions/spells/black/bio_iv.lua
@@ -31,7 +31,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     -- Add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
     dmg = addBonuses(caster, spell, target, dmg)
     -- Add in target adjustment
-    dmg = adjustForTarget(target, dmg, spell:getElement())
+    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, spell:getElement())
     -- Add in final adjustments including the actual damage dealt
     local final = finalMagicAdjustments(caster, target, spell, dmg)
 

--- a/scripts/actions/spells/black/drain.lua
+++ b/scripts/actions/spells/black/drain.lua
@@ -36,7 +36,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     --add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
     dmg = addBonuses(caster, spell, target, dmg)
     --add in target adjustment
-    dmg = adjustForTarget(target, dmg, spell:getElement())
+    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, spell:getElement())
 
     if dmg < 0 then
         dmg = 0

--- a/scripts/actions/spells/black/drain_ii.lua
+++ b/scripts/actions/spells/black/drain_ii.lua
@@ -36,7 +36,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     --add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
     dmg = addBonuses(caster, spell, target, dmg)
     --add in target adjustment
-    dmg = adjustForTarget(target, dmg, spell:getElement())
+    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, spell:getElement())
 
     if dmg < 0 then
         dmg = 0

--- a/scripts/actions/spells/black/impact.lua
+++ b/scripts/actions/spells/black/impact.lua
@@ -69,7 +69,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     -- Add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
     dmg = addBonuses(caster, spell, target, dmg)
     -- Add in target adjustment
-    dmg = adjustForTarget(target, dmg, spell:getElement())
+    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, spell:getElement())
     -- Add in final adjustments
     dmg = finalMagicAdjustments(caster, target, spell, dmg)
 

--- a/scripts/actions/spells/black/meteor.lua
+++ b/scripts/actions/spells/black/meteor.lua
@@ -31,7 +31,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     end
 
     --add in target adjustment
-    dmg = adjustForTarget(target, dmg, spell:getElement())
+    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, spell:getElement())
     --add in final adjustments
     dmg = finalMagicAdjustments(caster, target, spell, dmg)
     return dmg

--- a/scripts/actions/spells/white/dia.lua
+++ b/scripts/actions/spells/white/dia.lua
@@ -30,7 +30,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     -- Add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
     dmg = addBonuses(caster, spell, target, dmg)
     -- Add in target adjustment
-    dmg = adjustForTarget(target, dmg, spell:getElement())
+    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, spell:getElement())
     -- Add in final adjustments including the actual damage dealt
     local final = finalMagicAdjustments(caster, target, spell, dmg)
 

--- a/scripts/actions/spells/white/dia_ii.lua
+++ b/scripts/actions/spells/white/dia_ii.lua
@@ -30,7 +30,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     -- Add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
     dmg = addBonuses(caster, spell, target, dmg)
     -- Add in target adjustment
-    dmg = adjustForTarget(target, dmg, spell:getElement())
+    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, spell:getElement())
     -- Add in final adjustments including the actual damage dealt
     local final = finalMagicAdjustments(caster, target, spell, dmg)
 

--- a/scripts/actions/spells/white/dia_iii.lua
+++ b/scripts/actions/spells/white/dia_iii.lua
@@ -30,7 +30,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     -- Add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
     dmg = addBonuses(caster, spell, target, dmg)
     -- Add in target adjustment
-    dmg = adjustForTarget(target, dmg, spell:getElement())
+    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, spell:getElement())
     -- Add in final adjustments including the actual damage dealt
     local final = finalMagicAdjustments(caster, target, spell, dmg)
 

--- a/scripts/actions/spells/white/diaga.lua
+++ b/scripts/actions/spells/white/diaga.lua
@@ -30,7 +30,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     -- Add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
     dmg = addBonuses(caster, spell, target, dmg)
     -- Add in target adjustment
-    dmg = adjustForTarget(target, dmg, spell:getElement())
+    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, spell:getElement())
     -- Add in final adjustments including the actual damage dealt
     local final = finalMagicAdjustments(caster, target, spell, dmg)
 

--- a/scripts/actions/spells/white/diaga_ii.lua
+++ b/scripts/actions/spells/white/diaga_ii.lua
@@ -30,7 +30,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     -- Add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
     dmg = addBonuses(caster, spell, target, dmg)
     -- Add in target adjustment
-    dmg = adjustForTarget(target, dmg, spell:getElement())
+    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, spell:getElement())
     -- Add in final adjustments including the actual damage dealt
     local final = finalMagicAdjustments(caster, target, spell, dmg)
 

--- a/scripts/actions/spells/white/diaga_iii.lua
+++ b/scripts/actions/spells/white/diaga_iii.lua
@@ -30,7 +30,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     -- Add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
     dmg = addBonuses(caster, spell, target, dmg)
     -- Add in target adjustment
-    dmg = adjustForTarget(target, dmg, spell:getElement())
+    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, spell:getElement())
     -- Add in final adjustments including the actual damage dealt
     local final = finalMagicAdjustments(caster, target, spell, dmg)
 

--- a/scripts/globals/additional_effects.lua
+++ b/scripts/globals/additional_effects.lua
@@ -98,7 +98,7 @@ xi.additionalEffect.calcDamage = function(attacker, element, defender, damage)
     params.includemab = false -- May possibly need to include mab on case by case basis, further tests needed
     damage            = addBonusesAbility(attacker, element, defender, damage, params)
     damage            = damage * applyResistanceAddEffect(attacker, defender, element, 0)
-    damage            = adjustForTarget(defender, damage, element)
+    damage            = damage * xi.spells.damage.calculateNukeAbsorbOrNullify(defender, element)
     -- Todo: make sure day/weather/affinity bonuses tie in right here
     damage            = finalMagicNonSpellAdjustments(attacker, defender, element, damage)
 

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -397,7 +397,7 @@ xi.spells.blue.useBreathSpell = function(caster, target, spell, params, isConal)
     dmg = dmg * (1 + correlationMultiplier)
 
     -- Monster elemental adjustments
-    local mobEleAdjustments = getElementalDamageReduction(target, spell:getElement())
+    local mobEleAdjustments = xi.spells.damage.calculateSDT(target, spell:getElement())
     dmg = dmg * mobEleAdjustments
 
     -- Modifiers

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -347,7 +347,7 @@ xi.spells.blue.useDrainSpell = function(caster, target, spell, params, softCap, 
 
     dmg = dmg * applyResistanceEffect(caster, target, spell, params)
     dmg = addBonuses(caster, spell, target, dmg)
-    dmg = adjustForTarget(target, dmg, spell:getElement())
+    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, spell:getElement())
 
     -- limit damage
     if target:isUndead() then

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -246,22 +246,6 @@ function isValidHealTarget(caster, target)
             target:getObjType() == xi.objType.FELLOW)
 end
 
--- USED FOR DAMAGING MAGICAL SPELLS. Stage 3 of Calculating Magic Damage on wiki
--- Reduces damage ifit resists.
---
--- Output:
--- The factor to multiply down damage (1/2 1/4 1/8 1/16) - In this format so this func can be used for enfeebs on duration.
--- USED FOR Status Effect Enfeebs (blind, slow, para, etc.)
--- Output:
--- The factor to multiply down duration (1/2 1/4 1/8 1/16)
---[[
-local params = {}
-params.attribute = $2
-params.skillType = $3
-params.bonus = $4
-params.effect = $5
-]]
-
 -- TODO: This must be destroyed
 function applyResistanceEffect(actor, target, spell, params)
     local spellFamily = spell:getSpellFamily() or 0
@@ -313,42 +297,6 @@ function applyResistanceAddEffect(actor, target, element, bonusMacc)
     local resistRate   = xi.combat.magicHitRate.calculateResistRate(actor, target, xi.skill.NONE, element, magicHitRate, 0)
 
     return resistRate
-end
-
--- Returns the amount of resistance the target has to the given effect
-local effectToResistanceMod =
-{
-    [xi.effect.SLEEP_I      ] = xi.mod.SLEEPRES,
-    [xi.effect.SLEEP_II     ] = xi.mod.SLEEPRES,
-    [xi.effect.LULLABY      ] = xi.mod.SLEEPRES,
-    [xi.effect.POISON       ] = xi.mod.POISONRES,
-    [xi.effect.PARALYSIS    ] = xi.mod.PARALYZERES,
-    [xi.effect.BLINDNESS    ] = xi.mod.BLINDRES,
-    [xi.effect.SILENCE      ] = xi.mod.SILENCERES,
-    [xi.effect.PLAGUE       ] = xi.mod.VIRUSRES,
-    [xi.effect.DISEASE      ] = xi.mod.VIRUSRES,
-    [xi.effect.PETRIFICATION] = xi.mod.PETRIFYRES,
-    [xi.effect.BIND         ] = xi.mod.BINDRES,
-    [xi.effect.CURSE_I      ] = xi.mod.CURSERES,
-    [xi.effect.CURSE_II     ] = xi.mod.CURSERES,
-    [xi.effect.BANE         ] = xi.mod.CURSERES,
-    [xi.effect.WEIGHT       ] = xi.mod.GRAVITYRES,
-    [xi.effect.SLOW         ] = xi.mod.SLOWRES,
-    [xi.effect.ELEGY        ] = xi.mod.SLOWRES,
-    [xi.effect.STUN         ] = xi.mod.STUNRES,
-    [xi.effect.CHARM_I      ] = xi.mod.CHARMRES,
-    [xi.effect.CHARM_II     ] = xi.mod.CHARMRES,
-    [xi.effect.AMNESIA      ] = xi.mod.AMNESIARES,
-}
-
-xi.magic.getEffectResistance = function(target, effectId)
-    local statusResistance = target:getMod(xi.mod.STATUSRES)
-
-    if effectToResistanceMod[effectId] then
-        statusResistance = statusResistance + target:getMod(effectToResistanceMod[effectId])
-    end
-
-    return statusResistance
 end
 
 function finalMagicAdjustments(caster, target, spell, dmg)

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -27,7 +27,6 @@ xi.magic.dayElement =
 -- Tables by element
 -----------------------------------
 
-local strongAffinityDmg      = { xi.mod.FIRE_AFFINITY_DMG,     xi.mod.ICE_AFFINITY_DMG,     xi.mod.WIND_AFFINITY_DMG,      xi.mod.EARTH_AFFINITY_DMG,     xi.mod.THUNDER_AFFINITY_DMG,       xi.mod.WATER_AFFINITY_DMG,      xi.mod.LIGHT_AFFINITY_DMG,  xi.mod.DARK_AFFINITY_DMG }
 local strongAffinityAcc      = { xi.mod.FIRE_AFFINITY_ACC,     xi.mod.ICE_AFFINITY_ACC,     xi.mod.WIND_AFFINITY_ACC,      xi.mod.EARTH_AFFINITY_ACC,     xi.mod.THUNDER_AFFINITY_ACC,       xi.mod.WATER_AFFINITY_ACC,      xi.mod.LIGHT_AFFINITY_ACC,  xi.mod.DARK_AFFINITY_ACC }
 xi.magic.resistMod           = { xi.mod.FIRE_MEVA,             xi.mod.ICE_MEVA,             xi.mod.WIND_MEVA,              xi.mod.EARTH_MEVA,             xi.mod.THUNDER_MEVA,               xi.mod.WATER_MEVA,              xi.mod.LIGHT_MEVA,          xi.mod.DARK_MEVA }
 xi.magic.specificDmgTakenMod = { xi.mod.FIRE_SDT,              xi.mod.ICE_SDT,              xi.mod.WIND_SDT,               xi.mod.EARTH_SDT,              xi.mod.THUNDER_SDT,                xi.mod.WATER_SDT,               xi.mod.LIGHT_SDT,           xi.mod.DARK_SDT }
@@ -53,12 +52,6 @@ local hardCap = 120 --guesstimated
 -----------------------------------
 -- Returns the staff bonus for the caster and spell.
 -----------------------------------
--- affinities that strengthen/weaken the index element
-local function AffinityBonusDmg(caster, ele)
-    local affinity = caster:getMod(strongAffinityDmg[ele])
-    local bonus = 1.00 + affinity * 0.05 -- 5% per level of affinity
-    return bonus
-end
 
 local function AffinityBonusAcc(caster, ele)
     local affinity = caster:getMod(strongAffinityAcc[ele])
@@ -404,7 +397,7 @@ end
 
 function addBonuses(caster, spell, target, dmg, params)
     local ele             = spell:getElement()
-    local affinityBonus   = AffinityBonusDmg(caster, ele)
+    local affinityBonus   = xi.spells.damage.calculateElementalStaffBonus(caster, ele)
     local magicDefense    = xi.spells.damage.calculateSDT(target, ele)
     local dayWeatherBonus = xi.spells.damage.calculateDayAndWeather(caster, spell:getID(), ele)
     local casterJob       = caster:getMainJob()
@@ -477,7 +470,7 @@ function addBonuses(caster, spell, target, dmg, params)
 end
 
 function addBonusesAbility(caster, ele, target, dmg, params)
-    local affinityBonus = AffinityBonusDmg(caster, ele)
+    local affinityBonus = xi.spells.damage.calculateElementalStaffBonus(caster, ele)
     dmg = math.floor(dmg * affinityBonus)
 
     local magicDefense = xi.spells.damage.calculateSDT(target, ele)

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -477,7 +477,7 @@ end
 function addBonuses(caster, spell, target, dmg, params)
     local ele             = spell:getElement()
     local affinityBonus   = AffinityBonusDmg(caster, ele)
-    local magicDefense    = getElementalDamageReduction(target, ele)
+    local magicDefense    = xi.spells.damage.calculateSDT(target, ele)
     local dayWeatherBonus = xi.spells.damage.calculateDayAndWeather(caster, spell:getID(), ele)
     local casterJob       = caster:getMainJob()
 
@@ -552,7 +552,7 @@ function addBonusesAbility(caster, ele, target, dmg, params)
     local affinityBonus = AffinityBonusDmg(caster, ele)
     dmg = math.floor(dmg * affinityBonus)
 
-    local magicDefense = getElementalDamageReduction(target, ele)
+    local magicDefense = xi.spells.damage.calculateSDT(target, ele)
     dmg = math.floor(dmg * magicDefense)
 
     local dayWeatherBonus = xi.spells.damage.calculateDayAndWeather(caster, 0, ele)
@@ -581,17 +581,6 @@ function addBonusesAbility(caster, ele, target, dmg, params)
     dmg = math.floor(dmg * mab)
 
     return dmg
-end
-
--- get elemental damage reduction
-function getElementalDamageReduction(target, element)
-    local defense = 1
-    if element > 0 then
-        defense = 1 - (target:getMod(xi.magic.specificDmgTakenMod[element]) / 10000)
-        return utils.clamp(defense, 0.0, 2.0)
-    end
-
-    return defense
 end
 
 function handleThrenody(caster, target, spell, basePower, baseDuration, modifier)

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -32,7 +32,6 @@ local strongAffinityAcc      = { xi.mod.FIRE_AFFINITY_ACC,     xi.mod.ICE_AFFINI
 xi.magic.resistMod           = { xi.mod.FIRE_MEVA,             xi.mod.ICE_MEVA,             xi.mod.WIND_MEVA,              xi.mod.EARTH_MEVA,             xi.mod.THUNDER_MEVA,               xi.mod.WATER_MEVA,              xi.mod.LIGHT_MEVA,          xi.mod.DARK_MEVA }
 xi.magic.specificDmgTakenMod = { xi.mod.FIRE_SDT,              xi.mod.ICE_SDT,              xi.mod.WIND_SDT,               xi.mod.EARTH_SDT,              xi.mod.THUNDER_SDT,                xi.mod.WATER_SDT,               xi.mod.LIGHT_SDT,           xi.mod.DARK_SDT }
 xi.magic.absorbMod           = { xi.mod.FIRE_ABSORB,           xi.mod.ICE_ABSORB,           xi.mod.WIND_ABSORB,            xi.mod.EARTH_ABSORB,           xi.mod.LTNG_ABSORB,                xi.mod.WATER_ABSORB,            xi.mod.LIGHT_ABSORB,        xi.mod.DARK_ABSORB }
-local nullMod                = { xi.mod.FIRE_NULL,             xi.mod.ICE_NULL,             xi.mod.WIND_NULL,              xi.mod.EARTH_NULL,             xi.mod.LTNG_NULL,                  xi.mod.WATER_NULL,              xi.mod.LIGHT_NULL,          xi.mod.DARK_NULL }
 local blmMerit               = { xi.merit.FIRE_MAGIC_POTENCY,  xi.merit.ICE_MAGIC_POTENCY,  xi.merit.WIND_MAGIC_POTENCY,   xi.merit.EARTH_MAGIC_POTENCY,  xi.merit.LIGHTNING_MAGIC_POTENCY,  xi.merit.WATER_MAGIC_POTENCY }
 xi.magic.barSpell            = { xi.effect.BARFIRE,            xi.effect.BARBLIZZARD,       xi.effect.BARAERO,             xi.effect.BARSTONE,            xi.effect.BARTHUNDER,              xi.effect.BARWATER }
 
@@ -400,25 +399,6 @@ function finalMagicNonSpellAdjustments(caster, target, ele, dmg)
     --  in the case that updating enmity is needed, do it manually after calling this
     -- target:updateEnmityFromDamage(caster, dmg)
 
-    return dmg
-end
-
--- TODO: Use new function for spell absorbtion or nullification
-function adjustForTarget(target, dmg, ele)
-    if ele <= 0 then
-        return dmg
-    end
-
-    if dmg > 0 and math.random(0, 99) < target:getMod(xi.magic.absorbMod[ele]) then
-        return -dmg
-    end
-
-    if math.random(0, 99) < target:getMod(nullMod[ele]) then
-        return 0
-    end
-
-    --Moved non element specific absorb and null mod checks to core
-    --TODO: update all lua calls to magicDmgTaken with appropriate element and remove this function
     return dmg
 end
 

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -35,29 +35,12 @@ local blmMerit               = { xi.merit.FIRE_MAGIC_POTENCY,  xi.merit.ICE_MAGI
 xi.magic.barSpell            = { xi.effect.BARFIRE,            xi.effect.BARBLIZZARD,       xi.effect.BARAERO,             xi.effect.BARSTONE,            xi.effect.BARTHUNDER,              xi.effect.BARWATER }
 
 -- USED FOR DAMAGING MAGICAL SPELLS (Stages 1 and 2 in Calculating Magic Damage on wiki)
---Calculates magic damage using the standard magic damage calc.
---Does NOT handle resistance.
--- Inputs:
--- dmg - The base damage of the spell
--- multiplier - The INT multiplier of the spell
--- skilltype - The skill ID of the spell.
--- atttype - The attribute type (usually xi.mod.INT , except for things like Banish which is xi.mod.MND)
--- hasMultipleTargetReduction - true ifdamage is reduced on AoE. False otherwise (e.g. Charged Whisker vs -ga3 spells)
---
--- Output:
--- The total damage, before resistance and before equipment (so no HQ staff bonus worked out here).
 local softCap = 60 --guesstimated
 local hardCap = 120 --guesstimated
 
 -----------------------------------
 -- Returns the staff bonus for the caster and spell.
 -----------------------------------
-
-local function AffinityBonusAcc(caster, ele)
-    local affinity = caster:getMod(strongAffinityAcc[ele])
-    local bonus = 0 + affinity * 10 -- 10 acc per level of affinity
-    return bonus
-end
 
 local function calculateMagicBurst(caster, spell, target, params)
     local burst           = 1
@@ -506,7 +489,7 @@ end
 
 function handleThrenody(caster, target, spell, basePower, baseDuration, modifier)
     -- Process resitances
-    local staff  = AffinityBonusAcc(caster, spell:getElement())
+    local staff  = caster:getMod(strongAffinityAcc[spell:getElement()]) * 10
     local params = {}
 
     params.attribute = xi.mod.CHR

--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -545,7 +545,7 @@ xi.mob.onAddEffect = function(mob, target, damage, effect, params)
 
                 power = addBonusesAbility(mob, ae.ele, target, power, ae.bonusAbilityParams)
                 power = power * applyResistanceAddEffect(mob, target, ae.ele, 0)
-                power = adjustForTarget(target, power, ae.ele)
+                power = power * xi.spells.damage.calculateNukeAbsorbOrNullify(target, ae.ele)
 
                 if ae.sub ~= xi.subEffect.TP_DRAIN and ae.sub ~= xi.subEffect.MP_DRAIN then
                     power = finalMagicNonSpellAdjustments(mob, target, ae.ele, power)

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -397,7 +397,7 @@ xi.mobskills.mobBreathMove = function(mob, target, skill, percent, base, element
     if element and element > 0 then
         -- no skill available, pass nil
         local resist  = xi.mobskills.applyPlayerResistance(mob, nil, target, mob:getStat(xi.mod.INT)-target:getStat(xi.mod.INT), 0, element)
-        local defense = getElementalDamageReduction(target, element)
+        local defense = xi.spells.damage.calculateSDT(target, element)
 
         damage = damage * resist * defense
     end

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -384,30 +384,25 @@ xi.spells.damage.calculateMagianAffinity = function()
 end
 
 -- Elemental Specific Damage Taken (Elemental SDT)
+-- SDT (Species/Specific Damage Taken) is a stat/mod present in mobs and players that applies a % to specific damage types.
+-- Each of the 8 elements has an SDT modifier (Modifiers 54 to 61. Check script(globals/status.lua)
+-- Mob elemental modifiers are populated by the values set in "mob_resistances.sql" (The database). SDT columns.
+-- The value of the modifiers are base 10000. Positive numbers mean less damage taken. Negative mean more damage taken.
+-- Examples:
+-- A value of 5000 -> 50% LESS damage taken.
+-- A value of -5000 -> 50% MORE damage taken.
+-- A word on SDT as understood in some wikis, even if they are refering to resistance and not actual SDT
+-- SDT under 50% applies a flat 1/2 *, which was for a long time confused with an additional resist tier, which, in reality, its an independent multiplier.
+-- This is understandable, because in a way, it is effectively a whole tier, but recent testing with skillchains/magic bursts after resist was removed from them, proved this.
+-- SDT affects magic burst damage, but never in a "negative" way.
+-- https://www.bg-wiki.com/ffxi/Resist for some SDT info.
+-- *perhaps this simply means there is a cap/clamp limiting it there.
 xi.spells.damage.calculateSDT = function(target, spellElement)
-    local sdt    = 1 -- The variable we want to calculate
-    local sdtMod = 0
+    local sdt = 1 -- The variable we want to calculate
 
     if spellElement > xi.element.NONE then
-        sdtMod = target:getMod(xi.combat.element.specificDmgTakenMod[spellElement])
-
-    -- SDT (Species/Specific Damage Taken) is a stat/mod present in mobs and players that applies a % to specific damage types.
-    -- Each of the 8 elements has an SDT modifier (Modifiers 54 to 61. Check script(globals/status.lua)
-    -- Mob elemental modifiers are populated by the values set in "mob_resistances.sql" (The database). SDT columns.
-    -- The value of the modifiers are base 10000. Positive numbers mean less damage taken. Negative mean more damage taken.
-    -- Examples:
-    -- A value of 5000 -> 50% LESS damage taken.
-    -- A value of -5000 -> 50% MORE damage taken.
-
-        sdt = (sdtMod / -10000) + 1
+        sdt = 1 - target:getMod(xi.combat.element.specificDmgTakenMod[spellElement]) / 10000
     end
-
-    -- A word on SDT as understood in some wikis, even if they are refering to resistance and not actual SDT
-    -- SDT under 50% applies a flat 1/2 *, which was for a long time confused with an additional resist tier, which, in reality, its an independent multiplier.
-    -- This is understandable, because in a way, it is effectively a whole tier, but recent testing with skillchains/magic bursts after resist was removed from them, proved this.
-    -- SDT affects magic burst damage, but never in a "negative" way.
-    -- https://www.bg-wiki.com/ffxi/Resist for some SDT info.
-    -- *perhaps this simply means there is a cap/clamp limiting it there.
 
     return utils.clamp(sdt, 0, 3)
 end

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -581,12 +581,7 @@ end
 -- SDT follow-up. This time for specific modifiers.
 -- Referred to on item as "Magic Damage Taken -%", "Damage Taken -%" (Ex. Defending Ring) and "Magic Damage Taken II -%" (Aegis)
 xi.spells.damage.calculateTMDA = function(target, spellElement)
-    local damageType                  = xi.damageType.ELEMENTAL + spellElement
-    local targetMagicDamageAdjustment = target:checkLiementAbsorb(damageType) -- Check for Liement.
-
-    if targetMagicDamageAdjustment < 0 then -- skip MDT/DT/MDTII etc for Liement if we absorb.
-        return targetMagicDamageAdjustment
-    end
+    local targetMagicDamageAdjustment = 1
 
     -- The values set for this modifiers are base 10000.
     -- -2500 in item_mods.sql means -25% damage recived.
@@ -773,7 +768,15 @@ xi.spells.damage.calculateAreaOfEffectResistance = function(target, spell)
 end
 
 xi.spells.damage.calculateNukeAbsorbOrNullify = function(target, spellElement)
-    local nukeAbsorbOrNullify    = 1
+    local nukeAbsorbOrNullify = 1
+    local liementFactor       = target:checkLiementAbsorb(xi.damageType.ELEMENTAL + spellElement) -- Check for Liement.
+
+    -- Absobtion by liement.
+    if liementFactor < 0 then
+        return liementFactor
+    end
+
+    -- Elemental damage.
     local absorbElementModValue  = 0
     local nullifyElementModValue = 0
 
@@ -920,7 +923,7 @@ end
 -- Spell Helper Function
 -----------------------------------
 xi.spells.damage.useDamageSpell = function(caster, target, spell)
-    local finalDamage  = 0 -- The variable we want to calculate
+    local finalDamage = 0 -- The variable we want to calculate
 
     -- Get Tabled Variables.
     local spellId      = spell:getID()
@@ -930,51 +933,65 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
     local statUsed     = pTable[spellId][stat]
     local bonusMacc    = pTable[spellId][bonusSpellMacc]
 
-    -- Variables/steps to calculate finalDamage.
-    local spellDamage                 = xi.spells.damage.calculateBaseDamage(caster, target, spellId, spellGroup, skillType, statUsed)
-    local multipleTargetReduction     = xi.spells.damage.calculateMTDR(spell)
-    local elementalStaffBonus         = xi.spells.damage.calculateElementalStaffBonus(caster, spellElement)
-    local magianAffinity              = xi.spells.damage.calculateMagianAffinity()
-    local sdt                         = xi.spells.damage.calculateSDT(target, spellElement)
-    local resist                      = xi.spells.damage.calculateResist(caster, target, spellGroup, skillType, spellElement, statUsed, bonusMacc)
-    local dayAndWeather               = xi.spells.damage.calculateDayAndWeather(caster, spellId, spellElement)
-    local magicBonusDiff              = xi.spells.damage.calculateMagicBonusDiff(caster, target, spellId, skillType, spellElement)
-    local targetMagicDamageAdjustment = xi.spells.damage.calculateTMDA(target, spellElement)
-    local divineSealMultiplier        = xi.spells.damage.calculateDivineSealMultiplier(caster, skillType)
-    local divineEmblemMultiplier      = xi.spells.damage.calculateDivineEmblemMultiplier(caster, skillType)
-    local ebullienceMultiplier        = xi.spells.damage.calculateEbullienceMultiplier(caster, spellGroup)
-    local skillTypeMultiplier         = xi.spells.damage.calculateSkillTypeMultiplier(skillType)
-    local ninSkillBonus               = xi.spells.damage.calculateNinSkillBonus(caster, spellId, skillType)
-    local ninFutaeBonus               = xi.spells.damage.calculateNinFutaeBonus(caster, skillType)
-    local ninjutsuMultiplier          = xi.spells.damage.calculateNinjutsuMultiplier(caster, target, skillType)
-    local undeadDivinePenalty         = xi.spells.damage.calculateUndeadDivinePenalty(target, skillType)
-    local scarletDeliriumMultiplier   = xi.spells.damage.calculateScarletDeliriumMultiplier(caster)
-    local helixMeritMultiplier        = xi.spells.damage.calculateHelixMeritMultiplier(caster, spellId)
-    local areaOfEffectResistance      = xi.spells.damage.calculateAreaOfEffectResistance(target, spell)
-    local nukeAbsorbOrNullify         = xi.spells.damage.calculateNukeAbsorbOrNullify(target, spellElement)
+    -- Calculate damage absobtion or nullification.
+    local nukeAbsorbOrNullify = xi.spells.damage.calculateNukeAbsorbOrNullify(target, spellElement)
 
-    -- Magic burst
-    local magicBurst      = 1
-    local magicBurstBonus = 1
+    -- Skip everything if we nullify the spell.
+    if nukeAbsorbOrNullify == 0 then
+        spell:setMsg(xi.msg.basic.MAGIC_RESIST)
 
-    -- If spell is NOT blue magic OR (if its blue magic AND has status effect)
-    if
-        spellGroup ~= xi.magic.spellGroup.BLUE or
-        (spellGroup == xi.magic.spellGroup.BLUE and
-        (caster:hasStatusEffect(xi.effect.BURST_AFFINITY) or
-        caster:hasStatusEffect(xi.effect.AZURE_LORE)))
-    then
-        local _, skillchainCount = xi.magicburst.formMagicBurst(spellElement, target) -- External function. Not present in magic.lua.
+        return 0
+    end
 
-        if skillchainCount > 0 then
-            magicBurst      = xi.spells.damage.calculateIfMagicBurst(target, spellElement, skillchainCount)
-            magicBurstBonus = xi.spells.damage.calculateIfMagicBurstBonus(caster, target, spellId, spellElement)
+    -- Skip resistances, magic damage adjustment (TMDA), magic burst and nuke-wall if we absorb the spell.
+    local resist                      = 1
+    local targetMagicDamageAdjustment = 1
+    local magicBurst                  = 1
+    local magicBurstBonus             = 1
 
-            if spellGroup == xi.magic.spellGroup.BLUE then
-                caster:delStatusEffectSilent(xi.effect.BURST_AFFINITY)
+    if nukeAbsorbOrNullify > 0 then
+        resist                      = xi.spells.damage.calculateResist(caster, target, spellGroup, skillType, spellElement, statUsed, bonusMacc)
+        targetMagicDamageAdjustment = xi.spells.damage.calculateTMDA(target, spellElement)
+
+        -- If spell is NOT blue magic OR (if its blue magic AND has status effect)
+        if
+            spellGroup ~= xi.magic.spellGroup.BLUE or
+            (spellGroup == xi.magic.spellGroup.BLUE and
+            (caster:hasStatusEffect(xi.effect.BURST_AFFINITY) or
+            caster:hasStatusEffect(xi.effect.AZURE_LORE)))
+        then
+            local _, skillchainCount = xi.magicburst.formMagicBurst(spellElement, target) -- External function. Not present in magic.lua.
+
+            if skillchainCount > 0 then
+                magicBurst      = xi.spells.damage.calculateIfMagicBurst(target, spellElement, skillchainCount)
+                magicBurstBonus = xi.spells.damage.calculateIfMagicBurstBonus(caster, target, spellId, spellElement)
+
+                if spellGroup == xi.magic.spellGroup.BLUE then
+                    caster:delStatusEffectSilent(xi.effect.BURST_AFFINITY)
+                end
             end
         end
     end
+
+    -- Calculate base damage and the rest of damage multipliers.
+    local spellDamage               = xi.spells.damage.calculateBaseDamage(caster, target, spellId, spellGroup, skillType, statUsed)
+    local multipleTargetReduction   = xi.spells.damage.calculateMTDR(spell)
+    local elementalStaffBonus       = xi.spells.damage.calculateElementalStaffBonus(caster, spellElement)
+    local magianAffinity            = xi.spells.damage.calculateMagianAffinity()
+    local sdt                       = xi.spells.damage.calculateSDT(target, spellElement)
+    local dayAndWeather             = xi.spells.damage.calculateDayAndWeather(caster, spellId, spellElement)
+    local magicBonusDiff            = xi.spells.damage.calculateMagicBonusDiff(caster, target, spellId, skillType, spellElement)
+    local divineSealMultiplier      = xi.spells.damage.calculateDivineSealMultiplier(caster, skillType)
+    local divineEmblemMultiplier    = xi.spells.damage.calculateDivineEmblemMultiplier(caster, skillType)
+    local ebullienceMultiplier      = xi.spells.damage.calculateEbullienceMultiplier(caster, spellGroup)
+    local skillTypeMultiplier       = xi.spells.damage.calculateSkillTypeMultiplier(skillType)
+    local ninSkillBonus             = xi.spells.damage.calculateNinSkillBonus(caster, spellId, skillType)
+    local ninFutaeBonus             = xi.spells.damage.calculateNinFutaeBonus(caster, skillType)
+    local ninjutsuMultiplier        = xi.spells.damage.calculateNinjutsuMultiplier(caster, target, skillType)
+    local undeadDivinePenalty       = xi.spells.damage.calculateUndeadDivinePenalty(target, skillType)
+    local scarletDeliriumMultiplier = xi.spells.damage.calculateScarletDeliriumMultiplier(caster)
+    local helixMeritMultiplier      = xi.spells.damage.calculateHelixMeritMultiplier(caster, spellId)
+    local areaOfEffectResistance    = xi.spells.damage.calculateAreaOfEffectResistance(target, spell)
 
     -- Calculate finalDamage. It MUST be floored after EACH multiplication.
     finalDamage = math.floor(spellDamage * multipleTargetReduction)
@@ -1001,53 +1018,41 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
     finalDamage = math.floor(finalDamage * magicBurstBonus)
 
     -- Handle "Nuke Wall". It must be handled after all previous calculations, but before clamp.
-    local nukeWallFactor = xi.spells.damage.calculateNukeWallFactor(target, spellElement, finalDamage)
-
-    finalDamage = math.floor(finalDamage * nukeWallFactor)
-
-    -- Handle Phalanx
-    if finalDamage > 0 then
-        finalDamage = utils.clamp(finalDamage - target:getMod(xi.mod.PHALANX), 0, 99999)
+    if nukeAbsorbOrNullify > 0 then
+        local nukeWallFactor = xi.spells.damage.calculateNukeWallFactor(target, spellElement, finalDamage)
+        finalDamage          = math.floor(finalDamage * nukeWallFactor)
     end
-
-    -- Handle One For All
-    if finalDamage > 0 then
-        finalDamage = utils.clamp(utils.oneforall(target, finalDamage), 0, 99999)
-    end
-
-    -- Handle Stoneskin
-    if finalDamage > 0 then
-        finalDamage = utils.clamp(utils.stoneskin(target, finalDamage), -99999, 99999)
-    end
-
-    -- Handle spell nullification message.
-    if nukeAbsorbOrNullify == 0 then
-        spell:setMsg(xi.msg.basic.MAGIC_RESIST)
 
     -- Handle Magic Absorb message and HP recovery.
-    elseif finalDamage < 0 then
+    if finalDamage < 0 then
         finalDamage = target:addHP(-finalDamage)
         spell:setMsg(xi.msg.basic.MAGIC_RECOVERS_HP)
 
+        return finalDamage
+    end
+
+    -- Handle Phalanx, One for All, Stoneskin.
+    finalDamage = utils.clamp(finalDamage - target:getMod(xi.mod.PHALANX), 0, 99999)
+    finalDamage = utils.clamp(utils.oneforall(target, finalDamage), 0, 99999)
+    finalDamage = utils.clamp(utils.stoneskin(target, finalDamage), -99999, 99999)
+
     -- Handle final adjustments. Most are located in core. TODO: Decide if we want core handling this.
-    else
-        -- Check if the mob has a damage cap
-        finalDamage = target:checkDamageCap(finalDamage)
+    -- Check if the mob has a damage cap
+    finalDamage = target:checkDamageCap(finalDamage)
 
-        -- Handle Bind break and TP?
-        target:takeSpellDamage(caster, spell, finalDamage, xi.attackType.MAGICAL, xi.damageType.ELEMENTAL + spellElement)
+    -- Handle Bind break and TP?
+    target:takeSpellDamage(caster, spell, finalDamage, xi.attackType.MAGICAL, xi.damageType.ELEMENTAL + spellElement)
 
-        -- Handle Afflatus Misery.
-        target:handleAfflatusMiseryDamage(finalDamage)
+    -- Handle Afflatus Misery.
+    target:handleAfflatusMiseryDamage(finalDamage)
 
-        -- Handle Enmity.
-        target:updateEnmityFromDamage(caster, finalDamage)
+    -- Handle Enmity.
+    target:updateEnmityFromDamage(caster, finalDamage)
 
-        -- Add "Magic Burst!" message
-        if magicBurst > 1 then
-            spell:setMsg(xi.msg.basic.MAGIC_BURST_DAMAGE)
-            caster:triggerRoeEvent(xi.roeTrigger.MAGIC_BURST)
-        end
+    -- Add "Magic Burst!" message
+    if magicBurst > 1 then
+        spell:setMsg(xi.msg.basic.MAGIC_BURST_DAMAGE)
+        caster:triggerRoeEvent(xi.roeTrigger.MAGIC_BURST)
     end
 
     return finalDamage

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -381,7 +381,7 @@ local function getSingleHitDamage(attacker, target, dmg, ftp, wsParams, calcPara
         magicdmg = target:magicDmgTaken(magicdmg, wsParams.ele)
 
         if magicdmg > 0 then
-            magicdmg = adjustForTarget(target, magicdmg, wsParams.ele) -- this may absorb or nullify
+            magicdmg = magicdmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, wsParams.ele) -- this may absorb or nullify
         end
 
         if magicdmg > 0 then -- handle nonzero damage if previous function does not absorb or nullify
@@ -970,7 +970,7 @@ xi.weaponskills.doMagicWeaponskill = function(attacker, target, wsID, wsParams, 
             return dmg
         end
 
-        dmg = adjustForTarget(target, dmg, wsParams.ele)
+        dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, wsParams.ele)
 
         if dmg > 0 then
             dmg = dmg - target:getMod(xi.mod.PHALANX)

--- a/scripts/zones/Arrapago_Reef/mobs/Velionis.lua
+++ b/scripts/zones/Arrapago_Reef/mobs/Velionis.lua
@@ -46,7 +46,7 @@ entity.onSpikesDamage = function(mob, target, damage)
         params.includemab = false
         dmg = addBonusesAbility(mob, xi.element.FIRE, target, dmg, params)
         dmg = dmg * applyResistanceAddEffect(mob, target, xi.element.FIRE, 0)
-        dmg = adjustForTarget(target, dmg, xi.element.FIRE)
+        dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.FIRE)
         dmg = finalMagicNonSpellAdjustments(mob, target, xi.element.FIRE, dmg)
 
         if dmg < 0 then

--- a/scripts/zones/Attohwa_Chasm/mobs/Sargas.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Sargas.lua
@@ -28,7 +28,7 @@ entity.onSpikesDamage = function(mob, target, damage)
     params.includemab = false
     dmg = addBonusesAbility(mob, xi.element.THUNDER, target, dmg, params)
     dmg = dmg * applyResistanceAddEffect(mob, target, xi.element.THUNDER, 0)
-    dmg = adjustForTarget(target, dmg, xi.element.THUNDER)
+    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.THUNDER)
     dmg = finalMagicNonSpellAdjustments(mob, target, xi.element.THUNDER, dmg)
 
     if dmg < 0 then

--- a/scripts/zones/Beaucedine_Glacier/mobs/Humbaba.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Humbaba.lua
@@ -23,7 +23,7 @@ entity.onSpikesDamage = function(mob, target, damage)
     params.includemab = false
     dmg = addBonusesAbility(mob, xi.element.ICE, target, dmg, params)
     dmg = dmg * applyResistanceAddEffect(mob, target, xi.element.ICE, 0)
-    dmg = adjustForTarget(target, dmg, xi.element.ICE)
+    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.ICE)
     dmg = finalMagicNonSpellAdjustments(mob, target, xi.element.ICE, dmg)
 
     if dmg < 0 then

--- a/scripts/zones/Crawlers_Nest/mobs/Aqrabuamelu.lua
+++ b/scripts/zones/Crawlers_Nest/mobs/Aqrabuamelu.lua
@@ -19,7 +19,7 @@ entity.onSpikesDamage = function(mob, target, damage)
     params.includemab = false
     dmg = addBonusesAbility(mob, xi.element.ICE, target, dmg, params)
     dmg = dmg * applyResistanceAddEffect(mob, target, xi.element.ICE, 0)
-    dmg = adjustForTarget(target, dmg, xi.element.ICE)
+    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.ICE)
     dmg = finalMagicNonSpellAdjustments(mob, target, xi.element.ICE, dmg)
 
     if dmg < 0 then

--- a/scripts/zones/Halvung/mobs/Copper_Borer.lua
+++ b/scripts/zones/Halvung/mobs/Copper_Borer.lua
@@ -25,7 +25,7 @@ entity.onSpikesDamage = function(mob, target, damage)
     params.includemab = false
     dmg = addBonusesAbility(mob, xi.element.FIRE, target, dmg, params)
     dmg = dmg * applyResistanceAddEffect(mob, target, xi.element.FIRE, 0)
-    dmg = adjustForTarget(target, dmg, xi.element.FIRE)
+    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.FIRE)
     dmg = finalMagicNonSpellAdjustments(mob, target, xi.element.FIRE, dmg)
 
     if dmg < 0 then

--- a/scripts/zones/Ordelles_Caves/mobs/Bombast.lua
+++ b/scripts/zones/Ordelles_Caves/mobs/Bombast.lua
@@ -20,7 +20,7 @@ entity.onSpikesDamage = function(mob, target, damage)
     params.includemab = false
     dmg = addBonusesAbility(mob, xi.element.FIRE, target, dmg, params)
     dmg = dmg * applyResistanceAddEffect(mob, target, xi.element.FIRE, 0)
-    dmg = adjustForTarget(target, dmg, xi.element.FIRE)
+    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.FIRE)
     dmg = finalMagicNonSpellAdjustments(mob, target, xi.element.FIRE, dmg)
 
     if dmg < 0 then

--- a/scripts/zones/RoMaeve/mobs/Martinet.lua
+++ b/scripts/zones/RoMaeve/mobs/Martinet.lua
@@ -19,7 +19,7 @@ entity.onSpikesDamage = function(mob, target, damage)
     params.includemab = false
     dmg = addBonusesAbility(mob, xi.element.THUNDER, target, dmg, params)
     dmg = dmg * applyResistanceAddEffect(mob, target, xi.element.THUNDER, 0)
-    dmg = adjustForTarget(target, dmg, xi.element.THUNDER)
+    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.THUNDER)
     dmg = finalMagicNonSpellAdjustments(mob, target, xi.element.THUNDER, dmg)
 
     if dmg < 0 then

--- a/scripts/zones/Toraimarai_Canal/mobs/Brazen_Bones.lua
+++ b/scripts/zones/Toraimarai_Canal/mobs/Brazen_Bones.lua
@@ -22,7 +22,7 @@ entity.onSpikesDamage = function(mob, target, damage)
     params.includemab = false
     dmg = addBonusesAbility(mob, xi.element.ICE, target, dmg, params)
     dmg = dmg * applyResistanceAddEffect(mob, target, xi.element.ICE, 0)
-    dmg = adjustForTarget(target, dmg, xi.element.ICE)
+    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.ICE)
     dmg = finalMagicNonSpellAdjustments(mob, target, xi.element.ICE, dmg)
 
     if dmg < 0 then

--- a/scripts/zones/Upper_Delkfutts_Tower/mobs/Autarch.lua
+++ b/scripts/zones/Upper_Delkfutts_Tower/mobs/Autarch.lua
@@ -20,7 +20,7 @@ entity.onSpikesDamage = function(mob, target, damage)
     params.includemab = false
     dmg = addBonusesAbility(mob, xi.element.THUNDER, target, dmg, params)
     dmg = dmg * applyResistanceAddEffect(mob, target, xi.element.THUNDER, 0)
-    dmg = adjustForTarget(target, dmg, xi.element.THUNDER)
+    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.THUNDER)
     dmg = finalMagicNonSpellAdjustments(mob, target, xi.element.THUNDER, dmg)
 
     if dmg < 0 then


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Substitutes the usage of certain old functions with the new ones and removes unused logic. Continuing the effort to delete magic.lua file.
- Changes logic so we skip certain damage multipliers when we absorb an spell.

Edit: Winter took care of linment power aswell in a different PR, dropping that commit

## Steps to test these changes

None.

I HEAVILY RECOMMEND reviewing by commit.