### PR TITLE
[lua] Add some known ranged WS acc bonuses

### DIFF
--- a/scripts/actions/weaponskills/detonator.lua
+++ b/scripts/actions/weaponskills/detonator.lua
@@ -16,11 +16,12 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params     = {}
-    params.numHits   = 1
-    params.ftpMod    = { 1.5, 2.0, 2.5 }
-    params.atkVaries = { 2.0, 2.0, 2.0 } -- https://w.atwiki.jp/studiogobli/pages/93.html
-    params.agi_wsc   = 0.3
+    local params               = {}
+    params.numHits             = 1
+    params.ftpMod              = { 1.5, 2.0, 2.5 }
+    params.atkVaries           = { 2.0, 2.0, 2.0 } -- https://w.atwiki.jp/studiogobli/pages/93.html
+    params.agi_wsc             = 0.3
+    params.rangedAccuracyBonus = 30 -- https://www.ffxiah.com/forum/topic/52018/luck-of-the-draw-a-corsairs-guide-new/127/#3726841
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftpMod  = { 1.5, 2.5, 5.0 }

--- a/scripts/actions/weaponskills/empyreal_arrow.lua
+++ b/scripts/actions/weaponskills/empyreal_arrow.lua
@@ -15,12 +15,14 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params     = {}
-    params.numHits   = 1
-    params.ftpMod    = { 2.0, 2.75, 3.0 }
-    params.atkVaries = { 2.0, 2.0, 2.0 } -- https://w.atwiki.jp/studiogobli/pages/93.html
-    params.str_wsc   = 0.16
-    params.agi_wsc   = 0.25
+    local params               = {}
+    params.numHits             = 1
+    params.ftpMod              = { 2.0, 2.75, 3.0 }
+    params.atkVaries           = { 2.0, 2.0, 2.0 } -- https://w.atwiki.jp/studiogobli/pages/93.html
+    params.str_wsc             = 0.16
+    params.agi_wsc             = 0.25
+    params.rangedAccuracyBonus = 30 -- https://www.ffxiah.com/forum/topic/52018/luck-of-the-draw-a-corsairs-guide-new/127/#3726841 (Empyreal Arrow is a bow copy of Detonator)
+
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftpMod  = { 1.5, 2.5, 5.0 }

--- a/scripts/actions/weaponskills/piercing_arrow.lua
+++ b/scripts/actions/weaponskills/piercing_arrow.lua
@@ -16,10 +16,12 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
-    params.numHits = 1
-    params.ftpMod = { 1.0, 1.0, 1.0 }
-    params.str_wsc = 0.16 params.agi_wsc = 0.25
+    local params               = {}
+    params.numHits             = 1
+    params.ftpMod              = { 1.0, 1.0, 1.0 }
+    params.str_wsc             = 0.16 params.agi_wsc = 0.25
+    params.rangedAccuracyBonus = 30 -- https://www.ffxiah.com/forum/topic/52018/luck-of-the-draw-a-corsairs-guide-new/127/#3726841 (split shot is a clone of piercing arrow)
+
     -- Defense ignored is 0%, 35%, 50% as per wiki.bluegartr.com
     params.ignoredDefense = { 0.0, 0.35, 0.5 }
 

--- a/scripts/actions/weaponskills/split_shot.lua
+++ b/scripts/actions/weaponskills/split_shot.lua
@@ -15,10 +15,11 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
-    params.numHits = 1
-    params.ftpMod = { 1.0, 1.0, 1.0 }
-    params.agi_wsc = 0.3
+    local params               = {}
+    params.numHits             = 1
+    params.ftpMod              = { 1.0, 1.0, 1.0 }
+    params.agi_wsc             = 0.3
+    params.rangedAccuracyBonus = 30 -- https://www.ffxiah.com/forum/topic/52018/luck-of-the-draw-a-corsairs-guide-new/127/#3726841
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.agi_wsc = 0.7

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -883,6 +883,11 @@ xi.weaponskills.doRangedWeaponskill = function(attacker, target, wsID, wsParams,
         calcParams.bonusAcc = calcParams.bonusAcc - accLost
     end
 
+    -- Split Shot/Piercing Arrow and Empyreal Arrow/Detonator are confirmed for this. Theoretically Last Stand could have a bonus too, and if so it would likely be first hit only.
+    if wsParams.rangedAccuracyBonus then
+        calcParams.firstHitRate = getRangedHitRate(attacker, target, calcParams.bonusAcc + wsParams.rangedAccuracyBonus)
+    end
+
     calcParams.hitRate = getRangedHitRate(attacker, target, calcParams.bonusAcc)
 
     -- Send our params off to calculate our raw WS damage, hits landed, and shadows absorbed


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Apparently Split Shot and Detonator have some ws acc bonus on them: https://www.ffxiah.com/forum/topic/52018/luck-of-the-draw-a-corsairs-guide-new/127/#3726841

Seems to be +100 for detonator and conservatively +30 for split shot.
These were copied to the Bow version (they usually are just mirrors of marksmanship and vice versa)

## Steps to test these changes

Best to add some prints to see hit rate increasing, but you could fiddle around with !setmod eva on a mob to see Detonator hitting 95% with normal /ra being about 45%
