### PR TITLE
Mobskill: Updates Trembling to be absorbed by shadows

### DIFF
--- a/scripts/actions/mobskills/trembling.lua
+++ b/scripts/actions/mobskills/trembling.lua
@@ -3,7 +3,7 @@
 --
 --  Description: Deals physical damage to enemies within an area of effect. Additional effect: Dispel
 --  Type: Physical
---  Wipes Shadows
+--  Utsusemi/Blink absorb: Absorbed by 3 shadows.
 --  Range: 10' radial
 -----------------------------------
 ---@type TMobSkill
@@ -18,7 +18,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local accmod = 1
     local dmgmod = 4
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
-    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
+    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, xi.mobskills.shadowBehavior.NUMSHADOWS_3)
     local dispelled = math.random(2, 3)
 
     if info.hitslanded ~= 0 then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Trembling should be absorbed by shadows, as you can see in this video at 1:07 and 2:28:
https://youtu.be/Z-ZzM6fFE68

## Steps to test these changes
```lua
!spawnmob 16986355
!gotoid 16986355
!exec target:useMobAbility(1834)
```
Tested in game