### PR TITLE
Return no available traverser stones if epoch is unset

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -6904,6 +6904,13 @@ namespace charutils
             traverserClaimed = _sql->GetUIntData(1);
         }
 
+        if (traverserEpoch == 0)
+        {
+            // Players cannot accrue Traverser Stones until the epoch has been set.  This is not possible
+            // in quests, but is always displayed in player currencies.
+            return 0;
+        }
+
         // Handle reduction for Celerity Key Items
         uint8 stoneWaitHours = 20;
         for (int keyItem = 1385; keyItem <= 1387; ++keyItem)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Traverser stones as a currency are calculated based on time set a unique epoch set when completing the initial quest, but can be viewed in the currency menu at all times.  Return 0 if the condition to accrue is unset to prevent display issues.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
1. Check value in currency menu prior to setting epoch
2. Set epoch to time >20h in past and check value again
<!-- Clear and detailed steps to test your changes here -->
