### PR TITLE
Add many explict bounds to math.random calls

### DIFF
--- a/scripts/globals/chocobo_raising.lua
+++ b/scripts/globals/chocobo_raising.lua
@@ -65,7 +65,7 @@ local walkEnergyRandomness = 5
 -- The amount of energy taken by: short, medium and long walks (+ a random amount between 0 and walkEnergyRandomness)
 local walkEnergyAmount = { 25, 33, 50 }
 
--- Chance for an event to happen while on a walk (checked as chance < math.random(100))
+-- Chance for an event to happen while on a walk (checked as chance < math.random(1, 100))
 local walkEventChance = 33
 
 -- The amount of energy taken by: watch over chocobo
@@ -1812,7 +1812,7 @@ xi.chocoboRaising.onEventUpdateVCSTrainer = function(player, csid, option, npc)
                 local output     = { 0, 0, 0, 0, 0, 0, 0, 0 }
 
                 -- Will there be an event?
-                if math.random(100) < walkEventChance then
+                if math.random(1, 100) <= walkEventChance then
                     local possibleEvents = {}
 
                     -- If not holding an item, it's possible to find an item
@@ -1875,7 +1875,7 @@ xi.chocoboRaising.onEventUpdateVCSTrainer = function(player, csid, option, npc)
                 local output = { 0, 0, 0, 0, 0, 0, 0, 0 }
 
                 -- Will there be an event?
-                if walkEventChance < math.random(100) then
+                if math.random(1, 100) <= walkEventChance then
                     -- TODO: Hard-coded to randomly finding an item
                     output = { unpack(csData[1]) }
                 end
@@ -1926,7 +1926,7 @@ xi.chocoboRaising.onEventUpdateVCSTrainer = function(player, csid, option, npc)
                 local output     = { 0, 0, 0, 0, 0, 0, 0, 0 }
 
                 -- Will there be an event?
-                if walkEventChance < math.random(100) then
+                if math.random(1, 100) <= walkEventChance then
                     -- TODO: Hard-coded to randomly finding an item
                     output = { unpack(csData[1]) }
                 end

--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -969,7 +969,7 @@ xi.combat.physical.isBlocked = function(defender, attacker)
     local blocked = false
     if
         xi.combat.physical.canBlock(defender, attacker) and
-        xi.combat.physical.calculateBlockRate(defender, attacker) > math.random(100)
+        xi.combat.physical.calculateBlockRate(defender, attacker) > math.random(1, 100)
     then
         defender:trySkillUp(xi.skill.SHIELD, attacker:getMainLvl())
         blocked = true
@@ -982,7 +982,7 @@ xi.combat.physical.isParried = function(defender, attacker)
     local parried = false
     if
         xi.combat.physical.canParry(defender, attacker) and
-        xi.combat.physical.calculateParryRate(defender, attacker) > math.random(100)
+        xi.combat.physical.calculateParryRate(defender, attacker) > math.random(1, 100)
     then
         parried = true
         if defender:isPC() then
@@ -1002,7 +1002,7 @@ xi.combat.physical.isGuarded = function(defender, attacker)
     local guarded = false
     if
         xi.combat.physical.canGuard(defender, attacker) and
-        xi.combat.physical.calculateGuardRate(defender, attacker) > math.random(100)
+        xi.combat.physical.calculateGuardRate(defender, attacker) > math.random(1, 100)
     then
         guarded = true
         if defender:isPC() then

--- a/scripts/globals/job_utils/beastmaster.lua
+++ b/scripts/globals/job_utils/beastmaster.lua
@@ -638,7 +638,7 @@ xi.job_utils.beastmaster.attemptCharm = function(charmer, target)
     local chance = xi.job_utils.beastmaster.getCharmChance(charmer, target, true)
 
     -- If successful then calculate duration and charm
-    if chance > math.random(100) then
+    if chance > math.random(1, 100) then
         local duration = getCharmDuration(charmer, target)
 
         if duration > 0 then

--- a/scripts/globals/job_utils/corsair.lua
+++ b/scripts/globals/job_utils/corsair.lua
@@ -253,7 +253,7 @@ xi.job_utils.corsair.useDoubleUp = function(caster, target, ability, action)
         local snakeEye = caster:getStatusEffect(xi.effect.SNAKE_EYE)
 
         if snakeEye then
