### PR TITLE
[lua] Use correct variable in HB HP% check

### DIFF
--- a/scripts/globals/pets/wyvern.lua
+++ b/scripts/globals/pets/wyvern.lua
@@ -71,7 +71,7 @@ local function doHealingBreath(player, divisor)
         local party = player:getPartyWithTrusts()
         for _, member in pairs(party) do
             if
-                player:getHP() <= math.floor(player:getMaxHP() / divisor) and
+                member:getHP() <= math.floor(member:getMaxHP() / divisor) and
                 inBreathRange(member) and
                 not member:isDead()
             then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The wrong variable was being checked for party member HP/HPP and thus HB would never work on a party member

## Steps to test these changes

Use HB on a party member with appropriate HP% and see it work correctly
