### PR TITLE
[core] Adjust db::escapeString to emulate strlen

### DIFF
--- a/src/common/database.cpp
+++ b/src/common/database.cpp
@@ -195,6 +195,10 @@ auto db::escapeString(std::string const& str) -> std::string
     {
         char c = str[i];
 
+        // Emulate SqlConnection::EscapeString using strlen
+        if (c == '\0')
+            break;
+
         auto it = replacements.find(c);
         if (it != replacements.end())
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Apparently, escaped strings were making it in with garbage characters past a null terminator that the old code was not doing.
Partially solves #6518 

## Steps to test these changes

Change password, login, no problems
