### PR TITLE
Bind spells duration has a floor of 5 seconds if not fully resisted.

### DIFF
--- a/scripts/globals/spells/enfeebling_spell.lua
+++ b/scripts/globals/spells/enfeebling_spell.lua
@@ -449,8 +449,10 @@ xi.spells.enfeebling.useEnfeeblingSpell = function(caster, target, spell)
     -- STEP 5: Exceptions.
     ------------------------------
     -- Bind: Dependant on target speed.
+    -- Bind: Duration floor of 5 seconds.
     if spellEffect == xi.effect.BIND then
         potency = target:getSpeed()
+        duration = utils.clamp(duration, 5, 60)
 
     -- TODO: This is unnecesary, but, for now, we will comply with core.
     elseif spellEffect == xi.effect.SLEEP_I then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

This is a follow up on an earlier PR #6194 that implemented bind's random duration.
This earlier PR implemented bind's random duration with a floor of 1 second when not fully resisted, leading to instances of the spell's effect wearing off almost immediately.
[Further capture data](https://docs.google.com/spreadsheets/d/1MnIZySb1c03Ak9JHBuyaUAze76aFb0Pj6_Mvh6FbUYA/edit?pli=1&gid=0#gid=0) supports a floor for bind's duration when not fully resisted of 5 seconds.
Further discussion can be found in discord thread [here](https://discord.com/channels/933423693848260678/1180272981210046504).


## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1) Find a mob that is not bind immune
2) Cast bind and wait for the spell to wear off naturally
3) Verify time difference is between 5 and 60 seconds
4) Repeat many, many times.
5) Find a mob that is stun immune- verify change did not break this as well.