### PR TITLE
Core: Fix possible iterator invalidation in event handler

### DIFF
--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -2539,6 +2539,11 @@ end
 function CBaseEntity:triggerListener(eventName, ...)
 end
 
+---@param eventName string
+---@return boolean
+function CBaseEntity:hasListener(eventName)
+end
+
 ---@nodiscard
 ---@param targetID integer
 ---@return CBaseEntity?

--- a/src/map/ai/helpers/event_handler.cpp
+++ b/src/map/ai/helpers/event_handler.cpp
@@ -26,15 +26,11 @@ void CAIEventHandler::addListener(std::string const& eventname, sol::function co
     TracyZoneScoped;
     TracyZoneString(eventname);
     TracyZoneString(identifier);
-    // Remove entries with same identifier (if they exist)
-    eventListeners[eventname]
-        .erase(std::remove_if(eventListeners[eventname].begin(), eventListeners[eventname].end(),
-                              [&identifier](const ai_event_t& event)
-                              {
-                                  return identifier == event.identifier;
-                              }),
-               eventListeners[eventname].end());
 
+    // Remove entries with same identifier (if they exist).
+    removeFromAllListeners(identifier);
+
+    // Add the new listener.
     eventListeners[eventname].emplace_back(identifier, lua_func);
 }
 
@@ -42,19 +38,41 @@ void CAIEventHandler::removeListener(std::string const& identifier)
 {
     TracyZoneScoped;
     TracyZoneString(identifier);
-    for (auto&& eventListener : eventListeners)
-    {
-        auto remove = [&identifier](const ai_event_t& event)
-        {
-            return identifier == event.identifier;
-        };
 
-        auto it = std::remove_if(eventListener.second.begin(), eventListener.second.end(), remove);
-        eventListener.second.erase(it, eventListener.second.end());
+    // If we're currently triggering listeners, it isn't safe to remove
+    // the listener from the list, so we'll mark it for lazy removal later.
+    if (isTriggeringListeners)
+    {
+        eventsToRemove.push_back(identifier);
+        return;
     }
+
+    // Otherwise, we can remove the listener immediately.
+    removeFromAllListeners(identifier);
 }
 
 bool CAIEventHandler::hasListener(std::string const& eventName)
 {
-    return eventListeners.count(eventName) > 0;
+    const auto& listeners = eventListeners.find(eventName);
+    return listeners != eventListeners.end() && !listeners->second.empty();
+}
+
+void CAIEventHandler::removeFromAllListeners(const std::string& identifier)
+{
+    TracyZoneScoped;
+    TracyZoneString(identifier);
+
+    const auto isSameIdentifier = [&identifier](const ai_event_t& event)
+    {
+        return identifier == event.identifier;
+    };
+
+    for (auto& [_, listeners] : eventListeners)
+    {
+        // Partition the vector so that all elements that match the identifier are at the end.
+        auto it = std::remove_if(listeners.begin(), listeners.end(), isSameIdentifier);
+
+        // Erase the partitioned elements.
+        listeners.erase(it, listeners.end());
+    }
 }

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -11987,7 +11987,7 @@ void CLuaBaseEntity::addListener(std::string const& eventName, std::string const
  *  Function: removeListener()
  *  Purpose : Instructs the Event Handler to stop monitoring for an Event
  *  Example : pet:removeListener("AUTO_PATTERN_READER_TICK")
- *  Notes   : Used heavily in Pup Ability scripts
+ *  Notes   : Used heavily in PUP Ability scripts
  ************************************************************************/
 
 void CLuaBaseEntity::removeListener(std::string const& identifier)
@@ -12006,6 +12006,20 @@ void CLuaBaseEntity::removeListener(std::string const& identifier)
 void CLuaBaseEntity::triggerListener(std::string const& eventName, sol::variadic_args args)
 {
     m_PBaseEntity->PAI->EventHandler.triggerListener(eventName, sol::as_args(args));
+}
+
+/************************************************************************
+ *  Function: hasListener()
+ *  Purpose : true/false of whether or not the Event Handler is monitoring
+ *          : for a particular Event
+ *  Example : if mob:hasListener("COMBAT_TICK") then ...
+ *  Notes   : This uses the event name, not the unique identifier!
+ *          : This is just for the presence of an event in general, not a specific one
+ ************************************************************************/
+
+bool CLuaBaseEntity::hasListener(std::string const& eventName)
+{
+    return m_PBaseEntity->PAI->EventHandler.hasListener(eventName);
 }
 
 /************************************************************************
@@ -18560,6 +18574,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("addListener", CLuaBaseEntity::addListener);
     SOL_REGISTER("removeListener", CLuaBaseEntity::removeListener);
     SOL_REGISTER("triggerListener", CLuaBaseEntity::triggerListener);
+    SOL_REGISTER("hasListener", CLuaBaseEntity::hasListener);
 
     SOL_REGISTER("getEntity", CLuaBaseEntity::getEntity);
     SOL_REGISTER("canChangeState", CLuaBaseEntity::canChangeState);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -600,6 +600,7 @@ public:
     void addListener(std::string const& eventName, std::string const& identifier, sol::function const& func);
     void removeListener(std::string const& identifier);
     void triggerListener(std::string const& eventName, sol::variadic_args args);
+    bool hasListener(std::string const& eventName);
 
     auto getEntity(uint16 targetID) -> std::optional<CLuaBaseEntity>;
     bool canChangeState();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Tested with this on mob init, all expected values printed correctly:
```lua

    print("=== GOBLIN")
    print("hasListener ATTACK:", mob:hasListener('ATTACK')) -- expect false
    mob:addListener('ATTACK', 'COLLECTOR_ATTACK', function() end)
    print("hasListener ATTACK:", mob:hasListener('ATTACK')) -- expect true
    mob:removeListener('COLLECTOR_ATTACK')
    print("hasListener ATTACK:", mob:hasListener('ATTACK')) -- expect false
```
