### PR TITLE
[Lua] Fix hundred fists mobskill duration

### DIFF
--- a/scripts/actions/mobskills/hundred_fists.lua
+++ b/scripts/actions/mobskills/hundred_fists.lua
@@ -9,7 +9,8 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    xi.mobskills.mobBuffMove(mob, xi.effect.HUNDRED_FISTS, 1, 0, 30)
+    -- note that captures show that mobskill hundred fists is still 45 seconds on retail
+    xi.mobskills.mobBuffMove(mob, xi.effect.HUNDRED_FISTS, 1, 0, 45)
 
     skill:setMsg(xi.msg.basic.USES)
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes the mobskill hundred fists duration to be 45 seconds (instead of 30 seconds). This change is based on retail captures from a variety of MNK mobs by Siknoz including Ix'aern MNK [here](https://youtu.be/jj3slbaXClc), Seiryu [here](https://youtu.be/uvQx3xNsJ2w), King Arthro [here](https://youtu.be/YbuE9f5nTyo), and Dynamis Vanguard Militant [here](https://youtu.be/_DgjxpcvDpE). 

I have not found any MNK mobs that use a 30 second duration and the 30 second duration is probably a copy-paste error that occurred in this [commit](https://github.com/LandSandBoat/server/commit/69a54d2c85fd93ac3a31b58191694ffdf1b36e8a#diff-1f869b76cc4fdca52649628126f4406d87d56fbf37a69e24d5c8c4c9c243147f) (which changed duration from 45 to 30 seconds in 2015).

## Steps to test these changes
Fight MNK mobs that use hundred fists and see the correct duration of 45 seconds.