### PR TITLE
[lua] Resolve Automaton under/overflow with LEVEL_RESTRICTION

### DIFF
--- a/scripts/actions/abilities/pets/attachments/truesights.lua
+++ b/scripts/actions/abilities/pets/attachments/truesights.lua
@@ -1,36 +1,26 @@
 -----------------------------------
--- Attachment: Volt Gun
+-- Attachment: Truesights
 -----------------------------------
 ---@type TAttachment
 local attachmentObject = {}
 
-local function calcEnspellDmg(pet, maneuvers)
-    local skill = math.max(pet:getSkillLevel(xi.skill.AUTOMATON_MELEE), pet:getSkillLevel(xi.skill.AUTOMATON_RANGED), pet:getSkillLevel(xi.skill.AUTOMATON_MAGIC))
-    return (skill * 0.1) + ((skill * 0.05) * maneuvers)
-end
-
 attachmentObject.onEquip = function(pet, attachment)
-    pet:setMod(xi.mod.ENSPELL_DMG, calcEnspellDmg(pet, 0))
     xi.automaton.onAttachmentEquip(pet, attachment)
 end
 
 attachmentObject.onUnequip = function(pet, attachment)
-    pet:delMod(xi.mod.ENSPELL_DMG, pet:getMod(xi.mod.ENSPELL_DMG))
     xi.automaton.onAttachmentUnequip(pet, attachment)
 end
 
 attachmentObject.onManeuverGain = function(pet, attachment, maneuvers)
-    pet:setMod(xi.mod.ENSPELL_DMG, calcEnspellDmg(pet, maneuvers))
     xi.automaton.onManeuverGain(pet, attachment, maneuvers)
 end
 
 attachmentObject.onManeuverLose = function(pet, attachment, maneuvers)
-    pet:setMod(xi.mod.ENSPELL_DMG, calcEnspellDmg(pet, maneuvers))
     xi.automaton.onManeuverLose(pet, attachment, maneuvers)
 end
 
 attachmentObject.onUpdate = function(pet, attachment, maneuvers)
-    attachmentObject.onManeuverGain(pet, attachment, maneuvers)
     xi.automaton.updateAttachmentModifier(pet, attachment, maneuvers)
 end
 

--- a/scripts/actions/abilities/pets/attachments/volt_gun.lua
+++ b/scripts/actions/abilities/pets/attachments/volt_gun.lua
@@ -6,7 +6,7 @@ local attachmentObject = {}
 
 local function calcEnspellDmg(pet, maneuvers)
     local skill = math.max(pet:getSkillLevel(xi.skill.AUTOMATON_MELEE), pet:getSkillLevel(xi.skill.AUTOMATON_RANGED), pet:getSkillLevel(xi.skill.AUTOMATON_MAGIC))
-    return (skill * 0.1) + ((skill * 0.05) * maneuvers)
+    return math.floor(skill / 10 + skill * maneuvers / 20)
 end
 
 attachmentObject.onEquip = function(pet, attachment)

--- a/scripts/globals/automaton.lua
+++ b/scripts/globals/automaton.lua
@@ -158,6 +158,8 @@ local attachmentModifiers =
     ['turbo_charger_ii']    = { { xi.mod.HASTE_MAGIC,                 {   700,  1700,  2800,  4375 }, true  }, },
     ['vivi-valve']          = { { xi.mod.CURE_POTENCY,                {     5,    15,    30,    45 }, true  }, },
     ['vivi-valve_ii']       = { { xi.mod.CURE_POTENCY,                {    10,    20,    35,    50 }, true  }, },
+    ['volt_gun']            = { { xi.mod.ENSPELL,                     {     5,     5,     5,     5 }, false },
+                                { xi.mod.ENSPELL_CHANCE,              {     20,   35,    50,    65 }, false }, },
 }
 
 -- Auto Repair Kits and Mana Tanks use a formula based on Max HP/MP in the form of
@@ -226,8 +228,14 @@ xi.automaton.onAttachmentUnequip = function(pet, attachment)
     local modTable = attachmentModifiers[attachment:getName()]
 
     for k, modList in ipairs(modTable) do
-        pet:delMod(modList[1], modList[2][1])
+        if modList[2][1] then
+            pet:delMod(modList[1], modList[2][1])
+        else
+            pet:setMod(modList[1], 0)
+        end
     end
+
+    pet:clearLocalVarsWithPrefix(attachment:getName())
 end
 
 xi.automaton.onManeuverGain = function(pet, attachment, maneuvers)
