### PR TITLE
[LUA] Dealer Moogle: always return table for item selection

### DIFF
--- a/scripts/globals/dealer_moogle.lua
+++ b/scripts/globals/dealer_moogle.lua
@@ -3348,15 +3348,15 @@ local getItemSelection = function(player, list, idx, idxAlt1, idxAlt2)
         if debug.ENABLED and not debug.SHOWITEM then
             item = 0
         else
-            --- TODO: Refactor function to always return table, and find better way to determine behavior based on list type.
+            --- TODO: Find better way to determine behavior based on list type.
             ---@diagnostic disable-next-line: cast-local-type
             item = itemList[list][idxAlt1][idxAlt2]
         end
 
         if list == 12 then  -- Item, Quantity
-            --- TODO: Refactor function to always return table, and find better way to determine behavior based on list type.
+            --- TODO: Find better way to determine behavior based on list type.
             ---@diagnostic disable-next-line: cast-local-type
-            item = { item } -- Tabling here to save 100 pairs of { }
+            item = item
         end
     elseif
         list == 44 -- AW-Cos (Index Defaults to Female itemID, CS will automatically swap items based on gender)
@@ -3367,15 +3367,15 @@ local getItemSelection = function(player, list, idx, idxAlt1, idxAlt2)
 
         item = itemID - (gender * modifier) -- Generate the actual itemID by subtracting the shift value from the base itemID
     else
-        --- TODO: Refactor function to always return table, and find better way to determine behavior based on list type.
+        --- TODO: Find better way to determine behavior based on list type.
         ---@diagnostic disable-next-line: cast-local-type
         item = itemList[list][idx]
     end
 
-    return item
+    return { item }
 end
 
-local debugInfo = function(player, item, list, option, altIDs, idx)
+local debugInfo = function(player, items, list, option, altIDs, idx)
     local ID        = zones[player:getZoneID()]
     local idxAlt1   = altIDs[1]
     local idxAlt2   = altIDs[2]
@@ -3383,9 +3383,9 @@ local debugInfo = function(player, item, list, option, altIDs, idx)
 
     if debug.SHOWITEM then
         if keyitem == 0 then
-            player:messageSpecial(ID.text.ITEM_OBTAINED, item)
+            player:messageSpecial(ID.text.ITEM_OBTAINED, items[1])
         else
-            player:messageSpecial(ID.text.KEYITEM_OBTAINED, item)
+            player:messageSpecial(ID.text.KEYITEM_OBTAINED, items[1])
         end
     end
 
@@ -3480,26 +3480,28 @@ xi.dealerMoogle.onEventFinish = function(player, csid, option, npc)
         if list > 0 and idx == 0 then
             player:addKeyItem(listToKeyItem(list))
         elseif list > 0 and idx > 0 then
-            local item = getItemSelection(player, list, idx, idxAlt1, idxAlt2)
+            local items = getItemSelection(player, list, idx, idxAlt1, idxAlt2)
 
-            if debug.ENABLED then
-                debugInfo(player, item, list, option, altIDs, idx)
+            if
+                debug.ENABLED and
+                #items > 0
+            then
+                debugInfo(player, items, list, option, altIDs, idx)
             else
                 if keyItems == 0 then
-                    ---@diagnostic disable-next-line param-type-mismatch
-                    if npcUtil.giveItem(player, item) then
+                    if npcUtil.giveItem(player, items) then
                         player:delKeyItem(listToKeyItem(list))
                     else
                         -- TODO: CS Messaging that getting the item has failed
                     end
                 else
-                    if not player:hasKeyItem(item) then
+                    if not player:hasKeyItem(items) then
                         -- TODO: Refactor this so that we can more clearly define KI vs Item
                         ---@diagnostic disable-next-line: param-type-mismatch
-                        npcUtil.giveKeyItem(player, item)
+                        npcUtil.giveKeyItem(player, items)
                         player:delKeyItem(listToKeyItem(list))
-                    else
-                        player:messageBasic(xi.msg.basic.ALREADY_HAVE_KEY_ITEM, 0, item)
+                    elseif #items > 0 then
+                        player:messageBasic(xi.msg.basic.ALREADY_HAVE_KEY_ITEM, 0, items[1])
                         -- TODO: CS Messaging that getting the item has failed
                     end
                 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Returns a table from `getItemSelection` in `dealer_moogle.lua`
- Modifies `debugInfo` to accept items and uses the first value for `messageSpecial` which is looking for a single value, only entering this method if #items > 0
- uses the first value for `messageBasic` which is looking for a single value

## Steps to test these changes

finish event with dealer moogle
