### PR TITLE
Speed settings overhaul

### DIFF
--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -105,12 +105,18 @@ xi.settings.map =
     -- Enable/disable jobs other than BST and RNG having widescan
     ALL_JOBS_WIDESCAN = true,
 
-    -- Modifier to apply to player speed. 0 is the retail accurate default. Negative numbers will reduce it.
-    SPEED_MOD = 0,
+    -- Base player movement speed
+    BASE_SPEED = 50,
 
-    -- Modifier to apply to mount speed. 0 is the retail accurate default. Negative numbers will reduce it.
-    -- Note retail treats the mounted speed as double what it actually is.
-    MOUNT_SPEED_MOD = 0,
+    -- Player movement speed limit
+    SPEED_LIMIT = 80,
+
+    -- Mount speed, expressed as player speed. Can surpass speed limit.
+    MOUNT_SPEED = 80,
+
+    -- Player animation speed divisor
+    -- Raising this increases the players movement animation speed
+    ANIMATION_SPEED_DIVISOR = 1.0,
 
     -- Multiplier for speed of engaged mobs when their target is out of range.
     -- The default for almost all mobs on retail is 2.5x their normal speed.

--- a/src/map/entities/baseentity.cpp
+++ b/src/map/entities/baseentity.cpp
@@ -39,7 +39,7 @@ CBaseEntity::CBaseEntity()
 , m_TargID(0)
 , animation(0)
 , animationsub(0)
-, speedsub(50 + settings::get<int8>("map.SPEED_MOD"))
+, baseSpeed(settings::get<uint8>("map.BASE_SPEED"))
 , namevis(0)
 , allegiance(ALLEGIANCE_TYPE::MOB)
 , updatemask(0)
@@ -53,7 +53,8 @@ CBaseEntity::CBaseEntity()
 , m_nextUpdateTimer(std::chrono::steady_clock::now())
 {
     TracyZoneScoped;
-    speed = speedsub;
+    speed          = baseSpeed;
+    animationSpeed = static_cast<uint8>(std::clamp<float>((baseSpeed / settings::get<float>("map.ANIMATION_SPEED_DIVISOR")), std::numeric_limits<uint8>::min(), std::numeric_limits<uint8>::max()));
 }
 
 CBaseEntity::~CBaseEntity()

--- a/src/map/entities/baseentity.h
+++ b/src/map/entities/baseentity.h
@@ -303,20 +303,21 @@ public:
 
     bool IsDynamicEntity() const;
 
