### PR TITLE
[codeql] Replace c-style cast/objtype compare with dynamic_cast

### DIFF
--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -589,13 +589,13 @@ void CParty::AddMember(CBattleEntity* PEntity)
 
     if (m_PartyType == PARTY_PCS)
     {
-        if (PEntity->objtype != TYPE_PC)
+        CCharEntity* PChar = dynamic_cast<CCharEntity*>(PEntity);
+
+        if (!PEntity)
         {
             ShowWarning("Non-Player passed into function (%s).", PEntity->getName());
             return;
         }
-
-        CCharEntity* PChar = (CCharEntity*)PEntity;
 
         uint32 allianceid = 0;
         if (m_PAlliance)

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -1300,9 +1300,9 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
             case CHAR_INRANGE_SELF: // NOTE!!!: This falls through to CHAR_INRANGE so both self and the local area get the packet
             {
                 TracyZoneCString("CHAR_INRANGE_SELF");
-                if (PEntity->objtype == TYPE_PC)
+                if (auto* PChar = dynamic_cast<CCharEntity*>(PEntity))
                 {
-                    ((CCharEntity*)PEntity)->pushPacket<CBasicPacket>(*packet);
+                    PChar->pushPacket<CBasicPacket>(*packet);
                 }
             }
             [[fallthrough]];


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Resolves two CodeQL issues with type confusion by replacing entity objtype compare with dynamic_cast.  Also removes c-style casts in these two cases.

Note: Both casts are CBaseEntity/CBattleEntity -> CCharEntity, and no prior compare is executed.  The remaining CodeQL issues for this type involve longer switches which will require a bit more finesse to refactor

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Check party member add, messages to char in range
<!-- Clear and detailed steps to test your changes here -->
