### PR TITLE
Core: Add final_action/finally to xi namespace

### DIFF
--- a/src/common/xi.h
+++ b/src/common/xi.h
@@ -139,4 +139,50 @@ namespace xi
     //     :   object.visit(overloaded{...});
     //     :   object.get<T>() -> xi::optional<T>;
 
+    // https://github.com/microsoft/GSL/blob/main/include/gsl/util
+    // final_action allows you to ensure something gets run at the end of a scope
+    template <class F>
+    class final_action
+    {
+    public:
+        explicit final_action(const F& ff) noexcept
+        : f{ ff }
+        {
+        }
+
+        explicit final_action(F&& ff) noexcept
+        : f{ std::move(ff) }
+        {
+        }
+
+        ~final_action() noexcept
+        {
+            if (invoke)
+            {
+                f();
+            }
+        }
+
+        final_action(final_action&& other) noexcept
+        : f(std::move(other.f))
+        , invoke(std::exchange(other.invoke, false))
+        {
+        }
+
+        final_action(const final_action&)   = delete;
+        void operator=(const final_action&) = delete;
+        void operator=(final_action&&)      = delete;
+
+    private:
+        F    f;
+        bool invoke = true;
+    };
+
+    // finally() - convenience function to generate a final_action
+    template <class F>
+    [[nodiscard]] auto finally(F&& f) noexcept
+    {
+        return final_action<std::decay_t<F>>{ std::forward<F>(f) };
+    }
+
 } // namespace xi


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

We have a place for these things now. This is equivalent to the old `ScopeGuard`