### PR TITLE
[core] Use prepared statements for blobs

### DIFF
--- a/src/map/monstrosity.cpp
+++ b/src/map/monstrosity.cpp
@@ -225,41 +225,46 @@ void monstrosity::WriteMonstrosityData(CCharEntity* PChar)
     }
 
     const char* Query = "REPLACE INTO char_monstrosity SET "
-                        "charid = '%u', "
-                        "current_monstrosity_id = '%d', "
-                        "current_monstrosity_species = '%d', "
-                        "current_monstrosity_name_prefix_1 = '%d', "
-                        "current_monstrosity_name_prefix_2 = '%d', "
-                        "current_exp = '%d', "
-                        "equip = '%s', "
-                        "levels = '%s', "
-                        "instincts = '%s', "
-                        "variants = '%s', "
-                        "belligerency = '%d', "
-                        "entry_x = '%.3f', "
-                        "entry_y = '%.3f', "
-                        "entry_z = '%.3f', "
-                        "entry_rot = '%u', "
-                        "entry_zone_id = '%d', "
-                        "entry_mjob = '%d', "
-                        "entry_sjob = '%d'";
+                        "charid = ?, "
+                        "current_monstrosity_id = ?, "
+                        "current_monstrosity_species = ?, "
+                        "current_monstrosity_name_prefix_1 = ?, "
+                        "current_monstrosity_name_prefix_2 = ?, "
+                        "current_exp = ?, "
+                        "equip = ?, "
+                        "levels = ?, "
+                        "instincts = ?, "
+                        "variants = ?, "
+                        "belligerency = ?, "
+                        "entry_x = ?, "
+                        "entry_y = ?, "
+                        "entry_z = ?, "
+                        "entry_rot = ?, "
+                        "entry_zone_id = ?, "
+                        "entry_mjob = ?, "
+                        "entry_sjob = ?";
 
-    const auto equipEscaped     = db::encodeToBlob(PChar->m_PMonstrosity->EquippedInstincts);
-    const auto levelsEscaped    = db::encodeToBlob(PChar->m_PMonstrosity->levels);
-    const auto instinctsEscaped = db::encodeToBlob(PChar->m_PMonstrosity->instincts);
-    const auto variantsEscaped  = db::encodeToBlob(PChar->m_PMonstrosity->variants);
+    auto equip     = db::encodeToBlob(PChar->m_PMonstrosity->EquippedInstincts);
+    auto levels    = db::encodeToBlob(PChar->m_PMonstrosity->levels);
+    auto instincts = db::encodeToBlob(PChar->m_PMonstrosity->instincts);
+    auto variants  = db::encodeToBlob(PChar->m_PMonstrosity->variants);
 
-    db::query(Query,
+    std::basic_istream<char> equipStream(&equip);
+    std::basic_istream<char> levelsStream(&equip);
+    std::basic_istream<char> instinctsStream(&equip);
+    std::basic_istream<char> variantsStream(&equip);
+
+    db::preparedStmt(Query,
               PChar->id,
               PChar->m_PMonstrosity->MonstrosityId,
               PChar->m_PMonstrosity->Species,
               PChar->m_PMonstrosity->NamePrefix1,
               PChar->m_PMonstrosity->NamePrefix2,
               PChar->m_PMonstrosity->CurrentExp,
-              equipEscaped.c_str(),
-              levelsEscaped.c_str(),
-              instinctsEscaped.c_str(),
-              variantsEscaped.c_str(),
+              equipStream,
+              levelsStream,
+              instinctsStream,
+              variantsStream,
               static_cast<uint8>(PChar->m_PMonstrosity->Belligerency),
               PChar->m_PMonstrosity->EntryPos.x,
               PChar->m_PMonstrosity->EntryPos.y,

--- a/src/map/utils/blueutils.cpp
+++ b/src/map/utils/blueutils.cpp
@@ -322,10 +322,10 @@ namespace blueutils
     {
         if (PChar->GetMJob() == JOB_BLU || PChar->GetSJob() == JOB_BLU)
         {
-            auto set_blue_spells = db::encodeToBlob(PChar->m_SetBlueSpells);
-            auto query           = fmt::format("UPDATE chars SET set_blue_spells = '{}' WHERE charid = {} LIMIT 1",
-                                               set_blue_spells, PChar->id);
-            db::query(query);
+            auto                     set_blue_spells = db::encodeToBlob(PChar->m_SetBlueSpells);
+            std::basic_istream<char> blobStream(&set_blue_spells);
+            auto                     rset     = db::preparedStmt("UPDATE chars SET set_blue_spells = ? WHERE charid = ? LIMIT 1",
+                                                             blobStream, PChar->id);
         }
     }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Use prepared statements for blobs
Code is rough, meant for review & CI

## Steps to test these changes

!monstrosity with no errors
set blue magic spells, /logout, /login, see same blue magic spells
