### PR TITLE
Implement Impetus, make Formless Strikes more accurate

### DIFF
--- a/documentation/AI_Events.txt
+++ b/documentation/AI_Events.txt
@@ -33,6 +33,7 @@ DESPAWN - Entity
 TAKE_DAMAGE - Entity, amount, optionalAttacker, attackType, damageType
 
 MELEE_SWING_HIT - Entity, Target, attack
+MELEE_SWING_MISS - Entity, Target, attack
 CRITICAL_TAKE - Target, Attacker
 ATTACK - Attacker, defender, action
 ATTACKED - Defender, attacker, action

--- a/scripts/effects/impetus.lua
+++ b/scripts/effects/impetus.lua
@@ -5,12 +5,44 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
+    target:addListener('MELEE_SWING_MISS', 'IMPETUS_MISS', xi.job_utils.monk.impetusMissListener)
+    target:addListener('MELEE_SWING_HIT', 'IMPETUS_HIT', xi.job_utils.monk.impetusHitListener)
+
+    -- For reload from the DB (/logout, login), add the effect power
+    local mainPower = effect:getPower()    -- Stores Attack & Critical Hit Rate bonuses
+    local subPower  = effect:getSubPower() -- Stores Critical Hit Damage & Accuracy bonuses
+
+    if mainPower > 0 then
+        target:addMod(xi.mod.ATT, mainPower * 2)
+        target:addMod(xi.mod.CRITHITRATE, mainPower)
+    end
+
+    if subPower > 0 then
+        target:addMod(xi.mod.ACC, subPower * 2)
+        target:addMod(xi.mod.CRIT_DMG_INCREASE, subPower)
+    end
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
+    target:removeListener('MELEE_SWING_MISS')
+    target:removeListener('MELEE_SWING_HIT')
+
+    -- TODO: Support Tantra Cyclas + 1 (does not give critical hit damage)
+    local mainPower = effect:getPower()    -- Stores Attack & Critical Hit Rate bonuses
+    local subPower  = effect:getSubPower() -- Stores Critical Hit Damage & Accuracy bonuses
+
+    if mainPower > 0 then
+        target:delMod(xi.mod.ATT, mainPower * 2)
+        target:delMod(xi.mod.CRITHITRATE, mainPower)
+    end
+
+    if subPower > 0 then
+        target:delMod(xi.mod.ACC, subPower * 2)
+        target:delMod(xi.mod.CRIT_DMG_INCREASE, subPower)
+    end
 end
 
 return effectObject

--- a/scripts/enum/mod.lua
+++ b/scripts/enum/mod.lua
@@ -440,6 +440,7 @@ xi.mod =
 
     -- Monk
     ADDITIVE_GUARD                  = 1092, -- Additive % bonus to final Guard rate (adds after clamp)
+    AUGMENTS_IMPETUS                = 1097, -- see https://www.bg-wiki.com/ffxi/Impetus, adds Crit Hit Damage & Accuracy for Impetus
 
     -- Paladin
     ENHANCES_CHIVALRY               = 1061, -- Enhances "Chivalry" effect (increases the base TP modifier by the provided value / 100, e.g. mod value 5 = +0.05)

--- a/scripts/globals/job_utils/monk.lua
+++ b/scripts/globals/job_utils/monk.lua
@@ -121,8 +121,58 @@ xi.job_utils.monk.useHundredFists = function(player, target, ability)
     player:addStatusEffect(xi.effect.HUNDRED_FISTS, 1, 0, 45)
 end
 
