### PR TITLE
[Lua] Fix fSTR calculation for physical mobskills and avatar pacts

### DIFF
--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -107,45 +107,61 @@ local elementalBelt = -- Ordered by element.
 -- 'fSTR' in English Wikis. 'SV function' in JP wiki and Studio Gobli.
 -- BG wiki: https://www.bg-wiki.com/ffxi/FSTR
 -- Gobli Wiki: https://w-atwiki-jp.translate.goog/studiogobli/pages/14.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp
+-- Mob calculation: https://docs.google.com/spreadsheets/d/1YBoveP-weMdidrirY-vPDzHyxbEI2ryECINlfCnFkLI/edit?gid=224123492#gid=224123492&range=C50
 xi.combat.physical.calculateMeleeStatFactor = function(actor, target)
     local fSTR = 0 -- The variable we want to calculate.
 
     -- Calculate statDiff.
     local statDiff     = actor:getStat(xi.mod.STR) - target:getStat(xi.mod.VIT)
-    local weaponRank   = actor:getWeaponDmgRank()
-    local statLowerCap = (7 + weaponRank * 2) * -2
-    local statUpperCap = (14 + weaponRank * 2) * 2
 
-    statDiff = utils.clamp(statDiff, statLowerCap, statUpperCap)
-
-    -- Calculate fSTR based on stat difference.
-    if statDiff >= 12 then
-        fSTR = statDiff + 4
-    elseif statDiff >= 6 then
-        fSTR = statDiff + 6
-    elseif statDiff >= 1 then
-        fSTR = statDiff + 7
-    elseif statDiff >= -2 then
-        fSTR = statDiff + 8
-    elseif statDiff >= -7 then
-        fSTR = statDiff + 9
-    elseif statDiff >= -15 then
-        fSTR = statDiff + 10
-    elseif statDiff >= -21 then
-        fSTR = statDiff + 12
+    -- Pets and mobs have own calculation
+    if actor:isMob() or actor:isPet() then
+        local fSTRupperCap = 24
+        local fSTRlowerCap = -20
+        fSTR = math.floor((statDiff + 4) / 4)
+        fSTR = utils.clamp(fSTR, fSTRlowerCap, fSTRupperCap)
+        -- level 1 mobs always have fSTR of 1
+        if actor:isMob() and actor:getMainLvl() <= 1 then
+            fSTR = 1
+        end
+    -- players and trusts have different calculation
     else
-        fSTR = statDiff + 13
+        -- Calculate statDiff.
+        local weaponRank   = actor:getWeaponDmgRank()
+        local statLowerCap = (7 + weaponRank * 2) * -2
+        local statUpperCap = (14 + weaponRank * 2) * 2
+
+        statDiff = utils.clamp(statDiff, statLowerCap, statUpperCap)
+
+        -- Calculate fSTR based on stat difference.
+        if statDiff >= 12 then
+            fSTR = statDiff + 4
+        elseif statDiff >= 6 then
+            fSTR = statDiff + 6
+        elseif statDiff >= 1 then
+            fSTR = statDiff + 7
+        elseif statDiff >= -2 then
+            fSTR = statDiff + 8
+        elseif statDiff >= -7 then
+            fSTR = statDiff + 9
+        elseif statDiff >= -15 then
+            fSTR = statDiff + 10
+        elseif statDiff >= -21 then
+            fSTR = statDiff + 12
+        else
+            fSTR = statDiff + 13
+        end
+
+        -- Clamp fSTR.
+        local fSTRupperCap = weaponRank + 8
+        local fSTRlowerCap = weaponRank * -1
+
+        if weaponRank == 0 then
+            fSTRlowerCap = -1
+        end
+
+        fSTR = utils.clamp(fSTR / 4, fSTRlowerCap, fSTRupperCap)
     end
-
-    -- Clamp fSTR.
-    local fSTRupperCap = weaponRank + 8
-    local fSTRlowerCap = weaponRank * -1
-
-    if weaponRank == 0 then
-        fSTRlowerCap = -1
-    end
-
-    fSTR = utils.clamp(fSTR / 4, fSTRlowerCap, fSTRupperCap)
 
     return fSTR
 end
@@ -158,42 +174,57 @@ xi.combat.physical.calculateRangedStatFactor = function(actor, target)
 
     -- Calculate statDiff.
     local statDiff     = actor:getStat(xi.mod.STR) - target:getStat(xi.mod.VIT)
-    local weaponRank   = actor:getWeaponDmgRank()
-    local statLowerCap = (7 + weaponRank * 2) * -2
-    local statUpperCap = (14 + weaponRank * 2) * 2
 
-    statDiff = utils.clamp(statDiff, statLowerCap, statUpperCap)
-
-    -- Calculate fSTR based on stat difference.
-    if statDiff >= 12 then
-        fSTR = statDiff + 4
-    elseif statDiff >= 6 then
-        fSTR = statDiff + 6
-    elseif statDiff >= 1 then
-        fSTR = statDiff + 7
-    elseif statDiff >= -2 then
-        fSTR = statDiff + 8
-    elseif statDiff >= -7 then
-        fSTR = statDiff + 9
-    elseif statDiff >= -15 then
-        fSTR = statDiff + 10
-    elseif statDiff >= -21 then
-        fSTR = statDiff + 12
+    -- Pets and mobs have own calculation
+    if actor:isMob() or actor:isPet() then
+        local fSTRupperCap = 24
+        local fSTRlowerCap = -20
+        fSTR = math.floor((statDiff + 4) / 2)
+        fSTR = utils.clamp(fSTR, fSTRlowerCap, fSTRupperCap)
+        -- level 1 mobs always have fSTR of 1
+        if actor:isMob() and actor:getMainLvl() <= 1 then
+            fSTR = 1
+        end
+    -- players and trusts have different calculation
     else
