### PR TITLE
[core] [module] AH announcement module: return if item purchased

### DIFF
--- a/modules/custom/cpp/ah_announcement.cpp
+++ b/modules/custom/cpp/ah_announcement.cpp
@@ -95,6 +95,7 @@ class AHAnnouncementModule : public CPPModule
 
                         if (gil != nullptr && gil->isType(ITEM_CURRENCY) && gil->getQuantity() >= price && gil->getReserve() == 0)
                         {
+                            bool itemPurchasedSuccessfully = false;
                             // clang-format off
                             TransactionWrapper wrapper([&]() -> void
                             {
@@ -182,10 +183,17 @@ class AHAnnouncementModule : public CPPModule
                                             message::send(sellerId, std::make_unique<CChatMessagePacket>(PChar, MESSAGE_SYSTEM_3,
                                                 fmt::format("Your '{}' has sold to {} for {} gil!", name, PChar->name, price).c_str(), ""));
                                         }
+
+                                        itemPurchasedSuccessfully = true;
                                     }
                                 }
                             }); // TransactionWrapper
                             // clang-format on
+
+                            if (itemPurchasedSuccessfully)
+                            {
+                                return;
+                            }
                         }
                     }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Apparently, ah announcement module would report that you both bought and didn't buy an item when you bought an item

## Steps to test these changes

Buy item from yourself, see announcement and also see you bought it without a second message telling you that you failed