-    uint32          id;           // global identifier unique on the server
-    uint16          targid;       // local identifier unique to the zone
-    ENTITYTYPE      objtype;      // Type of entity
-    STATUS_TYPE     status;       // Entity status (different entities - different statuses)
-    uint16          m_TargID;     // the targid of the object the entity is looking at
-    std::string     name;         // Entity name
-    std::string     packetName;   // Used to override name when being sent to the client
-    look_t          look;         //
-    look_t          mainlook;     // only used if mob use changeSkin() or player /lockstyle
-    location_t      loc;          // Location of entity
-    uint8           animation;    // animation
-    uint8           animationsub; // Additional animation parameter
-    uint8           speed;        // speed of movement
-    uint8           speedsub;     // base movement speed
+    uint32          id;             // global identifier unique on the server
+    uint16          targid;         // local identifier unique to the zone
+    ENTITYTYPE      objtype;        // Type of entity
+    STATUS_TYPE     status;         // Entity status (different entities - different statuses)
+    uint16          m_TargID;       // the targid of the object the entity is looking at
+    std::string     name;           // Entity name
+    std::string     packetName;     // Used to override name when being sent to the client
+    look_t          look;           //
+    look_t          mainlook;       // only used if mob use changeSkin() or player /lockstyle
+    location_t      loc;            // Location of entity
+    uint8           animation;      // animation
+    uint8           animationsub;   // Additional animation parameter
+    uint8           baseSpeed;      // base movement speed
+    uint8           speed;          // speed of movement
+    uint8           animationSpeed; // speed of movement animation
     uint8           namevis;
     ALLEGIANCE_TYPE allegiance;     // what types of targets the entity can fight
     uint8           updatemask;     // what to update next server tick to players nearby

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -299,16 +299,14 @@ int32 CBattleEntity::GetMaxMP() const
 
 uint8 CBattleEntity::UpdateSpeed(bool run)
 {
-    uint8 baseSpeed   = speedsub;
     int16 outputSpeed = 0;
 
     // Mount speed. Independent from regular speed and unaffected by most things.
-    // Note: retail treats mounted speed as double what it actually is! 40 is in fact retail accurate!
     if (isMounted())
     {
-        baseSpeed   = 40 + settings::get<int8>("map.MOUNT_SPEED_MOD");
-        outputSpeed = baseSpeed * (100 + getMod(Mod::MOUNT_MOVE)) / 100;
-        speed       = std::clamp<uint8>(outputSpeed, std::numeric_limits<uint8>::min(), std::numeric_limits<uint8>::max());
+        outputSpeed = settings::get<uint8>("map.MOUNT_SPEED") / 2;
+        outputSpeed *= (100 + getMod(Mod::MOUNT_MOVE)) / 100;
+        speed = std::clamp<uint8>(outputSpeed, std::numeric_limits<uint8>::min(), std::numeric_limits<uint8>::max());
 
         return speed;
     }
@@ -355,7 +353,7 @@ uint8 CBattleEntity::UpdateSpeed(bool run)
     // Set cap if a PC (Default 80).
     if (objtype == TYPE_PC)
     {
-        outputSpeed = std::clamp<int16>(outputSpeed, 0, 80);
+        outputSpeed = std::clamp<int16>(outputSpeed, 0, settings::get<uint8>("map.SPEED_LIMIT"));
     }
 
     // Speed cap can be bypassed. Ex. Feast of swords. GM speed.

--- a/src/map/instance_loader.cpp
+++ b/src/map/instance_loader.cpp
@@ -134,8 +134,9 @@ CInstance* CInstanceLoader::LoadInstance()
             PMob->m_EcoSystem   = (ECOSYSTEM)_sql->GetIntData(23);
             PMob->m_ModelRadius = (float)_sql->GetIntData(24);
 
-            PMob->speed    = (uint8)_sql->GetIntData(25);
-            PMob->speedsub = (uint8)_sql->GetIntData(25);
+            PMob->baseSpeed      = (uint8)_sql->GetIntData(25);
+            PMob->speed          = (uint8)_sql->GetIntData(25);
+            PMob->animationSpeed = (uint8)_sql->GetIntData(25);
 
             PMob->strRank = (uint8)_sql->GetIntData(26);
             PMob->dexRank = (uint8)_sql->GetIntData(27);
@@ -258,10 +259,11 @@ CInstance* CInstanceLoader::LoadInstance()
 
                 PNpc->m_TargID = _sql->GetUIntData(6) >> 16; // "quite likely"
 
-                PNpc->speed        = (uint8)_sql->GetIntData(7);
-                PNpc->speedsub     = (uint8)_sql->GetIntData(8);
-                PNpc->animation    = (uint8)_sql->GetIntData(9);
-                PNpc->animationsub = (uint8)_sql->GetIntData(10);
+                PNpc->baseSpeed      = (uint8)_sql->GetIntData(8);
+                PNpc->speed          = (uint8)_sql->GetIntData(7);
+                PNpc->animationSpeed = (uint8)_sql->GetIntData(8);
+                PNpc->animation      = (uint8)_sql->GetIntData(9);
+                PNpc->animationsub   = (uint8)_sql->GetIntData(10);
 
                 PNpc->namevis = (uint8)_sql->GetIntData(11);
                 PNpc->status  = static_cast<STATUS_TYPE>(_sql->GetIntData(12));

--- a/src/map/packets/char.cpp
+++ b/src/map/packets/char.cpp
@@ -91,7 +91,7 @@ void CCharPacket::updateWith(CCharEntity* PChar, ENTITYUPDATE type, uint8 update
         packet.z   = PChar->loc.p.y; // Intentionally Swapped
 
         packet.Speed     = PChar->UpdateSpeed();
-        packet.SpeedBase = PChar->speedsub;
+        packet.SpeedBase = PChar->animationSpeed;
 
         packet.Flags0.MovTime     = PChar->loc.p.moving;
         packet.Flags0.RunMode     = 0;                      // Unknown

--- a/src/map/packets/char_update.cpp
+++ b/src/map/packets/char_update.cpp
@@ -281,7 +281,7 @@ CCharUpdatePacket::CCharUpdatePacket(CCharEntity* PChar)
     flags1.unknown_1_14 = 0;                      // Unknown.
     flags1.InvisFlag    = PChar->m_isGMHidden || PChar->StatusEffectContainer->HasStatusEffectByFlag(EFFECTFLAG_INVISIBLE);
     flags1.unknown_2_16 = 0; // Unknown.
-    flags1.SpeedBase    = PChar->speedsub;
+    flags1.SpeedBase    = PChar->animationSpeed;
     flags1.unknown_3_25 = 0; // Unknown
     flags1.BazaarFlag   = PChar->hasBazaar();
     flags1.CharmFlag    = PChar->isCharmed;

--- a/src/map/packets/entity_update.cpp
+++ b/src/map/packets/entity_update.cpp
@@ -119,7 +119,7 @@ void CEntityUpdatePacket::updateWith(CBaseEntity* PEntity, ENTITYUPDATE type, ui
         ref<uint16>(0x18) = PEntity->loc.p.moving;
         ref<uint16>(0x1A) = PEntity->m_TargID << 1;
         ref<uint8>(0x1C)  = PEntity->speed;
-        ref<uint8>(0x1D)  = PEntity->speedsub;
+        ref<uint8>(0x1D)  = PEntity->animationSpeed;
     }
 
     if (PEntity->allegiance == ALLEGIANCE_TYPE::PLAYER && PEntity->status == STATUS_TYPE::UPDATE)

--- a/src/map/packets/zone_in.cpp
+++ b/src/map/packets/zone_in.cpp
@@ -247,7 +247,7 @@ CZoneInPacket::CZoneInPacket(CCharEntity* PChar, const EventInfo* currentEvent)
     // 0x1A = Target Index
 
     ref<uint8>(0x1C) = PChar->UpdateSpeed();
-    ref<uint8>(0x1D) = PChar->speedsub;
+    ref<uint8>(0x1D) = PChar->animationSpeed;
     ref<uint8>(0x1E) = PChar->GetHPP();
     ref<uint8>(0x1F) = PChar->animation;
 

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -1576,8 +1576,9 @@ namespace mobutils
                 PMob->m_EcoSystem   = (ECOSYSTEM)_sql->GetIntData(20);
                 PMob->m_ModelRadius = (float)_sql->GetIntData(21);
 
-                PMob->speed    = (uint8)_sql->GetIntData(22); // Overwrites baseentity.cpp's defined speed
-                PMob->speedsub = (uint8)_sql->GetIntData(22); // Overwrites baseentity.cpp's defined speedsub
+                PMob->baseSpeed      = (uint8)_sql->GetIntData(22); // Overwrites baseentity.cpp's defined baseSpeed
+                PMob->speed          = (uint8)_sql->GetIntData(22); // Overwrites baseentity.cpp's defined speed
+                PMob->animationSpeed = (uint8)_sql->GetIntData(22); // Overwrites baseentity.cpp's defined animationSpeed
 
                 PMob->strRank = (uint8)_sql->GetIntData(23);
                 PMob->dexRank = (uint8)_sql->GetIntData(24);
@@ -1737,8 +1738,9 @@ namespace mobutils
                 PMob->m_EcoSystem   = (ECOSYSTEM)_sql->GetIntData(20);
                 PMob->m_ModelRadius = (float)_sql->GetIntData(21);
 
-                PMob->speed    = (uint8)_sql->GetIntData(22); // Overwrites baseentity.cpp's defined speed
-                PMob->speedsub = (uint8)_sql->GetIntData(22); // Overwrites baseentity.cpp's defined speedsub
+                PMob->baseSpeed      = (uint8)_sql->GetIntData(22); // Overwrites baseentity.cpp's defined baseSpeed
+                PMob->speed          = (uint8)_sql->GetIntData(22); // Overwrites baseentity.cpp's defined speed
+                PMob->animationSpeed = (uint8)_sql->GetIntData(22); // Overwrites baseentity.cpp's defined animationSpeed
 
                 PMob->strRank = (uint8)_sql->GetIntData(23);
                 PMob->dexRank = (uint8)_sql->GetIntData(24);

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -352,8 +352,9 @@ namespace petutils
                 break;
         }
 
-        PMob->speed    = petStats->speed;
-        PMob->speedsub = petStats->speed;
+        PMob->baseSpeed      = petStats->speed;
+        PMob->speed          = petStats->speed;
+        PMob->animationSpeed = petStats->speed;
 
         PMob->UpdateHealth();
         PMob->health.tp = 0;

--- a/src/map/utils/trustutils.cpp
+++ b/src/map/utils/trustutils.cpp
@@ -80,8 +80,8 @@ struct Trust_t
     uint8  cmbSkill;
     uint16 cmbDmgMult;
     uint16 cmbDelay;
-    uint8  speed;
-    uint8  subSpeed;
+    uint8  baseSpeed;
+    uint8  animationSpeed;
 
     // stat ranks
     uint8 strRank;
@@ -142,8 +142,8 @@ struct Trust_t
     , cmbSkill(0)
     , cmbDmgMult(0)
     , cmbDelay(0)
-    , speed(0)
-    , subSpeed(0)
+    , baseSpeed(0)
+    , animationSpeed(0)
     , strRank(0)
     , dexRank(0)
     , vitRank(0)
@@ -304,12 +304,8 @@ namespace trustutils
                 trust->HPscale   = _sql->GetFloatData(17);
                 trust->MPscale   = _sql->GetFloatData(18);
 
-                // retail seems to have a static *155* for all Trusts in client memory
-                // TODO: trust->speed = 155;
-                trust->speed = (uint8)_sql->GetIntData(19);
-
-                // similarly speedSub is always 50
-                trust->subSpeed = 50;
+                trust->baseSpeed      = 62;
+                trust->animationSpeed = 50;
 
                 trust->strRank = (uint8)_sql->GetIntData(20);
                 trust->dexRank = (uint8)_sql->GetIntData(21);
@@ -440,7 +436,9 @@ namespace trustutils
         PTrust->m_MobSkillList = trustData->m_MobSkillList;
         PTrust->HPscale        = trustData->HPscale;
         PTrust->MPscale        = trustData->MPscale;
-        PTrust->speed          = trustData->speed;
+        PTrust->baseSpeed      = trustData->baseSpeed;
+        PTrust->speed          = trustData->baseSpeed;
+        PTrust->animationSpeed = trustData->animationSpeed;
         PTrust->m_TrustID      = trustData->trustID;
         PTrust->status         = STATUS_TYPE::NORMAL;
         PTrust->m_ModelRadius  = trustData->radius;

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -342,8 +342,9 @@ namespace zoneutils
 
                                 PNpc->m_TargID = rset->get<uint32>("flag") >> 16;
 
-                                PNpc->speed    = rset->get<uint8>("speed");    // Overwrites baseentity.cpp's defined speed
-                                PNpc->speedsub = rset->get<uint8>("speedsub"); // Overwrites baseentity.cpp's defined speedsub
+                                PNpc->speed          = rset->get<uint8>("speed");    // Overwrites baseentity.cpp's defined speed
+                                PNpc->animationSpeed = rset->get<uint8>("speedsub"); // Overwrites baseentity.cpp's defined animationSpeed
+                                PNpc->baseSpeed      = rset->get<uint8>("speedsub"); // Overwrites baseentity.cpp's defined baseSpeed
 
                                 PNpc->animation    = rset->get<uint8>("animation");
                                 PNpc->animationsub = rset->get<uint8>("animationsub");
@@ -488,8 +489,9 @@ namespace zoneutils
                                 PMob->m_EcoSystem   = (ECOSYSTEM)sql->GetIntData(24);
                                 PMob->m_ModelRadius = (float)sql->GetIntData(25);
 
-                                PMob->speed    = (uint8)sql->GetIntData(26);
-                                PMob->speedsub = (uint8)sql->GetIntData(26);
+                                PMob->baseSpeed       = (uint8)sql->GetIntData(26);
+                                PMob->speed           = (uint8)sql->GetIntData(26);
+                                PMob->animationSpeed  = (uint8)sql->GetIntData(26);
 
                                 PMob->strRank = (uint8)sql->GetIntData(27);
                                 PMob->dexRank = (uint8)sql->GetIntData(28);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Split the single movement speed setting into multiple settings to improve ease of use and customizability. Base speed, speed limit, and mount speed are all now directly set instead of an offset to retail values.

Animation speed setting added that controls player movement animation speed. This is a little hard to explain. Take your current speed and divide it by your base speed. Normally this would be 50/50=1.0, this is the rate at which your running animation plays, 1x. Flee brings you to 80/50=1.6x animation speed. If you increase base speed to 80, then you still have a 1x animation speed. This setting is applied as a divisor to the base speed, so if you want to increase the base movement speed and also increase animation speed, you would increase this value (e.g. to make it always appear as if the player has a flee effect you would set BASE_SPEED to 80 and ANIMATION_SPEED_DIVISOR to 1.6). Will fix an additional issue brought up in #6610.

Speedsub was changed to animationSpeed to reflect this, and baseSpeed was added to track the base speed of an entity. For most entities these will be the same, but allows for player animation adjustments. This was left as speedsub in the DB so as to not require any changes to capturing tools.

Let's see if I can break this down a little more. What LSB and capture tools call `speedsub`, would be what Windower and Ashita refer to as "animation speed" (or SpeedBase in XiPackets documentation.) However, this is not necessarily the base movement speed. Other than player customization mentioned above, I have noticed with trusts on retail that they have an animation speed of 50 and normally a speed of 155. However, if you do some maneuvering and kind of kite them then run back into them you can get them to stop "running" and see their speed change to 62. This fits with the recent mob run speed changes where `62 * 2.5 = 155`. So we can see that trusts have a base speed of 62, run speed of 155 (normal 2.5x modifier), and 50 animation speed ("speedsub"). Here's a short clip demonstrating this:

https://github.com/user-attachments/assets/d06fe49f-735b-4bda-aa88-735c51f949fa

Side note, if you look at some old videos ([example1](https://www.youtube.com/watch?v=DBKbGXc7ZDk) [example2](https://youtu.be/8f9wpRTzHow?t=129)) the players appear to be moving with the same animation speed as current retail. With these changes, you can set BASE_SPEED to 40 and leave ANIMATION_SPEED_DIVISOR at 1.0 to achieve these results, whereas before you would be animating at 40/50=0.8x animation speed, making it appear as if your movement is slowed down (which it is compared to current retail, but doesn't appear to have been the case when the movement speed actually was 40.)

## Steps to test these changes

Play around with changing these settings:

```lua
xi.settings.map =
{
    BASE_SPEED = 80,
    SPEED_LIMIT = 255,
    MOUNT_SPEED = 255,
    ANIMATION_SPEED_DIVISOR = 2.0,
}
```
