### PR TITLE
Run CPP and SQL files in modules during CIs.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,6 +225,15 @@ jobs:
     #  with:
     #    path: build
     #    key: ${{ runner.os }}-clang
+    - name: Enable Modules
+      shell: bash
+      run: |
+        python3 << EOF
+        with open("modules/init.txt", "w") as f:
+            f.write("custom\n")
+            f.write("era\n")
+            f.write("renamer\n")
+        EOF
     - name: Configure CMake
       run: |
         export CC=/usr/bin/clang-15
@@ -320,6 +329,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
+      - name: Enable Modules
+        shell: bash
+        run: |
+          python3 << EOF
+          with open("modules/init.txt", "w") as f:
+              f.write("custom\n")
+              f.write("era\n")
+              f.write("renamer\n")
+          EOF
       - name: Cache 'build' folder
         uses: actions/cache@v4
         with:
@@ -429,6 +447,10 @@ jobs:
         for f in sql/*.sql; do
           echo -e "Importing $f into the database..."
           mysql xidb -h 127.0.0.1 -uroot -proot < $f
+        done
+        find modules/ -type f -name "*.sql" | while read sql_file; do
+          echo -e "Importing $sql_file into the database..."
+          mysql xidb -h 127.0.0.1 -uroot -proot < $sql_file
         done
         mysql xidb -h 127.0.0.1 -uroot -proot -e "SHOW tables"
     - name: Copy settings
@@ -608,6 +630,10 @@ jobs:
           echo -e "Importing $f into the database..."
           mysql xidb -h 127.0.0.1 -uroot -proot < $f
         done
+        find modules/ -type f -name "*.sql" | while read sql_file; do
+          echo -e "Importing $sql_file into the database..."
+          mysql xidb -h 127.0.0.1 -uroot -proot < $sql_file
+        done
         mysql xidb -h 127.0.0.1 -uroot -proot -e "SHOW tables"
     - name: Assign odd zones a different port
       run: |
@@ -688,6 +714,10 @@ jobs:
         for f in sql/*.sql; do
           echo -e "Importing $f into the database..."
           mysql xidb -h 127.0.0.1 -uroot -proot < $f
+        done
+        find modules/ -type f -name "*.sql" | while read sql_file; do
+          echo -e "Importing $sql_file into the database..."
+          mysql xidb -h 127.0.0.1 -uroot -proot < $sql_file
         done
         mysql xidb -h 127.0.0.1 -uroot -proot -e "SHOW tables"
     - name: Startup checks


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Attempting to resolve the issues Zach outlined in https://github.com/LandSandBoat/server/issues/5347 ~ CPP and SQL module files aren't being run for `Full_Startup_Checks_Linux`, `MultiInstance_Startup_Checks_Linux`, or `Full_Startup_Checks_Windows`.

## Steps to test these changes

Run CIs.
