### PR TITLE
[Magic] Make magic-hit-rate function work with songs and add support to fetch specific skill rank

### DIFF
--- a/scripts/actions/spells/black/death.lua
+++ b/scripts/actions/spells/black/death.lua
@@ -25,7 +25,7 @@ spellObject.onSpellCast = function(caster, target, spell)
             not target:isNM() and
             not target:hasStatusEffect(xi.effect.MAGIC_SHIELD)
         then
-            local resistRate = xi.combat.magicHitRate.calculateResistRate(caster, target, xi.magic.spellGroup.BLACK, xi.skill.DARK_MAGIC, xi.element.DARK, 0, 0, 0)
+            local resistRate = xi.combat.magicHitRate.calculateResistRate(caster, target, xi.magic.spellGroup.BLACK, xi.skill.DARK_MAGIC, 0, xi.element.DARK, 0, 0, 0)
 
             if resistRate == 1 then
                 instaDeath = true

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -692,7 +692,7 @@ xi.job_utils.dragoon.useDamageBreath = function(wyvern, target, skill, action, d
     local _, skillchainCount = xi.magicburst.formMagicBurst(element, target)
 
     -- 'Breath accuracy is directly affected by a wyvern's current HP', but no data exists.
-    local resist              = xi.combat.magicHitRate.calculateResistRate(wyvern, target, 0, 0, element, 0, 0, bonusMacc)
+    local resist              = xi.combat.magicHitRate.calculateResistRate(wyvern, target, 0, 0, 0, element, 0, 0, bonusMacc)
     local sdt                 = xi.spells.damage.calculateSDT(target, element)
     local nukeAbsorbOrNullify = xi.spells.damage.calculateNukeAbsorbOrNullify(target, element)
     local magicBurst          = 1

--- a/scripts/globals/job_utils/rune_fencer.lua
+++ b/scripts/globals/job_utils/rune_fencer.lua
@@ -517,7 +517,7 @@ local function getSwipeLungeDamageMultipliers(player, target, element, bonusMacc
     multipliers.eleStaffBonus       = xi.spells.damage.calculateElementalStaffBonus(player, element)
     multipliers.magianAffinity      = xi.spells.damage.calculateMagianAffinity() -- Presumed but untested.
     multipliers.SDT                 = xi.spells.damage.calculateSDT(target, element)
-    multipliers.resist              = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, element, 0, 0, bonusMacc)
+    multipliers.resist              = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, element, 0, 0, bonusMacc)
     multipliers.dayAndWeather       = xi.spells.damage.calculateDayAndWeather(player, 0, element)
     multipliers.magicBonusDiff      = xi.spells.damage.calculateMagicBonusDiff(player, target, 0, 0, element)
     multipliers.TMDA                = xi.spells.damage.calculateTMDA(target, element)

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -212,17 +212,17 @@ function applyResistanceEffect(actor, target, spell, params)
         end
     end
 
-    return xi.combat.magicHitRate.calculateResistRate(actor, target, spellFamily, skillType, element, statUsed, effectId, bonusMacc)
+    return xi.combat.magicHitRate.calculateResistRate(actor, target, spellFamily, skillType, 0, element, statUsed, effectId, bonusMacc)
 end
 
 -- Applies resistance for things that may not be spells - ie. Quick Draw
 function applyResistanceAbility(actor, target, element, skillType, bonusMacc)
-    return xi.combat.magicHitRate.calculateResistRate(actor, target, 0, skillType, element, 0, 0, bonusMacc)
+    return xi.combat.magicHitRate.calculateResistRate(actor, target, 0, skillType, 0, element, 0, 0, bonusMacc)
 end
 
 -- Applies resistance for additional effects
 function applyResistanceAddEffect(actor, target, element, bonusMacc)
