### PR TITLE
[Lua] Refactor zaldon trade in Inside the Belly

### DIFF
--- a/scripts/quests/otherAreas/Inside_the_Belly.lua
+++ b/scripts/quests/otherAreas/Inside_the_Belly.lua
@@ -101,7 +101,7 @@ local fishRewards =
         gil = 150,
         items =
         {
-            { chance = 50, itemId = xi.item.PINCH_OF_POISON_DUST, min = 1, max = 6 }, -- guessing 10%. Wiki unknown
+            { chance = 10, itemId = xi.item.PINCH_OF_POISON_DUST, min = 1, max = 6 }, -- guessing 10%. Wiki unknown
         }
     },
 
@@ -539,6 +539,8 @@ local function giveReward(player)
         if rewardItem.min ~= nil and rewardItem.max ~= nil then
             itemQt = math.random(rewardItem.min, rewardItem.max)
         end
+
+        npcUtil.giveItem(player, { { itemId, itemQt } })
     end
 
     npcUtil.giveCurrency(player, 'gil', reward.gil)
@@ -551,9 +553,14 @@ local function giveReward(player)
 end
 
 local function zaldonOnTrade(player, npc, trade)
-    for fish, _ in pairs(fishRewards) do
-        if npcUtil.tradeHas(trade, fish) then
-            return tradeFish(player, fish)
+    for itemSlot = 0, trade:getSlotCount() - 1 do
+        local itemId = trade:getItemId(itemSlot)
+
+        if
+            fishRewards[itemId] ~= nil and
+            npcUtil.tradeHasExactly(trade, itemId)
+        then
+            return tradeFish(player, itemId)
         end
     end
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Iterates through trade slots instead of fish reward table,  Instead of running npcUtil.tradeHasExactly 50 or so times, it just runs it once if there is a valid fish found in the trade.

Also fixes the issue of actually giving reward missing from last PR. #6609 

## Steps to test these changes

Trade Zaldon a variety of different trade combinations - he should only give you a reward if the trade has exactly one valid fish in it.
