### PR TITLE
[Magic] Add BRD merit and job point macc steps to magic-hit-rate

### DIFF
--- a/scripts/globals/combat/magic_hit_rate.lua
+++ b/scripts/globals/combat/magic_hit_rate.lua
@@ -173,6 +173,15 @@ local function magicAccuracyFromMerits(actor, skillType, actionElement)
             magicAcc = magicAcc + actor:getMerit(xi.merit.MAGIC_ACCURACY)
         end,
 
+        [xi.job.BRD] = function()
+            if
+                skillType == xi.skill.SINGING and
+                actor:hasStatusEffect(xi.effect.TROUBADOUR)
+            then
+                magicAcc = 64 * (actor:getMerit(xi.merit.TROUBADOUR) / 25 - 1)
+            end
+        end,
+
         [xi.job.NIN] = function()
             if skillType == xi.skill.NINJUTSU then
                 magicAcc = actor:getMerit(xi.merit.NIN_MAGIC_ACCURACY)
@@ -215,6 +224,12 @@ local function magicAccuracyFromJobPoints(actor, spellGroup, skillType)
 
             -- RDM Job Point: Magic Accuracy Bonus, All MACC + 1
             magicAcc = magicAcc + actor:getJobPointLevel(xi.jp.RDM_MAGIC_ACC_BONUS)
+        end,
+
+        [xi.job.BRD] = function()
+            if skillType == xi.skill.SINGING then
+                magicAcc = actor:getJobPointLevel(xi.jp.SONG_ACC_BONUS)
+            end
         end,
 
         [xi.job.NIN] = function()


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

As title sais.
- If a song uses the magic hit rate function, it will account for job points alocated to song MACC
- If a song uses the magic hit rate function when caster is under the effect of troubadour, it will receive bonus MACC based on merits, over the first, alocated to troubadour.

## Steps to test these changes

None.
