### PR TITLE
[core] CodeQL warning cleanup for zone_entities.cpp

### DIFF
--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -1519,9 +1519,10 @@ void CZoneEntities::ZoneServer(time_point tick)
                 PMob->PParty->RemoveMember(PMob);
             }
 
-            for (EntityList_t::const_iterator it = m_charList.begin(); it != m_charList.end(); ++it)
+            for (EntityList_t::const_iterator charIterator = m_charList.begin(); charIterator != m_charList.end(); ++charIterator)
             {
-                CCharEntity* PChar = static_cast<CCharEntity*>(it->second);
+                // This is safe because m_charList only receives inserts of CCharEntity
+                CCharEntity* PChar = static_cast<CCharEntity*>(charIterator->second);
 
                 if (PChar->PClaimedMob == PMob)
                 {
@@ -1583,9 +1584,10 @@ void CZoneEntities::ZoneServer(time_point tick)
         // This is only valid for dynamic entities
         if (PNpc->status == STATUS_TYPE::DISAPPEAR && PNpc->m_bReleaseTargIDOnDisappear)
         {
-            for (EntityList_t::const_iterator it = m_charList.begin(); it != m_charList.end(); ++it)
+            for (EntityList_t::const_iterator charIterator = m_charList.begin(); charIterator != m_charList.end(); ++charIterator)
             {
-                CCharEntity* PChar = (CCharEntity*)it->second;
+                // This is safe because m_charList only receives inserts of CCharEntity
+                CCharEntity* PChar = static_cast<CCharEntity*>(charIterator->second);
                 if (PChar->SpawnNPCList.find(PNpc->id) != PChar->SpawnNPCList.end())
                 {
                     PChar->SpawnNPCList.erase(PNpc->id);
@@ -1673,9 +1675,10 @@ void CZoneEntities::ZoneServer(time_point tick)
                     }
                 }
 
-                for (EntityList_t::const_iterator it = m_charList.begin(); it != m_charList.end(); ++it)
+                for (EntityList_t::const_iterator charIterator = m_charList.begin(); charIterator != m_charList.end(); ++charIterator)
                 {
-                    CCharEntity* PChar = (CCharEntity*)it->second;
+                    // This is safe because m_charList only receives inserts of CCharEntity
+                    CCharEntity* PChar = static_cast<CCharEntity*>(charIterator->second);
                     if (distance(PChar->loc.p, PTrust->loc.p) < 50)
                     {
                         PChar->SpawnTRUSTList.erase(PTrust->id);
@@ -1698,9 +1701,10 @@ void CZoneEntities::ZoneServer(time_point tick)
     std::vector<CCharEntity*> charsToWarp       = {};
     std::vector<CCharEntity*> charsToChangeZone = {};
 
-    for (EntityList_t::const_iterator it = m_charList.begin(); it != m_charList.end(); ++it)
+    for (EntityList_t::const_iterator charIterator = m_charList.begin(); charIterator != m_charList.end(); ++charIterator)
     {
-        CCharEntity* PChar = static_cast<CCharEntity*>(it->second);
+        // This is safe because m_charList only receives inserts of CCharEntity
+        CCharEntity* PChar = static_cast<CCharEntity*>(charIterator->second);
 
         ShowTrace(fmt::format("CZoneEntities::ZoneServer: Char: {} ({})", PChar->getName(), PChar->id).c_str());
 
@@ -1714,7 +1718,11 @@ void CZoneEntities::ZoneServer(time_point tick)
                 PChar->StatusEffectContainer->TickEffects(tick);
             }
             PChar->PAI->Tick(tick);
-            PChar->PTreasurePool->CheckItems(tick);
+
+            if (PChar->PTreasurePool)
+            {
+                PChar->PTreasurePool->CheckItems(tick);
+            }
         }
 
         // Else-if chain so only one end-result can be processed.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Stop reuse of `it` within appropriate scope causing messy code (and possibly undefined behavior?)
Add nullptr check to a raw pointer

## Steps to test these changes

Load up server, see nothing obviously different
