### PR TITLE
Use local vars, format tables for Glittering Ruby, Zipacna

### DIFF
--- a/scripts/actions/abilities/pets/glittering_ruby.lua
+++ b/scripts/actions/abilities/pets/glittering_ruby.lua
@@ -21,8 +21,8 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
         xi.effect.CHR_BOOST,
     }
 
-    effectId = utils.randomEntry(effects)
-    effectPower = math.random(12, 14)
+    local effectId    = utils.randomEntry(effects)
+    local effectPower = math.random(12, 14)
 
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 

--- a/scripts/actions/mobskills/glittering_ruby.lua
+++ b/scripts/actions/mobskills/glittering_ruby.lua
@@ -21,8 +21,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         xi.effect.CHR_BOOST,
     }
 
-    effectId = utils.randomEntry(effects)
-    effectPower = math.random(12, 14)
+    local effectId    = utils.randomEntry(effects)
+    local effectPower = math.random(12, 14)
 
     target:addStatusEffect(effectId, effectPower, 0, 90)
     skill:setMsg(xi.msg.basic.SKILL_GAIN_EFFECT)

--- a/scripts/zones/VeLugannon_Palace/mobs/Zipacna.lua
+++ b/scripts/zones/VeLugannon_Palace/mobs/Zipacna.lua
@@ -9,10 +9,10 @@ local ID = zones[xi.zone.VELUGANNON_PALACE]
 -- Spawn points from nm_spawn_points.sql
 local spawnPoints =
 {
-    blueShort   = {x = -196, y = 0,  z = 389},
-    blueLong    = {x = -121, y = 16, z = 420},
-    yellowShort = {x =  191, y = 0,  z = 399},
-    yellowLong  = {x =  141, y = 16, z = 440},
+    blueShort   = { x = -196, y = 0,  z = 389 },
+    blueLong    = { x = -121, y = 16, z = 420 },
+    yellowShort = { x =  191, y = 0,  z = 399 },
+    yellowLong  = { x =  141, y = 16, z = 440 },
 }
 
 local pathingDirection =


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
* Uses local variables for Glittering Ruby parameters
* Fixes padding for Zipacna table
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No impact to gameplay should be observed
<!-- Clear and detailed steps to test your changes here -->
