### PR TITLE
Async: Remove SqlConnection helpers

### DIFF
--- a/src/common/WheatyExceptionReport.cpp
+++ b/src/common/WheatyExceptionReport.cpp
@@ -641,7 +641,7 @@ void WheatyExceptionReport::PrintSystemInfo()
     ::GetSystemInfo(&SystemInfo);
 
     MEMORYSTATUS MemoryStatus;
-    MemoryStatus.dwLength = sizeof (MEMORYSTATUS);
+    MemoryStatus.dwLength = sizeof(MEMORYSTATUS);
     ::GlobalMemoryStatus(&MemoryStatus);
     TCHAR sString[1024];
     if (_GetProcessorName(sString, static_cast<DWORD>(std::size(sString))))

--- a/src/common/async.h
+++ b/src/common/async.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include "singleton.h"
-#include "sql.h"
+
 #include <task_system.hpp>
 
 #include <functional>
@@ -31,8 +31,6 @@
 class Async : public Singleton<Async>, private ts::task_system
 {
 public:
-    void query(std::string const& query);
-    void query(std::function<void(SqlConnection*)> const& func);
     void submit(std::function<void()> const& func);
 
 protected:

--- a/src/map/alliance.cpp
+++ b/src/map/alliance.cpp
@@ -81,7 +81,7 @@ void CAlliance::dissolveAlliance(bool playerInitiated)
         // | PARTY_THIRD, m_AllianceID);
         uint8 data[4]{};
         ref<uint32>(data, 0) = m_AllianceID;
-        message::send(MSG_ALLIANCE_DISSOLVE, data, sizeof data, nullptr);
+        message::send(MSG_ALLIANCE_DISSOLVE, data, sizeof(data), nullptr);
     }
     else
     {
@@ -169,11 +169,11 @@ void CAlliance::removeParty(CParty* party)
     // notify alliance
     uint8 data[4]{};
     ref<uint32>(data, 0) = m_AllianceID;
-    message::send(MSG_ALLIANCE_RELOAD, data, sizeof data, nullptr);
+    message::send(MSG_ALLIANCE_RELOAD, data, sizeof(data), nullptr);
 
     // notify leaving party
     ref<uint32>(data, 0) = party->GetPartyID();
-    message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
+    message::send(MSG_PT_RELOAD, data, sizeof(data), nullptr);
 }
 
 void CAlliance::delParty(CParty* party)
@@ -268,7 +268,7 @@ void CAlliance::addParty(CParty* party)
 
     uint8 data[4]{};
     ref<uint32>(data, 0) = m_AllianceID;
-    message::send(MSG_ALLIANCE_RELOAD, data, sizeof data, nullptr);
+    message::send(MSG_ALLIANCE_RELOAD, data, sizeof(data), nullptr);
 }
 
 void CAlliance::addParty(uint32 partyid) const
@@ -293,7 +293,7 @@ void CAlliance::addParty(uint32 partyid) const
     _sql->Query("UPDATE accounts_parties SET allianceid = %u, partyflag = partyflag | %d WHERE partyid = %u", m_AllianceID, newparty, partyid);
     uint8 data[4]{};
     ref<uint32>(data, 0) = m_AllianceID;
-    message::send(MSG_ALLIANCE_RELOAD, data, sizeof data, nullptr);
+    message::send(MSG_ALLIANCE_RELOAD, data, sizeof(data), nullptr);
 }
 
 void CAlliance::pushParty(CParty* PParty, uint8 number)

--- a/src/map/command_handler.cpp
+++ b/src/map/command_handler.cpp
@@ -23,6 +23,7 @@
 
 #include "autotranslate.h"
 #include "common/async.h"
+#include "common/database.h"
 #include "common/utils.h"
 #include "entities/charentity.h"
 #include "lua/lua_baseentity.h"
