### PR TITLE
[Lua] Made math.randoms more explicit

### DIFF
--- a/scripts/actions/abilities/pets/glittering_ruby.lua
+++ b/scripts/actions/abilities/pets/glittering_ruby.lua
@@ -10,26 +10,23 @@ end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     --randomly give str/dex/vit/agi/int/mnd/chr (+12)
-    local effect = math.random()
-    local effectid = xi.effect.CHR_BOOST
+    local effects =
+    {
+        xi.effect.STR_BOOST,
+        xi.effect.DEX_BOOST,
+        xi.effect.VIT_BOOST,
+        xi.effect.AGI_BOOST,
+        xi.effect.INT_BOOST,
+        xi.effect.MND_BOOST,
+        xi.effect.CHR_BOOST,
+    }
+
+    effectId = utils.randomEntry(effects)
+    effectPower = math.random(12, 14)
 
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    if effect <= 0.14 then --STR
-        effectid = xi.effect.STR_BOOST
-    elseif effect <= 0.28 then --DEX
-        effectid = xi.effect.DEX_BOOST
-    elseif effect <= 0.42 then --VIT
-        effectid = xi.effect.VIT_BOOST
-    elseif effect <= 0.56 then --AGI
-        effectid = xi.effect.AGI_BOOST
-    elseif effect <= 0.7 then --INT
-        effectid = xi.effect.INT_BOOST
-    elseif effect <= 0.84 then --MND
-        effectid = xi.effect.MND_BOOST
-    end
-
-    target:addStatusEffect(effectid, math.random(12, 14), 0, 90)
+    target:addStatusEffect(effectId, effectPower, 0, 90)
 
     if target:getID() == action:getPrimaryTargetID() then
         petskill:setMsg(xi.msg.basic.SKILL_GAIN_EFFECT_2)
@@ -37,7 +34,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
         petskill:setMsg(xi.msg.basic.JA_GAIN_EFFECT)
     end
 
-    return effectid
+    return effectId
 end
 
 return abilityObject

--- a/scripts/actions/abilities/pets/spring_water.lua
+++ b/scripts/actions/abilities/pets/spring_water.lua
@@ -32,7 +32,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     target:wakeUp()
     target:delStatusEffect(xi.effect.SILENCE)
 
-    if math.random() > 0.5 then
+    if math.random(1, 100) <= 50 then
         target:delStatusEffect(xi.effect.SLOW)
     end
 

--- a/scripts/actions/mobskills/death_trap.lua
+++ b/scripts/actions/mobskills/death_trap.lua
@@ -18,7 +18,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local duration   = 60
     local power      = mob:getMainLvl() / 3
 
-    if math.random() <= 0.5 then
+    if math.random(1, 100) <= 50 then
         -- stun
         typeEffect = xi.effect.STUN
         duration   = 10

--- a/scripts/actions/mobskills/glittering_ruby.lua
+++ b/scripts/actions/mobskills/glittering_ruby.lua
@@ -10,25 +10,24 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     --randomly give str/dex/vit/agi/int/mnd/chr (+12)
-    local effect = math.random()
-    local effectid = xi.effect.CHR_BOOST
-    if effect <= 0.14 then --STR
-        effectid = xi.effect.STR_BOOST
-    elseif effect <= 0.28 then --DEX
-        effectid = xi.effect.DEX_BOOST
-    elseif effect <= 0.42 then --VIT
-        effectid = xi.effect.VIT_BOOST
-    elseif effect <= 0.56 then --AGI
-        effectid = xi.effect.AGI_BOOST
-    elseif effect <= 0.7 then --INT
-        effectid = xi.effect.INT_BOOST
-    elseif effect <= 0.84 then --MND
-        effectid = xi.effect.MND_BOOST
-    end
+    local effects =
+    {
+        xi.effect.STR_BOOST,
+        xi.effect.DEX_BOOST,
+        xi.effect.VIT_BOOST,
+        xi.effect.AGI_BOOST,
+        xi.effect.INT_BOOST,
+        xi.effect.MND_BOOST,
+        xi.effect.CHR_BOOST,
+    }
 
