### PR TITLE
Add support for `experimental` flag

### DIFF
--- a/scripts/enum/msg.lua
+++ b/scripts/enum/msg.lua
@@ -50,12 +50,12 @@ xi.msg.channel =
 ---@enum xi.area
 xi.msg.area =
 {
-    SYSTEM      = 0, -- Server wide like the purple stuff :)
-    SAY         = 1, -- Will display in small area around player
-    SHOUT       = 2, -- Will display in wide area around player
-    PARTY       = 3, -- Will display to players entire party/alliance
-    YELL        = 4, -- If yell is enabled in zone, will display.
-    UNITY       = 5, -- Also World Wide
+    SYSTEM = 0, -- Server-wide
+    SAY    = 1, -- Will display in small area around player (50')
+    SHOUT  = 2, -- Will display in wide area around player (180')
+    PARTY  = 3, -- Will display to players entire party/alliance
+    YELL   = 4, -- If yell is enabled in zone, will display.
+    UNITY  = 5, -- Also World Wide
 }
 
 -----------------------------------

--- a/scripts/specs/types/MobEntity.lua
+++ b/scripts/specs/types/MobEntity.lua
@@ -28,3 +28,4 @@
 ---@field onSpellPrecast? fun(mob: CBaseEntity, spell: CSpell)
 ---@field onSteal? fun(player: CBaseEntity, target: CBaseEntity, ability: CAbility, action: CAction): integer?
 ---@field onMagicCastingCheck? fun(mob: CBaseEntity, target: CBaseEntity, spell: CSpell): integer?
+---@field experimental? boolean

--- a/scripts/specs/types/NpcEntity.lua
+++ b/scripts/specs/types/NpcEntity.lua
@@ -10,3 +10,4 @@
 ---@field onTimeTrigger? fun(npc: CBaseEntity, triggerId: integer)
 ---@field onTrade? fun(player: CBaseEntity, npc: CBaseEntity, trade: CTradeContainer)
 ---@field onTrigger? fun(player: CBaseEntity, npc: CBaseEntity): -1|nil
+---@field experimental? boolean

--- a/scripts/zones/AlTaieu/mobs/Absolute_Virtue.lua
+++ b/scripts/zones/AlTaieu/mobs/Absolute_Virtue.lua
@@ -1,11 +1,15 @@
 -----------------------------------
 -- Area: Al'Taieu
 --  HNM: Absolute Virtue
+-- !pos 461.266 -1.643 -580.192 33
+-- !exec SpawnMob(zones[xi.zone.ALTAIEU].mob.ABSOLUTE_VIRTUE)
 -----------------------------------
 local ID = zones[xi.zone.ALTAIEU]
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
+
+entity.experimental = true
 
 entity.onMobSpawn = function(mob)
     -- setMod

--- a/src/map/entities/baseentity.h
+++ b/src/map/entities/baseentity.h
@@ -318,6 +318,14 @@ public:
 
     bool isRenamed; // tracks if the entity's name has been overidden. Defaults to false.
 
+    // If an entity is marked as experimental, it will inform the interacting player(s) by
+    // printing messages, removing loot drops, buffing the entity so it is unbeatable, etc.
+    // We do this in the hopes that contributors will be able to implement partial logic
+    // for the entity (while still being retail-accurate) without having to be perfect.
+    // Once the logic is complete, the entity can be marked as non-experimental.
+    // We use similar logic in quests, missions, battlefields, and instances.
+    bool experimental = false;
+
     bool m_bReleaseTargIDOnDisappear;
 
     SPAWN_ANIMATION spawnAnimation;

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -130,7 +130,7 @@ namespace luautils
 
     // Cache helpers
     auto getEntityCachedFunction(CBaseEntity* PEntity, std::string funcName) -> sol::function;
-    void CacheLuaObjectFromFile(std::string const& filename, bool overwriteCurrentEntry = false);
+    auto CacheLuaObjectFromFile(std::string const& filename, bool overwriteCurrentEntry = false) -> sol::table;
     auto GetCacheEntryFromFilename(std::string const& filename) -> sol::table;
     void OnEntityLoad(CBaseEntity* PEntity);
 

--- a/src/map/packets/chat_message.h
+++ b/src/map/packets/chat_message.h
@@ -70,8 +70,8 @@ enum CHAT_MESSAGE_TYPE
 enum CHAT_MESSAGE_AREA
 {
     MESSAGE_AREA_SYSTEM = 0, // All zones world wide
-    MESSAGE_AREA_SAY    = 1, // Say range
-    MESSAGE_AREA_SHOUT  = 2, // Shout
+    MESSAGE_AREA_SAY    = 1, // Say range (50')
+    MESSAGE_AREA_SHOUT  = 2, // Shout (180')
     MESSAGE_AREA_PARTY  = 3, // Party and Alliance
     MESSAGE_AREA_YELL   = 4, // Yell zones only
     MESSAGE_AREA_UNITY  = 5, // Currently -all- unities

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -435,10 +435,10 @@ DECLARE_FORMAT_AS_UNDERLYING(ZONE_TYPE);
 
 enum GLOBAL_MESSAGE_TYPE
 {
-    CHAR_INRANGE,
-    CHAR_INRANGE_SELF,
-    CHAR_INSHOUT,
-    CHAR_INZONE
+    CHAR_INRANGE,      // All players within 50'
+    CHAR_INRANGE_SELF, // All players within 50' (including self)
+    CHAR_INSHOUT,      // All players within 180'
+    CHAR_INZONE,       // All players in zone
 };
 DECLARE_FORMAT_AS_UNDERLYING(GLOBAL_MESSAGE_TYPE);
 

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -1309,16 +1309,16 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
             case CHAR_INRANGE:
             {
                 TracyZoneCString("CHAR_INRANGE");
-                // todo: rewrite packet handlers and use enums instead of rawdog packet ids
+                // TODO: rewrite packet handlers and use enums instead of rawdog packet ids
                 // 30 yalms if action packet, 50 otherwise
-                const int checkDistanceSq = packet->getType() == 0x0028 ? 900 : 2500;
+                const int checkDistance = packet->getType() == 0x0028 ? 30 : 50;
 
                 for (EntityList_t::const_iterator it = m_charList.begin(); it != m_charList.end(); ++it)
                 {
                     CCharEntity* PCurrentChar = (CCharEntity*)it->second;
                     if (PEntity != PCurrentChar)
                     {
-                        if (distanceSquared(PEntity->loc.p, PCurrentChar->loc.p) < checkDistanceSq &&
+                        if (distance(PEntity->loc.p, PCurrentChar->loc.p) < checkDistance &&
                             ((PEntity->objtype != TYPE_PC) || (((CCharEntity*)PEntity)->m_moghouseID == PCurrentChar->m_moghouseID)))
                         {
                             uint16 packetType = packet->getType();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

As seen in the AV commit:
```lua
---@type TMobEntity
local entity = {}

entity.experimental = true

entity.onMobSpawn = function(mob)
    ...
```

This allows us to mark an entity as `experimental` at the engine level. We'll use this to hook in messaging, remove loot drops, make fights unwinnable, etc.

The goal is to start allowing partial implementations of things into the codebase while providing an intrusive and player-facing mechanism to mark them as incomplete.

An experimental mob/npc will:
- Announce to the log and all players in range that it's experimental and incomplete on spawn/engage/deathtrigger/trade. **This message cannot be turned off easily.**
- Not produce any loot/exp/prizes on kill/trigger/trade (settings dependant)
- Buff itself up to 2-3x its starting level (settings dependent)

TODO:
- [ ] Refactor entity:printToArea() to be usable on mobs, and for the messaging/args around it to be clearer.
- [ ] Add an arbitrary range :printToRange() helper
- [ ] Hook up the relevant settings for experimental loot disable and experimental level buffing