### PR TITLE
Core: Remove CCharEntity::pushPacket(raw packet)

### DIFF
--- a/modules/custom/cpp/ah_announcement.cpp
+++ b/modules/custom/cpp/ah_announcement.cpp
@@ -179,7 +179,7 @@ class AHAnnouncementModule : public CPPModule
                                             name[0] = std::toupper(name[0]);
 
                                             // Send message to seller!
-                                            message::send(sellerId, new CChatMessagePacket(PChar, MESSAGE_SYSTEM_3,
+                                            message::send(sellerId, std::make_unique<CChatMessagePacket>(PChar, MESSAGE_SYSTEM_3,
                                                 fmt::format("Your '{}' has sold to {} for {} gil!", name, PChar->name, price).c_str(), ""));
                                         }
                                     }

--- a/modules/custom/cpp/ah_announcement.cpp
+++ b/modules/custom/cpp/ah_announcement.cpp
@@ -53,7 +53,7 @@ class AHAnnouncementModule : public CPPModule
 
         auto originalHandler = PacketParser[0x04E];
 
-        auto newHandler = [this, originalHandler](map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket& data) -> void
+        auto newHandler = [originalHandler](map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket& data) -> void
         {
             TracyZoneScoped;
 
@@ -72,7 +72,7 @@ class AHAnnouncementModule : public CPPModule
 
                 if (PChar->getStorage(LOC_INVENTORY)->GetFreeSlotsCount() == 0)
                 {
-                    PChar->pushPacket(new CAuctionHousePacket(action, 0xE5, 0, 0, 0, 0));
+                    PChar->pushPacket<CAuctionHousePacket>(action, 0xE5, 0, 0, 0, 0);
                 }
                 else
                 {
@@ -85,7 +85,7 @@ class AHAnnouncementModule : public CPPModule
                             {
                                 if (PChar->getStorage(LocID)->SearchItem(itemid) != ERROR_SLOTID)
                                 {
-                                    PChar->pushPacket(new CAuctionHousePacket(action, 0xE5, 0, 0, 0, 0));
+                                    PChar->pushPacket<CAuctionHousePacket>(action, 0xE5, 0, 0, 0, 0);
                                     return;
                                 }
                             }

--- a/modules/custom/cpp/ah_pagination.cpp
+++ b/modules/custom/cpp/ah_pagination.cpp
@@ -37,7 +37,7 @@ class AHPaginationModule : public CPPModule
 
         auto originalHandler = PacketParser[0x04E];
 
-        auto newHandler = [this, ITEMS_PER_PAGE, TOTAL_PAGES, originalHandler](map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket& data) -> void
+        auto newHandler = [ITEMS_PER_PAGE, TOTAL_PAGES, originalHandler](map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket& data) -> void
         {
             TracyZoneScoped;
 

--- a/modules/renamer/cpp/renamer.cpp
+++ b/modules/renamer/cpp/renamer.cpp
@@ -1,6 +1,6 @@
-﻿#include "../src/map/packet_guard.h"
-#include "../src/map/utils/moduleutils.h"
-#include "../src/map/zone.h"
+﻿#include "map/packet_guard.h"
+#include "map/utils/moduleutils.h"
+#include "map/zone.h"
 
 extern uint8                                                                             PacketSize[512];
 extern std::function<void(map_session_data_t* const, CCharEntity* const, CBasicPacket&)> PacketParser[512];
@@ -15,14 +15,14 @@ class RenamerModule : public CPPModule
             return;
         }
 
-        auto* customPacket = new CBasicPacket();
+        auto customPacket = std::unique_ptr<CBasicPacket>();
         customPacket->setType(0x1FF);
         customPacket->setSize(0x100);
         for (std::size_t i = 0; i < data.size(); ++i)
         {
             customPacket->ref<uint8>(0x04 + i) = data[i];
         }
-        PChar->pushPacket(customPacket);
+        PChar->pushPacket(std::move(customPacket));
     }
 
     void OnInit() override

--- a/src/map/ability.cpp
+++ b/src/map/ability.cpp
@@ -345,7 +345,7 @@ namespace ability
     {
         // TODO: Add message field to table
 
-        memset(PAbilityList, 0, sizeof(PAbilityList));
+        std::memset(PAbilityList, 0, sizeof(PAbilityList));
 
         const char* Query = "SELECT "
                             "abilityId,"

--- a/src/map/ability.h
+++ b/src/map/ability.h
@@ -26,8 +26,8 @@
 #include "common/mmo.h"
 #include "packets/action.h"
 
-#include "status_effect.h"
 #include "entities/battleentity.h"
+#include "status_effect.h"
 
 enum ADDTYPE
 {

--- a/src/map/ai/helpers/gambits_container.h
+++ b/src/map/ai/helpers/gambits_container.h
@@ -142,6 +142,13 @@ namespace gambits
         G_SELECT   select;
         uint32     select_arg = 0;
 
+        Action_t(G_REACTION reaction, G_SELECT select, uint32 select_arg)
+        : reaction(reaction)
+        , select(select)
+        , select_arg(select_arg)
+        {
+        }
+
         bool parseInput(std::string const& key, uint32 value)
         {
             if (key.compare("reaction") == 0)

--- a/src/map/ai/states/ability_state.cpp
+++ b/src/map/ai/states/ability_state.cpp
@@ -65,7 +65,7 @@ CAbilityState::CAbilityState(CBattleEntity* PEntity, uint16 targid, uint16 abili
         actionTarget.animation = 121;
         actionTarget.messageID = 326;
         actionTarget.param     = PAbility->getID();
-        PEntity->loc.zone->PushPacket(PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+        PEntity->loc.zone->PushPacket(PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
         m_PEntity->PAI->EventHandler.triggerListener("ABILITY_START", CLuaBaseEntity(m_PEntity), CLuaAbility(PAbility));
 
         // face toward target
@@ -127,7 +127,7 @@ bool CAbilityState::Update(time_point tick)
             action_t action;
             m_PEntity->OnAbility(*this, action);
             m_PEntity->PAI->EventHandler.triggerListener("ABILITY_USE", CLuaBaseEntity(m_PEntity), CLuaBaseEntity(GetTarget()), CLuaAbility(m_PAbility.get()), CLuaAction(&action));
-            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
             if (auto* target = GetTarget())
             {
                 target->PAI->EventHandler.triggerListener("ABILITY_TAKE", CLuaBaseEntity(target), CLuaBaseEntity(m_PEntity), CLuaAbility(m_PAbility.get()), CLuaAction(&action));
@@ -149,7 +149,7 @@ bool CAbilityState::Update(time_point tick)
             actionTarget.animation       = 0x1FC;
             actionTarget.reaction        = REACTION::MISS;
 
-            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
         }
         Complete();
     }
@@ -282,7 +282,7 @@ bool CAbilityState::CanUseAbility()
                 actionTarget.param           = 0; // Observed as 639 on retail, but I'm not sure that it actually does anything.
                 actionTarget.messageID       = tooFarAway ? MSGBASIC_TOO_FAR_AWAY_RED : 0;
 
-                m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+                m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
             }
             return false;
         }

--- a/src/map/ai/states/ability_state.cpp
+++ b/src/map/ai/states/ability_state.cpp
@@ -47,7 +47,7 @@ CAbilityState::CAbilityState(CBattleEntity* PEntity, uint16 targid, uint16 abili
 
     if (!PTarget || m_errorMsg)
     {
-        throw CStateInitException(std::move(m_errorMsg));
+        throw CStateInitException(m_errorMsg->copy());
     }
     SetTarget(PTarget->targid);
     m_PAbility = std::make_unique<CAbility>(*PAbility);

--- a/src/map/ai/states/attack_state.cpp
+++ b/src/map/ai/states/attack_state.cpp
@@ -38,7 +38,7 @@ CAttackState::CAttackState(CBattleEntity* PEntity, uint16 targid)
     if (!GetTarget() || m_errorMsg)
     {
         PEntity->SetBattleTargetID(0);
-        throw CStateInitException(std::move(m_errorMsg));
+        throw CStateInitException(m_errorMsg->copy());
     }
     if (PEntity->PAI->PathFind)
     {

--- a/src/map/ai/states/attack_state.cpp
+++ b/src/map/ai/states/attack_state.cpp
@@ -68,7 +68,7 @@ bool CAttackState::Update(time_point tick)
                 // CMobEntity::OnAttack(...) can generate it's own action with a mobmod, and that leaves this action.actionType = 0, which is never valid. Skip sending the packet.
                 if (action.actiontype != ACTION_NONE)
                 {
-                    m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+                    m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
                 }
             }
         }

--- a/src/map/ai/states/despawn_state.cpp
+++ b/src/map/ai/states/despawn_state.cpp
@@ -31,7 +31,7 @@ CDespawnState::CDespawnState(CBaseEntity* _PEntity, bool instantDespawn)
 {
     if (!instantDespawn && (_PEntity->status != STATUS_TYPE::DISAPPEAR && !(static_cast<CMobEntity*>(_PEntity)->m_Behavior & BEHAVIOR_NO_DESPAWN)))
     {
-        _PEntity->loc.zone->PushPacket(_PEntity, CHAR_INRANGE, new CEntityAnimationPacket(_PEntity, _PEntity, CEntityAnimationPacket::Fade_Out));
+        _PEntity->loc.zone->PushPacket(_PEntity, CHAR_INRANGE, std::make_unique<CEntityAnimationPacket>(_PEntity, _PEntity, CEntityAnimationPacket::Fade_Out));
     }
 }
 

--- a/src/map/ai/states/item_state.cpp
+++ b/src/map/ai/states/item_state.cpp
@@ -82,7 +82,7 @@ CItemState::CItemState(CCharEntity* PEntity, uint16 targid, uint8 loc, uint8 slo
 
     if (!PTarget || m_errorMsg)
     {
-        throw CStateInitException(std::move(m_errorMsg));
+        throw CStateInitException(m_errorMsg->copy());
     }
 
     auto [error, param, value] = luautils::OnItemCheck(PTarget, m_PItem, ITEMCHECK::NONE, m_PEntity);
@@ -294,7 +294,7 @@ void CItemState::InterruptItem(action_t& action)
         actionTarget.messageID  = 0;
         actionTarget.knockback  = 0;
 
-        m_PEntity->pushPacket(std::move(m_errorMsg));
+        m_PEntity->pushPacket(m_errorMsg->copy());
     }
 }
 

--- a/src/map/ai/states/item_state.cpp
+++ b/src/map/ai/states/item_state.cpp
@@ -126,7 +126,7 @@ CItemState::CItemState(CCharEntity* PEntity, uint16 targid, uint8 loc, uint8 slo
     actionTarget.knockback  = 0;
 
     m_PEntity->PAI->EventHandler.triggerListener("ITEM_START", CLuaBaseEntity(PTarget), CLuaItem(m_PItem), CLuaAction(&action));
-    m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+    m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
 
     m_PItem->setSubType(ITEM_LOCKED);
 
@@ -182,7 +182,7 @@ bool CItemState::Update(time_point tick)
             FinishItem(action);
         }
         m_PEntity->PAI->EventHandler.triggerListener("ITEM_USE", CLuaBaseEntity(m_PEntity), CLuaItem(m_PItem), CLuaAction(&action));
-        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
         Complete();
     }
     else if (IsCompleted() && tick > GetEntryTime() + m_castTime + m_animationTime)

--- a/src/map/ai/states/item_state.cpp
+++ b/src/map/ai/states/item_state.cpp
@@ -294,7 +294,7 @@ void CItemState::InterruptItem(action_t& action)
         actionTarget.messageID  = 0;
         actionTarget.knockback  = 0;
 
-        m_PEntity->pushPacket(m_errorMsg.release());
+        m_PEntity->pushPacket(std::move(m_errorMsg));
     }
 }
 

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -52,12 +52,12 @@ CMagicState::CMagicState(CBattleEntity* PEntity, uint16 targid, SpellID spellid,
     auto* PTarget = m_PEntity->IsValidTarget(m_targid, m_PSpell->getValidTarget(), m_errorMsg);
     if (!PTarget || m_errorMsg)
     {
-        throw CStateInitException(std::move(m_errorMsg));
+        throw CStateInitException(m_errorMsg->copy());
     }
 
     if (!CanCastSpell(PTarget, false))
     {
-        throw CStateInitException(std::move(m_errorMsg));
+        throw CStateInitException(m_errorMsg->copy());
     }
 
     auto errorMsg = luautils::OnMagicCastingCheck(m_PEntity, PTarget, GetSpell());

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -94,7 +94,7 @@ CMagicState::CMagicState(CBattleEntity* PEntity, uint16 targid, SpellID spellid,
     // TODO: weaponskill lua object
     m_PEntity->PAI->EventHandler.triggerListener("MAGIC_START", CLuaBaseEntity(m_PEntity), CLuaSpell(m_PSpell.get()), CLuaAction(&action));
 
-    m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+    m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
 }
 
 bool CMagicState::Update(time_point tick)
@@ -110,7 +110,7 @@ bool CMagicState::Update(time_point tick)
             (HasMoved() && (m_PEntity->objtype != TYPE_PET || static_cast<CPetEntity*>(m_PEntity)->getPetType() != PET_TYPE::AUTOMATON)))
         {
             m_PEntity->OnCastInterrupted(*this, action, msg, false);
-            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
 
             Complete();
             return false;
@@ -121,7 +121,7 @@ bool CMagicState::Update(time_point tick)
             if (PChar->m_Locked)
             {
                 m_PEntity->OnCastInterrupted(*this, action, msg, true);
-                m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+                m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
 
                 Complete();
                 return false;
@@ -133,7 +133,7 @@ bool CMagicState::Update(time_point tick)
                 {
                     m_PEntity->OnCastInterrupted(*this, action, MSGBASIC_TRUST_NO_CAST_TRUST, true);
                     action.recast = 2; // seems hardcoded to 2
-                    m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+                    m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
 
                     Complete();
                     return false;
@@ -153,7 +153,7 @@ bool CMagicState::Update(time_point tick)
             if (PChar->m_Locked)
             {
                 m_PEntity->OnCastInterrupted(*this, action, msg, true);
-                m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+                m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
 
                 Complete();
                 return false;
@@ -164,7 +164,7 @@ bool CMagicState::Update(time_point tick)
         if (PTarget->PAI->IsUntargetable())
         {
             m_PEntity->OnCastInterrupted(*this, action, msg, true);
-            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
 
             Complete();
             return false;
@@ -176,7 +176,7 @@ bool CMagicState::Update(time_point tick)
             m_PEntity->setActionInterrupted(interruptedAction, PTarget, MSGBASIC_IS_PARALYZED_2, static_cast<uint16>(m_PSpell->getID()));
             interruptedAction.recast   = 2; // seems hardcoded to 2
             interruptedAction.actionid = static_cast<uint16>(m_PSpell->getID());
-            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(interruptedAction));
+            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(interruptedAction));
 
             // Yes, you're seeing this correctly.
             // A paralyze/interrupt proc on *spells* actually sends two actions. One that contains the para/intimidate message
@@ -194,7 +194,7 @@ bool CMagicState::Update(time_point tick)
             actionTarget.messageID       = 0;
             actionTarget.animation       = 0;
             actionTarget.param           = 0; // sometimes 1?
-            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
 
             Complete();
             return false;
@@ -205,7 +205,7 @@ bool CMagicState::Update(time_point tick)
             m_PEntity->setActionInterrupted(interruptedAction, PTarget, MSGBASIC_IS_INTIMIDATED, static_cast<uint16>(m_PSpell->getID()));
             interruptedAction.recast   = 2; // seems hardcoded to 2
             interruptedAction.actionid = static_cast<uint16>(m_PSpell->getID());
-            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(interruptedAction));
+            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(interruptedAction));
 
             // See comment in above block for paralyze
             action.id         = m_PEntity->id;
@@ -220,7 +220,7 @@ bool CMagicState::Update(time_point tick)
             actionTarget.messageID       = 0;
             actionTarget.animation       = 0;
             actionTarget.param           = 0; // sometimes 1?
-            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
 
             Complete();
             return false;
@@ -237,7 +237,7 @@ bool CMagicState::Update(time_point tick)
             PTarget->PAI->EventHandler.triggerListener("MAGIC_TAKE", CLuaBaseEntity(PTarget), CLuaBaseEntity(m_PEntity), CLuaSpell(m_PSpell.get()), CLuaAction(&action));
         }
 
-        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
 
         Complete();
     }
@@ -260,7 +260,7 @@ void CMagicState::Cleanup(time_point tick)
     {
         action_t action;
         m_PEntity->OnCastInterrupted(*this, action, MSGBASIC_IS_INTERRUPTED, false);
-        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
     }
 }
 

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -72,7 +72,7 @@ CMobSkillState::CMobSkillState(CBattleEntity* PEntity, uint16 targid, uint16 wsi
         actionTarget.animation  = 0;
         actionTarget.param      = m_PSkill->getID();
         actionTarget.messageID  = 43;
-        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
 
         // face toward target // TODO : add force param to turnTowardsTarget on certain TP moves like Petro Eyes
         battleutils::turnTowardsTarget(m_PEntity, PTarget);
@@ -126,7 +126,7 @@ bool CMobSkillState::Update(time_point tick)
     {
         action_t action;
         m_PEntity->OnMobSkillFinished(*this, action);
-        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
         auto delay   = std::chrono::milliseconds(m_PSkill->getAnimationTime());
         m_finishTime = tick + delay;
         Complete();
@@ -173,7 +173,7 @@ void CMobSkillState::Cleanup(time_point tick)
         actionTarget.animation       = 0x1FC; // Not perfectly accurate, this animation ID can change from time to time for unknown reasons.
         actionTarget.reaction        = REACTION::HIT;
 
-        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
 
         // On retail testing, mobs lose 33% of their TP at 2900 or higher TP
         // But lose 25% at < 2900 TP.

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -49,7 +49,7 @@ CMobSkillState::CMobSkillState(CBattleEntity* PEntity, uint16 targid, uint16 wsi
 
     if (!PTarget || m_errorMsg)
     {
-        throw CStateInitException(std::move(m_errorMsg));
+        throw CStateInitException(m_errorMsg->copy());
     }
 
     m_PSkill = std::make_unique<CMobSkill>(*skill);

--- a/src/map/ai/states/petskill_state.cpp
+++ b/src/map/ai/states/petskill_state.cpp
@@ -48,7 +48,7 @@ CPetSkillState::CPetSkillState(CPetEntity* PEntity, uint16 targid, uint16 wsid)
 
     if (!PTarget || m_errorMsg)
     {
-        throw CStateInitException(std::move(m_errorMsg));
+        throw CStateInitException(m_errorMsg->copy());
     }
 
     m_PSkill = std::make_unique<CPetSkill>(*skill);

--- a/src/map/ai/states/petskill_state.cpp
+++ b/src/map/ai/states/petskill_state.cpp
@@ -71,7 +71,7 @@ CPetSkillState::CPetSkillState(CPetEntity* PEntity, uint16 targid, uint16 wsid)
         actionTarget.animation  = 0;
         actionTarget.param      = m_PSkill->getID();
         actionTarget.messageID  = 326; // Seems hardcoded? TODO: Verify on more pet actions. Tested on Wyvern and SMN BPs.
-        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE, new CActionPacket(action));
+        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE, std::make_unique<CActionPacket>(action));
     }
     m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_STATE_ENTER", CLuaBaseEntity(m_PEntity), m_PSkill->getID());
     SpendCost();
@@ -97,7 +97,7 @@ bool CPetSkillState::Update(time_point tick)
     {
         action_t action;
         m_PEntity->OnPetSkillFinished(*this, action);
-        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
         auto delay   = std::chrono::milliseconds(m_PSkill->getAnimationTime());
         m_finishTime = tick + delay;
         Complete();
@@ -144,6 +144,6 @@ void CPetSkillState::Cleanup(time_point tick)
         actionTarget.animation       = 0x1FC; // Not perfectly accurate, this animation ID can change from time to time for unknown reasons.
         actionTarget.reaction        = REACTION::HIT;
 
-        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE, new CActionPacket(action));
+        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE, std::make_unique<CActionPacket>(action));
     }
 }

--- a/src/map/ai/states/range_state.cpp
+++ b/src/map/ai/states/range_state.cpp
@@ -85,7 +85,7 @@ CRangeState::CRangeState(CBattleEntity* PEntity, uint16 targid)
 
     m_PEntity->PAI->EventHandler.triggerListener("RANGE_START", CLuaBaseEntity(m_PEntity), CLuaAction(&action));
 
-    m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+    m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
 }
 
 void CRangeState::SpendCost()
@@ -128,7 +128,7 @@ bool CRangeState::Update(time_point tick)
             }
             // reset aim time so interrupted players only have to wait the correct 2.7s until next shot
             m_aimTime = std::chrono::seconds(0);
-            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
             m_PEntity->PAI->EventHandler.triggerListener("RANGE_STATE_EXIT", CLuaBaseEntity(m_PEntity), nullptr, CLuaAction(&action));
         }
         else
@@ -136,7 +136,7 @@ bool CRangeState::Update(time_point tick)
             m_errorMsg.reset();
 
             m_PEntity->OnRangedAttack(*this, action);
-            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
             m_PEntity->PAI->EventHandler.triggerListener("RANGE_STATE_EXIT", CLuaBaseEntity(m_PEntity), CLuaBaseEntity(PTarget), CLuaAction(&action));
         }
 

--- a/src/map/ai/states/range_state.cpp
+++ b/src/map/ai/states/range_state.cpp
@@ -124,7 +124,7 @@ bool CRangeState::Update(time_point tick)
 
             if (auto* PChar = dynamic_cast<CCharEntity*>(m_PEntity))
             {
-                PChar->pushPacket(m_errorMsg.release());
+                PChar->pushPacket(std::move(m_errorMsg));
             }
             // reset aim time so interrupted players only have to wait the correct 2.7s until next shot
             m_aimTime = std::chrono::seconds(0);

--- a/src/map/ai/states/range_state.cpp
+++ b/src/map/ai/states/range_state.cpp
@@ -38,18 +38,18 @@ CRangeState::CRangeState(CBattleEntity* PEntity, uint16 targid)
 
     if (!PTarget || m_errorMsg)
     {
-        throw CStateInitException(std::move(m_errorMsg));
+        throw CStateInitException(m_errorMsg->copy());
     }
 
     if (!CanUseRangedAttack(PTarget, false))
     {
-        throw CStateInitException(std::move(m_errorMsg));
+        throw CStateInitException(m_errorMsg->copy());
     }
 
     if (distance(m_PEntity->loc.p, PTarget->loc.p) > 25)
     {
         m_errorMsg = std::make_unique<CMessageBasicPacket>(m_PEntity, PTarget, 0, 0, MSGBASIC_TOO_FAR_AWAY);
-        throw CStateInitException(std::move(m_errorMsg));
+        throw CStateInitException(m_errorMsg->copy());
     }
 
     auto delay = m_PEntity->GetRangedWeaponDelay(false);
@@ -124,7 +124,7 @@ bool CRangeState::Update(time_point tick)
 
             if (auto* PChar = dynamic_cast<CCharEntity*>(m_PEntity))
             {
-                PChar->pushPacket(std::move(m_errorMsg));
+                PChar->pushPacket(m_errorMsg->copy());
             }
             // reset aim time so interrupted players only have to wait the correct 2.7s until next shot
             m_aimTime = std::chrono::seconds(0);

--- a/src/map/ai/states/state.cpp
+++ b/src/map/ai/states/state.cpp
@@ -79,9 +79,9 @@ bool CState::HasErrorMsg() const
     return m_errorMsg != nullptr;
 }
 
-CBasicPacket* CState::GetErrorMsg()
+auto CState::GetErrorMsg() -> std::unique_ptr<CBasicPacket>
 {
-    return m_errorMsg.release();
+    return std::move(m_errorMsg);
 }
 
 bool CState::DoUpdate(time_point tick)

--- a/src/map/ai/states/state.cpp
+++ b/src/map/ai/states/state.cpp
@@ -81,7 +81,7 @@ bool CState::HasErrorMsg() const
 
 auto CState::GetErrorMsg() -> std::unique_ptr<CBasicPacket>
 {
-    return std::move(m_errorMsg);
+    return m_errorMsg->copy();
 }
 
 bool CState::DoUpdate(time_point tick)

--- a/src/map/ai/states/state.h
+++ b/src/map/ai/states/state.h
@@ -51,8 +51,8 @@ public:
     void         SetTarget(uint16 targid);
 
     bool HasErrorMsg() const;
-    /* Releases ownership to the caller */
-    CBasicPacket* GetErrorMsg();
+
+    auto GetErrorMsg() -> std::unique_ptr<CBasicPacket>;
 
     bool DoUpdate(time_point tick);
     // try interrupt (on hit)

--- a/src/map/ai/states/weaponskill_state.cpp
+++ b/src/map/ai/states/weaponskill_state.cpp
@@ -44,7 +44,7 @@ CWeaponSkillState::CWeaponSkillState(CBattleEntity* PEntity, uint16 targid, uint
 
     if (!PTarget || m_errorMsg)
     {
-        throw CStateInitException(std::move(m_errorMsg));
+        throw CStateInitException(m_errorMsg->copy());
     }
 
     if (!m_PEntity->CanSeeTarget(PTarget, false))

--- a/src/map/ai/states/weaponskill_state.cpp
+++ b/src/map/ai/states/weaponskill_state.cpp
@@ -68,7 +68,7 @@ CWeaponSkillState::CWeaponSkillState(CBattleEntity* PEntity, uint16 targid, uint
     actionTarget.animation  = 0;
     actionTarget.param      = m_PSkill->getID();
     actionTarget.messageID  = 43;
-    m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+    m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
 }
 
 CWeaponSkill* CWeaponSkillState::GetSkill()
@@ -118,7 +118,7 @@ bool CWeaponSkillState::Update(time_point tick)
             SpendCost();
 
             m_PEntity->OnWeaponSkillFinished(*this, action);
-            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
 
             // Reset Restraint bonus and trackers on weaponskill use
             if (m_PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_RESTRAINT))
@@ -169,7 +169,7 @@ bool CWeaponSkillState::Update(time_point tick)
             actionTarget.messageID = 0;
             actionTarget.reaction  = REACTION::ABILITY | REACTION::HIT;
 
-            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
         }
 
         auto delay   = m_PSkill->getAnimationTime(); // TODO: Is delay time a fixed number if the weaponskill is used out of range?

--- a/src/map/anticheat.cpp
+++ b/src/map/anticheat.cpp
@@ -77,7 +77,7 @@ namespace anticheat
         {
             if (warningmsg != nullptr)
             {
-                memset(warningmsg, 0, warningsize);
+                std::memset(warningmsg, 0, warningsize);
                 char* warnptr = (char*)_sql->GetData(1);
                 if (warnptr != nullptr)
                 {

--- a/src/map/attackround.cpp
+++ b/src/map/attackround.cpp
@@ -441,7 +441,7 @@ void CAttackRound::ProcFollowUpAttacks()
                                 }
 
                                 charutils::UpdateItem(PChar, loc, slot, -1);
-                                PChar->pushPacket(new CInventoryFinishPacket());
+                                PChar->pushPacket<CInventoryFinishPacket>();
                             }
                         }
                     }

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -656,7 +656,7 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
                 PMob->PEnmityContainer->Clear();
             }
         }
-        PEntity->loc.zone->PushPacket(PEntity, CHAR_INRANGE, new CEntityAnimationPacket(PEntity, PEntity, CEntityAnimationPacket::Fade_Out));
+        PEntity->loc.zone->PushPacket(PEntity, CHAR_INRANGE, std::make_unique<CEntityAnimationPacket>(PEntity, PEntity, CEntityAnimationPacket::Fade_Out));
     }
 
     PEntity->PBattlefield = nullptr;

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1943,7 +1943,7 @@ void CBattleEntity::OnCastInterrupted(CMagicState& state, action_t& action, MSGB
         {
             actionTarget.reaction = REACTION::HIT;
             // For some reason, despite the system supporting interrupted message in the action packet (like auto attacks, JA), an 0x029 message is sent for spells.
-            loc.zone->PushPacket(this, CHAR_INRANGE_SELF, new CMessageBasicPacket(this, state.GetTarget() ? state.GetTarget() : this, 0, 0, msg));
+            loc.zone->PushPacket(this, CHAR_INRANGE_SELF, std::make_unique<CMessageBasicPacket>(this, state.GetTarget() ? state.GetTarget() : this, 0, 0, msg));
         }
     }
 }

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -69,7 +69,7 @@ CBattleEntity::CBattleEntity()
     m_Weapons[SLOT_AMMO]   = nullptr;
     m_dualWield            = false;
 
-    memset(&health, 0, sizeof(health));
+    std::memset(&health, 0, sizeof(health));
     health.maxhp = 1;
 
     PPet          = nullptr;

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -423,11 +423,11 @@ void CCharEntity::pushPacket(std::unique_ptr<CBasicPacket>&& packet)
     {
         if (PendingPositionPacket)
         {
-            PendingPositionPacket = std::make_unique<CBasicPacket>(*packet);
+            PendingPositionPacket = packet->copy();
         }
         else
         {
-            PendingPositionPacket = std::make_unique<CBasicPacket>(*packet);
+            PendingPositionPacket = packet->copy();
             PacketList.emplace_back(std::move(packet));
         }
     }

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -139,26 +139,26 @@ CCharEntity::CCharEntity()
     m_RecycleBin = std::make_unique<CItemContainer>(LOC_RECYCLEBIN);
 
     keys = {};
-    memset(&equip, 0, sizeof(equip));
-    memset(&equipLoc, 0, sizeof(equipLoc));
+    std::memset(&equip, 0, sizeof(equip));
+    std::memset(&equipLoc, 0, sizeof(equipLoc));
 
     m_SpellList = {};
-    memset(&m_LearnedAbilities, 0, sizeof(m_LearnedAbilities));
-    memset(&m_TitleList, 0, sizeof(m_TitleList));
-    memset(&m_ZonesList, 0, sizeof(m_ZonesList));
-    memset(&m_Abilities, 0, sizeof(m_Abilities));
-    memset(&m_TraitList, 0, sizeof(m_TraitList));
-    memset(&m_PetCommands, 0, sizeof(m_PetCommands));
-    memset(&m_WeaponSkills, 0, sizeof(m_WeaponSkills));
-    memset(&m_SetBlueSpells, 0, sizeof(m_SetBlueSpells));
-    memset(&m_FieldChocobo, 0, sizeof(m_FieldChocobo));
-    memset(&m_unlockedAttachments, 0, sizeof(m_unlockedAttachments));
+    std::memset(&m_LearnedAbilities, 0, sizeof(m_LearnedAbilities));
+    std::memset(&m_TitleList, 0, sizeof(m_TitleList));
+    std::memset(&m_ZonesList, 0, sizeof(m_ZonesList));
+    std::memset(&m_Abilities, 0, sizeof(m_Abilities));
+    std::memset(&m_TraitList, 0, sizeof(m_TraitList));
+    std::memset(&m_PetCommands, 0, sizeof(m_PetCommands));
+    std::memset(&m_WeaponSkills, 0, sizeof(m_WeaponSkills));
+    std::memset(&m_SetBlueSpells, 0, sizeof(m_SetBlueSpells));
+    std::memset(&m_FieldChocobo, 0, sizeof(m_FieldChocobo));
+    std::memset(&m_unlockedAttachments, 0, sizeof(m_unlockedAttachments));
 
