### PR TITLE
[Lua] Fix several Crawlers Nest and Davoi NM issues

### DIFF
--- a/scripts/zones/Crawlers_Nest/mobs/Demonic_Tiphia.lua
+++ b/scripts/zones/Crawlers_Nest/mobs/Demonic_Tiphia.lua
@@ -5,6 +5,18 @@
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobFight = function(mob, target)
+    -- captures show cure v repeatedly every 15 sec below 50% health
+    if
+        mob:getHPP() <= 50 and
+        mob:actionQueueEmpty() and
+        os.time() > mob:getLocalVar('cureDelay')
+    then
+        mob:castSpell(xi.magic.spell.CURE_V, mob)
+        mob:setLocalVar('cureDelay', os.time() + 15)
+    end
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 236)
 end

--- a/scripts/zones/Crawlers_Nest/mobs/Dynast_Beetle.lua
+++ b/scripts/zones/Crawlers_Nest/mobs/Dynast_Beetle.lua
@@ -5,6 +5,14 @@
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
+end
+
+entity.onAdditionalEffect = function(mob, target, damage)
+    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.SLOW)
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 237)
 end

--- a/scripts/zones/Davoi/mobs/Deloknok.lua
+++ b/scripts/zones/Davoi/mobs/Deloknok.lua
@@ -2,8 +2,14 @@
 -- Area: Davoi
 --  Mob: Deloknok
 -----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
+
+entity.onMobSpawn = function(mob)
+    mob:addMod(xi.mod.SLEEP_MEVA, 90)
+end
 
 entity.onMobDeath = function(mob, player, optParams)
 end

--- a/scripts/zones/Davoi/mobs/One-eyed_Gwajboj.lua
+++ b/scripts/zones/Davoi/mobs/One-eyed_Gwajboj.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Area: Davoi
---  Mob: Bilopdop
+--  Mob: One-eyed Gwajboj
 -----------------------------------
 mixins = { require('scripts/mixins/job_special') }
 -----------------------------------
@@ -9,6 +9,8 @@ local entity = {}
 
 entity.onMobSpawn = function(mob)
     mob:addMod(xi.mod.SLEEP_MEVA, 90)
+    mob:addMod(xi.mod.LULLABY_MEVA, 90)
+    mob:addMod(xi.mod.SILENCE_MEVA, 90)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Davoi/mobs/Three-eyed_Prozpuz.lua
+++ b/scripts/zones/Davoi/mobs/Three-eyed_Prozpuz.lua
@@ -1,14 +1,13 @@
 -----------------------------------
 -- Area: Davoi
---  Mob: Bilopdop
------------------------------------
-mixins = { require('scripts/mixins/job_special') }
+--  Mob: Three-eyed Prozpuz
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobSpawn = function(mob)
     mob:addMod(xi.mod.SLEEP_MEVA, 90)
