### PR TITLE
Apply speed mod setting to base speed

### DIFF
--- a/src/map/entities/baseentity.cpp
+++ b/src/map/entities/baseentity.cpp
@@ -39,8 +39,7 @@ CBaseEntity::CBaseEntity()
 , m_TargID(0)
 , animation(0)
 , animationsub(0)
-, speed(50 + settings::get<int8>("map.SPEED_MOD")) // It is downright dumb to init every entity at PLAYER speed, but until speed is reworked this hack stays.
-, speedsub(50)                                     // Retail does NOT adjust this when speed is adjusted.
+, speedsub(50 + settings::get<int8>("map.SPEED_MOD"))
 , namevis(0)
 , allegiance(ALLEGIANCE_TYPE::MOB)
 , updatemask(0)
@@ -54,6 +53,7 @@ CBaseEntity::CBaseEntity()
 , m_nextUpdateTimer(std::chrono::steady_clock::now())
 {
     TracyZoneScoped;
+    speed = speedsub;
 }
 
 CBaseEntity::~CBaseEntity()

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -355,7 +355,7 @@ uint8 CBattleEntity::UpdateSpeed(bool run)
     // Set cap if a PC (Default 80).
     if (objtype == TYPE_PC)
     {
-        outputSpeed = std::clamp<int16>(outputSpeed, 0, 80 + settings::get<int8>("map.SPEED_MOD"));
+        outputSpeed = std::clamp<int16>(outputSpeed, 0, 80);
     }
 
     // Speed cap can be bypassed. Ex. Feast of swords. GM speed.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes #6610 

Mobs, NPCs, pets, etc all get their speed/sub set from the DB so this should only really affect players and dynamic entities.

Removed the speed mod adjustment to the cap, since it doesn't really work. If you want era movement speed of 40, you still want a cap at 80, not 70.

I feel like this setting would make more sense as something like `BASE_SPEED = 50` instead of this current `50 + SPEED_MOD`, but idk what server ops would actually prefer and changing it suddenly may cause issues. An additional `SPEED_LIMIT = 80` setting could be added if we want an adjustable upper limit.

## Steps to test these changes

```
SPEED_MOD = -10,
```
Log in, see speed = 40.
