### PR TITLE
[Magic] Apply magic-hit-rate force-fail after resistance-rank handling

### DIFF
--- a/scripts/globals/combat/magic_hit_rate.lua
+++ b/scripts/globals/combat/magic_hit_rate.lua
@@ -417,22 +417,20 @@ xi.combat.magicHitRate.calculateResistanceFactor = function(actor, target, skill
     end
 
     ----------------------------------------
-    -- Force 1/8 if target has max resistance rank.
+    -- Handle target resistance rank.
     ----------------------------------------
     local targetResistRank = target:getMod(xi.combat.element.resistRankMod[actionElement]) or 0
 
-    if targetResistRank >= 11 then
-        return 0.0625
-    end
-
-    ----------------------------------------
-    -- Handle target resistance rank.
-    ----------------------------------------
     if targetResistRank > 4 then
         targetResistRank = utils.clamp(targetResistRank - rankModifier, 4, 11)
     end
 
-    -- TODO: Rayke logic might be needed here, depending on how it's implemented.
+    ----------------------------------------
+    -- Force 1/8 if target has max resistance rank.
+    ----------------------------------------
+    if targetResistRank >= 11 then
+        return 0.0625
+    end
 
     ----------------------------------------
     -- Handle magic hit rate.


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Applies resistance auto fail after handling resistance rank, not before
(in short, allow immunobreak effect to be applied before assuming we fail)

## Steps to test these changes

Cast enfeebling spells to immunobreak a mob and see it has an actual effect on resist rate
