### PR TITLE
Mob run speed changes

### DIFF
--- a/scripts/enum/mob_mod.lua
+++ b/scripts/enum/mob_mod.lua
@@ -90,5 +90,5 @@ xi.mobMod =
     CANNOT_GUARD           = 79, -- Check if the mob does not guard (despite being a MNK or PUP mob)
     SKIP_ALLEGIANCE_CHECK  = 80, -- Skip the allegiance check for valid target (allows for example a mob to cast a TARGET_ENEMY spell on itself)
     ABILITY_RESPONSE       = 81, -- Mob can respond to player ability use with onPlayerAbilityUse()
-    SPEED_BOOST_MULT       = 82, -- Multiplier for the base speed of a mob when the mob's target is out of range (range between 100 and 500, 250 means 2.5x, mechanism is from retail)
+    RUN_SPEED_MULT         = 82, -- Multiplier for the speed of a mob while running (generally when the target is out of range) 100 = 1.00x
 }

--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -112,13 +112,9 @@ xi.settings.map =
     -- Note retail treats the mounted speed as double what it actually is.
     MOUNT_SPEED_MOD = 0,
 
-    -- Enable or disable a mechanism for boosting the speed of engaged mobs (by a multiplier) when their target is out of range.
-    -- This is a retail mechanism that makes kiting more difficult
-    USE_MOB_SPEED_BOOST_MULTIPLIER = true,
-    -- The default boost multiplier of almost all mobs on retail is 250 (so 2.5x or 2.5 times their normal speed)
-    -- The minimum value is 100 (1x) which means that mobs get no such speed boost (though better to use the boolean toggle above)
-    -- The maximum value is 25500 (255x) which would put the speed of any mob at the system cap
-    DEFAULT_MOB_SPEED_BOOST_MULTIPLIER = 250,
+    -- Multiplier for speed of engaged mobs when their target is out of range.
+    -- The default for almost all mobs on retail is 2.5x their normal speed.
+    MOB_RUN_SPEED_MULTIPLIER = 2.5,
 
     -- Allows you to manipulate the constant multiplier in the skill-up rate formulas, having a potent effect on skill-up rates.
     SKILLUP_CHANCE_MULTIPLIER = 1.0,

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -633,6 +633,7 @@ void CMobController::FaceTarget(uint16 targid)
     {
         PMob->PAI->PathFind->LookAt(targ->loc.p);
     }
+    PMob->UpdateSpeed();
 }
 
 void CMobController::Move()

--- a/src/map/ai/controllers/pet_controller.cpp
+++ b/src/map/ai/controllers/pet_controller.cpp
@@ -123,7 +123,7 @@ void CPetController::DoRoamTick(time_point tick)
             }
             PPet->PAI->PathFind->FollowPath(m_Tick);
         }
-        else if (PPet->GetSpeed() > 0)
+        else if (PPet->speed > 0)
         {
             PPet->PAI->PathFind->WarpTo(PPet->PMaster->loc.p, PetRoamDistance);
         }

--- a/src/map/ai/controllers/player_charm_controller.cpp
+++ b/src/map/ai/controllers/player_charm_controller.cpp
@@ -108,7 +108,7 @@ void CPlayerCharmController::DoRoamTick(time_point tick)
             {
                 POwner->PAI->PathFind->FollowPath(m_Tick);
             }
-            else if (POwner->GetSpeed() > 0)
+            else if (POwner->speed > 0)
             {
                 POwner->PAI->PathFind->WarpTo(POwner->PMaster->loc.p, RoamDistance);
             }

--- a/src/map/ai/controllers/trust_controller.cpp
+++ b/src/map/ai/controllers/trust_controller.cpp
@@ -180,7 +180,7 @@ void CTrustController::DoCombatTick(time_point tick)
                             {
                                 POwner->PAI->PathFind->FollowPath(m_Tick);
                             }
-                            else if (POwner->GetSpeed() > 0)
+                            else if (POwner->speed > 0)
                             {
                                 POwner->PAI->PathFind->StepTo(PTarget->loc.p, true);
                             }
@@ -288,7 +288,7 @@ void CTrustController::DoRoamTick(time_point tick)
         {
             POwner->PAI->PathFind->FollowPath(m_Tick);
         }
-        else if (POwner->GetSpeed() > 0)
+        else if (POwner->speed > 0)
         {
             POwner->PAI->PathFind->StepTo(PFollowTarget->loc.p, true);
         }

--- a/src/map/ai/helpers/pathfind.h
+++ b/src/map/ai/helpers/pathfind.h
@@ -97,9 +97,6 @@ public:
     bool IsFollowingScriptedPath();
     bool IsPatrolling();
 
-    // calculate speed of mob with mode, mod_speed, etc
-    float GetRealSpeed();
-
     // look at the given point
     void LookAt(const position_t& point);
 

--- a/src/map/entities/baseentity.h
+++ b/src/map/entities/baseentity.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -299,7 +299,7 @@ public:
     void   SetModelId(uint16 modelId); // Set new modelid
     uint16 GetModelId() const;         // Get the modelid
 
