### PR TITLE
Lua: Change indexing format for GetTableOfIDs

### DIFF
--- a/scripts/zones/Bhaflau_Thickets/IDs.lua
+++ b/scripts/zones/Bhaflau_Thickets/IDs.lua
@@ -41,8 +41,8 @@ zones[xi.zone.BHAFLAU_THICKETS] =
     {
         CHIGOES              =
         {
-            ['Marid']        = GetTableOfIDs('Chigoe', 5),
-            ['Grand_Marid']  = GetTableOfIDs('Chigoe', 5),
+            ['Marid']        = utils.slice(GetTableOfIDs('Chigoe'), 1, 5), -- Entries 1-5 of the table (1-indexed, inclusive)
+            ['Grand_Marid']  = utils.slice(GetTableOfIDs('Chigoe'), 1, 5), -- Entries 1-5 of the table (1-indexed, inclusive)
         },
         DEA                = GetFirstID('Dea'),
         EMERGENT_ELM       = GetFirstID('Emergent_Elm'),

--- a/scripts/zones/Caedarva_Mire/IDs.lua
+++ b/scripts/zones/Caedarva_Mire/IDs.lua
@@ -49,8 +49,8 @@ zones[xi.zone.CAEDARVA_MIRE] =
         CAEDARVA_TOAD         = GetFirstID('Caedarva_Toad'),
         CHIGOES =
         {
-            ['Wild_Karakul'] = GetTableOfIDs('Chigoe', 5),
-            ['Mosshorn']     = GetTableOfIDs('Chigoe', 5, 5),
+            ['Wild_Karakul'] = utils.slice(GetTableOfIDs('Chigoe'), 1, 5), -- Entries 1-5 of the table (1-indexed, inclusive)
+            ['Mosshorn']     = utils.slice(GetTableOfIDs('Chigoe'), 6, 10), -- Entries 6-10 of the table (1-indexed, inclusive)
         },
         EXPERIMENTAL_LAMIA    = GetFirstID('Experimental_Lamia'),
         JAZARAAT              = GetFirstID('Jazaraat'),

--- a/scripts/zones/Grand_Palace_of_HuXzoi/IDs.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/IDs.lua
@@ -36,7 +36,7 @@ zones[xi.zone.GRAND_PALACE_OF_HUXZOI] =
     },
     mob =
     {
-        JAILER_OF_TEMPERANCE_PH = GetTableOfIDs('Eozdei_Still', 5), -- Get the first 5 in the zone
+        JAILER_OF_TEMPERANCE_PH = utils.slice(GetTableOfIDs('Eozdei_Still'), 1, 5), -- Entries 1-5 of the table (1-indexed, inclusive)
         IXGHRAH                 = GetFirstID('Ixghrah'),
         JAILER_OF_TEMPERANCE    = GetFirstID('Jailer_of_Temperance'),
         IXAERN_MNK              = GetFirstID('Ixaern_MNK'),


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Makes the usage clearer and more obvious for `GetTableOfIDs` and updates existing "extended usages" to use new format, with comments

Test code:
```lua
print("Total Chigoe IDs:")
print(#GetTableOfIDs('Chigoe'))

print("Chigoe IDs 1-5:")
local subTable = utils.slice(GetTableOfIDs('Chigoe'), 1, 5)
print(#subTable)
print(subTable[1])
print(subTable[2])

local subTable2 = utils.slice(GetTableOfIDs('Chigoe'), 6, 10)
print(#subTable2)
print(subTable2[1])
print(subTable2[2])
```

Output:
```
[11/02/24 13:11:55:669][map][lua] Total Chigoe IDs: (lua_print:203)
[11/02/24 13:11:55:669][map][lua] 28 (lua_print:203)
[11/02/24 13:11:55:669][map][lua] Chigoe IDs 1-5: (lua_print:203)
[11/02/24 13:11:55:669][map][lua] 5 (lua_print:203)
[11/02/24 13:11:55:669][map][lua] 17100806 (lua_print:203)
[11/02/24 13:11:55:669][map][lua] 17100807 (lua_print:203)
[11/02/24 13:11:55:669][map][lua] 5 (lua_print:203)
[11/02/24 13:11:55:669][map][lua] 17100811 (lua_print:203)
[11/02/24 13:11:55:669][map][lua] 17100812 (lua_print:203)
```

Seems fine to me!