### PR TITLE
[core] Display 1% HPP/MPP when HP/MP > 0 but HPP/MPP < 1.00%

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -259,7 +259,7 @@ uint8 CBattleEntity::GetHPP() const
         return 0;
     }
 
-    return static_cast<uint8>(std::floor((static_cast<float>(health.hp) / static_cast<float>(GetMaxHP())) * 100.f));
+    return static_cast<uint8>(std::max<uint8>(1, std::floor((static_cast<float>(health.hp) / static_cast<float>(GetMaxHP())) * 100.f)));
 }
 
 int32 CBattleEntity::GetMaxHP() const
@@ -280,7 +280,7 @@ uint8 CBattleEntity::GetMPP() const
         return 0;
     }
 
-    return static_cast<uint8>(std::floor((static_cast<float>(health.mp) / static_cast<float>(GetMaxMP())) * 100.f));
+    return static_cast<uint8>(std::max<uint8>(1, std::floor((static_cast<float>(health.mp) / static_cast<float>(GetMaxMP())) * 100.f)));
 }
 
 int32 CBattleEntity::GetMaxMP() const


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Display 1% HPP/MPP when HP/MP > 0 but HPP/MPP < 1.00%
basically we were prematurely showing 0% HPP/MPP

## Steps to test these changes

!hp 1 <me>
!mp 1 <me>
/p <hpp> <mpp> -> 1% 1%
