### PR TITLE
[core] Use enum instead of defines for Item IDs

### DIFF
--- a/src/map/items.h
+++ b/src/map/items.h
@@ -1,32 +1,34 @@
 ﻿#ifndef _ITEMS_H
 #define _ITEMS_H
 
-// Add items as needed, with 14K items in the database this
-// file would be huge if we put all of them in here.
+// Only add items as utilized in core.  There is no need to maintain a complete list
+// here.
 
-// Ninja tools
-#define ITEM_UCHITAKE        (1161)
-#define ITEM_TSURARA         (1164)
-#define ITEM_KAWAHORI_OGI    (1167)
-#define ITEM_MAKIBISHI       (1170)
-#define ITEM_HIRAISHIN       (1173)
-#define ITEM_MIZU_DEPPO      (1176)
-#define ITEM_RYUNO           (2644)
-#define ITEM_MOKUJIN         (2970)
-#define ITEM_SANJAKU_TENUGUI (2553)
-#define ITEM_KABENRO         (2642)
-#define ITEM_SHINOBI_TABI    (1194)
-#define ITEM_SHIHEI          (1179)
-#define ITEM_SOSHI           (2555)
-#define ITEM_KODOKU          (1191)
-#define ITEM_KAGINAWA        (1185)
-#define ITEM_JUSATSU         (1182)
-#define ITEM_SAIRUI_RAN      (1188)
-#define ITEM_JINKO           (2643)
-#define ITEM_INOSHISHINOFUDA (2971)
-#define ITEM_SHIKANOFUDA     (2972)
-#define ITEM_CHONOFUDA       (2973)
-#define ITEM_RANKA           (8803)
-#define ITEM_FURUSUMI        (8804)
+enum ITEMID : uint16
+{
+    UCHITAKE        = 1161,
+    TSURARA         = 1164,
+    KAWAHORI_OGI    = 1167,
+    MAKIBISHI       = 1170,
+    HIRAISHIN       = 1173,
+    MIZU_DEPPO      = 1176,
+    RYUNO           = 2644,
+    MOKUJIN         = 2970,
+    SANJAKU_TENUGUI = 2553,
+    KABENRO         = 2642,
+    SHINOBI_TABI    = 1194,
+    SHIHEI          = 1179,
+    SOSHI           = 2555,
+    KODOKU          = 1191,
+    KAGINAWA        = 1185,
+    JUSATSU         = 1182,
+    SAIRUI_RAN      = 1188,
+    JINKO           = 2643,
+    INOSHISHINOFUDA = 2971,
+    SHIKANOFUDA     = 2972,
+    CHONOFUDA       = 2973,
+    RANKA           = 8803,
+    FURUSUMI        = 8804,
+};
 
 #endif

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4138,34 +4138,34 @@ namespace battleutils
                 {
                     switch (toolID)
                     {
-                        case ITEM_UCHITAKE:
-                        case ITEM_TSURARA:
-                        case ITEM_KAWAHORI_OGI:
-                        case ITEM_MAKIBISHI:
-                        case ITEM_HIRAISHIN:
-                        case ITEM_MIZU_DEPPO:
-                            toolID = ITEM_INOSHISHINOFUDA;
+                        case ITEMID::UCHITAKE:
+                        case ITEMID::TSURARA:
+                        case ITEMID::KAWAHORI_OGI:
+                        case ITEMID::MAKIBISHI:
+                        case ITEMID::HIRAISHIN:
+                        case ITEMID::MIZU_DEPPO:
+                            toolID = ITEMID::INOSHISHINOFUDA;
                             break;
 
-                        case ITEM_RYUNO:
-                        case ITEM_MOKUJIN:
-                        case ITEM_SANJAKU_TENUGUI:
-                        case ITEM_KABENRO:
-                        case ITEM_SHINOBI_TABI:
-                        case ITEM_SHIHEI:
-                        case ITEM_RANKA:
-                        case ITEM_FURUSUMI:
+                        case ITEMID::RYUNO:
+                        case ITEMID::MOKUJIN:
+                        case ITEMID::SANJAKU_TENUGUI:
+                        case ITEMID::KABENRO:
+                        case ITEMID::SHINOBI_TABI:
+                        case ITEMID::SHIHEI:
+                        case ITEMID::RANKA:
+                        case ITEMID::FURUSUMI:
 
-                            toolID = ITEM_SHIKANOFUDA;
+                            toolID = ITEMID::SHIKANOFUDA;
                             break;
 
-                        case ITEM_SOSHI:
-                        case ITEM_KODOKU:
-                        case ITEM_KAGINAWA:
-                        case ITEM_JUSATSU:
-                        case ITEM_SAIRUI_RAN:
-                        case ITEM_JINKO:
-                            toolID = ITEM_CHONOFUDA;
+                        case ITEMID::SOSHI:
+                        case ITEMID::KODOKU:
+                        case ITEMID::KAGINAWA:
+                        case ITEMID::JUSATSU:
+                        case ITEMID::SAIRUI_RAN:
+                        case ITEMID::JINKO:
+                            toolID = ITEMID::CHONOFUDA;
                             break;
 
                         default:
@@ -4187,8 +4187,8 @@ namespace battleutils
             // Check For Futae Effect
             bool hasFutae = PChar->StatusEffectContainer->HasStatusEffect(EFFECT_FUTAE);
             // Futae only applies to Elemental Wheel Tools
-            bool useFutae = (toolID == ITEM_UCHITAKE || toolID == ITEM_TSURARA || toolID == ITEM_KAWAHORI_OGI || toolID == ITEM_MAKIBISHI ||
-                             toolID == ITEM_HIRAISHIN || toolID == ITEM_MIZU_DEPPO);
+            bool useFutae = (toolID == ITEMID::UCHITAKE || toolID == ITEMID::TSURARA || toolID == ITEMID::KAWAHORI_OGI || toolID == ITEMID::MAKIBISHI ||
+                             toolID == ITEMID::HIRAISHIN || toolID == ITEMID::MIZU_DEPPO);
 
             // If you have Futae active, Ninja Tool Expertise does not apply.
             if (ConsumeTool && hasFutae && useFutae)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Removes successive defines for Item IDs used in core, and replaces with enum.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
All impacted items that are currently used revolve around Ninja tools:
1. Test casting spell with no item
2. Test casting spell with item
3. Use universal tool
<!-- Clear and detailed steps to test your changes here -->
