### PR TITLE
[Core/SQL] Adds Support for Multiple Mob Pets

### DIFF
--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Ixaern_DRG.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Ixaern_DRG.lua
@@ -7,24 +7,22 @@ local ID = zones[xi.zone.THE_GARDEN_OF_RUHMET]
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobFight = function(mob, target)
-    -- Spawn the pets if they are despawned
-    -- TODO: summon animations?
-    local mobId = mob:getID()
-    local x = mob:getXPos()
-    local y = mob:getYPos()
-    local z = mob:getZPos()
+entity.onMobSpawn = function(mob)
+    mob:setLocalVar('petCount', 0)
+    mob:setLocalVar('petTimer', 0)
+end
 
-    for i = mobId + 1, mobId + 3 do
-        local wynav = GetMobByID(i)
-        if wynav and not wynav:isSpawned() then
-            local repopWynavs = wynav:getLocalVar('repop') -- see Wynav script
-            if mob:getBattleTime() - repopWynavs > 10 then
-                wynav:setSpawn(x + math.random(1, 5), y, z + math.random(1, 5))
-                wynav:spawn()
-                wynav:updateEnmity(target)
-            end
-        end
+entity.onMobFight = function(mob, target)
+    local petCount = mob:getLocalVar('petCount')
+    local petTimer = mob:getLocalVar('petTimer')
+
+    if
+        petCount < 3 and
+        petTimer < os.time() + 30
+    then
+        mob:useMobAbility(xi.jsa.CALL_WYVERN)
+        mob:setLocalVar('petCount', 3)
+        mob:setLocalVar('petTimer', os.time())
     end
 end
 
