### PR TITLE
Lua: Allow npcUtil.giveItem to force alternative message for consistency

### DIFF
--- a/scripts/globals/npc_util.lua
+++ b/scripts/globals/npc_util.lua
@@ -242,6 +242,9 @@ end
         "Try trading again after sorting your inventory"
         instead of
         "Come back again after sorting your inventory"
+    multiple (boolean default false)
+        if set, force message type as multiples version
+        eg. You obtain 1 chunk of rock salt!
 --]]
 
 ---@class itemQuantityEntry : { [xi.item]: xi.item, [integer]: integer }
@@ -251,7 +254,7 @@ end
 
 ---@param player CBaseEntity
 ---@param items xi.item|itemQuantityEntry|multipleItemList
----@param params { silent: boolean?, fromTrade: boolean? }?
+---@param params { silent: boolean?, fromTrade: boolean?, multiple: boolean? }?
 ---@return boolean
 function npcUtil.giveItem(player, items, params)
     params = params or {}
@@ -294,7 +297,10 @@ function npcUtil.giveItem(player, items, params)
     for _, v in pairs(givenItems) do
         if player:addItem(v[1], v[2], true) then
             if not params.silent and not messagedItems[v[1]] then
-                if v[2] > 1 then
+                if
+                    v[2] > 1 or
+                    params.multiple
+                then
                     player:messageSpecial(ID.text.ITEM_OBTAINED + 9, v[1], v[2])
                 else
                     player:messageSpecial(ID.text.ITEM_OBTAINED, v[1])
@@ -502,7 +508,7 @@ end
 
 ---@class rewardParam
 ---@field item xi.item|itemQuantityEntry|multipleItemList?
----@field itemParams { silent: boolean?, fromTrade: boolean? }?
+---@field itemParams { silent: boolean?, fromTrade: boolean?, multiple: boolean? }?
 ---@field keyItem xi.keyItem|{ [integer]: xi.keyItem }?
 ---@field ki xi.keyItem|{ [integer]: xi.keyItem }?
 ---@field fame integer?


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Currently, `npcUtil.giveItem` uses different message IDs based on the quantity. However, when distributing multiple items, this can lead to inconsistent messages for example:
```
Obtained: Flint stone.
You obtain 3 chunks of rock salt!
Obtained: Chocobo feather.
You obtain 2 bone chips!
```

This PR adds a new parameter "multiple" which will force messages to be given as the multiple item type.
```
You obtain 1 flint stone!
You obtain 3 chunks of rock salt!
You obtain 1 chocobo feather!
You obtain 2 bone chips!
```

Example usage:
```lua
npcUtil.giveItem(player, {
    { xi.item.FLINT_STONE,        1 },
    { xi.item.CHUNK_OF_ROCK_SALT, 3 },
    { xi.item.CHOCOBO_FEATHER,    1 },
    { xi.item.BONE_CHIP,          2 },
}, { multiple = true })
```

## Steps to test these changes
Tested in game with different quantities of items
