### PR TITLE
[Lua] Add missing confirmTrade to quest Brygid the Stylist returns

### DIFF
--- a/scripts/quests/bastok/Brygid_the_Stylist_Returns.lua
+++ b/scripts/quests/bastok/Brygid_the_Stylist_Returns.lua
@@ -195,6 +195,7 @@ quest.sections =
 
                 [383] = function(player, csid, option, npc)
                     if npcUtil.giveItem(player, optionToItems[quest:getVar(player, 'Option')][1]) then
+                        player:confirmTrade()
                         quest:complete(player)
                     end
                 end,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds missing confirmTrade to make sure subligar are consumed when traded for body
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
 Closes #6475 
## Steps to test these changes
Progress quest to the point where you trade the subligar for the body
Trade should complete and remove subligar from inventory
<!-- Clear and detailed steps to test your changes here -->
