### PR TITLE
[combat] Remake elemental table and retire magic.lua copies

### DIFF
--- a/scripts/commands/getstats.lua
+++ b/scripts/commands/getstats.lua
@@ -106,11 +106,11 @@ commandObj.onTrigger = function(player, option)
                         end
                     end
 
-                    message = message .. ' SDT: ' ..         target:getMod(xi.combat.element.specificDmgTakenMod[v])
-                    message = message .. ' resRank: ' ..     target:getMod(xi.combat.element.resistRankMod[v])
-                    message = message .. ' Null%: ' ..       target:getMod(xi.combat.element.nullMod[v])
-                    message = message .. ' Absorb%: ' ..     target:getMod(xi.combat.element.absorbMod[v])
-                    message = message .. ' MEva: ' ..        target:getMod(xi.combat.element.elementalMagicEva[v])
+                    message = message .. ' SDT: ' ..         target:getMod(xi.combat.element.getElementalSDTModifier(v))
+                    message = message .. ' resRank: ' ..     target:getMod(xi.combat.element.getElementalResistanceRankModifier(v))
+                    message = message .. ' Null%: ' ..       target:getMod(xi.combat.element.getElementalNullificationModifier(v))
+                    message = message .. ' Absorb%: ' ..     target:getMod(xi.combat.element.getElementalAbsorptionModifier(v))
+                    message = message .. ' MEva: ' ..        target:getMod(xi.combat.element.getElementalMEVAModifier(v))
                     eleMessages[v] = message
                 end
             end

--- a/scripts/effects/carol.lua
+++ b/scripts/effects/carol.lua
@@ -8,7 +8,7 @@ effectObject.onEffectGain = function(target, effect)
     local subPower = effect:getSubPower()
     local buff     = 0
 
-    if subPower > 8 then -- unpack and apply stat buff if present
+    if subPower > xi.element.DARK then -- unpack and apply stat buff if present
         if subPower >= 400 then
             subPower = subPower - 400
             buff     = 4
@@ -24,26 +24,24 @@ effectObject.onEffectGain = function(target, effect)
         end
     end
 
-    target:addMod(xi.magic.resistMod[subPower], effect:getPower())
+    effect:addMod(xi.combat.element.getElementalMEVAModifier(subPower), effect:getPower())
 
-    if buff > 0 then -- xi.magic.element ids and MODS ids unfortnately don't match
-        if subPower == 1 then -- fire add STR
-            target:addMod(xi.mod.STR, buff)
-        elseif subPower == 2 then -- ice add INT
-            target:addMod(xi.mod.INT, buff)
-        elseif subPower == 3 then -- wind add AGI
-            target:addMod(xi.mod.AGI, buff)
-        elseif subPower == 4 then -- earth add VIT
-            target:addMod(xi.mod.VIT, buff)
-        elseif subPower == 5 then -- thunder add DEX
-            target:addMod(xi.mod.DEX, buff)
-        elseif subPower == 6 then -- water add MND
-            target:addMod(xi.mod.MND, buff)
-        elseif subPower == 7 then -- light add CHR
-            target:addMod(xi.mod.CHR, buff)
-        elseif subPower == 8 then -- dark add MP
-            target:addMod(xi.mod.MP, buff * 10)
-        end
+    if subPower == xi.element.FIRE then -- fire add STR
+        effect:addMod(xi.mod.STR, buff)
+    elseif subPower == xi.element.ICE then -- ice add INT
+        effect:addMod(xi.mod.INT, buff)
+    elseif subPower == xi.element.WIND then -- wind add AGI
+        effect:addMod(xi.mod.AGI, buff)
+    elseif subPower == xi.element.EARTH then -- earth add VIT
+        effect:addMod(xi.mod.VIT, buff)
+    elseif subPower == xi.element.THUNDER then -- thunder add DEX
+        effect:addMod(xi.mod.DEX, buff)
+    elseif subPower == xi.element.WATER then -- water add MND
+        effect:addMod(xi.mod.MND, buff)
+    elseif subPower == xi.element.LIGHT then -- light add CHR
+        effect:addMod(xi.mod.CHR, buff)
+    elseif subPower == xi.element.DARK then -- dark add MP
+        effect:addMod(xi.mod.MP, buff * 10)
     end
 end
 
@@ -51,46 +49,6 @@ effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    local subPower = effect:getSubPower()
-    local buff     = 0
-
-    if subPower > 8 then -- unpack and apply stat buff if present
-        if subPower >= 400 then
-            subPower = subPower - 400
-            buff     = 4
-        elseif subPower >= 300 then
-            subPower = subPower - 300
-            buff     = 3
-        elseif subPower >= 200 then
-            subPower = subPower - 200
-            buff     = 2
-        else
-            subPower = subPower - 100
-            buff     = 1
-        end
-    end
-
-    target:delMod(xi.magic.resistMod[subPower], effect:getPower())
-
-    if buff > 0 then -- xi.magic.element and MODS unfortnately don't match
-        if subPower == 1 then -- fire add STR
-            target:delMod(xi.mod.STR, buff)
-        elseif subPower == 2 then -- ice add INT
-            target:delMod(xi.mod.INT, buff)
-        elseif subPower == 3 then -- wind add AGI
-            target:delMod(xi.mod.AGI, buff)
-        elseif subPower == 4 then -- earth add VIT
-            target:delMod(xi.mod.VIT, buff)
-        elseif subPower == 5 then -- thunder add DEX
-            target:delMod(xi.mod.DEX, buff)
-        elseif subPower == 6 then -- water add MND
-            target:delMod(xi.mod.MND, buff)
-        elseif subPower == 7 then -- light add CHR
-            target:delMod(xi.mod.CHR, buff)
-        elseif subPower == 8 then -- dark add MP
-            target:delMod(xi.mod.MP, buff * 10)
-        end
-    end
 end
 
 return effectObject

--- a/scripts/effects/tomahawk.lua
+++ b/scripts/effects/tomahawk.lua
@@ -3,21 +3,23 @@
 -----------------------------------
 ---@type TEffect
 local effectObject = {}
-local physSDT = { xi.mod.SLASH_SDT, xi.mod.PIERCE_SDT, xi.mod.IMPACT_SDT, xi.mod.HTH_SDT }
 
 effectObject.onEffectGain = function(target, effect)
+    local physSDT = { xi.mod.SLASH_SDT, xi.mod.PIERCE_SDT, xi.mod.IMPACT_SDT, xi.mod.HTH_SDT }
+
     for i = 1, #physSDT do
-        local sdtModPhys = target:getMod(physSDT[i])
+        local sdtModPhys    = target:getMod(physSDT[i])
         local reductionPhys = (1000 - sdtModPhys) * 0.25
 
         effect:addMod(physSDT[i], reductionPhys)
     end
 
