### PR TITLE
[Lua+Core] Fix 24 hour respawn RoTZ NMs (including bodyguarding)

### DIFF
--- a/scripts/mixins/rotz_bodyguarded_nm.lua
+++ b/scripts/mixins/rotz_bodyguarded_nm.lua
@@ -1,0 +1,60 @@
+-- Mixin for behavior that is common to six RoTZ NMs that have 21-24 hour respawns
+-- These mobs are Centurio XII-I, Meteormauler Zhagtegg, Coo Keja the Unseen, Meww the Turtlerider,
+-- Bo'Who Warmonger, and Bright-handed Kunberry
+-- These NMs have two bodyguard mobs that spawn with them if beastmen control the region they spawn in
+-- The bodyguards just link as normal mobs and are not in a party or superlinking
+require('scripts/globals/mixins')
+
+g_mixins = g_mixins or {}
+
+g_mixins.bodyguard = function(bodyguardedNM)
+    -- function for bodyguard roaming logic
+    local bodyGuardRoam = function(mob)
+        -- if bodyguarded NM is missing or dead then despawn the bodyguard
+        if not bodyguardedNM or (bodyguardedNM and bodyguardedNM:isDead()) then
+            DespawnMob(mob:getID())
+        -- else if bodyguard not following then follow NM
+        elseif
+            not mob:hasFollowTarget() and bodyguardedNM
+        then
+            mob:follow(bodyguardedNM, xi.followType.ROAM)
+        end
+    end
+
+    local bodyGuardDespawn = function(mob)
+        -- remove listeners on despawn as they are setup again on spawn
+        mob:removeListener('ROTZ_BODYGUARD_ROAM')
+        mob:removeListener('ROTZ_BODYGUARD_DESPAWN')
+    end
+
+    bodyguardedNM:addListener('SPAWN', 'ROTZ_BODYGUARDED_NM_SPAWN', function(mob)
+        local regionID = mob:getZone():getRegionID()
+        -- will spawn with body guard mobs if region is beastmen controlled
+        if GetRegionOwner(regionID) == xi.nation.BEASTMEN then
+            local nmID = mob:getID()
+            local nmSpawnPos = mob:getSpawnPos()
+            local guardIDs = { nmID + 1, nmID + 2 }
+            local spawnPosOffset = { 2, 4 }
+
+            for index, guardID in ipairs(guardIDs) do
+                local guard = GetMobByID(guardID)
+
+                if guard then
+                    -- despawn bodyguard if they are still spawned for some reason
+                    if guard:isSpawned() then
+                        DespawnMob(guard:getID())
+                    end
+
+                    guard:setSpawn(nmSpawnPos.x - spawnPosOffset[index], nmSpawnPos.y, nmSpawnPos.z)
+                    guard:spawn()
+                    guard:follow(mob, xi.followType.ROAM)
+                    guard:addListener('ROAM_TICK', 'ROTZ_BODYGUARD_ROAM', bodyGuardRoam)
+                    guard:addListener('DESPAWN', 'ROTZ_BODYGUARD_DESPAWN', bodyGuardDespawn)
+                    guard:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+                end
+            end
+        end
+    end)
+end
+
+return g_mixins.bodyguard

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -522,6 +522,10 @@ end
 function CBaseEntity:follow(target, followType)
 end
 
+---@return boolean
+function CBaseEntity:hasFollowTarget()
+end
+
 ---@return nil
 function CBaseEntity:unfollow()
 end

--- a/scripts/zones/Eastern_Altepa_Desert/mobs/Centurio_XII-I.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/mobs/Centurio_XII-I.lua
@@ -2,8 +2,20 @@
 -- Area: Eastern Altepa Desert (114)
 --   NM: Centurio XII-I
 -----------------------------------
