### PR TITLE
Core: Use charVars to gate yell messages

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -237,7 +237,6 @@ CCharEntity::CCharEntity()
     m_SaveTime    = 0;
     m_reloadParty = false;
 
-    m_LastYell       = 0;
     m_moghouseID     = 0;
     m_moghancementID = 0;
 

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -497,8 +497,6 @@ public:
     uint32 m_PlayTime;
     uint32 m_SaveTime;
 
-    uint32 m_LastYell;
-
     time_point m_LeaderCreatedPartyTime; // Time that a party member joined and this player was leader.
 
     uint8 m_GMlevel;    // Level of the GM flag assigned to this character


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

We used to track yells with `m_YellTime` on chars, but that would be destroyed and reset on zoning - allowing people to circumvent the yell timer. Moving it to expiring charvars fixes this issue. Will also work across processes because if the charvar isn't in the cache it'll get pulled, etc.

<img width="194" alt="image" src="https://github.com/user-attachments/assets/c5ea874d-abec-4f70-8d75-24bc51998b0e" />
