### PR TITLE
[codeql] Fix bitwise or where logical or should be used

### DIFF
--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -47,7 +47,7 @@ CMobSkillState::CMobSkillState(CBattleEntity* PEntity, uint16 targid, uint16 wsi
 
     auto* PTarget = m_PEntity->IsValidTarget(m_targid, skill->getValidTargets(), m_errorMsg);
 
-    if (!PTarget | this->HasErrorMsg())
+    if (!PTarget || this->HasErrorMsg())
     {
         if (this->HasErrorMsg())
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Changes bitwise or to logical or in CMobSkillState.  bool || bool
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
