### PR TITLE
[lua] [core] [RUN] Adjust Liement absorb math

### DIFF
--- a/scripts/globals/job_utils/rune_fencer.lua
+++ b/scripts/globals/job_utils/rune_fencer.lua
@@ -855,7 +855,7 @@ xi.job_utils.rune_fencer.useLiement = function(player, target, ability, action)
     end
 
     local runeEffects = target:getAllRuneEffects()
-    local absorbPower = 25
+    local absorbPower = 15 -- in core -> 85 + 15 * (1, 2, or 3) = 100, 115, 130
     local duration    = 10 + player:getMod(xi.mod.LIEMENT_DURATION)
     local absorbTypes = {} -- one absorb type per rune which can be additive
     local i           = 0

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -7047,7 +7047,7 @@ namespace battleutils
                 if (runeAbsorbCount > 0)
                 {
                     PBattleEntity->StatusEffectContainer->DelStatusEffectSilent(EFFECT_LIEMENT); // Liement absorbs once and disappears.
-                    float absorbMultiplier = (75 + runeAbsorbCount * absorbPower) / 100.0;
+                    float absorbMultiplier = (85 + runeAbsorbCount * absorbPower) / 100.0;
 
                     return absorbMultiplier * -1;
                 }


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Apparently my original math was bad, this will now correctly ramp the absorb %s

https://www.bg-wiki.com/ffxi/Liement
rune count: %
1: 100%
2: 115%
3: 130%


## Steps to test these changes

Use liement with 1/2/3 runes, breakpoint in ` CheckLiementAbsorb` and see the math come out to (approximately) the above