### PR TITLE
[Bug Fix] Elderly Pursuits

### DIFF
--- a/scripts/quests/otherAreas/Elderly_Pursuits.lua
+++ b/scripts/quests/otherAreas/Elderly_Pursuits.lua
@@ -92,11 +92,21 @@ quest.sections =
             ['Para'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    if quest:getVar(player, 'Prog') == 1 then
+                    if
+                        mob:getID() == ID.mob.PARA and
+                        quest:getVar(player, 'Prog') == 1
+                    then
                         quest:setVar(player, 'Prog', 2)
                     end
                 end,
             },
+
+            -- Resets the progress if the player killed Para but didn't check the ??? before zoning. Will result in the player needing to refight.
+            onZoneOut = function(player)
+                if quest:getVar(player, 'Prog') == 2 then
+                    quest:setVar(player, 'Prog', 1)
+                end
+            end,
         },
     },
 

--- a/scripts/zones/Carpenters_Landing/mobs/Para.lua
+++ b/scripts/zones/Carpenters_Landing/mobs/Para.lua
@@ -23,6 +23,8 @@ end
 
 entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180) -- 3 minutes
+    mob:setMod(xi.mod.UDMGMAGIC, -4000)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
 
     local para = GetMobByID(ID.mob.PARA)
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Bug fixes for Elderly Pursuits

* Added missing MDT to Para
* Added Light Sleep Immunity to Para
* Fixed bug that would allow the quest to progress if you killed ANY Para, not just the original
* Added the functionality that would require the player to re-fight Para if they zone before getting the KI

## Steps to test these changes

Start Quest
Get to the point where you fight the NM Para in Carpenter's Landing
Spawn NM
Have NM spawn a clone.
Kill clone.
Check ???
Quest will not progress since ORIGINAL Para is still alive

Kill ORIGINAL Para
Check ???
Player will receive KI

----

Kill NM
Zone
Check ???
NM will respawn.
