### PR TITLE
[core] Dirty & Undirty inventory when changing gear

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -969,6 +969,23 @@ void CCharEntity::PostTick()
         pushPacket(new CCharAppearancePacket(this));
     }
 
+    // notify client containers are dirty and then no longer dirty
+    if (!dirtyInventoryContainers.empty())
+    {
+
+        // Notify client containers were dirty
+        // Note: Retail sends this in the same chunk as the inventory equip packets, but it doesnt seem to matter as long as it arrives
+        for (const auto& [container, dirty]: dirtyInventoryContainers)
+        {
+            pushPacket(new CInventoryFinishPacket(container));
+        }
+
+        dirtyInventoryContainers.clear();
+
+        // Notify client containers are now ok
+        pushPacket(new CInventoryFinishPacket());
+    }
+
     if (ReloadParty())
     {
         charutils::ReloadParty(this);

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -23,6 +23,7 @@
 #define _CHARENTITY_H
 
 #include "event_info.h"
+#include "item_container.h"
 #include "monstrosity.h"
 #include "packets/char.h"
 #include "packets/entity_update.h"
@@ -510,6 +511,9 @@ public:
     void setStyleLocked(bool isStyleLocked);
     bool getBlockingAid() const;
     void setBlockingAid(bool isBlockingAid);
+
+    // Send updates about dirty containers in post tick
+    std::map<CONTAINER_ID, bool> dirtyInventoryContainers;
 
     bool       m_EquipSwap; // true if equipment was recently changed
     bool       m_EffectsChanged;


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Replaces & improves upon #4885

Retail sends dirty/undirty packets for _every effected container_ (found via capture) when changing gear (see https://github.com/atom0s/XiPackets/blob/main/world/server/0x001D/README.md for the dirty/undirty stuff)
This also fixes temp items disappearing on gear equip (Thanks for the report via old PR, mowford)


## Steps to test these changes

From #4885

Before this change, replicate the issue via:
- `!exec player:addTempItem(5393)`
- open quick item menu to see temp item available
- Then equip any pieced of gear and see that the temp item disappears from quick item menu

same process for unequipping an item.

After change see that the item stays visible after equipping and unequipping gear