-    memset(&m_questLog, 0, sizeof(m_questLog));
-    memset(&m_missionLog, 0, sizeof(m_missionLog));
+    std::memset(&m_questLog, 0, sizeof(m_questLog));
+    std::memset(&m_missionLog, 0, sizeof(m_missionLog));
     m_eminenceCache.activemap.reset();
 
-    memset(&m_claimedDeeds, 0, sizeof(m_claimedDeeds));
+    std::memset(&m_claimedDeeds, 0, sizeof(m_claimedDeeds));
 
     for (uint8 i = 0; i <= 3; ++i)
     {

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -411,6 +411,12 @@ void CCharEntity::pushPacket(std::unique_ptr<CBasicPacket>&& packet)
     TracyZoneString(getName());
     TracyZoneHex16(packet->getType());
 
+    if (isPacketFiltered(packet))
+    {
+        // packet will destruct itself when it goes out of scope
+        return;
+    }
+
     moduleutils::OnPushPacket(this, packet);
 
     if (packet->getType() == 0x5B)
@@ -508,6 +514,17 @@ void CCharEntity::erasePackets(uint8 num)
     {
         std::ignore = popPacket();
     }
+}
+
+bool CCharEntity::isPacketFiltered(std::unique_ptr<CBasicPacket>& packet)
+{
+    // Filter others synthesis results
+    if (packet->getType() == 0x70 && playerConfig.MessageFilter.others_synthesis_and_fishing_results)
+    {
+        return true;
+    }
+
+    return false;
 }
 
 bool CCharEntity::isNewPlayer() const

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -432,6 +432,7 @@ public:
     auto   getPacketListCopy() -> std::deque<std::unique_ptr<CBasicPacket>>; // Return a COPY of packet list
     size_t getPacketCount();
     void   erasePackets(uint8 num); // Erase num elements from front of packet list
+    bool   isPacketFiltered(std::unique_ptr<CBasicPacket>& packet);
 
     virtual void HandleErrorMessage(std::unique_ptr<CBasicPacket>&) override;
 

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -288,7 +288,6 @@ class CRangeState;
 class CItemState;
 class CItemUsable;
 
-typedef std::deque<CBasicPacket*>      PacketList_t;
 typedef std::map<uint32, CBaseEntity*> SpawnIDList_t;
 typedef std::vector<EntityID_t>        BazaarList_t;
 
@@ -544,7 +543,7 @@ public:
 
     CItemEquipment* getEquip(SLOTTYPE slot);
 
-    CBasicPacket* PendingPositionPacket = nullptr;
+    std::unique_ptr<CBasicPacket> PendingPositionPacket = nullptr;
 
     bool requestedInfoSync = false;
 
@@ -665,9 +664,9 @@ private:
     uint8      dataToPersist = 0;
     time_point nextDataPersistTime;
 
-    std::deque<std::unique_ptr<CBasicPacket>>        PacketList;           // The list of packets to be sent to the character during the next network cycle
-    std::unordered_map<uint32, CCharPacket*>         PendingCharPackets;   // Keep track of which char packets are queued up for this char, such that they can be updated
-    std::unordered_map<uint32, CEntityUpdatePacket*> PendingEntityPackets; // Keep track of which entity update packets are queued up for this char, such that they can be updated
+    std::deque<std::unique_ptr<CBasicPacket>>                        PacketList;           // The list of packets to be sent to the character during the next network cycle
+    std::unordered_map<uint32, std::unique_ptr<CCharPacket>>         PendingCharPackets;   // Keep track of which char packets are queued up for this char, such that they can be updated
+    std::unordered_map<uint32, std::unique_ptr<CEntityUpdatePacket>> PendingEntityPackets; // Keep track of which entity update packets are queued up for this char, such that they can be updated
 };
 
 #endif

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -425,16 +425,16 @@ public:
         pushPacket(std::make_unique<T>(std::forward<Args>(args)...));
     }
 
-    void          pushPacket(CBasicPacket*);                                                     // Adding a copy of a package to the PacketList
-    void          pushPacket(std::unique_ptr<CBasicPacket>);                                     // Push packet to packet list
-    void          updateCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint8 updatemask);     // Push or update a char packet
-    void          updateEntityPacket(CBaseEntity* PEntity, ENTITYUPDATE type, uint8 updatemask); // Push or update an entity update packet
-    bool          isPacketListEmpty();
-    CBasicPacket* popPacket();     // Get first packet from PacketList
-    PacketList_t  getPacketList(); // Return a COPY of packet list
-    size_t        getPacketCount();
-    void          erasePackets(uint8 num); // Erase num elements from front of packet list
-    virtual void  HandleErrorMessage(std::unique_ptr<CBasicPacket>&) override;
+    void   pushPacket(std::unique_ptr<CBasicPacket>&&);                                   // Push packet to packet list
+    void   updateCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint8 updatemask);     // Push or update a char packet
+    void   updateEntityPacket(CBaseEntity* PEntity, ENTITYUPDATE type, uint8 updatemask); // Push or update an entity update packet
+    bool   isPacketListEmpty();
+    auto   popPacket() -> std::unique_ptr<CBasicPacket>;                     // Get first packet from PacketList
+    auto   getPacketListCopy() -> std::deque<std::unique_ptr<CBasicPacket>>; // Return a COPY of packet list
+    size_t getPacketCount();
+    void   erasePackets(uint8 num); // Erase num elements from front of packet list
+
+    virtual void HandleErrorMessage(std::unique_ptr<CBasicPacket>&) override;
 
     CLinkshell*    PLinkshell1;
     CLinkshell*    PLinkshell2;
@@ -665,7 +665,7 @@ private:
     uint8      dataToPersist = 0;
     time_point nextDataPersistTime;
 
-    PacketList_t                                     PacketList;           // The list of packets to be sent to the character during the next network cycle
+    std::deque<std::unique_ptr<CBasicPacket>>        PacketList;           // The list of packets to be sent to the character during the next network cycle
     std::unordered_map<uint32, CCharPacket*>         PendingCharPackets;   // Keep track of which char packets are queued up for this char, such that they can be updated
     std::unordered_map<uint32, CEntityUpdatePacket*> PendingEntityPackets; // Keep track of which entity update packets are queued up for this char, such that they can be updated
 };

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -1160,11 +1160,11 @@ void CMobEntity::Die()
         {
             if (PLastAttacker)
             {
-                loc.zone->PushPacket(this, CHAR_INRANGE, new CMessageBasicPacket(PLastAttacker, this, 0, 0, MSGBASIC_DEFEATS_TARG));
+                loc.zone->PushPacket(this, CHAR_INRANGE, std::make_unique<CMessageBasicPacket>(PLastAttacker, this, 0, 0, MSGBASIC_DEFEATS_TARG));
             }
             else
             {
-                loc.zone->PushPacket(this, CHAR_INRANGE, new CMessageBasicPacket(this, this, 0, 0, MSGBASIC_FALLS_TO_GROUND));
+                loc.zone->PushPacket(this, CHAR_INRANGE, std::make_unique<CMessageBasicPacket>(this, this, 0, 0, MSGBASIC_FALLS_TO_GROUND));
             }
 
             DistributeRewards();

--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -414,7 +414,7 @@ void CTrustEntity::OnRangedAttack(CRangeState& state, action_t& action)
         // shadows took damage
         actionTarget.messageID = 0;
         actionTarget.reaction  = REACTION::EVADE;
-        PTarget->loc.zone->PushPacket(PTarget, CHAR_INRANGE_SELF, new CMessageBasicPacket(PTarget, PTarget, 0, shadowsTaken, MSGBASIC_SHADOW_ABSORB));
+        PTarget->loc.zone->PushPacket(PTarget, CHAR_INRANGE_SELF, std::make_unique<CMessageBasicPacket>(PTarget, PTarget, 0, shadowsTaken, MSGBASIC_SHADOW_ABSORB));
     }
 
     if (actionTarget.speceffect == SPECEFFECT::HIT && actionTarget.param > 0)

--- a/src/map/instance_loader.cpp
+++ b/src/map/instance_loader.cpp
@@ -115,7 +115,7 @@ CInstance* CInstanceLoader::LoadInstance()
             PMob->m_maxLevel = (uint8)_sql->GetIntData(12);
 
             uint16 sqlModelID[10];
-            memcpy(&sqlModelID, _sql->GetData(13), 20);
+            std::memcpy(&sqlModelID, _sql->GetData(13), 20);
             PMob->look = look_t(sqlModelID);
 
             PMob->SetMJob(_sql->GetIntData(14));
@@ -270,7 +270,7 @@ CInstance* CInstanceLoader::LoadInstance()
                 PNpc->m_flags = _sql->GetUIntData(13);
 
                 uint16 sqlModelID[10];
-                memcpy(&sqlModelID, _sql->GetData(14), 20);
+                std::memcpy(&sqlModelID, _sql->GetData(14), 20);
                 PNpc->look = look_t(sqlModelID);
 
                 PNpc->name_prefix = (uint8)_sql->GetIntData(15);

--- a/src/map/item_container.cpp
+++ b/src/map/item_container.cpp
@@ -34,7 +34,7 @@ CItemContainer::CItemContainer(uint16 LocationID)
 , m_size(0)
 , m_count(0)
 {
-    memset(m_ItemList, 0, sizeof(m_ItemList));
+    std::memset(m_ItemList, 0, sizeof(m_ItemList));
 }
 
 CItemContainer::~CItemContainer()