@@ -215,14 +216,10 @@ int32 CCommandHandler::call(sol::state& lua, CCharEntity* PChar, const std::stri
             std::string cmdlinestr = autotranslate::replaceBytes(commandline);
 
             // clang-format off
-            Async::getInstance()->query([name, cmdname, cmdlinestr](SqlConnection* _sql)
+            Async::getInstance()->submit([name, cmdname, cmdlinestr]()
             {
-                auto escaped_name        = _sql->EscapeString(name);
-                auto escaped_cmdname     = _sql->EscapeString(cmdname);
-                auto escaped_commandline = _sql->EscapeString(cmdlinestr);
-
-                const char* fmtQuery = "INSERT into audit_gm (date_time,gm_name,command,full_string) VALUES(current_timestamp(),'%s','%s','%s')";
-                if (_sql->Query(fmtQuery, escaped_name.data(), escaped_cmdname.data(), escaped_commandline.data()) == SQL_ERROR)
+                const auto query = "INSERT into audit_gm (date_time, gm_name, command, full_string) VALUES(current_timestamp(), ?, ?, ?)";
+                if (!db::preparedStmt(query, db::escapeString(name), db::escapeString(cmdname), db::escapeString(cmdlinestr)))
                 {
                     ShowError("cmdhandler::call: Failed to log GM command.");
                 }

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -339,12 +339,12 @@ CCharEntity::~CCharEntity()
         if (PParty->m_PAlliance)
         {
             ref<uint32>(data, 0) = PParty->m_PAlliance->m_AllianceID;
-            message::send(MSG_ALLIANCE_RELOAD, data, sizeof data, nullptr);
+            message::send(MSG_ALLIANCE_RELOAD, data, sizeof(data), nullptr);
         }
         else
         {
             ref<uint32>(data, 0) = PParty->GetPartyID();
-            message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
+            message::send(MSG_PT_RELOAD, data, sizeof(data), nullptr);
         }
     }
 

--- a/src/map/linkshell.cpp
+++ b/src/map/linkshell.cpp
@@ -94,7 +94,7 @@ void CLinkshell::setMessage(const std::string& message, const std::string& poste
     ref<uint32>(packetData, 4) = 0;
     if (message.size() != 0)
     {
-        message::send(MSG_CHAT_LINKSHELL, packetData, sizeof packetData,
+        message::send(MSG_CHAT_LINKSHELL, packetData, sizeof(packetData),
                       new CLinkshellMessagePacket(poster, message, m_name, std::numeric_limits<uint32>::min(), true));
     }
 }

--- a/src/map/linkshell.cpp
+++ b/src/map/linkshell.cpp
@@ -84,10 +84,12 @@ void CLinkshell::setName(const std::string& name)
 
 void CLinkshell::setMessage(const std::string& message, const std::string& poster)
 {
-    char sqlMessage[256];
-    _sql->EscapeString(sqlMessage, message.c_str());
-    _sql->Query("UPDATE linkshells SET poster = '%s', message = '%s', messagetime = %u WHERE linkshellid = %d", poster, sqlMessage,
-                static_cast<uint32>(time(nullptr)), m_id);
+    const auto query = "UPDATE linkshells SET poster = ?, message = ?, messagetime = ? WHERE linkshellid = ?";
+    if (!db::preparedStmt(query, poster, message, static_cast<uint32>(time(nullptr)), m_id))
+    {
+        ShowError("Failed to update linkshell message for linkshell %u", m_id);
+        return;
+    }
 
     int8 packetData[8]{};
     ref<uint32>(packetData, 0) = m_id;
@@ -350,10 +352,13 @@ void CLinkshell::PushLinkshellMessage(CCharEntity* PChar, bool ls1)
     const auto rset = db::preparedStmt("SELECT poster, message, messagetime FROM linkshells WHERE linkshellid = ?", m_id);
     if (rset && rset->rowsCount() && rset->next())
     {
-        const auto poster      = rset->get<std::string>("poster");
-        const auto message     = rset->get<std::string>("message");
-        const auto messageTime = rset->get<uint32>("messagetime");
-        PChar->pushPacket(new CLinkshellMessagePacket(poster, message, m_name, messageTime, ls1));
+        const auto poster      = rset->getOrDefault<std::string>("poster", "");
+        const auto message     = rset->getOrDefault<std::string>("message", "");
+        const auto messageTime = rset->getOrDefault<uint32>("messagetime", 0);
+        if (!message.empty())
+        {
+            PChar->pushPacket(new CLinkshellMessagePacket(poster, message, m_name, messageTime, ls1));
+        }
     }
 }
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -362,13 +362,13 @@ void CLuaBaseEntity::printToArea(std::string const& message, sol::object const& 
         {
             ref<uint32>(packetData, 0) = PChar->PParty->m_PAlliance->m_AllianceID;
             ref<uint32>(packetData, 4) = 0; // No ID so that the PChar sees the message too
-            message::send(MSG_CHAT_ALLIANCE, packetData, sizeof packetData, new CChatMessagePacket(PChar, messageLook, message, name));
+            message::send(MSG_CHAT_ALLIANCE, packetData, sizeof(packetData), new CChatMessagePacket(PChar, messageLook, message, name));
         }
         else if (PChar->PParty)
         {
             ref<uint32>(packetData, 0) = PChar->PParty->GetPartyID();
             ref<uint32>(packetData, 4) = 0; // No ID so that the PChar sees the message too
-            message::send(MSG_CHAT_PARTY, packetData, sizeof packetData, new CChatMessagePacket(PChar, messageLook, message, name));
+            message::send(MSG_CHAT_PARTY, packetData, sizeof(packetData), new CChatMessagePacket(PChar, messageLook, message, name));
         }
     }
     else if (messageRange == MESSAGE_AREA_YELL)

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -801,7 +801,7 @@ int32 recv_parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_da
                 uint8 data[4]{};
                 ref<uint32>(data, 0) = CharID;
 
-                message::send(MSG_KILL_SESSION, data, sizeof data, nullptr);
+                message::send(MSG_KILL_SESSION, data, sizeof(data), nullptr);
             }
         }
 

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -5518,11 +5518,13 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                     // clang-format off
                     // NOTE: We capture rawMessage as a std::string because if we cast data[6] into a const char*, the underlying data might
                     //     : be gone by the time we action this lambda on the worker thread.
-                    Async::getInstance()->query([name = PChar->getName(), rawMessage = std::string((const char*)data[6])](SqlConnection* _sql)
+                    Async::getInstance()->submit([name = PChar->getName(), zoneId = PChar->getZone(), rawMessage = std::string((const char*)data[6])]()
                     {
-                        auto message = _sql->EscapeString(rawMessage);
-                        std::ignore  = _sql->Query("INSERT INTO audit_chat (speaker,type,message,datetime) VALUES('%s','SAY','%s',current_timestamp())",
-                            name.c_str(), message.c_str());
+                        const auto query = "INSERT INTO audit_chat (speaker, type, zoneid, message, datetime) VALUES(?, 'SAY', ?, ?, current_timestamp())";
+                        if (!db::preparedStmt(query, name, zoneId, rawMessage))
+                        {
+                            ShowError("Failed to insert SAY audit_chat record for player '%s'", name);
+                        }
                     });
                     // clang-format on
                 }
@@ -5544,11 +5546,13 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                         // clang-format off
                         // NOTE: We capture rawMessage as a std::string because if we cast data[6] into a const char*, the underlying data might
                         //     : be gone by the time we action this lambda on the worker thread.
-                        Async::getInstance()->query([name = PChar->getName(), rawMessage = std::string((const char*)data[6])](SqlConnection* _sql)
+                        Async::getInstance()->submit([name = PChar->getName(), zoneId = PChar->getZone(), rawMessage = std::string((const char*)data[6])]()
                         {
-                            auto message = _sql->EscapeString(rawMessage);
-                            std::ignore  = _sql->Query("INSERT INTO audit_chat (speaker,type,message,datetime) VALUES('%s','SAY','%s',current_timestamp())",
-                                name.c_str(), message.c_str());
+                            const auto query = "INSERT INTO audit_chat (speaker, type, zoneid, message, datetime) VALUES(?, 'SAY', ?, ?, current_timestamp())";
+                            if (!db::preparedStmt(query, name, zoneId, rawMessage))
+                            {
+                                ShowError("Failed to insert SAY audit_chat record for player '%s'", name);
+                            }
                         });
                         // clang-format on
                     }
@@ -5567,11 +5571,13 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                         // clang-format off
                         // NOTE: We capture rawMessage as a std::string because if we cast data[6] into a const char*, the underlying data might
                         //     : be gone by the time we action this lambda on the worker thread.
-                        Async::getInstance()->query([name = PChar->getName(), rawMessage = std::string((const char*)data[6])](SqlConnection* _sql)
+                        Async::getInstance()->submit([name = PChar->getName(), zoneId = PChar->getZone(), rawMessage = std::string((const char*)data[6])]()
                         {
-                            auto message = _sql->EscapeString(rawMessage);
-                            std::ignore  = _sql->Query("INSERT INTO audit_chat (speaker,type,message,datetime) VALUES('%s','SHOUT','%s',current_timestamp())",
-                                name.c_str(), message.c_str());
+                            const auto query = "INSERT INTO audit_chat (speaker, type, zoneid, message, datetime) VALUES(?, 'SHOUT', ?, ?, current_timestamp())";
+                            if (!db::preparedStmt(query, name, zoneId, rawMessage))
+                            {
+                                ShowError("Failed to insert SHOUT audit_chat record for player '%s'", name);
+                            }
                         });
                         // clang-format on
                     }
@@ -5592,14 +5598,17 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                         {
                             char decodedLinkshellName[DecodeStringLength];
                             DecodeStringLinkshell(PChar->PLinkshell1->getName(), decodedLinkshellName);
+
                             // clang-format off
                             // NOTE: We capture rawMessage as a std::string because if we cast data[6] into a const char*, the underlying data might
                             //     : be gone by the time we action this lambda on the worker thread.
-                            Async::getInstance()->query([name = PChar->getName(), rawMessage = std::string((const char*)data[6]), decodedLinkshellName](SqlConnection* _sql)
+                            Async::getInstance()->submit([name = PChar->getName(), zoneId = PChar->getZone(), rawMessage = std::string((const char*)data[6]), decodedLinkshellName]()
                             {
-                                auto message = _sql->EscapeString(rawMessage);
-                                std::ignore  = _sql->Query("INSERT INTO audit_chat (speaker,type,lsName,message,datetime) VALUES('%s','LINKSHELL','%s','%s',current_timestamp())",
-                                    name.c_str(), decodedLinkshellName, message.c_str());
+                                const auto query = "INSERT INTO audit_chat (speaker, type, lsName, zoneid, message, datetime) VALUES(?, 'LINKSHELL', ?, ?, ?, current_timestamp())";
+                                if (!db::preparedStmt(query, name, decodedLinkshellName, zoneId, rawMessage))
+                                {
+                                    ShowError("Failed to insert LINKSHELL audit_chat record for player '%s'", name);
+                                }
                             });
                             // clang-format on
                         }
@@ -5620,15 +5629,19 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                         {
                             char decodedLinkshellName[DecodeStringLength];
                             DecodeStringLinkshell(PChar->PLinkshell2->getName(), decodedLinkshellName);
+
                             // clang-format off
                             // NOTE: We capture rawMessage as a std::string because if we cast data[6] into a const char*, the underlying data might
                             //     : be gone by the time we action this lambda on the worker thread.
-                            Async::getInstance()->query([name = PChar->getName(), rawMessage = std::string((const char*)data[6]), decodedLinkshellName](SqlConnection* _sql)
+                            Async::getInstance()->submit([name = PChar->getName(), zoneId = PChar->getZone(), rawMessage = std::string((const char*)data[6]), decodedLinkshellName]()
                             {
-                                auto message = _sql->EscapeString(rawMessage);
-                                std::ignore  = _sql->Query("INSERT INTO audit_chat (speaker,type,lsName,message,datetime) VALUES('%s','LINKSHELL','%s','%s',current_timestamp())",
-                                    name.c_str(), decodedLinkshellName, message.c_str());
+                                const auto query = "INSERT INTO audit_chat (speaker, type, lsName, zoneid, message, datetime) VALUES(?, 'LINKSHELL', ?, ?, ?, current_timestamp())";
+                                if (!db::preparedStmt(query, name, decodedLinkshellName, zoneId, rawMessage))
+                                {
+                                    ShowError("Failed to insert LINKSHELL audit_chat record for player '%s'", name);
+                                }
                             });
+                            // clang-format on
                         }
                     }
                 }
@@ -5638,7 +5651,7 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                     if (PChar->PParty != nullptr)
                     {
                         int8 packetData[8]{};
-                        if(PChar->PParty->m_PAlliance)
+                        if (PChar->PParty->m_PAlliance)
                         {
                             ref<uint32>(packetData, 0) = PChar->PParty->m_PAlliance->m_AllianceID;
                             ref<uint32>(packetData, 4) = PChar->id;
@@ -5656,11 +5669,13 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                             // clang-format off
                             // NOTE: We capture rawMessage as a std::string because if we cast data[6] into a const char*, the underlying data might
                             //     : be gone by the time we action this lambda on the worker thread.
-                            Async::getInstance()->query([name = PChar->getName(), rawMessage = std::string((const char*)data[6])](SqlConnection* _sql)
+                            Async::getInstance()->submit([name = PChar->getName(), zoneId = PChar->getZone(), rawMessage = std::string((const char*)data[6])]()
                             {
-                                auto message = _sql->EscapeString(rawMessage);
-                                std::ignore  = _sql->Query("INSERT INTO audit_chat (speaker,type,message,datetime) VALUES('%s','PARTY','%s',current_timestamp())",
-                                    name.c_str(), message.c_str());
+                                const auto query = "INSERT INTO audit_chat (speaker, type, zoneid, message, datetime) VALUES(?, 'PARTY', ?, ?, current_timestamp())";
+                                if (!db::preparedStmt(query, name, zoneId, rawMessage))
+                                {
+                                    ShowError("Failed to insert PARTY audit_chat record for player '%s'", name);
+                                }
                             });
                             // clang-format on
                         }
@@ -5689,11 +5704,13 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                                 // clang-format off
                                 // NOTE: We capture rawMessage as a std::string because if we cast data[6] into a const char*, the underlying data might
                                 //     : be gone by the time we action this lambda on the worker thread.
-                                Async::getInstance()->query([name = PChar->getName(), zoneid = PChar->getZone(), rawMessage = std::string((const char*)data[6])](SqlConnection* _sql)
+                                Async::getInstance()->submit([name = PChar->getName(), zoneId = PChar->getZone(), rawMessage = std::string((const char*)data[6])]()
                                 {
-                                    auto message = _sql->EscapeString(rawMessage);
-                                    std::ignore  = _sql->Query("INSERT INTO audit_chat (speaker,type,zoneid,message,datetime) VALUES('%s','YELL','%d','%s',current_timestamp())",
-                                        name.c_str(), zoneid, message.c_str());
+                                    const auto query = "INSERT INTO audit_chat (speaker, type, zoneid, message, datetime) VALUES(?, 'YELL', ?, ?, current_timestamp())";
+                                    if (!db::preparedStmt(query, name, zoneId, rawMessage))
+                                    {
+                                        ShowError("Failed to insert YELL audit_chat record for player '%s'", name);
+                                    }
                                 });
                                 // clang-format on
                             }
@@ -5726,11 +5743,13 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                             // clang-format off
                             // NOTE: We capture rawMessage as a std::string because if we cast data[6] into a const char*, the underlying data might
                             //     : be gone by the time we action this lambda on the worker thread.
-                            Async::getInstance()->query([name = PChar->getName(), unityLeader = PChar->PUnityChat->getLeader(), rawMessage = std::string((const char*)data[6])](SqlConnection* _sql)
+                            Async::getInstance()->submit([name = PChar->getName(), zoneId = PChar->getZone(), unityLeader = PChar->PUnityChat->getLeader(), rawMessage = std::string((const char*)data[6])]()
                             {
-                                auto message = _sql->EscapeString(rawMessage);
-                                std::ignore  = _sql->Query("INSERT INTO audit_chat (speaker,type,unity,message,datetime) VALUES('%s','UNITY','%d','%s',current_timestamp())",
-                                    name.c_str(), unityLeader, message.c_str());
+                                const auto query = "INSERT INTO audit_chat (speaker, type, zoneid, unity, message, datetime) VALUES(?, 'UNITY', ?, ?, ?, current_timestamp())";
+                                if (!db::preparedStmt(query, name, zoneId, unityLeader, rawMessage))
+                                {
+                                    ShowError("Failed to insert UNITY audit_chat record for player '%s'", name);
+                                }
                             });
                             // clang-format on
                         }
@@ -5759,14 +5778,14 @@ void SmallPacket0x0B6(map_session_data_t* const PSession, CCharEntity* const PCh
         return;
     }
 
-    std::string RecipientName = std::string((const char*)data[6], 15);
+    std::string recipientName = std::string((const char*)data[6], 15);
 
     char  message[256]    = {}; // /t messages using "<t>" with a long named NPC targeted caps out at 138 bytes, increasing to the nearest power of 2
     uint8 messagePosition = 0x15;
 
-    memcpy(&message, data[messagePosition], std::min(data.getSize() - messagePosition, sizeof(message)));
+    std::memcpy(&message, data[messagePosition], std::min(data.getSize() - messagePosition, sizeof(message)));
 
-    if (strcmp(RecipientName.c_str(), "_CUSTOM_MENU") == 0 &&
+    if (strcmp(recipientName.c_str(), "_CUSTOM_MENU") == 0 &&
         luautils::HasCustomMenuContext(PChar))
     {
         luautils::HandleCustomMenu(PChar, message);
@@ -5774,28 +5793,25 @@ void SmallPacket0x0B6(map_session_data_t* const PSession, CCharEntity* const PCh
     }
 
     int8 packetData[64]{};
-    strncpy((char*)packetData + 4, RecipientName.c_str(), RecipientName.length() + 1);
+    strncpy((char*)packetData + 4, recipientName.c_str(), recipientName.length() + 1);
     ref<uint32>(packetData, 0) = PChar->id;
 
-    message::send(MSG_CHAT_TELL, packetData, RecipientName.length() + 5, new CChatMessagePacket(PChar, MESSAGE_TELL, message));
+    message::send(MSG_CHAT_TELL, packetData, recipientName.length() + 5, new CChatMessagePacket(PChar, MESSAGE_TELL, message));
 
     if (settings::get<bool>("map.AUDIT_CHAT") && settings::get<bool>("map.AUDIT_TELL"))
     {
-        char escaped_speaker[16 * 2 + 1];
-        _sql->EscapeString(escaped_speaker, PChar->getName().c_str());
-
-        char escaped_recipient[16 * 2 + 1];
-        _sql->EscapeString(escaped_recipient, &RecipientName[0]);
-
-        std::string escaped_full_string;
-        escaped_full_string.reserve(strlen((const char*)data[21]) * 2 + 1);
-        _sql->EscapeString(escaped_full_string.data(), (const char*)data[21]);
-
-        const char* fmtQuery = "INSERT into audit_chat (speaker,type,recipient,message,datetime) VALUES('%s','TELL','%s','%s',current_timestamp())";
-        if (_sql->Query(fmtQuery, escaped_speaker, escaped_recipient, escaped_full_string.data()) == SQL_ERROR)
+        // clang-format off
+        // NOTE: We capture rawMessage as a std::string because if we cast data[6] into a const char*, the underlying data might
+        //     : be gone by the time we action this lambda on the worker thread.
+        Async::getInstance()->submit([name = PChar->getName(), zoneId = PChar->getZone(), recipient = recipientName, message]()
         {
-            ShowError("packet_system::call: Failed to log MESSAGE_TELL.");
-        }
+            const auto query = "INSERT INTO audit_chat (speaker, type, zoneid, recipient, message, datetime) VALUES(?, 'TELL', ?, ?, ?, current_timestamp())";
+            if (!db::preparedStmt(query, name, zoneId, recipient, message))
+            {
+                ShowError("Failed to insert TELL audit_chat record for player '%s'", name);
+            }
+        });
+        // clang-format on
     }
 }
 

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -4356,7 +4356,7 @@ void SmallPacket0x06E(map_session_data_t* const PSession, CCharEntity* const PCh
                     ref<uint16>(packetData, 4)  = targid;
                     ref<uint32>(packetData, 6)  = PChar->id;
                     ref<uint16>(packetData, 10) = PChar->targid;
-                    message::send(MSG_PT_INVITE, packetData, sizeof packetData, new CPartyInvitePacket(charid, targid, PChar, INVITE_PARTY));
+                    message::send(MSG_PT_INVITE, packetData, sizeof(packetData), new CPartyInvitePacket(charid, targid, PChar, INVITE_PARTY));
 
                     ShowDebug("Sent invite packet to lobby server from %s to (%d)", PChar->getName(), charid);
                 }
@@ -4431,7 +4431,7 @@ void SmallPacket0x06E(map_session_data_t* const PSession, CCharEntity* const PCh
                     ref<uint16>(packetData, 4)  = targid;
                     ref<uint32>(packetData, 6)  = PChar->id;
                     ref<uint16>(packetData, 10) = PChar->targid;
-                    message::send(MSG_PT_INVITE, packetData, sizeof packetData, new CPartyInvitePacket(charid, targid, PChar, INVITE_ALLIANCE));
+                    message::send(MSG_PT_INVITE, packetData, sizeof(packetData), new CPartyInvitePacket(charid, targid, PChar, INVITE_ALLIANCE));
 
                     ShowDebug("(Alliance)Sent invite packet to lobby server from %s to (%d)", PChar->getName(), charid);
                 }
@@ -4605,17 +4605,17 @@ void SmallPacket0x071(map_session_data_t* const PSession, CCharEntity* const PCh
                             if (PChar->PParty && PChar->PParty->m_PAlliance)
                             {
                                 ref<uint32>(reloadData, 0) = PChar->PParty->m_PAlliance->m_AllianceID;
-                                message::send(MSG_ALLIANCE_RELOAD, reloadData, sizeof reloadData, nullptr);
+                                message::send(MSG_ALLIANCE_RELOAD, reloadData, sizeof(reloadData), nullptr);
                             }
                             else // No alliance, notify party.
                             {
                                 ref<uint32>(reloadData, 0) = PChar->PParty->GetPartyID();
-                                message::send(MSG_PT_RELOAD, reloadData, sizeof reloadData, nullptr);
+                                message::send(MSG_PT_RELOAD, reloadData, sizeof(reloadData), nullptr);
                             }
 
                             // Notify the player they were just kicked -- they are no longer in the DB and party/alliance reloads won't notify them.
                             ref<uint32>(reloadData, 0) = id;
-                            message::send(MSG_PLAYER_KICK, reloadData, sizeof reloadData, nullptr);
+                            message::send(MSG_PLAYER_KICK, reloadData, sizeof(reloadData), nullptr);
                         }
                     }
                 }
@@ -4632,7 +4632,7 @@ void SmallPacket0x071(map_session_data_t* const PSession, CCharEntity* const PCh
                 memcpy(packetData + 0x04, data[0x0C], 20);
                 ref<uint32>(packetData, 24) = PChar->PLinkshell1->getID();
                 ref<uint8>(packetData, 28)  = PItemLinkshell->GetLSType();
-                message::send(MSG_LINKSHELL_REMOVE, packetData, sizeof packetData, nullptr);
+                message::send(MSG_LINKSHELL_REMOVE, packetData, sizeof(packetData), nullptr);
             }
         }
         break;
@@ -4647,7 +4647,7 @@ void SmallPacket0x071(map_session_data_t* const PSession, CCharEntity* const PCh
                 memcpy(packetData + 0x04, data[0x0C], 20);
                 ref<uint32>(packetData, 24) = PChar->PLinkshell2->getID();
                 ref<uint8>(packetData, 28)  = PItemLinkshell->GetLSType();
-                message::send(MSG_LINKSHELL_REMOVE, packetData, sizeof packetData, nullptr);
+                message::send(MSG_LINKSHELL_REMOVE, packetData, sizeof(packetData), nullptr);
             }
         }
         break;