-            if roll >= 5 and math.random(100) < snakeEye:getPower() then
+            if roll >= 5 and math.random(1, 100) < snakeEye:getPower() then
                 roll = 11
             else
                 roll = roll + 1

--- a/scripts/globals/job_utils/paladin.lua
+++ b/scripts/globals/job_utils/paladin.lua
@@ -202,7 +202,7 @@ xi.job_utils.paladin.useShieldBash = function(player, target, ability)
     -- Calculate stun proc chance
     chance = chance + (player:getMainLvl() - target:getMainLvl()) * 5
 
-    if math.random() * 100 < chance then
+    if math.random(1, 100) <= chance then
         target:addStatusEffect(xi.effect.STUN, 1, 0, 6)
     end
 

--- a/scripts/globals/job_utils/thief.lua
+++ b/scripts/globals/job_utils/thief.lua
@@ -344,7 +344,7 @@ xi.job_utils.thief.useMug = function(player, target, ability, action)
 
     if
         target:isMob() and
-        math.random(100) < mugChance and
+        math.random(1, 100) <= mugChance and
         target:getMobMod(xi.mobMod.MUG_GIL) > 0
     then
         local purse    = target:getMobMod(xi.mobMod.MUG_GIL)
@@ -401,7 +401,7 @@ xi.job_utils.thief.useSteal = function(player, target, ability, action)
         stolen = target:getStealItem()
     end
 
-    if target:isMob() and math.random(100) < stealChance and stolen ~= 0 then
+    if target:isMob() and math.random(1, 100) <= stealChance and stolen ~= 0 then
         player:addItem(stolen)
         target:itemStolen()
         ability:setMsg(xi.msg.basic.STEAL_SUCCESS) -- Item stolen successfully
@@ -420,7 +420,7 @@ xi.job_utils.thief.useSteal = function(player, target, ability, action)
         -- local effectStealSuccess = false
         if resist > 0.0625 then
             local auraStealChance = math.min(player:getMerit(xi.merit.AURA_STEAL), 95)
-            if math.random(100) < auraStealChance then
+            if math.random(1, 100) <= auraStealChance then
                 local targetShadows = target:getMod(xi.mod.UTSUSEMI)
 
                 stolen = player:stealStatusEffect(target)
@@ -444,8 +444,8 @@ xi.job_utils.thief.useSteal = function(player, target, ability, action)
             stolen per merit.
 
             if (effect ~= xi.effect.NONE or stolen ~= 0) and player:getMod(xi.mod.AUGMENTS_AURA_STEAL) > 0 then
-                if math.random(100) < auraStealChance then
-                    if stolenEffect2 ~= nil and math.random(100) < auraStealChance then
+                if math.random(1, 100) <= auraStealChance then
+                    if stolenEffect2 ~= nil and math.random(1, 100) <= auraStealChance then
                         player:stealStatusEffect(target)
                     else
                         target:dispelStatusEffect()

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -82,7 +82,7 @@ end
 
 local function MobTakeAoEShadow(mob, target, max)
     -- TODO: Use actual NIN skill, not this function
-    if target:getMainJob() == xi.job.NIN and math.random() < 0.6 then
+    if target:getMainJob() == xi.job.NIN and math.random(1, 100) <= 60 then
         max = max - 1
         if max < 1 then
             max = 1