--- a/src/map/items/item.cpp
+++ b/src/map/items/item.cpp
@@ -303,15 +303,15 @@ void CItem::setReceiver(std::string const& receiver)
 const std::string CItem::getSignature()
 {
     char signature[SignatureStringLength] = {};
-    memcpy(&signature, m_extra + 0x0C, sizeof(signature));
+    std::memcpy(&signature, m_extra + 0x0C, sizeof(signature));
 
     return signature; // return string copy
 }
 
 void CItem::setSignature(std::string const& signature)
 {
-    memset(m_extra + 0x0C, 0, sizeof(m_extra) - 0x0C);
-    memcpy(m_extra + 0x0C, signature.c_str(), signature.size());
+    std::memset(m_extra + 0x0C, 0, sizeof(m_extra) - 0x0C);
+    std::memcpy(m_extra + 0x0C, signature.c_str(), signature.size());
 }
 
 /************************************************************************

--- a/src/map/items/item_linkshell.cpp
+++ b/src/map/items/item_linkshell.cpp
@@ -67,15 +67,15 @@ void CItemLinkshell::SetLSColor(uint16 color)
 const std::string CItemLinkshell::getSignature()
 {
     char signature[LinkshellStringLength] = {};
-    memcpy(&signature, m_extra + 0x09, sizeof(signature));
+    std::memcpy(&signature, m_extra + 0x09, sizeof(signature));
 
     return signature; // return string copy
 }
 
 void CItemLinkshell::setSignature(std::string const& signature)
 {
-    memset(m_extra + 0x09, 0, sizeof(m_extra) - 0x09);
-    memcpy(m_extra + 0x09, signature.c_str(), signature.size());
+    std::memset(m_extra + 0x09, 0, sizeof(m_extra) - 0x09);
+    std::memcpy(m_extra + 0x09, signature.c_str(), signature.size());
 }
 
 void CItemLinkshell::SetLSType(LSTYPE value)

--- a/src/map/job_points.cpp
+++ b/src/map/job_points.cpp
@@ -56,10 +56,10 @@ void CJobPoints::LoadJobPoints()
                     JobPointType_t currentType = {};
                     currentType.id             = currentJob.jobCategory + j;
                     currentType.value          = _sql->GetUIntData(JOBPOINTS_SQL_COLUMN_OFFSET + j);
-                    memcpy(&currentJob.job_point_types[j], &currentType, sizeof(JobPointType_t));
+                    std::memcpy(&currentJob.job_point_types[j], &currentType, sizeof(JobPointType_t));
                 }
 
-                memcpy(&m_jobPoints[jobId], &currentJob, sizeof(JobPoints_t));
+                std::memcpy(&m_jobPoints[jobId], &currentJob, sizeof(JobPoints_t));
             }
         }
     }

--- a/src/map/linkshell.cpp
+++ b/src/map/linkshell.cpp
@@ -329,7 +329,7 @@ void CLinkshell::PushPacket(uint32 senderID, CBasicPacket* packet)
     {
         if (member->id != senderID && member->status != STATUS_TYPE::DISAPPEAR && !jailutils::InPrison(member))
         {
-            CBasicPacket* newPacket = new CBasicPacket(*packet);
+            auto newPacket = std::make_unique<CBasicPacket>(*packet);
             if (member->PLinkshell2 == this)
             {
                 if (newPacket->getType() == CChatMessagePacket::id)
@@ -341,7 +341,7 @@ void CLinkshell::PushPacket(uint32 senderID, CBasicPacket* packet)
                     newPacket->ref<uint8>(0x05) |= 0x40;
                 }
             }
-            member->pushPacket(newPacket);
+            member->pushPacket(std::move(newPacket));
         }
     }
     destroy(packet);

--- a/src/map/linkshell.cpp
+++ b/src/map/linkshell.cpp
@@ -186,7 +186,7 @@ void CLinkshell::ChangeMemberRank(const std::string& MemberName, uint8 toSack)
                         return;
                     }
                     newShellItem->setQuantity(1);
-                    memcpy(newShellItem->m_extra, PItemLinkshell->m_extra, 24);
+                    std::memcpy(newShellItem->m_extra, PItemLinkshell->m_extra, 24);
                     newShellItem->SetLSType(newId == 514 ? LSTYPE_PEARLSACK : LSTYPE_LINKPEARL);
                     newShellItem->setSubType(ITEM_LOCKED);
                     uint8 LocationID = PItemLinkshell->getLocationID();
@@ -377,7 +377,7 @@ namespace linkshell
             PLinkshell->setColor(_sql->GetIntData(1));
             char EncodedName[LinkshellStringLength];
 
-            memset(&EncodedName, 0, sizeof(EncodedName));
+            std::memset(&EncodedName, 0, sizeof(EncodedName));
 
             EncodeStringLinkshell(_sql->GetStringData(2).c_str(), EncodedName);
             PLinkshell->setName(EncodedName);

--- a/src/map/linkshell.cpp
+++ b/src/map/linkshell.cpp
@@ -329,7 +329,7 @@ void CLinkshell::PushPacket(uint32 senderID, const std::unique_ptr<CBasicPacket>
     {
         if (member->id != senderID && member->status != STATUS_TYPE::DISAPPEAR && !jailutils::InPrison(member))
         {
-            auto newPacket = std::make_unique<CBasicPacket>(*packet);
+            auto newPacket = packet->copy();
             if (member->PLinkshell2 == this)
             {
                 if (newPacket->getType() == CChatMessagePacket::id)

--- a/src/map/linkshell.cpp
+++ b/src/map/linkshell.cpp
@@ -97,7 +97,7 @@ void CLinkshell::setMessage(const std::string& message, const std::string& poste
     if (message.size() != 0)
     {
         message::send(MSG_CHAT_LINKSHELL, packetData, sizeof(packetData),
-                      new CLinkshellMessagePacket(poster, message, m_name, std::numeric_limits<uint32>::min(), true));
+                      std::make_unique<CLinkshellMessagePacket>(poster, message, m_name, std::numeric_limits<uint32>::min(), true));
     }
 }
 
@@ -323,7 +323,7 @@ void CLinkshell::BreakLinkshell()
 }
 
 // send linkshell message to all online members
-void CLinkshell::PushPacket(uint32 senderID, CBasicPacket* packet)
+void CLinkshell::PushPacket(uint32 senderID, const std::unique_ptr<CBasicPacket>& packet)
 {
     for (auto& member : members)
     {
@@ -344,7 +344,6 @@ void CLinkshell::PushPacket(uint32 senderID, CBasicPacket* packet)
             member->pushPacket(std::move(newPacket));
         }
     }
-    destroy(packet);
 }
 
 void CLinkshell::PushLinkshellMessage(CCharEntity* PChar, bool ls1)

--- a/src/map/linkshell.h
+++ b/src/map/linkshell.h
@@ -54,7 +54,7 @@ public:
     void RemoveMemberByName(const std::string& MemberName, uint8 kickerRank, bool breakLinkshell = false);
     void ChangeMemberRank(const std::string& MemberName, uint8 toSack);
 
-    void PushPacket(uint32 senderID, CBasicPacket* packet);
+    void PushPacket(uint32 senderID, const std::unique_ptr<CBasicPacket>& packet);
     void PushLinkshellMessage(CCharEntity* PChar, bool ls1);
 
     std::vector<CCharEntity*> members;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -211,7 +211,7 @@ void CLuaBaseEntity::showText(CLuaBaseEntity* mob, uint16 messageID, sol::object
     }
     else
     {
-        m_PBaseEntity->loc.zone->PushPacket(m_PBaseEntity, CHAR_INRANGE, new CMessageSpecialPacket(PBaseEntity, messageID, param0, param1, param3));
+        m_PBaseEntity->loc.zone->PushPacket(m_PBaseEntity, CHAR_INRANGE, std::make_unique<CMessageSpecialPacket>(PBaseEntity, messageID, param0, param1, param3));
     }
 }
 
@@ -291,7 +291,7 @@ void CLuaBaseEntity::messageText(CLuaBaseEntity* PLuaBaseEntity, uint16 messageI
     }
     else
     { // broadcast in range
-        m_PBaseEntity->loc.zone->PushPacket(m_PBaseEntity, CHAR_INRANGE, new CMessageTextPacket(PTarget, messageID, showName, mode));
+        m_PBaseEntity->loc.zone->PushPacket(m_PBaseEntity, CHAR_INRANGE, std::make_unique<CMessageTextPacket>(PTarget, messageID, showName, mode));
     }
 }
 
@@ -345,17 +345,17 @@ void CLuaBaseEntity::printToArea(std::string const& message, sol::object const& 
 
     if (messageRange == MESSAGE_AREA_SYSTEM)
     {
-        message::send(MSG_CHAT_SERVMES, nullptr, 0, new CChatMessagePacket(PChar, messageLook, message, name));
+        message::send(MSG_CHAT_SERVMES, nullptr, 0, std::make_unique<CChatMessagePacket>(PChar, messageLook, message, name));
     }
     else if (messageRange == MESSAGE_AREA_SAY)
     {
-        PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, new CChatMessagePacket(PChar, messageLook, message, name));
-        PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CChatMessagePacket(PChar, messageLook, message, name));
+        PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, std::make_unique<CChatMessagePacket>(PChar, messageLook, message, name));
+        PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, std::make_unique<CChatMessagePacket>(PChar, messageLook, message, name));
     }
     else if (messageRange == MESSAGE_AREA_SHOUT)
     {
-        PChar->loc.zone->PushPacket(PChar, CHAR_INSHOUT, new CChatMessagePacket(PChar, messageLook, message, name));
-        PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CChatMessagePacket(PChar, messageLook, message, name));
+        PChar->loc.zone->PushPacket(PChar, CHAR_INSHOUT, std::make_unique<CChatMessagePacket>(PChar, messageLook, message, name));
+        PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, std::make_unique<CChatMessagePacket>(PChar, messageLook, message, name));
     }
     else if (messageRange == MESSAGE_AREA_PARTY)
     {
@@ -364,24 +364,24 @@ void CLuaBaseEntity::printToArea(std::string const& message, sol::object const& 
         {
             ref<uint32>(packetData, 0) = PChar->PParty->m_PAlliance->m_AllianceID;
             ref<uint32>(packetData, 4) = 0; // No ID so that the PChar sees the message too
-            message::send(MSG_CHAT_ALLIANCE, packetData, sizeof(packetData), new CChatMessagePacket(PChar, messageLook, message, name));
+            message::send(MSG_CHAT_ALLIANCE, packetData, sizeof(packetData), std::make_unique<CChatMessagePacket>(PChar, messageLook, message, name));
         }
         else if (PChar->PParty)
         {
             ref<uint32>(packetData, 0) = PChar->PParty->GetPartyID();
             ref<uint32>(packetData, 4) = 0; // No ID so that the PChar sees the message too
-            message::send(MSG_CHAT_PARTY, packetData, sizeof(packetData), new CChatMessagePacket(PChar, messageLook, message, name));
+            message::send(MSG_CHAT_PARTY, packetData, sizeof(packetData), std::make_unique<CChatMessagePacket>(PChar, messageLook, message, name));
         }
     }
     else if (messageRange == MESSAGE_AREA_YELL)
     {
-        message::send(MSG_CHAT_YELL, nullptr, 0, new CChatMessagePacket(PChar, messageLook, message, name));
-        PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CChatMessagePacket(PChar, messageLook, message, name));
+        message::send(MSG_CHAT_YELL, nullptr, 0, std::make_unique<CChatMessagePacket>(PChar, messageLook, message, name));
+        PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, std::make_unique<CChatMessagePacket>(PChar, messageLook, message, name));
     }
     else if (messageRange == MESSAGE_AREA_UNITY)
     {
-        message::send(MSG_CHAT_UNITY, nullptr, 0, new CChatMessagePacket(PChar, messageLook, message, name));
-        PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CChatMessagePacket(PChar, messageLook, message, name));
+        message::send(MSG_CHAT_UNITY, nullptr, 0, std::make_unique<CChatMessagePacket>(PChar, messageLook, message, name));
+        PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, std::make_unique<CChatMessagePacket>(PChar, messageLook, message, name));
     }
     else
     {
@@ -413,7 +413,7 @@ void CLuaBaseEntity::messageBasic(uint16 messageID, sol::object const& p0, sol::
     else
     {
         // Broadcast in range
-        m_PBaseEntity->loc.zone->PushPacket(m_PBaseEntity, CHAR_INRANGE, new CMessageBasicPacket(m_PBaseEntity, PTarget, param0, param1, messageID));
+        m_PBaseEntity->loc.zone->PushPacket(m_PBaseEntity, CHAR_INRANGE, std::make_unique<CMessageBasicPacket>(m_PBaseEntity, PTarget, param0, param1, messageID));
     }
 }
 
@@ -443,8 +443,7 @@ void CLuaBaseEntity::messageName(uint16 messageID, sol::object const& entity, so
     }
     else
     {
-        m_PBaseEntity->loc.zone->PushPacket(m_PBaseEntity, CHAR_INRANGE,
-                                            new CMessageNamePacket(m_PBaseEntity, messageID, PNameEntity, param0, param1, param2, param3, chatType));
+        m_PBaseEntity->loc.zone->PushPacket(m_PBaseEntity, CHAR_INRANGE, std::make_unique<CMessageNamePacket>(m_PBaseEntity, messageID, PNameEntity, param0, param1, param2, param3, chatType));
     }
 }
 
@@ -462,8 +461,7 @@ void CLuaBaseEntity::messagePublic(uint16 messageID, CLuaBaseEntity const* PEnti
 
     if (PEntity != nullptr)
     {
-        m_PBaseEntity->loc.zone->PushPacket(m_PBaseEntity, CHAR_INRANGE_SELF,
-                                            new CMessageBasicPacket(m_PBaseEntity, PEntity->GetBaseEntity(), param0, param1, messageID));
+        m_PBaseEntity->loc.zone->PushPacket(m_PBaseEntity, CHAR_INRANGE_SELF, std::make_unique<CMessageBasicPacket>(m_PBaseEntity, PEntity->GetBaseEntity(), param0, param1, messageID));
     }
 }
 
@@ -843,7 +841,7 @@ void CLuaBaseEntity::injectActionPacket(uint32 inTargetID, uint16 inCategory, ui
     target.speceffect      = speceffect;
     target.reaction        = reaction;
 
-    m_PBaseEntity->loc.zone->PushPacket(m_PBaseEntity, CHAR_INRANGE_SELF, new CActionPacket(Action));
+    m_PBaseEntity->loc.zone->PushPacket(m_PBaseEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(Action));
 }
 
 /************************************************************************
@@ -899,7 +897,7 @@ void CLuaBaseEntity::entityAnimationPacket(const char* command, sol::object cons
     }
     else
     {
-        m_PBaseEntity->loc.zone->PushPacket(m_PBaseEntity, CHAR_INRANGE, new CEntityAnimationPacket(m_PBaseEntity, PTarget, command));
+        m_PBaseEntity->loc.zone->PushPacket(m_PBaseEntity, CHAR_INRANGE, std::make_unique<CEntityAnimationPacket>(m_PBaseEntity, PTarget, command));
     }
 }
 
@@ -2522,8 +2520,7 @@ void CLuaBaseEntity::sendEmote(CLuaBaseEntity* target, uint8 emID, uint8 emMode)
             const auto emoteID   = static_cast<Emote>(emID);
             const auto emoteMode = static_cast<EmoteMode>(emMode);
 
-            PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE,
-                                        new CCharEmotionPacket(PChar, PTarget->id, PTarget->targid, emoteID, emoteMode, 0));
+            PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, std::make_unique<CCharEmotionPacket>(PChar, PTarget->id, PTarget->targid, emoteID, emoteMode, 0));
         }
     }
 }
@@ -3108,7 +3105,7 @@ void CLuaBaseEntity::teleport(std::map<std::string, float> pos, sol::object cons
         m_PBaseEntity->loc.p.rotation  = worldAngle(m_PBaseEntity->loc.p, PLuaBaseEntity->GetBaseEntity()->loc.p);
     }
 
-    m_PBaseEntity->loc.zone->PushPacket(m_PBaseEntity, CHAR_INRANGE, new CPositionPacket(m_PBaseEntity));
+    m_PBaseEntity->loc.zone->PushPacket(m_PBaseEntity, CHAR_INRANGE, std::make_unique<CPositionPacket>(m_PBaseEntity));
     m_PBaseEntity->updatemask |= UPDATE_POS;
 }
 
@@ -11049,7 +11046,7 @@ void CLuaBaseEntity::disableLevelSync()
         }
     }
 
-    PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, new CCharSyncPacket(PChar));
+    PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, std::make_unique<CCharSyncPacket>(PChar));
 }
 
 /************************************************************************
@@ -11889,7 +11886,7 @@ void CLuaBaseEntity::enableEntities(sol::object const& obj)
  ************************************************************************/
 void CLuaBaseEntity::independentAnimation(CLuaBaseEntity* PTarget, uint16 animId, uint8 mode)
 {
-    m_PBaseEntity->loc.zone->PushPacket(m_PBaseEntity, CHAR_INRANGE_SELF, new CIndependentAnimationPacket(m_PBaseEntity, PTarget->GetBaseEntity(), animId, mode));
+    m_PBaseEntity->loc.zone->PushPacket(m_PBaseEntity, CHAR_INRANGE_SELF, std::make_unique<CIndependentAnimationPacket>(m_PBaseEntity, PTarget->GetBaseEntity(), animId, mode));
 }
 
 /************************************************************************
@@ -17528,7 +17525,7 @@ void CLuaBaseEntity::restoreFromChest(CLuaBaseEntity* PLuaBaseEntity, uint32 res
             target.animation       = animationID;
             target.messageID       = messageID;
             target.param           = messageParam;
-            PTarget->loc.zone->PushPacket(PTarget, CHAR_INRANGE, new CActionPacket(Action));
+            PTarget->loc.zone->PushPacket(PTarget, CHAR_INRANGE, std::make_unique<CActionPacket>(Action));
         }
     }
 }

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -3627,7 +3627,7 @@ void CLuaBaseEntity::goToEntity(uint32 targetID, sol::object const& option)
     uint16 playerZone = PChar->loc.zone->GetID();
 
     char buf[12];
-    memset(&buf[0], 0, sizeof(buf));
+    std::memset(&buf[0], 0, sizeof(buf));
 
     ref<bool>(&buf, 0)    = true;        // Toggle for message routing; goes to entity server first
     ref<bool>(&buf, 1)    = spawnedOnly; // Specification for Spawned Only or Any
@@ -3658,7 +3658,7 @@ bool CLuaBaseEntity::gotoPlayer(std::string const& playerName)
     if (ret != SQL_ERROR && _sql->NumRows() != 0 && _sql->NextRow() == SQL_SUCCESS)
     {
         char buf[30];
-        memset(&buf[0], 0, sizeof(buf));
+        std::memset(&buf[0], 0, sizeof(buf));
 
         ref<uint32>(&buf, 0) = _sql->GetUIntData(0); // target char
         ref<uint32>(&buf, 4) = m_PBaseEntity->id;    // warping to target char, their server will send us a zoning message with their pos
@@ -3690,7 +3690,7 @@ bool CLuaBaseEntity::bringPlayer(std::string const& playerName)
     if (ret != SQL_ERROR && _sql->NumRows() != 0 && _sql->NextRow() == SQL_SUCCESS)
     {
         char buf[30];
-        memset(&buf[0], 0, sizeof(buf));
+        std::memset(&buf[0], 0, sizeof(buf));
 
         ref<uint32>(&buf, 0)  = _sql->GetUIntData(0); // target char
         ref<uint32>(&buf, 4)  = 0;                    // wanting to bring target char here so wont give our id
@@ -3902,7 +3902,7 @@ bool CLuaBaseEntity::addItem(sol::variadic_args va)
                 {
                     char encoded[SignatureStringLength];
 
-                    memset(&encoded, 0, sizeof(encoded));
+                    std::memset(&encoded, 0, sizeof(encoded));
                     PItem->setSignature(EncodeStringSignature(signature, encoded));
                 }
 
@@ -4480,7 +4480,7 @@ bool CLuaBaseEntity::addLinkpearl(std::string const& lsname, bool equip)
             // build linkpearl
             char EncodedString[LinkshellStringLength];
 
-            memset(&EncodedString, 0, sizeof(EncodedString));
+            std::memset(&EncodedString, 0, sizeof(EncodedString));
             EncodeStringLinkshell(lsname, EncodedString);
             ((CItem*)PItemLinkPearl)->setSignature(EncodedString);
             PItemLinkPearl->SetLSID(_sql->GetUIntData(0));

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -787,7 +787,7 @@ void CLuaBaseEntity::injectPacket(std::string const& filename)
 
     if (File)
     {
-        CBasicPacket* PPacket = new CBasicPacket();
+        auto PPacket = std::make_unique<CBasicPacket>();
 
         fseek(File, 1, SEEK_SET);
         if (fread(&size, 1, 1, File) != 1)
@@ -805,7 +805,7 @@ void CLuaBaseEntity::injectPacket(std::string const& filename)
             return;
         }
 
-        ((CCharEntity*)m_PBaseEntity)->pushPacket(PPacket);
+        ((CCharEntity*)m_PBaseEntity)->pushPacket(std::move(PPacket));
 
         fclose(File);
     }
@@ -2838,14 +2838,14 @@ void CLuaBaseEntity::sendEmptyEntityUpdateToPlayer(CLuaBaseEntity* entityToUpdat
 {
     if (m_PBaseEntity->objtype == TYPE_PC && entityToUpdate->GetBaseEntity())
     {
-        auto* packet = new CBasicPacket();
+        auto packet = std::make_unique<CBasicPacket>();
         packet->setType(0x0E);
         packet->setSize(0x50);
         packet->ref<uint32>(0x04) = entityToUpdate->GetBaseEntity()->id;
         packet->ref<uint16>(0x08) = entityToUpdate->GetBaseEntity()->targid;
         packet->ref<uint8>(0x0A)  = 0x20; // Matches retail observation
         packet->ref<uint8>(0x30)  = 0x01; // MODEL_TYPE::MODEL_EQUIPPED
-        static_cast<CCharEntity*>(m_PBaseEntity)->pushPacket(packet);
+        static_cast<CCharEntity*>(m_PBaseEntity)->pushPacket(std::move(packet));
     }
 }
 
@@ -11711,14 +11711,14 @@ void CLuaBaseEntity::countdown(sol::object const& secondsObj)
     }
 
     CCharEntity* PChar  = (CCharEntity*)m_PBaseEntity;
-    auto*        packet = new CObjectiveUtilityPacket();
+    auto         packet = std::make_unique<CObjectiveUtilityPacket>();
 
     if (secondsObj.is<uint32>())
     {
         packet->addCountdown(secondsObj.as<uint32>());
     }
 
-    PChar->pushPacket(packet);
+    PChar->pushPacket(std::move(packet));
 }
 
 /************************************************************************
@@ -11771,7 +11771,7 @@ void CLuaBaseEntity::objectiveUtility(sol::object const& obj)
     }
 
     CCharEntity* PChar  = (CCharEntity*)m_PBaseEntity;
-    auto*        packet = new CObjectiveUtilityPacket();
+    auto         packet = std::make_unique<CObjectiveUtilityPacket>();
 
     if (obj.is<sol::table>())
     {
@@ -11857,7 +11857,7 @@ void CLuaBaseEntity::objectiveUtility(sol::object const& obj)
         }
     }
 
-    PChar->pushPacket(packet);
+    PChar->pushPacket(std::move(packet));
 }
 
 /************************************************************************

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1091,7 +1091,7 @@ namespace luautils
         TracyZoneScoped;
         if (CBaseEntity* PNpc = zoneutils::GetEntity(npcid, TYPE_NPC))
         {
-            PNpc->loc.zone->PushPacket(PNpc, CHAR_INRANGE, new CEntityVisualPacket(PNpc, command));
+            PNpc->loc.zone->PushPacket(PNpc, CHAR_INRANGE, std::make_unique<CEntityVisualPacket>(PNpc, command));
         }
     }
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1071,16 +1071,15 @@ int32 send_parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_da
                 // Store zoneout packet in case we need to re-send this
                 if (type == 0x00B && map_session_data->blowfish.status == BLOWFISH_PENDING_ZONE && map_session_data->zone_ipp == 0)
                 {
-                    if (auto IPPacket = dynamic_cast<CServerIPPacket*>(PSmallPacket.get()))
-                    {
-                        map_session_data->zone_ipp  = IPPacket->ipp;
-                        map_session_data->zone_type = IPPacket->type;
-                    }
+                    auto IPPacket = static_cast<CServerIPPacket*>(PSmallPacket.get());
+
+                    map_session_data->zone_ipp  = IPPacket->zoneIPP();
+                    map_session_data->zone_type = IPPacket->zoneType();
 
                     incrementKeyAfterEncrypt = true;
 
                     // Set client port to zero, indicating the client tried to zone out and no longer has a port until the next 0x00A
-                    _sql->Query("UPDATE accounts_sessions SET client_port = 0, last_zoneout_time = NOW() WHERE charid = %u", map_session_data->charID);
+                    db::preparedStmt("UPDATE accounts_sessions SET client_port = 0, last_zoneout_time = NOW() WHERE charid = ?", map_session_data->charID);
                 }
 
                 std::memcpy(buff + *buffsize, *PSmallPacket, PSmallPacket->getSize());

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -84,7 +84,7 @@ struct map_session_data_t
         {
             if (blowfish.hash[i] == 0)
             {
-                memset(blowfish.hash + i, 0, 16 - i);
+                std::memset(blowfish.hash + i, 0, 16 - i);
                 break;
             }
         }

--- a/src/map/merit.cpp
+++ b/src/map/merit.cpp
@@ -146,7 +146,7 @@ CMeritPoints::CMeritPoints(CCharEntity* PChar)
         return;
     }
 
-    memcpy(merits, meritNameSpace::GMeritsTemplate, sizeof(merits));
+    std::memcpy(merits, meritNameSpace::GMeritsTemplate, sizeof(merits));
 
     m_PChar = PChar;
     LoadMeritPoints(PChar->id);

--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -245,10 +245,9 @@ namespace message
                             // don't push to sender
                             if (PChar->id != ref<uint32>((uint8*)extra.data(), 0))
                             {
-                                CBasicPacket* newPacket = new CBasicPacket();
-                                memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
-
-                                PChar->pushPacket(newPacket);
+                                auto newPacket = std::make_unique<CBasicPacket>();
+                                std::memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
+                                PChar->pushPacket(std::move(newPacket));
                             }
                         });
                     }
@@ -263,9 +262,9 @@ namespace message
                 {
                     PZone->ForEachChar([&packet](CCharEntity* PChar)
                     {
-                        CBasicPacket* newPacket = new CBasicPacket();
-                        memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
-                        PChar->pushPacket(newPacket);
+                        auto newPacket = std::make_unique<CBasicPacket>();
+                        std::memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
+                        PChar->pushPacket(std::move(newPacket));
                     });
                 });
                 // clang-format on
@@ -310,9 +309,10 @@ namespace message
 
                     PInvitee->InvitePending.id     = ref<uint32>((uint8*)extra.data(), 6);
                     PInvitee->InvitePending.targid = ref<uint16>((uint8*)extra.data(), 10);
-                    CBasicPacket* newPacket        = new CBasicPacket();
-                    memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
-                    PInvitee->pushPacket(newPacket);
+
+                    auto newPacket = std::make_unique<CBasicPacket>();
+                    std::memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
+                    PInvitee->pushPacket(std::move(newPacket));
                 }
                 break;
             }
@@ -508,9 +508,9 @@ namespace message
                 CCharEntity* PChar = zoneutils::GetChar(ref<uint32>((uint8*)extra.data(), 0));
                 if (PChar)
                 {
-                    CBasicPacket* newPacket = new CBasicPacket();
-                    memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
-                    PChar->pushPacket(newPacket);
+                    auto newPacket = std::make_unique<CBasicPacket>();
+                    std::memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
+                    PChar->pushPacket(std::move(newPacket));
                 }
                 break;
             }

--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -121,11 +121,11 @@ namespace message
                     auto gm_sent = newPacket->ref<uint8>(0x05);
                     if (settings::get<bool>("map.BLOCK_TELL_TO_HIDDEN_GM") && PChar->m_isGMHidden && !gm_sent)
                     {
-                        send(MSG_DIRECT, extra.data(), sizeof(uint32), new CMessageStandardPacket(PChar, 0, 0, MsgStd::TellNotReceivedOffline));
+                        send(MSG_DIRECT, extra.data(), sizeof(uint32), std::make_unique<CMessageStandardPacket>(PChar, 0, 0, MsgStd::TellNotReceivedOffline));
                     }
                     else if (PChar->isAway() && !gm_sent)
                     {
-                        send(MSG_DIRECT, extra.data(), sizeof(uint32), new CMessageStandardPacket(PChar, 0, 0, MsgStd::TellNotReceivedAway));
+                        send(MSG_DIRECT, extra.data(), sizeof(uint32), std::make_unique<CMessageStandardPacket>(PChar, 0, 0, MsgStd::TellNotReceivedAway));
                     }
                     else
                     {
@@ -134,7 +134,7 @@ namespace message
                 }
                 else
                 {
-                    send(MSG_DIRECT, extra.data(), sizeof(uint32), new CMessageStandardPacket(PChar, 0, 0, MsgStd::TellNotReceivedOffline));
+                    send(MSG_DIRECT, extra.data(), sizeof(uint32), std::make_unique<CMessageStandardPacket>(PChar, 0, 0, MsgStd::TellNotReceivedOffline));
                 }
                 break;
             }
@@ -166,7 +166,7 @@ namespace message
 
                 if (PParty)
                 {
-                    CBasicPacket* newPacket = new CBasicPacket();
+                    auto newPacket = std::unique_ptr<CBasicPacket>();
                     std::memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
                     PParty->PushPacket(senderid, 0, newPacket);
                 }
@@ -202,7 +202,7 @@ namespace message
                 {
                     for (auto& currentParty : PAlliance->partyList)
                     {
-                        CBasicPacket* newPacket = new CBasicPacket();
+                        auto newPacket = std::unique_ptr<CBasicPacket>();
                         std::memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
                         currentParty->PushPacket(senderid, 0, newPacket);
                     }
@@ -215,7 +215,7 @@ namespace message
                 CLinkshell* PLinkshell  = linkshell::GetLinkshell(linkshellID);
                 if (PLinkshell)
                 {
-                    CBasicPacket* newPacket = new CBasicPacket();
+                    auto newPacket = std::unique_ptr<CBasicPacket>();
                     std::memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
                     PLinkshell->PushPacket(ref<uint32>((uint8*)extra.data(), 4), newPacket);
                 }
@@ -227,7 +227,7 @@ namespace message
                 CUnityChat* PUnityChat = unitychat::GetUnityChat(leader);
                 if (PUnityChat)
                 {
-                    CBasicPacket* newPacket = new CBasicPacket();
+                    auto newPacket = std::make_unique<CBasicPacket>();
                     std::memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
                     PUnityChat->PushPacket(ref<uint32>((uint8*)extra.data(), 4), newPacket);
                 }
@@ -285,7 +285,7 @@ namespace message
                         (inviteType == INVITE_ALLIANCE && (!PInvitee->PParty || PInvitee->PParty->GetLeader() != PInvitee || (PInvitee->PParty && PInvitee->PParty->m_PAlliance))))
                     {
                         ref<uint32>((uint8*)extra.data(), 0) = ref<uint32>((uint8*)extra.data(), 6);
-                        send(MSG_DIRECT, extra.data(), sizeof(uint32), new CMessageStandardPacket(PInvitee, 0, 0, MsgStd::CannotInvite));
+                        send(MSG_DIRECT, extra.data(), sizeof(uint32), std::make_unique<CMessageStandardPacket>(PInvitee, 0, 0, MsgStd::CannotInvite));
                         return;
                     }
                     // check /blockaid
@@ -293,17 +293,17 @@ namespace message
                     {
                         ref<uint32>((uint8*)extra.data(), 0) = ref<uint32>((uint8*)extra.data(), 6);
                         // Target is blocking assistance
-                        send(MSG_DIRECT, extra.data(), sizeof(uint32), new CMessageSystemPacket(0, 0, MsgStd::TargetIsCurrentlyBlocking));
+                        send(MSG_DIRECT, extra.data(), sizeof(uint32), std::make_unique<CMessageSystemPacket>(0, 0, MsgStd::TargetIsCurrentlyBlocking));
                         // Interaction was blocked
                         PInvitee->pushPacket<CMessageSystemPacket>(0, 0, MsgStd::BlockedByBlockaid);
                         // You cannot invite that person at this time.
-                        send(MSG_DIRECT, extra.data(), sizeof(uint32), new CMessageStandardPacket(PInvitee, 0, 0, MsgStd::CannotInvite));
+                        send(MSG_DIRECT, extra.data(), sizeof(uint32), std::make_unique<CMessageStandardPacket>(PInvitee, 0, 0, MsgStd::CannotInvite));
                         break;
                     }
                     if (PInvitee->StatusEffectContainer->HasStatusEffect(EFFECT_LEVEL_SYNC))
                     {
                         ref<uint32>((uint8*)extra.data(), 0) = ref<uint32>((uint8*)extra.data(), 6);
-                        send(MSG_DIRECT, extra.data(), sizeof(uint32), new CMessageStandardPacket(PInvitee, 0, 0, MsgStd::CannotInviteLevelSync));
+                        send(MSG_DIRECT, extra.data(), sizeof(uint32), std::make_unique<CMessageStandardPacket>(PInvitee, 0, 0, MsgStd::CannotInviteLevelSync));
                         return;
                     }
 
@@ -354,7 +354,7 @@ namespace message
                                     else
                                     {
                                         send(MSG_DIRECT, (uint8*)extra.data() + 6, sizeof(uint32),
-                                             new CMessageStandardPacket(PInviter, 0, 0, MsgStd::CannotBeProcessed));
+                                             std::make_unique<CMessageStandardPacket>(PInviter, 0, 0, MsgStd::CannotBeProcessed));
                                     }
                                 }
                                 else if (PInviter->PParty)
@@ -367,7 +367,7 @@ namespace message
                             else // Somehow, the inviter didn't have a party despite the database thinking they did.
                             {
                                 send(MSG_DIRECT, (uint8*)extra.data() + 6, sizeof(uint32),
-                                     new CMessageStandardPacket(PInviter, 0, 0, MsgStd::CannotBeProcessed));
+                                     std::make_unique<CMessageStandardPacket>(PInviter, 0, 0, MsgStd::CannotBeProcessed));
                             }
                         }
                         else
@@ -984,7 +984,7 @@ namespace message
         zContext.close();
     }
 
-    void send(MSGSERVTYPE type, void* data, size_t datalen, CBasicPacket* packet)
+    void send(MSGSERVTYPE type, void* data, size_t datalen, const std::unique_ptr<CBasicPacket>& packet)
     {
         TracyZoneScoped;
 
@@ -1032,7 +1032,7 @@ namespace message
         message::send(MSG_LUA_FUNCTION, packetData.data(), packetData.size());
     }
 
-    void send(uint32 playerId, CBasicPacket* packet)
+    void send(uint32 playerId, const std::unique_ptr<CBasicPacket>& packet)
     {
         TracyZoneScoped;
 
@@ -1041,7 +1041,7 @@ namespace message
         message::send(MSG_DIRECT, packetData.data(), packetData.size(), packet);
     }
 
-    void send(std::string const& playerName, CBasicPacket* packet)
+    void send(std::string const& playerName, const std::unique_ptr<CBasicPacket>& packet)
     {
         TracyZoneScoped;
 

--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -166,7 +166,7 @@ namespace message
 
                 if (PParty)
                 {
-                    auto newPacket = std::unique_ptr<CBasicPacket>();
+                    auto newPacket = std::make_unique<CBasicPacket>();
                     std::memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
                     PParty->PushPacket(senderid, 0, newPacket);
                 }
@@ -202,7 +202,7 @@ namespace message
                 {
                     for (auto& currentParty : PAlliance->partyList)
                     {
-                        auto newPacket = std::unique_ptr<CBasicPacket>();
+                        auto newPacket = std::make_unique<CBasicPacket>();
                         std::memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
                         currentParty->PushPacket(senderid, 0, newPacket);
                     }
@@ -215,7 +215,7 @@ namespace message
                 CLinkshell* PLinkshell  = linkshell::GetLinkshell(linkshellID);
                 if (PLinkshell)
                 {
-                    auto newPacket = std::unique_ptr<CBasicPacket>();
+                    auto newPacket = std::make_unique<CBasicPacket>();
                     std::memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
                     PLinkshell->PushPacket(ref<uint32>((uint8*)extra.data(), 4), newPacket);
                 }

--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -1002,13 +1002,7 @@ namespace message
         if (packet)
         {
             // clang-format off
-            msg.packet = zmq::message_t(*packet, packet->getSize(),
-            [](void* data, void* hint)
-            {
-                auto* intdata = (uint8*)data;
-                destroy_arr(intdata);
-            });
-            // clang-format on
+            msg.packet = zmq::message_t(*packet, packet->getSize());
         }
         else
         {

--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -111,13 +111,13 @@ namespace message
             case MSG_CHAT_TELL:
             {
                 char characterName[PacketNameLength] = {};
-                memcpy(&characterName, reinterpret_cast<char*>(extra.data()) + 4, PacketNameLength - 1);
+                std::memcpy(&characterName, reinterpret_cast<char*>(extra.data()) + 4, PacketNameLength - 1);
 
                 CCharEntity* PChar = zoneutils::GetCharByName(characterName);
                 if (PChar && PChar->status != STATUS_TYPE::DISAPPEAR && !jailutils::InPrison(PChar))
                 {
                     std::unique_ptr<CBasicPacket> newPacket = std::make_unique<CBasicPacket>();
-                    memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
+                    std::memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
                     auto gm_sent = newPacket->ref<uint8>(0x05);
                     if (settings::get<bool>("map.BLOCK_TELL_TO_HIDDEN_GM") && PChar->m_isGMHidden && !gm_sent)
                     {
@@ -167,7 +167,7 @@ namespace message
                 if (PParty)
                 {
                     CBasicPacket* newPacket = new CBasicPacket();
-                    memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
+                    std::memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
                     PParty->PushPacket(senderid, 0, newPacket);
                 }
                 break;
@@ -203,7 +203,7 @@ namespace message
                     for (auto& currentParty : PAlliance->partyList)
                     {
                         CBasicPacket* newPacket = new CBasicPacket();
-                        memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
+                        std::memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
                         currentParty->PushPacket(senderid, 0, newPacket);
                     }
                 }
@@ -216,7 +216,7 @@ namespace message
                 if (PLinkshell)
                 {
                     CBasicPacket* newPacket = new CBasicPacket();
-                    memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
+                    std::memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
                     PLinkshell->PushPacket(ref<uint32>((uint8*)extra.data(), 4), newPacket);
                 }
                 break;
@@ -228,7 +228,7 @@ namespace message
                 if (PUnityChat)
                 {
                     CBasicPacket* newPacket = new CBasicPacket();
-                    memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
+                    std::memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
                     PUnityChat->PushPacket(ref<uint32>((uint8*)extra.data(), 4), newPacket);
                 }
                 break;
@@ -521,7 +521,7 @@ namespace message
                 if (PLinkshell)
                 {
                     char memberName[PacketNameLength] = {};
-                    memcpy(&memberName, reinterpret_cast<char*>(extra.data()) + 4, PacketNameLength - 1);
+                    std::memcpy(&memberName, reinterpret_cast<char*>(extra.data()) + 4, PacketNameLength - 1);
                     PLinkshell->ChangeMemberRank(memberName, ref<uint8>((uint8*)extra.data(), 28));
                 }
                 break;
@@ -529,7 +529,7 @@ namespace message
             case MSG_LINKSHELL_REMOVE:
             {
                 char memberName[PacketNameLength] = {};
-                memcpy(&memberName, reinterpret_cast<char*>(extra.data()) + 4, PacketNameLength - 1);
+                std::memcpy(&memberName, reinterpret_cast<char*>(extra.data()) + 4, PacketNameLength - 1);
                 CCharEntity* PChar = zoneutils::GetCharByName(memberName);
 
                 if (PChar && PChar->PLinkshell1 && PChar->PLinkshell1->getID() == ref<uint32>((uint8*)extra.data(), 24))
@@ -564,7 +564,7 @@ namespace message
                     if (requester != 0)
                     {
                         char buf[30];
-                        memset(&buf[0], 0, sizeof(buf));
+                        std::memset(&buf[0], 0, sizeof(buf));
 
                         ref<uint32>(&buf, 0)  = requester;
                         ref<uint16>(&buf, 8)  = PChar->getZone();
@@ -617,7 +617,7 @@ namespace message
                     if (Entity && Entity->loc.zone)
                     {
                         char buf[22];
-                        memset(&buf[0], 0, sizeof(buf));
+                        std::memset(&buf[0], 0, sizeof(buf));
 
                         uint16 targetZone = ref<uint16>((uint8*)extra.data(), 2);
                         uint16 playerZone = ref<uint16>((uint8*)extra.data(), 4);
@@ -856,13 +856,13 @@ namespace message
     {
         const uint32 size      = sizeof(uint32) + sizeof(uint32) + sizeof(uint32) + sizeof(uint8) + 256;
         char         buf[size] = {};
-        memset(&buf[0], 0, size);
+        std::memset(&buf[0], 0, size);
 
         ref<uint32>(buf, 0) = charId;
         ref<int32>(buf, 4)  = value;
         ref<uint32>(buf, 8) = expiry;
         ref<uint8>(buf, 12) = static_cast<uint8>(std::min<size_t>(varName.size(), 255));
-        memcpy(buf + 13, varName.c_str(), varName.size());
+        std::memcpy(buf + 13, varName.c_str(), varName.size());
 
         message::send(MSG_CHARVAR_UPDATE, buf, size, nullptr);
     }
@@ -996,7 +996,7 @@ namespace message
         msg.data = zmq::message_t(datalen);
         if (datalen > 0)
         {
-            memcpy(msg.data.data(), data, datalen);
+            std::memcpy(msg.data.data(), data, datalen);
         }
 
         if (packet)

--- a/src/map/message.h
+++ b/src/map/message.h
@@ -74,10 +74,10 @@ namespace message
     void init();
     void init(const char* chatIp, uint16 chatPort);
     void handle_incoming();
-    void send(MSGSERVTYPE type, void* data, size_t datalen, CBasicPacket* packet = nullptr);
+    void send(MSGSERVTYPE type, void* data, size_t datalen, const std::unique_ptr<CBasicPacket>& packet = nullptr);
     void send(uint16 zone, std::string const& luaFunc);
-    void send(uint32 playerId, CBasicPacket* packet);
-    void send(std::string const& playerName, CBasicPacket* packet);
+    void send(uint32 playerId, const std::unique_ptr<CBasicPacket>& packet);
+    void send(std::string const& playerName, const std::unique_ptr<CBasicPacket>& packet);
     void send_charvar_update(uint32 charId, std::string const& varName, uint32 value, uint32 expiry);
     void rpc_send(uint16 sendZone, uint16 recvZone, std::string const& sendStr, sol::function recvFunc);
 

--- a/src/map/mob_spell_list.cpp
+++ b/src/map/mob_spell_list.cpp
@@ -55,7 +55,7 @@ namespace mobSpellList
     // Load list of spells
     void LoadMobSpellList()
     {
-        memset(PMobSpellList, 0, sizeof(PMobSpellList));
+        std::memset(PMobSpellList, 0, sizeof(PMobSpellList));
         PMobSpellList[0] = new CMobSpellList();
 
         const char* Query = "SELECT mob_spell_lists.spell_list_id, \

--- a/src/map/navmesh.cpp
+++ b/src/map/navmesh.cpp
@@ -177,7 +177,7 @@ bool CNavMesh::load(std::string const& filename)
         {
             break;
         }
-        memset(data, 0, tileHeader.dataSize);
+        std::memset(data, 0, tileHeader.dataSize);
         file.read(reinterpret_cast<char*>(data), tileHeader.dataSize);
 
         m_navMesh->addTile(data, tileHeader.dataSize, DT_TILE_FREE_DATA, tileHeader.tileRef, nullptr);

--- a/src/map/packet_guard.cpp
+++ b/src/map/packet_guard.cpp
@@ -104,7 +104,7 @@ namespace PacketGuard
     {
         // Count packets in queue
         std::map<std::string, uint32> packetCounterMap;
-        for (auto& entry : PChar->getPacketList())
+        for (auto& entry : PChar->getPacketListCopy())
         {
             auto packetStr = fmt::format("0x{:4X}", entry->getType());
             packetCounterMap[packetStr]++;

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -194,11 +194,11 @@ void PrintPacket(CBasicPacket& packet)
 {
     std::string message;
 
-    for (size_t idx = 0; idx < packet.getSize(); idx++)
+    for (std::size_t idx = 0U; idx < packet.getSize(); idx++)
     {
         message.append(fmt::format("{:02x} ", (char*)packet[idx]));
 
-        if (((idx + 1) % 16) == 0)
+        if (((idx + 1U) % 16U) == 0U)
         {
             message += "\n";
             ShowDebug(message.c_str());
@@ -907,7 +907,7 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
                 if (!PMob->GetCallForHelpFlag() && PMob->PEnmityContainer->HasID(PChar->id) && !PMob->m_CallForHelpBlocked)
                 {
                     PMob->SetCallForHelpFlag(true);
-                    PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CMessageBasicPacket(PChar, PChar, 0, 0, 19));
+                    PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, std::make_unique<CMessageBasicPacket>(PChar, PChar, 0, 0, 19));
                     return;
                 }
             }
@@ -1039,7 +1039,7 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
             {
                 charutils::UpdateItem(PChar, LOC_INVENTORY, slotID, -1);
                 PChar->pushPacket<CInventoryFinishPacket>();
-                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CChocoboDiggingPacket(PChar));
+                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, std::make_unique<CChocoboDiggingPacket>(PChar));
             }
         }
         break;
@@ -3932,7 +3932,7 @@ void SmallPacket0x05D(map_session_data_t* const PSession, CCharEntity* const PCh
         return;
     }
 
-    PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CCharEmotionPacket(PChar, TargetID, TargetIndex, EmoteID, emoteMode, extra));
+    PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, std::make_unique<CCharEmotionPacket>(PChar, TargetID, TargetIndex, EmoteID, emoteMode, extra));
 
     luautils::OnPlayerEmote(PChar, EmoteID);
 }
@@ -4354,7 +4354,7 @@ void SmallPacket0x06E(map_session_data_t* const PSession, CCharEntity* const PCh
                     ref<uint16>(packetData, 4)  = targid;
                     ref<uint32>(packetData, 6)  = PChar->id;
                     ref<uint16>(packetData, 10) = PChar->targid;
-                    message::send(MSG_PT_INVITE, packetData, sizeof(packetData), new CPartyInvitePacket(charid, targid, PChar, INVITE_PARTY));
+                    message::send(MSG_PT_INVITE, packetData, sizeof(packetData), std::make_unique<CPartyInvitePacket>(charid, targid, PChar, INVITE_PARTY));
 
                     ShowDebug("Sent invite packet to lobby server from %s to (%d)", PChar->getName(), charid);
                 }
@@ -4429,7 +4429,7 @@ void SmallPacket0x06E(map_session_data_t* const PSession, CCharEntity* const PCh
                     ref<uint16>(packetData, 4)  = targid;
                     ref<uint32>(packetData, 6)  = PChar->id;
                     ref<uint16>(packetData, 10) = PChar->targid;
-                    message::send(MSG_PT_INVITE, packetData, sizeof(packetData), new CPartyInvitePacket(charid, targid, PChar, INVITE_ALLIANCE));
+                    message::send(MSG_PT_INVITE, packetData, sizeof(packetData), std::make_unique<CPartyInvitePacket>(charid, targid, PChar, INVITE_ALLIANCE));
 
                     ShowDebug("(Alliance)Sent invite packet to lobby server from %s to (%d)", PChar->getName(), charid);
                 }
@@ -5405,7 +5405,7 @@ void SmallPacket0x0A2(map_session_data_t* const PSession, CCharEntity* const PCh
     TracyZoneScoped;
     uint16 diceroll = xirand::GetRandomNumber(1000);
 
-    PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CMessageStandardPacket(PChar, diceroll, MsgStd::DiceRoll));
+    PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, std::make_unique<CMessageStandardPacket>(PChar, diceroll, MsgStd::DiceRoll));
 }
 
 /************************************************************************
@@ -5502,7 +5502,7 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
     }
     else if (data.ref<uint8>(0x06) == '#' && PChar->m_GMlevel > 0)
     {
-        message::send(MSG_CHAT_SERVMES, nullptr, 0, new CChatMessagePacket(PChar, MESSAGE_SYSTEM_1, (const char*)data[7]));
+        message::send(MSG_CHAT_SERVMES, nullptr, 0, std::make_unique<CChatMessagePacket>(PChar, MESSAGE_SYSTEM_1, (const char*)data[7]));
     }
     else
     {
@@ -5525,7 +5525,7 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                     });
                     // clang-format on
                 }
-                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, new CChatMessagePacket(PChar, MESSAGE_SAY, (const char*)data[6]));
+                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, std::make_unique<CChatMessagePacket>(PChar, MESSAGE_SAY, (const char*)data[6]));
             }
             else
             {
@@ -5553,12 +5553,12 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                         });
                         // clang-format on
                     }
-                    PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, new CChatMessagePacket(PChar, MESSAGE_SAY, (const char*)data[6]));
+                    PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, std::make_unique<CChatMessagePacket>(PChar, MESSAGE_SAY, (const char*)data[6]));
                 }
                 break;
                 case MESSAGE_EMOTION:
                 {
-                    PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, new CChatMessagePacket(PChar, MESSAGE_EMOTION, (const char*)data[6]));
+                    PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, std::make_unique<CChatMessagePacket>(PChar, MESSAGE_EMOTION, (const char*)data[6]));
                 }
                 break;
                 case MESSAGE_SHOUT:
@@ -5578,7 +5578,7 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                         });
                         // clang-format on
                     }
-                    PChar->loc.zone->PushPacket(PChar, CHAR_INSHOUT, new CChatMessagePacket(PChar, MESSAGE_SHOUT, (const char*)data[6]));
+                    PChar->loc.zone->PushPacket(PChar, CHAR_INSHOUT, std::make_unique<CChatMessagePacket>(PChar, MESSAGE_SHOUT, (const char*)data[6]));
                 }
                 break;
                 case MESSAGE_LINKSHELL:
@@ -5589,7 +5589,7 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                         ref<uint32>(packetData, 0) = PChar->PLinkshell1->getID();
                         ref<uint32>(packetData, 4) = PChar->id;
                         message::send(MSG_CHAT_LINKSHELL, packetData, sizeof(packetData),
-                                      new CChatMessagePacket(PChar, MESSAGE_LINKSHELL, (const char*)data[6]));
+                                      std::make_unique<CChatMessagePacket>(PChar, MESSAGE_LINKSHELL, (const char*)data[6]));
 
                         if (settings::get<bool>("map.AUDIT_CHAT") && settings::get<uint8>("map.AUDIT_LINKSHELL"))
                         {
@@ -5620,7 +5620,7 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                         ref<uint32>(packetData, 0) = PChar->PLinkshell2->getID();
                         ref<uint32>(packetData, 4) = PChar->id;
                         message::send(MSG_CHAT_LINKSHELL, packetData, sizeof(packetData),
-                                      new CChatMessagePacket(PChar, MESSAGE_LINKSHELL, (const char*)data[6]));
+                                      std::make_unique<CChatMessagePacket>(PChar, MESSAGE_LINKSHELL, (const char*)data[6]));
 
                         if (settings::get<bool>("map.AUDIT_CHAT") && settings::get<uint8>("map.AUDIT_LINKSHELL"))
                         {
@@ -5652,13 +5652,13 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                         {
                             ref<uint32>(packetData, 0) = PChar->PParty->m_PAlliance->m_AllianceID;
                             ref<uint32>(packetData, 4) = PChar->id;
-                            message::send(MSG_CHAT_ALLIANCE, packetData, sizeof(packetData), new CChatMessagePacket(PChar, MESSAGE_PARTY, (const char*)data[6]));
+                            message::send(MSG_CHAT_ALLIANCE, packetData, sizeof(packetData), std::make_unique<CChatMessagePacket>(PChar, MESSAGE_PARTY, (const char*)data[6]));
                         }
                         else
                         {
                             ref<uint32>(packetData, 0) = PChar->PParty->GetPartyID();
                             ref<uint32>(packetData, 4) = PChar->id;
-                            message::send(MSG_CHAT_PARTY, packetData, sizeof(packetData), new CChatMessagePacket(PChar, MESSAGE_PARTY, (const char*)data[6]));
+                            message::send(MSG_CHAT_PARTY, packetData, sizeof(packetData), std::make_unique<CChatMessagePacket>(PChar, MESSAGE_PARTY, (const char*)data[6]));
                         }
 
                         if (settings::get<bool>("map.AUDIT_CHAT") && settings::get<uint8>("map.AUDIT_PARTY"))
@@ -5694,7 +5694,7 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                             int8 packetData[4]{};
                             ref<uint32>(packetData, 0) = PChar->id;
 
-                            message::send(MSG_CHAT_YELL, packetData, sizeof(packetData), new CChatMessagePacket(PChar, MESSAGE_YELL, (const char*)data[6]));
+                            message::send(MSG_CHAT_YELL, packetData, sizeof(packetData), std::make_unique<CChatMessagePacket>(PChar, MESSAGE_YELL, (const char*)data[6]));
 
                             if (settings::get<bool>("map.AUDIT_CHAT") && settings::get<uint8>("map.AUDIT_YELL"))
                             {
@@ -5731,7 +5731,7 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                         ref<uint32>(packetData, 0) = PChar->PUnityChat->getLeader();
                         ref<uint32>(packetData, 4) = PChar->id;
                         message::send(MSG_CHAT_UNITY, packetData, sizeof(packetData),
-                                      new CChatMessagePacket(PChar, MESSAGE_UNITY, (const char*)data[6]));
+                                      std::make_unique<CChatMessagePacket>(PChar, MESSAGE_UNITY, (const char*)data[6]));
 
                         roeutils::event(ROE_EVENT::ROE_UNITY_CHAT, PChar, RoeDatagram("unityMessage", (const char*)data[6]));
 
@@ -5793,7 +5793,7 @@ void SmallPacket0x0B6(map_session_data_t* const PSession, CCharEntity* const PCh
     strncpy((char*)packetData + 4, recipientName.c_str(), recipientName.length() + 1);
     ref<uint32>(packetData, 0) = PChar->id;
 
-    message::send(MSG_CHAT_TELL, packetData, recipientName.length() + 5, new CChatMessagePacket(PChar, MESSAGE_TELL, message));
+    message::send(MSG_CHAT_TELL, packetData, recipientName.length() + 5, std::make_unique<CChatMessagePacket>(PChar, MESSAGE_TELL, message));
 
     if (settings::get<bool>("map.AUDIT_CHAT") && settings::get<bool>("map.AUDIT_TELL"))
     {
@@ -8437,7 +8437,7 @@ void SmallPacket0x11D(map_session_data_t* const PSession, CCharEntity* const PCh
     auto const& targetIndex = data.ref<uint16>(0x08);
     auto const& extra       = data.ref<uint16>(0x0A);
 
-    PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CCharEmotionJumpPacket(PChar, targetIndex, extra));
+    PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, std::make_unique<CCharEmotionJumpPacket>(PChar, targetIndex, extra));
 }
 
 /************************************************************************

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -190,18 +190,15 @@ std::function<void(map_session_data_t* const, CCharEntity* const, CBasicPacket&)
  *                                                                       *
  ************************************************************************/
 
