### PR TITLE
[Fix] Bind effect

### DIFF
--- a/scripts/effects/bind.lua
+++ b/scripts/effects/bind.lua
@@ -5,8 +5,7 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    effect:setPower(target:getSpeed())
-    target:setSpeed(0)
+    effect:addMod(xi.mod.MOVE_SPEED_OVERRIDE, 300) -- Any number over 255 will make you stop
 
     -- Immunobreak reset.
     target:setMod(xi.mod.BIND_IMMUNOBREAK, 0)
@@ -16,7 +15,6 @@ effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:setSpeed(effect:getPower())
 end
 
 return effectObject

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -356,15 +356,6 @@ uint8 CBattleEntity::UpdateSpeed(bool run)
         outputSpeed = std::clamp<int16>(outputSpeed, 0, settings::get<uint8>("map.SPEED_LIMIT"));
     }
 
-    // Speed cap can be bypassed. Ex. Feast of swords. GM speed.
-    // TODO: Find exceptions. Add them here.
-
-    // GM speed bypass.
-    if (getMod(Mod::MOVE_SPEED_OVERRIDE) > 0)
-    {
-        outputSpeed = getMod(Mod::MOVE_SPEED_OVERRIDE);
-    }
-
     if (run && outputSpeed > 0 && getMod(Mod::MOVE_SPEED_OVERRIDE) == 0)
     {
         float multiplier = settings::get<float>("map.MOB_RUN_SPEED_MULTIPLIER");
@@ -393,7 +384,22 @@ uint8 CBattleEntity::UpdateSpeed(bool run)
         }
     }
 
+    // Speed cap can be bypassed. Ex. Feast of swords. GM speed.
+    // TODO: Find exceptions. Add them here.
+
+    // GM speed bypass.
+
+    if (getMod(Mod::MOVE_SPEED_OVERRIDE) > 255)
+    {
+        outputSpeed = 0;
+    }
+    else if (getMod(Mod::MOVE_SPEED_OVERRIDE) > 0)
+    {
+        outputSpeed = getMod(Mod::MOVE_SPEED_OVERRIDE);
+    }
+
     speed = static_cast<uint8>(std::clamp<int16>(outputSpeed, std::numeric_limits<uint8>::min(), std::numeric_limits<uint8>::max()));
+
     return speed;
 }
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Spped has gotten many changes lately and that broke bind. Shit happens.
Decided to re-use "GM speed" MOVE_SPEED_OVERRIDE modifier functionality to fix bind, since bind really does override any speed modifiers.

Close #6695

## Steps to test these changes

Cast bind on a mob or be casted bind.Have target not being able to move
