### PR TITLE
[LUA]Move PUP JA to jobUtils file

### DIFF
--- a/scripts/actions/abilities/activate.lua
+++ b/scripts/actions/abilities/activate.lua
@@ -9,27 +9,11 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    if player:getPet() ~= nil then
-        return xi.msg.basic.ALREADY_HAS_A_PET, 0
-    elseif not player:canUseMisc(xi.zoneMisc.PET) then
-        return xi.msg.basic.CANT_BE_USED_IN_AREA, 0
-    elseif player:isExceedingElementalCapacity() then
-        return xi.msg.basic.AUTO_EXCEEDS_CAPACITY, 0
-    end
-
-    return 0, 0
+    return xi.job_utils.puppetmaster.onAbilityCheckActivate(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.pet.spawnPet(player, xi.petId.AUTOMATON)
-
-    local pet = player:getPet()
-
-    if pet then
-        local jpValue = player:getJobPointLevel(xi.jp.AUTOMATON_HP_MP_BONUS)
-        pet:addMod(xi.mod.HP, jpValue * 10)
-        pet:addMod(xi.mod.MP, jpValue * 5)
-    end
+    return xi.job_utils.puppetmaster.onAbilityUseActivate(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/cooldown.lua
+++ b/scripts/actions/abilities/cooldown.lua
@@ -8,22 +8,11 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    if not player:getPet() then
-        -- TODO: Add check to verify this is an automaton
-        return xi.msg.basic.REQUIRES_A_PET, 0
-    end
-
-    return 0, 0
+    return xi.job_utils.puppetmaster.onAbilityCheckCooldown(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    local jpValue = player:getJobPointLevel(xi.jp.COOLDOWN_EFFECT)
-
-    player:reduceBurden(50, jpValue)
-
-    if player:hasStatusEffect(xi.effect.OVERLOAD) then
-        player:delStatusEffect(xi.effect.OVERLOAD)
-    end
+    return xi.job_utils.puppetmaster.onAbilityUseCooldown(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/deactivate.lua
+++ b/scripts/actions/abilities/deactivate.lua
@@ -9,21 +9,11 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    return 0, 0
+    return xi.job_utils.puppetmaster.onAbilityCheckDeactivate(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    -- Reset the Activate ability.
-    local pet = player:getPet()
-
-    if
-        pet and
-        pet:getHP() == pet:getMaxHP()
-    then
-        player:resetRecast(xi.recast.ABILITY, 205) -- activate
-    end
-
-    target:despawnPet()
+    return xi.job_utils.puppetmaster.onAbilityUseDeactivate(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/deploy.lua
+++ b/scripts/actions/abilities/deploy.lua
@@ -9,11 +9,11 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    return 0, 0
+    return xi.job_utils.puppetmaster.onAbilityCheckDeploy(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    player:petAttack(target)
+    return xi.job_utils.puppetmaster.onAbilityUseDeploy(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/deus_ex_automata.lua
+++ b/scripts/actions/abilities/deus_ex_automata.lua
@@ -9,28 +9,11 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    if player:getPet() ~= nil then
-        return xi.msg.basic.ALREADY_HAS_A_PET, 0
-    elseif not player:canUseMisc(xi.zoneMisc.PET) then
-        return xi.msg.basic.CANT_BE_USED_IN_AREA, 0
-    else
-        local jpValue = player:getJobPointLevel(xi.jp.DEUS_EX_AUTOMATA_RECAST)
-
-        ability:setRecast(ability:getRecast() - jpValue)
-
-        return 0, 0
-    end
+    return xi.job_utils.puppetmaster.onAbilityCheckDeuxExAutomata(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.pet.spawnPet(player, xi.petId.AUTOMATON)
-    local pet = player:getPet()
-
-    if pet then
-        local percent = math.floor((player:getMainLvl() / 3)) / 100
-        pet:setHP(math.max(pet:getHP() * percent, 1))
-        pet:setMP(pet:getMP() * percent)
-    end
+    return xi.job_utils.puppetmaster.onAbilityUseDeuxExAutomata(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/heady_artifice.lua
+++ b/scripts/actions/abilities/heady_artifice.lua
@@ -8,13 +8,11 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
-
-    return 0, 0
+    return xi.job_utils.puppetmaster.onAbilityCheckHeadyArtiface(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    -- target:addStatusEffect(xi.effect.HEADY_ARTIFICE, 18, 1, 1) -- TODO: implement xi.effect.HEADY_ARTIFICE
+    return xi.job_utils.puppetmaster.onAbilityUseHeadyArtiface(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/maintenance.lua
+++ b/scripts/actions/abilities/maintenance.lua
@@ -8,76 +8,12 @@
 ---@type TAbility
 local abilityObject = {}
 
-local idStrengths =
-{
-    [18731] = 1, -- Automaton Oil
-    [18732] = 2, -- Automaton Oil + 1
-    [18733] = 3, -- Automaton Oil + 2
-    [19185] = 4  -- Automaton Oil + 3
-}
-
-local removableStatus =
-{
-    xi.effect.PETRIFICATION,
-    xi.effect.SILENCE,
-    xi.effect.BANE,
-    xi.effect.CURSE_II,
-    xi.effect.CURSE_I,
-    xi.effect.PARALYSIS,
-    xi.effect.PLAGUE,
-    xi.effect.POISON,
-    xi.effect.DISEASE,
-    xi.effect.BLINDNESS,
-}
-
-local function removeStatus(target)
-    for _, effectId in ipairs(removableStatus) do
-        if target:delStatusEffect(effectId) then
-            return true
-        end
-    end
-
-    if target:eraseStatusEffect() ~= xi.effect.NONE then
-        return true
-    end
-
-    return false
-end
-
 abilityObject.onAbilityCheck = function(player, target, ability)
-    local pet = player:getPet()
-    if not pet then
-        return xi.msg.basic.REQUIRES_A_PET, 0
-    elseif not pet:isAutomaton() then
-        return xi.msg.basic.NO_EFFECT_ON_PET, 0
-    else
-        local id = player:getEquipID(xi.slot.AMMO)
-        if idStrengths[id] then
-            return 0, 0
-        else
-            return xi.msg.basic.UNABLE_TO_USE_JA, 0
-        end
-    end
+    return xi.job_utils.puppetmaster.onAbilityCheckMaintenance(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    local id         = player:getEquipID(xi.slot.AMMO)
-    local pet        = player:getPet()
-    local toRemove   = idStrengths[id] or 1
-    local numRemoved = 0
-
-    repeat
-        if not removeStatus(pet) then
-            break
-        end
-
-        toRemove   = toRemove - 1
-        numRemoved = numRemoved + 1
-    until toRemove <= 0
-
-    player:removeAmmo()
-
-    return numRemoved
+    return xi.job_utils.puppetmaster.onAbilityUseMaintenance(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/overdrive.lua
+++ b/scripts/actions/abilities/overdrive.lua
@@ -9,21 +9,11 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    local pet = player:getPet()
-    if not pet then
-        return xi.msg.basic.REQUIRES_A_PET, 0
-    elseif not pet:isAutomaton() then
-        return xi.msg.basic.NO_EFFECT_ON_PET, 0
-    else
-        ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
-        return 0, 0
-    end
+    return xi.job_utils.puppetmaster.onAbilityCheckOverdrive(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    player:addStatusEffect(xi.effect.OVERDRIVE, 0, 0, 60)
-
-    return xi.effect.OVERDRIVE
+    return xi.job_utils.puppetmaster.onAbilityUseOverdrive(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/repair.lua
+++ b/scripts/actions/abilities/repair.lua
@@ -8,97 +8,12 @@
 ---@type TAbility
 local abilityObject = {}
 
-local removableEffectIds =
-{
-    xi.effect.PETRIFICATION,
-    xi.effect.SILENCE,
-    xi.effect.BANE,
-    xi.effect.CURSE_II,
-    xi.effect.CURSE_I,
-    xi.effect.PARALYSIS,
-    xi.effect.PLAGUE,
-    xi.effect.POISON,
-    xi.effect.DISEASE,
-    xi.effect.BLINDNESS,
-}
-
--- https://www.bg-wiki.com/ffxi/Repair
-local oilType =
-{
---  ItemId                               { Base, %HP, Time(s) }
-    [xi.item.CAN_OF_AUTOMATON_OIL   ] = { 20, 0.1, 15 },
-    [xi.item.CAN_OF_AUTOMATON_OIL_P1] = { 40, 0.2, 30 },
-    [xi.item.CAN_OF_AUTOMATON_OIL_P2] = { 60, 0.3, 45 },
-    [xi.item.CAN_OF_AUTOMATON_OIL_P3] = { 80, 0.4, 60 },
-}
-
-local function removeStatus(pet)
-    for _, effectId in ipairs(removableEffectIds) do
-        if pet:delStatusEffect(effectId) then
-            return true
-        end
-    end
-
-    if pet:eraseStatusEffect() ~= xi.effect.NONE then
-        return true
-    end
-
-    return false
-end
-
 abilityObject.onAbilityCheck = function(player, target, ability)
-    local pet = player:getPet()
-    if not pet then
-        return xi.msg.basic.REQUIRES_A_PET, 0
-    elseif not pet:isAutomaton() then
-        return xi.msg.basic.NO_EFFECT_ON_PET, 0
-    else
-        local id = player:getEquipID(xi.slot.AMMO)
-
-        if oilType[id] then
-            return 0, 0
-        else
-            return xi.msg.basic.UNABLE_TO_USE_JA, 0
-        end
-    end
+    return xi.job_utils.puppetmaster.onAbilityCheckRepair(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    local pet = player:getPet()
-    if not pet then
-        return
-    end
-
-    local petMaxHP            = pet:getMaxHP()
-    local numRemovableEffects = player:getMod(xi.mod.REPAIR_EFFECT)
-
-    -- Need to start to calculate the HP to restore to the pet.
-    -- Ref: https://www.bg-wiki.com/ffxi/Repair
-    local oilData      = oilType[player:getEquipID(xi.slot.AMMO)]
-    local regenAmount  = oilData[1]
-    local totalHealing = oilData[2] * petMaxHP
-    local regenTime    = oilData[3]
-
-    for _ = 1, numRemovableEffects do
-        if not removeStatus(pet) then
-            break
-        end
-    end
-
-    local bonus  = 1 + player:getMerit(xi.merit.REPAIR_EFFECT) / 100
-    totalHealing = totalHealing * bonus
-
-    bonus       = bonus + player:getMod(xi.mod.REPAIR_POTENCY) / 100
-    regenAmount = regenAmount * bonus
-
-    totalHealing = pet:addHP(totalHealing)
-
-    pet:wakeUp()
-
-    pet:delStatusEffect(xi.effect.REGEN)
-    pet:addStatusEffect(xi.effect.REGEN, regenAmount, 3, regenTime) -- 3 = tick, each 3 seconds.
-    player:removeAmmo()
-    return totalHealing
+    return xi.job_utils.puppetmaster.onAbilityUseRepair(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/retrieve.lua
+++ b/scripts/actions/abilities/retrieve.lua
@@ -9,11 +9,11 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    return 0, 0
+    return xi.job_utils.puppetmaster.onAbilityCheckRetrieve(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    player:petRetreat()
+    return xi.job_utils.puppetmaster.onAbilityUseRetrieve(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/role_reversal.lua
+++ b/scripts/actions/abilities/role_reversal.lua
@@ -9,27 +9,11 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    local pet = player:getPet()
-
-    if not pet then
-        return xi.msg.basic.REQUIRES_A_PET, 0
-    elseif not pet:isAutomaton() then
-        return xi.msg.basic.NO_EFFECT_ON_PET, 0
-    else
-        return 0, 0
-    end
+    return xi.job_utils.puppetmaster.onAbilityCheckRoleReversal(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    local pet = player:getPet()
-    if pet then
-        local bonus    = 1 + (player:getMerit(xi.merit.ROLE_REVERSAL) - 5) / 100
-        local playerHP = player:getHP()
-        local petHP    = pet:getHP()
-
-        pet:setHP(math.max(playerHP * bonus, 1))
-        player:setHP(math.max(petHP * bonus, 1))
-    end
+    return xi.job_utils.puppetmaster.onAbilityUseRoleReversal(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/tactical_switch.lua
+++ b/scripts/actions/abilities/tactical_switch.lua
@@ -8,11 +8,11 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    return 0, 0
+    return xi.job_utils.puppetmaster.onAbilityCheckTacticalSwitch(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    -- target:addStatusEffect(xi.effect.TACTICAL_SWITCH, 18, 1, 1) -- TODO: implement xi.effect.TACTICAL_SWITCH
+    return xi.job_utils.puppetmaster.onAbilityUseTacticalSwitch(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/ventriloquy.lua
+++ b/scripts/actions/abilities/ventriloquy.lua
@@ -9,57 +9,11 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    local pet = player:getPet()
-
-    if not pet then
-        return xi.msg.basic.REQUIRES_A_PET, 0
-    elseif not pet:isAutomaton() then
-        return xi.msg.basic.NO_EFFECT_ON_PET, 0
-    end
-
-    return 0, 0
+    return xi.job_utils.puppetmaster.onAbilityCheckVentriloquy(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    local pet = player:getPet()
-    if pet then
-        local enmitylist            = target:getEnmityList()
-        local playerfound, petfound = false, false
-
-        for k, v in pairs(enmitylist) do
-            if v.entity:getTargID() == player:getTargID() then
-                playerfound = true
-            elseif v.entity:getTargID() == pet:getTargID() then
-                petfound = true
-            end
-        end
-
-        if playerfound and petfound then
-            local bonus             = (player:getMerit(xi.merit.VENTRILOQUY) - 5) / 100
-            local playerCE          = target:getCE(player)
-            local playerVE          = target:getVE(player)
-            local petCE             = target:getCE(pet)
-            local petVE             = target:getVE(pet)
-            local playerEnmityBonus = 1
-            local petEnmityBonus    = 1
-
-            if
-                target:getTarget():getTargID() == player:getTargID() or
-                ((playerCE + playerVE) >= (petCE + petVE) and target:getTarget():getTargID() ~= pet:getTargID())
-            then
-                playerEnmityBonus = playerEnmityBonus + bonus
-                petEnmityBonus    = petEnmityBonus - bonus
-            else
-                playerEnmityBonus = playerEnmityBonus - bonus
-                petEnmityBonus    = petEnmityBonus + bonus
-            end
-
-            target:setCE(player, petCE * petEnmityBonus)
-            target:setVE(player, petVE * petEnmityBonus)
-            target:setCE(pet, playerCE * playerEnmityBonus)
-            target:setVE(pet, playerVE * playerEnmityBonus)
-        end
-    end
+    return xi.job_utils.puppetmaster.onAbilityUseVentriloquy(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/globals/job_utils/puppetmaster.lua
+++ b/scripts/globals/job_utils/puppetmaster.lua
@@ -1,0 +1,395 @@
+-----------------------------------
+-- Puppetmaster Job Utilities
+-----------------------------------
+require('scripts/globals/ability')
+require('scripts/globals/jobpoints')
+-----------------------------------
+xi = xi or {}
+xi.job_utils = xi.job_utils or {}
+xi.job_utils.puppetmaster = xi.job_utils.puppetmaster or {}
+-----------------------------------
+
+local removableEffectIds =
+{
+    xi.effect.PETRIFICATION,
+    xi.effect.SILENCE,
+    xi.effect.BANE,
+    xi.effect.CURSE_II,
+    xi.effect.CURSE_I,
+    xi.effect.PARALYSIS,
+    xi.effect.PLAGUE,
+    xi.effect.POISON,
+    xi.effect.DISEASE,
+    xi.effect.BLINDNESS,
+}
+
+-- https://www.bg-wiki.com/ffxi/Repair
+local oilType =
+{
+--  ItemId                               { Base, %HP, Time(s) }
+    [xi.item.CAN_OF_AUTOMATON_OIL   ] = { 20, 0.1, 15 },
+    [xi.item.CAN_OF_AUTOMATON_OIL_P1] = { 40, 0.2, 30 },
+    [xi.item.CAN_OF_AUTOMATON_OIL_P2] = { 60, 0.3, 45 },
+    [xi.item.CAN_OF_AUTOMATON_OIL_P3] = { 80, 0.4, 60 },
+}
+
+-- Removes status effects based on the oil used.
+local idStrengths =
+{
+    [xi.item.CAN_OF_AUTOMATON_OIL   ] = 1, -- Automaton Oil
+    [xi.item.CAN_OF_AUTOMATON_OIL_P1] = 2, -- Automaton Oil + 1
+    [xi.item.CAN_OF_AUTOMATON_OIL_P2] = 3, -- Automaton Oil + 2
+    [xi.item.CAN_OF_AUTOMATON_OIL_P3] = 4  -- Automaton Oil + 3
+}
+
+-- On Ability Check Overdrive
+xi.job_utils.puppetmaster.onAbilityCheckOverdrive = function(player, target, ability)
+    local pet = player:getPet()
+    if not pet then
+        return xi.msg.basic.REQUIRES_A_PET, 0
+    elseif not pet:isAutomaton() then
+        return xi.msg.basic.NO_EFFECT_ON_PET, 0
+    else
+        ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
+        return 0, 0
+    end
+end
+
+-- On Ability Use Overdrive
+xi.job_utils.puppetmaster.onAbilityUseOverdrive = function(player, target, ability)
+    player:addStatusEffect(xi.effect.OVERDRIVE, 0, 0, 60)
+
+    return xi.effect.OVERDRIVE
+end
+
+-- On Ability Check Activate
+xi.job_utils.puppetmaster.onAbilityCheckActivate = function(player, target, ability)
+    if player:getPet() ~= nil then
+        return xi.msg.basic.ALREADY_HAS_A_PET, 0
+    elseif not player:canUseMisc(xi.zoneMisc.PET) then
+        return xi.msg.basic.CANT_BE_USED_IN_AREA, 0
+    elseif player:isExceedingElementalCapacity() then
+        return xi.msg.basic.AUTO_EXCEEDS_CAPACITY, 0
+    end
+
+    return 0, 0
+end
+
+-- On Ability Use Activate
+xi.job_utils.puppetmaster.onAbilityUseActivate = function(player, target, ability)
+    xi.pet.spawnPet(player, xi.petId.AUTOMATON)
+
+    local pet = player:getPet()
+
+    if pet then
+        local jpValue = player:getJobPointLevel(xi.jp.AUTOMATON_HP_MP_BONUS)
+        pet:addMod(xi.mod.HP, jpValue * 10)
+        pet:addMod(xi.mod.MP, jpValue * 5)
+    end
+end
+
+-- On Ability Check Deux Ex Automata
+xi.job_utils.puppetmaster.onAbilityCheckDeuxExAutomata = function(player, target, ability)
+    if player:getPet() ~= nil then
+        return xi.msg.basic.ALREADY_HAS_A_PET, 0
+    elseif not player:canUseMisc(xi.zoneMisc.PET) then
+        return xi.msg.basic.CANT_BE_USED_IN_AREA, 0
+    else
+        local jpValue = player:getJobPointLevel(xi.jp.DEUS_EX_AUTOMATA_RECAST)
+
+        ability:setRecast(ability:getRecast() - jpValue)
+
+        return 0, 0
+    end
+end
+
+-- On Ability Use Deux Ex Automata
+xi.job_utils.puppetmaster.onAbilityUseDeuxExAutomata = function(player, target, ability)
+    xi.pet.spawnPet(player, xi.petId.AUTOMATON)
+    local pet = player:getPet()
+
+    if pet then
+        local percent = math.floor((player:getMainLvl() / 3)) / 100
+        pet:setHP(math.max(pet:getHP() * percent, 1))
+        pet:setMP(pet:getMP() * percent)
+    end
+end
+
+--Repair and Maintenance Function - TODO: verify that this function should be here and not on the items "Enhances Repair"
+-- https://www.bg-wiki.com/ffxi/Repair
+local function removeStatus(pet)
+    for _, effectId in ipairs(removableEffectIds) do
+        if pet:delStatusEffect(effectId) then
+            return true
+        end
+    end
+
+    if pet:eraseStatusEffect() ~= xi.effect.NONE then
+        return true
+    end
+
+    return false
+end
+
+-- On Ability Check Repair
+xi.job_utils.puppetmaster.onAbilityCheckRepair = function(player, target, ability)
+    local pet = player:getPet()
+    if not pet then
+        return xi.msg.basic.REQUIRES_A_PET, 0
+    elseif not pet:isAutomaton() then
+        return xi.msg.basic.NO_EFFECT_ON_PET, 0
+    else
+        local id = player:getEquipID(xi.slot.AMMO)
+
+        if oilType[id] then
+            return 0, 0
+        else
+            return xi.msg.basic.UNABLE_TO_USE_JA, 0
+        end
+    end
+end
+
+-- On Ability Use Repair
+xi.job_utils.puppetmaster.onAbilityUseRepair = function(player, target, ability)
+    local pet = player:getPet()
+    if not pet then
+        return
+    end
+
+    local petMaxHP            = pet:getMaxHP()
+    local numRemovableEffects = player:getMod(xi.mod.REPAIR_EFFECT)
+
+    -- Need to start to calculate the HP to restore to the pet.
+    -- Ref: https://www.bg-wiki.com/ffxi/Repair
+    local oilData      = oilType[player:getEquipID(xi.slot.AMMO)]
+    local regenAmount  = oilData[1]
+    local totalHealing = oilData[2] * petMaxHP
+    local regenTime    = oilData[3]
+
+    for _ = 1, numRemovableEffects do
+        if not removeStatus(pet) then
+            break
+        end
+    end
+
+    local bonus  = 1 + player:getMerit(xi.merit.REPAIR_EFFECT) / 100
+    totalHealing = totalHealing * bonus
+
+    bonus       = bonus + player:getMod(xi.mod.REPAIR_POTENCY) / 100
+    regenAmount = regenAmount * bonus
+
+    totalHealing = pet:addHP(totalHealing)
+
+    pet:wakeUp()
+
+    pet:delStatusEffect(xi.effect.REGEN)
+    pet:addStatusEffect(xi.effect.REGEN, regenAmount, 3, regenTime) -- 3 = tick, each 3 seconds.
+    player:removeAmmo()
+    return totalHealing
+end
+
+-- On Ability Check Maintenance
+xi.job_utils.puppetmaster.onAbilityCheckMaintenance = function(player, target, ability)
+    local pet = player:getPet()
+    if not pet then
+        return xi.msg.basic.REQUIRES_A_PET, 0
+    elseif not pet:isAutomaton() then
+        return xi.msg.basic.NO_EFFECT_ON_PET, 0
+    else
+        local id = player:getEquipID(xi.slot.AMMO)
+        if idStrengths[id] then
+            return 0, 0
+        else
+            return xi.msg.basic.UNABLE_TO_USE_JA, 0
+        end
+    end
+end
+
+-- On Ability Use Maintenance
+xi.job_utils.puppetmaster.onAbilityUseMaintenance = function(player, target, ability)
+    local id         = player:getEquipID(xi.slot.AMMO)
+    local pet        = player:getPet()
+    local toRemove   = idStrengths[id] or 1
+    local numRemoved = 0
+
+    repeat
+        if not removeStatus(pet) then
+            break
+        end
+
+        toRemove   = toRemove - 1
+        numRemoved = numRemoved + 1
+    until toRemove <= 0
+
+    player:removeAmmo()
+
+    return numRemoved
+end
+
+-- On Ability Check RoleReversal
+xi.job_utils.puppetmaster.onAbilityCheckRoleReversal = function(player, target, ability)
+    local pet = player:getPet()
+
+    if not pet then
+        return xi.msg.basic.REQUIRES_A_PET, 0
+    elseif not pet:isAutomaton() then
+        return xi.msg.basic.NO_EFFECT_ON_PET, 0
+    else
+        return 0, 0
+    end
+end
+
+-- On Ability Use Role Reversal
+xi.job_utils.puppetmaster.onAbilityUseRoleReversal = function(player, target, ability)
+    local pet = player:getPet()
+    if pet then
+        local bonus    = 1 + (player:getMerit(xi.merit.ROLE_REVERSAL) - 5) / 100
+        local playerHP = player:getHP()
+        local petHP    = pet:getHP()
+
+        pet:setHP(math.max(playerHP * bonus, 1))
+        player:setHP(math.max(petHP * bonus, 1))
+    end
+end
+
+-- On Ability Check Ventriloquy
+xi.job_utils.puppetmaster.onAbilityCheckVentriloquy = function(player, target, ability)
+    local pet = player:getPet()
+
+    if not pet then
+        return xi.msg.basic.REQUIRES_A_PET, 0
+    elseif not pet:isAutomaton() then
+        return xi.msg.basic.NO_EFFECT_ON_PET, 0
+    end
+
+    return 0, 0
+end
+
+-- On Ability Use Ventriloquy
+xi.job_utils.puppetmaster.onAbilityUseVentriloquy = function(player, target, ability)
+    local pet = player:getPet()
+    if pet then
+        local enmitylist            = target:getEnmityList()
+        local playerfound, petfound = false, false
+
+        for k, v in pairs(enmitylist) do
+            if v.entity:getTargID() == player:getTargID() then
+                playerfound = true
+            elseif v.entity:getTargID() == pet:getTargID() then
+                petfound = true
+            end
+        end
+
+        if playerfound and petfound then
+            local bonus             = (player:getMerit(xi.merit.VENTRILOQUY) - 5) / 100
+            local playerCE          = target:getCE(player)
+            local playerVE          = target:getVE(player)
+            local petCE             = target:getCE(pet)
+            local petVE             = target:getVE(pet)
+            local playerEnmityBonus = 1
+            local petEnmityBonus    = 1
+
+            if
+                target:getTarget():getTargID() == player:getTargID() or
+                ((playerCE + playerVE) >= (petCE + petVE) and target:getTarget():getTargID() ~= pet:getTargID())
+            then
+                playerEnmityBonus = playerEnmityBonus + bonus
+                petEnmityBonus    = petEnmityBonus - bonus
+            else
+                playerEnmityBonus = playerEnmityBonus - bonus
+                petEnmityBonus    = petEnmityBonus + bonus
+            end
+
+            target:setCE(player, petCE * petEnmityBonus)
+            target:setVE(player, petVE * petEnmityBonus)
+            target:setCE(pet, playerCE * playerEnmityBonus)
+            target:setVE(pet, playerVE * playerEnmityBonus)
+        end
+    end
+end
+
+-- On Ability Check Tactical Switch
+xi.job_utils.puppetmaster.onAbilityCheckTacticalSwitch = function(player, target, ability)
+    return 0, 0
+end
+
+-- On Ability Use Tactical Switch
+xi.job_utils.puppetmaster.onAbilityUseTacticalSwitch = function(player, target, ability)
+    -- target:addStatusEffect(xi.effect.TACTICAL_SWITCH, 18, 1, 1) -- TODO: implement xi.effect.TACTICAL_SWITCH
+end
+
+-- On Ability Check Cooldown
+xi.job_utils.puppetmaster.onAbilityCheckCooldown = function(player, target, ability)
+    local pet = player:getPet()
+
+    if not pet then
+        return xi.msg.basic.REQUIRES_A_PET, 0
+    elseif not pet:isAutomaton() then
+        return xi.msg.basic.NO_EFFECT_ON_PET, 0
+    end
+
+    return 0, 0
+end
+
+-- On Ability Use Cooldown
+xi.job_utils.puppetmaster.onAbilityUseCooldown = function(player, target, ability)
+    local jpValue = player:getJobPointLevel(xi.jp.COOLDOWN_EFFECT)
+
+    player:reduceBurden(50, jpValue)
+
+    if player:hasStatusEffect(xi.effect.OVERLOAD) then
+        player:delStatusEffect(xi.effect.OVERLOAD)
+    end
+end
+
+-- On Ability Check Heady Artiface
+xi.job_utils.puppetmaster.onAbilityCheckHeadyArtiface = function(player, target, ability)
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
+
+    return 0, 0
+end
+
+-- On Ability Use Heady Artiface
+xi.job_utils.puppetmaster.onAbilityUseHeadyArtiface = function(player, target, ability)
+    -- target:addStatusEffect(xi.effect.HEADY_ARTIFICE, 18, 1, 1) -- TODO: implement xi.effect.HEADY_ARTIFICE
+end
+
+-- On Ability Check Deploy
+xi.job_utils.puppetmaster.onAbilityCheckDeploy = function(player, target, ability)
+    return 0, 0
+end
+
+-- On Ability Use Deploy
+xi.job_utils.puppetmaster.onAbilityUseDeploy = function(player, target, ability)
+    player:petAttack(target)
+end
+
+-- On Ability Check Retrieve
+xi.job_utils.puppetmaster.onAbilityCheckRetrieve = function(player, target, ability)
+    return 0, 0
+end
+
+-- On Ability Use Retrieve
+xi.job_utils.puppetmaster.onAbilityUseRetrieve = function(player, target, ability)
+    player:petRetreat()
+end
+
+-- On Ability Check Deactivate
+xi.job_utils.puppetmaster.onAbilityCheckDeactivate = function(player, target, ability)
+    return 0, 0
+end
+
+-- On Ability Use Deactivate
+xi.job_utils.puppetmaster.onAbilityUseDeactivate = function(player, target, ability)
+    -- Reset the Activate ability.
+    local pet = player:getPet()
+
+    if
+        pet and
+        pet:getHP() == pet:getMaxHP()
+    then
+        player:resetRecast(xi.recast.ABILITY, 205) -- activate
+    end
+
+    target:despawnPet()
+end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Moves all PUP Job Abilities to job_utils lua.
The only change I made was 
https://github.com/LandSandBoat/server/blob/base/scripts/actions/abilities/cooldown.lua#L12

Where I added the check for if not automaton.

Looking at ways to do some trimming for repetitive code like checking for automaton. However, each of the onAbilityCheck for pup seems to have an additional check so it may need to stay how it is.  
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
![image](https://github.com/user-attachments/assets/8fb1ba95-cd11-48bb-9414-906bdc7c1f15)

- Updated based on the 3 CI check fails. 
- 
## Steps to test these changes
Unlock pup and use the job abilities. 
<!-- Clear and detailed steps to test your changes here -->