-    for i = 1, #xi.magic.specificDmgTakenMod do
-        local sdtModMagic = target:getMod(xi.magic.specificDmgTakenMod[i])
+    for element = xi.element.FIRE, xi.element.DARK do
+        local elementSDTMod  = xi.combat.element.getElementalSDTModifier(element)
+        local sdtModMagic    = target:getMod(elementSDTMod)
         local reductionMagic = sdtModMagic * 0.25
 
-        effect:addMod(xi.magic.specificDmgTakenMod[i], -reductionMagic)
+        effect:addMod(elementSDTMod, -reductionMagic)
     end
 end
 
@@ -25,7 +27,6 @@ effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    -- Mods are stacked on the effect and will be removed automatically when the effect wears off
 end
 
 return effectObject

--- a/scripts/globals/abyssea.lua
+++ b/scripts/globals/abyssea.lua
@@ -829,7 +829,7 @@ xi.abyssea.getNewYellowWeakness = function(mob)
         chosenDay = xi.day.FIRESDAY
     end
 
-    local element = xi.magic.dayElement[chosenDay]
+    local element = xi.combat.element.getDayElement(chosenDay)
 
     return yellowWeakness[element][math.random(1, #yellowWeakness[element])] -- Choose an specific spell the mob is weak to.
 end

--- a/scripts/globals/combat/element_tables.lua
+++ b/scripts/globals/combat/element_tables.lua
@@ -6,36 +6,293 @@ xi = xi or {}
 xi.combat = xi.combat or {}
 xi.combat.element = xi.combat.element or {}
 -----------------------------------
--- Element order = 1:Fire, 2:Ice, 3:Air, 4:Earth, 5:Thunder, 6:Water, 7:Light, 8:Dark
------------------------------------
--- 8 elements table.
------------------------------------
--- Weak day elements. Because the strong one is obvious.
-xi.combat.element.weakDay             = { xi.day.WATERSDAY,          xi.day.FIRESDAY,          xi.day.ICEDAY,             xi.day.WINDSDAY,            xi.day.EARTHSDAY,               xi.day.LIGHTNINGDAY,        xi.day.DARKSDAY,            xi.day.LIGHTSDAY          }
 
--- Strong/Weak weather elements.
-xi.combat.element.strongSingleWeather = { xi.weather.HOT_SPELL,      xi.weather.SNOW,          xi.weather.WIND,           xi.weather.DUST_STORM,      xi.weather.THUNDER,             xi.weather.RAIN,            xi.weather.AURORAS,         xi.weather.GLOOM          }
-xi.combat.element.strongDoubleWeather = { xi.weather.HEAT_WAVE,      xi.weather.BLIZZARDS,     xi.weather.GALES,          xi.weather.SAND_STORM,      xi.weather.THUNDERSTORMS,       xi.weather.SQUALL,          xi.weather.STELLAR_GLARE,   xi.weather.DARKNESS       }
-xi.combat.element.weakSingleWeather   = { xi.weather.RAIN,           xi.weather.HOT_SPELL,     xi.weather.SNOW,           xi.weather.WIND,            xi.weather.DUST_STORM,          xi.weather.THUNDER,         xi.weather.GLOOM,           xi.weather.AURORAS        }
-xi.combat.element.weakDoubleWeather   = { xi.weather.SQUALL,         xi.weather.HEAT_WAVE,     xi.weather.BLIZZARDS,      xi.weather.GALES,           xi.weather.SAND_STORM,          xi.weather.THUNDERSTORMS,   xi.weather.DARKNESS,        xi.weather.STELLAR_GLARE  }
+local column =
+{
+    ELEMENT_OPPOSED       =  1,
+    WEATHER_SINGLE        =  2,
+    WEATHER_DOUBLE        =  3,
+    MOD_ELEMENTAL_SDT     =  4,
+    MOD_RES_RANK          =  5,
+    MOD_ELEMENT_NULL      =  6,
+    MOD_ELEMENT_ABSORB    =  7,
+    MOD_ELEMENT_MACC      =  8,
+    MOD_ELEMENT_MEVA      =  9,
+    MOD_AFFINITY_DMG      = 10,
+    MOD_AFFINITY_MACC     = 11,
+    MOD_FORCE_DW_BONUS    = 12,
+    EFFECT_BARSPELL       = 13,
+    MERIT_ELEMENT_POTENCY = 14,
+    MERIT_ELEMENT_MACC    = 15,
+}
 
--- Elemental modifiers.
-xi.combat.element.specificDmgTakenMod = { xi.mod.FIRE_SDT,           xi.mod.ICE_SDT,           xi.mod.WIND_SDT,           xi.mod.EARTH_SDT,           xi.mod.THUNDER_SDT,             xi.mod.WATER_SDT,           xi.mod.LIGHT_SDT,           xi.mod.DARK_SDT           }
-xi.combat.element.resistRankMod       = { xi.mod.FIRE_RES_RANK,      xi.mod.ICE_RES_RANK,      xi.mod.WIND_RES_RANK,      xi.mod.EARTH_RES_RANK,      xi.mod.THUNDER_RES_RANK,        xi.mod.WATER_RES_RANK,      xi.mod.LIGHT_RES_RANK,      xi.mod.DARK_RES_RANK      }
-xi.combat.element.nullMod             = { xi.mod.FIRE_NULL,          xi.mod.ICE_NULL,          xi.mod.WIND_NULL,          xi.mod.EARTH_NULL,          xi.mod.LTNG_NULL,               xi.mod.WATER_NULL,          xi.mod.LIGHT_NULL,          xi.mod.DARK_NULL          }
-xi.combat.element.absorbMod           = { xi.mod.FIRE_ABSORB,        xi.mod.ICE_ABSORB,        xi.mod.WIND_ABSORB,        xi.mod.EARTH_ABSORB,        xi.mod.LTNG_ABSORB,             xi.mod.WATER_ABSORB,        xi.mod.LIGHT_ABSORB,        xi.mod.DARK_ABSORB        }
-xi.combat.element.elementalMagicAcc   = { xi.mod.FIREACC,            xi.mod.ICEACC,            xi.mod.WINDACC,            xi.mod.EARTHACC,            xi.mod.THUNDERACC,              xi.mod.WATERACC,            xi.mod.LIGHTACC,            xi.mod.DARKACC            }
-xi.combat.element.elementalMagicEva   = { xi.mod.FIRE_MEVA,          xi.mod.ICE_MEVA,          xi.mod.WIND_MEVA,          xi.mod.EARTH_MEVA,          xi.mod.THUNDER_MEVA,            xi.mod.WATER_MEVA,          xi.mod.LIGHT_MEVA,          xi.mod.DARK_MEVA          }
-xi.combat.element.strongAffinityDmg   = { xi.mod.FIRE_AFFINITY_DMG,  xi.mod.ICE_AFFINITY_DMG,  xi.mod.WIND_AFFINITY_DMG,  xi.mod.EARTH_AFFINITY_DMG,  xi.mod.THUNDER_AFFINITY_DMG,    xi.mod.WATER_AFFINITY_DMG,  xi.mod.LIGHT_AFFINITY_DMG,  xi.mod.DARK_AFFINITY_DMG  }
-xi.combat.element.strongAffinityAcc   = { xi.mod.FIRE_AFFINITY_ACC,  xi.mod.ICE_AFFINITY_ACC,  xi.mod.WIND_AFFINITY_ACC,  xi.mod.EARTH_AFFINITY_ACC,  xi.mod.THUNDER_AFFINITY_ACC,    xi.mod.WATER_AFFINITY_ACC,  xi.mod.LIGHT_AFFINITY_ACC,  xi.mod.DARK_AFFINITY_ACC  }
-xi.combat.element.elementalObi        = { xi.mod.FORCE_FIRE_DWBONUS, xi.mod.FORCE_ICE_DWBONUS, xi.mod.FORCE_WIND_DWBONUS, xi.mod.FORCE_EARTH_DWBONUS, xi.mod.FORCE_LIGHTNING_DWBONUS, xi.mod.FORCE_WATER_DWBONUS, xi.mod.FORCE_LIGHT_DWBONUS, xi.mod.FORCE_DARK_DWBONUS }
+xi.combat.element.dataTable =
+{
+    [xi.element.FIRE   ] = { xi.element.WATER,   xi.weather.HOT_SPELL,  xi.weather.HEAT_WAVE,     xi.mod.FIRE_SDT,    xi.mod.FIRE_RES_RANK,    xi.mod.FIRE_NULL,  xi.mod.FIRE_ABSORB,  xi.mod.FIREACC,    xi.mod.FIRE_MEVA,    xi.mod.FIRE_AFFINITY_DMG,    xi.mod.FIRE_AFFINITY_ACC,    xi.mod.FORCE_FIRE_DWBONUS,      xi.effect.BARFIRE,     xi.merit.FIRE_MAGIC_POTENCY,      xi.merit.FIRE_MAGIC_ACCURACY      },
+    [xi.element.ICE    ] = { xi.element.FIRE,    xi.weather.SNOW,       xi.weather.BLIZZARDS,     xi.mod.ICE_SDT,     xi.mod.ICE_RES_RANK,     xi.mod.ICE_NULL,   xi.mod.ICE_ABSORB,   xi.mod.ICEACC,     xi.mod.ICE_MEVA,     xi.mod.ICE_AFFINITY_DMG,     xi.mod.ICE_AFFINITY_ACC,     xi.mod.FORCE_ICE_DWBONUS,       xi.effect.BARBLIZZARD, xi.merit.ICE_MAGIC_POTENCY,       xi.merit.ICE_MAGIC_ACCURACY       },
+    [xi.element.WIND   ] = { xi.element.ICE,     xi.weather.WIND,       xi.weather.GALES,         xi.mod.WIND_SDT,    xi.mod.WIND_RES_RANK,    xi.mod.WIND_NULL,  xi.mod.WIND_ABSORB,  xi.mod.WINDACC,    xi.mod.WIND_MEVA,    xi.mod.WIND_AFFINITY_DMG,    xi.mod.WIND_AFFINITY_ACC,    xi.mod.FORCE_WIND_DWBONUS,      xi.effect.BARAERO,     xi.merit.WIND_MAGIC_POTENCY,      xi.merit.WIND_MAGIC_ACCURACY      },
+    [xi.element.EARTH  ] = { xi.element.WIND,    xi.weather.DUST_STORM, xi.weather.SAND_STORM,    xi.mod.EARTH_SDT,   xi.mod.EARTH_RES_RANK,   xi.mod.EARTH_NULL, xi.mod.EARTH_ABSORB, xi.mod.EARTHACC,   xi.mod.EARTH_MEVA,   xi.mod.EARTH_AFFINITY_DMG,   xi.mod.EARTH_AFFINITY_ACC,   xi.mod.FORCE_EARTH_DWBONUS,     xi.effect.BARSTONE,    xi.merit.EARTH_MAGIC_POTENCY,     xi.merit.EARTH_MAGIC_ACCURACY     },
+    [xi.element.THUNDER] = { xi.element.EARTH,   xi.weather.THUNDER,    xi.weather.THUNDERSTORMS, xi.mod.THUNDER_SDT, xi.mod.THUNDER_RES_RANK, xi.mod.LTNG_NULL,  xi.mod.LTNG_ABSORB,  xi.mod.THUNDERACC, xi.mod.THUNDER_MEVA, xi.mod.THUNDER_AFFINITY_DMG, xi.mod.THUNDER_AFFINITY_ACC, xi.mod.FORCE_LIGHTNING_DWBONUS, xi.effect.BARTHUNDER,  xi.merit.LIGHTNING_MAGIC_POTENCY, xi.merit.LIGHTNING_MAGIC_ACCURACY },
+    [xi.element.WATER  ] = { xi.element.THUNDER, xi.weather.RAIN,       xi.weather.SQUALL,        xi.mod.WATER_SDT,   xi.mod.WATER_RES_RANK,   xi.mod.WATER_NULL, xi.mod.WATER_ABSORB, xi.mod.WATERACC,   xi.mod.WATER_MEVA,   xi.mod.WATER_AFFINITY_DMG,   xi.mod.WATER_AFFINITY_ACC,   xi.mod.FORCE_WATER_DWBONUS,     xi.effect.BARWATER,    xi.merit.WATER_MAGIC_POTENCY,     xi.merit.WATER_MAGIC_ACCURACY     },
+    [xi.element.LIGHT  ] = { xi.element.DARK,    xi.weather.AURORAS,    xi.weather.STELLAR_GLARE, xi.mod.LIGHT_SDT,   xi.mod.LIGHT_RES_RANK,   xi.mod.LIGHT_NULL, xi.mod.LIGHT_ABSORB, xi.mod.LIGHTACC,   xi.mod.LIGHT_MEVA,   xi.mod.LIGHT_AFFINITY_DMG,   xi.mod.LIGHT_AFFINITY_ACC,   xi.mod.FORCE_LIGHT_DWBONUS,     0,                     0,                                0                                 },
+    [xi.element.DARK   ] = { xi.element.LIGHT,   xi.weather.GLOOM,      xi.weather.DARKNESS,      xi.mod.DARK_SDT,    xi.mod.DARK_RES_RANK,    xi.mod.DARK_NULL,  xi.mod.DARK_ABSORB,  xi.mod.DARKACC,    xi.mod.DARK_MEVA,    xi.mod.DARK_AFFINITY_DMG,    xi.mod.DARK_AFFINITY_ACC,    xi.mod.FORCE_DARK_DWBONUS,      0,                     0,                                0                                 },
+}
+
+xi.combat.element.getOppositeElement = function(element)
+    -- Validate fed value.
+    local elementToCheck = element or 0
+
+    if elementToCheck < xi.element.FIRE or elementToCheck > xi.element.DARK then
+        return 0
+    end
+
+    -- Fetch opposite element.
+    elementToCheck = xi.combat.element.dataTable[elementToCheck][column.ELEMENT_OPPOSED]
+
+    return elementToCheck
+end
 
 -----------------------------------
--- 6 elements tables. (No Light nor Dark)
+-- Day-related functions
 -----------------------------------
--- Elemental effects.
-xi.combat.element.barSpell            = { xi.effect.BARFIRE,            xi.effect.BARBLIZZARD,       xi.effect.BARAERO,            xi.effect.BARSTONE,            xi.effect.BARTHUNDER,              xi.effect.BARWATER            }
+xi.combat.element.getAssociatedDay = function(element)
+    -- Validate fed value.
+    local elementToCheck = element or 0
 
--- Elemental merits.
-xi.combat.element.blmMerit            = { xi.merit.FIRE_MAGIC_POTENCY,  xi.merit.ICE_MAGIC_POTENCY,  xi.merit.WIND_MAGIC_POTENCY,  xi.merit.EARTH_MAGIC_POTENCY,  xi.merit.LIGHTNING_MAGIC_POTENCY,  xi.merit.WATER_MAGIC_POTENCY  }
-xi.combat.element.rdmMerit            = { xi.merit.FIRE_MAGIC_ACCURACY, xi.merit.ICE_MAGIC_ACCURACY, xi.merit.WIND_MAGIC_ACCURACY, xi.merit.EARTH_MAGIC_ACCURACY, xi.merit.LIGHTNING_MAGIC_ACCURACY, xi.merit.WATER_MAGIC_ACCURACY }
+    if elementToCheck < xi.element.FIRE or elementToCheck > xi.element.DARK then
+        return -1
+    end
+
+    return elementToCheck - 1
+end
+
+xi.combat.element.getOppositeDay = function(element)
+    -- Validate fed value.
+    local elementToCheck = element or 0
+
+    if elementToCheck < xi.element.FIRE or elementToCheck > xi.element.DARK then
+        return -1
+    end
+
+    -- Fetch opposite element.
+    elementToCheck = xi.combat.element.dataTable[elementToCheck][column.ELEMENT_OPPOSED]
+
+    return elementToCheck - 1
+end
+
+xi.combat.element.getDayElement = function(day)
+    -- Validate fed value.
+    local dayToCheck = day or -1
+
+    return dayToCheck + 1
+end
+
+-----------------------------------
+-- Weather-related functions
+-----------------------------------
+xi.combat.element.getAssociatedSingleWeather = function(element)
+    -- Validate fed value.
+    local elementToCheck = element or 0
+
+    if elementToCheck < xi.element.FIRE or elementToCheck > xi.element.DARK then
+        return 0
+    end
+
+    return xi.combat.element.dataTable[elementToCheck][column.WEATHER_SINGLE]
+end
+
+xi.combat.element.getOppositeSingleWeather = function(element)
+    -- Validate fed value.
+    local elementToCheck = element or 0
+
+    if elementToCheck < xi.element.FIRE or elementToCheck > xi.element.DARK then
+        return 0
+    end
+
+    -- Fetch opposite element.
+    elementToCheck = xi.combat.element.dataTable[elementToCheck][column.ELEMENT_OPPOSED]
+
+    return xi.combat.element.dataTable[elementToCheck][column.WEATHER_SINGLE]
+end
+
+xi.combat.element.getAssociatedDoubleWeather = function(element)
+    -- Validate fed value.
+    local elementToCheck = element or 0
+
+    if elementToCheck < xi.element.FIRE or elementToCheck > xi.element.DARK then
+        return 0
+    end
+
+    return xi.combat.element.dataTable[elementToCheck][column.WEATHER_DOUBLE]
+end
+
+xi.combat.element.getOppositeDoubleWeather = function(element)
+    -- Validate fed value.
+    local elementToCheck = element or 0
+
+    if elementToCheck < xi.element.FIRE or elementToCheck > xi.element.DARK then
+        return
+    end
+
+    -- Fetch opposite element.
+    elementToCheck = xi.combat.element.dataTable[elementToCheck][column.ELEMENT_OPPOSED]
+
+    return xi.combat.element.dataTable[elementToCheck][column.WEATHER_DOUBLE]
+end
+
+xi.combat.element.getWeatherElement = function(weather)
+    -- Validate fed value.
+    local weatherToCheck = weather or 0
+
+    for elementChecked = xi.element.FIRE, xi.element.DARK do
+        local elementalSingle = xi.combat.element.dataTable[elementChecked][column.WEATHER_SINGLE]
+        local elementalDouble = xi.combat.element.dataTable[elementChecked][column.WEATHER_DOUBLE]
+
+        if weatherToCheck == elementalSingle or weatherToCheck == elementalDouble then
+            return elementChecked
+        end
+    end
+
+    return xi.element.NONE
+end
+
+-----------------------------------
+-- Modifier-related functions
+-----------------------------------
+xi.combat.element.getElementalSDTModifier = function(element)
+    -- Validate fed value.
+    local elementToCheck = element or 0
+
+    if elementToCheck < xi.element.FIRE or elementToCheck > xi.element.DARK then
+        return 0
+    end
+
+    return xi.combat.element.dataTable[elementToCheck][column.MOD_ELEMENTAL_SDT]
+end
+
+xi.combat.element.getElementalResistanceRankModifier = function(element)
+    -- Validate fed value.
+    local elementToCheck = element or 0
+
+    if elementToCheck < xi.element.FIRE or elementToCheck > xi.element.DARK then
+        return 0
+    end
+
+    return xi.combat.element.dataTable[elementToCheck][column.MOD_RES_RANK]
+end
+
+xi.combat.element.getElementalNullificationModifier = function(element)
+    -- Validate fed value.
+    local elementToCheck = element or 0
+
+    if elementToCheck < xi.element.FIRE or elementToCheck > xi.element.DARK then
+        return 0
+    end
+
+    return xi.combat.element.dataTable[elementToCheck][column.MOD_ELEMENT_NULL]
+end
+
+xi.combat.element.getElementalAbsorptionModifier = function(element)
+    -- Validate fed value.
+    local elementToCheck = element or 0
+
+    if elementToCheck < xi.element.FIRE or elementToCheck > xi.element.DARK then
+        return 0
+    end
+
+    return xi.combat.element.dataTable[elementToCheck][column.MOD_ELEMENT_ABSORB]
+end
+
+xi.combat.element.getElementalMACCModifier = function(element)
+    -- Validate fed value.
+    local elementToCheck = element or 0
+
+    if elementToCheck < xi.element.FIRE or elementToCheck > xi.element.DARK then
+        return 0
+    end
+
+    return xi.combat.element.dataTable[elementToCheck][column.MOD_ELEMENT_MACC]
+end
+
+xi.combat.element.getElementalMEVAModifier = function(element)
+    -- Validate fed value.
+    local elementToCheck = element or 0
+
+    if elementToCheck < xi.element.FIRE or elementToCheck > xi.element.DARK then
+        return 0
+    end
+
+    return xi.combat.element.dataTable[elementToCheck][column.MOD_ELEMENTAL_MEVA]
+end
+
+xi.combat.element.getElementalAffinityDMGModifier = function(element)
+    -- Validate fed value.
+    local elementToCheck = element or 0
+
+    if elementToCheck < xi.element.FIRE or elementToCheck > xi.element.DARK then
+        return 0
+    end
+
+    return xi.combat.element.dataTable[elementToCheck][column.MOD_AFFINITY_DMG]
+end
+
+xi.combat.element.getElementalAffinityMACCModifier = function(element)
+    -- Validate fed value.
+    local elementToCheck = element or 0
+
+    if elementToCheck < xi.element.FIRE or elementToCheck > xi.element.DARK then
+        return 0
+    end
+
+    return xi.combat.element.dataTable[elementToCheck][column.MOD_AFFINITY_MACC]
+end
+
+xi.combat.element.getForcedDayOrWeatherBonusModifier = function(element)
+    -- Validate fed value.
+    local elementToCheck = element or 0
+
+    if elementToCheck < xi.element.FIRE or elementToCheck > xi.element.DARK then
+        return 0
+    end
+
+    return xi.combat.element.dataTable[elementToCheck][column.MOD_FORCE_DW_BONUS]
+end
+
+-----------------------------------
+-- Effect-related functions
+-----------------------------------
+xi.combat.element.getAssociatedBarspellEffect = function(element)
+    -- Validate fed value.
+    local elementToCheck = element or 0
+
+    if elementToCheck < xi.element.FIRE or elementToCheck > xi.element.WATER then
+        return 0
+    end
+
+    return xi.combat.element.dataTable[elementToCheck][column.EFFECT_BARSPELL]
+end
+
+-----------------------------------
+-- Merit-related functions
+-----------------------------------
+xi.combat.element.getElementalPotencyMerit = function(element)
+    -- Validate fed value.
+    local elementToCheck = element or 0
+
+    if elementToCheck < xi.element.FIRE or elementToCheck > xi.element.WATER then
+        return 0
+    end
+
+    return xi.combat.element.dataTable[elementToCheck][column.MERIT_ELEMENT_POTENCY]
+end
+
+xi.combat.element.getElementalAccuracyMerit = function(element)
+    -- Validate fed value.
+    local elementToCheck = element or 0
+
+    if elementToCheck < xi.element.FIRE or elementToCheck > xi.element.WATER then
+        return 0
+    end
+
+    return xi.combat.element.dataTable[elementToCheck][column.MERIT_ELEMENT_MACC]
+end

--- a/scripts/globals/combat/magic_hit_rate.lua
+++ b/scripts/globals/combat/magic_hit_rate.lua
@@ -33,7 +33,7 @@ local function magicAccuracyFromElement(actor, actionElement)
     local magicAcc = 0
 
     if actionElement > xi.element.NONE then
-        magicAcc = actor:getMod(xi.combat.element.elementalMagicAcc[actionElement]) + actor:getMod(xi.combat.element.strongAffinityAcc[actionElement]) * 10
+        magicAcc = actor:getMod(xi.combat.element.getElementalMACCModifier(actionElement)) + actor:getMod(xi.combat.element.getElementalAffinityMACCModifier(actionElement)) * 10
     end
 
     return magicAcc
@@ -89,7 +89,7 @@ local function magicAccuracyFromStatusEffects(actor, spellGroup, skillType, acti
     if
         actor:hasStatusEffect(xi.effect.KLIMAFORM) and
         actionElement > 0 and
-        (actorWeather == xi.combat.element.strongSingleWeather[actionElement] or actorWeather == xi.combat.element.strongDoubleWeather[actionElement])
+        (actorWeather == xi.combat.element.getAssociatedSingleWeather(actionElement) or actorWeather == xi.combat.element.getAssociatedDoubleWeather(actionElement))
     then
         magicAcc = magicAcc + 15
     end
@@ -143,7 +143,7 @@ local function magicAccuracyFromMerits(actor, skillType, actionElement)
                 actionElement >= xi.element.FIRE and
                 actionElement <= xi.element.WATER
             then
-                magicAcc = actor:getMerit(xi.combat.element.rdmMerit[actionElement])
+                magicAcc = actor:getMerit(xi.combat.element.getElementalAccuracyMerit(actionElement))
             end
 
             -- Category 2
@@ -235,7 +235,7 @@ local function magicAccuracyFromDayElement(actor, actionElement)
 
     if
         actionElement ~= xi.element.NONE and
-        (math.random(1, 100) <= 33 or actor:getMod(xi.combat.element.elementalObi[actionElement]) >= 1)
+        (math.random(1, 100) <= 33 or actor:getMod(xi.combat.element.getForcedDayOrWeatherBonusModifier(actionElement)) >= 1)
     then
         local dayElement = VanadielDayElement()
 
@@ -244,7 +244,7 @@ local function magicAccuracyFromDayElement(actor, actionElement)
             magicAcc = magicAcc + 5
 
         -- Weak day.
-        elseif dayElement == xi.combat.element.weakDay[actionElement] then
+        elseif dayElement == xi.combat.element.getOppositeElement(actionElement) then
             magicAcc = magicAcc - 5
         end
     end
@@ -259,20 +259,20 @@ local function magicAccuracyFromWeatherElement(actor, actionElement)
     -- Calculate if weather bonus triggers.
     if
         actionElement ~= xi.element.NONE and
-        (math.random(1, 100) <= 33 or actor:getMod(xi.combat.element.elementalObi[actionElement]) >= 1)
+        (math.random(1, 100) <= 33 or actor:getMod(xi.combat.element.getForcedDayOrWeatherBonusModifier(actionElement)) >= 1)
     then
         local actorWeather = actor:getWeather()
 
         -- Strong weathers.
-        if actorWeather == xi.combat.element.strongSingleWeather[actionElement] then
+        if actorWeather == xi.combat.element.getAssociatedSingleWeather(actionElement) then
             magicAcc = magicAcc + actor:getMod(xi.mod.IRIDESCENCE) * 5 + 5
-        elseif actorWeather == xi.combat.element.strongDoubleWeather[actionElement] then
+        elseif actorWeather == xi.combat.element.getAssociatedDoubleWeather(actionElement) then
             magicAcc = magicAcc + actor:getMod(xi.mod.IRIDESCENCE) * 5 + 10
 
         -- Weak weathers.
-        elseif actorWeather == xi.combat.element.weakSingleWeather[actionElement] then
+        elseif actorWeather == xi.combat.element.getOppositeSingleWeather(actionElement) then
             magicAcc = magicAcc - actor:getMod(xi.mod.IRIDESCENCE) * 5 - 5
-        elseif actorWeather == xi.combat.element.weakDoubleWeather[actionElement] then
+        elseif actorWeather == xi.combat.element.getOppositeDoubleWeather(actionElement) then
             magicAcc = magicAcc - actor:getMod(xi.mod.IRIDESCENCE) * 5 - 10
         end
     end
@@ -352,8 +352,8 @@ xi.combat.magicHitRate.calculateTargetMagicEvasion = function(actor, target, act
     -- Elemental magic evasion.
     if actionElement ~= xi.element.NONE then
         -- Mod set in database for mobs. Base 0 means not resistant nor weak. Bar-element spells included here.
-        resMod     = target:getMod(xi.combat.element.elementalMagicEva[actionElement])
-        resistRank = utils.clamp(target:getMod(xi.combat.element.resistRankMod[actionElement]), -3, 11)
+        resMod     = target:getMod(xi.combat.element.getElementalMEVAModifier(actionElement))
+        resistRank = utils.clamp(target:getMod(xi.combat.element.getElementalResistanceRankModifier(actionElement)), -3, 11)
 
         if resistRank > 4 then
             resistRank = utils.clamp(resistRank - rankModifier, 4, 11)
@@ -423,7 +423,7 @@ xi.combat.magicHitRate.calculateResistanceFactor = function(actor, target, skill
     ----------------------------------------
     -- Handle target resistance rank.
     ----------------------------------------
-    local targetResistRank = target:getMod(xi.combat.element.resistRankMod[actionElement]) or 0
+    local targetResistRank = target:getMod(xi.combat.element.getElementalResistanceRankModifier(actionElement)) or 0
 
     if targetResistRank > 4 then
         targetResistRank = utils.clamp(targetResistRank - rankModifier, 4, 11)

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -7,33 +7,6 @@ require('scripts/globals/utils')
 xi = xi or {}
 xi.magic = xi.magic or {}
 
------------------------------------
--- Day to Element Mapping
------------------------------------
-
-xi.magic.dayElement =
-{
-    [xi.day.FIRESDAY    ] = xi.element.FIRE,
-    [xi.day.ICEDAY      ] = xi.element.ICE,
-    [xi.day.WINDSDAY    ] = xi.element.WIND,
-    [xi.day.EARTHSDAY   ] = xi.element.EARTH,
-    [xi.day.LIGHTNINGDAY] = xi.element.THUNDER,
-    [xi.day.WATERSDAY   ] = xi.element.WATER,
-    [xi.day.LIGHTSDAY   ] = xi.element.LIGHT,
-    [xi.day.DARKSDAY    ] = xi.element.DARK,
-}
-
------------------------------------
--- Tables by element
------------------------------------
-
-local strongAffinityAcc      = { xi.mod.FIRE_AFFINITY_ACC,     xi.mod.ICE_AFFINITY_ACC,     xi.mod.WIND_AFFINITY_ACC,      xi.mod.EARTH_AFFINITY_ACC,     xi.mod.THUNDER_AFFINITY_ACC,       xi.mod.WATER_AFFINITY_ACC,      xi.mod.LIGHT_AFFINITY_ACC,  xi.mod.DARK_AFFINITY_ACC }
-xi.magic.resistMod           = { xi.mod.FIRE_MEVA,             xi.mod.ICE_MEVA,             xi.mod.WIND_MEVA,              xi.mod.EARTH_MEVA,             xi.mod.THUNDER_MEVA,               xi.mod.WATER_MEVA,              xi.mod.LIGHT_MEVA,          xi.mod.DARK_MEVA }
-xi.magic.specificDmgTakenMod = { xi.mod.FIRE_SDT,              xi.mod.ICE_SDT,              xi.mod.WIND_SDT,               xi.mod.EARTH_SDT,              xi.mod.THUNDER_SDT,                xi.mod.WATER_SDT,               xi.mod.LIGHT_SDT,           xi.mod.DARK_SDT }
-xi.magic.absorbMod           = { xi.mod.FIRE_ABSORB,           xi.mod.ICE_ABSORB,           xi.mod.WIND_ABSORB,            xi.mod.EARTH_ABSORB,           xi.mod.LTNG_ABSORB,                xi.mod.WATER_ABSORB,            xi.mod.LIGHT_ABSORB,        xi.mod.DARK_ABSORB }
-local blmMerit               = { xi.merit.FIRE_MAGIC_POTENCY,  xi.merit.ICE_MAGIC_POTENCY,  xi.merit.WIND_MAGIC_POTENCY,   xi.merit.EARTH_MAGIC_POTENCY,  xi.merit.LIGHTNING_MAGIC_POTENCY,  xi.merit.WATER_MAGIC_POTENCY }
-xi.magic.barSpell            = { xi.effect.BARFIRE,            xi.effect.BARBLIZZARD,       xi.effect.BARAERO,             xi.effect.BARSTONE,            xi.effect.BARTHUNDER,              xi.effect.BARWATER }
-
 -- USED FOR DAMAGING MAGICAL SPELLS (Stages 1 and 2 in Calculating Magic Damage on wiki)
 local softCap = 60 --guesstimated
 local hardCap = 120 --guesstimated
@@ -402,9 +375,9 @@ function addBonuses(caster, spell, target, dmg, params)
 
         local mdefBarBonus = 0
         if ele >= xi.element.FIRE and ele <= xi.element.WATER then
-            mab = mab + caster:getMerit(blmMerit[ele])
-            if target:hasStatusEffect(xi.magic.barSpell[ele]) then -- bar- spell magic defense bonus
-                mdefBarBonus = target:getStatusEffect(xi.magic.barSpell[ele]):getSubPower()
+            mab = mab + caster:getMerit(xi.combat.element.getElementalPotencyMerit(ele))
+            if target:hasStatusEffect(xi.combat.element.getAssociatedBarspellEffect(ele)) then -- bar- spell magic defense bonus
+                mdefBarBonus = target:getStatusEffect(xi.combat.element.getAssociatedBarspellEffect(ele)):getSubPower()
             end
         end
 
@@ -445,9 +418,9 @@ function addBonusesAbility(caster, ele, target, dmg, params)
     if
         ele >= xi.element.FIRE and
         ele <= xi.element.WATER and
-        target:hasStatusEffect(xi.magic.barSpell[ele])
+        target:hasStatusEffect(xi.combat.element.getAssociatedBarspellEffect(ele))
     then -- bar- spell magic defense bonus
-        mdefBarBonus = target:getStatusEffect(xi.magic.barSpell[ele]):getSubPower()
+        mdefBarBonus = target:getStatusEffect(xi.combat.element.getAssociatedBarspellEffect(ele)):getSubPower()
     end
 
     if params ~= nil and params.bonusmab ~= nil and params.includemab then
@@ -467,7 +440,7 @@ end
 
 function handleThrenody(caster, target, spell, basePower, baseDuration, modifier)
     -- Process resitances
-    local staff  = caster:getMod(strongAffinityAcc[spell:getElement()]) * 10
+    local staff  = caster:getMod(xi.combat.element.getElementalAffinityMACCModifier(spell:getElement())) * 10
     local params = {}
 
     params.attribute = xi.mod.CHR

--- a/scripts/globals/pets/avatar.lua
+++ b/scripts/globals/pets/avatar.lua
@@ -46,14 +46,14 @@ local setMagicCastCooldown = function(pet)
     local actorWeather = pet:getWeather()
     -- Strong weathers.
     if
-        actorWeather == xi.combat.element.strongSingleWeather[petElement] or
-        actorWeather == xi.combat.element.strongDoubleWeather[petElement]
+        actorWeather == xi.combat.element.getAssociatedSingleWeather(petElement) or
+        actorWeather == xi.combat.element.getAssociatedDoubleWeather(petElement)
     then
         castingCooldown = castingCooldown - 2
     -- Weak weathers.
     elseif
-        actorWeather == xi.combat.element.weakSingleWeather[petElement] or
-        actorWeather == xi.combat.element.weakDoubleWeather[petElement]
+        actorWeather == xi.combat.element.getOppositeSingleWeather(petElement) or
+        actorWeather == xi.combat.element.getOppositeDoubleWeather(petElement)
     then
         castingCooldown = castingCooldown + 2
     end
@@ -63,7 +63,7 @@ local setMagicCastCooldown = function(pet)
     if dayElement == petElement then
         castingCooldown = castingCooldown - 3
     -- Weak day.
-    elseif dayElement == xi.combat.element.weakDay[petElement] then
+    elseif dayElement == xi.combat.element.getOppositeElement(petElement) then
         castingCooldown = castingCooldown + 3
     end
 

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -376,7 +376,7 @@ xi.spells.damage.calculateElementalStaffBonus = function(caster, spellElement)
     local elementalStaffBonus = 1
 
     if spellElement > xi.element.NONE then
-        elementalStaffBonus = elementalStaffBonus + caster:getMod(xi.combat.element.strongAffinityDmg[spellElement]) * 0.05
+        elementalStaffBonus = elementalStaffBonus + caster:getMod(xi.combat.element.getElementalAffinityDMGModifier(spellElement)) * 0.05
     end
 
     return elementalStaffBonus
@@ -410,7 +410,7 @@ xi.spells.damage.calculateSDT = function(target, spellElement)
     local sdt = 1 -- The variable we want to calculate
 
     if spellElement > xi.element.NONE then
-        sdt = 1 - target:getMod(xi.combat.element.specificDmgTakenMod[spellElement]) / 10000
+        sdt = 1 - target:getMod(xi.combat.element.getElementalSDTModifier(spellElement)) / 10000
     end
 
     return utils.clamp(sdt, 0, 3)
@@ -439,19 +439,19 @@ xi.spells.damage.calculateDayAndWeather = function(caster, spellId, spellElement
     -- Calculate Weather bonus + Iridescence bonus.
     if
         math.random(1, 100) <= 33 or
-        caster:getMod(xi.combat.element.elementalObi[spellElement]) >= 1 or
+        caster:getMod(xi.combat.element.getForcedDayOrWeatherBonusModifier(spellElement)) >= 1 or
         isHelixSpell
     then
         -- Strong weathers.
-        if weather == xi.combat.element.strongSingleWeather[spellElement] then
+        if weather == xi.combat.element.getAssociatedSingleWeather(spellElement) then
             dayAndWeather = dayAndWeather + 0.1 + caster:getMod(xi.mod.IRIDESCENCE) * 0.05
-        elseif weather == xi.combat.element.strongDoubleWeather[spellElement] then
+        elseif weather == xi.combat.element.getAssociatedDoubleWeather(spellElement) then
             dayAndWeather = dayAndWeather + 0.25 + caster:getMod(xi.mod.IRIDESCENCE) * 0.05
 
         -- Weak weathers.
-        elseif weather == xi.combat.element.weakSingleWeather[spellElement] then
+        elseif weather == xi.combat.element.getOppositeSingleWeather(spellElement) then
             dayAndWeather = dayAndWeather - 0.1 - caster:getMod(xi.mod.IRIDESCENCE) * 0.05
-        elseif weather == xi.combat.element.weakDoubleWeather[spellElement] then
+        elseif weather == xi.combat.element.getOppositeDoubleWeather(spellElement) then
             dayAndWeather = dayAndWeather - 0.25 - caster:getMod(xi.mod.IRIDESCENCE) * 0.05
         end
     end
@@ -459,7 +459,7 @@ xi.spells.damage.calculateDayAndWeather = function(caster, spellId, spellElement
     -- Calculate day bonus
     if
         math.random(1, 100) <= 33 or
-        caster:getMod(xi.combat.element.elementalObi[spellElement]) >= 1 or
+        caster:getMod(xi.combat.element.getForcedDayOrWeatherBonusModifier(spellElement)) >= 1 or
         isHelixSpell
     then
         -- Strong day.
@@ -467,7 +467,7 @@ xi.spells.damage.calculateDayAndWeather = function(caster, spellId, spellElement
             dayAndWeather = dayAndWeather + 0.1 + caster:getMod(xi.mod.DAY_NUKE_BONUS) / 100 -- sorc. tonban(+1)/zodiac ring
 
         -- Weak day.
-        elseif dayElement == xi.combat.element.weakDay[spellElement] then
+        elseif dayElement == xi.combat.element.getOppositeElement(spellElement) then
             dayAndWeather = dayAndWeather - 0.1
         end
     end
@@ -537,10 +537,10 @@ xi.spells.damage.calculateMagicBonusDiff = function(caster, target, spellId, ski
         spellElement >= xi.element.FIRE and
         spellElement <= xi.element.WATER
     then
-        mab = mab + caster:getMerit(xi.combat.element.blmMerit[spellElement])
+        mab = mab + caster:getMerit(xi.combat.element.getElementalPotencyMerit(spellElement))
 
-        if target:hasStatusEffect(xi.combat.element.barSpell[spellElement]) then -- bar- spell magic defense bonus
-            mDefBarBonus = target:getStatusEffect(xi.combat.element.barSpell[spellElement]):getSubPower()
+        if target:hasStatusEffect(xi.combat.element.getAssociatedBarspellEffect(spellElement)) then -- bar- spell magic defense bonus
+            mDefBarBonus = target:getStatusEffect(xi.combat.element.getAssociatedBarspellEffect(spellElement)):getSubPower()
         end
     end
 
@@ -772,8 +772,8 @@ xi.spells.damage.calculateNukeAbsorbOrNullify = function(target, spellElement)
     local nullifyElementModValue = 0
 
     if spellElement > xi.element.NONE then
-        absorbElementModValue  = target:getMod(xi.combat.element.absorbMod[spellElement])
-        nullifyElementModValue = target:getMod(xi.combat.element.nullMod[spellElement])
+        absorbElementModValue  = target:getMod(xi.combat.element.getElementalAbsorptionModifier(spellElement))
+        nullifyElementModValue = target:getMod(xi.combat.element.getElementalNullificationModifier(spellElement))
     end
 
     -- Calculate chance for spell absorption.
@@ -803,7 +803,7 @@ xi.spells.damage.calculateIfMagicBurst = function(target, spellElement, skillcha
     local magicBurst = 1 -- The variable we want to calculate
 
     if spellElement > xi.element.NONE then
-        local resistRank = target:getMod(xi.combat.element.resistRankMod[spellElement])
+        local resistRank = target:getMod(xi.combat.element.getElementalResistanceRankModifier(spellElement))
         local rankTable  = { 1.15, 0.85, 0.6, 0.5, 0.4, 0.15, 0.05 }
         local rankBonus  = 0
 

--- a/scripts/globals/spells/enfeebling_spell.lua
+++ b/scripts/globals/spells/enfeebling_spell.lua
@@ -404,7 +404,7 @@ xi.spells.enfeebling.useEnfeeblingSpell = function(caster, target, spell)
         local rankModifier        = target:getMod(immunobreakModifier)
 
         if spellElement ~= xi.element.NONE then
-            resistRank = target:getMod(xi.combat.element.resistRankMod[spellElement])
+            resistRank = target:getMod(xi.combat.element.getElementalResistanceRankModifier(spellElement))
         end
 
         if

--- a/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Jailer_of_Temperance.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Jailer_of_Temperance.lua
@@ -19,13 +19,11 @@ entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.SLASH_SDT, 0)
     mob:setMod(xi.mod.PIERCE_SDT, 0)
     mob:setMod(xi.mod.IMPACT_SDT, 1000)
-    -- Set the magic resists. It always takes no damage from direct magic
-    for n = 1, #xi.magic.resistMod, 1 do
-        mob:setMod(xi.magic.resistMod[n], 0)
-    end
 
-    for n = 1, #xi.magic.specificDmgTakenMod, 1 do
-        mob:setMod(xi.magic.specificDmgTakenMod[n], 10000)
+    -- Set the magic resists. It always takes no damage from direct magic
+    for element = xi.element.FIRE, xi.element.DARK do
+        mob:setMod(xi.combat.element.getElementalMEVAModifier(element), 0)
+        mob:setMod(xi.combat.element.getElementalSDTModifier(element), 10000)
     end
 end
 

--- a/scripts/zones/Promyvion-Vahzl/mobs/Provoker.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Provoker.lua
@@ -13,7 +13,7 @@ end
 
 entity.onMobFight = function(mob, target)
     local changeTime = mob:getLocalVar('changeTime')
-    local element = mob:getLocalVar('element')
+    local element    = mob:getLocalVar('element')
 
     if changeTime == 0 then
         mob:setLocalVar('changeTime', math.random(2, 3) * 15)
@@ -23,15 +23,15 @@ entity.onMobFight = function(mob, target)
     if mob:getBattleTime() >= changeTime then
         local newElement = element
         while newElement == element do
-            newElement = math.random(1, 8)
+            newElement = math.random(xi.element.FIRE, xi.element.DARK)
         end
 
         if element ~= 0 then
-            mob:delMod(xi.magic.absorbMod[element], 100)
+            mob:delMod(xi.combat.element.getElementalAbsorptionModifier(element), 100)
         end
 
         mob:useMobAbility(624)
-        mob:addMod(xi.magic.absorbMod[newElement], 100)
+        mob:addMod(xi.combat.element.getElementalAbsorptionModifier(newElement), 100)
         mob:setLocalVar('changeTime', mob:getBattleTime() + math.random(2, 3) * 15)
         mob:setLocalVar('element', newElement)
     end

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Aweuvhi.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Aweuvhi.lua
@@ -29,30 +29,20 @@ entity.onMobFight = function(mob)
         -- According to http://wiki.ffxiclopedia.org/wiki/Category:Euvhi
         -- When in an open state, damage taken by the Euvhi is doubled. Inflicting a large amount of damage to an Euvhi in an open state will cause it to close.
         -- Make everything do double
+        local powerMod = 1000
+        local powerSDT = 10000
         if mob:getAnimationSub() == 2 then
-            mob:setMod(xi.mod.HTH_SDT, 2000)
-            mob:setMod(xi.mod.SLASH_SDT, 2000)
-            mob:setMod(xi.mod.PIERCE_SDT, 2000)
-            mob:setMod(xi.mod.IMPACT_SDT, 2000)
-            for n = 1, #xi.magic.resistMod, 1 do
-                mob:setMod(xi.magic.resistMod[n], 2000)
-            end
+            powerMod = 2000
+            powerSDT = -10000
+        end
 
-            for n = 1, #xi.magic.specificDmgTakenMod, 1 do
-                mob:setMod(xi.magic.specificDmgTakenMod[n], -10000)
-            end
-        else -- Reset all damage types
-            mob:setMod(xi.mod.HTH_SDT, 1000)
-            mob:setMod(xi.mod.SLASH_SDT, 1000)
-            mob:setMod(xi.mod.PIERCE_SDT, 1000)
-            mob:setMod(xi.mod.IMPACT_SDT, 1000)
-            for n = 1, #xi.magic.resistMod, 1 do
-                mob:setMod(xi.magic.resistMod[n], 1000)
-            end
-
-            for n = 1, #xi.magic.specificDmgTakenMod, 1 do
-                mob:setMod(xi.magic.specificDmgTakenMod[n], 10000)
-            end
+        mob:setMod(xi.mod.HTH_SDT, powerMod)
+        mob:setMod(xi.mod.SLASH_SDT, powerMod)
+        mob:setMod(xi.mod.PIERCE_SDT, powerMod)
+        mob:setMod(xi.mod.IMPACT_SDT, powerMod)
+        for element = xi.element.FIRE, xi.element.DARK do
+            mob:setMod(xi.combat.element.getElementalMEVAModifier(element), powerMod)
+            mob:setMod(xi.combat.element.getElementalSDTModifier(element), powerSDT)
         end
     end
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Unifies all diferent elemental tables under 1 element-indexed table.
- Adds safety to fetched data by creating functions to validate parameters and allowed element ranges. This will remove the need to constantly define element ranges all over the code in the future.
- Most importantly: Removes logic from magic.lua, and that makes me smile.

## Steps to test these changes

Cast spells and have them do spelly things.
