### PR TITLE
Chore: Update clang-format rules (clang-format-19)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,33 +1,275 @@
-﻿---
+﻿
 # https://clang.llvm.org/docs/ClangFormatStyleOptions.html
-# We base things of WebKit + Allman braces
-# BasedOnStyle: WebKit
-AccessModifierOffset: -4
-AlignConsecutiveMacros: true
-AlignConsecutiveAssignments: true
-AlignConsecutiveDeclarations: true
-AlignTrailingComments: true
-AllowShortFunctionsOnASingleLine: None
-AlwaysBreakTemplateDeclarations: true
-BreakBeforeBraces: Allman
-BreakConstructorInitializers: BeforeComma
-# This is just to make clang-format chill out! Use your best judgement!
-ColumnLimit: 0
-CompactNamespaces: 'false'
-ConstructorInitializerIndentWidth: 0
-Cpp11BracedListStyle: 'false'
-IndentCaseLabels: 'true'
-IndentWidth: 4
-KeepEmptyLinesAtTheStartOfBlocks: 'false'
+---
 Language: Cpp
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: Left
+AlignConsecutiveAssignments:
+  Enabled: true
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionPointers: false
+  PadOperators: true
+AlignConsecutiveBitFields:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionPointers: false
+  PadOperators: false
+AlignConsecutiveDeclarations:
+  Enabled: true
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionPointers: false
+  PadOperators: false
+AlignConsecutiveMacros:
+  Enabled: true
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionPointers: false
+  PadOperators: false
+AlignConsecutiveShortCaseStatements:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCaseArrows: false
+  AlignCaseColons: false
+AlignConsecutiveTableGenBreakingDAGArgColons:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionPointers: false
+  PadOperators: false
+AlignConsecutiveTableGenCondOperatorColons:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionPointers: false
+  PadOperators: false
+AlignConsecutiveTableGenDefinitionColons:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionPointers: false
+  PadOperators: false
+AlignEscapedNewlines: Right
+AlignOperands: Align
+AlignTrailingComments:
+  Kind: Always
+  OverEmptyLines: 0
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowBreakBeforeNoexceptSpecifier: Never
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseExpressionOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortCompoundRequirementOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: Empty
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AttributeMacros:
+- __capability
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: Both
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterExternBlock: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  BeforeCatch: false
+  BeforeElse: false
+  BeforeLambdaBody: false
+  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakAdjacentStringLiterals: true
+BreakAfterAttributes: Leave
+BreakAfterJavaFieldAnnotations: false
+BreakAfterReturnType: None
+BreakArrays: false
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Allman
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeComma
+BreakFunctionDefinitionParameters: false
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: true
+BreakTemplateDeclarations: MultiLine
+ColumnLimit: 0
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat: false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+- foreach
+- Q_FOREACH
+- BOOST_FOREACH
+IfMacros:
+- KJ_IF_MAYBE
+IncludeBlocks: Preserve
+IncludeCategories:
+- Regex: '^"(llvm|llvm-c|clang|clang-c)/'
+  Priority: 2
+  SortPriority: 0
+  CaseSensitive: false
+- Regex: '^(<|"(gtest|gmock|isl|json)/)'
+  Priority: 3
+  SortPriority: 0
+  CaseSensitive: false
+- Regex: '.*'
+  Priority: 1
+  SortPriority: 0
+  CaseSensitive: false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: true
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentRequiresClause: true
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+InsertBraces: true
+InsertNewlineAtEOF: true
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary: 0
+  BinaryMinDigits: 0
+  Decimal: 0
+  DecimalMinDigits: 0
+  Hex: 0
+  HexMinDigits: 0
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLines:
+  AtEndOfFile: false
+  AtStartOfBlock: false
+  AtStartOfFile: false
+LambdaBodyIndentation: Signature
+LineEnding: DeriveLF
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MainIncludeChar: Quote
+MaxEmptyLinesToKeep: 1
 NamespaceIndentation: All
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 4
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PackConstructorInitializers: BinPack
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakScopeResolution: 500
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Left
+PPIndentWidth: -1
+QualifierAlignment: Left
+ReferenceAlignment: Left
 ReflowComments: true