@@ -241,13 +241,13 @@ xi.mobskills.mobPhysicalMove = function(mob, target, skill, numHits, accMod, dmg
 
     firstHitChance = utils.clamp(firstHitChance, 35, 95)
 
-    if (math.random() * 100) <= firstHitChance then
+    if (math.random(1, 100)) <= firstHitChance then
         -- use helper function check for parry guard and blocking and handle the hit
         hitslanded, finaldmg = handleSinglePhysicalHit(mob, target, hitdamage, hitslanded, finaldmg, tpEffect, minRatio, maxRatio)
     end
 
     while hitsdone < numHits do
-        if (math.random() * 100) <= hitrate then --it hit
+        if (math.random(1, 100)) <= hitrate then --it hit
             hitslanded, finaldmg = handleSinglePhysicalHit(mob, target, hitdamage, hitslanded, finaldmg, tpEffect, minRatio, maxRatio)
         end
 

--- a/scripts/globals/pets/avatar.lua
+++ b/scripts/globals/pets/avatar.lua
@@ -419,7 +419,7 @@ xi.pets.avatar.getLightSpiritSpell = function(pet)
             for hpColor = 1, 3 do
                 if
                     tempHPP < 25 * hpColor and
-                    math.random(100) < 50
+                    math.random(1, 100) <= 50
                 then
                     hpp = tempHPP
                     cureTarget = member

--- a/scripts/globals/strangeapparatus.lua
+++ b/scripts/globals/strangeapparatus.lua
@@ -296,7 +296,7 @@ xi.strangeApparatus =
                         end
                     end
 
-                    if not hasDoctorStatus(player) and math.random() < 0.5 then
+                    if not hasDoctorStatus(player) and math.random(1, 100) <= 50 then
                         item = data.cluster -- give clusters instead of reward
                         qty  = 2
                     end

--- a/scripts/missions/amk/helpers.lua
+++ b/scripts/missions/amk/helpers.lua
@@ -76,7 +76,7 @@ xi.amk.helpers.cardianOrbDrop = function(mob, player, orb)
 
         -- Chance ranges from 4% to 25.8% (based on max mob lvl of 44)
         local dropChance = (3 * mob:getMainLvl()) + (30 * utils.clamp(partySize, 1, 6)) - 10
-        local roll = math.random(1000)
+        local roll = math.random(1, 1000)
 
         if roll < dropChance then
             mob:setLocalVar('Mission[10][5]cardianOrbDrop', 1)

--- a/scripts/mixins/job_special.lua
+++ b/scripts/mixins/job_special.lua
@@ -290,7 +290,7 @@ g_mixins.job_special = function(jobSpecialMob)
     end)
 
     jobSpecialMob:addListener('ENGAGE', 'JOB_SPECIAL_ENGAGE', function(mob)
-        if math.random(100) <= mob:getLocalVar('[jobSpecial]chance') then
+        if math.random(1, 100) <= mob:getLocalVar('[jobSpecial]chance') then
             mob:setLocalVar('[jobSpecial]readyInitial', os.time() + mob:getLocalVar('[jobSpecial]delayInitial'))
         end
     end)

--- a/scripts/zones/Carpenters_Landing/mobs/Tempest_Tigon.lua
+++ b/scripts/zones/Carpenters_Landing/mobs/Tempest_Tigon.lua
@@ -10,7 +10,7 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    if math.random() > .5 then
+    if math.random(1, 100) <= 50 then
         return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENAERO, { chance = 50 })
     else
         return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENWATER, { chance = 50 })

--- a/scripts/zones/Empyreal_Paradox/mobs/Promathia_2.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Promathia_2.lua
@@ -79,7 +79,7 @@ entity.onSpellPrecast = function(mob, spell)
 end
 
 entity.onMagicCastingCheck = function(mob, target, spell)
-    if math.random() > 0.75 then
+    if math.random(1, 100) <= 25 then
         return 219
     else
         return 218

--- a/scripts/zones/Ghelsba_Outpost/mobs/Kalamainu.lua
+++ b/scripts/zones/Ghelsba_Outpost/mobs/Kalamainu.lua
@@ -19,7 +19,7 @@ entity.onMobEngage = function(mob, target)
 end
 
 entity.onMobWeaponSkill = function(mob, target, skill)
-    if math.random() < 0.5 then
+    if math.random(1, 100) <= 50 then
         return 370 -- favor baleful gaze
     end
 end

--- a/scripts/zones/Ghelsba_Outpost/mobs/Kilioa.lua
+++ b/scripts/zones/Ghelsba_Outpost/mobs/Kilioa.lua
@@ -19,7 +19,7 @@ entity.onMobEngage = function(mob, target)
 end
 
 entity.onMobWeaponSkill = function(mob, target, skill)
-    if math.random() < 0.5 then
+    if math.random(1, 100) <= 50 then
         return 370 -- favor baleful gaze
     end
 end

--- a/scripts/zones/Newton_Movalpolos/mobs/Bugbear_Matman.lua
+++ b/scripts/zones/Newton_Movalpolos/mobs/Bugbear_Matman.lua
@@ -17,7 +17,7 @@ end
 
 entity.onMobWeaponSkillPrepare = function(mob, target)
     -- Below 30% Bugbear Matman heavily prefers Heavy Whisk
-    if mob:getHPP() <= 30 and math.random() > 0.4 then
+    if mob:getHPP() <= 30 and math.random(1, 100) <= 60 then
         return 358
     end
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Make random bounds explicit

## Steps to test these changes

Test output of math.random(1,100), should produce values from 1 to 100, same as math.random(100).
