### PR TITLE
[Lua] Purge of 'exp' to 'xp', simplified npc_util.lua logic

### DIFF
--- a/scripts/globals/npc_util.lua
+++ b/scripts/globals/npc_util.lua
@@ -650,11 +650,7 @@ function npcUtil.completeQuest(player, area, quest, params)
         player:messageSpecial(ID.text.BAYLD_OBTAINED, params['bayld'] * xi.settings.main.BAYLD_RATE)
     end
 
-    -- TODO: Find a more elegant way to handle this, but allow for xp vs exp keys.  This should
-    -- be one or the other, not both.
-    if params['exp'] ~= nil and type(params['exp']) == 'number' then
-        player:addExp(params['exp'] * xi.settings.main.EXP_RATE)
-    elseif params['xp'] ~= nil and type(params['xp']) == 'number' then
+    if params['xp'] ~= nil and type(params['xp']) == 'number' then
         player:addExp(params['xp'] * xi.settings.main.EXP_RATE)
     end
 
@@ -741,11 +737,7 @@ function npcUtil.completeMission(player, logId, missionId, params)
         player:messageSpecial(ID.text.BAYLD_OBTAINED, params['bayld'] * xi.settings.main.BAYLD_RATE)
     end
 
-    -- TODO: Find a more elegant way to handle this, but allow for xp vs exp keys.  This should
-    -- be one or the other, not both.
-    if params['exp'] ~= nil and type(params['exp']) == 'number' then
-        player:addExp(params['exp'] * xi.settings.main.EXP_RATE)
-    elseif params['xp'] ~= nil and type(params['xp']) == 'number' then
+    if params['xp'] ~= nil and type(params['xp']) == 'number' then
         player:addExp(params['xp'] * xi.settings.main.EXP_RATE)
     end
 

--- a/scripts/missions/soa/3_3_4_Shared_Consciousness.lua
+++ b/scripts/missions/soa/3_3_4_Shared_Consciousness.lua
@@ -11,8 +11,8 @@ local mission = Mission:new(xi.mission.log_id.SOA, xi.mission.id.soa.SHARED_CONS
 
 mission.reward =
 {
-    exp         = 1000,
     bayld       = 1000,
+    xp          = 1000,
     title       = xi.title.SUNSHINE_CADET,
     nextMission = { xi.mission.log_id.SOA, xi.mission.id.soa.CLEAR_SKIES },
 }

--- a/scripts/quests/adoulin/The_Starving.lua
+++ b/scripts/quests/adoulin/The_Starving.lua
@@ -9,8 +9,8 @@ local quest = Quest:new(xi.questLog.ADOULIN, xi.quest.id.adoulin.THE_STARVING)
 
 quest.reward =
 {
-    fameArea = xi.fameArea.ADOULIN,
     xp       = 1000,
+    fameArea = xi.fameArea.ADOULIN,
     bayld    = 500,
 }
 

--- a/scripts/quests/crystalWar/Lost_in_Translocation.lua
+++ b/scripts/quests/crystalWar/Lost_in_Translocation.lua
@@ -12,9 +12,9 @@ local quest = Quest:new(xi.questLog.CRYSTAL_WAR, xi.quest.id.crystalWar.LOST_IN_
 
 quest.reward =
 {
-    gil     = 2000,
-    exp     = 2000,
     keyItem = xi.ki.MAP_OF_GRAUBERG,
+    gil     = 2000,
+    xp      = 2000,
 }
 
 local mapKeyItems =

--- a/scripts/quests/jeuno/Northward.lua
+++ b/scripts/quests/jeuno/Northward.lua
@@ -9,12 +9,12 @@ local quest = Quest:new(xi.questLog.JEUNO, xi.quest.id.jeuno.NORTHWARD)
 
 quest.reward =
 {
-    exp      = 2000,
+    keyItem  = xi.ki.MAP_OF_CASTLE_ZVAHL,
+    gil      = 2000,
+    xp       = 2000,
+    title    = xi.title.ENVOY_TO_THE_NORTH,
     fame     = 30,
     fameArea = xi.fameArea.JEUNO,
-    gil      = 2000,
-    keyItem  = xi.ki.MAP_OF_CASTLE_ZVAHL,
-    title    = xi.title.ENVOY_TO_THE_NORTH,
 }
 
 quest.sections =

--- a/scripts/quests/jeuno/The_Antique_Collector.lua
+++ b/scripts/quests/jeuno/The_Antique_Collector.lua
@@ -12,12 +12,12 @@ local quest = Quest:new(xi.questLog.JEUNO, xi.quest.id.jeuno.THE_ANTIQUE_COLLECT
 
 quest.reward =
 {
-    exp      = 2000,
+    keyItem  = xi.ki.MAP_OF_DELKFUTTS_TOWER,
+    gil      = 2000,
+    xp       = 2000,
+    title    = xi.title.TRADER_OF_ANTIQUITIES,
     fame     = 30,
     fameArea = xi.fameArea.JEUNO,
-    gil      = 2000,
-    keyItem  = xi.ki.MAP_OF_DELKFUTTS_TOWER,
-    title    = xi.title.TRADER_OF_ANTIQUITIES,
 }
 
 quest.sections =

--- a/scripts/quests/otherAreas/The_Rescue.lua
+++ b/scripts/quests/otherAreas/The_Rescue.lua
@@ -12,11 +12,11 @@ local quest = Quest:new(xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.THE_RESC
 
 quest.reward =
 {
-    exp      = 2000,
-    gil      = 5000,
-    fameArea = xi.fameArea.SELBINA_RABAO,
     keyItem  = xi.ki.MAP_OF_THE_RANGUEMONT_PASS,
+    gil      = 5000,
+    xp       = 2000,
     title    = xi.title.HONORARY_CITIZEN_OF_SELBINA,
+    fameArea = xi.fameArea.SELBINA_RABAO,
 }
 
 quest.sections =


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Implements a very elegant solution to ambiguous naming convention for IF xp parameter.

If there is truly a need for the handling of both, would recommend 
```
if params['xp'] == nil then
    params['xp'] = params['exp']
end
```
written before each of the three implementations to prioritize "xp" over "exp" as it seems to be the preferred nomenclature in this codebase.

## Steps to test these changes

Complete a quest and check amount of exp gained.
