### PR TITLE
[core] Use job rank for Evasion on mob and not use DB values

### DIFF
--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -718,12 +718,12 @@ namespace mobutils
             }
         }
 
-        PMob->addModifier(Mod::DEF, GetBaseDefEva(PMob, PMob->defRank)); // Base Defense for all mobs
-        PMob->addModifier(Mod::EVA, GetBaseDefEva(PMob, PMob->evaRank)); // Base Evasion for all mobs
-        PMob->addModifier(Mod::ATT, GetBaseSkill(PMob, PMob->attRank));  // Base Attack for all mobs is Rank A+ but pull from DB for specific cases
-        PMob->addModifier(Mod::ACC, GetBaseSkill(PMob, PMob->accRank));  // Base Accuracy for all mobs is Rank A+ but pull from DB for specific cases
-        PMob->addModifier(Mod::RATT, GetBaseSkill(PMob, PMob->attRank)); // Base Ranged Attack for all mobs is Rank A+ but pull from DB for specific cases
-        PMob->addModifier(Mod::RACC, GetBaseSkill(PMob, PMob->accRank)); // Base Ranged Accuracy for all mobs is Rank A+ but pull from DB for specific cases
+        PMob->addModifier(Mod::DEF, GetBaseDefEva(PMob, PMob->defRank));                       // Base Defense for all mobs
+        PMob->addModifier(Mod::EVA, GetBaseDefEva(PMob, JobSkillRankToBaseEvaRank(mJob))); // Evasion is based off main job rank. // TODO: add family bonuses (colibri has static evasion+ porrogos have % boost.)
+        PMob->addModifier(Mod::ATT, GetBaseSkill(PMob, PMob->attRank));                        // Base Attack for all mobs is Rank A+ but pull from DB for specific cases
+        PMob->addModifier(Mod::ACC, GetBaseSkill(PMob, PMob->accRank));                        // Base Accuracy for all mobs is Rank A+ but pull from DB for specific cases
+        PMob->addModifier(Mod::RATT, GetBaseSkill(PMob, PMob->attRank));                       // Base Ranged Attack for all mobs is Rank A+ but pull from DB for specific cases
+        PMob->addModifier(Mod::RACC, GetBaseSkill(PMob, PMob->accRank));                       // Base Ranged Accuracy for all mobs is Rank A+ but pull from DB for specific cases
 
         // Known Base Parry for all mobs is Rank C
         // MOBMOD_CAN_PARRY uses the mod value as the rank, unknown if mobs in current retail or somewhere else have a different parry rank
@@ -1029,6 +1029,34 @@ namespace mobutils
             PMob->setMobMod(MOBMOD_SKILL_LIST, skillListId);
         }
     }
+
+    uint8 JobSkillRankToBaseEvaRank(JOBTYPE job)
+    {
+        uint8 evasionSkillRank = battleutils::GetSkillRank(SKILL_EVASION, job);
+
+        switch (evasionSkillRank)
+        {
+            case 1:
+            case 2:
+                return 1; // A, A+; A- doesnt exist anymore
+            case 3:
+            case 4:
+            case 5:
+                return 2; // B+, B, B-
+            case 6:
+            case 7:
+            case 8:
+                return 3; // C+, C, C-
+            case 9:
+                return 4; // D
+            case 10:
+                return 5; // E
+            default:
+                ShowError("JobSkillRankToBaseEvaRank: rank not implemented. Job SKILL_EVASION rank is likely not valid or no longer exists (A- rank in particular.)");
+        }
+
+        return 3; // Give them C rank as a fallback.
+    };
 
     void SetupDynamisMob(CMobEntity* PMob)
     {

--- a/src/map/utils/mobutils.h
+++ b/src/map/utils/mobutils.h
@@ -64,6 +64,8 @@ namespace mobutils
     void SetupNMMob(CMobEntity* PMob);
     void SetupPetSkills(CMobEntity* PMob);
 
+    uint8 JobSkillRankToBaseEvaRank(JOBTYPE job);
+
     uint16 GetWeaponDamage(CMobEntity* PMob, uint16 slot);
     uint16 GetMagicEvasion(CMobEntity* PMob);
     uint16 GetBaseDefEva(CMobEntity* PMob, uint8 rank);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Mob skills should be based off their main job ranks for evasion specifically, not the DB rank (which was generally true since most mobs are C rank anyway..)

This includes a flattening of +/- skills to just base rank, as +/- skills arent known yet for mobs 60+.

## Steps to test these changes
Load server, see THF beastmen get more evasion than non-THF beastmen, mage beastmen have less than warriors, etc

THF: (48 evasion is trait)
![image](https://github.com/user-attachments/assets/50983467-296e-4b5b-8ac3-ba73cf4b31f3)
DRG
![image](https://github.com/user-attachments/assets/7ffa89c1-2ec8-436e-a1cf-b415b9a434f1)