-void PrintPacket(CBasicPacket data)
+void PrintPacket(CBasicPacket& packet)
 {
     std::string message;
-    char        buffer[5];
 
-    for (size_t y = 0; y < data.getSize(); y++)
+    for (size_t idx = 0; idx < packet.getSize(); idx++)
     {
-        std::memset(buffer, 0, sizeof(buffer));                               // TODO: Replace these three lines with std::format when/if we move to C++ 20.
-        snprintf(buffer, sizeof(buffer), "%02hhx ", *((uint8*)data[(int)y])); //
-        message.append(buffer);                                               //
+        message.append(fmt::format("{:02x} ", (char*)packet[idx]));
 
-        if (((y + 1) % 16) == 0)
+        if (((idx + 1) % 16) == 0)
         {
             message += "\n";
             ShowDebug(message.c_str());
@@ -209,7 +206,7 @@ void PrintPacket(CBasicPacket data)
         }
     }
 
-    if (message.length() > 0)
+    if (!message.empty())
     {
         message += "\n";
         ShowDebug(message.c_str());
@@ -1213,7 +1210,7 @@ void SmallPacket0x01B(map_session_data_t* const PSession, CCharEntity* const PCh
 void SmallPacket0x01C(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket& data)
 {
     TracyZoneScoped;
-    PrintPacket(std::move(data));
+    PrintPacket(data);
 }
 
 /************************************************************************
@@ -2155,7 +2152,7 @@ void SmallPacket0x03D(map_session_data_t* const PSession, CCharEntity* const PCh
     TracyZoneScoped;
 
     char blacklistedName[PacketNameLength] = {};
-    memcpy(&blacklistedName, data[0x08], PacketNameLength - 1);
+    std::memcpy(&blacklistedName, data[0x08], PacketNameLength - 1);
 
     std::string name = blacklistedName;
     uint8       cmd  = data.ref<uint8>(0x18);
@@ -2523,7 +2520,7 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                             size_t length = 0;
                             char*  extra  = nullptr;
                             _sql->GetData(5, &extra, &length);
-                            memcpy(PItem->m_extra, extra, (length > sizeof(PItem->m_extra) ? sizeof(PItem->m_extra) : length));
+                            std::memcpy(PItem->m_extra, extra, (length > sizeof(PItem->m_extra) ? sizeof(PItem->m_extra) : length));
 
                             if (boxtype == 2)
                             {
@@ -2614,12 +2611,12 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                     }
 
                     char receiver[PacketNameLength] = {};
-                    memcpy(&receiver, data[0x10], PacketNameLength - 1);
+                    std::memcpy(&receiver, data[0x10], PacketNameLength - 1);
                     PUBoxItem->setReceiver(receiver);
                     PUBoxItem->setSender(PChar->getName());
                     PUBoxItem->setQuantity(quantity);
                     PUBoxItem->setSlotID(PItem->getSlotID());
-                    memcpy(PUBoxItem->m_extra, PItem->m_extra, sizeof(PUBoxItem->m_extra));
+                    std::memcpy(PUBoxItem->m_extra, PItem->m_extra, sizeof(PUBoxItem->m_extra));
 
                     char extra[sizeof(PItem->m_extra) * 2 + 1];
                     _sql->EscapeStringLen(extra, (const char*)PItem->m_extra, sizeof(PItem->m_extra));
@@ -2871,7 +2868,7 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                             size_t length = 0;
                             char*  extra  = nullptr;
                             _sql->GetData(3, &extra, &length);
-                            memcpy(PItem->m_extra, extra, (length > sizeof(PItem->m_extra) ? sizeof(PItem->m_extra) : length));
+                            std::memcpy(PItem->m_extra, extra, (length > sizeof(PItem->m_extra) ? sizeof(PItem->m_extra) : length));
 
                             PItem->setSender(_sql->GetStringData(4));
                             if (PChar->UContainer->IsSlotEmpty(slotID))
@@ -4560,7 +4557,7 @@ void SmallPacket0x071(map_session_data_t* const PSession, CCharEntity* const PCh
             if (PChar->PParty && PChar->PParty->GetLeader() == PChar)
             {
                 char charName[PacketNameLength] = {};
-                memcpy(&charName, data[0x0C], PacketNameLength - 1);
+                std::memcpy(&charName, data[0x0C], PacketNameLength - 1);
 
                 CCharEntity* PVictim = dynamic_cast<CCharEntity*>(PChar->PParty->GetMemberByName(charName));
                 if (PVictim)
@@ -4630,7 +4627,7 @@ void SmallPacket0x071(map_session_data_t* const PSession, CCharEntity* const PCh
             {
                 int8 packetData[29]{};
                 ref<uint32>(packetData, 0) = PChar->id;
-                memcpy(packetData + 0x04, data[0x0C], 20);
+                std::memcpy(packetData + 0x04, data[0x0C], 20);
                 ref<uint32>(packetData, 24) = PChar->PLinkshell1->getID();
                 ref<uint8>(packetData, 28)  = PItemLinkshell->GetLSType();
                 message::send(MSG_LINKSHELL_REMOVE, packetData, sizeof(packetData), nullptr);
@@ -4645,7 +4642,7 @@ void SmallPacket0x071(map_session_data_t* const PSession, CCharEntity* const PCh
             {
                 int8 packetData[29]{};
                 ref<uint32>(packetData, 0) = PChar->id;
-                memcpy(packetData + 0x04, data[0x0C], 20);
+                std::memcpy(packetData + 0x04, data[0x0C], 20);
                 ref<uint32>(packetData, 24) = PChar->PLinkshell2->getID();
                 ref<uint8>(packetData, 28)  = PItemLinkshell->GetLSType();
                 message::send(MSG_LINKSHELL_REMOVE, packetData, sizeof(packetData), nullptr);
@@ -4660,7 +4657,7 @@ void SmallPacket0x071(map_session_data_t* const PSession, CCharEntity* const PCh
                 for (std::size_t i = 0; i < PChar->PParty->m_PAlliance->partyList.size(); ++i)
                 {
                     char charName[PacketNameLength] = {};
-                    memcpy(&charName, data[0x0C], PacketNameLength - 1);
+                    std::memcpy(&charName, data[0x0C], PacketNameLength - 1);
 
                     PVictim = dynamic_cast<CCharEntity*>(PChar->PParty->m_PAlliance->partyList[i]->GetMemberByName(charName));
                     if (PVictim && PVictim->PParty && PVictim->PParty->m_PAlliance) // victim is in this party
@@ -4878,7 +4875,7 @@ void SmallPacket0x077(map_session_data_t* const PSession, CCharEntity* const PCh
             if (PChar->PParty != nullptr && PChar->PParty->GetLeader() == PChar)
             {
                 char memberName[PacketNameLength] = {};
-                memcpy(&memberName, data[0x04], PacketNameLength - 1);
+                std::memcpy(&memberName, data[0x04], PacketNameLength - 1);
 
                 ShowDebug(fmt::format("(Party)Altering permissions of {} to {}", str(memberName), str(data[0x15])));
                 PChar->PParty->AssignPartyRole(memberName, data.ref<uint8>(0x15));
@@ -4891,7 +4888,7 @@ void SmallPacket0x077(map_session_data_t* const PSession, CCharEntity* const PCh
             {
                 int8 packetData[29]{};
                 ref<uint32>(packetData, 0) = PChar->id;
-                memcpy(packetData + 0x04, data[0x04], 20);
+                std::memcpy(packetData + 0x04, data[0x04], 20);
                 ref<uint32>(packetData, 24) = PChar->PLinkshell1->getID();
                 ref<uint8>(packetData, 28)  = data.ref<uint8>(0x15);
                 message::send(MSG_LINKSHELL_RANK_CHANGE, packetData, sizeof(packetData), nullptr);
@@ -4904,7 +4901,7 @@ void SmallPacket0x077(map_session_data_t* const PSession, CCharEntity* const PCh
             {
                 int8 packetData[29]{};
                 ref<uint32>(packetData, 0) = PChar->id;
-                memcpy(packetData + 0x04, data[0x04], 20);
+                std::memcpy(packetData + 0x04, data[0x04], 20);
                 ref<uint32>(packetData, 24) = PChar->PLinkshell2->getID();
                 ref<uint8>(packetData, 28)  = data.ref<uint8>(0x15);
                 message::send(MSG_LINKSHELL_RANK_CHANGE, packetData, sizeof(packetData), nullptr);
@@ -4917,7 +4914,7 @@ void SmallPacket0x077(map_session_data_t* const PSession, CCharEntity* const PCh
                 PChar->PParty->m_PAlliance->getMainParty() == PChar->PParty)
             {
                 char memberName[PacketNameLength] = {};
-                memcpy(&memberName, data[0x04], PacketNameLength - 1);
+                std::memcpy(&memberName, data[0x04], PacketNameLength - 1);
 
                 ShowDebug(fmt::format("(Alliance)Changing leader to {}", str(memberName)));
                 PChar->PParty->m_PAlliance->assignAllianceLeader(str(data[0x04]).c_str());
@@ -5497,7 +5494,7 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
     char  message[256]    = {};
     uint8 messagePosition = 0x07;
 
-    memcpy(&message, data[messagePosition], std::min(data.getSize() - messagePosition, sizeof(message)));
+    std::memcpy(&message, data[messagePosition], std::min(data.getSize() - messagePosition, sizeof(message)));
 
     if (data.ref<uint8>(0x06) == '!' && !jailutils::InPrison(PChar) && (CCommandHandler::call(lua, PChar, message) == 0 || PChar->m_GMlevel > 0))
     {
@@ -5954,7 +5951,7 @@ void SmallPacket0x0C3(map_session_data_t* const PSession, CCharEntity* const PCh
         if (PItemLinkPearl)
         {
             PItemLinkPearl->setQuantity(1);
-            memcpy(PItemLinkPearl->m_extra, PItemLinkshell->m_extra, 24);
+            std::memcpy(PItemLinkPearl->m_extra, PItemLinkshell->m_extra, 24);
             PItemLinkPearl->SetLSType(LSTYPE_LINKPEARL);
             charutils::AddItem(PChar, LOC_INVENTORY, PItemLinkPearl);
         }
@@ -5988,8 +5985,8 @@ void SmallPacket0x0C4(map_session_data_t* const PSession, CCharEntity* const PCh
             char DecodedName[DecodeStringLength];
             char EncodedName[LinkshellStringLength];
 
-            memset(&DecodedName, 0, sizeof(DecodedName));
-            memset(&EncodedName, 0, sizeof(EncodedName));
+            std::memset(&DecodedName, 0, sizeof(DecodedName));
+            std::memset(&EncodedName, 0, sizeof(EncodedName));
 
             char* decodePtr = reinterpret_cast<char*>(data[12]);
             DecodeStringLinkshell(decodePtr, DecodedName);
@@ -6710,7 +6707,7 @@ void SmallPacket0x0E2(map_session_data_t* const PSession, CCharEntity* const PCh
                 if (static_cast<uint8>(PItemLinkshell->GetLSType()) <= PChar->PLinkshell1->m_postRights)
                 {
                     char lsMessage[128] = {};
-                    memcpy(&lsMessage, data[16], sizeof(lsMessage));
+                    std::memcpy(&lsMessage, data[16], sizeof(lsMessage));
                     PChar->PLinkshell1->setMessage(lsMessage, PChar->getName());
                     return;
                 }
@@ -8238,10 +8235,6 @@ void SmallPacket0x110(map_session_data_t* const PSession, CCharEntity* const PCh
     if (settings::get<bool>("map.FISHING_ENABLE") && PChar->GetMLevel() >= settings::get<uint8>("map.FISHING_MIN_LEVEL"))
     {
         fishingutils::HandleFishingAction(PChar, data);
-    }
-    else
-    {
-        return;
     }
 }
 

--- a/src/map/packet_system.h
+++ b/src/map/packet_system.h
@@ -33,7 +33,7 @@ extern uint8 PacketSize[512];
 
 extern std::function<void(map_session_data_t* const, CCharEntity* const, CBasicPacket&)> PacketParser[512];
 
-void PrintPacket(CBasicPacket data);
+void PrintPacket(CBasicPacket& data);
 void PacketParserInitialize();
 
 #endif

--- a/src/map/packets/action.cpp
+++ b/src/map/packets/action.cpp
@@ -66,7 +66,7 @@ CActionPacket::CActionPacket(action_t& action)
         break;
         case ACTION_WEAPONSKILL_FINISH:
         {
-            packBitsBE(data, action.actionid, 86, 16);
+            packBitsBE(buffer_.data(), action.actionid, 86, 16);
         }
         break;
         case ACTION_JOBABILITY_START:
@@ -82,7 +82,7 @@ CActionPacket::CActionPacket(action_t& action)
             ActionType = ACTION_WEAPONSKILL_START;
 
             // Magic numbers?
-            packBitsBE(data, 28787, 86, 16);
+            packBitsBE(buffer_.data(), 28787, 86, 16);
             ref<uint8>(0x0D) = 0x5D;
             ref<uint8>(0x0E) = 0x19;
         }
@@ -90,13 +90,13 @@ CActionPacket::CActionPacket(action_t& action)
         case ACTION_DANCE:
         case ACTION_JOBABILITY_FINISH:
         {
-            packBitsBE(data, action.actionid, 86, 10);
-            packBitsBE(data, action.recast, 118, 10);
+            packBitsBE(buffer_.data(), action.actionid, 86, 10);
+            packBitsBE(buffer_.data(), action.recast, 118, 10);
         }
         break;
         case ACTION_RUN_WARD_EFFUSION:
         {
-            packBitsBE(data, action.actionid, 86, 10);
+            packBitsBE(buffer_.data(), action.actionid, 86, 10);
         }
         break;
         case ACTION_WEAPONSKILL_START:
@@ -128,7 +128,7 @@ CActionPacket::CActionPacket(action_t& action)
             uint16 id = action.actionid;
 
             // higher number of bits than anything else that we know of. CAP OF 8191 (2300ish is abyssea tp moves)!
-            packBitsBE(data, id, 86, 13);
+            packBitsBE(buffer_.data(), id, 86, 13);
         }
         break;
         case ACTION_ITEM_START:
@@ -153,7 +153,7 @@ CActionPacket::CActionPacket(action_t& action)
         break;
         case ACTION_ITEM_FINISH:
         {
-            packBitsBE(data, action.actionid, 86, 16);
+            packBitsBE(buffer_.data(), action.actionid, 86, 16);
         }
         break;
         case ACTION_RANGED_START:
@@ -195,48 +195,48 @@ CActionPacket::CActionPacket(action_t& action)
         case ACTION_MAGIC_START:
         {
             // FourCC command "ca" - cast
-            packBitsBE(data, 0x6163, 86, 16);
+            packBitsBE(buffer_.data(), 0x6163, 86, 16);
 
             switch (action.spellgroup)
             {
                 case SPELLGROUP_WHITE:
                 {
-                    packBitsBE(data, 0x6877, 102, 16); // "wh" - white magic
+                    packBitsBE(buffer_.data(), 0x6877, 102, 16); // "wh" - white magic
                 }
                 break;
                 case SPELLGROUP_BLACK:
                 {
-                    packBitsBE(data, 0x6B62, 102, 16); // "bk" - black magic
+                    packBitsBE(buffer_.data(), 0x6B62, 102, 16); // "bk" - black magic
                 }
                 break;
                 case SPELLGROUP_BLUE:
                 {
-                    packBitsBE(data, 0x6C62, 102, 16); // "bl" - blue magic
+                    packBitsBE(buffer_.data(), 0x6C62, 102, 16); // "bl" - blue magic
                 }
                 break;
                 case SPELLGROUP_SONG:
                 {
-                    packBitsBE(data, 0x6F73, 102, 16); // "so" - song
+                    packBitsBE(buffer_.data(), 0x6F73, 102, 16); // "so" - song
                 }
                 break;
                 case SPELLGROUP_NINJUTSU:
                 {
-                    packBitsBE(data, 0x6A6E, 102, 16); // "nj" - ninjutsu
+                    packBitsBE(buffer_.data(), 0x6A6E, 102, 16); // "nj" - ninjutsu
                 }
                 break;
                 case SPELLGROUP_SUMMONING:
                 {
-                    packBitsBE(data, 0x6D73, 102, 16); // "sm" - summoning magic
+                    packBitsBE(buffer_.data(), 0x6D73, 102, 16); // "sm" - summoning magic
                 }
                 break;
                 case SPELLGROUP_GEOMANCY:
                 {
-                    packBitsBE(data, 0x6567, 102, 16); // "ge" - geomancy
+                    packBitsBE(buffer_.data(), 0x6567, 102, 16); // "ge" - geomancy
                 }
                 break;
                 case SPELLGROUP_TRUST:
                 {
-                    packBitsBE(data, 0x6166, 102, 16); // "fa" - faith aka trust
+                    packBitsBE(buffer_.data(), 0x6166, 102, 16); // "fa" - faith aka trust
                 }
                 break;
                 default:
@@ -248,58 +248,58 @@ CActionPacket::CActionPacket(action_t& action)
         break;
         case ACTION_MAGIC_FINISH:
         {
-            packBitsBE(data, action.actionid, 86, 10);
+            packBitsBE(buffer_.data(), action.actionid, 86, 10);
             // either this way or enumerate all recast timers and compare the spell id.
-            packBitsBE(data, action.recast, 118, 10);
+            packBitsBE(buffer_.data(), action.recast, 118, 10);
         }
         break;
         case ACTION_MAGIC_INTERRUPT:
         {
-            packBitsBE(data, action.recast, 118, 16);
+            packBitsBE(buffer_.data(), action.recast, 118, 16);
 
             // FourCC command "sp" - interrupt
-            packBitsBE(data, 0x7073, 86, 16);
+            packBitsBE(buffer_.data(), 0x7073, 86, 16);
 
             switch (action.spellgroup)
             {
                 case SPELLGROUP_WHITE:
                 {
-                    packBitsBE(data, 0x6877, 102, 16); // "wh" - white magic
+                    packBitsBE(buffer_.data(), 0x6877, 102, 16); // "wh" - white magic
                 }
                 break;
                 case SPELLGROUP_BLACK:
                 {
-                    packBitsBE(data, 0x6B62, 102, 16); // "bk" - black magic
+                    packBitsBE(buffer_.data(), 0x6B62, 102, 16); // "bk" - black magic
                 }
                 break;
                 case SPELLGROUP_BLUE:
                 {
-                    packBitsBE(data, 0x6C62, 102, 16); // "bl" - blue magic
+                    packBitsBE(buffer_.data(), 0x6C62, 102, 16); // "bl" - blue magic
                 }
                 break;
                 case SPELLGROUP_SONG:
                 {
-                    packBitsBE(data, 0x6F73, 102, 16); // "so" - song
+                    packBitsBE(buffer_.data(), 0x6F73, 102, 16); // "so" - song
                 }
                 break;
                 case SPELLGROUP_NINJUTSU:
                 {
-                    packBitsBE(data, 0x6A6E, 102, 16); // "nj" - ninjutsu
+                    packBitsBE(buffer_.data(), 0x6A6E, 102, 16); // "nj" - ninjutsu
                 }
                 break;
                 case SPELLGROUP_SUMMONING:
                 {
-                    packBitsBE(data, 0x6D73, 102, 16); // "sm" - summoning magic
+                    packBitsBE(buffer_.data(), 0x6D73, 102, 16); // "sm" - summoning magic
                 }
                 break;
                 case SPELLGROUP_GEOMANCY:
                 {
-                    packBitsBE(data, 0x6567, 102, 16); // "ge" - geomancy
+                    packBitsBE(buffer_.data(), 0x6567, 102, 16); // "ge" - geomancy
                 }
                 break;
                 case SPELLGROUP_TRUST:
                 {
-                    packBitsBE(data, 0x6166, 102, 16); // "fa" - faith aka trust
+                    packBitsBE(buffer_.data(), 0x6166, 102, 16); // "fa" - faith aka trust
                 }
                 break;
                 default:
@@ -316,7 +316,7 @@ CActionPacket::CActionPacket(action_t& action)
         }
     }
 
-    uint32 bitOffset = packBitsBE(data, ActionType, 82, 4);
+    uint32 bitOffset = packBitsBE(buffer_.data(), ActionType, 82, 4);
     auto   targets   = 0;
     auto   actions   = 0;
 
@@ -328,26 +328,26 @@ CActionPacket::CActionPacket(action_t& action)
         {
             break;
         }
-        bitOffset = packBitsBE(data, list.ActionTargetID, bitOffset, 32);
-        bitOffset = packBitsBE(data, list.actionTargets.size(), bitOffset, 4);
+        bitOffset = packBitsBE(buffer_.data(), list.ActionTargetID, bitOffset, 32);
+        bitOffset = packBitsBE(buffer_.data(), list.actionTargets.size(), bitOffset, 4);
 
         for (auto&& target : list.actionTargets)
         {
-            bitOffset = packBitsBE(data, static_cast<uint64>(target.reaction), bitOffset, 5);   // Physical reaction to damage
-            bitOffset = packBitsBE(data, target.animation, bitOffset, 12);                      // animation ID
-            bitOffset = packBitsBE(data, static_cast<uint64>(target.speceffect), bitOffset, 7); // specialEffect
-            bitOffset = packBitsBE(data, target.knockback, bitOffset, 3);                       // knockback amount (mobskill only)
-            bitOffset = packBitsBE(data, target.param, bitOffset, 17);                          // message parameter (damage/healing)
-            bitOffset = packBitsBE(data, target.messageID, bitOffset, 10);                      // message
-            bitOffset = packBitsBE(data, static_cast<uint64>(target.modifier), bitOffset, 31);  // "Resist!", Immunobreak, MB for Swipe/Lunge, Cover message modifiers.
+            bitOffset = packBitsBE(buffer_.data(), static_cast<uint64>(target.reaction), bitOffset, 5);   // Physical reaction to damage
+            bitOffset = packBitsBE(buffer_.data(), target.animation, bitOffset, 12);                      // animation ID
+            bitOffset = packBitsBE(buffer_.data(), static_cast<uint64>(target.speceffect), bitOffset, 7); // specialEffect
+            bitOffset = packBitsBE(buffer_.data(), target.knockback, bitOffset, 3);                       // knockback amount (mobskill only)
+            bitOffset = packBitsBE(buffer_.data(), target.param, bitOffset, 17);                          // message parameter (damage/healing)
+            bitOffset = packBitsBE(buffer_.data(), target.messageID, bitOffset, 10);                      // message
+            bitOffset = packBitsBE(buffer_.data(), static_cast<uint64>(target.modifier), bitOffset, 31);  // "Resist!", Immunobreak, MB for Swipe/Lunge, Cover message modifiers.
                                                                                                 // 4 bits are currently used, with the other bits unknown
 
             if (target.additionalEffect != SUBEFFECT_NONE)
             {
-                bitOffset = packBitsBE(data, 1, bitOffset, 1);
-                bitOffset = packBitsBE(data, target.additionalEffect, bitOffset, 10);
-                bitOffset = packBitsBE(data, target.addEffectParam, bitOffset, 17);
-                bitOffset = packBitsBE(data, target.addEffectMessage, bitOffset, 10);
+                bitOffset = packBitsBE(buffer_.data(), 1, bitOffset, 1);
+                bitOffset = packBitsBE(buffer_.data(), target.additionalEffect, bitOffset, 10);
+                bitOffset = packBitsBE(buffer_.data(), target.addEffectParam, bitOffset, 17);
+                bitOffset = packBitsBE(buffer_.data(), target.addEffectMessage, bitOffset, 10);
             }
             else
             {
@@ -355,10 +355,10 @@ CActionPacket::CActionPacket(action_t& action)
             }
             if (target.spikesEffect != SUBEFFECT_NONE)
             {
-                bitOffset = packBitsBE(data, 1, bitOffset, 1);
-                bitOffset = packBitsBE(data, target.spikesEffect, bitOffset, 10);
-                bitOffset = packBitsBE(data, target.spikesParam, bitOffset, 14);
-                bitOffset = packBitsBE(data, target.spikesMessage, bitOffset, 10);
+                bitOffset = packBitsBE(buffer_.data(), 1, bitOffset, 1);
+                bitOffset = packBitsBE(buffer_.data(), target.spikesEffect, bitOffset, 10);
+                bitOffset = packBitsBE(buffer_.data(), target.spikesParam, bitOffset, 14);
+                bitOffset = packBitsBE(buffer_.data(), target.spikesMessage, bitOffset, 10);
             }
             else
             {

--- a/src/map/packets/action.cpp
+++ b/src/map/packets/action.cpp
@@ -340,7 +340,7 @@ CActionPacket::CActionPacket(action_t& action)
             bitOffset = packBitsBE(buffer_.data(), target.param, bitOffset, 17);                          // message parameter (damage/healing)
             bitOffset = packBitsBE(buffer_.data(), target.messageID, bitOffset, 10);                      // message
             bitOffset = packBitsBE(buffer_.data(), static_cast<uint64>(target.modifier), bitOffset, 31);  // "Resist!", Immunobreak, MB for Swipe/Lunge, Cover message modifiers.
-                                                                                                // 4 bits are currently used, with the other bits unknown
+                                                                                                          // 4 bits are currently used, with the other bits unknown
 
             if (target.additionalEffect != SUBEFFECT_NONE)
             {

--- a/src/map/packets/auction_house.cpp
+++ b/src/map/packets/auction_house.cpp
@@ -129,7 +129,7 @@ CAuctionHousePacket::CAuctionHousePacket(uint8 action, uint8 message, CCharEntit
         ref<uint8>(0x14) = 0x03;
         ref<uint8>(0x16) = 0x01; // Value is changed, the purpose is unknown UNKNOWN
 
-        memcpy(data + (0x18), PChar->getName().c_str(), PChar->getName().size());
+        std::memcpy(buffer_.data() + 0x18, PChar->getName().c_str(), PChar->getName().size());
 
         ref<uint16>(0x28) = PChar->m_ah_history.at(slot).itemid;    // Id sell items item id
         ref<uint8>(0x2A)  = 1 - PChar->m_ah_history.at(slot).stack; // Number of items stack size

--- a/src/map/packets/basic.h
+++ b/src/map/packets/basic.h
@@ -95,6 +95,17 @@ public:
         std::memcpy(data, other.data, PACKET_SIZE);
     }
 
+    CBasicPacket(const std::unique_ptr<CBasicPacket>& other)
+    : data(new uint8[PACKET_SIZE])
+    , type(ref<uint8>(0))
+    , size(ref<uint8>(1))
+    , code(ref<uint16>(2))
+    , owner(true)
+    {
+        TracyZoneScoped;
+        std::memcpy(data, other->data, PACKET_SIZE);
+    }
+
     CBasicPacket(CBasicPacket&& other)
     : data(other.data)
     , type(ref<uint8>(0))

--- a/src/map/packets/basic.h
+++ b/src/map/packets/basic.h
@@ -1,20 +1,20 @@
 ﻿/*
 ===========================================================================
 
-Copyright © 2010-2015 Darkstar Dev Teams
+  Copyright (c) 2010-2015 Darkstar Dev Teams
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see http://www.gnu.org/licenses/
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
 
 ===========================================================================
 */
@@ -41,12 +41,12 @@ enum ENTITYUPDATE
     ENTITY_DESPAWN,
 };
 
-/** Base class for all packets
- *
- * Contains a 0x104 byte sized buffer
- * Access the raw data with ref<T>(index)
- *
- */
+//
+// Base class for all packets
+//
+// Contains a 0x1FF byte sized buffer
+// Access the raw data with ref<T>(index)
+//
 class CBasicPacket
 {
 protected:
@@ -104,8 +104,6 @@ public:
         return ref<uint16>(2);
     }
 
-    /* Setters for the header */
-
     // Set the first 9 bits to the ID. The highest bit overflows into the second byte.
     void setType(unsigned int new_id)
     {
@@ -151,7 +149,7 @@ public:
         return reinterpret_cast<uint8*>(buffer_.data()) + index;
     }
 
-    // used for setting "proper" packet sizes rounded to the nearest four away from zero
+    // Used for setting "proper" packet sizes rounded to the nearest four away from zero
     uint32 roundUpToNearestFour(uint32 input)
     {
         int remainder = input % 4;

--- a/src/map/packets/basic.h
+++ b/src/map/packets/basic.h
@@ -84,15 +84,6 @@ public:
     CBasicPacket& operator=(const CBasicPacket& other)     = delete;
     CBasicPacket& operator=(CBasicPacket&& other) noexcept = delete;
 
-    /// <summary>
-    /// Copies the given packet data.
-    /// </summary>
-    /// <param name="other"></param>
-    void copy(CBasicPacket* other)
-    {
-        std::memcpy(buffer_.data(), other->buffer_.data(), PACKET_SIZE);
-    }
-
     uint16 getType()
     {
         return ref<uint16>(0) & 0x1FF;
@@ -142,7 +133,7 @@ public:
         return buffer_.data();
     }
 
-    uint8* operator[](const int index)
+    uint8* operator[](const std::size_t index)
     {
         return reinterpret_cast<uint8*>(buffer_.data()) + index;
     }

--- a/src/map/packets/basic.h
+++ b/src/map/packets/basic.h
@@ -139,6 +139,14 @@ public:
         return reinterpret_cast<std::remove_pointer_t<T>*>(buffer_.data());
     }
 
+    // Reinterpret the underlying buffer as a different type and apply a function to it
+    template <typename T>
+    void as(const auto& fn)
+    {
+        static_assert(std::is_standard_layout_v<T>, "Type must be standard layout (No virtual functions, inheritance, etc.)");
+        fn(reinterpret_cast<std::remove_pointer_t<T>*>(buffer_.data()));
+    }
+
     operator uint8*()
     {
         return buffer_.data();

--- a/src/map/packets/basic.h
+++ b/src/map/packets/basic.h
@@ -137,8 +137,8 @@ public:
     template <typename T>
     auto as() -> std::remove_pointer_t<T>*
     {
-        using Type = std::remove_pointer_t<T>;
-        return reinterpret_cast<Type*>(buffer_.data());
+        static_assert(std::is_standard_layout_v<T>, "Type must be standard layout (No virtual functions, inheritance, etc.)");
+        return reinterpret_cast<std::remove_pointer_t<T>*>(buffer_.data());
     }
 
     operator uint8*()

--- a/src/map/packets/basic.h
+++ b/src/map/packets/basic.h
@@ -84,6 +84,11 @@ public:
     CBasicPacket& operator=(const CBasicPacket& other)     = delete;
     CBasicPacket& operator=(CBasicPacket&& other) noexcept = delete;
 
+    auto copy() -> std::unique_ptr<std::remove_pointer_t<decltype(this)>>
+    {
+        return std::make_unique<std::remove_pointer_t<decltype(this)>>(*this);
+    }
+
     uint16 getType()
     {
         return ref<uint16>(0) & 0x1FF;

--- a/src/map/packets/basic.h
+++ b/src/map/packets/basic.h
@@ -121,11 +121,19 @@ public:
         ref<uint16>(2) = new_sequence;
     }
 
-    /* Indexer for the data buffer */
+    // Indexer for the buffer's data
     template <typename T>
     T& ref(std::size_t index)
     {
         return ::ref<T>(buffer_.data(), index);
+    }
+
+    // Reinterpret and use the underlying buffer as a different type
+    template <typename T>
+    auto as() -> std::remove_pointer_t<T>*
+    {
+        using Type = std::remove_pointer_t<T>;
+        return reinterpret_cast<Type*>(buffer_.data());
     }
 
     operator uint8*()

--- a/src/map/packets/bazaar_check.cpp
+++ b/src/map/packets/bazaar_check.cpp
@@ -36,5 +36,5 @@ CBazaarCheckPacket::CBazaarCheckPacket(CCharEntity* PChar, BAZAARCHECK type)
     ref<uint8>(0x08)  = type;
     ref<uint16>(0x0E) = PChar->targid;
 
-    memcpy(data + (0x10), PChar->getName().c_str(), PChar->getName().size());
+    std::memcpy(buffer_.data() + 0x10, PChar->getName().c_str(), PChar->getName().size());
 }

--- a/src/map/packets/bazaar_close.cpp
+++ b/src/map/packets/bazaar_close.cpp
@@ -31,5 +31,5 @@ CBazaarClosePacket::CBazaarClosePacket(CCharEntity* PChar)
     this->setType(0x107);
     this->setSize(0x16);
 
-    memcpy(data + (0x04), PChar->getName().c_str(), PChar->getName().size());
+    std::memcpy(buffer_.data() + 0x04, PChar->getName().c_str(), PChar->getName().size());
 }

--- a/src/map/packets/bazaar_confirmation.cpp
+++ b/src/map/packets/bazaar_confirmation.cpp
@@ -37,7 +37,7 @@ CBazaarConfirmationPacket::CBazaarConfirmationPacket(CCharEntity* PChar, uint8 S
     ref<uint8>(0x08)  = Quantity;
     ref<uint8>(0x20)  = SlotID;
 
-    memcpy(data + (0x10), PChar->getName().c_str(), PChar->getName().size());
+    std::memcpy(buffer_.data() + 0x10, PChar->getName().c_str(), PChar->getName().size());
 }
 
 CBazaarConfirmationPacket::CBazaarConfirmationPacket(CCharEntity* PChar, CItem* PItem)
@@ -51,5 +51,5 @@ CBazaarConfirmationPacket::CBazaarConfirmationPacket(CCharEntity* PChar, CItem* 
         ref<uint16>(0x08) = PItem->getID();
     }
 
-    memcpy(data + (0x0A), PChar->getName().c_str(), PChar->getName().size());
+    std::memcpy(buffer_.data() + 0x0A, PChar->getName().c_str(), PChar->getName().size());
 }