@@ -39,14 +37,6 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    -- despawn pets
-    local mobId = mob:getID()
-    for i = mobId + 1, mobId + 3 do
-        if GetMobByID(i):isSpawned() then
-            DespawnMob(i)
-        end
-    end
-
     -- Pick a new PH for Ix'Aern (DRG)
     local groups = ID.mob.AWAERN_DRG_GROUPS
     SetServerVariable('[SEA]IxAernDRG_PH', groups[math.random(1, #groups)] + math.random(0, 2))

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Ixaern_DRGs_Wynav.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Ixaern_DRGs_Wynav.lua
@@ -2,6 +2,8 @@
 -- Area: The Garden of Ru'Hmet
 --  Mob: Ix'aern DRG's Wynav
 -----------------------------------
+local ID = zones[xi.zone.THE_GARDEN_OF_RUHMET]
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
 
@@ -41,7 +43,13 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    mob:setLocalVar('repop', mob:getBattleTime()) -- This get erased on respawn automatic.
+    local ixaern   = GetMobByID(ID.mob.IXAERN_DRG)
+
+    if ixaern then
+        local petCount = ixaern:getLocalVar('petCount')
+
+        ixaern:setLocalVar('petCount', petCount - 1)
+    end
 end
 
 return entity

--- a/sql/mob_pets.sql
+++ b/sql/mob_pets.sql
@@ -22,7 +22,8 @@ CREATE TABLE `mob_pets` (
   `job` tinyint(4) DEFAULT '9',
   `mobname` varchar(24) DEFAULT NULL,
   `petname` varchar(24) DEFAULT NULL,
-  PRIMARY KEY (`mob_mobid`)
+  PRIMARY KEY (`mob_mobid`, `pet_offset`),
+  INDEX (`mob_mobid`)
 ) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -261,6 +262,9 @@ INSERT INTO `mob_pets` VALUES (16920662,1,14,'Awaern','Aerns_Wynav');
 INSERT INTO `mob_pets` VALUES (16920779,1,9,'Awaern','Aerns_Euvhi');
 INSERT INTO `mob_pets` VALUES (16920783,1,14,'Awaern','Aerns_Wynav');
 INSERT INTO `mob_pets` VALUES (16920787,1,15,'Awaern','Aerns_Elemental');
+INSERT INTO `mob_pets` VALUES (16921022,1,14,'Ixaern_DRG','Ixaern_DRGs_Wynav');
+INSERT INTO `mob_pets` VALUES (16921022,2,14,'Ixaern_DRG','Ixaern_DRGs_Wynav');
+INSERT INTO `mob_pets` VALUES (16921022,3,14,'Ixaern_DRG','Ixaern_DRGs_Wynav');
 
 -- ------------------------------------------------------------
 -- Temenos (Zone 37)

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -200,10 +200,21 @@ void CMobController::TryLink()
         }
     }
 
-    // my pet should help as well
-    if (PMob->PPet != nullptr && PMob->PPet->PAI->IsRoaming())
+    // my pets should help as well
+    if (PMob->PPet != nullptr)
     {
-        PMob->PPet->PAI->Engage(PTarget->targid);
+        CBattleEntity* PPet = PMob->PPet;
+        // Iterate over all my pets
+        while (PPet != nullptr)
+        {
+            // Check if they are roaming
+            if (PPet->PAI->IsRoaming())
+            {
+                // Have them attack my target
+                PPet->PAI->Engage(PTarget->targid);
+            }
+            PPet = PPet->PPetNext;
+        }
     }
 
     // Handle monster linking if they are close enough
@@ -1086,12 +1097,16 @@ void CMobController::FollowRoamPath()
         PMob->PAI->PathFind->FollowPath(m_Tick);
 
         CBattleEntity* PPet = PMob->PPet;
-        if (PPet != nullptr && PPet->PAI->IsSpawned() && !PPet->PAI->IsEngaged())
+        while (PPet != nullptr)
         {
-            // pet should follow me if roaming
-            position_t targetPoint = nearPosition(PMob->loc.p, 2.1f, (float)M_PI);
+            if (PPet->PAI->IsSpawned() && !PPet->PAI->IsEngaged())
+            {
+                // pet should follow me if roaming
+                position_t targetPoint = nearPosition(PMob->loc.p, 2.1f, (float)M_PI);
 
-            PPet->PAI->PathFind->PathTo(targetPoint);
+                PPet->PAI->PathFind->PathTo(targetPoint);
+            }
+            PPet = PPet->PPetNext;
         }
 
         // if I just finished reset my last action time

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -771,7 +771,8 @@ public:
 
     CParty*         PParty;
     CBattleEntity*  PPet;
-    CBattleEntity*  PMaster; // Owner/owner of the entity (applies to all combat entities)
+    CBattleEntity*  PPetNext; // Support for multiple pets on same master
+    CBattleEntity*  PMaster;  // Owner/owner of the entity (applies to all combat entities)
     CBattleEntity*  PLastAttacker;
     time_point      LastAttacked;
     battlehistory_t BattleHistory{}; // Stores info related to most recent combat actions taken towards this entity.

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -14632,19 +14632,26 @@ void CLuaBaseEntity::spawnPet(sol::object const& arg0)
             return;
         }
 
-        CMobEntity* PPet = static_cast<CMobEntity*>(PMob->PPet);
+        CMobEntity* PPetTemp = static_cast<CMobEntity*>(PMob->PPet);
 
-        // if a number is given its an avatar or elemental spawn
-        if ((arg0 != sol::lua_nil) && arg0.is<int>())
+        while (PPetTemp != nullptr)
         {
-            petutils::SpawnMobPet(PMob, arg0.as<uint32>());
+            CMobEntity* PPet = static_cast<CMobEntity*>(PPetTemp);
+
+            // if a number is given its an avatar or elemental spawn
+            if ((arg0 != sol::lua_nil) && arg0.is<int>())
+            {
+                petutils::SpawnMobPet(PMob, arg0.as<uint32>());
+            }
+
+            // always spawn on master
+            PPet->m_SpawnPoint = nearPosition(PMob->loc.p, 2.2f, static_cast<float>(M_PI));
+
+            // setup AI
+            PPet->Spawn();
+
+            PPetTemp = static_cast<CMobEntity*>(PPetTemp->PPetNext);
         }
