### PR TITLE
[Blue magic] Clean drain-type blue spells logic

### DIFF
--- a/scripts/effects/rampart.lua
+++ b/scripts/effects/rampart.lua
@@ -7,58 +7,37 @@ local effectObject = {}
 effectObject.onEffectGain = function(target, effect)
     local power = effect:getPower()
 
+    -- Regular effect
+    effect:addMod(xi.mod.SLASH_SDT, power)
+    effect:addMod(xi.mod.PIERCE_SDT, power)
+    effect:addMod(xi.mod.IMPACT_SDT, power)
+    effect:addMod(xi.mod.HTH_SDT, power)
+    effect:addMod(xi.mod.FIRE_SDT, power)
+    effect:addMod(xi.mod.ICE_SDT, power)
+    effect:addMod(xi.mod.WIND_SDT, power)
+    effect:addMod(xi.mod.EARTH_SDT, power)
+    effect:addMod(xi.mod.THUNDER_SDT, power)
+    effect:addMod(xi.mod.WATER_SDT, power)
+    effect:addMod(xi.mod.LIGHT_SDT, power)
+    effect:addMod(xi.mod.DARK_SDT, power)
+
+    -- Iron will trait and augment. TODO: Why player only?
     if target:isPC() and target:hasTrait(xi.trait.IRON_WILL) then
-        target:addMod(xi.mod.SPELLINTERRUPT, target:getMerit(xi.merit.IRON_WILL))
+        effect:addMod(xi.mod.SPELLINTERRUPT, target:getMerit(xi.merit.IRON_WILL))
+
+        if target:getMod(xi.mod.ENHANCES_IRON_WILL) > 0 then
+            local subPower = target:getMod(xi.mod.ENHANCES_IRON_WILL) * target:getMerit(xi.merit.IRON_WILL) / 19
+
+            effect:addMod(xi.mod.FASTCAST, subPower)
+            effect:setSubPower(subPower)
+        end
     end
-
-    if target:getMod(xi.mod.ENHANCES_IRON_WILL) > 0 then
-        local subPower = target:getMod(xi.mod.ENHANCES_IRON_WILL) * (target:getMerit(xi.merit.IRON_WILL) / 19)
-
-        target:addMod(xi.mod.FASTCAST, subPower)
-        effect:setSubPower(subPower)
-    end
-
-    target:addMod(xi.mod.SLASH_SDT, power)
-    target:addMod(xi.mod.PIERCE_SDT, power)
-    target:addMod(xi.mod.IMPACT_SDT, power)
-    target:addMod(xi.mod.HTH_SDT, power)
-    target:addMod(xi.mod.FIRE_SDT, power)
-    target:addMod(xi.mod.ICE_SDT, power)
-    target:addMod(xi.mod.WIND_SDT, power)
-    target:addMod(xi.mod.EARTH_SDT, power)
-    target:addMod(xi.mod.THUNDER_SDT, power)
-    target:addMod(xi.mod.WATER_SDT, power)
-    target:addMod(xi.mod.LIGHT_SDT, power)
-    target:addMod(xi.mod.DARK_SDT, power)
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    local power    = effect:getPower()
-    local subPower = effect:getSubPower()
-
-    if target:isPC() and target:hasTrait(xi.trait.IRON_WILL) then
-        target:delMod(xi.mod.SPELLINTERRUPT, target:getMerit(xi.merit.IRON_WILL))
-    end
-
-    if subPower > 0 then
-        target:delMod(xi.mod.FASTCAST, subPower)
-    end
-
-    target:delMod(xi.mod.SLASH_SDT, power)
-    target:delMod(xi.mod.PIERCE_SDT, power)
-    target:delMod(xi.mod.IMPACT_SDT, power)
-    target:delMod(xi.mod.HTH_SDT, power)
-    target:delMod(xi.mod.FIRE_SDT, power)
-    target:delMod(xi.mod.ICE_SDT, power)
-    target:delMod(xi.mod.WIND_SDT, power)
-    target:delMod(xi.mod.EARTH_SDT, power)
-    target:delMod(xi.mod.THUNDER_SDT, power)
-    target:delMod(xi.mod.WATER_SDT, power)
-    target:delMod(xi.mod.LIGHT_SDT, power)
-    target:delMod(xi.mod.DARK_SDT, power)
 end
 
 return effectObject

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -230,17 +230,25 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
     -- Perform the attacks --
     -------------------------
 