@@ -269,6 +277,8 @@ xi.automaton.updateAttachmentModifier = function(pet, attachment, maneuvers)
 
         if modValue ~= previousMod then
             if previousMod ~= 0 then
+                -- If the automaton was reset to a blank state (LEVEL_RESTRICTION)
+                -- and the local variables were not cleared, this will under/overflow
                 pet:delMod(modList[1], previousMod)
             end
 

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -3429,8 +3429,20 @@ function CBaseEntity:getAutomatonFrame()
 end
 
 ---@nodiscard
+---@param itemId integer
+---@return nil
+function CBaseEntity:setAutomatonFrame(itemId)
+end
+
+---@nodiscard
 ---@return integer
 function CBaseEntity:getAutomatonHead()
+end
+
+---@nodiscard
+---@param itemId integer
+---@return nil
+function CBaseEntity:setAutomatonHead(itemId)
 end
 
 ---@param itemID integer
@@ -3455,6 +3467,13 @@ end
 ---@param slotId integer
 ---@return CItem?
 function CBaseEntity:getAttachment(slotId)
+end
+
+---@nodiscard
+---@param itemId integer
+---@param slotId integer
+---@return nil
+function CBaseEntity:setAttachment(itemId, slotId)
 end
 
 ---@nodiscard

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -720,16 +720,12 @@ void CLuaBaseEntity::setLocalVar(std::string const& var, uint32 val)
 
 void CLuaBaseEntity::clearLocalVarsWithPrefix(std::string const& prefix)
 {
-    auto& localVars = m_PBaseEntity->GetLocalVars();
-
-    auto iter = localVars.begin();
-    while (iter != localVars.end())
+    for (const auto& localVar : m_PBaseEntity->GetLocalVars())
     {
-        if (iter->first.rfind(prefix, 0) == 0)
+        if (starts_with(localVar.first, prefix))
         {
-            m_PBaseEntity->SetLocalVar(iter->first.c_str(), 0);
+            m_PBaseEntity->SetLocalVar(localVar.first, 0);
         }
-        ++iter;
     }
 
     return;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -712,6 +712,30 @@ void CLuaBaseEntity::setLocalVar(std::string const& var, uint32 val)
 }
 
 /************************************************************************
+ *  Function: clearLocalVarsWithPrefix()
+ *  Purpose : Deletes all local variables with the given prefix.
+ *  Example : pet:clearLocalVarsWithPrefix("volt");
+ *  Notes   :
+ ************************************************************************/
+
+void CLuaBaseEntity::clearLocalVarsWithPrefix(std::string const& prefix)
+{
+    auto& localVars = m_PBaseEntity->GetLocalVars();
+
+    auto iter = localVars.begin();
+    while (iter != localVars.end())
+    {
+        if (iter->first.rfind(prefix, 0) == 0)
+        {
+            m_PBaseEntity->SetLocalVar(iter->first.c_str(), 0);
+        }
+        ++iter;
+    }
+
+    return;
+}
+
+/************************************************************************
  *  Function: resetLocalVars()
  *  Purpose : Reset local variables back to default (ex: on Mob disengage)
  *  Example : GetMobByID(Defender):resetLocalVars();
@@ -6615,6 +6639,11 @@ uint8 CLuaBaseEntity::levelRestriction(sol::object const& level)
 
         if (PChar->GetMLevel() != NewMLevel)
         {
+            if (PChar->PAutomaton)
+            {
+                // Call each attachment onUnequip handler and zero out localVars tracking applied buffs
+                puppetutils::PreLevelRestriction(PChar);
+            }
             charutils::RemoveAllEquipMods(PChar);
             PChar->SetMLevel(NewMLevel);
             PChar->SetSLevel(PChar->jobs.job[PChar->GetSJob()]);
@@ -6697,6 +6726,9 @@ uint8 CLuaBaseEntity::levelRestriction(sol::object const& level)
                             return PChar->m_LevelRestriction;
                         }
                         petutils::CalculateAutomatonStats(PChar, PPet);
+
+                        // Call each attachment onEquip handler and replay maneuvers against the new stats
+                        puppetutils::PostLevelRestriction(PChar);
                         break;
                     case PET_TYPE::LUOPAN:
                         petutils::CalculateLuopanStats(PChar, PPet);
@@ -15704,6 +15736,32 @@ uint8 CLuaBaseEntity::getAutomatonFrame()
 }
 
 /************************************************************************
+ *  Function: setAutomatonFrame(frameItemID)
+ *  Purpose : Sets the provided frame on the automaton
+ *  Example : player:setAutomatonFrame(xi.item.VALOREDGE_FRAME)
+ *  Notes   :
+ ************************************************************************/
+
+void CLuaBaseEntity::setAutomatonFrame(uint8 frameItemID)
+{
+    auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity);
+
+    if (PChar == nullptr)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->getName());
+        return;
+    }
+
+    if (PChar->PAutomaton)
+    {
+        puppetutils::setFrame(PChar, frameItemID - 0x2000);
+        PChar->pushPacket<CCharJobExtraPacket>(PChar, true);
+        PChar->pushPacket<CCharJobExtraPacket>(PChar, false);
+        puppetutils::SaveAutomaton(PChar);
+    }
+}
+
+/************************************************************************
  *  Function: getAutomatonHead()
  *  Purpose : Returns the integer value of the (active?) automation head
  *  Example : local head = pet:getAutomatonHead()
@@ -15720,6 +15778,32 @@ uint8 CLuaBaseEntity::getAutomatonHead()
 
     auto* PAutomaton = static_cast<CAutomatonEntity*>(m_PBaseEntity);
     return static_cast<uint8>(PAutomaton->getHead());
+}
+
+/************************************************************************
+ *  Function: setAutomatonHead(headItemID)
+ *  Purpose : Sets the automaton head to the specified item
+ *  Example : player:setAutomatonHead(xi.item.VALOREDGE_HEAD)
+ *  Notes   :
+ ************************************************************************/
+
+void CLuaBaseEntity::setAutomatonHead(uint8 headItemID)
+{
+    auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity);
+
+    if (PChar == nullptr)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->getName());
+        return;
+    }
+
+    if (PChar->PAutomaton)
+    {
+        puppetutils::setHead(PChar, headItemID - 0x2000);
+        PChar->pushPacket<CCharJobExtraPacket>(PChar, true);
+        PChar->pushPacket<CCharJobExtraPacket>(PChar, false);
+        puppetutils::SaveAutomaton(PChar);
+    }
 }
 
 /************************************************************************
@@ -15821,6 +15905,30 @@ std::optional<CLuaItem> CLuaBaseEntity::getAttachment(uint8 slotId)
     }
 
     return std::nullopt;
+}
+
+/************************************************************************
+ *  Function: setAttachment(attachmentItemID, slotID)
+ *  Purpose : Sets the attachment of an automaton in the slot specified
+ *  Example : player:setAttachment(8465, 0)
+ ************************************************************************/
+
+void CLuaBaseEntity::setAttachment(uint8 attachmentItemID, uint8 slotID)
+{
+    auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity);
+
+    if (PChar == nullptr)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->getName());
+        return;
+    }
+    if (PChar->PAutomaton)
+    {
+        puppetutils::setAttachment(PChar, slotID, attachmentItemID - 0x2100);
+        PChar->pushPacket<CCharJobExtraPacket>(PChar, true);
+        PChar->pushPacket<CCharJobExtraPacket>(PChar, false);
+        puppetutils::SaveAutomaton(PChar);
+    }
 }
 
 /************************************************************************
@@ -18485,6 +18593,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("getLocalVars", CLuaBaseEntity::getLocalVars);
     SOL_REGISTER("getLocalVar", CLuaBaseEntity::getLocalVar);
     SOL_REGISTER("setLocalVar", CLuaBaseEntity::setLocalVar);
+    SOL_REGISTER("clearLocalVarsWithPrefix", CLuaBaseEntity::clearLocalVarsWithPrefix);
     SOL_REGISTER("resetLocalVars", CLuaBaseEntity::resetLocalVars);
     SOL_REGISTER("clearVarsWithPrefix", CLuaBaseEntity::clearVarsWithPrefix);
     SOL_REGISTER("getLastOnline", CLuaBaseEntity::getLastOnline);
@@ -19159,13 +19268,16 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("hasAttachment", CLuaBaseEntity::hasAttachment);
     SOL_REGISTER("getAutomatonName", CLuaBaseEntity::getAutomatonName);
     SOL_REGISTER("getAutomatonFrame", CLuaBaseEntity::getAutomatonFrame);
+    SOL_REGISTER("setAutomatonFrame", CLuaBaseEntity::setAutomatonFrame);
     SOL_REGISTER("getAutomatonHead", CLuaBaseEntity::getAutomatonHead);
+    SOL_REGISTER("setAutomatonHead", CLuaBaseEntity::setAutomatonHead);
     SOL_REGISTER("unlockAttachment", CLuaBaseEntity::unlockAttachment);
 
     SOL_REGISTER("getActiveManeuverCount", CLuaBaseEntity::getActiveManeuverCount);
     SOL_REGISTER("removeOldestManeuver", CLuaBaseEntity::removeOldestManeuver);
     SOL_REGISTER("removeAllManeuvers", CLuaBaseEntity::removeAllManeuvers);
     SOL_REGISTER("getAttachment", CLuaBaseEntity::getAttachment);
+    SOL_REGISTER("setAttachment", CLuaBaseEntity::setAttachment);
     SOL_REGISTER("getAttachments", CLuaBaseEntity::getAttachments);
     SOL_REGISTER("updateAttachments", CLuaBaseEntity::updateAttachments);
     SOL_REGISTER("reduceBurden", CLuaBaseEntity::reduceBurden);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -720,15 +720,13 @@ void CLuaBaseEntity::setLocalVar(std::string const& var, uint32 val)
 
 void CLuaBaseEntity::clearLocalVarsWithPrefix(std::string const& prefix)
 {
-    for (const auto& localVar : m_PBaseEntity->GetLocalVars())
+    for (const auto& [localVar, _] : m_PBaseEntity->GetLocalVars())
     {
-        if (starts_with(localVar.first, prefix))
+        if (starts_with(localVar, prefix))
         {
-            m_PBaseEntity->SetLocalVar(localVar.first, 0);
+            m_PBaseEntity->SetLocalVar(localVar, 0);
         }
     }
-
-    return;
 }
 
 /************************************************************************

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -75,6 +75,7 @@ public:
     auto   getLocalVars() -> sol::table;
     uint32 getLocalVar(std::string const& var);
     void   setLocalVar(std::string const& var, uint32 val);
+    void   clearLocalVarsWithPrefix(std::string const& prefix);
     void   resetLocalVars();
     void   clearVarsWithPrefix(std::string const& prefix);
     uint32 getLastOnline(); // Returns the unix timestamp of last time the player logged out or zoned
@@ -782,13 +783,16 @@ public:
     bool  hasAttachment(uint16 itemID);
     auto  getAutomatonName() -> std::string;
     uint8 getAutomatonFrame();
+    void  setAutomatonFrame(uint8 frameItemID);
     uint8 getAutomatonHead();
+    void  setAutomatonHead(uint8 headItemID);
     bool  unlockAttachment(uint16 itemID);
     uint8 getActiveManeuverCount();
     void  removeOldestManeuver();
     void  removeAllManeuvers();
     auto  getAttachment(uint8 slotId) -> std::optional<CLuaItem>;
     auto  getAttachments() -> sol::table;
+    void  setAttachment(uint8 attachmentItemID, uint8 slotID);
     void  updateAttachments();
     void  reduceBurden(float percentReduction, sol::object const& intReductionObj);
     bool  isExceedingElementalCapacity();

--- a/src/map/utils/puppetutils.cpp
+++ b/src/map/utils/puppetutils.cpp
@@ -789,12 +789,15 @@ namespace puppetutils
 
                 if (attachment != 0)
                 {
-                    CItemPuppet* PAttachment = (CItemPuppet*)itemutils::GetItemPointer(0x2100 + attachment);
+                    CItemPuppet* PAttachment = dynamic_cast<CItemPuppet*>(itemutils::GetItemPointer(0x2100 + attachment));
 
-                    // Attachment scripts may have custom unequip logic that needs to run before the restriction is applied
-                    // If they were to delMod after the restriction is applied, under/overflow may occur.
-                    // This will also clear the localVars holding previously applied modifiers
-                    luautils::OnAttachmentUnequip(PAutomaton, PAttachment);
+                    if (PAttachment)
+                    {
+                        // Attachment scripts may have custom unequip logic that needs to run before the restriction is applied
+                        // If they were to delMod after the restriction is applied, under/overflow may occur.
+                        // This will also clear the localVars holding previously applied modifiers
+                        luautils::OnAttachmentUnequip(PAutomaton, PAttachment);
+                    }
                 }
             }
         }
@@ -812,10 +815,12 @@ namespace puppetutils
 
                 if (attachment != 0)
                 {
-                    CItemPuppet* PAttachment = (CItemPuppet*)itemutils::GetItemPointer(0x2100 + attachment);
-
-                    // Attachment scripts may have custom equip logic that needs to be computed against the LvRestricted puppet stats
-                    luautils::OnAttachmentEquip(PAutomaton, PAttachment);
+                    CItemPuppet* PAttachment = dynamic_cast<CItemPuppet*>(itemutils::GetItemPointer(0x2100 + attachment));
+                    if (PAttachment)
+                    {
+                        // Attachment scripts may have custom equip logic that needs to be computed against the LvRestricted puppet stats
+                        luautils::OnAttachmentEquip(PAutomaton, PAttachment);
+                    }
                 }
             }
 

--- a/src/map/utils/puppetutils.h
+++ b/src/map/utils/puppetutils.h
@@ -41,6 +41,8 @@ namespace puppetutils
     void   LoadAutomatonStats(CCharEntity* PChar);
     void   CheckAttachmentsForManeuver(CCharEntity* PChar, EFFECT maneuver, bool gain);
     void   UpdateAttachments(CCharEntity* PChar);
+    void   PreLevelRestriction(CCharEntity* PChar);
+    void   PostLevelRestriction(CCharEntity* PChar);
 }; // namespace puppetutils
 
 #endif


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
When applying `LEVEL_RESTRICTION`, the automaton modifiers are reset by the `levelRestriction ` handler but the internal state of `automaton.lua` is not. 
When maneuvers wear after the `LEVEL_RESTRICTION` effect is applied, the `onManaveurLost` logic then tries to substract the modifiers it thinks are currently applied to the automaton. 

Depending on the buffs provided, this can lead to over or underflow of the modifier:
- Magniplug grants nearly capped weapon damage
- Mana Tank grants negative Refresh
- Auto-Repair kits gives a Poison-like effect
- Armor Plates makes the Automaton take more damage


Steps to reproduce ([video](https://youtu.be/GP4-TgT349Y)):
```
!changejob PUP 75
!addallattachments
Equip any frame/head
Equip "Magniplug" attachment (affects weapon/ranged damage)

Use "Activate" to summon automaton
(Use !getstats 3 on the automaton in between steps)
!addeffect FIRE_MANEUVER
!addeffect FIRE_MANEUVER
!addeffect FIRE_MANEUVER
!addeffect LEVEL_RESTRICTION 10
!deleffect FIRE_MANEUVER
!deleffect FIRE_MANEUVER
!deleffect FIRE_MANEUVER

Congratulations, you're the proud owner of an automaton with 65000+ weapon damage.
```

This PR does several things:
- Ensures _all_ modifiers are cleared and zero out related local variables when onAttachmentUnequip is called
- Adds a Pre/PostLevelRestriction to puppetutils, called by levelRestriction at different stages to ensure we can clean up existing state AND recalculate the attachments on the new automaton stats
- Adds a clearLocalVarsWithPrefix lua function, similar in spirit to clearVarsWithPrefix
- Adds setAttachment/setAutomatonHead/setAutomatonFrame lua functions, which I used for testing
- Enable Truesights attachment (unrelated to issue but it was a quick fix)
- Refactor Volt Gun attachment script to apply stats in a slightly different but still accurate way.

Several of these changes are not strictly related to the issue and could be removed from the PR, let me know.

Notes:
- Level restriction does not wipe maneuvers (or any other buff) today. On Retail level restriction wipes buffs in the majority of cases with only a handful of exceptions. This change should also work if this were to become a default behavior of levelRestriction and maneuvers were wiped.
- Initially tried to implement it using `onPetLevelRestriction` but it was too difficult without a major rewrite of `automaton.lua`

## Steps to test these changes
https://youtu.be/dBSDdiD2OT8

Collected data about every attachment  I could test (88/105)

https://docs.google.com/spreadsheets/d/1cEZ2CZkZEAgN-NbqpQzDVZT6BLkXy2SpQYkDX9v4Ykc/edit?usp=sharing

Maneuvers description:
- 0 maneuver, just onEquip bonus (without level restriction)
- 1 -> 3 maneuvers (without level restriction)
- 3 ->0 maneuvers (after level restriction)
- 1 -> 3 maneuvers (still under level restriction)

Test script [available here](https://gist.github.com/sruon/23f4842fa1001b3a550c13f1e910fdbc)
```
// Test without optical fiber, results in pup_attachments.csv next to xi_map.exe
!automatontest

// To test with optical fiber
!automatontest anythinghere
```

