### PR TITLE
Fix ecliptic attrition

### DIFF
--- a/scripts/actions/abilities/ecliptic_attrition.lua
+++ b/scripts/actions/abilities/ecliptic_attrition.lua
@@ -13,7 +13,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    return xi.job_utils.geomancer.geoOnAbilityCheck(player, target, ability)
+    return xi.job_utils.geomancer.geoOnEclipticAttritionCheck(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1781,6 +1781,17 @@ void CStatusEffectContainer::HandleAura(CStatusEffect* PStatusEffect)
                     if (PEffect && (PEffect->GetEffectFlags() & EFFECTFLAG_ALWAYS_EXPIRING) != 0)
                     {
                         PEffect->SetStartTime(server_clock::now());
+
+                        // Effect updated, probably from Ecliptic Attrition
+                        // Update status effect with new potency.
+                        // Take care to design your "owning" effects such as the EFFECT::EFFECT_COLURE_ACTIVE to control the subpower, rather than the resulting effect ticking down.
+                        // Otherwise odd things may happen
+                        if (PEffect->GetPower() != PStatusEffect->GetSubPower())
+                        {
+                            luautils::OnEffectLose(PMember, PEffect);
+                            PEffect->SetPower(PStatusEffect->GetSubPower());
+                            luautils::OnEffectGain(PMember, PEffect);
+                        }
                     }
                     else
                     {
@@ -1812,6 +1823,17 @@ void CStatusEffectContainer::HandleAura(CStatusEffect* PStatusEffect)
                     if (PEffect && (PEffect->GetEffectFlags() & EFFECTFLAG_ALWAYS_EXPIRING) != 0)
                     {
                         PEffect->SetStartTime(server_clock::now());
+
+                        // Effect updated, probably from Ecliptic Attrition
+                        // Update status effect with new potency.
+                        // Take care to design your "owning" effects such as the EFFECT::EFFECT_COLURE_ACTIVE to control the subpower, rather than the resulting effect ticking down.
+                        // Otherwise odd things may happen
+                        if (PEffect->GetPower() != PStatusEffect->GetSubPower())
+                        {
+                            luautils::OnEffectLose(PTarget, PEffect);
+                            PEffect->SetPower(PStatusEffect->GetSubPower());
+                            luautils::OnEffectGain(PTarget, PEffect);
+                        }
                     }
                     else
                     {
@@ -1846,6 +1868,17 @@ void CStatusEffectContainer::HandleAura(CStatusEffect* PStatusEffect)
                     if (PEffect && (PEffect->GetEffectFlags() & EFFECTFLAG_ALWAYS_EXPIRING) != 0)
                     {
                         PEffect->SetStartTime(server_clock::now());
+
+                        // Effect updated, probably from Ecliptic Attrition
+                        // Update status effect with new potency.
+                        // Take care to design your "owning" effects such as the EFFECT::EFFECT_COLURE_ACTIVE to control the subpower, rather than the resulting effect ticking down.
+                        // Otherwise odd things may happen
+                        if (PEffect->GetPower() != PStatusEffect->GetSubPower())
+                        {
+                            luautils::OnEffectLose(PMember, PEffect);
+                            PEffect->SetPower(PStatusEffect->GetSubPower());
+                            luautils::OnEffectGain(PMember, PEffect);
+                        }
                     }
                     else
                     {
@@ -1880,6 +1913,17 @@ void CStatusEffectContainer::HandleAura(CStatusEffect* PStatusEffect)
                     if (PEffect && (PEffect->GetEffectFlags() & EFFECTFLAG_ALWAYS_EXPIRING) != 0)
                     {
                         PEffect->SetStartTime(server_clock::now());
+
+                        // Effect updated, probably from Ecliptic Attrition
+                        // Update status effect with new potency.
+                        // Take care to design your "owning" effects such as the EFFECT::EFFECT_COLURE_ACTIVE to control the subpower, rather than the resulting effect ticking down.
+                        // Otherwise odd things may happen
+                        if (PEffect->GetPower() != PStatusEffect->GetSubPower())
+                        {
+                            luautils::OnEffectLose(PTarget, PEffect);
+                            PEffect->SetPower(PStatusEffect->GetSubPower());
+                            luautils::OnEffectGain(PTarget, PEffect);
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes Ecliptic Attrition - 
Resulting aura effect powers now update if the owning effect's subpower changes

## Steps to test these changes

Use Geo-Fury, ecliptic attrition, see the effect power boosted:
![image](https://github.com/user-attachments/assets/630e6962-dbcf-4ae4-bddf-1712fd62fc19)

