### PR TITLE
[core] Trigger time of day based latents on ALL day events

### DIFF
--- a/src/map/time_server.cpp
+++ b/src/map/time_server.cpp
@@ -140,24 +140,22 @@ int32 time_server(time_point tick, CTaskMgr::CTask* PTask)
         }
     }
 
+    // Some notable time-event has occurred. -- CVanaTime::SyncTime() has hit a time of day where latents trigger
     if (VanadielTOTD != TIME_NONE)
     {
         TracyZoneScoped;
         zoneutils::TOTDChange(VanadielTOTD);
 
-        if ((VanadielTOTD == TIME_DAY) || (VanadielTOTD == TIME_DUSK) || (VanadielTOTD == TIME_NIGHT))
+        // clang-format off
+        zoneutils::ForEachZone([](CZone* PZone)
         {
-            // clang-format off
-            zoneutils::ForEachZone([](CZone* PZone)
+            PZone->ForEachChar([](CCharEntity* PChar)
             {
-                PZone->ForEachChar([](CCharEntity* PChar)
-                {
-                    PChar->PLatentEffectContainer->CheckLatentsDay();
-                    PChar->PLatentEffectContainer->CheckLatentsJobLevel();
-                });
+                PChar->PLatentEffectContainer->CheckLatentsDay();
+                PChar->PLatentEffectContainer->CheckLatentsJobLevel(); // Eerie CLoak +1 latent is nighttime + level multiple of 13
             });
-            // clang-format on
-        }
+        });
+        // clang-format on
 
         fishingutils::RestockFishingAreas();
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

For some reason, time based latents were only triggered on the following times of day:

`if ((VanadielTOTD == TIME_DAY) || (VanadielTOTD == TIME_DUSK) || (VanadielTOTD == TIME_NIGHT))`

This is despite the fact other times of day (such as dusk til dawn) are valid latents.

This also has a side effect of making `zoneutils::TOTDChange(VanadielTOTD);` call on other cases that it wasn't previously. This seems like it would have an effect on mob spawning/despawning (such as undead), but we'll have to deal with that if it causes issues because some latents require the other VanadielTOTD cases.

## Steps to test these changes

Use latent effects with day/night/dusk til dawn etc and see things work