--- a/src/map/packets/bazaar_item.cpp
+++ b/src/map/packets/bazaar_item.cpp
@@ -56,6 +56,6 @@ CBazaarItemPacket::CBazaarItemPacket(CItem* PItem, uint8 SlotID, uint16 Tax)
             ref<uint32>(0x19) = ((CItemUsable*)PItem)->getUseDelay() + currentTime;
         }
         // 12? characters? seems a bit short. TODO: research this.
-        memcpy(data + (0x1D), PItem->getSignature().c_str(), std::min<size_t>(PItem->getSignature().size(), 12));
+        std::memcpy(buffer_.data() + 0x1D, PItem->getSignature().c_str(), std::min<size_t>(PItem->getSignature().size(), 12));
     }
 }

--- a/src/map/packets/bazaar_message.cpp
+++ b/src/map/packets/bazaar_message.cpp
@@ -32,10 +32,10 @@ CBazaarMessagePacket::CBazaarMessagePacket(CCharEntity* PChar)
     this->setType(0xCA);
     this->setSize(0x94);
 
-    memcpy(data + 0x04, PChar->bazaar.message.c_str(), (PChar->bazaar.message.size() > 120) ? 120 : PChar->bazaar.message.size());
+    std::memcpy(buffer_.data() + 0x04, PChar->bazaar.message.c_str(), (PChar->bazaar.message.size() > 120) ? 120 : PChar->bazaar.message.size());
 
     ref<uint8>(0x7F)  = 0x07; // 0x06
     ref<uint16>(0x90) = PChar->profile.title;
 
-    memcpy(data + (0x80), PChar->getName().c_str(), PChar->getName().size());
+    std::memcpy(buffer_.data() + 0x80, PChar->getName().c_str(), PChar->getName().size());
 }

--- a/src/map/packets/bazaar_purchase.cpp
+++ b/src/map/packets/bazaar_purchase.cpp
@@ -34,5 +34,5 @@ CBazaarPurchasePacket::CBazaarPurchasePacket(CCharEntity* PChar, bool result)
 
     ref<uint8>(0x04) = !result;
 
-    memcpy(data + (0x08), PChar->getName().c_str(), PChar->getName().size());
+    std::memcpy(buffer_.data() + 0x08, PChar->getName().c_str(), PChar->getName().size());
 }

--- a/src/map/packets/blacklist_edit_response.cpp
+++ b/src/map/packets/blacklist_edit_response.cpp
@@ -35,7 +35,7 @@ CBlacklistEditResponsePacket::CBlacklistEditResponsePacket(uint32 accid, const s
         case 0x01: // Removed successfully..
             ref<uint32>(0x04) = accid;
             ref<uint8>(0x18)  = action;
-            memcpy(data + 0x08, targetName.c_str(), targetName.size());
+            std::memcpy(buffer_.data() + 0x08, targetName.c_str(), targetName.size());
             break;
 
         case 0x02: // Command error..

--- a/src/map/packets/caught_fish.cpp
+++ b/src/map/packets/caught_fish.cpp
@@ -36,5 +36,5 @@ CCaughtFishPacket::CCaughtFishPacket(CCharEntity* PChar, uint16 param0, uint16 m
     ref<uint8>(0x14)  = count;
     ref<uint32>(0x1C) = 0x00;
 
-    memcpy(data + (0x20), PChar->getName().c_str(), PChar->getName().size());
+    std::memcpy(buffer_.data() + 0x20, PChar->getName().c_str(), PChar->getName().size());
 }

--- a/src/map/packets/caught_monster.cpp
+++ b/src/map/packets/caught_monster.cpp
@@ -33,5 +33,5 @@ CCaughtMonsterPacket::CCaughtMonsterPacket(CCharEntity* PChar, uint16 messageID)
     ref<uint32>(0x08) = PChar->targid;
     ref<uint16>(0x0A) = messageID + 0x8000;
 
-    memcpy(data + (0x10), PChar->getName().c_str(), PChar->getName().size());
+    std::memcpy(buffer_.data() + 0x10, PChar->getName().c_str(), PChar->getName().size());
 }

--- a/src/map/packets/char.cpp
+++ b/src/map/packets/char.cpp
@@ -72,7 +72,7 @@ void CCharPacket::updateWith(CCharEntity* PChar, ENTITYUPDATE type, uint8 update
     }
     else // Update and OR the flags together
     {
-        // static_cast doesn't set the bits the way we need it to, so do some memcpy
+        // static_cast doesn't set the bits the way we need it to, so do some std::memcpy
         uint8 tempSendFlg = {};
         std::memcpy(&tempSendFlg, &packet.SendFlg, sizeof(charflags::sendflags_t));
 
@@ -266,5 +266,5 @@ void CCharPacket::updateWith(CCharEntity* PChar, ENTITYUPDATE type, uint8 update
         packet.Flags4.JobMasterFlag = PChar->getMod(Mod::SUPERIOR_LEVEL) == 5 && PChar->m_jobMasterDisplay;
     }
 
-    std::memcpy(&data[0], &packet, sizeof(packet));
+    std::memcpy(&buffer_.data()[0], &packet, sizeof(packet));
 }

--- a/src/map/packets/char_abilities.cpp
+++ b/src/map/packets/char_abilities.cpp
@@ -32,8 +32,8 @@ CCharAbilitiesPacket::CCharAbilitiesPacket(CCharEntity* PChar)
     this->setType(0xAC);
     this->setSize(0xE4);
 
-    memcpy(data + (0x04), PChar->m_WeaponSkills, 32);
-    memcpy(data + (0x44), PChar->m_Abilities, 64);
-    memcpy(data + (0x84), PChar->m_PetCommands, 64);
-    memcpy(data + (0xC4), PChar->m_TraitList, 18);
+    std::memcpy(buffer_.data() + 0x04, PChar->m_WeaponSkills, 32);
+    std::memcpy(buffer_.data() + 0x44, PChar->m_Abilities, 64);
+    std::memcpy(buffer_.data() + 0x84, PChar->m_PetCommands, 64);
+    std::memcpy(buffer_.data() + 0xC4, PChar->m_TraitList, 18);
 }

--- a/src/map/packets/char_check.cpp
+++ b/src/map/packets/char_check.cpp
@@ -84,7 +84,7 @@ CCheckPacket::CCheckPacket(CCharEntity* PChar, CCharEntity* PTarget)
             {
                 ref<uint8>(0x0B) = count;
 
-                PChar->pushPacket<CBasicPacket>(*this);
+                PChar->pushPacket(this->copy());
 
                 this->setSize(0x0C);
                 std::memset(buffer_.data() + 0x0B, 0, PACKET_SIZE - 11);
@@ -95,12 +95,12 @@ CCheckPacket::CCheckPacket(CCharEntity* PChar, CCharEntity* PTarget)
     if (count == 0)
     {
         this->setSize(0x28);
-        PChar->pushPacket<CBasicPacket>(*this);
+        PChar->pushPacket(this->copy());
     }
     else if (count != 8)
     {
         ref<uint8>(0x0B) = (count > 8 ? count - 8 : count);
-        PChar->pushPacket<CBasicPacket>(*this);
+        PChar->pushPacket(this->copy());
     }
 
     this->setSize(0x54);

--- a/src/map/packets/char_check.cpp
+++ b/src/map/packets/char_check.cpp
@@ -75,7 +75,7 @@ CCheckPacket::CCheckPacket(CCharEntity* PChar, CCharEntity* PTarget)
                 ref<uint16>(size * 2 + 0x0C) = ((CItemEquipment*)PItem)->getAugment(3);
             }
             // 12 characters? seems a bit short. // TODO: research.
-            memcpy(data + (size * 2 + 0x10), PItem->getSignature().c_str(), std::clamp<size_t>(PItem->getSignature().size(), 0, 12));
+            std::memcpy(buffer_.data() + (size * 2 + 0x10), PItem->getSignature().c_str(), std::clamp<size_t>(PItem->getSignature().size(), 0, 12));
 
             this->setSize(size * 2 + 0x1C);
             count++;
@@ -87,7 +87,7 @@ CCheckPacket::CCheckPacket(CCharEntity* PChar, CCharEntity* PTarget)
                 PChar->pushPacket<CBasicPacket>(*this);
 
                 this->setSize(0x0C);
-                memset(data + (0x0B), 0, PACKET_SIZE - 11);
+                std::memset(buffer_.data() + 0x0B, 0, PACKET_SIZE - 11);
             }
         }
     }
@@ -104,7 +104,7 @@ CCheckPacket::CCheckPacket(CCharEntity* PChar, CCharEntity* PTarget)
     }
 
     this->setSize(0x54);
-    memset(data + (0x0B), 0, PACKET_SIZE - 11);
+    std::memset(buffer_.data() + 0x0B, 0, PACKET_SIZE - 11);
 
     ref<uint8>(0x0A) = 0x01;
 
@@ -114,7 +114,7 @@ CCheckPacket::CCheckPacket(CCharEntity* PChar, CCharEntity* PTarget)
     {
         ref<uint16>(0x0E) = PLinkshell->getID();
         // 15 characters? seems a bit short // TODO: research.
-        memcpy(data + (0x10), PLinkshell->getSignature().c_str(), std::clamp<size_t>(PLinkshell->getSignature().size(), 0, 15));
+        std::memcpy(buffer_.data() + 0x10, PLinkshell->getSignature().c_str(), std::clamp<size_t>(PLinkshell->getSignature().size(), 0, 15));
         // ref<uint16>(0x0C) = PLinkshell->GetLSID();
         ref<uint16>(0x20) = PLinkshell->GetLSRawColor();
     }

--- a/src/map/packets/char_job_extra.cpp
+++ b/src/map/packets/char_job_extra.cpp
@@ -60,7 +60,7 @@ CCharJobExtraPacket::CCharJobExtraPacket(CCharEntity* PChar, bool mjob)
 
     if (job == JOB_BLU)
     {
-        memcpy(data + (0x08), &PChar->m_SetBlueSpells, 20);
+        std::memcpy(buffer_.data() + 0x08, &PChar->m_SetBlueSpells, 20);
     }
     else if (job == JOB_PUP && PChar->PAutomaton != nullptr)
     {
@@ -92,7 +92,7 @@ CCharJobExtraPacket::CCharJobExtraPacket(CCharEntity* PChar, bool mjob)
         ref<uint32>(0x50) = PChar->m_unlockedAttachments.attachments[6];
         ref<uint32>(0x54) = PChar->m_unlockedAttachments.attachments[7];
 
-        memcpy(data + (0x58), PChar->PAutomaton->getName().c_str(), PChar->PAutomaton->getName().size());
+        std::memcpy(buffer_.data() + 0x58, PChar->PAutomaton->getName().c_str(), PChar->PAutomaton->getName().size());
 
         ref<uint16>(0x68) = PChar->PAutomaton->health.hp == 0 ? PChar->PAutomaton->GetMaxHP() : PChar->PAutomaton->health.hp;
         ref<uint16>(0x6A) = PChar->PAutomaton->GetMaxHP();

--- a/src/map/packets/char_jobs.cpp
+++ b/src/map/packets/char_jobs.cpp
@@ -37,10 +37,10 @@ CCharJobsPacket::CCharJobsPacket(CCharEntity* PChar)
     ref<uint8>(0x08) = PChar->GetMJob(); // Highlight the main job in Yellow
     ref<uint8>(0x0B) = PChar->GetSJob(); // Highlight the sub job in Blue
 
-    memcpy(data + (0x0C), &PChar->jobs, 22);
+    std::memcpy(buffer_.data() + 0x0C, &PChar->jobs, 22);
 
-    memcpy(data + (0x20), &PChar->stats, 14);
-    memcpy(data + (0x44), &PChar->jobs, 27);
+    std::memcpy(buffer_.data() + 0x20, &PChar->stats, 14);
+    std::memcpy(buffer_.data() + 0x44, &PChar->jobs, 27);
 
     ref<uint32>(0x3C) = PChar->health.maxhp;
     ref<uint32>(0x40) = PChar->health.maxmp;

--- a/src/map/packets/char_mounts.cpp
+++ b/src/map/packets/char_mounts.cpp
@@ -32,5 +32,5 @@ CCharMountsPacket::CCharMountsPacket(CCharEntity* PChar)
     this->setType(0xAE);
     this->setSize(0x0C);
 
-    memcpy(data + (0x04), &(PChar->keys.tables[6].keyList), 0x0C);
+    std::memcpy(buffer_.data() + 0x04, &(PChar->keys.tables[6].keyList), 0x0C);
 }

--- a/src/map/packets/char_skills.cpp
+++ b/src/map/packets/char_skills.cpp
@@ -33,7 +33,7 @@ CCharSkillsPacket::CCharSkillsPacket(CCharEntity* PChar)
     this->setType(0x62);
     this->setSize(0x100);
 
-    memcpy(data + (0x80), &PChar->WorkingSkills, 128);
+    std::memcpy(buffer_.data() + 0x80, &PChar->WorkingSkills, 128);
 
     // remove automaton skills from this menu (they are in another packet)
     ref<uint16>(0xAC) = 0x8000;

--- a/src/map/packets/char_stats.cpp
+++ b/src/map/packets/char_stats.cpp
@@ -48,7 +48,7 @@ CCharStatsPacket::CCharStatsPacket(CCharEntity* PChar)
     ref<uint16>(0x10) = PChar->jobs.exp[PChar->GetMJob()];
     ref<uint16>(0x12) = charutils::GetExpNEXTLevel(PChar->jobs.job[PChar->GetMJob()]);
 
-    memcpy(data + (0x14), &PChar->stats, 14); // TODO: it won't work with merits
+    std::memcpy(buffer_.data() + 0x14, &PChar->stats, 14); // TODO: it won't work with merits
 
     // Hasso gives STR only if main weapon is two handed
     if (auto* weapon = dynamic_cast<CItemWeapon*>(PChar->m_Weapons[SLOT_MAIN]); weapon && weapon->isTwoHanded())

--- a/src/map/packets/char_update.cpp
+++ b/src/map/packets/char_update.cpp
@@ -367,7 +367,7 @@ CCharUpdatePacket::CCharUpdatePacket(CCharEntity* PChar)
     packet.Flags5 = flags5;
     packet.Flags6 = flags6;
 
-    std::memcpy(&data[0], &packet, sizeof(packet));
+    std::memcpy(&buffer_.data()[0], &packet, sizeof(packet));
 
     // Mog wardrobe enabled bits (apparently used by windower in get_bag_info(N).enabled):
     // 0x01 = Wardrobe 3

--- a/src/map/packets/chat_message.cpp
+++ b/src/map/packets/chat_message.cpp
@@ -51,6 +51,6 @@ CChatMessagePacket::CChatMessagePacket(CCharEntity* PChar, CHAT_MESSAGE_TYPE Mes
 
     ref<uint16>(0x06) = PChar->getZone();
 
-    memcpy(data + (0x08), &name[0], std::min(name.size(), (size_t)0xF));
-    memcpy(data + (0x17), &message[0], buffSize);
+    std::memcpy(buffer_.data() + 0x08, &name[0], std::min(name.size(), (size_t)0xF));
+    std::memcpy(buffer_.data() + 0x17, &message[0], buffSize);
 }

--- a/src/map/packets/conquest_map.cpp
+++ b/src/map/packets/conquest_map.cpp
@@ -80,43 +80,43 @@ CConquestPacket::CConquestPacket(CCharEntity* PChar)
     ref<uint8>(0x9C)  = 0x01;
 
     // Overview Map Data [0xA0 - 0xA3]
-    packBitsBE(data + 0xA0, besieged::GetAstralCandescence(), 0, 2);
-    packBitsBE(data + 0xA0, besieged::GetAlZahbiOrders(), 2, 2);
+    packBitsBE(buffer_.data() + 0xA0, besieged::GetAstralCandescence(), 0, 2);
+    packBitsBE(buffer_.data() + 0xA0, besieged::GetAlZahbiOrders(), 2, 2);
 
-    packBitsBE(data + 0xA0, besieged::GetMamookLevel(), 4, 4);
-    packBitsBE(data + 0xA1, besieged::GetHalvungLevel(), 0, 4);
-    packBitsBE(data + 0xA1, besieged::GetArrapagoLevel(), 4, 4);
+    packBitsBE(buffer_.data() + 0xA0, besieged::GetMamookLevel(), 4, 4);
+    packBitsBE(buffer_.data() + 0xA1, besieged::GetHalvungLevel(), 0, 4);
+    packBitsBE(buffer_.data() + 0xA1, besieged::GetArrapagoLevel(), 4, 4);
 
-    packBitsBE(data + 0xA2, besieged::GetMamookOrders(), 0, 3);
-    packBitsBE(data + 0xA2, besieged::GetHalvungOrders(), 3, 3);
-    packBitsBE(data + 0xA2, besieged::GetArrapagoOrders(), 6, 3);
-    packBitsBE(data + 0xA2, 1, 9, 1); // TODO: Unknown constant
+    packBitsBE(buffer_.data() + 0xA2, besieged::GetMamookOrders(), 0, 3);
+    packBitsBE(buffer_.data() + 0xA2, besieged::GetHalvungOrders(), 3, 3);
+    packBitsBE(buffer_.data() + 0xA2, besieged::GetArrapagoOrders(), 6, 3);
+    packBitsBE(buffer_.data() + 0xA2, 1, 9, 1); // TODO: Unknown constant
 
     // Mamook Stronghold - Mamool Ja Data
-    packBitsBE(data + 0xA4, besieged::GetMamookOrders(), 0, 3);
-    packBitsBE(data + 0xA4, besieged::GetMamookForces(), 3, 8);
-    packBitsBE(data + 0xA4, besieged::GetMamookLevel(), 11, 4);
-    packBitsBE(data + 0xA4, besieged::GetMamookMirrorDestroyed(), 15, 1);
-    packBitsBE(data + 0xA6, (besieged::GetMamookMirrors() / 2), 0, 4);
-    packBitsBE(data + 0xA6, besieged::GetMamookPrisoners(), 4, 4);
+    packBitsBE(buffer_.data() + 0xA4, besieged::GetMamookOrders(), 0, 3);
+    packBitsBE(buffer_.data() + 0xA4, besieged::GetMamookForces(), 3, 8);
+    packBitsBE(buffer_.data() + 0xA4, besieged::GetMamookLevel(), 11, 4);
+    packBitsBE(buffer_.data() + 0xA4, besieged::GetMamookMirrorDestroyed(), 15, 1);
+    packBitsBE(buffer_.data() + 0xA6, (besieged::GetMamookMirrors() / 2), 0, 4);
+    packBitsBE(buffer_.data() + 0xA6, besieged::GetMamookPrisoners(), 4, 4);
     ref<uint8>(0xA7) = 0x00; // Mamook
 
     // Halvung Stronghold - Trolls Data
-    packBitsBE(data + 0xA8, besieged::GetHalvungOrders(), 0, 3);
-    packBitsBE(data + 0xA8, besieged::GetHalvungForces(), 3, 8);
-    packBitsBE(data + 0xA8, besieged::GetHalvungLevel(), 11, 4);
-    packBitsBE(data + 0xA8, besieged::GetHalvungMirrorDestroyed(), 15, 1);
-    packBitsBE(data + 0xAA, (besieged::GetHalvungMirrors() / 2), 0, 4);
-    packBitsBE(data + 0xAA, besieged::GetHalvungPrisoners(), 4, 4);
+    packBitsBE(buffer_.data() + 0xA8, besieged::GetHalvungOrders(), 0, 3);
+    packBitsBE(buffer_.data() + 0xA8, besieged::GetHalvungForces(), 3, 8);
+    packBitsBE(buffer_.data() + 0xA8, besieged::GetHalvungLevel(), 11, 4);
+    packBitsBE(buffer_.data() + 0xA8, besieged::GetHalvungMirrorDestroyed(), 15, 1);
+    packBitsBE(buffer_.data() + 0xAA, (besieged::GetHalvungMirrors() / 2), 0, 4);
+    packBitsBE(buffer_.data() + 0xAA, besieged::GetHalvungPrisoners(), 4, 4);
     ref<uint8>(0xAB) = 0x00; // Halvung
 
     // Arrapago Stronghold - Undead Data
-    packBitsBE(data + 0xAC, besieged::GetArrapagoOrders(), 0, 3);
-    packBitsBE(data + 0xAC, besieged::GetArrapagoForces(), 3, 8);
-    packBitsBE(data + 0xAC, besieged::GetArrapagoLevel(), 11, 4);
-    packBitsBE(data + 0xAC, besieged::GetArrapagoMirrorDestroyed(), 15, 1);
-    packBitsBE(data + 0xAE, (besieged::GetArrapagoMirrors() / 2), 0, 4);
-    packBitsBE(data + 0xAE, besieged::GetArrapagoPrisoners(), 4, 4);
+    packBitsBE(buffer_.data() + 0xAC, besieged::GetArrapagoOrders(), 0, 3);
+    packBitsBE(buffer_.data() + 0xAC, besieged::GetArrapagoForces(), 3, 8);
+    packBitsBE(buffer_.data() + 0xAC, besieged::GetArrapagoLevel(), 11, 4);
+    packBitsBE(buffer_.data() + 0xAC, besieged::GetArrapagoMirrorDestroyed(), 15, 1);
+    packBitsBE(buffer_.data() + 0xAE, (besieged::GetArrapagoMirrors() / 2), 0, 4);
+    packBitsBE(buffer_.data() + 0xAE, besieged::GetArrapagoPrisoners(), 4, 4);
     ref<uint8>(0xAF) = 0x00; // Arrapago
 
     ref<uint32>(0xB0) = charutils::GetPoints(PChar, "imperial_standing");

--- a/src/map/packets/delivery_box.cpp
+++ b/src/map/packets/delivery_box.cpp
@@ -76,13 +76,13 @@ CDeliveryBoxPacket::CDeliveryBoxPacket(uint8 action, uint8 boxid, CItem* PItem, 
             {
                 ref<uint8>(0x10) = 0x07;
                 std::memcpy(buffer_.data() + 0x14, PItem->getSender().c_str(),
-                       PItem->getSender().size()); // Sender's name.  Client disables "Return" if it starts with "AH"
+                            PItem->getSender().size()); // Sender's name.  Client disables "Return" if it starts with "AH"
             }
             else
             {
                 ref<uint8>(0x10) = PItem->isSent() ? 0x03 : 0x05; // 0x05 in send: canceled. other values are unknown
                 std::memcpy(buffer_.data() + 0x14, PItem->getReceiver().c_str(),
-                       PItem->getReceiver().size()); // Receiver's name.  Client disables "Return" if it starts with "AH"
+                            PItem->getReceiver().size()); // Receiver's name.  Client disables "Return" if it starts with "AH"
             }
         }
         if (action == 0x02)

