### PR TITLE
Core: Introduce luautils::callGlobal helper

### DIFF
--- a/src/common/filewatcher.cpp
+++ b/src/common/filewatcher.cpp
@@ -78,7 +78,7 @@ void Filewatcher::handleFileAction(efsw::WatchID watchid, std::string const& dir
     }
 }
 
-auto Filewatcher::getChangedLuaFiles() -> std::vector<std::pair<std::filesystem::path, Action>>
+auto Filewatcher::popChangedLuaFilesList() -> std::vector<std::pair<std::filesystem::path, Action>>
 {
     std::set<std::pair<std::filesystem::path, Action>> actions; // For de-duping
 

--- a/src/common/filewatcher.h
+++ b/src/common/filewatcher.h
@@ -50,7 +50,7 @@ public:
         Moved    = 4,
     };
 
-    auto getChangedLuaFiles() -> std::vector<std::pair<std::filesystem::path, Action>>;
+    auto popChangedLuaFilesList() -> std::vector<std::pair<std::filesystem::path, Action>>;
 
 private:
     std::unique_ptr<efsw::FileWatcher> fileWatcherImpl;

--- a/src/common/xi.h
+++ b/src/common/xi.h
@@ -50,9 +50,14 @@ namespace xi
         {
         }
 
-        constexpr explicit optional(T&& value) noexcept
+        constexpr optional(T&& value)
+        : m_value(std::forward<T>(value))
         {
-            m_value = std::move(value);
+        }
+
+        constexpr optional(const T& value)
+        : m_value(value)
+        {
         }
 
         constexpr optional(const optional& other)                = default;

--- a/src/common/xi.h
+++ b/src/common/xi.h
@@ -50,14 +50,9 @@ namespace xi
         {
         }
 
-        constexpr optional(T&& value)
-        : m_value(std::forward<T>(value))
+        constexpr explicit optional(T&& value) noexcept
         {
-        }
-
-        constexpr optional(const T& value)
-        : m_value(value)
-        {
+            m_value = std::move(value);
         }
 
         constexpr optional(const optional& other)                = default;

--- a/src/map/ai/ai_container.cpp
+++ b/src/map/ai/ai_container.cpp
@@ -150,7 +150,7 @@ bool CAIContainer::Trigger(CCharEntity* player)
 {
     // TODO: ensure idempotency of all onTrigger lua calls (i.e. chests can only be opened once)
     bool isDoor = luautils::OnTrigger(player, PEntity) == -1;
-    PEntity->PAI->EventHandler.triggerListener("ON_TRIGGER", CLuaBaseEntity(player), CLuaBaseEntity(PEntity));
+    PEntity->PAI->EventHandler.triggerListener("ON_TRIGGER", player, PEntity);
     if (CanChangeState())
     {
         auto ret = ChangeState<CTriggerState>(PEntity, player->targid, isDoor);
@@ -418,7 +418,7 @@ void CAIContainer::Tick(time_point _tick)
     m_Tick     = _tick;
 
     // TODO: timestamp in the event?
-    EventHandler.triggerListener("TICK", CLuaBaseEntity(PEntity));
+    EventHandler.triggerListener("TICK", PEntity);
     PEntity->Tick(_tick);
 
     // TODO: check this in the controller instead maybe? (might not want to check every tick)
@@ -431,7 +431,7 @@ void CAIContainer::Tick(time_point _tick)
         PathFind->FollowPath(_tick);
         if (PathFind->OnPoint())
         {
-            EventHandler.triggerListener("PATH", CLuaBaseEntity(PEntity));
+            EventHandler.triggerListener("PATH", PEntity);
             luautils::OnPath(PEntity);
         }
     }

--- a/src/map/ai/controllers/automaton_controller.cpp
+++ b/src/map/ai/controllers/automaton_controller.cpp
@@ -237,7 +237,7 @@ bool CAutomatonController::TryAction()
     if (m_Tick > m_LastActionTime + (m_actionCooldown - std::chrono::milliseconds(PAutomaton->getMod(Mod::AUTO_DECISION_DELAY) * 10)))
     {
         m_LastActionTime = m_Tick;
-        PAutomaton->PAI->EventHandler.triggerListener("AUTOMATON_AI_TICK", CLuaBaseEntity(PAutomaton), CLuaBaseEntity(PTarget));
+        PAutomaton->PAI->EventHandler.triggerListener("AUTOMATON_AI_TICK", PAutomaton, PTarget);
 
         return true;
     }
@@ -1594,7 +1594,7 @@ bool CAutomatonController::TryAttachment()
         return false;
     }
 
-    PAutomaton->PAI->EventHandler.triggerListener("AUTOMATON_ATTACHMENT_CHECK", CLuaBaseEntity(PAutomaton), CLuaBaseEntity(PTarget));
+    PAutomaton->PAI->EventHandler.triggerListener("AUTOMATON_ATTACHMENT_CHECK", PAutomaton, PTarget);
 
     return false;
 }

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -586,7 +586,7 @@ void CMobController::DoCombatTick(time_point tick)
 
     TryLink();
 
-    PMob->PAI->EventHandler.triggerListener("COMBAT_TICK", CLuaBaseEntity(PMob));
+    PMob->PAI->EventHandler.triggerListener("COMBAT_TICK", PMob);
     luautils::OnMobFight(PMob, PTarget);
 
     if (PMob->PAI->IsCurrentState<CInactiveState>() || !PMob->PAI->CanChangeState())
@@ -604,7 +604,7 @@ void CMobController::DoCombatTick(time_point tick)
         }
         else
         {
-            PMob->PAI->EventHandler.triggerListener("RUN_AWAY", CLuaBaseEntity(PMob), CLuaBaseEntity(PFollowTarget));
+            PMob->PAI->EventHandler.triggerListener("RUN_AWAY", PMob, PFollowTarget);
             ClearFollowTarget();
         }
         return;
@@ -1024,7 +1024,7 @@ void CMobController::DoRoamTick(time_point tick)
                 else if (PMob->m_roamFlags & ROAMFLAG_SCRIPTED)
                 {
                     // allow custom event action
-                    PMob->PAI->EventHandler.triggerListener("ROAM_ACTION", CLuaBaseEntity(PMob));
+                    PMob->PAI->EventHandler.triggerListener("ROAM_ACTION", PMob);
                     luautils::OnMobRoamAction(PMob);
                     m_LastActionTime = m_Tick;
                 }
@@ -1063,7 +1063,7 @@ void CMobController::DoRoamTick(time_point tick)
     }
     if (m_Tick >= m_LastRoamScript + 3s)
     {
-        PMob->PAI->EventHandler.triggerListener("ROAM_TICK", CLuaBaseEntity(PMob));
+        PMob->PAI->EventHandler.triggerListener("ROAM_TICK", PMob);
         luautils::OnMobRoam(PMob);
         m_LastRoamScript = m_Tick;
     }
@@ -1121,7 +1121,7 @@ void CMobController::FollowRoamPath()
 
         if (PMob->PAI->PathFind->OnPoint())
         {
-            PMob->PAI->EventHandler.triggerListener("PATH", CLuaBaseEntity(PMob));
+            PMob->PAI->EventHandler.triggerListener("PATH", PMob);
             luautils::OnPath(PMob);
         }
     }

--- a/src/map/ai/controllers/trust_controller.cpp
+++ b/src/map/ai/controllers/trust_controller.cpp
@@ -211,7 +211,7 @@ void CTrustController::DoCombatTick(time_point tick)
 
         m_GambitsContainer->Tick(tick);
 
-        POwner->PAI->EventHandler.triggerListener("COMBAT_TICK", CLuaBaseEntity(POwner), CLuaBaseEntity(POwner->PMaster), CLuaBaseEntity(PTarget));
+        POwner->PAI->EventHandler.triggerListener("COMBAT_TICK", POwner, POwner->PMaster, PTarget);
     }
 }
 

--- a/src/map/ai/helpers/action_queue.cpp
+++ b/src/map/ai/helpers/action_queue.cpp
@@ -78,7 +78,7 @@ void CAIActionQueue::handleAction(queueAction_t& action)
 {
     if (action.lua_func.valid())
     {
-        auto result = action.lua_func(CLuaBaseEntity(PEntity));
+        auto result = action.lua_func(PEntity);
         if (!result.valid())
         {
             sol::error err = result;

--- a/src/map/ai/states/ability_state.cpp
+++ b/src/map/ai/states/ability_state.cpp
@@ -73,14 +73,14 @@ CAbilityState::CAbilityState(CBattleEntity* PEntity, uint16 targid, uint16 abili
         actionTarget.messageID = 326;
         actionTarget.param     = PAbility->getID();
         PEntity->loc.zone->PushPacket(PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
-        m_PEntity->PAI->EventHandler.triggerListener("ABILITY_START", CLuaBaseEntity(m_PEntity), CLuaAbility(PAbility));
+        m_PEntity->PAI->EventHandler.triggerListener("ABILITY_START", m_PEntity, PAbility);
 
         // face toward target
         battleutils::turnTowardsTarget(m_PEntity, PTarget);
     }
     else
     {
-        m_PEntity->PAI->EventHandler.triggerListener("ABILITY_START", CLuaBaseEntity(m_PEntity), CLuaAbility(PAbility));
+        m_PEntity->PAI->EventHandler.triggerListener("ABILITY_START", m_PEntity, PAbility);
     }
 }
 
@@ -133,11 +133,11 @@ bool CAbilityState::Update(time_point tick)
         {
             action_t action;
             m_PEntity->OnAbility(*this, action);
-            m_PEntity->PAI->EventHandler.triggerListener("ABILITY_USE", CLuaBaseEntity(m_PEntity), CLuaBaseEntity(GetTarget()), CLuaAbility(m_PAbility.get()), CLuaAction(&action));
+            m_PEntity->PAI->EventHandler.triggerListener("ABILITY_USE", m_PEntity, GetTarget(), m_PAbility.get(), &action);
             m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
             if (auto* target = GetTarget())
             {
-                target->PAI->EventHandler.triggerListener("ABILITY_TAKE", CLuaBaseEntity(target), CLuaBaseEntity(m_PEntity), CLuaAbility(m_PAbility.get()), CLuaAction(&action));
+                target->PAI->EventHandler.triggerListener("ABILITY_TAKE", target, m_PEntity, m_PAbility.get(), &action);
             }
         }
         else if (m_castTime > 0s) // Instant abilities do not need to be interrupted
@@ -168,7 +168,7 @@ bool CAbilityState::Update(time_point tick)
             CCharEntity* PChar = static_cast<CCharEntity*>(m_PEntity);
             PChar->m_charHistory.abilitiesUsed++;
         }
-        m_PEntity->PAI->EventHandler.triggerListener("ABILITY_STATE_EXIT", CLuaBaseEntity(m_PEntity), CLuaAbility(m_PAbility.get()));
+        m_PEntity->PAI->EventHandler.triggerListener("ABILITY_STATE_EXIT", m_PEntity, m_PAbility.get());
         return true;
     }
 

--- a/src/map/ai/states/item_state.cpp
+++ b/src/map/ai/states/item_state.cpp
@@ -132,7 +132,7 @@ CItemState::CItemState(CCharEntity* PEntity, uint16 targid, uint8 loc, uint8 slo
     actionTarget.messageID  = 28;
     actionTarget.knockback  = 0;
 
-    m_PEntity->PAI->EventHandler.triggerListener("ITEM_START", CLuaBaseEntity(PTarget), CLuaItem(m_PItem), CLuaAction(&action));
+    m_PEntity->PAI->EventHandler.triggerListener("ITEM_START", PTarget, m_PItem, &action);
     m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
 
     m_PItem->setSubType(ITEM_LOCKED);
@@ -188,7 +188,7 @@ bool CItemState::Update(time_point tick)
         {
             FinishItem(action);
         }
-        m_PEntity->PAI->EventHandler.triggerListener("ITEM_USE", CLuaBaseEntity(m_PEntity), CLuaItem(m_PItem), CLuaAction(&action));
+        m_PEntity->PAI->EventHandler.triggerListener("ITEM_USE", m_PEntity, m_PItem, &action);
         m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
         Complete();
     }
@@ -199,7 +199,7 @@ bool CItemState::Update(time_point tick)
             CCharEntity* PChar = m_PEntity;
             PChar->m_charHistory.itemsUsed++;
         }
-        m_PEntity->PAI->EventHandler.triggerListener("ITEM_STATE_EXIT", CLuaBaseEntity(m_PEntity), CLuaItem(m_PItem));
+        m_PEntity->PAI->EventHandler.triggerListener("ITEM_STATE_EXIT", m_PEntity, m_PItem);
         return true;
     }
     return false;

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -106,7 +106,7 @@ CMagicState::CMagicState(CBattleEntity* PEntity, uint16 targid, SpellID spellid,
     }
 
     // TODO: weaponskill lua object
-    m_PEntity->PAI->EventHandler.triggerListener("MAGIC_START", CLuaBaseEntity(m_PEntity), CLuaSpell(m_PSpell.get()), CLuaAction(&action));
+    m_PEntity->PAI->EventHandler.triggerListener("MAGIC_START", m_PEntity, m_PSpell.get(), &action);
 
     m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
 }
@@ -247,8 +247,8 @@ bool CMagicState::Update(time_point tick)
         else
         {
             m_PEntity->OnCastFinished(*this, action);
-            m_PEntity->PAI->EventHandler.triggerListener("MAGIC_USE", CLuaBaseEntity(m_PEntity), CLuaBaseEntity(PTarget), CLuaSpell(m_PSpell.get()), CLuaAction(&action));
-            PTarget->PAI->EventHandler.triggerListener("MAGIC_TAKE", CLuaBaseEntity(PTarget), CLuaBaseEntity(m_PEntity), CLuaSpell(m_PSpell.get()), CLuaAction(&action));
+            m_PEntity->PAI->EventHandler.triggerListener("MAGIC_USE", m_PEntity, PTarget, m_PSpell.get(), &action);
+            PTarget->PAI->EventHandler.triggerListener("MAGIC_TAKE", PTarget, m_PEntity, m_PSpell.get(), &action);
         }
 
         m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
@@ -262,7 +262,7 @@ bool CMagicState::Update(time_point tick)
             CCharEntity* PChar = static_cast<CCharEntity*>(m_PEntity);
             PChar->m_charHistory.spellsCast++;
         }
-        m_PEntity->PAI->EventHandler.triggerListener("MAGIC_STATE_EXIT", CLuaBaseEntity(m_PEntity), CLuaSpell(m_PSpell.get()));
+        m_PEntity->PAI->EventHandler.triggerListener("MAGIC_STATE_EXIT", m_PEntity, m_PSpell.get());
         return true;
     }
     return false;

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -84,7 +84,7 @@ CMobSkillState::CMobSkillState(CBattleEntity* PEntity, uint16 targid, uint16 wsi
         // face toward target // TODO : add force param to turnTowardsTarget on certain TP moves like Petro Eyes
         battleutils::turnTowardsTarget(m_PEntity, PTarget);
     }
-    m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_STATE_ENTER", CLuaBaseEntity(m_PEntity), m_PSkill->getID());
+    m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_STATE_ENTER", m_PEntity, m_PSkill->getID());
     SpendCost();
 }
 
@@ -145,7 +145,7 @@ bool CMobSkillState::Update(time_point tick)
         {
             static_cast<CMobEntity*>(PTarget)->PEnmityContainer->UpdateEnmity(m_PEntity, 0, 0);
         }
-        m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_STATE_EXIT", CLuaBaseEntity(m_PEntity), m_PSkill->getID());
+        m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_STATE_EXIT", m_PEntity, m_PSkill->getID());
 
         if (m_PEntity->objtype == TYPE_PET && m_PEntity->PMaster && m_PEntity->PMaster->objtype == TYPE_PC && (m_PSkill->isBloodPactRage() || m_PSkill->isBloodPactWard()))
         {

--- a/src/map/ai/states/petskill_state.cpp
+++ b/src/map/ai/states/petskill_state.cpp
@@ -80,7 +80,7 @@ CPetSkillState::CPetSkillState(CPetEntity* PEntity, uint16 targid, uint16 wsid)
         actionTarget.messageID  = 326; // Seems hardcoded? TODO: Verify on more pet actions. Tested on Wyvern and SMN BPs.
         m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE, std::make_unique<CActionPacket>(action));
     }
-    m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_STATE_ENTER", CLuaBaseEntity(m_PEntity), m_PSkill->getID());
+    m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_STATE_ENTER", m_PEntity, m_PSkill->getID());
     SpendCost();
 }
 
@@ -116,7 +116,7 @@ bool CPetSkillState::Update(time_point tick)
         {
             static_cast<CMobEntity*>(PTarget)->PEnmityContainer->UpdateEnmity(m_PEntity, 0, 0);
         }
-        m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_STATE_EXIT", CLuaBaseEntity(m_PEntity), m_PSkill->getID());
+        m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_STATE_EXIT", m_PEntity, m_PSkill->getID());
 
         if (m_PEntity->objtype == TYPE_PET && m_PEntity->PMaster && m_PEntity->PMaster->objtype == TYPE_PC && (m_PSkill->isBloodPactRage() || m_PSkill->isBloodPactWard()))
         {

--- a/src/map/ai/states/range_state.cpp
+++ b/src/map/ai/states/range_state.cpp
@@ -109,7 +109,7 @@ CRangeState::CRangeState(CBattleEntity* PEntity, uint16 targid)
     actionTarget_t& actionTarget = actionList.getNewActionTarget();
     actionTarget.animation       = ANIMATION_RANGED;
 
-    m_PEntity->PAI->EventHandler.triggerListener("RANGE_START", CLuaBaseEntity(m_PEntity), CLuaAction(&action));
+    m_PEntity->PAI->EventHandler.triggerListener("RANGE_START", m_PEntity, &action);
 
     m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
 }
@@ -155,7 +155,7 @@ bool CRangeState::Update(time_point tick)
             // reset aim time so interrupted players only have to wait the correct 2.7s until next shot
             m_aimTime = std::chrono::seconds(0);
             m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
