### PR TITLE
Chore: Cleanup Mixed British/American Spelling to American English

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,4 +27,4 @@ assignees:
 
 ## Expected behavior
 
-<!-- Add expected behaviour here -->
+<!-- Add expected behavior here -->

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -49,13 +49,13 @@ set(CMAKE_CXX_FLAGS_MSAN
         CACHE STRING "Flags used by the C++ compiler during MemorySanitizer builds."
         FORCE)
 
-# UndefinedBehaviour
+# Undefinedbehavior
 # LeakSanitizer is a run-time undefined behavior detector.
 set(CMAKE_C_FLAGS_UBSAN
         "-fsanitize=undefined"
-        CACHE STRING "Flags used by the C compiler during UndefinedBehaviourSanitizer builds."
+        CACHE STRING "Flags used by the C compiler during UndefinedBehaviorSanitizer builds."
         FORCE)
 set(CMAKE_CXX_FLAGS_UBSAN
         "-fsanitize=undefined"
-        CACHE STRING "Flags used by the C++ compiler during UndefinedBehaviourSanitizer builds."
+        CACHE STRING "Flags used by the C++ compiler during UndefinedBehaviorSanitizer builds."
         FORCE)

--- a/documentation/adls/sol_refactoring.md
+++ b/documentation/adls/sol_refactoring.md
@@ -7,7 +7,7 @@ Multiple problems, explained in detail [here](https://github.com/LandSandBoat/se
 In short:
 - Our use of Lua relied on constantly reading files from this disk, which was very slow.
 - Lua binding library was hard to use.
-- Errors on the boundary between C++ and Lua would cause undefined behaviour or crashes.
+- Errors on the boundary between C++ and Lua would cause undefined behavior or crashes.
 
 ### What were/are the options?
 Only Sol was considered.

--- a/modules/custom/lua/persist_nm_time_of_deaths.lua
+++ b/modules/custom/lua/persist_nm_time_of_deaths.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Persists NM time of deaths to the database. They must be added to the list here
--- to get this extra behaviour.
+-- to get this extra behavior.
 -- This is useful if you don't want players rushing to NM spawns after a server
 -- restart or a crash (or trying to force crashes/restarts to get NM pops)
 -----------------------------------

--- a/scripts/actions/mobskills/gigaflare.lua
+++ b/scripts/actions/mobskills/gigaflare.lua
@@ -28,8 +28,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     mob:setMobAbilityEnabled(true) -- enable the spells/other mobskills again
     mob:setMagicCastingEnabled(true)
 
-    if bit.band(mob:getBehaviour(), xi.behavior.NO_TURN) == 0 then -- re-enable noturn
-        mob:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.NO_TURN))
+    if bit.band(mob:getBehavior(), xi.behavior.NO_TURN) == 0 then -- re-enable noturn
+        mob:setBehavior(bit.bor(mob:getBehavior(), xi.behavior.NO_TURN))
     end
 
     local damage = mob:getWeaponDmg() * 15

--- a/scripts/actions/mobskills/megaflare.lua
+++ b/scripts/actions/mobskills/megaflare.lua
@@ -28,8 +28,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     mob:setMagicCastingEnabled(true)
     mob:setAutoAttackEnabled(true)
 
-    if bit.band(mob:getBehaviour(), xi.behavior.NO_TURN) == 0 then -- re-enable noturn
-        mob:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.NO_TURN))
+    if bit.band(mob:getBehavior(), xi.behavior.NO_TURN) == 0 then -- re-enable noturn
+        mob:setBehavior(bit.bor(mob:getBehavior(), xi.behavior.NO_TURN))
     end
 
     -- Damage calculation

--- a/scripts/actions/mobskills/polar_blast.lua
+++ b/scripts/actions/mobskills/polar_blast.lua
@@ -37,11 +37,11 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     if
         mob:getFamily() == 313 and
-        bit.band(mob:getBehaviour(), xi.behavior.NO_TURN) == 0 and
+        bit.band(mob:getBehavior(), xi.behavior.NO_TURN) == 0 and
         mob:getAnimationSub() == 1
     then
         -- re-enable no turn if third head is dead (Tinnin), else it's re-enabled after the upcoming Pyric Blast
-        mob:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.NO_TURN))
+        mob:setBehavior(bit.bor(mob:getBehavior(), xi.behavior.NO_TURN))
     end
 
     return dmg

--- a/scripts/actions/mobskills/pyric_blast.lua
+++ b/scripts/actions/mobskills/pyric_blast.lua
@@ -37,10 +37,10 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     if
         mob:getFamily() == 313 and
-        bit.band(mob:getBehaviour(), xi.behavior.NO_TURN) == 0
+        bit.band(mob:getBehavior(), xi.behavior.NO_TURN) == 0
     then
         -- re-enable no turn if all three heads are up
-        mob:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.NO_TURN))
+        mob:setBehavior(bit.bor(mob:getBehavior(), xi.behavior.NO_TURN))
     end
 
     return dmg

--- a/scripts/actions/spells/trust/qultada.lua
+++ b/scripts/actions/spells/trust/qultada.lua
@@ -21,7 +21,7 @@ spellObject.onMobSpawn = function(mob)
     mob:addSimpleGambit(ai.t.TARGET, ai.c.ALWAYS, 0, ai.r.RATTACK, 0, 0, 10)
 
     -- Notable: Uses a balance of melee and ranged attacks.
-    -- TODO: Observe his WS behaviour on retail
+    -- TODO: Observe his WS behavior on retail
     mob:setTrustTPSkillSettings(ai.tp.OPENER, ai.s.RANDOM)
 
     -- https://forum.square-enix.com/ffxi/threads/49425-Dec-10-2015-%28JST%29-Version-Update?p=567979&viewfull=1#post567979

--- a/scripts/battlefields/Apollyon/ne_apollyon.lua
+++ b/scripts/battlefields/Apollyon/ne_apollyon.lua
@@ -23,8 +23,8 @@ local content = Limbus:new({
     timeExtension    = 5,
 })
 
-function content:onBattlefieldInitialise(battlefield)
-    Limbus.onBattlefieldInitialise(self, battlefield)
+function content:onBattlefieldInitialize(battlefield)
+    Limbus.onBattlefieldInitialize(self, battlefield)
 
     for i, crateID in ipairs(ID.NE_APOLLYON.npc.TIME_CRATES) do
         npcUtil.showCrate(GetNPCByID(crateID))

--- a/scripts/battlefields/Apollyon/nw_apollyon.lua
+++ b/scripts/battlefields/Apollyon/nw_apollyon.lua
@@ -21,8 +21,8 @@ local content = Limbus:new({
     timeExtension   = 5,
 })
 
-function content:onBattlefieldInitialise(battlefield)
-    Limbus.onBattlefieldInitialise(self, battlefield)
+function content:onBattlefieldInitialize(battlefield)
+    Limbus.onBattlefieldInitialize(self, battlefield)
 
     for i, crateID in ipairs(ID.NW_APOLLYON.npc.TIME_CRATES) do
         npcUtil.showCrate(GetNPCByID(crateID))

--- a/scripts/battlefields/Temenos/central_temenos_4th_floor.lua
+++ b/scripts/battlefields/Temenos/central_temenos_4th_floor.lua
@@ -35,8 +35,8 @@ local despawnGroupCrates = function(crateGroup)
     end
 end
 
-function content:onBattlefieldInitialise(battlefield)
-    Limbus.onBattlefieldInitialise(self, battlefield)
+function content:onBattlefieldInitialize(battlefield)
+    Limbus.onBattlefieldInitialize(self, battlefield)
 
     -- Crates are always spawned with in fixed groups
     -- Randomize crate type order by shuffling setup functions

--- a/scripts/battlefields/Temenos/temenos_eastern_tower.lua
+++ b/scripts/battlefields/Temenos/temenos_eastern_tower.lua
@@ -174,8 +174,8 @@ local setupRecoverCrate = function(crateID, floor, crateOffset, count)
     end
 end
 