+-- TODO: Support Tantra Cyclas + 1 (does not give critical hit damage)
+-- Probably will be exceptionally jank, very low priority
+xi.job_utils.monk.impetusMissListener = function(attacker, victim, attack)
+    local effect = attacker:getStatusEffect(xi.effect.IMPETUS)
+
+    if effect then
+        local mainPower = effect:getPower()    -- Stores Attack & Critical Hit Rate bonuses
+        local subPower  = effect:getSubPower() -- Stores Critical Hit Damage & Accuracy bonuses
+
+        if mainPower > 0 then
+            attacker:delMod(xi.mod.ATT, mainPower * 2)
+            attacker:delMod(xi.mod.CRITHITRATE, mainPower)
+
+            effect:setPower(0)
+        end
+
+        if subPower > 0 then
+            attacker:delMod(xi.mod.ACC, subPower * 2)
+            attacker:delMod(xi.mod.CRIT_DMG_INCREASE, subPower)
+
+            effect:setSubPower(0)
+        end
+    end
+end
+
+-- TODO: Support Tantra Cyclas + 1 (does not give critical hit damage)
+-- Probably will be exceptionally jank, very low priority
+xi.job_utils.monk.impetusHitListener = function(attacker, victim, attack)
+    local effect = attacker:getStatusEffect(xi.effect.IMPETUS)
+
+    if effect then
+        local mainPower = effect:getPower()    -- Stores Attack & Critical Hit Rate bonuses
+        local subPower  = effect:getSubPower() -- Stores Critical Hit Damage & Accuracy bonuses
+
+        if mainPower < 50 then
+            attacker:addMod(xi.mod.ATT, 2)
+            attacker:addMod(xi.mod.CRITHITRATE, 1)
+
+            effect:setPower(mainPower + 1)
+        end
+
+        if attacker:getMod(xi.mod.AUGMENTS_IMPETUS) > 0 and subPower < 50 then
+            attacker:addMod(xi.mod.ACC, 2)
+            attacker:addMod(xi.mod.CRIT_DMG_INCREASE, 1)
+
+            effect:setSubPower(subPower + 1)
+        end
+    end
+end
+
 xi.job_utils.monk.useImpetus = function(player, target, ability)
-    player:addStatusEffect(xi.effect.IMPETUS, 2, 0, 180)
+    player:addStatusEffect(xi.effect.IMPETUS, 0, 0, 180)
 end
 
 xi.job_utils.monk.useInnerStrength = function(player, target, ability)

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -4802,12 +4802,13 @@ INSERT INTO `item_mods` VALUES (11084,85,7);    -- GAXE: 7
 INSERT INTO `item_mods` VALUES (11084,1046,30); -- ENHANCES_BLOOD_RAGE: 30
 
 -- Tantra Cyclas +2
-INSERT INTO `item_mods` VALUES (11085,1,64);  -- DEF: 64
-INSERT INTO `item_mods` VALUES (11085,8,12);  -- STR: 12
-INSERT INTO `item_mods` VALUES (11085,10,12); -- VIT: 12
-INSERT INTO `item_mods` VALUES (11085,23,15); -- ATT: 15
-INSERT INTO `item_mods` VALUES (11085,25,15); -- ACC: 15
-INSERT INTO `item_mods` VALUES (11085,173,5); -- MARTIAL_ARTS: 5
+INSERT INTO `item_mods` VALUES (11085,1,64);   -- DEF: 64
+INSERT INTO `item_mods` VALUES (11085,8,12);   -- STR: 12
+INSERT INTO `item_mods` VALUES (11085,10,12);  -- VIT: 12
+INSERT INTO `item_mods` VALUES (11085,23,15);  -- ATT: 15
+INSERT INTO `item_mods` VALUES (11085,25,15);  -- ACC: 15
+INSERT INTO `item_mods` VALUES (11085,173,5);  -- MARTIAL_ARTS: 5
+INSERT INTO `item_mods` VALUES (11085,1097,2); -- AUGMENTS_IMPETUS: 2
 
 -- Orison Bliaud +2
 INSERT INTO `item_mods` VALUES (11086,1,49);   -- DEF: 49
@@ -5503,11 +5504,12 @@ INSERT INTO `item_mods` VALUES (11184,85,5);    -- GAXE: 5
 INSERT INTO `item_mods` VALUES (11184,1046,15); -- ENHANCES_BLOOD_RAGE: 15
 
 -- Tantra Cyclas +1
