### PR TITLE
[Lua, Fishing, Quest] Converted Quest "The Gift" to IF format

### DIFF
--- a/scripts/quests/otherAreas/The_Gift.lua
+++ b/scripts/quests/otherAreas/The_Gift.lua
@@ -1,0 +1,89 @@
+-----------------------------------
+-- The Gift
+-----------------------------------
+-- Log ID: 4, Quest ID: 21
+-- !addquest 4 21
+-- !additem 4375
+-- Oswald  : !pos 47.119 -15.273 7.989 248
+-----------------------------------
+
+local quest = Quest:new(xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.THE_GIFT)
+
+quest.reward =
+{
+    item     = xi.item.SLEEP_DAGGER,
+    title    = xi.title.SAVIOR_OF_LOVE,
+    fameArea = xi.fameArea.SELBINA_RABAO,
+}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_AVAILABLE and
+                player:getQuestStatus(xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.UNDER_THE_SEA) == xi.questStatus.QUEST_COMPLETED and
+                player:getQuestStatus(xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.THE_SAND_CHARM) >= xi.questStatus.QUEST_ACCEPTED and
+                xi.settings.map.FISHING_ENABLE == true
+        end,
+
+        [xi.zone.SELBINA] =
+        {
+            ['Oswald'] = quest:progressEvent(70, xi.item.DANCESHROOM), -- Girlfriend needs a shroom
+
+            onEventFinish =
+            {
+                [70] = function(player, csid, option, npc)
+                    if option == 50 then
+                        quest:begin(player)
+                    end
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_ACCEPTED
+        end,
+
+        [xi.zone.SELBINA] =
+        {
+            ['Oswald'] =
+            {
+                onTrigger = function(player, npc)
+                    return quest:event(71) -- They are really hard to come by
+                end,
+
+                onTrade = function(player, npc, trade)
+                    if npcUtil.tradeHasExactly(trade, xi.item.DANCESHROOM) then
+                        return quest:progressEvent(72, 0, xi.item.DANCESHROOM) -- You found it! Please take this reward
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [72] = function(player, csid, option, npc)
+                    if quest:complete(player) then
+                        player:confirmTrade()
+                    end
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_COMPLETED and
+                player:getQuestStatus(xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.THE_REAL_GIFT) == xi.questStatus.QUEST_AVAILABLE
+        end,
+
+        [xi.zone.SELBINA] =
+        {
+            ['Oswald'] = quest:progressEvent(78):replaceDefault(),
+            -- I've been all over Vana'diel, but the inn is my favorite.
+        },
+    },
+}
+
+return quest

--- a/scripts/quests/otherAreas/Under_the_Sea.lua
+++ b/scripts/quests/otherAreas/Under_the_Sea.lua
@@ -13,8 +13,9 @@ local quest = Quest:new(xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.UNDER_TH
 
 quest.reward =
 {
-    item  = xi.item.AMBER_EARRING,
-    title = xi.title.LIL_CUPID,
+    item     = xi.item.AMBER_EARRING,
+    title    = xi.title.LIL_CUPID,
+    fameArea = xi.fameArea.SELBINA_RABAO,
 }
 
 quest.sections =


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Converts quest "The Gift" to IF format.  Also, added fame reward to Under the Sea quest

## Steps to test these changes

Have not started/completed either prereq quest: Under the sea, Sand Charm
Talk to oswald; Quest won't start "Sorry... I was lost in thought" <-- old default
!completequest 4 17
!addquest 4 8
Quest will start, he asks for danceshroom for his sick girlfriend, accept if you're not cold-hearted
!additem 4375 -- danceshroom
Trade to Oswald, get sleep dagger, and complete quest
Talk to Oswald, should have new flavor text
