### PR TITLE
Enable Virtue Stone offhand attacks for Faith Baghnakhs

### DIFF
--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -37196,7 +37196,7 @@ INSERT INTO `item_mods` VALUES (18359,950,3);   -- ITEM_ADDEFFECT_ELEMENT: 3
 
 -- Faith Baghnakhs
 INSERT INTO `item_mods` VALUES (18360,13,7);  -- MND: 7
-INSERT INTO `item_mods` VALUES (18360,826,2); -- AMMO_SWING_TYPE: 2
+INSERT INTO `item_mods` VALUES (18360,826,2); -- AMMO_SWING_TYPE: 1.  - HtH are treated like 1H and can proc on both hands.
 
 -- Ponderous Manoples
 INSERT INTO `item_mods` VALUES (18361,10,2); -- VIT: 2

--- a/src/map/attackround.cpp
+++ b/src/map/attackround.cpp
@@ -350,14 +350,14 @@ void CAttackRound::CreateAttacks(CItemWeapon* PWeapon, PHYSICAL_ATTACK_DIRECTION
         uint8           loc       = PChar->equipLoc[SLOT_AMMO];
         uint8           ammoCount = 0;
 
-        // Two handed and Hand-to-Hand
+        // Two handed
         if (battleutils::GetScaledItemModifier(PChar, PMain, Mod::AMMO_SWING_TYPE) == 2 &&
             xirand::GetRandomNumber(100) < m_attacker->getMod(Mod::AMMO_SWING) && PAmmo != nullptr && ammoCount < PAmmo->getQuantity())
         {
             AddAttackSwing(PHYSICAL_ATTACK_TYPE::NORMAL, direction, 1);
             ammoCount += 1;
         }
-        // One handed
+        // One handed and Hand-to-Hand
         else
         {
             if (direction == RIGHTATTACK && battleutils::GetScaledItemModifier(PChar, PMain, Mod::AMMO_SWING_TYPE) == 1 &&
@@ -366,7 +366,7 @@ void CAttackRound::CreateAttacks(CItemWeapon* PWeapon, PHYSICAL_ATTACK_DIRECTION
                 AddAttackSwing(PHYSICAL_ATTACK_TYPE::NORMAL, RIGHTATTACK, 1);
                 ammoCount += 1;
             }
-            if (direction == LEFTATTACK && PSub != nullptr && battleutils::GetScaledItemModifier(PChar, PSub, Mod::AMMO_SWING_TYPE) == 1 &&
+            if (direction == LEFTATTACK && battleutils::GetScaledItemModifier(PChar, IsH2H() ? PMain : PSub, Mod::AMMO_SWING_TYPE) == 1 &&
                 xirand::GetRandomNumber(100) < m_attacker->getMod(Mod::AMMO_SWING) && PAmmo != nullptr && ammoCount < PAmmo->getQuantity())
             {
                 AddAttackSwing(PHYSICAL_ATTACK_TYPE::NORMAL, LEFTATTACK, 1);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This change will Enable Virtue Stone offhand attacks for Faith Baghnakhs.  Today Faith Baghnakhs are treated as 2H weapons and only able to proc once per attack round.  This PR changes Faith Baghnakhs to be treated as 1H weaopns for purposes of Virtue Stone procs and makes adjustments to attackround to enable correct processing.  The end result is that Faith Baghnakhs can trigger an additional attack proc on both the left and right swing of an attack round - independent of each other.

This behavior is noted on [Wiki](https://ffxiclopedia.fandom.com/wiki/Faith_Baghnakhs), [JP wiki](https://wiki.ffo.jp/html/2827.html), and reproducible [today on retail](https://www.youtube.com/watch?v=K0-26HjZtuo)  ~50s mark.

## Steps to test these changes

1. Be a Mnk or Nin.  Choose a Subjob with not native multiple attack traits.  Choose gear with no multiple attack traits.
2. Equip Faith Baghnakhs and Vitrue Stones.
3. Find a target mob - tag with !immortal.
4. Engage the mob and attack.
5. EquipMon is useful for tracking Virtue Stone Consumption - as is artifically applying SLOW to make distinct attack rounds clear.  Alternatively you can unlock and turn to not be facing the target, then turn back to trigger an attack round, then turn away.
6. Note that up to two virtue stones can be consumed each attack round.
7. Note that for each virture stone consumed - an additional attack is added.

## Regression Testing
Tested the following - even though most can be inferred from the code.
1. No Weapon Equipped with Virtue Stones - no additional attacks.
2. No Weaopn with No Stones - no additional attacks.
3. No Weapon Equipped with Virtue Stones and a Shield Equipped - no issues.
4. Faith Baghnakhs and NO Virtue Stones - no additional attacks.
5. Faith Baghnakhs and 1 Virtue Stone - only a single attack, once, stone consumed.
6. Faith Baghnakhs and 1 Virtue Stone and forced 100% proc rate - first swing always procs, second never does.
7. Faith Baghnakhs and Virtue Stones with forced 100% `DOUBLE_ATTACK` - 4 non-kick attack rounds.
8. Faith Baghnakhs and Virtue Stones with forced 100% `TRIPLE_ATTACK` - 8 non-kick attack rounds.
9. Faith Baghnakhs and Virtue Stones with forced 100% `TRIPLE_ATTACK` and 100% Kick Attack Rate - 8 non-kick attack rounds. 
8 is the correct per round swing limit.
10. Justiice Sword with Virtue Stones - no Offhand - works as expected.
11. Mainhand Morgenstern (any weapon) offhand Justice Sword with Virtue Stones - works as expected.

## Notes for further improvement.
Recent Retail captures have shown that HtH additional attacks follow a specific animation pattern which LSB does not strickly adhere to.
Credit to @siknoz for this information.

This PR does not attempt to address this gap and further capture information may be requied to determine how this should be resolved.

>for h2h, multi attacks come in the form of a single left after a "base" left, right
>1 da is lrl
>2 da is lrll
>1 ta is lrll
>2 ta is lrllll
>kicks come next
>penultimate is virtue stone left
>last is virtue stone right
>98% of h2h rounds follow this to the letter
