### PR TITLE
[Lua] Fix distance of mob astral flow skills and related issues

### DIFF
--- a/scripts/actions/mobskills/astral_flow_pet.lua
+++ b/scripts/actions/mobskills/astral_flow_pet.lua
@@ -33,14 +33,14 @@ end
 -- [mobskillId] = { petFamily1, petFamily2, ... }
 local petAstralFlowAbility =
 {
-    [839] = { 36, 381 }, -- Fenrir (Howling Moon)
-    [913] = { 38, 383 }, -- Ifrit (Inferno)
-    [914] = { 45, 388 }, -- Titan (Earthen Fury)
-    [915] = { 40, 384 }, -- Leviathan (Tidal Wave)
-    [916] = { 37, 382 }, -- Garuda (Aerial Blast)
-    [917] = { 44, 387 }, -- Shiva (Diamond Dust)
-    [918] = { 43, 386 }, -- Ramuh (Judgment Bolt)
-    [919] = { 34, 379 }, -- Carbuncle (Searing Light)
+    [xi.mobSkill.HOWLING_MOON_2]  = { 36, 381 }, -- Fenrir (Howling Moon)
+    [xi.mobSkill.INFERNO_1]       = { 38, 383 }, -- Ifrit (Inferno)
+    [xi.mobSkill.EARTHEN_FURY_1]  = { 45, 388 }, -- Titan (Earthen Fury)
+    [xi.mobSkill.TIDAL_WAVE_1]    = { 40, 384 }, -- Leviathan (Tidal Wave)
+    [xi.mobSkill.AERIAL_BLAST_1]  = { 37, 382 }, -- Garuda (Aerial Blast)
+    [xi.mobSkill.DIAMOND_DUST_1]  = { 44, 387 }, -- Shiva (Diamond Dust)
+    [xi.mobSkill.JUDGMENT_BOLT_1] = { 43, 386 }, -- Ramuh (Judgment Bolt)
+    [xi.mobSkill.SEARING_LIGHT_1] = { 34, 379 }, -- Carbuncle (Searing Light)
 }
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
@@ -58,7 +58,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     -- Find proper pet skill
     local petFamily = pet:getFamily()