-            m_PEntity->PAI->EventHandler.triggerListener("RANGE_STATE_EXIT", CLuaBaseEntity(m_PEntity), nullptr, CLuaAction(&action));
+            m_PEntity->PAI->EventHandler.triggerListener("RANGE_STATE_EXIT", m_PEntity, nullptr, &action);
         }
         else
         {
@@ -163,7 +163,7 @@ bool CRangeState::Update(time_point tick)
 
             m_PEntity->OnRangedAttack(*this, action);
             m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
-            m_PEntity->PAI->EventHandler.triggerListener("RANGE_STATE_EXIT", CLuaBaseEntity(m_PEntity), CLuaBaseEntity(PTarget), CLuaAction(&action));
+            m_PEntity->PAI->EventHandler.triggerListener("RANGE_STATE_EXIT", m_PEntity, PTarget, &action);
         }
 
         Complete();

--- a/src/map/ai/states/weaponskill_state.cpp
+++ b/src/map/ai/states/weaponskill_state.cpp
@@ -142,8 +142,8 @@ bool CWeaponSkillState::Update(time_point tick)
                 uint32 weaponskillVar    = PTarget->GetLocalVar("weaponskillHit");
                 uint32 weaponskillDamage = weaponskillVar & 0xFFFFFF;
 
-                m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_USE", CLuaBaseEntity(m_PEntity), CLuaBaseEntity(PTarget), m_PSkill->getID(), m_spent, CLuaAction(&action), weaponskillDamage);
-                PTarget->PAI->EventHandler.triggerListener("WEAPONSKILL_TAKE", CLuaBaseEntity(PTarget), CLuaBaseEntity(m_PEntity), m_PSkill->getID(), m_spent, CLuaAction(&action));
+                m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_USE", m_PEntity, PTarget, m_PSkill->getID(), m_spent, &action, weaponskillDamage);
+                PTarget->PAI->EventHandler.triggerListener("WEAPONSKILL_TAKE", PTarget, m_PEntity, m_PSkill->getID(), m_spent, &action);
 
                 if (m_PEntity->objtype == TYPE_PC)
                 {
@@ -190,7 +190,7 @@ bool CWeaponSkillState::Update(time_point tick)
             CCharEntity* PChar = static_cast<CCharEntity*>(m_PEntity);
             PChar->m_charHistory.wsUsed++;
         }
-        m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_STATE_EXIT", CLuaBaseEntity(m_PEntity), m_PSkill->getID());
+        m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_STATE_EXIT", m_PEntity, m_PSkill->getID());
         return true;
     }
     return false;

--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -528,7 +528,7 @@ bool CAttack::CheckCounter()
             }
             else
             {
-                m_attacker->PAI->EventHandler.triggerListener("MELEE_SWING_MISS", CLuaBaseEntity(m_attacker), CLuaBaseEntity(m_victim), CLuaAttack(this));
+                m_attacker->PAI->EventHandler.triggerListener("MELEE_SWING_MISS", m_attacker, m_victim, this);
             }
         }
         else if (m_victim->StatusEffectContainer->HasStatusEffect(EFFECT_PERFECT_COUNTER))

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -928,7 +928,7 @@ void CBattlefield::handleDeath(CBaseEntity* PEntity)
 
             if (group.deathCallback.valid())
             {
-                auto result = group.deathCallback(CLuaBattlefield(this), CLuaBaseEntity(PEntity), deathCount);
+                auto result = group.deathCallback(this, PEntity, deathCount);
                 if (!result.valid())
                 {
                     sol::error err = result;
@@ -938,7 +938,7 @@ void CBattlefield::handleDeath(CBaseEntity* PEntity)
 
             if (group.allDeathCallback.valid() && deathCount >= group.mobIds.size())
             {
-                auto result = group.allDeathCallback(CLuaBattlefield(this), CLuaBaseEntity(PEntity));
+                auto result = group.allDeathCallback(this, PEntity);
                 if (!result.valid())
                 {
                     sol::error err = result;
@@ -948,7 +948,7 @@ void CBattlefield::handleDeath(CBaseEntity* PEntity)
 
             if (group.randomDeathCallback.valid() && mobId == group.randomMobId)
             {
-                auto result = group.randomDeathCallback(CLuaBattlefield(this), CLuaBaseEntity(PEntity));
+                auto result = group.randomDeathCallback(this, PEntity);
                 if (!result.valid())
                 {
                     sol::error err = result;

--- a/src/map/command_handler.cpp
+++ b/src/map/command_handler.cpp
@@ -285,7 +285,7 @@ int32 CCommandHandler::call(sol::state& lua, CCharEntity* PChar, const std::stri
     }
 
     // Call the function
-    auto result = onTrigger(CLuaBaseEntity(PChar), sol::as_args(args));
+    auto result = onTrigger(PChar, sol::as_args(args));
     if (!result.valid())
     {
         sol::error err = result;

--- a/src/map/entities/automatonentity.cpp
+++ b/src/map/entities/automatonentity.cpp
@@ -211,7 +211,7 @@ void CAutomatonEntity::Spawn()
     status = allegiance == ALLEGIANCE_TYPE::MOB ? STATUS_TYPE::UPDATE : STATUS_TYPE::NORMAL;
     updatemask |= UPDATE_HP;
     PAI->Reset();
-    PAI->EventHandler.triggerListener("SPAWN", CLuaBaseEntity(this));
+    PAI->EventHandler.triggerListener("SPAWN", this);
     animation = ANIMATION_NONE;
     m_OwnerID.clean();
     HideName(false);

--- a/src/map/entities/baseentity.cpp
+++ b/src/map/entities/baseentity.cpp
@@ -72,7 +72,7 @@ void CBaseEntity::Spawn()
     updatemask |= UPDATE_HP;
     ResetLocalVars();
     PAI->Reset();
-    PAI->EventHandler.triggerListener("SPAWN", CLuaBaseEntity(this));
+    PAI->EventHandler.triggerListener("SPAWN", this);
 }
 
 void CBaseEntity::FadeOut()

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -763,8 +763,8 @@ int32 CBattleEntity::takeDamage(int32 amount, CBattleEntity* attacker /* = nullp
                                 DAMAGE_TYPE damageType /* = DAMAGE_NONE*/, bool isSkillchainDamage /* = false */)
 {
     TracyZoneScoped;
-    PLastAttacker                             = attacker;
-    this->BattleHistory.lastHitTaken_atkType  = attackType;
+    PLastAttacker                            = attacker;
+    this->BattleHistory.lastHitTaken_atkType = attackType;
 
     PAI->EventHandler.triggerListener("TAKE_DAMAGE", this, amount, attacker, (uint16)attackType, (uint16)damageType);
 

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -701,7 +701,7 @@ void CMobEntity::DropItems(CCharEntity* PChar)
 
         LootContainer loot(dropList);
 
-        PAI->EventHandler.triggerListener("ITEM_DROPS", CLuaBaseEntity(this), CLuaLootContainer(&loot));
+        PAI->EventHandler.triggerListener("ITEM_DROPS", this, &loot);
 
         // clang-format off
         loot.ForEachGroup([&](const DropGroup_t& group)
@@ -1133,7 +1133,7 @@ void CMobEntity::OnDespawn(CDespawnState& /*unused*/)
     PAI->Internal_Respawn(std::chrono::milliseconds(m_RespawnTime));
     luautils::OnMobDespawn(this);
     // #event despawn
-    PAI->EventHandler.triggerListener("DESPAWN", CLuaBaseEntity(this));
+    PAI->EventHandler.triggerListener("DESPAWN", this);
 }
 
 void CMobEntity::Die()

--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -472,7 +472,7 @@ void CTrustEntity::OnDespawn(CDespawnState& /*unused*/)
         luautils::OnMobDespawn(this);
     }
     FadeOut();
-    PAI->EventHandler.triggerListener("DESPAWN", CLuaBaseEntity(this));
+    PAI->EventHandler.triggerListener("DESPAWN", this);
 }
 
 void CTrustEntity::OnCastFinished(CMagicState& state, action_t& action)

--- a/src/map/lua/CMakeLists.txt
+++ b/src/map/lua/CMakeLists.txt
@@ -31,5 +31,7 @@ set(LUA_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/lua_zone.h
     ${CMAKE_CURRENT_SOURCE_DIR}/luautils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/luautils.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/sol_bindings.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/sol_bindings.h
     PARENT_SCOPE
 )

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -97,7 +97,7 @@ public:
 
     void updateEvent(sol::variadic_args va);
     void updateEventString(sol::variadic_args va); // (string, string, string, string, uint32, ...)
-    auto getEventTarget() -> std::optional<CLuaBaseEntity>;
+    auto getEventTarget() -> CBaseEntity*;
     bool isInEvent();       // Returns true if the player is in an event
     void release();         // Stops event
     bool startSequence();   // Flags the player as being in a sequence
@@ -111,7 +111,7 @@ public:
     // Object Identification
     uint32 getID();
     uint16 getTargID();
-    auto   getCursorTarget() -> std::optional<CLuaBaseEntity>;
+    auto   getCursorTarget() -> CBaseEntity*;
 
     uint8 getObjType() const;
 
@@ -179,7 +179,7 @@ public:
     bool  isBehind(CLuaBaseEntity const* target, sol::object const& angleArg);  // true if you're behind the input target
     bool  isBeside(CLuaBaseEntity const* target, sol::object const& angleArg);  // true if you're to the side of the input target
 
-    auto   getZone(sol::object const& arg0) -> std::optional<CLuaZone>;
+    auto   getZone(sol::object const& arg0) -> CZone*;
     uint16 getZoneID();
     auto   getZoneName() -> std::string;
     bool   hasVisitedZone(uint16 zone);
@@ -229,7 +229,7 @@ public:
 
     // Items
     uint16 getEquipID(SLOTTYPE slot);
-    auto   getEquippedItem(uint8 slot) -> std::optional<CLuaItem>;
+    auto   getEquippedItem(uint8 slot) -> CItem*;
     bool   hasEquipped(uint16 equipmentID); // Returns true if item is equipped in any slot
     bool   hasItem(uint16 itemID, sol::object const& location);
     uint32 getItemCount(uint16 itemID);
@@ -238,9 +238,9 @@ public:
     bool   delContainerItems(sol::object const& containerID);
     bool   addUsedItem(uint16 itemID);
     bool   addTempItem(uint16 itemID, sol::object const& arg1);
-    uint8  getWornUses(uint16 itemID);                                                      // Check if the item is already worn
-    uint8  incrementItemWear(uint16 itemID);                                                // Increment the item's worn value and returns it
-    auto   findItem(uint16 itemID, sol::object const& location) -> std::optional<CLuaItem>; // Like hasItem, but returns the item object (nil if not found)
+    uint8  getWornUses(uint16 itemID);                                     // Check if the item is already worn
+    uint8  incrementItemWear(uint16 itemID);                               // Increment the item's worn value and returns it
+    auto   findItem(uint16 itemID, sol::object const& location) -> CItem*; // Like hasItem, but returns the item object (nil if not found)
 
     void createShop(uint8 size, sol::object const& arg1);
     void addShopItem(uint16 itemID, double rawPrice, sol::object const& arg2, sol::object const& arg3);
@@ -248,7 +248,7 @@ public:
     bool breakLinkshell(std::string const& lsname);
     bool addLinkpearl(std::string const& lsname, bool equip);
 
-    auto addSoulPlate(std::string const& name, uint16 mobFamily, uint8 zeni, uint16 skillIndex, uint8 fp) -> std::optional<CLuaItem>;
+    auto addSoulPlate(std::string const& name, uint16 mobFamily, uint8 zeni, uint16 skillIndex, uint8 fp) -> CItem*;
 
     // Trading
     uint8 getContainerSize(uint8 locationID);
@@ -256,7 +256,7 @@ public:
     uint8 getFreeSlotsCount(sol::object const& locID);         // Gets value of free slots in Entity inventory
     void  confirmTrade();                                      // Complete trade with an npc, only removing confirmed items
     void  tradeComplete();                                     // Complete trade with an npc
-    auto  getTrade() -> std::optional<CLuaTradeContainer>;
+    auto  getTrade() -> CTradeContainer*;
 
     // Equipping
     bool canEquipItem(uint16 itemID, sol::object const& chkLevel);
@@ -275,7 +275,7 @@ public:
     void clearGearSetMods();
 
     // Storing
-    auto  getStorageItem(uint8 container, uint8 slotID, uint8 equipID) -> std::optional<CLuaItem>;
+    auto  getStorageItem(uint8 container, uint8 slotID, uint8 equipID) -> CItem*;
     uint8 storeWithPorterMoogle(uint16 slipId, sol::table const& extraTable, sol::table const& storableItemIdsTable);
     auto  getRetrievableItemsForSlip(uint16 slipId) -> sol::table;
     void  retrieveItemFromSlip(uint16 slipId, uint16 itemId, uint16 extraId, uint8 extraData);
@@ -545,8 +545,8 @@ public:
     auto   getPartyWithTrusts() -> sol::table;
     uint8  getPartySize(sol::object const& arg0);
     bool   hasPartyJob(uint8 job);
-    auto   getPartyMember(uint8 member, uint8 allianceparty) -> std::optional<CLuaBaseEntity>;
-    auto   getPartyLeader() -> std::optional<CLuaBaseEntity>;
+    auto   getPartyMember(uint8 member, uint8 allianceparty) -> CBaseEntity*;
+    auto   getPartyLeader() -> CBaseEntity*;
     uint32 getLeaderID();
     uint32 getPartyLastMemberJoinedTime();
     void   forMembersInRange(float range, sol::function function);
@@ -569,7 +569,7 @@ public:
     uint8 checkDifficulty(CLuaBaseEntity* PLuaBaseEntity);
 
     // Instances
-    auto getInstance() -> std::optional<CLuaInstance>;
+    auto getInstance() -> CInstance*;
     void setInstance(CLuaInstance* PLuaInstance);
     void createInstance(uint16 instanceID);
     void instanceEntry(CLuaBaseEntity* PLuaBaseEntity, uint32 response);
@@ -579,7 +579,7 @@ public:
     uint16 copyConfrontationEffect(uint16 targetID); // copy confrontation effect, param = targetEntity:getTargID()
 
     // Battlefields
-    auto  getBattlefield() -> std::optional<CLuaBattlefield>;                                                                      // returns CBattlefield* or nullptr if not available
+    auto  getBattlefield() -> CBattlefield*;                                                                                       // returns CBattlefield* or nullptr if not available
     int32 getBattlefieldID();                                                                                                      // returns entity->PBattlefield->GetID() or -1 if not available
     uint8 registerBattlefield(sol::object const& arg0, sol::object const& arg1, sol::object const& arg2, sol::object const& arg3); // attempt to register a battlefield, returns BATTLEFIELD_RETURNCODE
     bool  battlefieldAtCapacity(int battlefieldID);                                                                                // returns 1 if this battlefield is full
@@ -619,7 +619,7 @@ public:
     void triggerListener(std::string const& eventName, sol::variadic_args args);
     bool hasListener(std::string const& eventName);
 
-    auto getEntity(uint16 targetID) -> std::optional<CLuaBaseEntity>;
+    auto getEntity(uint16 targetID) -> CBaseEntity*;
     bool canChangeState();
 
     void wakeUp();
@@ -660,8 +660,8 @@ public:
     // Status Effects
     bool  addStatusEffect(sol::variadic_args va);
     bool  addStatusEffectEx(sol::variadic_args va);
-    auto  getStatusEffect(uint16 StatusID, sol::object const& SubType, sol::object const& SourceType, sol::object const& SourceTypeParam) -> std::optional<CLuaStatusEffect>;
-    auto  getStatusEffectBySource(uint16 StatusID, EffectSourceType SourceType, uint16 SourceTypeParam) -> std::optional<CLuaStatusEffect>;
+    auto  getStatusEffect(uint16 StatusID, sol::object const& SubType, sol::object const& SourceType, sol::object const& SourceTypeParam) -> CStatusEffect*;
+    auto  getStatusEffectBySource(uint16 StatusID, EffectSourceType SourceType, uint16 SourceTypeParam) -> CStatusEffect*;
     auto  getStatusEffects() -> sol::table;
     int16 getStatusEffectElement(uint16 statusId);
     bool  canGainStatusEffect(uint16 effect, sol::object const& powerObj);
@@ -755,7 +755,7 @@ public:
     void spawnPet(sol::object const& arg0);
     void despawnPet();
 
-    auto   spawnTrust(uint16 trustId) -> std::optional<CLuaBaseEntity>;
+    auto   spawnTrust(uint16 trustId) -> CBaseEntity*;
     void   clearTrusts();
     uint32 getTrustID();
     void   trustPartyMessage(uint32 message_id);
@@ -768,11 +768,11 @@ public:
 
     bool   hasPet();
     bool   hasJugPet();
-    auto   getPet() -> std::optional<CLuaBaseEntity>;
+    auto   getPet() -> CBaseEntity*;
     uint32 getPetID();
     bool   isAutomaton();
     bool   isAvatar();
-    auto   getMaster() -> std::optional<CLuaBaseEntity>;
+    auto   getMaster() -> CBaseEntity*;
     uint8  getPetElement();
     void   setPet(sol::object const& petObj);
     uint8  getMinimumPetLevel(); // Returns the minimum level of the pet, such as level 23 for Courier Carrie or 0 if non applicable.
@@ -800,7 +800,7 @@ public:
     uint8 getActiveManeuverCount();
     void  removeOldestManeuver();
     void  removeAllManeuvers();
-    auto  getAttachment(uint8 slotId) -> std::optional<CLuaItem>;
+    auto  getAttachment(uint8 slotId) -> CItem*;
     auto  getAttachments() -> sol::table;
     void  setAttachment(uint8 attachmentItemID, uint8 slotID);
     void  updateAttachments();
@@ -877,10 +877,10 @@ public:
     uint16 getRoamFlags();
     void   setRoamFlags(uint16 newRoamFlags);
 
-    auto getTarget() -> std::optional<CLuaBaseEntity>;
+    auto getTarget() -> CBaseEntity*;
     void updateTarget(); // Force mob to update target from enmity container (ie after updateEnmity)
     auto getEnmityList() -> sol::table;
-    auto getTrickAttackChar(CLuaBaseEntity* PLuaBaseEntity) -> std::optional<CLuaBaseEntity>; // true if TA target is available
+    auto getTrickAttackChar(CLuaBaseEntity* PLuaBaseEntity) -> CBaseEntity*; // true if TA target is available
 
     bool actionQueueEmpty();
 

--- a/src/map/lua/lua_battlefield.cpp
+++ b/src/map/lua/lua_battlefield.cpp
@@ -107,7 +107,7 @@ sol::table CLuaBattlefield::getPlayers()
     {
         if (PChar)
         {
-            table.add(CLuaBaseEntity(PChar));
+            table.add(PChar);
         }
     });
     // clang-format on
@@ -122,7 +122,7 @@ sol::table CLuaBattlefield::getPlayersAndTrusts()
     {
         if (PChar)
         {
-            table.add(CLuaBaseEntity(PChar));
+            table.add(PChar);
             for (auto const& PTrust : PChar->PTrusts)
             {
                 table.add(CLuaBaseEntity(PTrust));

--- a/src/map/lua/lua_battlefield.cpp
+++ b/src/map/lua/lua_battlefield.cpp
@@ -256,22 +256,21 @@ void CLuaBattlefield::setStatus(uint8 status)
     m_PLuaBattlefield->SetStatus(status);
 }
 
-std::optional<CLuaBaseEntity> CLuaBattlefield::insertEntity(uint16 targid, bool ally, bool inBattlefield)
+auto CLuaBattlefield::insertEntity(uint16 targid, bool ally, bool inBattlefield) -> CBaseEntity*
 {
     BATTLEFIELDMOBCONDITION conditions = static_cast<BATTLEFIELDMOBCONDITION>(0);
     ENTITYTYPE              filter     = static_cast<ENTITYTYPE>(0x1F);
 
-    auto* PEntity =
-        ally ? mobutils::InstantiateAlly(targid, m_PLuaBattlefield->GetZoneID()) : m_PLuaBattlefield->GetZone()->GetEntity(targid, filter);
+    auto* PEntity = ally ? mobutils::InstantiateAlly(targid, m_PLuaBattlefield->GetZoneID()) : m_PLuaBattlefield->GetZone()->GetEntity(targid, filter);
 
     if (PEntity)
     {
         m_PLuaBattlefield->InsertEntity(PEntity, inBattlefield, conditions, ally);
-        return std::optional<CLuaBaseEntity>(PEntity);
+        return PEntity;
     }
 
     ShowError("CLuaBattlefield::insertEntity - targid ID %u not found!", targid);
-    return std::nullopt;
+    return nullptr;
 }
 
 bool CLuaBattlefield::cleanup(bool cleanup)

--- a/src/map/lua/lua_battlefield.h
+++ b/src/map/lua/lua_battlefield.h
@@ -71,7 +71,7 @@ public:
     void setRecord(std::string const& name, uint32 seconds);
     void setStatus(uint8 status);
     void setLocalVar(std::string const& name, uint64_t value);
-    auto insertEntity(uint16 targid, bool ally, bool inBattlefield) -> std::optional<CLuaBaseEntity>;
+    auto insertEntity(uint16 targid, bool ally, bool inBattlefield) -> CBaseEntity*;
     bool cleanup(bool cleanup);
     void win();
     void lose();

--- a/src/map/lua/lua_instance.cpp
+++ b/src/map/lua/lua_instance.cpp
@@ -159,7 +159,7 @@ uint32 CLuaInstance::getWipeTime()
     return static_cast<uint32>(time_ms);
 }
 
-std::optional<CLuaBaseEntity> CLuaInstance::getEntity(uint16 targid, sol::object const& filterObj)
+auto CLuaInstance::getEntity(uint16 targid, sol::object const& filterObj) -> CBaseEntity*
 {
     uint8 filter = -1;
     if (filterObj.is<uint8>())
@@ -167,14 +167,7 @@ std::optional<CLuaBaseEntity> CLuaInstance::getEntity(uint16 targid, sol::object
         filter = filterObj.as<uint8>();
     }
 
-    CBaseEntity* PEntity = m_PLuaInstance->GetEntity(targid, filter);
-
-    if (PEntity)
-    {
-        return std::optional<CLuaBaseEntity>(PEntity);
-    }
-
-    return std::nullopt;
+    return m_PLuaInstance->GetEntity(targid, filter);
 }
 
 uint32 CLuaInstance::getStage()
@@ -242,20 +235,20 @@ bool CLuaInstance::completed()
     return m_PLuaInstance->Completed();
 }
 
-std::optional<CLuaBaseEntity> CLuaInstance::insertAlly(uint32 groupid)
+auto CLuaInstance::insertAlly(uint32 groupid) -> CBaseEntity*
 {
     CMobEntity* PAlly = mobutils::InstantiateAlly(groupid, m_PLuaInstance->GetZone()->GetID(), m_PLuaInstance);
 
     if (PAlly)
     {
-        return std::optional<CLuaBaseEntity>(PAlly);
+        return PAlly;
     }
 
     ShowError("CLuaBattlefield::insertAlly - group ID %u not found!", groupid);
-    return std::nullopt;
+    return PAlly;
 }
 
-auto CLuaInstance::insertDynamicEntity(sol::table table) -> std::optional<CLuaBaseEntity>
+auto CLuaInstance::insertDynamicEntity(sol::table table) -> CBaseEntity*
 {
     return luautils::GenerateDynamicEntity(m_PLuaInstance->GetZone(), m_PLuaInstance, std::move(table));
 }

--- a/src/map/lua/lua_instance.h
+++ b/src/map/lua/lua_instance.h
@@ -58,7 +58,7 @@ public:
     uint32 getLastTimeUpdate();
     uint32 getProgress();
     uint32 getWipeTime();
-    auto   getEntity(uint16 targid, sol::object const& filterObj) -> std::optional<CLuaBaseEntity>;
+    auto   getEntity(uint16 targid, sol::object const& filterObj) -> CBaseEntity*;
     uint32 getStage();
     auto   getLocalVar(std::string const& name) -> uint64_t;
 
@@ -75,8 +75,8 @@ public:
     void complete();
     bool completed();
 
-    auto insertAlly(uint32 groupid) -> std::optional<CLuaBaseEntity>;
-    auto insertDynamicEntity(sol::table table) -> std::optional<CLuaBaseEntity>;
+    auto insertAlly(uint32 groupid) -> CBaseEntity*;
+    auto insertDynamicEntity(sol::table table) -> CBaseEntity*;
 
     bool operator==(const CLuaInstance& other) const
     {

--- a/src/map/lua/lua_trade_container.cpp
+++ b/src/map/lua/lua_trade_container.cpp
@@ -45,7 +45,7 @@ uint32 CLuaTradeContainer::getGil()
     return itemID == 0xFFFF ? m_pMyTradeContainer->getQuantity(0) : 0;
 }
 
-std::optional<CLuaItem> CLuaTradeContainer::getItem(sol::object const& SlotIDObj)
+auto CLuaTradeContainer::getItem(sol::object const& SlotIDObj) -> CItem*
 {
     uint8 SlotID = 0;
     if (SlotIDObj.is<uint8>())
@@ -53,12 +53,7 @@ std::optional<CLuaItem> CLuaTradeContainer::getItem(sol::object const& SlotIDObj
         SlotID = SlotIDObj.as<uint8>();
     }
 
-    if (auto PItem = m_pMyTradeContainer->getItem(SlotID))
-    {
-        return std::optional<CLuaItem>(PItem);
-    }
-
-    return std::nullopt;
+    return m_pMyTradeContainer->getItem(SlotID);
 }
 
 //======================================================//

--- a/src/map/lua/lua_trade_container.h
+++ b/src/map/lua/lua_trade_container.h
@@ -41,7 +41,7 @@ public:
     friend std::ostream& operator<<(std::ostream& out, const CTradeContainer& trade);
 
     uint32 getGil();
-    auto   getItem(sol::object const& SlotIDObj) -> std::optional<CLuaItem>;
+    auto   getItem(sol::object const& SlotIDObj) -> CItem*;
     uint16 getItemId(sol::object const& SlotIDObj);
     uint16 getItemSubId(sol::object const& SlotIDObj);
     uint32 getItemQty(uint16 itemID);

--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -112,7 +112,7 @@ sol::table CLuaZone::getPlayers()
     // clang-format off
     m_pLuaZone->ForEachChar([&table](CCharEntity* PChar)
     {
-        table.add(CLuaBaseEntity(PChar));
+        table.add(PChar);
     });
     // clang-format on
     return table;

--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -162,13 +162,13 @@ ZONE_TYPE CLuaZone::getTypeMask()
     return m_pLuaZone->GetTypeMask();
 }
 
-std::optional<CLuaBattlefield> CLuaZone::getBattlefieldByInitiator(uint32 charID)
+auto CLuaZone::getBattlefieldByInitiator(uint32 charID) -> CBattlefield*
 {
     if (m_pLuaZone->m_BattlefieldHandler)
     {
-        return std::optional<CLuaBattlefield>(m_pLuaZone->m_BattlefieldHandler->GetBattlefieldByInitiator(charID));
+        return m_pLuaZone->m_BattlefieldHandler->GetBattlefieldByInitiator(charID);
     }
-    return std::nullopt;
+    return nullptr;
 }
 
 WEATHER CLuaZone::getWeather()
@@ -217,7 +217,7 @@ bool CLuaZone::isNavigablePoint(const sol::table& point)
     }
 }
 
-std::optional<CLuaBaseEntity> CLuaZone::insertDynamicEntity(sol::table table)
+auto CLuaZone::insertDynamicEntity(sol::table table) -> CBaseEntity*
 {
     return luautils::GenerateDynamicEntity(m_pLuaZone, nullptr, std::move(table));
 }

--- a/src/map/lua/lua_zone.h
+++ b/src/map/lua/lua_zone.h
@@ -56,12 +56,12 @@ public:
     auto        getName() -> const std::string&;
     REGION_TYPE getRegionID();
     ZONE_TYPE   getTypeMask();
-    auto        getBattlefieldByInitiator(uint32 charID) -> std::optional<CLuaBattlefield>;
+    auto        getBattlefieldByInitiator(uint32 charID) -> CBattlefield*;
     WEATHER     getWeather();
     uint32      getUptime();
     void        reloadNavmesh();
     bool        isNavigablePoint(const sol::table& position);
-    auto        insertDynamicEntity(sol::table table) -> std::optional<CLuaBaseEntity>;
+    auto        insertDynamicEntity(sol::table table) -> CBaseEntity*;
 
     auto getSoloBattleMusic();
     auto getPartyBattleMusic();

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1192,17 +1192,14 @@ namespace luautils
         }
     }
 