-INSERT INTO `item_mods` VALUES (11185,1,61);  -- DEF: 61
-INSERT INTO `item_mods` VALUES (11185,8,8);   -- STR: 8
-INSERT INTO `item_mods` VALUES (11185,10,8);  -- VIT: 8
-INSERT INTO `item_mods` VALUES (11185,23,12); -- ATT: 12
-INSERT INTO `item_mods` VALUES (11185,25,12); -- ACC: 12
+INSERT INTO `item_mods` VALUES (11185,1,61);   -- DEF: 61
+INSERT INTO `item_mods` VALUES (11185,8,8);    -- STR: 8
+INSERT INTO `item_mods` VALUES (11185,10,8);   -- VIT: 8
+INSERT INTO `item_mods` VALUES (11185,23,12);  -- ATT: 12
+INSERT INTO `item_mods` VALUES (11185,25,12);  -- ACC: 12
+INSERT INTO `item_mods` VALUES (11185,1097,1); -- AUGMENTS_IMPETUS: 1 -- Note, this still acts like Tantra Cyclas +2 (or higher) for now
 
 -- Orison Bliaud +1
 INSERT INTO `item_mods` VALUES (11186,1,46);   -- DEF: 46
@@ -49169,7 +49171,7 @@ INSERT INTO `item_mods` VALUES (23153,68,95);   -- EVA: 95
 INSERT INTO `item_mods` VALUES (23153,173,7);   -- MARTIAL_ARTS: 7
 INSERT INTO `item_mods` VALUES (23153,384,400); -- HASTE_GEAR: 4%
 INSERT INTO `item_mods` VALUES (23153,841,8);   -- ALL_WSDMG_FIRST_HIT: 8
--- TODO: Augments Impetus: Increases Critical Hit Damage by 1% and ACC by 2 for each consecutive successful attack while worn
+INSERT INTO `item_mods` VALUES (23153,1097,2);  -- AUGMENTS_IMPETUS: 2
 
 -- Ebers Bliaut +2
 INSERT INTO `item_mods` VALUES (23154,1,145);   -- DEF: 145
@@ -65530,6 +65532,7 @@ INSERT INTO `item_mods` VALUES (26900,31,40);   -- MEVA: 40
 INSERT INTO `item_mods` VALUES (26900,68,25);   -- EVA: 25
 INSERT INTO `item_mods` VALUES (26900,173,5);   -- MARTIAL_ARTS: 5
 INSERT INTO `item_mods` VALUES (26900,384,400); -- HASTE_GEAR: 400
+INSERT INTO `item_mods` VALUES (26900,1097,2);  -- AUGMENTS_IMPETUS: 2
 
 -- Bhikku Cyclas +1
 INSERT INTO `item_mods` VALUES (26901,1,125);   -- DEF: 125
@@ -65548,6 +65551,7 @@ INSERT INTO `item_mods` VALUES (26901,31,59);   -- MEVA: 59
 INSERT INTO `item_mods` VALUES (26901,68,55);   -- EVA: 55
 INSERT INTO `item_mods` VALUES (26901,173,6);   -- MARTIAL_ARTS: 6
 INSERT INTO `item_mods` VALUES (26901,384,400); -- HASTE_GEAR: 400
+INSERT INTO `item_mods` VALUES (26901,1097,2);  -- AUGMENTS_IMPETUS: 2
 
 -- Ebers Bliaud
 INSERT INTO `item_mods` VALUES (26902,1,87);    -- DEF: 87

--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -509,13 +509,22 @@ bool CAttack::CheckCounter()
     {
         if ((xirand::GetRandomNumber(100) < std::clamp<uint16>(m_victim->getMod(Mod::COUNTER) + meritCounter, 0, 80) ||
              xirand::GetRandomNumber(100) < seiganChance) &&
-            facing(m_victim->loc.p, m_attacker->loc.p, 64) && xirand::GetRandomNumber(100) < battleutils::GetHitRate(m_victim, m_attacker))
+            facing(m_victim->loc.p, m_attacker->loc.p, 64))
         {
-            m_isCountered = true;
-            m_isCritical  = (xirand::GetRandomNumber(100) < battleutils::GetCritHitRate(m_victim, m_attacker, false));
+            if (xirand::GetRandomNumber(100) < battleutils::GetHitRate(m_victim, m_attacker))
+            {
+                m_isCountered = true;
+                m_isCritical  = (xirand::GetRandomNumber(100) < battleutils::GetCritHitRate(m_victim, m_attacker, false));
+            }
+            else
+            {
+                m_attacker->PAI->EventHandler.triggerListener("MELEE_SWING_MISS", CLuaBaseEntity(m_attacker), CLuaBaseEntity(m_victim), CLuaAttack(this));
+            }
         }
         else if (m_victim->StatusEffectContainer->HasStatusEffect(EFFECT_PERFECT_COUNTER))
