### PR TITLE
[lua][sql] Colonization Reive Framework

### DIFF
--- a/scripts/globals/colonization_reive_data.lua
+++ b/scripts/globals/colonization_reive_data.lua
@@ -1,0 +1,1547 @@
+-----------------------------------
+-- Colonization Reive Data
+-----------------------------------
+xi = xi or {}
+xi.reives = xi.reives or {}
+
+local CEIZAK_BATTLEGROUNDS_ID  = zones[xi.zone.CEIZAK_BATTLEGROUNDS]
+local CIRDAS_CAVERNS_ID        = zones[xi.zone.CIRDAS_CAVERNS]
+local DHO_GATES_ID             = zones[xi.zone.DHO_GATES]
+local FORET_DE_HENNETIEL_ID    = zones[xi.zone.FORET_DE_HENNETIEL]
+local KAMIHR_DRIFTS_ID         = zones[xi.zone.KAMIHR_DRIFTS]
+local MARJAMI_RAVINE_ID        = zones[xi.zone.MARJAMI_RAVINE]
+local MOH_GATES_ID             = zones[xi.zone.MOH_GATES]
+local MORIMAR_BASALT_FIELDS_ID = zones[xi.zone.MORIMAR_BASALT_FIELDS]
+local OUTER_RAKAZNAR_ID        = zones[xi.zone.OUTER_RAKAZNAR]
+local RAKAZNAR_INNER_COURT_ID  = zones[xi.zone.RAKAZNAR_INNER_COURT]
+local SIH_GATES_ID             = zones[xi.zone.SIH_GATES]
+local WOH_GATES_ID             = zones[xi.zone.WOH_GATES]
+local YAHSE_HUNTING_GROUNDS_ID = zones[xi.zone.YAHSE_HUNTING_GROUNDS]
+local YORCIA_WEALD_ID          = zones[xi.zone.YORCIA_WEALD]
+
+--Zone Data
+xi.reives.zoneData =
+{
+    [xi.zone.CEIZAK_BATTLEGROUNDS] =
+    {
+        reiveObjRespawnTime = 3600, -- 60 minutes
+        reiveMobRespawnTime = 300,  -- 5 minutes
+        reive =
+        {
+            -- !pos 120 0.184 -54 261
+            [1] =
+            {
+                mob =
+                {
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 3,
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 4,
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 5,
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 6,
+                },
+                obstacles =
+                {
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET,
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 1,
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 2,
+                },
+                collision =
+                {
+                    CEIZAK_BATTLEGROUNDS_ID.npc.REIVE_COLLISION_OFFSET,
+                    CEIZAK_BATTLEGROUNDS_ID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+
+            -- !pos -134 0.184 39 261
+            [2] =
+            {
+                mob =
+                {
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 19,
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 20,
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 21,
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 22,
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 23,
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 24,
+                },
+                obstacles =
+                {
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 16,
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 17,
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 18,
+                },
+                collision =
+                {
+                    CEIZAK_BATTLEGROUNDS_ID.npc.REIVE_COLLISION_OFFSET + 2,
+                    CEIZAK_BATTLEGROUNDS_ID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+    
+            -- !pos -239 0.184 174 261
+            [3] =
+            {
+                mob =
+                {
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 10,
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 11,
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 12,
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 13,
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 14,
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 15,
+                },
+                obstacles =
+                {
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 7,
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 8,
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 9,
+                },
+                collision =
+                {
+                    CEIZAK_BATTLEGROUNDS_ID.npc.REIVE_COLLISION_OFFSET + 4,
+                    CEIZAK_BATTLEGROUNDS_ID.npc.REIVE_COLLISION_OFFSET + 5,
+                },
+            },
+    
+            -- !pos -280.499 0.409 182 261
+            [4] =
+            {
+                mob =
+                {
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 28,
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 29,
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 30,
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 31,
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 32,
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 33,
+                },
+                obstacles =
+                {
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 25,
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 26,
+                    CEIZAK_BATTLEGROUNDS_ID.mob.REIVE_MOB_OFFSET + 27,
+                },
+                collision =
+                {
+                    CEIZAK_BATTLEGROUNDS_ID.npc.REIVE_COLLISION_OFFSET + 6,
+                    CEIZAK_BATTLEGROUNDS_ID.npc.REIVE_COLLISION_OFFSET + 7,
+                },
+            },
+        },
+    },
+
+    [xi.zone.CIRDAS_CAVERNS] =
+    {
+        reiveObjRespawnTime = 3600, -- 60 minutes
+        reiveMobRespawnTime = 300,  -- 5 minutes
+        reive =
+        {
+
+            -- !pos -120 19.972 22 270
+            [1] =
+            {
+                mob =
+                {
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 2,
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 3,
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 4,
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 5,
+                },
+                obstacles =
+                {
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET,
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 1,
+                },
+                collision =
+                {
+                    CIRDAS_CAVERNS_ID.npc.REIVE_COLLISION_OFFSET + 12,
+                    CIRDAS_CAVERNS_ID.npc.REIVE_COLLISION_OFFSET + 13,
+                },
+            },
+
+            -- !pos 439 19.972 142 270
+            [2] =
+            {
+                mob =
+                {
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 8,
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 9,
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 10,
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 11,
+                },
+                obstacles =
+                {
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 6,
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 7,
+                },
+                collision =
+                {
+                    CIRDAS_CAVERNS_ID.npc.REIVE_COLLISION_OFFSET,
+                    CIRDAS_CAVERNS_ID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+
+            -- !pos 98 19.972 -40 270
+            [3] =
+            {
+                mob =
+                {
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 14,
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 15,
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 16,
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 17,
+                },
+                obstacles =
+                {
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 12,
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 13,
+                },
+                collision =
+                {
+                    CIRDAS_CAVERNS_ID.npc.REIVE_COLLISION_OFFSET + 8,
+                    CIRDAS_CAVERNS_ID.npc.REIVE_COLLISION_OFFSET + 9,
+                },
+            },
+
+            -- !pos -62 19.972 160 270
+            [4] =
+            {
+                mob =
+                {
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 20,
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 21,
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 22,
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 23,
+                },
+                obstacles =
+                {
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 18,
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 19,
+                },
+                collision =
+                {
+                    CIRDAS_CAVERNS_ID.npc.REIVE_COLLISION_OFFSET + 10,
+                    CIRDAS_CAVERNS_ID.npc.REIVE_COLLISION_OFFSET + 11,
+                },
+            },
+
+            -- !pos 160 19.972 301 270
+            [5] =
+            {
+                mob =
+                {
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 26,
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 27,
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 28,
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 29,
+                },
+                obstacles =
+                {
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 24,
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 25,
+                },
+                collision =
+                {
+                    CIRDAS_CAVERNS_ID.npc.REIVE_COLLISION_OFFSET + 4,
+                    CIRDAS_CAVERNS_ID.npc.REIVE_COLLISION_OFFSET + 5,
+                },
+            },
+
+            -- !pos 220.215 20 40.89 270
+            [6] =
+            {
+                mob =
+                {
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 32,
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 33,
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 34,
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 35,
+                },
+                obstacles =
+                {
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 30,
+                    CIRDAS_CAVERNS_ID.mob.REIVE_MOB_OFFSET + 31,
+                },
+                collision =
+                {
+                    CIRDAS_CAVERNS_ID.npc.REIVE_COLLISION_OFFSET + 2,
+                    CIRDAS_CAVERNS_ID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+        },
+    },
+
+    [xi.zone.DHO_GATES] =
+    {
+        reiveObjRespawnTime = 3600, -- 60 minutes
+        reiveMobRespawnTime = 300,  -- 5 minutes
+        reive =
+        {
+            -- !pos -60 -9.9 73.8 272
+            [1] =
+            {
+                mob =
+                {
+                    DHO_GATES_ID.mob.REIVE_MOB_OFFSET + 2,
+                    DHO_GATES_ID.mob.REIVE_MOB_OFFSET + 3,
+                    DHO_GATES_ID.mob.REIVE_MOB_OFFSET + 4,
+                    DHO_GATES_ID.mob.REIVE_MOB_OFFSET + 5,
+                },
+                obstacles =
+                {
+                    DHO_GATES_ID.mob.REIVE_MOB_OFFSET,
+                    DHO_GATES_ID.mob.REIVE_MOB_OFFSET + 1,
+                },
+                collision =
+                {
+                    DHO_GATES_ID.npc.REIVE_COLLISION_OFFSET,
+                    DHO_GATES_ID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+
+            -- !pos -154 -20 300.9 272
+            [2] =
+            {
+                mob =
+                {
+                    DHO_GATES_ID.mob.REIVE_MOB_OFFSET + 8,
+                    DHO_GATES_ID.mob.REIVE_MOB_OFFSET + 9,
+                    DHO_GATES_ID.mob.REIVE_MOB_OFFSET + 10,
+                    DHO_GATES_ID.mob.REIVE_MOB_OFFSET + 11,
+                },
+                obstacles =
+                {
+                    DHO_GATES_ID.mob.REIVE_MOB_OFFSET + 6,
+                    DHO_GATES_ID.mob.REIVE_MOB_OFFSET + 7,
+                },
+                collision =
+                {
+                    DHO_GATES_ID.npc.REIVE_COLLISION_OFFSET + 2,
+                    DHO_GATES_ID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+        },
+    },
+
+    [xi.zone.FORET_DE_HENNETIEL] =
+    {
+        reiveObjRespawnTime = 3600, -- 60 minutes
+        reiveMobRespawnTime = 300,  -- 5 minutes
+        reive =
+        {
+            -- !pos 183.4 -1.9 220 262
+            [1] =
+            {
+                mob =
+                {
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 1,
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 2,
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 3,
+                },
+                obstacles =
+                {
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET,
+                },
+                collision =
+                {
+                    FORET_DE_HENNETIEL_ID.npc.REIVE_COLLISION_OFFSET + 10,
+                    FORET_DE_HENNETIEL_ID.npc.REIVE_COLLISION_OFFSET + 11,
+                },
+            },
+            -- !pos 136.5 -2.1 258 262
+            [2] =
+            {
+                mob =
+                {
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 5,
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 6,
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 7,
+                },
+                obstacles =
+                {
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 4,
+                },
+                collision =
+                {
+                    FORET_DE_HENNETIEL_ID.npc.REIVE_COLLISION_OFFSET + 8,
+                    FORET_DE_HENNETIEL_ID.npc.REIVE_COLLISION_OFFSET + 9,
+                },
+            },
+    
+            -- !pos -16.6 -1.8 380 262
+            [3] =
+            {
+                mob =
+                {
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 9,
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 10,
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 11,
+                },
+                obstacles =
+                {
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 8,
+                },
+                collision =
+                {
+                    FORET_DE_HENNETIEL_ID.npc.REIVE_COLLISION_OFFSET + 6,
+                    FORET_DE_HENNETIEL_ID.npc.REIVE_COLLISION_OFFSET + 7,
+                },
+            },
+    
+            -- !pos -63 -2.1 418 262
+            [4] =
+            {
+                mob =
+                {
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 13,
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 14,
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 15,
+                },
+                obstacles =
+                {
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 12,
+                },
+                collision =
+                {
+                    FORET_DE_HENNETIEL_ID.npc.REIVE_COLLISION_OFFSET + 4,
+                    FORET_DE_HENNETIEL_ID.npc.REIVE_COLLISION_OFFSET + 5,
+                },
+            },
+    
+            -- !pos 343 -1.8 -299.4 262
+            [5] =
+            {
+                mob =
+                {
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 17,
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 18,
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 19,
+                },
+                obstacles =
+                {
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 16,
+                },
+                collision =
+                {
+                    FORET_DE_HENNETIEL_ID.npc.REIVE_COLLISION_OFFSET + 18,
+                    FORET_DE_HENNETIEL_ID.npc.REIVE_COLLISION_OFFSET + 19,
+                },
+            },
+    
+            -- !pos 296 -2.0 -261 262
+            [6] =
+            {
+                mob =
+                {
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 21,
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 22,
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 23,
+                },
+                obstacles =
+                {
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 20,
+                },
+                collision =
+                {
+                    FORET_DE_HENNETIEL_ID.npc.REIVE_COLLISION_OFFSET + 16,
+                    FORET_DE_HENNETIEL_ID.npc.REIVE_COLLISION_OFFSET + 17,
+                },
+            },
+    
+            -- !pos -16.5 -1.93 -219 262
+            [7] =
+            {
+                mob =
+                {
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 25,
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 26,
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 27,
+                },
+                obstacles =
+                {
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 24,
+                },
+                collision =
+                {
+                    FORET_DE_HENNETIEL_ID.npc.REIVE_COLLISION_OFFSET + 14,
+                    FORET_DE_HENNETIEL_ID.npc.REIVE_COLLISION_OFFSET + 15,
+                },
+            },
+    
+            -- !pos -63.4 -2.1 -181 262
+            [8] =
+            {
+                mob =
+                {
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 29,
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 30,
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 31,
+                },
+                obstacles =
+                {
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 28,
+                },
+                collision =
+                {
+                    FORET_DE_HENNETIEL_ID.npc.REIVE_COLLISION_OFFSET + 12,
+                    FORET_DE_HENNETIEL_ID.npc.REIVE_COLLISION_OFFSET + 13,
+                },
+            },
+    
+            -- !pos -380.9 -1.9 23 262
+            [9] =
+            {
+                mob =
+                {
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 33,
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 34,
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 35,
+                },
+                obstacles =
+                {
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 32,
+                },
+                collision =
+                {
+                    FORET_DE_HENNETIEL_ID.npc.REIVE_COLLISION_OFFSET + 2,
+                    FORET_DE_HENNETIEL_ID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+    
+            -- !pos -418.8 -2 -23.3 262
+            [10] =
+            {
+                mob =
+                {
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 37,
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 38,
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 39,
+                },
+                obstacles =
+                {
+                    FORET_DE_HENNETIEL_ID.mob.REIVE_MOB_OFFSET + 36,
+                },
+                collision =
+                {
+                    FORET_DE_HENNETIEL_ID.npc.REIVE_COLLISION_OFFSET,
+                    FORET_DE_HENNETIEL_ID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+        },
+    },
+
+    [xi.zone.KAMIHR_DRIFTS] =
+    {
+        reiveObjRespawnTime = 3600, -- 60 minutes
+        reiveMobRespawnTime = 300,  -- 5 minutes
+        reive =
+        {
+            -- !pos 114.7 40 -269.3 267
+            [1] =
+            {
+                mob =
+                {
+                    KAMIHR_DRIFTS_ID.mob.REIVE_MOB_OFFSET + 2,
+                    KAMIHR_DRIFTS_ID.mob.REIVE_MOB_OFFSET + 3,
+                    KAMIHR_DRIFTS_ID.mob.REIVE_MOB_OFFSET + 4,
+                    KAMIHR_DRIFTS_ID.mob.REIVE_MOB_OFFSET + 5,
+                },
+                obstacles =
+                {
+                    KAMIHR_DRIFTS_ID.mob.REIVE_MOB_OFFSET,
+                    KAMIHR_DRIFTS_ID.mob.REIVE_MOB_OFFSET + 1,
+                },
+                collision =
+                {
+                    KAMIHR_DRIFTS_ID.npc.REIVE_COLLISION_OFFSET,
+                },
+            },
+
+            -- !pos 246 40 -110 267
+            [2] =
+            {
+                mob =
+                {
+                    KAMIHR_DRIFTS_ID.mob.REIVE_MOB_OFFSET + 8,
+                    KAMIHR_DRIFTS_ID.mob.REIVE_MOB_OFFSET + 9,
+                    KAMIHR_DRIFTS_ID.mob.REIVE_MOB_OFFSET + 10,
+                    KAMIHR_DRIFTS_ID.mob.REIVE_MOB_OFFSET + 11,
+                },
+                obstacles =
+                {
+                    KAMIHR_DRIFTS_ID.mob.REIVE_MOB_OFFSET + 6,
+                    KAMIHR_DRIFTS_ID.mob.REIVE_MOB_OFFSET + 7,
+                },
+                collision =
+                {
+                    KAMIHR_DRIFTS_ID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+
+            -- !pos -34 20 11 267
+            [3] =
+            {
+                mob =
+                {
+                    KAMIHR_DRIFTS_ID.mob.REIVE_MOB_OFFSET + 14,
+                    KAMIHR_DRIFTS_ID.mob.REIVE_MOB_OFFSET + 15,
+                    KAMIHR_DRIFTS_ID.mob.REIVE_MOB_OFFSET + 16,
+                    KAMIHR_DRIFTS_ID.mob.REIVE_MOB_OFFSET + 17,
+                },
+                obstacles =
+                {
+                    KAMIHR_DRIFTS_ID.mob.REIVE_MOB_OFFSET + 12,
+                    KAMIHR_DRIFTS_ID.mob.REIVE_MOB_OFFSET + 13,
+                },
+                collision =
+                {
+                    KAMIHR_DRIFTS_ID.npc.REIVE_COLLISION_OFFSET + 2,
+                },
+            },
+
+            -- !pos -354 0.2 269.4 267
+            [4] =
+            {
+                mob =
+                {
+                    KAMIHR_DRIFTS_ID.mob.REIVE_MOB_OFFSET + 20,
+                    KAMIHR_DRIFTS_ID.mob.REIVE_MOB_OFFSET + 21,
+                    KAMIHR_DRIFTS_ID.mob.REIVE_MOB_OFFSET + 22,
+                    KAMIHR_DRIFTS_ID.mob.REIVE_MOB_OFFSET + 23,
+                },
+                obstacles =
+                {
+                    KAMIHR_DRIFTS_ID.mob.REIVE_MOB_OFFSET + 18,
+                    KAMIHR_DRIFTS_ID.mob.REIVE_MOB_OFFSET + 19,
+                },
+                collision =
+                {
+                    KAMIHR_DRIFTS_ID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+        },
+    },
+
+    [xi.zone.MARJAMI_RAVINE] =
+    {
+        reiveObjRespawnTime = 3600, -- 60 minutes
+        reiveMobRespawnTime = 300,  -- 5 minutes
+        reive =
+        {
+
+            -- !pos 339 -41.6 -18 266
+            [1] =
+            {
+                mob =
+                {
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 1,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 2,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 3,
+                },
+                obstacles =
+                {
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 4,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 5,
+                },
+                collision =
+                {
+                    MARJAMI_RAVINE_ID.npc.REIVE_COLLISION_OFFSET,
+                },
+            },
+
+            -- !pos 218 -21.6 60 266
+            [2] =
+            {
+                mob =
+                {
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 8,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 9,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 10,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 11,
+                },
+                obstacles =
+                {
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 6,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 7,
+                },
+                collision =
+                {
+                    MARJAMI_RAVINE_ID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+
+            -- !pos 180 -1.6 -138 266
+            [3] =
+            {
+                mob =
+                {
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 14,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 15,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 16,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 17,
+                },
+                obstacles =
+                {
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 12,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 13,
+                },
+                collision =
+                {
+                    MARJAMI_RAVINE_ID.npc.REIVE_COLLISION_OFFSET + 2,
+                },
+            },
+
+            -- !pos 102 38 -180 266
+            [4] =
+            {
+                mob =
+                {
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 20,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 21,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 22,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 23,
+                },
+                obstacles =
+                {
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 18,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 19,
+                },
+                collision =
+                {
+                    MARJAMI_RAVINE_ID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+
+            -- !pos -98 38 -140 266
+            [5] =
+            {
+                mob =
+                {
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 26,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 27,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 28,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 29,
+                },
+                obstacles =
+                {
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 24,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 25,
+                },
+                collision =
+                {
+                    MARJAMI_RAVINE_ID.npc.REIVE_COLLISION_OFFSET + 4,
+                },
+            },
+
+            -- !pos -178 -2.4 -60 266
+            [6] =
+            {
+                mob =
+                {
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 32,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 33,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 34,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 35,
+                },
+                obstacles =
+                {
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 30,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 31,
+                },
+                collision =
+                {
+                    MARJAMI_RAVINE_ID.npc.REIVE_COLLISION_OFFSET + 5,
+                },
+            },
+
+            -- !pos -298 -22.4 100 266
+            [7] =
+            {
+                mob =
+                {
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 38,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 39,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 40,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 41,
+                },
+                obstacles =
+                {
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 36,
+                    MARJAMI_RAVINE_ID.mob.REIVE_MOB_OFFSET + 37,
+                },
+                collision =
+                {
+                    MARJAMI_RAVINE_ID.npc.REIVE_COLLISION_OFFSET + 6,
+                },
+            },
+        },
+    },
+
+    [xi.zone.MOH_GATES] =
+    {
+        reiveObjRespawnTime = 3600, -- 60 minutes
+        reiveMobRespawnTime = 300,  -- 5 minutes
+        reive =
+        {
+            -- !pos 240 19 -57.5 269
+            [1] =
+            {
+                mob =
+                {
+                    MOH_GATES_ID.mob.REIVE_MOB_OFFSET + 3,
+                    MOH_GATES_ID.mob.REIVE_MOB_OFFSET + 4,
+                    MOH_GATES_ID.mob.REIVE_MOB_OFFSET + 5,
+                    MOH_GATES_ID.mob.REIVE_MOB_OFFSET + 6,
+                    MOH_GATES_ID.mob.REIVE_MOB_OFFSET + 7,
+                    MOH_GATES_ID.mob.REIVE_MOB_OFFSET + 8,
+                },
+                obstacles =
+                {
+                    MOH_GATES_ID.mob.REIVE_MOB_OFFSET,
+                    MOH_GATES_ID.mob.REIVE_MOB_OFFSET + 1,
+                    MOH_GATES_ID.mob.REIVE_MOB_OFFSET + 2,
+                },
+                collision =
+                {
+                    MOH_GATES_ID.npc.REIVE_COLLISION_OFFSET + 2,
+                    MOH_GATES_ID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+
+            -- !pos 102 29.8 -160 269
+            [2] =
+            {
+                mob =
+                {
+                    MOH_GATES_ID.mob.REIVE_MOB_OFFSET + 12,
+                    MOH_GATES_ID.mob.REIVE_MOB_OFFSET + 13,
+                    MOH_GATES_ID.mob.REIVE_MOB_OFFSET + 14,
+                    MOH_GATES_ID.mob.REIVE_MOB_OFFSET + 15,
+                    MOH_GATES_ID.mob.REIVE_MOB_OFFSET + 16,
+                    MOH_GATES_ID.mob.REIVE_MOB_OFFSET + 17,
+                },
+                obstacles =
+                {
+                    MOH_GATES_ID.mob.REIVE_MOB_OFFSET + 9,
+                    MOH_GATES_ID.mob.REIVE_MOB_OFFSET + 10,
+                    MOH_GATES_ID.mob.REIVE_MOB_OFFSET + 11,
+                },
+                collision =
+                {
+                    MOH_GATES_ID.npc.REIVE_COLLISION_OFFSET,
+                    MOH_GATES_ID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+        },
+    },
+
+    [xi.zone.MORIMAR_BASALT_FIELDS] =
+    {
+        reiveObjRespawnTime = 3600, -- 60 minutes
+        reiveMobRespawnTime = 300,  -- 5 minutes
+        reive =
+        {
+
+            -- !pos 119.7 -0.08 -54.9 265
+            [1] =
+            {
+                mob =
+                {
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 3,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 4,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 5,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 6,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 7,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 8,
+                },
+                obstacles =
+                {
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 0,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 1,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 2,
+                },
+                collision =
+                {
+                    MORIMAR_BASALT_FIELDS_ID.npc.REIVE_COLLISION_OFFSET + 4,
+                    MORIMAR_BASALT_FIELDS_ID.npc.REIVE_COLLISION_OFFSET + 5,
+                },
+            },
+            
+            -- !pos -3.5 0.106 60 265
+            [2] =
+            {
+                mob =
+                {
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 12,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 13,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 14,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 15,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 16,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 17,
+                },
+                obstacles =
+                {
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 9,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 10,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 11,
+                },
+                collision =
+                {
+                    MORIMAR_BASALT_FIELDS_ID.npc.REIVE_COLLISION_OFFSET + 2,
+                    MORIMAR_BASALT_FIELDS_ID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+
+            -- !pos -60 -15.89 -276.5 265
+            [3] =
+            {
+                mob =
+                {
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 21,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 22,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 23,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 24,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 25,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 26,
+                },
+                obstacles =
+                {
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 18,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 19,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 20,
+                },
+                collision =
+                {
+                    MORIMAR_BASALT_FIELDS_ID.npc.REIVE_COLLISION_OFFSET + 10,
+                    MORIMAR_BASALT_FIELDS_ID.npc.REIVE_COLLISION_OFFSET + 11,
+                },
+            },
+            
+            -- !pos -123 -15.89 -419.9 265  -- TODO: Need Fix for collision. Likely need a capture for the collision position.
+            [4] =
+            {
+                mob =
+                {
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 30,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 31,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 32,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 33,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 34,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 35,
+                },
+                obstacles =
+                {
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 27,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 28,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 29,
+                },
+                collision =
+                {
+                    MORIMAR_BASALT_FIELDS_ID.npc.REIVE_COLLISION_OFFSET + 12,
+                    MORIMAR_BASALT_FIELDS_ID.npc.REIVE_COLLISION_OFFSET + 13,
+                },
+            },
+
+            -- !pos -363 -31.89 -140 265
+            [5] =
+            {
+                mob =
+                {
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 48,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 49,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 50,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 51,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 52,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 53,
+                },
+                obstacles =
+                {
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 45,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 46,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 47,
+                },
+                collision =
+                {
+                    MORIMAR_BASALT_FIELDS_ID.npc.REIVE_COLLISION_OFFSET + 6,
+                    MORIMAR_BASALT_FIELDS_ID.npc.REIVE_COLLISION_OFFSET + 7,
+                },
+            },
+
+            -- !pos -243 -47.89 399.9 265
+            [6] =
+            {
+                mob =
+                {
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 57,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 58,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 59,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 60,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 61,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 62,
+                },
+                obstacles =
+                {
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 54,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 55,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 56,
+                },
+                collision =
+                {
+                    MORIMAR_BASALT_FIELDS_ID.npc.REIVE_COLLISION_OFFSET,
+                    MORIMAR_BASALT_FIELDS_ID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+
+            -- !pos -240.7 -32.45 -219.4 265
+            [7] =
+            {
+                mob =
+                {
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 39,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 40,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 41,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 42,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 43,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 44,
+                },
+                obstacles =
+                {
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 36,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 37,
+                    MORIMAR_BASALT_FIELDS_ID.mob.REIVE_MOB_OFFSET + 38,
+                },
+                collision =
+                {
+                    MORIMAR_BASALT_FIELDS_ID.npc.REIVE_COLLISION_OFFSET + 8,
+                    MORIMAR_BASALT_FIELDS_ID.npc.REIVE_COLLISION_OFFSET + 9,
+                },
+            },
+        },
+    },
+
+    [xi.zone.OUTER_RAKAZNAR] =
+    {
+        reiveObjRespawnTime = 900, -- 15 minutes
+        reiveMobRespawnTime = 60,  -- 1 minute
+        reive =
+        {
+
+            -- !pos 743.4 100 120.1 274
+            [1] =
+            {
+                mob =
+                {
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 3,
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 4,
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 5,
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 6,
+                },
+                obstacles =
+                {
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET,
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 1,
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 2,
+                },
+                collision =
+                {
+                    OUTER_RAKAZNAR_ID.npc.REIVE_COLLISION_OFFSET,
+                },
+            },
+
+            -- !pos 720 100 -175.4 274
+            [2] =
+            {
+                mob =
+                {
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 10,
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 11,
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 12,
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 13,
+                },
+                obstacles =
+                {
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 7,
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 8,
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 9,
+                },
+                collision =
+                {
+                    OUTER_RAKAZNAR_ID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+
+            -- !pos 424 100 -159.9 274
+            [3] =
+            {
+                mob =
+                {
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 17,
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 18,
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 19,
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 20,
+                },
+                obstacles =
+                {
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 14,
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 15,
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 16,
+                },
+                collision =
+                {
+                    OUTER_RAKAZNAR_ID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+
+            -- !pos 440 100 135.2 274
+            [4] =
+            {
+                mob =
+                {
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 24,
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 25,
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 26,
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 27,
+                },
+                obstacles =
+                {
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 21,
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 22,
+                    OUTER_RAKAZNAR_ID.mob.REIVE_MOB_OFFSET + 23,
+                },
+                collision =
+                {
+                    OUTER_RAKAZNAR_ID.npc.REIVE_COLLISION_OFFSET + 2,
+                },
+            },
+        },
+    },
+
+    [xi.zone.RAKAZNAR_INNER_COURT] =
+    {
+        reiveObjRespawnTime = 900, -- 15 minutes
+        reiveMobRespawnTime = 60,  -- 1 minute
+        reive =
+        {
+            -- !pos 894.2 100 199.8 276
+            [1] =
+            {
+                mob =
+                {
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 3,
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 4,
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 5,
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 6,
+                },
+                obstacles =
+                {
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET,
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 1,
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 2,
+                },
+                collision =
+                {
+                    RAKAZNAR_INNER_COURT_ID.npc.REIVE_COLLISION_OFFSET,
+                },
+            },
+
+            -- !pos 519.9 100 228.6 276
+            [2] =
+            {
+                mob =
+                {
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 10,
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 11,
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 12,
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 13,
+                },
+                obstacles =
+                {
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 7,
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 8,
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 9,
+                },
+                collision =
+                {
+                    RAKAZNAR_INNER_COURT_ID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+
+            -- !pos 506 90 -160 276
+            [3] =
+            {
+                mob =
+                {
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 17,
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 18,
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 19,
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 20,
+                },
+                obstacles =
+                {
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 14,
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 15,
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 16,
+                },
+                collision =
+                {
+                    RAKAZNAR_INNER_COURT_ID.npc.REIVE_COLLISION_OFFSET + 2,
+                },
+            },
+
+            -- !pos 879.9 90 -173.8 276
+            [4] =
+            {
+                mob =
+                {
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 24,
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 25,
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 26,
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 27,
+                },
+                obstacles =
+                {
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 21,
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 22,
+                    RAKAZNAR_INNER_COURT_ID.mob.REIVE_MOB_OFFSET + 23,
+                },
+                collision =
+                {
+                    RAKAZNAR_INNER_COURT_ID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+        },
+    },
+
+    [xi.zone.SIH_GATES] =
+    {
+        reiveObjRespawnTime = 3600, -- 60 minutes
+        reiveMobRespawnTime = 300,  -- 5 minutes
+        reive =
+        {
+
+            -- !pos -118.8 -10 -99 268
+            [1] =
+            {
+                mob =
+                {
+                    SIH_GATES_ID.mob.REIVE_MOB_OFFSET + 3,
+                    SIH_GATES_ID.mob.REIVE_MOB_OFFSET + 4,
+                    SIH_GATES_ID.mob.REIVE_MOB_OFFSET + 5,
+                    SIH_GATES_ID.mob.REIVE_MOB_OFFSET + 6,
+                    SIH_GATES_ID.mob.REIVE_MOB_OFFSET + 7,
+                    SIH_GATES_ID.mob.REIVE_MOB_OFFSET + 8,
+                },
+                obstacles =
+                {
+                    SIH_GATES_ID.mob.REIVE_MOB_OFFSET,
+                    SIH_GATES_ID.mob.REIVE_MOB_OFFSET + 1,
+                    SIH_GATES_ID.mob.REIVE_MOB_OFFSET + 2,
+                },
+                collision =
+                {
+                    SIH_GATES_ID.npc.REIVE_COLLISION_OFFSET,
+                    SIH_GATES_ID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+
+            -- !pos -77.9 -9.8 -259.9 268
+            [2] =
+            {
+                mob =
+                {
+                    SIH_GATES_ID.mob.REIVE_MOB_OFFSET + 12,
+                    SIH_GATES_ID.mob.REIVE_MOB_OFFSET + 13,
+                    SIH_GATES_ID.mob.REIVE_MOB_OFFSET + 14,
+                    SIH_GATES_ID.mob.REIVE_MOB_OFFSET + 15,
+                    SIH_GATES_ID.mob.REIVE_MOB_OFFSET + 16,
+                    SIH_GATES_ID.mob.REIVE_MOB_OFFSET + 17,
+                },
+                obstacles =
+                {
+                    SIH_GATES_ID.mob.REIVE_MOB_OFFSET + 9,
+                    SIH_GATES_ID.mob.REIVE_MOB_OFFSET + 10,
+                    SIH_GATES_ID.mob.REIVE_MOB_OFFSET + 11,
+                },
+                collision =
+                {
+                    SIH_GATES_ID.npc.REIVE_COLLISION_OFFSET + 2,
+                    SIH_GATES_ID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+        },
+    },
+
+    [xi.zone.WOH_GATES] =
+    {
+        reiveObjRespawnTime = 3600, -- 60 minutes
+        reiveMobRespawnTime = 300,  -- 5 minutes
+        reive =
+        {
+
+            -- !pos 276 30 99.5 273
+            [1] =
+            {
+                mob =
+                {
+                    WOH_GATES_ID.mob.REIVE_MOB_OFFSET + 2,
+                    WOH_GATES_ID.mob.REIVE_MOB_OFFSET + 3,
+                    WOH_GATES_ID.mob.REIVE_MOB_OFFSET + 4,
+                    WOH_GATES_ID.mob.REIVE_MOB_OFFSET + 5,
+                },
+                obstacles =
+                {
+                    WOH_GATES_ID.mob.REIVE_MOB_OFFSET,
+                    WOH_GATES_ID.mob.REIVE_MOB_OFFSET + 1,
+                },
+                collision =
+                {
+                    WOH_GATES_ID.npc.REIVE_COLLISION_OFFSET,
+                    WOH_GATES_ID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+
+            -- !pos 284 30.6 259.7 273
+            [2] =
+            {
+                mob =
+                {
+                    WOH_GATES_ID.mob.REIVE_MOB_OFFSET + 8,
+                    WOH_GATES_ID.mob.REIVE_MOB_OFFSET + 9,
+                    WOH_GATES_ID.mob.REIVE_MOB_OFFSET + 10,
+                    WOH_GATES_ID.mob.REIVE_MOB_OFFSET + 11,
+                },
+                obstacles =
+                {
+                    WOH_GATES_ID.mob.REIVE_MOB_OFFSET + 6,
+                    WOH_GATES_ID.mob.REIVE_MOB_OFFSET + 7,
+                },
+                collision =
+                {
+                    WOH_GATES_ID.npc.REIVE_COLLISION_OFFSET + 2,
+                    WOH_GATES_ID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+        },
+    },
+    
+    [xi.zone.YAHSE_HUNTING_GROUNDS] =
+    {
+        reiveObjRespawnTime = 3600, -- 60 minutes
+        reiveMobRespawnTime = 300,  -- 5 minutes
+        reive =
+        {
+            -- !pos -155.5 0.3 141.9 260
+            [1] =
+            {
+                mob =
+                {
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 17,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 18,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 19,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 20,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 21,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 22,
+                },
+                obstacles =
+                {
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 14,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 15,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 16,
+                },
+                collision =
+                {
+                    YAHSE_HUNTING_GROUNDS_ID.npc.REIVE_COLLISION_OFFSET + 8,
+                    YAHSE_HUNTING_GROUNDS_ID.npc.REIVE_COLLISION_OFFSET + 9,
+                },
+            },
+
+            -- !pos 116 0.3 -177.9 260
+            [2] =
+            {
+                mob =
+                {
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 26,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 27,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 28,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 29,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 30,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 31,
+                },
+                obstacles =
+                {
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 23,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 24,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 25,
+                },
+                collision =
+                {
+                    YAHSE_HUNTING_GROUNDS_ID.npc.REIVE_COLLISION_OFFSET + 4,
+                    YAHSE_HUNTING_GROUNDS_ID.npc.REIVE_COLLISION_OFFSET + 5,
+                },
+            },
+    
+            -- !pos 153 0.49 -19.7 260
+            [3] =
+            {
+                mob =
+                {
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 10,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 11,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 12,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 13,
+                },
+                obstacles =
+                {
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 7,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 8,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 9,
+                },
+                collision =
+                {
+                    YAHSE_HUNTING_GROUNDS_ID.npc.REIVE_COLLISION_OFFSET + 0,
+                    YAHSE_HUNTING_GROUNDS_ID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+    
+            -- !pos -315.7 0.41 -221 260
+            [4] =
+            {
+                mob =
+                {
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 35,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 36,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 37,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 38,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 39,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 40,
+                },
+                obstacles =
+                {
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 32,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 33,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 34,
+                },
+                collision =
+                {
+                    YAHSE_HUNTING_GROUNDS_ID.npc.REIVE_COLLISION_OFFSET + 6,
+                    YAHSE_HUNTING_GROUNDS_ID.npc.REIVE_COLLISION_OFFSET + 7,
+                },
+            },
+    
+            -- !pos 115 0.27 -176 260
+            [5] =
+            {
+                mob =
+                {
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 3,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 4,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 5,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 6,
+                },
+                obstacles =
+                {
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 0,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 1,
+                    YAHSE_HUNTING_GROUNDS_ID.mob.REIVE_MOB_OFFSET + 2,
+                },
+                collision =
+                {
+                    YAHSE_HUNTING_GROUNDS_ID.npc.REIVE_COLLISION_OFFSET + 2,
+                    YAHSE_HUNTING_GROUNDS_ID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+        },
+    },
+
+    [xi.zone.YORCIA_WEALD] =
+    {
+        reiveObjRespawnTime = 3600, -- 60 minutes
+        reiveMobRespawnTime = 300,  -- 5 minutes
+        reive =
+        {
+
+            -- !pos 100 1.6 342 263
+            [1] =
+            {
+                mob =
+                {
+                    YORCIA_WEALD_ID.mob.REIVE_MOB_OFFSET + 2,
+                    YORCIA_WEALD_ID.mob.REIVE_MOB_OFFSET + 3,
+                    YORCIA_WEALD_ID.mob.REIVE_MOB_OFFSET + 4,
+                    YORCIA_WEALD_ID.mob.REIVE_MOB_OFFSET + 5,
+                },
+                obstacles =
+                {
+                    YORCIA_WEALD_ID.mob.REIVE_MOB_OFFSET + 0,
+                    YORCIA_WEALD_ID.mob.REIVE_MOB_OFFSET + 1,
+                },
+                collision =
+                {
+                    YORCIA_WEALD_ID.npc.REIVE_COLLISION_OFFSET + 0,
+                },
+            },
+
+            -- !pos -102 1.57 180 263
+            [2] =
+            {
+                mob =
+                {
+                    YORCIA_WEALD_ID.mob.REIVE_MOB_OFFSET + 8,
+                    YORCIA_WEALD_ID.mob.REIVE_MOB_OFFSET + 9,
+                    YORCIA_WEALD_ID.mob.REIVE_MOB_OFFSET + 10,
+                    YORCIA_WEALD_ID.mob.REIVE_MOB_OFFSET + 11,
+                },
+                obstacles =
+                {
+                    YORCIA_WEALD_ID.mob.REIVE_MOB_OFFSET + 6,
+                    YORCIA_WEALD_ID.mob.REIVE_MOB_OFFSET + 7,
+                },
+                collision =
+                {
+                    YORCIA_WEALD_ID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+
+            -- !pos 258 1.57 -140 263
+            [3] =
+            {
+                mob =
+                {
+                    YORCIA_WEALD_ID.mob.REIVE_MOB_OFFSET + 14,
+                    YORCIA_WEALD_ID.mob.REIVE_MOB_OFFSET + 15,
+                    YORCIA_WEALD_ID.mob.REIVE_MOB_OFFSET + 16,
+                    YORCIA_WEALD_ID.mob.REIVE_MOB_OFFSET + 17,
+                },
+                obstacles =
+                {
+                    YORCIA_WEALD_ID.mob.REIVE_MOB_OFFSET + 12,
+                    YORCIA_WEALD_ID.mob.REIVE_MOB_OFFSET + 13,
+                },
+                collision =
+                {
+                    YORCIA_WEALD_ID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+
+            -- !pos 60 1.63 -178 263
+            [4] =
+            {
+                mob =
+                {
+                    YORCIA_WEALD_ID.mob.REIVE_MOB_OFFSET + 20,
+                    YORCIA_WEALD_ID.mob.REIVE_MOB_OFFSET + 21,
+                    YORCIA_WEALD_ID.mob.REIVE_MOB_OFFSET + 22,
+                    YORCIA_WEALD_ID.mob.REIVE_MOB_OFFSET + 23,
+                },
+                obstacles =
+                {
+                    YORCIA_WEALD_ID.mob.REIVE_MOB_OFFSET + 18,
+                    YORCIA_WEALD_ID.mob.REIVE_MOB_OFFSET + 19,
+                },
+                collision =
+                {
+                    YORCIA_WEALD_ID.npc.REIVE_COLLISION_OFFSET + 2,
+                },
+            },
+        },
+    },
+}

--- a/scripts/globals/colonization_reive_data.lua
+++ b/scripts/globals/colonization_reive_data.lua
@@ -1,0 +1,1547 @@
+-----------------------------------
+-- Colonization Reive Data
+-----------------------------------
+xi = xi or {}
+xi.reives = xi.reives or {}
+
+local ceizakBattlegroundsID = zones[xi.zone.CEIZAK_BATTLEGROUNDS]
+local cirdasCavernsID       = zones[xi.zone.CIRDAS_CAVERNS]
+local dhoGatesID            = zones[xi.zone.DHO_GATES]
+local foretDeHennetielID    = zones[xi.zone.FORET_DE_HENNETIEL]
+local kamihrDriftsID        = zones[xi.zone.KAMIHR_DRIFTS]
+local marjamiRavineID       = zones[xi.zone.MARJAMI_RAVINE]
+local mohGatesID            = zones[xi.zone.MOH_GATES]
+local morimarBasaltFieldsID = zones[xi.zone.MORIMAR_BASALT_FIELDS]
+local outerRakaznarID       = zones[xi.zone.OUTER_RAKAZNAR]
+local rakaznarInnerCourtID  = zones[xi.zone.RAKAZNAR_INNER_COURT]
+local sihGatesID            = zones[xi.zone.SIH_GATES]
+local wohGatesID            = zones[xi.zone.WOH_GATES]
+local yahseHuntingGroundsID = zones[xi.zone.YAHSE_HUNTING_GROUNDS]
+local yorciaWealdID         = zones[xi.zone.YORCIA_WEALD]
+
+--Zone Data
+xi.reives.zoneData =
+{
+    [xi.zone.CEIZAK_BATTLEGROUNDS] =
+    {
+        reiveObjRespawnTime = 3600, -- 60 minutes
+        reiveMobRespawnTime = 300,  -- 5 minutes
+        reive =
+        {
+            -- !pos 120 0.184 -54 261
+            [1] =
+            {
+                mob =
+                {
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 3,
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 4,
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 5,
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 6,
+                },
+                obstacles =
+                {
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET,
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 1,
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 2,
+                },
+                collision =
+                {
+                    ceizakBattlegroundsID.npc.REIVE_COLLISION_OFFSET,
+                    ceizakBattlegroundsID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+
+            -- !pos -134 0.184 39 261
+            [2] =
+            {
+                mob =
+                {
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 19,
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 20,
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 21,
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 22,
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 23,
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 24,
+                },
+                obstacles =
+                {
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 16,
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 17,
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 18,
+                },
+                collision =
+                {
+                    ceizakBattlegroundsID.npc.REIVE_COLLISION_OFFSET + 2,
+                    ceizakBattlegroundsID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+    
+            -- !pos -239 0.184 174 261
+            [3] =
+            {
+                mob =
+                {
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 10,
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 11,
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 12,
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 13,
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 14,
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 15,
+                },
+                obstacles =
+                {
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 7,
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 8,
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 9,
+                },
+                collision =
+                {
+                    ceizakBattlegroundsID.npc.REIVE_COLLISION_OFFSET + 4,
+                    ceizakBattlegroundsID.npc.REIVE_COLLISION_OFFSET + 5,
+                },
+            },
+    
+            -- !pos -280.499 0.409 182 261
+            [4] =
+            {
+                mob =
+                {
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 28,
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 29,
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 30,
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 31,
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 32,
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 33,
+                },
+                obstacles =
+                {
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 25,
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 26,
+                    ceizakBattlegroundsID.mob.REIVE_MOB_OFFSET + 27,
+                },
+                collision =
+                {
+                    ceizakBattlegroundsID.npc.REIVE_COLLISION_OFFSET + 6,
+                    ceizakBattlegroundsID.npc.REIVE_COLLISION_OFFSET + 7,
+                },
+            },
+        },
+    },
+
+    [xi.zone.CIRDAS_CAVERNS] =
+    {
+        reiveObjRespawnTime = 3600, -- 60 minutes
+        reiveMobRespawnTime = 300,  -- 5 minutes
+        reive =
+        {
+
+            -- !pos -120 19.972 22 270
+            [1] =
+            {
+                mob =
+                {
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 2,
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 3,
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 4,
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 5,
+                },
+                obstacles =
+                {
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET,
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 1,
+                },
+                collision =
+                {
+                    cirdasCavernsID.npc.REIVE_COLLISION_OFFSET + 12,
+                    cirdasCavernsID.npc.REIVE_COLLISION_OFFSET + 13,
+                },
+            },
+
+            -- !pos 439 19.972 142 270
+            [2] =
+            {
+                mob =
+                {
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 8,
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 9,
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 10,
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 11,
+                },
+                obstacles =
+                {
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 6,
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 7,
+                },
+                collision =
+                {
+                    cirdasCavernsID.npc.REIVE_COLLISION_OFFSET,
+                    cirdasCavernsID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+
+            -- !pos 98 19.972 -40 270
+            [3] =
+            {
+                mob =
+                {
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 14,
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 15,
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 16,
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 17,
+                },
+                obstacles =
+                {
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 12,
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 13,
+                },
+                collision =
+                {
+                    cirdasCavernsID.npc.REIVE_COLLISION_OFFSET + 8,
+                    cirdasCavernsID.npc.REIVE_COLLISION_OFFSET + 9,
+                },
+            },
+
+            -- !pos -62 19.972 160 270
+            [4] =
+            {
+                mob =
+                {
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 20,
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 21,
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 22,
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 23,
+                },
+                obstacles =
+                {
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 18,
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 19,
+                },
+                collision =
+                {
+                    cirdasCavernsID.npc.REIVE_COLLISION_OFFSET + 10,
+                    cirdasCavernsID.npc.REIVE_COLLISION_OFFSET + 11,
+                },
+            },
+
+            -- !pos 160 19.972 301 270
+            [5] =
+            {
+                mob =
+                {
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 26,
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 27,
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 28,
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 29,
+                },
+                obstacles =
+                {
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 24,
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 25,
+                },
+                collision =
+                {
+                    cirdasCavernsID.npc.REIVE_COLLISION_OFFSET + 4,
+                    cirdasCavernsID.npc.REIVE_COLLISION_OFFSET + 5,
+                },
+            },
+
+            -- !pos 220.215 20 40.89 270
+            [6] =
+            {
+                mob =
+                {
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 32,
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 33,
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 34,
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 35,
+                },
+                obstacles =
+                {
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 30,
+                    cirdasCavernsID.mob.REIVE_MOB_OFFSET + 31,
+                },
+                collision =
+                {
+                    cirdasCavernsID.npc.REIVE_COLLISION_OFFSET + 2,
+                    cirdasCavernsID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+        },
+    },
+
+    [xi.zone.DHO_GATES] =
+    {
+        reiveObjRespawnTime = 3600, -- 60 minutes
+        reiveMobRespawnTime = 300,  -- 5 minutes
+        reive =
+        {
+            -- !pos -60 -9.9 73.8 272
+            [1] =
+            {
+                mob =
+                {
+                    dhoGatesID.mob.REIVE_MOB_OFFSET + 2,
+                    dhoGatesID.mob.REIVE_MOB_OFFSET + 3,
+                    dhoGatesID.mob.REIVE_MOB_OFFSET + 4,
+                    dhoGatesID.mob.REIVE_MOB_OFFSET + 5,
+                },
+                obstacles =
+                {
+                    dhoGatesID.mob.REIVE_MOB_OFFSET,
+                    dhoGatesID.mob.REIVE_MOB_OFFSET + 1,
+                },
+                collision =
+                {
+                    dhoGatesID.npc.REIVE_COLLISION_OFFSET,
+                    dhoGatesID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+
+            -- !pos -154 -20 300.9 272
+            [2] =
+            {
+                mob =
+                {
+                    dhoGatesID.mob.REIVE_MOB_OFFSET + 8,
+                    dhoGatesID.mob.REIVE_MOB_OFFSET + 9,
+                    dhoGatesID.mob.REIVE_MOB_OFFSET + 10,
+                    dhoGatesID.mob.REIVE_MOB_OFFSET + 11,
+                },
+                obstacles =
+                {
+                    dhoGatesID.mob.REIVE_MOB_OFFSET + 6,
+                    dhoGatesID.mob.REIVE_MOB_OFFSET + 7,
+                },
+                collision =
+                {
+                    dhoGatesID.npc.REIVE_COLLISION_OFFSET + 2,
+                    dhoGatesID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+        },
+    },
+
+    [xi.zone.FORET_DE_HENNETIEL] =
+    {
+        reiveObjRespawnTime = 3600, -- 60 minutes
+        reiveMobRespawnTime = 300,  -- 5 minutes
+        reive =
+        {
+            -- !pos 183.4 -1.9 220 262
+            [1] =
+            {
+                mob =
+                {
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 1,
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 2,
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 3,
+                },
+                obstacles =
+                {
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET,
+                },
+                collision =
+                {
+                    foretDeHennetielID.npc.REIVE_COLLISION_OFFSET + 10,
+                    foretDeHennetielID.npc.REIVE_COLLISION_OFFSET + 11,
+                },
+            },
+            -- !pos 136.5 -2.1 258 262
+            [2] =
+            {
+                mob =
+                {
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 5,
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 6,
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 7,
+                },
+                obstacles =
+                {
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 4,
+                },
+                collision =
+                {
+                    foretDeHennetielID.npc.REIVE_COLLISION_OFFSET + 8,
+                    foretDeHennetielID.npc.REIVE_COLLISION_OFFSET + 9,
+                },
+            },
+    
+            -- !pos -16.6 -1.8 380 262
+            [3] =
+            {
+                mob =
+                {
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 9,
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 10,
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 11,
+                },
+                obstacles =
+                {
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 8,
+                },
+                collision =
+                {
+                    foretDeHennetielID.npc.REIVE_COLLISION_OFFSET + 6,
+                    foretDeHennetielID.npc.REIVE_COLLISION_OFFSET + 7,
+                },
+            },
+    
+            -- !pos -63 -2.1 418 262
+            [4] =
+            {
+                mob =
+                {
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 13,
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 14,
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 15,
+                },
+                obstacles =
+                {
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 12,
+                },
+                collision =
+                {
+                    foretDeHennetielID.npc.REIVE_COLLISION_OFFSET + 4,
+                    foretDeHennetielID.npc.REIVE_COLLISION_OFFSET + 5,
+                },
+            },
+    
+            -- !pos 343 -1.8 -299.4 262
+            [5] =
+            {
+                mob =
+                {
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 17,
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 18,
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 19,
+                },
+                obstacles =
+                {
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 16,
+                },
+                collision =
+                {
+                    foretDeHennetielID.npc.REIVE_COLLISION_OFFSET + 18,
+                    foretDeHennetielID.npc.REIVE_COLLISION_OFFSET + 19,
+                },
+            },
+    
+            -- !pos 296 -2.0 -261 262
+            [6] =
+            {
+                mob =
+                {
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 21,
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 22,
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 23,
+                },
+                obstacles =
+                {
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 20,
+                },
+                collision =
+                {
+                    foretDeHennetielID.npc.REIVE_COLLISION_OFFSET + 16,
+                    foretDeHennetielID.npc.REIVE_COLLISION_OFFSET + 17,
+                },
+            },
+    
+            -- !pos -16.5 -1.93 -219 262
+            [7] =
+            {
+                mob =
+                {
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 25,
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 26,
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 27,
+                },
+                obstacles =
+                {
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 24,
+                },
+                collision =
+                {
+                    foretDeHennetielID.npc.REIVE_COLLISION_OFFSET + 14,
+                    foretDeHennetielID.npc.REIVE_COLLISION_OFFSET + 15,
+                },
+            },
+    
+            -- !pos -63.4 -2.1 -181 262
+            [8] =
+            {
+                mob =
+                {
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 29,
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 30,
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 31,
+                },
+                obstacles =
+                {
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 28,
+                },
+                collision =
+                {
+                    foretDeHennetielID.npc.REIVE_COLLISION_OFFSET + 12,
+                    foretDeHennetielID.npc.REIVE_COLLISION_OFFSET + 13,
+                },
+            },
+    
+            -- !pos -380.9 -1.9 23 262
+            [9] =
+            {
+                mob =
+                {
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 33,
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 34,
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 35,
+                },
+                obstacles =
+                {
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 32,
+                },
+                collision =
+                {
+                    foretDeHennetielID.npc.REIVE_COLLISION_OFFSET + 2,
+                    foretDeHennetielID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+    
+            -- !pos -418.8 -2 -23.3 262
+            [10] =
+            {
+                mob =
+                {
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 37,
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 38,
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 39,
+                },
+                obstacles =
+                {
+                    foretDeHennetielID.mob.REIVE_MOB_OFFSET + 36,
+                },
+                collision =
+                {
+                    foretDeHennetielID.npc.REIVE_COLLISION_OFFSET,
+                    foretDeHennetielID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+        },
+    },
+
+    [xi.zone.KAMIHR_DRIFTS] =
+    {
+        reiveObjRespawnTime = 3600, -- 60 minutes
+        reiveMobRespawnTime = 300,  -- 5 minutes
+        reive =
+        {
+            -- !pos 114.7 40 -269.3 267
+            [1] =
+            {
+                mob =
+                {
+                    kamihrDriftsID.mob.REIVE_MOB_OFFSET + 2,
+                    kamihrDriftsID.mob.REIVE_MOB_OFFSET + 3,
+                    kamihrDriftsID.mob.REIVE_MOB_OFFSET + 4,
+                    kamihrDriftsID.mob.REIVE_MOB_OFFSET + 5,
+                },
+                obstacles =
+                {
+                    kamihrDriftsID.mob.REIVE_MOB_OFFSET,
+                    kamihrDriftsID.mob.REIVE_MOB_OFFSET + 1,
+                },
+                collision =
+                {
+                    kamihrDriftsID.npc.REIVE_COLLISION_OFFSET,
+                },
+            },
+
+            -- !pos 246 40 -110 267
+            [2] =
+            {
+                mob =
+                {
+                    kamihrDriftsID.mob.REIVE_MOB_OFFSET + 8,
+                    kamihrDriftsID.mob.REIVE_MOB_OFFSET + 9,
+                    kamihrDriftsID.mob.REIVE_MOB_OFFSET + 10,
+                    kamihrDriftsID.mob.REIVE_MOB_OFFSET + 11,
+                },
+                obstacles =
+                {
+                    kamihrDriftsID.mob.REIVE_MOB_OFFSET + 6,
+                    kamihrDriftsID.mob.REIVE_MOB_OFFSET + 7,
+                },
+                collision =
+                {
+                    kamihrDriftsID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+
+            -- !pos -34 20 11 267
+            [3] =
+            {
+                mob =
+                {
+                    kamihrDriftsID.mob.REIVE_MOB_OFFSET + 14,
+                    kamihrDriftsID.mob.REIVE_MOB_OFFSET + 15,
+                    kamihrDriftsID.mob.REIVE_MOB_OFFSET + 16,
+                    kamihrDriftsID.mob.REIVE_MOB_OFFSET + 17,
+                },
+                obstacles =
+                {
+                    kamihrDriftsID.mob.REIVE_MOB_OFFSET + 12,
+                    kamihrDriftsID.mob.REIVE_MOB_OFFSET + 13,
+                },
+                collision =
+                {
+                    kamihrDriftsID.npc.REIVE_COLLISION_OFFSET + 2,
+                },
+            },
+
+            -- !pos -354 0.2 269.4 267
+            [4] =
+            {
+                mob =
+                {
+                    kamihrDriftsID.mob.REIVE_MOB_OFFSET + 20,
+                    kamihrDriftsID.mob.REIVE_MOB_OFFSET + 21,
+                    kamihrDriftsID.mob.REIVE_MOB_OFFSET + 22,
+                    kamihrDriftsID.mob.REIVE_MOB_OFFSET + 23,
+                },
+                obstacles =
+                {
+                    kamihrDriftsID.mob.REIVE_MOB_OFFSET + 18,
+                    kamihrDriftsID.mob.REIVE_MOB_OFFSET + 19,
+                },
+                collision =
+                {
+                    kamihrDriftsID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+        },
+    },
+
+    [xi.zone.MARJAMI_RAVINE] =
+    {
+        reiveObjRespawnTime = 3600, -- 60 minutes
+        reiveMobRespawnTime = 300,  -- 5 minutes
+        reive =
+        {
+
+            -- !pos 339 -41.6 -18 266
+            [1] =
+            {
+                mob =
+                {
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 1,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 2,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 3,
+                },
+                obstacles =
+                {
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 4,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 5,
+                },
+                collision =
+                {
+                    marjamiRavineID.npc.REIVE_COLLISION_OFFSET,
+                },
+            },
+
+            -- !pos 218 -21.6 60 266
+            [2] =
+            {
+                mob =
+                {
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 8,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 9,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 10,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 11,
+                },
+                obstacles =
+                {
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 6,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 7,
+                },
+                collision =
+                {
+                    marjamiRavineID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+
+            -- !pos 180 -1.6 -138 266
+            [3] =
+            {
+                mob =
+                {
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 14,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 15,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 16,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 17,
+                },
+                obstacles =
+                {
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 12,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 13,
+                },
+                collision =
+                {
+                    marjamiRavineID.npc.REIVE_COLLISION_OFFSET + 2,
+                },
+            },
+
+            -- !pos 102 38 -180 266
+            [4] =
+            {
+                mob =
+                {
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 20,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 21,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 22,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 23,
+                },
+                obstacles =
+                {
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 18,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 19,
+                },
+                collision =
+                {
+                    marjamiRavineID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+
+            -- !pos -98 38 -140 266
+            [5] =
+            {
+                mob =
+                {
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 26,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 27,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 28,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 29,
+                },
+                obstacles =
+                {
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 24,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 25,
+                },
+                collision =
+                {
+                    marjamiRavineID.npc.REIVE_COLLISION_OFFSET + 4,
+                },
+            },
+
+            -- !pos -178 -2.4 -60 266
+            [6] =
+            {
+                mob =
+                {
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 32,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 33,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 34,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 35,
+                },
+                obstacles =
+                {
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 30,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 31,
+                },
+                collision =
+                {
+                    marjamiRavineID.npc.REIVE_COLLISION_OFFSET + 5,
+                },
+            },
+
+            -- !pos -298 -22.4 100 266
+            [7] =
+            {
+                mob =
+                {
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 38,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 39,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 40,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 41,
+                },
+                obstacles =
+                {
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 36,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 37,
+                },
+                collision =
+                {
+                    marjamiRavineID.npc.REIVE_COLLISION_OFFSET + 6,
+                },
+            },
+        },
+    },
+
+    [xi.zone.MOH_GATES] =
+    {
+        reiveObjRespawnTime = 3600, -- 60 minutes
+        reiveMobRespawnTime = 300,  -- 5 minutes
+        reive =
+        {
+            -- !pos 240 19 -57.5 269
+            [1] =
+            {
+                mob =
+                {
+                    mohGatesID.mob.REIVE_MOB_OFFSET + 3,
+                    mohGatesID.mob.REIVE_MOB_OFFSET + 4,
+                    mohGatesID.mob.REIVE_MOB_OFFSET + 5,
+                    mohGatesID.mob.REIVE_MOB_OFFSET + 6,
+                    mohGatesID.mob.REIVE_MOB_OFFSET + 7,
+                    mohGatesID.mob.REIVE_MOB_OFFSET + 8,
+                },
+                obstacles =
+                {
+                    mohGatesID.mob.REIVE_MOB_OFFSET,
+                    mohGatesID.mob.REIVE_MOB_OFFSET + 1,
+                    mohGatesID.mob.REIVE_MOB_OFFSET + 2,
+                },
+                collision =
+                {
+                    mohGatesID.npc.REIVE_COLLISION_OFFSET + 2,
+                    mohGatesID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+
+            -- !pos 102 29.8 -160 269
+            [2] =
+            {
+                mob =
+                {
+                    mohGatesID.mob.REIVE_MOB_OFFSET + 12,
+                    mohGatesID.mob.REIVE_MOB_OFFSET + 13,
+                    mohGatesID.mob.REIVE_MOB_OFFSET + 14,
+                    mohGatesID.mob.REIVE_MOB_OFFSET + 15,
+                    mohGatesID.mob.REIVE_MOB_OFFSET + 16,
+                    mohGatesID.mob.REIVE_MOB_OFFSET + 17,
+                },
+                obstacles =
+                {
+                    mohGatesID.mob.REIVE_MOB_OFFSET + 9,
+                    mohGatesID.mob.REIVE_MOB_OFFSET + 10,
+                    mohGatesID.mob.REIVE_MOB_OFFSET + 11,
+                },
+                collision =
+                {
+                    mohGatesID.npc.REIVE_COLLISION_OFFSET,
+                    mohGatesID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+        },
+    },
+
+    [xi.zone.MORIMAR_BASALT_FIELDS] =
+    {
+        reiveObjRespawnTime = 3600, -- 60 minutes
+        reiveMobRespawnTime = 300,  -- 5 minutes
+        reive =
+        {
+
+            -- !pos 119.7 -0.08 -54.9 265
+            [1] =
+            {
+                mob =
+                {
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 3,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 4,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 5,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 6,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 7,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 8,
+                },
+                obstacles =
+                {
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 0,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 1,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 2,
+                },
+                collision =
+                {
+                    morimarBasaltFieldsID.npc.REIVE_COLLISION_OFFSET + 4,
+                    morimarBasaltFieldsID.npc.REIVE_COLLISION_OFFSET + 5,
+                },
+            },
+            
+            -- !pos -3.5 0.106 60 265
+            [2] =
+            {
+                mob =
+                {
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 12,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 13,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 14,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 15,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 16,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 17,
+                },
+                obstacles =
+                {
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 9,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 10,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 11,
+                },
+                collision =
+                {
+                    morimarBasaltFieldsID.npc.REIVE_COLLISION_OFFSET + 2,
+                    morimarBasaltFieldsID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+
+            -- !pos -60 -15.89 -276.5 265
+            [3] =
+            {
+                mob =
+                {
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 21,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 22,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 23,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 24,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 25,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 26,
+                },
+                obstacles =
+                {
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 18,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 19,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 20,
+                },
+                collision =
+                {
+                    morimarBasaltFieldsID.npc.REIVE_COLLISION_OFFSET + 10,
+                    morimarBasaltFieldsID.npc.REIVE_COLLISION_OFFSET + 11,
+                },
+            },
+            
+            -- !pos -123 -15.89 -419.9 265  -- TODO: Need Fix for collision. Likely need a capture for the collision position.
+            [4] =
+            {
+                mob =
+                {
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 30,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 31,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 32,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 33,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 34,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 35,
+                },
+                obstacles =
+                {
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 27,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 28,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 29,
+                },
+                collision =
+                {
+                    morimarBasaltFieldsID.npc.REIVE_COLLISION_OFFSET + 12,
+                    morimarBasaltFieldsID.npc.REIVE_COLLISION_OFFSET + 13,
+                },
+            },
+
+            -- !pos -363 -31.89 -140 265
+            [5] =
+            {
+                mob =
+                {
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 48,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 49,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 50,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 51,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 52,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 53,
+                },
+                obstacles =
+                {
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 45,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 46,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 47,
+                },
+                collision =
+                {
+                    morimarBasaltFieldsID.npc.REIVE_COLLISION_OFFSET + 6,
+                    morimarBasaltFieldsID.npc.REIVE_COLLISION_OFFSET + 7,
+                },
+            },
+
+            -- !pos -243 -47.89 399.9 265
+            [6] =
+            {
+                mob =
+                {
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 57,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 58,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 59,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 60,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 61,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 62,
+                },
+                obstacles =
+                {
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 54,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 55,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 56,
+                },
+                collision =
+                {
+                    morimarBasaltFieldsID.npc.REIVE_COLLISION_OFFSET,
+                    morimarBasaltFieldsID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+
+            -- !pos -240.7 -32.45 -219.4 265
+            [7] =
+            {
+                mob =
+                {
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 39,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 40,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 41,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 42,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 43,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 44,
+                },
+                obstacles =
+                {
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 36,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 37,
+                    morimarBasaltFieldsID.mob.REIVE_MOB_OFFSET + 38,
+                },
+                collision =
+                {
+                    morimarBasaltFieldsID.npc.REIVE_COLLISION_OFFSET + 8,
+                    morimarBasaltFieldsID.npc.REIVE_COLLISION_OFFSET + 9,
+                },
+            },
+        },
+    },
+
+    [xi.zone.OUTER_RAKAZNAR] =
+    {
+        reiveObjRespawnTime = 900, -- 15 minutes
+        reiveMobRespawnTime = 60,  -- 1 minute
+        reive =
+        {
+
+            -- !pos 743.4 100 120.1 274
+            [1] =
+            {
+                mob =
+                {
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 3,
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 4,
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 5,
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 6,
+                },
+                obstacles =
+                {
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET,
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 1,
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 2,
+                },
+                collision =
+                {
+                    outerRakaznarID.npc.REIVE_COLLISION_OFFSET,
+                },
+            },
+
+            -- !pos 720 100 -175.4 274
+            [2] =
+            {
+                mob =
+                {
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 10,
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 11,
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 12,
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 13,
+                },
+                obstacles =
+                {
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 7,
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 8,
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 9,
+                },
+                collision =
+                {
+                    outerRakaznarID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+
+            -- !pos 424 100 -159.9 274
+            [3] =
+            {
+                mob =
+                {
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 17,
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 18,
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 19,
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 20,
+                },
+                obstacles =
+                {
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 14,
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 15,
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 16,
+                },
+                collision =
+                {
+                    outerRakaznarID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+
+            -- !pos 440 100 135.2 274
+            [4] =
+            {
+                mob =
+                {
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 24,
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 25,
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 26,
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 27,
+                },
+                obstacles =
+                {
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 21,
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 22,
+                    outerRakaznarID.mob.REIVE_MOB_OFFSET + 23,
+                },
+                collision =
+                {
+                    outerRakaznarID.npc.REIVE_COLLISION_OFFSET + 2,
+                },
+            },
+        },
+    },
+
+    [xi.zone.RAKAZNAR_INNER_COURT] =
+    {
+        reiveObjRespawnTime = 900, -- 15 minutes
+        reiveMobRespawnTime = 60,  -- 1 minute
+        reive =
+        {
+            -- !pos 894.2 100 199.8 276
+            [1] =
+            {
+                mob =
+                {
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 3,
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 4,
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 5,
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 6,
+                },
+                obstacles =
+                {
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET,
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 1,
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 2,
+                },
+                collision =
+                {
+                    rakaznarInnerCourtID.npc.REIVE_COLLISION_OFFSET,
+                },
+            },
+
+            -- !pos 519.9 100 228.6 276
+            [2] =
+            {
+                mob =
+                {
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 10,
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 11,
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 12,
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 13,
+                },
+                obstacles =
+                {
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 7,
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 8,
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 9,
+                },
+                collision =
+                {
+                    rakaznarInnerCourtID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+
+            -- !pos 506 90 -160 276
+            [3] =
+            {
+                mob =
+                {
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 17,
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 18,
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 19,
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 20,
+                },
+                obstacles =
+                {
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 14,
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 15,
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 16,
+                },
+                collision =
+                {
+                    rakaznarInnerCourtID.npc.REIVE_COLLISION_OFFSET + 2,
+                },
+            },
+
+            -- !pos 879.9 90 -173.8 276
+            [4] =
+            {
+                mob =
+                {
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 24,
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 25,
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 26,
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 27,
+                },
+                obstacles =
+                {
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 21,
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 22,
+                    rakaznarInnerCourtID.mob.REIVE_MOB_OFFSET + 23,
+                },
+                collision =
+                {
+                    rakaznarInnerCourtID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+        },
+    },
+
+    [xi.zone.SIH_GATES] =
+    {
+        reiveObjRespawnTime = 3600, -- 60 minutes
+        reiveMobRespawnTime = 300,  -- 5 minutes
+        reive =
+        {
+
+            -- !pos -118.8 -10 -99 268
+            [1] =
+            {
+                mob =
+                {
+                    sihGatesID.mob.REIVE_MOB_OFFSET + 3,
+                    sihGatesID.mob.REIVE_MOB_OFFSET + 4,
+                    sihGatesID.mob.REIVE_MOB_OFFSET + 5,
+                    sihGatesID.mob.REIVE_MOB_OFFSET + 6,
+                    sihGatesID.mob.REIVE_MOB_OFFSET + 7,
+                    sihGatesID.mob.REIVE_MOB_OFFSET + 8,
+                },
+                obstacles =
+                {
+                    sihGatesID.mob.REIVE_MOB_OFFSET,
+                    sihGatesID.mob.REIVE_MOB_OFFSET + 1,
+                    sihGatesID.mob.REIVE_MOB_OFFSET + 2,
+                },
+                collision =
+                {
+                    sihGatesID.npc.REIVE_COLLISION_OFFSET,
+                    sihGatesID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+
+            -- !pos -77.9 -9.8 -259.9 268
+            [2] =
+            {
+                mob =
+                {
+                    sihGatesID.mob.REIVE_MOB_OFFSET + 12,
+                    sihGatesID.mob.REIVE_MOB_OFFSET + 13,
+                    sihGatesID.mob.REIVE_MOB_OFFSET + 14,
+                    sihGatesID.mob.REIVE_MOB_OFFSET + 15,
+                    sihGatesID.mob.REIVE_MOB_OFFSET + 16,
+                    sihGatesID.mob.REIVE_MOB_OFFSET + 17,
+                },
+                obstacles =
+                {
+                    sihGatesID.mob.REIVE_MOB_OFFSET + 9,
+                    sihGatesID.mob.REIVE_MOB_OFFSET + 10,
+                    sihGatesID.mob.REIVE_MOB_OFFSET + 11,
+                },
+                collision =
+                {
+                    sihGatesID.npc.REIVE_COLLISION_OFFSET + 2,
+                    sihGatesID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+        },
+    },
+
+    [xi.zone.WOH_GATES] =
+    {
+        reiveObjRespawnTime = 3600, -- 60 minutes
+        reiveMobRespawnTime = 300,  -- 5 minutes
+        reive =
+        {
+
+            -- !pos 276 30 99.5 273
+            [1] =
+            {
+                mob =
+                {
+                    wohGatesID.mob.REIVE_MOB_OFFSET + 2,
+                    wohGatesID.mob.REIVE_MOB_OFFSET + 3,
+                    wohGatesID.mob.REIVE_MOB_OFFSET + 4,
+                    wohGatesID.mob.REIVE_MOB_OFFSET + 5,
+                },
+                obstacles =
+                {
+                    wohGatesID.mob.REIVE_MOB_OFFSET,
+                    wohGatesID.mob.REIVE_MOB_OFFSET + 1,
+                },
+                collision =
+                {
+                    wohGatesID.npc.REIVE_COLLISION_OFFSET,
+                    wohGatesID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+
+            -- !pos 284 30.6 259.7 273
+            [2] =
+            {
+                mob =
+                {
+                    wohGatesID.mob.REIVE_MOB_OFFSET + 8,
+                    wohGatesID.mob.REIVE_MOB_OFFSET + 9,
+                    wohGatesID.mob.REIVE_MOB_OFFSET + 10,
+                    wohGatesID.mob.REIVE_MOB_OFFSET + 11,
+                },
+                obstacles =
+                {
+                    wohGatesID.mob.REIVE_MOB_OFFSET + 6,
+                    wohGatesID.mob.REIVE_MOB_OFFSET + 7,
+                },
+                collision =
+                {
+                    wohGatesID.npc.REIVE_COLLISION_OFFSET + 2,
+                    wohGatesID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+        },
+    },
+    
+    [xi.zone.YAHSE_HUNTING_GROUNDS] =
+    {
+        reiveObjRespawnTime = 3600, -- 60 minutes
+        reiveMobRespawnTime = 300,  -- 5 minutes
+        reive =
+        {
+            -- !pos -155.5 0.3 141.9 260
+            [1] =
+            {
+                mob =
+                {
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 17,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 18,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 19,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 20,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 21,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 22,
+                },
+                obstacles =
+                {
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 14,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 15,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 16,
+                },
+                collision =
+                {
+                    yahseHuntingGroundsID.npc.REIVE_COLLISION_OFFSET + 8,
+                    yahseHuntingGroundsID.npc.REIVE_COLLISION_OFFSET + 9,
+                },
+            },
+
+            -- !pos 116 0.3 -177.9 260
+            [2] =
+            {
+                mob =
+                {
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 26,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 27,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 28,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 29,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 30,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 31,
+                },
+                obstacles =
+                {
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 23,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 24,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 25,
+                },
+                collision =
+                {
+                    yahseHuntingGroundsID.npc.REIVE_COLLISION_OFFSET + 4,
+                    yahseHuntingGroundsID.npc.REIVE_COLLISION_OFFSET + 5,
+                },
+            },
+    
+            -- !pos 153 0.49 -19.7 260
+            [3] =
+            {
+                mob =
+                {
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 10,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 11,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 12,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 13,
+                },
+                obstacles =
+                {
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 7,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 8,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 9,
+                },
+                collision =
+                {
+                    yahseHuntingGroundsID.npc.REIVE_COLLISION_OFFSET + 0,
+                    yahseHuntingGroundsID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+    
+            -- !pos -315.7 0.41 -221 260
+            [4] =
+            {
+                mob =
+                {
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 35,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 36,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 37,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 38,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 39,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 40,
+                },
+                obstacles =
+                {
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 32,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 33,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 34,
+                },
+                collision =
+                {
+                    yahseHuntingGroundsID.npc.REIVE_COLLISION_OFFSET + 6,
+                    yahseHuntingGroundsID.npc.REIVE_COLLISION_OFFSET + 7,
+                },
+            },
+    
+            -- !pos 115 0.27 -176 260
+            [5] =
+            {
+                mob =
+                {
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 3,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 4,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 5,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 6,
+                },
+                obstacles =
+                {
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 0,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 1,
+                    yahseHuntingGroundsID.mob.REIVE_MOB_OFFSET + 2,
+                },
+                collision =
+                {
+                    yahseHuntingGroundsID.npc.REIVE_COLLISION_OFFSET + 2,
+                    yahseHuntingGroundsID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+        },
+    },
+
+    [xi.zone.YORCIA_WEALD] =
+    {
+        reiveObjRespawnTime = 3600, -- 60 minutes
+        reiveMobRespawnTime = 300,  -- 5 minutes
+        reive =
+        {
+
+            -- !pos 100 1.6 342 263
+            [1] =
+            {
+                mob =
+                {
+                    yorciaWealdID.mob.REIVE_MOB_OFFSET + 2,
+                    yorciaWealdID.mob.REIVE_MOB_OFFSET + 3,
+                    yorciaWealdID.mob.REIVE_MOB_OFFSET + 4,
+                    yorciaWealdID.mob.REIVE_MOB_OFFSET + 5,
+                },
+                obstacles =
+                {
+                    yorciaWealdID.mob.REIVE_MOB_OFFSET + 0,
+                    yorciaWealdID.mob.REIVE_MOB_OFFSET + 1,
+                },
+                collision =
+                {
+                    yorciaWealdID.npc.REIVE_COLLISION_OFFSET + 0,
+                },
+            },
+
+            -- !pos -102 1.57 180 263
+            [2] =
+            {
+                mob =
+                {
+                    yorciaWealdID.mob.REIVE_MOB_OFFSET + 8,
+                    yorciaWealdID.mob.REIVE_MOB_OFFSET + 9,
+                    yorciaWealdID.mob.REIVE_MOB_OFFSET + 10,
+                    yorciaWealdID.mob.REIVE_MOB_OFFSET + 11,
+                },
+                obstacles =
+                {
+                    yorciaWealdID.mob.REIVE_MOB_OFFSET + 6,
+                    yorciaWealdID.mob.REIVE_MOB_OFFSET + 7,
+                },
+                collision =
+                {
+                    yorciaWealdID.npc.REIVE_COLLISION_OFFSET + 3,
+                },
+            },
+
+            -- !pos 258 1.57 -140 263
+            [3] =
+            {
+                mob =
+                {
+                    yorciaWealdID.mob.REIVE_MOB_OFFSET + 14,
+                    yorciaWealdID.mob.REIVE_MOB_OFFSET + 15,
+                    yorciaWealdID.mob.REIVE_MOB_OFFSET + 16,
+                    yorciaWealdID.mob.REIVE_MOB_OFFSET + 17,
+                },
+                obstacles =
+                {
+                    yorciaWealdID.mob.REIVE_MOB_OFFSET + 12,
+                    yorciaWealdID.mob.REIVE_MOB_OFFSET + 13,
+                },
+                collision =
+                {
+                    yorciaWealdID.npc.REIVE_COLLISION_OFFSET + 1,
+                },
+            },
+
+            -- !pos 60 1.63 -178 263
+            [4] =
+            {
+                mob =
+                {
+                    yorciaWealdID.mob.REIVE_MOB_OFFSET + 20,
+                    yorciaWealdID.mob.REIVE_MOB_OFFSET + 21,
+                    yorciaWealdID.mob.REIVE_MOB_OFFSET + 22,
+                    yorciaWealdID.mob.REIVE_MOB_OFFSET + 23,
+                },
+                obstacles =
+                {
+                    yorciaWealdID.mob.REIVE_MOB_OFFSET + 18,
+                    yorciaWealdID.mob.REIVE_MOB_OFFSET + 19,
+                },
+                collision =
+                {
+                    yorciaWealdID.npc.REIVE_COLLISION_OFFSET + 2,
+                },
+            },
+        },
+    },
+}

--- a/scripts/globals/colonization_reive_data.lua
+++ b/scripts/globals/colonization_reive_data.lua
@@ -632,15 +632,15 @@ xi.reives.zoneData =
             {
                 mob =
                 {
-                    marjamiRavineID.mob.REIVE_MOB_OFFSET,
-                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 1,
                     marjamiRavineID.mob.REIVE_MOB_OFFSET + 2,
                     marjamiRavineID.mob.REIVE_MOB_OFFSET + 3,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 4,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 5,
                 },
                 obstacles =
                 {
-                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 4,
-                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 5,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET,
+                    marjamiRavineID.mob.REIVE_MOB_OFFSET + 1,
                 },
                 collision =
                 {

--- a/scripts/globals/colonization_reive_data.lua
+++ b/scripts/globals/colonization_reive_data.lua
@@ -916,7 +916,7 @@ xi.reives.zoneData =
                 },
             },
 
-            -- !pos -123 -15.89 -419.9 265  -- TODO: Need Fix for collision. Likely need a capture for the collision position.
+            -- !pos -123 -15.89 -419.9 265
             [4] =
             {
                 mob =
@@ -937,7 +937,7 @@ xi.reives.zoneData =
                 collision =
                 {
                     morimarBasaltFieldsID.npc.REIVE_COLLISION_OFFSET + 12,
-                    -- TODO: Missing a blocker here.
+                    morimarBasaltFieldsID.npc.REIVE_COLLISION_OFFSET + 13,
                 },
             },
 

--- a/scripts/globals/colonization_reives.lua
+++ b/scripts/globals/colonization_reives.lua
@@ -1,54 +1,247 @@
 -----------------------------------
 --  Colonization Reives
 -- https://www.bg-wiki.com/ffxi/Category:Reive#Colonization_Reive
+-- https://wiki.ffo.jp/html/28105.html
 -----------------------------------
 require('scripts/globals/utils')
 -----------------------------------
 xi = xi or {}
 xi.reives = xi.reives or {}
 
--- NOTE: Reives blockers act like doors and blockers in other parts of the game.
+-- NOTE: Reives collision blockers act like doors and blockers in other parts of the game.
 --       One NPC acts as the visual element and another acts as the collision
 --       blocker.
+-- NOTE: Some zones have the collision and visual combined into one NPC (See Khamihr Drifts for an example).
 
-xi.reives.setupZone = function(zone)
-    local ID = zones[zone:getID()]
+-----------------------------------
+-- Fetches the the mob ID of obstacles and returns the reive table number they belong to.
+-- Used to track which obstacle IDs belong to which reives in the mob script.
+-----------------------------------
+xi.reives.findReiveNumByObstacle = function(zoneID, obstacleId)
+    -- Access the zone data based on the zoneID
+    local zoneData = xi.reives.zoneData[zoneID]
 
-    if xi.settings.main.ENABLE_SOA == 1 then
-        for idx, _ in ipairs(ID.reive) do
-            xi.reives.enableReive(ID, idx)
+    if zoneData then
+        -- Iterate through each reive in the zone's reive table.
+        for reiveNum, reiveData in pairs(zoneData.reive) do
+            -- Check if the obstacleId matches any of the obstacle IDs in the associated reive.
+            for _, id in pairs(reiveData.obstacles) do
+                if id == obstacleId then
+                    return reiveNum
+                end
+            end
+        end
+    else
+        -- print('No data found for zoneID:', zoneID)
+    end
+
+    -- Return nil if no matching reive was found
+    return nil
+end
+
+-----------------------------------
+-- Iterates through mobs located in the reive's obstacle table and tracks how many are active.
+-- Used to track reive progress before triggering battle end/cleanup.
+-- Note: "Would using a listener to handle incremental counting be better?"
+-----------------------------------
+xi.reives.checkObjectiveStatus = function(zoneID, reiveNum)
+    -- Check if zoneID and reiveNum exist in the zoneData.
+    local zoneData = xi.reives.zoneData[zoneID]
+    if not zoneData or not zoneData.reive[reiveNum] then
+        -- print('Invalid zoneID or reiveNum.')
+        return false
+    end
+
+    local reiveData = zoneData.reive[reiveNum]
+    local check = true
+
+    -- Iterate over each obstacle in the reive's obstacle table.
+    for _, id in ipairs(reiveData.obstacles) do
+        local mob = GetMobByID(id)
+
+        -- Ensure the mob is valid before calling isDead.
+        if mob and not mob:isDead() then
+            check = false
+            break -- No need to check further if any obstacle is alive.
+        end
+    end
+
+    return check -- If all obstacles are dead, return true (reive is completed)
+end
+
+-----------------------------------
+-- Added to a reive obstacle's spawn script. Handles spawning and respawning of reives.
+-----------------------------------
+xi.reives.onMobSpawn = function(mob)
+    local mobID  = mob:getID()
+    local zoneID = mob:getZoneID()
+
+    -- Iterate through each zone in zoneData
+    for zone, data in pairs(xi.reives.zoneData) do
+        if zone == zoneID then
+            -- Iterate through each reive in the zone's reive table
+            for i, reiveData in pairs(data.reive) do
+                -- Check if the mobID matches any of the obstacle IDs
+                for _, obstacleID in pairs(reiveData.obstacles) do
+                    if mobID == obstacleID then
+                        -- Call enableReive if the mobID matches an obstacleID
+                        xi.reives.enableReive(zoneID, i)
+                    end
+                end
+            end
         end
     end
 end
 
-xi.reives.enableReive = function(ID, reiveNum)
-    for _, entryId in pairs(ID.reive[reiveNum].mob) do
-        SpawnMob(entryId)
+-----------------------------------
+-- Added to a reive obstacle's onMobDeath script. Handles disabling of reives.
+-----------------------------------
+xi.reives.onMobDeath = function(mob)
+    -- Find the reive number based on the mob ID (which is an obstacle ID)
+    local obstacleId = mob:getID()
+    local zoneID     = mob:getZoneID()
+    local reiveNum   = xi.reives.findReiveNumByObstacle(zoneID, obstacleId)
 
-        -- TODO: Set name flags (sword)
-    end
+    if reiveNum then
 
-    for _, entryId in pairs(ID.reive[reiveNum].obstacles) do
-        GetMobByID(entryId):setAnimation(xi.animation.CLOSE_DOOR)
-    end
-
-    for _, entryId in pairs(ID.reive[reiveNum].collision) do
-        GetNPCByID(entryId):setAnimation(xi.animation.CLOSE_DOOR)
+        -- If no obstacles remain, or remaining obstacles match initial count, disable the reive
+        if xi.reives.checkObjectiveStatus(zoneID, reiveNum) then
+            xi.reives.disableReive(zoneID, reiveNum)
+        end
     end
 end
 
-xi.reives.disableReive = function(ID, reiveNum)
-    for _, entryId in pairs(ID.reive[reiveNum].mob) do
-        DespawnMob(entryId)
+-----------------------------------
+-- Set up the initial enableReive on zone start up.
+-----------------------------------
+xi.reives.setupZone = function(zone)
+    local zoneID = zone:getID()
 
-        -- TODO: Mobs should go grey and fade away, instead of plain despawn
+    if xi.settings.main.ENABLE_SOA == 1 then -- If SOA is enabled, spawn the zone's reives on zone initialize.
+        for reiveNum, _ in ipairs(xi.reives.zoneData[zoneID].reive) do
+            xi.reives.enableReive(zoneID, reiveNum)
+        end
+    end
+end
+
+-----------------------------------
+-- xi.reives.enableReive = function(zoneID, reiveNum)
+-- Contains functions used to start a reive.
+-- zoneID:   Which zone this reive is located in (Data stored in globals/colonization_reive_data.lua)
+-- reiveNum: Reive number passed from mob's onMobSpawn script using the xi.reives.onMobSpawn helper function.
+-----------------------------------
+xi.reives.enableReive = function(zoneID, reiveNum)
+    local zoneData            = xi.reives.zoneData[zoneID]
+    local reiveObjRespawnTime = 0
+    local reiveMobRespawnTime = zoneData.reiveMobRespawnTime
+
+    if not zoneData or not zoneData.reive[reiveNum] then
+        -- print('Invalid zoneID or reiveNum.')
+
+        return
     end
 
-    for _, entryId in pairs(ID.reive[reiveNum].obstacles) do
-        GetMobByID(entryId):setAnimation(xi.animation.OPEN_DOOR)
+    local reiveData = zoneData.reive[reiveNum]
+
+    -- Handle mobs
+    for _, entryId in pairs(reiveData.mob) do
+        local mob = GetMobByID(entryId)
+        if mob then
+            if not mob:isAlive() then
+                SpawnMob(entryId)  -- Spawn the reive defenders
+                -- TODO: Set name flags (sword)
+            end
+
+            mob:setRespawnTime(reiveMobRespawnTime)  -- Set respawn time of the reive defenders
+        end
     end
 
-    for _, entryId in pairs(ID.reive[reiveNum].collision) do
-        GetNPCByID(entryId):setAnimation(xi.animation.OPEN_DOOR)
+    -- Handle obstacles
+    for _, entryId in pairs(reiveData.obstacles) do
+        local mob = GetMobByID(entryId)
+        if mob then
+            if not mob:isAlive() then
+                SpawnMob(entryId)  -- Spawn the reive obstacles
+                mob:setAnimation(xi.animation.CLOSE_DOOR)
+            end
+            mob:setAutoAttackEnabled(false)         -- Obstacles do not auto attack.
+            mob:setMobAbilityEnabled(false)         -- Obstacles should not use mobskills.
+            mob:setMobMod(xi.mobMod.NO_MOVE, 1)     -- Obstacles do not move.
+            mob:setMobMod(xi.mobMod.NO_REST, 1)     -- Obstacles do not recover HP when not in combat.
+            mob:setRespawnTime(reiveObjRespawnTime) -- Set the respawn time of obstacles to 0 while reive is active.
+            -- TODO: Handle mob damage reduction based on keyitems the player has or doesn't have.
+            -- TODO: Defender mobs should not aggro by default unless players are already in combat with the objectives.
+        end
     end
+
+    -- Handle collision objects
+    for _, entryId in pairs(reiveData.collision) do
+        local npc = GetNPCByID(entryId)
+        if npc then
+            npc:setAnimation(xi.animation.CLOSE_DOOR)  -- Close the collision blocker
+        end
+    end
+
+    -- TODO:
+    -- Handle announcement message when a reive spawns.
+    -- Handle confrontation effect when a player walks into the reive battle area and the associated boundry fence.
+    -- Players should get a count down if they attempt to leave the fenced area and will fail/get locked out of reive combat for a duration if they do not return.
+    -- Lockout for leaving the area is 5 minutes.
+end
+
+-----------------------------------
+-- xi.reives.disableReive = function(ID, reiveNum, respawnTime)
+-- Contains functions to end a reive.
+-- zoneID      : Zone the reive is located in.
+-- reiveNum    : Reive number defined.
+-----------------------------------
+xi.reives.disableReive = function(zoneID, reiveNum)
+    -- Access the zone data and reive data
+    local zoneData = xi.reives.zoneData[zoneID]
+    if not zoneData or not zoneData.reive[reiveNum] then
+        -- print('Invalid zoneID or reiveNum.')
+        return
+    end
+
+    local reiveData           = zoneData.reive[reiveNum]
+    local reiveObjRespawnTime = zoneData.reiveObjRespawnTime
+    local reiveMobRespawnTime = 0
+
+    -- print('Reive Disabled', reiveNum)
+
+    -- Handle mobs
+    for _, entryId in pairs(reiveData.mob) do
+        local mob = GetMobByID(entryId)
+        if mob then
+            mob:setRespawnTime(reiveMobRespawnTime) -- Sets RespawnTime of Adds to 0 so they don't respawn until the reive begins again.
+            if mob:isSpawned() then
+                DespawnMob(entryId) -- Despawn defender mobs on reive end.
+                -- TODO: Mobs should go grey and fade away, instead of plain despawn
+            end
+        end
+    end
+
+    -- Handle obstacles
+    for _, entryId in pairs(reiveData.obstacles) do
+        local mob = GetMobByID(entryId)
+        if mob then
+            mob:setAnimation(xi.animation.OPEN_DOOR)
+            mob:setRespawnTime(reiveObjRespawnTime) -- Set the time for the next reive spawn
+            if mob:isSpawned() then
+                DespawnMob(entryId)
+            end
+        end
+    end
+
+    -- Handle collision objects
+    for _, entryId in pairs(reiveData.collision) do
+        local npc = GetNPCByID(entryId)
+        if npc then
+            npc:setAnimation(xi.animation.OPEN_DOOR) -- Open the collision blocker until the next reive spawns
+            -- print('collision open', reiveNum)
+        end
+    end
+
+    -- TODO: Handle disabling of the confrontation effect/objective fence.
+    -- TODO: Handle rewards after defeating the reive.
 end

--- a/scripts/globals/colonization_reives.lua
+++ b/scripts/globals/colonization_reives.lua
@@ -1,54 +1,247 @@
 -----------------------------------
 --  Colonization Reives
 -- https://www.bg-wiki.com/ffxi/Category:Reive#Colonization_Reive
+-- https://wiki.ffo.jp/html/28105.html
 -----------------------------------
 require('scripts/globals/utils')
 -----------------------------------
 xi = xi or {}
 xi.reives = xi.reives or {}
 
--- NOTE: Reives blockers act like doors and blockers in other parts of the game.
+-- NOTE: Reives collision blockers act like doors and blockers in other parts of the game.
 --       One NPC acts as the visual element and another acts as the collision
 --       blocker.
+-- NOTE: Some zones have the collision and visual combined into one NPC (See Khamihr Drifts for an example).
 
-xi.reives.setupZone = function(zone)
-    local ID = zones[zone:getID()]
+-----------------------------------
+-- Fetches the the mob ID of obstacles and returns the reive table number they belong to.
+-- Used to track which obstacle IDs belong to which reives in the mob script.
+-----------------------------------
+xi.reives.findReiveNumByObstacle = function(zoneID, obstacleId)
+    -- Access the zone data based on the zoneID
+    local zoneData = xi.reives.zoneData[zoneID]
 
-    if xi.settings.main.ENABLE_SOA == 1 then
-        for idx, _ in ipairs(ID.reive) do
-            xi.reives.enableReive(ID, idx)
+    if zoneData then
+        -- Iterate through each reive in the zone's reive table.
+        for reiveNum, reiveData in pairs(zoneData.reive) do
+            -- Check if the obstacleId matches any of the obstacle IDs in the associated reive.
+            for _, id in pairs(reiveData.obstacles) do
+                if id == obstacleId then
+                    return reiveNum
+                end
+            end
+        end
+    else
+        print("No data found for zoneID:", zoneID)
+    end
+    
+    -- Return nil if no matching reive was found
+    return nil
+end
+
+-----------------------------------
+-- Iterates through mobs located in the reive's obstacle table and tracks how many are active.
+-- Used to track reive progress before triggering battle end/cleanup.
+-- Note: "Would using a listener to handle incremental counting be better?"
+-----------------------------------
+xi.reives.checkObjectiveStatus = function(zoneID, reiveNum)
+    -- Check if zoneID and reiveNum exist in the zoneData.
+    local zoneData = xi.reives.zoneData[zoneID]
+    if not zoneData or not zoneData.reive[reiveNum] then
+        print("Invalid zoneID or reiveNum.")
+        return false
+    end
+
+    local reiveData = zoneData.reive[reiveNum]
+    local check = true
+
+    -- Iterate over each obstacle in the reive's obstacle table.
+    for _, id in ipairs(reiveData.obstacles) do
+        local mob = GetMobByID(id)
+        
+        -- Ensure the mob is valid before calling isDead.
+        if mob and not mob:isDead() then
+            check = false
+            break -- No need to check further if any obstacle is alive.
+        end
+    end
+
+    return check -- If all obstacles are dead, return true (reive is completed)
+end
+
+-----------------------------------
+-- Added to a reive obstacle's spawn script. Handles spawning and respawning of reives.
+-----------------------------------
+xi.reives.onMobSpawn = function(mob)
+    local mobID  = mob:getID()
+    local zoneID = mob:getZoneID()
+
+    -- Iterate through each zone in zoneData
+    for zone, data in pairs(xi.reives.zoneData) do
+        if zone == zoneID then
+            -- Iterate through each reive in the zone's reive table
+            for i, reiveData in pairs(data.reive) do
+                -- Check if the mobID matches any of the obstacle IDs
+                for _, obstacleID in pairs(reiveData.obstacles) do
+                    if mobID == obstacleID then
+                        -- Call enableReive if the mobID matches an obstacleID
+                        xi.reives.enableReive(zoneID, i)
+                    end
+                end
+            end
         end
     end
 end
 
-xi.reives.enableReive = function(ID, reiveNum)
-    for _, entryId in pairs(ID.reive[reiveNum].mob) do
-        SpawnMob(entryId)
+-----------------------------------
+-- Added to a reive obstacle's onMobDeath script. Handles disabling of reives.
+-----------------------------------
+xi.reives.onMobDeath = function(mob)
+    -- Find the reive number based on the mob ID (which is an obstacle ID)
+    local obstacleId = mob:getID()
+    local zoneID     = mob:getZoneID()
+    local reiveNum   = xi.reives.findReiveNumByObstacle(zoneID, obstacleId)
 
-        -- TODO: Set name flags (sword)
-    end
+    if reiveNum then
 
-    for _, entryId in pairs(ID.reive[reiveNum].obstacles) do
-        GetMobByID(entryId):setAnimation(xi.animation.CLOSE_DOOR)
-    end
-
-    for _, entryId in pairs(ID.reive[reiveNum].collision) do
-        GetNPCByID(entryId):setAnimation(xi.animation.CLOSE_DOOR)
+        -- If no obstacles remain, or remaining obstacles match initial count, disable the reive
+        if xi.reives.checkObjectiveStatus(zoneID, reiveNum) then
+            xi.reives.disableReive(zoneID, reiveNum)
+        end
     end
 end
 
-xi.reives.disableReive = function(ID, reiveNum)
-    for _, entryId in pairs(ID.reive[reiveNum].mob) do
-        DespawnMob(entryId)
+-----------------------------------
+-- Set up the initial enableReive on zone start up.
+-----------------------------------
+xi.reives.setupZone = function(zone)
+    local ZoneID = zone:getID()
 
-        -- TODO: Mobs should go grey and fade away, instead of plain despawn
+    if xi.settings.main.ENABLE_SOA == 1 then -- If SOA is enabled, spawn the zone's reives on zone initialize.
+        for reiveNum, _ in ipairs(xi.reives.zoneData[ZoneID].reive) do
+            xi.reives.enableReive(ZoneID, reiveNum)
+        end
+    end
+end
+
+-----------------------------------
+-- xi.reives.enableReive = function(zoneID, reiveNum)
+-- Contains functions used to start a reive.
+-- zoneID:   Which zone this reive is located in (Data stored in globals/colonization_reive_data.lua)
+-- reiveNum: Reive number passed from mob's onMobSpawn script using the xi.reives.onMobSpawn helper function.
+-----------------------------------
+xi.reives.enableReive = function(zoneID, reiveNum)
+    local zoneData            = xi.reives.zoneData[zoneID]
+    local reiveObjRespawnTime = 0
+    local reiveMobRespawnTime = zoneData.reiveMobRespawnTime
+
+    -- Access the zone data and reive data
+    local zoneData = xi.reives.zoneData[zoneID]
+    if not zoneData or not zoneData.reive[reiveNum] then
+        print('Invalid zoneID or reiveNum.')
+        return
     end
 
-    for _, entryId in pairs(ID.reive[reiveNum].obstacles) do
-        GetMobByID(entryId):setAnimation(xi.animation.OPEN_DOOR)
+    local reiveData = zoneData.reive[reiveNum]
+
+    -- Handle mobs
+    for _, entryId in pairs(reiveData.mob) do
+        local mob = GetMobByID(entryId)
+        if mob then
+            if not mob:isAlive() then
+                SpawnMob(entryId)  -- Spawn the reive defenders
+                -- TODO: Set name flags (sword)
+            end
+            mob:setRespawnTime(reiveMobRespawnTime)  -- Set respawn time of the reive defenders
+        end
     end
 
-    for _, entryId in pairs(ID.reive[reiveNum].collision) do
-        GetNPCByID(entryId):setAnimation(xi.animation.OPEN_DOOR)
+    -- Handle obstacles
+    for _, entryId in pairs(reiveData.obstacles) do
+        local mob = GetMobByID(entryId)
+        if mob then
+            if not mob:isAlive() then
+                SpawnMob(entryId)  -- Spawn the reive obstacles
+                mob:setAnimation(xi.animation.CLOSE_DOOR)
+            end
+            mob:setAutoAttackEnabled(false)         -- Obstacles do not auto attack.
+            mob:setMobAbilityEnabled(false)         -- Obstacles should not use mobskills.
+            mob:setMobMod(xi.mobMod.NO_MOVE, 1)     -- Obstacles do not move.
+            mob:setMobMod(xi.mobMod.NO_REST, 1)     -- Obstacles do not recover HP when not in combat.
+            mob:setRespawnTime(reiveObjRespawnTime) -- Set the respawn time of obstacles to 0 while reive is active.
+            -- TODO: Handle mob damage reduction based on keyitems the player has or doesn't have.
+            -- TODO: Defender mobs should not aggro by default unless players are already in combat with the objectives.
+        end
     end
+
+    -- Handle collision objects
+    for _, entryId in pairs(reiveData.collision) do
+        local npc = GetNPCByID(entryId)
+        if npc then
+            npc:setAnimation(xi.animation.CLOSE_DOOR)  -- Close the collision blocker
+        end
+    end
+
+    -- TODO:
+    -- Handle announcement message when a reive spawns.
+    -- Handle confrontation effect when a player walks into the reive battle area and the associated boundry fence. 
+    -- Players should get a count down if they attempt to leave the fenced area and will fail/get locked out of reive combat for a duration if they do not return.
+    -- Lockout for leaving the area is 5 minutes.
+end
+
+-----------------------------------
+-- xi.reives.disableReive = function(ID, reiveNum, respawnTime)
+-- Contains functions to end a reive.
+-- zoneID      : Zone the reive is located in.
+-- reiveNum    : Reive number defined.
+-----------------------------------
+xi.reives.disableReive = function(zoneID, reiveNum)
+    -- Access the zone data and reive data
+    local zoneData = xi.reives.zoneData[zoneID]
+    if not zoneData or not zoneData.reive[reiveNum] then
+        print('Invalid zoneID or reiveNum.')
+        return
+    end
+
+    local reiveData           = zoneData.reive[reiveNum]
+    local reiveObjRespawnTime = zoneData.reiveObjRespawnTime
+    local reiveMobRespawnTime = 0
+
+    print('Reive Disabled', reiveNum)
+
+    -- Handle mobs
+    for _, entryId in pairs(reiveData.mob) do
+        local mob = GetMobByID(entryId)
+        if mob then
+            mob:setRespawnTime(reiveMobRespawnTime) -- Sets RespawnTime of Adds to 0 so they don't respawn until the reive begins again.
+            if mob:isSpawned() then
+                DespawnMob(entryId) -- Despawn defender mobs on reive end.
+                -- TODO: Mobs should go grey and fade away, instead of plain despawn
+            end
+        end
+    end
+
+    -- Handle obstacles
+    for _, entryId in pairs(reiveData.obstacles) do
+        local mob = GetMobByID(entryId)
+        if mob then
+            mob:setAnimation(xi.animation.OPEN_DOOR)
+            mob:setRespawnTime(reiveObjRespawnTime) -- Set the time for the next reive spawn
+            if mob:isSpawned() then
+                DespawnMob(entryId)
+            end
+        end
+    end
+
+    -- Handle collision objects
+    for _, entryId in pairs(reiveData.collision) do
+        local npc = GetNPCByID(entryId)
+        if npc then
+            npc:setAnimation(xi.animation.OPEN_DOOR) -- Open the collision blocker until the next reive spawns
+            print('collision open', reiveNum)
+        end
+    end
+
+    -- TODO: Handle disabling of the confrontation effect/objective fence.
+    -- TODO: Handle rewards after defeating the reive.
 end

--- a/scripts/zones/Ceizak_Battlegrounds/IDs.lua
+++ b/scripts/zones/Ceizak_Battlegrounds/IDs.lua
@@ -37,35 +37,11 @@ zones[xi.zone.CEIZAK_BATTLEGROUNDS] =
         TRANSCENDENT_SCORPION   = GetFirstID('Transcendent_Scorpion'),
         MASTOP                  = GetFirstID('Mastop'),
         TAXET                   = GetFirstID('Taxet'),
+        REIVE_MOB_OFFSET        = GetFirstID('Knotted_Root'),
     },
     npc =
     {
-    },
-    reive =
-    {
-        -- Bounding Chapuli (I-8)
-        [1] =
-        {
-            mob =
-            {
-                17846627,
-                17846628,
-                17846629,
-                17846630,
-            },
-            -- Knotted Vines
-            obstacles =
-            {
-                17846624,
-                17846625,
-                17846626,
-            },
-            collision =
-            {
-                17846761,
-                17846762,
-            },
-        },
+        REIVE_COLLISION_OFFSET = GetFirstID('_790'),
     },
 }
 

--- a/scripts/zones/Ceizak_Battlegrounds/mobs/Knotted_Root.lua
+++ b/scripts/zones/Ceizak_Battlegrounds/mobs/Knotted_Root.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- Area: Ceizak Battlegrounds
+-- NPC: Knotted Root
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.reives.onMobSpawn(mob)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    xi.reives.onMobDeath(mob)
+end
+
+return entity

--- a/scripts/zones/Cirdas_Caverns/IDs.lua
+++ b/scripts/zones/Cirdas_Caverns/IDs.lua
@@ -18,9 +18,11 @@ zones[xi.zone.CIRDAS_CAVERNS] =
     },
     mob =
     {
+        REIVE_MOB_OFFSET = GetFirstID('Knotted_Root'),
     },
     npc =
     {
+        REIVE_COLLISION_OFFSET = GetFirstID('_pim'),
     },
 }
 

--- a/scripts/zones/Cirdas_Caverns/Zone.lua
+++ b/scripts/zones/Cirdas_Caverns/Zone.lua
@@ -5,6 +5,8 @@
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
+    xi.reives.setupZone(zone)
+
     -- Area around Ergon Locus (17883912)
     local locusX = -140.000
     local locusY = 10.000

--- a/scripts/zones/Cirdas_Caverns/mobs/Knotted_Root.lua
+++ b/scripts/zones/Cirdas_Caverns/mobs/Knotted_Root.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- Area: Cirdas Caverns
+-- NPC: Knotted Root
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.reives.onMobSpawn(mob)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    xi.reives.onMobDeath(mob)
+end
+
+return entity

--- a/scripts/zones/Dho_Gates/IDs.lua
+++ b/scripts/zones/Dho_Gates/IDs.lua
@@ -18,9 +18,11 @@ zones[xi.zone.DHO_GATES] =
     },
     mob =
     {
+        REIVE_MOB_OFFSET = GetFirstID('Knotted_Root'),
     },
     npc =
     {
+        REIVE_COLLISION_OFFSET = GetFirstID('_7k0'),
     },
 }
 

--- a/scripts/zones/Dho_Gates/Zone.lua
+++ b/scripts/zones/Dho_Gates/Zone.lua
@@ -5,6 +5,7 @@
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
+    xi.reives.setupZone(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Dho_Gates/mobs/Knotted_Root.lua
+++ b/scripts/zones/Dho_Gates/mobs/Knotted_Root.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- Area: Dho Gates
+-- NPC: Knotted Root
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.reives.onMobSpawn(mob)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    xi.reives.onMobDeath(mob)
+end
+
+return entity

--- a/scripts/zones/Foret_de_Hennetiel/IDs.lua
+++ b/scripts/zones/Foret_de_Hennetiel/IDs.lua
@@ -33,9 +33,11 @@ zones[xi.zone.FORET_DE_HENNETIEL] =
     },
     mob =
     {
+        REIVE_MOB_OFFSET = GetFirstID('Broadleaf_Palm'),
     },
     npc =
     {
+        REIVE_COLLISION_OFFSET = GetFirstID('_7a0'),
     },
 }
 

--- a/scripts/zones/Foret_de_Hennetiel/Zone.lua
+++ b/scripts/zones/Foret_de_Hennetiel/Zone.lua
@@ -5,6 +5,8 @@
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
+    xi.reives.setupZone(zone)
+
     zone:registerTriggerArea(1, 529.946, 17.69, 157.579, 0, 0, 0) -- Ergon Locus, Circular Trigger Area, 17.69 Radius
 end
 

--- a/scripts/zones/Foret_de_Hennetiel/mobs/Broadleaf_Palm.lua
+++ b/scripts/zones/Foret_de_Hennetiel/mobs/Broadleaf_Palm.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- Area: Foret De Hennetiel
+-- NPC: Broadleaf Palm
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.reives.onMobSpawn(mob)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    xi.reives.onMobDeath(mob)
+end
+
+return entity

--- a/scripts/zones/Kamihr_Drifts/IDs.lua
+++ b/scripts/zones/Kamihr_Drifts/IDs.lua
@@ -33,9 +33,11 @@ zones[xi.zone.KAMIHR_DRIFTS] =
     },
     mob =
     {
+        REIVE_MOB_OFFSET = GetFirstID('Icy_Palisade'),
     },
     npc =
     {
+        REIVE_COLLISION_OFFSET = GetFirstID('_7f0'),
     },
 }
 

--- a/scripts/zones/Kamihr_Drifts/Zone.lua
+++ b/scripts/zones/Kamihr_Drifts/Zone.lua
@@ -5,6 +5,7 @@
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
+    xi.reives.setupZone(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Kamihr_Drifts/mobs/Icy_Palisade.lua
+++ b/scripts/zones/Kamihr_Drifts/mobs/Icy_Palisade.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- Area: Kamihr Drifts
+-- NPC: Icy Palisade
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.reives.onMobSpawn(mob)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    xi.reives.onMobDeath(mob)
+end
+
+return entity

--- a/scripts/zones/Marjami_Ravine/IDs.lua
+++ b/scripts/zones/Marjami_Ravine/IDs.lua
@@ -33,9 +33,11 @@ zones[xi.zone.MARJAMI_RAVINE] =
     },
     mob =
     {
+        REIVE_MOB_OFFSET = GetFirstID('Monolithic_Boulder'),
     },
     npc =
     {
+        REIVE_COLLISION_OFFSET = GetFirstID('_7e0'),
     },
 }
 

--- a/scripts/zones/Marjami_Ravine/Zone.lua
+++ b/scripts/zones/Marjami_Ravine/Zone.lua
@@ -5,6 +5,7 @@
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
+    xi.reives.setupZone(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Marjami_Ravine/mobs/Monolithic_Boulder.lua
+++ b/scripts/zones/Marjami_Ravine/mobs/Monolithic_Boulder.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- Area: Marjami Ravine
+-- NPC: Monolithic Boulder
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.reives.onMobSpawn(mob)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    xi.reives.onMobDeath(mob)
+end
+
+return entity

--- a/scripts/zones/Moh_Gates/IDs.lua
+++ b/scripts/zones/Moh_Gates/IDs.lua
@@ -18,9 +18,11 @@ zones[xi.zone.MOH_GATES] =
     },
     mob =
     {
+        REIVE_MOB_OFFSET = GetFirstID('Knotted_Root'),
     },
     npc =
     {
+        REIVE_COLLISION_OFFSET = GetFirstID('_7h0'),
     },
 }
 

--- a/scripts/zones/Moh_Gates/Zone.lua
+++ b/scripts/zones/Moh_Gates/Zone.lua
@@ -5,6 +5,7 @@
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
+    xi.reives.setupZone(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Moh_Gates/mobs/Knotted_Root.lua
+++ b/scripts/zones/Moh_Gates/mobs/Knotted_Root.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- Area: Moh Gates
+-- NPC: Knotted Root
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.reives.onMobSpawn(mob)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    xi.reives.onMobDeath(mob)
+end
+
+return entity

--- a/scripts/zones/Morimar_Basalt_Fields/IDs.lua
+++ b/scripts/zones/Morimar_Basalt_Fields/IDs.lua
@@ -31,9 +31,11 @@ zones[xi.zone.MORIMAR_BASALT_FIELDS] =
     },
     mob =
     {
+        REIVE_MOB_OFFSET = GetFirstID('Bedrock_Crag'),
     },
     npc =
     {
+        REIVE_COLLISION_OFFSET = GetFirstID('_7d0'),
     },
 }
 

--- a/scripts/zones/Morimar_Basalt_Fields/Zone.lua
+++ b/scripts/zones/Morimar_Basalt_Fields/Zone.lua
@@ -5,6 +5,7 @@
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
+    xi.reives.setupZone(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Morimar_Basalt_Fields/mobs/Bedrock_Crag.lua
+++ b/scripts/zones/Morimar_Basalt_Fields/mobs/Bedrock_Crag.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- Area: Morimar Basalt Fields
+-- NPC: Root
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.reives.onMobSpawn(mob)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    xi.reives.onMobDeath(mob)
+end
+
+return entity

--- a/scripts/zones/Outer_RaKaznar/IDs.lua
+++ b/scripts/zones/Outer_RaKaznar/IDs.lua
@@ -27,9 +27,11 @@ zones[xi.zone.OUTER_RAKAZNAR] =
     },
     mob =
     {
+        REIVE_MOB_OFFSET = GetFirstID('Amaranth_Barrier'),
     },
     npc =
     {
+        REIVE_COLLISION_OFFSET = GetFirstID('_7m0'),
     },
 }
 

--- a/scripts/zones/Outer_RaKaznar/Zone.lua
+++ b/scripts/zones/Outer_RaKaznar/Zone.lua
@@ -5,6 +5,8 @@
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
+    xi.reives.setupZone(zone)
+
     zone:registerTriggerArea(1, -942, -191.6, -22, -937, -191.4, -18)
 end
 

--- a/scripts/zones/Outer_RaKaznar/mobs/Amaranth_Barrier.lua
+++ b/scripts/zones/Outer_RaKaznar/mobs/Amaranth_Barrier.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- Area: Outer RaKaznar
+-- NPC: Amaranth Barrier
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.reives.onMobSpawn(mob)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    xi.reives.onMobDeath(mob)
+end
+
+return entity

--- a/scripts/zones/RaKaznar_Inner_Court/IDs.lua
+++ b/scripts/zones/RaKaznar_Inner_Court/IDs.lua
@@ -19,9 +19,11 @@ zones[xi.zone.RAKAZNAR_INNER_COURT] =
     },
     mob =
     {
+        REIVE_MOB_OFFSET = GetFirstID('Heliotrope_Barrier'),
     },
     npc =
     {
+        REIVE_COLLISION_OFFSET = GetFirstID('_7o0'),
     },
 }
 

--- a/scripts/zones/RaKaznar_Inner_Court/Zone.lua
+++ b/scripts/zones/RaKaznar_Inner_Court/Zone.lua
@@ -5,6 +5,7 @@
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
+    xi.reives.setupZone(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/RaKaznar_Inner_Court/mobs/Heliotrope_Barrier.lua
+++ b/scripts/zones/RaKaznar_Inner_Court/mobs/Heliotrope_Barrier.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- Area: RaKaznar Inner Court
+-- NPC: Heliotrope Barrier
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.reives.onMobSpawn(mob)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    xi.reives.onMobDeath(mob)
+end
+
+return entity

--- a/scripts/zones/Sih_Gates/IDs.lua
+++ b/scripts/zones/Sih_Gates/IDs.lua
@@ -18,9 +18,11 @@ zones[xi.zone.SIH_GATES] =
     },
     mob =
     {
+        REIVE_MOB_OFFSET = GetFirstID('Knotted_Root'),
     },
     npc =
     {
+        REIVE_COLLISION_OFFSET = GetFirstID('_7g0'),
     },
 }
 

--- a/scripts/zones/Sih_Gates/Zone.lua
+++ b/scripts/zones/Sih_Gates/Zone.lua
@@ -5,6 +5,7 @@
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
+    xi.reives.setupZone(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Sih_Gates/mobs/Knotted_Root.lua
+++ b/scripts/zones/Sih_Gates/mobs/Knotted_Root.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- Area: Sih Gates
+-- NPC: Knotted Root
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.reives.onMobSpawn(mob)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    xi.reives.onMobDeath(mob)
+end
+
+return entity

--- a/scripts/zones/Woh_Gates/IDs.lua
+++ b/scripts/zones/Woh_Gates/IDs.lua
@@ -18,9 +18,11 @@ zones[xi.zone.WOH_GATES] =
     },
     mob =
     {
+        REIVE_MOB_OFFSET = GetFirstID('Knotted_Root'),
     },
     npc =
     {
+        REIVE_COLLISION_OFFSET = GetFirstID('_7l0'),
     },
 }
 

--- a/scripts/zones/Woh_Gates/Zone.lua
+++ b/scripts/zones/Woh_Gates/Zone.lua
@@ -5,6 +5,7 @@
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
+    xi.reives.setupZone(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Woh_Gates/mobs/Knotted_Root.lua
+++ b/scripts/zones/Woh_Gates/mobs/Knotted_Root.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- Area: Woh Gates
+-- NPC: Knotted Root
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.reives.onMobSpawn(mob)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    xi.reives.onMobDeath(mob)
+end
+
+return entity

--- a/scripts/zones/Yahse_Hunting_Grounds/IDs.lua
+++ b/scripts/zones/Yahse_Hunting_Grounds/IDs.lua
@@ -30,9 +30,11 @@ zones[xi.zone.YAHSE_HUNTING_GROUNDS] =
     },
     mob =
     {
+        REIVE_MOB_OFFSET = GetFirstID('Knotted_Root'),
     },
     npc =
     {
+        REIVE_COLLISION_OFFSET = GetFirstID('_780'),
     },
 }
 

--- a/scripts/zones/Yahse_Hunting_Grounds/Zone.lua
+++ b/scripts/zones/Yahse_Hunting_Grounds/Zone.lua
@@ -7,6 +7,8 @@ local ID = zones[xi.zone.YAHSE_HUNTING_GROUNDS]
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
+    xi.reives.setupZone(zone)
+
     -- Ergon Locus area at F-6
     zone:registerTriggerArea(1, -447.7, 6.6, 362.799, 0, 0, 0)
 end

--- a/scripts/zones/Yahse_Hunting_Grounds/mobs/Knotted_Root.lua
+++ b/scripts/zones/Yahse_Hunting_Grounds/mobs/Knotted_Root.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- Area: Ceizak Battlegrounds
+-- NPC: Root
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.reives.onMobSpawn(mob)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    xi.reives.onMobDeath(mob)
+end
+
+return entity

--- a/scripts/zones/Yorcia_Weald/IDs.lua
+++ b/scripts/zones/Yorcia_Weald/IDs.lua
@@ -27,9 +27,11 @@ zones[xi.zone.YORCIA_WEALD] =
     },
     mob =
     {
+        REIVE_MOB_OFFSET = GetFirstID('Gnarled_Rampart'),
     },
     npc =
     {
+        REIVE_COLLISION_OFFSET = GetFirstID('_7b0'),
     },
 }
 

--- a/scripts/zones/Yorcia_Weald/Zone.lua
+++ b/scripts/zones/Yorcia_Weald/Zone.lua
@@ -5,6 +5,7 @@
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
+    xi.reives.setupZone(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Yorcia_Weald/mobs/Gnarled_Rampart.lua
+++ b/scripts/zones/Yorcia_Weald/mobs/Gnarled_Rampart.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- Area: Yorcia Weald
+-- NPC: Gnarled Rampart
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.reives.onMobSpawn(mob)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    xi.reives.onMobDeath(mob)
+end
+
+return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Implements a basic framework to handle basic reive functionality such as spawning/clearing.
Defending mobs spawn with their corresponding reives.
TODOs are marked in code.

Note: This is a port from my server. It functions on my codebase and likely should function on upstream as well (Shift proofed), but I have not tested it yet until I get my retail client updated. Leaving as a draft until I or someone up to date else can test it.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

1. Open scripts/globals/colonization_reive_data.lua. Pick a reive to go to. (The !pos xyz cords are listed for each reive).
2. Kill defender mobs. See that they respawn as expected matching the time listed in the colonization_reive_data data table.
3. Kill 1 reive objective mob. (Knotted Root etc). See that it does not respawn. You can lower the objective respawn time to test this.
4. Damage an objective but do not kill. Exit combat. Come back and see that the objective does not regenerate.
5. Kill all objectives. Reive ending should display correct animation effects and you should be able to pass the blocked area.

Note: Reive # 4 in Morimar Basalt Fields won't unblock. I added a TODO to it. It likely needs a capture for the blocker NPC/position.

<!-- Clear and detailed steps to test your changes here -->
