### PR TITLE
[Fix] Correct "questStatus" typos in quest files

### DIFF
--- a/scripts/quests/otherAreas/A_Bitter_Past.lua
+++ b/scripts/quests/otherAreas/A_Bitter_Past.lua
@@ -137,7 +137,7 @@ quest.sections =
 
     {
         check = function(player, status, vars)
-            return status == xi.questStaus.QUEST_COMPLETED
+            return status == xi.questStatus.QUEST_COMPLETED
         end,
 
         [xi.zone.TAVNAZIAN_SAFEHOLD] =

--- a/scripts/quests/windurst/The_Fanged_One.lua
+++ b/scripts/quests/windurst/The_Fanged_One.lua
@@ -131,7 +131,7 @@ quest.sections =
 
     {
         check = function(player, status, vars)
-            return status == xi.questStaus.QUEST_COMPLETED
+            return status == xi.questStatus.QUEST_COMPLETED
         end,
 
         [xi.zone.WINDURST_WOODS] =


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Changes `questStaus` to `questStatus`
Close #6667 

## Steps to test these changes

None.
