### PR TITLE
db: p.stmt and query will now reconnect after disconnects

### DIFF
--- a/settings/default/network.lua
+++ b/settings/default/network.lua
@@ -30,6 +30,9 @@ xi.settings.network =
 
     SEARCH_PORT = 54002,
 
+    -- DB queries will attempt each query once, and reconnect and retry up to `SQL_QUERY_RETRY_COUNT` times.
+    SQL_QUERY_RETRY_COUNT = 1,
+
     ENABLE_HTTP = false,
     HTTP_HOST   = "localhost",
     HTTP_PORT   = 8088,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Using the new `db` command to test the connection:
```
[12/21/24 14:04:22:427][world][info] ZMQ Server listening... (message_server_init:426)
db
> Query successful: SELECT 1
> Prepared statement successful: SELECT 1
db
> Query successful: SELECT 1
> Prepared statement successful: SELECT 1
restarting MariaDB service
> Unknown command: restarting
db
[12/21/24 14:05:03:381][world][info] Connection lost, re-establishing connection and retrying query (attempt 1) (db::queryStr::<lambda_1>::operator ():149)
> Query successful: SELECT 1
> Prepared statement successful: SELECT 1
db
> Query successful: SELECT 1
> Prepared statement successful: SELECT 1
stopping MariaDB service
> Unknown command: stopping
db
[12/21/24 14:05:22:426][world][info] Connection lost, re-establishing connection and retrying query (attempt 1) (db::queryStr::<lambda_1>::operator ():149)
[12/21/24 14:05:24:479][world][critical] !!! Failed to connect to database, terminating server !!! (db::getConnection:66)
[12/21/24 14:05:24:479][world][critical] Could not connect to address=(host=127.0.0.1)(port=3306)(type=master) : Can't connect to server on '127.0.0.1' (10061) (db::getConnection:67)
PS C:\ffxi\server> 
```
