### PR TITLE
Content tags npcs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ AppPackages/
 TestResults
 [Tt]est[Rr]esult*
 *.Cache
+*.cache
 ClientBin
 [Ss]tyle[Cc]op.*
 ~$*


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Corrects the content tags of several NPCs

## Steps to test these changes

Nolan was added in 2015: https://forum.square-enix.com/ffxi/threads/46976 which puts him around the initial release of ROV I believe

According to https://www.bg-wiki.com/ffxi/The_History_of_Final_Fantasy_XI/2011 Domenic was added Dec 15th 2011. Believe this puts them in Abyyssea territory

According to https://www.bg-wiki.com/ffxi/The_History_of_Final_Fantasy_XI/2011 Kindlix and Pyropox were added May 10th 2011. Believe this puts them in Abyyssea territory

Owains earliest mention is 2012 and he sells items seemingly related to voidwatch