### PR TITLE
Core: Refactor CZoneEntities::ZoneServer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -391,7 +391,7 @@ jobs:
       - name: Build
         shell: cmd
         run: |
-          cmake --build build -j4
+          cmake --build build --config Release -j4
       - name: Archive Executables
         uses: actions/upload-artifact@v4
         with:

--- a/src/common/cbasetypes.h
+++ b/src/common/cbasetypes.h
@@ -9,29 +9,7 @@
 #include <utility>
 
 #include "logging.h"
-
-// The following definitions are set by CMake based on the architecture
-// #define ENV64BIT
-// #define ENV32BIT
-
-// Ensure one of the definitions is set
-#if !defined(ENV64BIT) && !defined(ENV32BIT)
-#error "Neither ENV64BIT nor ENV32BIT is defined"
-#endif
-
-// Debug mode
-#if defined(_DEBUG) && !defined(DEBUG)
-#define DEBUG
-#endif
-
-// Release mode
-#if !defined(_DEBUG) && !defined(RELEASE)
-#define RELEASE
-#endif
-
-// define a break macro for debugging
-#define XI_DEBUG_BREAK_IF(_CONDITION_) \
-    static_assert(false, "Use of XI_DEBUG_BREAK_IF is deprecated. Check your conditions and log appropriately instead.")
+#include "macros.h"
 
 // typedef/using
 using int8  = std::int8_t;
@@ -71,26 +49,6 @@ inline void destroy_arr(T*& ptr)
     ptr = nullptr;
 }
 
-// string case comparison for *nix portability
-#if !defined(_MSC_VER)
-#define strcmpi strcasecmp
-#define stricmp strcasecmp
-
-// https://stackoverflow.com/questions/12044519/what-is-the-windows-equivalent-of-the-unix-function-gmtime-r
-// gmtime_r() is the thread-safe version of gmtime(). The MSVC implementation of gmtime() is already thread safe,
-// the returned struct tm* is allocated in thread-local storage.
-// That doesn't make it immune from trouble if the function is called multiple times on the same
-// thread and the returned pointer is stored.
-// You can use gmtime_s() instead. Closest to gmtime_r() but with the arguments reversed
-
-// Provide func_s implementations for Unix
-#define _gmtime_s(a, b)    gmtime_r(b, a)
-#define _localtime_s(a, b) localtime_r(b, a)
-#else // MSVC
-#define _gmtime_s(a, b)    gmtime_s(a, b)
-#define _localtime_s(a, b) localtime_s(a, b)
-#endif
-
 #include <chrono>
 
 using namespace std::literals::chrono_literals;
@@ -118,18 +76,6 @@ struct PtrGreater
 
 template <class T>
 using MinHeapPtr = std::priority_queue<T, std::vector<T>, PtrGreater<T>>;
-
-#define DISALLOW_COPY(TypeName)                    \
-    TypeName(const TypeName&)            = delete; \
-    TypeName& operator=(const TypeName&) = delete;
-
-#define DISALLOW_MOVE(TypeName)               \
-    TypeName(TypeName&&)            = delete; \
-    TypeName& operator=(TypeName&&) = delete;
-
-#define DISALLOW_COPY_AND_MOVE(TypeName) \
-    DISALLOW_COPY(TypeName)              \
-    DISALLOW_MOVE(TypeName)
 
 #include "tracy.h"
 

--- a/src/common/macros.h
+++ b/src/common/macros.h
@@ -72,7 +72,7 @@
 //
 // Assembly Analysis: https://github.com/LandSandBoat/server/pull/6751
 //
-#define FOR_EACH_PAIR_CAST_SECOND(_collection, _type, _var) \
+#define FOR_EACH_PAIR_CAST_SECOND(_type, _var, _collection) \
     for (const auto& [_key, _value] : _collection)          \
         if (auto _var = static_cast<_type>(_value); true)
 

--- a/src/common/macros.h
+++ b/src/common/macros.h
@@ -1,0 +1,97 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+// The following definitions are set by CMake based on the architecture
+// #define ENV64BIT
+// #define ENV32BIT
+
+// Ensure one of the definitions is set
+#if !defined(ENV64BIT) && !defined(ENV32BIT)
+#error "Neither ENV64BIT nor ENV32BIT is defined"
+#endif
+
+// Debug mode
+#if defined(_DEBUG) && !defined(DEBUG)
+#define DEBUG
+#endif
+
+// Release mode
+#if !defined(_DEBUG) && !defined(RELEASE)
+#define RELEASE
+#endif
+
+// define a break macro for debugging
+#define XI_DEBUG_BREAK_IF(_CONDITION_) \
+    static_assert(false, "Use of XI_DEBUG_BREAK_IF is deprecated. Check your conditions and log appropriately instead.")
+
+#define DISALLOW_COPY(TypeName)                    \
+    TypeName(const TypeName&)            = delete; \
+    TypeName& operator=(const TypeName&) = delete;
+
+#define DISALLOW_MOVE(TypeName)               \
+    TypeName(TypeName&&)            = delete; \
+    TypeName& operator=(TypeName&&) = delete;
+
+#define DISALLOW_COPY_AND_MOVE(TypeName) \
+    DISALLOW_COPY(TypeName)              \
+    DISALLOW_MOVE(TypeName)
+
+//
+// This `FOR_EACH_PAIR_CAST_SECOND` macro replaces a common pattern we had in the hot path:
+//
+// ```cpp
+//     for (EntityList_t::const_iterator it = m_charList.begin(); it != m_charList.end(); ++it)
+//     {
+//         CCharEntity* PCurrentChar = (CCharEntity*)it->second;
+// ```
+//
+// It provides a cleaner and more concise way to iterate over collections
+// while maintaining the same performance characteristics as the original code.
+//
+// Both the original and macro version produce identical assembly output.
+//
+// Assembly Analysis: https://github.com/LandSandBoat/server/pull/6751
+//
+#define FOR_EACH_PAIR_CAST_SECOND(_collection, _type, _var) \
+    for (const auto& [_key, _value] : _collection)          \
+        if (auto _var = static_cast<_type>(_value); true)
+
+// string case comparison for *nix portability
+#if !defined(_MSC_VER)
+#define strcmpi strcasecmp
+#define stricmp strcasecmp
+
+// https://stackoverflow.com/questions/12044519/what-is-the-windows-equivalent-of-the-unix-function-gmtime-r
+// gmtime_r() is the thread-safe version of gmtime(). The MSVC implementation of gmtime() is already thread safe,
+// the returned struct tm* is allocated in thread-local storage.
+// That doesn't make it immune from trouble if the function is called multiple times on the same
+// thread and the returned pointer is stored.
+// You can use gmtime_s() instead. Closest to gmtime_r() but with the arguments reversed
+
+// Provide func_s implementations for Unix
+#define _gmtime_s(a, b)    gmtime_r(b, a)
+#define _localtime_s(a, b) localtime_r(b, a)
+#else // MSVC
+#define _gmtime_s(a, b)    gmtime_s(a, b)
+#define _localtime_s(a, b) localtime_s(a, b)
+#endif

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -91,24 +91,6 @@ bool bin2hex(char* output, unsigned char* input, size_t count)
     return true;
 }
 
