### PR TITLE
[ci] Disable math.random style check, restore float parameter calls

### DIFF
--- a/scripts/zones/Bibiki_Bay/npcs/Clamming_Point.lua
+++ b/scripts/zones/Bibiki_Bay/npcs/Clamming_Point.lua
@@ -121,7 +121,7 @@ entity.onEventUpdate = function(player, csid, option, npc)
 
             player:incrementCharVar('ClammingKitWeight', 10000)
         else
-            local dropRate = math.random(0.0, 1.0) -- TODO: Adjust all values to use 0..100 scale as opposed to 0..1
+            local dropRate = math.random() -- TODO: Adjust all values to use 0..100 scale as opposed to 0..1
             local improvedResults = giveImprovedResults(player)
 
             player:updateEvent(player:getCharVar('ClammingKitWeight'), player:getCharVar('ClammingKitSize'))

--- a/scripts/zones/Nyzul_Isle/mobs/Gem_Heister_Roorooroon.lua
+++ b/scripts/zones/Nyzul_Isle/mobs/Gem_Heister_Roorooroon.lua
@@ -9,7 +9,7 @@ local entity = {}
 local function pickRunPoint(mob)
     mob:setLocalVar('ignore', 1)
     local distance   = math.random(10, 25)
-    local angle      = math.random(0.0, 1.0) * math.pi
+    local angle      = math.random() * math.pi
     local fromTarget = mob:getTarget()
 
     if fromTarget == nil then

--- a/scripts/zones/Nyzul_Isle/mobs/Stealth_Bomber_Gagaroon.lua
+++ b/scripts/zones/Nyzul_Isle/mobs/Stealth_Bomber_Gagaroon.lua
@@ -9,7 +9,7 @@ local entity = {}
 local function pickRunPoint(mob)
     mob:setLocalVar('ignore', 1)
     local distance   = math.random(10, 25)
-    local angle      = math.random(0.0, 1.0) * math.pi
+    local angle      = math.random() * math.pi
     local fromTarget = mob:getTarget()
 
     if fromTarget == nil then

--- a/tools/ci/lua_stylecheck.py
+++ b/tools/ci/lua_stylecheck.py
@@ -415,7 +415,9 @@ class LuaStyleCheck:
                 self.check_no_newline_before_end(code_line)
                 self.check_no_function_decl_padding(code_line)
                 self.check_invalid_enum(code_line)
-                self.check_random_bounds(code_line)
+
+                # TODO: Disabled until a solution for float parameters to math.random() is found
+                # self.check_random_bounds(code_line)
 
                 # Keep track of ID variable assignments and if they are referenced.
                 # TODO: Track each unique variable, and expand this to potentially something
@@ -510,7 +512,7 @@ elif target == 'scripts':
         total_errors += LuaStyleCheck(filename).errcount
 elif target == 'test':
     total_errors = LuaStyleCheck('tools/ci/tests/stylecheck.lua', show_errors = False).errcount
-    expected_errors = 85
+    expected_errors = 82
 else:
     total_errors = LuaStyleCheck(target).errcount
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Temporarily disables math.random bound checking in CI, and restores 3x calls to math.random where a float parameter is required.  Currently, passing a float to the function will still be treated as int, and return invalid results.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
CI disabled, two Nyzul mobs restored along with Clamming Point droprate
<!-- Clear and detailed steps to test your changes here -->
