### PR TITLE
[vscode] add gdb attach config to attach to xi_map

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -145,6 +145,21 @@
           "cwd": "${workspaceFolder}",
           "MIMode": "lldb",
           "targetArchitecture": "x64"
+        },
+        {
+            "name": "(gdb) Attach to xi_map",
+            "type": "cppdbg",
+            "request": "attach",
+            "program": "${workspaceFolder}/xi_map",
+            "processId": "${command:pickProcess}",
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ]
         }
     ],
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a vscode config to attach to an already running xi_map

## Steps to test these changes

Launch xi_map, later attach via vscode, see breakpoints work
