### PR TITLE
[core] Add CState::HasErrorMsg safety

### DIFF
--- a/src/map/ai/states/state.cpp
+++ b/src/map/ai/states/state.cpp
@@ -81,7 +81,14 @@ bool CState::HasErrorMsg() const
 
 auto CState::GetErrorMsg() -> std::unique_ptr<CBasicPacket>
 {
-    return m_errorMsg->copy();
+    if (HasErrorMsg())
+    {
+        return m_errorMsg->copy();
+    }
+
+    ShowError("State attempted to get error message when error message was null");
+
+    return std::unique_ptr<CBasicPacket>();
 }
 
 bool CState::DoUpdate(time_point tick)

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1382,11 +1382,14 @@ void CCharEntity::OnCastInterrupted(CMagicState& state, action_t& action, MSGBAS
     TracyZoneScoped;
     CBattleEntity::OnCastInterrupted(state, action, msg, blockedCast);
 
-    auto message = state.GetErrorMsg();
-
-    if (message && action.actiontype != ACTION_MAGIC_INTERRUPT) // Interrupt is handled elsewhere
+    if (state.HasErrorMsg())
     {
-        pushPacket(std::move(message));
+        auto message = state.GetErrorMsg();
+
+        if (message && action.actiontype != ACTION_MAGIC_INTERRUPT) // Interrupt is handled elsewhere
+        {
+            pushPacket(std::move(message));
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes #6729 
Check if state has an error message before emitting a message on cast interrupt
Also show an error if attempting to get a null error mesage

## Steps to test these changes

See #6729 