--- a/src/map/packets/delivery_box.cpp
+++ b/src/map/packets/delivery_box.cpp
@@ -32,7 +32,7 @@ CDeliveryBoxPacket::CDeliveryBoxPacket(uint8 action, uint8 boxid, uint8 count, u
     this->setType(0x4B);
     this->setSize(0x14);
 
-    memset(data + 4, 0xFF, 12);
+    std::memset(buffer_.data() + 4, 0xFF, 12);
 
     ref<uint8>(0x04) = action;
     ref<uint8>(0x05) = boxid;
@@ -60,7 +60,7 @@ CDeliveryBoxPacket::CDeliveryBoxPacket(uint8 action, uint8 boxid, CItem* PItem, 
     this->setType(0x4B);
     this->setSize(0x58);
 
-    memset(data + 4, 0xFF, 12);
+    std::memset(buffer_.data() + 4, 0xFF, 12);
 
     ref<uint8>(0x04) = action;
     ref<uint8>(0x05) = boxid;
@@ -75,13 +75,13 @@ CDeliveryBoxPacket::CDeliveryBoxPacket(uint8 action, uint8 boxid, CItem* PItem, 
             if (boxid == 1)
             {
                 ref<uint8>(0x10) = 0x07;
-                memcpy(data + 0x14, PItem->getSender().c_str(),
+                std::memcpy(buffer_.data() + 0x14, PItem->getSender().c_str(),
                        PItem->getSender().size()); // Sender's name.  Client disables "Return" if it starts with "AH"
             }
             else
             {
                 ref<uint8>(0x10) = PItem->isSent() ? 0x03 : 0x05; // 0x05 in send: canceled. other values are unknown
-                memcpy(data + 0x14, PItem->getReceiver().c_str(),
+                std::memcpy(buffer_.data() + 0x14, PItem->getReceiver().c_str(),
                        PItem->getReceiver().size()); // Receiver's name.  Client disables "Return" if it starts with "AH"
             }
         }
@@ -109,6 +109,6 @@ CDeliveryBoxPacket::CDeliveryBoxPacket(uint8 action, uint8 boxid, CItem* PItem, 
         ref<uint16>(0x2C) = PItem->getSubID(); // Only used to display which item was sold on the AH
         ref<uint16>(0x30) = PItem->getID();
         ref<uint32>(0x38) = PItem->getQuantity();
-        memcpy(data + 0x3C, PItem->m_extra, sizeof(PItem->m_extra));
+        std::memcpy(buffer_.data() + 0x3C, PItem->m_extra, sizeof(PItem->m_extra));
     }
 }

--- a/src/map/packets/entity_animation.cpp
+++ b/src/map/packets/entity_animation.cpp
@@ -35,7 +35,7 @@ CEntityAnimationPacket::CEntityAnimationPacket(CBaseEntity* PEntity, CBaseEntity
     ref<uint32>(0x04) = PEntity->id;
     ref<uint32>(0x08) = PTarget->id;
 
-    memcpy(data + ((0x0C)), type, 4);
+    std::memcpy(buffer_.data() + 0x0C, type, 4);
 
     ref<uint16>(0x10) = PEntity->targid;
     ref<uint16>(0x12) = PTarget->targid;

--- a/src/map/packets/entity_set_name.cpp
+++ b/src/map/packets/entity_set_name.cpp
@@ -46,8 +46,8 @@ CEntitySetNamePacket::CEntitySetNamePacket(CBaseEntity* PEntity)
         ref<uint16>(0x0C) = PTrust->PMaster->targid;
     }
 
-    packBitsBE(data + 0x04, 0x18 + PEntity->packetName.size(), 0, 6, 10); // Message Size
-    std::memcpy(data + 0x18, PEntity->packetName.c_str(), PEntity->packetName.size());
+    packBitsBE(buffer_.data() + 0x04, 0x18 + PEntity->packetName.size(), 0, 6, 10); // Message Size
+    std::memcpy(buffer_.data() + 0x18, PEntity->packetName.c_str(), PEntity->packetName.size());
 
     // Unknown, maybe entity flags?
     ref<uint8>(0x10) = 0x04;

--- a/src/map/packets/entity_update.cpp
+++ b/src/map/packets/entity_update.cpp
@@ -167,7 +167,7 @@ void CEntityUpdatePacket::updateWith(CBaseEntity* PEntity, ENTITYUPDATE type, ui
 
                 // depending on size of name, this can be 0x20, 0x22, or 0x24
                 this->setSize(0x48);
-                std::memcpy(data + 0x34, name.c_str(), std::min<size_t>(name.size(), PacketNameLength));
+                std::memcpy(buffer_.data() + 0x34, name.c_str(), std::min<size_t>(name.size(), PacketNameLength));
             }
         }
         break;
@@ -225,11 +225,11 @@ void CEntityUpdatePacket::updateWith(CBaseEntity* PEntity, ENTITYUPDATE type, ui
                 this->setSize(0x48);
                 if (PMob->packetName.empty())
                 {
-                    std::memcpy(data + 0x34, PEntity->getName().c_str(), std::min<size_t>(PEntity->getName().size(), PacketNameLength));
+                    std::memcpy(buffer_.data() + 0x34, PEntity->getName().c_str(), std::min<size_t>(PEntity->getName().size(), PacketNameLength));
                 }
                 else
                 {
-                    std::memcpy(data + 0x34, PMob->packetName.c_str(), std::min<size_t>(PMob->packetName.size(), PacketNameLength));
+                    std::memcpy(buffer_.data() + 0x34, PMob->packetName.c_str(), std::min<size_t>(PMob->packetName.size(), PacketNameLength));
                 }
             }
         }
@@ -261,14 +261,14 @@ void CEntityUpdatePacket::updateWith(CBaseEntity* PEntity, ENTITYUPDATE type, ui
         case MODEL_CHOCOBO:
         {
             this->setSize(0x48);
-            std::memcpy(data + 0x30, &PEntity->look, sizeof(look_t));
+            std::memcpy(buffer_.data() + 0x30, &PEntity->look, sizeof(look_t));
         }
         break;
         case MODEL_DOOR:
         {
             this->setSize(0x48);
             ref<uint16>(0x30) = PEntity->look.size;
-            std::memcpy(data + 0x34, PEntity->getName().c_str(), (PEntity->getName().size() > 12 ? 12 : PEntity->getName().size()));
+            std::memcpy(buffer_.data() + 0x34, PEntity->getName().c_str(), (PEntity->getName().size() > 12 ? 12 : PEntity->getName().size()));
         }
         break;
         case MODEL_SHIP:
@@ -277,7 +277,7 @@ void CEntityUpdatePacket::updateWith(CBaseEntity* PEntity, ENTITYUPDATE type, ui
             this->setSize(0x48);
             ref<uint16>(0x30) = PEntity->look.size;
             auto name         = getTransportNPCName(PEntity);
-            std::memcpy(data + 0x34, name.data(), name.size());
+            std::memcpy(buffer_.data() + 0x34, name.data(), name.size());
         }
         break;
     }
@@ -291,14 +291,14 @@ void CEntityUpdatePacket::updateWith(CBaseEntity* PEntity, ENTITYUPDATE type, ui
         ref<uint8>(0x0A) = 0x57; // Carefully chosen bits to make FUNC_Packet_Incoming_0x000E behave (Same type as first 0x00E Fellow packet)
         ref<uint8>(0x18) = 0x01; // Copy longer name in FUNC_Packet_Incoming_0x000E
 
-        std::memcpy(data + 0x30, &PEntity->look, sizeof(look_t));
+        std::memcpy(buffer_.data() + 0x30, &PEntity->look, sizeof(look_t));
 
         auto name       = PEntity->packetName;
         auto nameOffset = 0x44;
         auto maxLength  = std::min<size_t>(name.size(), PacketNameLength);
 
         // Make sure to zero-out the existing name area of the packet
-        auto start = data + nameOffset;
+        auto start = buffer_.data() + nameOffset;
         auto size  = this->getSize();
         std::memset(start, 0U, size);
 
@@ -326,7 +326,7 @@ void CEntityUpdatePacket::updateWith(CBaseEntity* PEntity, ENTITYUPDATE type, ui
         }
 
         // Make sure to zero-out the existing name area of the packet
-        auto start = data + nameOffset;
+        auto start = buffer_.data() + nameOffset;
         auto size  = this->getSize();
         std::memset(start, 0U, size);
 

--- a/src/map/packets/entity_visual.cpp
+++ b/src/map/packets/entity_visual.cpp
@@ -38,5 +38,5 @@ CEntityVisualPacket::CEntityVisualPacket(CBaseEntity* PEntity, const char type[4
         ref<uint16>(0x10) = PEntity->targid;
         ref<uint16>(0x12) = PEntity->targid;
     }
-    memcpy(data + ((0x0C)), type, 4);
+    std::memcpy(buffer_.data() + 0x0C, type, 4);
 }

--- a/src/map/packets/event_string.cpp
+++ b/src/map/packets/event_string.cpp
@@ -66,7 +66,7 @@ CEventStringPacket::CEventStringPacket(CCharEntity* PChar, EventInfo* eventInfo)
 
     for (auto const& stringPair : eventInfo->strings)
     {
-        memcpy(data + 0x10 + 0x10 * stringPair.first, stringPair.second.c_str(), stringPair.second.size());
+        std::memcpy(buffer_.data() + 0x10 + 0x10 * stringPair.first, stringPair.second.c_str(), stringPair.second.size());
     }
 
     for (auto paramPair : eventInfo->params)

--- a/src/map/packets/event_update_string.cpp
+++ b/src/map/packets/event_update_string.cpp
@@ -43,8 +43,8 @@ CEventUpdateStringPacket::CEventUpdateStringPacket(std::string const& string0, s
     ref<uint32>(0x20) = param7;
     ref<uint32>(0x24) = param8;
 
-    memcpy(data + 0x28, string0.c_str(), 15);
-    memcpy(data + 0x38, string1.c_str(), 15);
-    memcpy(data + 0x48, string2.c_str(), 15);
-    memcpy(data + 0x58, string3.c_str(), 15);
+    std::memcpy(buffer_.data() + 0x28, string0.c_str(), 15);
+    std::memcpy(buffer_.data() + 0x38, string1.c_str(), 15);
+    std::memcpy(buffer_.data() + 0x48, string2.c_str(), 15);
+    std::memcpy(buffer_.data() + 0x58, string3.c_str(), 15);
 }

--- a/src/map/packets/fish_ranking.cpp
+++ b/src/map/packets/fish_ranking.cpp
@@ -28,7 +28,7 @@
 
 #include <cstring>
 
-CFishRankingPacket::CFishRankingPacket(std::vector<FishingContestEntry> entries, int8 language, int32 timestamp, int32 msgOffset, uint32 totalEntries, uint8 msgChunk)
+CFishRankingPacket::CFishRankingPacket(const std::vector<FishingContestEntry>& entries, int8 language, int32 timestamp, int32 msgOffset, uint32 totalEntries, uint8 msgChunk)
 {
     this->setType(0x4D);
     this->setSize(0x28);

--- a/src/map/packets/fish_ranking.cpp
+++ b/src/map/packets/fish_ranking.cpp
@@ -64,7 +64,7 @@ CFishRankingPacket::CFishRankingPacket(std::vector<FishingContestEntry> entries,
         {
             if (offset + blockSize <= 0xFF)
             {
-                std::memcpy(data + offset, entry.name, static_cast<uint8>(sizeof(entry.name)));
+                std::memcpy(buffer_.data() + offset, entry.name, static_cast<uint8>(sizeof(entry.name)));
                 ref<uint8>(offset + 0x10)  = entry.mjob;
                 ref<uint8>(offset + 0x11)  = entry.sjob;
                 ref<uint8>(offset + 0x12)  = entry.mlvl;

--- a/src/map/packets/fish_ranking.h
+++ b/src/map/packets/fish_ranking.h
@@ -32,7 +32,7 @@ struct FishingContestEntry;
 class CFishRankingPacket : public CBasicPacket
 {
 public:
-    CFishRankingPacket(std::vector<FishingContestEntry> entries, int8 language, int32 timestamp, int32 message_offset, uint32 numEntries, uint8 msg_chunk);
+    CFishRankingPacket(const std::vector<FishingContestEntry>& entries, int8 language, int32 timestamp, int32 message_offset, uint32 numEntries, uint8 msg_chunk);
 };
 
 #endif

--- a/src/map/packets/fishing.cpp
+++ b/src/map/packets/fishing.cpp
@@ -34,7 +34,7 @@
         0x4b, 0x00, 0x00, 0x00, 0x97, 0x00, 0x00, 0x00
     };
 
-    memcpy(data+4, &packet, 20);
+    std::memcpy(buffer_.data()+4, &packet, 20);
 
     ref<uint16>(data, (0x04)) = stamina;
     ref<uint8>(data, (0x06)) = id3;

--- a/src/map/packets/guild_menu.cpp
+++ b/src/map/packets/guild_menu.cpp
@@ -36,7 +36,7 @@ CGuildMenuPacket::CGuildMenuPacket(GUILDSTATUS status, uint8 open, uint8 close, 
         case GUILD_OPEN:
         case GUILD_CLOSE:
         {
-            packBitsBE(data + (0x08), 0xFFFFFF, open, close - open);
+            packBitsBE(buffer_.data() + 0x08, 0xFFFFFF, open, close - open);
         }
         break;
         case GUILD_HOLYDAY:

--- a/src/map/packets/guild_menu_buy.cpp
+++ b/src/map/packets/guild_menu_buy.cpp
@@ -61,7 +61,7 @@ CGuildMenuBuyPacket::CGuildMenuBuyPacket(CCharEntity* PChar, CItemContainer* PGu
                 ref<uint8>(0xF4) = ItemCount;
                 ref<uint8>(0xF5) = (PacketCount == 0 ? 0x40 : PacketCount);
 
-                PChar->pushPacket<CBasicPacket>(*this);
+                PChar->pushPacket(this->copy());
 
                 ItemCount = 0;
                 PacketCount++;

--- a/src/map/packets/guild_menu_buy.cpp
+++ b/src/map/packets/guild_menu_buy.cpp
@@ -66,7 +66,7 @@ CGuildMenuBuyPacket::CGuildMenuBuyPacket(CCharEntity* PChar, CItemContainer* PGu
                 ItemCount = 0;
                 PacketCount++;
 
-                memset(data + 4, 0, PACKET_SIZE - 8);
+                std::memset(buffer_.data() + 4, 0, PACKET_SIZE - 8);
             }
             ref<uint16>(0x08 * ItemCount + 0x04) = PItem->getID();
             ref<uint8>(0x08 * ItemCount + 0x06)  = PItem->getQuantity();

--- a/src/map/packets/guild_menu_sell.cpp
+++ b/src/map/packets/guild_menu_sell.cpp
@@ -64,7 +64,7 @@ CGuildMenuSellPacket::CGuildMenuSellPacket(CCharEntity* PChar, CItemContainer* P
             ItemCount = 0;
             PacketCount++;
 
-            memset(data + 4, 0, PACKET_SIZE - 8);
+            std::memset(buffer_.data() + 4, 0, PACKET_SIZE - 8);
         }
         ref<uint16>(0x08 * ItemCount + 0x04) = PItem->getID();
         ref<uint8>(0x08 * ItemCount + 0x06)  = PItem->getQuantity();

--- a/src/map/packets/guild_menu_sell.cpp
+++ b/src/map/packets/guild_menu_sell.cpp
@@ -59,7 +59,7 @@ CGuildMenuSellPacket::CGuildMenuSellPacket(CCharEntity* PChar, CItemContainer* P
             ref<uint8>(0xF4) = ItemCount;
             ref<uint8>(0xF5) = (PacketCount == 0 ? 0x40 : PacketCount);
 
-            PChar->pushPacket<CBasicPacket>(*this);
+            PChar->pushPacket(this->copy());
 
             ItemCount = 0;
             PacketCount++;

--- a/src/map/packets/inventory_item.cpp
+++ b/src/map/packets/inventory_item.cpp
@@ -42,7 +42,7 @@ CInventoryItemPacket::CInventoryItemPacket(CItem* PItem, uint8 LocationID, uint8
         ref<uint32>(0x04) = PItem->getQuantity();
         ref<uint32>(0x08) = PItem->getCharPrice();
         ref<uint16>(0x0C) = PItem->getID();
-        memcpy(data + 0x11, PItem->m_extra, sizeof(PItem->m_extra));
+        std::memcpy(buffer_.data() + 0x11, PItem->m_extra, sizeof(PItem->m_extra));
 
         if (PItem->isSubType(ITEM_CHARGED))
         {

--- a/src/map/packets/jobpoint_details.cpp
+++ b/src/map/packets/jobpoint_details.cpp
@@ -53,7 +53,7 @@ CJobPointDetailsPacket::CJobPointDetailsPacket(CCharEntity* PChar)
         // Send a packet every 2 jobs...
         if (i % 2 == 1)
         {
-            PChar->pushPacket<CBasicPacket>(*this);
+            PChar->pushPacket(this->copy());
 
             // Reset Data
             uint8 jpPacketSize = JP_DETAIL_DATA_SIZE * 20;

--- a/src/map/packets/jobpoint_details.cpp
+++ b/src/map/packets/jobpoint_details.cpp
@@ -57,7 +57,7 @@ CJobPointDetailsPacket::CJobPointDetailsPacket(CCharEntity* PChar)
 
             // Reset Data
             uint8 jpPacketSize = JP_DETAIL_DATA_SIZE * 20;
-            std::memset(data + 4, 0, sizeof(jpPacketSize));
+            std::memset(buffer_.data() + 4, 0, sizeof(jpPacketSize));
         }
     }
 }

--- a/src/map/packets/key_items.cpp
+++ b/src/map/packets/key_items.cpp
@@ -37,8 +37,8 @@ CKeyItemsPacket::CKeyItemsPacket(CCharEntity* PChar, KEYS_TABLE KeyTable)
         return;
     }
 
-    memcpy(data + (0x04), &(PChar->keys.tables[KeyTable].keyList), 0x40);
-    memcpy(data + (0x44), &(PChar->keys.tables[KeyTable].seenList), 0x40);
+    std::memcpy(buffer_.data() + 0x04, &(PChar->keys.tables[KeyTable].keyList), 0x40);
+    std::memcpy(buffer_.data() + 0x44, &(PChar->keys.tables[KeyTable].seenList), 0x40);
 
     ref<uint8>(0x84) = KeyTable;
 }

--- a/src/map/packets/linkshell_message.cpp
+++ b/src/map/packets/linkshell_message.cpp
@@ -41,9 +41,9 @@ CLinkshellMessagePacket::CLinkshellMessagePacket(const std::string& poster, cons
         ref<uint8>(0x05) |= 0x40; // LS2
     }
 
-    memcpy(data + (0x08), message.c_str(), std::min<size_t>(message.size(), 128));
-    memcpy(data + (0x8C), poster.c_str(), std::min<size_t>(poster.size(), 15));
-    memcpy(data + (0xA0), lsname.c_str(), std::min<size_t>(lsname.size(), 16));
+    std::memcpy(buffer_.data() + 0x08, message.c_str(), std::min<size_t>(message.size(), 128));
+    std::memcpy(buffer_.data() + 0x8C, poster.c_str(), std::min<size_t>(poster.size(), 15));
+    std::memcpy(buffer_.data() + 0xA0, lsname.c_str(), std::min<size_t>(lsname.size(), 16));
 
     ref<uint32>(0x88) = posttime;
 

--- a/src/map/packets/menu_config.cpp
+++ b/src/map/packets/menu_config.cpp
@@ -50,5 +50,5 @@ CMenuConfigPacket::CMenuConfigPacket(CCharEntity* PChar)
 
     std::memcpy(&packet.PartyLanguages, &PChar->search.language, sizeof(packet.PartyLanguages));
 
-    std::memcpy(data, &packet, sizeof(GP_SERV_CONFIG));
+    std::memcpy(buffer_.data(), &packet, sizeof(GP_SERV_CONFIG));
 }

--- a/src/map/packets/menu_unity.cpp
+++ b/src/map/packets/menu_unity.cpp
@@ -63,7 +63,7 @@ CMenuUnityPacket::CMenuUnityPacket(CCharEntity* PChar)
     // CMenuUnityPacket: Update Type 0x0001
     // Full Unity Results: Total contributing members in Unity
     this->setSize(0x8C);
-    memset(data + 4, 0, PACKET_SIZE - 4);
+    std::memset(buffer_.data() + 4, 0, PACKET_SIZE - 4);
 
     ref<uint8>(0x04) = 0x07; // Switch Block 7
     ref<uint8>(0x06) = 0x88; // Variable Data Size
@@ -79,7 +79,7 @@ CMenuUnityPacket::CMenuUnityPacket(CCharEntity* PChar)
     // CMenuUnityPacket: Update Type 0x0002
     // Full Unity Results: Total Points gained this week per unity
     this->setSize(0x8C);
-    memset(data + 4, 0, PACKET_SIZE - 4);
+    std::memset(buffer_.data() + 4, 0, PACKET_SIZE - 4);
 
     ref<uint8>(0x04) = 0x07; // Switch Block 7
     ref<uint8>(0x06) = 0x88; // Variable Data Size
@@ -95,7 +95,7 @@ CMenuUnityPacket::CMenuUnityPacket(CCharEntity* PChar)
     for (int i = 3; i < 32; i++)
     {
         this->setSize(0x8C);
-        memset(data + 4, 0, PACKET_SIZE - 4);
+        std::memset(buffer_.data() + 4, 0, PACKET_SIZE - 4);
 
         ref<uint8>(0x04) = 0x07; // Switch Block 7
         ref<uint8>(0x06) = 0x88; // Variable Data Size
@@ -106,7 +106,7 @@ CMenuUnityPacket::CMenuUnityPacket(CCharEntity* PChar)
 
     // CMenuUnityPacket: Update Type 0x0100
     this->setSize(0x8C);
-    memset(data + 4, 0, PACKET_SIZE - 4);
+    std::memset(buffer_.data() + 4, 0, PACKET_SIZE - 4);
 
     ref<uint8>(0x04) = 0x07; // Switch Block 7
     ref<uint8>(0x06) = 0x88; // Variable Data Size
@@ -118,7 +118,7 @@ CMenuUnityPacket::CMenuUnityPacket(CCharEntity* PChar)
     // CMenuUnityPacket: Update Type 0x0101
     // Partial Unity Ranking: Total Members in Unity
     this->setSize(0x8C);
-    memset(data + 4, 0, PACKET_SIZE - 4);
+    std::memset(buffer_.data() + 4, 0, PACKET_SIZE - 4);
 
     ref<uint8>(0x04) = 0x07; // Switch Block 7
     ref<uint8>(0x06) = 0x88; // Variable Data Size
@@ -135,7 +135,7 @@ CMenuUnityPacket::CMenuUnityPacket(CCharEntity* PChar)
     // CMenuUnityPacket: Update Type 0x0102
     // Partial Unity Ranking: Total Points this week in Unity
     this->setSize(0x8C);
-    memset(data + 4, 0, PACKET_SIZE - 4);
+    std::memset(buffer_.data() + 4, 0, PACKET_SIZE - 4);
 
     ref<uint8>(0x04) = 0x07; // Switch Block 7
     ref<uint8>(0x06) = 0x88; // Variable Data Size
@@ -152,7 +152,7 @@ CMenuUnityPacket::CMenuUnityPacket(CCharEntity* PChar)
     for (int i = 3; i < 32; i++)
     {
         this->setSize(0x8C);
-        memset(data + 4, 0, PACKET_SIZE - 4);
+        std::memset(buffer_.data() + 4, 0, PACKET_SIZE - 4);
 
         ref<uint8>(0x04) = 0x07; // Switch Block 7
         ref<uint8>(0x06) = 0x88; // Variable Data Size

--- a/src/map/packets/menu_unity.cpp
+++ b/src/map/packets/menu_unity.cpp
@@ -58,7 +58,7 @@ CMenuUnityPacket::CMenuUnityPacket(CCharEntity* PChar)
     ref<uint8>(0x08) = 0x00;
     ref<uint8>(0x09) = 0x00; // Type 0
 
-    PChar->pushPacket<CBasicPacket>(*this);
+    PChar->pushPacket(this->copy());
 
     // CMenuUnityPacket: Update Type 0x0001
     // Full Unity Results: Total contributing members in Unity
@@ -74,7 +74,7 @@ CMenuUnityPacket::CMenuUnityPacket(CCharEntity* PChar)
         ref<uint32>(i * 4 + 0x10) = unity_previous[i].first;
     }
 
-    PChar->pushPacket<CBasicPacket>(*this);
+    PChar->pushPacket(this->copy());
 
     // CMenuUnityPacket: Update Type 0x0002
     // Full Unity Results: Total Points gained this week per unity
@@ -90,7 +90,7 @@ CMenuUnityPacket::CMenuUnityPacket(CCharEntity* PChar)
         ref<uint32>(i * 4 + 0x10) = unity_previous[i].second;
     }
 
-    PChar->pushPacket<CBasicPacket>(*this);
+    PChar->pushPacket(this->copy());
 
     for (int i = 3; i < 32; i++)
     {
@@ -101,7 +101,7 @@ CMenuUnityPacket::CMenuUnityPacket(CCharEntity* PChar)
         ref<uint8>(0x06) = 0x88; // Variable Data Size
         ref<uint8>(0x09) = i;    // Type 3
 
-        PChar->pushPacket<CBasicPacket>(*this);
+        PChar->pushPacket(this->copy());
     }
 
     // CMenuUnityPacket: Update Type 0x0100
@@ -113,7 +113,7 @@ CMenuUnityPacket::CMenuUnityPacket(CCharEntity* PChar)
     ref<uint8>(0x08) = 0x01;
     ref<uint8>(0x09) = 0x00; // Type 0100
 
-    PChar->pushPacket<CBasicPacket>(*this);
+    PChar->pushPacket(this->copy());
 
     // CMenuUnityPacket: Update Type 0x0101
     // Partial Unity Ranking: Total Members in Unity
@@ -130,7 +130,7 @@ CMenuUnityPacket::CMenuUnityPacket(CCharEntity* PChar)
         ref<uint32>(i * 4 + 0x10) = unity_current[i].first;
     }
 
-    PChar->pushPacket<CBasicPacket>(*this);
+    PChar->pushPacket(this->copy());
 
     // CMenuUnityPacket: Update Type 0x0102
     // Partial Unity Ranking: Total Points this week in Unity
@@ -147,7 +147,7 @@ CMenuUnityPacket::CMenuUnityPacket(CCharEntity* PChar)
         ref<uint32>(i * 4 + 0x10) = unity_current[i].second;
     }
 
-    PChar->pushPacket<CBasicPacket>(*this);
+    PChar->pushPacket(this->copy());
 
     for (int i = 3; i < 32; i++)
     {
@@ -159,6 +159,6 @@ CMenuUnityPacket::CMenuUnityPacket(CCharEntity* PChar)
         ref<uint8>(0x08) = 0x01;
         ref<uint8>(0x09) = i; // Type 0103
 
-        PChar->pushPacket<CBasicPacket>(*this);
+        PChar->pushPacket(this->copy());
     }
 }

--- a/src/map/packets/merit_points_categories.cpp
+++ b/src/map/packets/merit_points_categories.cpp
@@ -90,14 +90,14 @@ void CMeritPointsCategoriesPacket::MeritPointsCategoriesPacket(CCharEntity* PCha
 {
     for (uint8 i = 0; i < MAX_MERITS_IN_PACKET; ++i)
     {
-        memcpy(data + (0x08) + sizeof(uint32) * i, &PChar->PMeritPoints->GetMeritByIndex(offset + i)->data, sizeof(uint32));
+        std::memcpy(buffer_.data() + 0x08 + sizeof(uint32) * i, &PChar->PMeritPoints->GetMeritByIndex(offset + i)->data, sizeof(uint32));
     }
 
     if (!PChar->m_moghouseID)
     {
         for (uint8 i = 0; i < MAX_MERITS_IN_PACKET; ++i)
         {
-            (*(Merit_t*)(data + (0x08) + sizeof(uint32) * i)).next = 0; // Reset the next value for all merits
+            (*(Merit_t*)(buffer_.data() + 0x08 + sizeof(uint32) * i)).next = 0; // Reset the next value for all merits
         }
     }
 }

--- a/src/map/packets/merit_points_categories.cpp
+++ b/src/map/packets/merit_points_categories.cpp
@@ -66,7 +66,7 @@ CMeritPointsCategoriesPacket::CMeritPointsCategoriesPacket(CCharEntity* PChar)
     {
         MeritPointsCategoriesPacket(PChar, i * MAX_MERITS_IN_PACKET);
 
-        PChar->pushPacket<CBasicPacket>(*this);
+        PChar->pushPacket(this->copy());
     }
     MeritPointsCategoriesPacket(PChar, static_cast<uint8>(5 * MAX_MERITS_IN_PACKET));
 }

--- a/src/map/packets/message_name.cpp
+++ b/src/map/packets/message_name.cpp
@@ -47,5 +47,5 @@ CMessageNamePacket::CMessageNamePacket(CBaseEntity* PActor, uint16 messageID, CB
     ref<int32>(0x1C) = param3;
 
     CBaseEntity* PNameEntity = PNameActor ? PNameActor : PActor;
-    memcpy(data + 0x20, PNameEntity->getName().c_str(), PNameEntity->getName().size());
+    std::memcpy(buffer_.data() + 0x20, PNameEntity->getName().c_str(), PNameEntity->getName().size());
 }

--- a/src/map/packets/message_special.cpp
+++ b/src/map/packets/message_special.cpp
@@ -45,7 +45,7 @@ CMessageSpecialPacket::CMessageSpecialPacket(CBaseEntity* PEntity, uint16 messag
     if (ShowName)
     {
         this->setSize(0x30);
-        memcpy(data + (0x1E), PEntity->getName().c_str(), std::min<size_t>(PEntity->getName().size(), PacketNameLength));
+        std::memcpy(buffer_.data() + 0x1E, PEntity->getName().c_str(), std::min<size_t>(PEntity->getName().size(), PacketNameLength));
     }
     else if (PEntity->objtype == TYPE_PC)
     {

--- a/src/map/packets/message_standard.cpp
+++ b/src/map/packets/message_standard.cpp
@@ -50,7 +50,7 @@ CMessageStandardPacket::CMessageStandardPacket(uint32 param0, uint16 MessageID)
 
     ref<uint16>(0x0A) = MessageID;
 
-    snprintf((char*)data + (0x0D), 16, "Para0 %u ", param0);
+    snprintf((char*)buffer_.data() + 0x0D, 16, "Para0 %u ", param0);
 }
 
 CMessageStandardPacket::CMessageStandardPacket(uint32 param0, uint32 param1, uint16 MessageID)
@@ -60,7 +60,7 @@ CMessageStandardPacket::CMessageStandardPacket(uint32 param0, uint32 param1, uin
 
     ref<uint16>(0x0A) = MessageID;
 
-    snprintf((char*)data + (0x0D), 24, "Para0 %u Para1 %u", param0, param1);
+    snprintf((char*)buffer_.data() + 0x0D, 24, "Para0 %u Para1 %u", param0, param1);
 }
 
 CMessageStandardPacket::CMessageStandardPacket(CCharEntity* PChar, uint32 param0, uint32 param1, MsgStd MessageID)
@@ -81,7 +81,7 @@ CMessageStandardPacket::CMessageStandardPacket(CCharEntity* PChar, uint32 param0
 
             ref<uint8>(0x0C) = 0x10;
 
-            snprintf((char*)data + (0x0D), 24, "string2 %s", PChar->getName().c_str());
+            snprintf((char*)buffer_.data() + 0x0D, 24, "string2 %s", PChar->getName().c_str());
         }
         else if (MessageID == MsgStd::MonstrosityCheckIn || MessageID == MsgStd::MonstrosityCheckOut)
         {
@@ -89,12 +89,12 @@ CMessageStandardPacket::CMessageStandardPacket(CCharEntity* PChar, uint32 param0
 
             ref<uint16>(0x0A) = static_cast<uint16>(MessageID);
 
-            snprintf((char*)data + (0x0D), 24, "string2 %s", PChar->getName().c_str());
+            snprintf((char*)buffer_.data() + 0x0D, 24, "string2 %s", PChar->getName().c_str());
         }
     }
     else
     {
-        snprintf((char*)data + (0x0D), 24, "Para0 %u Para1 %u", param0, param1);
+        snprintf((char*)buffer_.data() + 0x0D, 24, "Para0 %u Para1 %u", param0, param1);
     }
 }
 
@@ -105,9 +105,9 @@ CMessageStandardPacket::CMessageStandardPacket(uint32 param0, uint32 param1, uin
 
     ref<uint16>(0x0A) = static_cast<uint16>(MessageID);
 
-    snprintf((char*)data + (0x0D), 100, "Para0 %u Para1 %u Para2 %u Para3 %u", param0, param1, param2, param3);
+    snprintf((char*)buffer_.data() + 0x0D, 100, "Para0 %u Para1 %u Para2 %u Para3 %u", param0, param1, param2, param3);
 
-    this->setSize((this->getSize() + (strlen((char*)data + (0x0D)) >> 1)) & 0xFE);
+    this->setSize((this->getSize() + (strlen((char*)buffer_.data() + 0x0D) >> 1)) & 0xFE);
 }
 
 // Only used with MsgStd::DiceRoll (/random)
@@ -118,7 +118,7 @@ CMessageStandardPacket::CMessageStandardPacket(CCharEntity* PChar, uint32 param0
 
     ref<uint16>(0x0A) = static_cast<uint16>(MessageID);
 
-    snprintf((char*)data + (0x0D), 40, "string2 %s string3 %u", PChar->getName().c_str(), param0);
+    snprintf((char*)buffer_.data() + 0x0D, 40, "string2 %s string3 %u", PChar->getName().c_str(), param0);
 
     // ref<uint8>(data,(0x2F)) = 0x02;
 }

--- a/src/map/packets/monipulator1.cpp
+++ b/src/map/packets/monipulator1.cpp
@@ -64,8 +64,8 @@ CMonipulatorPacket1::CMonipulatorPacket1(CCharEntity* PChar)
     ref<uint8>(0x14) = 0x2C;
 
     // Bitpacked 2-bit values. 0 = no instincts from that species, 1 == first instinct, 2 == first and second instinct, 3 == first, second, and third instinct.
-    std::memcpy(data + 0x1C, PChar->m_PMonstrosity->instincts.data(), 64); // Instinct Bitfield 1
+    std::memcpy(buffer_.data() + 0x1C, PChar->m_PMonstrosity->instincts.data(), 64); // Instinct Bitfield 1
 
     // Mapped onto the item ID for these creatures. (00 doesn't exist, 01 is rabbit, 02 is behemoth, etc.)
-    std::memcpy(data + 0x5C, PChar->m_PMonstrosity->levels.data(), 128); // Monster Level Bitfield
+    std::memcpy(buffer_.data() + 0x5C, PChar->m_PMonstrosity->levels.data(), 128); // Monster Level Bitfield
 }

--- a/src/map/packets/monipulator2.cpp
+++ b/src/map/packets/monipulator2.cpp
@@ -50,8 +50,8 @@ CMonipulatorPacket2::CMonipulatorPacket2(CCharEntity* PChar)
 
     // Contains job/race instincts from the 0x03 set. Has 8 unused bytes. This is a 1:1 mapping.
     // Since this has 8 unused bytes, we're only going to use 4 from instincts[20:23]
-    std::memcpy(data + 0x88, PChar->m_PMonstrosity->instincts.data() + 20, 4); // Instinct Bitfield 3
+    std::memcpy(buffer_.data() + 0x88, PChar->m_PMonstrosity->instincts.data() + 20, 4); // Instinct Bitfield 3
 
     // Does not show normal monsters, only variants. Bit is 1 if the variant is owned. Length is an estimation including the possible padding.
-    std::memcpy(data + 0x94, PChar->m_PMonstrosity->variants.data(), 32); // Variants Bitfield
+    std::memcpy(buffer_.data() + 0x94, PChar->m_PMonstrosity->variants.data(), 32); // Variants Bitfield
 }