-    target:addStatusEffect(effectid, math.random(12, 14), 0, 90)
+    effectId = utils.randomEntry(effects)
+    effectPower = math.random(12, 14)
+
+    target:addStatusEffect(effectId, effectPower, 0, 90)
     skill:setMsg(xi.msg.basic.SKILL_GAIN_EFFECT)
-    return effectid
+
+    return effectId
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/prishe_item_2.lua
+++ b/scripts/actions/mobskills/prishe_item_2.lua
@@ -18,7 +18,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
         mob:hasStatusEffect(xi.effect.MUTE)
     then
         return 0
-    elseif math.random() < 0.25 then
+    elseif math.random(1, 100) <= 25 then
         return 1
     end
 
@@ -37,7 +37,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         mob:delStatusEffect(xi.effect.PLAGUE)
         mob:delStatusEffect(xi.effect.CURSE_I)
         mob:delStatusEffect(xi.effect.MUTE)
-    elseif math.random() < 0.5 then
+    elseif math.random(1, 100) <= 50 then
         -- Carnal Incense!
         mob:messageText(mob, ID.text.PRISHE_TEXT + 10, false)
         mob:addStatusEffect(xi.effect.PHYSICAL_SHIELD, 1, 0, 30)

--- a/scripts/actions/weaponskills/starburst.lua
+++ b/scripts/actions/weaponskills/starburst.lua
@@ -20,7 +20,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.includemab = true
     -- 50/50 shot of being light or dark
     params.ele = xi.element.LIGHT
-    if math.random() < 0.5 then
+    if math.random(1, 100) <= 50 then
         params.ele = xi.element.DARK
     end
 

--- a/scripts/actions/weaponskills/sunburst.lua
+++ b/scripts/actions/weaponskills/sunburst.lua
@@ -22,7 +22,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.includemab = true
     -- 50/50 shot of being light or dark
     params.ele = xi.element.LIGHT
-    if math.random() < 0.5 then
+    if math.random(1, 100) <= 50 then
         params.ele = xi.element.DARK
     end
 

--- a/scripts/battlefields/Temenos/temenos_western_tower.lua
+++ b/scripts/battlefields/Temenos/temenos_western_tower.lua
@@ -81,7 +81,7 @@ content.handleMobDeath = function(floor, battlefield, mob, count)
 
     local crateCount = battlefield:getLocalVar('CrateCount'..floor)
 
-    if crateCount < 3 and math.random(4) == 1 then
+    if crateCount < 3 and math.random(1, 100) <= 25 then
         -- Crate type randomization happens in onBattlefieldRegister
         local crateID = ID.TEMENOS_WESTERN_TOWER.npc.CRATE_OFFSETS[floor] + crateCount
 

--- a/scripts/globals/caskets.lua
+++ b/scripts/globals/caskets.lua
@@ -495,7 +495,7 @@ local function getDrops(npc, dropType, zoneId)
             if item == 0 or item == nil then
                 items[i] = 4112 -- default to potion
             else
