### PR TITLE
Lua: Fixes condition for qm1 in the Stars of Ifrit quest

### DIFF
--- a/scripts/zones/San_dOria-Jeuno_Airship/Zone.lua
+++ b/scripts/zones/San_dOria-Jeuno_Airship/Zone.lua
@@ -27,8 +27,8 @@ zoneObject.onGameHour = function(zone)
 
     if
         IsMoonFull() and
-        vanadielHour >= 18 and
-        vanadielHour < 6
+        (vanadielHour >= 18 or
+        vanadielHour < 6)
     then
         qmObj:setStatus(xi.status.NORMAL)
     else


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This NPC should appear between 18 and 6 on full moon. However, the condition is wrong, so that it never appears. This PR corrects the issue. https://www.bg-wiki.com/ffxi/The_Stars_of_Ifrit

## Steps to test these changes
During full moon, the NPC will appear between 18 and 6.