-    std::optional<CLuaItem> GetItemByID(uint32 itemId)
+    CItem* GetItemByID(uint32 itemId)
     {
-        if (auto* PItem = itemutils::GetItemPointer(itemId))
-        {
-            return PItem;
-        }
+        TracyZoneScoped;
 
-        return std::nullopt;
+        return itemutils::GetItemPointer(itemId);
     }
 
-    std::optional<CLuaBaseEntity> GetNPCByID(uint32 npcid, sol::object const& instanceObj)
+    CBaseEntity* GetNPCByID(uint32 npcid, sol::object const& instanceObj)
     {
         TracyZoneScoped;
 
@@ -1225,10 +1222,10 @@ namespace luautils
         if (!PNpc)
         {
             ShowWarning("luautils::GetNPCByID NPC doesn't exist (%d)", npcid);
-            return std::nullopt;
+            return nullptr;
         }
 
-        return std::optional<CLuaBaseEntity>(PNpc);
+        return PNpc;
     }
 
     void InitInteractionGlobal()
@@ -1252,20 +1249,14 @@ namespace luautils
         }
     }
 
-    std::optional<CLuaZone> GetZone(uint16 zoneId)
+    CZone* GetZone(uint16 zoneId)
     {
         TracyZoneScoped;
 
-        CZone* zone = zoneutils::GetZone(zoneId);
-        if (zone)
-        {
-            return std::optional<CLuaZone>(zone);
-        }
-
-        return std::nullopt;
+        return zoneutils::GetZone(zoneId);
     }
 
-    std::optional<CLuaBaseEntity> GetMobByID(uint32 mobid, sol::object const& instanceObj)
+    CBaseEntity* GetMobByID(uint32 mobid, sol::object const& instanceObj)
     {
         TracyZoneScoped;
 
@@ -1289,13 +1280,13 @@ namespace luautils
         if (!PMob)
         {
             ShowWarning("luautils::GetMobByID Mob doesn't exist (%d)", mobid);
-            return std::nullopt;
+            return nullptr;
         }
 
-        return std::optional<CLuaBaseEntity>(PMob);
+        return PMob;
     }
 
-    std::optional<CLuaBaseEntity> GetEntityByID(uint32 entityid, sol::object const& instanceObj, sol::object const& arg3)
+    CBaseEntity* GetEntityByID(uint32 entityid, sol::object const& instanceObj, sol::object const& arg3)
     {
         TracyZoneScoped;
 
@@ -1324,10 +1315,10 @@ namespace luautils
             {
                 ShowWarning("luautils::GetEntityByID Mob doesn't exist (%d)", entityid);
             }
-            return std::nullopt;
+            return nullptr;
         }
 
-        return std::optional<CLuaBaseEntity>(PEntity);
+        return PEntity;
     }
 
     void WeekUpdateConquest(uint8 updateType)
@@ -1675,7 +1666,7 @@ namespace luautils
      *  Spawn a mob using mob ID                                             *
      *                                                                       *
      ************************************************************************/
-    std::optional<CLuaBaseEntity> SpawnMob(uint32 mobid, sol::object const& arg2, sol::object const& arg3)
+    CBaseEntity* SpawnMob(uint32 mobid, sol::object const& arg2, sol::object const& arg3)
     {
         TracyZoneScoped;
 
@@ -1719,10 +1710,10 @@ namespace luautils
         else
         {
             ShowDebug("SpawnMob: mob <%u> not found", mobid);
-            return std::nullopt;
+            return nullptr;
         }
 
-        return std::optional<CLuaBaseEntity>(PMob);
+        return PMob;
     }
 
     /************************************************************************
@@ -1766,18 +1757,11 @@ namespace luautils
      *                                                                       *
      ************************************************************************/
 
-    std::optional<CLuaBaseEntity> GetPlayerByName(std::string const& name)
+    CBaseEntity* GetPlayerByName(std::string const& name)
     {
         TracyZoneScoped;
 
-        CCharEntity* PTargetChar = zoneutils::GetCharByName(name.c_str());
-
-        if (PTargetChar != nullptr)
-        {
-            return std::optional<CLuaBaseEntity>(PTargetChar);
-        }
-
-        return std::nullopt;
+        return zoneutils::GetCharByName(name.c_str());
     }
 
     /************************************************************************
@@ -1786,18 +1770,11 @@ namespace luautils
      *                                                                       *
      ************************************************************************/
 
