### PR TITLE
[core] Use byte instead of char in PrintPacket

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -196,7 +196,8 @@ void PrintPacket(CBasicPacket& packet)
 
     for (std::size_t idx = 0U; idx < packet.getSize(); idx++)
     {
-        message.append(fmt::format("{:02x} ", (char*)packet[idx]));
+        uint8 byte = *packet[idx];
+        message.append(fmt::format("{:02x} ", byte));
 
         if (((idx + 1U) % 16U) == 0U)
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This fixes a crash where fmt was expecting a number but didn't get one

possibly related to #6725 

## Steps to test these changes

I produced this by using provoke on a mob which uses PrintPacket to show the packet (for some reason or another)
