### PR TITLE
Core: Adds missing region to Sanction effect

### DIFF
--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -1006,6 +1006,7 @@ void CMobEntity::DropItems(CCharEntity* PChar)
                 case REGION_TYPE::MAMOOL_JA_SAVAGE:
                 case REGION_TYPE::HALVUNG:
                 case REGION_TYPE::ARRAPAGO:
+                case REGION_TYPE::ALZADAAL:
                     effect = 2;
                     break;
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Sanction is missing a ToAU region, causing crystals to drop from mobs around Nyzul Isle Staging Point with Signet and not with Sanction.

## Steps to test these changes
Mobs in Alzadaal Undersea Ruins should only drop crystals if the player has Sanction and not if the player has Signet