### PR TITLE
Core: Load synth recipes at startup time

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -328,6 +328,7 @@
 
         "GetSynergyRecipeByID",
         "GetSynergyRecipeByTrade",
+        "ReloadSynthRecipes",
     ],
     "Lua.diagnostics.disable": [
         "lowercase-global"

--- a/scripts/commands/reloadrecipes.lua
+++ b/scripts/commands/reloadrecipes.lua
@@ -1,0 +1,18 @@
+-----------------------------------
+-- func: reloadrecipes
+-- desc: Reloads crafting recipes from the DB
+-----------------------------------
+---@type TCommand
+local commandObj = {}
+
+commandObj.cmdprops =
+{
+    permission = 5,
+    parameters = ''
+}
+
+commandObj.onTrigger = function(player)
+    ReloadSynthRecipes()
+end
+
+return commandObj

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -105,6 +105,7 @@
 #include "utils/moduleutils.h"
 #include "utils/serverutils.h"
 #include "utils/synergyutils.h"
+#include "utils/synthutils.h"
 #include "utils/zoneutils.h"
 
 void ReportErrorToPlayer(CBaseEntity* PEntity, std::string const& message = "") noexcept
@@ -238,6 +239,7 @@ namespace luautils
         lua.set_function("RoeParseTimed", &roeutils::ParseTimedSchedule);
         lua.set_function("GetSynergyRecipeByID", &luautils::GetSynergyRecipeByID);
         lua.set_function("GetSynergyRecipeByTrade", &luautils::GetSynergyRecipeByTrade);
+        lua.set_function("ReloadSynthRecipes", &synthutils::LoadSynthRecipes);
 
         // Fishing Contest Functions
         lua.set_function("GetFishingContest", &luautils::GetFishingContest);

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -71,6 +71,7 @@
 #include "utils/petutils.h"
 #include "utils/serverutils.h"
 #include "utils/synergyutils.h"
+#include "utils/synthutils.h"
 #include "utils/trustutils.h"
 #include "utils/zoneutils.h"
 
@@ -292,6 +293,7 @@ int32 do_init(int32 argc, char** argv)
     jobpointutils::LoadGifts();
     daily::LoadDailyItems();
     roeutils::UpdateUnityRankings();
+    synthutils::LoadSynthRecipes();
     synergyutils::LoadSynergyRecipes();
     CItemEquipment::LoadAugmentData(); // TODO: Move to itemutils
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -403,6 +403,13 @@ int32 do_init(int32 argc, char** argv)
         settings::init();
     });
 
+    gConsoleService->RegisterCommand("reload_recipes", "Reload crafting recipes.",
+    [&](std::vector<std::string>& inputs)
+    {
+        fmt::print("Reloading crafting recipes\n");
+        synthutils::LoadSynthRecipes();
+    });
+
     gConsoleService->RegisterCommand("exit", "Terminate the program.",
     [&](std::vector<std::string>& inputs)
     {

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -1909,7 +1909,7 @@ void SmallPacket0x037(map_session_data_t* const PSession, CCharEntity* const PCh
 
     if (PChar->m_moghouseID)
     {
-        ShowError("Invalid storage ID passed to packet %u by %s", StorageID, PChar->getName());
+        ShowError("Player trying to use item in moghouse %s", PChar->getName());
         return;
     }
 

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -189,6 +189,12 @@ namespace synthutils
 
     void LoadSynthRecipes()
     {
+        TracyZoneScoped;
+
+        ShowInfo("Loading synth recipes");
+
+        synthRecipes.clear();
+
         // TODO: If we limit by ID ranges, we could use multiple threads to load the recipes
 
         const auto rset = db::preparedStmt("SELECT \
@@ -291,6 +297,8 @@ namespace synthutils
 
     bool isRightRecipe(CCharEntity* PChar)
     {
+        TracyZoneScoped;
+
         const auto crystal     = PChar->CraftContainer->getItemID(0);
         const auto ingredient1 = PChar->CraftContainer->getItemID(1);
         const auto ingredient2 = PChar->CraftContainer->getItemID(2);

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -273,14 +273,6 @@ namespace synthutils
                 .ContentTag   = rset->getOrDefault<std::string>("content_tag", ""),
             };
 
-            // Check content tag before adding to the map
-            // TODO: If this loading is multi-threaded, Lua cannot be accessed from any thread
-            //     : apart from the main thread!
-            if (!luautils::IsContentEnabled(recipe.ContentTag.c_str()))
-            {
-                continue; // Skip this recipe
-            }
-
             synthRecipes[recipe.key()] = recipe;
         }
     }
@@ -314,6 +306,12 @@ namespace synthutils
         if (synthRecipes.find(possibleRecipeKey) != synthRecipes.end())
         {
             const auto& recipe = synthRecipes[possibleRecipeKey];
+
+            if (!luautils::IsContentEnabled(recipe.ContentTag.c_str()))
+            {
+                PChar->pushPacket<CSynthMessagePacket>(PChar, SYNTH_BADRECIPE);
+                return false;
+            }
 
             if (recipe.KeyItem == 0 || charutils::hasKeyItem(PChar, recipe.KeyItem))
             {

--- a/src/map/utils/synthutils.h
+++ b/src/map/utils/synthutils.h
@@ -55,6 +55,7 @@ namespace synthutils
         SYNTHESIS_HQ3     = 4
     };
 
+    void  LoadSynthRecipes();
     int32 startSynth(CCharEntity* PChar);
     int32 sendSynthDone(CCharEntity* PChar);
     void  doSynthFail(CCharEntity* PChar);

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -96,6 +96,8 @@ global_objects=(
     BuildString
 
     GetFirstID
+
+    ReloadSynthRecipes
 )
 
 ignores=(


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Will make looking up synth recipes at runtime faster and safer. Currently in draft, will come back to this next weekend probably.