### PR TITLE
Fix traverser_start datatype, set epoch function

### DIFF
--- a/sql/char_unlocks.sql
+++ b/sql/char_unlocks.sql
@@ -13,7 +13,7 @@ CREATE TABLE `char_unlocks` (
   `campaign_windy` int(10) unsigned NOT NULL DEFAULT 0,
   `homepoints` blob DEFAULT NULL,
   `survivals` blob DEFAULT NULL,
-  `traverser_start` int(10) unsigned NOT NULL DEFAULT 0,
+  `traverser_start` TIMESTAMP DEFAULT 0,
   `traverser_claimed` int(10) unsigned NOT NULL DEFAULT 0,
   `abyssea_conflux` blob DEFAULT NULL,
   `waypoints` blob DEFAULT NULL,

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -6860,7 +6860,7 @@ namespace charutils
     {
         TracyZoneScoped;
 
-        auto fmtQuery = "UPDATE char_unlocks SET traverser_start = unix_timestamp() WHERE charid = %u";
+        auto fmtQuery = "UPDATE char_unlocks SET traverser_start = CURRENT_TIMESTAMP() WHERE charid = %u";
 
         _sql->Query(fmtQuery, PChar->id);
     }

--- a/tools/migrations/026_abyssea_unlocks.py
+++ b/tools/migrations/026_abyssea_unlocks.py
@@ -21,7 +21,7 @@ def migrate(cur, db):
     try:
         cur.execute(
             "ALTER TABLE char_unlocks \
-        ADD COLUMN `traverser_start` TIMESTAMP DEFAULT CURRENT_TIMESTAMP, \
+        ADD COLUMN `traverser_start` TIMESTAMP DEFAULT 0, \
         ADD COLUMN `traverser_claimed` int(10) unsigned NOT NULL DEFAULT '0';"
         )
         db.commit()


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes migration default value and raw sql to use the same type, defaulting to 0, as well as the set function to use `CURRENT_TIMESTAMP()` function to generate initial value when quest is unlocked.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
With a conforming db (timestamp, not int type), check initial Abyssea quests for epoch set
Change epoch to previous date to verify stone accumulation
<!-- Clear and detailed steps to test your changes here -->