-    local hitsdone   = 0
-    local hitslanded = 0
-    local finaldmg   = 0
-    local sneakIsApplicable = caster:hasStatusEffect(xi.effect.SNEAK_ATTACK) and
-                                spell:isAoE() == 0 and
-                                params.attackType ~= xi.attackType.RANGED and
-                                (caster:isBehind(target) or caster:hasStatusEffect(xi.effect.HIDE))
-    local trickAttackTarget = (caster:hasStatusEffect(xi.effect.TRICK_ATTACK) and
-                                spell:isAoE() == 0 and
-                                params.attackType ~= xi.attackType.RANGED) and
-                                caster:getTrickAttackChar(target) or nil
+    local hitsdone          = 0
+    local hitslanded        = 0
+    local finaldmg          = 0
+    local sneakIsApplicable = false
+    local trickAttackTarget = nil
+
+    if spell:isAoE() == 0 and params.attackType ~= xi.attackType.RANGED then
+        if
+            caster:hasStatusEffect(xi.effect.SNEAK_ATTACK) and
+            (caster:isBehind(target) or caster:hasStatusEffect(xi.effect.HIDE))
+        then
+            sneakIsApplicable = true
+        end
+
+        if caster:hasStatusEffect(xi.effect.TRICK_ATTACK) then
+            trickAttackTarget = caster:getTrickAttackChar(target)
+        end
+    end
+
     while hitsdone < params.numhits do
         local chance = math.random()
 
@@ -337,36 +345,62 @@ xi.spells.blue.useMagicalSpell = function(caster, target, spell, params)
     return xi.spells.blue.applySpellDamage(caster, target, spell, finaldmg, params, nil)
 end
 
--- Perform a draining magical Blue Magic spell
-xi.spells.blue.useDrainSpell = function(caster, target, spell, params, softCap, mpDrain)
-    -- determine base damage
-    local dmg = params.dmgMultiplier * math.floor(caster:getSkillLevel(xi.skill.BLUE_MAGIC) * 0.11)
-    if softCap > 0 then
-        dmg = utils.clamp(dmg, 0, softCap)
-    end
+-- Spell script Helper function.
+xi.spells.blue.useDrainSpell = function(caster, target, spell, params, damageCap, mpDrain)
+    local finalDamage = 0
 
-    dmg = dmg * applyResistanceEffect(caster, target, spell, params)
-    dmg = addBonuses(caster, spell, target, dmg)
-    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, spell:getElement())
-
-    -- limit damage
-    if target:isUndead() then
+    -- Early returns
+    if
+        target:isUndead() or
+        xi.spells.damage.calculateNukeAbsorbOrNullify(target, spell:getElement()) == 0 -- Drain spells cannot be absorbed, but they can be nullified.
+    then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    else
-        -- only drain what the mob has
-        if mpDrain then
-            dmg = dmg * xi.settings.main.BLUE_POWER
-            dmg = utils.clamp(dmg, 0, target:getMP())
-            target:delMP(dmg)
-            caster:addMP(dmg)
-        else
-            dmg = utils.clamp(dmg, 0, target:getHP())
-            dmg = xi.spells.blue.applySpellDamage(caster, target, spell, dmg, params, nil)
-            caster:addHP(dmg)
-        end
+
+        return 0
     end
 
-    return dmg
+    -- Base damage
+    finalDamage = math.floor(caster:getSkillLevel(xi.skill.BLUE_MAGIC) * 0.11)
+    finalDamage = math.floor(finalDamage * params.dmgMultiplier)
+    if damageCap > 0 then
+        finalDamage = utils.clamp(finalDamage, 0, damageCap)
+    end
+
+    -- Multipliers
+    finalDamage = math.floor(finalDamage * applyResistanceEffect(caster, target, spell, params))
+    finalDamage = math.floor(addBonuses(caster, spell, target, finalDamage))
+    finalDamage = math.floor(finalDamage * xi.spells.damage.calculateTMDA(target, spell:getElement()))
+    finalDamage = math.floor(finalDamage * xi.settings.main.BLUE_POWER)
+
+    -- MP drain
+    if mpDrain then
+        finalDamage = utils.clamp(finalDamage, 0, target:getMP())
+
+        target:delMP(finalDamage)
+        caster:addMP(finalDamage)
+
+        return finalDamage
+    end
+
+    -- Handle Phalanx, One for All, Stoneskin and target HP (Cant be higher than current HP)
+    finalDamage = utils.clamp(finalDamage - target:getMod(xi.mod.PHALANX), 0, 99999)
+    finalDamage = utils.clamp(utils.oneforall(target, finalDamage), 0, 99999)
+    finalDamage = utils.clamp(utils.stoneskin(target, finalDamage), -99999, 99999)
+    finalDamage = utils.clamp(finalDamage, 0, target:getHP())
+
+    -- Check if the mob has a damage cap
+    finalDamage = target:checkDamageCap(finalDamage)
+
+    target:takeSpellDamage(caster, spell, finalDamage, xi.attackType.MAGICAL, xi.damageType.ELEMENTAL + spell:getElement())
+
+    if not target:isPC() then
+        target:updateEnmityFromDamage(caster, finalDamage)
+    end
+
+    target:handleAfflatusMiseryDamage(finalDamage)
+    caster:addHP(finalDamage)
+
+    return finalDamage
 end
 
 -- Get the damage and resistance for a breath Blue Magic spell
