### PR TITLE
[ci] Fix changed file arrays used in loops

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,9 @@ jobs:
       if: always()
       run: |
         readarray -t removed_files <<<"$(jq -r '.[]' <<<'${{ steps.changed-files.outputs.all }}')"
-        for removed_file in ${removed_files[@]}; do
+        echo "CHANGED_FILES=${removed_files[@]}" >> $GITHUB_ENV
+
+        for removed_file in $CHANGED_FILES; do
             echo "${removed_file}"
         done
     - name: Git Formatting Checks
@@ -67,7 +69,7 @@ jobs:
       if: always()
       run: |
         touch general_checks.txt
-        for changed_file in ${{ steps.changed-files.outputs.all }}; do
+        for changed_file in $CHANGED_FILES; do
           if [[ -f $changed_file ]]; then
             bash tools/ci/general.sh ${changed_file} >> general_checks.txt || true
           fi
@@ -82,7 +84,7 @@ jobs:
       if: always()
       run: |
         touch cpp_checks.txt
-        for changed_file in ${{ steps.changed-files.outputs.all }}; do
+        for changed_file in $CHANGED_FILES; do
           if [[ -f $changed_file ]]; then
             if [[ $changed_file == *.cpp ]]; then
               bash tools/ci/cpp.sh ${changed_file} 2>> cpp_checks.txt >> cpp_checks.txt || true
@@ -100,7 +102,7 @@ jobs:
       run: |
         clang-format-18 -version
         touch cpp_formatting_checks.txt
-        for changed_file in ${{ steps.changed-files.outputs.all }}; do
+        for changed_file in $CHANGED_FILES; do
           if [[ -f $changed_file ]]; then
             if [[ $changed_file == *.cpp || $changed_file == *.h ]]; then
               clang-format-18 -style=file -i ${changed_file}
@@ -138,7 +140,7 @@ jobs:
         touch lua_checks.txt
         python3 tools/ci/lua_stylecheck.py test >> lua_checks.txt
 
-        for changed_file in ${{ steps.changed-files.outputs.all }}; do
+        for changed_file in $CHANGED_FILES; do
           if [[ -f $changed_file ]]; then
             if [[ $changed_file == *.lua ]]; then
               bash tools/ci/lua.sh ${changed_file} >> lua_checks.txt || true
@@ -158,7 +160,7 @@ jobs:
       if: always()
       run: |
         touch sql_checks.txt
-        for changed_file in ${{ steps.changed-files.outputs.all }}; do
+        for changed_file in $CHANGED_FILES; do
           if [[ -f $changed_file ]]; then
             if [[ $changed_file == *.sql ]]; then
               bash tools/ci/sql.sh ${changed_file} >> sql_checks.txt || true
@@ -178,7 +180,7 @@ jobs:
       if: always()
       run: |
         touch python_checks.txt
-        for changed_file in ${{ steps.changed-files.outputs.all }}; do
+        for changed_file in $CHANGED_FILES; do
           if [[ -f $changed_file ]]; then
             if [[ $changed_file == *.py ]]; then
               bash tools/ci/python.sh ${changed_file} >> python_checks.txt || true


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Sanity checks were using `${{ steps.changed-files.outputs.all }}` (json array) as a list to iterate in a bash loop which would result in no files checked.  Since we're listing all changed files in a previous step, export this to a github environment variable and reuse for other checks.

Note: cppcheck is _quite_ unhappy with some things, and this may cause issues on that end until resolved.  We're running on all files now though.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
CI should fail when expected to
<!-- Clear and detailed steps to test your changes here -->