-SortIncludes: 'true'
-SortUsingDeclarations: 'true'
+RemoveBracesLLVM: false
+RemoveParentheses: Leave
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SkipMacroDefinitionBody: false
+SortIncludes: CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: LexicographicNumeric
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeJsonColon: false
 SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros: true
+  AfterOverloadedOperator: false
+  AfterPlacementOperator: true
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
 SpacesBeforeTrailingComments: 1
-Standard: Cpp11
+SpacesInAngles: Never
+SpacesInContainerLiterals: true
+SpacesInLineCommentPrefix:
+  Minimum: 1
+  Maximum: -1
+SpacesInParens: Never
+SpacesInParensOptions:
+  ExceptDoubleParentheses: false
+  InCStyleCasts: false
+  InConditionalStatements: false
+  InEmptyParentheses: false
+  Other: false
+SpacesInSquareBrackets: false
+Standard: Latest
+StatementAttributeLikeMacros:
+- Q_EMIT
+StatementMacros:
+- Q_UNUSED
+- QT_REQUIRE_VERSION
+TableGenBreakInsideDAGArg: DontBreak
+TabWidth: 8
 UseTab: Never
-
+VerilogBreakBetweenInstancePorts: true
+WhitespaceSensitiveMacros:
+- BOOST_PP_STRINGIZE
+- CF_SWIFT_NAME
+- NS_SWIFT_NAME
+- PP_STRINGIZE
+- STRINGIZE
 ...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,13 +3,13 @@ name: "build"
 on:
   pull_request:
     types:
-      - opened
-      - synchronize
-      - reopened
+    - opened
+    - synchronize
+    - reopened
   push:
     branches:
-      - base
-      - everything
+    - base
+    - everything
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
@@ -97,28 +97,28 @@ jobs:
           exit 1
         fi
         exit 0
-    - name: Run CPP Formatting Checks (clang-format-18)
+    - name: Run CPP Formatting Checks (clang-format-19)
       if: always()
       run: |
-        clang-format-18 -version
+        clang-format -version
         touch cpp_formatting_checks.txt
         for changed_file in $CHANGED_FILES; do
           if [[ -f $changed_file ]]; then
             if [[ $changed_file == *.cpp || $changed_file == *.h ]]; then
-              clang-format-18 -style=file -i ${changed_file}
+              python3 tools/run_clang_format.py ${changed_file}
             fi
           fi
         done
         git diff >> cpp_formatting_checks.txt
         git diff --color >> cpp_formatting_checks_color.txt
-    - name: Upload CPP Formatting Diff (clang-format-18)
+    - name: Upload CPP Formatting Diff (clang-format-19)
       if: hashFiles('cpp_formatting_checks.txt') != ''
       uses: actions/upload-artifact@v4
       with:
         name: clang_format_diff
         path: |
           cpp_formatting_checks.txt
-    - name: Report CPP Formatting Checks (clang-format-18)
+    - name: Report CPP Formatting Checks (clang-format-19)
       if: always()
       run: |
         if [ -s cpp_formatting_checks_color.txt ]
@@ -126,7 +126,7 @@ jobs:
           echo ""
           echo "You have errors in your C++ code formatting."
           echo "Please see below in red for the incorrect formatting, and in green for the correct formatting."
-          echo "You can either fix the formatting by hand or use clang-format."
+          echo "You can either fix the formatting by hand, use clang-format manually, using the diff file above, or the tools/run_clang_format.py script."
           echo "(You can safely ignore warnings about \$TERM and tput)"
           echo ""
           cat cpp_formatting_checks_color.txt | diff-so-fancy || true
@@ -332,32 +332,32 @@ jobs:
     env:
       MSBUILD_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-      - name: Cache 'build' folder
