### PR TITLE
Core: Don't clean up instances in DecreaseZoneCounter

### DIFF
--- a/src/map/zone_instance.h
+++ b/src/map/zone_instance.h
@@ -25,14 +25,12 @@
 #include "instance.h"
 #include "zone.h"
 
-typedef std::vector<std::unique_ptr<CInstance>> instanceList_t;
-
 class CZoneInstance : public CZone
 {
 public:
     DISALLOW_COPY_AND_MOVE(CZoneInstance);
 
-    virtual CCharEntity* GetCharByName(std::string const& name) override; // finds the player if exists in zone
+    virtual CCharEntity* GetCharByName(const std::string& name) override; // finds the player if exists in zone
     virtual CCharEntity* GetCharByID(uint32 id) override;
     virtual CBaseEntity* GetEntity(uint16 targid, uint8 filter = -1) override; // get a pointer to any entity in the zone
 
@@ -68,9 +66,9 @@ public:
     virtual void ZoneServer(time_point tick) override;
     virtual void CheckTriggerAreas() override;
 
-    virtual void ForEachChar(std::function<void(CCharEntity*)> const& func) override;
-    virtual void ForEachCharInstance(CBaseEntity* PEntity, std::function<void(CCharEntity*)> const& func) override;
-    virtual void ForEachMobInstance(CBaseEntity* PEntity, std::function<void(CMobEntity*)> const& func) override;
+    virtual void ForEachChar(const std::function<void(CCharEntity*)>& func) override;
+    virtual void ForEachCharInstance(CBaseEntity* PEntity, const std::function<void(CCharEntity*)>& func) override;
+    virtual void ForEachMobInstance(CBaseEntity* PEntity, const std::function<void(CMobEntity*)>& func) override;
 
     CInstance* CreateInstance(uint16 instanceid);
 
@@ -78,7 +76,9 @@ public:
     ~CZoneInstance() override;
 
 private:
-    instanceList_t instanceList;
+    typedef std::vector<std::unique_ptr<CInstance>> instanceList_t;
+
+    instanceList_t m_InstanceList;
 };
 
 #endif // _CZONEINSTANCE_H


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes: https://github.com/LandSandBoat/server/issues/6403

EDIT: Yup, before/after stops the crash, and the logging around cleanup happens as expected. Interesting that this is crashing in the first place, `!instance 7700` was my test case when I redid the instance system some years ago

We have logic that keeps a zone alive for 1-2 extra ticks before it goes to sleep, so we don't need to so eagerly clean up.

Also had a bit of a tidy up, got rid of the removal-during-iteration thing, etc.