### PR TITLE
HPP/MPP adjustments, use divisors for healing breath trigger points

### DIFF
--- a/scripts/actions/mobskills/calamitous_wind.lua
+++ b/scripts/actions/mobskills/calamitous_wind.lua
@@ -12,7 +12,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getHPP() > 50 then
+    if mob:getHPP() >= 50 then
         return 1
     else
         return 0

--- a/scripts/actions/mobskills/colossal_blow.lua
+++ b/scripts/actions/mobskills/colossal_blow.lua
@@ -13,7 +13,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local currentHP = target:getHP()
     local damage    = currentHP
 
-    -- if have more hp then 30%, then reduce to 5%
+    -- if we have more than 30% hp, reduce to 5%
     if target:getHPP() > 30 then
         damage = currentHP * .95
     end

--- a/scripts/actions/mobskills/feral_peck.lua
+++ b/scripts/actions/mobskills/feral_peck.lua
@@ -17,7 +17,7 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local damage    = target:getHP()
 
-    -- If have more hp then 30%, then reduce a 10%
+    -- If we have more than 30% HP, then reduce by 10%
     if target:getHPP() > 30 then
         damage = damage * 0.9
     end

--- a/scripts/actions/mobskills/fulmination.lua
+++ b/scripts/actions/mobskills/fulmination.lua
@@ -23,9 +23,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     local family = mob:getFamily()
     local mobHPP = mob:getHPP()
 
-    if family == 168 and mobHPP <= 35 then -- Khimaira < 35%
+    if family == 168 and mobHPP < 35 then -- Khimaira < 35%
         return 0
-    elseif family == 315 and mobHPP <= 50 then -- Tyger < 50%
+    elseif family == 315 and mobHPP < 50 then -- Tyger < 50%
         return 0
     end
 

--- a/scripts/actions/mobskills/gates_of_hades.lua
+++ b/scripts/actions/mobskills/gates_of_hades.lua
@@ -20,7 +20,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
         end
     end
 
-    if mob:getHPP() <= 25 then
+    if mob:getHPP() < 25 then
         return 0
     end
 

--- a/scripts/actions/mobskills/self-destruct.lua
+++ b/scripts/actions/mobskills/self-destruct.lua
@@ -5,7 +5,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:isMobType(xi.mobType.NOTORIOUS) or mob:getHPP() > 75 then
+    if mob:isMobType(xi.mobType.NOTORIOUS) or mob:getHPP() >= 75 then
         return 1
     end
 

--- a/scripts/actions/mobskills/soothing_aroma.lua
+++ b/scripts/actions/mobskills/soothing_aroma.lua
@@ -8,7 +8,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getHPP() > 50 and mob:getPool() == 3326 then
+    if mob:getHPP() >= 50 and mob:getPool() == 3326 then
         -- Raskovnik doesn't use this for the 1st half of its HP.
         return 1
     end

--- a/scripts/actions/mobskills/target_analysis.lua
+++ b/scripts/actions/mobskills/target_analysis.lua
@@ -22,7 +22,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     local mobhp = mob:getHPP()
 
     if
-        (skillList == 54 and mobhp < 26) or
+        (skillList == 54 and mobhp < 25) or
         (skillList == 727 and mob:getAnimationSub() == 1)
     then
         return 0

--- a/scripts/globals/pets/wyvern.lua
+++ b/scripts/globals/pets/wyvern.lua
@@ -42,7 +42,8 @@ local wyvernTypes =
     [xi.job.RUN]  = wyvernCapabilities.MULTI,
 }
 
-local function doHealingBreath(player, threshold)
+-- healing breath uses ratios, so use a divisor as input
+local function doHealingBreath(player, divisor)
     local breathHealRange = 14
 
     local healingbreath = xi.jobAbility.HEALING_BREATH
@@ -62,7 +63,7 @@ local function doHealingBreath(player, threshold)
     end
 
     if
-        player:getHPP() <= threshold and
+        player:getHP() <= math.floor(player:getMaxHP() / divisor) and
         inBreathRange(player)
     then
         player:getPet():useJobAbility(healingbreath, player)
@@ -70,7 +71,7 @@ local function doHealingBreath(player, threshold)
         local party = player:getPartyWithTrusts()
         for _, member in pairs(party) do
             if
-                member:getHPP() <= threshold and
+                player:getHP() <= math.floor(player:getMaxHP() / divisor) and
                 inBreathRange(member) and
                 not member:isDead()
             then
@@ -138,13 +139,14 @@ xi.pets.wyvern.onMobSpawn = function(mob)
             end
         end)
 
