### PR TITLE
[sql] Actually use Scale/Solid greaves item ID in Smithing gp

### DIFF
--- a/sql/guild_item_points.sql
+++ b/sql/guild_item_points.sql
@@ -298,8 +298,8 @@ INSERT INTO `guild_item_points` VALUES (2,16646,0,86,4560,7); -- Bronze Axe +1 (
 -- Blacksmithing / Recruit
 INSERT INTO `guild_item_points` VALUES (2,12816,1,358,8640,0); -- Scale Cuisses (358 / 8640)
 INSERT INTO `guild_item_points` VALUES (2,12863,1,410,8640,0); -- Solid Cuisses (410 / 8640)
-INSERT INTO `guild_item_points` VALUES (2,12816,1,217,7200,1); -- Scale Greaves (217 / 7200)
-INSERT INTO `guild_item_points` VALUES (2,12863,1,269,7200,1); -- Solid Greaves (269 / 7200)
+INSERT INTO `guild_item_points` VALUES (2,12944,1,217,7200,1); -- Scale Greaves (217 / 7200)
+INSERT INTO `guild_item_points` VALUES (2,13024,1,269,7200,1); -- Solid Greaves (269 / 7200)
 INSERT INTO `guild_item_points` VALUES (2,12299,1,189,6960,2); -- Aspis (189 / 6960)
 INSERT INTO `guild_item_points` VALUES (2,12325,1,233,6960,2); -- Aspis +1 (233 / 6960)
 INSERT INTO `guild_item_points` VALUES (2,17042,1,85,5520,3); -- Bronze Hammer (85 / 5520)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Actually use Scale/Solid greaves item ID in Smithing gp
The duplicate entry was cusing Scale/Solid Cuisses to use the wrong GP value
## Steps to test these changes

Trade GP item for Scale/Solid Cuisses and Scale/Solid Greaves and see the correct GP
