### PR TITLE
Port Sengikori from Cactuar & implement gear effects

### DIFF
--- a/scripts/effects/sengikori.lua
+++ b/scripts/effects/sengikori.lua
@@ -5,16 +5,16 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.SKILLCHAINDMG, 2500)
-    target:addMod(xi.mod.UDMGMAGIC, 2500)
+    -- target:addMod(xi.mod.SKILLCHAINDMG, 2500)
+    -- target:addMod(xi.mod.UDMGMAGIC, 2500)
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.SKILLCHAINDMG, 2500)
-    target:delMod(xi.mod.UDMGMAGIC, 2500)
+    -- target:delMod(xi.mod.SKILLCHAINDMG, 2500)
+    -- target:delMod(xi.mod.UDMGMAGIC, 2500)
 end
 
 return effectObject

--- a/scripts/effects/sengikori.lua
+++ b/scripts/effects/sengikori.lua
@@ -5,16 +5,12 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    -- target:addMod(xi.mod.SKILLCHAINDMG, 2500)
-    -- target:addMod(xi.mod.UDMGMAGIC, 2500)
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    -- target:delMod(xi.mod.SKILLCHAINDMG, 2500)
-    -- target:delMod(xi.mod.UDMGMAGIC, 2500)
 end
 
 return effectObject

--- a/scripts/effects/skillchain.lua
+++ b/scripts/effects/skillchain.lua
@@ -11,6 +11,7 @@ effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
+    target:setMod(xi.mod.SENGIKORI_DEBUFF, 0)
 end
 
 return effectObject

--- a/scripts/effects/skillchain.lua
+++ b/scripts/effects/skillchain.lua
@@ -11,7 +11,9 @@ effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:setMod(xi.mod.SENGIKORI_DEBUFF, 0)
+    -- Remove Sengikori "debuff" once the SC is gone
+    target:setMod(xi.mod.SENGIKORI_SC_DMG_DEBUFF, 0)
+    target:setMod(xi.mod.SENGIKORI_MB_DMG_DEBUFF, 0)
 end
 
 return effectObject

--- a/scripts/enum/mod.lua
+++ b/scripts/enum/mod.lua
@@ -465,6 +465,9 @@ xi.mod =
     TANDEM_STRIKE_POWER             = 271,  -- Grants a bonus to your and your pet's accuracy and magic accuracy when you and your pet are attacking the same target.
     TANDEM_BLOW_POWER               = 272,  -- Reduces amount of TP gained by enemies when striking them if you and your pet are attacking the same target.
 