-function content:onBattlefieldInitialise(battlefield)
-    Limbus.onBattlefieldInitialise(self, battlefield)
+function content:onBattlefieldInitialize(battlefield)
+    Limbus.onBattlefieldInitialize(self, battlefield)
 
     local crateSetupFuncs =
     {

--- a/scripts/battlefields/Temenos/temenos_western_tower.lua
+++ b/scripts/battlefields/Temenos/temenos_western_tower.lua
@@ -55,8 +55,8 @@ local setupRecoverCrate = function(crateID, floor)
     end
 end
 
-function content:onBattlefieldInitialise(battlefield)
-    Limbus.onBattlefieldInitialise(self, battlefield)
+function content:onBattlefieldInitialize(battlefield)
+    Limbus.onBattlefieldInitialize(self, battlefield)
 
     local crateSetupFuncs =
     {

--- a/scripts/commands/chocobo.lua
+++ b/scripts/commands/chocobo.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- func: chocobo <colour> <head> <tail> <feet>
+-- func: chocobo <color> <head> <tail> <feet>
 -- desc: Register and use a chocobo with a specific look
 --
 -- examples:

--- a/scripts/enum/behavior.lua
+++ b/scripts/enum/behavior.lua
@@ -3,7 +3,7 @@
 -----------------------------------
 xi = xi or {}
 
----@enum xi.behaviour
+---@enum xi.behavior
 xi.behavior =
 {
     NONE         = 0x000,

--- a/scripts/globals/ability.lua
+++ b/scripts/globals/ability.lua
@@ -30,7 +30,7 @@ xi.ability.adjustDamage = function(dmg, mob, skill, target, skilltype, skillpara
     -- this is for AoE because its only set once
     skill:setMsg(xi.msg.basic.USES_JA_TAKE_DAMAGE)
 
-    -- Handle shadows depending on shadow behaviour / skilltype
+    -- Handle shadows depending on shadow behavior / skilltype
     if
         shadowbehav ~= xi.mobskills.shadowBehavior.WIPE_SHADOWS and
         shadowbehav ~= xi.mobskills.shadowBehavior.IGNORE_SHADOWS

--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -44,7 +44,7 @@ local maxAreas =
     },
 }
 
-function onBattlefieldHandlerInitialise(zone)
+function onBattlefieldHandlerInitialize(zone)
     local id      = zone:getID()
     local default = 3
 
@@ -944,11 +944,11 @@ function Battlefield:onEventFinishBattlefield(player, csid, option, npc)
 end
 
 -- Override this function if necessary to perform additional steps in battlefield
--- initialise.
+-- Initialize.
 function Battlefield:setupBattlefield(battlefield)
 end
 
-function Battlefield:onBattlefieldInitialise(battlefield)
+function Battlefield:onBattlefieldInitialize(battlefield)
     local hasMultipleAreas = not self.area
     battlefield:addGroups(self.groups, hasMultipleAreas)
 

--- a/scripts/globals/chocobo_racing.lua
+++ b/scripts/globals/chocobo_racing.lua
@@ -163,7 +163,7 @@ local startRaceImpl = function(player)
             -- 0x7: Mithra
             local races = { 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7 }
 
-            -- Colours:
+            -- Colors:
             -- 0x0: Yellow
             -- 0x1: Yellow
             -- 0x2: Black
@@ -173,11 +173,11 @@ local startRaceImpl = function(player)
             -- 0x6: Red
             -- 0x7: Red
             -- 0x8: Green
-            local colours = { 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8 }
+            local colors = { 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8 }
 
             for _, offset in ipairs({ 0x0C, 0x18, 0x24, 0x30, 0x3C, 0x48, 0x54, 0x60 }) do
                 local race   = utils.randomEntry(races)
-                local colour = utils.randomEntry(colours)
+                local color = utils.randomEntry(colors)
 
                 -- Remember Lua is 1-offset!
                 packet[offset + 0 + 1] = 0x0E
@@ -187,7 +187,7 @@ local startRaceImpl = function(player)
                 packet[offset + 4 + 1] = 0x00
                 packet[offset + 5 + 1] = 0x00
                 packet[offset + 6 + 1] = 0x08
-                packet[offset + 7 + 1] = bit.lshift(race, 4) + colour
+                packet[offset + 7 + 1] = bit.lshift(race, 4) + color
                 packet[offset + 8 + 1] = 0x41
                 packet[offset + 9 + 1] = 0x00
                 packet[offset + 10 + 1] = 0x00

--- a/scripts/globals/chocobo_raising.lua
+++ b/scripts/globals/chocobo_raising.lua
@@ -543,7 +543,7 @@ local stage =
     ADULT_4    = 7, -- Retired?
 }
 
-local colour =
+local color =
 {
     YELLOW = 0,
     BLACK  = 1,
@@ -743,7 +743,7 @@ xi.chocoboRaising.newChocobo = function(player, egg)
     newChoco.recessive_gene = 0 -- TODO
 
     -- TODO: Pick various stats based on genetics
-    newChoco.colour             = colour.YELLOW
+    newChoco.color             = color.YELLOW
     newChoco.strength           = 0
     newChoco.endurance          = 0
     newChoco.discernment        = 0
@@ -1054,7 +1054,7 @@ local handleCSUpdate = function(player, chocoState, doEventUpdate)
     if doEventUpdate then
         player:updateEventString(chocoState.first_name, chocoState.last_name, chocoState.first_name, chocoState.first_name,
             0, 0, 0, 0, 0, 0, 0, 0)
-        player:updateEvent(#chocoState.csList, csToPlay, 0, chocoState.colour, chocoState.stage, 0, currentAgeOfChocoboDuringCutscene, 1)
+        player:updateEvent(#chocoState.csList, csToPlay, 0, chocoState.color, chocoState.stage, 0, currentAgeOfChocoboDuringCutscene, 1)
     end
 
     return chocoState
@@ -1624,7 +1624,7 @@ xi.chocoboRaising.onEventUpdateVCSTrainer = function(player, csid, option, npc)
                     local itemData     = validFoods[itemId]
                     local hungerAmount = itemData[1]
                     local energyAmount = itemData[3]
-                    local glowColour   = itemData[10]
+                    local glowColor   = itemData[10]
 
                     player:messageSpecial(ID.text.CHOCOBO_FEEDING_ITEM, itemId, idx)
 
@@ -1652,10 +1652,10 @@ xi.chocoboRaising.onEventUpdateVCSTrainer = function(player, csid, option, npc)
 
                     -- If multiple items, glow is always green
                     if #chocoState.foodGiven > 1 then
-                        glowColour = glow.GREEN
+                        glowColor = glow.GREEN
                     end
 
-                    player:updateEvent(10, glowColour, 0, 0, reaction, numberToRank(chocoState.hunger), 0, 0)
+                    player:updateEvent(10, glowColor, 0, 0, reaction, numberToRank(chocoState.hunger), 0, 0)
                 end
 
                 chocoState.foodGiven = nil
@@ -1692,7 +1692,7 @@ xi.chocoboRaising.onEventUpdateVCSTrainer = function(player, csid, option, npc)
                 end
 
                 -- Event update parameters.
-                player:updateEvent(chocoState.colour, enlargedCrest, enlargedFeet, moreTailFeathers, chocoState.stage, 1, 0, 0)
+                player:updateEvent(chocoState.color, enlargedCrest, enlargedFeet, moreTailFeathers, chocoState.stage, 1, 0, 0)
             end,
 
             [46] = function() -- Ask about chocobo's condition (menu)

--- a/scripts/globals/dark_ixion.lua
+++ b/scripts/globals/dark_ixion.lua
@@ -312,7 +312,7 @@ xi.darkixion.roamingMods = function(mob)
     mob:setLocalVar('charging', 0)
     mob:setLocalVar('double', 0)
     mob:setLocalVar('lastHit', 0)
-    mob:setBehaviour(0)
+    mob:setBehavior(0)
     mob:setAutoAttackEnabled(true)
     mob:setMobAbilityEnabled(true)
 end

--- a/scripts/globals/instance.lua
+++ b/scripts/globals/instance.lua
@@ -409,7 +409,7 @@ xi.instance.onEventUpdate = function(player, csid, option, npc)
     end
 end
 
--- 'Default' behaviour. It's up to each instance whether or not they want to use this logic
+-- 'Default' behavior. It's up to each instance whether or not they want to use this logic
 xi.instance.onInstanceCreatedCallback = function(player, instance)
     local zoneLookup = xi.instance.lookup[instance:getZone():getID()]
     local instanceId = instance:getID()

--- a/scripts/globals/limbus.lua
+++ b/scripts/globals/limbus.lua
@@ -119,8 +119,8 @@ function Limbus:onEventFinishEnter(player, csid, option, npc)
 end
 
 ---@diagnostic disable-next-line: duplicate-set-field
-function Limbus:onBattlefieldInitialise(battlefield)
-    Battlefield.onBattlefieldInitialise(self, battlefield)
+function Limbus:onBattlefieldInitialize(battlefield)
+    Battlefield.onBattlefieldInitialize(self, battlefield)
     SetServerVariable(self.serverVar, battlefield:getTimeLimit() / 60)
     self:closeDoors()
 

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -477,7 +477,7 @@ xi.mobskills.mobFinalAdjustments = function(dmg, mob, skill, target, attackType,
         skill:setMsg(xi.msg.basic.DAMAGE)
     end
 
-    --Handle shadows depending on shadow behaviour / attackType
+    --Handle shadows depending on shadow behavior / attackType
     if
         shadowbehav ~= xi.mobskills.shadowBehavior.WIPE_SHADOWS and
         shadowbehav ~= xi.mobskills.shadowBehavior.IGNORE_SHADOWS

--- a/scripts/globals/spells/enhancing_spell.lua
+++ b/scripts/globals/spells/enhancing_spell.lua
@@ -467,7 +467,7 @@ xi.spells.enhancing.useEnhancingSpell = function(caster, target, spell)
     local tickTime        = pTable[spellId][8]
 
     ------------------------------------------------------------
-    -- Handle exceptions and weird behaviour here, before calculating anything.
+    -- Handle exceptions and weird behavior here, before calculating anything.
     ------------------------------------------------------------
     -- Bar-Element (They use addStatusEffect argument 6. Bar-Status current implementation doesn't.)
     if spellEffect >= xi.effect.BARFIRE and spellEffect <= xi.effect.BARWATER then

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -286,7 +286,7 @@ xi.summon.avatarFinalAdjustments = function(dmg, mob, skill, target, skilltype, 
         skill:setMsg(xi.msg.basic.DAMAGE)
     end
 
-    -- Handle shadows depending on shadow behaviour / skilltype
+    -- Handle shadows depending on shadow behavior / skilltype
     dmg = utils.takeShadows(target, dmg, shadowbehav)
 
     -- handle Third Eye using shadowbehav as a guide

--- a/scripts/mixins/families/aern.lua
+++ b/scripts/mixins/families/aern.lua
@@ -1,7 +1,7 @@
 -- Aern family mixin
 -- Customization:
 --   Setting AERN_RERAISE_MAX will determine the number of times it will reraise.
---   By default, this will be 1 40% of the time and 0 the rest (ie. default aern behaviour).
+--   By default, this will be 1 40% of the time and 0 the rest (ie. default aern behavior).
 --   For multiple reraises, this can be set on spawn for more reraises.
 --   To run a function when a reraise occurs, add a listener to AERN_RERAISE
 

--- a/scripts/mixins/families/chariot.lua
+++ b/scripts/mixins/families/chariot.lua
@@ -5,7 +5,7 @@ g_mixins.families = g_mixins.families or {}
 
 g_mixins.families.chariot = function(chariotMob)
     chariotMob:addListener('SPAWN', 'CHARIOT_SPAWN', function(mob)
-        mob:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.NO_TURN))
+        mob:setBehavior(bit.bor(mob:getBehavior(), xi.behavior.NO_TURN))
     end)
 
     chariotMob:addListener('ENGAGE', 'CHARIOT_ENGAGE', function(mob)

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -3697,12 +3697,12 @@ end
 
 ---@nodiscard
 ---@return integer
-function CBaseEntity:getBehaviour()
+function CBaseEntity:getBehavior()
 end
 
 ---@param behavior integer
 ---@return nil
-function CBaseEntity:setBehaviour(behavior)
+function CBaseEntity:setBehavior(behavior)
 end
 
 ---@nodiscard

--- a/scripts/zones/AlTaieu/mobs/Absolute_Virtue.lua
+++ b/scripts/zones/AlTaieu/mobs/Absolute_Virtue.lua
@@ -49,7 +49,7 @@ xi.av = xi.av or {}
 -- While this flag is in place, AV's won't drop any loot. Sorry!
 xi.av.experimental = true
 
--- Set to true to get local debug prints about AV's behaviour
+-- Set to true to get local debug prints about AV's behavior
 local debugAV = false
 local avdebug = utils.getDebugPlayerPrinter(debugAV)
 

--- a/scripts/zones/Apollyon/mobs/Proto-Omega.lua
+++ b/scripts/zones/Apollyon/mobs/Proto-Omega.lua
@@ -51,7 +51,7 @@ entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.COUNTER, 10)
     mob:setMod(xi.mod.REGAIN, 50)
     mob:setMod(xi.mod.REGEN, 25)
-    mob:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.NO_TURN))
+    mob:setBehavior(bit.bor(mob:getBehavior(), xi.behavior.NO_TURN))
     -- base speed of 60 is based on retail capture and applies to all forms
     -- also has standard boost (2.5x) up to 150 when target is out of range
     mob:setSpeed(60)

--- a/scripts/zones/Balgas_Dais/mobs/Wyrm.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Wyrm.lua
@@ -49,7 +49,7 @@ entity.onMobFight = function(mob, target)
         mob:addStatusEffect(xi.effect.DEFENSE_BOOST, 75, 0, 0)
         mob:addStatusEffect(xi.effect.MAGIC_DEF_BOOST, 75, 0, 0)
         mob:setMobMod(xi.mobMod.SKILL_LIST, 262) -- restore standard ground skill set
-        mob:setBehaviour(1024) -- reset behavior to not face target
+        mob:setBehavior(1024) -- reset behavior to not face target
 
     -- Go airborne at 66% HP, gets only called once
     -- TODO: Should move physically to center/origin before taking off; maybe with pathTo()?
@@ -63,7 +63,7 @@ entity.onMobFight = function(mob, target)
         mob:addStatusEffectEx(xi.effect.ALL_MISS, 0, 1, 0, 0) -- melee attacks miss now
         mob:setMobSkillAttack(1146) -- change default attack to ranged fire magic damage
         mob:setMobMod(xi.mobMod.SKILL_LIST, 1147) -- change skill set to flying moves
-        mob:setBehaviour(0) -- face target while flying
+        mob:setBehavior(0) -- face target while flying
     end
 end
 

--- a/scripts/zones/LaLoff_Amphitheater/mobs/Ark_Angel_TT.lua
+++ b/scripts/zones/LaLoff_Amphitheater/mobs/Ark_Angel_TT.lua
@@ -42,9 +42,9 @@ end
 entity.onMobFight = function(mob, target)
     if
         mob:hasStatusEffect(xi.effect.BLOOD_WEAPON) and
-        bit.band(mob:getBehaviour(), xi.behavior.STANDBACK) > 0
+        bit.band(mob:getBehavior(), xi.behavior.STANDBACK) > 0
     then
-        mob:setBehaviour(bit.band(mob:getBehaviour(), bit.bnot(xi.behavior.STANDBACK)))
+        mob:setBehavior(bit.band(mob:getBehavior(), bit.bnot(xi.behavior.STANDBACK)))
         mob:setMobMod(xi.mobMod.TELEPORT_TYPE, 0)
         mob:setMobMod(xi.mobMod.SPAWN_LEASH, 0)
         mob:setSpellList(0)
@@ -52,9 +52,9 @@ entity.onMobFight = function(mob, target)
 
     if
         not mob:hasStatusEffect(xi.effect.BLOOD_WEAPON) and
-        bit.band(mob:getBehaviour(), xi.behavior.STANDBACK) == 0
+        bit.band(mob:getBehavior(), xi.behavior.STANDBACK) == 0
     then
-        mob:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.STANDBACK))
+        mob:setBehavior(bit.bor(mob:getBehavior(), xi.behavior.STANDBACK))
         mob:setMobMod(xi.mobMod.TELEPORT_TYPE, 1)
         mob:setMobMod(xi.mobMod.SPAWN_LEASH, 22)
         mob:setSpellList(39)

--- a/scripts/zones/Riverne-Site_B01/mobs/Bahamut.lua
+++ b/scripts/zones/Riverne-Site_B01/mobs/Bahamut.lua
@@ -71,8 +71,8 @@ entity.onMobFight = function(mob, target)
                 end
 
                 if mob:checkDistance(target) <= 15 then -- without this check if the target is out of range it will keep attemping and failing to use Megaflare. Both Megaflare and Gigaflare have range 15.
-                    if bit.band(mob:getBehaviour(), xi.behavior.NO_TURN) > 0 then -- default behaviour
-                        mob:setBehaviour(bit.band(mob:getBehaviour(), bit.bnot(xi.behavior.NO_TURN)))
+                    if bit.band(mob:getBehavior(), xi.behavior.NO_TURN) > 0 then -- default behavior
+                        mob:setBehavior(bit.band(mob:getBehavior(), bit.bnot(xi.behavior.NO_TURN)))
                     end
 
                     mob:useMobAbility(1551)
@@ -90,8 +90,8 @@ entity.onMobFight = function(mob, target)
                 mob:setLocalVar('tauntShown', 3) -- again, taunt won't show again until the move is successfully used.
             end
 
-            if bit.band(mob:getBehaviour(), xi.behavior.NO_TURN) > 0 then -- default behaviour
-                mob:setBehaviour(bit.band(mob:getBehaviour(), bit.bnot(xi.behavior.NO_TURN)))
+            if bit.band(mob:getBehavior(), xi.behavior.NO_TURN) > 0 then -- default behavior
+                mob:setBehavior(bit.band(mob:getBehavior(), bit.bnot(xi.behavior.NO_TURN)))
             end
 
             mob:useMobAbility(1552)

--- a/scripts/zones/Sauromugue_Champaign/mobs/Old_Sabertooth.lua
+++ b/scripts/zones/Sauromugue_Champaign/mobs/Old_Sabertooth.lua
@@ -23,8 +23,8 @@ local pathNodes =
 }
 
 entity.onMobSpawn = function(mob)