-                if math.random() < 0.05 then
+                if math.random(1, 100) <= 5 then
                     items[1] = xi.casket_loot.casketItems[zoneId].regionalItems[math.random(1, #xi.casket_loot.casketItems[zoneId].regionalItems)]
                 else
                     items[i] = item

--- a/scripts/globals/teleports.lua
+++ b/scripts/globals/teleports.lua
@@ -312,7 +312,7 @@ end
 -----------------------------------
 
 xi.teleport.toChamberOfPassage = function(player)
-    if math.random(1, 2) == 1 then
+    if math.random(1, 100) <= 50 then
         player:setPos(133.400, 1.485, 47.427, 96, 50) -- (R) Aht Urhgan Whitegate Chamber of Passage Left
     else
         player:setPos(116.670, 1.485, 47.427, 32, 50) -- (R) Aht Urhgan Whitegate Chamber of Passage Right

--- a/scripts/missions/amk/helpers.lua
+++ b/scripts/missions/amk/helpers.lua
@@ -526,7 +526,7 @@ local xarc = zones[xi.zone.XARCABARD]
 
 -- returns -1 or 1 to offset the wrong answer randomly
 local randomSign = function()
-    return math.random(1, 2) == 1 and 1 or -1
+    return math.random(1, 100) <= 50 and 1 or -1
 end
 
 -- Structured list of the trivia questions

--- a/scripts/quests/bastok/Beauty_and_the_Galka.lua
+++ b/scripts/quests/bastok/Beauty_and_the_Galka.lua
@@ -107,7 +107,7 @@ quest.sections =
                 onTrigger = function(player, npc)
                     if player:hasKeyItem(xi.ki.PALBOROUGH_MINES_LOGS) then
                         return quest:progressEvent(10)
-                    elseif math.random(1, 2) == 1 then
+                    elseif math.random(1, 100) <= 50 then
                         return quest:event(8)
                     else
                         return quest:event(9)

--- a/scripts/quests/windurst/Food_for_Thought.lua
+++ b/scripts/quests/windurst/Food_for_Thought.lua
@@ -138,7 +138,7 @@ quest.sections =
                     if npcUtil.tradeHasExactly(trade, xi.item.HARD_BOILED_EGG) then
                         -- Traded item without receiving order
                         if kenapaProg < 3 then
-                            if math.random(1, 2) == 1 then
+                            if math.random(1, 100) <= 50 then
                                 return quest:progressEvent(331)
                             else
                                 return quest:progressEvent(330, 120)
@@ -213,7 +213,7 @@ quest.sections =
 
                         -- Traded all 3 items & Didn't ask for order
                         if ohbiruProgress < 2 then
-                            if math.random(1, 2) == 1 then
+                            if math.random(1, 100) <= 50 then
                                 return quest:progressEvent(325, 440)
                             else
                                 return quest:progressEvent(326)

--- a/scripts/quests/windurst/Overnight_Delivery.lua
+++ b/scripts/quests/windurst/Overnight_Delivery.lua
@@ -222,7 +222,7 @@ quest.sections =
             ['Kenapa-Keppa'] =
             {
                 onTrigger = function(player, npc)
-                    if math.random(1, 2) == 1 then
+                    if math.random(1, 100) <= 50 then
                         return quest:event(349):replaceDefault()
                     else
                         return quest:event(350):replaceDefault()

--- a/scripts/zones/Arrapago_Remnants/npcs/Armoury_Crate.lua
+++ b/scripts/zones/Arrapago_Remnants/npcs/Armoury_Crate.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     player:addTreasure(5374) player:addTreasure(first[math.random(#first)]) player:addTreasure(first[math.random(#first)])
     player:addTreasure(second[math.random(#second)]) player:addTreasure(second[math.random(#second)])
 
-    if math.random(1, 2) == 1 then
+    if math.random(1, 100) <= 50 then
         player:addTreasure(5375)
     else
         player:addTreasure(5374)

--- a/scripts/zones/Cloister_of_Flames/mobs/Ifrit_Prime_WTB.lua
+++ b/scripts/zones/Cloister_of_Flames/mobs/Ifrit_Prime_WTB.lua
@@ -80,7 +80,7 @@ entity.onMobFight = function(mob, target)
                 -- depending on if they are damaged
                 local spellTarget = nil
                 if elementalDamaged and avatarDamaged then
-                    if math.random(1, 2) == 1 then
+                    if math.random(1, 100) <= 50 then
                         spellTarget = mob
                     else
                         spellTarget = elemental

--- a/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Queen.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Queen.lua
@@ -43,7 +43,7 @@ entity.onMobFight = function(mob, target)
 
                 -- Pick a random Prince or Princess
                 local petId = 0
-                local offset = math.random(4)
+                local offset = math.random(1, 4)
                 for i = 0, 3 do
                     local id = bombQueenId + 1 + (offset + i) % 4
                     if GetMobByID(id):getCurrentAction() == xi.action.NONE then

--- a/scripts/zones/Lower_Jeuno/npcs/Bki_Tbujhja.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Bki_Tbujhja.lua
@@ -56,7 +56,7 @@ entity.onTrigger = function(player, npc)
         player:getCharVar('TheRequiemCS') == 3 and
         not player:hasKeyItem(xi.ki.STAR_RING1)
     then
-        if math.random(1, 2) == 1 then
+        if math.random(1, 100) <= 50 then
             player:startEvent(147) -- oh, did you take the holy water and play the requiem? you must do both!
         else
             player:startEvent(149) -- his stone sarcophagus is deep inside the eldieme necropolis.

--- a/scripts/zones/Lower_Jeuno/npcs/Treasure_Coffer.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Treasure_Coffer.lua
@@ -1737,7 +1737,7 @@ local function givePrize(player, ki)
 
                 for i = 1, 4 do
                     -- static 50% chance to get any augment at all each loop
-                    if #addAug == 0 or math.random(1, 2) == 1 then
+                    if #addAug == 0 or math.random(1, 100) <= 50 then
                         -- since lua arrays start at index 1, set start at 1 to guarantee at least one augment
                         roll = math.random(1, #pAug)
                     else

--- a/scripts/zones/Maze_of_Shakhrami/Zone.lua
+++ b/scripts/zones/Maze_of_Shakhrami/Zone.lua
@@ -7,7 +7,7 @@ local ID = zones[xi.zone.MAZE_OF_SHAKHRAMI]
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
-    if math.random(1, 2) == 1 then
+    if math.random(1, 100) <= 50 then
         DisallowRespawn(ID.mob.LEECH_KING, true)
         DisallowRespawn(ID.mob.ARGUS, false)
         UpdateNMSpawnPoint(ID.mob.ARGUS)

--- a/scripts/zones/Maze_of_Shakhrami/mobs/Argus.lua
+++ b/scripts/zones/Maze_of_Shakhrami/mobs/Argus.lua
@@ -11,7 +11,7 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    if math.random(2) == 1 then
+    if math.random(1, 100) <= 50 then
         DisallowRespawn(ID.mob.LEECH_KING, true)
         DisallowRespawn(ID.mob.ARGUS, false)
         UpdateNMSpawnPoint(ID.mob.ARGUS)

--- a/scripts/zones/Maze_of_Shakhrami/mobs/Leech_King.lua
+++ b/scripts/zones/Maze_of_Shakhrami/mobs/Leech_King.lua
@@ -11,7 +11,7 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    if math.random(2) == 1 then
+    if math.random(1, 100) <= 50 then
         DisallowRespawn(ID.mob.LEECH_KING, true)
         DisallowRespawn(ID.mob.ARGUS, false)
         UpdateNMSpawnPoint(ID.mob.ARGUS)

--- a/scripts/zones/PsoXja/globals.lua
+++ b/scripts/zones/PsoXja/globals.lua
@@ -17,7 +17,7 @@ psoXjaGlobal.attemptPickLock = function(player, npc, correctSideOfDoor)
         if GetMobByID(gargoyle):isSpawned() then
             player:messageSpecial(ID.text.DOOR_LOCKED)
         else
-            if math.random(1, 2) == 1 then
+            if math.random(1, 100) <= 50 then
                 npc:messageName(ID.text.DISCOVER_DISARM_FAIL, player)
                 SpawnMob(gargoyle):updateClaim(player)
             else

--- a/scripts/zones/Rolanberry_Fields_[S]/mobs/Dyinyinga.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/mobs/Dyinyinga.lua
@@ -39,8 +39,8 @@ entity.onMobFight = function(mob, target)
                     newZ = newZ + (newZ > tarZ and 1 or -1) * math.random(1, 3)
                 else
                     -- random direction
-                    newX = newX + (math.random(1, 2) == 1 and 1 or -1) * math.random(1, 3)
-                    newZ = newZ + (math.random(1, 2) == 1 and 1 or -1) * math.random(1, 3)
+                    newX = newX + (math.random(1, 100) <= 50 and 1 or -1) * math.random(1, 3)
+                    newZ = newZ + (math.random(1, 100) <= 50 and 1 or -1) * math.random(1, 3)
                 end
 
                 mob:pathTo(newX, newY, newZ)

--- a/scripts/zones/Sea_Serpent_Grotto/npcs/Hurr_the_Betrayer.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/npcs/Hurr_the_Betrayer.lua
@@ -32,7 +32,7 @@ entity.onTrigger = function(player, npc)
         player:getCharVar('SahaginKeyItems') == 0 and
         not player:hasItem(xi.item.SAHAGIN_KEY)
     then
-        if math.random(1, 2) == 1 then
+        if math.random(1, 100) <= 50 then
             player:startEvent(105) -- Requires 3 Mythril Beastcoins and a Norg Shell
             player:setCharVar('SahaginKeyItems', 1)
         else

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Qnzdei.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Qnzdei.lua
@@ -47,7 +47,7 @@ entity.onMobSpawn = function(mob)
 
     -- Qn'Zdei randomly spin at speeds 4, 8, 16, 64 and can be reversed (negative)
     mob:setLocalVar('spinSpeed', utils.randomEntry(spinSpeeds))
-    if math.random(1, 2) == 1 then
+    if math.random(1, 100) <= 50 then
         mob:setLocalVar('reversed', 1)
     end
 end

--- a/scripts/zones/Windurst_Walls/npcs/Hiwon-Biwon.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Hiwon-Biwon.lua
@@ -20,7 +20,7 @@ entity.onTrigger = function(player, npc)
 
         if not utils.mask.getBit(prog, 2) then
             if cursesFoiledAgain1 == xi.questStatus.QUEST_ACCEPTED then
-                if math.random(1, 2) == 1 then
+                if math.random(1, 100) <= 50 then
                     player:startEvent(283) -- Give scoop while sick
                 else
                     player:startEvent(284) -- Give scoop while sick

--- a/scripts/zones/Windurst_Walls/npcs/Ran.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Ran.lua
@@ -9,7 +9,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if math.random() >= .5 then
+    if math.random(1, 100) <= 50 then
         player:startEvent(272)
     else
         player:startEvent(273)

--- a/scripts/zones/Windurst_Waters/npcs/Kenapa-Keppa.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Kenapa-Keppa.lua
@@ -28,7 +28,7 @@ entity.onTrigger = function(player, npc)
     then
         player:startEvent(519)
     else
-        if math.random(1, 2) == 1 then
+        if math.random(1, 100) <= 50 then
             player:startEvent(302) -- Standard converstation
         else
             player:startEvent(303) -- Standard converstation

--- a/scripts/zones/Windurst_Waters/npcs/Kyume-Romeh.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Kyume-Romeh.lua
@@ -38,7 +38,7 @@ entity.onTrigger = function(player, npc)
             player:startEvent(669) -- Quest not furthered
         end
     else
-        if math.random(1, 2) == 1 then
+        if math.random(1, 100) <= 50 then
             player:startEvent(604) -- Standard Conversation
         else
             player:startEvent(393) -- Standard Conversation

--- a/scripts/zones/Windurst_Waters/npcs/Naiko-Paneiko.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Naiko-Paneiko.lua
@@ -20,7 +20,7 @@ entity.onTrigger = function(player, npc)
         local prog = player:getCharVar('QuestMakingHeadlines_var')
 
         if not utils.mask.isFull(prog, 4) then
-            if math.random(1, 2) == 1 then
+            if math.random(1, 100) <= 50 then
                 player:startEvent(666) -- Quest Reminder 1
             else
                 player:startEvent(671) -- Quest Reminder 2
@@ -28,7 +28,7 @@ entity.onTrigger = function(player, npc)
         elseif not utils.mask.getBit(prog, 4) then
             player:startEvent(673) -- Advises to validate story
         else
-            if math.random(1, 2) == 1 then
+            if math.random(1, 100) <= 50 then
                 player:startEvent(674) -- Quest finish 1
             else
                 player:startEvent(670) -- Quest finish 2


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Address #6407.  Attempt to standardize lua math.random calls to return ints from a bounded range rather than floats.  There are more instances of this, but not trying to overload this PR, as the specific instances vary a lot in context, and some require more testing than others.

## Steps to test these changes

Be summoner, use blood pact "Glittering ruby", get random stat buff.
