### PR TITLE
[combat] Add safety checks to status effect data fetching logic

### DIFF
--- a/scripts/globals/combat/status_effect_tables.lua
+++ b/scripts/globals/combat/status_effect_tables.lua
@@ -33,8 +33,12 @@ xi.combat.statusEffect.getAssociatedImmunity = function(effectId, actionElement)
     local effectToCheck  = effectId or 0
     local elementToCheck = actionElement or 0
 
-    -- Fetch immunity from table.
-    local associatedImmunity = xi.combat.statusEffect.dataTable[effectToCheck][1] or 0
+    -- Fetch immunity from table if entry exists.
+    local associatedImmunity = 0
+
+    if xi.combat.statusEffect.dataTable[effectToCheck] then
+        associatedImmunity = xi.combat.statusEffect.dataTable[effectToCheck][1]
+    end
 
     -- Sleep exception.
     if
@@ -51,18 +55,26 @@ xi.combat.statusEffect.getAssociatedResistanceModifier = function(effectId)
     -- Sanitize fed value
     local effectToCheck = effectId or 0
 
-    -- Fetch resistance from table.
-    local associatedResistance = xi.combat.statusEffect.dataTable[effectToCheck][2] or 0
+    -- Fetch modifier ID from table if entry exists.
+    local associatedResistanceModifier = 0
 
-    return associatedResistance
+    if xi.combat.statusEffect.dataTable[effectToCheck] then
+        associatedResistanceModifier = xi.combat.statusEffect.dataTable[effectToCheck][2]
+    end
+
+    return associatedResistanceModifier
 end
 
 xi.combat.statusEffect.getAssociatedMagicEvasionModifier = function(effectId)
     -- Sanitize fed value
     local effectToCheck = effectId or 0
 
-    -- Fetch resistance from table.
-    local associatedMagicEvasionModifier = xi.combat.statusEffect.dataTable[effectToCheck][3] or 0
+    -- Fetch modifier ID from table if entry exists.
+    local associatedMagicEvasionModifier = 0
+
+    if xi.combat.statusEffect.dataTable[effectToCheck] then
+        associatedMagicEvasionModifier = xi.combat.statusEffect.dataTable[effectToCheck][3]
+    end
 
     return associatedMagicEvasionModifier
 end
@@ -71,8 +83,12 @@ xi.combat.statusEffect.getAssociatedImmunobreakModifier = function(effectId)
     -- Sanitize fed value
     local effectToCheck = effectId or 0
 
-    -- Fetch resistance from table.
-    local associatedImmunobreakModifier = xi.combat.statusEffect.dataTable[effectToCheck][4] or 0
+    -- Fetch modifier ID from table if entry exists.
+    local associatedImmunobreakModifier = 0
+
+    if xi.combat.statusEffect.dataTable[effectToCheck] then
+        associatedImmunobreakModifier = xi.combat.statusEffect.dataTable[effectToCheck][4]
+    end
 
     return associatedImmunobreakModifier
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Ensure a table entry for an status effect exists before attempting to fetch it.
It seems an `or 0` just doesnt cut it

## Steps to test these changes

Have mobs use status effect mobskills and not see errors in log.