-    mob:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.STANDBACK))
-    mob:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.NO_TURN))
+    mob:setBehavior(bit.bor(mob:getBehavior(), xi.behavior.STANDBACK))
+    mob:setBehavior(bit.bor(mob:getBehavior(), xi.behavior.NO_TURN))
     mob:setMobAbilityEnabled(false)
     mob:setAutoAttackEnabled(false)
     mob:setRoamFlags(bit.bor(xi.roamFlag.IGNORE, xi.roamFlag.SCRIPTED))
@@ -35,7 +35,7 @@ entity.onMobSpawn = function(mob)
             tiger:setLocalVar('tookDamage', 1)
             tiger:setMobAbilityEnabled(true)
             tiger:setAutoAttackEnabled(true)
-            tiger:setBehaviour(0)
+            tiger:setBehavior(0)
         end
     end)
 end

--- a/scripts/zones/Sealions_Den/helpers/TenzenFunctions.lua
+++ b/scripts/zones/Sealions_Den/helpers/TenzenFunctions.lua
@@ -89,7 +89,7 @@ tenzenFunctions.formSwap = function(mob)
             battleTime - changeTime > 60
         then
             mob:setAnimationSub(5) -- 5 lowered bow mode (1033 animation) 6 is raised bow mode (1034 animation)
