### PR TITLE
[search] Improve handling of duplicate IPs using searches

### DIFF
--- a/src/search/search_handler.h
+++ b/src/search/search_handler.h
@@ -24,6 +24,7 @@
 #include <asio/ts/buffer.hpp>
 #include <asio/ts/internet.hpp>
 #include <common/logging.h>
+#include <map>
 #include <unordered_set>
 
 #include "common/blowfish.h"
@@ -46,7 +47,7 @@ class search_handler
 : public std::enable_shared_from_this<search_handler>
 {
 public:
-    search_handler(asio::ip::tcp::socket socket, asio::io_context& io_context, shared_guarded<std::unordered_set<std::string>>& in_IPAddressInUseList, shared_guarded<std::unordered_set<std::string>>& in_IPAddressWhitelist);
+    search_handler(asio::ip::tcp::socket socket, asio::io_context& io_context, shared_guarded<std::map<std::string, uint16_t>>& IPAddressesInUseList, shared_guarded<std::unordered_set<std::string>>& IPAddressWhitelist);
 
     ~search_handler();
 
@@ -82,17 +83,19 @@ private:
     // A single IP should only have one request in flight at a time, so we are going to
     // be tracking the IP addresses of incoming requests and if we haven't cleared the
     // record for it - we block until it's done
-    shared_guarded<std::unordered_set<std::string>>& IPAddressesInUse_;
+    shared_guarded<std::map<std::string, uint16_t>>& IPAddressesInUse_;
 
     // NOTE: We're only using the read-lock for this
     shared_guarded<std::unordered_set<std::string>>& IPAddressWhitelist_;
 
-    // Used to block this thread when IP address is being served if it's not whitelisted
-    asio::steady_timer timer;
+    // Deadline timer to drop a read
+    asio::steady_timer deadline_;
 
-    bool isIPAddressInUse(std::string const& ipAddrressStr);
-    void addToUsedIPAddresses(std::string const& ipAddressStr);
-    void removeFromUsedIPAddresses(std::string const& ipAddressStr);
+    void checkDeadline();
+
+    uint16_t getNumSessionsInUse(std::string const& ipAddressStr);
+    void     addToUsedIPAddresses(std::string const& ipAddressStr);
+    void     removeFromUsedIPAddresses(std::string const& ipAddressStr);
 
     bool validatePacket(uint16_t length);
     void decrypt(uint16_t length);

--- a/src/search/search_server.h
+++ b/src/search/search_server.h
@@ -66,7 +66,7 @@ private:
     // A single IP should only have one request in flight at a time, so we are going to
     // be tracking the IP addresses of incoming requests and if we haven't cleared the
     // record for it - we block until it's done
-    shared_guarded<std::unordered_set<std::string>> IPAddressesInUse_;
+    shared_guarded<std::map<std::string, uint16_t>> IPAddressesInUse_;
 
     // NOTE: We're only using the read-lock for this
     shared_guarded<std::unordered_set<std::string>> IPAddressWhitelist_;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Add timeout of open-session with no data being sent A single IP address is allowed up to 5 simultaneous connections, otherwise they are dropped instead of blocked

## Steps to test these changes

use this python script to immediately connect 6 times, notice the 6th is instantly dropped, and the other 5 get closed in 2 seconds.
```python
import socket

import time

address = "127.0.0.1"
port    = 54002

sock1 = socket.socket()
sock1.connect((address, port))

sock2 = socket.socket()
sock2.connect((address, port))

sock3 = socket.socket()
sock3.connect((address, port))

sock4 = socket.socket()
sock4.connect((address, port))

sock5 = socket.socket()
sock5.connect((address, port))

sock6 = socket.socket()
sock6.connect((address, port))

while True:
    time.sleep(1)
```