### PR TITLE
[lua] Mobskill: Reactor Cool mobBuffMove fix

### DIFF
--- a/scripts/actions/mobskills/reactor_cool.lua
+++ b/scripts/actions/mobskills/reactor_cool.lua
@@ -14,7 +14,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    skill:setMsg(xi.mobskills.MobBuffMove(mob, xi.effect.ICE_SPIKES, math.random(15, 30), 0, 60))
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.ICE_SPIKES, math.random(15, 30), 0, 60))
 
     local effect1 = mob:getStatusEffect(xi.effect.ICE_SPIKES)
     if effect1 then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Corrects a casing issue with the mobBuffMove function in the reactor_cool mobskill script.

Correct: "mobBuffMove"

Incorrect: "MobBuffMove"

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

Fight a pot in sea or force a mob to use the skill with `!exec target:useMobAbility(1463)`
See that the mob gains ice spikes as intended.

<!-- Clear and detailed steps to test your changes here -->
