### PR TITLE
[Lua] Add getTotalSkill function to xi.crafting

### DIFF
--- a/scripts/globals/crafting/crafting_utils.lua
+++ b/scripts/globals/crafting/crafting_utils.lua
@@ -39,6 +39,19 @@ xi.crafting.guildTable =
     [xi.guild.COOKING     ] = { xi.skill.COOKING,      'guild_cooking'      },
 }
 
+xi.crafting.craftMod =
+{
+    [xi.skill.FISHING     ] = xi.mod.FISH,
+    [xi.skill.WOODWORKING ] = xi.mod.WOOD,
+    [xi.skill.SMITHING    ] = xi.mod.SMITH,
+    [xi.skill.GOLDSMITHING] = xi.mod.GOLDSMITH,
+    [xi.skill.CLOTHCRAFT  ] = xi.mod.CLOTH,
+    [xi.skill.LEATHERCRAFT] = xi.mod.LEATHER,
+    [xi.skill.BONECRAFT   ] = xi.mod.BONE,
+    [xi.skill.ALCHEMY     ] = xi.mod.ALCHEMY,
+    [xi.skill.COOKING     ] = xi.mod.COOK,
+}
+
 xi.crafting.hasJoinedGuild = function(player, guildId)
     local joinedGuildMask = player:getCharVar('Guild_Member')
 
@@ -53,4 +66,11 @@ end
 
 xi.crafting.getRealSkill = function(player, skillId)
     return math.floor(player:getCharSkillLevel(skillId) / 10)
+end
+
+xi.crafting.getTotalSkill = function(player, skillId)
+    local skill = xi.crafting.getRealSkill(player, skillId)
+    local mod   = player:getMod(xi.crafting.craftMod[skillId])
+
+    return skill + mod
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Add function to crafting_utils to get the total crafting skill + modifiers (gear, support).  This will be useful for fishing quests.

## Steps to test these changes

`local skill = xi.crafting.getTotalSkill(player, xi.skill.GOLDSMITHING)`
`print(skill)`
-- skill should be the players real crafting skill
`!additem goldsmiths_apron`
-- now it should be real skill + 1