-        uses: actions/cache@v4
-        with:
-          path: build
-          key: ${{ runner.os }}-msvc64d
-      - name: Configure CMake
-        shell: cmd
-        run: |
-          mkdir -p build
-          cmake -S . -B build -A x64 -DCMAKE_BUILD_TYPE=Debug
-      - name: Build
-        shell: cmd
-        run: |
-          cmake --build build -j4
-      - name: Archive Executables
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows_executables
-          path: |
-            xi_connect.exe
-            xi_map.exe
-            xi_search.exe
-            xi_world.exe
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+    - name: Cache 'build' folder
+      uses: actions/cache@v4
+      with:
+        path: build
+        key: ${{ runner.os }}-msvc64d
+    - name: Configure CMake
+      shell: cmd
+      run: |
+        mkdir -p build
+        cmake -S . -B build -A x64 -DCMAKE_BUILD_TYPE=Debug
+    - name: Build
+      shell: cmd
+      run: |
+        cmake --build build -j4
+    - name: Archive Executables
+      uses: actions/upload-artifact@v4
+      with:
+        name: windows_executables
+        path: |
+          xi_connect.exe
+          xi_map.exe
+          xi_search.exe
+          xi_world.exe
 
   Windows_64bit_Release_Tracy_Modules:
     needs: Sanity_Checks
@@ -365,61 +365,61 @@ jobs:
     env:
       MSBUILD_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-      - name: Cache 'build' folder
-        uses: actions/cache@v4
-        with:
-          path: build
-          key: ${{ runner.os }}-msvc64-t
-      - name: Enable Modules
-        shell: bash
-        run: |
-          python3 << EOF
-          with open("modules/init.txt", "w") as f:
-              f.write("custom\n")
-              f.write("era\n")
-              f.write("example\n")
-              f.write("renamer\n")
-          EOF
-      - name: Configure CMake
-        shell: cmd
-        run: |
-          mkdir -p build
-          cmake -S . -B build -A x64 -DCMAKE_BUILD_TYPE=Release -DENABLE_TRACY=ON
-      - name: Build
-        shell: cmd
-        run: |
-          cmake --build build --config Release -j4
-      - name: Archive Executables
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows_modules_executables
-          path: |
-            xi_connect.exe
-            xi_map_tracy.exe
-            xi_search.exe
-            xi_world.exe
-          
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+    - name: Cache 'build' folder
+      uses: actions/cache@v4
+      with:
+        path: build
+        key: ${{ runner.os }}-msvc64-t
+    - name: Enable Modules
+      shell: bash
+      run: |
+        python3 << EOF
+        with open("modules/init.txt", "w") as f:
+            f.write("custom\n")
+            f.write("era\n")
+            f.write("example\n")
+            f.write("renamer\n")
+        EOF
+    - name: Configure CMake
+      shell: cmd
+      run: |
+        mkdir -p build
+        cmake -S . -B build -A x64 -DCMAKE_BUILD_TYPE=Release -DENABLE_TRACY=ON
+    - name: Build
+      shell: cmd
+      run: |
+        cmake --build build --config Release -j4
+    - name: Archive Executables
+      uses: actions/upload-artifact@v4
+      with:
+        name: windows_modules_executables
+        path: |
+          xi_connect.exe
+          xi_map_tracy.exe
+          xi_search.exe
+          xi_world.exe
+
   MacOS_64bit:
     needs: Sanity_Checks
     # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-      - name: Install Dependencies (Brew)
-        run: |
-          brew install mariadb zeromq zmq luajit
-      - name: Configure CMake
-        run: |
-          mkdir -p build
-          cmake -S . -B build
-      - name: Build
-        run: |
-          cmake --build build -j4
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+    - name: Install Dependencies (Brew)
+      run: |
+        brew install mariadb zeromq zmq luajit
+    - name: Configure CMake
+      run: |
+        mkdir -p build
+        cmake -S . -B build
+    - name: Build
+      run: |
+        cmake --build build -j4
 
   Full_Startup_Checks_Linux:
     runs-on: ubuntu-24.04
@@ -431,7 +431,7 @@ jobs:
           MYSQL_DATABASE: xidb
           MYSQL_ROOT_PASSWORD: root
         ports:
-          - 3306:3306
+        - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=10s --health-retries=10
     steps:
     - uses: actions/checkout@v4
@@ -601,7 +601,7 @@ jobs:
           MYSQL_DATABASE: xidb
           MYSQL_ROOT_PASSWORD: root
         ports:
-          - 3306:3306
+        - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=10s --health-retries=10
     steps:
     - uses: actions/checkout@v4

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -9,3 +9,4 @@ regex
 argparse
 requests
 bcrypt
