### PR TITLE
[Core] Fix issue where charmed mobs never uncharm due to time

### DIFF
--- a/src/map/ai/controllers/pet_controller.cpp
+++ b/src/map/ai/controllers/pet_controller.cpp
@@ -40,10 +40,30 @@ void CPetController::Tick(time_point tick)
     TracyZoneScoped;
     TracyZoneString(PPet->getName());
 
-    if (PPet->objtype == TYPE_PET && static_cast<CPetEntity*>(PPet)->shouldDespawn(tick))
+    bool isPlayerPet = PPet->objtype == TYPE_PET || (PPet->objtype == TYPE_MOB && PPet->PMaster && PPet->PMaster->objtype == TYPE_PC);
+
+    // if a player pet then check if a charmed mob or jug pet and if it should despawn
+    if (isPlayerPet)
     {
-        petutils::DespawnPet(PPet->PMaster);
-        return;
+        // if a charmed mob and charm time is up then despawn
+        if (PPet->isCharmed && tick > PPet->charmTime)
+        {
+            petutils::DespawnPet(PPet->PMaster);
+            return;
+        }
+
+        // if a jug pet and the current time > jug spawn time + jug duration then despawn
+        auto* PPetEntity = dynamic_cast<CPetEntity*>(PPet);
+        if (PPetEntity && PPetEntity->isAlive() && PPetEntity->getPetType() == PET_TYPE::JUG_PET)
+        {
+            // need to covert tick to unix time (in seconds) because getJugSpawnTime and getJugDuration give unix time
+            auto tickAsUnixTime = static_cast<uint32>(std::chrono::duration_cast<std::chrono::seconds>(tick.time_since_epoch()).count());
+            if (tickAsUnixTime > PPetEntity->getJugSpawnTime() + PPetEntity->getJugDuration())
+            {
+                petutils::DespawnPet(PPetEntity->PMaster);
+                return;
+            }
+        }
     }
     CMobController::Tick(tick);
 }

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -186,8 +186,8 @@ struct teleport_t
 struct PetInfo_t
 {
     bool     respawnPet;   // Used for spawning pet on zone
-    int32    jugSpawnTime; // Keeps track of original spawn time in seconds since epoch
-    int32    jugDuration;  // Number of seconds a jug pet should last after its original spawn time
+    uint32   jugSpawnTime; // Keeps track of original spawn time in seconds since epoch
+    uint32   jugDuration;  // Number of seconds a jug pet should last after its original spawn time
     uint8    petID;        // ID as in wyvern(48) , carbuncle(8) ect..
     PET_TYPE petType;      // Type of pet being transferred
     uint8    petLevel;     // Level the pet was spawned with

--- a/src/map/entities/petentity.cpp
+++ b/src/map/entities/petentity.cpp
@@ -85,7 +85,7 @@ bool CPetEntity::isBstPet()
     return getPetType() == PET_TYPE::JUG_PET || objtype == TYPE_MOB;
 }
 
-int32 CPetEntity::getJugSpawnTime()
+uint32 CPetEntity::getJugSpawnTime()
 {
     if (m_PetType != PET_TYPE::JUG_PET)
     {
@@ -94,10 +94,10 @@ int32 CPetEntity::getJugSpawnTime()
     }
 
     const auto epoch = m_jugSpawnTime.time_since_epoch();
-    return static_cast<int32>(std::chrono::duration_cast<std::chrono::seconds>(epoch).count());
+    return static_cast<uint32>(std::chrono::duration_cast<std::chrono::seconds>(epoch).count());
 }
 
-void CPetEntity::setJugSpawnTime(int32 spawnTime)
+void CPetEntity::setJugSpawnTime(uint32 spawnTime)
 {
     if (m_PetType != PET_TYPE::JUG_PET)
     {
@@ -105,10 +105,10 @@ void CPetEntity::setJugSpawnTime(int32 spawnTime)
         return;
     }
 
-    m_jugSpawnTime = std::chrono::system_clock::time_point(std::chrono::duration<int>(spawnTime));
+    m_jugSpawnTime = std::chrono::system_clock::time_point(std::chrono::duration<uint32>(spawnTime));
 }
 
-int32 CPetEntity::getJugDuration()
+uint32 CPetEntity::getJugDuration()
 {
     if (m_PetType != PET_TYPE::JUG_PET)
     {
@@ -116,10 +116,10 @@ int32 CPetEntity::getJugDuration()
         return 0;
     }
 
-    return static_cast<int32>(std::chrono::duration_cast<std::chrono::seconds>(m_jugDuration).count());
+    return static_cast<uint32>(std::chrono::duration_cast<std::chrono::seconds>(m_jugDuration).count());
 }
 
