### PR TITLE
[lua] Ensure white procs can't happen without SJ_RESTRICTION effect in Dynamis

### DIFF
--- a/scripts/globals/dynamis.lua
+++ b/scripts/globals/dynamis.lua
@@ -823,7 +823,7 @@ xi.dynamis.procMonster = function(mob, player)
 
         local extensions = getExtensions(player)
         if extensions > 2 then
-            if player:getSubJob() == xi.job.NONE and math.random(1, 100) == 1 then
+            if player:hasStatusEffect(xi.effect.SJ_RESTRICTION) and math.random(1, 100) == 1 then
                 mob:setLocalVar('dynamis_proc', 4)
                 mob:addStatusEffect(xi.effect.TERROR, 0, 0, 30)
                 mob:weaknessTrigger(3)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Currently the Dynamis proc system checks if the player is missing a subjob before rolling for a white proc at a 1% rate, which is the correct behavior for CoP Dynamis zones. However the logic is applied across the board, even for non-CoP zones (where white procs are not a thing on retail https://www.bg-wiki.com/ffxi/Category:Dynamis#Dynamis_Proc_System)

If the player never obtained a subjob or managed to remove their subjob through a change job glitch, they would be able to get white procs in non-CoP Dynamis zones.

The PR changes the subjob check to instead check if the player has the SJ_RESTRICTION effect applied, which in normal conditions is only possible when entering CoP Dynamis zones.

A zone check may also work instead of checking for SJ_RESTRICTION.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
It's best to temporarily update the line to proc 100% of the time as the white proc rate is only 1% natively
```
-- Pre PR behavior
if player:getSubJob() == xi.job.NONE then

-- Post PR beheavior
if player:hasStatusEffect(xi.effect.SJ_RESTRICTION) then
```
```
!zone Dynamis-Bastok
# Add TE KIs to enable proc system
!addkeyitem CRIMSON_GRANULES_OF_TIME
!addkeyitem AZURE_GRANULES_OF_TIME
!addkeyitem AMBER_GRANULES_OF_TIME
!addkeyitem ALABASTER_GRANULES_OF_TIME
!addkeyitem OBSIDIAN_GRANULES_OF_TIME
# Force the SJ_RESTRICTION effect to remove your subjob
!addeffect SJ_RESTRICTION
```
Find a mob with the following job: RNG, NIN, BST, MNK, THF
Use job abilities to proc.

Result on base branch: White proc and a 100 will drop
Result with this PR applied: Red proc and no 100 will drop