### PR TITLE
[Fix] SW Apollyon floor 2 crates spawning after each mob was killed

### DIFF
--- a/scripts/battlefields/Apollyon/sw_apollyon.lua
+++ b/scripts/battlefields/Apollyon/sw_apollyon.lua
@@ -338,11 +338,13 @@ content.groups =
             'Apollyon_Sapling',
         },
 
-        spawned  = false,
-        allDeath = function(battlefield, mob)
-            npcUtil.showCrate(GetNPCByID(ID.SW_APOLLYON.npc.ITEM_CRATES[2]))
-            npcUtil.showCrate(GetNPCByID(ID.SW_APOLLYON.npc.TIME_CRATES[2]))
-            xi.limbus.showRecoverCrate(ID.SW_APOLLYON.npc.RECOVER_CRATES[2])
+        spawned = false,
+        death = function(battlefield, mob, count)
+            if count == 7 then
+                npcUtil.showCrate(GetNPCByID(ID.SW_APOLLYON.npc.ITEM_CRATES[2]))
+                npcUtil.showCrate(GetNPCByID(ID.SW_APOLLYON.npc.TIME_CRATES[2]))
+                xi.limbus.showRecoverCrate(ID.SW_APOLLYON.npc.RECOVER_CRATES[2])
+            end
         end,
     },
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

As title says. Real issue is, this mobs dont start spawned. That means that, once you spawn and kill the first one, the other, not being spawned, are counted as being dead, resulting in the "all dead" function triggering. Rinse and repeat.

## Steps to test these changes

Run through floor 2. Watch crates only spawn after actually killing all 7 mobs (Jidra adds).
