### PR TITLE
[Combat] Expand status-effect table utility and apply usage to Weaponskills

### DIFF
--- a/scripts/actions/weaponskills/armor_break.lua
+++ b/scripts/actions/weaponskills/armor_break.lua
@@ -18,21 +18,25 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 1
-    params.ftpMod = { 1, 1, 1 }
-    params.str_wsc = 0.2 params.vit_wsc = 0.2
+    params.ftpMod  = { 1, 1, 1 }
+    params.str_wsc = 0.2
+    params.vit_wsc = 0.2
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.str_wsc = 0.6 params.vit_wsc = 0.6
+        params.str_wsc = 0.6
+        params.vit_wsc = 0.6
     end
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and not target:hasStatusEffect(xi.effect.DEFENSE_DOWN) then
-        local duration = (120 + (tp / 1000 * 60)) * applyResistanceAddEffect(player, target, xi.element.WIND, 0)
-        target:addStatusEffect(xi.effect.DEFENSE_DOWN, 25, 0, duration)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.DEFENSE_DOWN
+    local actionElement = xi.element.WIND
+    local power         = 25
+    local duration      = math.floor((120 + 6 * tp / 100) * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/blade_kamu.lua
+++ b/scripts/actions/weaponskills/blade_kamu.lua
@@ -16,28 +16,31 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
-    params.numHits = 1
-    params.ftpMod = { 1.0, 1.0, 1.0 }
-    params.str_wsc = 0.5 params.int_wsc = 0.5
+    local params     = {}
+    params.numHits   = 1
+    params.ftpMod    = { 1, 1, 1 }
+    params.str_wsc   = 0.5
+    params.int_wsc   = 0.5
     params.atkVaries = { 1.3, 1.3, 1.3 }
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.str_wsc = 0.6 params.int_wsc = 0.6
+        params.str_wsc        = 0.6
+        params.int_wsc        = 0.6
         params.ignoredDefense = { 0.25, 0.25, 0.25 }
-        params.atkVaries = { 2.25, 2.25, 2.25 } -- http://wiki.ffo.jp/html/15893.html
+        params.atkVaries      = { 2.25, 2.25, 2.25 } -- http://wiki.ffo.jp/html/15893.html
     end
 
     -- Apply Aftermath
     xi.aftermath.addStatusEffect(player, tp, xi.slot.MAIN, xi.aftermath.type.MYTHIC)
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
-    if damage > 0 then
-        if not target:hasStatusEffect(xi.effect.ACCURACY_DOWN) then
-            local duration = tp / 1000 * 60 * applyResistanceAddEffect(player, target, xi.element.EARTH, 0)
-            target:addStatusEffect(xi.effect.ACCURACY_DOWN, 10, 0, duration)
-        end
-    end
+
+    -- Handle status effect
+    local effectId      = xi.effect.ACCURACY_DOWN
+    local actionElement = xi.element.EARTH
+    local power         = 10
+    local duration      = math.floor(6 * tp / 100 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/blade_metsu.lua
+++ b/scripts/actions/weaponskills/blade_metsu.lua
@@ -18,13 +18,13 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 1
-    params.ftpMod = { 3.0, 3.0, 3.0 }
+    params.ftpMod  = { 3, 3, 3 }
     params.dex_wsc = 0.6
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.ftpMod = { 5.0, 5.0, 5.0 }
+        params.ftpMod  = { 5, 5, 5 }
         params.dex_wsc = 0.8
     end
 
@@ -32,12 +32,13 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     xi.aftermath.addStatusEffect(player, tp, xi.slot.MAIN, xi.aftermath.type.RELIC)
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
-    if damage > 0 then
-        if not target:hasStatusEffect(xi.effect.PARALYSIS) then
-            local duration = 60 * applyResistanceAddEffect(player, target, xi.element.ICE, 0)
-            target:addStatusEffect(xi.effect.PARALYSIS, 10, 0, duration)
-        end
-    end
+
+    -- Handle status effect
+    local effectId      = xi.effect.PARALYSIS
+    local actionElement = xi.element.ICE
+    local power         = 10
+    local duration      = math.floor(60 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/blade_retsu.lua
+++ b/scripts/actions/weaponskills/blade_retsu.lua
@@ -16,28 +16,24 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 2
-    params.ftpMod = { 1.0, 1.0, 1.0 }
-    params.str_wsc = 0.2 params.dex_wsc = 0.2
+    params.ftpMod  = { 1, 1, 1 }
+    params.str_wsc = 0.2
+    params.dex_wsc = 0.2
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.dex_wsc = 0.6
     end
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
-    if damage > 0 and not target:hasStatusEffect(xi.effect.PARALYSIS) then
-        local duration = (tp / 1000 * 30) * applyResistanceAddEffect(player, target, xi.element.ICE, 0)
-        -- paralyze proc based on lvl difference
-        local power = 30 + (player:getMainLvl() - target:getMainLvl()) * 3
-        if power > 35 then
-            power = 35
-        elseif power < 5 then
-            power = 5
-        end
 
-        target:addStatusEffect(xi.effect.PARALYSIS, power, 0, duration)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.PARALYSIS
+    local actionElement = xi.element.ICE
+    local power         = utils.clamp(30 + 3 * (player:getMainLvl() - target:getMainLvl()), 5, 35)
+    local duration      = math.floor(3 * tp / 100 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/blade_yu.lua
+++ b/scripts/actions/weaponskills/blade_yu.lua
@@ -14,25 +14,28 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
-    params.ftpMod = { 2.25, 2.25, 2.25 }
-    params.dex_wsc = 0.28 params.int_wsc = 0.28
-    -- http://wiki.ffo.jp/html/20351.html
-    params.ele = xi.element.WATER
-    params.skill = xi.skill.KATANA
+    local params      = {}
+    params.ftpMod     = { 2.25, 2.25, 2.25 }
+    params.dex_wsc    = 0.28
+    params.int_wsc    = 0.28
+    params.ele        = xi.element.WATER
+    params.skill      = xi.skill.KATANA
     params.includemab = true
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.ftpMod = { 3.0, 3.0, 3.0 }
-        params.dex_wsc = 0.4 params.int_wsc = 0.4
+        params.ftpMod  = { 3, 3, 3 }
+        params.dex_wsc = 0.4
+        params.int_wsc = 0.4
     end
 
     local damage, tpHits, extraHits = xi.weaponskills.doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
 
-    if damage > 0 and not target:hasStatusEffect(xi.effect.POISON) then
-        local duration = (75 + (tp / 1000 * 15)) * applyResistanceAddEffect(player, target, xi.element.WATER, 0)
-        target:addStatusEffect(xi.effect.POISON, 10, 0, duration)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.POISON
+    local actionElement = xi.element.WATER
+    local power         = 10
+    local duration      = math.floor((75 + 15 * tp / 1000) * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, false, damage
 end

--- a/scripts/actions/weaponskills/bora_axe.lua
+++ b/scripts/actions/weaponskills/bora_axe.lua
@@ -16,24 +16,27 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
-    params.numHits = 1
-    params.ftpMod = { 1.0, 1.0, 1.0 }
-    params.dex_wsc = 0.6
+    local params     = {}
+    params.numHits   = 1
+    params.ftpMod    = { 1, 1, 1 }
+    params.dex_wsc   = 0.6
     params.atkVaries = { 3.5, 3.5, 3.5 }
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.ftpMod = { 4.5, 4.5, 4.5 }
-        params.dex_wsc = 1.0
-        params.atkVaries = { 1.0, 1.0, 1.0 }
+        params.ftpMod    = { 4.5, 4.5, 4.5 }
+        params.dex_wsc   = 1
+        params.atkVaries = { 1, 1, 1 }
     end
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    local chance = (tp-1000) * applyResistanceAddEffect(player, target, xi.element.ICE, 0) > math.random() * 150
-    if damage > 0 and not target:hasStatusEffect(xi.effect.BIND) and chance then
-        local duration = 20 * applyResistanceAddEffect(player, target, xi.element.ICE, 0)
-        target:addStatusEffect(xi.effect.BIND, 1, 0, duration)
+    -- Handle status effect
+    if math.random(1, 100) <= tp / 30 * applyResistanceAddEffect(player, target, xi.element.ICE, 0) then
+        local effectId      = xi.effect.BIND
+        local actionElement = xi.element.ICE
+        local power         = 1
+        local duration      = math.floor(20 * applyResistanceAddEffect(player, target, actionElement, 0))
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
     end
 
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/actions/weaponskills/brainshaker.lua
+++ b/scripts/actions/weaponskills/brainshaker.lua
@@ -15,21 +15,23 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 1
-    params.ftpMod = { 1.0, 1.0, 1.0 }
+    params.ftpMod  = { 1, 1, 1 }
     params.str_wsc = 0.3
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.str_wsc = 1.0
+        params.str_wsc = 1
     end
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and not target:hasStatusEffect(xi.effect.STUN) then
-        local duration = (tp / 500) * applyResistanceAddEffect(player, target, xi.element.THUNDER, 0)
-        target:addStatusEffect(xi.effect.STUN, 1, 0, duration)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.STUN
+    local actionElement = xi.element.THUNDER
+    local power         = 1
+    local duration      = math.floor(tp / 500 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/death_blossom.lua
+++ b/scripts/actions/weaponskills/death_blossom.lua
@@ -16,27 +16,26 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 3
-    params.ftpMod = { 1.125, 1.125, 1.125 }
-    -- wscs are in % so 0.2=20%
+    params.ftpMod  = { 1.125, 1.125, 1.125 }
     params.str_wsc = 0.3
     params.mnd_wsc = 0.5
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.ftpMod = { 4.0, 4.0, 4.0 }
+        params.ftpMod = { 4, 4, 4 }
     end
 
     -- Apply aftermath
     xi.aftermath.addStatusEffect(player, tp, xi.slot.MAIN, xi.aftermath.type.MYTHIC)
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
-    if damage > 0 then
-        local duration = tp / 1000 * 20 - 5
-        if not target:hasStatusEffect(xi.effect.MAGIC_EVASION_DOWN) then
-            target:addStatusEffect(xi.effect.MAGIC_EVASION_DOWN, 10, 0, duration)
-        end
-    end
+
+    -- Handle status effect
+    local effectId = xi.effect.MAGIC_EVASION_DOWN
+    local power    = 10
+    local duration = math.floor(tp / 50 - 5)
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, 0, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/exenterator.lua
+++ b/scripts/actions/weaponskills/exenterator.lua
@@ -17,23 +17,25 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 4
-    params.ftpMod = { 1.0, 1.0, 1.0 }
+    params.ftpMod  = { 1, 1, 1 }
     params.agi_wsc = player:getMerit(xi.merit.EXENTERATOR) * 0.17
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.multiHitfTP = true
-        params.agi_wsc = 0.7 + (player:getMerit(xi.merit.EXENTERATOR) * 0.03)
-        params.ftpMod = { 1.1875, 1.1875, 1.1875 }
+        params.agi_wsc     = 0.7 + player:getMerit(xi.merit.EXENTERATOR) * 0.03
+        params.ftpMod      = { 1.1875, 1.1875, 1.1875 }
     end
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and not target:hasStatusEffect(xi.effect.ACCURACY_DOWN) then
-        local duration = (45 + (tp / 1000 * 45)) * applyResistanceAddEffect(player, target, xi.element.EARTH, 0)
-        target:addStatusEffect(xi.effect.ACCURACY_DOWN, 20, 0, duration)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.ACCURACY_DOWN
+    local actionElement = xi.element.EARTH
+    local power         = 20
+    local duration      = math.floor((45 + 45 * tp / 1000) * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/flat_blade.lua
+++ b/scripts/actions/weaponskills/flat_blade.lua
@@ -15,21 +15,24 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 1
-    params.ftpMod = { 1.0, 1.0, 1.0 }
+    params.ftpMod  = { 1, 1, 1 }
     params.str_wsc = 0.3
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.str_wsc = 1.0
+        params.str_wsc = 1
     end
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    local chance = (tp-1000) * applyResistanceAddEffect(player, target, xi.element.THUNDER, 0) > math.random() * 150
-    if damage > 0 and not target:hasStatusEffect(xi.effect.STUN) and chance then
-        local duration = 4 * applyResistanceAddEffect(player, target, xi.element.THUNDER, 0)
-        target:addStatusEffect(xi.effect.STUN, 1, 0, duration)
+    -- Handle status effect
+    if math.random(1, 100) <= tp / 30 * applyResistanceAddEffect(player, target, xi.element.THUNDER, 0) then
+        local effectId      = xi.effect.STUN
+        local actionElement = xi.element.THUNDER
+        local power         = 1
+        local duration      = math.floor(4 * applyResistanceAddEffect(player, target, actionElement, 0))
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
     end
 
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/actions/weaponskills/full_break.lua
+++ b/scripts/actions/weaponskills/full_break.lua
@@ -19,32 +19,29 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 1
-    params.ftpMod = { 1.0, 1.0, 1.0 }
-    params.str_wsc = 0.5 params.vit_wsc = 0.5
+    params.ftpMod  = { 1, 1, 1 }
+    params.str_wsc = 0.5
+    params.vit_wsc = 0.5
+
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 then
-        local duration = (tp / 1000 * 30) + 60
+    -- Handle status effects.
+    local effects =
+    {
+        [1] = { xi.effect.ATTACK_DOWN,   xi.element.WATER, 12.5 },
+        [2] = { xi.effect.DEFENSE_DOWN,  xi.element.WIND,  12.5 },
+        [3] = { xi.effect.ACCURACY_DOWN, xi.element.EARTH, 20   },
+        [4] = { xi.effect.EVASION_DOWN,  xi.element.ICE,   20   },
+    }
 
-        -- TODO: Table effects, value, and element and loop
-
-        if not target:hasStatusEffect(xi.effect.DEFENSE_DOWN) then
-            target:addStatusEffect(xi.effect.DEFENSE_DOWN, 12.5, 0, duration * applyResistanceAddEffect(player, target, xi.element.WIND, 0))
-        end
-
-        if not target:hasStatusEffect(xi.effect.ATTACK_DOWN) then
-            target:addStatusEffect(xi.effect.ATTACK_DOWN, 12.5, 0, duration * applyResistanceAddEffect(player, target, xi.element.WATER, 0))
-        end
-
-        if not target:hasStatusEffect(xi.effect.EVASION_DOWN) then
-            target:addStatusEffect(xi.effect.EVASION_DOWN, 20, 0, duration * applyResistanceAddEffect(player, target, xi.element.ICE, 0))
-        end
-
-        if not target:hasStatusEffect(xi.effect.ACCURACY_DOWN) then
-            target:addStatusEffect(xi.effect.ACCURACY_DOWN, 20, 0, duration * applyResistanceAddEffect(player, target, xi.element.EARTH, 0))
-        end
+    for index = 1, #effects do
+        local effectId      = effects[index][1]
+        local actionElement = effects[index][2]
+        local power         = effects[index][3]
+        local duration      = math.floor(60 + 3 * tp / 100 * applyResistanceAddEffect(player, target, actionElement, 0))
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
     end
 
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/actions/weaponskills/garland_of_bliss.lua
+++ b/scripts/actions/weaponskills/garland_of_bliss.lua
@@ -16,28 +16,30 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
-    params.ftpMod = { 2.0, 2.0, 2.0 }
-    params.mnd_wsc = 0.4
-    params.ele = xi.element.LIGHT
-    params.skill = xi.skill.STAFF
+    local params      = {}
+    params.ftpMod     = { 2, 2, 2 }
+    params.mnd_wsc    = 0.4
+    params.ele        = xi.element.LIGHT
+    params.skill      = xi.skill.STAFF
     params.includemab = true
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.ftpMod = { 2.25, 2.25, 2.25 }
-        params.str_wsc = 0.3 params.mnd_wsc = 0.7
+        params.ftpMod  = { 2.25, 2.25, 2.25 }
+        params.str_wsc = 0.3
+        params.mnd_wsc = 0.7
     end
 
     -- Apply Aftermath
     xi.aftermath.addStatusEffect(player, tp, xi.slot.MAIN, xi.aftermath.type.MYTHIC)
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
-    if damage > 0 then
-        if not target:hasStatusEffect(xi.effect.DEFENSE_DOWN) then
-            local duration = (30 + tp / 1000 * 30) * applyResistanceAddEffect(player, target, xi.element.WIND, 0)
-            target:addStatusEffect(xi.effect.DEFENSE_DOWN, 12.5, 0, duration)
-        end
-    end
+
+    -- Handle status effect
+    local effectId      = xi.effect.DEFENSE_DOWN
+    local actionElement = xi.element.WIND
+    local power         = 12.5
+    local duration      = math.floor((30 + 3 * tp / 100) * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/gate_of_tartarus.lua
+++ b/scripts/actions/weaponskills/gate_of_tartarus.lua
@@ -17,9 +17,9 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 1
-    params.ftpMod = { 3.0, 3.0, 3.0 }
+    params.ftpMod  = { 3, 3, 3 }
     params.chr_wsc = 0.6
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
@@ -31,12 +31,12 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 then
-        if not target:hasStatusEffect(xi.effect.ATTACK_DOWN) then
-            local duration = 120 * applyResistanceAddEffect(player, target, xi.element.WATER, 0)
-            target:addStatusEffect(xi.effect.ATTACK_DOWN, 20, 0, duration)
-        end
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.ATTACK_DOWN
+    local actionElement = xi.element.WATER
+    local power         = 20
+    local duration      = math.floor(120 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/glory_slash.lua
+++ b/scripts/actions/weaponskills/glory_slash.lua
@@ -16,17 +16,19 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 1
-    params.ftpMod = { 3.0, 3.5, 4.0 }
+    params.ftpMod  = { 3, 3.5, 4 }
     params.str_wsc = 0.3
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and not target:hasStatusEffect(xi.effect.STUN) then
-        local duration = (tp / 500) * applyResistanceAddEffect(player, target, xi.element.THUNDER, 0)
-        target:addStatusEffect(xi.effect.STUN, 1, 0, duration)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.STUN
+    local actionElement = xi.element.THUNDER
+    local power         = 1
+    local duration      = math.floor(tp / 500 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/guillotine.lua
+++ b/scripts/actions/weaponskills/guillotine.lua
@@ -11,22 +11,25 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 4
-    params.ftpMod = { 0.875, 0.875, 0.875 }
-    -- wscs are in % so 0.2=20%
-    params.str_wsc = 0.25 params.mnd_wsc = 0.25
+    params.ftpMod  = { 0.875, 0.875, 0.875 }
+    params.str_wsc = 0.25
+    params.mnd_wsc = 0.25
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.str_wsc = 0.3 params.mnd_wsc = 0.5
+        params.str_wsc = 0.3
+        params.mnd_wsc = 0.5
     end
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and not target:hasStatusEffect(xi.effect.SILENCE) then
-        local duration = (30 + (tp / 1000 * 30)) * applyResistanceAddEffect(player, target, xi.element.WIND, 0)
-        target:addStatusEffect(xi.effect.SILENCE, 1, 0, duration)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.SILENCE
+    local actionElement = xi.element.WIND
+    local power         = 1
+    local duration      = math.floor((30 + 3 * tp / 100) * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/herculean_slash.lua
+++ b/scripts/actions/weaponskills/herculean_slash.lua
@@ -15,11 +15,11 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
-    params.ftpMod = { 3.5, 3.5, 3.5 }
-    params.vit_wsc = 0.6
-    params.ele = xi.element.ICE
-    params.skill = xi.skill.GREAT_SWORD
+    local params      = {}
+    params.ftpMod     = { 3.5, 3.5, 3.5 }
+    params.vit_wsc    = 0.6
+    params.ele        = xi.element.ICE
+    params.skill      = xi.skill.GREAT_SWORD
     params.includemab = true
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
@@ -28,10 +28,12 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
 
-    if damage > 0 and not target:hasStatusEffect(xi.effect.PARALYSIS) then
-        local duration = (tp / 1000 * 60) * applyResistanceAddEffect(player, target, xi.element.ICE, 0)
-        target:addStatusEffect(xi.effect.PARALYSIS, 30, 0, duration)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.PARALYSIS
+    local actionElement = xi.element.ICE
+    local power         = 30
+    local duration      = math.floor(6 * tp / 100 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/infernal_scythe.lua
+++ b/scripts/actions/weaponskills/infernal_scythe.lua
@@ -15,11 +15,12 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
-    params.ftpMod = { 3.5, 3.5, 3.5 }
-    params.str_wsc = 0.3 params.int_wsc = 0.3
-    params.ele = xi.element.DARK
-    params.skill = xi.skill.SCYTHE
+    local params      = {}
+    params.ftpMod     = { 3.5, 3.5, 3.5 }
+    params.str_wsc    = 0.3
+    params.int_wsc    = 0.3
+    params.ele        = xi.element.DARK
+    params.skill      = xi.skill.SCYTHE
     params.includemab = true
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
@@ -28,10 +29,12 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
 
-    if damage > 0 and not target:hasStatusEffect(xi.effect.ATTACK_DOWN) then
-        local duration = (tp / 1000 * 180) * applyResistanceAddEffect(player, target, xi.element.WATER, 0)
-        target:addStatusEffect(xi.effect.ATTACK_DOWN, 25, 0, duration)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.ATTACK_DOWN
+    local actionElement = xi.element.WATER
+    local power         = 25
+    local duration      = math.floor(18 * tp / 100 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/leg_sweep.lua
+++ b/scripts/actions/weaponskills/leg_sweep.lua
@@ -15,23 +15,24 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 1
-    params.ftpMod = { 1.0, 1.0, 1.0 }
+    params.ftpMod  = { 1, 1, 1 }
     params.str_wsc = 0.3
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.str_wsc = 1.0
+        params.str_wsc = 1
     end
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    local chance = (tp-1000) * applyResistanceAddEffect(player, target, xi.element.THUNDER, 0) > math.random() * 150
-    if damage > 0 and chance then
-        if not target:hasStatusEffect(xi.effect.STUN) then
-            local duration = 4 * applyResistanceAddEffect(player, target, xi.element.THUNDER, 0)
-            target:addStatusEffect(xi.effect.STUN, 1, 0, duration)
-        end
+    -- Handle status effect
+    if math.random(1, 100) <= tp / 30 * applyResistanceAddEffect(player, target, xi.element.THUNDER, 0) then
+        local effectId      = xi.effect.STUN
+        local actionElement = xi.element.THUNDER
+        local power         = 1
+        local duration      = math.floor(4 * applyResistanceAddEffect(player, target, actionElement, 0))
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
     end
 
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/actions/weaponskills/metatron_torment.lua
+++ b/scripts/actions/weaponskills/metatron_torment.lua
@@ -21,9 +21,9 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 1
-    params.ftpMod = { 2.75, 2.75, 2.75 }
+    params.ftpMod  = { 2.75, 2.75, 2.75 }
     params.str_wsc = 0.6
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
@@ -34,10 +34,13 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     xi.aftermath.addStatusEffect(player, tp, xi.slot.MAIN, xi.aftermath.type.RELIC)
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
-    if damage > 0 then
-        local duration = 120 * applyResistanceAddEffect(player, target, xi.element.WIND, 0)
-        target:addStatusEffect(xi.effect.DEFENSE_DOWN, 19, 0, duration)
-    end
+
+    -- Handle status effect
+    local effectId      = xi.effect.DEFENSE_DOWN
+    local actionElement = xi.element.WIND
+    local power         = 19
+    local duration      = math.floor(120 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/mordant_rime.lua
+++ b/scripts/actions/weaponskills/mordant_rime.lua
@@ -16,14 +16,14 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 2
-    params.ftpMod = { 3.0, 3.0, 3.0 }
+    params.ftpMod  = { 3, 3, 3 }
     params.dex_wsc = 0.3
     params.chr_wsc = 0.5
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.ftpMod = { 5.0, 5.0, 5.0 }
+        params.ftpMod  = { 5, 5, 5 }
         params.chr_wsc = 0.7
     end
 
@@ -32,12 +32,13 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and not target:hasStatusEffect(xi.effect.WEIGHT) then
-        if not target:hasStatusEffect(xi.effect.WEIGHT) then
-            if tp - 1000 > math.random() * 150 then
-                target:addStatusEffect(xi.effect.WEIGHT, 50, 0, 60)
-            end
-        end
+    -- Handle status effect
+    if math.random(1, 100) <= tp / 30 * applyResistanceAddEffect(player, target, xi.element.THUNDER, 0) then
+        local effectId      = xi.effect.WEIGHT
+        local actionElement = xi.element.WIND
+        local power         = 25
+        local duration      = math.floor(60 * applyResistanceAddEffect(player, target, actionElement, 0))
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
     end
 
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/actions/weaponskills/nightmare_scythe.lua
+++ b/scripts/actions/weaponskills/nightmare_scythe.lua
@@ -15,21 +15,25 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 1
-    params.ftpMod = { 1.0, 1.0, 1.0 }
-    params.str_wsc = 0.3 params.mnd_wsc = 0.3
+    params.ftpMod  = { 1, 1, 1 }
+    params.str_wsc = 0.3
+    params.mnd_wsc = 0.3
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.str_wsc = 0.6 params.mnd_wsc = 0.6
+        params.str_wsc = 0.6
+        params.mnd_wsc = 0.6
     end
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and not target:hasStatusEffect(xi.effect.BLINDNESS) then
-        local duration = (tp / 1000 * 60) * applyResistanceAddEffect(player, target, xi.element.DARK, 0)
-        target:addStatusEffect(xi.effect.BLINDNESS, 15, 0, duration)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.BLINDNESS
+    local actionElement = xi.element.DARK
+    local power         = 15
+    local duration      = math.floor(6 * tp / 100 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/numbing_shot.lua
+++ b/scripts/actions/weaponskills/numbing_shot.lua
@@ -14,9 +14,9 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 1
-    params.ftpMod = { 3.0, 3.0, 3.0 }
+    params.ftpMod  = { 3, 3, 3 }
     params.agi_wsc = 0.6
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
@@ -25,10 +25,12 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doRangedWeaponskill(player, target, wsID, params, tp, action, primary)
 
-    if damage > 0 and not target:hasStatusEffect(xi.effect.PARALYSIS) then
-        local duration = (tp / 1000 * 60) * applyResistanceAddEffect(player, target, xi.element.ICE, 0)
-        target:addStatusEffect(xi.effect.PARALYSIS, 30, 0, duration)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.PARALYSIS
+    local actionElement = xi.element.ICE
+    local power         = 30
+    local duration      = math.floor(6 * tp / 100 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/omniscience.lua
+++ b/scripts/actions/weaponskills/omniscience.lua
@@ -16,11 +16,11 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
-    params.ftpMod = { 2.0, 2.0, 2.0 }
-    params.mnd_wsc = 0.3
-    params.ele = xi.element.DARK
-    params.skill = xi.skill.STAFF
+    local params      = {}
+    params.ftpMod     = { 2, 2, 2 }
+    params.mnd_wsc    = 0.3
+    params.ele        = xi.element.DARK
+    params.skill      = xi.skill.STAFF
     params.includemab = true
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
@@ -32,12 +32,11 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     -- Apply Aftermath
     xi.aftermath.addStatusEffect(player, tp, xi.slot.MAIN, xi.aftermath.type.MYTHIC)
 
-    if damage > 0 then
-        if not target:hasStatusEffect(xi.effect.MAGIC_ATK_DOWN) then
-            local duration = tp / 1000 * 60
-            target:addStatusEffect(xi.effect.MAGIC_ATK_DOWN, 10, 0, duration)
-        end
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.MAGIC_ATK_DOWN
+    local power         = 10
+    local duration      = math.floor(6 * tp / 100)
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, 0, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/onslaught.lua
+++ b/scripts/actions/weaponskills/onslaught.lua
@@ -18,9 +18,9 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 1
-    params.ftpMod = { 2.75, 2.75, 2.75 }
+    params.ftpMod  = { 2.75, 2.75, 2.75 }
     params.dex_wsc = 0.6
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
@@ -31,12 +31,13 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     xi.aftermath.addStatusEffect(player, tp, xi.slot.MAIN, xi.aftermath.type.RELIC)
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
-    if damage > 0 then
-        if not target:hasStatusEffect(xi.effect.ACCURACY_DOWN) then
-            local duration = 120 * applyResistanceAddEffect(player, target, xi.element.EARTH, 0)
-            target:addStatusEffect(xi.effect.ACCURACY_DOWN, 30, 0, duration)
-        end
-    end
+
+    -- Handle status effect
+    local effectId      = xi.effect.ACCURACY_DOWN
+    local actionElement = xi.element.EARTH
+    local power         = 30
+    local duration      = math.floor(120 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/pyrrhic_kleos.lua
+++ b/scripts/actions/weaponskills/pyrrhic_kleos.lua
@@ -17,15 +17,17 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 4
-    params.ftpMod = { 1.5, 1.5, 1.5 }
-    params.str_wsc = 0.2 params.dex_wsc = 0.3
+    params.ftpMod  = { 1.5, 1.5, 1.5 }
+    params.str_wsc = 0.2
+    params.dex_wsc = 0.3
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.multiHitfTP = true -- http://wiki.ffo.jp/html/15896.html
-        params.ftpMod = { 1.75, 1.75, 1.75 }
-        params.str_wsc = 0.4 params.dex_wsc = 0.4
+        params.ftpMod      = { 1.75, 1.75, 1.75 }
+        params.str_wsc     = 0.4
+        params.dex_wsc     = 0.4
     end
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
@@ -33,12 +35,12 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     -- Apply Aftermath
     xi.aftermath.addStatusEffect(player, tp, xi.slot.MAIN, xi.aftermath.type.MYTHIC)
 
-    if damage > 0 then
-        if not target:hasStatusEffect(xi.effect.EVASION_DOWN) then
-            local duration = tp / 1000 * 60 * applyResistanceAddEffect(player, target, xi.element.ICE, 0)
-            target:addStatusEffect(xi.effect.EVASION_DOWN, 10, 0, duration)
-        end
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.EVASION_DOWN
+    local actionElement = xi.element.ICE
+    local power         = 10
+    local duration      = math.floor(6 * tp / 100 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/randgrith.lua
+++ b/scripts/actions/weaponskills/randgrith.lua
@@ -19,22 +19,23 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 1
-    params.ftpMod = { 2.75, 2.75, 2.75 }
-    params.str_wsc = 0.4 params.mnd_wsc = 0.4
+    params.ftpMod  = { 2.75, 2.75, 2.75 }
+    params.str_wsc = 0.4
+    params.mnd_wsc = 0.4
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     -- Apply aftermath
     xi.aftermath.addStatusEffect(player, tp, xi.slot.MAIN, xi.aftermath.type.RELIC)
 
-    if damage > 0 then
-        if not target:hasStatusEffect(xi.effect.EVASION_DOWN) then
-            local duration = 120 * applyResistanceAddEffect(player, target, xi.element.ICE, 0)
-            target:addStatusEffect(xi.effect.EVASION_DOWN, 32, 0, duration)
-        end
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.EVASION_DOWN
+    local actionElement = xi.element.ICE
+    local power         = 32
+    local duration      = math.floor(120 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/rudras_storm.lua
+++ b/scripts/actions/weaponskills/rudras_storm.lua
@@ -14,13 +14,13 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 1
-    params.ftpMod = { 3.25, 4.25, 5.25 }
+    params.ftpMod  = { 3.25, 4.25, 5.25 }
     params.dex_wsc = 0.6
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.ftpMod = { 5.0, 10.19, 13.0 }
+        params.ftpMod = { 5, 10.19, 13 }
         params.dex_wsc = 0.8
     end
 
@@ -29,12 +29,12 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    -- xi.effect.WEIGHT power value is equal to lead breath as per bg-wiki: http://www.bg-wiki.com/bg/Rudra%27s_Storm
-    if damage > 0 then
-        if not target:hasStatusEffect(xi.effect.WEIGHT) then
-            target:addStatusEffect(xi.effect.WEIGHT, 50, 0, 60)
-        end
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.WEIGHT
+    local actionElement = xi.element.WIND
+    local power         = 25
+    local duration      = 60
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/shadowstitch.lua
+++ b/scripts/actions/weaponskills/shadowstitch.lua
@@ -15,23 +15,24 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 1
-    params.ftpMod = { 1.0, 1.0, 1.0 }
+    params.ftpMod  = { 1, 1, 1 }
     params.chr_wsc = 0.3
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.chr_wsc = 1.0
+        params.chr_wsc = 1
     end
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 then
-        local chance = (tp - 1000) * applyResistanceAddEffect(player, target, xi.element.ICE, 0) > math.random() * 150
-        if not target:hasStatusEffect(xi.effect.BIND) and chance then
-            local duration = (5 + (tp / 1000 * 5)) * applyResistanceAddEffect(player, target, xi.element.ICE, 0)
-            target:addStatusEffect(xi.effect.BIND, 1, 0, duration)
-        end
+    -- Handle status effect
+    if math.random(1, 100) <= tp / 30 * applyResistanceAddEffect(player, target, xi.element.ICE, 0) then
+        local effectId      = xi.effect.BIND
+        local actionElement = xi.element.ICE
+        local power         = 1
+        local duration      = math.floor((5 + tp / 200) * applyResistanceAddEffect(player, target, actionElement, 0))
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
     end
 
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/actions/weaponskills/shattersoul.lua
+++ b/scripts/actions/weaponskills/shattersoul.lua
@@ -20,20 +20,23 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 3
-    params.ftpMod = { 1.375, 1.375, 1.375 }
+    params.ftpMod  = { 1.375, 1.375, 1.375 }
     params.int_wsc = player:getMerit(xi.merit.SHATTERSOUL) * 0.17
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.int_wsc = 0.7 + (player:getMerit(xi.merit.SHATTERSOUL) * 0.03)
+        params.int_wsc = 0.7 + player:getMerit(xi.merit.SHATTERSOUL) * 0.03
     end
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and not target:hasStatusEffect(xi.effect.MAGIC_DEF_DOWN) then
-        target:addStatusEffect(xi.effect.MAGIC_DEF_DOWN, 10, 0, 120)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.MAGIC_DEF_DOWN
+    local actionElement = xi.element.THUNDER
+    local power         = 10
+    local duration      = math.floor(120 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/shell_crusher.lua
+++ b/scripts/actions/weaponskills/shell_crusher.lua
@@ -16,21 +16,23 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 1
-    params.ftpMod = { 1.0, 1.0, 1.0 }
+    params.ftpMod  = { 1, 1, 1 }
     params.str_wsc = 0.35
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.str_wsc = 1.0
+        params.str_wsc = 1
     end
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and not target:hasStatusEffect(xi.effect.DEFENSE_DOWN) then
-        local duration = (120 + (tp / 1000 * 60)) * applyResistanceAddEffect(player, target, xi.element.WIND, 0)
-        target:addStatusEffect(xi.effect.DEFENSE_DOWN, 25, 0, duration)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.DEFENSE_DOWN
+    local actionElement = xi.element.WIND
+    local power         = 25
+    local duration      = math.floor((120 + 6 * tp / 100) * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/shield_break.lua
+++ b/scripts/actions/weaponskills/shield_break.lua
@@ -18,21 +18,25 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 1
-    params.ftpMod = { 1.0, 1.0, 1.0 }
-    params.str_wsc = 0.2 params.vit_wsc = 0.2
+    params.ftpMod  = { 1, 1, 1 }
+    params.str_wsc = 0.2
+    params.vit_wsc = 0.2
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.str_wsc = 0.6 params.vit_wsc = 0.6
+        params.str_wsc = 0.6
+        params.vit_wsc = 0.6
     end
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and not target:hasStatusEffect(xi.effect.EVASION_DOWN) then
-        local duration = (120 + (tp / 1000 * 60)) * applyResistanceAddEffect(player, target, xi.element.ICE, 0)
-        target:addStatusEffect(xi.effect.EVASION_DOWN, 40, 0, duration)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.EVASION_DOWN
+    local actionElement = xi.element.ICE
+    local power         = 40
+    local duration      = math.floor((120 + 6 * tp / 100) * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/shijin_spiral.lua
+++ b/scripts/actions/weaponskills/shijin_spiral.lua
@@ -15,26 +15,26 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
-    params.numHits = 5
-    params.ftpMod = { 1.0625, 1.0625, 1.0625 }
-    params.dex_wsc = player:getMerit(xi.merit.SHIJIN_SPIRAL) * 0.17
+    local params     = {}
+    params.numHits   = 5
+    params.ftpMod    = { 1.0625, 1.0625, 1.0625 }
+    params.dex_wsc   = player:getMerit(xi.merit.SHIJIN_SPIRAL) * 0.17
     params.atkVaries = { 1.05, 1.05, 1.05 }
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.multiHitfTP = true -- http://wiki.ffo.jp/html/25607.html
-        params.ftpMod = { 1.5, 1.5, 1.5 }
-        params.dex_wsc = 0.7 + (player:getMerit(xi.merit.SHIJIN_SPIRAL) * 0.03)
+        params.ftpMod      = { 1.5, 1.5, 1.5 }
+        params.dex_wsc     = 0.7 + player:getMerit(xi.merit.SHIJIN_SPIRAL) * 0.03
     end
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 then
-        local duration = 3 * ((tp / 1000) + 5) -- Plague effect is -50TP/tick and lasts for 5-8 ticks.
-        if not target:hasStatusEffect(xi.effect.PLAGUE) then
-            target:addStatusEffect(xi.effect.PLAGUE, 5, 0, duration)
-        end
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.PLAGUE
+    local actionElement = xi.element.FIRE
+    local power         = 5
+    local duration      = math.floor(15 + 3 * tp / 1000)
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/shockwave.lua
+++ b/scripts/actions/weaponskills/shockwave.lua
@@ -15,16 +15,20 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params  = {}
     params.numHits = 1
-    params.ftpMod = { 1.0, 1.0, 1.0 }
-    params.str_wsc = 0.3 params.mnd_wsc = 0.3
+    params.ftpMod  = { 1, 1, 1 }
+    params.str_wsc = 0.3
+    params.mnd_wsc = 0.3
+
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and not target:hasStatusEffect(xi.effect.SLEEP_I) then
-        local duration = (tp / 1000 * 60) * applyResistanceAddEffect(player, target, xi.element.DARK, 0)
-        target:addStatusEffect(xi.effect.SLEEP_I, 1, 0, duration)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.SLEEP_I
+    local actionElement = xi.element.DARK
+    local power         = 1
+    local duration      = math.floor(6 * tp / 100 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/shoulder_tackle.lua
+++ b/scripts/actions/weaponskills/shoulder_tackle.lua
@@ -15,21 +15,23 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 1
-    params.ftpMod = { 1.0, 1.0, 1.0 }
+    params.ftpMod  = { 1, 1, 1 }
     params.vit_wsc = 0.3
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.multiHitfTP = true -- http://wiki.ffo.jp/html/2417.html
-        params.vit_wsc = 1.0
+        params.vit_wsc     = 1
     end
 
-    if damage > 0 and not target:hasStatusEffect(xi.effect.STUN) then
-        local duration = (tp / 500) * applyResistanceAddEffect(player, target, xi.element.THUNDER, 0)
-        target:addStatusEffect(xi.effect.STUN, 1, 0, duration)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.STUN
+    local actionElement = xi.element.THUNDER
+    local power         = 1
+    local duration      = math.floor(tp / 500 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/skullbreaker.lua
+++ b/scripts/actions/weaponskills/skullbreaker.lua
@@ -15,19 +15,22 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 1
-    params.ftpMod = { 1.0, 1.0, 1.0 }
+    params.ftpMod  = { 1, 1, 1 }
     params.str_wsc = 0.3
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.str_wsc = 1.0
+        params.str_wsc = 1
     end
 
-    if damage > 0 and not target:hasStatusEffect(xi.effect.INT_DOWN) then
-        target:addStatusEffect(xi.effect.INT_DOWN, 10, 0, 140)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.INT_DOWN
+    local actionElement = xi.element.FIRE
+    local power         = 10
+    local duration      = math.floor(140 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/smash_axe.lua
+++ b/scripts/actions/weaponskills/smash_axe.lua
@@ -15,21 +15,23 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 1
-    params.ftpMod = { 1.0, 1.0, 1.0 }
+    params.ftpMod  = { 1, 1, 1 }
     params.str_wsc = 0.3
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.str_wsc = 1.0
+        params.str_wsc = 1
     end
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and not target:hasStatusEffect(xi.effect.STUN) then
-        local duration = (tp / 500) * applyResistanceAddEffect(player, target, xi.element.THUNDER, 0)
-        target:addStatusEffect(xi.effect.STUN, 1, 0, duration)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.STUN
+    local actionElement = xi.element.THUNDER
+    local power         = 1
+    local duration      = math.floor(tp / 500 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/sniper_shot.lua
+++ b/scripts/actions/weaponskills/sniper_shot.lua
@@ -14,9 +14,9 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 1
-    params.ftpMod = { 1.0, 1.0, 1.0 }
+    params.ftpMod  = { 1, 1, 1 }
     params.agi_wsc = 0.3
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
@@ -25,9 +25,12 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doRangedWeaponskill(player, target, wsID, params, tp, action, primary)
 
-    if damage > 0 and not target:hasStatusEffect(xi.effect.INT_DOWN) then
-        target:addStatusEffect(xi.effect.INT_DOWN, 10, 0, 140)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.INT_DOWN
+    local actionElement = xi.element.FIRE
+    local power         = 10
+    local duration      = math.floor(140 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/stardiver.lua
+++ b/scripts/actions/weaponskills/stardiver.lua
@@ -13,26 +13,24 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
-    params.numHits = 4
-    params.ftpMod = { 0.75, 1.25, 1.75 }
-    params.str_wsc = player:getMerit(xi.merit.STARDIVER) * 0.17
-
-    -- https://www.bluegartr.com/threads/106679-Test-Server-Findings?p=4920448&viewfull=1#post4920448
+    local params       = {}
+    params.numHits     = 4
+    params.ftpMod      = { 0.75, 1.25, 1.75 }
+    params.str_wsc     = player:getMerit(xi.merit.STARDIVER) * 0.17
     params.multiHitfTP = true
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.str_wsc = 0.7 + (player:getMerit(xi.merit.STARDIVER) * 0.03)
+        params.str_wsc = 0.7 + player:getMerit(xi.merit.STARDIVER) * 0.03
     end
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if
-        damage > 0 and
-        not target:hasStatusEffect(xi.effect.CRIT_HIT_EVASION_DOWN)
-    then
-        target:addStatusEffect(xi.effect.CRIT_HIT_EVASION_DOWN, 5, 0, 60)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.CRIT_HIT_EVASION_DOWN
+    local actionElement = xi.element.EARTH
+    local power         = 5
+    local duration      = math.floor(60 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/tachi_ageha.lua
+++ b/scripts/actions/weaponskills/tachi_ageha.lua
@@ -17,22 +17,25 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 1
-    params.ftpMod = { 2.80, 2.80, 2.80 }
+    params.ftpMod  = { 2.8, 2.8, 2.8 }
     params.chr_wsc = 0.50
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.ftpMod = { 2.625, 2.625, 2.625 }
-        params.str_wsc = 0.4 params.chr_wsc = 0.6
+        params.ftpMod  = { 2.625, 2.625, 2.625 }
+        params.str_wsc = 0.4
+        params.chr_wsc = 0.6
     end
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and not target:hasStatusEffect(xi.effect.DEFENSE_DOWN) then
-        local duration = (tp / 1000 * 60) * applyResistanceAddEffect(player, target, xi.element.WIND, 0)
-        target:addStatusEffect(xi.effect.DEFENSE_DOWN, 25, 0, duration)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.DEFENSE_DOWN
+    local actionElement = xi.element.WIND
+    local power         = 25
+    local duration      = math.floor(6 * tp / 100 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/tachi_gekko.lua
+++ b/scripts/actions/weaponskills/tachi_gekko.lua
@@ -17,22 +17,24 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
-    params.numHits = 1
-    params.ftpMod = { 1.5625, 1.88, 2.5 }
-    params.str_wsc = 0.75
-    params.atkVaries = { 2.0, 2.0, 2.0 }
+    local params     = {}
+    params.numHits   = 1
+    params.ftpMod    = { 1.5625, 1.88, 2.5 }
+    params.str_wsc   = 0.75
+    params.atkVaries = { 2, 2, 2 }
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftpMod = { 1.5625, 2.6875, 4.125 }
     end
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
-    -- Silence duration changed from 60 to 45 as per bg-wiki: http://www.bg-wiki.com/bg/Tachi:_Gekko
-    if damage > 0 and not target:hasStatusEffect(xi.effect.SILENCE) then
-        local duration = 60 * applyResistanceAddEffect(player, target, xi.element.WIND, 0)
-        target:addStatusEffect(xi.effect.SILENCE, 1, 0, duration)
-    end
+ 
+    -- Handle status effect
+    local effectId      = xi.effect.SILENCE
+    local actionElement = xi.element.WIND
+    local power         = 1
+    local duration      = math.floor(45 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/tachi_hobaku.lua
+++ b/scripts/actions/weaponskills/tachi_hobaku.lua
@@ -15,9 +15,9 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 1
-    params.ftpMod = { 1.0, 1.0, 1.0 }
+    params.ftpMod  = { 1, 1, 1 }
     params.str_wsc = 0.3
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
@@ -26,11 +26,13 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    local chance = (tp - 1000) * applyResistanceAddEffect(player, target, xi.element.THUNDER, 0) > math.random() * 150
-    if damage > 0 and chance then
-        if not target:hasStatusEffect(xi.effect.STUN) then
-            target:addStatusEffect(xi.effect.STUN, 1, 0, 4)
-        end
+    -- Handle status effect
+    if math.random(1, 100) <= tp / 30 * applyResistanceAddEffect(player, target, xi.element.THUNDER, 0) then
+        local effectId      = xi.effect.STUN
+        local actionElement = xi.element.THUNDER
+        local power         = 1
+        local duration      = 3
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
     end
 
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/actions/weaponskills/tachi_kasha.lua
+++ b/scripts/actions/weaponskills/tachi_kasha.lua
@@ -18,24 +18,26 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
-    params.numHits = 1
-    params.ftpMod = { 1.56, 1.88, 2.5 }
-    params.str_wsc = 0.75
+    local params     = {}
+    params.numHits   = 1
+    params.ftpMod    = { 1.56, 1.88, 2.5 }
+    params.str_wsc   = 0.75
     params.atkVaries = { 1.5, 1.5, 1.5 }
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.ftpMod = { 1.5625, 2.6875, 4.125 }
-        params.str_wsc = 0.75
+        params.ftpMod    = { 1.5625, 2.6875, 4.125 }
+        params.str_wsc   = 0.75
         params.atkVaries = { 1.65, 1.65, 1.65 }
     end
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and not target:hasStatusEffect(xi.effect.PARALYSIS) then
-        local duration = 60 * applyResistanceAddEffect(player, target, xi.element.ICE, 0)
-        target:addStatusEffect(xi.effect.PARALYSIS, 25, 0, duration)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.PARALYSIS
+    local actionElement = xi.element.ICE
+    local power         = 25
+    local duration      = math.floor(60 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/tachi_yukikaze.lua
+++ b/scripts/actions/weaponskills/tachi_yukikaze.lua
@@ -17,23 +17,25 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
-    params.numHits = 1
-    params.ftpMod = { 1.5625, 1.88, 2.5 }
-    params.str_wsc = 0.75
+    local params     = {}
+    params.numHits   = 1
+    params.ftpMod    = { 1.5625, 1.88, 2.5 }
+    params.str_wsc   = 0.75
     params.atkVaries = { 1.33, 1.33, 1.33 }
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.ftpMod = { 1.5625, 2.6875, 4.125 }
+        params.ftpMod    = { 1.5625, 2.6875, 4.125 }
         params.atkVaries = { 1.5, 1.5, 1.5 }
     end
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and not target:hasStatusEffect(xi.effect.BLINDNESS) then
-        local duration = 60 * applyResistanceAddEffect(player, target, xi.element.DARK, 0)
-        target:addStatusEffect(xi.effect.BLINDNESS, 25, 0, duration)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.BLINDNESS
+    local actionElement = xi.element.DARK
+    local power         = 25
+    local duration      = math.floor(60 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/ukkos_fury.lua
+++ b/scripts/actions/weaponskills/ukkos_fury.lua
@@ -20,11 +20,11 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
-    params.numHits = 2
-    params.ftpMod = { 2.0, 2.0, 2.0 }
-    params.str_wsc = 0.6
-    params.critVaries = { 0.20, 0.35, 0.55 }
+    local params      = {}
+    params.numHits    = 2
+    params.ftpMod     = { 2, 2, 2 }
+    params.str_wsc    = 0.6
+    params.critVaries = { 0.2, 0.35, 0.55 }
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.str_wsc = 0.8
@@ -35,12 +35,12 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     -- Apply aftermath
     xi.aftermath.addStatusEffect(player, tp, xi.slot.MAIN, xi.aftermath.type.EMPYREAN)
 
-    if damage > 0 then
-        if not target:hasStatusEffect(xi.effect.SLOW) then
-            local duration = 60 * applyResistanceAddEffect(player, target, xi.element.EARTH, 0)
-            target:addStatusEffect(xi.effect.SLOW, 1500, 0, duration)
-        end
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.SLOW
+    local actionElement = xi.element.EARTH
+    local power         = 1500
+    local duration      = math.floor(60 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/uriel_blade.lua
+++ b/scripts/actions/weaponskills/uriel_blade.lua
@@ -15,18 +15,22 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
-    params.ftpMod = { 4.5, 6.0, 7.5 }
-    params.str_wsc = 0.32 params.mnd_wsc = 0.32
-    params.ele = xi.element.LIGHT
-    params.skill = xi.skill.SWORD
+    local params      = {}
+    params.ftpMod     = { 4.5, 6, 7.5 }
+    params.str_wsc    = 0.32
+    params.mnd_wsc    = 0.32
+    params.ele        = xi.element.LIGHT
+    params.skill      = xi.skill.SWORD
     params.includemab = true
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
 
-    if damage > 0 and not target:hasStatusEffect(xi.effect.FLASH) then
-    target:addStatusEffect(xi.effect.FLASH, 200, 0, 15)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.FLASH
+    local actionElement = xi.element.LIGHT
+    local power         = 200
+    local duration      = math.floor(15 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/vidohunir.lua
+++ b/scripts/actions/weaponskills/vidohunir.lua
@@ -16,11 +16,11 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
-    params.ftpMod = { 1.75, 1.75, 1.75 }
-    params.int_wsc = 0.3
-    params.ele = xi.element.DARK
-    params.skill = xi.skill.STAFF
+    local params      = {}
+    params.ftpMod     = { 1.75, 1.75, 1.75 }
+    params.int_wsc    = 0.3
+    params.ele        = xi.element.DARK
+    params.skill      = xi.skill.STAFF
     params.includemab = true
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
@@ -32,12 +32,12 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
 
-    if damage > 0 then
-        local duration = tp / 1000 * 60
-        if not target:hasStatusEffect(xi.effect.MAGIC_DEF_DOWN) then
-            target:addStatusEffect(xi.effect.MAGIC_DEF_DOWN, 10, 0, duration)
-        end
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.MAGIC_DEF_DOWN
+    local actionElement = xi.element.THUNDER
+    local power         = 10
+    local duration      = math.floor(6 * tp / 100 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/viper_bite.lua
+++ b/scripts/actions/weaponskills/viper_bite.lua
@@ -17,21 +17,23 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params     = {}
     params.numHits   = 1
-    params.ftpMod    = { 1.0, 1.0, 1.0 }
-    params.atkVaries = { 2.0, 2.0, 2.0 }
+    params.ftpMod    = { 1, 1, 1 }
+    params.atkVaries = { 2, 2, 2 }
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.dex_wsc = 1.0
+        params.dex_wsc = 1
     end
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and not target:hasStatusEffect(xi.effect.POISON) then
-        local duration = (30 + (tp / 1000 * 60)) * applyResistanceAddEffect(player, target, xi.element.WATER, 0)
-        target:addStatusEffect(xi.effect.POISON, 3, 0, duration)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.POISON
+    local actionElement = xi.element.WATER
+    local power         = 3
+    local duration      = math.floor((30 + 6 * tp / 100) * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/wasp_sting.lua
+++ b/scripts/actions/weaponskills/wasp_sting.lua
@@ -15,20 +15,22 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 1
-    params.ftpMod = { 1.0, 1.0, 1.0 }
+    params.ftpMod  = { 1, 1, 1 }
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.dex_wsc = 1.0
+        params.dex_wsc = 1
     end
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and not target:hasStatusEffect(xi.effect.POISON) then
-        local duration = (75 + (tp / 1000 * 15)) * applyResistanceAddEffect(player, target, xi.element.WATER, 0)
-        target:addStatusEffect(xi.effect.POISON, 1, 0, duration)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.POISON
+    local actionElement = xi.element.WATER
+    local power         = 1
+    local duration      = math.floor((75 + 15 * tp / 1000) * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/weapon_break.lua
+++ b/scripts/actions/weaponskills/weapon_break.lua
@@ -18,21 +18,25 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 1
-    params.ftpMod = { 1.0, 1.0, 1.0 }
-    params.str_wsc = 0.32 params.vit_wsc = 0.32
+    params.ftpMod  = { 1, 1, 1 }
+    params.str_wsc = 0.32
+    params.vit_wsc = 0.32
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.str_wsc = 0.6 params.vit_wsc = 0.6
+        params.str_wsc = 0.6
+        params.vit_wsc = 0.6
     end
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and not target:hasStatusEffect(xi.effect.ATTACK_DOWN) then
-        local duration = (120 + (tp / 1000 * 60)) * applyResistanceAddEffect(player, target, xi.element.WATER, 0)
-        target:addStatusEffect(xi.effect.ATTACK_DOWN, 25, 0, duration)
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.ATTACK_DOWN
+    local actionElement = xi.element.WATER
+    local power         = 25
+    local duration      = math.floor(120 + 6 * tp / 100 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/globals/combat/status_effect_tables.lua
+++ b/scripts/globals/combat/status_effect_tables.lua
@@ -1,68 +1,149 @@
 -----------------------------------
 -- Table defining diferent status effect properties.
 -----------------------------------
+-- Info
+-- Resistance:  https://wiki-ffo-jp.translate.goog/html/1801.html?_x_tr_sl=ja&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=sc
+-- Effects:     https://wiki-ffo-jp.translate.goog/html/1720.html?_x_tr_sl=ja&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=sc
+-- Resist:      https://wiki-ffo-jp.translate.goog/html/795.html?_x_tr_sl=ja&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=sc
+-- Immunobreak: https://wiki-ffo-jp.translate.goog/html/27204.html?_x_tr_sl=ja&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=sc
+
+-- NOTE: I have yet to find a case where the effect "associated element" isnt determined by the element of the action that causes it.
+-- Example: Siren's elegy is wind while spell elegies are earth. Same effect, diferent elements.
+-- Unlike sleep, elegy effect doesnt have an associated "effect resistance rank" and uses "element resistance rank" instead.
+-----------------------------------
 xi = xi or {}
 xi.combat = xi.combat or {}
 xi.combat.statusEffect = xi.combat.statusEffect or {}
 -----------------------------------
 
+-- Table column names.
+local column =
+{
+    nullifiedByEffect  = 1, -- [effect] is nullified by { effect }. In other words, [effect] cant be applied because { effect } is active.
+    nullifiesTheEffect = 2, -- TODO: IMPLEMENT. [effect] nullifies { effect }.
+    associatedElement  = 3, -- Players and most effects dont have "effect resistance ranks", so they always use the effect "associated element" "resistance rank".
+    associatedImmunity = 4, -- Detected by "Completely resists" message. Cant immunobreak/resistance-hack it.
+    resistTraitMod     = 5, -- Detected by "Resist!" message. Cant immunobreak/resistance-hack it if triggered.
+    resistanceRankMod  = 6, -- TODO: IMPLEMENT. For mobs, status effects can either: Use an specific status effect ressistance rank OR use their associated element resistance rank.
+    magicEvasionMod    = 7,
+    immunobreakMod     = 8,
+}
+
 -- Table associating an status effect with their corresponding immunobreak, MEVA and resistance modifiers and immunities.
 xi.combat.statusEffect.dataTable =
 {
-    [xi.effect.ADDLE        ] = { xi.immunity.ADDLE,      0,                  0,                    xi.mod.ADDLE_IMMUNOBREAK    },
-    [xi.effect.BIND         ] = { xi.immunity.BIND,       xi.mod.BINDRES,     xi.mod.BIND_MEVA,     xi.mod.BIND_IMMUNOBREAK     },
-    [xi.effect.BLINDNESS    ] = { xi.immunity.BLIND,      xi.mod.BLINDRES,    xi.mod.BLIND_MEVA,    xi.mod.BLIND_IMMUNOBREAK    },
-    [xi.effect.CURSE_I      ] = { xi.immunity.NONE,       xi.mod.CURSERES,    xi.mod.CURSE_MEVA,    0                           },
-    [xi.effect.NONE         ] = { xi.immunity.DISPEL,     0,                  0,                    0                           },
-    [xi.effect.PARALYSIS    ] = { xi.immunity.PARALYZE,   xi.mod.PARALYZERES, xi.mod.PARALYZE_MEVA, xi.mod.PARALYZE_IMMUNOBREAK },
-    [xi.effect.PETRIFICATION] = { xi.immunity.PETRIFY,    xi.mod.PETRIFYRES,  xi.mod.PETRIFY_MEVA,  xi.mod.PETRIFY_IMMUNOBREAK  },
-    [xi.effect.PLAGUE       ] = { xi.immunity.NONE,       xi.mod.VIRUSRES,    xi.mod.VIRUS_MEVA,    0                           },
-    [xi.effect.POISON       ] = { xi.immunity.POISON,     xi.mod.POISONRES,   xi.mod.POISON_MEVA,   xi.mod.POISON_IMMUNOBREAK   },
-    [xi.effect.SILENCE      ] = { xi.immunity.SILENCE,    xi.mod.SILENCERES,  xi.mod.SILENCE_MEVA,  xi.mod.SILENCE_IMMUNOBREAK  },
-    [xi.effect.SLEEP_I      ] = { xi.immunity.DARK_SLEEP, xi.mod.SLEEPRES,    xi.mod.SLEEP_MEVA,    xi.mod.SLEEP_IMMUNOBREAK    },
-    [xi.effect.SLOW         ] = { xi.immunity.SLOW,       xi.mod.SLOWRES,     xi.mod.SLOW_MEVA,     xi.mod.SLOW_IMMUNOBREAK     },
-    [xi.effect.STUN         ] = { xi.immunity.STUN,       xi.mod.STUNRES,     xi.mod.STUN_MEVA,     0                           },
-    [xi.effect.WEIGHT       ] = { xi.immunity.GRAVITY,    xi.mod.GRAVITYRES,  xi.mod.GRAVITY_MEVA,  xi.mod.GRAVITY_IMMUNOBREAK  },
+    [xi.effect.ADDLE        ] = { 0,               0, xi.element.FIRE,    xi.immunity.ADDLE,      xi.mod.SLOWRES,     0, 0,                    xi.mod.ADDLE_IMMUNOBREAK    },
+    [xi.effect.BIND         ] = { 0,               0, xi.element.ICE,     xi.immunity.BIND,       xi.mod.BINDRES,     0, xi.mod.BIND_MEVA,     xi.mod.BIND_IMMUNOBREAK     },
+    [xi.effect.BLINDNESS    ] = { 0,               0, xi.element.DARK,    xi.immunity.BLIND,      xi.mod.BLINDRES,    0, xi.mod.BLIND_MEVA,    xi.mod.BLIND_IMMUNOBREAK    },
+    [xi.effect.BURN         ] = { xi.effect.DROWN, 0, xi.element.FIRE,    0,                      0,                  0, 0,                    0                           },
+    [xi.effect.CHOKE        ] = { xi.effect.FROST, 0, xi.element.WIND,    0,                      0,                  0, 0,                    0                           },
+    [xi.effect.CURSE_I      ] = { 0,               0, xi.element.DARK,    xi.immunity.NONE,       xi.mod.CURSERES,    0, xi.mod.CURSE_MEVA,    0                           },
+    [xi.effect.DROWN        ] = { xi.effect.SHOCK, 0, xi.element.WATER,   0,                      0,                  0, 0,                    0                           },
+    [xi.effect.FLASH        ] = { 0,               0, xi.element.LIGHT,   xi.immunity.BLIND,      xi.mod.BLINDRES,    0, xi.mod.BLIND_MEVA,    xi.mod.BLIND_IMMUNOBREAK    },
+    [xi.effect.FROST        ] = { xi.effect.BURN,  0, xi.element.ICE,     0,                      0,                  0, 0,                    0                           },
+    [xi.effect.NONE         ] = { 0,               0, xi.element.DARK,    xi.immunity.DISPEL,     0,                  0, 0,                    0                           },
+    [xi.effect.PARALYSIS    ] = { 0,               0, xi.element.ICE,     xi.immunity.PARALYZE,   xi.mod.PARALYZERES, 0, xi.mod.PARALYZE_MEVA, xi.mod.PARALYZE_IMMUNOBREAK },
+    [xi.effect.PETRIFICATION] = { 0,               0, xi.element.EARTH,   xi.immunity.PETRIFY,    xi.mod.PETRIFYRES,  0, xi.mod.PETRIFY_MEVA,  xi.mod.PETRIFY_IMMUNOBREAK  },
+    [xi.effect.PLAGUE       ] = { 0,               0, xi.element.FIRE,    xi.immunity.NONE,       xi.mod.VIRUSRES,    0, xi.mod.VIRUS_MEVA,    0                           },
+    [xi.effect.POISON       ] = { 0,               0, xi.element.WATER,   xi.immunity.POISON,     xi.mod.POISONRES,   0, xi.mod.POISON_MEVA,   xi.mod.POISON_IMMUNOBREAK   },
+    [xi.effect.RASP         ] = { xi.effect.CHOKE, 0, xi.element.EARTH,   0,                      0,                  0, 0,                    0                           },
+    [xi.effect.SHOCK        ] = { xi.effect.RASP,  0, xi.element.THUNDER, 0,                      0,                  0, 0,                    0                           },
+    [xi.effect.SILENCE      ] = { 0,               0, xi.element.WIND,    xi.immunity.SILENCE,    xi.mod.SILENCERES,  0, xi.mod.SILENCE_MEVA,  xi.mod.SILENCE_IMMUNOBREAK  },
+    [xi.effect.SLEEP_I      ] = { 0,               0, xi.element.DARK,    xi.immunity.DARK_SLEEP, xi.mod.SLEEPRES,    0, xi.mod.SLEEP_MEVA,    xi.mod.SLEEP_IMMUNOBREAK    },
+    [xi.effect.SLOW         ] = { 0,               0, xi.element.EARTH,   xi.immunity.SLOW,       xi.mod.SLOWRES,     0, xi.mod.SLOW_MEVA,     xi.mod.SLOW_IMMUNOBREAK     },
+    [xi.effect.STUN         ] = { 0,               0, xi.element.THUNDER, xi.immunity.STUN,       xi.mod.STUNRES,     0, xi.mod.STUN_MEVA,     0                           },
+    [xi.effect.WEIGHT       ] = { 0,               0, xi.element.WIND,    xi.immunity.GRAVITY,    xi.mod.GRAVITYRES,  0, xi.mod.GRAVITY_MEVA,  xi.mod.GRAVITY_IMMUNOBREAK  },
 }
 
 -----------------------------------
 -- Helper functions to easily fetch table data.
 -----------------------------------
+xi.combat.statusEffect.getNullificatingEffect = function(effectId)
+    -- Sanitize fed value
+    local effectToCheck = effectId or 0
+
+    -- Fetch effect ID from table if entry exists.
+    if xi.combat.statusEffect.dataTable[effectToCheck] then
+        return xi.combat.statusEffect.dataTable[effectToCheck][column.nullifiedByEffect]
+    end
+
+    return 0
+end
+
+xi.combat.statusEffect.getEffectToRemove = function(effectId)
+    -- Sanitize fed value
+    local effectToCheck = effectId or 0
+
+    -- Fetch effect ID from table if entry exists.
+    if xi.combat.statusEffect.dataTable[effectToCheck] then
+        return xi.combat.statusEffect.dataTable[effectToCheck][column.nullifiesTheEffect]
+    end
+
+    return 0
+end
+
+xi.combat.statusEffect.getAssociatedElement = function(effectId, actionElement)
+    -- Sanitize fed values
+    local effectToCheck  = effectId or 0
+    local elementToCheck = actionElement or 0
+
+    -- Sleep exception.
+    if effectToCheck == xi.effect.SLEEP_I then
+        return elementToCheck
+    end
+
+    -- Fetch element from table if entry exists.
+    if xi.combat.statusEffect.dataTable[effectToCheck] then
+        return xi.combat.statusEffect.dataTable[effectToCheck][column.associatedElement]
+    end
+
+    -- Assume the effect "element" is the same as the action element.
+    return elementToCheck
+end
+
 xi.combat.statusEffect.getAssociatedImmunity = function(effectId, actionElement)
     -- Sanitize fed values
     local effectToCheck  = effectId or 0
     local elementToCheck = actionElement or 0
 
-    -- Fetch immunity from table if entry exists.
-    local associatedImmunity = 0
-
-    if xi.combat.statusEffect.dataTable[effectToCheck] then
-        associatedImmunity = xi.combat.statusEffect.dataTable[effectToCheck][1]
-    end
-
     -- Sleep exception.
     if
-        associatedImmunity == xi.immunity.DARK_SLEEP and
+        effectToCheck == xi.effect.SLEEP_I and
         elementToCheck == xi.element.LIGHT
     then
-        associatedImmunity = xi.immunity.LIGHT_SLEEP
+        return xi.immunity.LIGHT_SLEEP
     end
 
-    return associatedImmunity
+    -- Fetch immunity from table if entry exists.
+    if xi.combat.statusEffect.dataTable[effectToCheck] then
+        return xi.combat.statusEffect.dataTable[effectToCheck][column.associatedImmunity]
+    end
+
+    return 0
 end
 
-xi.combat.statusEffect.getAssociatedResistanceModifier = function(effectId)
+xi.combat.statusEffect.getAssociatedResistTraitModifier = function(effectId)
     -- Sanitize fed value
     local effectToCheck = effectId or 0
 
     -- Fetch modifier ID from table if entry exists.
-    local associatedResistanceModifier = 0
-
     if xi.combat.statusEffect.dataTable[effectToCheck] then
-        associatedResistanceModifier = xi.combat.statusEffect.dataTable[effectToCheck][2]
+        return xi.combat.statusEffect.dataTable[effectToCheck][column.resistTraitMod]
     end
 
-    return associatedResistanceModifier
+    return 0
+end
+
+xi.combat.statusEffect.getAssociatedResistanceRankModifier = function(effectId)
+    -- Sanitize fed value
+    local effectToCheck = effectId or 0
+
+    -- Fetch modifier ID from table if entry exists.
+    if xi.combat.statusEffect.dataTable[effectToCheck] then
+        return xi.combat.statusEffect.dataTable[effectToCheck][column.resistanceRankMod]
+    end
+
+    return 0
 end
 
 xi.combat.statusEffect.getAssociatedMagicEvasionModifier = function(effectId)
@@ -70,13 +151,11 @@ xi.combat.statusEffect.getAssociatedMagicEvasionModifier = function(effectId)
     local effectToCheck = effectId or 0
 
     -- Fetch modifier ID from table if entry exists.
-    local associatedMagicEvasionModifier = 0
-
     if xi.combat.statusEffect.dataTable[effectToCheck] then
-        associatedMagicEvasionModifier = xi.combat.statusEffect.dataTable[effectToCheck][3]
+        return xi.combat.statusEffect.dataTable[effectToCheck][column.magicEvasionMod]
     end
 
-    return associatedMagicEvasionModifier
+    return 0
 end
 
 xi.combat.statusEffect.getAssociatedImmunobreakModifier = function(effectId)
@@ -84,13 +163,11 @@ xi.combat.statusEffect.getAssociatedImmunobreakModifier = function(effectId)
     local effectToCheck = effectId or 0
 
     -- Fetch modifier ID from table if entry exists.
-    local associatedImmunobreakModifier = 0
-
     if xi.combat.statusEffect.dataTable[effectToCheck] then
-        associatedImmunobreakModifier = xi.combat.statusEffect.dataTable[effectToCheck][4]
+        return xi.combat.statusEffect.dataTable[effectToCheck][column.immunobreakMod]
     end
 
-    return associatedImmunobreakModifier
+    return 0
 end
 
 -----------------------------------
@@ -113,24 +190,34 @@ xi.combat.statusEffect.isTargetImmune = function(target, effectId, actionElement
 end
 
 xi.combat.statusEffect.isTargetResistant = function(actor, target, effectId)
-    local modifierId = xi.combat.statusEffect.getAssociatedResistanceModifier(effectId)
+    local modifierId = xi.combat.statusEffect.getAssociatedResistTraitModifier(effectId)
     if modifierId == 0 then
         return false
     end
 
-    local resistancePower = target:getMod(modifierId) + target:getMod(xi.mod.STATUSRES)
-    if resistancePower == 0 then
+    local resistancePower = target:getMod(modifierId) + target:getMod(xi.mod.STATUSRES) + 5
+    if resistancePower <= 5 then
         return false
     end
 
-    local roll      = math.random(1, 100)
-    resistancePower = resistancePower + 5
-
+    -- TODO: Investigate if this happens always or not. Ex: Terror.
     if actor:isNM() then
         resistancePower = math.floor(resistancePower / 2)
     end
 
-    if roll <= resistancePower then
+    if math.random(1, 100) <= resistancePower then
+        return true
+    end
+
+    return false
+end
+
+xi.combat.statusEffect.isEffectNullified = function(target, effectId)
+    local effectId = xi.combat.statusEffect.getNullificatingEffect(effectId)
+    if
+        effectId > 0 and
+        target:hasStatusEffect(effectId)
+    then
         return true
     end
 

--- a/scripts/globals/spells/enfeebling_spell.lua
+++ b/scripts/globals/spells/enfeebling_spell.lua
@@ -313,7 +313,7 @@ xi.spells.enfeebling.calculateDuration = function(caster, target, spellId, spell
     return math.floor(duration)
 end
 
-xi.spells.enfeebling.handleEffectNullification = function(caster, target, spell, spellId, spellEffect)
+xi.spells.enfeebling.handleEffectNullification = function(caster, target, spell, spellEffect)
     -- Determine if target mob is completely immune to a status effect.
     if xi.combat.statusEffect.isTargetImmune(target, spellEffect, spell:getElement()) then
         spell:setMsg(xi.msg.basic.MAGIC_COMPLETE_RESIST)
@@ -329,33 +329,11 @@ xi.spells.enfeebling.handleEffectNullification = function(caster, target, spell,
         return true
     end
 
-    -- Table for elemental debuff effects and which effect nullifies it.
-    local elementalDebuffTable =
-    {
-        -- effect = Nullified by
-        [xi.effect.BURN ] = { xi.effect.DROWN },
-        [xi.effect.CHOKE] = { xi.effect.FROST },
-        [xi.effect.DROWN] = { xi.effect.SHOCK },
-        [xi.effect.FROST] = { xi.effect.BURN  },
-        [xi.effect.RASP ] = { xi.effect.CHOKE },
-        [xi.effect.SHOCK] = { xi.effect.RASP  },
-    }
+    -- Target already has an status effect that nullifies current.
+    if xi.combat.statusEffect.isEffectNullified(spellEffect) then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
 
-    -- Elemental DoTs effects.
-    if
-        spellEffect == xi.effect.BURN or
-        spellEffect == xi.effect.CHOKE or
-        spellEffect == xi.effect.DROWN or
-        spellEffect == xi.effect.FROST or
-        spellEffect == xi.effect.RASP or
-        spellEffect == xi.effect.SHOCK
-    then
-        -- Target already has an status effect that nullifies current.
-        if target:hasStatusEffect(elementalDebuffTable[spellEffect][1]) then
-            spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-
-            return true
-        end
+        return true
     end
 
     return false
@@ -369,7 +347,7 @@ xi.spells.enfeebling.useEnfeeblingSpell = function(caster, target, spell)
     ------------------------------
     -- STEP 1: Check spell nullification.
     ------------------------------
-    if xi.spells.enfeebling.handleEffectNullification(caster, target, spell, spellId, spellEffect) then
+    if xi.spells.enfeebling.handleEffectNullification(caster, target, spell, spellEffect) then
         return spellEffect
     end
 

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -1429,3 +1429,15 @@ xi.weaponskills.handleWSGorgetBelt = function(attacker)
 
     return ftpBonus, accBonus
 end
+
+xi.weaponskills.handleWeaponskillEffect = function(actor, target, effectId, actionElement, damage, power, duration)
+    if
+        damage > 0 and
+        not target:hasStatusEffect(effectId) and
+        not xi.combat.statusEffect.isTargetImmune(target, effectId, actionElement) and
+        not xi.combat.statusEffect.isTargetResistant(actor, target, effectId) and
+        not xi.combat.statusEffect.isEffectNullified(effectId)
+    then
+        target:addStatusEffect(effectId, power, 0, duration)
+    end
+end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds functionality to the statuseffect table.
- Applies that functionality to all effect-inducing weaponskill scripts which we have.
- Applies effect nullification from "incompatible effects" checks to spells.

This work is made towards the following objectives:
- Introducing "status effect resistance ranks" in small chunks while also not breaking our current functionality.
- Expanding our system to make mobskills and weaponskills check for immunities, resist triggers and effects that are nullified/nullify other effects, properly.

## Steps to test these changes

- Cast drown, shock and the other elemental DoT spells and have them be nullified as they should.
- Use effect-inducing weaponskills without them erroring.
