### PR TITLE
[lua] Add Fallen Star through logging for Wish Upon A Star

### DIFF
--- a/scripts/quests/bastok/Wish_Upon_a_Star.lua
+++ b/scripts/quests/bastok/Wish_Upon_a_Star.lua
@@ -75,6 +75,42 @@ quest.sections =
             return status == xi.questStatus.QUEST_ACCEPTED
         end,
 
+        [xi.zone.YUHTUNGA_JUNGLE] =
+        {
+            ['Logging_Point'] =
+            {
+                onTrade = function(player, npc, trade)
+                    if
+                        not player:hasItem(xi.item.FALLEN_STAR) and
+                        npcUtil.tradeHas(trade, xi.item.HATCHET)
+                    then
+                        if npcUtil.giveItem(player, xi.item.FALLEN_STAR, { silent = true, fromTrade = true }) then
+                            player:confirmTrade()
+                            return quest:progressEvent(205, xi.item.FALLEN_STAR)
+                        end
+                    end
+                end
+            },
+        },
+
+        [xi.zone.YHOATOR_JUNGLE] =
+        {
+            ['Logging_Point'] =
+            {
+                onTrade = function(player, npc, trade)
+                    if
+                        not player:hasItem(xi.item.FALLEN_STAR) and
+                        npcUtil.tradeHas(trade, xi.item.HATCHET)
+                    then
+                        if npcUtil.giveItem(player, xi.item.FALLEN_STAR, { silent = true, fromTrade = true }) then
+                            player:confirmTrade()
+                            return quest:progressEvent(10, xi.item.FALLEN_STAR)
+                        end
+                    end
+                end
+            },
+        },
+
         [xi.zone.BASTOK_MARKETS] =
         {
             ['Enu'] =


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds the ability to obtain the Fallen Star item through logging in order to complete the Bastok quest Wish Upon A Star

Fixes #4147

Capture: https://youtu.be/nydSKo3GzRQ?t=530
Also tested myself and got it 1/1 as well, can upload capture if needed.

## Steps to test these changes

Obtain the quest and trade a hatchet to a logging point in Yhoator or Yuhtunga Jungle.
