### PR TITLE
[lua] Fix Casket Drop Rate Prowess

### DIFF
--- a/scripts/globals/caskets.lua
+++ b/scripts/globals/caskets.lua
@@ -185,7 +185,7 @@ local function dropChance(player)
     --end
 
     if player:hasStatusEffect(xi.effect.PROWESS_CASKET_RATE) then
-        prowessCasketsPower = casketProwessEffect:getPower()
+        prowessCasketsPower = casketProwessEffect:getPower() / 100
     end
 
     local rand = math.random()


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes treasure casket drop rate bonus from GoV Prowess effects. The bonus being based on effect power was being fed into
`rand < utils.clamp(xi.settings.main.CASKET_DROP_RATE + kupowersMMBPower + prowessCasketsPower, 0, 1)`
without any adjustments to convert it into a float. This caused the casket drop rate to be capped out because the value would always be more than 1(The clamp for the float).

This PR divides the effect power by 100 so that the final bonus value reflects the proper percent bonus to be added to the base casket drop rate. An effect power of 4 will now be 0.04 which would equate to a 4% increase.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
1. Go to a GoV book zone, complete regime until you get casket rate increase or use `!exec player:addStatusEffect(xi.effect.PROWESS_CASKET_RATE, 4, 0, 0)` to give yourself 1 rank of Prowess Casket Rate bonus(4%).
2. Kill mobs and see that the drop rate is not 100%.
2b. Use a print in the above function to verify the actual drop rate is correct.


<!-- Clear and detailed steps to test your changes here -->
