### PR TITLE
[core] Enable chat filter for others synth results (S2C 0x070)

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -406,6 +406,17 @@ void CCharEntity::clearPacketList()
     }
 }
 
+bool CCharEntity::isPacketFiltered(CBasicPacket* packet)
+{
+    // Filter others synthesis results
+    if (packet->getType() == 0x70 && playerConfig.MessageFilter.others_synthesis_and_fishing_results)
+    {
+        return true;
+    }
+
+    return false;
+}
+
 void CCharEntity::pushPacket(CBasicPacket* packet)
 {
     TracyZoneScoped;
@@ -413,6 +424,11 @@ void CCharEntity::pushPacket(CBasicPacket* packet)
     TracyZoneHex16(packet->getType());
 
     moduleutils::OnPushPacket(this, packet);
+
+    if (CCharEntity::isPacketFiltered(packet))
+    {
+        return;
+    }
 
     if (packet->getType() == 0x5B)
     {

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -425,6 +425,7 @@ public:
         pushPacket(std::make_unique<T>(std::forward<Args>(args)...));
     }
 
+    bool          isPacketFiltered(CBasicPacket*);
     void          pushPacket(CBasicPacket*);                                                     // Adding a copy of a package to the PacketList
     void          pushPacket(std::unique_ptr<CBasicPacket>);                                     // Push packet to packet list
     void          updateCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint8 updatemask);     // Push or update a char packet


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Enable chat filter for others synth results (S2C 0x070). The server does NOT send packets when your synth filter is on via capture:

(capture is from an "other" char (casey) and the synther is robocop)
Filter off:
![image](https://github.com/user-attachments/assets/e1480539-3b04-499a-94d3-c4b34de20c91)
Filter on:
![image](https://github.com/user-attachments/assets/1ca753b8-56be-4c75-ad2c-c44865355b6a)


## Steps to test these changes

have 2 clients, synth on one, toggle filter on the other and see the chat filter work
![image](https://github.com/user-attachments/assets/b679739f-e1e0-4fa6-b799-9e95a08b17c7)
