### PR TITLE
db: Add reconnect logic into db::detail::getState()

### DIFF
--- a/src/common/database.cpp
+++ b/src/common/database.cpp
@@ -24,13 +24,13 @@
 #include "logging.h"
 #include "settings.h"
 #include "taskmgr.h"
-#include "utils.h"
 
 #include <chrono>
 using namespace std::chrono_literals;
 
 namespace
 {
+    // TODO: Manual checkout and pooling of state
     mutex_guarded<db::detail::State> state;
 } // namespace
 
@@ -65,14 +65,22 @@ mutex_guarded<db::detail::State>& db::detail::getState()
 {
     TracyZoneScoped;
 
-    // TODO: Manual pooling?
-    // TODO: Locking of individual connections by passing back a handle with a `*this` reference to free the connection on handle destruction?
+    // NOTE: mariadb-connector-cpp doesn't seem to make any guarantees about whether or not isValid() or reconnect()
+    //     : are const. So we're going to have to wrap calls to them as though they aren't.
 
     // clang-format off
-    if (state.read([&](const auto& state) { return state.connection != nullptr; }))
+    if (state.write([&](auto& state)
+    {
+        // If we have a valid and connected connection: return it
+        // TODO: Does this logic make ping_connection redundant?
+        return state.connection != nullptr && (state.connection->isValid() || state.connection->reconnect());
+    }))
     {
         return state;
     }
+
+    // Otherwise, create a new connection. Writing it to the state.connection unique_ptr will release any previous connection
+    // that might be there.
 
     state.write([&](auto& state)
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

I had a report of someone running a server locally, and shutting their laptop - putting all their processes into sleep mode. When they opened their laptop and all their processes woke up, `db::` connections would no longer be valid and so queries would fail. This adds some logic I saw on SO: https://stackoverflow.com/questions/33003635/mysql-c-connector-how-to-keep-the-connection-alive-and-reconnect-if-connectio

We need `db::` to be rock-solid and reliable at all times (provided there's a database to connect to) - even if it comes at the cost of having to reconnect in bad circumstances.

Improves upon https://github.com/LandSandBoat/server/pull/5360
