### PR TITLE
Better level sync effect handling

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -309,7 +309,7 @@ CCharEntity::~CCharEntity()
         {
             if (PParty->GetSyncTarget() == this || PParty->GetLeader() == this)
             {
-                PParty->SetSyncTarget("", 551);
+                PParty->SetSyncTarget("", MsgStd::LevelSyncDeactivateLeftArea);
             }
             if (PParty->GetSyncTarget() != nullptr)
             {
@@ -323,7 +323,7 @@ CCharEntity::~CCharEntity()
                 }
                 if (count < 2) // 3, because one is zoning out - thus at least 2 will be left
                 {
-                    PParty->SetSyncTarget("", 552);
+                    PParty->SetSyncTarget("", MsgStd::LevelSyncRemoveTooFewMembers);
                 }
             }
         }

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -10958,7 +10958,7 @@ void CLuaBaseEntity::disableLevelSync()
     {
         if (PChar->PParty->GetSyncTarget() == PChar)
         {
-            PChar->PParty->SetSyncTarget("", 553);
+            PChar->PParty->SetSyncTarget("", MsgStd::LevelSyncRemoveLeftParty);
         }
         else
         {

--- a/src/map/packets/message_basic.cpp
+++ b/src/map/packets/message_basic.cpp
@@ -22,6 +22,7 @@
 #include "common/socket.h"
 
 #include "message_basic.h"
+#include "message_standard.h"
 
 #include "entities/baseentity.h"
 
@@ -39,6 +40,11 @@ CMessageBasicPacket::CMessageBasicPacket(CBaseEntity* PSender, CBaseEntity* PTar
     ref<uint32>(0x0C) = param;
     ref<uint32>(0x10) = value;
     ref<uint16>(0x18) = messageID;
+}
+
+CMessageBasicPacket::CMessageBasicPacket(CBaseEntity* PSender, CBaseEntity* PTarget, int32 param, int32 value, MsgStd messageID)
+: CMessageBasicPacket(PSender, PTarget, param, value, static_cast<uint16>(messageID))
+{
 }
 
 uint16 CMessageBasicPacket::getMessageID()

--- a/src/map/packets/message_basic.h
+++ b/src/map/packets/message_basic.h
@@ -24,6 +24,8 @@
 
 #include "common/cbasetypes.h"
 
+#include "message_standard.h"
+
 #include "basic.h"
 
 /*
@@ -221,7 +223,9 @@ class CBaseEntity;
 class CMessageBasicPacket : public CBasicPacket
 {
 public:
+    // TODO: Replace uint16 with MsgStd version
     CMessageBasicPacket(CBaseEntity* PSender, CBaseEntity* PTarget, int32 param, int32 value, uint16 messageID);
+    CMessageBasicPacket(CBaseEntity* PSender, CBaseEntity* PTarget, int32 param, int32 value, MsgStd messageID);
     uint16 getMessageID();
 };
 

--- a/src/map/packets/message_standard.h
+++ b/src/map/packets/message_standard.h
@@ -110,6 +110,7 @@ enum class MsgStd
     LevelSyncWarning             = 235, // Warning! This is a Level Sync party ...
     CannotInviteLevelSync        = 236, // You cannot invite that person at this time. This player is either undergoing Level Sync...
     CannotJoinLevelSync          = 237, // You cannot join this party.  You are either undergoing Level Sync...
+    LevelSyncSet                 = 238, // The party's level has been restricted to <level>.
     Compass                      = 239, // The compass reads: ...
     CannotHere                   = 256, // You cannot use that command in this area.
     HeadgearShow                 = 260,
@@ -133,6 +134,21 @@ enum class MsgStd
     TrustEnmity                  = 300, // You cannot use Trust magic while having gained enmity.
     TrustSoloOrLeader            = 301, // You cannot use Trust magic unless you are solo or the party leader.
     AnErrorHasOccured            = 308, // An error has occurred.
+    LevelSyncActivated           = 540, // Level Sync activated. Your level has been restricted to <Level>. Equipment effected by the level restriction will be adjusted accordingly. Experience...
+    LevelSyncDesigneeBelowMin    = 541, // Level Sync could not be activated. The designated player is below level 10.
+    LevelSyncDesigneeInOtherArea = 542, // Level Sync could not be activated. The designated player is in a different area.
+    LevelSyncPreventedByStatus   = 543, // Level Sync could not be activated. One or more party members are currently under the effect of a status which prevents synchronization.
+    LevelSyncWillBeRemoved       = 544, // Level synchronization will be removed in x seconds.
+    LevelSyncNoExpTooFarOrUnc    = 545, // No experience points gained... The Level Sync designee is either too far from the enemy, or unconcious.
+    LevelSyncIneligibleForExp    = 548, // The party member you selected is incapable of receiving experience points, and as such cannot be a Level Sync designee.
+    LevelSyncNoExpIneligible     = 549, // No experience points gained... The Level Sync designee is incapable of receiving experience points.
+    LevelSyncDeactivateForStatus = 550, // Level sync will be deactivated in 30 seconds. One or more party members have received the effect of a status which prevents synchronization.
+    LevelSyncDeactivateLeftArea  = 551, // Level sync will be deactivated in 30 seconds. The party leader or the Level Sync designee has left the area.
+    LevelSyncRemoveTooFewMembers = 552, // Level sync will be deactivated in 30 seconds. Less than two party members fulfill the requirements for Level Sync.
+    LevelSyncRemoveLeftParty     = 553, // Level sync will be deactivated in 30 seconds. The party leader has removed synchronization, or the Level Sync designee has left the party.
+    LevelSyncRemoveLowLevel      = 554, // Level sync will be deactivated in 30 seconds. The Level Sync designee has fallen below level 10.
+    LevelSyncRemoveJobChange     = 555, // Level sync will be deactivated in 30 seconds. A party member has undergone a job change.
+    LevelSyncRemoveIneligibleExp = 556, // Level sync will be deactivated in 30 seconds. The Level Sync designee is incapable of receiving experience points.
 };
 
 class CCharEntity;

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -148,7 +148,7 @@ void CParty::DisbandParty(bool playerInitiated)
             CStatusEffect* sync = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_LEVEL_SYNC);
             if (sync && sync->GetDuration() == 0)
             {
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 30, 553));
+                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 30, MsgStd::LevelSyncRemoveLeftParty));
                 sync->SetStartTime(server_clock::now());
                 sync->SetDuration(30000);
             }
@@ -207,10 +207,10 @@ void CParty::AssignPartyRole(const std::string& MemberName, uint8 role)
             SetQuarterMaster("");
             break;
         case 6:
-            SetSyncTarget(MemberName, 238);
+            SetSyncTarget(MemberName, MsgStd::LevelSyncSet);
             break;
         case 7:
-            SetSyncTarget("", 553);
+            SetSyncTarget("", MsgStd::LevelSyncRemoveLeftParty);
             break;
     }
     uint8 data[4]{};
@@ -311,11 +311,11 @@ void CParty::RemoveMember(CBattleEntity* PEntity)
                 }
                 if (m_PSyncTarget == PChar)
                 {
-                    SetSyncTarget("", 553);
+                    SetSyncTarget("", MsgStd::LevelSyncRemoveLeftParty);
                     CStatusEffect* sync = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_LEVEL_SYNC);
                     if (sync && sync->GetDuration() == 0)
                     {
-                        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 30, 553));
+                        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 30, MsgStd::LevelSyncRemoveLeftParty));
                         sync->SetStartTime(server_clock::now());
                         sync->SetDuration(30000);
                     }
@@ -328,7 +328,7 @@ void CParty::RemoveMember(CBattleEntity* PEntity)
                         CStatusEffect* sync = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_LEVEL_SYNC);
                         if (sync && sync->GetDuration() == 0)
                         {
-                            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 30, 553));
+                            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 30, MsgStd::LevelSyncRemoveLeftParty));
                             sync->SetStartTime(server_clock::now());
                             sync->SetDuration(30000);
                         }
@@ -407,11 +407,11 @@ void CParty::DelMember(CBattleEntity* PEntity)
                 }
                 if (m_PSyncTarget == PChar)
                 {
-                    SetSyncTarget("", 553);
+                    SetSyncTarget("", MsgStd::LevelSyncRemoveLeftParty);
                     CStatusEffect* sync = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_LEVEL_SYNC);
                     if (sync && sync->GetDuration() == 0)
                     {
-                        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 30, 553));
+                        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 30, MsgStd::LevelSyncRemoveLeftParty));
                         sync->SetStartTime(server_clock::now());
                         sync->SetDuration(30000);
                     }
@@ -424,7 +424,7 @@ void CParty::DelMember(CBattleEntity* PEntity)
                         CStatusEffect* sync = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_LEVEL_SYNC);
                         if (sync && sync->GetDuration() == 0)
                         {
-                            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 30, 553));
+                            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 30, MsgStd::LevelSyncRemoveLeftParty));
                             sync->SetStartTime(server_clock::now());
                             sync->SetDuration(30000);
                         }
@@ -637,7 +637,7 @@ void CParty::AddMember(CBattleEntity* PEntity)
         {
             if (PChar->getZone() == m_PSyncTarget->getZone())
             {
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, m_PSyncTarget->GetMLevel(), 540));
+                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, m_PSyncTarget->GetMLevel(), MsgStd::LevelSyncActivated));
                 PChar->StatusEffectContainer->AddStatusEffect(new CStatusEffect(EFFECT_LEVEL_SYNC, EFFECT_LEVEL_SYNC, m_PSyncTarget->GetMLevel(), 0, 0), true);
                 PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DISPELABLE | EFFECTFLAG_ON_ZONE);
                 PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, new CCharSyncPacket(PChar));
@@ -1057,7 +1057,7 @@ void CParty::SetLeader(const std::string& MemberName)
     }
 }
 
-void CParty::SetSyncTarget(const std::string& MemberName, uint16 message)
+void CParty::SetSyncTarget(const std::string& MemberName, MsgStd message)
 {
     CBattleEntity* PEntity = GetMemberByName(MemberName);
 
@@ -1069,12 +1069,12 @@ void CParty::SetSyncTarget(const std::string& MemberName, uint16 message)
             // enable level sync
             if (PChar->GetMLevel() < 10)
             {
-                ((CCharEntity*)GetLeader())->pushPacket(new CMessageBasicPacket((CCharEntity*)GetLeader(), (CCharEntity*)GetLeader(), 0, 10, 541));
+                ((CCharEntity*)GetLeader())->pushPacket(new CMessageBasicPacket((CCharEntity*)GetLeader(), (CCharEntity*)GetLeader(), 0, 10, MsgStd::LevelSyncDesigneeBelowMin));
                 return;
             }
             else if (PChar->getZone() != GetLeader()->getZone())
             {
-                ((CCharEntity*)GetLeader())->pushPacket(new CMessageBasicPacket((CCharEntity*)GetLeader(), (CCharEntity*)GetLeader(), 0, 0, 542));
+                ((CCharEntity*)GetLeader())->pushPacket(new CMessageBasicPacket((CCharEntity*)GetLeader(), (CCharEntity*)GetLeader(), 0, 0, MsgStd::LevelSyncDesigneeInOtherArea));
                 return;
             }
             else
@@ -1083,7 +1083,7 @@ void CParty::SetSyncTarget(const std::string& MemberName, uint16 message)
                 {
                     if (member->StatusEffectContainer->HasStatusEffect({ EFFECT_LEVEL_RESTRICTION, EFFECT_LEVEL_SYNC, EFFECT_SJ_RESTRICTION, EFFECT_CONFRONTATION, EFFECT_BATTLEFIELD }))
                     {
-                        ((CCharEntity*)GetLeader())->pushPacket(new CMessageBasicPacket((CCharEntity*)GetLeader(), (CCharEntity*)GetLeader(), 0, 0, 543));
+                        ((CCharEntity*)GetLeader())->pushPacket(new CMessageBasicPacket((CCharEntity*)GetLeader(), (CCharEntity*)GetLeader(), 0, 0, MsgStd::LevelSyncPreventedByStatus));
                         return;
                     }
                 }
@@ -1099,7 +1099,7 @@ void CParty::SetSyncTarget(const std::string& MemberName, uint16 message)
 
                     if (member->status != STATUS_TYPE::DISAPPEAR && member->getZone() == PChar->getZone())
                     {
-                        member->pushPacket(new CMessageStandardPacket(PChar->GetMLevel(), 0, 0, 0, static_cast<MsgStd>(message)));
+                        member->pushPacket(new CMessageStandardPacket(PChar->GetMLevel(), 0, 0, 0, message));
                         member->StatusEffectContainer->AddStatusEffect(new CStatusEffect(EFFECT_LEVEL_SYNC, EFFECT_LEVEL_SYNC, PChar->GetMLevel(), 0, 0), true);
                         member->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DISPELABLE | EFFECTFLAG_ON_ZONE);
                         member->loc.zone->PushPacket(member, CHAR_INRANGE, new CCharSyncPacket(member));
@@ -1130,7 +1130,7 @@ void CParty::SetSyncTarget(const std::string& MemberName, uint16 message)
                         CStatusEffect* sync = member->StatusEffectContainer->GetStatusEffect(EFFECT_LEVEL_SYNC);
                         if (sync && sync->GetDuration() == 0)
                         {
-                            member->pushPacket(new CMessageBasicPacket(member, member, 10, 30, message));
+                            member->pushPacket(new CMessageBasicPacket(member, member, 0, 30, message));
                             sync->SetStartTime(server_clock::now());
                             sync->SetDuration(30000);
                         }
@@ -1227,7 +1227,7 @@ void CParty::RefreshSync()
     uint8        syncLevel = sync->jobs.job[sync->GetMJob()];
     if (syncLevel < 10)
     {
-        SetSyncTarget("", 554);
+        SetSyncTarget("", MsgStd::LevelSyncRemoveLowLevel);
     }
     for (auto& i : members)
     {
@@ -1267,7 +1267,7 @@ void CParty::RefreshSync()
             charutils::CheckValidEquipment(member);
             member->pushPacket(new CCharAbilitiesPacket(member));
         }
-        member->pushPacket(new CMessageBasicPacket(member, member, 0, syncLevel, 540));
+        member->pushPacket(new CMessageBasicPacket(member, member, 0, syncLevel, MsgStd::LevelSyncActivated));
     }
     m_PSyncTarget = sync;
 }

--- a/src/map/party.h
+++ b/src/map/party.h
@@ -24,6 +24,7 @@
 
 #include "common/cbasetypes.h"
 #include "map.h"
+#include "packets/message_standard.h"
 
 #include <vector>
 
@@ -86,7 +87,7 @@ public:
     void   SetPartyID(uint32 id);                // set new party ID
     void   AssignPartyRole(const std::string& MemberName, uint8 role);
     void   DisableSync();
-    void   SetSyncTarget(const std::string& MemberName, uint16 message);
+    void   SetSyncTarget(const std::string& MemberName, MsgStd message);
     void   RefreshSync();
     void   SetPartyNumber(uint8 number);
     bool   HasOnlyOneMember() const;

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -5015,7 +5015,7 @@ namespace charutils
                 PChar->jobs.exp[PChar->GetMJob()] = GetExpNEXTLevel(PChar->jobs.job[PChar->GetMJob()]) - 1;
                 if (PChar->PParty && PChar->PParty->GetSyncTarget() == PChar)
                 {
-                    PChar->PParty->SetSyncTarget("", 556);
+                    PChar->PParty->SetSyncTarget("", MsgStd::LevelSyncRemoveIneligibleExp);
                 }
             }
             else

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -614,6 +614,15 @@ void CZone::updateCharLevelRestriction(CCharEntity* PChar)
 
     if (m_levelRestriction != 0)
     {
+        // remove buffs in level cap zones as well (such as riverne sites)
+        PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DISPELABLE, true);
+        PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_ERASABLE, true);
+        PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_ATTACK, true);
+        PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_ON_ZONE, true);
+        PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_SONG, true);
+        PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_ROLL, true);
+        PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_SYNTH_SUPPORT, true);
+        PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_BLOODPACT, true);
         PChar->StatusEffectContainer->AddStatusEffect(new CStatusEffect(EFFECT_LEVEL_RESTRICTION, EFFECT_LEVEL_RESTRICTION, m_levelRestriction, 0, 0));
     }
 }
@@ -1099,6 +1108,15 @@ void CZone::CharZoneIn(CCharEntity* PChar)
         if (PChar->PPet)
         {
             PChar->PPet->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_CONFRONTATION, true);
+        }
+    }
+    else if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_LEVEL_SYNC))
+    {
+        // Logging in with no party and a level sync status = bad.
+        if (!PChar->PParty)
+        {
+            PChar->StatusEffectContainer->DelStatusEffectSilent(EFFECT_LEVEL_SYNC);
+            PChar->StatusEffectContainer->DelStatusEffectSilent(EFFECT_LEVEL_RESTRICTION);
         }
     }
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Prevent zoning in with pre-existing level sync but no party: [Source](https://github.com/AirSkyBoat/AirSkyBoat/commit/2461a8a5119aa9d1155e66f3b30cdedbce2ba45c)

Remove buffs in level capped zone: [Source](https://github.com/AirSkyBoat/AirSkyBoat/commit/497093728a28856d7537ae76b47b9e6a1369c545)

Moves Level sync magic numbers to message_standard.h

## Steps to test these changes

Zone with party level sync where party disbands prior to zoning in.

In level capped zone, trigger new level sync and see status effects of flag wear: EFFECTFLAG_DISPELABLE, EFFECTFLAG_ERASABLE, EFFECTFLAG_ATTACK, EFFECTFLAG_ON_ZONE, EFFECTFLAG_SONG, EFFECTFLAG_ROLL, EFFECTFLAG_SYNTH_SUPPORT, EFFECTFLAG_BLOODPACT