### PR TITLE
Fix Terra Crystal item ID in synthutils

### DIFF
--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -820,7 +820,7 @@ namespace synthutils
                 break;
 
             case 4099: // Earth Crystal
-            case 4041: // Terra Crystal
+            case 4241: // Terra Crystal
                 effect  = EFFECT_EARTHSYNTH;
                 element = ELEMENT_EARTH;
                 break;


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes item ID of terra crystal, resulting in false anti-cheat triggering because no effect was set.

Close #6512 

## Steps to test these changes

Craft using a terra crystal and have it not trigger the anti-cheat.