--- a/src/map/packets/party_effects.cpp
+++ b/src/map/packets/party_effects.cpp
@@ -41,6 +41,6 @@ void CPartyEffectsPacket::AddMemberEffects(CBattleEntity* PMember)
     ref<uint32>(members * 0x30 + 0x04) = PMember->id;
     ref<uint16>(members * 0x30 + 0x08) = PMember->targid;
     ref<uint64>(members * 0x30 + 0x0C) = PMember->StatusEffectContainer->m_Flags;
-    memcpy(data + (members * 0x30 + 0x14), PMember->StatusEffectContainer->m_StatusIcons, 32);
+    std::memcpy(buffer_.data() + (members * 0x30 + 0x14), PMember->StatusEffectContainer->m_StatusIcons, 32);
     ++members;
 }

--- a/src/map/packets/party_invite.cpp
+++ b/src/map/packets/party_invite.cpp
@@ -37,5 +37,5 @@ CPartyInvitePacket::CPartyInvitePacket(uint32 id, uint16 targid, CCharEntity* PI
 
     ref<uint8>(0x0B) = InviteType;
 
-    memcpy(data + (0x0C), PInviter->getName().c_str(), PInviter->getName().size());
+    std::memcpy(buffer_.data() + 0x0C, PInviter->getName().c_str(), PInviter->getName().size());
 }

--- a/src/map/packets/party_member_update.cpp
+++ b/src/map/packets/party_member_update.cpp
@@ -73,7 +73,7 @@ CPartyMemberUpdatePacket::CPartyMemberUpdatePacket(CCharEntity* PChar, uint8 Mem
         }
     }
 
-    memcpy(data + (0x28), PChar->getName().c_str(), PChar->getName().size());
+    std::memcpy(buffer_.data() + 0x28, PChar->getName().c_str(), PChar->getName().size());
 }
 
 CPartyMemberUpdatePacket::CPartyMemberUpdatePacket(CTrustEntity* PTrust, uint8 MemberNumber)
@@ -103,7 +103,7 @@ CPartyMemberUpdatePacket::CPartyMemberUpdatePacket(CTrustEntity* PTrust, uint8 M
     ref<uint8>(0x24) = PTrust->GetSJob();
     ref<uint8>(0x25) = PTrust->GetSLevel();
 
-    memcpy(data + (0x28), PTrust->packetName.c_str(), PTrust->packetName.size());
+    std::memcpy(buffer_.data() + 0x28, PTrust->packetName.c_str(), PTrust->packetName.size());
 }
 
 CPartyMemberUpdatePacket::CPartyMemberUpdatePacket(uint32 id, const std::string& name, uint16 memberFlags, uint8 MemberNumber, uint16 ZoneID)
@@ -116,5 +116,5 @@ CPartyMemberUpdatePacket::CPartyMemberUpdatePacket(uint32 id, const std::string&
     ref<uint16>(0x14) = memberFlags;
     ref<uint16>(0x20) = ZoneID;
 
-    memcpy(data + (0x28), name.c_str(), name.size());
+    std::memcpy(buffer_.data() + 0x28, name.c_str(), name.size());
 }

--- a/src/map/packets/pet_sync.cpp
+++ b/src/map/packets/pet_sync.cpp
@@ -37,7 +37,7 @@ CPetSyncPacket::CPetSyncPacket(CCharEntity* PChar)
     this->setType(0x68);
     this->setSize(0x1C);
 
-    ref<uint8>(0x04) |= 0x04;                    // Message Type
+    ref<uint8>(0x04) |= 0x04;                            // Message Type
     packBitsBE(buffer_.data() + 0x04, (0x18), 0, 6, 10); // Message Size (0 for Despawn)
     ref<uint16>(0x06) = PChar->targid;
     ref<uint32>(0x08) = PChar->id;

--- a/src/map/packets/pet_sync.cpp
+++ b/src/map/packets/pet_sync.cpp
@@ -38,14 +38,14 @@ CPetSyncPacket::CPetSyncPacket(CCharEntity* PChar)
     this->setSize(0x1C);
 
     ref<uint8>(0x04) |= 0x04;                    // Message Type
-    packBitsBE(data + (0x04), (0x18), 0, 6, 10); // Message Size (0 for Despawn)
+    packBitsBE(buffer_.data() + 0x04, (0x18), 0, 6, 10); // Message Size (0 for Despawn)
     ref<uint16>(0x06) = PChar->targid;
     ref<uint32>(0x08) = PChar->id;
 
     if (PChar->PPet != nullptr)
     {
         this->setSize(0x2C);
-        packBitsBE(data + 0x04, 0x18 + PChar->PPet->getName().size(), 0, 6, 10); // Message Size
+        packBitsBE(buffer_.data() + 0x04, 0x18 + PChar->PPet->getName().size(), 0, 6, 10); // Message Size
         ref<uint16>(0x0C) = PChar->PPet->targid;
         ref<uint8>(0x0E)  = PChar->PPet->GetHPP();
         ref<uint8>(0x0F)  = PChar->PPet->GetMPP();
@@ -55,6 +55,6 @@ CPetSyncPacket::CPetSyncPacket(CCharEntity* PChar)
             ref<uint32>(0x14) = PChar->PPet->GetBattleTarget()->id;
         }
 
-        memcpy(data + (0x18), PChar->PPet->getName().c_str(), PChar->PPet->getName().size());
+        std::memcpy(buffer_.data() + 0x18, PChar->PPet->getName().c_str(), PChar->PPet->getName().size());
     }
 }

--- a/src/map/packets/quest_mission_log.cpp
+++ b/src/map/packets/quest_mission_log.cpp
@@ -127,11 +127,11 @@ void CQuestMissionLogPacket::generateQuestPacket(CCharEntity* PChar, uint8 logID
 {
     if (status == LOG_QUEST_CURRENT)
     {
-        memcpy(data + 4, PChar->m_questLog[logID].current, 32);
+        std::memcpy(buffer_.data() + 4, PChar->m_questLog[logID].current, 32);
     }
     else if (status == LOG_QUEST_COMPLETE)
     {
-        memcpy(data + 4, PChar->m_questLog[logID].complete, 32);
+        std::memcpy(buffer_.data() + 4, PChar->m_questLog[logID].complete, 32);
     }
 }
 
@@ -168,7 +168,7 @@ void CQuestMissionLogPacket::generateCompleteMissionPacket(CCharEntity* PChar)
     {
         for (uint8 questMissionID = 0; questMissionID < 64; questMissionID++)
         {
-            data[(questMissionID / 8) + (logID * 0x08) + 4] ^= ((PChar->m_missionLog[logID].complete[questMissionID]) << (questMissionID % 8));
+            buffer_[(questMissionID / 8) + (logID * 0x08) + 4] ^= ((PChar->m_missionLog[logID].complete[questMissionID]) << (questMissionID % 8));
         }
     }
 }
@@ -189,13 +189,13 @@ void CQuestMissionLogPacket::generateCompleteExpMissionPacket(CCharEntity* PChar
     uint8 logID = MISSION_TOAU;
     for (uint8 questMissionID = 0; questMissionID < 64; questMissionID++)
     {
-        data[(questMissionID / 8) + 4] ^= ((PChar->m_missionLog[logID].complete[questMissionID]) << (questMissionID % 8));
+        buffer_[(questMissionID / 8) + 4] ^= ((PChar->m_missionLog[logID].complete[questMissionID]) << (questMissionID % 8));
     }
 
     logID = MISSION_WOTG;
     for (uint8 questMissionID = 0; questMissionID < 64; questMissionID++)
     {
-        data[(questMissionID / 8) + 0x08 + 4] ^= ((PChar->m_missionLog[logID].complete[questMissionID]) << (questMissionID % 8));
+        buffer_[(questMissionID / 8) + 0x08 + 4] ^= ((PChar->m_missionLog[logID].complete[questMissionID]) << (questMissionID % 8));
     }
 }
 
@@ -203,7 +203,7 @@ void CQuestMissionLogPacket::generateCampaignMissionPacket(CCharEntity* PChar, u
 {
     for (uint16 questMissionID = startQMID; questMissionID < (startQMID + 256); questMissionID++)
     {
-        data[(questMissionID / 8) + 4] ^= ((PChar->m_campaignLog.complete[questMissionID]) << (questMissionID % 8));
+        buffer_[(questMissionID / 8) + 4] ^= ((PChar->m_campaignLog.complete[questMissionID]) << (questMissionID % 8));
     }
 }
 
@@ -211,6 +211,6 @@ void CQuestMissionLogPacket::generateAssaultMissionPacket(CCharEntity* PChar)
 {
     for (uint16 questMissionID = 0; questMissionID < 128; questMissionID++)
     {
-        data[(questMissionID / 8) + 0x10 + 4] ^= ((PChar->m_assaultLog.complete[questMissionID]) << (questMissionID % 8));
+        buffer_[(questMissionID / 8) + 0x10 + 4] ^= ((PChar->m_assaultLog.complete[questMissionID]) << (questMissionID % 8));
     }
 }

--- a/src/map/packets/roe_questlog.cpp
+++ b/src/map/packets/roe_questlog.cpp
@@ -32,5 +32,5 @@ CRoeQuestLogPacket::CRoeQuestLogPacket(CCharEntity* PChar, uint8 order)
 
     ref<uint32>(0x84) = order;
 
-    memcpy(data + 0x04, &(PChar->m_eminenceLog.complete[order * 128]), 128);
+    std::memcpy(buffer_.data() + 0x04, &(PChar->m_eminenceLog.complete[order * 128]), 128);
 }

--- a/src/map/packets/send_blacklist.cpp
+++ b/src/map/packets/send_blacklist.cpp
@@ -70,5 +70,5 @@ CSendBlacklist::CSendBlacklist(CCharEntity* PChar, std::vector<std::pair<uint32,
         std::memcpy(&packet.List[i].Name, blacklist[i].second.c_str(), std::min<size_t>(blacklist[i].second.length(), 16));
     }
 
-    std::memcpy(data, &packet, packet.size * 4);
+    std::memcpy(buffer_.data(), &packet, packet.size * 4);
 }

--- a/src/map/packets/server_ip.cpp
+++ b/src/map/packets/server_ip.cpp
@@ -25,16 +25,22 @@
 #include "server_ip.h"
 #include "utils/zoneutils.h"
 
-CServerIPPacket::CServerIPPacket(CCharEntity* PChar, uint8 type, uint64 ipp)
+CServerIPPacket::CServerIPPacket(CCharEntity* PChar, uint8 zone_type, uint64 zone_ipp)
 {
     this->setType(0x0B);
     this->setSize(0x1C);
 
-    // Store inputs to reconstruct later in map.cpp in case we detect the player needs the packet again
-    this->type = type;
-    this->ipp  = ipp;
+    ref<uint8>(0x04)  = zone_type;
+    ref<uint32>(0x08) = (uint32)zone_ipp;
+    ref<uint16>(0x0C) = (uint16)(zone_ipp >> 32);
+}
 
-    ref<uint8>(0x04)  = type;
-    ref<uint32>(0x08) = (uint32)ipp;
-    ref<uint16>(0x0C) = (uint16)(ipp >> 32);
+uint8 CServerIPPacket::zoneType()
+{
+    return ref<uint8>(0x04);
+}
+
+uint64 CServerIPPacket::zoneIPP()
+{
+    return ref<uint32>(0x08) | (uint64)ref<uint16>(0x0C) << 32;
 }

--- a/src/map/packets/server_ip.h
+++ b/src/map/packets/server_ip.h
@@ -31,10 +31,10 @@ class CCharEntity;
 class CServerIPPacket : public CBasicPacket
 {
 public:
-    CServerIPPacket(CCharEntity* PChar, uint8 type, uint64 ipp);
+    CServerIPPacket(CCharEntity* PChar, uint8 zone_type, uint64 zone_ipp);
 
-    uint8  type;
-    uint64 ipp;
+    uint8  zoneType();
+    uint64 zoneIPP();
 };
 
 #endif

--- a/src/map/packets/server_message.cpp
+++ b/src/map/packets/server_message.cpp
@@ -52,6 +52,6 @@ CServerMessagePacket::CServerMessagePacket(const std::string& message, int8 lang
         this->setSize(((((0x14 + textSize) + 4) >> 1) & 0xFE) * 2);
 
         // TODO: can
-        std::memcpy(data + 0x18, message.c_str() + message_offset, std::min(sndLength, message.length() - message_offset));
+        std::memcpy(buffer_.data() + 0x18, message.c_str() + message_offset, std::min(sndLength, message.length() - message_offset));
     }
 }

--- a/src/map/packets/shop_items.cpp
+++ b/src/map/packets/shop_items.cpp
@@ -39,7 +39,7 @@ CShopItemsPacket::CShopItemsPacket(CCharEntity* PChar)
     {
         if (i == 20)
         {
-            PChar->pushPacket<CBasicPacket>(*this);
+            PChar->pushPacket(this->copy());
 
             i = 0;
             this->setSize(0x08);

--- a/src/map/packets/shop_items.cpp
+++ b/src/map/packets/shop_items.cpp
@@ -43,7 +43,7 @@ CShopItemsPacket::CShopItemsPacket(CCharEntity* PChar)
 
             i = 0;
             this->setSize(0x08);
-            memset(data + 4, 0, PACKET_SIZE - 8);
+            std::memset(buffer_.data() + 4, 0, PACKET_SIZE - 8);
         }
         this->setSize(this->getSize() + 0x0C); // TODO: Verify
 

--- a/src/map/packets/status_effects.cpp
+++ b/src/map/packets/status_effects.cpp
@@ -31,7 +31,7 @@ CStatusEffectPacket::CStatusEffectPacket(CCharEntity* PChar)
 
     int i = 0;
 
-    std::fill(reinterpret_cast<uint16*>(data + 0x08), reinterpret_cast<uint16*>(data + 0x08) + 32, 0x00FF);
+    std::fill(reinterpret_cast<uint16*>(buffer_.data() + 0x08), reinterpret_cast<uint16*>(buffer_.data() + 0x08) + 32, 0x00FF);
 
     ref<uint8>(0x04) = 0x09;
     ref<uint8>(0x06) = 0xC4;

--- a/src/map/packets/synth_result.cpp
+++ b/src/map/packets/synth_result.cpp
@@ -56,5 +56,5 @@ CSynthResultMessagePacket::CSynthResultMessagePacket(CCharEntity* PChar, SYNTH_M
         }
     }
 
-    memcpy(data + (0x1E), PChar->getName().c_str(), PChar->getName().size());
+    std::memcpy(buffer_.data() + 0x1E, PChar->getName().c_str(), PChar->getName().size());
 }

--- a/src/map/packets/trade_update.cpp
+++ b/src/map/packets/trade_update.cpp
@@ -55,10 +55,10 @@ CTradeUpdatePacket::CTradeUpdatePacket(CItem* PItem, uint8 SlotID)
         ref<uint16>(0x14) = ((CItemLinkshell*)PItem)->GetLSRawColor();
         ref<uint8>(0x16)  = ((CItemLinkshell*)PItem)->GetLSType();
 
-        memcpy(data + (0x17), PItem->getSignature().c_str(), std::min<size_t>(PItem->getSignature().size(), 15));
+        std::memcpy(buffer_.data() + 0x17, PItem->getSignature().c_str(), std::min<size_t>(PItem->getSignature().size(), 15));
     }
     else
     {
-        memcpy(data + (0x1A), PItem->getSignature().c_str(), std::min<size_t>(PItem->getSignature().size(), 12));
+        std::memcpy(buffer_.data() + 0x1A, PItem->getSignature().c_str(), std::min<size_t>(PItem->getSignature().size(), 12));
     }
 }

--- a/src/map/packets/treasure_lot_item.cpp
+++ b/src/map/packets/treasure_lot_item.cpp
@@ -49,7 +49,7 @@ CTreasureLotItemPacket::CTreasureLotItemPacket(CBaseEntity* PWinner, uint8 slotI
     ref<uint8>(0x14) = slotID;
     ref<uint8>(0x15) = MessageType;
 
-    memcpy(data + (0x16), PWinner->getName().c_str(), PWinner->getName().size());
+    std::memcpy(buffer_.data() + 0x16, PWinner->getName().c_str(), PWinner->getName().size());
 }
 
 CTreasureLotItemPacket::CTreasureLotItemPacket(CBaseEntity* PHighestLotter, uint16 HighestLot, CBaseEntity* PLotter, uint8 SlotID, uint16 Lot)
@@ -62,14 +62,14 @@ CTreasureLotItemPacket::CTreasureLotItemPacket(CBaseEntity* PHighestLotter, uint
         ref<uint32>(0x04) = PHighestLotter->id;
         ref<uint16>(0x0C) = PHighestLotter->targid;
         ref<uint16>(0x0E) = HighestLot;
-        memcpy(data + 0x16, PHighestLotter->getName().c_str(), PHighestLotter->getName().size());
+        std::memcpy(buffer_.data() + 0x16, PHighestLotter->getName().c_str(), PHighestLotter->getName().size());
     }
 
     ref<uint32>(0x08) = PLotter->id;
     ref<uint16>(0x10) = PLotter->targid;
-    packBitsBE(data, Lot, 144, 16); // this fixes an offset problem with lot numbers
+    packBitsBE(buffer_.data(), Lot, 144, 16); // this fixes an offset problem with lot numbers
     // ref<uint8>(data,(0x12)) = Lot;
     ref<uint8>(0x14) = SlotID;
 
-    memcpy(data + 0x26, PLotter->getName().c_str(), PLotter->getName().size());
+    std::memcpy(buffer_.data() + 0x26, PLotter->getName().c_str(), PLotter->getName().size());
 }

--- a/src/map/packets/wide_scan.cpp
+++ b/src/map/packets/wide_scan.cpp
@@ -53,5 +53,5 @@ CWideScanPacket::CWideScanPacket(CCharEntity* PChar, CBaseEntity* PEntity)
     ref<uint16>(0x08) = (int16)(PEntity->loc.p.x - PChar->loc.p.x); // Difference in x-value between character and object coordinates
     ref<uint16>(0x0A) = (int16)(PEntity->loc.p.z - PChar->loc.p.z); // Difference in z-value between character and object coordinates
 
-    // memcpy(data+(0x0C), PEntity->GetName(), (PEntity->name.size() > 14 ? 14 : PEntity->name.size()));
+    // std::memcpy(buffer_.data()+(0x0C), PEntity->GetName(), (PEntity->name.size() > 14 ? 14 : PEntity->name.size()));
 }

--- a/src/map/packets/world_pass.cpp
+++ b/src/map/packets/world_pass.cpp
@@ -51,7 +51,7 @@ CWorldPassPacket::CWorldPassPacket(uint32 WorldPass)
             return;
         }
 
-        memset(data + 0x10, 0, 10);
-        memcpy(data + 0x10, strbuff.c_str(), strbuff.length());
+        std::memset(buffer_.data() + 0x10, 0, 10);
+        std::memcpy(buffer_.data() + 0x10, strbuff.c_str(), strbuff.length());
     }
 }

--- a/src/map/packets/zone_in.cpp
+++ b/src/map/packets/zone_in.cpp
@@ -228,7 +228,7 @@ CZoneInPacket::CZoneInPacket(CCharEntity* PChar, const EventInfo* currentEvent)
     // unsigned char packet [] = {
     // 0x0D, 0x3A, 0x0C, 0x00, 0x11, 0x00, 0x19, 0x00, 0x02, 0xE4, 0x93, 0x10, 0x91, 0xE5, 0x93, 0x10}; // 0x2a = 0x10
     // 0x89, 0x39, 0x0C, 0x00, 0x19, 0x00, 0x07, 0x00, 0x5C, 0xE1, 0x93, 0x10, 0x81, 0xE3, 0x93, 0x10}; // 0x2a = 0x08
-    // memcpy(data + 0x70, &packet, 16);
+    // std::memcpy(buffer_.data() + 0x70, &packet, 16);
 
     // data[0x2A] = 0x08;//data[0x2A] = 0x80;  // in zone 3 controls the routes of transport 0x10 and 0x08
 
@@ -330,7 +330,7 @@ CZoneInPacket::CZoneInPacket(CCharEntity* PChar, const EventInfo* currentEvent)
     }
 
     auto const& nameStr = PChar->getName();
-    std::memcpy(data + 0x84, nameStr.data(), nameStr.size());
+    std::memcpy(buffer_.data() + 0x84, nameStr.data(), nameStr.size());
 
     ref<uint32>(0xA0) = PChar->GetPlayTime(); // time spent by the character in the game from the moment of creation
 
@@ -346,13 +346,13 @@ CZoneInPacket::CZoneInPacket(CCharEntity* PChar, const EventInfo* currentEvent)
     ref<uint8>(0xB4) = PChar->GetMJob();
     ref<uint8>(0xB7) = PChar->GetSJob();
 
-    memcpy(data + (0xCC), &PChar->stats, 14);
+    std::memcpy(buffer_.data() + 0xCC, &PChar->stats, 14);
 
     ref<uint32>(0xE8) = PChar->GetMaxHP();
     ref<uint32>(0xEC) = PChar->GetMaxMP();
     // ref<uint8>(0xEF) = TODO: implement flag of 1 = high for "has unlocked sub and can change jobs"
 
-    std::memcpy(&data[offsetof(GP_SERV_LOGIN, ConfData)], &PChar->playerConfig, sizeof(SAVE_CONF));
+    std::memcpy(&buffer_[offsetof(GP_SERV_LOGIN, ConfData)], &PChar->playerConfig, sizeof(SAVE_CONF));
 
     ref<uint8>(0x100) = 0x01; // observed: RoZ = 3, CoP = 5, ToAU = 9, WoTG = 11, SoA/original areas = 1
 

--- a/src/map/packets/zone_visited.cpp
+++ b/src/map/packets/zone_visited.cpp
@@ -31,5 +31,5 @@ CZoneVisitedPacket::CZoneVisitedPacket(CCharEntity* PChar)
     this->setType(0x08);
     this->setSize(0x34);
 
-    memcpy(data + 4, PChar->m_ZonesList, 38);
+    std::memcpy(buffer_.data() + 4, PChar->m_ZonesList, 38);
 }

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -1177,7 +1177,7 @@ void CParty::PushPacket(uint32 senderID, uint16 ZoneID, const std::unique_ptr<CB
         {
             if (ZoneID == 0 || member->getZone() == ZoneID)
             {
-                member->pushPacket<CBasicPacket>(*packet);
+                member->pushPacket(packet->copy());
             }
         }
     }

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -123,7 +123,8 @@ void CParty::DisbandParty(bool playerInitiated)
     if (m_PartyType == PARTY_PCS)
     {
         SetQuarterMaster("");
-        PushPacket(0, 0, new CPartyDefinePacket(nullptr));
+        auto partyDefinePacket = std::make_unique<CPartyDefinePacket>(nullptr);
+        PushPacket(0, 0, std::move(partyDefinePacket));
 
         for (auto& member : members)
         {
@@ -640,7 +641,7 @@ void CParty::AddMember(CBattleEntity* PEntity)
                 PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, m_PSyncTarget->GetMLevel(), MsgStd::LevelSyncActivated);
                 PChar->StatusEffectContainer->AddStatusEffect(new CStatusEffect(EFFECT_LEVEL_SYNC, EFFECT_LEVEL_SYNC, m_PSyncTarget->GetMLevel(), 0, 0), true);
                 PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DISPELABLE | EFFECTFLAG_ON_ZONE);
-                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, new CCharSyncPacket(PChar));
+                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, std::make_unique<CCharSyncPacket>(PChar));
             }
         }
 
@@ -1102,7 +1103,7 @@ void CParty::SetSyncTarget(const std::string& MemberName, MsgStd message)
                         member->pushPacket<CMessageStandardPacket>(PChar->GetMLevel(), 0, 0, 0, message);
                         member->StatusEffectContainer->AddStatusEffect(new CStatusEffect(EFFECT_LEVEL_SYNC, EFFECT_LEVEL_SYNC, PChar->GetMLevel(), 0, 0), true);
                         member->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DISPELABLE | EFFECTFLAG_ON_ZONE);
-                        member->loc.zone->PushPacket(member, CHAR_INRANGE, new CCharSyncPacket(member));
+                        member->loc.zone->PushPacket(member, CHAR_INRANGE, std::make_unique<CCharSyncPacket>(member));
                     }
                 }
                 _sql->Query("UPDATE accounts_parties SET partyflag = partyflag & ~%d WHERE partyid = %u AND partyflag & %d", PARTY_SYNC, m_PartyID,
@@ -1161,7 +1162,7 @@ void CParty::SetQuarterMaster(const std::string& MemberName)
 // Send a packet to all members of the group if the zone is specified as 0
 // or to the party members in the specified zone.
 // Packet for PPartyMember is not sent in both cases
-void CParty::PushPacket(uint32 senderID, uint16 ZoneID, CBasicPacket* packet)
+void CParty::PushPacket(uint32 senderID, uint16 ZoneID, const std::unique_ptr<CBasicPacket>& packet)
 {
     for (auto& i : members)
     {
@@ -1180,7 +1181,6 @@ void CParty::PushPacket(uint32 senderID, uint16 ZoneID, CBasicPacket* packet)
             }
         }
     }
-    destroy(packet);
 }
 
 void CParty::PushEffectsPacket()

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -1204,7 +1204,7 @@ void CParty::PushEffectsPacket()
                     }
                 }
             }
-            PMemberChar->pushPacket(effects.release());
+            PMemberChar->pushPacket(std::move(effects));
         }
         m_EffectsChanged = false;
     }

--- a/src/map/party.h
+++ b/src/map/party.h
@@ -99,7 +99,7 @@ public:
 
     std::size_t GetMemberCountAcrossAllProcesses();
 
-    void PushPacket(uint32 senderID, uint16 ZoneID, CBasicPacket* packet); // Send a packet to all group members, with the exception of PPartyMember
+    void PushPacket(uint32 senderID, uint16 ZoneID, const std::unique_ptr<CBasicPacket>& packet); // Send a packet to all group members, with the exception of PPartyMember
     void PushEffectsPacket();
     void EffectsChanged();
 

--- a/src/map/spell.cpp
+++ b/src/map/spell.cpp
@@ -70,7 +70,7 @@ uint8 CSpell::getJob(JOBTYPE JobID)
 
 void CSpell::setJob(int8* jobs)
 {
-    memcpy(&m_job[1], jobs, 22);
+    std::memcpy(&m_job[1], jobs, 22);
 }
 
 uint32 CSpell::getCastTime() const

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -206,7 +206,7 @@ CStatusEffectContainer::CStatusEffectContainer(CBattleEntity* PEntity)
         return;
     }
 
-    memset(m_StatusIcons, 0xFF, sizeof(m_StatusIcons));
+    std::memset(m_StatusIcons, 0xFF, sizeof(m_StatusIcons));
 }
 
 CStatusEffectContainer::~CStatusEffectContainer()
@@ -1381,7 +1381,7 @@ void CStatusEffectContainer::UpdateStatusIcons()
     auto* PChar = static_cast<CCharEntity*>(m_POwner);
 
     m_Flags = 0;
-    memset(m_StatusIcons, EFFECT_NONE, sizeof(m_StatusIcons));
+    std::memset(m_StatusIcons, EFFECT_NONE, sizeof(m_StatusIcons));
 
     uint8 count = 0;
 

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -642,7 +642,7 @@ void CStatusEffectContainer::RemoveStatusEffect(CStatusEffect* PStatusEffect, bo
         {
             if (!silent && PStatusEffect->GetIcon() != 0 && (!(PStatusEffect->HasEffectFlag(EFFECTFLAG_NO_LOSS_MESSAGE))) && !m_POwner->isDead())
             {
-                m_POwner->loc.zone->PushPacket(m_POwner, CHAR_INRANGE, new CMessageBasicPacket(m_POwner, m_POwner, PStatusEffect->GetIcon(), 0, 206));
+                m_POwner->loc.zone->PushPacket(m_POwner, CHAR_INRANGE, std::make_unique<CMessageBasicPacket>(m_POwner, m_POwner, PStatusEffect->GetIcon(), 0, 206));
             }
         }
     }

--- a/src/map/unitychat.cpp
+++ b/src/map/unitychat.cpp
@@ -62,7 +62,7 @@ void CUnityChat::PushPacket(uint32 senderID, const std::unique_ptr<CBasicPacket>
     {
         if (member->id != senderID && member->status != STATUS_TYPE::DISAPPEAR && !jailutils::InPrison(member))
         {
-            member->pushPacket<CBasicPacket>(*packet);
+            member->pushPacket(packet->copy());
         }
     }
 }