-    std::optional<CLuaBaseEntity> GetPlayerByID(uint32 pid)
+    CBaseEntity* GetPlayerByID(uint32 pid)
     {
         TracyZoneScoped;
 
-        CCharEntity* PTargetChar = zoneutils::GetChar(pid);
-
-        if (PTargetChar != nullptr)
-        {
-            return std::optional<CLuaBaseEntity>(PTargetChar);
-        }
-
-        return std::nullopt;
+        return zoneutils::GetChar(pid);
     }
 
     /************************************************************************
@@ -2049,14 +2026,11 @@ namespace luautils
     {
         TracyZoneScoped;
 
-        std::string                 filename;
-        std::optional<CLuaInstance> optInstance = std::nullopt;
+        std::string filename;
         if (PChar->PInstance)
         {
             filename =
                 std::string("./scripts/zones/") + PChar->loc.zone->getName() + "/instances/" + PChar->PInstance->GetName() + ".lua";
-
-            optInstance = CLuaInstance(PChar->PInstance);
         }
         else
         {
@@ -2084,7 +2058,7 @@ namespace luautils
         }
 
         auto onTriggerAreaEnterFramework = lua["InteractionGlobal"]["onTriggerAreaEnter"];
-        auto result                      = onTriggerAreaEnterFramework(PChar, PTriggerArea.get(), optInstance, onTriggerAreaEnter);
+        auto result                      = onTriggerAreaEnterFramework(PChar, PTriggerArea.get(), PChar->PInstance, onTriggerAreaEnter);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2097,14 +2071,11 @@ namespace luautils
     {
         TracyZoneScoped;
 
-        std::string                 filename;
-        std::optional<CLuaInstance> optInstance = std::nullopt;
+        std::string filename;
         if (PChar->PInstance)
         {
             filename =
                 std::string("scripts/zones/") + PChar->loc.zone->getName() + "/instances/" + PChar->PInstance->GetName() + ".lua";
-
-            optInstance = CLuaInstance(PChar->PInstance);
         }
         else
         {
@@ -2132,7 +2103,7 @@ namespace luautils
         }
 
         auto onTriggerAreaLeaveFramework = lua["InteractionGlobal"]["onTriggerAreaLeave"];
-        auto result                      = onTriggerAreaLeaveFramework(PChar, PTriggerArea.get(), optInstance, onTriggerAreaLeave);
+        auto result                      = onTriggerAreaLeaveFramework(PChar, PTriggerArea.get(), PChar->PInstance, onTriggerAreaLeave);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2629,13 +2600,7 @@ namespace luautils
             return { 56, 0, 0 };
         }
 
-        std::optional<CLuaBaseEntity> caster = std::nullopt;
-        if (PCaster)
-        {
-            caster = PCaster;
-        }
-
-        auto result = onItemCheck(PTarget, PItem, static_cast<uint32>(param), caster);
+        auto result = onItemCheck(PTarget, PItem, static_cast<uint32>(param), PCaster);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2836,13 +2801,7 @@ namespace luautils
             return {};
         }
 
-        std::optional<CLuaSpell> luaSpell;
-        if (startingSpellId.has_value())
-        {
-            luaSpell = spell::GetSpell(startingSpellId.value());
-        }
-
-        auto result = onMobMagicPrepare(PCaster, PTarget, luaSpell);
+        auto result = onMobMagicPrepare(PCaster, PTarget, spell::GetSpell(startingSpellId.value()));
         if (!result.valid())
         {
             sol::error err = result;
@@ -3331,13 +3290,7 @@ namespace luautils
             return;
         }
 
-        std::optional<CLuaBaseEntity> optionalKiller = std::nullopt;
-        if (PAttacker)
-        {
-            optionalKiller = PAttacker;
-        }
-
-        auto result = onCriticalHit(PMob, optionalKiller);
+        auto result = onCriticalHit(PMob, PAttacker);
         if (!result.valid())
         {
             sol::error err = result;
@@ -3406,12 +3359,6 @@ namespace luautils
                     uint16 weaponskillUsed   = weaponskillVar >> 24;
                     uint32 weaponskillDamage = weaponskillVar & 0xFFFFFF;
 
-                    std::optional<CBaseEntity*> optAllyEntity = std::nullopt;
-                    if (PMember)
-                    {
-                        optAllyEntity = PMember;
-                    }
-
                     optParams["isKiller"]          = PMember == PChar;
                     optParams["noKiller"]          = false;
                     optParams["isWeaponSkillKill"] = weaponskillUsed > 0;
@@ -3422,7 +3369,7 @@ namespace luautils
                     PChar->eventPreparation->scriptFile   = filename;
 
                     // onMobDeath(mob, player, optParams)
-                    auto result = onMobDeathFramework(PMob, optAllyEntity, optParams, onMobDeath);
+                    auto result = onMobDeathFramework(PMob, PMember, optParams, onMobDeath);
 
                     // NOTE: result is only NOT valid if the function call fails. If it returns nil its still valid (this is expected)
                     if (!result.valid())
@@ -3431,7 +3378,7 @@ namespace luautils
                         ShowError("luautils::onMobDeath: %s", err.what());
                     }
 
-                    PChar->PAI->EventHandler.triggerListener("DEFEATED_MOB", PMob, optAllyEntity, optParams);
+                    PChar->PAI->EventHandler.triggerListener("DEFEATED_MOB", PMob, PMember, optParams);
                 }
             });
             // clang-format on
@@ -3693,13 +3640,7 @@ namespace luautils
             return std::tuple<int32, uint8, uint8>();
         }
 
-        std::optional<CBaseEntity*> optTrickAttackChar = std::nullopt;
-        if (taChar)
-        {
-            optTrickAttackChar = taChar;
-        }
-
-        auto result = onUseWeaponSkill(PChar, PMob, wskill->getID(), tp, primary, &action, optTrickAttackChar);
+        auto result = onUseWeaponSkill(PChar, PMob, wskill->getID(), tp, primary, &action, taChar);
         if (!result.valid())
         {
             sol::error err = result;
@@ -4927,25 +4868,25 @@ namespace luautils
      *                                                                       *
      ************************************************************************/
 
-    std::optional<CLuaItem> GetReadOnlyItem(uint32 id)
+    CItem* GetReadOnlyItem(uint32 id)
     {
         TracyZoneScoped;
-        CItem* PItem = itemutils::GetItemPointer(id);
-        return PItem ? std::optional<CLuaItem>(PItem) : std::nullopt;
+
+        return itemutils::GetItemPointer(id);
     }
 
-    std::optional<CLuaAbility> GetAbility(uint16 id)
+    CAbility* GetAbility(uint16 id)
     {
         TracyZoneScoped;
-        CAbility* PAbility = ability::GetAbility(id);
-        return PAbility ? std::optional<CLuaAbility>(PAbility) : std::nullopt;
+
+        return ability::GetAbility(id);
     }
 
-    std::optional<CLuaSpell> GetSpell(uint16 id)
+    CSpell* GetSpell(uint16 id)
     {
         TracyZoneScoped;
-        CSpell* PSpell = spell::GetSpell(static_cast<SpellID>(id));
-        return PSpell ? std::optional<CLuaSpell>(PSpell) : std::nullopt;
+
+        return spell::GetSpell(static_cast<SpellID>(id));
     }
 
     sol::table NearLocation(sol::table const& table, float radius, float theta)
@@ -5047,31 +4988,43 @@ namespace luautils
     {
         TracyZoneScoped;
 
-        auto funcFromChar = GetCacheEntryFromFilename(PChar->currentEvent->scriptFile)[functionName];
-        if (funcFromChar.valid())
+        const auto currentEventEntry = GetCacheEntryFromFilename(PChar->currentEvent->scriptFile);
+        if (currentEventEntry.valid())
         {
-            return funcFromChar;
+            const auto funcFromChar = currentEventEntry[functionName];
+            if (funcFromChar.valid())
+            {
+                return funcFromChar;
+            }
         }
 
         if (PChar->PInstance)
         {
-            auto instance_filename = fmt::format(
+            const auto instanceFilename = fmt::format(
                 "./scripts/zones/{}/instances/{}",
                 PChar->PInstance->GetZone()->getName(),
                 PChar->PInstance->GetName());
 
-            auto funcFromInstance = GetCacheEntryFromFilename(instance_filename)[functionName];
-            if (funcFromInstance.valid())
+            const auto instanceEntry = GetCacheEntryFromFilename(instanceFilename);
+            if (instanceEntry.valid())
             {
-                return funcFromInstance;
+                const auto funcFromInstance = instanceEntry[functionName];
+                if (funcFromInstance.valid())
+                {
+                    return funcFromInstance;
+                }
             }
         }
 
-        auto zone_filename = fmt::format("./scripts/zones/{}/Zone.lua", PChar->loc.zone->getName());
-        auto funcFromZone  = GetCacheEntryFromFilename(zone_filename)[functionName];
-        if (funcFromZone.valid())
+        const auto zoneFilename = fmt::format("./scripts/zones/{}/Zone.lua", PChar->loc.zone->getName());
+        const auto zoneEntry    = GetCacheEntryFromFilename(zoneFilename);
+        if (zoneEntry.valid())
         {
-            return funcFromZone;
+            const auto funcFromZone = zoneEntry[functionName];
+            if (funcFromZone.valid())
+            {
+                return funcFromZone;
+            }
         }
 
         return sol::lua_nil;
@@ -5393,7 +5346,7 @@ namespace luautils
         return id;
     }
 
-    std::optional<CLuaBaseEntity> GenerateDynamicEntity(CZone* PZone, CInstance* PInstance, sol::table table)
+    CBaseEntity* GenerateDynamicEntity(CZone* PZone, CInstance* PInstance, sol::table table)
     {
         CBaseEntity* PEntity = nullptr;
         if (table.get_or<uint8>("objtype", TYPE_NPC) == TYPE_NPC)
@@ -5413,7 +5366,7 @@ namespace luautils
         if (PEntity == nullptr)
         {
             ShowWarning("Failed to insert Dynamic Entity.");
-            return std::nullopt;
+            return nullptr;
         }
 
         // NOTE: Mob allegiance is the default for NPCs

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1100,7 +1100,7 @@ namespace luautils
     {
         if (auto* PItem = itemutils::GetItemPointer(itemId))
         {
-            return CLuaItem(PItem);
+            return PItem;
         }
 
         return std::nullopt;
@@ -1826,7 +1826,7 @@ namespace luautils
             return;
         }
 
-        auto result = onInitialize(CLuaZone(PZone));
+        auto result = onInitialize(PZone);
         if (!result.valid())
         {
             sol::error err = result;
@@ -1849,7 +1849,7 @@ namespace luautils
             return;
         }
 
-        auto result = onZoneTick(CLuaZone(PZone));
+        auto result = onZoneTick(PZone);
         if (!result.valid())
         {
             sol::error err = result;
@@ -1870,7 +1870,7 @@ namespace luautils
             return;
         }
 
-        auto result = onGameIn(CLuaBaseEntity(PChar), PChar->GetPlayTime(false) == 0, zoning);
+        auto result = onGameIn(PChar, PChar->GetPlayTime(false) == 0, zoning);
         if (!result.valid())
         {
             sol::error err = result;
@@ -1905,7 +1905,7 @@ namespace luautils
         auto onZoneInFramework = lua["InteractionGlobal"]["onZoneIn"];
         auto onZoneIn          = GetCacheEntryFromFilename(filename)["onZoneIn"];
 
-        auto result = onZoneInFramework(CLuaBaseEntity(PChar), PChar->loc.prevzone, onZoneIn);
+        auto result = onZoneInFramework(PChar, PChar->loc.prevzone, onZoneIn);
         if (!result.valid())
         {
             sol::error err = result;
@@ -1940,7 +1940,7 @@ namespace luautils
         auto afterZoneInFramework = lua["InteractionGlobal"]["afterZoneIn"];
         auto afterZoneIn          = GetCacheEntryFromFilename(filename)["afterZoneIn"];
 
-        auto result = afterZoneInFramework(CLuaBaseEntity(PChar), afterZoneIn);
+        auto result = afterZoneInFramework(PChar, afterZoneIn);
         if (!result.valid())
         {
             sol::error err = result;
@@ -1961,7 +1961,7 @@ namespace luautils
         auto onZoneOutFramework = lua["InteractionGlobal"]["onZoneOut"];
         auto onZoneOut          = GetCacheEntryFromFilename(filename)["onZoneOut"];
 
-        auto result = onZoneOutFramework(CLuaBaseEntity(PChar), onZoneOut);
+        auto result = onZoneOutFramework(PChar, onZoneOut);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2103,7 +2103,7 @@ namespace luautils
         auto onTriggerFramework = lua["InteractionGlobal"]["onTrigger"];
         auto onTrigger          = GetCacheEntryFromFilename(filename)["onTrigger"];
 
-        auto result = onTriggerFramework(CLuaBaseEntity(PChar), CLuaBaseEntity(PNpc), onTrigger);
+        auto result = onTriggerFramework(PChar, PNpc, onTrigger);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2134,7 +2134,7 @@ namespace luautils
             optTarget = CLuaBaseEntity(PChar->currentEvent->targetEntity);
         }
 
-        auto func_result = onEventUpdateFramework(CLuaBaseEntity(PChar), eventID, result, optTarget, onEventUpdate);
+        auto func_result = onEventUpdateFramework(PChar, eventID, result, optTarget, onEventUpdate);
 
         PChar->eventPreparation = previousPrep;
 
@@ -2168,7 +2168,7 @@ namespace luautils
             optTarget = CLuaBaseEntity(PChar->currentEvent->targetEntity);
         }
 
-        auto result = onEventUpdateFramework(CLuaBaseEntity(PChar), PChar->currentEvent->eventId, updateString, optTarget, onEventUpdate);
+        auto result = onEventUpdateFramework(PChar, PChar->currentEvent->eventId, updateString, optTarget, onEventUpdate);
 
         PChar->eventPreparation = previousPrep;
 
@@ -2207,7 +2207,7 @@ namespace luautils
             optTarget = CLuaBaseEntity(PChar->currentEvent->targetEntity);
         }
 
-        auto func_result = onEventFinishFramework(CLuaBaseEntity(PChar), eventID, result, optTarget, onEventFinish);
+        auto func_result = onEventFinishFramework(PChar, eventID, result, optTarget, onEventFinish);
 
         // Restore eventPreparation before potentially bailing out of function due to errors
         PChar->eventPreparation = previousPrep;
@@ -2246,7 +2246,7 @@ namespace luautils
         auto onTradeFramework = lua["InteractionGlobal"]["onTrade"];
         auto onTrade          = GetCacheEntryFromFilename(filename)["onTrade"];
 
-        auto result = onTradeFramework(CLuaBaseEntity(PChar), CLuaBaseEntity(PNpc), CLuaTradeContainer(PChar->TradeContainer), onTrade);
+        auto result = onTradeFramework(PChar, PNpc, PChar->TradeContainer, onTrade);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2271,7 +2271,7 @@ namespace luautils
             return;
         }
 
-        auto result = onSpawn(CLuaBaseEntity(PNpc));
+        auto result = onSpawn(PNpc);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2297,7 +2297,7 @@ namespace luautils
             return;
         }
 
-        auto result = onAdditionalEffect(CLuaBaseEntity(PAttacker), CLuaBaseEntity(PDefender), damage);
+        auto result = onAdditionalEffect(PAttacker, PDefender, damage);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2324,7 +2324,7 @@ namespace luautils
             return;
         }
 
-        auto result = onSpikesDamage(CLuaBaseEntity(PDefender), CLuaBaseEntity(PAttacker), damage);
+        auto result = onSpikesDamage(PDefender, PAttacker, damage);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2353,7 +2353,7 @@ namespace luautils
             return -1;
         }
 
-        auto result = additionalEffectAttack(CLuaBaseEntity(PAttacker), CLuaBaseEntity(PDefender), baseAttackDamage, CLuaItem(PItem));
+        auto result = additionalEffectAttack(PAttacker, PDefender, baseAttackDamage, PItem);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2380,7 +2380,7 @@ namespace luautils
             return;
         }
 
-        auto result = additionalEffectSpikes(CLuaBaseEntity(PDefender), CLuaBaseEntity(PAttacker), baseAttackDamage, CLuaItem(PItem));
+        auto result = additionalEffectSpikes(PDefender, PAttacker, baseAttackDamage, PItem);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2405,7 +2405,7 @@ namespace luautils
             return;
         }
 
-        auto result = onEffectGain(CLuaBaseEntity(PEntity), CLuaStatusEffect(PStatusEffect));
+        auto result = onEffectGain(PEntity, CLuaStatusEffect(PStatusEffect));
         if (!result.valid())
         {
             sol::error err = result;
@@ -2426,7 +2426,7 @@ namespace luautils
             return;
         }
 
-        auto result = onEffectTick(CLuaBaseEntity(PEntity), CLuaStatusEffect(PStatusEffect));
+        auto result = onEffectTick(PEntity, CLuaStatusEffect(PStatusEffect));
         if (!result.valid())
         {
             sol::error err = result;
@@ -2447,7 +2447,7 @@ namespace luautils
             return;
         }
 
-        auto result = onEffectLose(CLuaBaseEntity(PEntity), CLuaStatusEffect(PStatusEffect));
+        auto result = onEffectLose(PEntity, CLuaStatusEffect(PStatusEffect));
         if (!result.valid())
         {
             sol::error err = result;
@@ -2468,7 +2468,7 @@ namespace luautils
             return;
         }
 
-        auto result = onEquip(CLuaBaseEntity(PEntity), CLuaItem(attachment));
+        auto result = onEquip(PEntity, CLuaItem(attachment));
         if (!result.valid())
         {
             sol::error err = result;
@@ -2488,7 +2488,7 @@ namespace luautils
             return;
         }
 
-        auto result = onUnequip(CLuaBaseEntity(PEntity), CLuaItem(attachment));
+        auto result = onUnequip(PEntity, CLuaItem(attachment));
         if (!result.valid())
         {
             sol::error err = result;
@@ -2508,7 +2508,7 @@ namespace luautils
             return;
         }
 
-        auto result = onManeuverGain(CLuaBaseEntity(PEntity), CLuaItem(attachment), maneuvers);
+        auto result = onManeuverGain(PEntity, CLuaItem(attachment), maneuvers);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2528,7 +2528,7 @@ namespace luautils
             return;
         }
 
-        auto result = onManeuverLose(CLuaBaseEntity(PEntity), CLuaItem(attachment), maneuvers);
+        auto result = onManeuverLose(PEntity, CLuaItem(attachment), maneuvers);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2548,7 +2548,7 @@ namespace luautils
             return;
         }
 
-        auto result = onUpdate(CLuaBaseEntity(PEntity), CLuaItem(attachment), maneuvers);
+        auto result = onUpdate(PEntity, CLuaItem(attachment), maneuvers);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2573,10 +2573,10 @@ namespace luautils
         std::optional<CLuaBaseEntity> caster = std::nullopt;
         if (PCaster)
         {
-            caster = CLuaBaseEntity(PCaster);
+            caster = PCaster;
         }
 
-        auto result = onItemCheck(CLuaBaseEntity(PTarget), CLuaItem(PItem), static_cast<uint32>(param), caster);
+        auto result = onItemCheck(PTarget, PItem, static_cast<uint32>(param), caster);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2616,7 +2616,7 @@ namespace luautils
             }
         }
 
-        auto result = onItemUse(CLuaBaseEntity(PTarget), CLuaBaseEntity(PUser), CLuaItem(PItem));
+        auto result = onItemUse(PTarget, PUser, PItem);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2638,7 +2638,7 @@ namespace luautils
             return;
         }
 
-        auto result = onItemDrop(CLuaBaseEntity(PUser), CLuaItem(PItem));
+        auto result = onItemDrop(PUser, PItem);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2659,7 +2659,7 @@ namespace luautils
             return;
         }
 
-        auto result = onItemEquip(CLuaBaseEntity(PUser), CLuaItem(PItem));
+        auto result = onItemEquip(PUser, PItem);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2680,7 +2680,7 @@ namespace luautils
             return;
         }
 
-        auto result = onItemUnequip(CLuaBaseEntity(PUser), CLuaItem(PItem));
+        auto result = onItemUnequip(PUser, PItem);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2700,7 +2700,7 @@ namespace luautils
             return;
         }
 
-        auto result = checkForGearSet(CLuaBaseEntity(PTarget));
+        auto result = checkForGearSet(PTarget);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2725,7 +2725,7 @@ namespace luautils
             return 0;
         }
 
