### PR TITLE
[Fix] Make player petrification break with direct damage.

### DIFF
--- a/scripts/globals/spells/enfeebling_spell.lua
+++ b/scripts/globals/spells/enfeebling_spell.lua
@@ -462,6 +462,12 @@ xi.spells.enfeebling.useEnfeeblingSpell = function(caster, target, spell)
     elseif spellEffect == xi.effect.ADDLE then
         subpotency = 20 + utils.clamp(math.floor((caster:getStat(statUsed) - target:getStat(statUsed)) / 5), 0, 20)
 
+    -- Break: Player petrification sucks.
+    elseif spellEffect == xi.effect.PETRIFICATION then
+        if caster:isPC() then
+            subpotency = 1
+        end
+
     -- Dispel: It's special in that it has no real effect.
     elseif spellEffect == xi.effect.NONE then
         spellEffect = target:dispelStatusEffect()

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -9556,8 +9556,7 @@ void CLuaBaseEntity::takeDamage(int32 damage, sol::object const& attacker, sol::
 
     // Check to see if the target has a nightmare effect active, reset wakeUp accordingly
     // see mobskills/nightmare.lua for full explanation
-    if (
-        PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_SLEEP) &&
+    if (PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_SLEEP) &&
         PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_SLEEP)->GetTier() > 0)
     {
         // Don't break nightmare sleep from any dmg that doesn't break bind (DoT damage)
@@ -9568,12 +9567,17 @@ void CLuaBaseEntity::takeDamage(int32 damage, sol::object const& attacker, sol::
 
         // Diabolos NM/mob ability
         // "Damage will not wake you up from Nightmare, only Cure and Benediction (Benediction will also remove the Bio effect)."
-        if (
-            wakeUp == true &&
+        if (wakeUp == true &&
             PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_SLEEP)->GetTier() > 1)
         {
             wakeUp = false;
         }
+    }
+
+    if (PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_PETRIFICATION) &&
+        PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_PETRIFICATION)->GetSubPower() == 1)
+    {
+        removePetrify = true;
     }
 
     ATTACK_TYPE attackType = (atkType != sol::lua_nil) ? static_cast<ATTACK_TYPE>(atkType.as<uint8>()) : ATTACK_TYPE::NONE;


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

As title sais.

## Steps to test these changes

Go RDM. Learn Break and use it on a a mob. Hit it. Have petrify break instead of not.
