### PR TITLE
[core] Adjust draw-in behavior and add additional functionality

### DIFF
--- a/scripts/enum/mob_mod.lua
+++ b/scripts/enum/mob_mod.lua
@@ -91,4 +91,7 @@ xi.mobMod =
     SKIP_ALLEGIANCE_CHECK  = 80, -- Skip the allegiance check for valid target (allows for example a mob to cast a TARGET_ENEMY spell on itself)
     ABILITY_RESPONSE       = 81, -- Mob can respond to player ability use with onPlayerAbilityUse()
     SPEED_BOOST_MULT       = 82, -- Multiplier for the base speed of a mob when the mob's target is out of range (range between 100 and 500, 250 means 2.5x, mechanism is from retail)
+    DRAW_IN_FRONT          = 83, -- Mob will draw in slightly in front of them instead of the center of their hitbox (HNMs such as Tiamat)
+    DRAW_IN_CUSTOM_RANGE   = 84, -- Override the default range of MeleeRange*2 of when players start to get drawn-in
+    DRAW_IN_BIND           = 85, -- Forces mob to draw in the moment you leave melee range (ex. Mimics)
 }

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -708,9 +708,19 @@ void CMobController::Move()
         if (((currentDistance > closeDistance) || move) && PMob->PAI->CanFollowPath())
         {
             // TODO: can this be moved to scripts entirely?
-            if (PMob->getMobMod(MOBMOD_DRAW_IN) > 0)
+            if (PMob->getMobMod(MOBMOD_DRAW_IN))
             {
-                if (currentDistance >= PMob->GetMeleeRange() * 2 && battleutils::DrawIn(PTarget, PMob, PMob->GetMeleeRange() - 0.2f))
+                uint8 drawInRange = PMob->getMobMod(MOBMOD_DRAW_IN_CUSTOM_RANGE) > 0 ? PMob->getMobMod(MOBMOD_DRAW_IN_CUSTOM_RANGE) : PMob->GetMeleeRange() * 2;
+
+                // Draw in when target is farther than 2x melee range
+                if (currentDistance > drawInRange && battleutils::DrawIn(PTarget, PMob, PMob->GetMeleeRange() - 0.2f, drawInRange))
+                {
+                    FaceTarget();
+                    return;
+                }
+                // If i'm bound/can't move, draw in the moment they leave my melee range
+                else if (PMob->getMobMod(MOBMOD_DRAW_IN_BIND) && (PMob->speed == 0 || PMob->getMobMod(MOBMOD_NO_MOVE)) &&
+                    currentDistance > PMob->GetMeleeRange() && battleutils::DrawIn(PTarget, PMob, PMob->GetMeleeRange() - 1.2f, PMob->GetMeleeRange()))
                 {
                     FaceTarget();
                     return;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -17172,7 +17172,8 @@ void CLuaBaseEntity::drawIn(sol::variadic_args va)
         return;
     }
 
-    auto mobObj = dynamic_cast<CMobEntity*>(m_PBaseEntity);
+    auto   mobObj      = dynamic_cast<CMobEntity*>(m_PBaseEntity);
+    float  drawInRange = mobObj->GetMeleeRange() * 2;
 
     if (va.size() == 0)
     {
@@ -17182,7 +17183,7 @@ void CLuaBaseEntity::drawIn(sol::variadic_args va)
         {
             return;
         }
-        battleutils::DrawIn(defaultTarget, mobObj, mobObj->GetMeleeRange() - 0.2f);
+        battleutils::DrawIn(defaultTarget, mobObj, mobObj->GetMeleeRange() - 0.2f, drawInRange);
         return;
     }
 
@@ -17204,7 +17205,7 @@ void CLuaBaseEntity::drawIn(sol::variadic_args va)
 
     if (PTarget)
     {
-        battleutils::DrawIn(PTarget, mobObj, mobObj->GetMeleeRange() - 0.2f);
+        battleutils::DrawIn(PTarget, mobObj, mobObj->GetMeleeRange() - 0.2f, drawInRange);
     }
 
     return;

--- a/src/map/mob_modifier.h
+++ b/src/map/mob_modifier.h
@@ -111,6 +111,9 @@ enum MOBMODIFIER : int
     MOBMOD_SKIP_ALLEGIANCE_CHECK  = 80, // Skip the allegiance check for valid target (allows for example a mob to cast a TARGET_ENEMY spell on itself)
     MOBMOD_ABILITY_RESPONSE       = 81, // Mob can respond to player ability use with onPlayerAbilityUse()
     MOBMOD_SPEED_BOOST_MULT       = 82, // Multiplier for the base speed of a mob when the mob's target is out of range (range between 100 and 25500, 250 means 2.5x, mechanism is from retail)
+    MOBMOD_DRAW_IN_FRONT          = 83, // Mob will draw in slightly in front of them instead of the center of their hitbox (HNMs such as Tiamat)
+    MOBMOD_DRAW_IN_CUSTOM_RANGE   = 84, // Override the default range of MeleeRange*2 of when players start to get drawn-in
+    MOBMOD_DRAW_IN_BIND           = 85, // Forces mob to draw in the moment you leave melee range (ex. Mimics)
 };
 
 #endif

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -246,7 +246,7 @@ namespace battleutils
     WEATHER GetWeather(CBattleEntity* PEntity, bool ignoreScholar);
     WEATHER GetWeather(CBattleEntity* PEntity, bool ignoreScholar, uint16 zoneWeather);
     bool    WeatherMatchesElement(WEATHER weather, uint8 element);
-    bool    DrawIn(CBattleEntity* PEntity, CMobEntity* PMob, float offset);
+    bool    DrawIn(CBattleEntity* PEntity, CMobEntity* PMob, float offset, float drawInRange);
     void    DoWildCardToEntity(CCharEntity* PCaster, CCharEntity* PTarget, uint8 roll);
     bool    DoRandomDealToEntity(CCharEntity* PChar, CBattleEntity* PTarget);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

While working on mechanics for certain HNMs, I noted that draw in appears to work differently all over the game. This PR adjusts the default draw in behavior, along with adding mob mods to customize draw in on a per mob basis as needed.

- Currently default draw in takes you slightly in front of where the mob is facing. I have adjusted the default to instead draw you into the middle of the mob's hit box.
   - Mobmod DRAW_IN_FRONT was created to add the original default behavior back if needed, although I haven't been able to locate any captures that follow this behavior.
- Mobmod DRAW_IN_CUSTOM_RANGE was added to manually adjust how far the player needs to be from the mob for draw in to occur. Some mobs were seen to draw in at different ranges, such as Roc.
- Mobmod DRAW_IN_BIND was added as some mobs will draw you in the moment you leave melee, such as mimics.
   - I only see this behavior happen on mimics, so another option would be to get rid of this mob mod and hard code mimics to have this behavior. Thought it would be better to have this mod in case there are other scenarios where this happens.

I plan to follow up this PR with making mob mod adjustments to all of the relevant mob luas, unless you'd like me to include it all in this one PR.

Captures used for this:
- Tiamat: https://www.youtube.com/watch?v=Bi8jnNLK0jA
- Roc: https://www.youtube.com/watch?v=-QwzOBYaR9s
- Mimics: https://www.youtube.com/watch?v=v1a8vgLdzjA
- KV: https://www.youtube.com/watch?v=bm6l0WsHkTM

## Steps to test these changes
Default behavior:

1. Engage a mob with DRAW_IN mobmod set
2. Move farther than melee range x2 to trigger draw in
3. See that your character is placed in the middle of the mob's hit box

Mobmods:

1. Add mobmod DRAW_IN_FRONT to a mob, and perform the same steps above.
2. See that your character is placed slightly in front of the mob in the direction of where the mob is looking.
3. Set DRAW_IN_CUSTOM_RANGE with a value of 15
5. Move away from the mob farther than 15 distance and see that draw in triggers
6. Set DRAW_IN_BIND with a value of 1
7. Bind the mob, or set mobmod of NO_MOVE
8. Move away from the mob and see that you get drawn in the moment you leave melee range