### PR TITLE
[core] Use different DEF formulas dep. on entity type

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1061,7 +1061,7 @@ uint16 CBattleEntity::DEF()
     int32 DEF       = 8 + m_modStat[Mod::DEF];
     float vitFactor = 1.5f;
 
-    if (this->objtype == TYPE_MOB || (this->objtype == TYPE_PET && this->isCharmed))
+    if (this->objtype == TYPE_MOB)
     {
         vitFactor = 0.5f;
     }

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1053,20 +1053,21 @@ uint16 CBattleEntity::ACC(uint8 attackNumber, uint16 offsetAccuracy)
 
 uint16 CBattleEntity::DEF()
 {
-    int32 DEF = 0;
     // VIT * 1.5 for PCs / Alter egos / Fellows / Familiars / Wyverns / Avatars / Automatons / Luopans
-    // VIT / 2 for Enemy NPCs and pets controlled by Charm
+    // VIT * 0.5 for Enemy NPCs and pets controlled by Charm
     // https://wiki.ffo.jp/html/313.html
     // https://wiki.ffo.jp/html/35712.html
     // https://forum.square-enix.com/ffxi/threads/51154-Aug.-3-2016-%28JST%29-Version-Update?p=583669&viewfull=1#post583669
-    if (this->objtype == TYPE_MOB || this->objtype == TYPE_PET && this->isCharmed)
+    int32 DEF       = 8 + m_modStat[Mod::DEF];
+    float vitFactor = 1.5f;
+
+    if (this->objtype == TYPE_MOB || (this->objtype == TYPE_PET && this->isCharmed))
     {
-        DEF = 8 + m_modStat[Mod::DEF] + VIT() / 2;
+        vitFactor = 0.5f;
     }
-    else
-    {
-        DEF = 8 + m_modStat[Mod::DEF] + std::floor(VIT() * 1.5f);
-    }
+
+    DEF = DEF + std::floor(VIT() * vitFactor);
+
     if (this->StatusEffectContainer->HasStatusEffect(EFFECT_COUNTERSTANCE, 0))
     {
         return DEF / 2;

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1053,7 +1053,20 @@ uint16 CBattleEntity::ACC(uint8 attackNumber, uint16 offsetAccuracy)
 
 uint16 CBattleEntity::DEF()
 {
-    int32 DEF = 8 + m_modStat[Mod::DEF] + std::floor(VIT() * 1.5f); // https://wiki.ffo.jp/html/313.html
+    int32 DEF = 0;
+    // VIT * 1.5 for PCs / Alter egos / Fellows / Familiars / Wyverns / Avatars / Automatons / Luopans
+    // VIT / 2 for Enemy NPCs and pets controlled by Charm
+    // https://wiki.ffo.jp/html/313.html
+    // https://wiki.ffo.jp/html/35712.html
+    // https://forum.square-enix.com/ffxi/threads/51154-Aug.-3-2016-%28JST%29-Version-Update?p=583669&viewfull=1#post583669
+    if (this->objtype == TYPE_MOB || this->objtype == TYPE_PET && this->isCharmed)
+    {
+        DEF = 8 + m_modStat[Mod::DEF] + VIT() / 2;
+    }
+    else
+    {
+        DEF = 8 + m_modStat[Mod::DEF] + std::floor(VIT() * 1.5f);
+    }
     if (this->StatusEffectContainer->HasStatusEffect(EFFECT_COUNTERSTANCE, 0))
     {
         return DEF / 2;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
#6480 introduced a new DEF formula where VIT * 1.5 is added to DEF, which correctly mirrors the retail formula for players and their associated entities. However the change also applies to monsters which has caused their DEF to raise across the board.

The patch notes of the time clearly state mobs and charmed pets are excluded from that change.

> The amount of defense a player gains by increasing VIT has been increased for the following characters.
> 
>     PCs / Alter egos / Fellows / Familiars / Wyverns/ Avatars / Automatons / Luopans
>     * Enemy NPCs and pets controlled with the job ability Charm are not subject to this adjustment.

https://forum.square-enix.com/ffxi/threads/51154-Aug.-3-2016-%28JST%29-Version-Update?p=583669&viewfull=1#post583669

https://wiki.ffo.jp/html/35712.html

This PR simply differentiates on the entity type at the time of calculating DEF and applies the correct formula.

## Steps to test these changes

Results of my test (pre-#6480 formula, post-#6480 formula, this PR formula)

https://docs.google.com/spreadsheets/d/16yNgFhjr2j48mC8uCm98CRP6XFnSUOy7o8OGhPifm6g/edit?usp=sharing

All tests done at LV75 with no merits or gear.

```
!changejob DRG 75
Use "Call Wyvern" and get wyvern stats

!changejob GEO 75
Use "Geo-Fury" and get Luopan stats

!changejob SMN 75
Use "Fenrir" and get Fenrir stats

!additem 17865 12
!changejob BST 75
Equip broth, Use "Call Beast" and get LullabyMelodia stats (ensure LullabyMelodia level is consistent)

!changejob PUP 75
Use "Activate" and get Automaton stats

!fafnir
Get Fafnir stats

Use "ArkEV" and get her stats

Find a charmable pet and get its stats pre-Charm and post-Charm. Ensure levels are consistent across tests.

```