-        fSTR = statDiff + 13
+        -- Calculate statDiff.
+        local weaponRank   = actor:getWeaponDmgRank()
+        local statLowerCap = (7 + weaponRank * 2) * -2
+        local statUpperCap = (14 + weaponRank * 2) * 2
+
+        statDiff = utils.clamp(statDiff, statLowerCap, statUpperCap)
+
+        -- Calculate fSTR based on stat difference.
+        if statDiff >= 12 then
+            fSTR = statDiff + 4
+        elseif statDiff >= 6 then
+            fSTR = statDiff + 6
+        elseif statDiff >= 1 then
+            fSTR = statDiff + 7
+        elseif statDiff >= -2 then
+            fSTR = statDiff + 8
+        elseif statDiff >= -7 then
+            fSTR = statDiff + 9
+        elseif statDiff >= -15 then
+            fSTR = statDiff + 10
+        elseif statDiff >= -21 then
+            fSTR = statDiff + 12
+        else
+            fSTR = statDiff + 13
+        end
+
+        -- Clamp fSTR.
+        local fSTRupperCap = (weaponRank + 8) * 2
+        local fSTRlowerCap = weaponRank * -2
+
+        if weaponRank == 0 then
+            fSTRlowerCap = -2
+        elseif weaponRank == 1 then
+            fSTRlowerCap = -3
+        end
+
+        fSTR = utils.clamp(fSTR / 2, fSTRlowerCap, fSTRupperCap)
     end
-
-    -- Clamp fSTR.
-    local fSTRupperCap = (weaponRank + 8) * 2
-    local fSTRlowerCap = weaponRank * -2
-
-    if weaponRank == 0 then
-        fSTRlowerCap = -2
-    elseif weaponRank == 1 then
-        fSTRlowerCap = -3
-    end
-
-    fSTR = utils.clamp(fSTR / 2, fSTRlowerCap, fSTRupperCap)
 
     return fSTR
 end

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -152,7 +152,13 @@ end
 -----------------------------------
 xi.mobskills.mobPhysicalMove = function(mob, target, skill, numHits, accMod, dmgMod, tpEffect, mtp000, mtp150, mtp300, offcratiomod)
     local returninfo    = {}
-    local dSTR          = utils.clamp(mob:getStat(xi.mod.STR) - target:getStat(xi.mod.VIT), -10, 10)
+
+    -- mobs use fSTR (but with special calculation in the called function)
+    local fSTR = xi.combat.physical.calculateMeleeStatFactor(mob, target)
+    if tpEffect == xi.mobskills.magicalTpBonus.RANGED then
+        fSTR = xi.combat.physical.calculateRangedStatFactor(mob, target)
+    end
+
     local targetEvasion = target:getEVA() + target:getMod(xi.mod.SPECIAL_ATTACK_EVASION)
 
     if
@@ -163,8 +169,7 @@ xi.mobskills.mobPhysicalMove = function(mob, target, skill, numHits, accMod, dmg
         targetEvasion = targetEvasion + target:getStatusEffect(xi.effect.YONIN):getPower()
     end
 
-    -- Apply WSC (TODO: Change to include WSC)
-    local base = math.max(1, mob:getWeaponDmg() + dSTR)
+    local base = math.max(1, mob:getWeaponDmg() + fSTR)
 
     --work out and cap ratio
     if not offcratiomod then -- default to attack. Pretty much every physical mobskill will use this, Cannonball being the exception.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR is the start of a series of PRs that will help improve mobskill logic and calculations. 

The PR fixes the fSTR calculation for physical mobskills and avatar bloodpacts to be retail accurate (as per Jimmayus [spreadsheet](https://docs.google.com/spreadsheets/d/1YBoveP-weMdidrirY-vPDzHyxbEI2ryECINlfCnFkLI/edit?gid=224123492#gid=224123492&range=C50)). LSB has already changed the mob and pet auto-attack fSTR calculation in this [PR](https://github.com/LandSandBoat/server/pull/3371) but the mobskill and avatar blood pact calculations were not changed at that time.

The change is implemented by modifying the fSTR functions `calculateMeleeStatFactor` and `calculateRangedStatFactor` in `physical_utilities.lua` to also work for mobs and pets (which share the same fSTR calculation). These are the new global functions added by Xaver in this [PR](https://github.com/LandSandBoat/server/pull/3624) that will eventually be used by all scripts.

Also remove the WSC TODO comment as according to Jimmayus calculations that does not exist for mobskills.

## Steps to test these changes
Fight mobs and notice that mobskills and avatar bloodpacts do somewhat different damage based depending on the dSTR (which is converted to fSTR by the function).