### PR TITLE
Update "Composure" effect accuracy calculations for current retail

### DIFF
--- a/scripts/effects/composure.lua
+++ b/scripts/effects/composure.lua
@@ -7,18 +7,15 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    local jpValue = target:getJobPointLevel(xi.jp.COMPOSURE_EFFECT)
+    local power = math.floor((24 * target:getMainLvl() + 74) / 49) + target:getJobPointLevel(xi.jp.COMPOSURE_EFFECT)
 
-    target:addMod(xi.mod.ACC, 15 + jpValue)
+    effect:addMod(xi.mod.ACC, power)
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    local jpValue = target:getJobPointLevel(xi.jp.COMPOSURE_EFFECT)
-
-    target:delMod(xi.mod.ACC, 15 + jpValue)
 end
 
 return effectObject


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

As title sais

https://www.bg-wiki.com/ffxi/Composure

## Steps to test these changes

Use composure at different levels and see the accuracy bonus vary