-            mob:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.STANDBACK))
+            mob:setBehavior(bit.bor(mob:getBehavior(), xi.behavior.STANDBACK))
             mob:setMobSkillAttack(1171)
             mob:setLocalVar('changeTime', mob:getBattleTime())
 
@@ -104,7 +104,7 @@ tenzenFunctions.formSwap = function(mob)
             battleTime - changeTime > 30
         then
             mob:setAnimationSub(0)
-            mob:setBehaviour(bit.band(mob:getBehaviour(), bit.bnot(xi.behavior.STANDBACK)))
+            mob:setBehavior(bit.band(mob:getBehavior(), bit.bnot(xi.behavior.STANDBACK)))
             mob:setMobSkillAttack(0)
             mob:setMod(xi.mod.DELAY, 0) -- attack slower back to great katana
             mob:setLocalVar('changeTime', mob:getBattleTime())

--- a/scripts/zones/Sealions_Den/mobs/Omega.lua
+++ b/scripts/zones/Sealions_Den/mobs/Omega.lua
@@ -12,7 +12,7 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.NO_TURN))
+    mob:setBehavior(bit.bor(mob:getBehavior(), xi.behavior.NO_TURN))
     mob:setMod(xi.mod.REGAIN, 100)
     mob:setMobMod(xi.mobMod.SKILL_LIST, 54)
 end

--- a/scripts/zones/Sealions_Den/mobs/Tenzen.lua
+++ b/scripts/zones/Sealions_Den/mobs/Tenzen.lua
@@ -12,7 +12,7 @@ entity.onMobSpawn = function(mob)
     -- Tenzen in Warriors Path is a completely scripted encounter once you trigger certain states
     -- Leaving mods here as visuals
     mob:setMod(xi.mod.DEF, 350)
-    mob:setBehaviour(bit.band(mob:getBehaviour(), bit.bnot(xi.behavior.STANDBACK)))
+    mob:setBehavior(bit.band(mob:getBehavior(), bit.bnot(xi.behavior.STANDBACK)))
     mob:setMobMod(xi.mobMod.NO_MOVE, 1)
     mob:setMobMod(xi.mobMod.SIGHT_RANGE, 10)
     mob:setAnimationSub(0)

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Ixzdei_BLM.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Ixzdei_BLM.lua
@@ -129,7 +129,7 @@ entity.onMobFight = function(mob, target)
                 local spawnPos = zdeiOne:getSpawnPos()
                 mob:setMagicCastingEnabled(false)
                 mob:pathTo(spawnPos.x, spawnPos.y, spawnPos.z)
