### PR TITLE
Core: Only print console input if character is printable

### DIFF
--- a/src/common/console_service.cpp
+++ b/src/common/console_service.cpp
@@ -82,9 +82,9 @@ bool getLine(std::string& line)
         return false;
     }
 
-    fmt::print("{:c}", keyCharacter); // echo character back to console, apparently using ReadConsoleInput & GetStdHandle prevents echo?
     if (std::isprint(keyCharacter))
     {
+        fmt::print("{:c}", keyCharacter); // echo character back to console, apparently using ReadConsoleInput & GetStdHandle prevents echo?
         line += keyCharacter;
     }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Console input appears to be handled one byte at a time, and certain keys such as arrow keys are two-byte inputs, where the first input is a non-printable character causing the print to choke.  In the case of arrow keys, the initial byte sent is 224, followed by a second byte which is printable.

Moves print for input character to existing `isprint()` condition.  This is not an elegant fix, as while the first character will be ignored, in the case of arrow keys the second byte will be added to the string.  (Arrow keys, for example, will still print either H, P, K, or M)
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Start console, roll face on keyboard.
<!-- Clear and detailed steps to test your changes here -->
