### PR TITLE
[Lua] Fix default isParty logic for battlefield addEssentialMobs

### DIFF
--- a/scripts/battlefields/Temenos/central_temenos_2nd_floor.lua
+++ b/scripts/battlefields/Temenos/central_temenos_2nd_floor.lua
@@ -266,7 +266,7 @@ content.groups =
             'Mystic_Avatar_Carbuncle',
         },
         mobMods = { [xi.mobMod.DETECTION] = xi.detects.HEARING },
-        inParty = true,
+        isParty = true,
     },
 
     {

--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -1201,6 +1201,7 @@ function Battlefield:addEssentialMobs(mobNames)
     table.insert(self.groups, {
         mobs      = mobNames,
         superlink = true,
+        isParty   = true,
         allDeath  = utils.bind(self.handleAllMonstersDefeated, self),
     })
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR changes the default `isParty` to true for the battlefield function `addEssentialMobs`. This is needed because despite the default for `addEssentialMobs` being `superlink = true` the mobs will not superlink unless they are in the same party. Therefore, the current situation is that in some BCNMs (for example wings of fury and probably others) that use `addEssentialMobs` you can pull one mob at a time (which should not be possible). I do not know of any BCNMs where the mobs should not superlink, but if so these can be coded without using `addEssentialMobs`. I have discussed the change with @jmcmorris already and he thinks it is logical.

The PR also fixes a small related issue with Central Temenos 2nd floor where isParty is misspelled as inParty.

## Steps to test these changes
Enter BCNM wings of furry and pull a Furries from the back and watch that the mobs superlink now