### PR TITLE
[core] [lua] Force luopans to be unable to move

### DIFF
--- a/scripts/globals/pets/luopan.lua
+++ b/scripts/globals/pets/luopan.lua
@@ -10,6 +10,8 @@ xi.pets.luopan.onMobSpawn = function(mob)
     mob:timer(600000, function(mobArg)
         mobArg:setHP(0)
     end)
+
+    mob:setMod(xi.mod.MOVE_SPEED_OVERRIDE, 256) -- this mod > 255 = no movement
 end
 
 xi.pets.luopan.onMobDeath = function(mob)

--- a/src/map/ai/controllers/pet_controller.cpp
+++ b/src/map/ai/controllers/pet_controller.cpp
@@ -105,6 +105,10 @@ void CPetController::DoRoamTick(time_point tick)
                 return;
             }
         }
+        else if (PetEntity->m_PetID == PETID_LUOPAN) // Luopans do nothing
+        {
+            return;
+        }
     }
 
     float currentDistance = distance(PPet->loc.p, PPet->PMaster->loc.p);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Apparently movespeed pr accidentally allowed luopans to move (target them and they move towards you)
This PR force luopans to be unable to move
Mob controller returns early before move logic, but also using move_speed_override > 255 = movement isn't possible

## Steps to test these changes

Summon a luopan and see it stick in place via targeting, the bubble graphics apparently stay in place