-    virtual void HandleErrorMessage(std::unique_ptr<CBasicPacket>&){};
+    virtual void HandleErrorMessage(std::unique_ptr<CBasicPacket>&) {};
 
     bool IsDynamicEntity() const;
 
@@ -316,7 +316,7 @@ public:
     uint8           animation;    // animation
     uint8           animationsub; // Additional animation parameter
     uint8           speed;        // speed of movement
-    uint8           speedsub;     // Additional movement speed parameter
+    uint8           speedsub;     // base movement speed
     uint8           namevis;
     ALLEGIANCE_TYPE allegiance;     // what types of targets the entity can fight
     uint8           updatemask;     // what to update next server tick to players nearby

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -563,7 +563,7 @@ public:
     uint16 RATT(uint8 skill, uint16 bonusSkill = 0);
     uint16 RACC(uint8 skill, uint16 bonusSkill = 0);
 
-    uint8 GetSpeed();
+    uint8 UpdateSpeed(bool run = false);
 
     bool isDead();
     bool isAlive();

--- a/src/map/mob_modifier.h
+++ b/src/map/mob_modifier.h
@@ -110,7 +110,7 @@ enum MOBMODIFIER : int
     MOBMOD_CANNOT_GUARD           = 79, // Check if the mob does not guard(despite being a MNK or PUP mob)
     MOBMOD_SKIP_ALLEGIANCE_CHECK  = 80, // Skip the allegiance check for valid target (allows for example a mob to cast a TARGET_ENEMY spell on itself)
     MOBMOD_ABILITY_RESPONSE       = 81, // Mob can respond to player ability use with onPlayerAbilityUse()
-    MOBMOD_SPEED_BOOST_MULT       = 82, // Multiplier for the base speed of a mob when the mob's target is out of range (range between 100 and 25500, 250 means 2.5x, mechanism is from retail)
+    MOBMOD_RUN_SPEED_MULT         = 82, // Multiplier for the speed of a mob while running (generally when the target is out of range) 100 = 1.00x
 };
 
 #endif

--- a/src/map/packets/char.cpp
+++ b/src/map/packets/char.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -90,7 +90,7 @@ void CCharPacket::updateWith(CCharEntity* PChar, ENTITYUPDATE type, uint8 update
         packet.y   = PChar->loc.p.z; // Intentionally Swapped, apparently internal x/y/z is not FFXI x/y/z
         packet.z   = PChar->loc.p.y; // Intentionally Swapped
 
-        packet.Speed     = PChar->GetSpeed();
+        packet.Speed     = PChar->UpdateSpeed();
         packet.SpeedBase = PChar->speedsub;
 
         packet.Flags0.MovTime     = PChar->loc.p.moving;

--- a/src/map/packets/char_update.cpp
+++ b/src/map/packets/char_update.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -275,7 +275,7 @@ CCharUpdatePacket::CCharUpdatePacket(CCharEntity* PChar)
     // flags 1 starts at 0x2C
     charUpateFlags::flags1_t flags1 = {};
 
-    flags1.Speed        = PChar->GetSpeed();
+    flags1.Speed        = PChar->UpdateSpeed();
     flags1.Hackmove     = PChar->wallhackEnabled; // GM wallhack, walk through walls
     flags1.FreezeFlag   = 0;                      // Freeze client in place. Is this used?
     flags1.unknown_1_14 = 0;                      // Unknown.

--- a/src/map/packets/zone_in.cpp
+++ b/src/map/packets/zone_in.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -246,7 +246,7 @@ CZoneInPacket::CZoneInPacket(CCharEntity* PChar, const EventInfo* currentEvent)
 
     // 0x1A = Target Index
 
-    ref<uint8>(0x1C) = PChar->GetSpeed();
+    ref<uint8>(0x1C) = PChar->UpdateSpeed();
     ref<uint8>(0x1D) = PChar->speedsub;
     ref<uint8>(0x1E) = PChar->GetHPP();
     ref<uint8>(0x1F) = PChar->animation;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Follow-up to #6303 

There is indeed an issue with kiting currently, though it could have been reported in a way more conducive to finding a solution.

The step distance calculation has been changed, and now seems more in line with retail speeds in various conditions. I would appreciate more testing, but I'm pretty confident in the current results. I renamed the setting and mob mod to make it a little more clear what it's used for.

Mob controller controls if mob should run or not, so remove the distance checks from the speed calculations. Rework GetSpeed to UpdateSpeed. Mobs only need to update their speed during pathfinding, and players only for update packets, so this allows us to read speed without necessarily recalculating (fixes an issue in the entity update packet where the run speed wasn't changing like it should).

~~I also renamed speedsub to speedBase in a separate commit, since I think it's more descriptive. I can drop this if wanted.~~

## Demonstration

Current: https://www.youtube.com/watch?v=I_euKvJ2zFc

Improved: https://www.youtube.com/watch?v=CDAWdI0Vmh4

Retail: https://www.youtube.com/watch?v=-rFpXKWLUvY

This is the route from the Aydeewa survival guide to the TVR RoE NM. Note towards the end of the video where the funguars deaggro, which matches retail.

## Steps to test these changes

Kite things with different speeds, compare to retail.

Batallia Downs has quick access to Goblins (40 speed) and tigers (60 speed).
