### PR TITLE
[core] Refactor charutils::LoadJobChangeGear

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -2613,37 +2613,54 @@ namespace charutils
 
         if (_sql->Query(Query, PChar->id, PChar->GetMJob()) == SQL_SUCCESS && _sql->NumRows() != 0 && _sql->NextRow() == SQL_SUCCESS)
         {
+            std::vector<uint8> validContainers = { LOC_INVENTORY, LOC_WARDROBE, LOC_WARDROBE2, LOC_WARDROBE3, LOC_WARDROBE4, LOC_WARDROBE5, LOC_WARDROBE6, LOC_WARDROBE7, LOC_WARDROBE8 };
+
             for (uint8 equipSlot = SLOT_MAIN; equipSlot <= SLOT_BACK; equipSlot++)
             {
                 uint16 itemId = _sql->GetUIntData(equipSlot);
 
                 if (itemId > 0)
                 {
-                    for (int container = LOC_INVENTORY; container <= LOC_WARDROBE8; container++)
+                    for (const auto container : validContainers)
                     {
                         bool found = false;
 
-                        if (container == LOC_INVENTORY || (container >= LOC_WARDROBE && container <= LOC_WARDROBE8))
+                        for (uint8 slot = 0; slot < PChar->getStorage(container)->GetSize(); slot++)
                         {
-                            for (uint8 slot = 0; slot < PChar->getStorage(container)->GetSize(); slot++)
-                            {
-                                CItem* PItem  = PChar->getStorage(container)->GetItem(slot);
-                                auto*  PEquip = dynamic_cast<CItemEquipment*>(PItem);
+                            auto* PEquip = dynamic_cast<CItemEquipment*>(PChar->getStorage(container)->GetItem(slot));
 
-                                if ((PItem != nullptr && PItem->getID() == itemId && PEquip != nullptr) &&
-                                    (PEquip != PChar->getEquip(static_cast<SLOTTYPE>(equipSlot - 1)) &&
-                                     PEquip != PChar->getEquip(static_cast<SLOTTYPE>(equipSlot + 1))))
+                            // ensure this is the item we actually want from the db
+                            if (PEquip && PEquip->getID() == itemId)
+                            {
+                                // Validate that we're not trying to equip the same item to two different slots
+                                CItemEquipment* compareItem = nullptr;
+
+                                // Get item that theoretically could be equipped an adjacent slot
+                                if (equipSlot == SLOT_MAIN || equipSlot == SLOT_EAR1 || equipSlot == SLOT_RING1)
+                                {
+                                    // Check one item to the "right"
+                                    compareItem = PChar->getEquip(static_cast<SLOTTYPE>(equipSlot + 1));
+                                }
+                                else if (equipSlot == SLOT_SUB || equipSlot == SLOT_EAR2 || equipSlot == SLOT_RING2)
+                                {
+                                    // Check one item to the "left"
+                                    compareItem = PChar->getEquip(static_cast<SLOTTYPE>(equipSlot - 1));
+                                }
+
+                                // If there's no item to compare then this item is valid
+                                // If there is, check they aren't the same via pointer comparison (2 unique copies)
+                                if (!compareItem || (compareItem && compareItem != PEquip))
                                 {
                                     found = true;
-                                    charutils::EquipItem(PChar, PItem->getSlotID(), equipSlot, static_cast<CONTAINER_ID>(container));
+                                    charutils::EquipItem(PChar, PEquip->getSlotID(), equipSlot, static_cast<CONTAINER_ID>(container));
                                     break;
                                 }
                             }
+                        }
 
-                            if (found)
-                            {
-                                break;
-                            }
+                        if (found)
+                        {
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Refactors the charutils::LoadJobChangeGear function

previous defects:
No bounds checking for getting an item from `SLOT_MAIN -1` which would have wrapped to 255
Excess item checking on both slot +1, slot -1 instead of slot +1 or slot -1
Equipping items from LOC_MOGSAFE2 _worked_ because it was between LOC_WARDROBE and LOC_WARDROBE2

Probably better to review as a complete file. the diff is kind of a mess
## Steps to test these changes

Change job with NIN using 2 of the same item in main/sub, ear1/ear2, ring1/ring2, and make sure they are actually unique items and not the same item twice:

You can do this by forcing the code to check incrementing inventory bags:
1 Kunai from wardrobe 1, 1 Kunai from wardrobe 2,
1 shell earring from wardrobe 5, 1 from wardrobe 6,
1 astral ring from wardrobe 3, 1 astral ring from wardrobe 4,
![image](https://github.com/user-attachments/assets/5b97196a-d172-495f-8ac8-71d534a9840d)

Then you can verify all from one bag (this is a bit harder):
If you target to unequip one duplicate item (order is slightly non-deterministic), the other item should stay unequipped even after zoning 

Change job when wearing an item in inventory, move said item out to mogsafe 2 and see it NOT  equip when you change job back