--- a/src/map/unitychat.cpp
+++ b/src/map/unitychat.cpp
@@ -56,7 +56,7 @@ bool CUnityChat::DelMember(CCharEntity* PChar)
     return !members.empty();
 }
 
-void CUnityChat::PushPacket(uint32 senderID, CBasicPacket* packet)
+void CUnityChat::PushPacket(uint32 senderID, const std::unique_ptr<CBasicPacket>& packet)
 {
     for (auto& member : members)
     {
@@ -65,7 +65,6 @@ void CUnityChat::PushPacket(uint32 senderID, CBasicPacket* packet)
             member->pushPacket<CBasicPacket>(*packet);
         }
     }
-    destroy(packet);
 }
 
 namespace unitychat

--- a/src/map/unitychat.h
+++ b/src/map/unitychat.h
@@ -35,7 +35,7 @@ public:
     void AddMember(CCharEntity* PChar);
     bool DelMember(CCharEntity* PChar);
 
-    void PushPacket(uint32 senderID, CBasicPacket* packet);
+    void PushPacket(uint32 senderID, const std::unique_ptr<CBasicPacket>& packet);
 
     std::vector<CCharEntity*> members;
 

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -5647,7 +5647,7 @@ namespace battleutils
                     PTarget->loc.zone->UpdateEntityPacket(PTarget, ENTITY_UPDATE, UPDATE_POS);
                 }
 
-                PTarget->loc.zone->PushPacket(PTarget, CHAR_INRANGE, new CMessageBasicPacket(PTarget, PTarget, 0, 0, 232));
+                PTarget->loc.zone->PushPacket(PTarget, CHAR_INRANGE, std::make_unique<CMessageBasicPacket>(PTarget, PTarget, 0, 0, 232));
             }
         }
 

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4635,7 +4635,7 @@ namespace battleutils
             if (PChar)
             {
                 charutils::BuildingCharAbilityTable(PChar);
-                memset(&PChar->m_PetCommands, 0, sizeof(PChar->m_PetCommands));
+                std::memset(&PChar->m_PetCommands, 0, sizeof(PChar->m_PetCommands));
                 PChar->pushPacket<CCharAbilitiesPacket>(PChar);
                 PChar->pushPacket<CCharUpdatePacket>(PChar);
                 PChar->pushPacket<CPetSyncPacket>(PChar);

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -4781,7 +4781,7 @@ namespace charutils
             // Add capacity points
             if (PChar->PJobPoints->AddCapacityPoints(capacityPoints))
             {
-                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CMessageCombatPacket(PChar, PMob, PChar->PJobPoints->GetJobPoints(), 0, 719));
+                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, std::make_unique<CMessageCombatPacket>(PChar, PMob, PChar->PJobPoints->GetJobPoints(), 0, 719));
             }
             PChar->pushPacket<CMenuJobPointsPacket>(PChar);
 
@@ -4897,7 +4897,7 @@ namespace charutils
                     PChar->PParty->ReloadParty();
                 }
 
-                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CMessageCombatPacket(PChar, PChar, PChar->jobs.job[PChar->GetMJob()], 0, 11));
+                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, std::make_unique<CMessageCombatPacket>(PChar, PChar, PChar->jobs.job[PChar->GetMJob()], 0, 11));
                 luautils::OnPlayerLevelDown(PChar);
                 PChar->updatemask |= UPDATE_HP;
             }
@@ -4997,7 +4997,7 @@ namespace charutils
             // add limit points
             if (PChar->PMeritPoints->AddLimitPoints(exp))
             {
-                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CMessageCombatPacket(PChar, PMob, PChar->PMeritPoints->GetMeritPoints(), 0, 50));
+                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, std::make_unique<CMessageCombatPacket>(PChar, PMob, PChar->PMeritPoints->GetMeritPoints(), 0, 50));
             }
         }
         else
@@ -5116,7 +5116,7 @@ namespace charutils
                 PChar->pushPacket<CCharJobExtraPacket>(PChar, true);
                 PChar->pushPacket<CCharSyncPacket>(PChar);
 
-                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CMessageCombatPacket(PChar, PMob, PChar->jobs.job[PChar->GetMJob()], 0, 9));
+                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, std::make_unique<CMessageCombatPacket>(PChar, PMob, PChar->jobs.job[PChar->GetMJob()], 0, 9));
                 PChar->pushPacket<CCharStatsPacket>(PChar);
 
                 luautils::OnPlayerLevelUp(PChar);

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -2221,7 +2221,7 @@ namespace charutils
                 auto* PItem          = PChar->getEquip((SLOTTYPE)i);
                 PChar->styleItems[i] = (PItem == nullptr) ? 0 : PItem->getID();
             }
-            memcpy(&PChar->mainlook, &PChar->look, sizeof(PChar->look));
+            std::memcpy(&PChar->mainlook, &PChar->look, sizeof(PChar->look));
         }
         else
         {
@@ -2919,7 +2919,7 @@ namespace charutils
 
     void BuildingCharWeaponSkills(CCharEntity* PChar)
     {
-        memset(&PChar->m_WeaponSkills, 0, sizeof(PChar->m_WeaponSkills));
+        std::memset(&PChar->m_WeaponSkills, 0, sizeof(PChar->m_WeaponSkills));
 
         CItemWeapon* PItem        = nullptr;
         int          main_ws      = 0;
@@ -2981,7 +2981,7 @@ namespace charutils
             return;
         }
 
-        memset(&PChar->m_PetCommands, 0, sizeof(PChar->m_PetCommands));
+        std::memset(&PChar->m_PetCommands, 0, sizeof(PChar->m_PetCommands));
 
         if (PetID == 0)
         { // technically Fire Spirit but we're using this to null the abilities shown
@@ -3374,7 +3374,7 @@ namespace charutils
             PChar->delModifier(PTrait->getMod(), PTrait->getValue());
         }
         PChar->TraitList.clear();
-        memset(&PChar->m_TraitList, 0, sizeof(PChar->m_TraitList));
+        std::memset(&PChar->m_TraitList, 0, sizeof(PChar->m_TraitList));
 
         auto mjob = PChar->GetMJob();
         auto sjob = PChar->GetSJob();

--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -73,7 +73,7 @@ namespace fishingutils
     std::map<uint16, std::map<uint32, uint16>>        FishingGroups;         // groupid, fishid, rarity
     std::map<uint16, std::map<uint32, uint8>>         FishingBaitAffinities; // baitid, fishid, power
 
-    uint32 HandleFishingAction(CCharEntity* PChar, CBasicPacket data)
+    uint32 HandleFishingAction(CCharEntity* PChar, CBasicPacket& data)
     {
         uint16 stamina = data.ref<uint16>(0x08);
         uint8  action  = data.ref<uint8>(0x0E);
@@ -2965,7 +2965,7 @@ namespace fishingutils
 
                     for (int i = 0; i < fishingArea->numBounds; i++)
                     {
-                        memcpy((void*)&fishingArea->areaBounds[i], &bounds[i * sizeof(areavector_t)], sizeof(areavector_t));
+                        std::memcpy((void*)&fishingArea->areaBounds[i], &bounds[i * sizeof(areavector_t)], sizeof(areavector_t));
                     }
                 }
                 else
@@ -3061,7 +3061,7 @@ namespace fishingutils
                     for (int i = 0; i < numFish; i++)
                     {
                         uint16 fishid = 0;
-                        memcpy(&fishid, &reqFish[i * sizeof(uint16)], sizeof(uint16));
+                        std::memcpy(&fishid, &reqFish[i * sizeof(uint16)], sizeof(uint16));
                         fish->reqFish->emplace_back(fishid);
                     }
                 }

--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -1518,18 +1518,18 @@ namespace fishingutils
 
             if (Count > 1)
             {
-                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CCaughtFishPacket(PChar, FishID, MessageOffset + FISHMESSAGEOFFSET_CATCH_MULTI, Count));
+                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, std::make_unique<CCaughtFishPacket>(PChar, FishID, MessageOffset + FISHMESSAGEOFFSET_CATCH_MULTI, Count));
             }
             else
             {
-                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CCaughtFishPacket(PChar, FishID, MessageOffset + FISHMESSAGEOFFSET_CATCH, Count));
+                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, std::make_unique<CCaughtFishPacket>(PChar, FishID, MessageOffset + FISHMESSAGEOFFSET_CATCH, Count));
             }
 
             return 1;
         }
         else
         {
-            PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CCaughtFishPacket(PChar, FishID, MessageOffset + FISHMESSAGEOFFSET_CATCH_INV_FULL, Count));
+            PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, std::make_unique<CCaughtFishPacket>(PChar, FishID, MessageOffset + FISHMESSAGEOFFSET_CATCH_INV_FULL, Count));
         }
 
         return 0;
@@ -1558,18 +1558,18 @@ namespace fishingutils
 
             if (Count > 1)
             {
-                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CCaughtFishPacket(PChar, ItemID, MessageOffset + FISHMESSAGEOFFSET_CATCH_MULTI, Count));
+                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, std::make_unique<CCaughtFishPacket>(PChar, ItemID, MessageOffset + FISHMESSAGEOFFSET_CATCH_MULTI, Count));
             }
             else
             {
-                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CCaughtFishPacket(PChar, ItemID, MessageOffset + FISHMESSAGEOFFSET_CATCH, Count));
+                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, std::make_unique<CCaughtFishPacket>(PChar, ItemID, MessageOffset + FISHMESSAGEOFFSET_CATCH, Count));
             }
 
             return 1;
         }
         else
         {
-            PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CCaughtFishPacket(PChar, ItemID, MessageOffset + FISHMESSAGEOFFSET_CATCH_INV_FULL, Count));
+            PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, std::make_unique<CCaughtFishPacket>(PChar, ItemID, MessageOffset + FISHMESSAGEOFFSET_CATCH_INV_FULL, Count));
         }
 
         return 0;
@@ -1597,7 +1597,7 @@ namespace fishingutils
 
         PChar->animation = ANIMATION_FISHING_MONSTER;
         PChar->updatemask |= UPDATE_HP;
-        PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CCaughtMonsterPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_MONSTER));
+        PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, std::make_unique<CCaughtMonsterPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_MONSTER));
 
         position_t p = PChar->loc.p;
         position_t m;
@@ -1653,7 +1653,7 @@ namespace fishingutils
 
         PChar->animation = ANIMATION_FISHING_CAUGHT;
         PChar->updatemask |= UPDATE_HP;
-        PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CCaughtMonsterPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_CATCH_CHEST));
+        PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, std::make_unique<CCaughtMonsterPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_CATCH_CHEST));
 
         position_t p = PChar->loc.p;
         position_t m;

--- a/src/map/utils/fishingutils.h
+++ b/src/map/utils/fishingutils.h
@@ -928,7 +928,7 @@ namespace fishingutils
     void   ReduceFishPool(uint16 zoneId, uint8 areaId, uint16 fishId);
     void   RestockFishingAreas();
     void   CreateFishingPools();
-    uint32 HandleFishingAction(CCharEntity* PChar, CBasicPacket data);
+    uint32 HandleFishingAction(CCharEntity* PChar, CBasicPacket& data);
 
     // Calculations
     uint32              GetSundayMidnightTimestamp();

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -718,12 +718,12 @@ namespace mobutils
             }
         }
 
-        PMob->addModifier(Mod::DEF, GetBaseDefEva(PMob, PMob->defRank));                       // Base Defense for all mobs
+        PMob->addModifier(Mod::DEF, GetBaseDefEva(PMob, PMob->defRank));                   // Base Defense for all mobs
         PMob->addModifier(Mod::EVA, GetBaseDefEva(PMob, JobSkillRankToBaseEvaRank(mJob))); // Evasion is based off main job rank. // TODO: add family bonuses (colibri has static evasion+ porrogos have % boost.)
-        PMob->addModifier(Mod::ATT, GetBaseSkill(PMob, PMob->attRank));                        // Base Attack for all mobs is Rank A+ but pull from DB for specific cases
-        PMob->addModifier(Mod::ACC, GetBaseSkill(PMob, PMob->accRank));                        // Base Accuracy for all mobs is Rank A+ but pull from DB for specific cases
-        PMob->addModifier(Mod::RATT, GetBaseSkill(PMob, PMob->attRank));                       // Base Ranged Attack for all mobs is Rank A+ but pull from DB for specific cases
-        PMob->addModifier(Mod::RACC, GetBaseSkill(PMob, PMob->accRank));                       // Base Ranged Accuracy for all mobs is Rank A+ but pull from DB for specific cases
+        PMob->addModifier(Mod::ATT, GetBaseSkill(PMob, PMob->attRank));                    // Base Attack for all mobs is Rank A+ but pull from DB for specific cases
+        PMob->addModifier(Mod::ACC, GetBaseSkill(PMob, PMob->accRank));                    // Base Accuracy for all mobs is Rank A+ but pull from DB for specific cases
+        PMob->addModifier(Mod::RATT, GetBaseSkill(PMob, PMob->attRank));                   // Base Ranged Attack for all mobs is Rank A+ but pull from DB for specific cases
+        PMob->addModifier(Mod::RACC, GetBaseSkill(PMob, PMob->accRank));                   // Base Ranged Accuracy for all mobs is Rank A+ but pull from DB for specific cases
 
         // Known Base Parry for all mobs is Rank C
         // MOBMOD_CAN_PARRY uses the mod value as the rank, unknown if mobs in current retail or somewhere else have a different parry rank
@@ -1866,7 +1866,7 @@ namespace mobutils
         actionTarget_t& target = list.getNewActionTarget();
         target.animation       = animationID;
         target.param           = 2582;
-        PTarget->loc.zone->PushPacket(PTarget, CHAR_INRANGE, new CActionPacket(action));
+        PTarget->loc.zone->PushPacket(PTarget, CHAR_INRANGE, std::make_unique<CActionPacket>(action));
     }
 
 }; // namespace mobutils

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -1585,7 +1585,7 @@ namespace mobutils
                 PMob->m_maxLevel = (uint8)_sql->GetIntData(9);
 
                 uint16 sqlModelID[10];
-                memcpy(&sqlModelID, _sql->GetData(10), 20);
+                std::memcpy(&sqlModelID, _sql->GetData(10), 20);
                 PMob->look = look_t(sqlModelID);
 
                 PMob->SetMJob(_sql->GetIntData(11));
@@ -1747,7 +1747,7 @@ namespace mobutils
                 PMob->m_maxLevel = (uint8)_sql->GetIntData(9);
 
                 uint16 sqlModelID[10];
-                memcpy(&sqlModelID, _sql->GetData(10), 20);
+                std::memcpy(&sqlModelID, _sql->GetData(10), 20);
                 PMob->look = look_t(sqlModelID);
 
                 PMob->SetMJob(_sql->GetIntData(11));

--- a/src/map/utils/moduleutils.cpp
+++ b/src/map/utils/moduleutils.cpp
@@ -98,7 +98,7 @@ namespace moduleutils
         }
     }
 
-    void OnPushPacket(CCharEntity* PChar, CBasicPacket* packet)
+    void OnPushPacket(CCharEntity* PChar, const std::unique_ptr<CBasicPacket>& packet)
     {
         TracyZoneScoped;
         for (auto* module : cppModules())
@@ -172,6 +172,7 @@ namespace moduleutils
 
         // Load zone_settings information
         std::unordered_map<std::string, uint16> zoneSettingsPorts;
+
         auto rset = db::preparedStmt("SELECT name, zoneport FROM zone_settings");
         while (rset && rset->next())
         {

--- a/src/map/utils/moduleutils.h
+++ b/src/map/utils/moduleutils.h
@@ -54,7 +54,7 @@ public:
     virtual void OnTimeServerTick() {};
     virtual void OnCharZoneIn(CCharEntity* PChar) {};
     virtual void OnCharZoneOut(CCharEntity* PChar) {};
-    virtual void OnPushPacket(CCharEntity* PChar, CBasicPacket* packet) {};
+    virtual void OnPushPacket(CCharEntity* PChar, const std::unique_ptr<CBasicPacket>& packet) {};
 
     template <typename T>
     static T* Register()
@@ -79,7 +79,7 @@ namespace moduleutils
     void OnTimeServerTick();
     void OnCharZoneIn(CCharEntity* PChar);
     void OnCharZoneOut(CCharEntity* PChar);
-    void OnPushPacket(CCharEntity* PChar, CBasicPacket* packet);
+    void OnPushPacket(CCharEntity* PChar, const std::unique_ptr<CBasicPacket>& packet);
 
     // The program has two "states":
     // - Load-time: As all data is being loaded and init'd

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -113,7 +113,7 @@ namespace petutils
                 Pet->name.insert(0, (const char*)_sql->GetData(1));
 
                 uint16 sqlModelID[10];
-                memcpy(&sqlModelID, _sql->GetData(2), 20);
+                std::memcpy(&sqlModelID, _sql->GetData(2), 20);
                 Pet->look = look_t(sqlModelID);
 
                 Pet->minLevel  = (uint8)_sql->GetIntData(3);

--- a/src/map/utils/puppetutils.cpp
+++ b/src/map/utils/puppetutils.cpp
@@ -171,12 +171,12 @@ namespace puppetutils
 
             char unlockedAttachmentsEscaped[sizeof(PChar->m_unlockedAttachments) * 2 + 1];
             char unlockedAttachments[sizeof(PChar->m_unlockedAttachments)];
-            memcpy(unlockedAttachments, &PChar->m_unlockedAttachments, sizeof(unlockedAttachments));
+            std::memcpy(unlockedAttachments, &PChar->m_unlockedAttachments, sizeof(unlockedAttachments));
             _sql->EscapeStringLen(unlockedAttachmentsEscaped, unlockedAttachments, sizeof(unlockedAttachments));
 
             char equippedAttachmentsEscaped[sizeof(PChar->PAutomaton->m_Equip) * 2 + 1];
             char equippedAttachments[sizeof(PChar->PAutomaton->m_Equip)];
-            memcpy(equippedAttachments, &PChar->PAutomaton->m_Equip, sizeof(equippedAttachments));
+            std::memcpy(equippedAttachments, &PChar->PAutomaton->m_Equip, sizeof(equippedAttachments));
             _sql->EscapeStringLen(equippedAttachmentsEscaped, equippedAttachments, sizeof(equippedAttachments));
 
             _sql->Query(Query, unlockedAttachmentsEscaped, equippedAttachmentsEscaped, PChar->id);
@@ -189,7 +189,7 @@ namespace puppetutils
 
             char unlockedAttachmentsEscaped[sizeof(PChar->m_unlockedAttachments) * 2 + 1];
             char unlockedAttachments[sizeof(PChar->m_unlockedAttachments)];
-            memcpy(unlockedAttachments, &PChar->m_unlockedAttachments, sizeof(unlockedAttachments));
+            std::memcpy(unlockedAttachments, &PChar->m_unlockedAttachments, sizeof(unlockedAttachments));
             _sql->EscapeStringLen(unlockedAttachmentsEscaped, unlockedAttachments, sizeof(unlockedAttachments));
 
             _sql->Query(Query, unlockedAttachmentsEscaped, PChar->id);

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -777,7 +777,7 @@ namespace synthutils
             currentZone != ZONE_49 &&
             currentZone < MAX_ZONEID)
         {
-            PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, new CSynthResultMessagePacket(PChar, SYNTH_FAIL));
+            PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, std::make_unique<CSynthResultMessagePacket>(PChar, SYNTH_FAIL));
         }
 
         PChar->pushPacket<CSynthMessagePacket>(PChar, SYNTH_FAIL, 29695);
@@ -910,7 +910,7 @@ namespace synthutils
 
         if (PChar->loc.zone->GetID() != 255 && PChar->loc.zone->GetID() != 0)
         {
-            PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CSynthAnimationPacket(PChar, effect, result));
+            PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, std::make_unique<CSynthAnimationPacket>(PChar, effect, result));
         }
         else
         {
@@ -1025,7 +1025,7 @@ namespace synthutils
             PChar->pushPacket<CInventoryFinishPacket>();
             if (PChar->loc.zone->GetID() != 255 && PChar->loc.zone->GetID() != 0)
             {
-                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, new CSynthResultMessagePacket(PChar, SYNTH_SUCCESS, itemID, quantity));
+                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, std::make_unique<CSynthResultMessagePacket>(PChar, SYNTH_SUCCESS, itemID, quantity));
                 PChar->pushPacket<CSynthMessagePacket>(PChar, SYNTH_SUCCESS, itemID, quantity);
             }
             else

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -1009,7 +1009,7 @@ namespace synthutils
                 {
                     char encodedSignature[SignatureStringLength];
 
-                    memset(&encodedSignature, 0, sizeof(encodedSignature));
+                    std::memset(&encodedSignature, 0, sizeof(encodedSignature));
                     PItem->setSignature(EncodeStringSignature(PChar->name.c_str(), encodedSignature));
 
                     char signature_esc[31]; // max charname: 15 chars * 2 + 1

--- a/src/map/utils/trustutils.cpp
+++ b/src/map/utils/trustutils.cpp
@@ -281,7 +281,7 @@ namespace trustutils
                 trust->packet_name.insert(0, (const char*)_sql->GetData(2));
 
                 uint16 sqlModelID[10];
-                memcpy(&sqlModelID, _sql->GetData(3), 20);
+                std::memcpy(&sqlModelID, _sql->GetData(3), 20);
                 trust->look = look_t(sqlModelID);
 
                 trust->m_Family       = (uint16)_sql->GetIntData(4);

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -470,7 +470,7 @@ namespace zoneutils
                                 PMob->m_maxLevel = (uint8)sql->GetIntData(13);
 
                                 uint16 sqlModelID[10];
-                                memcpy(&sqlModelID, sql->GetData(14), 20);
+                                std::memcpy(&sqlModelID, sql->GetData(14), 20);
                                 PMob->look = look_t(sqlModelID);
 
                                 PMob->SetMJob(sql->GetIntData(15));

--- a/src/map/weapon_skill.cpp
+++ b/src/map/weapon_skill.cpp
@@ -26,7 +26,7 @@ CWeaponSkill::CWeaponSkill(uint16 id)
 : m_ID(id)
 , m_TypeID(0)
 {
-    memset(m_Job, 0, sizeof(m_Job));
+    std::memset(m_Job, 0, sizeof(m_Job));
     m_Skilllevel          = 0;
     m_AnimationId         = 0;
     m_Element             = 0;
@@ -71,7 +71,7 @@ void CWeaponSkill::setUnlockId(uint8 id)
 
 void CWeaponSkill::setJob(int8* jobs)
 {
-    memcpy(&m_Job[1], jobs, 22);
+    std::memcpy(&m_Job[1], jobs, 22);
 }
 
 void CWeaponSkill::setSkillLevel(uint16 level)

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -646,7 +646,7 @@ void CZone::SetWeather(WEATHER weather)
     m_Weather           = weather;
     m_WeatherChangeTime = CVanaTime::getInstance()->getVanaTime();
 
-    m_zoneEntities->PushPacket(nullptr, CHAR_INZONE, new CWeatherPacket(m_WeatherChangeTime, m_Weather, xirand::GetRandomNumber(4, 28)));
+    m_zoneEntities->PushPacket(nullptr, CHAR_INZONE, std::make_unique<CWeatherPacket>(m_WeatherChangeTime, m_Weather, xirand::GetRandomNumber(4, 28)));
 }
 
 void CZone::UpdateWeather()
@@ -898,7 +898,7 @@ CCharEntity* CZone::GetCharByID(uint32 id)
     return m_zoneEntities->GetCharByID(id);
 }
 
-void CZone::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message_type, CBasicPacket* packet)
+void CZone::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message_type, const std::unique_ptr<CBasicPacket>& packet)
 {
     TracyZoneScoped;
     m_zoneEntities->PushPacket(PEntity, message_type, packet);

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -479,7 +479,7 @@ void CZone::LoadNavMesh()
     }
 
     char file[255];
-    memset(file, 0, sizeof(file));
+    std::memset(file, 0, sizeof(file));
     snprintf(file, sizeof(file), "navmeshes/%s.nav", getName().c_str());
 
     if (!m_navMesh->load(file))

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -497,7 +497,7 @@ struct zoneWeather_t
     zoneWeather_t(uint8 _normal, uint8 _common, uint8 _rare)
     : normal(_normal)
     , common(_common)
-    , rare(_rare) {};
+    , rare(_rare){};
 };
 
 /************************************************************************
@@ -610,7 +610,7 @@ public:
     void InsertTriggerArea(CTriggerArea* triggerArea);
 
     virtual void TOTDChange(TIMETYPE TOTD);
-    virtual void PushPacket(CBaseEntity*, GLOBAL_MESSAGE_TYPE, CBasicPacket*);
+    virtual void PushPacket(CBaseEntity*, GLOBAL_MESSAGE_TYPE, const std::unique_ptr<CBasicPacket>&);
 
     virtual void UpdateCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint8 updatemask);
     virtual void UpdateEntityPacket(CBaseEntity* PEntity, ENTITYUPDATE type, uint8 updatemask, bool alwaysInclude = false);

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -1271,7 +1271,7 @@ void CZoneEntities::UpdateEntityPacket(CBaseEntity* PEntity, ENTITYUPDATE type, 
     }
 }
 
-void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message_type, CBasicPacket* packet)
+void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message_type, const std::unique_ptr<CBasicPacket>& packet)
 {
     TracyZoneScoped;
     TracyZoneHex16(packet->getType());
@@ -1287,7 +1287,6 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
         // Ensure this packet is not despawning us..
         if (packet->ref<uint8>(0x0A) != 0x20)
         {
-            destroy(packet);
             return;
         }
     }
@@ -1434,7 +1433,6 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
         }
         // clang-format on
     }
-    destroy(packet);
 }
 
 void CZoneEntities::WideScan(CCharEntity* PChar, uint16 radius)

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -1301,7 +1301,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
                 TracyZoneCString("CHAR_INRANGE_SELF");
                 if (auto* PChar = dynamic_cast<CCharEntity*>(PEntity))
                 {
-                    PChar->pushPacket<CBasicPacket>(*packet);
+                    PChar->pushPacket(packet->copy());
                 }
             }
             [[fallthrough]];
@@ -1362,7 +1362,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
                                     SpawnIDList_t::const_iterator iter = spawnlist.lower_bound(id);
                                     if (!(iter == spawnlist.end() || spawnlist.key_comp()(id, iter->first)))
                                     {
-                                        PCurrentChar->pushPacket<CBasicPacket>(*packet);
+                                        PCurrentChar->pushPacket(packet->copy());
                                     }
                                 };
 
@@ -1389,7 +1389,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
                             }
                             else
                             {
-                                PCurrentChar->pushPacket<CBasicPacket>(*packet);
+                                PCurrentChar->pushPacket(packet->copy());
                             }
                         }
                     }
@@ -1407,7 +1407,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
                         if (distance(PEntity->loc.p, PCurrentChar->loc.p) < 180 &&
                             ((PEntity->objtype != TYPE_PC) || (((CCharEntity*)PEntity)->m_moghouseID == PCurrentChar->m_moghouseID)))
                         {
-                            PCurrentChar->pushPacket<CBasicPacket>(*packet);
+                            PCurrentChar->pushPacket(packet->copy());
                         }
                     }
                 }
@@ -1424,7 +1424,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
                     {
                         if (PEntity != PCurrentChar)
                         {
-                            PCurrentChar->pushPacket<CBasicPacket>(*packet);
+                            PCurrentChar->pushPacket(packet->copy());
                         }
                     }
                 }

--- a/src/map/zone_entities.h
+++ b/src/map/zone_entities.h
@@ -69,7 +69,7 @@ public:
     void WeatherChange(WEATHER weather);
     void MusicChange(uint16 BlockID, uint16 MusicTrackID);
 
-    void PushPacket(CBaseEntity*, GLOBAL_MESSAGE_TYPE, CBasicPacket*); // send a global package within the zone
+    void PushPacket(CBaseEntity*, GLOBAL_MESSAGE_TYPE, const std::unique_ptr<CBasicPacket>&); // send a global package within the zone
 
     void ZoneServer(time_point tick);
 

--- a/src/map/zone_instance.cpp
+++ b/src/map/zone_instance.cpp
@@ -350,7 +350,7 @@ void CZoneInstance::TOTDChange(TIMETYPE TOTD)
     }
 }
 
-void CZoneInstance::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message_type, CBasicPacket* packet)
+void CZoneInstance::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message_type, const std::unique_ptr<CBasicPacket>& packet)
 {
     TracyZoneScoped;
     if (PEntity)

--- a/src/map/zone_instance.h
+++ b/src/map/zone_instance.h
@@ -57,8 +57,8 @@ public:
     virtual void FindPartyForMob(CBaseEntity* PEntity) override;         // looking for a party for the monster
     virtual void TransportDepart(uint16 boundary, uint16 zone) override; // ship/boat is leaving, passengers need to be collected
 
-    virtual void TOTDChange(TIMETYPE TOTD) override;                                    // process the world's reactions to changing time of day
-    virtual void PushPacket(CBaseEntity*, GLOBAL_MESSAGE_TYPE, CBasicPacket*) override; // send a global package within the zone
+    virtual void TOTDChange(TIMETYPE TOTD) override;                                                           // process the world's reactions to changing time of day
+    virtual void PushPacket(CBaseEntity*, GLOBAL_MESSAGE_TYPE, const std::unique_ptr<CBasicPacket>&) override; // send a global package within the zone
 
     virtual void UpdateCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint8 updatemask) override;
     virtual void UpdateEntityPacket(CBaseEntity* PEntity, ENTITYUPDATE type, uint8 updatemask, bool alwaysInclude = false) override;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes #6545

After looking here: I realised how easy it still is to leak packets: https://github.com/LandSandBoat/server/pull/6711

A big step towards: https://github.com/LandSandBoat/server/issues/5171

The scope of this blew up, as always. Now, `CBasicPacket` is ONLY a wrapper around `std::array<uint8, PACKET_SIZE> buffer_;`. It doesn't do non-owning, I've audited how they're constructed, etc. We also now NEVER `new` a packet - it's always constructed as a `unique_ptr`, and we are careful to pass around references or move them as needed. This also means that we have to be obvious when we wither `std::move()` or `->copy()` packets in places.

But now, there's no question about what happens where - we can see what our data is doing.

**Testing**

- [x] Log in
- [x] /wave
- [x] Zone into {Dynamis - Bastok}
- [x] Spells -> targeting failure
- [x] RA -> targeting failure
- [x] Action packet
- [x] Mounts
- [x] Chocobo raising menu
- [x] Train everything around
- [x] Crafting
- [x] Interacting with NPCs
- [x] Moghouse
- [x] Party
- [x] Trusts
- [x] Linkshell
- [x] IPC/ZMQ
- [x] Tell/Party/Shout/Yell
- [x] Events with updates (BCNM entry, Instance entry)
- [x] BCNMs
- [x] Instances
- [x] Trading
- [x] AH
- [x] Monstrosity
