### PR TITLE
[lua] Properly apply SJ_RESTRICTION effect in Dynamis Dreamlands

### DIFF
--- a/scripts/globals/dynamis.lua
+++ b/scripts/globals/dynamis.lua
@@ -466,7 +466,7 @@ xi.dynamis.zoneOnZoneIn = function(player, prevZone)
                 playerArg:messageBasic(xi.msg.basic.UNABLE_TO_ACCESS_SJ)
             end)
 
-            player:addStatusEffect(xi.effect.SJ_RESTRICTION, 0, 0, 0, 7200)
+            player:addStatusEffect(xi.effect.SJ_RESTRICTION, 0, 0, 0, 0, 0)
         end
 
         player:addStatusEffectEx(xi.effect.DYNAMIS, 0, 0, 3, 3600)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [X] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [X] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [X] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

`SJ_RESTRICTION ` effect applied upon entering CoP Dreamlands currently does not execute the underlying lua file, leading to subjob abilities remaining visible to the client and usable unless the client forced a recalculation of the abilities list through the use of an ability modifying the list of abilities (Call Wyvern, Light Arts...)

After troubleshooting, it appeared to me the [sj_restriction.lua](https://github.com/LandSandBoat/server/blob/71887f9d6865f3da82c2cacdb895e5b4d9582c0b/scripts/effects/sj_restriction.lua#L8) was not being executed to begin with (whereas doing `!addeffect SJ_RESTRICTION` would properly do)

This PR changes the way the `SJ_RESTRICTION `effect is applied upon entering Dynamis through the use of different parameters. I am not quite clear on the distinction between the various `addStatusEffect `calls, there might be another underlying issue there.

Steps to reproduce issue on base branch:
```
!gotoid 17261192
!changejob DNC 99
!changesjob WAR49
Enter by selecting "Ready! (Support jobs restricted)"

Result: All WAR abilities are available and working
```

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

```
!gotoid 17261192
!changejob DNC 99
!changesjob WAR49
Enter by selecting "Ready! (Support jobs restricted)"

Result: WAR abilities are not available
```

<!-- Clear and detailed steps to test your changes here -->
