### PR TITLE
Fix textOffset for Magian Trial #1826

### DIFF
--- a/scripts/globals/magian_data.lua
+++ b/scripts/globals/magian_data.lua
@@ -4025,7 +4025,7 @@ xi.magian.trials =
             },
         },
 
-        textOffset     = 358,
+        textOffset     = 660,
         defeatMob      = true,
         mobEcosystem   = xi.ecosystem.BEAST,
         useWeaponskill = xi.weaponskill.FINAL_HEAVEN,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Changes textOffset for magian trial 1826 to reflect the requirement of finishing blows with Final Heaven against beasts
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
1. !exec player:addItem(xi.item.SPHARAI, 1, 740, 5)
2. Trade item to moogle
3. Verify correct message as below

![image](https://github.com/user-attachments/assets/cc6fea8e-01ae-45ce-a188-34580966bfb0)

<!-- Clear and detailed steps to test your changes here -->
