### PR TITLE
misc fixes: SCH AF QM positions update (bandaid), Warp Cudgel use time

### DIFF
--- a/scripts/zones/Fort_Karugo-Narugo_[S]/npcs/Indescript_Markings.lua
+++ b/scripts/zones/Fort_Karugo-Narugo_[S]/npcs/Indescript_Markings.lua
@@ -29,15 +29,16 @@ entity.onTrigger = function(player, npc)
         player:setCharVar('AF_SCH_BOOTS', loafersQuestProgress + 1)
 
         -- Move the markings around
+        -- These positions are probably made up
         local positions =
         {
-            [1] = { -72.612, -28.5, 671.24 }, -- G-5 NE
-            [2] = { -158,    -61,   268 },    -- G-7
-            [3] = { -2,      -52,   235 },    -- H-8
-            [4] = { 224,     -28,   -22 },    -- I-10
-            [5] = { 210,     -42,   -78 },    -- I-9
-            [6] = { -176,    -37,   617 },    -- G-5 SW
-            [7] = { 29,      -13,   710 },    -- H-5
+            [1] = { -72.612, -27.5,  671.24 }, -- G-5 NE
+            [2] = { -158,    -61.5,  268 },    -- G-7
+            [3] = { -2,      -52,    235 },    -- H-8
+            [4] = { 224,     -32.25, -22 },    -- I-10
+            [5] = { 210,     -42.75, -78 },    -- I-9
+            [6] = { -176,    -37,    617 },    -- G-5 SW
+            [7] = { 29,      -13.5,  710 },    -- H-5
         }
 
         local newPosition = npcUtil.pickNewPosition(npc:getID(), positions)

--- a/sql/item_usable.sql
+++ b/sql/item_usable.sql
@@ -2239,7 +2239,7 @@ INSERT INTO `item_usable` VALUES (16603,'halo_claymore',1,3,0,0,100,30,600,0);
 INSERT INTO `item_usable` VALUES (16613,'spirit_sword',1,3,78,0,100,30,600,0);
 INSERT INTO `item_usable` VALUES (16858,'sacred_lance',1,3,78,0,30,30,300,0);
 INSERT INTO `item_usable` VALUES (16954,'pealing_nagan',20,1,0,0,50,30,600,0);
-INSERT INTO `item_usable` VALUES (17040,'warp_cudgel',1,8,80,3,30,30,3600,0);
+INSERT INTO `item_usable` VALUES (17040,'warp_cudgel',1,8,80,3,30,3,3600,0);
 INSERT INTO `item_usable` VALUES (17468,'raise_rod',9,3,33,0,20,30,60,0);
 INSERT INTO `item_usable` VALUES (17469,'raise_ii_rod',9,4,33,0,20,30,60,0);
 INSERT INTO `item_usable` VALUES (17470,'pealing_buzdygan',20,1,0,0,50,30,600,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

SCH AF QM positions were a bit jank in Fort KNS, some were below the ground. I manually moved them up, as one was inaccessible. These clearly need captures. Most of them are not directly flat on the floor like you would expect with SE.

Fixes #6579
Warp cudgel first use time was 30 seconds, but retail expects 3. 

## Steps to test these changes

Redo SCH fort KNS QM over and over and don't get a QM under the ground
See warp cudgel be able to be used in 3 seconds