@@ -4707,11 +4707,11 @@ void SmallPacket0x071(map_session_data_t* const PSession, CCharEntity* const PCh
                                 // notify party they were removed
                                 uint8 removeData[4]{};
                                 ref<uint32>(removeData, 0) = partyid;
-                                message::send(MSG_PT_RELOAD, removeData, sizeof removeData, nullptr);
+                                message::send(MSG_PT_RELOAD, removeData, sizeof(removeData), nullptr);
 
                                 // notify alliance a party was removed
                                 ref<uint32>(removeData, 0) = allianceID;
-                                message::send(MSG_ALLIANCE_RELOAD, removeData, sizeof removeData, nullptr);
+                                message::send(MSG_ALLIANCE_RELOAD, removeData, sizeof(removeData), nullptr);
                             }
                         }
                     }
@@ -4835,7 +4835,7 @@ void SmallPacket0x074(map_session_data_t* const PSession, CCharEntity* const PCh
         ref<uint16>(packetData, 10) = PChar->targid;
         ref<uint8>(packetData, 12)  = InviteAnswer;
         PChar->InvitePending.clean();
-        message::send(MSG_PT_INV_RES, packetData, sizeof packetData, nullptr);
+        message::send(MSG_PT_INV_RES, packetData, sizeof(packetData), nullptr);
         ShowDebug("(Party)Sent invite packet to send to lobby server for %s", PChar->getName());
     }
     PChar->InvitePending.clean();