+mixins = { require('scripts/mixins/job_special'), require('scripts/mixins/rotz_bodyguarded_nm') }
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
+
+-- all body guard functionality in the rotz_bodyguarded_nm mixin
+
+entity.onMobSpawn = function(mob)
+    -- retail captures show these mods are not dependent on region control
+    mob:setMod(xi.mod.UDMGPHYS, -5000)
+    mob:setMod(xi.mod.UDMGRANGE, -5000)
+    mob:setMod(xi.mod.UDMGBREATH, -5000)
+    mob:setMod(xi.mod.UDMGMAGIC, -5000)
+end
 
 entity.onMobDeath = function(mob, player, optParams)
 end

--- a/scripts/zones/Jugner_Forest/Zone.lua
+++ b/scripts/zones/Jugner_Forest/Zone.lua
@@ -14,6 +14,9 @@ zoneObject.onInitialize = function(zone)
     UpdateNMSpawnPoint(ID.mob.FRAELISSA)
     GetMobByID(ID.mob.FRAELISSA):setRespawnTime(math.random(900, 10800))
 
+    UpdateNMSpawnPoint(ID.mob.METEORMAULER)
+    GetMobByID(ID.mob.METEORMAULER):setRespawnTime(math.random(900, 10800))
+
     xi.conq.setRegionalConquestOverseers(zone:getRegionID())
 
     xi.helm.initZone(zone, xi.helmType.LOGGING)

--- a/scripts/zones/Jugner_Forest/mobs/Meteormauler_Zhagtegg.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Meteormauler_Zhagtegg.lua
@@ -2,62 +2,27 @@
 -- Area: Jugner Forest
 --   NM: Meteormauler Zhagtegg
 -----------------------------------
-mixins = { require('scripts/mixins/job_special') }
+mixins = { require('scripts/mixins/job_special'), require('scripts/mixins/rotz_bodyguarded_nm') }
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
--- TODO: Implement better pathing systems for guards to follow master
+-- all body guard functionality in the rotz_bodyguarded_nm mixin
 
 entity.onMobSpawn = function(mob)
-    local meteormauler = mob:getID()
-    -- Takes half damage from all attacks
-    mob:addMod(xi.mod.DMG, -5000)
-
-    -- May spawn in a party with two other Orcs
-    if math.random(1, 3) == 2 then
-        GetMobByID(meteormauler + 1):setSpawn(mob:getXPos() + 2, mob:getYPos(), mob:getZPos())
-        GetMobByID(meteormauler + 2):setSpawn(mob:getXPos() + 4, mob:getYPos(), mob:getZPos())
-        SpawnMob(meteormauler + 1)
-        SpawnMob(meteormauler + 2)
-    end
-end
-
-entity.onMobEngage = function(mob, target)
-    local mobId = mob:getID()
-    for i = 1, 2 do
-        local guardObj = GetMobByID(mobId + i)
-
-        if guardObj then
-            guardObj:updateEnmity(target)
-        end
-    end
-end
-
-entity.onMobRoam = function(mob)
-    local mobId = mob:getID()
-    for i = 1, 2 do
-        local guard = GetMobByID(mobId + i)
-
-        if guard then
-            if guard:isSpawned() and guard:getID() == mobId + 1 then
-                guard:pathTo(mob:getXPos() + 1, mob:getYPos() + 3, mob:getZPos() + 0.15)
-            elseif guard:isSpawned() and guard:getID() == mobId + 2 then
-                guard:pathTo(mob:getXPos() + 3, mob:getYPos() + 5, mob:getZPos() + 0.15)
-            end
-        end
-    end
+    -- retail captures show these mods are not dependent on region control
+    mob:setMod(xi.mod.UDMGPHYS, -5000)
+    mob:setMod(xi.mod.UDMGRANGE, -5000)
+    mob:setMod(xi.mod.UDMGBREATH, -5000)
+    mob:setMod(xi.mod.UDMGMAGIC, -5000)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    local meteormauler = mob:getID()
-    UpdateNMSpawnPoint(meteormauler)
+    UpdateNMSpawnPoint(mob:getID())
     mob:setRespawnTime(75600 + math.random(0, 600)) -- 21 hours, 10 minute window
-    DespawnMob(meteormauler + 1)
-    DespawnMob(meteormauler + 2)
 end
 
 return entity

