### PR TITLE
[core][lua][sql] Implement contradance

### DIFF
--- a/scripts/actions/abilities/contradance.lua
+++ b/scripts/actions/abilities/contradance.lua
@@ -1,6 +1,7 @@
 -----------------------------------
 -- Ability: Contradance
 -- Description: Increases the amount of HP restored by your next Waltz.
+-- Actual function: Doubles final Curing Waltz result, makes Healing Waltz AoE from target (10' range)
 -- Obtained: DNC Level 50
 -- Recast Time: 00:05:00
 -- Duration: 00:01:00

--- a/scripts/actions/abilities/healing_waltz.lua
+++ b/scripts/actions/abilities/healing_waltz.lua
@@ -36,6 +36,9 @@ abilityObject.onAbilityCheck = function(player, target, ability)
             end
         end
 
+        -- Inform core we want to cleanup Contradance if it's active after the ability is done
+        ability:setPostActionCleanupEffect(xi.effect.CONTRADANCE)
+
         return 0, 0
     end
 end

--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -202,6 +202,9 @@ xi.job_utils.dancer.checkWaltzAbility = function(player, target, ability)
     elseif player:hasStatusEffect(xi.effect.TRANCE) then
         ability:setRecast(math.min(ability:getRecast(), 6))
 
+        -- Inform core we want to cleanup Contradance if it's active after the ability is done
+        ability:setPostActionCleanupEffect(xi.effect.CONTRADANCE)
+
         return 0, 0
     elseif player:getTP() < waltzCost then
         return xi.msg.basic.NOT_ENOUGH_TP, 0
@@ -227,6 +230,9 @@ xi.job_utils.dancer.checkWaltzAbility = function(player, target, ability)
         end
 
         ability:setRecast(utils.clamp(newRecast, 0, newRecast))
+
+        -- Inform core we want to cleanup Contradance if it's active after the ability is done
+        ability:setPostActionCleanupEffect(xi.effect.CONTRADANCE)
 
         return 0, 0
     end
@@ -470,9 +476,8 @@ xi.job_utils.dancer.useWildFlourishAbility = function(player, target, ability, a
     return 0
 end
 
--- TODO: Implement Contradance status effect.
 xi.job_utils.dancer.useContradanceAbility = function(player, target, ability)
-    -- player:addStatusEffect(xi.effect.CONTRADANCE, 19, 1, 60)
+    player:addStatusEffect(xi.effect.CONTRADANCE, 0, 0, 60)
 end
 
 xi.job_utils.dancer.useWaltzAbility = function(player, target, ability, action)
@@ -503,6 +508,11 @@ xi.job_utils.dancer.useWaltzAbility = function(player, target, ability, action)
     amtCured = (target:getStat(xi.mod.VIT) + player:getStat(xi.mod.CHR)) * statMultiplier + waltzInfo[3]
     amtCured = math.floor(amtCured * (1.0 + (math.min(50, player:getMod(xi.mod.WALTZ_POTENCY)) / 100)))
     -- TODO: Account for Waltz Potency Received
+
+    -- Contradance is a 2x multiplier after all other terms
+    if player:hasStatusEffect(xi.effect.CONTRADANCE) then
+        amtCured = amtCured * 2
+    end
 
     amtCured = amtCured * xi.settings.main.CURE_POWER
     amtCured = math.min(amtCured, target:getMaxHP() - target:getHP())

--- a/scripts/specs/core/CAbility.lua
+++ b/scripts/specs/core/CAbility.lua
@@ -83,3 +83,8 @@ end
 ---@return nil
 function CAbility:setRange(range)
 end
+
+---@param effectToCleanup integer|CStatusEffect
+---@return nil
+function CAbility:setPostActionCleanupEffect(effectToCleanup)
+end

--- a/sql/abilities.sql
+++ b/sql/abilities.sql
@@ -388,7 +388,7 @@ INSERT INTO `abilities` VALUES (380,'effusion',22,1,1,0,143,0,0,0,2000,0,6,0.0,0
 INSERT INTO `abilities` VALUES (381,'chocobo_jig_ii',19,70,1,60,218,126,0,13,2000,0,14,10.0,1,1,300,0,0,'SOA');
 INSERT INTO `abilities` VALUES (382,'relinquish',23,1,1,60,253,0,0,312,0,0,6,0.0,0,0,0,0,0,NULL);
 INSERT INTO `abilities` VALUES (383,'vivacious_pulse',22,65,1,60,242,102,0,327,2000,0,6,0.0,0,0,0,0,0,'SOA');
-INSERT INTO `abilities` VALUES (384,'contradance',19,50,1,300,229,0,0,329,2000,0,6,0.0,0,0,0,0,0,NULL); -- check animation
+INSERT INTO `abilities` VALUES (384,'contradance',19,50,1,300,229,0,0,81,2000,0,6,0.0,0,0,0,0,0,NULL);
 INSERT INTO `abilities` VALUES (385,'apogee',15,70,1,180,108,100,0,94,2000,0,6,0.0,0,1,80,0,0,'SOA');
 INSERT INTO `abilities` VALUES (386,'entrust',21,75,1,600,93,100,0,332,2000,0,6,0.0,0,1,300,0,0,'SOA');
 INSERT INTO `abilities` VALUES (387,'bestial_loyalty',9,23,1,1200,94,100,0,83,2000,0,6,18.0,0,1,0,900,0,'SOA');

--- a/src/map/ability.cpp
+++ b/src/map/ability.cpp
@@ -92,6 +92,11 @@ void CAbility::setActionType(ACTIONTYPE type)
     m_actionType = type;
 }
 
+void CAbility::setPostActionEffectCleanup(EFFECT effectToCleanup)
+{
+    m_cleanupEffect = effectToCleanup;
+}
+
 JOBTYPE CAbility::getJob()
 {
     return m_Job;
@@ -175,6 +180,11 @@ uint16 CAbility::getMeritModID() const
 ACTIONTYPE CAbility::getActionType()
 {
     return m_actionType;
+}
+
+EFFECT CAbility::getPostActionEffectCleanup()
+{
+    return m_cleanupEffect;
 }
 
 void CAbility::setValidTarget(uint16 validTarget)

--- a/src/map/ability.h
+++ b/src/map/ability.h
@@ -26,6 +26,7 @@
 #include "common/mmo.h"
 #include "packets/action.h"
 
+#include "status_effect.h"
 #include "entities/battleentity.h"
 
 enum ADDTYPE
@@ -719,6 +720,7 @@ public:
     uint16     getVE() const;
     uint16     getMeritModID() const;
     ACTIONTYPE getActionType();
+    EFFECT     getPostActionEffectCleanup();
 
     void setID(uint16 id);
     void setMobSkillID(uint16 id);
@@ -738,6 +740,7 @@ public:
     void setVE(uint16 VE);
     void setMeritModID(uint16 value);
     void setActionType(ACTIONTYPE type);
+    void setPostActionEffectCleanup(EFFECT effectToCleanup);
 
     const std::string& getName();
     void               setName(const std::string& name);
@@ -762,6 +765,7 @@ private:
     std::string m_name;
     uint16      m_mobskillId;
     ACTIONTYPE  m_actionType{};
+    EFFECT      m_cleanupEffect;
 };
 
 /************************************************************************

--- a/src/map/lua/lua_ability.cpp
+++ b/src/map/lua/lua_ability.cpp
@@ -111,6 +111,11 @@ void CLuaAbility::setRange(float range)
     m_PLuaAbility->setRange(range);
 }
 
+void CLuaAbility::setPostActionCleanupEffect(EFFECT effectToCleanup)
+{
+    m_PLuaAbility->setPostActionEffectCleanup(effectToCleanup);
+}
+
 //==========================================================//
 
 void CLuaAbility::Register()
@@ -132,6 +137,7 @@ void CLuaAbility::Register()
     SOL_REGISTER("getVE", CLuaAbility::getVE);
     SOL_REGISTER("setVE", CLuaAbility::setVE);
     SOL_REGISTER("setRange", CLuaAbility::setRange);
+    SOL_REGISTER("setPostActionCleanupEffect", CLuaAbility::setPostActionCleanupEffect);
 }
 
 std::ostream& operator<<(std::ostream& os, const CLuaAbility& ability)

--- a/src/map/lua/lua_ability.h
+++ b/src/map/lua/lua_ability.h
@@ -58,6 +58,7 @@ public:
     uint16 getVE();
     void   setVE(uint16 ve);
     void   setRange(float range);
+    void   setPostActionCleanupEffect(EFFECT effectToCleanup);
 
     bool operator==(const CLuaAbility& other) const
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Supercedes #5753
Implements contradance
On retail:
Contradance is a direct double after all terms
![image](https://github.com/user-attachments/assets/a34f23b5-e8b7-4638-b532-14395855e070)

add 5% potency:
![image](https://github.com/user-attachments/assets/24718f04-ee08-45fe-a47b-db01c9668da2)

post 5% potency is doubled:
![image](https://github.com/user-attachments/assets/17c7a5b3-ef5d-482a-aa04-aa4df69e0da1)

Contradance works on all targets of divine waltz (note: HP capped early so the values are low)
![image](https://github.com/user-attachments/assets/7370c3b2-b30b-496c-9adf-2a300ab0834a)


Range is <= 10' EXACTLY on retail for Healing Waltz with Contradance up

Packet cap for anim:
![image](https://github.com/user-attachments/assets/a0869f60-a220-407b-8d30-87836a9ade40)

## Steps to test these changes

Use Divine Waltz/Curing waltz, note HP restored
Use Contradance, repeat and notice all HP restored is doubled (unless you hit cap)
Contradance Effect should drop off after divine/curing waltz

Use Healing Waltz @ <= 10' range with contradance, see it AoE and remove effect after 
