### PR TITLE
[login] Remove static assert to allow builds again RE: `PASSWORD()`, `bcrypt`, etc.

### DIFF
--- a/src/login/auth_session.cpp
+++ b/src/login/auth_session.cpp
@@ -187,9 +187,6 @@ void auth_session::read_func()
             }();
             // clang-format on
 
-            // OLD PASSWORD HASH MIGRATION
-            static_assert(currentYear() <= 2024, "Migration period for old password hashes has expired. Please simplify this code after 2024-12-31 or open an issue upstream to do so.");
-
             if (isBcryptHash(passHash))
             {
                 // It's a BCrypt hash, so we can validate it.
@@ -413,9 +410,6 @@ void auth_session::read_func()
                 return "";
             }();
             // clang-format on
-
-            // OLD PASSWORD HASH MIGRATION
-            static_assert(currentYear() <= 2024, "Migration period for old password hashes has expired. Please simplify this code after 2024-12-31 or open an issue upstream to do so.");
 
             if (isBcryptHash(passHash))
             {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

2025 soon depending on your timezone, static assert is not happy. Based off some previous discussion i'm removing it instead of changing the year unless there are objections

## Steps to test these changes

CI passes