@@ -376,9 +410,9 @@ xi.spells.blue.useBreathSpell = function(caster, target, spell, params, isConal)
     results[2] = 0 -- resistance (used in spell to determine added effect resistance)
 
     -- Initial damage
-    local dmg = (caster:getHP() / params.hpMod)
+    local dmg = caster:getHP() / params.hpMod
     if params.lvlMod > 0 then
-        dmg = dmg + (caster:getMainLvl() / params.lvlMod)
+        dmg = dmg + caster:getMainLvl() / params.lvlMod
     end
 
     -- Conal breath spells
@@ -394,14 +428,14 @@ xi.spells.blue.useBreathSpell = function(caster, target, spell, params, isConal)
 
     -- Monster correlation
     local correlationMultiplier = calculateCorrelation(params.ecosystem, target:getEcosystem(), caster:getMerit(xi.merit.MONSTER_CORRELATION))
-    dmg = dmg * (1 + correlationMultiplier)
+    dmg = math.floor(dmg * (1 + correlationMultiplier))
 
     -- Monster elemental adjustments
     local mobEleAdjustments = xi.spells.damage.calculateSDT(target, spell:getElement())
-    dmg = dmg * mobEleAdjustments
+    dmg = math.floor(dmg * mobEleAdjustments)
 
     -- Modifiers
-    dmg = dmg * (1 + (caster:getMod(xi.mod.BREATH_DMG_DEALT) / 100))
+    dmg = math.floor(dmg * (1 + caster:getMod(xi.mod.BREATH_DMG_DEALT) / 100))
 
     -- Resistance
     local resistance = applyResistanceEffect(caster, target, spell, params)
@@ -418,11 +452,7 @@ end
 
 -- Apply spell damage
 xi.spells.blue.applySpellDamage = function(caster, target, spell, dmg, params, trickAttackTarget)
-    if dmg < 0 then
-        dmg = 0
-    end
-
-    dmg                 = dmg * xi.settings.main.BLUE_POWER
+    dmg                 = math.floor(dmg * xi.settings.main.BLUE_POWER)
     local attackType    = params.attackType or xi.attackType.NONE
     local damageType    = params.damageType or xi.damageType.NONE
     local tpHits        = params.tphitslanded or 0
@@ -430,8 +460,8 @@ xi.spells.blue.applySpellDamage = function(caster, target, spell, dmg, params, t
 
     -- handle MDT, One For All, Liement
     if attackType == xi.attackType.MAGICAL then
-        local targetMagicDamageAdjustment = xi.spells.damage.calculateTMDA(target, damageType) -- Apply checks for Liement, MDT/MDTII/DT
-        dmg                               = math.floor(dmg * targetMagicDamageAdjustment)
+        local absorbOrNullify = xi.spells.damage.calculateNukeAbsorbOrNullify(target, spell:getElement())
+        dmg                   = math.floor(dmg * absorbOrNullify)
 
         if dmg < 0 then
             target:takeSpellDamage(caster, spell, dmg, attackType, damageType)
@@ -439,6 +469,9 @@ xi.spells.blue.applySpellDamage = function(caster, target, spell, dmg, params, t
             -- TODO: verify Afflatus/enmity from absorb?
             return dmg
         end
+
+        local targetMagicDamageAdjustment = xi.spells.damage.calculateTMDA(target, spell:getElement())
+        dmg                               = math.floor(dmg * targetMagicDamageAdjustment)
 
         dmg = utils.oneforall(target, dmg)
     end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Moved rampart mods to be applied directly to the effect instead of the effect target. This is unrelated to the other logic, but I had to check the effect and decided to change it while I was there.
- Fixes TMDA function being fed a wrong parameter. (Damage type instead of element)
- Streamlines the drain blue spells, considering they follow, mostly, the same rules. This frees it from some of the daisy-chain methodology.
- NOTE: This isnt meant to fix absolutely anything. Whats wrong will continue being wrong, it will just make it easier for the time blue magic gets rewritten.

## Steps to test these changes

None. Blue magic still sucks.
