### PR TITLE
[lua] Sagheera ABCs count for unused chips fix

### DIFF
--- a/scripts/zones/Port_Jeuno/npcs/Sagheera.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Sagheera.lua
@@ -255,17 +255,17 @@ local tier1Chips =
     xi.item.IVORY_CHIP,
     xi.item.SCARLET_CHIP,
     xi.item.EMERALD_CHIP,
-    xi.item.SILVER_CHIP,
-    xi.item.CERULEAN_CHIP,
     xi.item.SMALT_CHIP,
     xi.item.SMOKY_CHIP,
+    xi.item.CHARCOAL_CHIP,
+    xi.item.MAGENTA_CHIP,
 }
 
 local tier2Chips =
 {
     xi.item.ORCHID_CHIP,
-    xi.item.CHARCOAL_CHIP,
-    xi.item.MAGENTA_CHIP,
+    xi.item.CERULEAN_CHIP,
+    xi.item.SILVER_CHIP,
 }
 
 local tier1ChipValue = 5


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Make Sagheera return the correct amount of Ancient Beastcoins for trading in unused chips

Sagheera is supposed to offer 5 coins for each tier 1 chip (Omega, and first tier of Ultima) and 10 coins for the 2nd tier leading to Ultima. The chips were not placed in the correct category in the lua file leading to certain chips rewarding more than it should and vice-versa.

> Will trade unused Limbus chips for Ancient Beastcoins.
>     Rewards 5 Ancient Beastcoins per unused Tier 1 Chip ([Emerald Chip](https://www.bg-wiki.com/ffxi/Emerald_Chip), [Ivory Chip](https://www.bg-wiki.com/ffxi/Ivory_Chip), [Scarlet Chip](https://www.bg-wiki.com/ffxi/Scarlet_Chip), [Smoky Chip](https://www.bg-wiki.com/ffxi/Smoky_Chip), [Smalt Chip](https://www.bg-wiki.com/ffxi/Smalt_Chip), [Magenta Chip](https://www.bg-wiki.com/ffxi/Magenta_Chip), and [Charcoal Chip](https://www.bg-wiki.com/ffxi/Charcoal_Chip))
>     Rewards 10 Ancient Beastcoins per unused Tier 2 Chip ([Silver Chip](https://www.bg-wiki.com/ffxi/Silver_Chip), [Orchid Chip](https://www.bg-wiki.com/ffxi/Orchid_Chip), and [Cerulean Chip](https://www.bg-wiki.com/ffxi/Cerulean_Chip))

https://www.bg-wiki.com/ffxi/Sagheera

The values being changed:

> Silver chip 5 -> 10
> Cerulean chip 5 -> 10
> Charcoal chip 10 -> 5
> Magenta chip 10 -> 5

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

!gotoid 17784962
-- Silver chip
!giveitem 1907
-- Cerulean chip
!giveitem 1908
-- Orchid Chip
!giveitem 1986
!addmission 6 828

Trade Sagheera the Silver, Cerulean, Orchid chips, she will offer 10 coins for each.