-    return xi.combat.magicHitRate.calculateResistRate(actor, target, 0, xi.skill.NONE, element, 0, 0, bonusMacc)
+    return xi.combat.magicHitRate.calculateResistRate(actor, target, 0, xi.skill.NONE, 0, element, 0, 0, bonusMacc)
 end
 
 function finalMagicAdjustments(caster, target, spell, dmg)

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -362,7 +362,7 @@ xi.mobskills.applyPlayerResistance = function(actor, effectId, target, diff, bon
         bonusMacc = bonusMacc + diff
     end
 
-    return xi.combat.magicHitRate.calculateResistRate(actor, target, 0, xi.skill.NONE, element, 0, effectId, bonusMacc)
+    return xi.combat.magicHitRate.calculateResistRate(actor, target, 0, xi.skill.NONE, 0, element, 0, effectId, bonusMacc)
 end
 
 xi.mobskills.mobAddBonuses = function(actor, target, damage, element, skill) -- used for SMN magical bloodpacts, despite the name.

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -950,7 +950,7 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
     local magicBurstBonus             = 1
 
     if nukeAbsorbOrNullify > 0 then
-        resist                      = xi.combat.magicHitRate.calculateResistRate(caster, target, spellGroup, skillType, spellElement, statUsed, 0, bonusMacc)
+        resist                      = xi.combat.magicHitRate.calculateResistRate(caster, target, spellGroup, skillType, 0, spellElement, statUsed, 0, bonusMacc)
         targetMagicDamageAdjustment = xi.spells.damage.calculateTMDA(target, spellElement)
 
         -- If spell is NOT blue magic OR (if its blue magic AND has status effect)

--- a/scripts/globals/spells/enfeebling_spell.lua
+++ b/scripts/globals/spells/enfeebling_spell.lua
@@ -378,7 +378,7 @@ xi.spells.enfeebling.useEnfeeblingSpell = function(caster, target, spell)
     local resistStages = pTable[spellId][column.RESIST_STAGES]
     local message      = pTable[spellId][column.MESSAGE_OFFSET]
     local bonusMacc    = pTable[spellId][column.BONUS_MACC]
-    local resistRate   = xi.combat.magicHitRate.calculateResistRate(caster, target, spellGroup, skillType, spellElement, statUsed, spellEffect, bonusMacc)
+    local resistRate   = xi.combat.magicHitRate.calculateResistRate(caster, target, spellGroup, skillType, 0, spellElement, statUsed, spellEffect, bonusMacc)
 
     if spellEffect ~= xi.effect.NONE then
         -- Stymie

--- a/scripts/globals/spells/enhancing_song.lua
+++ b/scripts/globals/spells/enhancing_song.lua
@@ -131,15 +131,18 @@ xi.spells.enhancing.calculateSongPower = function(caster, target, spell, spellId
     local divisor     = pTable[spellId][column.DIVISOR]
     local singingLvl  = caster:getSkillLevel(xi.skill.SINGING)
 
-    -- Add ranged skill level ONLY if it's an instrument.
-    local rangeType = caster:getWeaponSkillType(xi.slot.RANGED)
-    local rangedLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
+    if caster:isPC() then
+        -- Add ranged skill level ONLY if it's an instrument.
+        local rangeType = caster:getWeaponSkillType(xi.slot.RANGED)
 
-    -- String instruments have half the skill effectiveness and amplify the AoE in exchange.
-    if rangeType == xi.skill.WIND_INSTRUMENT then
-        singingLvl = singingLvl + rangedLvl
-    elseif rangeType == xi.skill.STRING_INSTRUMENT then
-        singingLvl = singingLvl + math.floor(rangedLvl / 2)
+        -- String instruments have half the skill effectiveness and amplify the AoE in exchange.
+        if rangeType == xi.skill.WIND_INSTRUMENT then
+            singingLvl = singingLvl + caster:getSkillLevel(rangeType)
+        elseif rangeType == xi.skill.STRING_INSTRUMENT then
+            singingLvl = singingLvl + math.floor(caster:getSkillLevel(rangeType) / 2)
+        end
+    else
+        singingLvl = singingLvl * 2
     end
 
     -- Get Potency bonuses from Singing Skill and Instrument Skill. TODO: Investigate JP-Wiki. Most of this makes no sense.


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Make magic-hit-rate function work with songs: To be ussed in PR #6709 
- Adds support to fetch specific skill rank level instead of current skill level. This was requested by WinterS to use with bolt calculations.

## Steps to test these changes
None
