### PR TITLE
Fix SoA 1-3 post-cutscene position

### DIFF
--- a/scripts/globals/waypoint.lua
+++ b/scripts/globals/waypoint.lua
@@ -343,7 +343,11 @@ end
 
 xi.waypoint.onEventFinish = function(player, csid, option, npc)
     if option > 0 and option <= 303 then
-        player:setPos(unpack(waypointInfo[option][4]))
+        if player:getCurrentMission(xi.mission.log_id.SOA) == xi.mission.id.soa.ONWARD_TO_ADOULIN then
+            player:setPos(169.638, 0.491, -27.128, 207, xi.zone.CEIZAK_BATTLEGROUNDS)
+        else
+            player:setPos(unpack(waypointInfo[option][4]))
+        end
     elseif option == 1000 then
         -- Decline Confirmation (Default Off)
         player:setTeleportMenu(xi.teleport.type.WAYPOINT, true)

--- a/scripts/missions/soa/1_3_Onward_to_Adoulin.lua
+++ b/scripts/missions/soa/1_3_Onward_to_Adoulin.lua
@@ -35,7 +35,6 @@ mission.sections =
                 [10120] = function(player, csid, option, npc)
                     if option == 1 then
                         player:setMissionStatus(mission.areaId, 1)
-                        player:setPos(172, 0.3, -21, 211, xi.zone.CEIZAK_BATTLEGROUNDS)
                     end
                 end,
             },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. --> 
Currently after doing the Seekers of Adoulin mission 1-3 cutscene your character will appear inside the wall/under the map because it's ignoring the `setpos` in the mission lua file and instead using the pos from the `waypoint.lua` global.

The pos xyz coords I used were taken from this capture video:
https://www.youtube.com/watch?v=KydZTu0PT2Q

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Need a character that has 0 progress on Seekers of Adoulin missions
`!gotoid 17780960`
`!addmission 12 3`
`!addkeyitem geomagnetron`
`!addkeyitem adoulinian_charter_permit`
Click on the waypoint.
Press Yes in the menu.
After cutscene see that you appear in the correct location and not under the map/inside the wall.
Waypoints all work as normal.
