### PR TITLE
[lua] IX DRK and Qnaern fixes

### DIFF
--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Ixaern_DRK.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Ixaern_DRK.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Area: The Garden of Ru'Hmet
---   NM: Ix'aern DRK
+-- NM: Ix'aern DRK
 -- !pos -240 5.00 440 35
 -- !pos -280 5.00 240 35
 -- !pos -560 5.00 239 35
@@ -10,6 +10,8 @@ mixins = { require('scripts/mixins/job_special') }
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
+
+-- TODO: Resistances need verifying: Light_Sleep, Poison, Requiem, Terror, Dispel, Petrify
 
 entity.onMobInitialize = function(IxAernDrkMob)
     IxAernDrkMob:addListener('DEATH', 'AERN_DEATH', function(mob, killer)
@@ -27,6 +29,7 @@ entity.onMobInitialize = function(IxAernDrkMob)
             mob:setMobMod(xi.mobMod.NO_DROPS, 1)
             mob:timer(9000, function(mobArg)
                 mobArg:setHP(mob:getMaxHP())
+                mobArg:setMP(mob:getMaxMP())
                 mobArg:setAnimationSub(3)
                 mobArg:resetAI()
                 mobArg:stun(3000)
@@ -76,6 +79,18 @@ end
 
 entity.onMobSpawn = function(mob)
     mob:setAnimationSub(1)
+
+    -- Not immune to: Drain, Aspir
+    -- Resistances Confirmed
+    mob:addImmunity(xi.immunity.ELEGY)
+    mob:addImmunity(xi.immunity.STUN)
+    mob:addImmunity(xi.immunity.BIND)
+    mob:addImmunity(xi.immunity.SLOW)
+    mob:addImmunity(xi.immunity.PARALYZE)
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.GRAVITY)
+    mob:addImmunity(xi.immunity.SILENCE)
+    mob:addImmunity(xi.immunity.BLIND)
 
     xi.mix.jobSpecial.config(mob, {
         specials =

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Qnaern.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Qnaern.lua
@@ -10,6 +10,11 @@ mixins = { require('scripts/mixins/job_special') }
 local entity = {}
 
 entity.onMobSpawn = function(mob)
+
+    -- Resistances Confirmed
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.BIND)
+
     xi.mix.jobSpecial.config(mob, {
         specials =
         {


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds status immunities for IX'DRK and the Qnaern adds that spawn with it.
Adds mp pool refresh upon respawning.

## Steps to test these changes

1. Spawn IX'DRK `!spawnmob 16921018` (Spawns at default spawn location in DB, since normal spawn mechanics are bypassed by force spawning(farming the aern's for hate then popping from qm))
2. `!gotoid 16921018`
3. Cast Spells on DRK to confirm immunities:
4. Battlefield Elegy, Stun, Bind, Paralyze, Sleep, Gravity, Silence, Blind
5. Drain DRK of mp pool `!mp 0`
6. Kill DRK and let respawn `!hp 0`
7. Aspir to confirm DRK respawned with mp
8. Spawn IX'DRK's adds `!spawnmob 16921019` `!spawnmob 16921020` (Spawns at default spawn location in DB, both in same area)
9. `!gotoid 16921019`
10. Cast Spells on Qnaern's to confirm immunity
11. Sleep, Bind

## Captures
https://drive.google.com/drive/folders/1ngMO7luqQFHAmTFuSfJxFtYbNgTmGT4n?usp=drive_link
https://youtu.be/Kxmsw9FJ1To
https://youtu.be/j7k9HsChq4c
https://www.dropbox.com/s/hw73rusjz3veofb/Ixaern%20DRK.rar?dl=0