### PR TITLE
[search] Wait for replies from client before sending more data

### DIFF
--- a/src/search/search.h
+++ b/src/search/search.h
@@ -40,4 +40,38 @@ struct search_req
     uint8       commentType;
 };
 
+class searchPacket
+{
+public:
+    // max size of search packet is 1024 in packets
+    static constexpr uint16_t max_size = 1024;
+
+    searchPacket(uint8_t* buffer, uint16_t length)
+    {
+        if (length > max_size)
+        {
+            size = 0;
+            ShowError(fmt::format("Error: search packet with size above {} requested!", max_size));
+            return;
+        }
+
+        std::memcpy(buff_.data(), buffer, length);
+        size = length;
+    }
+
+    uint16_t getSize()
+    {
+        return size;
+    }
+
+    uint8_t* getData()
+    {
+        return buff_.data();
+    }
+private:
+
+    std::array<uint8_t, max_size> buff_;
+    uint16_t                      size;
+};
+
 #endif

--- a/src/search/search_handler.h
+++ b/src/search/search_handler.h
@@ -57,7 +57,7 @@ public:
 
     void handle_error(std::error_code ec, std::shared_ptr<search_handler> self);
 
-    void do_write(uint16_t length);
+    void do_write();
 
     void read_func(uint16_t length);
 
@@ -110,4 +110,6 @@ private:
     auto _HandleSearchRequest() -> search_req;
 
     blowfish_t blowfish;
+
+    std::deque<searchPacket> searchPackets;
 };


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Apparently we are supposed to expect a reply and to wait for it. Otherwise bad things happen. (see #6633)

## Steps to test these changes
search linkshell, party, /sea all, search comment, AH item list, AH sale list, AH detailed sale list on 2+ clients at a time with no errors on _windows_ and linux
