### PR TITLE
add '.cache' folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ AppPackages/
 TestResults
 [Tt]est[Rr]esult*
 *.Cache
+*.cache
 ClientBin
 [Ss]tyle[Cc]op.*
 ~$*


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

On case sensitive systems the .cache folder isn't caught by the gitignore

## Steps to test these changes

Make a server on linux (and presumably macOS). The changes to the .cache folder will be tracked by git until you add "*.cache" to the gitignore file.
