### PR TITLE
[Core] Add retail mob movement speed boost mechanism

### DIFF
--- a/scripts/enum/mob_mod.lua
+++ b/scripts/enum/mob_mod.lua
@@ -90,4 +90,5 @@ xi.mobMod =
     CANNOT_GUARD           = 79, -- Check if the mob does not guard (despite being a MNK or PUP mob)
     SKIP_ALLEGIANCE_CHECK  = 80, -- Skip the allegiance check for valid target (allows for example a mob to cast a TARGET_ENEMY spell on itself)
     ABILITY_RESPONSE       = 81, -- Mob can respond to player ability use with onPlayerAbilityUse()
+    SPEED_BOOST_MULT       = 82, -- Multiplier for the base speed of a mob when the mob's target is out of range (range between 100 and 500, 250 means 2.5x, mechanism is from retail)
 }

--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -112,8 +112,13 @@ xi.settings.map =
     -- Note retail treats the mounted speed as double what it actually is.
     MOUNT_SPEED_MOD = 0,
 
-    -- This is an integer percentage. Modifier to apply to agro'd monster speed (i.e. while engaged in combat). 0 is the retail accurate default. Negative numbers will reduce ALL mobs's speed.
-    MOB_SPEED_MOD = 0,
+    -- Enable or disable a mechanism for boosting the speed of engaged mobs (by a multiplier) when their target is out of range.
+    -- This is a retail mechanism that makes kiting more difficult
+    USE_MOB_SPEED_BOOST_MULTIPLIER = true,
+    -- The default boost multiplier of almost all mobs on retail is 250 (so 2.5x or 2.5 times their normal speed)
+    -- The minimum value is 100 (1x) which means that mobs get no such speed boost (though better to use the boolean toggle above)
+    -- The maximum value is 25500 (255x) which would put the speed of any mob at the system cap
+    DEFAULT_MOB_SPEED_BOOST_MULTIPLIER = 250,
 
     -- Allows you to manipulate the constant multiplier in the skill-up rate formulas, having a potent effect on skill-up rates.
     SKILLUP_CHANCE_MULTIPLIER = 1.0,

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -314,8 +314,11 @@ uint8 CBattleEntity::GetSpeed()
         outputSpeed = outputSpeed + mazurkaQuickeningEffect;
     }
 
-    // Set cap (Default 80).
-    outputSpeed = std::clamp<int16>(outputSpeed, 0, 80 + settings::get<int8>("map.SPEED_MOD"));
+    // Set cap if a PC (Default 80).
+    if (objtype == TYPE_PC)
+    {
+        outputSpeed = std::clamp<int16>(outputSpeed, 0, 80 + settings::get<int8>("map.SPEED_MOD"));
+    }
 
     // Speed cap can be bypassed. Ex. Feast of swords. GM speed.
     // TODO: Find exceptions. Add them here.

--- a/src/map/mob_modifier.h
+++ b/src/map/mob_modifier.h
@@ -110,6 +110,7 @@ enum MOBMODIFIER : int
     MOBMOD_CANNOT_GUARD           = 79, // Check if the mob does not guard(despite being a MNK or PUP mob)
     MOBMOD_SKIP_ALLEGIANCE_CHECK  = 80, // Skip the allegiance check for valid target (allows for example a mob to cast a TARGET_ENEMY spell on itself)
     MOBMOD_ABILITY_RESPONSE       = 81, // Mob can respond to player ability use with onPlayerAbilityUse()
+    MOBMOD_SPEED_BOOST_MULT       = 82, // Multiplier for the base speed of a mob when the mob's target is out of range (range between 100 and 25500, 250 means 2.5x, mechanism is from retail)
 };
 
 #endif


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR adds a retail accurate version of the mob movement speed boost. Essentially, on retail a mob boosts it's speed (almost always by 2.5x in retail) when it's target is out of melee range. This boost can be seen in packet captures of mobs when kiting (as speed is included in mob update packets). This speed boost is applied after other speed modifications (such as gravity), however if the mob has a negative speed modification then the boost is only about half as powerful (instead of 2.5x it is 1.2x). This smaller boost means that spells such as gravity are still useful when kiting (otherwise they would be worthless).

The implementation includes settings in the map settings file to turn the system on/off and to set the default multiplier (to between 1 to 5, the default is the retail value of 2.5). Also a mob mod is added for special cases where the boost multiplier of a mob is not 2.5x. The only mobs verified to have non standard multipliers are Gunpod and maybe Cactuar Rapido.

The system is based on captures including kiting proto-omega ([video](https://youtu.be/0g_vzzSTrE8?si=Hws2gpAxoUm01uXn) and [packets](https://drive.google.com/file/d/1rIniG1aN6V6qVAthP1Q4jGseK6up1Jqv/view?usp=sharing)) and several other captures I am still uploading.

Also the PR adds a check to only apply the speed cap of 80 to players (as no evidence is applies to others and certain very fast mobs can have high base speeds).

## Steps to test these changes
Kite mobs with and without gravity