-                mob:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.STANDBACK))
+                mob:setBehavior(bit.bor(mob:getBehavior(), xi.behavior.STANDBACK))
                 mob:timer(8000, function(mobArg)
                     if
                         mob:checkDistance(spawnPos.x, spawnPos.y, spawnPos.z) < 2 and
@@ -152,7 +152,7 @@ entity.onMobFight = function(mob, target)
                 local spawnPos = zdeiTwo:getSpawnPos()
                 mob:setMagicCastingEnabled(false)
                 mob:pathTo(spawnPos.x, spawnPos.y, spawnPos.z)
-                mob:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.STANDBACK))
+                mob:setBehavior(bit.bor(mob:getBehavior(), xi.behavior.STANDBACK))
                 mob:timer(8000, function(mobArg)
                     if
                         mob:checkDistance(spawnPos.x, spawnPos.y, spawnPos.z) < 2 and

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Ixzdei_RDM.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Ixzdei_RDM.lua
@@ -132,7 +132,7 @@ entity.onMobFight = function(mob, target)
                 local spawnPos = zdeiOne:getSpawnPos()
                 mob:setMagicCastingEnabled(false)
                 mob:pathTo(spawnPos.x, spawnPos.y, spawnPos.z) -- go back to pedastal to heal
-                mob:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.STANDBACK))
+                mob:setBehavior(bit.bor(mob:getBehavior(), xi.behavior.STANDBACK))
                 mob:timer(8000, function(mobArg)
                     if
                         mob:checkDistance(spawnPos.x, spawnPos.y, spawnPos.z) < 2 and
@@ -155,7 +155,7 @@ entity.onMobFight = function(mob, target)
                 local spawnPos = zdeiTwo:getSpawnPos()
                 mob:setMagicCastingEnabled(false)
                 mob:pathTo(spawnPos.x, spawnPos.y, spawnPos.z)
-                mob:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.STANDBACK))
+                mob:setBehavior(bit.bor(mob:getBehavior(), xi.behavior.STANDBACK))
                 mob:timer(8000, function(mobArg)
                     if
                         mob:checkDistance(spawnPos.x, spawnPos.y, spawnPos.z) < 2 and

--- a/scripts/zones/Wajaom_Woodlands/mobs/Tinnin.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Tinnin.lua
@@ -82,8 +82,8 @@ entity.onMobFight = function(mob, target)
             mob:addHP(mob:getMaxHP() * .05)
         end
 
-        if bit.band(mob:getBehaviour(), xi.behavior.NO_TURN) > 0 then -- disable no turning for the forced mobskills upon head growth
-            mob:setBehaviour(bit.band(mob:getBehaviour(), bit.bnot(xi.behavior.NO_TURN)))
+        if bit.band(mob:getBehavior(), xi.behavior.NO_TURN) > 0 then -- disable no turning for the forced mobskills upon head growth
+            mob:setBehavior(bit.band(mob:getBehavior(), bit.bnot(xi.behavior.NO_TURN)))
         end
 
         -- These need to be listed in reverse order as forced moves are added to the top of the queue.
@@ -104,8 +104,8 @@ entity.onMobFight = function(mob, target)
             mob:addHP(mob:getMaxHP() * .05)
         end
 
-        if bit.band(mob:getBehaviour(), xi.behavior.NO_TURN) > 0 then -- disable no turning for the forced mobskills upon head growth
-            mob:setBehaviour(bit.band(mob:getBehaviour(), bit.bnot(xi.behavior.NO_TURN)))
+        if bit.band(mob:getBehavior(), xi.behavior.NO_TURN) > 0 then -- disable no turning for the forced mobskills upon head growth
+            mob:setBehavior(bit.band(mob:getBehavior(), bit.bnot(xi.behavior.NO_TURN)))
         end
 
         -- Reverse order, same deal.

--- a/sql/char_chocobos.sql
+++ b/sql/char_chocobos.sql
@@ -15,7 +15,7 @@ CREATE TABLE `char_chocobos` (
   `last_update_age` tinyint unsigned NOT NULL,
   `stage` tinyint unsigned NOT NULL,
   `location` tinyint unsigned NOT NULL,
-  `colour` tinyint unsigned NOT NULL,
+  `color` tinyint unsigned NOT NULL,
   `dominant_gene` tinyint unsigned NOT NULL,
   `recessive_gene` tinyint unsigned NOT NULL,
   `strength` tinyint unsigned NOT NULL,

--- a/src/common/application.cpp
+++ b/src/common/application.cpp
@@ -57,7 +57,7 @@ Application::Application(std::string const& serverName, int argc, char** argv)
     logging::InitializeLog(serverName, logName, false);
     lua_init();
     settings::init();
-    ShowInfo("Begin %s-server initialisation...", serverName);
+    ShowInfo("Begin %s-server Init...", serverName);
 
     debug::init();
 

--- a/src/common/socket.cpp
+++ b/src/common/socket.cpp
@@ -278,7 +278,7 @@ bool _vsocket_init()
         }
     }
 #elif defined(HAVE_SETRLIMIT) && !defined(CYGWIN)
-    // NOTE: getrlimit and setrlimit have bogus behaviour in cygwin.
+    // NOTE: getrlimit and setrlimit have bogus behavior in cygwin.
     //       "Number of fds is virtually unlimited in cygwin" (sys/param.h)
     { // set socket limit to MAX_FD
         struct rlimit rlp;
@@ -305,7 +305,7 @@ bool _vsocket_init()
 
     sFD_ZERO(&readfds);
 
-    // initialise last send-receive tick
+    // initialize last send-receive tick
     last_tick = time(nullptr);
     return true;
 }

--- a/src/map/ai/controllers/automaton_controller.cpp
+++ b/src/map/ai/controllers/automaton_controller.cpp
@@ -43,7 +43,7 @@ CAutomatonController::CAutomatonController(CAutomatonEntity* PPet)
     setCooldowns();
     if (shouldStandBack())
     {
-        PAutomaton->m_Behaviour |= BEHAVIOUR_STANDBACK;
+        PAutomaton->m_Behavior |= BEHAVIOR_STANDBACK;
     }
 }
 
@@ -227,7 +227,7 @@ void CAutomatonController::Move()
 
     if ((shouldStandBack() && (currentDistance > 225)) || (PAutomaton->health.mp < 8 && PAutomaton->health.maxmp > 8))
     {
-        PAutomaton->m_Behaviour &= ~BEHAVIOUR_STANDBACK;
+        PAutomaton->m_Behavior &= ~BEHAVIOR_STANDBACK;
     }
 
     CPetController::Move();
@@ -1636,7 +1636,7 @@ bool CAutomatonController::Disengage()
     PTarget = nullptr;
     if (shouldStandBack())
     {
-        PAutomaton->m_Behaviour |= BEHAVIOUR_STANDBACK;
+        PAutomaton->m_Behavior |= BEHAVIOR_STANDBACK;
     }
     return CMobController::Disengage();
 }

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -179,8 +179,8 @@ void CMobController::TryLink()
         return;
     }
 
-    // handle pet behaviour on the targets behalf (faster than in ai_pet_dummy)
-    // Avatars defend masters by attacking mobs if the avatar isn't attacking anything currently (bodyguard behaviour)
+    // handle pet behavior on the targets behalf (faster than in ai_pet_dummy)
+    // Avatars defend masters by attacking mobs if the avatar isn't attacking anything currently (bodyguard behavior)
     if (PTarget->PPet != nullptr && PTarget->PPet->GetBattleTargetID() == 0)
     {
         if (PTarget->PPet->objtype == TYPE_PET && ((CPetEntity*)PTarget->PPet)->getPetType() == PET_TYPE::AVATAR)
@@ -270,7 +270,7 @@ bool CMobController::CanDetectTarget(CBattleEntity* PTarget, bool forceSight)
         return isTargetAndInRange || PMob->CanSeeTarget(PTarget);
     }
 
-    if ((PMob->m_Behaviour & BEHAVIOUR_AGGRO_AMBUSH) && currentDistance < 3 && !hasSneak)
+    if ((PMob->m_Behavior & BEHAVIOR_AGGRO_AMBUSH) && currentDistance < 3 && !hasSneak)
     {
         return true;
     }
@@ -629,7 +629,7 @@ void CMobController::FaceTarget(uint16 targid)
     {
         targ = PMob->GetEntity(targid);
     }
-    if (!(PMob->m_Behaviour & BEHAVIOUR_NO_TURN) && targ)
+    if (!(PMob->m_Behavior & BEHAVIOR_NO_TURN) && targ)
     {
         PMob->PAI->PathFind->LookAt(targ->loc.p);
     }
@@ -1356,7 +1356,7 @@ bool CMobController::CanMoveForward(float currentDistance)
         standbackRange = PMob->getMobMod(MOBMOD_STANDBACK_RANGE);
     }
 
-    if (PMob->m_Behaviour & BEHAVIOUR_STANDBACK && currentDistance < standbackRange && PMob->CanSeeTarget(PTarget))
+    if (PMob->m_Behavior & BEHAVIOR_STANDBACK && currentDistance < standbackRange && PMob->CanSeeTarget(PTarget))
     {
         return false;
     }