-
-        // always spawn on master
-        PPet->m_SpawnPoint = nearPosition(PMob->loc.p, 2.2f, static_cast<float>(M_PI));
-
-        // setup AI
-        PPet->Spawn();
     }
 }
 

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -635,10 +635,28 @@ namespace zoneutils
                                 // pet is always spawned by master
                                 PPet->m_AllowRespawn = false;
                                 PPet->m_SpawnType    = SPAWNTYPE_SCRIPTED;
+                                PPet->PPetNext       = nullptr;
                                 PPet->SetDespawnTime(0s);
 
-                                PMaster->PPet = PPet;
-                                PPet->PMaster = PMaster;
+                                if (PMaster->PPet == nullptr)
+                                {
+                                    PMaster->PPet = PPet;
+                                    PPet->PMaster = PMaster;
+                                }
+                                else
+                                {
+                                    // We know that PMaster->PPet is not nullptr at least once
+                                    // Iterate until we find end of Pet Linked List
+                                    CMobEntity* PPetTemp = static_cast<CMobEntity*>(PMaster->PPet);
+                                    while (PPetTemp->PPetNext != nullptr)
+                                    {
+                                        PPetTemp = static_cast<CMobEntity*>(PPetTemp->PPetNext);
+                                    }
+                                    // Attach the new pet (PPet) to the last pet (PPetTemp)
+                                    // Link the new pet to the Master
+                                    PPetTemp->PPetNext = PPet;
+                                    PPet->PMaster      = PMaster;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Adds Support for Mobs with Multiple Pets through mob_pets and core
- This allows for multi-pet AI to be handled within core instead of within each lua file where multiple pet behavior was not always properly handled and removes redundant loops from lua files.
- Updates `mob_pets.sql` to use a composite key of the Master Mob ID with the Pet Offset and uses an index on the Master Mob ID instead of just a Primary Key on the Master Mob ID.
- Created linked lists within the pets entities.  The pets have links with each other (PPetNext), but always contain a link back to the parent (PMaster).
  - The new pointer is always initialized to a nullptr.
  - Loops are used within the mob_controller that iterates over these linked pets until it reaches this nullptr to control all the associated pets at the same time.

Some of the mobs that summon multiple pets:
  - Jailer of Love
  - Ix'aern DRG
  - Absolute Virtue
  - Pandemonium Warden
  - Odin V2
  - Xzomits
  - Some Escha NMs
  - Some VW NMs
  - etc...

For sake of simplicity, and to show a basic implementation of using multiple pets - I have updated Ix'Aern DRG with some basic logic to summon all 3 of its wynavs with 'Call Wyvern' and, since it uses the ability multiple times, how tracking can be done to re-trigger the ability and show that they are all resummoned and follow the proper pet logic.

NOTE: This is only a slight modification to replace the looping structure that was in place for Ix'aern DRG from before.  This is not an accurate re-implementation of the encounter.  Someone else is currently working on that with retail capture data and will PR that soon.  This is strictly to provide an example usage of this multi-pet support PR.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

1 - `!zone The Garden of Ru'Hmet`
2 - `!spawnmob 16921022`
3 - `!gotoid 16921022`
4 - Enage Ix'Aern DRG
Note that all 3 pets are summoned through the Call Wyvern JA

5 - Kite the mob away from its spawn point and then `!goto <me>` to drop aggro
Note that the pets now follow their master back

6 - Attempt to use the SMN Pull Technique to only aggro Ix'Aern DRG
  - `!changejob smn 75`
  - Summon Carbuncle and then Assault on Ix'Aern DRG
  - After the mobs are engaged to the pet, Retreat Carbuncle
  - After carbuncle is near you, Release carbuncle
Note that the pets now detect that the master is still engaged and continue to fight the player.
_Previously, this would allow players to engage Ix'Aern DRG while the pets remained in an idle/roaming state._

7 - Use `!hp 0` on 1~2 of the pets
8 - Wait till Ix'Aern DRG attempts to re-use Call Wyvern
Note that the missing pets are re-summoned and engage with whatever the masters current target is.