### PR TITLE
Core: Don't print out env var values for settings

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -191,8 +191,8 @@ namespace settings
                 // block.
                 if (std::getenv(envKey.c_str()))
                 {
-                    auto value = std::string(std::getenv(envKey.c_str()));
-                    ShowInfo(fmt::format("Applying ENV VAR {}: {} -> {}", envKey, key, value));
+                    auto value = std::string(trim(std::getenv(envKey.c_str())));
+                    ShowInfo(fmt::format("Applying ENV VAR {} to {}", envKey, key));
 
                     // If we don't convert the PORTS to doubles (or ints), then the LUA
                     // doesn't interpret them correctly and it breaks everything.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

If you want to use env vars for your DB passwords etc, this now won't print them to the log...