### PR TITLE
[core] Add nullness checking from static analysis

### DIFF
--- a/src/map/enmity_container.cpp
+++ b/src/map/enmity_container.cpp
@@ -381,17 +381,21 @@ void CEnmityContainer::SetVE(CBattleEntity* PEntity, const int32 amount)
 void CEnmityContainer::UpdateEnmityFromDamage(CBattleEntity* PEntity, int32 Damage)
 {
     TracyZoneScoped;
-    Damage          = (Damage < 1 ? 1 : Damage);
-    int16 damageMod = battleutils::GetEnmityModDamage(m_EnmityHolder->GetMLevel());
 
-    int32 CE = (int32)(80.f / damageMod * Damage);
-    int32 VE = (int32)(240.f / damageMod * Damage);
-
-    UpdateEnmity(PEntity, CE, VE);
-
-    if (m_EnmityHolder && m_EnmityHolder->m_HiPCLvl < PEntity->GetMLevel())
+    if (m_EnmityHolder)
     {
-        m_EnmityHolder->m_HiPCLvl = PEntity->GetMLevel();
+        Damage          = (Damage < 1 ? 1 : Damage);
+        int16 damageMod = battleutils::GetEnmityModDamage(m_EnmityHolder->GetMLevel());
+
+        int32 CE = (int32)(80.f / damageMod * Damage);
+        int32 VE = (int32)(240.f / damageMod * Damage);
+
+        UpdateEnmity(PEntity, CE, VE);
+
+        if (m_EnmityHolder->m_HiPCLvl < PEntity->GetMLevel())
+        {
+            m_EnmityHolder->m_HiPCLvl = PEntity->GetMLevel();
+        }
     }
 }
 