@@ -4893,7 +4893,7 @@ void SmallPacket0x077(map_session_data_t* const PSession, CCharEntity* const PCh
                 memcpy(packetData + 0x04, data[0x04], 20);
                 ref<uint32>(packetData, 24) = PChar->PLinkshell1->getID();
                 ref<uint8>(packetData, 28)  = data.ref<uint8>(0x15);
-                message::send(MSG_LINKSHELL_RANK_CHANGE, packetData, sizeof packetData, nullptr);
+                message::send(MSG_LINKSHELL_RANK_CHANGE, packetData, sizeof(packetData), nullptr);
             }
         }
         break;
@@ -4906,7 +4906,7 @@ void SmallPacket0x077(map_session_data_t* const PSession, CCharEntity* const PCh
                 memcpy(packetData + 0x04, data[0x04], 20);
                 ref<uint32>(packetData, 24) = PChar->PLinkshell2->getID();
                 ref<uint8>(packetData, 28)  = data.ref<uint8>(0x15);
-                message::send(MSG_LINKSHELL_RANK_CHANGE, packetData, sizeof packetData, nullptr);
+                message::send(MSG_LINKSHELL_RANK_CHANGE, packetData, sizeof(packetData), nullptr);
             }
         }
         break;
@@ -4923,7 +4923,7 @@ void SmallPacket0x077(map_session_data_t* const PSession, CCharEntity* const PCh
 
                 uint8 allianceData[4]{};
                 ref<uint32>(allianceData, 0) = PChar->PParty->m_PAlliance->m_AllianceID;
-                message::send(MSG_ALLIANCE_RELOAD, allianceData, sizeof allianceData, nullptr);
+                message::send(MSG_ALLIANCE_RELOAD, allianceData, sizeof(allianceData), nullptr);
             }
         }
         break;
