### PR TITLE
[Core/Lua] Add Additional Check for Battlefield Registration

### DIFF
--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -717,6 +717,7 @@ function Battlefield.onEntryTrigger(player, npc)
         end
 
         local options = utils.mask.setBit(0, content.index, true)
+        player:setLocalVar('[BCNM]EnterExisting', 1)
         return Battlefield:event(32000, 0, 0, 0, options, 0, 0, 0, 0)
     end
 
@@ -817,6 +818,11 @@ function Battlefield:onEntryEventUpdate(player, csid, option, npc)
             else
                 player:updateEvent(xi.battlefield.returnCode.WAIT)
             end
+        elseif result == xi.battlefield.returnCode.REQS_NOT_MET then
+            -- Ensure Battlefield Effect is removed
+            -- If you cant enter now, you cant enter by trying again right now...
+            player:delStatusEffect(xi.effect.BATTLEFIELD)
+            player:updateEvent(xi.battlefield.returnCode.REQS_NOT_MET)
         end
 
         -- TODO: Remove the localVar when issue with function return is resolved

--- a/src/map/battlefield_handler.cpp
+++ b/src/map/battlefield_handler.cpp
@@ -234,10 +234,29 @@ uint8 CBattlefieldHandler::RegisterBattlefield(CCharEntity* PChar, const Battlef
                 break;
             }
         }
+        // If the player has no Registered Battlefield...
+        if (!PBattlefield)
+        {
+            // ...but they do have the BCNM Status Effect somehow (This should not happen, but keeping to be safe)
+            if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_BATTLEFIELD))
+            {
+                // Do not allow them to attain a new registration
+                return BATTLEFIELD_RETURN_CODE_REQS_NOT_MET;
+            }
+            // ...but they did have the flag to enter an existing one
+            if (PChar->GetLocalVar("[BCNM]EnterExisting") == 1)
+            {
+                // Reset the flag, and do not allow them to attain a new registration
+                PChar->SetLocalVar("[BCNM]EnterExisting", 0);
+                return BATTLEFIELD_RETURN_CODE_REQS_NOT_MET;
+            }
+        }
     }
-    // Entity wasn't found in battlefield, assume they have the effect but not physically inside battlefield
-    if (PBattlefield)
+    // If they have a Registered Battlefield -AND- they have the Battlefield Status Effect
+    if (PBattlefield && PChar->StatusEffectContainer->HasStatusEffect(EFFECT_BATTLEFIELD))
     {
+        // Reset their progress var to 0 and proceed to attempt to enter them into the BCNM
+        PChar->SetLocalVar("[BCNM]EnterExisting", 0);
         if (!PBattlefield->CheckInProgress())
         {
             // players haven't started fighting yet, try entering


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Adds additional conditions for battlefield registration return codes.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
XXXXXXX