### PR TITLE
Core: Cache augment data on startup

### DIFF
--- a/src/map/items/item_equipment.h
+++ b/src/map/items/item_equipment.h
@@ -121,6 +121,10 @@ public:
     std::vector<CPetModifier> petModList;
     std::vector<itemLatent>   latentList;
 
+    // static
+    // TODO: Move this to itemutils
+    static void LoadAugmentData();
+
 private:
     uint8  m_reqLvl;
     uint8  m_iLvl;

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -25,6 +25,7 @@
 #include "common/blowfish.h"
 #include "common/console_service.h"
 #include "common/database.h"
+#include "common/debug.h"
 #include "common/logging.h"
 #include "common/md52.h"
 #include "common/timer.h"
@@ -33,16 +34,10 @@
 #include "common/version.h"
 #include "common/zlib.h"
 
-#include <cmath>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
-#include <thread>
-
 #include "ability.h"
-#include "common/debug.h"
-#include "common/vana_time.h"
+#include "daily_system.h"
 #include "job_points.h"
+#include "latent_effect_container.h"
 #include "linkshell.h"
 #include "message.h"
 #include "mob_spell_list.h"
@@ -58,11 +53,13 @@
 #include "zone_entities.h"
 
 #include "ai/controllers/automaton_controller.h"
-#include "daily_system.h"
-#include "latent_effect_container.h"
+
+#include "items/item_equipment.h"
+
 #include "packets/basic.h"
 #include "packets/chat_message.h"
 #include "packets/server_ip.h"
+
 #include "utils/battleutils.h"
 #include "utils/charutils.h"
 #include "utils/fishingutils.h"
@@ -77,6 +74,12 @@
 #include "utils/synergyutils.h"
 #include "utils/trustutils.h"
 #include "utils/zoneutils.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <thread>
 
 #include <nonstd/jthread.hpp>
 
@@ -291,6 +294,7 @@ int32 do_init(int32 argc, char** argv)
     daily::LoadDailyItems();
     roeutils::UpdateUnityRankings();
     synergyutils::LoadSynergyRecipes();
+    CItemEquipment::LoadAugmentData(); // TODO: Move to itemutils
 
     if (!std::filesystem::exists("./navmeshes/") || std::filesystem::is_empty("./navmeshes/"))
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes https://github.com/LandSandBoat/server/issues/6441

We absolutely shouldn't be querying for static data at runtime... ever... for any reason... lol

Also while looking at this, we seem to store the data in the db sanely, but we're doing some sort of sillybuggers about negative values once we load it? Will need some investigation. Did this quickly on my lunch break, need to fire this up and test on my Windows machine before merging.