+    -- Samurai
+    SENGIKORI_DEBUFF                = 1088, -- % Increase to closing skillchain damage and magic bursts. Applied to defender.
+
     -- Dragoon
     WYVERN_LVL_BONUS                = 1043, -- Wyvern: Lv.+ (Increases wyvern's base level above 99)
 

--- a/scripts/enum/mod.lua
+++ b/scripts/enum/mod.lua
@@ -466,7 +466,9 @@ xi.mod =
     TANDEM_BLOW_POWER               = 272,  -- Reduces amount of TP gained by enemies when striking them if you and your pet are attacking the same target.
 
     -- Samurai
-    SENGIKORI_DEBUFF                = 1088, -- % Increase to closing skillchain damage and magic bursts. Applied to defender.
+    SENGIKORI_SC_DMG_DEBUFF         = 1088, -- % Increase to closing skillchain damage. Applied to defender.
+    SENGIKORI_MB_DMG_DEBUFF         = 1089, -- % Increase to magic burst damage. Applied to defender.
+    SENGIKORI_BONUS                 = 1090, -- additive % increase to Sengikori
 
     -- Dragoon
     WYVERN_LVL_BONUS                = 1043, -- Wyvern: Lv.+ (Increases wyvern's base level above 99)

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -809,6 +809,15 @@ xi.spells.damage.calculateIfMagicBurst = function(target, spellElement, skillcha
         magicBurst = 1.25 + rankBonus + skillchainCount / 10
     end
 
+    -- Sengikori appears to add to base mb multiplier per JP wiki https://wiki.ffo.jp/html/20051.html
+    if
+        skillchainCount >= 1 and
+        target:getMod(xi.mod.SENGIKORI_DEBUFF) > 0
+    then
+        magicBurst = magicBurst + target:getMod(xi.mod.SENGIKORI_DEBUFF) / 100
+        target:setMod(xi.mod.SENGIKORI_DEBUFF, 0) -- Consume the "Effect" upon magic burst.
+    end
+
     return magicBurst
 end
 

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -812,10 +812,10 @@ xi.spells.damage.calculateIfMagicBurst = function(target, spellElement, skillcha
     -- Sengikori appears to add to base mb multiplier per JP wiki https://wiki.ffo.jp/html/20051.html
     if
         skillchainCount >= 1 and
-        target:getMod(xi.mod.SENGIKORI_DEBUFF) > 0
+        target:getMod(xi.mod.SENGIKORI_MB_DMG_DEBUFF) > 0
     then
-        magicBurst = magicBurst + target:getMod(xi.mod.SENGIKORI_DEBUFF) / 100
-        target:setMod(xi.mod.SENGIKORI_DEBUFF, 0) -- Consume the "Effect" upon magic burst.
+        magicBurst = magicBurst + target:getMod(xi.mod.SENGIKORI_MB_DMG_DEBUFF) / 100
+        target:setMod(xi.mod.SENGIKORI_MB_DMG_DEBUFF, 0) -- Consume the "Effect" upon magic burst.
     end
 
     return magicBurst

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -1069,6 +1069,13 @@ xi.weaponskills.takeWeaponskillDamage = function(defender, attacker, wsParams, p
         defender:updateEnmityFromDamage(enmityEntity, finaldmg * enmityMult)
     end
 
+    if attacker:hasStatusEffect(xi.effect.SENGIKORI) then
+        if finaldmg > 0 then
+            defender:setMod(xi.mod.SENGIKORI_DEBUFF, 25) -- Apply Debuff to target.
+            attacker:delStatusEffect(xi.effect.SENGIKORI)
+        end
+    end
+
     if finaldmg > 0 then
         -- Pack the weaponskill ID in the top 8 bits of this variable which is utilized
         -- in OnMobDeath in luautils.  Max WSID is 255.

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -1069,11 +1069,27 @@ xi.weaponskills.takeWeaponskillDamage = function(defender, attacker, wsParams, p
         defender:updateEnmityFromDamage(enmityEntity, finaldmg * enmityMult)
     end
 
-    if attacker:hasStatusEffect(xi.effect.SENGIKORI) then
-        if finaldmg > 0 then
-            defender:setMod(xi.mod.SENGIKORI_DEBUFF, 25) -- Apply Debuff to target.
-            attacker:delStatusEffect(xi.effect.SENGIKORI)
+    -- TODO: does this effect not apply if you do 0 damage (or absorb)?
+    -- Skillchains will still "proc" if you do 0 damage, so assume it does for now
+    if
+        (wsResults.tpHitsLanded +
+        wsResults.extraHitsLanded > 0) and
+        attacker:hasStatusEffect(xi.effect.SENGIKORI)
+    then
+        local sengikoriBonus = attacker:getMod(xi.mod.SENGIKORI_BONUS) -- Additive % bonus: https://www.ffxiah.com/forum/topic/23457/july-11-sam-update/4/#1421344
+        local power = 25 + sengikoriBonus                              -- base 25% bonus for SC or MB
+
+        -- If no SC effect, apply SC damage debuff
+        -- If there is one, apply MB damage debuff
+        -- This "effect" lasts until the it's used or the SC goes away
+        -- see https://wiki.ffo.jp/html/20051.html
+        if defender:hasStatusEffect(xi.effect.SKILLCHAIN) then
+            defender:setMod(xi.mod.SENGIKORI_MB_DMG_DEBUFF, power)
+        else
+            defender:setMod(xi.mod.SENGIKORI_SC_DMG_DEBUFF, power)
         end
+
+        attacker:delStatusEffect(xi.effect.SENGIKORI)
     end
 
     if finaldmg > 0 then

--- a/sql/item_equipment.sql
+++ b/sql/item_equipment.sql
@@ -11388,6 +11388,7 @@ INSERT INTO `item_equipment` VALUES (23349,'horos_t._shoes_+2',99,119,262144,304
 INSERT INTO `item_equipment` VALUES (23350,'peda._loafers_+2',99,119,524288,215,0,0,256,0,0,0);
 INSERT INTO `item_equipment` VALUES (23351,'bagua_sandals_+2',99,119,1048576,310,0,0,256,0,0,0);
 INSERT INTO `item_equipment` VALUES (23352,'futhark_boots_+2',99,119,2097152,339,0,0,256,0,0,0);
+INSERT INTO `item_equipment` VALUES (23364,'kas._sune-ate_+2',99,119,2048,293,0,0,256,0,0,0);
 INSERT INTO `item_equipment` VALUES (23375,'pummelers_mask_+3',99,119,1,64,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23376,'anch._crown_+3',99,119,2,66,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23377,'theophany_cap_+3',99,119,4,68,0,0,16,0,0,0);

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -5303,11 +5303,12 @@ INSERT INTO `item_mods` VALUES (11154,27,-8); -- ENMITY: -8
 INSERT INTO `item_mods` VALUES (11154,105,7); -- MARKSMAN: 7
 
 -- Unkai Sune-Ate +2
-INSERT INTO `item_mods` VALUES (11155,1,28);  -- DEF: 28
-INSERT INTO `item_mods` VALUES (11155,8,8);   -- STR: 8
-INSERT INTO `item_mods` VALUES (11155,23,15); -- ATT: 15
-INSERT INTO `item_mods` VALUES (11155,25,15); -- ACC: 15
-INSERT INTO `item_mods` VALUES (11155,73,6);  -- STORETP: 6
+INSERT INTO `item_mods` VALUES (11155,1,28);    -- DEF: 28
+INSERT INTO `item_mods` VALUES (11155,8,8);     -- STR: 8
+INSERT INTO `item_mods` VALUES (11155,23,15);   -- ATT: 15
+INSERT INTO `item_mods` VALUES (11155,25,15);   -- ACC: 15
+INSERT INTO `item_mods` VALUES (11155,73,6);    -- STORETP: 6
+INSERT INTO `item_mods` VALUES (11155,1090,10); -- SENGIKORI_BONUS : 10
 
 -- Iga Kyahan +2
 INSERT INTO `item_mods` VALUES (11156,1,23);    -- DEF: 23
@@ -5983,11 +5984,12 @@ INSERT INTO `item_mods` VALUES (11254,27,-5); -- ENMITY: -5
 INSERT INTO `item_mods` VALUES (11254,105,5); -- MARKSMAN: 5
 
 -- Unkai Sune-Ate +1
-INSERT INTO `item_mods` VALUES (11255,1,26);  -- DEF: 26
-INSERT INTO `item_mods` VALUES (11255,8,5);   -- STR: 5
-INSERT INTO `item_mods` VALUES (11255,23,10); -- ATT: 10
-INSERT INTO `item_mods` VALUES (11255,25,10); -- ACC: 10
-INSERT INTO `item_mods` VALUES (11255,73,4);  -- STORETP: 4
+INSERT INTO `item_mods` VALUES (11255,1,26);   -- DEF: 26
+INSERT INTO `item_mods` VALUES (11255,8,5);    -- STR: 5
+INSERT INTO `item_mods` VALUES (11255,23,10);  -- ATT: 10
+INSERT INTO `item_mods` VALUES (11255,25,10);  -- ACC: 10
+INSERT INTO `item_mods` VALUES (11255,73,4);   -- STORETP: 4
+INSERT INTO `item_mods` VALUES (11255,1090,5); -- SENGIKORI_BONUS : 5
 
 -- Iga Kyahan +1
 INSERT INTO `item_mods` VALUES (11256,1,21);    -- DEF: 21
@@ -53421,7 +53423,7 @@ INSERT INTO `item_mods` VALUES (23363,384,400); -- HASTE_GEAR: 4%
 INSERT INTO `item_mods` VALUES (23363,841,8);   -- ALL_WSDMG_FIRST_HIT: 8
 -- TODO: Enhances "Unlimited Shot" effect
 
--- Kasuga sune-ate +2
+-- Kasuga Sune-Ate +2
 INSERT INTO `item_mods` VALUES (23364,1,106);   -- DEF: 106
 INSERT INTO `item_mods` VALUES (23364,2,35);    -- HP:  35
 INSERT INTO `item_mods` VALUES (23364,8,26);    -- STR: 26
@@ -53438,8 +53440,8 @@ INSERT INTO `item_mods` VALUES (23364,31,120);  -- MEVA: 120
 INSERT INTO `item_mods` VALUES (23364,68,95);   -- EVA:  95
 INSERT INTO `item_mods` VALUES (23364,384,300); -- HASTE_GEAR: 3%
 INSERT INTO `item_mods` VALUES (23364,944,12);  -- CONSERVE_TP: 12
--- TODO: Physical damage limit +7%
--- TODO: "Sengikori"+12
+INSERT INTO `item_mods` VALUES (23364,1090,12); -- SENGIKORI_BONUS : 12
+INSERT INTO `item_mods` VALUES (23364,1081,12); -- DAMAGE_LIMITP : 7
 
 -- Hattori Kyahan +2
 INSERT INTO `item_mods` VALUES (23365,1,93);    -- DEF: 93
@@ -72155,6 +72157,7 @@ INSERT INTO `item_mods` VALUES (27433,68,25);   -- EVA: 25
 INSERT INTO `item_mods` VALUES (27433,73,8);    -- STORETP: 8
 INSERT INTO `item_mods` VALUES (27433,306,10);  -- ZANSHIN: 10
 INSERT INTO `item_mods` VALUES (27433,384,300); -- HASTE_GEAR: 300
+INSERT INTO `item_mods` VALUES (27433,1090,10); -- SENGIKORI_BONUS : 10
 
 -- Kasuga Sune-Ate +1
 INSERT INTO `item_mods` VALUES (27434,1,86);    -- DEF: 86
@@ -72173,6 +72176,7 @@ INSERT INTO `item_mods` VALUES (27434,68,55);   -- EVA: 55
 INSERT INTO `item_mods` VALUES (27434,73,8);    -- STORETP: 8
 INSERT INTO `item_mods` VALUES (27434,306,11);  -- ZANSHIN: 11
 INSERT INTO `item_mods` VALUES (27434,384,300); -- HASTE_GEAR: 300
+INSERT INTO `item_mods` VALUES (27434,1090,11); -- SENGIKORI_BONUS : 11
 
 -- Hattori Kyahan
 INSERT INTO `item_mods` VALUES (27435,1,52);    -- DEF: 52

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -551,6 +551,7 @@ enum class Mod
     THIRD_EYE_COUNTER_RATE    = 508,  // Adds counter to 3rd eye anticipates & if using Seigan counter rate is increased by 15%
     THIRD_EYE_ANTICIPATE_RATE = 839,  // Adds anticipate rate in percents
     THIRD_EYE_BONUS           = 1055, // TODO: Bonus Third Eye Evasion (count)
+    SENGIKORI_DEBUFF          = 1088, // % Increase to closing skillchain damage and magic bursts. Applied to defender.
 
     // Ninja
     UTSUSEMI             = 307, // Everyone's favorite --tracks shadows.
@@ -1026,7 +1027,7 @@ enum class Mod
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     // 570 through 825 used by WS DMG mods these are not spares.
     //
-    // SPARE IDs: 1088 and onward
+    // SPARE IDs: 1089 and onward
 };
 
 // temporary workaround for using enum class as unordered_map key until compilers support it

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -551,7 +551,9 @@ enum class Mod
     THIRD_EYE_COUNTER_RATE    = 508,  // Adds counter to 3rd eye anticipates & if using Seigan counter rate is increased by 15%
     THIRD_EYE_ANTICIPATE_RATE = 839,  // Adds anticipate rate in percents
     THIRD_EYE_BONUS           = 1055, // TODO: Bonus Third Eye Evasion (count)
-    SENGIKORI_DEBUFF          = 1088, // % Increase to closing skillchain damage and magic bursts. Applied to defender.
+    SENGIKORI_SC_DMG_DEBUFF   = 1088, // % Increase to closing skillchain damage. Applied to defender.
+    SENGIKORI_MB_DMG_DEBUFF   = 1089, // % Increase to magic burst damage. Applied to defender.
+    SENGIKORI_BONUS           = 1090, // additive % increase to Sengikori
 
     // Ninja
     UTSUSEMI             = 307, // Everyone's favorite --tracks shadows.
@@ -1027,7 +1029,7 @@ enum class Mod
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     // 570 through 825 used by WS DMG mods these are not spares.
     //
-    // SPARE IDs: 1089 and onward
+    // SPARE IDs: 1091 and onward
 };
 
 // temporary workaround for using enum class as unordered_map key until compilers support it

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -3993,6 +3993,13 @@ namespace battleutils
         {
             damage = (int32)(damage * (1.f + PChar->PMeritPoints->GetMeritValue(MERIT_INNIN_EFFECT, PChar) / 100.f));
         }
+
+        if (PDefender->getMod(Mod::SENGIKORI_DEBUFF) > 0 && chainCount == 1) // Only applies to initial opening SC
+        {
+            damage = (int32)(damage * (1.f + PDefender->getMod(Mod::SENGIKORI_DEBUFF) / 100.f));
+            PDefender->setModifier(Mod::SENGIKORI_DEBUFF, 0); // Consume the effect
+        }
+
         damage = damage * (10000 - resistance) / 10000;
         damage = MagicDmgTaken(PDefender, damage, appliedEle);
         if (damage > 0)

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -3994,10 +3994,10 @@ namespace battleutils
             damage = (int32)(damage * (1.f + PChar->PMeritPoints->GetMeritValue(MERIT_INNIN_EFFECT, PChar) / 100.f));
         }
 
-        if (PDefender->getMod(Mod::SENGIKORI_DEBUFF) > 0 && chainCount == 1) // Only applies to initial opening SC
+        if (PDefender->getMod(Mod::SENGIKORI_SC_DMG_DEBUFF) > 0)
         {
-            damage = (int32)(damage * (1.f + PDefender->getMod(Mod::SENGIKORI_DEBUFF) / 100.f));
-            PDefender->setModifier(Mod::SENGIKORI_DEBUFF, 0); // Consume the effect
+            damage = static_cast<int32>(damage * (1.f + PDefender->getMod(Mod::SENGIKORI_SC_DMG_DEBUFF) / 100.f));
+            PDefender->setModifier(Mod::SENGIKORI_SC_DMG_DEBUFF, 0); // Consume the effect
         }
 
         damage = damage * (10000 - resistance) / 10000;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

As title says, implements Sengikori from @UmeboshiXI's base code.

Note the implementation is a bit strange due to how Sengikori works, it seemingly attaches a "debuff" to the skillchain, but due to how skillchains work (they delete/re add a new effect) it can't be attached to the skillchain

## Steps to test these changes

see https://www.bg-wiki.com/ffxi/Sengikori (use it for SC & MB) and see bonuses. I would recommend using breakpoints in SC damage and this patch for magic bursts
Also test with/without gear mods
```diff
diff --git a/scripts/globals/spells/damage_spell.lua b/scripts/globals/spells/damage_spell.lua
index 57e464994b..ab7c65d8bb 100644
--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -817,6 +817,7 @@ xi.spells.damage.calculateIfMagicBurst = function(target, spellElement, skillcha
         magicBurst = magicBurst + target:getMod(xi.mod.SENGIKORI_MB_DMG_DEBUFF) / 100
         target:setMod(xi.mod.SENGIKORI_MB_DMG_DEBUFF, 0) -- Consume the "Effect" upon magic burst.
     end
+    print(magicBurst)
 
     return magicBurst
 end
```