-    local skillId   = 919 -- Default to Searing Light if not found below
+    local skillId   = xi.mobSkill.SEARING_LIGHT_1 -- Default to Searing Light if not found below
 
     for mobSkillId, petFamilyList in pairs(petAstralFlowAbility) do
         if utils.contains(petFamily, petFamilyList) then

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -852,7 +852,7 @@ INSERT INTO `mob_skills` VALUES (834,516,'ecliptic_growl',1,0.0,10.0,516,3000,1,
 INSERT INTO `mob_skills` VALUES (835,517,'lunar_roar',1,0.0,10.0,515,3000,4,128,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (836,518,'eclipse_bite',0,0.0,10.0,518,3000,4,64,0,0,9,4,0); -- Gravitation (9) / Scission (4)
 INSERT INTO `mob_skills` VALUES (837,519,'ecliptic_howl',1,0.0,10.0,517,3000,1,128,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (838,521,'howling_moon',1,0.0,10.0,520,3000,4,64,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (838,521,'howling_moon',1,0.0,30.0,520,3000,4,64,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (839,521,'howling_moon',1,0.0,30.0,520,3000,4,64,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (840,526,'punch',0,0.0,10.0,528,3000,4,64,0,0,3,0,0); -- Liquefication (3)
 INSERT INTO `mob_skills` VALUES (841,527,'fire_ii',0,0.0,10.0,529,3000,4,64,0,0,0,0,0);
@@ -862,7 +862,7 @@ INSERT INTO `mob_skills` VALUES (844,530,'crimson_howl',1,0.0,10.0,532,3000,1,12
 INSERT INTO `mob_skills` VALUES (845,531,'fire_iv',0,0.0,10.0,533,3000,4,64,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (846,532,'flaming_crush',0,0.0,10.0,534,3000,4,64,0,0,11,5,0); -- Fusion (11) / Reverberation (5)
 INSERT INTO `mob_skills` VALUES (847,533,'meteor_strike',0,0.0,10.0,535,3000,4,64,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (848,534,'inferno',1,0.0,10.0,536,3000,4,64,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (848,534,'inferno',1,0.0,30.0,536,3000,4,64,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (849,539,'rock_throw',0,0.0,12.0,544,3000,4,64,0,0,4,0,0); -- Scission (4)
 INSERT INTO `mob_skills` VALUES (850,540,'stone_ii',0,0.0,10.0,545,3000,4,64,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (851,541,'rock_buster',0,0.0,10.0,546,3000,4,64,0,0,5,0,0); -- Reverberation (5)
@@ -871,7 +871,7 @@ INSERT INTO `mob_skills` VALUES (853,543,'earthen_ward',1,0.0,10.0,548,3000,1,12
 INSERT INTO `mob_skills` VALUES (854,544,'stone_iv',0,0.0,10.0,549,3000,4,64,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (855,545,'mountain_buster',0,0.0,10.0,550,3000,4,64,0,0,9,7,0); -- Gravitation (9) / Induration (7)
 INSERT INTO `mob_skills` VALUES (856,546,'geocrush',0,0.0,10.0,551,3000,4,64,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (857,547,'earthen_fury',1,0.0,10.0,552,3000,4,64,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (857,547,'earthen_fury',1,0.0,30.0,552,3000,4,64,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (858,552,'barracuda_dive',0,0.0,10.0,560,3000,4,64,0,0,5,0,0); -- Reverberation (5)
 INSERT INTO `mob_skills` VALUES (859,553,'water_ii',0,0.0,10.0,561,3000,4,64,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (860,554,'tail_whip',0,0.0,10.0,562,3000,4,64,0,0,6,0,0); -- Detonation (6)
@@ -880,7 +880,7 @@ INSERT INTO `mob_skills` VALUES (862,556,'slowga',1,0.0,10.0,564,3000,4,128,0,0,
 INSERT INTO `mob_skills` VALUES (863,557,'water_iv',0,0.0,20.0,565,3000,4,64,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (864,558,'spinning_dive',0,0.0,10.0,566,3000,4,64,0,0,10,6,0); -- Distortion (10) / Detonation (6)
 INSERT INTO `mob_skills` VALUES (865,559,'grand_fall',0,0.0,10.0,567,3000,4,64,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (866,560,'tidal_wave',1,0.0,20.0,568,3000,4,64,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (866,560,'tidal_wave',1,0.0,30.0,568,3000,4,64,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (867,565,'claw',0,0.0,10.0,576,3000,4,64,0,0,6,0,0); -- Detonation (6)
 INSERT INTO `mob_skills` VALUES (868,566,'aero_ii',0,0.0,10.0,577,3000,4,64,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (869,569,'whispering_wind',1,0.0,10.0,578,3000,1,128,0,0,0,0,0);
@@ -889,7 +889,7 @@ INSERT INTO `mob_skills` VALUES (871,567,'aerial_armor',1,0.0,10.0,580,3000,1,12
 INSERT INTO `mob_skills` VALUES (872,570,'aero_iv',0,0.0,10.0,581,3000,4,64,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (873,571,'predator_claws',0,0.0,10.0,582,3000,4,64,0,0,12,4,0); -- Fragmentation (12) / Scission (4)
 INSERT INTO `mob_skills` VALUES (874,572,'wind_blade',0,0.0,10.0,583,3000,4,64,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (875,573,'aerial_blast',1,0.0,10.0,584,3000,4,64,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (875,573,'aerial_blast',1,0.0,30.0,584,3000,4,64,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (876,578,'axe_kick',0,0.0,10.0,592,3000,4,64,0,0,7,0,0); -- Induration (7)
 INSERT INTO `mob_skills` VALUES (877,579,'blizzard_ii',0,0.0,10.0,593,3000,4,64,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (878,580,'frost_armor',1,0.0,10.0,594,3000,1,128,0,0,0,0,0);
@@ -898,7 +898,7 @@ INSERT INTO `mob_skills` VALUES (880,582,'double_slap',0,0.0,10.0,596,3000,4,64,
 INSERT INTO `mob_skills` VALUES (881,583,'blizzard_iv',0,0.0,10.0,597,3000,4,64,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (882,584,'rush',0,0.0,10.0,598,3000,4,64,0,0,10,4,0); -- Distortion (10) / Scission (4)
 INSERT INTO `mob_skills` VALUES (883,585,'heavenly_strike',0,0.0,10.0,599,3000,4,64,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (884,586,'diamond_dust',1,0.0,10.0,600,3000,4,64,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (884,586,'diamond_dust',1,0.0,30.0,600,3000,4,64,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (885,591,'shock_strike',0,0.0,10.0,608,3000,4,64,0,0,8,0,0); -- Impaction (8)
 INSERT INTO `mob_skills` VALUES (886,592,'thunder_ii',0,0.0,10.0,609,3000,4,64,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (887,593,'rolling_thunder',1,0.0,10.0,610,3000,1,128,0,0,0,0,0);
@@ -907,7 +907,7 @@ INSERT INTO `mob_skills` VALUES (889,595,'lightning_armor',1,0.0,10.0,612,3000,1
 INSERT INTO `mob_skills` VALUES (890,596,'thunder_iv',0,0.0,10.0,613,3000,4,64,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (891,597,'chaotic_strike',0,0.0,10.0,614,3000,4,64,0,0,12,1,0); -- Fragmentation (12) / Transfixion (1)
 INSERT INTO `mob_skills` VALUES (892,598,'thunderstorm',0,0.0,10.0,615,3000,4,64,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (893,599,'judgment_bolt',1,0.0,10.0,616,3000,4,64,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (893,599,'judgment_bolt',1,0.0,30.0,616,3000,4,64,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (894,621,'healing_breath_i',0,0.0,10.0,2000,2000,2,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (895,622,'healing_breath_ii',0,0.0,10.0,2000,2000,2,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (896,623,'healing_breath_iii',0,0.0,10.0,2000,2000,2,0,0,0,0,0,0);
@@ -926,14 +926,14 @@ INSERT INTO `mob_skills` VALUES (908,607,'shining_ruby',1,0.0,10.0,498,3000,1,12
 INSERT INTO `mob_skills` VALUES (909,608,'glittering_ruby',1,0.0,10.0,499,3000,1,128,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (910,609,'meteorite',0,0.0,10.0,500,3000,4,64,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (911,610,'healing_ruby_ii',1,0.0,10.0,501,3000,1,128,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (912,611,'searing_light',1,0.0,10.0,502,0,4,64,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (913,534,'inferno',1,0.0,25.0,2000,0,4,64,0,0,0,0,0); -- mob avatar skills
-INSERT INTO `mob_skills` VALUES (914,547,'earthen_fury',1,0.0,25.0,2000,0,4,64,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (915,560,'tidal_wave',1,0.0,25.0,2000,0,4,64,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (916,573,'aerial_blast',1,0.0,25.0,2000,0,4,64,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (917,586,'diamond_dust',1,0.0,25.0,2000,0,4,64,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (918,599,'judgment_bolt',1,0.0,25.0,2000,0,4,64,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (919,611,'searing_light',1,0.0,25.0,2000,0,4,64,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (912,611,'searing_light',1,0.0,30.0,502,3000,4,64,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (913,534,'inferno',1,0.0,30.0,2000,0,4,64,0,0,0,0,0); -- mob avatar skills
+INSERT INTO `mob_skills` VALUES (914,547,'earthen_fury',1,0.0,30.0,2000,0,4,64,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (915,560,'tidal_wave',1,0.0,30.0,2000,0,4,64,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (916,573,'aerial_blast',1,0.0,30.0,2000,0,4,64,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (917,586,'diamond_dust',1,0.0,30.0,2000,0,4,64,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (918,599,'judgment_bolt',1,0.0,30.0,2000,0,4,64,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (919,611,'searing_light',1,0.0,30.0,2000,0,4,64,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (920,503,'everyones_grudge',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (921,504,'everyones_rancor',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (922,143,'blind_vortex',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
@@ -1037,7 +1037,7 @@ INSERT INTO `mob_skills` VALUES (1019,720,'eagle_eye_shot',0,0.0,25.0,2000,0,4,2
 INSERT INTO `mob_skills` VALUES (1020,721,'meikyo_shisui',0,0.0,7.0,2000,0,1,2,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1021,722,'mijin_gakure',1,0.0,20.0,2000,0,4,2,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1022,723,'call_wyvern',0,0.0,7.0,2000,0,1,4,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1023,724,'astral_flow_pet',0,0.0,7.0,2000,0,1,2,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1023,438,'astral_flow_pet',0,0.0,7.0,2000,0,1,2,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1024,725,'warp_out',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1025,726,'warp_in',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1026,727,'arbor_storm',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This fixes several small issues related to mob astral flow including:

1 All mob astral-flow-based skills should have 30 yalm range. The different types are:

A) SMN mobs that spawn an untargetable avatar instantly when using Astral Flow and the avatar then immediately uses a move (like Diamond Dust). Several examples include Kirin, Crimson-toothed Pawberry, Viscount Morax, etc. Range capture by Carnap from Crimson-toothed Pawberry [here](https://www.youtube.com/watch?v=YFvxUhx4moE).

B) SMN mobs that spawn a (targetable) avatar on engage and later use Astral Flow causing that avatar to use a move (like Diamond Dust). Examples include any SMN beastmen in Dynamis. Captures of Ranges by Carnap from Dynamis-Valk [here](https://www.youtube.com/watch?v=bBxfi0b2rDE) and  [here](https://www.youtube.com/watch?v=KFY7puh0d5I).

C) Mobs that actually are avatars that use a move (like Diamond Dust) as their normal 2hr. Examples include the Trial By avatars and Mystic Avatars in Temenos. Captures of Range by Carnap from Trial By fights [here](https://youtu.be/P90Eo7TpuNQ), [here](https://youtu.be/FdnL50soDxM), and [here](https://youtu.be/SLRj4CAHi_o).

2 The mob skills for Type B should use the mobskill ID of Type C (rather than Type A). Capture of mobskill ID by Siknoz from Dynamis Bastok [here](https://youtu.be/_DgjxpcvDpE?t=1572)

3 The actual astral flow animation for Type B should be 438 instead of 724. Capture of animation ID by Siknoz from Dynamis Bastok [here](https://youtu.be/_DgjxpcvDpE?t=1572)

## Steps to test these changes
Fight the example mobs described above to test range and other changes.