+clang-format

--- a/tools/run_clang_format.bat
+++ b/tools/run_clang_format.bat
@@ -1,7 +1,0 @@
-REM Run from repo root
-REM Uses clang-format-15
-
-for /r %cd%\src\ %%f in (*.cpp) do clang-format -style=file -i %%f
-for /r %cd%\src\ %%f in (*.h) do clang-format -style=file -i %%f
-for /r %cd%\modules\ %%f in (*.cpp) do clang-format -style=file -i %%f
-for /r %cd%\modules\ %%f in (*.h) do clang-format -style=file -i %%f

--- a/tools/run_clang_format.py
+++ b/tools/run_clang_format.py
@@ -1,0 +1,73 @@
+# Run from repo root
+
+import os
+import subprocess
+import sys
+
+# Set exe
+CLANG_FORMAT = os.path.join("tools", "clang-format.exe")
+
+# If a filename is provided use that, otherwise try and format the whole src and modules directories
+target = None
+if len(sys.argv) > 1:
+    target = sys.argv[1]
+
+    if not os.path.exists(target):
+        print(f"Error: {target} not found")
+        sys.exit(1)
+
+if not target:
+    print("No target provided, formatting all files in src/ and modules/")
+    target = "all"
+
+# Check if clang-format exists
+if not os.path.exists(CLANG_FORMAT):
+    print("clang-format not found in tools directory, looking in PATH"),
+    try:
+        result = subprocess.run(
+            ["clang-format", "--version"], capture_output=True, text=True, check=True
+        )
+        print("Found clang-format in PATH")
+        CLANG_FORMAT = "clang-format"
+    except subprocess.CalledProcessError as e:
+        print(f"Error running clang-format: {e}")
+        sys.exit(1)
+
+# Ensure we're using clang-format-19
+print("Checking clang-format version...")
+try:
+    result = subprocess.run(
+        [CLANG_FORMAT, "--version"], capture_output=True, text=True, check=True
+    )
+    CLANG_FORMAT_VERSION = result.stdout.strip()
+    if "version 19" not in CLANG_FORMAT_VERSION:
+        print(
+            f"Error: clang-format version 19.x.x is required (got: {CLANG_FORMAT_VERSION})"
+        )
+        sys.exit(1)
+except subprocess.CalledProcessError as e:
+    print(f"Error running clang-format: {e}")
+    sys.exit(1)
+
+# Format files in src/ and modules/ directories
+if target == "all":
+    print("Formatting src/ files...")
+    for root, _, files in os.walk("src"):
+        for file in files:
+            if file.endswith(".h") or file.endswith(".cpp"):
+                filename = os.path.join(root, file)
+                print(f"Formatting {filename}")
+                subprocess.run([CLANG_FORMAT, "-style=file", "-i", filename])
+
+    print("Formatting modules/ files...")
+    for root, _, files in os.walk("modules"):
+        for file in files:
+            if file.endswith(".h") or file.endswith(".cpp"):
+                filename = os.path.join(root, file)
+                print(f"Formatting {filename}")
+                subprocess.run([CLANG_FORMAT, "-style=file", "-i", filename])
+else:  # Format single file
+    print(f"Formatting {target}")
+    subprocess.run([CLANG_FORMAT, "-style=file", "-i", target])
+
+print("Done!")

--- a/tools/run_clang_format.sh
+++ b/tools/run_clang_format.sh
@@ -1,3 +1,0 @@
-# Run from repo root
-for f in $(find src/ -name '*.h' -or -name '*.cpp'); do clang-format-15 -style=file -i $f; done
-for f in $(find modules/ -name '*.h' -or -name '*.cpp'); do clang-format-15 -style=file -i $f; done


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Of note/TODO:
- Death to all `clang-format on/off` blocks
- We now live in a west const world
- I'm still fighting with macros
- I'm still fighting with things like settings::overloaded
- I'm still fighting with conditional reflowing, etc.
- I'm still fighting with type and assignment alignment
- I decided to keep namespace nesting
- Spaces around simple {} etc.
- Make it easy to setup the tooling for Windows/Linux/OSX, have it work easily/automatically in VSCode
- Make it hard to use the wrong versions of clang-format, etc.
- Update CI
