### PR TITLE
Core: Replace entity ptr for WideScanTarget with EntityID_t

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -457,6 +457,7 @@
         "__config": "cpp",
         "__hash_table": "cpp",
         "__node_handle": "cpp",
-        "__verbose_abort": "cpp"
+        "__verbose_abort": "cpp",
+        "__locale": "cpp"
     },
 }

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -19,8 +19,8 @@
 ===========================================================================
 */
 
-#ifndef _UTILS_H_
-#define _UTILS_H_
+#pragma once
+
 #define _USE_MATH_DEFINES
 
 #include "common/cbasetypes.h"
@@ -146,5 +146,3 @@ static mutex_guarded<std::unordered_map<std::string, time_point>> lastExecutionT
     });                                                                               \
 }
 // clang-format on
-
-#endif

--- a/src/common/xi.h
+++ b/src/common/xi.h
@@ -1,0 +1,142 @@
+/*
+===========================================================================
+
+  Copyright (c) 2024 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <optional>
+#include <type_traits>
+#include <utility>
+
+// The purpose of this namespace IS NOT to replace the C++ standard library.
+//
+// It is to provide convenience wrappers around common standard library types
+// so that they are easier and more intuitive to use in the context of this project.
+//
+// You should be:
+// - Forwarding all of the expected and useful functions from the underlying standard library type
+// - Not forwarding/hiding the ones that are not useful
+// - Adding new functions that are useful and convenient
+
+namespace xi
+{
+
+    // A wrapper around std::optional to allow usage of object.apply([](auto& obj) { ... });
+    // https://en.cppreference.com/w/cpp/utility/optional
+    template <typename T>
+    class optional
+    {
+    public:
+        constexpr optional() = default;
+        constexpr explicit optional(std::nullopt_t) noexcept
+        : m_value(std::nullopt)
+        {
+        }
+        constexpr optional(const optional& other)                = default;
+        constexpr optional(optional&& other) noexcept            = default;
+        constexpr optional& operator=(const optional& other)     = default;
+        constexpr optional& operator=(optional&& other) noexcept = default;
+        ~optional()                                              = default;
+
+        constexpr optional& operator=(std::nullopt_t) noexcept
+        {
+            m_value = std::nullopt;
+            return *this;
+        }
+
+        constexpr optional& operator=(T&& value)
+        {
+            m_value = std::move(value);
+            return *this;
+        }
+
+        template <typename F>
+        constexpr void apply(F&& f) &
+        {
+            if (m_value)
+            {
+                f(*m_value);
+            }
+        }
+
+        template <typename F>
+        constexpr void apply(F&& f) const&
+        {
+            if (m_value)
+            {
+                f(*m_value);
+            }
+        }
+
+        constexpr explicit operator bool() const noexcept
+        {
+            return m_value.has_value();
+        }
+
+        constexpr T& operator*() &
+        {
+            return *m_value;
+        }
+
+        constexpr const T& operator*() const&
+        {
+            return *m_value;
+        }
+
+        constexpr T* operator->() noexcept
+        {
+            return m_value.operator->();
+        }
+
+        constexpr const T* operator->() const noexcept
+        {
+            return m_value.operator->();
+        }
+
+        constexpr void reset() noexcept
+        {
+            m_value.reset();
+        }
+
+        template <typename... Args>
+        constexpr T& emplace(Args&&... args)
+        {
+            return m_value.emplace(std::forward<Args>(args)...);
+        }
+
+        constexpr bool operator==(const optional& other) const
+        {
+            return m_value == other.m_value;
+        }
+
+        constexpr bool operator!=(const optional& other) const
+        {
+            return m_value != other.m_value;
+        }
+
+    private:
+        std::optional<T> m_value;
+    };
+
+    // TODO: A wrapper around std::variant to allow usage of:
+    //     :   object.visit(overloaded{...});
+    //     :   object.get<T>() -> xi::optional<T>;
+
+} // namespace xi

--- a/src/map/entities/baseentity.h
+++ b/src/map/entities/baseentity.h
@@ -206,18 +206,24 @@ enum class SPAWN_ANIMATION : uint8
     SPECIAL = 1,
 };
 
-// TODO:it is possible to make this structure part of the class, instead of the current ID and Targid, but without the Clean method
-
+// TODO: It is possible to make this structure part of the class, instead of the current ID and Targid, but without the clean() method.
 struct EntityID_t
 {
+    // TODO: Add a constructor that takes an id and targid.
+    // TODO: Clean with a destructor.
     void clean()
     {
         id     = 0;
         targid = 0;
     }
 
-    uint32 id;
-    uint16 targid;
+    // TODO: Globally rename targid to index, zoneIndex, etc.
+
+    uint32 id;     // "Long" global ID of the entity. Built from 0x10000000 | (zoneId << 16) | targid.
+    uint16 targid; // The "index" of the entity in the current zone. Used for local targeting and referencing.
+
+    // TODO: Store the zoneId of this entity's zone. We can then use the targid (index) and the zoneId to build the global id.
+    // TODO: Store an incremental u64 as a UUID for the entity for disambiguation in the case of dynamic entities that might have the same targid.
 };
 
 class CAIContainer;

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -209,15 +209,16 @@ CCharEntity::CCharEntity()
 
     BazaarID.clean();
 
+    WideScanTarget = std::nullopt;
+
     lastTradeInvite = {};
     TradePending.clean();
     InvitePending.clean();
 
-    PLinkshell1     = nullptr;
-    PLinkshell2     = nullptr;
-    PUnityChat      = nullptr;
-    PTreasurePool   = nullptr;
-    PWideScanTarget = nullptr;
+    PLinkshell1   = nullptr;
+    PLinkshell2   = nullptr;
+    PUnityChat    = nullptr;
+    PTreasurePool = nullptr;
 
     PAutomaton             = nullptr;
     PClaimedMob            = nullptr;

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -29,6 +29,7 @@
 
 #include "common/cbasetypes.h"
 #include "common/mmo.h"
+#include "common/xi.h"
 
 #include <bitset>
 #include <deque>
@@ -444,7 +445,11 @@ public:
     CUContainer*     UContainer;     // Container used for universal actions -- used for trading at least despite the dedicated trading container above
     CTradeContainer* CraftContainer; // Container used for crafting actions.
 
-    CBaseEntity* PWideScanTarget;
+    // TODO: All member instances of EntityID_t should be std::optional<EntityID_t> to allow for them not to be set,
+    //     : instead of checking for entityId.id != 0, etc.
+    // TODO: We don't want to replace this with just an ID, because in the future EntityID_t will be able to
+    //     : disambiguate between entities who have been rebuilt (players, dynamic entities) and have the same ID.
+    xi::optional<EntityID_t> WideScanTarget;
 
     SpawnIDList_t SpawnPCList;    // list of visible characters
     SpawnIDList_t SpawnMOBList;   // list of visible monsters

--- a/src/map/packets/wide_scan_track.cpp
+++ b/src/map/packets/wide_scan_track.cpp
@@ -26,7 +26,7 @@
 #include "entities/baseentity.h"
 #include "wide_scan_track.h"
 
-CWideScanTrackPacket::CWideScanTrackPacket(CBaseEntity* PEntity)
+CWideScanTrackPacket::CWideScanTrackPacket(const CBaseEntity* PEntity)
 {
     this->setType(0xF5);
     this->setSize(0x18);

--- a/src/map/packets/wide_scan_track.h
+++ b/src/map/packets/wide_scan_track.h
@@ -31,7 +31,7 @@ class CBaseEntity;
 class CWideScanTrackPacket : public CBasicPacket
 {
 public:
-    CWideScanTrackPacket(CBaseEntity* PEntity);
+    CWideScanTrackPacket(const CBaseEntity* PEntity);
 };
 
 #endif

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -7184,7 +7184,8 @@ namespace charutils
 
         PChar->TradePending.clean();
         PChar->InvitePending.clean();
-        PChar->PWideScanTarget = nullptr;
+
+        PChar->WideScanTarget = std::nullopt;
 
         if (PChar->animation == ANIMATION_ATTACK)
         {

--- a/src/map/utils/itemutils.cpp
+++ b/src/map/utils/itemutils.cpp
@@ -635,7 +635,7 @@ namespace itemutils
 
     /************************************************************************
      *                                                                       *
-     *  Initialization of the  game objects             bbbb                 *
+     *  Initialization of the  game objects                                  *
      *                                                                       *
      ************************************************************************/
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Replaces: https://github.com/LandSandBoat/server/pull/6392

The previous PR became a staging ground for me testing entity lookup. This is the minimum amount of work for this ptr replacement.
