### PR TITLE
[ci] Check disallowed commit words explicitly

### DIFF
--- a/tools/ci/git.sh
+++ b/tools/ci/git.sh
@@ -6,6 +6,15 @@ python << EOF
 import re
 import subprocess
 
+disallowed_words = [
+    "oops",
+    "whoops",
+    "lol",
+    "lulz",
+    "kek",
+    "kekw"
+]
+
 def get_commit_hashes():
     commit_hashes = []
 
@@ -82,7 +91,7 @@ for hash, lines in get_commit_messages().items():
             print_error(hash, lines, line, "Detected automatic commit message (Example: \"Update filename.ext\").\nPlease "
                 "provide a more detailed summary of your changes.")
 
-        if 'oops' in line.lower() or 'lol' in line.lower():
-            print_error(hash, lines, line, "Detected unhelpful language in commit message.\nPlease "
-                "describe what you have changed with this commit.\nUnhelpful language:\nOops\nWhoops\nlol")
+        for invalid_word in disallowed_words:
+            if re.match(r'\b({0})\b'.format(invalid_word), line.lower()):
+                print_error(hash, lines, line, f"Detected unhelpful language in commit message.\nPlease describe what you have changed with this commit.\nUnhelpful language: {invalid_word}")
 EOF


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Changes git commit message checks to use expicit word lists as opposed to contains.  This avoids issues like "loops" containing "oops"
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
CI will fail on explicit word that is disallowed, but not fail in other scenarios
<!-- Clear and detailed steps to test your changes here -->