-void CPetEntity::setJugDuration(int32 seconds)
+void CPetEntity::setJugDuration(uint32 seconds)
 {
     if (m_PetType != PET_TYPE::JUG_PET)
     {
@@ -270,27 +270,6 @@ void CPetEntity::Spawn()
     // TODO: Calling a grand-parent's impl. of an overridden function is bad
     CBattleEntity::Spawn();
     luautils::OnMobSpawn(this);
-}
-
-bool CPetEntity::shouldDespawn(time_point tick)
-{
-    // This check was moved from the original call site when this method was added.
-    // It is in theory not needed, but we are not removing it without further testing.
-    // TODO: Consider removing this when possible.
-    if (isCharmed && tick > charmTime)
-    {
-        return true;
-    }
-
-    if (PMaster != nullptr &&
-        PAI->IsSpawned() &&
-        m_PetType == PET_TYPE::JUG_PET &&
-        tick > m_jugSpawnTime + m_jugDuration)
-    {
-        return true;
-    }
-
-    return false;
 }
 
 void CPetEntity::loadPetZoningInfo()

--- a/src/map/entities/petentity.h
+++ b/src/map/entities/petentity.h
@@ -55,9 +55,9 @@ public:
     PET_TYPE          getPetType();
     uint8             getSpawnLevel();
     void              setSpawnLevel(uint8 level);
-    int32             getJugSpawnTime();             // initial spawn time (in seconds since epoch) of this pet if it's a jug pet
-    int32             getJugDuration();              // duration of this jug pet in seconds
-    void              setJugDuration(int32 seconds); // sets the duration of this jug pet in seconds
+    uint32            getJugSpawnTime();              // initial spawn time (in seconds since epoch) of this pet if it's a jug pet
+    uint32            getJugDuration();               // duration of this jug pet in seconds
+    void              setJugDuration(uint32 seconds); // sets the duration of this jug pet in seconds
     bool              isBstPet();
     uint32            m_PetID;
     const std::string GetScriptName();
@@ -66,9 +66,8 @@ public:
     virtual void      FadeOut() override;
     virtual void      Die() override;
     virtual void      Spawn() override;
-    bool              shouldPersistThroughZone();     // if true, zoning should not cause a currently active pet to despawn
-    bool              shouldDespawn(time_point tick); // if true, the pet should despawn at this point in time
-    void              loadPetZoningInfo();            // loads info from previous zone (hp / mp / tp / spawn time). This MUST be called after Spawn()
+    bool              shouldPersistThroughZone(); // if true, zoning should not cause a currently active pet to despawn
+    void              loadPetZoningInfo();        // loads info from previous zone (hp / mp / tp / spawn time). This MUST be called after Spawn()
     virtual void      OnAbility(CAbilityState&, action_t&) override;
     virtual bool      ValidTarget(CBattleEntity* PInitiator, uint16 targetFlags) override;
     void              OnPetSkillFinished(CPetSkillState& state, action_t& action);
@@ -80,7 +79,7 @@ private:
     time_point m_jugSpawnTime; // original spawn time of a jug pet
     duration   m_jugDuration;  // Time before the jug is despawned after being called
 
-    void setJugSpawnTime(int32 spawnTime); // sets the initial spawn time of this pet in seconds since epoch
+    void setJugSpawnTime(uint32 spawnTime); // sets the initial spawn time of this pet in seconds since epoch
 };
 
 #endif

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -703,8 +703,8 @@ namespace charutils
                 PChar->petZoningInfo.petType      = static_cast<PET_TYPE>(rset->getUInt("pet_type"));
                 PChar->petZoningInfo.petLevel     = rset->getUInt("pet_level");
                 PChar->petZoningInfo.respawnPet   = true;
-                PChar->petZoningInfo.jugSpawnTime = PChar->getCharVar("jugpet-spawn-time");
-                PChar->petZoningInfo.jugDuration  = PChar->getCharVar("jugpet-duration-seconds");
+                PChar->petZoningInfo.jugSpawnTime = static_cast<uint32>(PChar->getCharVar("jugpet-spawn-time"));
+                PChar->petZoningInfo.jugDuration  = static_cast<uint32>(PChar->getCharVar("jugpet-duration-seconds"));
 
                 // clear the charvars used for jug state
                 PChar->clearCharVarsWithPrefix("jugpet-");
@@ -5439,8 +5439,8 @@ namespace charutils
 
         // These two are jug only variables. We should probably move pet char stats into its own table, but in the meantime
         // we use charvars for jug specific things
-        PChar->setCharVar("jugpet-spawn-time", PChar->petZoningInfo.jugSpawnTime);
-        PChar->setCharVar("jugpet-duration-seconds", PChar->petZoningInfo.jugDuration);
+        PChar->setCharVar("jugpet-spawn-time", static_cast<int32>(PChar->petZoningInfo.jugSpawnTime));
+        PChar->setCharVar("jugpet-duration-seconds", static_cast<int32>(PChar->petZoningInfo.jugDuration));
     }
 
     /************************************************************************

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1791,7 +1791,7 @@ namespace petutils
         {
             uint8 spawnLevel = static_cast<CCharEntity*>(PMaster)->petZoningInfo.petLevel;
             PPet->setSpawnLevel(spawnLevel > 0 ? spawnLevel : UINT8_MAX);
-            PPet->setJugDuration(static_cast<int32>(PPetData->time));
+            PPet->setJugDuration(PPetData->time);
             CalculateJugPetStats(PMaster, PPet);
         }
         else if (PPet->getPetType() == PET_TYPE::WYVERN)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes an issue whereby monsters charmed by players never uncharm due to the charm time ending. I think the issue was introduced in this [PR](https://github.com/LandSandBoat/server/pull/3164) where a check was added with `objtype == TYPE_PET` which only applies to jug pets and not charmed mobs. Thus `charmTime` is never checked.

Also the linked PR added a comment that the check in `shouldDespawn` was not longer needed, however this is not the case. I am unsure of the reasoning for that comment, thus this PR removes it.

## Steps to test these changes
Charm a mob as a BST and watch the mob eventually uncharm after some time (rather than staying charmed forever).
