### PR TITLE
Core: Only continue asio sessions inside lambda capture

### DIFF
--- a/src/login/auth_session.cpp
+++ b/src/login/auth_session.cpp
@@ -61,12 +61,11 @@ namespace
 
 void auth_session::start()
 {
-    auto self(shared_from_this());
     if (socket_.lowest_layer().is_open())
     {
         // clang-format off
         socket_.async_handshake(asio::ssl::stream_base::server,
-        [this, self](std::error_code ec)
+        [this, self = shared_from_this()](std::error_code ec)
         {
             if (!ec)
             {
@@ -91,10 +90,9 @@ void auth_session::start()
 
 void auth_session::do_read()
 {
-    auto self(shared_from_this());
     // clang-format off
     socket_.async_read_some(asio::buffer(data_, max_length),
-    [this, self](std::error_code ec, std::size_t length)
+    [this, self = shared_from_this()](std::error_code ec, std::size_t length)
     {
         if (!ec)
         {
@@ -530,10 +528,9 @@ void auth_session::read_func()
 
 void auth_session::do_write(std::size_t length)
 {
-    auto self(shared_from_this());
     // clang-format off
     asio::async_write(socket_, asio::buffer(data_, length),
-    [this, self](std::error_code ec, std::size_t /*length*/)
+    [this, self = shared_from_this()](std::error_code ec, std::size_t /*length*/)
     {
         if (!ec)
         {

--- a/src/login/handler_session.cpp
+++ b/src/login/handler_session.cpp
@@ -57,11 +57,9 @@ void handler_session::start()
 
 void handler_session::do_read()
 {
-    auto self(shared_from_this());
-
     // clang-format off
     socket_.next_layer().async_read_some(asio::buffer(data_, max_length),
-    [this, self](std::error_code ec, std::size_t length)
+    [this, self = shared_from_this()](std::error_code ec, std::size_t length)
     {
         if (!ec)
         {
@@ -78,10 +76,9 @@ void handler_session::do_read()
 
 void handler_session::do_write(std::size_t length)
 {
-    auto self(shared_from_this());
     // clang-format off
     asio::async_write(socket_.next_layer(), asio::buffer(data_, length),
-    [this, self](std::error_code ec, std::size_t /*length*/)
+    [this, self = shared_from_this()](std::error_code ec, std::size_t /*length*/)
     {
         if (!ec)
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

I was doing some reading about ASIO over the weekend and I saw this pattern a lot. Should have no noticeable difference, and theoretically construct 1x less shared_ptr in these cases.