--- a/src/map/merit.cpp
+++ b/src/map/merit.cpp
@@ -340,7 +340,7 @@ void CMeritPoints::RaiseMerit(MERIT_TYPE merit)
 {
     Merit_t* PMerit = GetMeritPointer(merit);
 
-    if (m_MeritPoints >= PMerit->next && PMerit->count < PMerit->upgrade && GetMeritCountInSameCategory(merit) < meritCatInfo[GetMeritCategory(merit)].MaxPoints)
+    if (PMerit && m_MeritPoints >= PMerit->next && PMerit->count < PMerit->upgrade && GetMeritCountInSameCategory(merit) < meritCatInfo[GetMeritCategory(merit)].MaxPoints)
     {
         m_MeritPoints -= PMerit->next;
 
@@ -372,30 +372,32 @@ void CMeritPoints::RaiseMerit(MERIT_TYPE merit)
 void CMeritPoints::LowerMerit(MERIT_TYPE merit)
 {
     Merit_t* PMerit = GetMeritPointer(merit);
-
-    if (PMerit->count > 0)
+    if (PMerit)
     {
-        PMerit->next = upgrade[meritCatInfo[GetMeritCategory(merit)].UpgradeID][--PMerit->count];
-    }
-
-    if (PMerit->spellid != 0 && PMerit->count == 0)
-    {
-        if (charutils::delSpell(m_PChar, PMerit->spellid))
+        if (PMerit->count > 0)
         {
-            charutils::DeleteSpell(m_PChar, PMerit->spellid);
-            m_PChar->pushPacket(new CCharSpellsPacket(m_PChar));
-
-            // Reset traits
-            charutils::BuildingCharTraitsTable(m_PChar);
+            PMerit->next = upgrade[meritCatInfo[GetMeritCategory(merit)].UpgradeID][--PMerit->count];
         }
-    }
 
-    if (PMerit->wsunlockid != 0 && PMerit->count == 0 && charutils::hasLearnedWeaponskill(m_PChar, PMerit->wsunlockid))
-    {
-        charutils::delLearnedWeaponskill(m_PChar, PMerit->wsunlockid);
-        charutils::BuildingCharWeaponSkills(m_PChar);
-        charutils::SaveLearnedAbilities(m_PChar);
-        m_PChar->pushPacket(new CCharAbilitiesPacket(m_PChar));
+        if (PMerit->spellid != 0 && PMerit->count == 0)
+        {
+            if (charutils::delSpell(m_PChar, PMerit->spellid))
+            {
+                charutils::DeleteSpell(m_PChar, PMerit->spellid);
+                m_PChar->pushPacket(new CCharSpellsPacket(m_PChar));
+
+                // Reset traits
+                charutils::BuildingCharTraitsTable(m_PChar);
+            }
+        }
+
+        if (PMerit->wsunlockid != 0 && PMerit->count == 0 && charutils::hasLearnedWeaponskill(m_PChar, PMerit->wsunlockid))
+        {
+            charutils::delLearnedWeaponskill(m_PChar, PMerit->wsunlockid);
+            charutils::BuildingCharWeaponSkills(m_PChar);
+            charutils::SaveLearnedAbilities(m_PChar);
+            m_PChar->pushPacket(new CCharAbilitiesPacket(m_PChar));
+        }
     }
 }
 

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -4855,7 +4855,7 @@ void SmallPacket0x077(map_session_data_t* const PSession, CCharEntity* const PCh
     {
         case 0: // party
         {
-            if (PChar->PParty != nullptr && PChar->PParty->GetLeader() == PChar)
+            if (PChar && PChar->PParty != nullptr && PChar->PParty->GetLeader() == PChar)
             {
                 char memberName[PacketNameLength] = {};
                 memcpy(&memberName, data[0x04], PacketNameLength - 1);
@@ -4867,7 +4867,7 @@ void SmallPacket0x077(map_session_data_t* const PSession, CCharEntity* const PCh
         break;
         case 1: // linkshell
         {
-            if (PChar->PLinkshell1 != nullptr)
+            if (PChar && PChar->PLinkshell1 != nullptr)
             {
                 int8 packetData[29]{};
                 ref<uint32>(packetData, 0) = PChar->id;
@@ -4880,7 +4880,7 @@ void SmallPacket0x077(map_session_data_t* const PSession, CCharEntity* const PCh
         break;
         case 2: // linkshell2
         {
-            if (PChar->PLinkshell2 != nullptr)
+            if (PChar && PChar->PLinkshell2 != nullptr)
             {
                 int8 packetData[29]{};
                 ref<uint32>(packetData, 0) = PChar->id;
@@ -4893,7 +4893,7 @@ void SmallPacket0x077(map_session_data_t* const PSession, CCharEntity* const PCh
         break;
         case 5: // alliance
         {
-            if (PChar->PParty && PChar->PParty->m_PAlliance && PChar->PParty->GetLeader() == PChar &&
+            if (PChar && PChar->PParty && PChar->PParty->m_PAlliance && PChar->PParty->GetLeader() == PChar &&
                 PChar->PParty->m_PAlliance->getMainParty() == PChar->PParty)
             {
                 char memberName[PacketNameLength] = {};

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1103,9 +1103,12 @@ bool CStatusEffectContainer::ApplyCorsairEffect(CStatusEffect* PStatusEffect, ui
     }
     else
     {
-        // i'm a liar, can overwrite rolls
-        PStatusEffect->SetEffectSlot(oldestRoll->GetEffectSlot());
-        DelStatusEffect(oldestRoll->GetStatusID());
+        if (oldestRoll)
+        {
+            // i'm a liar, can overwrite rolls
+            PStatusEffect->SetEffectSlot(oldestRoll->GetEffectSlot());
+            DelStatusEffect(oldestRoll->GetStatusID());
+        }
         AddStatusEffect(PStatusEffect);
         return true;
     }

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2326,7 +2326,7 @@ namespace battleutils
                 auto* sub_weapon = dynamic_cast<CItemWeapon*>(PAttacker->m_Weapons[SLOT_SUB]);
 
                 if (sub_weapon && sub_weapon->getDmgType() > DAMAGE_TYPE::NONE && sub_weapon->getDmgType() < DAMAGE_TYPE::HTH &&
-                    weapon->getSkillType() != SKILL_HAND_TO_HAND)
+                    (!weapon || (weapon && weapon->getSkillType() != SKILL_HAND_TO_HAND)))
                 {
                     delay = delay / 2;
                 }
@@ -2492,7 +2492,7 @@ namespace battleutils
                 auto* sub_weapon = dynamic_cast<CItemWeapon*>(PAttacker->m_Weapons[SLOT_SUB]);
 
                 if (sub_weapon && sub_weapon->getDmgType() > DAMAGE_TYPE::NONE && sub_weapon->getDmgType() < DAMAGE_TYPE::HTH &&
-                    weapon->getSkillType() != SKILL_HAND_TO_HAND)
+                    (!weapon || (weapon && weapon->getSkillType() != SKILL_HAND_TO_HAND)))
                 {
                     delay /= 2;
                 }

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -7230,12 +7230,18 @@ namespace charutils
                 PChar->resetPetZoningInfo();
             }
 
-            PSession->shuttingDown = 1;
+            if (PSession)
+            {
+                PSession->shuttingDown = 1;
+            }
             _sql->Query("UPDATE char_stats SET zoning = 0 WHERE charid = %u", PChar->id);
         }
         else
         {
-            PSession->shuttingDown = 2;
+            if (PSession)
+            {
+                PSession->shuttingDown = 2;
+            }
             _sql->Query("UPDATE char_stats SET zoning = 1 WHERE charid = %u", PChar->id);
             charutils::CheckEquipLogic(PChar, SCRIPT_CHANGEZONE, PChar->getZone());
         }

--- a/src/map/utils/puppetutils.cpp
+++ b/src/map/utils/puppetutils.cpp
@@ -312,9 +312,12 @@ namespace puppetutils
 
             if (valid)
             {
-                for (int i = 0; i < 8; i++)
+                if (PAttachment)
                 {
-                    PChar->PAutomaton->addElementCapacity(i, (PAttachment->getElementSlots() >> (i * 4)) & 0xF);
+                    for (int i = 0; i < 8; i++)
+                    {
+                        PChar->PAutomaton->addElementCapacity(i, (PAttachment->getElementSlots() >> (i * 4)) & 0xF);
+                    }
                 }
                 luautils::OnAttachmentEquip(PChar->PAutomaton, PAttachment);
                 PChar->PAutomaton->setAttachment(slotId, attachment);

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -1300,7 +1300,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
             case CHAR_INRANGE_SELF: // NOTE!!!: This falls through to CHAR_INRANGE so both self and the local area get the packet
             {
                 TracyZoneCString("CHAR_INRANGE_SELF");
-                if (PEntity->objtype == TYPE_PC)
+                if (PEntity && PEntity->objtype == TYPE_PC)
                 {
                     ((CCharEntity*)PEntity)->pushPacket(new CBasicPacket(*packet));
                 }
@@ -1316,7 +1316,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
                 for (EntityList_t::const_iterator it = m_charList.begin(); it != m_charList.end(); ++it)
                 {
                     CCharEntity* PCurrentChar = (CCharEntity*)it->second;
-                    if (PEntity != PCurrentChar)
+                    if (PEntity && PEntity != PCurrentChar)
                     {
                         if (distanceSquared(PEntity->loc.p, PCurrentChar->loc.p) < checkDistanceSq &&
                             ((PEntity->objtype != TYPE_PC) || (((CCharEntity*)PEntity)->m_moghouseID == PCurrentChar->m_moghouseID)))
@@ -1403,7 +1403,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
                 for (EntityList_t::const_iterator it = m_charList.begin(); it != m_charList.end(); ++it)
                 {
                     CCharEntity* PCurrentChar = (CCharEntity*)it->second;
-                    if (PEntity != PCurrentChar)
+                    if (PEntity && PEntity != PCurrentChar)
                     {
                         if (distance(PEntity->loc.p, PCurrentChar->loc.p) < 180 &&
                             ((PEntity->objtype != TYPE_PC) || (((CCharEntity*)PEntity)->m_moghouseID == PCurrentChar->m_moghouseID)))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds some nullness checking I found in a static code analysis

## Steps to test these changes

Test things effected, see no change