--- a/scripts/zones/Meriphataud_Mountains/mobs/Coo_Keja_the_Unseen.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Coo_Keja_the_Unseen.lua
@@ -2,12 +2,20 @@
 -- Area: Meriphataud Mountains (119)
 --   NM: Coo Keja the Unseen
 -----------------------------------
-mixins = { require('scripts/mixins/job_special') }
+mixins = { require('scripts/mixins/job_special'), require('scripts/mixins/rotz_bodyguarded_nm') }
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
+-- all body guard functionality in the rotz_bodyguarded_nm mixin
+
 entity.onMobSpawn = function(mob)
+    -- retail captures show these mods are not dependent on region control
+    mob:setMod(xi.mod.UDMGPHYS, -5000)
+    mob:setMod(xi.mod.UDMGRANGE, -5000)
+    mob:setMod(xi.mod.UDMGBREATH, -5000)
+    mob:setMod(xi.mod.UDMGMAGIC, -5000)
+
     xi.mix.jobSpecial.config(mob, {
         specials =
         {

--- a/scripts/zones/Pashhow_Marshlands/mobs/BoWho_Warmonger.lua
+++ b/scripts/zones/Pashhow_Marshlands/mobs/BoWho_Warmonger.lua
@@ -2,8 +2,20 @@
 -- Area: Pashhow Marshlands
 --   NM: Bo'Who Warmonger
 -----------------------------------
+mixins = { require('scripts/mixins/job_special'), require('scripts/mixins/rotz_bodyguarded_nm') }
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
+
+-- all body guard functionality in the rotz_bodyguarded_nm mixin
+
+entity.onMobSpawn = function(mob)
+    -- retail captures show these mods are not dependent on region control
+    mob:setMod(xi.mod.UDMGPHYS, -5000)
+    mob:setMod(xi.mod.UDMGRANGE, -5000)
+    mob:setMod(xi.mod.UDMGBREATH, -5000)
+    mob:setMod(xi.mod.UDMGMAGIC, -5000)
+end
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 60, 1, xi.regime.type.FIELDS)

--- a/scripts/zones/Yhoator_Jungle/mobs/Bright-handed_Kunberry.lua
+++ b/scripts/zones/Yhoator_Jungle/mobs/Bright-handed_Kunberry.lua
@@ -5,7 +5,8 @@
 mixins =
 {
     require('scripts/mixins/families/tonberry'),
-    require('scripts/mixins/job_special')
+    require('scripts/mixins/job_special'),
+    require('scripts/mixins/rotz_bodyguarded_nm')
 }
 -----------------------------------
 ---@type TMobEntity
@@ -13,6 +14,16 @@ local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 133, 1, xi.regime.type.FIELDS)
+end
+
+-- all body guard functionality in the rotz_bodyguarded_nm mixin
+
+entity.onMobSpawn = function(mob)
+    -- retail captures show these mods are not dependent on region control
+    mob:setMod(xi.mod.UDMGPHYS, -5000)
+    mob:setMod(xi.mod.UDMGRANGE, -5000)
+    mob:setMod(xi.mod.UDMGBREATH, -5000)
+    mob:setMod(xi.mod.UDMGMAGIC, -5000)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Yuhtunga_Jungle/IDs.lua
+++ b/scripts/zones/Yuhtunga_Jungle/IDs.lua
@@ -63,6 +63,7 @@ zones[xi.zone.YUHTUNGA_JUNGLE] =
         VOLUPTUOUS_VILMA     = GetFirstID('Voluptuous_Vilma'),
         NASUS_OFFSET         = GetFirstID('Nasus'),
         SIREN                = GetFirstID('Siren'),
+        TURTLERIDER          = GetFirstID('Meww_the_Turtlerider'),
     },
     npc =
     {

--- a/scripts/zones/Yuhtunga_Jungle/Zone.lua
+++ b/scripts/zones/Yuhtunga_Jungle/Zone.lua
@@ -16,6 +16,8 @@ zoneObject.onInitialize = function(zone)
 
     xi.bmt.updatePeddlestox(xi.zone.YUHTUNGA_JUNGLE, ID.npc.PEDDLESTOX)
 
+    GetMobByID(ID.mob.TURTLERIDER):setRespawnTime(math.random(900, 10800))
+
     GetMobByID(ID.mob.PYUU_THE_SPATEMAKER):setRespawnTime(math.random(5400, 7200))
 end
 

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Meww_the_Turtlerider.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Meww_the_Turtlerider.lua
@@ -2,13 +2,28 @@
 -- Area: Yuhtunga Jungle
 --  Mob: Meww the Turtlerider
 -----------------------------------
-mixins = { require('scripts/mixins/job_special') }
+mixins = { require('scripts/mixins/job_special'), require('scripts/mixins/rotz_bodyguarded_nm') }
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
+-- all body guard functionality in the rotz_bodyguarded_nm mixin
+
+entity.onMobSpawn = function(mob)
+    -- retail captures show these mods are not dependent on region control
+    mob:setMod(xi.mod.UDMGPHYS, -5000)
+    mob:setMod(xi.mod.UDMGRANGE, -5000)
+    mob:setMod(xi.mod.UDMGBREATH, -5000)
+    mob:setMod(xi.mod.UDMGMAGIC, -5000)
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 127, 1, xi.regime.type.FIELDS)
+end
+
+entity.onMobDespawn = function(mob)
+    UpdateNMSpawnPoint(mob:getID())
+    mob:setRespawnTime(math.random(75600, 86400)) -- 21 to 24 hours
 end
 
 return entity

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -7406,7 +7406,7 @@ INSERT INTO `mob_groups` VALUES (33,2373,104,'Land_Pugil',330,0,1498,0,0,17,20,0
 INSERT INTO `mob_groups` VALUES (34,485,104,'Bogy',330,1,322,0,0,25,29,0);
 INSERT INTO `mob_groups` VALUES (35,4309,104,'Water_Elemental',330,4,2629,0,0,27,29,0);
 INSERT INTO `mob_groups` VALUES (36,4345,104,'Will-o-the-Wisp',330,8,569,0,0,24,25,0);
-INSERT INTO `mob_groups` VALUES (37,2643,104,'Meteormauler_Zhagtegg',75600,0,1664,0,0,35,40,0);
+INSERT INTO `mob_groups` VALUES (37,2643,104,'Meteormauler_Zhagtegg',0,128,1664,0,0,35,40,0);
 INSERT INTO `mob_groups` VALUES (38,1421,104,'Fraelissa',3600,0,905,2500,0,33,35,0);
 INSERT INTO `mob_groups` VALUES (39,1420,104,'Fradubio',0,32,904,10000,0,55,60,0);
 INSERT INTO `mob_groups` VALUES (40,1129,104,'Duessa',0,128,0,0,0,40,50,0);
@@ -7844,6 +7844,9 @@ INSERT INTO `mob_groups` VALUES (77,0,109,'Ubuginu_Armor',0,128,0,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (78,0,109,'Hachiryu_Armor',0,128,0,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (79,0,109,'Omodaka_Armor',0,128,0,0,0,0,0,0);
 
+INSERT INTO `mob_groups` VALUES (80,525,109,'Brass_Quadav',0,128,350,0,0,20,26,0);
+INSERT INTO `mob_groups` VALUES (81,2986,109,'Onyx_Quadav',0,128,1864,0,0,16,20,0);
+
 -- ------------------------------------------------------------
 -- Rolanberry_Fields (Zone 110)
 -- ------------------------------------------------------------
@@ -8154,7 +8157,7 @@ INSERT INTO `mob_groups` VALUES (23,186,114,'Antican_Sagittarius',330,0,135,0,0,
 INSERT INTO `mob_groups` VALUES (24,189,114,'Antican_Speculator',330,0,138,0,0,44,49,0);
 INSERT INTO `mob_groups` VALUES (25,5891,114,'Sabotender_Corrido',7200,0,3090,9000,0,72,73,0);
 INSERT INTO `mob_groups` VALUES (26,1709,114,'Goblin_Robber',330,0,1145,0,0,45,49,0);
-INSERT INTO `mob_groups` VALUES (27,676,114,'Centurio_XII-I',0,128,444,0,0,56,56,0);
+INSERT INTO `mob_groups` VALUES (27,676,114,'Centurio_XII-I',0,128,444,5000,0,56,56,0);
 INSERT INTO `mob_groups` VALUES (28,1701,114,'Goblin_Poacher',330,0,1140,0,0,45,49,0);
 INSERT INTO `mob_groups` VALUES (29,1138,114,'Dune_Widow',0,32,720,0,0,45,47,0);
 INSERT INTO `mob_groups` VALUES (30,1705,114,'Goblin_Reaper',330,0,1142,0,0,45,49,0);
@@ -8194,6 +8197,9 @@ INSERT INTO `mob_groups` VALUES (61,677,114,'Centurio_XIII-V',0,128,3226,0,0,55,
 
 INSERT INTO `mob_groups` VALUES (62,3484,114,'Satyral',0,128,0,0,0,1,1,0);
 INSERT INTO `mob_groups` VALUES (63,6838,114,'Cactrot_Veloz',0,128,0,0,0,0,0,0);
+
+INSERT INTO `mob_groups` VALUES (64,170,114,'Antican_Decurio',0,128,119,0,0,44,49,0);
+INSERT INTO `mob_groups` VALUES (65,189,114,'Antican_Speculator',0,128,138,0,0,44,49,0);
 
 -- ------------------------------------------------------------
 -- West_Sarutabaruta (Zone 115)
@@ -8557,6 +8563,9 @@ INSERT INTO `mob_groups` VALUES (75,0,119,'Ubuginu_Armor',0,128,0,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (76,0,119,'Hachiryu_Armor',0,128,0,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (77,0,119,'Omodaka_Armor',0,128,0,0,0,0,0,0);
 
+INSERT INTO `mob_groups` VALUES (78,4459,119,'Yagudo_Votary',0,128,2774,0,0,21,25,0);
+INSERT INTO `mob_groups` VALUES (79,4456,119,'Yagudo_Theologist',0,128,2770,0,0,21,25,0);
+
 -- ------------------------------------------------------------
 -- Sauromugue_Champaign (Zone 120)
 -- ------------------------------------------------------------
@@ -8765,7 +8774,7 @@ INSERT INTO `mob_groups` VALUES (20,4309,123,'Water_Elemental',330,4,2629,0,0,48
 INSERT INTO `mob_groups` VALUES (21,833,123,'Creek_Sahagin',330,0,532,0,0,34,38,0);
 INSERT INTO `mob_groups` VALUES (22,3373,123,'River_Sahagin',330,0,2105,0,0,34,38,0);
 INSERT INTO `mob_groups` VALUES (23,3788,123,'Stream_Sahagin',330,0,2344,0,0,34,38,0);
-INSERT INTO `mob_groups` VALUES (24,2647,123,'Meww_the_Turtlerider',75600,0,1666,4500,10000,47,47,0);
+INSERT INTO `mob_groups` VALUES (24,2647,123,'Meww_the_Turtlerider',0,128,1666,4500,10000,47,47,0);
 INSERT INTO `mob_groups` VALUES (25,6845,123,'Pyuu_the_Spatemaker',0,128,3296,8700,10000,73,73,0);
 INSERT INTO `mob_groups` VALUES (26,2491,123,'Makara',330,0,1229,0,0,35,38,0);
 INSERT INTO `mob_groups` VALUES (27,3393,123,'Rose_Garden',0,128,2123,5000,0,50,50,0);
@@ -8803,6 +8812,9 @@ INSERT INTO `mob_groups` VALUES (55,0,123,'Steamy_Samantha',0,128,0,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (56,0,123,'Sultry_Samantha',0,128,0,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (57,0,123,'Sybaritic_Samantha',0,128,0,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (58,6170,123,'Siren',0,128,0,0,0,80,80,0);
+
+INSERT INTO `mob_groups` VALUES (59,833,123,'Creek_Sahagin',0,128,532,0,0,34,38,0);
+INSERT INTO `mob_groups` VALUES (60,3788,123,'Stream_Sahagin',0,128,2344,0,0,34,38,0);
 
 -- ------------------------------------------------------------
 -- Yhoator_Jungle (Zone 124)
@@ -8877,6 +8889,9 @@ INSERT INTO `mob_groups` VALUES (61,3954,124,'Tonberry_Decimator',0,128,3226,0,0
 INSERT INTO `mob_groups` VALUES (62,1174,124,'Edacious_Opo-opo',0,128,744,0,0,60,60,0);
 INSERT INTO `mob_groups` VALUES (63,2201,124,'Kedgebelly_Kate',0,128,0,0,0,1,1,0);
 INSERT INTO `mob_groups` VALUES (64,0,124,'Woodland_Mender',0,128,0,0,0,0,0,0);
+
+INSERT INTO `mob_groups` VALUES (65,3958,124,'Tonberry_Hexer',0,128,2437,0,0,45,49,0);
+INSERT INTO `mob_groups` VALUES (66,3956,124,'Tonberry_Harasser',0,128,2435,0,0,45,49,0);
 
 -- ------------------------------------------------------------
 -- Western_Altepa_Desert (Zone 125)

--- a/sql/mob_pool_mods.sql
+++ b/sql/mob_pool_mods.sql
@@ -89,12 +89,6 @@ INSERT INTO `mob_pool_mods` VALUES (459,23,50,0);  -- ATT: 50
 INSERT INTO `mob_pool_mods` VALUES (459,73,25,0);  -- STORETP: 25
 INSERT INTO `mob_pool_mods` VALUES (459,430,20,0); -- QUAD_ATTACK: 20
 
--- Bowho Warmonger
-INSERT INTO `mob_pool_mods` VALUES (519,160,-50,0); -- DMG: -50
-
--- Bright-Handed Kunberry
-INSERT INTO `mob_pool_mods` VALUES (532,160,-50,0); -- DMG: -50
-
 -- Bugbby
 INSERT INTO `mob_pool_mods` VALUES (559,62,-50,0);   -- ATTP: -50
 -- Byakko
@@ -104,9 +98,6 @@ INSERT INTO `mob_pool_mods` VALUES (592,302,45,0); -- TRIPLE_ATTACK: 45
 
 -- Cargo Crab Colin
 INSERT INTO `mob_pool_mods` VALUES (639,63,25,0); -- DEFP: 25
-
--- Centurio Xii-I
-INSERT INTO `mob_pool_mods` VALUES (676,160,-50,0); -- DMG: -50
 
 -- Cerberus
 INSERT INTO `mob_pool_mods` VALUES (680,1,322,0);   -- DEF: 322
@@ -274,12 +265,6 @@ INSERT INTO `mob_pool_mods` VALUES (2499,240,90,0); -- SLEEPRES: 90
 
 -- Mammet-22 Zeta
 INSERT INTO `mob_pool_mods` VALUES (2500,240,90,0); -- SLEEPRES: 90
-
--- Meteormauler Zhagtegg
-INSERT INTO `mob_pool_mods` VALUES (2643,160,-50,0); -- DMG: -50
-
--- Meww The Turtlerider
-INSERT INTO `mob_pool_mods` VALUES (2647,160,-50,0); -- DMG: -50
 
 -- Mimic
 INSERT INTO `mob_pool_mods` VALUES (2664,12,1,1); -- DRAW_IN: 1

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -1323,6 +1323,16 @@ void CMobController::SetFollowTarget(CBaseEntity* PTarget, FollowType followType
     m_followType  = followType;
 }
 
+bool CMobController::HasFollowTarget()
+{
+    if (PFollowTarget && m_followType != FollowType::None)
+    {
+        return true;
+    }
+
+    return false;
+}
+
 void CMobController::ClearFollowTarget()
 {
     PFollowTarget = nullptr;

--- a/src/map/ai/controllers/mob_controller.h
+++ b/src/map/ai/controllers/mob_controller.h
@@ -58,6 +58,7 @@ public:
     void         TapDeclaimTime();
     virtual bool Cast(uint16 targid, SpellID spellid) override;
     void         SetFollowTarget(CBaseEntity* PTarget, FollowType followType);
+    bool         HasFollowTarget();
     void         ClearFollowTarget();
 
     void OnCastStopped(CMagicState& state, action_t& action);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -2019,6 +2019,18 @@ void CLuaBaseEntity::follow(CLuaBaseEntity* target, uint8 followType)
     controller->SetFollowTarget(target->m_PBaseEntity, static_cast<FollowType>(followType));
 }
 
+bool CLuaBaseEntity::hasFollowTarget()
+{
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Invalid entity (%s) calling function.", m_PBaseEntity->getName());
+        return false;
+    }
+
+    auto* controller = static_cast<CMobController*>(m_PBaseEntity->PAI->GetController());
+    return controller->HasFollowTarget();
+}
+
 /************************************************************************
  *  Function: unfollow()
  *  Purpose : Makes a Mob stop following
@@ -18100,6 +18112,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("checkDistance", CLuaBaseEntity::checkDistance);
     SOL_REGISTER("wait", CLuaBaseEntity::wait);
     SOL_REGISTER("follow", CLuaBaseEntity::follow);
+    SOL_REGISTER("hasFollowTarget", CLuaBaseEntity::hasFollowTarget);
     SOL_REGISTER("unfollow", CLuaBaseEntity::unfollow);
     SOL_REGISTER("setCarefulPathing", CLuaBaseEntity::setCarefulPathing);
 

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -140,6 +140,7 @@ public:
     float checkDistance(sol::variadic_args va);                                    // Check Distance and returns distance number
     void  wait(sol::object const& milliseconds);                                   // make the npc wait a number of ms and then back into roam
     void  follow(CLuaBaseEntity* target, uint8 followType);                        // makes an npc follow or runaway from another target
+    bool  hasFollowTarget();                                                       // checks if the mob has a target that it is currently following (via follow function)
     void  unfollow();                                                              // makes an npc stop following
     // int32 WarpTo(lua_Stat* L);           // warp to the given point -- These don't exist, breaking them just in case someone uncomments
     // int32 RoamAround(lua_Stat* L);       // pick a random point to walk to


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR unifies and fixes behavior for a related group of RoTZ NMs that all have bodyguard mobs and long respawn windows (21-24 hours). These NMs include Centurio XII-I, Meteormauler Zhagtegg, Coo Keja the Unseen, Meww the Turtlerider, Bo'Who Warmonger, and Bright-handed Kunberry. 

All the NMs have two bodyguard mobs that spawn with and follow the NM if the region the NM spawns in is beastmen controlled. This bodyguard behavior is centralized in a new mixin `rotz_bodyguarded_nm.lua` that all of the six NM now include. The bodyguards link normally with the NM (but do not superlink and thus are not in a party with the NM). The bodyguards despawn if they disengage (and roam) at any time while the bodyguarded NM is dead, but they will not despawn if they are still engaged. Also bodyguards do not despawn even if dragged with the NM far away from home (they path back home just following the NM).

Also all of the NMs have a 50% damage taken reduction mod (which is implemented as the 4 `UDMG` mods because of the 50% cap on the `DMG` mod. Also the incorrect mob pool mod (`DMG: -50` ) of these NMs has been removed.

Also related issues with the NMs has been fixed such as their bodyguards spawning as normal respawn mobs or not having spawn coordinates at all. And Centurio_XII has had it's HP corrected.

The behavior of these NMs and bodyguards was validated in several captures and additional retail testing by Siknoz and myself including captures found [here](https://youtu.be/xzbLHSVSYqQ), [here](https://youtu.be/LXFCCpyamEM), [here](https://youtu.be/rZFtVY4G5A8), and an additional capture still to be uploaded.

## Steps to test these changes
Spawn any of these NMs with beastmen in control of the region and a player nation in control of the region. Also can test the bodyguard despawn behavior after the NM is killed and then doing !goto playerName.