-        auto result = onSpellCast(CLuaBaseEntity(PCaster), CLuaBaseEntity(PTarget), CLuaSpell(PSpell));
+        auto result = onSpellCast(PCaster, PTarget, PSpell);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2753,7 +2753,7 @@ namespace luautils
             return;
         }
 
-        auto result = onSpellPrecast(CLuaBaseEntity(PCaster), CLuaSpell(PSpell));
+        auto result = onSpellPrecast(PCaster, PSpell);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2783,7 +2783,7 @@ namespace luautils
             luaSpell = spell::GetSpell(startingSpellId.value());
         }
 
-        auto result = onMobMagicPrepare(CLuaBaseEntity(PCaster), CLuaBaseEntity(PTarget), luaSpell);
+        auto result = onMobMagicPrepare(PCaster, PTarget, luaSpell);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2818,7 +2818,7 @@ namespace luautils
             return;
         }
 
-        auto result = onMagicHit(CLuaBaseEntity(PCaster), CLuaBaseEntity(PTarget), CLuaSpell(PSpell));
+        auto result = onMagicHit(PCaster, PTarget, PSpell);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2838,7 +2838,7 @@ namespace luautils
             return;
         }
 
-        auto result = onWeaponskillHit(CLuaBaseEntity(PMob), CLuaBaseEntity(PAttacker), PWeaponskill);
+        auto result = onWeaponskillHit(PMob, PAttacker, PWeaponskill);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2858,7 +2858,7 @@ namespace luautils
             return false;
         }
 
-        auto result = checkBattlefieldTrustCount(CLuaBaseEntity(PCaster));
+        auto result = checkBattlefieldTrustCount(PCaster);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2879,7 +2879,7 @@ namespace luautils
             return;
         }
 
-        auto result = onMobInitialize(CLuaBaseEntity(PMob));
+        auto result = onMobInitialize(PMob);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2929,7 +2929,7 @@ namespace luautils
         // get the parameter "mixinOptions" (optional)
         auto mixinOptions = lua["mixinOptions"];
 
-        auto result = applyMixins(CLuaBaseEntity(PMob), mixins, mixinOptions);
+        auto result = applyMixins(PMob, mixins, mixinOptions);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2976,7 +2976,7 @@ namespace luautils
         // get the parameter "mixinOptions" (optional)
         auto mixinOptions = lua["mixinOptions"];
 
-        auto result = applyMixins(CLuaBaseEntity(PMob), mixins, mixinOptions);
+        auto result = applyMixins(PMob, mixins, mixinOptions);
         if (!result.valid())
         {
             sol::error err = result;
@@ -2999,7 +2999,7 @@ namespace luautils
             return;
         }
 
-        auto result = onPath(CLuaBaseEntity(PEntity));
+        auto result = onPath(PEntity);
         if (!result.valid())
         {
             sol::error err = result;
@@ -3022,7 +3022,7 @@ namespace luautils
             return;
         }
 
-        auto result = onPathPoint(CLuaBaseEntity(PEntity));
+        auto result = onPathPoint(PEntity);
         if (!result.valid())
         {
             sol::error err = result;
@@ -3045,7 +3045,7 @@ namespace luautils
             return;
         }
 
-        auto result = onPathComplete(CLuaBaseEntity(PEntity));
+        auto result = onPathComplete(PEntity);
         if (!result.valid())
         {
             sol::error err = result;
@@ -3071,9 +3071,7 @@ namespace luautils
             return MaxAreas;
         }
 
-        CLuaZone LuaZone(PZone);
-
-        auto result = onBattlefieldHandlerInitialize(CLuaZone(PZone));
+        auto result = onBattlefieldHandlerInitialize(PZone);
         if (!result.valid())
         {
             sol::error err = result;
@@ -3093,7 +3091,7 @@ namespace luautils
             return;
         }
 
-        invokeBattlefieldEvent(PBattlefield->GetID(), "onBattlefieldInitialize", CLuaBattlefield(PBattlefield));
+        invokeBattlefieldEvent(PBattlefield->GetID(), "onBattlefieldInitialize", PBattlefield);
     }
 
     void OnBattlefieldTick(CBattlefield* PBattlefield)
@@ -3108,7 +3106,7 @@ namespace luautils
         auto name    = PBattlefield->GetName();
         auto seconds = std::chrono::duration_cast<std::chrono::seconds>(PBattlefield->GetTimeInside()).count();
 
-        if (invokeBattlefieldEvent(PBattlefield->GetID(), "onBattlefieldTick", CLuaBattlefield(PBattlefield), seconds) == 0)
+        if (invokeBattlefieldEvent(PBattlefield->GetID(), "onBattlefieldTick", PBattlefield, seconds) == 0)
         {
             return;
         }
@@ -3125,7 +3123,7 @@ namespace luautils
             return;
         }
 
-        invokeBattlefieldEvent(PBattlefield->GetID(), "onBattlefieldStatusChange", CLuaBattlefield(PBattlefield), PBattlefield->GetStatus());
+        invokeBattlefieldEvent(PBattlefield->GetID(), "onBattlefieldStatusChange", PBattlefield, PBattlefield->GetStatus());
     }
 
     void OnMobEngage(CBaseEntity* PMob, CBaseEntity* PTarget)
@@ -3159,7 +3157,7 @@ namespace luautils
             return;
         }
 
-        auto result = onMobEngage(CLuaBaseEntity(PMob), CLuaBaseEntity(PTarget));
+        auto result = onMobEngage(PMob, PTarget);
         if (!result.valid())
         {
             sol::error err = result;
@@ -3184,7 +3182,7 @@ namespace luautils
 
         uint8 weather = PMob->loc.zone->GetWeather();
 
-        auto result = onMobDisengage(CLuaBaseEntity(PMob), weather);
+        auto result = onMobDisengage(PMob, weather);
         if (!result.valid())
         {
             sol::error err = result;
@@ -3206,7 +3204,7 @@ namespace luautils
             return;
         }
 
-        auto result = onMobFollow(CLuaBaseEntity(PMob), CLuaBaseEntity(PTarget));
+        auto result = onMobFollow(PMob, PTarget);
         if (!result.valid())
         {
             sol::error err = result;
@@ -3228,7 +3226,7 @@ namespace luautils
             return;
         }
 
-        auto result = onMobUnfollow(CLuaBaseEntity(PMob), CLuaBaseEntity(PTarget));
+        auto result = onMobUnfollow(PMob, PTarget);
         if (!result.valid())
         {
             sol::error err = result;
@@ -3251,7 +3249,7 @@ namespace luautils
             return;
         }
 
-        auto result = onMobFight(CLuaBaseEntity(PMob), CLuaBaseEntity(PTarget));
+        auto result = onMobFight(PMob, PTarget);
         if (!result.valid())
         {
             sol::error err = result;
@@ -3277,10 +3275,10 @@ namespace luautils
         std::optional<CLuaBaseEntity> optionalKiller = std::nullopt;
         if (PAttacker)
         {
-            optionalKiller = CLuaBaseEntity(PAttacker);
+            optionalKiller = PAttacker;
         }
 
-        auto result = onCriticalHit(CLuaBaseEntity(PMob), optionalKiller);
+        auto result = onCriticalHit(PMob, optionalKiller);
         if (!result.valid())
         {
             sol::error err = result;
@@ -3321,12 +3319,10 @@ namespace luautils
             {
                 if (PMember->getZone() == PChar->getZone())
                 {
-                    CLuaBaseEntity LuaMobEntity(PMob);
-                    CLuaBaseEntity LuaAllyEntity(PMember);
-                    bool           isKiller          = PMember == PChar;
-                    bool           isWeaponSkillKill = (PMob->GetLocalVar("weaponskillHit") & 0xFFFFFF) > 0;
+                    bool isKiller          = PMember == PChar;
+                    bool   isWeaponSkillKill = (PMob->GetLocalVar("weaponskillHit") & 0xFFFFFF) > 0;
 
-                    auto result = onMobDeathEx(LuaMobEntity, LuaAllyEntity, isKiller, isWeaponSkillKill);
+                    auto result = onMobDeathEx(PMob, PMember, isKiller, isWeaponSkillKill);
                     if (!result.valid())
                     {
                         sol::error err = result;
@@ -3347,15 +3343,14 @@ namespace luautils
                 CCharEntity* PMember = (CCharEntity*)PPartyMember;
                 if (PMember && PMember->getZone() == PChar->getZone())
                 {
-                    CLuaBaseEntity                LuaMobEntity(PMob);
-                    std::optional<CLuaBaseEntity> optLuaAllyEntity  = std::nullopt;
-                    uint32                        weaponskillVar    = PMob->GetLocalVar("weaponskillHit");
-                    uint16                        weaponskillUsed   = weaponskillVar >> 24;
-                    uint32                        weaponskillDamage = weaponskillVar & 0xFFFFFF;
+                    uint32 weaponskillVar    = PMob->GetLocalVar("weaponskillHit");
+                    uint16 weaponskillUsed   = weaponskillVar >> 24;
+                    uint32 weaponskillDamage = weaponskillVar & 0xFFFFFF;
 
+                    std::optional<CBaseEntity*> optAllyEntity = std::nullopt;
                     if (PMember)
                     {
-                        optLuaAllyEntity = CLuaBaseEntity(PMember);
+                        optAllyEntity = PMember;
                     }
 
                     optParams["isKiller"]          = PMember == PChar;
@@ -3368,7 +3363,7 @@ namespace luautils
                     PChar->eventPreparation->scriptFile   = filename;
 
                     // onMobDeath(mob, player, optParams)
-                    auto result = onMobDeathFramework(LuaMobEntity, optLuaAllyEntity, optParams, onMobDeath);
+                    auto result = onMobDeathFramework(PMob, optAllyEntity, optParams, onMobDeath);
 
                     // NOTE: result is only NOT valid if the function call fails. If it returns nil its still valid (this is expected)
                     if (!result.valid())
@@ -3377,7 +3372,7 @@ namespace luautils
                         ShowError("luautils::onMobDeath: %s", err.what());
                     }
 
-                    PChar->PAI->EventHandler.triggerListener("DEFEATED_MOB", LuaMobEntity, optLuaAllyEntity, optParams);
+                    PChar->PAI->EventHandler.triggerListener("DEFEATED_MOB", PMob, optAllyEntity, optParams);
                 }
             });
             // clang-format on
@@ -3388,7 +3383,7 @@ namespace luautils
             sol::function onMobDeath          = getEntityCachedFunction(PMob, "onMobDeath");
 
             // onMobDeath(mob, player, optParams)
-            auto result = onMobDeathFramework(CLuaBaseEntity(PMob), sol::lua_nil, optParams, onMobDeath);
+            auto result = onMobDeathFramework(PMob, sol::lua_nil, optParams, onMobDeath);
 
             // NOTE: result is only NOT valid if the function call fails. If it returns nil its still valid (this is expected)
             if (!result.valid())
@@ -3414,7 +3409,7 @@ namespace luautils
             return;
         }
 
-        auto result = onMobSpawn(CLuaBaseEntity(PMob));
+        auto result = onMobSpawn(PMob);
         if (!result.valid())
         {
             sol::error err = result;
@@ -3437,7 +3432,7 @@ namespace luautils
             return;
         }
 
-        auto result = onMobRoamAction(CLuaBaseEntity(PMob));
+        auto result = onMobRoamAction(PMob);
         if (!result.valid())
         {
             sol::error err = result;
@@ -3455,7 +3450,7 @@ namespace luautils
             return;
         }
 
-        auto result = onMobRoam(CLuaBaseEntity(PMob));
+        auto result = onMobRoam(PMob);
         if (!result.valid())
         {
             sol::error err = result;
@@ -3478,7 +3473,7 @@ namespace luautils
             return;
         }
 
-        auto result = onMobDespawn(CLuaBaseEntity(PMob));
+        auto result = onMobDespawn(PMob);
         if (!result.valid())
         {
             sol::error err = result;
@@ -3501,7 +3496,7 @@ namespace luautils
             return;
         }
 
-        auto result = onPlayerAbilityUse(CLuaBaseEntity(PMob), CLuaBaseEntity(PPlayer), CLuaAbility(PAbility));
+        auto result = onPlayerAbilityUse(PMob, PPlayer, PAbility);
         if (!result.valid())
         {
             sol::error err = result;
@@ -3524,7 +3519,7 @@ namespace luautils
             return;
         }
 
-        auto result = onPetLevelRestriction(CLuaBaseEntity(PMob));
+        auto result = onPetLevelRestriction(PMob);
         if (!result.valid())
         {
             sol::error err = result;
@@ -3564,7 +3559,7 @@ namespace luautils
             return;
         }
 
-        auto result = onGameHour(CLuaZone(PZone));
+        auto result = onGameHour(PZone);
         if (!result.valid())
         {
             sol::error err = result;
@@ -3583,20 +3578,7 @@ namespace luautils
             return;
         }
 
-        auto name = PZone->getName();
-
-        auto onZoneWeatherChange = lua["xi"]["zones"][name]["Zone"]["onZoneWeatherChange"];
-        if (!onZoneWeatherChange.valid())
-        {
-            return;
-        }
-
-        auto result = onZoneWeatherChange(weather);
-        if (!result.valid())
-        {
-            sol::error err = result;
-            ShowError("luautils::onZoneWeatherChange: %s", err.what());
-        }
+        callGlobal<void>(fmt::format("xi.zones.{}.Zone.onZoneWeatherChange", PZone->getName()), weather);
     }
 
     void OnTOTDChange(uint16 ZoneID, uint8 TOTD)
@@ -3639,13 +3621,13 @@ namespace luautils
             return std::tuple<int32, uint8, uint8>();
         }
 
-        std::optional<CLuaBaseEntity> optTrickAttackLuaChar = std::nullopt;
+        std::optional<CBaseEntity*> optTrickAttackChar = std::nullopt;
         if (taChar)
         {
-            optTrickAttackLuaChar = CLuaBaseEntity(taChar);
+            optTrickAttackChar = taChar;
         }
 
-        auto result = onUseWeaponSkill(CLuaBaseEntity(PChar), CLuaBaseEntity(PMob), wskill->getID(), tp, primary, CLuaAction(&action), optTrickAttackLuaChar);
+        auto result = onUseWeaponSkill(PChar, PMob, wskill->getID(), tp, primary, &action, optTrickAttackChar);
         if (!result.valid())
         {
             sol::error err = result;
@@ -3681,7 +3663,7 @@ namespace luautils
             return 0;
         }
 