-float distance(const position_t& A, const position_t& B, bool ignoreVertical)
-{
-    return sqrt(distanceSquared(A, B, ignoreVertical));
-}
-
-float distanceSquared(const position_t& A, const position_t& B, bool ignoreVertical)
-{
-    float diff_x = A.x - B.x;
-    float diff_y = ignoreVertical ? 0 : A.y - B.y;
-    float diff_z = A.z - B.z;
-    return diff_x * diff_x + diff_y * diff_y + diff_z * diff_z;
-}
-
-bool distanceWithin(const position_t& A, const position_t& B, float within, bool ignoreVertical)
-{
-    return distanceSquared(A, B, ignoreVertical) <= square(within);
-}
-
 int32 intpow32(int32 base, int32 exponent)
 {
     int32 power = 1;
@@ -165,7 +147,7 @@ uint8 worldAngle(const position_t& A, const position_t& B)
 {
     uint8 angle = (uint8)(atanf((B.z - A.z) / (B.x - A.x)) * -(128.0f / M_PI));
 
-    return distanceWithin(A, B, 0.1f, true) ? A.rotation : (A.x > B.x ? angle + 128 : angle);
+    return isWithinDistance(A, B, 0.1f, true) ? A.rotation : (A.x > B.x ? angle + 128 : angle);
 }
 
 uint8 relativeAngle(uint8 world, int16 diff)

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -43,12 +43,27 @@ int32 checksum(uint8* buf, uint32 buflen, char checkhash[16]);
 int   config_switch(const char* str);
 bool  bin2hex(char* output, unsigned char* input, size_t count);
 
-float           distance(const position_t& A, const position_t& B, bool ignoreVertical = false);                     // distance between positions. Use only horizontal plane (x and z) if ignoreVertical is set.
-float           distanceSquared(const position_t& A, const position_t& B, bool ignoreVertical = false);              // squared distance between positions (use squared unless otherwise needed)
-bool            distanceWithin(const position_t& A, const position_t& B, float within, bool ignoreVertical = false); // returns true if the distance between the points is <= within.
-constexpr float square(float distance)                                                                               // constexpr square (used with distanceSquared)
+constexpr float square(auto distance) // constexpr square (used with distanceSquared)
 {
     return distance * distance;
+}
+
+inline float distanceSquared(const position_t& A, const position_t& B, bool ignoreVertical = false)
+{
+    float dX = A.x - B.x;
+    float dY = ignoreVertical ? 0 : A.y - B.y;
+    float dZ = A.z - B.z;
+    return dX * dX + dY * dY + dZ * dZ;
+}
+
+inline float distance(const position_t& A, const position_t& B, bool ignoreVertical = false)
+{
+    return std::sqrt(distanceSquared(A, B, ignoreVertical));
+}
+
+inline bool isWithinDistance(const position_t& A, const position_t& B, float within, bool ignoreVertical = false)
+{
+    return distanceSquared(A, B, ignoreVertical) <= square(within);
 }
 
 int32      intpow32(int32 base, int32 exponent); // Exponential power of integers

--- a/src/map/ai/controllers/automaton_controller.cpp
+++ b/src/map/ai/controllers/automaton_controller.cpp
@@ -223,9 +223,8 @@ void CAutomatonController::DoCombatTick(time_point tick)
 
 void CAutomatonController::Move()
 {
-    float currentDistance = distanceSquared(PAutomaton->loc.p, PTarget->loc.p);
-
-    if ((shouldStandBack() && (currentDistance > 225)) || (PAutomaton->health.mp < 8 && PAutomaton->health.maxmp > 8))
+    if ((shouldStandBack() && !isWithinDistance(PAutomaton->loc.p, PTarget->loc.p, 15.0f)) ||
+        (PAutomaton->health.mp < 8 && PAutomaton->health.maxmp > 8))
     {
         PAutomaton->m_Behavior &= ~BEHAVIOR_STANDBACK;
     }

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -745,7 +745,7 @@ void CMobController::Move()
                             PMob->PAI->PathFind->PathInRange(PTarget->loc.p, closeDistance, PATHFLAG_WALLHACK | PATHFLAG_RUN);
                         }
                     }
-                    else if (distanceSquared(PMob->PAI->PathFind->GetDestination(), PTarget->loc.p) > 10)
+                    else if (!isWithinDistance(PMob->PAI->PathFind->GetDestination(), PTarget->loc.p, 2.5f))
                     {
                         // try to find path towards target
                         PMob->PAI->PathFind->PathInRange(PTarget->loc.p, closeDistance, PATHFLAG_WALLHACK | PATHFLAG_RUN);

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -221,11 +221,11 @@ void CPathFind::ResumePatrol()
         float closestPoint = FLT_MAX;
         for (size_t i = 0; i < m_points.size(); ++i)
         {
-            float distance = distanceSquared(m_POwner->loc.p, m_points[i].position);
-            if (distance < closestPoint)
+            const float distanceSq = distanceSquared(m_POwner->loc.p, m_points[i].position);
+            if (distanceSq < closestPoint)
             {
                 m_currentPoint = (int16)i;
-                closestPoint   = distance;
+                closestPoint   = distanceSq;
             }
         }
     }
@@ -495,9 +495,8 @@ bool CPathFind::FindRandomPath(const position_t& start, float maxRadius, uint8 m
             return false;
         }
 
-        float distSq = distanceSquared(startPosition, status.second, true);
         // only add the roam point if it's _actually_ within range of the spawn point...
-        if (distSq < maxRadius * maxRadius)
+        if (isWithinDistance(startPosition, status.second, maxRadius, true))
         {
             m_turnPoints.emplace_back(status.second);
         }
