### PR TITLE
[Lua] Fix several Den of Rancor mob issues

### DIFF
--- a/scripts/zones/Den_of_Rancor/mobs/Hakutaku.lua
+++ b/scripts/zones/Den_of_Rancor/mobs/Hakutaku.lua
@@ -6,8 +6,17 @@
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.GIL_MIN, 1600)
-    mob:setMobMod(xi.mobMod.GIL_MAX, 3500)
+    mob:setMobMod(xi.mobMod.GIL_MIN, 18000)
+end
+
+entity.onMobSpawn = function(mob)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.PETRIFY)
+
+    mob:setMod(xi.mod.SILENCE_MEVA, 200)
+    mob:setMod(xi.mod.TRIPLE_ATTACK, 25)
+    mob:setMod(xi.mod.DOUBLE_ATTACK, 15)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Den_of_Rancor/mobs/Ogama.lua
+++ b/scripts/zones/Den_of_Rancor/mobs/Ogama.lua
@@ -5,6 +5,25 @@
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobFight = function(mob, target)
+    local mobHPP = mob:getHPP()
+    local appliedDmgBoost = mob:getLocalVar('appliedDmgBoost')
+
+    if
+        mobHPP <= 50 and
+        appliedDmgBoost == 0
+    then
+        mob:addMod(xi.mod.MAIN_DMG_RATING, mob:getMainLvl() + 2)
+        mob:setLocalVar('appliedDmgBoost', 1)
+    elseif
+        mobHPP > 50 and
+        appliedDmgBoost == 1
+    then
+        mob:delMod(xi.mod.MAIN_DMG_RATING, mob:getMainLvl() + 2)
+        mob:setLocalVar('appliedDmgBoost', 0)
+    end
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 398)
 end

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -10980,7 +10980,7 @@ INSERT INTO `mob_groups` VALUES (32,2948,160,'Ogama',0,32,1840,0,0,80,84,0);
 INSERT INTO `mob_groups` VALUES (33,3953,160,'Tonberry_Decapitator',1260,0,2433,0,0,72,74,0);
 INSERT INTO `mob_groups` VALUES (34,3972,160,'Tonberry_Tracker',1560,0,2449,0,0,72,74,0);
 INSERT INTO `mob_groups` VALUES (35,3964,160,'Tonberry_Pontifex',86400,0,2443,0,0,75,75,0);
-INSERT INTO `mob_groups` VALUES (36,1877,160,'Hakutaku',0,128,1270,50000,0,85,85,0);
+INSERT INTO `mob_groups` VALUES (36,1877,160,'Hakutaku',0,128,1270,50000,50000,85,85,0);
 INSERT INTO `mob_groups` VALUES (37,2718,160,'Mokumokuren',0,128,0,9000,0,80,82,0);
 INSERT INTO `mob_groups` VALUES (38,6409,160,'Mousse',960,0,1749,0,0,64,70,0);
 INSERT INTO `mob_groups` VALUES (39,6882,160,'Azrael',0,128,0,0,0,0,0,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
1. Add to Hakutaku the correct gil, status immunities, silence meva, double attack, and triple attack based on retail [capture](https://youtu.be/ZQMUnCc5Zko) by Siknoz. Also add similar amount of MP as verified HP (as no reports of Hakutaku running out of MP). 

2. Double the main damage of Ogama when under 50% HP (based on [retail video](https://www.youtube.com/watch?v=qHVbD0MhCxo) showing damage as HP changes).

## Steps to test these changes
Fight Hakutaku and Ogama and compare to retail capture and retail video.
