### PR TITLE
Moghouse: Add support for Orchestrion, Spinet, and other music furniture

### DIFF
--- a/scripts/globals/moghouse.lua
+++ b/scripts/globals/moghouse.lua
@@ -107,6 +107,67 @@ xi.moghouse.set2ndFloorStyle = function(player, style)
     player:setMoghouseFlag(mhflag)
 end
 
+xi.moghouse.getAvailableMusic = function(player)
+    -- See documentation/songdata.txt or documentation/MusicIDs.txt for song data.
+    local possibleSongs = {}
+
+    local orchestrion  = player:findItem(xi.item.ORCHESTRION)
+    local spinet       = player:findItem(xi.item.SPINET)
+    local nanaaStatue1 = player:findItem(xi.item.NANAA_MIHGO_STATUE)
+    local nanaaStatue2 = player:findItem(xi.item.NANAA_MIHGO_STATUE_II)
+
+    local hasOrchestrion  = orchestrion and orchestrion:isInstalled()
+    local hasSpinet       = spinet and spinet:isInstalled()
+    local hasNanaaStatue1 = nanaaStatue1 and nanaaStatue1:isInstalled()
+    local hasNanaaStatue2 = nanaaStatue2 and nanaaStatue2:isInstalled()
+
+    -- NOTE: Since Spinet, Nanaa Mihgo Statue I, and Nanaa Mihgo Statue II are promotional-only items,
+    --     : it is extremely difficult to get them and test what they do when used together.
+    --     : We're completely guessing how they interact with each other.
+    --     : TODO: Do these overwrite eachother in some way, or do they work together (as we've implemented
+    --     : them here)?
+    if not hasOrchestrion then
+        -- https://www.bg-wiki.com/ffxi/Orchestrion
+        if hasSpinet then
+            table.insert(possibleSongs, 112) -- Selbina
+            table.insert(possibleSongs, 196) -- Fighters of the Crystal
+            table.insert(possibleSongs, 230) -- A New Horizon
+            table.insert(possibleSongs, 187) -- Ragnarok
+            table.insert(possibleSongs, 215) -- Clash of Standards
+            table.insert(possibleSongs, 47)  -- Echoes of Creation
+            table.insert(possibleSongs, 49)  -- Luck of the Mog
+            table.insert(possibleSongs, 50)  -- Feast of the Ladies
+            table.insert(possibleSongs, 51)  -- Abyssea
+            table.insert(possibleSongs, 52)  -- Melodies Errant
+            table.insert(possibleSongs, 109) -- Ronfaure
+            table.insert(possibleSongs, 251) -- Autumn Footfalls
+            table.insert(possibleSongs, 48)  -- Main Theme
+            table.insert(possibleSongs, 126) -- Mog House
+        end
+
+        if hasNanaaStatue1 then
+            table.insert(possibleSongs, 69) -- Distant Worlds (Nanaa Mihgo's Version)
+        end
+
+        if hasNanaaStatue2 then
+            table.insert(possibleSongs, 59) -- The Pioneers (Nanaa Mihgo's Version)
+        end
+    end
+
+    return possibleSongs
+end
+
+xi.moghouse.trySetMusic = function(player)
+    local possibleSongs = xi.moghouse.getAvailableMusic(player)
+
+    if #possibleSongs > 0 then
+        -- This needs a moment before music changes can take effect
+        player:timer(1000, function(playerArg)
+            playerArg:changeMusic(6, utils.randomEntry(possibleSongs))
+        end)
+    end
+end
+
 xi.moghouse.onMoghouseZoneIn = function(player, prevZone)
     local cs = -1
 
@@ -154,6 +215,8 @@ xi.moghouse.onMoghouseZoneIn = function(player, prevZone)
         local nation = player:getNation()
         xi.moghouse.set2ndFloorStyle(player, nation)
     end
+
+    xi.moghouse.trySetMusic(player)
 
     return cs
 end

--- a/scripts/globals/symphonic_curator.lua
+++ b/scripts/globals/symphonic_curator.lua
@@ -3,10 +3,7 @@
 -----------------------------------
 require('scripts/globals/utils')
 -----------------------------------
--- See documentation/songdata.txt for extracted table of data.
--- NOTE: You can force the Symphonic Curator menu by swapping the moogle global calls for
---     : Moogle in a MH zone with the symphonic_curator global calls and interacting
---     : with the MH moogle.
+-- See documentation/songdata.txt or documentation/MusicIDs.txt for song data.
 -----------------------------------
 
 xi = xi or {}
@@ -57,12 +54,12 @@ xi.symphonic_curator.onTrigger = function(player, npc)
 
     -- 0000 = all instruments shown
     -- 1111 = all instruments hidden
-    local instrumentsAvailable = 0xFF
+    local instrumentsAvailable = 0x0F
 
-    local orchestrion  = player:findItem(426)
-    local spinet       = player:findItem(3677)
-    local nanaaStatue1 = player:findItem(286)
-    local nanaaStatue2 = player:findItem(287)
+    local orchestrion  = player:findItem(xi.item.ORCHESTRION)
+    local spinet       = player:findItem(xi.item.SPINET)
+    local nanaaStatue1 = player:findItem(xi.item.NANAA_MIHGO_STATUE)
+    local nanaaStatue2 = player:findItem(xi.item.NANAA_MIHGO_STATUE_II)
 
     local hasOrchestrion  = orchestrion and orchestrion:isInstalled()
     local hasSpinet       = spinet and spinet:isInstalled()

--- a/src/map/items/item_furnishing.cpp
+++ b/src/map/items/item_furnishing.cpp
@@ -180,7 +180,7 @@ bool CItemFurnishing::getOn2ndFloor()
 
 bool CItemFurnishing::isGardeningPot()
 {
-    auto id = CItem::getID();
+    const auto id = CItem::getID();
     return id == 216 ||  // porcelain_flowerpot
            id == 217 ||  // brass_flowerpot
            id == 218 ||  // earthen_flowerpot

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -668,7 +668,7 @@ void SmallPacket0x016(map_session_data_t* const PSession, CCharEntity* const PCh
                 PEntity->loc.p.z == 1.5 &&
                 PEntity->look.face == 0x52)
             {
-                // Using the same logic as in ZoneEntities::SpawnMoogle:
+                // Using the same logic as in ZoneEntities::SpawnConditionalNPCs:
                 // Change the status of the entity, send the packet, change it back to disappear
                 PEntity->status = STATUS_TYPE::NORMAL;
                 PChar->updateEntityPacket(PEntity, ENTITY_SPAWN, UPDATE_ALL_MOB);
@@ -1076,9 +1076,9 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
         break;
         case 0x14: // complete character update
         {
-            if (PChar->m_moghouseID != 0)
+            if (PChar->m_moghouseID != 0) // TODO: For now this is only in the moghouse
             {
-                PChar->loc.zone->SpawnMoogle(PChar);
+                PChar->loc.zone->SpawnConditionalNPCs(PChar);
             }
             else
             {
@@ -7150,6 +7150,8 @@ void SmallPacket0x0FA(map_session_data_t* const PSession, CCharEntity* const PCh
             PChar->pushPacket<CInventorySizePacket>(PChar);
 
             luautils::OnFurniturePlaced(PChar, PItem);
+
+            PChar->loc.zone->SpawnConditionalNPCs(PChar);
         }
         PChar->pushPacket<CInventoryItemPacket>(PItem, containerID, slotID);
         PChar->pushPacket<CInventoryFinishPacket>();
@@ -7246,6 +7248,8 @@ void SmallPacket0x0FB(map_session_data_t* const PSession, CCharEntity* const PCh
                 PChar->pushPacket<CInventorySizePacket>(PChar);
 
                 luautils::OnFurnitureRemoved(PChar, PItem);
+
+                PChar->loc.zone->SpawnConditionalNPCs(PChar);
             }
             PChar->pushPacket<CInventoryItemPacket>(PItem, containerID, PItem->getSlotID());
             PChar->pushPacket<CInventoryFinishPacket>();

--- a/src/map/packets/zone_in.cpp
+++ b/src/map/packets/zone_in.cpp
@@ -162,11 +162,11 @@ uint16 GetMogHouseModelID(CCharEntity* PChar)
         case REGION_TYPE::SARUTA_FRONT:
             return 219;
         case REGION_TYPE::SANDORIA:
-            return PChar->profile.nation == 0 ? 0x0121 : 0x0101;
+            return PChar->profile.nation == NATION_SANDORIA ? 0x0121 : 0x0101;
         case REGION_TYPE::BASTOK:
-            return PChar->profile.nation == 1 ? 0x0122 : 0x0102;
+            return PChar->profile.nation == NATION_BASTOK ? 0x0122 : 0x0102;
         case REGION_TYPE::WINDURST:
-            return PChar->profile.nation == 2 ? 0x0123 : 0x0120;
+            return PChar->profile.nation == NATION_WINDURST ? 0x0123 : 0x0120;
         case REGION_TYPE::JEUNO:
             return 0x0100;
         case REGION_TYPE::ADOULIN_ISLANDS:

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -7301,4 +7301,25 @@ namespace charutils
         PChar->status = STATUS_TYPE::DISAPPEAR;
     }
 
+    bool isOrchestrionPlaced(CCharEntity* PChar)
+    {
+        for (auto safeContainerId : { LOC_MOGSAFE, LOC_MOGSAFE2 })
+        {
+            CItemContainer* PContainer = PChar->getStorage(safeContainerId);
+            for (int slotIndex = 1; slotIndex <= PContainer->GetSize(); ++slotIndex)
+            {
+                CItem* PContainerItem = PContainer->GetItem(slotIndex);
+                if (PContainerItem != nullptr && PContainerItem->isType(ITEM_FURNISHING))
+                {
+                    CItemFurnishing* PFurniture = static_cast<CItemFurnishing*>(PContainerItem);
+                    if (PFurniture->isInstalled() && PFurniture->getID() == 426)
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
 }; // namespace charutils

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -283,6 +283,8 @@ namespace charutils
     void forceSynthCritFail(const std::string& sourceFunction, CCharEntity* PChar);
 
     void removeCharFromZone(CCharEntity* PChar);
+
+    bool isOrchestrionPlaced(CCharEntity* PChar);
 }; // namespace charutils
 
 #endif // _CHARUTILS_H

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -844,13 +844,13 @@ void CZone::SpawnPCs(CCharEntity* PChar)
 
 /************************************************************************
  *                                                                       *
- *  Displaying Moogle in MogHouse                                        *
+ *  Displaying Moogle in MogHouse, etc.                                  *
  *                                                                       *
  ************************************************************************/
 
-void CZone::SpawnMoogle(CCharEntity* PChar)
+void CZone::SpawnConditionalNPCs(CCharEntity* PChar)
 {
-    m_zoneEntities->SpawnMoogle(PChar);
+    m_zoneEntities->SpawnConditionalNPCs(PChar);
 }
 
 /************************************************************************

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -586,8 +586,8 @@ public:
     virtual void SpawnPETs(CCharEntity* PChar);
     virtual void SpawnNPCs(CCharEntity* PChar);
     virtual void SpawnTRUSTs(CCharEntity* PChar);
-    virtual void SpawnMoogle(CCharEntity* PChar);    // Spawn Moogle in Moghouse in zone (if applicable)
-    virtual void SpawnTransport(CCharEntity* PChar); // Spawn ships/boats in the zone
+    virtual void SpawnConditionalNPCs(CCharEntity* PChar); // Spawn Moogle in Moghouse in zone (if applicable)
+    virtual void SpawnTransport(CCharEntity* PChar);       // Spawn ships/boats in the zone
     void         SavePlayTime();
 
     virtual void WideScan(CCharEntity* PChar, uint16 radius);

--- a/src/map/zone_entities.h
+++ b/src/map/zone_entities.h
@@ -44,8 +44,8 @@ public:
     void SpawnPETs(CCharEntity* PChar);
     void SpawnNPCs(CCharEntity* PChar);
     void SpawnTRUSTs(CCharEntity* PChar);
-    void SpawnMoogle(CCharEntity* PChar);    // display Moogle in MogHouse in zone
-    void SpawnTransport(CCharEntity* PChar); // display ship/boat in zone
+    void SpawnConditionalNPCs(CCharEntity* PChar); // display Moogle in MogHouse in zone
+    void SpawnTransport(CCharEntity* PChar);       // display ship/boat in zone
     void DespawnPC(CCharEntity* PChar);
     void SavePlayTime();
 

--- a/src/map/zone_instance.cpp
+++ b/src/map/zone_instance.cpp
@@ -323,12 +323,12 @@ void CZoneInstance::SpawnPCs(CCharEntity* PChar)
     }
 }
 
-void CZoneInstance::SpawnMoogle(CCharEntity* PChar)
+void CZoneInstance::SpawnConditionalNPCs(CCharEntity* PChar)
 {
     TracyZoneScoped;
     if (PChar->PInstance)
     {
-        PChar->PInstance->SpawnMoogle(PChar);
+        PChar->PInstance->SpawnConditionalNPCs(PChar);
     }
 }
 

--- a/src/map/zone_instance.h
+++ b/src/map/zone_instance.h
@@ -39,8 +39,8 @@ public:
     virtual void SpawnPETs(CCharEntity* PChar) override;
     virtual void SpawnTRUSTs(CCharEntity* PChar) override;
     virtual void SpawnNPCs(CCharEntity* PChar) override;
-    virtual void SpawnMoogle(CCharEntity* PChar) override;    // display Moogle in MogHouse in zone
-    virtual void SpawnTransport(CCharEntity* PChar) override; // display ship/boat in zone
+    virtual void SpawnConditionalNPCs(CCharEntity* PChar) override; // display Moogle in MogHouse in zone
+    virtual void SpawnTransport(CCharEntity* PChar) override;       // display ship/boat in zone
 
     virtual void WideScan(CCharEntity* PChar, uint16 radius) override;
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This starts to build out the logic for `Zone->SpawnConditionalNPCs()`, which includes the "always on if you're in MH1F Moogle" and "available if you've placed it, Orchestrion".

Fixed/Checked:
- Audited flags for all Symphnic Curators, they're no longer visible in the overworld: `!gotoid 17760411`, etc. (they were before!)
- Retail: Capture Curator in upper-upper-Jeuno -> `It isn't naturally visible, so we don't need-need a capture`
- Retail: Can you use Symphonic Curator in rental MH if it's available at home? -> `No`
- Retail: Is SC available on second floor? -> `Yes`
- Retail: If you remove the Orchestrion, does the SC disappear right away? -> `Yes`
- Retail: SC will appear/disappear as you place/remove the furniture.
- If you have SC placed: That NPC won't be visible in the overworld of the same zone you have your MH in

![image](https://github.com/user-attachments/assets/a4ced28a-65f7-4fbd-af44-998ad9d8822b)
