### PR TITLE
Update Ilrusi Atoll to Assault Framework

### DIFF
--- a/scripts/zones/Arrapago_Reef/npcs/_jic.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/_jic.lua
@@ -12,94 +12,18 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    -- TODO: Fix, implement & balance Assault
-    --[[
-    if player:hasKeyItem(xi.ki.ILRUSI_ASSAULT_ORDERS) then
-        local assaultid = player:getCurrentAssault()
-        local recommendedLevel = getRecommendedAssaultLevel(assaultid)
-        local armband = 0
-        if player:hasKeyItem(xi.ki.ASSAULT_ARMBAND) then
-            armband = 1
-        end
-        player:startEvent(219, assaultid, -4, 0, recommendedLevel, 4, armband)
-    else
+    if not xi.instance.onTrigger(player, npc, xi.zone.ILRUSI_ATOLL) then
         player:messageSpecial(ID.text.NOTHING_HAPPENS)
     end
-    ]]
-    player:messageSpecial(ID.text.NOTHING_HAPPENS)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
-    local assaultid = player:getCurrentAssault()
-
-    local cap = bit.band(option, 0x03)
-    if cap == 0 then
-        cap = 99
-    elseif cap == 1 then
-        cap = 70
-    elseif cap == 2 then
-        cap = 60
-    else
-        cap = 50
-    end
-
-    player:setCharVar('AssaultCap', cap)
-
-    local party = player:getParty()
-
-    if party ~= nil then
-        for i, v in pairs(party) do
-            if
-                not v:hasKeyItem(xi.ki.ILRUSI_ASSAULT_ORDERS and
-                v:getCurrentAssault() == assaultid)
-            then
-                player:messageText(npc, ID.text.MEMBER_NO_REQS, false)
-                player:instanceEntry(npc, 1)
-                return
-            elseif v:getZoneID() == player:getZoneID() and v:checkDistance(player) > 50 then
-                player:messageText(npc, ID.text.MEMBER_TOO_FAR, false)
-                player:instanceEntry(npc, 1)
-                return
-            end
-        end
-    end
-
-    player:createInstance(player:getCurrentAssault())
+    xi.assault.onAssaultUpdate(player, csid, option)
+    xi.instance.onEventUpdate(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    if csid == 108 or (csid == 219 and option == 4) then
-        player:setPos(0, 0, 0, 0, 55)
-    end
+    xi.instance.onEventFinish(player, csid, option)
 end
-
--- TODO: NPC does not support onInstanceCreated.  Move relevant
--- code to instance script when created.
---[[
-entity.onInstanceCreated = function(player, target, instance)
-    if instance then
-        instance:setLevelCap(player:getCharVar('AssaultCap'))
-        player:setCharVar('AssaultCap', 0)
-        player:setInstance(instance)
-        player:instanceEntry(target, 4)
-        player:delKeyItem(xi.ki.ILRUSI_ASSAULT_ORDERS)
-        player:delKeyItem(xi.ki.ASSAULT_ARMBAND)
-
-        local party = player:getParty()
-        if party ~= nil then
-            for i, v in pairs(party) do
-                if v:getID() ~= player:getID() and v:getZoneID() == player:getZoneID() then
-                    v:setInstance(instance)
-                    v:startEvent(108, 2)
-                    v:delKeyItem(xi.ki.ILRUSI_ASSAULT_ORDERS)
-                end
-            end
-        end
-    else
-        player:messageText(target, ID.text.CANNOT_ENTER, false)
-        player:instanceEntry(target, 3)
-    end
-end
-]]
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Updates Arrapago Reef's Runic Seal to use the existing assault framework global
- Adds messaging offset for assaults in Arrapago Reef

## Steps to test these changes
Enter into any pre-existing Ilrusi Atoll assault using the Runic Seal in Arrapago Reef
