### PR TITLE
Fix various lua styling errors

### DIFF
--- a/scripts/items/kingdom_earring.lua
+++ b/scripts/items/kingdom_earring.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- ID: 16039
--- Kingdom Earring  
+-- Kingdom Earring
 -- Enchantment: "Teleport" (Southern San d'Oria)
 -----------------------------------
 ---@type TItem

--- a/scripts/zones/Ceizak_Battlegrounds/mobs/Unfettered_Twitherym.lua
+++ b/scripts/zones/Ceizak_Battlegrounds/mobs/Unfettered_Twitherym.lua
@@ -77,7 +77,6 @@ entity.onMobFight = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
-    originalDamage = mob:getMod(xi.mod.UDMGPHYS)
     local lastPhase = nil
 
     mob:addListener('WEAPONSKILL_USE', 'ANY_MOBSKILL_CHECK', function(mobArg, _, weaponSkill)

--- a/scripts/zones/Yuhtunga_Jungle/Zone.lua
+++ b/scripts/zones/Yuhtunga_Jungle/Zone.lua
@@ -73,9 +73,9 @@ zoneObject.onZoneWeatherChange = function(weather)
     if bayawak then
         if weather == xi.weather.HOT_SPELL or weather == xi.weather.HEAT_WAVE then
             DisallowRespawn(bayawak:getID(), false)
-    
+
             -- Spawn if respawn is up
-            if os.time() > bayawak:getLocalVar("respawn") then
+            if os.time() > bayawak:getLocalVar('respawn') then
                 SpawnMob(bayawak:getID())
             end
         else

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Bayawak.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Bayawak.lua
@@ -31,7 +31,7 @@ end
 entity.onMobDespawn = function(mob)
     local respawn = math.random(5400, 7200)
     mob:setRespawnTime(respawn)
-    mob:setLocalVar("respawn", os.time() + respawn)
+    mob:setLocalVar('respawn', os.time() + respawn)
     DisallowRespawn(mob:getID(), true) -- prevents accidental 'pop' during no fire weather and immediate despawn
     UpdateNMSpawnPoint(mob:getID())
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Corrects the following Lua styling errors after running locally:
* Removes trailing whitespace from Kingdom Earring
* Removes unused global variable in Unfettered Twitherym
* Removes whitespace-only line in Yuhtunga Jungle Zone.lua
* Replaces double-quotes with single-quotes

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No impact to existing gameplay
<!-- Clear and detailed steps to test your changes here -->