+        -- 1/3 and 1/2 divisor for healing breath
         master:addListener('MAGIC_USE', 'PET_WYVERN_MAGIC', function(player, target, spell, action)
-            local threshold = 33
+            local divisor = 3
             if player:getMod(xi.mod.WYVERN_EFFECTIVE_BREATH) > 0 then
-                threshold = 50
+                divisor = 2
             end
 
-            doHealingBreath(player, threshold)
+            doHealingBreath(player, divisor)
         end)
     elseif
         wyvernType == wyvernCapabilities.OFFENSIVE or
@@ -155,14 +157,15 @@ xi.pets.wyvern.onMobSpawn = function(mob)
         end)
     end
 
+    -- 1/4 and 1/3rd divisors for HP
     if wyvernType == wyvernCapabilities.MULTI then
         master:addListener('MAGIC_USE', 'PET_WYVERN_MAGIC', function(player, target, spell, action)
-            local threshold = 25
+            local divisor = 4
             if player:getMod(xi.mod.WYVERN_EFFECTIVE_BREATH) > 0 then
-                threshold = 33
+                divisor = 3
             end
 
-            doHealingBreath(player, threshold)
+            doHealingBreath(player, divisor)
         end)
     end
 

--- a/src/map/ai/controllers/automaton_controller.cpp
+++ b/src/map/ai/controllers/automaton_controller.cpp
@@ -402,8 +402,8 @@ bool CAutomatonController::TrySpellcast(const CurrentManeuvers& maneuvers)
                 m_LastEnhanceTime = m_Tick;
                 return true;
             }
-            else if ((maneuvers.dark || PAutomaton->GetHPP() <= 75 || PAutomaton->GetMPP() <= 75) &&
-                     TryEnfeeble(maneuvers)) // Dark or self HPP/MPP <= 75 -> Enfeeble
+            else if ((maneuvers.dark || PAutomaton->GetHPP() < 75 || PAutomaton->GetMPP() < 75) &&
+                     TryEnfeeble(maneuvers)) // Dark or self HPP/MPP < 75 -> Enfeeble
             {
                 m_LastEnfeebleTime = m_Tick;
                 return true;
@@ -844,13 +844,13 @@ bool CAutomatonController::TryEnfeeble(const CurrentManeuvers& maneuvers)
         }
         case HEAD_SPIRITREAVER:
         {
-            if (PAutomaton->GetMPP() <= 75 && PTarget->health.mp > 0) // MPP <= 75 -> Aspir
+            if (PAutomaton->GetMPP() < 75 && PTarget->health.mp > 0) // MPP < 75 -> Aspir
             {
                 castPriority.emplace_back(SpellID::Aspir_II);
                 castPriority.emplace_back(SpellID::Aspir);
             }
 
-            if (PAutomaton->GetHPP() <= 75 && PTarget->m_EcoSystem != ECOSYSTEM::UNDEAD)
+            if (PAutomaton->GetHPP() < 75 && PTarget->m_EcoSystem != ECOSYSTEM::UNDEAD)
             { // HPP <= 75 -> Drain
                 castPriority.emplace_back(SpellID::Drain);
             }

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -254,7 +254,12 @@ void CBattleEntity::UpdateHealth()
 
 uint8 CBattleEntity::GetHPP() const
 {
-    return (uint8)ceil(((float)health.hp / (float)GetMaxHP()) * 100);
+    if (health.hp == 0)
+    {
+        return 0;
+    }
+
+    return static_cast<uint8>(std::floor((static_cast<float>(health.hp) / static_cast<float>(GetMaxHP())) * 100.f));
 }
 
 int32 CBattleEntity::GetMaxHP() const
@@ -270,7 +275,12 @@ int32 CBattleEntity::GetMaxHP() const
 
 uint8 CBattleEntity::GetMPP() const
 {
-    return (uint8)ceil(((float)health.mp / (float)GetMaxMP()) * 100);
+    if (health.mp == 0)
+    {
+        return 0;
+    }
+
+    return static_cast<uint8>(std::floor((static_cast<float>(health.mp) / static_cast<float>(GetMaxMP())) * 100.f));
 }
 
 int32 CBattleEntity::GetMaxMP() const


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

See #5093 
Closes #5093  (mostly)

Noteworthy: HPP/MPP values adjusted down by 1% and a lot of code may have anticipated the error. This PR does not intend to fix everything, as there's too many known unknowns. I did a brief examination of mobskills and some have unverified hp% trigger values so I left them alone. Same with all mob behavior scripts. That said, I would assume most behavior changes due to this will not be significant.

## Steps to test these changes

See #5093 for details -- but in essence just see HPP/MPP act like retail does it. Test healing breath with hybrid sub to use floor(MaxHP/3) as trigger point
