### PR TITLE
Core: Use EntityID_t for PWideScanTarget

### DIFF
--- a/src/map/entities/baseentity.cpp
+++ b/src/map/entities/baseentity.cpp
@@ -31,8 +31,12 @@
 
 #include <cstring>
 
+// TODO: Don't use static here, use a proper unique identifier generator.
+static uint64 sUniqueIdentifier = 0;
+
 CBaseEntity::CBaseEntity()
-: id(0)
+: hash(++sUniqueIdentifier)
+, id(0)
 , targid(0)
 , objtype(ENTITYTYPE::TYPE_NONE)
 , status(STATUS_TYPE::DISAPPEAR)

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -212,12 +212,12 @@ CCharEntity::CCharEntity()
     lastTradeInvite = {};
     TradePending.clean();
     InvitePending.clean();
+    WideScanTarget.clean();
 
     PLinkshell1     = nullptr;
     PLinkshell2     = nullptr;
     PUnityChat      = nullptr;
     PTreasurePool   = nullptr;
-    PWideScanTarget = nullptr;
 
     PAutomaton             = nullptr;
     PClaimedMob            = nullptr;

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -444,7 +444,6 @@ public:
     CUContainer*     UContainer;     // Container used for universal actions -- used for trading at least despite the dedicated trading container above
     CTradeContainer* CraftContainer; // Container used for crafting actions.
 
-    CBaseEntity* PWideScanTarget;
 
     SpawnIDList_t SpawnPCList;    // list of visible characters
     SpawnIDList_t SpawnMOBList;   // list of visible monsters
@@ -455,9 +454,12 @@ public:
     void SetName(const std::string& name); // set the name of character, limited to 15 characters
 
     time_point   lastTradeInvite;
-    EntityID_t   TradePending{};  // Character ID offering trade
-    EntityID_t   InvitePending{}; // Character ID sending party invite
-    EntityID_t   BazaarID{};      // Pointer to the bazaar we are browsing.
+
+    EntityToken TradePendingEntityToken{};   // Character ID offering trade
+    EntityToken InvitePendingEntityToken{};  // Character ID sending party invite
+    EntityToken BazaarBrowingEntityToken{};  // Pointer to the bazaar we are browsing.
+    EntityToken WideScanTargetEntityToken{}; //
+
     BazaarList_t BazaarCustomers; // Array holding the IDs of the current customers
 
     std::unique_ptr<monstrosity::MonstrosityData_t> m_PMonstrosity;

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -592,13 +592,13 @@ void SmallPacket0x015(map_session_data_t* const PSession, CCharEntity* const PCh
         PChar->loc.zone->SpawnTRUSTs(PChar);
         PChar->requestedInfoSync = true; // Ask to update PCs during CZoneEntities::ZoneServer
 
-        if (PChar->PWideScanTarget != nullptr)
+        if (const auto* PWidescanTarget = PChar->WideScanTargetEntityToken.resolve())
         {
-            PChar->pushPacket(new CWideScanTrackPacket(PChar->PWideScanTarget));
+            PChar->pushPacket(new CWideScanTrackPacket(PWidescanTarget));
 
-            if (PChar->PWideScanTarget->status == STATUS_TYPE::DISAPPEAR)
+            if (PWidescanTarget->status == STATUS_TYPE::DISAPPEAR)
             {
-                PChar->PWideScanTarget = nullptr;
+                PChar->WideScanTargetEntityToken.clear();
             }
         }
     }
@@ -6908,7 +6908,7 @@ void SmallPacket0x0F5(map_session_data_t* const PSession, CCharEntity* const PCh
     if (target == nullptr)
     {
         // Target not found
-        PChar->PWideScanTarget = nullptr;
+        PChar->WideScanTargetEntityToken.clear();
         return;
     }
 
@@ -6918,7 +6918,7 @@ void SmallPacket0x0F5(map_session_data_t* const PSession, CCharEntity* const PCh
     // Only allow players to track targets that are actually scannable, and within their wide scan range
     if (target->isWideScannable() && dist <= widescanRange)
     {
-        PChar->PWideScanTarget = target;
+        PChar->WideScanTargetEntityToken = target->getEntityToken();
     }
 }
 
@@ -6931,7 +6931,7 @@ void SmallPacket0x0F5(map_session_data_t* const PSession, CCharEntity* const PCh
 void SmallPacket0x0F6(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket& data)
 {
     TracyZoneScoped;
-    PChar->PWideScanTarget = nullptr;
+    PChar->WideScanTargetEntityToken.clear();
 }
 
 /************************************************************************

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -7172,7 +7172,7 @@ namespace charutils
 
         PChar->TradePending.clean();
         PChar->InvitePending.clean();
-        PChar->PWideScanTarget = nullptr;
+        PChar->WideScanTarget.clean();
 
         if (PChar->animation == ANIMATION_ATTACK)
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

We love scope creep. I think this is going to become my long awaited introduction of some sort of `EntityToken` structure. We already have `EntityID_t` which does a lot of what I want. This will refactor it into the token, add the `.resolve()` function, and then replace all existing usaged with the new one.

Obviously will include proper testing of everything, renaming, refactoring, comments, all the good stuff. I'll also keep an eye out for anywhere I might be able to add this for stability that won't be HUGE (so, PPet, PMaster etc. is probably too big for this round, but it's the obvious candidate)