-        auto result = onMobWeaponSkillPrepare(CLuaBaseEntity(PMob), CLuaBaseEntity(PTarget));
+        auto result = onMobWeaponSkillPrepare(PMob, PTarget);
         if (!result.valid())
         {
             sol::error err = result;
@@ -3710,7 +3692,7 @@ namespace luautils
             auto onMobWeaponSkill = lua["xi"]["zones"][zone]["mobs"][name]["onMobWeaponSkill"];
             if (onMobWeaponSkill.valid())
             {
-                auto result = onMobWeaponSkill(CLuaBaseEntity(PTarget), CLuaBaseEntity(PMob), CLuaMobSkill(PMobSkill), CLuaAction(action));
+                auto result = onMobWeaponSkill(PTarget, PMob, PMobSkill, action);
                 if (!result.valid())
                 {
                     sol::error err = result;
@@ -3729,7 +3711,7 @@ namespace luautils
             return 0;
         }
 
-        auto result = onMobWeaponSkill(CLuaBaseEntity(PTarget), CLuaBaseEntity(PMob), CLuaMobSkill(PMobSkill));
+        auto result = onMobWeaponSkill(PTarget, PMob, PMobSkill);
         if (!result.valid())
         {
             sol::error err = result;
@@ -3752,7 +3734,7 @@ namespace luautils
             return 1;
         }
 
-        auto result = onMobSkillCheck(CLuaBaseEntity(PTarget), CLuaBaseEntity(PMob), CLuaMobSkill(PMobSkill));
+        auto result = onMobSkillCheck(PTarget, PMob, PMobSkill);
         if (!result.valid())
         {
             sol::error err = result;
@@ -3776,7 +3758,7 @@ namespace luautils
             return PTarget;
         }
 
-        auto result = onMobSkillTarget(CLuaBaseEntity(static_cast<CBaseEntity*>(PTarget)), CLuaBaseEntity(PMob), CLuaMobSkill(PMobSkill));
+        auto result = onMobSkillTarget(PTarget, PMob, PMobSkill);
         if (!result.valid())
         {
             sol::error err = result;
@@ -3806,7 +3788,7 @@ namespace luautils
             return 1;
         }
 
-        auto result = onAutomatonAbilityCheck(CLuaBaseEntity(PTarget), CLuaBaseEntity(PAutomaton), CLuaMobSkill(PMobSkill));
+        auto result = onAutomatonAbilityCheck(PTarget, PAutomaton, PMobSkill);
         if (!result.valid())
         {
             sol::error err = result;
@@ -3827,7 +3809,7 @@ namespace luautils
             return 0;
         }
 
-        auto result = onAutomatonAbility(CLuaBaseEntity(PTarget), CLuaBaseEntity(PMob), CLuaMobSkill(PMobSkill), CLuaBaseEntity(PMobMaster), CLuaAction(action));
+        auto result = onAutomatonAbility(PTarget, PMob, PMobSkill, PMobMaster, action);
         if (!result.valid())
         {
             sol::error err = result;
@@ -3982,7 +3964,7 @@ namespace luautils
             return;
         }
 
-        auto result = onMonstrosityUpdate(CLuaBaseEntity(PChar), GetMonstrosityLuaTable(PChar));
+        auto result = onMonstrosityUpdate(PChar, GetMonstrosityLuaTable(PChar));
         if (!result.valid())
         {
             sol::error err = result;
@@ -4002,7 +3984,7 @@ namespace luautils
             return;
         }
 
-        auto result = onMonstrosityReturnToEntrance(CLuaBaseEntity(PChar));
+        auto result = onMonstrosityReturnToEntrance(PChar);
         if (!result.valid())
         {
             sol::error err = result;
@@ -4022,7 +4004,7 @@ namespace luautils
             return 47;
         }
 
-        auto result = onMagicCastingCheck(CLuaBaseEntity(PChar), CLuaBaseEntity(PTarget), CLuaSpell(PSpell));
+        auto result = onMagicCastingCheck(PChar, PTarget, PSpell);
         if (!result.valid())
         {
             sol::error err = result;
@@ -4061,7 +4043,7 @@ namespace luautils
             return 0;
         }
 
-        auto result = onAbilityCheck(CLuaBaseEntity(PChar), CLuaBaseEntity(PTarget), CLuaAbility(PAbility));
+        auto result = onAbilityCheck(PChar, PTarget, PAbility);
         if (!result.valid())
         {
             sol::error err = result;
@@ -4091,7 +4073,7 @@ namespace luautils
             return 0;
         }
 
-        auto result = onPetAbility(CLuaBaseEntity(PTarget), CLuaBaseEntity(PMob), CLuaMobSkill(PMobSkill), CLuaBaseEntity(PMobMaster), CLuaAction(action));
+        auto result = onPetAbility(PTarget, PMob, PMobSkill, PMobMaster, action);
         if (!result.valid())
         {
             sol::error err = result;
@@ -4129,7 +4111,7 @@ namespace luautils
             return 0;
         }
 
-        auto result = onPetAbility(CLuaBaseEntity(PTarget), CLuaBaseEntity(PPet), CLuaPetSkill(PPetSkill), CLuaBaseEntity(PMobMaster), CLuaAction(action));
+        auto result = onPetAbility(PTarget, PPet, PPetSkill, PMobMaster, action);
         if (!result.valid())
         {
             sol::error err = result;
@@ -4170,7 +4152,7 @@ namespace luautils
             return 0;
         }
 
-        auto result = onUseAbility(CLuaBaseEntity(PUser), CLuaBaseEntity(PTarget), CLuaAbility(PAbility), CLuaAction(action));
+        auto result = onUseAbility(PUser, PTarget, PAbility, action);
         if (!result.valid())
         {
             sol::error err = result;
@@ -4199,7 +4181,7 @@ namespace luautils
         auto onStealFramework = lua["InteractionGlobal"]["onSteal"];
         auto onSteal          = GetCacheEntryFromFilename(filename)["onSteal"];
 
-        auto result = onStealFramework(CLuaBaseEntity(PChar), CLuaBaseEntity(PMob), CLuaAbility(PAbility), CLuaAction(action), onSteal);
+        auto result = onStealFramework(PChar, PMob, PAbility, action, onSteal);
         if (!result.valid())
         {
             sol::error err = result;
@@ -4216,7 +4198,7 @@ namespace luautils
         return 0;
     }
 
-    bool OnCanUseSpell(CBattleEntity* PChar, CSpell* Spell) // triggers when CanUseSpell is invoked on spell.cpp for PCs only
+    bool OnCanUseSpell(CBattleEntity* PChar, CSpell* PSpell) // triggers when CanUseSpell is invoked on spell.cpp for PCs only
     {
         TracyZoneScoped;
 
@@ -4227,7 +4209,7 @@ namespace luautils
             return false;
         }
 
-        auto result = canUseSpellOverride(CLuaBaseEntity(PChar), CLuaSpell(Spell));
+        auto result = canUseSpellOverride(PChar, PSpell);
         if (!result.valid())
         {
             sol::error err = result;
@@ -4286,7 +4268,7 @@ namespace luautils
             return;
         }
 
-        auto result = onInstanceZoneIn(CLuaBaseEntity(PChar), CLuaInstance(PInstance));
+        auto result = onInstanceZoneIn(PChar, PInstance);
         if (!result.valid())
         {
             sol::error err = result;
@@ -4313,7 +4295,7 @@ namespace luautils
             return;
         }
 
-        auto result = afterInstanceRegister(CLuaBaseEntity(PChar));
+        auto result = afterInstanceRegister(PChar);
         if (!result.valid())
         {
             sol::error err = result;
@@ -4356,7 +4338,7 @@ namespace luautils
             return;
         }
 
-        auto result = onInstanceTimeUpdate(CLuaInstance(PInstance), time);
+        auto result = onInstanceTimeUpdate(PInstance, time);
         if (!result.valid())
         {
             sol::error err = result;
@@ -4376,7 +4358,7 @@ namespace luautils
             return;
         }
 
-        auto result = onInstanceFailure(CLuaInstance(PInstance));
+        auto result = onInstanceFailure(PInstance);
         if (!result.valid())
         {
             sol::error err = result;
@@ -4403,7 +4385,7 @@ namespace luautils
             return;
         }
 
-        auto result = onInstanceCreatedCallback(CLuaBaseEntity(PChar), CLuaInstance(PInstance));
+        auto result = onInstanceCreatedCallback(PChar, PInstance);
         if (!result.valid())
         {
             sol::error err = result;
@@ -4424,7 +4406,7 @@ namespace luautils
             return;
         }
 
-        auto result = onInstanceCreated(CLuaInstance(PInstance));
+        auto result = onInstanceCreated(PInstance);
         if (!result.valid())
         {
             sol::error err = result;
@@ -4445,7 +4427,7 @@ namespace luautils
             return;
         }
 
-        auto result = onInstanceProgressUpdate(CLuaInstance(PInstance), PInstance->GetProgress());
+        auto result = onInstanceProgressUpdate(PInstance, PInstance->GetProgress());
         if (!result.valid())
         {
             sol::error err = result;
@@ -4467,7 +4449,7 @@ namespace luautils
             return;
         }
 
-        auto result = onInstanceStageChange(CLuaInstance(PInstance), PInstance->GetStage());
+        auto result = onInstanceStageChange(PInstance, PInstance->GetStage());
         if (!result.valid())
         {
             sol::error err = result;
@@ -4488,7 +4470,7 @@ namespace luautils
             return;
         }
 
-        auto result = onInstanceComplete(CLuaInstance(PInstance));
+        auto result = onInstanceComplete(PInstance);
         if (!result.valid())
         {
             sol::error err = result;
@@ -4588,7 +4570,7 @@ namespace luautils
             return;
         }
 
-        auto result = onTransportEvent(CLuaBaseEntity(PChar), TransportID);
+        auto result = onTransportEvent(PChar, TransportID);
         if (!result.valid())
         {
             sol::error err = result;
@@ -4606,7 +4588,7 @@ namespace luautils
             return;
         }
 
-        auto result = onTimeTrigger(CLuaBaseEntity(PNpc), triggerID);
+        auto result = onTimeTrigger(PNpc, triggerID);
         if (!result.valid())
         {
             sol::error err = result;
@@ -4627,10 +4609,7 @@ namespace luautils
             return;
         }
 
-        CLuaZone LuaZone(PZone);
-
-        // xi.conquest.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-        auto result = onConquestUpdate(LuaZone, type, influence, owner, ranking, isConquestAlliance);
+        auto result = onConquestUpdate(PZone, type, influence, owner, ranking, isConquestAlliance);
         if (!result.valid())
         {
             sol::error err = result;
@@ -4642,40 +4621,14 @@ namespace luautils
     {
         TracyZoneScoped;
 
-        auto onServerStart = lua["xi"]["server"]["onServerStart"];
-        if (!onServerStart.valid())
-        {
-            ShowWarning("luautils::onServerStart");
-            return;
-        }
-
-        auto result = onServerStart();
-        if (!result.valid())
-        {
-            sol::error err = result;
-            ShowError("luautils::onServerStart: %s", err.what());
-            return;
-        }
+        callGlobal<void>("xi.server.onServerStart");
     }
 
     void OnJSTMidnight()
     {
         TracyZoneScoped;
 
-        auto onJSTMidnight = lua["xi"]["server"]["onJSTMidnight"];
-        if (!onJSTMidnight.valid())
-        {
-            ShowWarning("luautils::onJSTMidnight");
-            return;
-        }
-
-        auto result = onJSTMidnight();
-        if (!result.valid())
-        {
-            sol::error err = result;
-            ShowError("luautils::onJSTMidnight: %s", err.what());
-            return;
-        }
+        callGlobal<void>("xi.server.onJSTMidnight");
     }
 
     /************************************************************************
@@ -4688,20 +4641,7 @@ namespace luautils
     {
         TracyZoneScoped;
 
-        auto onTimeServerTick = lua["xi"]["server"]["onTimeServerTick"];
-        if (!onTimeServerTick.valid())
-        {
-            ShowWarning("luautils::onTimeServerTick");
-            return;
-        }
-
-        auto result = onTimeServerTick();
-        if (!result.valid())
-        {
-            sol::error err = result;
-            ShowError("luautils::onTimeServerTick: %s", err.what());
-            return;
-        }
+        callGlobal<void>("xi.server.onTimeServerTick");
     }
 
     /************************************************************************
@@ -4713,7 +4653,7 @@ namespace luautils
     {
         TracyZoneScoped;
 
-        invokeBattlefieldEvent(PBattlefield->GetID(), "onBattlefieldEnter", CLuaBaseEntity(PChar), CLuaBattlefield(PBattlefield));
+        invokeBattlefieldEvent(PBattlefield->GetID(), "onBattlefieldEnter", PChar, PBattlefield);
     }
 
     /************************************************************************
@@ -4732,7 +4672,7 @@ namespace luautils
     {
         TracyZoneScoped;
 
-        invokeBattlefieldEvent(PBattlefield->GetID(), "onBattlefieldLeave", CLuaBaseEntity(PChar), CLuaBattlefield(PBattlefield), LeaveCode);
+        invokeBattlefieldEvent(PBattlefield->GetID(), "onBattlefieldLeave", PChar, PBattlefield, LeaveCode);
     }
 
     void OnBattlefieldKick(CCharEntity* PChar)
@@ -4745,7 +4685,7 @@ namespace luautils
         {
             uint16 power = status->GetPower();
 
-            invokeBattlefieldEvent(power, "onBattlefieldKick", CLuaBaseEntity(PChar));
+            invokeBattlefieldEvent(power, "onBattlefieldKick", PChar);
         }
     }
 
@@ -4761,7 +4701,7 @@ namespace luautils
     {
         TracyZoneScoped;
 
-        invokeBattlefieldEvent(PBattlefield->GetID(), "onBattlefieldRegister", CLuaBaseEntity(PChar), CLuaBattlefield(PBattlefield));
+        invokeBattlefieldEvent(PBattlefield->GetID(), "onBattlefieldRegister", PChar, PBattlefield);
     }
 
     /************************************************************************
@@ -4773,7 +4713,7 @@ namespace luautils
     {
         TracyZoneScoped;
 
-        invokeBattlefieldEvent(PBattlefield->GetID(), "onBattlefieldDestroy", CLuaBattlefield(PBattlefield));
+        invokeBattlefieldEvent(PBattlefield->GetID(), "onBattlefieldDestroy", PBattlefield);
     }
 
     void DisallowRespawn(uint32 mobid, bool allowRespawn)
@@ -5003,7 +4943,7 @@ namespace luautils
             return;
         }
 
-        auto result = onPlayerDeath(CLuaBaseEntity(PChar));
+        auto result = onPlayerDeath(PChar);
         if (!result.valid())
         {
             sol::error err = result;
@@ -5024,7 +4964,7 @@ namespace luautils
             return;
         }
 
-        auto result = onPlayerLevelUp(CLuaBaseEntity(PChar));
+        auto result = onPlayerLevelUp(PChar);
         if (!result.valid())
         {
             sol::error err = result;
@@ -5045,7 +4985,7 @@ namespace luautils
             return;
         }
 
-        auto result = onPlayerLevelDown(CLuaBaseEntity(PChar));
+        auto result = onPlayerLevelDown(PChar);
         if (!result.valid())
         {
             sol::error err = result;
@@ -5066,7 +5006,7 @@ namespace luautils
             return;
         }
 
-        auto result = onPlayerMount(CLuaBaseEntity(PChar));
+        auto result = onPlayerMount(PChar);
         if (!result.valid())
         {
             sol::error err = result;
@@ -5087,7 +5027,7 @@ namespace luautils
             return;
         }
 
-        auto result = onPlayerEmote(CLuaBaseEntity(PChar), static_cast<uint8>(EmoteID));
+        auto result = onPlayerEmote(PChar, static_cast<uint8>(EmoteID));
         if (!result.valid())
         {
             sol::error err = result;
@@ -5108,7 +5048,7 @@ namespace luautils
             return;
         }
 
-        auto result = onPlayerVolunteer(CLuaBaseEntity(PChar), text);
+        auto result = onPlayerVolunteer(PChar, text);
         if (!result.valid())
         {
             sol::error err = result;
@@ -5132,7 +5072,7 @@ namespace luautils
         }
 
         // Run lua-side chocobo digging.
-        auto result = onChocoboDig(CLuaBaseEntity(PChar));
+        auto result = onChocoboDig(PChar);
         if (!result.valid())
         {
             sol::error err = result;
@@ -5210,7 +5150,7 @@ namespace luautils
             return;
         }
 
-        auto result = onFurniturePlaced(CLuaBaseEntity(PChar));
+        auto result = onFurniturePlaced(PChar);
         if (!result.valid())
         {
             sol::error err = result;
@@ -5232,7 +5172,7 @@ namespace luautils
             return;
         }
 
-        auto result = onFurnitureRemoved(CLuaBaseEntity(PChar));
+        auto result = onFurnitureRemoved(PChar);
         if (!result.valid())
         {
             sol::error err = result;
@@ -5256,7 +5196,7 @@ namespace luautils
         auto onStart = table["onStart"];
         if (onStart.valid())
         {
-            onStart(CLuaBaseEntity(PChar));
+            onStart(PChar);
         }
 
         auto escape = [](std::string const& s)
@@ -5369,7 +5309,7 @@ namespace luautils
             auto onCancelled = context["onCancelled"];
             if (onCancelled.valid())
             {
-                onCancelled(CLuaBaseEntity(PChar), wasCancelledEvent);
+                onCancelled(PChar, wasCancelledEvent);
             }
         }
         else
@@ -5398,7 +5338,7 @@ namespace luautils
 
                     if (result.compare(name) == 0)
                     {
-                        auto result = func(CLuaBaseEntity(PChar));
+                        auto result = func(PChar);
                         if (!result.valid())
                         {
                             sol::error err = result;
@@ -5414,7 +5354,7 @@ namespace luautils
         auto onEnd = context["onEnd"];
         if (onEnd.valid())
         {
-            onEnd(CLuaBaseEntity(PChar));
+            onEnd(PChar);
         }
 
         customMenuContext.erase(PChar->id);
@@ -5600,7 +5540,7 @@ namespace luautils
             if (mixins.valid())
             {
                 // Use the global function "applyMixins"
-                auto result = lua["applyMixins"](CLuaBaseEntity(PMob), mixins);
+                auto result = lua["applyMixins"](PMob, mixins);
                 if (!result.valid())
                 {
                     sol::error err = result;
@@ -5648,7 +5588,7 @@ namespace luautils
 
         PEntity->updatemask |= UPDATE_ALL_CHAR;
 
-        return CLuaBaseEntity(PEntity);
+        return PEntity;
     }
 
     // Fishing Contest utilities

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1296,20 +1296,7 @@ namespace luautils
     {
         TracyZoneScoped;
 
-        auto setRegionalConquestOverseers = lua["xi"]["conquest"]["setRegionalConquestOverseers"];
-        if (!setRegionalConquestOverseers.valid())
-        {
-            sol::error err = setRegionalConquestOverseers;
-            ShowError("luautils::setRegionalConquestOverseers: %s", err.what());
-            return;
-        }
-
-        auto result = setRegionalConquestOverseers(regionID);
-        if (!result.valid())
-        {
-            sol::error err = result;
-            ShowError("luautils::setRegionalConquestOverseers: %s", err.what());
-        }
+        callGlobal<void>("xi.conquest.setRegionalConquestOverseers", regionID);
     }
 
     void SendLuaFuncStringToZone(uint16 zoneId, std::string const& str)
@@ -1320,24 +1307,28 @@ namespace luautils
     uint32 VanadielTime()
     {
         TracyZoneScoped;
+
         return CVanaTime::getInstance()->getVanaTime();
     }
 
     uint8 VanadielTOTD()
     {
         TracyZoneScoped;
+
         return static_cast<uint8>(CVanaTime::getInstance()->GetCurrentTOTD());
     }
 
     uint32 VanadielYear()
     {
         TracyZoneScoped;
+
         return CVanaTime::getInstance()->getYear();
     }
 
     uint32 VanadielMonth()
     {
         TracyZoneScoped;
+
         return CVanaTime::getInstance()->getMonth();
     }
 
@@ -1863,20 +1854,7 @@ namespace luautils
 
         ShowTraceFmt("luautils::OnGameIn: {}", PChar->getName());
 
-        auto onGameIn = lua["xi"]["player"]["onGameIn"];
-        if (!onGameIn.valid())
-        {
-            ShowError("luautils::onGameIn");
-            return;
-        }
-
-        auto result = onGameIn(PChar, PChar->GetPlayTime(false) == 0, zoning);
-        if (!result.valid())
-        {
-            sol::error err = result;
-            ShowError("luautils::onGameIn: %s", err.what());
-            ReportErrorToPlayer(PChar, err.what());
-        }
+        callGlobal<void>("xi.player.onGameIn", PChar, PChar->GetPlayTime(false) == 0, zoning);
     }
 
     void OnZoneIn(CCharEntity* PChar)
@@ -3578,7 +3556,20 @@ namespace luautils
             return;
         }
 
-        callGlobal<void>(fmt::format("xi.zones.{}.Zone.onZoneWeatherChange", PZone->getName()), weather);
+        auto name = PZone->getName();
+
+        auto onZoneWeatherChange = lua["xi"]["zones"][name]["Zone"]["onZoneWeatherChange"];
+        if (!onZoneWeatherChange.valid())
+        {
+            return;
+        }
+
+        auto result = onZoneWeatherChange(weather);
+        if (!result.valid())
+        {
+            sol::error err = result;
+            ShowError("luautils::onZoneWeatherChange: %s", err.what());
+        }
     }
 
     void OnTOTDChange(uint16 ZoneID, uint8 TOTD)
@@ -4835,23 +4826,7 @@ namespace luautils
     {
         TracyZoneScoped;
 
-        // xi.server.getServerMessage = function(language) ...
-        auto getServerMessage = lua["xi"]["server"]["getServerMessage"];
-        if (!getServerMessage.valid())
-        {
-            ShowWarning("luautils::getServerMessage");
-            return "";
-        }
-
-        auto result = getServerMessage(language);
-        if (!result.valid())
-        {
-            sol::error err = result;
-            ShowError("luautils::getServerMessage: %s", err.what());
-            return "";
-        }
-
-        return result.get_type() == sol::type::string ? result.get<std::string>() : "";
+        return callGlobal<std::string>("xi.server.getServerMessage", language);
     }
 
     /************************************************************************
@@ -4936,152 +4911,49 @@ namespace luautils
     {
         TracyZoneScoped;
 
-        auto onPlayerDeath = lua["xi"]["player"]["onPlayerDeath"];
-        if (!onPlayerDeath.valid())
-        {
-            ShowWarning("luautils::onPlayerDeath");
-            return;
-        }
-
-        auto result = onPlayerDeath(PChar);
-        if (!result.valid())
-        {
-            sol::error err = result;
-            ShowError("luautils::onPlayerDeath: %s", err.what());
-            ReportErrorToPlayer(PChar, err.what());
-            return;
-        }
+        callGlobal<void>("xi.server.onPlayerDeath", PChar);
     }
 
     void OnPlayerLevelUp(CCharEntity* PChar)
     {
         TracyZoneScoped;
 
-        auto onPlayerLevelUp = lua["xi"]["player"]["onPlayerLevelUp"];
-        if (!onPlayerLevelUp.valid())
-        {
-            ShowWarning("luautils::onPlayerLevelUp");
-            return;
-        }
-
-        auto result = onPlayerLevelUp(PChar);
-        if (!result.valid())
-        {
-            sol::error err = result;
-            ShowError("luautils::onPlayerLevelUp: %s", err.what());
-            ReportErrorToPlayer(PChar, err.what());
-            return;
-        }
+        callGlobal<void>("xi.server.onPlayerLevelUp", PChar);
     }
 
     void OnPlayerLevelDown(CCharEntity* PChar)
     {
         TracyZoneScoped;
 
-        auto onPlayerLevelDown = lua["xi"]["player"]["onPlayerLevelDown"];
-        if (!onPlayerLevelDown.valid())
-        {
-            ShowWarning("luautils::onPlayerLevelDown");
-            return;
-        }
-
-        auto result = onPlayerLevelDown(PChar);
-        if (!result.valid())
-        {
-            sol::error err = result;
-            ShowError("luautils::onPlayerLevelDown: %s", err.what());
-            ReportErrorToPlayer(PChar, err.what());
-            return;
-        }
+        callGlobal<void>("xi.server.onPlayerLevelDown", PChar);
     }
 
     void OnPlayerMount(CCharEntity* PChar)
     {
         TracyZoneScoped;
 
-        auto onPlayerMount = lua["xi"]["player"]["onPlayerMount"];
-        if (!onPlayerMount.valid())
-        {
-            ShowWarning("luautils::onPlayerMount");
-            return;
-        }
-
-        auto result = onPlayerMount(PChar);
-        if (!result.valid())
-        {
-            sol::error err = result;
-            ShowError("luautils::onPlayerMount: %s", err.what());
-            ReportErrorToPlayer(PChar, err.what());
-            return;
-        }
+        callGlobal<void>("xi.server.onPlayerMount", PChar);
     }
 
     void OnPlayerEmote(CCharEntity* PChar, Emote EmoteID)
     {
         TracyZoneScoped;
 
-        auto onPlayerEmote = lua["xi"]["player"]["onPlayerEmote"];
-        if (!onPlayerEmote.valid())
-        {
-            ShowWarning("luautils::onPlayerEmote");
-            return;
-        }
-
-        auto result = onPlayerEmote(PChar, static_cast<uint8>(EmoteID));
-        if (!result.valid())
-        {
-            sol::error err = result;
-            ShowError("luautils::onPlayerEmote: %s", err.what());
-            ReportErrorToPlayer(PChar, err.what());
-            return;
-        }
+        callGlobal<void>("xi.server.onPlayerEmote", PChar, static_cast<uint8>(EmoteID));
     }
 
     void OnPlayerVolunteer(CCharEntity* PChar, std::string const& text)
     {
         TracyZoneScoped;
 
-        auto onPlayerVolunteer = lua["xi"]["player"]["onPlayerVolunteer"];
-        if (!onPlayerVolunteer.valid())
-        {
-            ShowWarning("luautils::onPlayerVolunteer");
-            return;
-        }
-
-        auto result = onPlayerVolunteer(PChar, text);
-        if (!result.valid())
-        {
-            sol::error err = result;
-            ShowError("luautils::onPlayerVolunteer: %s", err.what());
-            ReportErrorToPlayer(PChar, err.what());
-            return;
-        }
+        callGlobal<void>("xi.player.onPLayerVolunteer", PChar, text);
     }
 
     bool OnChocoboDig(CCharEntity* PChar)
     {
         TracyZoneScoped;
 
-        auto onChocoboDig = lua["xi"]["chocoboDig"]["start"];
-
-        // Check that the function exists.
-        if (!onChocoboDig.valid())
-        {
-            ShowWarning("luautils::onChocoboDig");
-            return false;
-        }
-
-        // Run lua-side chocobo digging.
-        auto result = onChocoboDig(PChar);
-        if (!result.valid())
-        {
-            sol::error err = result;
-            ShowError("luautils::onChocoboDig: %s", err.what());
-            ReportErrorToPlayer(PChar, err.what());
-            return false;
-        }
-
-        return result.get_type(0) == sol::type::boolean ? result.get<bool>() : false;
+        return callGlobal<bool>("xi.server.onChocoboDig", PChar);
     }
 
     // Loads a Lua function with a fallback hierarchy

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -114,8 +114,16 @@ namespace luautils
 {
     namespace detail
     {
-        auto findCachedObject(const std::string& objName) -> sol::reference;
-        void cacheObject(const std::string& objName, sol::reference obj);
+        // TODO:
+        // Instead of always taking a string of the form "xi.server.onTimeServerTick"
+        // and splitting it into parts, then using those parts to walk up the Lua
+        // global table, we can build a map of that string to the underlying sol::reference.
+        //
+        // This however comes with the cost of maintaining this map, and those sol::references
+        // keep the underlying objects alive, so we need to be careful about what we cache.
+
+        // auto findCachedObject(const std::string& objName) -> sol::reference;
+        // void cacheObject(const std::string& objName, sol::reference obj);
         auto findGlobalLuaFunction(const std::string& funcName) -> sol::function;
     } // namespace detail
 
@@ -135,6 +143,9 @@ namespace luautils
     // luautils::callGlobal<void>("xi.player.onPlayerDeath", PChar);
     // auto value = callGlobal<uint32>("xi.server.functionThatReturnsANumber");
     // ```
+    //
+    // NOTE: This is slower (but safet) than looking up something manually like this:
+    //     : lua["xi"]["server"]["onTimeServerTick"]();
     template <typename T, typename... Targs>
     auto callGlobal(const std::string& funcName, Targs... args)
     {
@@ -412,6 +423,8 @@ namespace luautils
     void OnPlayerMount(CCharEntity* PChar);
     void OnPlayerEmote(CCharEntity* PChar, Emote EmoteID);
     void OnPlayerVolunteer(CCharEntity* PChar, std::string const& text);
+
+    bool OnChocoboDig(CCharEntity* PChar);
 
     // Utility method: checks for and loads a lua function for events
     auto LoadEventScript(CCharEntity* PChar, const char* functionName) -> sol::function;

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -34,16 +34,7 @@ extern sol::state lua;
 // SOL_ALL_SAFETIES_ON = 1
 // SOL_NO_CHECK_NUMBER_PRECISION = 1
 #include "sol/sol.hpp"
-
-// sol changes this behavior to return 0 rather than truncating
-// we rely on that, so change it back
-#undef lua_tointeger
-#define lua_tointeger(L, n) static_cast<lua_Integer>(std::floor(lua_tonumber(L, n)))
-
-#define SOL_USERTYPE(TypeName, BindingTypeName) \
-    std::string className = TypeName;           \
-    lua.new_usertype<BindingTypeName>(className)
-#define SOL_REGISTER(FuncName, Func) lua[className][FuncName] = &Func
+#include "sol_bindings.h"
 
 #include "items/item_equipment.h"
 #include "spell.h"

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -212,11 +212,11 @@ namespace luautils
 
     void SendEntityVisualPacket(uint32 npcid, const char* command);
     void InitInteractionGlobal();
-    auto GetZone(uint16 zoneId) -> std::optional<CLuaZone>;
-    auto GetItemByID(uint32 itemId) -> std::optional<CLuaItem>;
-    auto GetNPCByID(uint32 npcid, sol::object const& instanceObj) -> std::optional<CLuaBaseEntity>;
-    auto GetMobByID(uint32 mobid, sol::object const& instanceObj) -> std::optional<CLuaBaseEntity>;
-    auto GetEntityByID(uint32 mobid, sol::object const& instanceObj, sol::object const& arg3) -> std::optional<CLuaBaseEntity>;
+    auto GetZone(uint16 zoneId) -> CZone*;
+    auto GetItemByID(uint32 itemId) -> CItem*;
+    auto GetNPCByID(uint32 npcid, sol::object const& instanceObj) -> CBaseEntity*;
+    auto GetMobByID(uint32 mobid, sol::object const& instanceObj) -> CBaseEntity*;
+    auto GetEntityByID(uint32 mobid, sol::object const& instanceObj, sol::object const& arg3) -> CBaseEntity*;
 
     void  WeekUpdateConquest(uint8 updateType);
     uint8 GetRegionOwner(uint8 type);
@@ -227,14 +227,14 @@ namespace luautils
     void  SetRegionalConquestOverseers(uint8 regionID); // Update NPC Conquest Guard
     void  SendLuaFuncStringToZone(uint16 zoneId, std::string const& str);
 
-    auto GetReadOnlyItem(uint32 id) -> std::optional<CLuaItem>; // Returns a read only lookup item object of the specified ID
-    auto GetAbility(uint16 id) -> std::optional<CLuaAbility>;
-    auto GetSpell(uint16 id) -> std::optional<CLuaSpell>;
+    auto GetReadOnlyItem(uint32 id) -> CItem*; // Returns a read only lookup item object of the specified ID
+    auto GetAbility(uint16 id) -> CAbility*;
+    auto GetSpell(uint16 id) -> CSpell*;
 
-    auto SpawnMob(uint32 mobid, sol::object const& arg2, sol::object const& arg3) -> std::optional<CLuaBaseEntity>; // Spawn Mob By Mob Id - NMs, BCNM...
-    void DespawnMob(uint32 mobid, sol::object const& arg2);                                                         // Despawn (Fade Out) Mob By Id
-    auto GetPlayerByName(std::string const& name) -> std::optional<CLuaBaseEntity>;
-    auto GetPlayerByID(uint32 pid) -> std::optional<CLuaBaseEntity>;
+    auto SpawnMob(uint32 mobid, sol::object const& arg2, sol::object const& arg3) -> CBaseEntity*; // Spawn Mob By Mob Id - NMs, BCNM...
+    void DespawnMob(uint32 mobid, sol::object const& arg2);                                        // Despawn (Fade Out) Mob By Id
+    auto GetPlayerByName(std::string const& name) -> CBaseEntity*;
+    auto GetPlayerByID(uint32 pid) -> CBaseEntity*;
     bool PlayerHasValidSession(uint32 playerId);
     void SendToJailOffline(uint32 playerId, int8 cellId, float posX, float posY, float posZ, uint8 rot);
     void DrawIn(CLuaBaseEntity* PLuaBaseEntity, sol::table const& table, float offset, float degrees);
@@ -444,7 +444,7 @@ namespace luautils
     uint16 GetItemIDByName(std::string const& name);
     auto   SendItemToDeliveryBox(const std::string& playerName, uint16 itemId, uint32 quantity, const std::string& senderText) -> SendToDBoxReturnCode;
 
-    std::optional<CLuaBaseEntity> GenerateDynamicEntity(CZone* PZone, CInstance* PInstance, sol::table table);
+    auto GenerateDynamicEntity(CZone* PZone, CInstance* PInstance, sol::table table) -> CBaseEntity*;
 
     // Fishing Contest
     auto GetFishingContest() -> sol::table;

--- a/src/map/lua/sol_bindings.cpp
+++ b/src/map/lua/sol_bindings.cpp
@@ -1,0 +1,114 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "sol_bindings.h"
+
+#include "ability.h"
+#include "lua_ability.h"
+SOL_BIND_DEF(CLuaAbility, CAbility);
+
+#include "packets/action.h"
+#include "lua_action.h"
+SOL_BIND_DEF(CLuaAction, action_t);
+
+#include "attackround.h"
+#include "lua_attack.h"
+SOL_BIND_DEF(CLuaAttack, CAttack);
+
+#include "entities/baseentity.h"
+#include "lua_baseentity.h"
+SOL_BIND_DEF(CLuaBaseEntity, CBaseEntity);
+
+#include "entities/automatonentity.h"
+#include "entities/battleentity.h"
+#include "entities/charentity.h"
+#include "entities/fellowentity.h"
+#include "entities/mobentity.h"
+#include "entities/npcentity.h"
+#include "entities/petentity.h"
+#include "entities/trustentity.h"
+SOL_BIND_DEF_SUB(CLuaBaseEntity, CBaseEntity, CBattleEntity);
+SOL_BIND_DEF_SUB(CLuaBaseEntity, CBaseEntity, CNpcEntity);
+SOL_BIND_DEF_SUB(CLuaBaseEntity, CBaseEntity, CCharEntity);
+SOL_BIND_DEF_SUB(CLuaBaseEntity, CBaseEntity, CMobEntity);
+SOL_BIND_DEF_SUB(CLuaBaseEntity, CBaseEntity, CAutomatonEntity);
+SOL_BIND_DEF_SUB(CLuaBaseEntity, CBaseEntity, CFellowEntity);
+SOL_BIND_DEF_SUB(CLuaBaseEntity, CBaseEntity, CPetEntity);
+SOL_BIND_DEF_SUB(CLuaBaseEntity, CBaseEntity, CTrustEntity);
+
+#include "battlefield.h"
+#include "lua_battlefield.h"
+SOL_BIND_DEF(CLuaBattlefield, CBattlefield);
+
+#include "instance.h"
+#include "lua_instance.h"
+SOL_BIND_DEF(CLuaInstance, CInstance);
+
+#include "items/item.h"
+#include "lua_item.h"
+SOL_BIND_DEF(CLuaItem, CItem);
+
+#include "items/item_currency.h"
+#include "items/item_equipment.h"
+#include "items/item_fish.h"
+#include "items/item_flowerpot.h"
+#include "items/item_furnishing.h"
+#include "items/item_general.h"
+#include "items/item_linkshell.h"
+#include "items/item_puppet.h"
+#include "items/item_shop.h"
+#include "items/item_usable.h"
+#include "items/item_weapon.h"
+SOL_BIND_DEF_SUB(CLuaItem, CItem, CItemCurrency);
+SOL_BIND_DEF_SUB(CLuaItem, CItem, CItemEquipment);
+SOL_BIND_DEF_SUB(CLuaItem, CItem, CItemFish);
+SOL_BIND_DEF_SUB(CLuaItem, CItem, CItemFlowerpot);
+SOL_BIND_DEF_SUB(CLuaItem, CItem, CItemFurnishing);
+SOL_BIND_DEF_SUB(CLuaItem, CItem, CItemGeneral);
+SOL_BIND_DEF_SUB(CLuaItem, CItem, CItemLinkshell);
+SOL_BIND_DEF_SUB(CLuaItem, CItem, CItemPuppet);
+SOL_BIND_DEF_SUB(CLuaItem, CItem, CItemShop);
+SOL_BIND_DEF_SUB(CLuaItem, CItem, CItemUsable);
+SOL_BIND_DEF_SUB(CLuaItem, CItem, CItemWeapon);
+
+#include "mobskill.h"
+#include "lua_mobskill.h"
+SOL_BIND_DEF(CLuaMobSkill, CMobSkill);
+
+#include "spell.h"
+#include "lua_spell.h"
+SOL_BIND_DEF(CLuaSpell, CSpell);
+
+#include "status_effect.h"
+#include "lua_statuseffect.h"
+SOL_BIND_DEF(CLuaStatusEffect, CStatusEffect);
+
+#include "trade_container.h"
+#include "lua_trade_container.h"
+SOL_BIND_DEF(CLuaTradeContainer, CTradeContainer);
+
+#include "trigger_area.h"
+#include "lua_trigger_area.h"
+SOL_BIND_DEF(CLuaTriggerArea, CTriggerArea);
+
+#include "zone.h"
+#include "lua_zone.h"
+SOL_BIND_DEF(CLuaZone, CZone);

--- a/src/map/lua/sol_bindings.cpp
+++ b/src/map/lua/sol_bindings.cpp
@@ -108,7 +108,7 @@ SOL_BIND_DEF(CLuaTradeContainer, CTradeContainer);
 
 #include "trigger_area.h"
 #include "lua_trigger_area.h"
-SOL_BIND_DEF(CLuaTriggerArea, CTriggerArea);
+SOL_BIND_DEF(CLuaTriggerArea, ITriggerArea);
 
 #include "zone.h"
 #include "lua_zone.h"

--- a/src/map/lua/sol_bindings.cpp
+++ b/src/map/lua/sol_bindings.cpp
@@ -21,6 +21,7 @@
 
 #include "sol_bindings.h"
 
+// clang-format off
 #include "ability.h"
 #include "lua_ability.h"
 SOL_BIND_DEF(CLuaAbility, CAbility);
@@ -112,3 +113,4 @@ SOL_BIND_DEF(CLuaTriggerArea, CTriggerArea);
 #include "zone.h"
 #include "lua_zone.h"
 SOL_BIND_DEF(CLuaZone, CZone);
+// clang-format on

--- a/src/map/lua/sol_bindings.h
+++ b/src/map/lua/sol_bindings.h
@@ -141,8 +141,8 @@ class CTradeContainer;
 SOL_BIND_DEC(CLuaTradeContainer, CTradeContainer);
 
 class CLuaTriggerArea;
-class CTriggerArea;
-SOL_BIND_DEC(CLuaTriggerArea, CTriggerArea);
+class ITriggerArea;
+SOL_BIND_DEC(CLuaTriggerArea, ITriggerArea);
 
 class CLuaZone;
 class CZone;

--- a/src/map/lua/sol_bindings.h
+++ b/src/map/lua/sol_bindings.h
@@ -1,0 +1,149 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include "sol/sol.hpp"
+
+// sol changes this behavior to return 0 rather than truncating
+// we rely on that, so change it back
+#undef lua_tointeger
+#define lua_tointeger(L, n) static_cast<lua_Integer>(std::floor(lua_tonumber(L, n)))
+
+#define SOL_USERTYPE(TypeName, BindingTypeName) \
+    std::string className = TypeName;           \
+    lua.new_usertype<BindingTypeName>(className)
+
+#define SOL_REGISTER(FuncName, Func) lua[className][FuncName] = &Func
+
+#define SOL_BIND_DEC(LuaType, CppType) \
+    int sol_lua_push(sol::types<CppType*>, lua_State* L, CppType* obj);
+
+#define SOL_BIND_DEC_SUB(LuaType, BaseCppType, CppType) \
+    int sol_lua_push(sol::types<CppType*>, lua_State* L, CppType* obj);
+
+#define SOL_BIND_DEF(LuaType, CppType)                                                      \
+    int sol_lua_push(sol::types<CppType*>, lua_State* L, CppType* obj)                      \
+    {                                                                                       \
+        return obj ? sol::stack::push<LuaType>(L, obj) : sol::stack::push(L, sol::lua_nil); \
+    }
+
+#define SOL_BIND_DEF_SUB(LuaType, BaseCppType, CppType)                                                   \
+    int sol_lua_push(sol::types<CppType*>, lua_State* L, CppType* obj)                                    \
+    {                                                                                                     \
+        return obj ? sol::stack::push<LuaType>(L, (BaseCppType*)obj) : sol::stack::push(L, sol::lua_nil); \
+    }
+
+//
+// Class bindings
+//
+
+class CAbility;
+class CLuaAbility;
+SOL_BIND_DEC(CLuaAbility, CAbility);
+
+class CLuaAction;
+struct action_t;
+SOL_BIND_DEC(CLuaAction, action_t);
+
+class CLuaAttack;
+class CAttack;
+SOL_BIND_DEC(CLuaAttack, CAttack);
+
+class CLuaBaseEntity;
+class CBaseEntity;
+SOL_BIND_DEC(CLuaBaseEntity, CBaseEntity);
+
+class CBattleEntity;
+class CNpcEntity;
+class CCharEntity;
+class CMobEntity;
+class CAutomatonEntity;
+class CFellowEntity;
+class CPetEntity;
+class CTrustEntity;
+SOL_BIND_DEC_SUB(CLuaBaseEntity, CBaseEntity, CBattleEntity);
+SOL_BIND_DEC_SUB(CLuaBaseEntity, CBaseEntity, CNpcEntity);
+SOL_BIND_DEC_SUB(CLuaBaseEntity, CBaseEntity, CCharEntity);
+SOL_BIND_DEC_SUB(CLuaBaseEntity, CBaseEntity, CMobEntity);
+SOL_BIND_DEC_SUB(CLuaBaseEntity, CBaseEntity, CAutomatonEntity);
+SOL_BIND_DEC_SUB(CLuaBaseEntity, CBaseEntity, CFellowEntity);
+SOL_BIND_DEC_SUB(CLuaBaseEntity, CBaseEntity, CPetEntity);
+SOL_BIND_DEC_SUB(CLuaBaseEntity, CBaseEntity, CTrustEntity);
+
+class CLuaBattlefield;
+class CBattlefield;
+SOL_BIND_DEC(CLuaBattlefield, CBattlefield);
+
+class CLuaInstance;
+class CInstance;
+SOL_BIND_DEC(CLuaInstance, CInstance);
+
+class CLuaItem;
+class CItem;
+SOL_BIND_DEC(CLuaItem, CItem);
+
+class CItemCurrency;
+class CItemEquipment;
+class CItemFish;
+class CItemFlowerpot;
+class CItemFurnishing;
+class CItemGeneral;
+class CItemLinkshell;
+class CItemPuppet;
+class CItemShop;
+class CItemUsable;
+class CItemWeapon;
+SOL_BIND_DEC_SUB(CLuaItem, CItem, CItemCurrency);
+SOL_BIND_DEC_SUB(CLuaItem, CItem, CItemEquipment);
+SOL_BIND_DEC_SUB(CLuaItem, CItem, CItemFish);
+SOL_BIND_DEC_SUB(CLuaItem, CItem, CItemFlowerpot);
+SOL_BIND_DEC_SUB(CLuaItem, CItem, CItemFurnishing);
+SOL_BIND_DEC_SUB(CLuaItem, CItem, CItemGeneral);
+SOL_BIND_DEC_SUB(CLuaItem, CItem, CItemLinkshell);
+SOL_BIND_DEC_SUB(CLuaItem, CItem, CItemPuppet);
+SOL_BIND_DEC_SUB(CLuaItem, CItem, CItemShop);
+SOL_BIND_DEC_SUB(CLuaItem, CItem, CItemUsable);
+SOL_BIND_DEC_SUB(CLuaItem, CItem, CItemWeapon);
+
+class CLuaMobSkill;
+class CMobSkill;
+SOL_BIND_DEC(CLuaMobSkill, CMobSkill);
+
+class CLuaSpell;
+class CSpell;
+SOL_BIND_DEC(CLuaSpell, CSpell);
+
+class CLuaStatusEffect;
+class CStatusEffect;
+SOL_BIND_DEC(CLuaStatusEffect, CStatusEffect);
+
+class CLuaTradeContainer;
+class CTradeContainer;
+SOL_BIND_DEC(CLuaTradeContainer, CTradeContainer);
+
+class CLuaTriggerArea;
+class CTriggerArea;
+SOL_BIND_DEC(CLuaTriggerArea, CTriggerArea);
+
+class CLuaZone;
+class CZone;
+SOL_BIND_DEC(CLuaZone, CZone);

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -1044,7 +1044,7 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
             }
 
             // Consume Gysahl Green and push animation on dig attempt.
-            if (luautils::OnChocoboDig(PChar))
+            if (luautils::callGlobal<bool>("xi.chocoboDig.start", PChar))
             {
                 charutils::UpdateItem(PChar, LOC_INVENTORY, slotID, -1);
                 PChar->pushPacket<CInventoryFinishPacket>();

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -1044,7 +1044,7 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
             }
 
             // Consume Gysahl Green and push animation on dig attempt.
-            if (luautils::callGlobal<bool>("xi.chocoboDig.start", PChar))
+            if (luautils::OnChocoboDig(PChar))
             {
                 charutils::UpdateItem(PChar, LOC_INVENTORY, slotID, -1);
                 PChar->pushPacket<CInventoryFinishPacket>();

--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -74,7 +74,7 @@ void call_onRecordTrigger(CCharEntity* PChar, uint16 recordID, const RoeDatagram
         }
         else if (auto PMob = std::get_if<CMobEntity*>(&datagram.data))
         {
-            params[datagram.luaKey] = CLuaBaseEntity(*PMob);
+            params[datagram.luaKey] = *PMob;
         }
         else if (auto text = std::get_if<std::string>(&datagram.data))
         {
@@ -87,7 +87,7 @@ void call_onRecordTrigger(CCharEntity* PChar, uint16 recordID, const RoeDatagram
     }
 
     // Call
-    auto result = onRecordTrigger(CLuaBaseEntity(PChar), recordID, params);
+    auto result = onRecordTrigger(PChar, recordID, params);
     if (!result.valid())
     {
         sol::error err = result;

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -516,7 +516,7 @@ bool CStatusEffectContainer::AddStatusEffect(CStatusEffect* PStatusEffect, bool 
         ApplyStateAlteringEffects(PStatusEffect);
 
         luautils::OnEffectGain(m_POwner, PStatusEffect);
-        m_POwner->PAI->EventHandler.triggerListener("EFFECT_GAIN", CLuaBaseEntity(m_POwner), CLuaStatusEffect(PStatusEffect));
+        m_POwner->PAI->EventHandler.triggerListener("EFFECT_GAIN", m_POwner, PStatusEffect);
 
         m_POwner->addModifiers(&PStatusEffect->modList);
 
@@ -617,7 +617,7 @@ void CStatusEffectContainer::RemoveStatusEffect(CStatusEffect* PStatusEffect, bo
     {
         PStatusEffect->deleted = true;
         luautils::OnEffectLose(m_POwner, PStatusEffect);
-        m_POwner->PAI->EventHandler.triggerListener("EFFECT_LOSE", CLuaBaseEntity(m_POwner), CLuaStatusEffect(PStatusEffect));
+        m_POwner->PAI->EventHandler.triggerListener("EFFECT_LOSE", m_POwner, PStatusEffect);
 
         m_POwner->delModifiers(&PStatusEffect->modList);
         if (m_POwner->objtype == TYPE_PC)
@@ -2028,7 +2028,7 @@ void CStatusEffectContainer::TickEffects(time_point tick)
         }
     }
     DeleteStatusEffects();
-    m_POwner->PAI->EventHandler.triggerListener("EFFECTS_TICK", CLuaBaseEntity(m_POwner));
+    m_POwner->PAI->EventHandler.triggerListener("EFFECTS_TICK", m_POwner);
 }
 
 /************************************************************************

--- a/src/map/time_server.cpp
+++ b/src/map/time_server.cpp
@@ -167,7 +167,7 @@ int32 time_server(time_point tick, CTaskMgr::CTask* PTask)
 
     luautils::OnTimeServerTick();
 
-    luautils::ReloadFilewatchList();
+    luautils::TryReloadFilewatchList();
 
     moduleutils::OnTimeServerTick();
 

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2601,7 +2601,7 @@ namespace battleutils
             auto tpGainFunc = lua["xi"]["combat"]["tp"]["calculateTPGainOnMagicalDamage"];
             if (tpGainFunc.valid())
             {
-                PDefender->addTP(tpGainFunc(damage, CLuaBaseEntity(PAttacker), CLuaBaseEntity(PDefender)));
+                PDefender->addTP(tpGainFunc(damage, PAttacker, PDefender));
             }
         }
 
@@ -2965,11 +2965,10 @@ namespace battleutils
 
         auto levelCorrectionFunc = lua["xi"]["combat"]["levelCorrection"]["isLevelCorrectedZone"];
         auto meleePDIFFunc       = lua["xi"]["combat"]["physical"]["calculateMeleePDIF"];
-        auto luaAttackerEntity   = CLuaBaseEntity(PAttacker);
 
         if (meleePDIFFunc.valid() && levelCorrectionFunc.valid())
         {
-            auto levelCorrectionResult = levelCorrectionFunc(luaAttackerEntity);
+            auto levelCorrectionResult = levelCorrectionFunc(PAttacker);
             if (!levelCorrectionResult.valid())
             {
                 sol::error err = levelCorrectionResult;

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -3992,7 +3992,7 @@ namespace battleutils
         //            TODO:     × (1 + Day/Weather bonuses)
         //            TODO:     × (1 + Staff Affinity)
 
-        auto damage = (int32)floor((double)(abs(lastSkillDamage)) * g_SkillChainDamageModifiers[chainLevel][chainCount] / 1000 *
+        auto damage = (int32)floor((double)(abs(lastSkillDamage))*g_SkillChainDamageModifiers[chainLevel][chainCount] / 1000 *
                                    (100 + PAttacker->getMod(Mod::SKILLCHAINBONUS)) / 100 * (10000 + PAttacker->getMod(Mod::SKILLCHAINDMG)) / 10000);
 
         auto* PChar = dynamic_cast<CCharEntity*>(PAttacker);

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -3992,7 +3992,7 @@ namespace battleutils
         //            TODO:     × (1 + Day/Weather bonuses)
         //            TODO:     × (1 + Staff Affinity)
 
-        auto damage = (int32)floor((double)(abs(lastSkillDamage))*g_SkillChainDamageModifiers[chainLevel][chainCount] / 1000 *
+        auto damage = (int32)floor((double)(abs(lastSkillDamage)) * g_SkillChainDamageModifiers[chainLevel][chainCount] / 1000 *
                                    (100 + PAttacker->getMod(Mod::SKILLCHAINBONUS)) / 100 * (10000 + PAttacker->getMod(Mod::SKILLCHAINDMG)) / 10000);
 
         auto* PChar = dynamic_cast<CCharEntity*>(PAttacker);

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1659,11 +1659,10 @@ namespace battleutils
 
         auto levelCorrectionFunc = lua["xi"]["combat"]["levelCorrection"]["isLevelCorrectedZone"];
         auto rangedPDIFFunc      = lua["xi"]["combat"]["physical"]["calculateRangedPDIF"];
-        auto luaAttackerEntity   = CLuaBaseEntity(PAttacker);
 
         if (rangedPDIFFunc.valid() && levelCorrectionFunc.valid())
         {
-            auto levelCorrectionResult = levelCorrectionFunc(luaAttackerEntity);
+            auto levelCorrectionResult = levelCorrectionFunc(PAttacker);
             if (!levelCorrectionResult.valid())
             {
                 sol::error err = levelCorrectionResult;
@@ -1671,7 +1670,7 @@ namespace battleutils
                 return pDIF;
             }
 
-            auto rangedPDIFFuncResult = rangedPDIFFunc(luaAttackerEntity, CLuaBaseEntity(PDefender), weaponType, 1.0, isCritical, levelCorrectionResult.get<bool>(0), false, 0.0, false, bonusRangedAttack);
+            auto rangedPDIFFuncResult = rangedPDIFFunc(PAttacker, PDefender, weaponType, 1.0, isCritical, levelCorrectionResult.get<bool>(0), false, 0.0, false, bonusRangedAttack);
             if (!rangedPDIFFuncResult.valid())
             {
                 sol::error err = rangedPDIFFuncResult;
@@ -2976,7 +2975,7 @@ namespace battleutils
                 return pDIF;
             }
 
-            auto meleePDIFFuncResult = meleePDIFFunc(luaAttackerEntity, CLuaBaseEntity(PDefender), weaponType, bonusAttPercent, isCritical, levelCorrectionResult.get<bool>(0), false, 0.0, false, weaponSlot, false);
+            auto meleePDIFFuncResult = meleePDIFFunc(PAttacker, PDefender, weaponType, bonusAttPercent, isCritical, levelCorrectionResult.get<bool>(0), false, 0.0, false, weaponSlot, false);
             if (!meleePDIFFuncResult.valid())
             {
                 sol::error err = meleePDIFFuncResult;

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -5079,7 +5079,7 @@ namespace charutils
             }
         }
 
-        PChar->PAI->EventHandler.triggerListener("EXPERIENCE_POINTS", CLuaBaseEntity(PChar), CLuaBaseEntity(PMob), exp);
+        PChar->PAI->EventHandler.triggerListener("EXPERIENCE_POINTS", PChar, PMob, exp);
 
         // Player levels up
         if ((currentExp + exp) >= GetExpNEXTLevel(PChar->jobs.job[PChar->GetMJob()]) && !onLimitMode)

--- a/src/map/utils/moduleutils.cpp
+++ b/src/map/utils/moduleutils.cpp
@@ -286,34 +286,30 @@ namespace moduleutils
         {
             if (!override.applied)
             {
-                auto firstElem = override.nameParts.front();
-                auto lastTable = override.nameParts.size() < 2 ? firstElem : *(override.nameParts.end() - 2);
-                auto lastElem  = override.nameParts.back();
-
                 sol::table table = lua["_G"];
                 for (auto& part : override.nameParts)
                 {
-                    table = table[part].get_or<sol::table>(sol::lua_nil);
-                    if (table == sol::lua_nil)
-                    {
-                        break;
-                    }
-
-                    if (part == lastTable)
+                    if (part == override.nameParts.back())
                     {
                         DebugModules(fmt::format("Applying override: {}", override.overrideName));
 
-                        if (table[lastElem] == sol::lua_nil)
+                        if (table[override.nameParts.back()] == sol::lua_nil)
                         {
                             DebugModules("Inserting empty function to override for: %s (%s)", override.overrideName, override.filename);
-                            table[lastElem] = []() {};
+                            table[override.nameParts.back()] = []() {};
                         }
 
                         // Function defined in LoadLuaModules()
-                        lua["applyOverride"](table, lastElem, override.func, override.overrideName, override.filename);
+                        lua["applyOverride"](table, override.nameParts.back(), override.func, override.overrideName, override.filename);
 
                         override.applied = true;
 
+                        break;
+                    }
+
+                    table = table[part].get_or<sol::table>(sol::lua_nil);
+                    if (table == sol::lua_nil)
+                    {
                         break;
                     }
                 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Allow calling of functions in Lua from C++ without needing to manually prepare so many things for Lua, or to manually/dangerously access the lua state:
```cpp
        luautils::callGlobal<void>("xi.server.onServerStart");
```

etc.