### PR TITLE
[Magic] Fix food macc multiplier being 0

### DIFF
--- a/scripts/globals/combat/magic_hit_rate.lua
+++ b/scripts/globals/combat/magic_hit_rate.lua
@@ -281,12 +281,15 @@ end
 
 -- Magic Accuracy from Food.
 local function magicAccuracyFromFoodMultiplier(actor)
-    local magicAcc = actor:getMod(xi.mod.FOOD_MACCP) / 100
-    local foodCap  = actor:getMod(xi.mod.FOOD_MACC_CAP) / 100
+    local magicAcc          = 1
+    local foodMagicAccBonus = actor:getMod(xi.mod.FOOD_MACCP) / 100
+    local foodMagicAccCap   = actor:getMod(xi.mod.FOOD_MACC_CAP) / 100
 
-    if foodCap > 0 then
-        magicAcc = 1 + utils.clamp(magicAcc, 0, foodCap)
+    if foodMagicAccCap > 0 then
+        foodMagicAccBonus = utils.clamp(foodMagicAccBonus, 0, foodMagicAccCap)
     end
+
+    magicAcc = magicAcc + foodMagicAccBonus
 
     return magicAcc
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes (my) oversight when calculating macc from food, making the multiplier be 0 when no macc food was used

## Steps to test these changes

Add debug prints to macc calculations.
Cast a damaging spell.
See your macc not be 0