--- a/src/map/ai/controllers/trust_controller.cpp
+++ b/src/map/ai/controllers/trust_controller.cpp
@@ -237,7 +237,7 @@ void CTrustController::DoRoamTick(time_point tick)
             [[fallthrough]];
         default: // Something invalid set
         {
-            // Default retail behaviour: Master engages a monster and executes a melee swing
+            // Default retail behavior: Master engages a monster and executes a melee swing
             trustEngageCondition = PMaster->GetBattleTarget() && masterMeleeSwing;
             break;
         }

--- a/src/map/ai/states/despawn_state.cpp
+++ b/src/map/ai/states/despawn_state.cpp
@@ -29,7 +29,7 @@
 CDespawnState::CDespawnState(CBaseEntity* _PEntity, bool instantDespawn)
 : CState(_PEntity, _PEntity->targid)
 {
-    if (!instantDespawn && (_PEntity->status != STATUS_TYPE::DISAPPEAR && !(static_cast<CMobEntity*>(_PEntity)->m_Behaviour & BEHAVIOUR_NO_DESPAWN)))
+    if (!instantDespawn && (_PEntity->status != STATUS_TYPE::DISAPPEAR && !(static_cast<CMobEntity*>(_PEntity)->m_Behavior & BEHAVIOR_NO_DESPAWN)))
     {
         _PEntity->loc.zone->PushPacket(_PEntity, CHAR_INRANGE, new CEntityAnimationPacket(_PEntity, _PEntity, CEntityAnimationPacket::Fade_Out));
     }
@@ -37,7 +37,7 @@ CDespawnState::CDespawnState(CBaseEntity* _PEntity, bool instantDespawn)
 
 bool CDespawnState::Update(time_point tick)
 {
-    if (tick > GetEntryTime() + 3s && !IsCompleted() && !(static_cast<CMobEntity*>(m_PEntity)->m_Behaviour & BEHAVIOUR_NO_DESPAWN))
+    if (tick > GetEntryTime() + 3s && !IsCompleted() && !(static_cast<CMobEntity*>(m_PEntity)->m_Behavior & BEHAVIOR_NO_DESPAWN))
     {
         static_cast<CMobEntity*>(m_PEntity)->OnDespawn(*this);
         Complete();

--- a/src/map/battlefield_handler.cpp
+++ b/src/map/battlefield_handler.cpp
@@ -50,7 +50,7 @@
 
 CBattlefieldHandler::CBattlefieldHandler(CZone* PZone)
 : m_PZone(PZone)
-, m_MaxBattlefields(luautils::OnBattlefieldHandlerInitialise(PZone))
+, m_MaxBattlefields(luautils::OnBattlefieldHandlerInitialize(PZone))
 {
 }
 
@@ -163,7 +163,7 @@ uint8 CBattlefieldHandler::LoadBattlefield(CCharEntity* PChar, const Battlefield
     }
 
     luautils::OnBattlefieldRegister(PChar, PBattlefield);
-    luautils::OnBattlefieldInitialise(PBattlefield);
+    luautils::OnBattlefieldInitialize(PBattlefield);
     PBattlefield->InsertEntity(PChar, true);
 
     return BATTLEFIELD_RETURN_CODE_CUTSCENE;

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -90,7 +90,7 @@ CMobEntity::CMobEntity()
 , m_TrueDetection(false)
 , m_Link(0)
 , m_isAggroable(false)
-, m_Behaviour(BEHAVIOUR_NONE)
+, m_Behavior(BEHAVIOR_NONE)
 , m_SpawnType(SPAWNTYPE_NORMAL)
 , m_battlefieldID(0)
 , m_bcnmID(0)
@@ -535,7 +535,7 @@ bool CMobEntity::ValidTarget(CBattleEntity* PInitiator, uint16 targetFlags)
         return true;
     }
 
-    if (targetFlags & TARGET_PLAYER_DEAD && (m_Behaviour & BEHAVIOUR_RAISABLE) && isDead())
+    if (targetFlags & TARGET_PLAYER_DEAD && (m_Behavior & BEHAVIOR_RAISABLE) && isDead())
     {
         return true;
     }
@@ -547,7 +547,7 @@ bool CMobEntity::ValidTarget(CBattleEntity* PInitiator, uint16 targetFlags)
 
     if (targetFlags & TARGET_NPC)
     {
-        if (allegiance == PInitiator->allegiance && !(m_Behaviour & BEHAVIOUR_NOHELP) && !isCharmed)
+        if (allegiance == PInitiator->allegiance && !(m_Behavior & BEHAVIOR_NOHELP) && !isCharmed)
         {
             return true;
         }
@@ -1157,7 +1157,7 @@ void CMobEntity::FadeOut()
 void CMobEntity::OnDeathTimer()
 {
     TracyZoneScoped;
-    if (!(m_Behaviour & BEHAVIOUR_RAISABLE))
+    if (!(m_Behavior & BEHAVIOR_RAISABLE))
     {
         PAI->Despawn();
     }

--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -91,15 +91,15 @@ enum DETECT : uint16
     DETECT_SCENT       = 0x100
 };
 
-enum BEHAVIOUR : uint16
+enum BEHAVIOR : uint16
 {
-    BEHAVIOUR_NONE         = 0x000,
-    BEHAVIOUR_NO_DESPAWN   = 0x001, // mob does not despawn on death
-    BEHAVIOUR_STANDBACK    = 0x002, // mob will standback forever
-    BEHAVIOUR_RAISABLE     = 0x004, // mob can be raised via Raise spells
-    BEHAVIOUR_NOHELP       = 0x008, // mob can not be targeted by helpful magic from players (cure, protect, etc)
-    BEHAVIOUR_AGGRO_AMBUSH = 0x200, // mob aggroes by ambush
-    BEHAVIOUR_NO_TURN      = 0x400  // mob does not turn to face target
+    BEHAVIOR_NONE         = 0x000,
+    BEHAVIOR_NO_DESPAWN   = 0x001, // mob does not despawn on death
+    BEHAVIOR_STANDBACK    = 0x002, // mob will standback forever
+    BEHAVIOR_RAISABLE     = 0x004, // mob can be raised via Raise spells
+    BEHAVIOR_NOHELP       = 0x008, // mob can not be targeted by helpful magic from players (cure, protect, etc)
+    BEHAVIOR_AGGRO_AMBUSH = 0x200, // mob aggroes by ambush
+    BEHAVIOR_NO_TURN      = 0x400  // mob does not turn to face target
 };
 
 class CMobSkillState;
@@ -190,7 +190,7 @@ public:
     float HPscale; // HP boost percentage
     float MPscale; // MP boost percentage
 
-    uint16 m_roamFlags;    // defines its roaming behaviour
+    uint16 m_roamFlags;    // defines its roaming behavior
     uint8  m_specialFlags; // flags for special skill
 
     bool m_StatPoppedMobs; // true if dyna statue has popped mobs
@@ -218,7 +218,7 @@ public:
     bool      m_TrueDetection; // Has true sight or sound
     uint8     m_Link;          // link with mobs of it's family
     bool      m_isAggroable;   // Can be aggroed by other monsters when in the player allegiance
-    uint16    m_Behaviour;     // mob behaviour
+    uint16    m_Behavior;      // mob behavior
     SPAWNTYPE m_SpawnType;     // condition for mob to spawn
 
     int8   m_battlefieldID; // battlefield belonging to

--- a/src/map/instance_loader.cpp
+++ b/src/map/instance_loader.cpp
@@ -127,7 +127,7 @@ CInstance* CInstanceLoader::LoadInstance()
             ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setDelay((_sql->GetIntData(18) * 1000) / 60);
             ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setBaseDelay((_sql->GetIntData(18) * 1000) / 60);
 
-            PMob->m_Behaviour   = (uint16)_sql->GetIntData(19);
+            PMob->m_Behavior    = (uint16)_sql->GetIntData(19);
             PMob->m_Link        = (uint8)_sql->GetIntData(20);
             PMob->m_Type        = (uint8)_sql->GetIntData(21);
             PMob->m_Immunity    = (IMMUNITY)_sql->GetIntData(22);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -14730,7 +14730,7 @@ void CLuaBaseEntity::trustPartyMessage(uint32 message_id)
  *  Function: addSimpleGambit()
  *  Purpose :
  *  Example : trust:addSimpleGambit(target, condition, condition_arg, reaction, selector, selector_arg)
- *  Notes   : Adds a behaviour to the gambit system
+ *  Notes   : Adds a behavior to the gambit system
  ************************************************************************/
 
 std::string CLuaBaseEntity::addSimpleGambit(uint16 targ, uint16 cond, uint32 condition_arg, uint16 react, uint16 select, uint32 selector_arg, sol::object const& retry)
@@ -14768,7 +14768,7 @@ std::string CLuaBaseEntity::addSimpleGambit(uint16 targ, uint16 cond, uint32 con
  *  Function: removeSimpleGambit()
  *  Purpose :
  *  Example : trust:removeSimpleGambit(id)
- *  Notes   : Removes a behaviour from the gambit system, using the id returned
+ *  Notes   : Removes a behavior from the gambit system, using the id returned
  *          : from addSimpleGambit
  ************************************************************************/
 
@@ -16634,39 +16634,39 @@ uint32 CLuaBaseEntity::getBattleTime()
 }
 
 /************************************************************************
- *  Function: getBehaviour()
+ *  Function: getBehavior()
  *  Purpose : Returns the current Mob behavior
- *  Example : mob:getBehaviour()
+ *  Example : mob:getBehavior()
  *  Notes   : Currently used in bitwise calculations for high-tier NM's
  ************************************************************************/
 
-uint16 CLuaBaseEntity::getBehaviour()
+uint16 CLuaBaseEntity::getBehavior()
 {
     if (m_PBaseEntity->objtype != TYPE_MOB)
     {
-        ShowWarning("Attempting to get behaviour for invalid entity type (%s).", m_PBaseEntity->getName());
+        ShowWarning("Attempting to get behavior for invalid entity type (%s).", m_PBaseEntity->getName());
         return 0;
     }
 
-    return static_cast<CMobEntity*>(m_PBaseEntity)->m_Behaviour;
+    return static_cast<CMobEntity*>(m_PBaseEntity)->m_Behavior;
 }
 
 /************************************************************************
- *  Function: setBehaviour()
+ *  Function: setBehavior()
  *  Purpose : Sets a particular behavior for a Mob
- *  Example : mob:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.NO_TURN))
+ *  Example : mob:setBehavior(bit.bor(mob:getBehavior(), xi.behavior.NO_TURN))
  *  Notes   : Currently used in bitwise calculations for high-tier NM's
  ************************************************************************/
 
-void CLuaBaseEntity::setBehaviour(uint16 behavior)
+void CLuaBaseEntity::setBehavior(uint16 behavior)
 {
     if (m_PBaseEntity->objtype != TYPE_MOB)
     {
-        ShowWarning("Attempting to set behaviour for invalid entity type (%s).", m_PBaseEntity->getName());
+        ShowWarning("Attempting to set behavior for invalid entity type (%s).", m_PBaseEntity->getName());
         return;
     }
 
-    static_cast<CMobEntity*>(m_PBaseEntity)->m_Behaviour = behavior;
+    static_cast<CMobEntity*>(m_PBaseEntity)->m_Behavior = behavior;
 }
 
 /************************************************************************
@@ -17679,7 +17679,7 @@ auto CLuaBaseEntity::getChocoboRaisingInfo() -> sol::table
             last_update_age, \
             stage, \
             location, \
-            colour, \
+            color, \
             dominant_gene, \
             recessive_gene, \
             strength, \
@@ -17725,7 +17725,7 @@ auto CLuaBaseEntity::getChocoboRaisingInfo() -> sol::table
             table["last_update_age"] = _sql->GetUIntData(5);
             table["stage"]           = _sql->GetUIntData(6);
             table["location"]        = _sql->GetUIntData(7);
-            table["colour"]          = _sql->GetUIntData(8);
+            table["color"]           = _sql->GetUIntData(8);
 
             table["dominant_gene"]  = _sql->GetUIntData(9);
             table["recessive_gene"] = _sql->GetUIntData(10);
@@ -17774,7 +17774,7 @@ bool CLuaBaseEntity::setChocoboRaisingInfo(sol::table const& table)
                                 last_update_age = %u, \
                                 stage = %u, \
                                 location = %u, \
-                                colour = %u, \
+                                color = %u, \
                                 dominant_gene = %u, \
                                 recessive_gene = %u, \
                                 strength = %u, \
@@ -17802,7 +17802,7 @@ bool CLuaBaseEntity::setChocoboRaisingInfo(sol::table const& table)
                             table.get_or<uint32>("last_update_age", 0),
                             table.get_or<uint32>("stage", 1),
                             table.get_or<uint32>("location", 0),
-                            table.get_or<uint32>("colour", 0),
+                            table.get_or<uint32>("color", 0),
                             table.get_or<uint32>("dominant_gene", 0),
                             table.get_or<uint32>("recessive_gene", 0),
                             table.get_or<uint32>("strength", 0),
@@ -18834,8 +18834,8 @@ void CLuaBaseEntity::Register()
 
     SOL_REGISTER("getBattleTime", CLuaBaseEntity::getBattleTime);
 
-    SOL_REGISTER("getBehaviour", CLuaBaseEntity::getBehaviour);
-    SOL_REGISTER("setBehaviour", CLuaBaseEntity::setBehaviour);
+    SOL_REGISTER("getBehavior", CLuaBaseEntity::getBehavior);
+    SOL_REGISTER("setBehavior", CLuaBaseEntity::setBehavior);
     SOL_REGISTER("getLink", CLuaBaseEntity::getLink);
     SOL_REGISTER("setLink", CLuaBaseEntity::setLink);
     SOL_REGISTER("getRoamFlags", CLuaBaseEntity::getRoamFlags);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -848,8 +848,8 @@ public:
 
     uint32 getBattleTime();
 
-    uint16 getBehaviour();
-    void   setBehaviour(uint16 behavior);
+    uint16 getBehavior();
+    void   setBehavior(uint16 behavior);
     uint8  getLink();
     void   setLink(uint8 link);
     uint16 getRoamFlags();

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1811,7 +1811,7 @@ namespace luautils
         return true;
     }
 
-    void OnZoneInitialise(uint16 ZoneID)
+    void OnZoneInitialize(uint16 ZoneID)
     {
         TracyZoneScoped;
 
@@ -1826,7 +1826,7 @@ namespace luautils
         auto name     = PZone->getName();
         auto filename = fmt::format("./scripts/zones/{}/Zone.lua", name);
 
-        ShowTraceFmt("luautils::OnZoneInitialise: {}", name);
+        ShowTraceFmt("luautils::OnZoneInitialize: {}", name);
 
         CacheLuaObjectFromFile(filename);
 
@@ -3069,7 +3069,7 @@ namespace luautils
         }
     }
 
-    int32 OnBattlefieldHandlerInitialise(CZone* PZone)
+    int32 OnBattlefieldHandlerInitialize(CZone* PZone)
     {
         TracyZoneScoped;
 
@@ -3081,26 +3081,26 @@ namespace luautils
         int32 MaxAreas = 3;
 
         // TODO: This is loaded globally, fix this
-        auto onBattlefieldHandlerInitialise = lua["onBattlefieldHandlerInitialise"];
-        if (!onBattlefieldHandlerInitialise.valid())
+        auto onBattlefieldHandlerInitialize = lua["onBattlefieldHandlerInitialize"];
+        if (!onBattlefieldHandlerInitialize.valid())
         {
             return MaxAreas;
         }
 
         CLuaZone LuaZone(PZone);
 
-        auto result = onBattlefieldHandlerInitialise(CLuaZone(PZone));
+        auto result = onBattlefieldHandlerInitialize(CLuaZone(PZone));
         if (!result.valid())
         {
             sol::error err = result;
-            ShowError("luautils::onBattlefieldHandlerInitialise: %s", err.what());
+            ShowError("luautils::onBattlefieldHandlerInitialize: %s", err.what());
             return MaxAreas;
         }
 
         return result.get_type(0) == sol::type::number ? result.get<int32>(0) : MaxAreas;
     }
 
-    void OnBattlefieldInitialise(CBattlefield* PBattlefield)
+    void OnBattlefieldInitialize(CBattlefield* PBattlefield)
     {
         TracyZoneScoped;
 
@@ -3109,7 +3109,7 @@ namespace luautils
             return;
         }
 
-        invokeBattlefieldEvent(PBattlefield->GetID(), "onBattlefieldInitialise", CLuaBattlefield(PBattlefield));
+        invokeBattlefieldEvent(PBattlefield->GetID(), "onBattlefieldInitialize", CLuaBattlefield(PBattlefield));
     }
 
     void OnBattlefieldTick(CBattlefield* PBattlefield)

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -35,7 +35,7 @@ extern sol::state lua;
 // SOL_NO_CHECK_NUMBER_PRECISION = 1
 #include "sol/sol.hpp"
 
-// sol changes this behaviour to return 0 rather than truncating
+// sol changes this behavior to return 0 rather than truncating
 // we rely on that, so change it back
 #undef lua_tointeger
 #define lua_tointeger(L, n) static_cast<lua_Integer>(std::floor(lua_tonumber(L, n)))
@@ -213,7 +213,7 @@ namespace luautils
     void OnZoneIn(CCharEntity* PChar);
     void OnZoneOut(CCharEntity* PChar);
     void AfterZoneIn(CBaseEntity* PChar);
-    void OnZoneInitialise(uint16 ZoneID);
+    void OnZoneInitialize(uint16 ZoneID);
     void OnZoneTick(CZone* PZone);
     void OnTriggerAreaEnter(CCharEntity* PChar, CTriggerArea* PTriggerArea);
     void OnTriggerAreaLeave(CCharEntity* PChar, CTriggerArea* PTriggerArea);
@@ -282,8 +282,8 @@ namespace luautils
     void OnPathPoint(CBaseEntity* PEntity);
     void OnPathComplete(CBaseEntity* PEntity);
 
-    int32 OnBattlefieldHandlerInitialise(CZone* PZone);
-    void  OnBattlefieldInitialise(CBattlefield* PBattlefield); // what to do when initialising battlefield, battlefield:setLocalVar("lootId") here for any which have loot
+    int32 OnBattlefieldHandlerInitialize(CZone* PZone);
+    void  OnBattlefieldInitialize(CBattlefield* PBattlefield); // what to do when initialising battlefield, battlefield:setLocalVar("lootId") here for any which have loot
     void  OnBattlefieldTick(CBattlefield* PBattlefield);
     void  OnBattlefieldStatusChange(CBattlefield* PBattlefield);
 

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -5900,7 +5900,7 @@ namespace battleutils
 
         // Big mobs typically should ignore this -- Such as dragons/wyrms or other big things.
         // Some TP moves like Petro Eyes from normal dragons _also_ ignore their standard behavior, so we must allow it sometimes.
-        if (PMob && (PMob->m_Behaviour & BEHAVIOUR_NO_TURN) && !force)
+        if (PMob && (PMob->m_Behavior & BEHAVIOR_NO_TURN) && !force)
         {
             return;
         }

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -768,7 +768,7 @@ namespace mobutils
             SetupPetSkills(PMob);
         }
 
-        PMob->m_Behaviour |= PMob->getMobMod(MOBMOD_BEHAVIOR);
+        PMob->m_Behavior |= PMob->getMobMod(MOBMOD_BEHAVIOR);
 
         if (zoneType & ZONE_TYPE::DUNGEON)
         {
@@ -1569,7 +1569,7 @@ namespace mobutils
                 ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setDelay((_sql->GetIntData(15) * 1000) / 60);
                 ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setBaseDelay((_sql->GetIntData(15) * 1000) / 60);
 
-                PMob->m_Behaviour   = (uint16)_sql->GetIntData(16);
+                PMob->m_Behavior    = (uint16)_sql->GetIntData(16);
                 PMob->m_Link        = (uint8)_sql->GetIntData(17);
                 PMob->m_Type        = (uint8)_sql->GetIntData(18);
                 PMob->m_Immunity    = (IMMUNITY)_sql->GetIntData(19);
@@ -1730,7 +1730,7 @@ namespace mobutils
                 ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setDelay((_sql->GetIntData(15) * 1000) / 60);
                 ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setBaseDelay((_sql->GetIntData(15) * 1000) / 60);
 
-                PMob->m_Behaviour   = (uint16)_sql->GetIntData(16);
+                PMob->m_Behavior    = (uint16)_sql->GetIntData(16);
                 PMob->m_Link        = (uint8)_sql->GetIntData(17);
                 PMob->m_Type        = (uint8)_sql->GetIntData(18);
                 PMob->m_Immunity    = (IMMUNITY)_sql->GetIntData(19);

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -479,7 +479,7 @@ namespace zoneutils
                                 ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setDelay((sql->GetIntData(19) * 1000) / 60);
                                 ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setBaseDelay((sql->GetIntData(19) * 1000) / 60);
 
-                                PMob->m_Behaviour   = (uint16)sql->GetIntData(20);
+                                PMob->m_Behavior   = (uint16)sql->GetIntData(20);
                                 PMob->m_Link        = (uint8)sql->GetIntData(21);
                                 PMob->m_Type        = (uint8)sql->GetIntData(22);
                                 PMob->m_Immunity    = (IMMUNITY)sql->GetIntData(23);
@@ -648,7 +648,7 @@ namespace zoneutils
         // clang-format on
 
         ShowInfo("Loading Mob scripts");
-        // handle mob initialise functions after they're all loaded
+        // handle mob Initialize functions after they're all loaded
         // clang-format off
         ForEachZone([](CZone* PZone)
         {
@@ -804,7 +804,7 @@ namespace zoneutils
         {
             if (PZone.second->GetIP() != 0)
             {
-                luautils::OnZoneInitialise(PZone.second->GetID());
+                luautils::OnZoneInitialize(PZone.second->GetID());
             }
         }
 

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -70,7 +70,7 @@ global_objects=(
     Limbus
     SeasonalEvent
 
-    onBattlefieldHandlerInitialise
+    onBattlefieldHandlerInitialize
     applyResistanceAddEffect
 
     addBonuses

--- a/tools/migrations/043_modify_choco_colour_column.py
+++ b/tools/migrations/043_modify_choco_colour_column.py
@@ -1,0 +1,28 @@
+import mariadb
+
+
+def migration_name():
+    return "Rename colour column to color in char_chocobos"
+
+
+def check_preconditions(cur):
+    return
+
+
+def needs_to_run(cur):
+    # Ensure column doesn't already exist.
+    cur.execute("SHOW COLUMNS FROM char_chocobos LIKE 'color';")
+
+    row = cur.fetchone()
+    if row:
+        return False
+
+    return True
+
+
+def migrate(cur, db):
+    try:
+        cur.execute("ALTER TABLE char_chocobos RENAME COLUMN colour to color;")
+        db.commit()
+    except mariadb.Error as err:
+        print("Something went wrong: {}".format(err))


### PR DESCRIPTION
While American English doesn't have the corner on the English language, there were multiple British spellings and American spellings in the same file, in some instances. There were many more American spellings of these words than British so I went with the American way of spelling. 

Standardized spelling of: 
initialisation to initialization.
colour to color
behaviour to behavior
Added a migration to rename char_chocobos column colours to color

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Standardizes the spelling of 
Initialization, Colour, Behaviour 


<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Build server and no longer will see initialisation 
<!-- Clear and detailed steps to test your changes here -->
