### PR TITLE
db: Handle std::array and structs in binders

### DIFF
--- a/src/common/database.cpp
+++ b/src/common/database.cpp
@@ -193,11 +193,13 @@ auto db::escapeString(std::string const& str) -> std::string
 
     for (size_t i = 0; i < str.size(); ++i)
     {
-        char c = str[i];
+        const char c = str[i];
 
-        // Emulate SqlConnection::EscapeString using strlen
+        // Emulate original strlen-based SqlConnection::EscapeString
         if (c == '\0')
+        {
             break;
+        }
 
         auto it = replacements.find(c);
         if (it != replacements.end())

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -356,7 +356,8 @@ public:
     void resetPetZoningInfo();            // Reset pet zoning info (when changing job ect)
     bool shouldPetPersistThroughZoning(); // If true, zoning should not cause a currently active pet to despawn
 
-    uint8  m_SetBlueSpells[20]{}; // The 0x200 offsetted blue magic spell IDs which the user has set. (1 byte per spell)
+    std::array<uint8, 20> m_SetBlueSpells{}; // The 0x200 offsetted blue magic spell IDs which the user has set. (1 byte per spell)
+
     uint32 m_FieldChocobo{};
     uint32 m_claimedDeeds[5]{};
     uint32 m_uniqueEvents[5]{};

--- a/src/map/utils/blueutils.cpp
+++ b/src/map/utils/blueutils.cpp
@@ -322,10 +322,11 @@ namespace blueutils
     {
         if (PChar->GetMJob() == JOB_BLU || PChar->GetSJob() == JOB_BLU)
         {
-            auto set_blue_spells = db::encodeToBlob(PChar->m_SetBlueSpells);
-            auto query           = fmt::format("UPDATE chars SET set_blue_spells = '{}' WHERE charid = {} LIMIT 1",
-                                               set_blue_spells, PChar->id);
-            db::query(query);
+            if (!db::preparedStmt("UPDATE chars SET set_blue_spells = ? WHERE charid = ? LIMIT 1",
+                                  PChar->m_SetBlueSpells, PChar->id))
+            {
+                ShowError("Failed to save set blue spells for %s", PChar->getName());
+            }
         }
     }
 
@@ -338,7 +339,7 @@ namespace blueutils
             auto rset = db::preparedStmt("SELECT set_blue_spells FROM chars WHERE charid = ? LIMIT 1", PChar->id);
             if (rset && rset->rowsCount() && rset->next())
             {
-                db::extractFromBlob(rset, "set_blue_spells", PChar->m_SetBlueSpells);
+                PChar->m_SetBlueSpells = rset->get<std::array<uint8, 20>>("set_blue_spells");
             }
 
             for (unsigned char& m_SetBlueSpell : PChar->m_SetBlueSpells)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Allows you to set and get std::arrays and simple structs directly in `preparedStmt` with no additional steps. No escaping, no nothing.

```cpp
    // Get

        data->EquippedInstincts = rset->get<std::array<uint16, 12>>("equip");
        data->levels            = rset->get<std::array<uint8, 128>>("levels");
        data->instincts         = rset->get<std::array<uint8, 64>>("instincts");
        data->variants          = rset->get<std::array<uint8, 32>>("variants");
    }

    ...

    // Set
    db::preparedStmt(query,
                     PChar->id,
                     PChar->m_PMonstrosity->MonstrosityId,
                     PChar->m_PMonstrosity->Species,
                     PChar->m_PMonstrosity->NamePrefix1,
                     PChar->m_PMonstrosity->NamePrefix2,
                     PChar->m_PMonstrosity->CurrentExp,

                     // THESE ARE ALL STRUCTS/ARRAYS!
                     PChar->m_PMonstrosity->EquippedInstincts,
                     PChar->m_PMonstrosity->levels,
                     PChar->m_PMonstrosity->instincts,
                     PChar->m_PMonstrosity->variants,

                     static_cast<uint8>(PChar->m_PMonstrosity->Belligerency),
                     PChar->m_PMonstrosity->EntryPos.x,
                     PChar->m_PMonstrosity->EntryPos.y,
                     PChar->m_PMonstrosity->EntryPos.z,
                     PChar->m_PMonstrosity->EntryPos.rotation,
                     PChar->m_PMonstrosity->EntryZoneId,
                     PChar->m_PMonstrosity->EntryMainJob,
                     PChar->m_PMonstrosity->EntrySubJob);
```

Replaces https://github.com/LandSandBoat/server/pull/6519

## Testing

- [x] Enable DEBUG_SQL in logging and see the bindings and blobs working as intended
- [x] Log in as BLU, set spells (including Cocoon), use spells, !goto <me>, use spells, set spells
- [x] !monstrosity, !monstrosity