@@ -5591,7 +5591,7 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                         int8 packetData[8]{};
                         ref<uint32>(packetData, 0) = PChar->PLinkshell1->getID();
                         ref<uint32>(packetData, 4) = PChar->id;
-                        message::send(MSG_CHAT_LINKSHELL, packetData, sizeof packetData,
+                        message::send(MSG_CHAT_LINKSHELL, packetData, sizeof(packetData),
                                       new CChatMessagePacket(PChar, MESSAGE_LINKSHELL, (const char*)data[6]));
 
                         if (settings::get<bool>("map.AUDIT_CHAT") && settings::get<uint8>("map.AUDIT_LINKSHELL"))
@@ -5622,7 +5622,7 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                         int8 packetData[8]{};
                         ref<uint32>(packetData, 0) = PChar->PLinkshell2->getID();
                         ref<uint32>(packetData, 4) = PChar->id;
-                        message::send(MSG_CHAT_LINKSHELL, packetData, sizeof packetData,
+                        message::send(MSG_CHAT_LINKSHELL, packetData, sizeof(packetData),
                                       new CChatMessagePacket(PChar, MESSAGE_LINKSHELL, (const char*)data[6]));
 
                         if (settings::get<bool>("map.AUDIT_CHAT") && settings::get<uint8>("map.AUDIT_LINKSHELL"))
@@ -5655,13 +5655,13 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                         {
                             ref<uint32>(packetData, 0) = PChar->PParty->m_PAlliance->m_AllianceID;
                             ref<uint32>(packetData, 4) = PChar->id;
-                            message::send(MSG_CHAT_ALLIANCE, packetData, sizeof packetData, new CChatMessagePacket(PChar, MESSAGE_PARTY, (const char*)data[6]));
+                            message::send(MSG_CHAT_ALLIANCE, packetData, sizeof(packetData), new CChatMessagePacket(PChar, MESSAGE_PARTY, (const char*)data[6]));
                         }
                         else
                         {
                             ref<uint32>(packetData, 0) = PChar->PParty->GetPartyID();
                             ref<uint32>(packetData, 4) = PChar->id;
-                            message::send(MSG_CHAT_PARTY, packetData, sizeof packetData, new CChatMessagePacket(PChar, MESSAGE_PARTY, (const char*)data[6]));
+                            message::send(MSG_CHAT_PARTY, packetData, sizeof(packetData), new CChatMessagePacket(PChar, MESSAGE_PARTY, (const char*)data[6]));
                         }
 
                         if (settings::get<bool>("map.AUDIT_CHAT") && settings::get<uint8>("map.AUDIT_PARTY"))
@@ -5697,7 +5697,7 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                             int8 packetData[4]{};
                             ref<uint32>(packetData, 0) = PChar->id;
 
-                            message::send(MSG_CHAT_YELL, packetData, sizeof packetData, new CChatMessagePacket(PChar, MESSAGE_YELL, (const char*)data[6]));
+                            message::send(MSG_CHAT_YELL, packetData, sizeof(packetData), new CChatMessagePacket(PChar, MESSAGE_YELL, (const char*)data[6]));
 
                             if (settings::get<bool>("map.AUDIT_CHAT") && settings::get<uint8>("map.AUDIT_YELL"))
                             {
@@ -5733,7 +5733,7 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                         int8 packetData[8]{};
                         ref<uint32>(packetData, 0) = PChar->PUnityChat->getLeader();
                         ref<uint32>(packetData, 4) = PChar->id;
-                        message::send(MSG_CHAT_UNITY, packetData, sizeof packetData,
+                        message::send(MSG_CHAT_UNITY, packetData, sizeof(packetData),
                                       new CChatMessagePacket(PChar, MESSAGE_UNITY, (const char*)data[6]));
 
                         roeutils::event(ROE_EVENT::ROE_UNITY_CHAT, PChar, RoeDatagram("unityMessage", (const char*)data[6]));

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -160,7 +160,7 @@ void CParty::DisbandParty(bool playerInitiated)
         {
             uint8 data[4]{};
             ref<uint32>(data, 0) = m_PartyID;
-            message::send(MSG_PT_DISBAND, data, sizeof data, nullptr);
+            message::send(MSG_PT_DISBAND, data, sizeof(data), nullptr);
         }
     }
     else if (m_PartyType == PARTY_MOBS)
@@ -217,12 +217,12 @@ void CParty::AssignPartyRole(const std::string& MemberName, uint8 role)
     if (m_PAlliance)
     {
         ref<uint32>(data, 0) = m_PAlliance->m_AllianceID;
-        message::send(MSG_ALLIANCE_RELOAD, data, sizeof data, nullptr);
+        message::send(MSG_ALLIANCE_RELOAD, data, sizeof(data), nullptr);
     }
     else
     {
         ref<uint32>(data, 0) = m_PartyID;
-        message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
+        message::send(MSG_PT_RELOAD, data, sizeof(data), nullptr);
     }
 }
 
@@ -353,12 +353,12 @@ void CParty::RemoveMember(CBattleEntity* PEntity)
                 if (m_PAlliance)
                 {
                     ref<uint32>(data, 0) = m_PAlliance->m_AllianceID;
-                    message::send(MSG_ALLIANCE_RELOAD, data, sizeof data, nullptr);
+                    message::send(MSG_ALLIANCE_RELOAD, data, sizeof(data), nullptr);
                 }
                 else
                 {
                     ref<uint32>(data, 0) = m_PartyID;
-                    message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
+                    message::send(MSG_PT_RELOAD, data, sizeof(data), nullptr);
                 }
 
                 if (PChar->PTreasurePool != nullptr && PChar->PTreasurePool->GetPoolType() != TREASUREPOOL_ZONE)
@@ -609,12 +609,12 @@ void CParty::AddMember(CBattleEntity* PEntity)
         if (m_PAlliance)
         {
             ref<uint32>(data, 0) = m_PAlliance->m_AllianceID;
-            message::send(MSG_ALLIANCE_RELOAD, data, sizeof data, nullptr);
+            message::send(MSG_ALLIANCE_RELOAD, data, sizeof(data), nullptr);
         }
         else
         {
             ref<uint32>(data, 0) = m_PartyID;
-            message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
+            message::send(MSG_PT_RELOAD, data, sizeof(data), nullptr);
         }
 
         ReloadTreasurePool(PChar);
@@ -681,12 +681,12 @@ void CParty::AddMember(uint32 id)
         if (m_PAlliance)
         {
             ref<uint32>(data, 0) = m_PAlliance->m_AllianceID;
-            message::send(MSG_ALLIANCE_RELOAD, data, sizeof data, nullptr);
+            message::send(MSG_ALLIANCE_RELOAD, data, sizeof(data), nullptr);
         }
         else
         {
             ref<uint32>(data, 0) = m_PartyID;
-            message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
+            message::send(MSG_PT_RELOAD, data, sizeof(data), nullptr);
         }
 
         /*if (PChar->nameflags.flags & FLAG_INVITE)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Simplifies usage, looks like Async will likely be on the way out when I introduce coros+scheduler