+    mob:addMod(xi.mod.LULLABY_MEVA, 90)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -4704,7 +4704,7 @@ INSERT INTO `mob_groups` VALUES (74,3407,83,'Royal_Palliator',0,128,0,0,0,60,60,
 INSERT INTO `mob_groups` VALUES (75,3408,83,'Royal_Provisioner',0,128,0,0,0,60,60,0);
 INSERT INTO `mob_groups` VALUES (76,777,83,'Conqueror_Bakgodek',0,128,506,0,0,60,60,0);
 INSERT INTO `mob_groups` VALUES (77,3767,83,'Steelhide_Protector',0,128,0,0,0,60,60,0);
-INSERT INTO `mob_groups` VALUES (78,6759,83,'One-eyed_Gwajboj',0,128,0,0,0,60,60,0);
+INSERT INTO `mob_groups` VALUES (78,6759,83,'One-eyed_Gwajboj',0,128,0,10000,0,60,60,0);
 INSERT INTO `mob_groups` VALUES (79,1852,83,'Gutrender_Trooper',0,128,0,0,0,60,60,0);
 INSERT INTO `mob_groups` VALUES (80,935,83,'Deathlord_Rojgnoj',0,128,580,0,0,60,60,0);
 INSERT INTO `mob_groups` VALUES (81,3730,83,'Spinebeak_Neckchopper',0,128,0,0,0,60,60,0);
@@ -4714,7 +4714,7 @@ INSERT INTO `mob_groups` VALUES (84,737,83,'Clan_Reaper_Grunt',0,128,0,0,0,0,0,0
 INSERT INTO `mob_groups` VALUES (85,96,83,'Alpha_Gnole_Anders',0,128,53,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (86,132,83,'Anderss_Guard',0,128,0,0,0,60,60,0);
 INSERT INTO `mob_groups` VALUES (87,2734,83,'Moonfang_Warrior',0,128,1728,0,0,60,60,0);
-INSERT INTO `mob_groups` VALUES (88,3902,83,'Three-eyed_Prozpuz',0,128,307,0,0,60,60,0);
+INSERT INTO `mob_groups` VALUES (88,3902,83,'Three-eyed_Prozpuz',0,128,307,10000,0,60,60,0);
 INSERT INTO `mob_groups` VALUES (89,3907,83,'Throatripper_Predator',0,128,0,0,0,60,60,0);
 INSERT INTO `mob_groups` VALUES (90,735,83,'Clan_Bear_Fighter',0,128,0,0,0,65,65,0);
 INSERT INTO `mob_groups` VALUES (91,776,83,'Confederate_Mantelet',0,128,0,0,0,60,60,0);
@@ -10454,8 +10454,8 @@ INSERT INTO `mob_groups` VALUES (41,3006,149,'Orcish_Dragoon',960,0,1891,0,0,65,
 INSERT INTO `mob_groups` VALUES (42,1046,149,'Dirtyhanded_Gochakzuk',300,0,666,4000,0,71,71,0);
 INSERT INTO `mob_groups` VALUES (43,1478,149,'Gavotvut',0,128,307,0,0,45,45,0);
 INSERT INTO `mob_groups` VALUES (44,340,149,'Barakbok',0,128,0,0,0,43,43,0);
-INSERT INTO `mob_groups` VALUES (45,419,149,'Bilopdop',0,128,0,0,0,55,55,0);
-INSERT INTO `mob_groups` VALUES (46,964,149,'Deloknok',0,128,0,0,0,53,53,0);
+INSERT INTO `mob_groups` VALUES (45,419,149,'Bilopdop',0,128,0,10800,0,55,55,0);
+INSERT INTO `mob_groups` VALUES (46,964,149,'Deloknok',0,128,0,6000,0,53,53,0);
 INSERT INTO `mob_groups` VALUES (47,3233,149,'Purpleflash_Brukdok',600,0,2044,0,0,45,45,0);
 INSERT INTO `mob_groups` VALUES (48,2980,149,'One-eyed_Gwajboj',0,128,1859,0,0,62,62,0);
 INSERT INTO `mob_groups` VALUES (49,6678,149,'Three-eyed_Prozpuz',0,128,307,0,0,60,60,0);
@@ -12892,7 +12892,7 @@ INSERT INTO `mob_groups` VALUES (29,3707,197,'Soul_Stinger',300,0,2295,0,0,48,50
 INSERT INTO `mob_groups` VALUES (30,6332,197,'Mushussu',300,0,1756,0,0,53,55,0);
 INSERT INTO `mob_groups` VALUES (31,7035,197,'Rumble_Crawler',300,0,2132,0,0,53,55,0);
 INSERT INTO `mob_groups` VALUES (32,4322,197,'Wespe',300,0,2644,0,0,55,57,0);
-INSERT INTO `mob_groups` VALUES (33,979,197,'Demonic_Tiphia',0,32,610,0,0,60,60,0);
+INSERT INTO `mob_groups` VALUES (33,979,197,'Demonic_Tiphia',0,32,610,10000,0,60,60,0);
 INSERT INTO `mob_groups` VALUES (34,1099,197,'Dragonfly',300,0,697,0,0,55,58,0);
 INSERT INTO `mob_groups` VALUES (35,832,197,'Crawler_Hunter',300,0,531,0,0,60,62,0);
 INSERT INTO `mob_groups` VALUES (36,4705,197,'Aqrabuamelu',7200,0,2947,7500,0,72,75,0);

--- a/sql/mob_spell_lists.sql
+++ b/sql/mob_spell_lists.sql
@@ -1361,7 +1361,6 @@ INSERT INTO `mob_spell_lists` VALUES ('Animated_Shield',96,273,37,255); -- sleep
 INSERT INTO `mob_spell_lists` VALUES ('Stubborn_Dredvodd',97,54,1,255); -- stoneskin (1~255)
 
 -- Demonic_Tiphia (98)
-INSERT INTO `mob_spell_lists` VALUES ('Demonic_Tiphia',98,5,1,255);   -- cure_v (1~255)
 INSERT INTO `mob_spell_lists` VALUES ('Demonic_Tiphia',98,143,1,255); -- erase (1~255)
 INSERT INTO `mob_spell_lists` VALUES ('Demonic_Tiphia',98,274,1,255); -- sleepga_ii (1~255)
 INSERT INTO `mob_spell_lists` VALUES ('Demonic_Tiphia',98,356,1,255); -- paralyga (1~255)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes several issues with mobs in Crawlers Nest and Davoi:
1. Add a Cure V spam mechanism and correct HP to Demonic Tiphia (Siknoz capture [here](https://youtu.be/AMxh_grKZ24))
2. Add an Additional Effect Slow to attacks of Dynast Beetle ([retail video](https://youtu.be/cUApMZhahIk?t=48))
3. Add Hundred Fists, Sleep MEVA, and correct HP to Bilopdop (Siknoz capture [here](https://youtu.be/M_zLzsMSaw0))
4. Add Invincible, Sleep MEVA, and correct HP to Deloknok (Siknoz capture [here](https://youtu.be/M_zLzsMSaw0))
5. Add Invincible, Sleep/Lullaby/Silence MEVA , and correct HP to One-eyed Gwajboj (KnowOne capture [here](https://www.youtube.com/watch?v=1-99TtfPVFE))
6. Add Sleep/Lullaby MEVA and correct HP to Three-eyed Prozpuz (KnowOne capture [here](https://www.youtube.com/watch?v=1-99TtfPVFE))

## Steps to test these changes
Fight these mobs and check against captures