### PR TITLE
[Lua] Fix Feeler Antlion ??? despawning and respawning

### DIFF
--- a/scripts/zones/Attohwa_Chasm/IDs.lua
+++ b/scripts/zones/Attohwa_Chasm/IDs.lua
@@ -29,17 +29,20 @@ zones[xi.zone.ATTOHWA_CHASM] =
     },
     mob =
     {
-        LIOUMERE         = GetFirstID('Lioumere'),
-        CITIPATI         = GetFirstID('Citipati'),
-        TIAMAT           = GetFirstID('Tiamat'),
-        FEELER_ANTLION   = GetFirstID('Feeler_Antlion'),
-        AMBUSHER_ANTLION = GetFirstID('Ambusher_Antlion'),
+        LIOUMERE            = GetFirstID('Lioumere'),
+        CITIPATI            = GetFirstID('Citipati'),
+        TIAMAT              = GetFirstID('Tiamat'),
+        FEELER_ANTLION      = GetFirstID('Feeler_Antlion'),
+        AMBUSHER_ANTLION    = GetFirstID('Ambusher_Antlion'),
+        ALASTOR_ANTLION     = GetFirstID('Alastor_Antlion'),
+        EXECUTIONER_ANTLION = GetTableOfIDs('Executioner_Antlion'),
     },
     npc =
     {
-        MIASMA_OFFSET   = GetFirstID('_071'),
-        GASPONIA_OFFSET = GetFirstID('_07n'),
-        EXCAVATION      = GetTableOfIDs('Excavation_Point'),
+        MIASMA_OFFSET     = GetFirstID('_071'),
+        GASPONIA_OFFSET   = GetFirstID('_07n'),
+        EXCAVATION        = GetTableOfIDs('Excavation_Point'),
+        QM_FEELER_ANTLION = GetFirstID('qm_feeler_antlion'),
     },
 }
 

--- a/scripts/zones/Attohwa_Chasm/globals.lua
+++ b/scripts/zones/Attohwa_Chasm/globals.lua
@@ -1,0 +1,37 @@
+-----------------------------------
+-- Zone: Attohwa_Chasm
+-- Desc: this file contains functions that are shared by multiple luas in this zone's directory
+-----------------------------------
+local ID = zones[xi.zone.ATTOHWA_CHASM]
+-----------------------------------
+
+local attohwaChasmGlobal =
+{
+    -- Check to see if any mobs associated with Feeler Antlion are still spawned
+    -- if not then can start the timer to respawn the ???; a custom function is needed
+    -- because npcUtil.popFromQM does not support ??? timer when mobs pop other mobs
+    canStartFeelerQMTimer = function(despawningMobID)
+        -- assume true that none of the mobs are spawned
+        local canStartTimer = true
+
+        -- first check feeler and alastor to make sure not spawned
+        local feeler = GetMobByID(ID.mob.FEELER_ANTLION)
+        local alastor = GetMobByID(ID.mob.ALASTOR_ANTLION)
+        if (feeler and feeler:isSpawned()) or (alastor and alastor:isSpawned()) then
+            canStartTimer = false
+        end
+
+        -- then check all executioners to make sure not spawned
+        for _, executionerID in ipairs(ID.mob.EXECUTIONER_ANTLION) do
+            local executioner = GetMobByID(executionerID)
+            if executioner and executioner:isSpawned() then
+                canStartTimer = false
+                break
+            end
+        end
+
+        return canStartTimer
+    end,
+}
+
+return attohwaChasmGlobal

--- a/scripts/zones/Attohwa_Chasm/mobs/Alastor_Antlion.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Alastor_Antlion.lua
@@ -2,7 +2,9 @@
 -- Area: Attohwa Chasm
 --   NM: Alastor Antlion
 -----------------------------------
+local ID = zones[xi.zone.ATTOHWA_CHASM]
 mixins = { require('scripts/mixins/families/antlion_ambush_noaggro') }
+local attohwaChasmGlobal = require('scripts/zones/Attohwa_Chasm/globals')
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
@@ -21,6 +23,12 @@ entity.onAdditionalEffect = function(mob, target, damage)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
+end
+
+entity.onMobDespawn = function(mob)
+    if attohwaChasmGlobal.canStartFeelerQMTimer() then
+        GetNPCByID(ID.npc.QM_FEELER_ANTLION):updateNPCHideTime(xi.settings.main.FORCE_SPAWN_QM_RESET_TIME)
+    end
 end
 
 return entity

--- a/scripts/zones/Attohwa_Chasm/mobs/Executioner_Antlion.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Executioner_Antlion.lua
@@ -2,7 +2,9 @@
 -- Area: Attohwa Chasm
 --  Mob: Executioner Antlion
 -----------------------------------
+local ID = zones[xi.zone.ATTOHWA_CHASM]
 mixins = { require('scripts/mixins/families/antlion_ambush_noaggro') }
+local attohwaChasmGlobal = require('scripts/zones/Attohwa_Chasm/globals')
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
@@ -12,6 +14,12 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
+end
+
+entity.onMobDespawn = function(mob)
+    if attohwaChasmGlobal.canStartFeelerQMTimer() then
+        GetNPCByID(ID.npc.QM_FEELER_ANTLION):updateNPCHideTime(xi.settings.main.FORCE_SPAWN_QM_RESET_TIME)
+    end
 end
 
 return entity

--- a/scripts/zones/Attohwa_Chasm/mobs/Feeler_Antlion.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Feeler_Antlion.lua
@@ -2,6 +2,9 @@
 -- Area: Attohwa Chasm
 --  Mob: Feeler Antlion
 -----------------------------------
+local ID = zones[xi.zone.ATTOHWA_CHASM]
+local attohwaChasmGlobal = require('scripts/zones/Attohwa_Chasm/globals')
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
 
@@ -16,6 +19,12 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
+end
+
+entity.onMobDespawn = function(mob)
+    if attohwaChasmGlobal.canStartFeelerQMTimer() then
+        GetNPCByID(ID.npc.QM_FEELER_ANTLION):updateNPCHideTime(xi.settings.main.FORCE_SPAWN_QM_RESET_TIME)
+    end
 end
 
 return entity

--- a/scripts/zones/Attohwa_Chasm/npcs/qm_feeler_antlion.lua
+++ b/scripts/zones/Attohwa_Chasm/npcs/qm_feeler_antlion.lua
@@ -19,6 +19,7 @@ entity.onTrade = function(player, npc, trade)
         player:tradeComplete()
         nm:setSpawn(npc:getXPos() - 3, npc:getYPos() - 2, npc:getZPos() - 1)
         SpawnMob(ID.mob.FEELER_ANTLION):updateClaim(player)
+        npc:setStatus(xi.status.DISAPPEAR)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
The PR fixes an issue where the ??? for Feeler Antlion never despawns when popping Feeler Antlion.

The PR adds code to despawn the ??? and also adds a custom function  `canStartFeelerQMTimer` to control the respawning of the ???. A custom function is needed as `npcUtil.popFromQM` does not support ??? timers when mobs spawn other mobs (such as Feeler Antlion spawning Alastor Antlion and Executioner Antlion). The custom function is called in `onMobDespawn` of Feeler, Alastor, and Executioner and checks if any these mobs are still spawned and if not then start the ??? respawn timer.

## Steps to test these changes
Spawn Feeler Antlion from ??? and test different scenarios of killing Feeler, Alastor, Executioner and seeing when the ??? respawns.