@@ -505,8 +504,11 @@ bool CPathFind::FindRandomPath(const position_t& start, float maxRadius, uint8 m
         // {
         //     ShowDebug("CPathFind::FindRandomPath (%s - %d) random point too far: sq distance (%f)", m_POwner->GetName(), m_POwner->id, distSq);
         // }
+
         if (m_turnPoints.size() >= m_turnLength)
+        {
             break;
+        }
     }
     if (m_turnPoints.size() > 0)
     {
@@ -549,7 +551,7 @@ bool CPathFind::FindClosestPath(const position_t& start, const position_t& end)
 void CPathFind::LookAt(const position_t& point)
 {
     // Avoid unpredictable results if we're too close.
-    if (!distanceWithin(m_POwner->loc.p, point, 0.1f, true))
+    if (!isWithinDistance(m_POwner->loc.p, point, 0.1f, true))
     {
         m_POwner->loc.p.rotation = worldAngle(m_POwner->loc.p, point);
         m_POwner->updatemask |= UPDATE_POS;
@@ -580,11 +582,11 @@ bool CPathFind::AtPoint(const position_t& pos)
 {
     if (m_distanceFromPoint == 0)
     {
-        return distanceWithin(m_POwner->loc.p, pos, 0.1f);
+        return isWithinDistance(m_POwner->loc.p, pos, 0.1f);
     }
     else
     {
-        return distanceWithin(m_POwner->loc.p, pos, m_distanceFromPoint + 0.2f);
+        return isWithinDistance(m_POwner->loc.p, pos, m_distanceFromPoint + 0.2f);
     }
 }
 

--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -235,7 +235,7 @@ void CTargetFind::addAllInMobList(CBattleEntity* PTarget, bool withPet)
     CCharEntity* PChar = dynamic_cast<CCharEntity*>(findMaster(m_PBattleEntity));
     if (PChar)
     {
-        FOR_EACH_PAIR_CAST_SECOND(PChar->SpawnMOBList, CMobEntity*, PBattleTarget)
+        FOR_EACH_PAIR_CAST_SECOND(CMobEntity*, PBattleTarget, PChar->SpawnMOBList)
         {
             if (PBattleTarget && isMobOwner(PBattleTarget))
             {
@@ -332,9 +332,9 @@ void CTargetFind::addAllInRange(CBattleEntity* PTarget, float radius, ALLEGIANCE
         if (PTarget->objtype == TYPE_PC)
         {
             CCharEntity* PChar = static_cast<CCharEntity*>(PTarget);
-            for (auto& list : { PChar->SpawnPCList, PChar->SpawnPETList })
+            for (auto& spawnList : { PChar->SpawnPCList, PChar->SpawnPETList })
             {
-                FOR_EACH_PAIR_CAST_SECOND(list, CBattleEntity*, PBattleEntity)
+                FOR_EACH_PAIR_CAST_SECOND(CBattleEntity*, PBattleEntity, spawnList)
                 {
                     if (PBattleEntity && isWithinArea(&(PBattleEntity->loc.p)) && !PBattleEntity->isDead() &&
                         PBattleEntity->allegiance == ALLEGIANCE_TYPE::PLAYER)

--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -235,9 +235,8 @@ void CTargetFind::addAllInMobList(CBattleEntity* PTarget, bool withPet)
     CCharEntity* PChar = dynamic_cast<CCharEntity*>(findMaster(m_PBattleEntity));
     if (PChar)
     {
-        for (SpawnIDList_t::const_iterator it = PChar->SpawnMOBList.begin(); it != PChar->SpawnMOBList.end(); ++it)
+        FOR_EACH_PAIR_CAST_SECOND(PChar->SpawnMOBList, CMobEntity*, PBattleTarget)
         {
-            CBattleEntity* PBattleTarget = dynamic_cast<CBattleEntity*>(it->second);
             if (PBattleTarget && isMobOwner(PBattleTarget))
             {
                 addEntity(PBattleTarget, withPet);
@@ -311,12 +310,10 @@ void CTargetFind::addAllInEnmityList()
 {
     if (m_PBattleEntity->objtype == TYPE_MOB)
     {
-        CMobEntity*   mob        = (CMobEntity*)m_PBattleEntity;
-        EnmityList_t* enmityList = mob->PEnmityContainer->GetEnmityList();
+        CMobEntity* PMob = static_cast<CMobEntity*>(m_PBattleEntity);
 
-        for (auto& it : *enmityList)
+        for (const auto& [_, PEnmityObject] : *PMob->PEnmityContainer->GetEnmityList())
         {
-            EnmityObject_t& PEnmityObject = it.second;
             if (PEnmityObject.PEnmityOwner)
             {
                 addEntity(PEnmityObject.PEnmityOwner, false);
@@ -335,11 +332,10 @@ void CTargetFind::addAllInRange(CBattleEntity* PTarget, float radius, ALLEGIANCE
         if (PTarget->objtype == TYPE_PC)
         {
             CCharEntity* PChar = static_cast<CCharEntity*>(PTarget);
-            for (const auto& list : { PChar->SpawnPCList, PChar->SpawnPETList })
+            for (auto& list : { PChar->SpawnPCList, PChar->SpawnPETList })
             {
-                for (const auto& pair : list)
+                FOR_EACH_PAIR_CAST_SECOND(list, CBattleEntity*, PBattleEntity)
                 {
-                    CBattleEntity* PBattleEntity = static_cast<CBattleEntity*>(pair.second);
                     if (PBattleEntity && isWithinArea(&(PBattleEntity->loc.p)) && !PBattleEntity->isDead() &&
                         PBattleEntity->allegiance == ALLEGIANCE_TYPE::PLAYER)
                     {

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -356,7 +356,7 @@ bool CMagicState::CanCastSpell(CBattleEntity* PTarget, bool isEndOfCast)
 
     if (dynamic_cast<CMobEntity*>(m_PEntity))
     {
-        if (distanceSquared(m_PEntity->loc.p, PTarget->loc.p) > square(28.5f))
+        if (!isWithinDistance(m_PEntity->loc.p, PTarget->loc.p, 28.5f))
         {
             return false;
         }

--- a/src/map/enmity_container.cpp
+++ b/src/map/enmity_container.cpp
@@ -500,8 +500,8 @@ bool CEnmityContainer::IsWithinEnmityRange(CBattleEntity* PEntity) const
     {
         return false;
     }
-    float maxRange = square(m_EnmityHolder->m_Type == MOBTYPE_NOTORIOUS ? 28.f : 25.f);
-    return distanceSquared(m_EnmityHolder->loc.p, PEntity->loc.p) <= maxRange;
+    float maxRange = m_EnmityHolder->m_Type == MOBTYPE_NOTORIOUS ? 28.0f : 25.0f;
+    return isWithinDistance(m_EnmityHolder->loc.p, PEntity->loc.p, maxRange);
 }
 
 EnmityList_t* CEnmityContainer::GetEnmityList()

--- a/src/map/instance.cpp
+++ b/src/map/instance.cpp
@@ -245,17 +245,35 @@ bool CInstance::CharRegistered(CCharEntity* PChar)
 
 void CInstance::ClearEntities()
 {
-    auto clearStates = [](auto& entity)
+    auto clearStates = [](CBattleEntity* entity)
     {
-        if (static_cast<CBattleEntity*>(entity.second)->isAlive())
+        if (static_cast<CBattleEntity*>(entity)->isAlive())
         {
-            entity.second->PAI->ClearStateStack();
+            entity->PAI->ClearStateStack();
         }
     };
-    std::for_each(m_charList.cbegin(), m_charList.cend(), clearStates);
-    std::for_each(m_mobList.cbegin(), m_mobList.cend(), clearStates);
-    std::for_each(m_petList.cbegin(), m_petList.cend(), clearStates);
-    std::for_each(m_trustList.cbegin(), m_trustList.cend(), clearStates);
+
+    // clang-format off
+    ForEachChar([&](CCharEntity* PChar)
+    {
+        clearStates(PChar);
+    });
+
+    ForEachMob([&](CMobEntity* PMob)
+    {
+        clearStates(PMob);
+    });
+
+    ForEachPet([&](CPetEntity* PPet)
+    {
+        clearStates(PPet);
+    });
+
+    ForEachTrust([&](CTrustEntity* PTrust)
+    {
+        clearStates(PTrust);
+    });
+    // clang-format on
 }
 
 void CInstance::Fail()

--- a/src/map/instance_loader.h
+++ b/src/map/instance_loader.h
@@ -38,9 +38,9 @@ public:
     CInstance* LoadInstance();
 
 private:
-    CInstance*   instance;
-    CZone*       zone;
-    CCharEntity* requester;
+    CInstance*   m_PInstance;
+    CZone*       m_PZone;
+    CCharEntity* m_PRequester;
 };
 
 #endif

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -12805,7 +12805,7 @@ void CLuaBaseEntity::transferEnmity(CLuaBaseEntity* entity, uint8 percent, float
 
     if (PIterEntity)
     {
-        FOR_EACH_PAIR_CAST_SECOND(PIterEntity->SpawnMOBList, CMobEntity*, PMob)
+        FOR_EACH_PAIR_CAST_SECOND(CMobEntity*, PMob, PIterEntity->SpawnMOBList)
         {
             if (isWithinDistance(PMob->loc.p, PEntity->loc.p, range))
             {

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -1728,7 +1728,7 @@ void CLuaBaseEntity::lookAt(sol::object const& arg0, sol::object const& arg1, so
     }
 
     // Avoid unpredictable results if we're too close.
-    if (!distanceWithin(m_PBaseEntity->loc.p, point, 0.1f, true))
+    if (!isWithinDistance(m_PBaseEntity->loc.p, point, 0.1f, true))
     {
         m_PBaseEntity->loc.p.rotation = worldAngle(m_PBaseEntity->loc.p, point);
         m_PBaseEntity->updatemask |= UPDATE_POS;
@@ -1813,7 +1813,7 @@ bool CLuaBaseEntity::atPoint(sol::variadic_args va)
         pos.z = vec[2];
     }
 
-    return distanceWithin(m_PBaseEntity->loc.p, pos, 0.01f);
+    return isWithinDistance(m_PBaseEntity->loc.p, pos, 0.01f);
 }
 
 /************************************************************************
@@ -10916,7 +10916,7 @@ void CLuaBaseEntity::forMembersInRange(float range, sol::function function)
     // clang-format off
     target->ForParty([&target, &range, &function](CBattleEntity* member)
     {
-        if (target->loc.zone == member->loc.zone && distanceSquared(target->loc.p, member->loc.p) < (range * range))
+        if (target->loc.zone == member->loc.zone && isWithinDistance(target->loc.p, member->loc.p, range))
         {
             function(CLuaBaseEntity(member));
         }
@@ -12805,12 +12805,11 @@ void CLuaBaseEntity::transferEnmity(CLuaBaseEntity* entity, uint8 percent, float
 
     if (PIterEntity)
     {
-        for (auto&& mob_pair : PIterEntity->SpawnMOBList)
+        FOR_EACH_PAIR_CAST_SECOND(PIterEntity->SpawnMOBList, CMobEntity*, PMob)
         {
-            if (distanceSquared(mob_pair.second->loc.p, PEntity->loc.p) < (range * range))
+            if (isWithinDistance(PMob->loc.p, PEntity->loc.p, range))
             {
-                battleutils::TransferEnmity(static_cast<CBattleEntity*>(PEntity), static_cast<CBattleEntity*>(m_PBaseEntity),
-                                            static_cast<CMobEntity*>(mob_pair.second), percent);
+                battleutils::TransferEnmity(static_cast<CBattleEntity*>(PEntity), static_cast<CBattleEntity*>(m_PBaseEntity), PMob, percent);
             }
         }
     }

--- a/src/map/lua/lua_instance.cpp
+++ b/src/map/lua/lua_instance.cpp
@@ -60,57 +60,62 @@ uint32 CLuaInstance::getEntranceZoneID()
 
 sol::table CLuaInstance::getAllies()
 {
+    // clang-format off
     auto table = lua.create_table();
-    for (auto& member : m_PLuaInstance->m_allyList)
+    m_PLuaInstance->ForEachAlly([&](CMobEntity* PAlly)
     {
-        table.add(CLuaBaseEntity(member.second));
-    }
-
+        table.add(CLuaBaseEntity(PAlly));
+    });
     return table;
+    // clang-format on
 }
 
 sol::table CLuaInstance::getChars()
 {
+    // clang-format off
     auto table = lua.create_table();
-    for (auto& member : m_PLuaInstance->m_charList)
+    m_PLuaInstance->ForEachChar([&](CCharEntity* PChar)
     {
-        table.add(CLuaBaseEntity(member.second));
-    }
-
+        table.add(CLuaBaseEntity(PChar));
+    });
     return table;
+    // clang-format on
 }
 
 sol::table CLuaInstance::getMobs()
 {
+    // clang-format off
     auto table = lua.create_table();
-    for (auto& member : m_PLuaInstance->m_mobList)
+    m_PLuaInstance->ForEachMob([&](CMobEntity* PMob)
     {
-        table.add(CLuaBaseEntity(member.second));
-    }
-
+        table.add(CLuaBaseEntity(PMob));
+    });
     return table;
+    // clang-format on
 }
 
 sol::table CLuaInstance::getNpcs()
 {
+    // clang-format off
     auto table = lua.create_table();
-    for (auto& member : m_PLuaInstance->m_npcList)
+    m_PLuaInstance->ForEachNpc([&](CNpcEntity* PNpc)
     {
-        table.add(CLuaBaseEntity(member.second));
-    }
-
+        table.add(CLuaBaseEntity(PNpc));
+    });
     return table;
+    // clang-format on
 }
 
 sol::table CLuaInstance::getPets()
 {
+    // clang-format off
     auto table = lua.create_table();
-    for (auto& member : m_PLuaInstance->m_petList)
+    m_PLuaInstance->ForEachPet([&](CPetEntity* PPet)
     {
-        table.add(CLuaBaseEntity(member.second));
-    }
-
+        table.add(CLuaBaseEntity(PPet));
+    });
     return table;
+    // clang-format on
 }
 
 uint32 CLuaInstance::getTimeLimit()

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1376,15 +1376,14 @@ int32 map_cleanup(time_point tick, CTaskMgr::CTask* PTask)
     // clang-format off
     zoneutils::ForEachZone([](CZone* PZone)
     {
-        auto& staledynamicTargIds = PZone->GetZoneEntities()->dynamicTargIdsToDelete;
+        auto& staledynamicTargIds = PZone->GetZoneEntities()->m_dynamicTargIdsToDelete;
 
-        auto it = staledynamicTargIds.begin();
-        while(it != staledynamicTargIds.end())
+        for (auto it = staledynamicTargIds.begin(); it != staledynamicTargIds.end();)
         {
             // Erase dynamic targid if it's stale enough
             if ((server_clock::now() - it->second) > 60s)
             {
-                PZone->GetZoneEntities()->dynamicTargIds.erase(it->first);
+                PZone->GetZoneEntities()->m_dynamicTargIds.erase(it->first);
                 it = staledynamicTargIds.erase(it);
             }
             else

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1376,23 +1376,10 @@ int32 map_cleanup(time_point tick, CTaskMgr::CTask* PTask)
     // clang-format off
     zoneutils::ForEachZone([](CZone* PZone)
     {
-        auto& staledynamicTargIds = PZone->GetZoneEntities()->m_dynamicTargIdsToDelete;
-
-        for (auto it = staledynamicTargIds.begin(); it != staledynamicTargIds.end();)
-        {
-            // Erase dynamic targid if it's stale enough
-            if ((server_clock::now() - it->second) > 60s)
-            {
-                PZone->GetZoneEntities()->m_dynamicTargIds.erase(it->first);
-                it = staledynamicTargIds.erase(it);
-            }
-            else
-            {
-                ++it;
-            }
-        }
+        PZone->GetZoneEntities()->EraseStaleDynamicTargIDs();
     });
     // clang-format on
+
     return 0;
 }
 

--- a/src/map/pch.h
+++ b/src/map/pch.h
@@ -60,6 +60,7 @@
 #include <numeric>
 #include <optional>
 #include <queue>
+#include <ranges>
 #include <regex>
 #include <set>
 #include <sstream>
@@ -83,6 +84,7 @@
 #include "common/database.h"
 #include "common/kernel.h"
 #include "common/logging.h"
+#include "common/macros.h"
 #include "common/md52.h"
 #include "common/mmo.h"
 #include "common/socket.h"
@@ -92,6 +94,7 @@
 #include "common/tracy.h"
 #include "common/utils.h"
 #include "common/version.h"
+#include "common/xi.h"
 #include "common/xirand.h"
 
 #include <concurrentqueue.h>

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1228,11 +1228,11 @@ namespace battleutils
         {
             if (PAttacker->objtype == TYPE_PC && PAttacker->PParty != nullptr)
             {
-                for (auto& member : PAttacker->PParty->members)
+                for (auto* PMember : PAttacker->PParty->members)
                 {
-                    PDefender->StatusEffectContainer->DelStatusEffect(EFFECT_DRAIN_DAZE, member->id);
-                    PDefender->StatusEffectContainer->DelStatusEffect(EFFECT_HASTE_DAZE, member->id);
-                    PDefender->StatusEffectContainer->DelStatusEffect(EFFECT_ASPIR_DAZE, member->id);
+                    PDefender->StatusEffectContainer->DelStatusEffect(EFFECT_DRAIN_DAZE, PMember->id);
+                    PDefender->StatusEffectContainer->DelStatusEffect(EFFECT_HASTE_DAZE, PMember->id);
+                    PDefender->StatusEffectContainer->DelStatusEffect(EFFECT_ASPIR_DAZE, PMember->id);
                 }
             }
             else if (PAttacker->objtype == TYPE_TRUST && PAttacker->PMaster)
@@ -4344,16 +4344,16 @@ namespace battleutils
             // Collect all potential TA targets who are closer to the mob than the TA user
             for (auto&& party : taPartyList)
             {
-                for (auto&& member : party->members)
+                for (auto&& PMember : party->members)
                 {
-                    float distTAtarget = distance(member->loc.p, PMob->loc.p);
+                    float distTAtarget = distance(PMember->loc.p, PMob->loc.p);
                     // require closer target not be closer than .5 yalms (.5*.5=.25 distsquared) to mob
                     if (distTAtarget >= worldAngleMinDistance && distTAtarget < distTAmob)
                     {
-                        taTargetList.emplace_back(distTAtarget, member);
+                        taTargetList.emplace_back(distTAtarget, PMember);
                     }
 
-                    if (auto* PChar = dynamic_cast<CCharEntity*>(member))
+                    if (auto* PChar = dynamic_cast<CCharEntity*>(PMember))
                     {
                         for (auto* PTrust : PChar->PTrusts)
                         {
@@ -4426,9 +4426,9 @@ namespace battleutils
             return;
         }
 
-        for (auto* entity : *PTarget->PNotorietyContainer)
+        for (auto* PEntity : *PTarget->PNotorietyContainer)
         {
-            if (CMobEntity* PCurrentMob = dynamic_cast<CMobEntity*>(entity))
+            if (CMobEntity* PCurrentMob = dynamic_cast<CMobEntity*>(PEntity))
             {
                 if (PCurrentMob->m_HiPCLvl > 0 && PCurrentMob->PEnmityContainer->HasID(PTarget->id))
                 {
@@ -4463,10 +4463,8 @@ namespace battleutils
 
         if (PIterSource)
         {
-            for (SpawnIDList_t::const_iterator it = PIterSource->SpawnMOBList.begin(); it != PIterSource->SpawnMOBList.end(); ++it)
+            FOR_EACH_PAIR_CAST_SECOND(PIterSource->SpawnMOBList, CMobEntity*, PCurrentMob)
             {
-                CMobEntity* PCurrentMob = (CMobEntity*)it->second;
-
                 if (PCurrentMob->m_HiPCLvl > 0 && PCurrentMob->PEnmityContainer->HasID(PSource->id))
                 {
                     PCurrentMob->PEnmityContainer->UpdateEnmity(PSource, CE, VE, false, false, false);
@@ -6813,12 +6811,13 @@ namespace battleutils
         // If the cover ability target is in a party, try to find a cover ability user
         if (PCoverAbilityTarget->PParty != nullptr)
         {
-            for (auto member : PCoverAbilityTarget->PParty->members)
+            for (auto* PMember : PCoverAbilityTarget->PParty->members)
             {
-                if (coverAbilityTargetID == member->GetLocalVar("COVER_ABILITY_TARGET") && member->StatusEffectContainer->HasStatusEffect(EFFECT_COVER) &&
-                    member->isAlive())
+                if (coverAbilityTargetID == PMember->GetLocalVar("COVER_ABILITY_TARGET") &&
+                    PMember->StatusEffectContainer->HasStatusEffect(EFFECT_COVER) &&
+                    PMember->isAlive())
                 {
-                    PCoverAbilityUser = member;
+                    PCoverAbilityUser = PMember;
                     break;
                 }
             }

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4463,7 +4463,7 @@ namespace battleutils
 
         if (PIterSource)
         {
-            FOR_EACH_PAIR_CAST_SECOND(PIterSource->SpawnMOBList, CMobEntity*, PCurrentMob)
+            FOR_EACH_PAIR_CAST_SECOND(CMobEntity*, PCurrentMob, PIterSource->SpawnMOBList)
             {
                 if (PCurrentMob->m_HiPCLvl > 0 && PCurrentMob->PEnmityContainer->HasID(PSource->id))
                 {

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -4088,7 +4088,7 @@ namespace charutils
             // clang-format off
             PChar->ForAlliance([PMob, &members](CBattleEntity* PPartyMember)
             {
-                if (PPartyMember->getZone() == PMob->getZone() && distanceSquared(PPartyMember->loc.p, PMob->loc.p) < square(100.f))
+                if (PPartyMember->getZone() == PMob->getZone() && isWithinDistance(PPartyMember->loc.p, PMob->loc.p, 100.f))
                 {
                     members.emplace_back((CCharEntity*)PPartyMember);
                 }
@@ -4120,7 +4120,7 @@ namespace charutils
                 }
             }
         }
-        else if (distanceSquared(PChar->loc.p, PMob->loc.p) < square(100.f))
+        else if (isWithinDistance(PChar->loc.p, PMob->loc.p, 100.f))
         {
             // Check for gilfinder
             gil += gil * PChar->getMod(Mod::GILFINDER) / 100;

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -1539,7 +1539,7 @@ namespace mobutils
         {
             if (_sql->NextRow() == SQL_SUCCESS)
             {
-                PMob            = new CMobEntity;
+                PMob            = new CMobEntity();
                 PMob->PInstance = instance;
 
                 PMob->name.insert(0, (const char*)_sql->GetData(1));
@@ -1645,14 +1645,10 @@ namespace mobutils
                 PMob->m_TrueDetection = _sql->GetUIntData(69);
                 PMob->setMobMod(MOBMOD_DETECTION, _sql->GetUIntData(70));
 
-                CZone* newZone = zoneutils::GetZone(zoneID);
-                if (newZone)
+                if (CZone* PZone = zoneutils::GetZone(zoneID))
                 {
-                    // Get dynamic targid
-                    newZone->GetZoneEntities()->AssignDynamicTargIDandLongID(PMob);
-
-                    // Insert ally into zone's mob list. TODO: Do we need to assign party for allies?
-                    newZone->GetZoneEntities()->m_mobList[PMob->targid] = PMob;
+                    PZone->GetZoneEntities()->AssignDynamicTargIDandLongID(PMob);
+                    PZone->GetZoneEntities()->InsertMOB(PMob);
                 }
                 else
                 {

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -339,11 +339,11 @@ bool CZone::IsWeatherStatic() const
 
 zoneLine_t* CZone::GetZoneLine(uint32 zoneLineID)
 {
-    for (zoneLineList_t::const_iterator i = m_zoneLineList.begin(); i != m_zoneLineList.end(); ++i)
+    for (const auto& zoneLine : m_zoneLineList)
     {
-        if ((*i)->m_zoneLineID == zoneLineID)
+        if (zoneLine->m_zoneLineID == zoneLineID)
         {
-            return (*i);
+            return zoneLine;
         }
     }
     return nullptr;
@@ -1141,11 +1141,11 @@ void CZone::CharZoneIn(CCharEntity* PChar)
 void CZone::CharZoneOut(CCharEntity* PChar)
 {
     TracyZoneScoped;
-    for (triggerAreaList_t::const_iterator triggerAreaItr = m_triggerAreaList.begin(); triggerAreaItr != m_triggerAreaList.end(); ++triggerAreaItr)
+    for (const auto& triggerArea : m_triggerAreaList)
     {
-        if ((*triggerAreaItr)->GetTriggerAreaID() == PChar->m_InsideTriggerAreaID)
+        if (triggerArea->GetTriggerAreaID() == PChar->m_InsideTriggerAreaID)
         {
-            luautils::OnTriggerAreaLeave(PChar, *triggerAreaItr);
+            luautils::OnTriggerAreaLeave(PChar, triggerArea);
             break;
         }
     }
@@ -1231,15 +1231,15 @@ void CZone::CheckTriggerAreas()
         //     : use them here to make the search domain smaller.
 
         uint32 triggerAreaID = 0;
-        for (triggerAreaList_t::const_iterator triggerAreaItr = m_triggerAreaList.begin(); triggerAreaItr != m_triggerAreaList.end(); ++triggerAreaItr)
+        for (const auto& triggerArea : m_triggerAreaList)
         {
-            if ((*triggerAreaItr)->isPointInside(PChar->loc.p))
+            if (triggerArea->isPointInside(PChar->loc.p))
             {
-                triggerAreaID = (*triggerAreaItr)->GetTriggerAreaID();
+                triggerAreaID = triggerArea->GetTriggerAreaID();
 
-                if ((*triggerAreaItr)->GetTriggerAreaID() != PChar->m_InsideTriggerAreaID)
+                if (triggerArea->GetTriggerAreaID() != PChar->m_InsideTriggerAreaID)
                 {
-                    luautils::OnTriggerAreaEnter(PChar, *triggerAreaItr);
+                    luautils::OnTriggerAreaEnter(PChar, triggerArea);
                 }
 
                 if (PChar->m_InsideTriggerAreaID == 0)
@@ -1247,9 +1247,9 @@ void CZone::CheckTriggerAreas()
                     break;
                 }
             }
-            else if ((*triggerAreaItr)->GetTriggerAreaID() == PChar->m_InsideTriggerAreaID)
+            else if (triggerArea->GetTriggerAreaID() == PChar->m_InsideTriggerAreaID)
             {
-                luautils::OnTriggerAreaLeave(PChar, *triggerAreaItr);
+                luautils::OnTriggerAreaLeave(PChar, triggerArea);
             }
         }
         PChar->m_InsideTriggerAreaID = triggerAreaID;

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -959,63 +959,54 @@ void CZone::ZoneServer(time_point tick)
 void CZone::ForEachChar(std::function<void(CCharEntity*)> const& func)
 {
     TracyZoneScoped;
-    for (auto PChar : m_zoneEntities->GetCharList())
+    FOR_EACH_PAIR_CAST_SECOND(m_zoneEntities->m_charList, CCharEntity*, PChar)
     {
-        func((CCharEntity*)PChar.second);
+        func(PChar);
     }
 }
 
 void CZone::ForEachCharInstance(CBaseEntity* PEntity, std::function<void(CCharEntity*)> const& func)
 {
     TracyZoneScoped;
-    for (auto PChar : m_zoneEntities->GetCharList())
-    {
-        func((CCharEntity*)PChar.second);
-    }
+    ForEachChar(func);
 }
 
 void CZone::ForEachMob(std::function<void(CMobEntity*)> const& func)
 {
     TracyZoneScoped;
-    for (auto PMob : m_zoneEntities->m_mobList)
+    FOR_EACH_PAIR_CAST_SECOND(m_zoneEntities->m_mobList, CMobEntity*, PMob)
     {
-        func((CMobEntity*)PMob.second);
+        func(PMob);
     }
 }
 
 void CZone::ForEachMobInstance(CBaseEntity* PEntity, std::function<void(CMobEntity*)> const& func)
 {
     TracyZoneScoped;
-    for (auto PMob : m_zoneEntities->m_mobList)
-    {
-        func((CMobEntity*)PMob.second);
-    }
+    ForEachMob(func);
 }
 
 void CZone::ForEachTrust(std::function<void(CTrustEntity*)> const& func)
 {
     TracyZoneScoped;
-    for (auto PTrust : m_zoneEntities->m_trustList)
+    FOR_EACH_PAIR_CAST_SECOND(m_zoneEntities->m_trustList, CTrustEntity*, PTrust)
     {
-        func((CTrustEntity*)PTrust.second);
+        func(PTrust);
     }
 }
 
 void CZone::ForEachTrustInstance(CBaseEntity* PEntity, std::function<void(CTrustEntity*)> const& func)
 {
     TracyZoneScoped;
-    for (auto PTrust : m_zoneEntities->m_trustList)
-    {
-        func((CTrustEntity*)PTrust.second);
-    }
+    ForEachTrust(func);
 }
 
 void CZone::ForEachNpc(std::function<void(CNpcEntity*)> const& func)
 {
     TracyZoneScoped;
-    for (auto PNpc : m_zoneEntities->m_npcList)
+    FOR_EACH_PAIR_CAST_SECOND(m_zoneEntities->m_npcList, CNpcEntity*, PNpc)
     {
-        func((CNpcEntity*)PNpc.second);
+        func(PNpc);
     }
 }
 
@@ -1223,10 +1214,8 @@ void CZone::CheckTriggerAreas()
 {
     TracyZoneScoped;
 
-    for (auto const& [targid, PEntity] : m_zoneEntities->m_charList)
+    FOR_EACH_PAIR_CAST_SECOND(m_zoneEntities->m_charList, CCharEntity*, PChar)
     {
-        auto* PChar = static_cast<CCharEntity*>(PEntity);
-
         // TODO: When we start to use octrees or spatial hashing to split up zones,
         //     : use them here to make the search domain smaller.
 

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -519,7 +519,9 @@ struct zoneLine_t
 class CBasicPacket;
 class CBaseEntity;
 class CCharEntity;
+class CMobEntity;
 class CNpcEntity;
+class CPetEntity;
 class CBattleEntity;
 class CTrustEntity;
 class CTreasurePool;
@@ -600,9 +602,6 @@ public:
     virtual void InsertPET(CBaseEntity* PPet);
     virtual void InsertTRUST(CBaseEntity* PTrust);
 
-    virtual void DeletePET(CBaseEntity* PPet);
-    virtual void DeleteTRUST(CBaseEntity* PTrust);
-
     virtual void FindPartyForMob(CBaseEntity* PEntity);
     virtual void TransportDepart(uint16 boundary, uint16 zone);  // Collect passengers if ship/boat is departing
     virtual void updateCharLevelRestriction(CCharEntity* PChar); // Removes the character's level restriction. If the zone has a level restriction, it is applied after it is removed.
@@ -627,9 +626,14 @@ public:
     virtual void ForEachCharInstance(CBaseEntity* PEntity, std::function<void(CCharEntity*)> const& func);
     virtual void ForEachMob(std::function<void(CMobEntity*)> const& func);
     virtual void ForEachMobInstance(CBaseEntity* PEntity, std::function<void(CMobEntity*)> const& func);
+    virtual void ForEachNpc(std::function<void(CNpcEntity*)> const& func);
+    virtual void ForEachNpcInstance(CBaseEntity* PEntity, std::function<void(CNpcEntity*)> const& func);
     virtual void ForEachTrust(std::function<void(CTrustEntity*)> const& func);
     virtual void ForEachTrustInstance(CBaseEntity* PEntity, std::function<void(CTrustEntity*)> const& func);
-    virtual void ForEachNpc(std::function<void(CNpcEntity*)> const& func);
+    virtual void ForEachPet(std::function<void(CPetEntity*)> const& func);
+    virtual void ForEachPetInstance(CBaseEntity* PEntity, std::function<void(CPetEntity*)> const& func);
+    virtual void ForEachAlly(std::function<void(CMobEntity*)> const& func);
+    virtual void ForEachAllyInstance(CBaseEntity* PEntity, std::function<void(CMobEntity*)> const& func);
 
     CZone(ZONEID ZoneID, REGION_TYPE RegionID, CONTINENT_TYPE ContinentID, uint8 levelRestriction);
     virtual ~CZone();

--- a/src/map/zone_entities.h
+++ b/src/map/zone_entities.h
@@ -37,6 +37,9 @@
 class CZoneEntities
 {
 public:
+    CZoneEntities(CZone*);
+    ~CZoneEntities();
+
     void HealAllMobs();
     void TryAddToNearbySpawnLists(CBaseEntity* PEntity);
 
@@ -67,8 +70,6 @@ public:
     void InsertMOB(CBaseEntity* PMob);
     void InsertPET(CBaseEntity* PPet);
     void InsertTRUST(CBaseEntity* PTrust);
-    void DeletePET(CBaseEntity* PPet);
-    void DeleteTRUST(CBaseEntity* PTrust);
 
     void FindPartyForMob(CBaseEntity* PEntity);         // looking for a party for the monster
     void TransportDepart(uint16 boundary, uint16 zone); // ship/boat is leaving, passengers need to be collected
@@ -87,8 +88,19 @@ public:
     EntityList_t GetMobList() const;
     bool         CharListEmpty() const;
 
-    uint16 GetNewCharTargID();
-    void   AssignDynamicTargIDandLongID(CBaseEntity* PEntity);
+    void ForEachChar(std::function<void(CCharEntity*)> const& func);
+    void ForEachMob(std::function<void(CMobEntity*)> const& func);
+    void ForEachNpc(std::function<void(CNpcEntity*)> const& func);
+    void ForEachTrust(std::function<void(CTrustEntity*)> const& func);
+    void ForEachPet(std::function<void(CPetEntity*)> const& func);
+    void ForEachAlly(std::function<void(CMobEntity*)> const& func);
+
+    auto GetNewCharTargID() -> uint16;
+    void AssignDynamicTargIDandLongID(CBaseEntity* PEntity);
+    void EraseStaleDynamicTargIDs();
+
+private:
+    CZone* m_zone;
 
     EntityList_t m_allyList;
     EntityList_t m_mobList;
@@ -104,11 +116,6 @@ public:
 
     std::vector<std::pair<uint16, time_point>> m_dynamicTargIdsToDelete; // list of targids pending deletion at a later date
 
-    CZoneEntities(CZone*);
-    ~CZoneEntities();
-
-private:
-    CZone*     m_zone;
     time_point m_EffectCheckTime{ server_clock::now() };
 
     time_point m_computeTime{ server_clock::now() };

--- a/src/map/zone_entities.h
+++ b/src/map/zone_entities.h
@@ -119,10 +119,10 @@ private:
     time_point m_EffectCheckTime{ server_clock::now() };
 
     time_point m_computeTime{ server_clock::now() };
-    uint16     m_lastCharComputeTargId;
+    uint16     m_lastCharComputeTargId{ 0 };
 
     time_point m_charPersistTime{ server_clock::now() };
-    uint16     m_lastCharPersistTargId;
+    uint16     m_lastCharPersistTargId{ 0 };
 
     //
     // Intermediate collections for use inside ZoneServer

--- a/src/map/zone_entities.h
+++ b/src/map/zone_entities.h
@@ -31,6 +31,7 @@ class CZoneEntities
 {
 public:
     void HealAllMobs();
+    void TryAddToNearbySpawnLists(CBaseEntity* PEntity);
 
     CCharEntity* GetCharByName(const std::string& name); // finds the player if exists in zone
     CCharEntity* GetCharByID(uint32 id);

--- a/src/map/zone_entities.h
+++ b/src/map/zone_entities.h
@@ -24,6 +24,13 @@
 
 #include "zone.h"
 
+#include "entities/baseentity.h"
+#include "entities/charentity.h"
+#include "entities/mobentity.h"
+#include "entities/npcentity.h"
+#include "entities/petentity.h"
+#include "entities/trustentity.h"
+
 #include <set>
 #include <vector>
 
@@ -91,11 +98,11 @@ public:
     EntityList_t m_TransportList;
     EntityList_t m_charList;
 
-    uint16           nextDynamicTargID; // The next dynamic targ ID to chosen -- SE rotates them forwards and skips entries that already exist.
-    std::set<uint16> charTargIds;       // sorted set of targids for characters
-    std::set<uint16> dynamicTargIds;    // sorted set of targids for dynamic entities
+    uint16           m_nextDynamicTargID; // The next dynamic targ ID to chosen -- SE rotates them forwards and skips entries that already exist.
+    std::set<uint16> m_charTargIds;       // sorted set of targids for characters
+    std::set<uint16> m_dynamicTargIds;    // sorted set of targids for dynamic entities
 
-    std::vector<std::pair<uint16, time_point>> dynamicTargIdsToDelete; // list of targids pending deletion at a later date
+    std::vector<std::pair<uint16, time_point>> m_dynamicTargIdsToDelete; // list of targids pending deletion at a later date
 
     CZoneEntities(CZone*);
     ~CZoneEntities();
@@ -104,11 +111,24 @@ private:
     CZone*     m_zone;
     time_point m_EffectCheckTime{ server_clock::now() };
 
-    time_point computeTime{ server_clock::now() };
-    uint16     lastCharComputeTargId;
+    time_point m_computeTime{ server_clock::now() };
+    uint16     m_lastCharComputeTargId;
 
-    time_point charPersistTime{ server_clock::now() };
-    uint16     lastCharPersistTargId;
+    time_point m_charPersistTime{ server_clock::now() };
+    uint16     m_lastCharPersistTargId;
+
+    //
+    // Intermediate collections for use inside ZoneServer
+    //
+
+    std::vector<CMobEntity*>   m_mobsToDelete;
+    std::vector<CNpcEntity*>   m_npcsToDelete;
+    std::vector<CPetEntity*>   m_petsToDelete;
+    std::vector<CTrustEntity*> m_trustsToDelete;
+    std::vector<CMobEntity*>   m_aggroableMobs;
+    std::vector<CCharEntity*>  m_charsToLogout;
+    std::vector<CCharEntity*>  m_charsToWarp;
+    std::vector<CCharEntity*>  m_charsToChangeZone;
 };
 
 #endif

--- a/src/map/zone_instance.cpp
+++ b/src/map/zone_instance.cpp
@@ -105,15 +105,6 @@ void CZoneInstance::InsertNPC(CBaseEntity* PNpc)
     }
 }
 
-void CZoneInstance::DeletePET(CBaseEntity* PPet)
-{
-    TracyZoneScoped;
-    if (PPet->PInstance)
-    {
-        PPet->PInstance->DeletePET(PPet);
-    }
-}
-
 void CZoneInstance::InsertPET(CBaseEntity* PPet)
 {
     TracyZoneScoped;
@@ -129,15 +120,6 @@ void CZoneInstance::InsertTRUST(CBaseEntity* PTrust)
     if (PTrust->PInstance)
     {
         PTrust->PInstance->InsertTRUST(PTrust);
-    }
-}
-
-void CZoneInstance::DeleteTRUST(CBaseEntity* PTrust)
-{
-    TracyZoneScoped;
-    if (PTrust->PInstance)
-    {
-        PTrust->PInstance->DeleteTRUST(PTrust);
     }
 }
 
@@ -353,6 +335,7 @@ void CZoneInstance::TOTDChange(TIMETYPE TOTD)
 void CZoneInstance::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message_type, const std::unique_ptr<CBasicPacket>& packet)
 {
     TracyZoneScoped;
+
     if (PEntity)
     {
         if (PEntity->PInstance)
@@ -372,6 +355,7 @@ void CZoneInstance::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
 void CZoneInstance::UpdateCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint8 updatemask)
 {
     TracyZoneScoped;
+
     if (PChar)
     {
         if (PChar->PInstance)
@@ -391,6 +375,7 @@ void CZoneInstance::UpdateCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint
 void CZoneInstance::UpdateEntityPacket(CBaseEntity* PEntity, ENTITYUPDATE type, uint8 updatemask, bool alwaysInclude)
 {
     TracyZoneScoped;
+
     if (PEntity)
     {
         if (PEntity->PInstance)
@@ -410,6 +395,7 @@ void CZoneInstance::UpdateEntityPacket(CBaseEntity* PEntity, ENTITYUPDATE type, 
 void CZoneInstance::WideScan(CCharEntity* PChar, uint16 radius)
 {
     TracyZoneScoped;
+
     if (PChar->PInstance)
     {
         PChar->PInstance->WideScan(PChar, radius);
@@ -419,6 +405,7 @@ void CZoneInstance::WideScan(CCharEntity* PChar, uint16 radius)
 void CZoneInstance::ZoneServer(time_point tick)
 {
     TracyZoneScoped;
+
     std::vector<CInstance*> instancesToRemove;
     for (const auto& PInstance : m_InstanceList)
     {
@@ -447,16 +434,12 @@ void CZoneInstance::ZoneServer(time_point tick)
 void CZoneInstance::CheckTriggerAreas()
 {
     TracyZoneScoped;
+
     for (const auto& PInstance : m_InstanceList)
     {
-        for (const auto& [targid, PEntity] : PInstance->m_charList)
+        // clang-format off
+        PInstance->ForEachChar([&](CCharEntity* PChar)
         {
-            auto* PChar = dynamic_cast<CCharEntity*>(PEntity);
-            if (!PChar)
-            {
-                continue;
-            }
-
             // TODO: When we start to use octrees or spatial hashing to split up zones,
             //     : use them here to make the search domain smaller.
 
@@ -483,46 +466,128 @@ void CZoneInstance::CheckTriggerAreas()
                 }
             }
             PChar->m_InsideTriggerAreaID = triggerAreaID;
-        }
+        });
+        // clang-format on
     }
 }
 
 void CZoneInstance::ForEachChar(const std::function<void(CCharEntity*)>& func)
 {
     TracyZoneScoped;
+
     for (const auto& PInstance : m_InstanceList)
     {
-        for (const auto& [targid, PEntity] : PInstance->GetCharList())
-        {
-            if (auto* PChar = dynamic_cast<CCharEntity*>(PEntity))
-            {
-                func(PChar);
-            }
-        }
+        PInstance->ForEachChar(func);
     }
 }
 
 void CZoneInstance::ForEachCharInstance(CBaseEntity* PEntity, const std::function<void(CCharEntity*)>& func)
 {
     TracyZoneScoped;
-    for (const auto& [_, PEntity] : PEntity->PInstance->GetCharList())
+
+    if (PEntity->PInstance)
     {
-        if (auto* PChar = dynamic_cast<CCharEntity*>(PEntity))
-        {
-            func(PChar);
-        }
+        PEntity->PInstance->ForEachChar(func);
+    }
+}
+
+void CZoneInstance::ForEachMob(const std::function<void(CMobEntity*)>& func)
+{
+    TracyZoneScoped;
+
+    for (const auto& PInstance : m_InstanceList)
+    {
+        PInstance->ForEachMob(func);
     }
 }
 
 void CZoneInstance::ForEachMobInstance(CBaseEntity* PEntity, const std::function<void(CMobEntity*)>& func)
 {
     TracyZoneScoped;
-    for (const auto& [_, PEntity] : PEntity->PInstance->m_mobList)
+
+    if (PEntity->PInstance)
     {
-        if (auto* PMob = dynamic_cast<CMobEntity*>(PEntity))
-        {
-            func(PMob);
-        }
+        PEntity->PInstance->ForEachMob(func);
+    }
+}
+
+void CZoneInstance::ForEachNpc(const std::function<void(CNpcEntity*)>& func)
+{
+    TracyZoneScoped;
+
+    for (const auto& PInstance : m_InstanceList)
+    {
+        PInstance->ForEachNpc(func);
+    }
+}
+
+void CZoneInstance::ForEachNpcInstance(CBaseEntity* PEntity, const std::function<void(CNpcEntity*)>& func)
+{
+    TracyZoneScoped;
+
+    if (PEntity->PInstance)
+    {
+        PEntity->PInstance->ForEachNpc(func);
+    }
+}
+
+void CZoneInstance::ForEachTrust(const std::function<void(CTrustEntity*)>& func)
+{
+    TracyZoneScoped;
+
+    for (const auto& PInstance : m_InstanceList)
+    {
+        PInstance->ForEachTrust(func);
+    }
+}
+
+void CZoneInstance::ForEachTrustInstance(CBaseEntity* PEntity, const std::function<void(CTrustEntity*)>& func)
+{
+    TracyZoneScoped;
+
+    if (PEntity->PInstance)
+    {
+        PEntity->PInstance->ForEachTrust(func);
+    }
+}
+
+void CZoneInstance::ForEachPet(const std::function<void(CPetEntity*)>& func)
+{
+    TracyZoneScoped;
+
+    for (const auto& PInstance : m_InstanceList)
+    {
+        PInstance->ForEachPet(func);
+    }
+}
+
+void CZoneInstance::ForEachPetInstance(CBaseEntity* PEntity, const std::function<void(CPetEntity*)>& func)
+{
+    TracyZoneScoped;
+
+    if (PEntity->PInstance)
+    {
+        PEntity->PInstance->ForEachPet(func);
+    }
+}
+
+void CZoneInstance::ForEachAlly(const std::function<void(CMobEntity*)>& func)
+{
+    TracyZoneScoped;
+
+    for (const auto& PInstance : m_InstanceList)
+    {
+        PInstance->ForEachAlly(func);
+    }
+}
+
+void CZoneInstance::ForEachAllyInstance(CBaseEntity* PEntity, const std::function<void(CMobEntity*)>& func)
+{
+    TracyZoneScoped;
+
+    if (PEntity->PInstance)
+    {
+        PEntity->PInstance->ForEachAlly(func);
     }
 }
 

--- a/src/map/zone_instance.cpp
+++ b/src/map/zone_instance.cpp
@@ -461,15 +461,15 @@ void CZoneInstance::CheckTriggerAreas()
             //     : use them here to make the search domain smaller.
 
             uint32 triggerAreaID = 0;
-            for (triggerAreaList_t::const_iterator triggerAreaItr = m_triggerAreaList.begin(); triggerAreaItr != m_triggerAreaList.end(); ++triggerAreaItr)
+            for (const auto& triggerArea : m_triggerAreaList)
             {
-                if ((*triggerAreaItr)->isPointInside(PChar->loc.p))
+                if (triggerArea->isPointInside(PChar->loc.p))
                 {
-                    triggerAreaID = (*triggerAreaItr)->GetTriggerAreaID();
+                    triggerAreaID = triggerArea->GetTriggerAreaID();
 
-                    if ((*triggerAreaItr)->GetTriggerAreaID() != PChar->m_InsideTriggerAreaID)
+                    if (triggerArea->GetTriggerAreaID() != PChar->m_InsideTriggerAreaID)
                     {
-                        luautils::OnTriggerAreaEnter(PChar, *triggerAreaItr);
+                        luautils::OnTriggerAreaEnter(PChar, triggerArea);
                     }
 
                     if (PChar->m_InsideTriggerAreaID == 0)
@@ -477,9 +477,9 @@ void CZoneInstance::CheckTriggerAreas()
                         break;
                     }
                 }
-                else if ((*triggerAreaItr)->GetTriggerAreaID() == PChar->m_InsideTriggerAreaID)
+                else if (triggerArea->GetTriggerAreaID() == PChar->m_InsideTriggerAreaID)
                 {
-                    luautils::OnTriggerAreaLeave(PChar, *triggerAreaItr);
+                    luautils::OnTriggerAreaLeave(PChar, triggerArea);
                 }
             }
             PChar->m_InsideTriggerAreaID = triggerAreaID;

--- a/src/map/zone_instance.h
+++ b/src/map/zone_instance.h
@@ -51,8 +51,6 @@ public:
     virtual void InsertMOB(CBaseEntity* PMob) override;
     virtual void InsertPET(CBaseEntity* PPet) override;
     virtual void InsertTRUST(CBaseEntity* PTrust) override;
-    virtual void DeleteTRUST(CBaseEntity* PTrust) override;
-    virtual void DeletePET(CBaseEntity* PPet) override;
 
     virtual void FindPartyForMob(CBaseEntity* PEntity) override;         // looking for a party for the monster
     virtual void TransportDepart(uint16 boundary, uint16 zone) override; // ship/boat is leaving, passengers need to be collected
@@ -66,9 +64,18 @@ public:
     virtual void ZoneServer(time_point tick) override;
     virtual void CheckTriggerAreas() override;
 
-    virtual void ForEachChar(const std::function<void(CCharEntity*)>& func) override;
-    virtual void ForEachCharInstance(CBaseEntity* PEntity, const std::function<void(CCharEntity*)>& func) override;
-    virtual void ForEachMobInstance(CBaseEntity* PEntity, const std::function<void(CMobEntity*)>& func) override;
+    void ForEachChar(std::function<void(CCharEntity*)> const& func) override;
+    void ForEachCharInstance(CBaseEntity* PEntity, std::function<void(CCharEntity*)> const& func) override;
+    void ForEachMob(std::function<void(CMobEntity*)> const& func) override;
+    void ForEachMobInstance(CBaseEntity* PEntity, std::function<void(CMobEntity*)> const& func) override;
+    void ForEachNpc(std::function<void(CNpcEntity*)> const& func) override;
+    void ForEachNpcInstance(CBaseEntity* PEntity, std::function<void(CNpcEntity*)> const& func) override;
+    void ForEachTrust(std::function<void(CTrustEntity*)> const& func) override;
+    void ForEachTrustInstance(CBaseEntity* PEntity, std::function<void(CTrustEntity*)> const& func) override;
+    void ForEachPet(std::function<void(CPetEntity*)> const& func) override;
+    void ForEachPetInstance(CBaseEntity* PEntity, std::function<void(CPetEntity*)> const& func) override;
+    void ForEachAlly(std::function<void(CMobEntity*)> const& func) override;
+    void ForEachAllyInstance(CBaseEntity* PEntity, std::function<void(CMobEntity*)> const& func) override;
 
     CInstance* CreateInstance(uint16 instanceid);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR changes the pattern we have inside our "hot loop" (`ZoneServer`) of iterating with `const_iterator` and deleting things as we go, as they disappear, etc. This makes the logic and lifetimes of these entities very hard to reason about.

Instead, we will collect them up in `XToDelete` containers and clear them out at the end of the tick.

I've also written a macro (and thoroughly tested performance) that replaces these iterator loops and does the casting we want, while looking somewhat like a regular for loop. Performance is _exactly_ the same.

Moved a couple of lookups that were inside loops to be outside of loops - hopefully the compiler did this anyway.

General cleanup, refactoring, renaming, etc. Lifting intermediate containers out of the hot loop, pre-setting their capacity so they're less likely to expand at runtime, using the _ever so slightly faster_ distance calc helper in the hottest loop, tracy cleanup, TaskMgr cleanup, etc.

This is very much prep work for the spatial partitioning work I've been ramping up to do. Once this loop is clean and tidy, it'll be that much easier to change the logic.

## Steps to test these changes

To test:
- [x] Literally everything, jesus christ.
- [x] Instances
  - [x] !instance 7700 - Is aggro broken here? 
  - [x] Crash while !instance 7700 to exit?
  - [x] Amnaf not aggroing? -> doesn't aggro on `base` either
- [ ] Transport: `[01/23/25 09:52:48:438][map][error] CLuaBaseEntity::StartEventHelper: Could not start event, Character Entity already triggered. (CLuaBaseEntity::StartEventHelper:938)` is this my problem? It seems to work? Check on base

Done:
- [x] Where I've swapped loop styles, make sure I've not typo'd and iterated a different container (entity lists vs spawn lists)
- [x] Player zoning
- [x] DEs: Insertion, deletion, updating, etc.
- [x] Pets: Insertion, deletion, updating, etc.
- [x] Have I broken BCNM allies?
  - [x] The two Allies in Dawn seem to work fine 
- [x] BCNMs (Entered and completed Dawn - fine)
- [x] Have I fixed characters not being visible onZoneIn? -> Alas, seemingly not
- [x] Pets: PMaster problems? -> Nope
- [x] Trusts: All still sane?
- [x] NPCs & Shops: Still good?
- [x] Automatons?
- [x] Wyverns?
- [x] BST Jugs and Charm mobs
- [x] SMN Avatars
- [x] Mob vs Mob fighting
- [x] Aggro in general
- [x] Distance checking: Make sure I have converted all of the squared distances and true/false checks correctly. Each one. Individually.
- [x] Weather
- [x] Monstrosity + Feretory
- [x] Entering Mog Garden
- [x] Transport + Ferries

## Loop Proof

I was driving myself insane trying to get exactly the same performance results to show up in Tracy, so I decided it would be useful to compare the assembly output of the original loops with the new macro-based solution I've settled on:

<details>
  <summary>Code</summary>

```cpp
#include <unordered_map>
#include <string>
#include <iostream>

class CBaseEntity
{
public:
    virtual ~CBaseEntity() = default;

    void doSomethingBasic() const
    {
        std::cout << "Doing something basic" << std::endl;
    }
};

class CCharEntity : public CBaseEntity
{
public:
    void doSomethingCharacterful() const
    {
        std::cout << "Doing something characterful" << std::endl;
    }
};

using EntityList_t = std::unordered_map<int, CBaseEntity*>;

#define FOR_EACH_PAIR_CAST_SECOND(_collection, _type, _var)              \
    for (const auto& [_key, _value] : _collection)                       \
        if (auto _var = static_cast<_type>(_value); true)

#define FOR_EACH_PAIR_SECOND(_collection, _var)                          \
    for (const auto& [_key, _value] : _collection)                       \
        if (auto _var = _value; true)

void originalLoop(const EntityList_t& m_charList)
{
    for (EntityList_t::const_iterator it = m_charList.begin(); it != m_charList.end(); ++it)
    {
        CCharEntity* PCurrentChar = (CCharEntity*)it->second;
        PCurrentChar->doSomethingCharacterful();
    }
}

void macroLoopWithCast(const EntityList_t& m_charList)
{
    FOR_EACH_PAIR_CAST_SECOND(m_charList, CCharEntity*, PCurrentChar)
    {
        PCurrentChar->doSomethingCharacterful();
    }
}

void macroLoopNoCast(const EntityList_t& m_charList)
{
    FOR_EACH_PAIR_SECOND(m_charList, PCurrentEntity)
    {
        PCurrentEntity->doSomethingBasic();
    }
}

int main()
{
    EntityList_t m_charList;
    m_charList[1] = new CCharEntity();
    m_charList[2] = new CCharEntity();

    originalLoop(m_charList);
    macroLoopWithCast(m_charList);
    macroLoopNoCast(m_charList);

    for (auto& [key, value] : m_charList)
    {
        delete value;
    }

    return 0;
}
```

</details>

<details>
  <summary>Assembly</summary>

As you can see, all three styles of loop produce exactly the same 11 assembly instructions.

```asm
originalLoop(std::unordered_map<int, CBaseEntity*, std::hash<int>, std::equal_to<int>, std::allocator<std::pair<int const, CBaseEntity*>>> const&):
        push    rbx
        mov     rbx, qword ptr [rdi + 16]
        test    rbx, rbx
        je      .LBB0_3
.LBB0_1:
        mov     rdi, qword ptr [rbx + 16]
        call    CCharEntity::doSomethingCharacterful() const
        mov     rbx, qword ptr [rbx]
        test    rbx, rbx
        jne     .LBB0_1
.LBB0_3:
        pop     rbx
        ret
```

```asm
macroLoopWithCast(std::unordered_map<int, CBaseEntity*, std::hash<int>, std::equal_to<int>, std::allocator<std::pair<int const, CBaseEntity*>>> const&):
        push    rbx
        mov     rbx, qword ptr [rdi + 16]
        test    rbx, rbx
        je      .LBB2_3
.LBB2_1:
        mov     rdi, qword ptr [rbx + 16]
        call    CCharEntity::doSomethingCharacterful() const
        mov     rbx, qword ptr [rbx]
        test    rbx, rbx
        jne     .LBB2_1
.LBB2_3:
        pop     rbx
        ret
```

```asm
macroLoopNoCast(std::unordered_map<int, CBaseEntity*, std::hash<int>, std::equal_to<int>, std::allocator<std::pair<int const, CBaseEntity*>>> const&):
        push    rbx
        mov     rbx, qword ptr [rdi + 16]
        test    rbx, rbx
        je      .LBB3_3
.LBB3_1:
        mov     rdi, qword ptr [rbx + 16]
        call    CBaseEntity::doSomethingBasic() const
        mov     rbx, qword ptr [rbx]
        test    rbx, rbx
        jne     .LBB3_1
.LBB3_3:
        pop     rbx
        ret
```

</details>

Godbolt: https://godbolt.org/z/GE4v4PE3x