-        { // Perfect Counter only counters hits that normal counter misses, always critical, can counter 1-3 times before wearing
+        {
+            // Perfect Counter only counters hits that normal counter misses, always critical, can counter 1-3 times before wearing
+            // TODO: Perfect Counter can negate an attack even if it misses (No accuracy check yet)
             m_isCountered = true;
             m_isCritical  = true;
 

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2378,6 +2378,8 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                         }
                     }
                 }
+
+                this->PAI->EventHandler.triggerListener("MELEE_SWING_MISS", CLuaBaseEntity(this), CLuaBaseEntity(PTarget), CLuaAttack(&attack));
             }
             else
             {
@@ -2492,6 +2494,8 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
             {
                 charutils::TrySkillUP(PChar, SKILL_EVASION, GetMLevel());
             }
+
+            this->PAI->EventHandler.triggerListener("MELEE_SWING_MISS", CLuaBaseEntity(this), CLuaBaseEntity(PTarget), CLuaAttack(&attack));
         }
 
         // If we didn't hit at all, set param to 0 if we didn't blink any shadows.

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -417,6 +417,7 @@ enum class Mod
     DODGE_EFFECT         = 552,  // Dodge effect in percents
     FOCUS_EFFECT         = 561,  // Focus effect in percents
     ADDITIVE_GUARD       = 1092, // Additive % bonus to final Guard rate (adds after clamp)
+    AUGMENTS_IMPETUS     = 1097, // see https://www.bg-wiki.com/ffxi/Impetus, adds Crit Hit Damage & Accuracy for Impetus
 
     // White Mage
     AFFLATUS_SOLACE  = 293, // Pool of HP accumulated during Afflatus Solace
@@ -1034,7 +1035,7 @@ enum class Mod
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     // 570 through 825 used by WS DMG mods these are not spares.
     //
-    // SPARE IDs: 1093 and onward
+    // SPARE IDs: 1098 and onward
 };
 
 // temporary workaround for using enum class as unordered_map key until compilers support it

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2077,8 +2077,10 @@ namespace battleutils
         if (PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_FORMLESS_STRIKES) && !isCounter)
         {
             attackType        = ATTACK_TYPE::SPECIAL;
-            uint8 formlessMod = 70;
+            uint8 formlessMod = 55; // Start at 55
 
+            // https://www.bg-wiki.com/ffxi/Formless_Strikes
+            // Merit value of 1 is +5%, so 60% normal power
             if (PAttacker->objtype == TYPE_PC)
             {
                 formlessMod += ((CCharEntity*)PAttacker)->PMeritPoints->GetMeritValue(MERIT_FORMLESS_STRIKES, (CCharEntity*)PAttacker);
@@ -2087,8 +2089,8 @@ namespace battleutils
             damage = damage * formlessMod / 100;
 
             // TODO: chance to 'resist'
-
-            damage = MagicDmgTaken(PDefender, damage, ELEMENT_NONE);
+            // breath damage, not magic damage
+            damage = BreathDmgTaken(PDefender, damage);
         }
         else
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implement Impetus, make Formless Strikes more accurate

## Steps to test these changes

Test impetus per https://www.bg-wiki.com/ffxi/Impetus (no job points yet, tantra cyclas +1 acts like +2 and above)
Ensure effect reloads on zone properly and sets to zero properly

Check formless strikes works with breath damage, not magic damage
