### PR TITLE
[core] [settings] Implement SA/TA TH proc bonuses, add setting for TH procs in general

### DIFF
--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -95,6 +95,9 @@ xi.settings.map =
     -- Disables ability to equip higher level gear when level cap/sync effect is on player.
     DISABLE_GEAR_SCALING = false,
 
+    -- Disables Treasure Hunter procs (Era behavior wants this true)
+    DISABLE_TREASURE_HUNTER_PROCS = false,
+
     -- Weaponskill point base (before skillchain) for breaking latent - whole numbers only. retail is 1.
     WS_POINTS_BASE = 1,
 

--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -461,6 +461,16 @@ bool CAttack::CheckAnticipated()
     }
 }
 
+bool CAttack::CheckHadSneakAttack() const
+{
+    return m_isSA;
+}
+
+bool CAttack::CheckHadTrickAttack() const
+{
+    return m_isTA;
+}
+
 bool CAttack::IsCountered() const
 {
     return m_isCountered;
@@ -563,22 +573,20 @@ bool CAttack::CheckCover()
  ************************************************************************/
 void CAttack::ProcessDamage()
 {
-    auto saDmgBonus = false;
-    auto taDmgBonus = false;
     // Sneak attack.
     if (m_attacker->GetMJob() == JOB_THF && m_isFirstSwing && m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_SNEAK_ATTACK) &&
         (behind(m_attacker->loc.p, m_victim->loc.p, 64) || m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_HIDE) ||
          m_victim->StatusEffectContainer->HasStatusEffect(EFFECT_DOUBT)))
     {
         m_bonusBasePhysicalDamage += m_attacker->DEX() * (1.0f + m_attacker->getMod(Mod::SNEAK_ATK_DEX) / 100.0f);
-        saDmgBonus = true;
+        m_isSA = true;
     }
 
     // Trick attack.
     if (m_attacker->GetMJob() == JOB_THF && m_isFirstSwing && m_attackRound->GetTAEntity() != nullptr)
     {
         m_bonusBasePhysicalDamage += m_attacker->AGI() * (1.0f + m_attacker->getMod(Mod::TRICK_ATK_AGI) / 100.0f);
-        taDmgBonus = true;
+        m_isTA = true;
     }
 
     // Consume mana
@@ -644,13 +652,13 @@ void CAttack::ProcessDamage()
         attackutils::CheckForDamageMultiplier((CCharEntity*)m_attacker, dynamic_cast<CItemWeapon*>(m_attacker->m_Weapons[slot]), m_damage, m_attackType, slot, m_isFirstSwing);
 
     // Apply Sneak Attack Augment Mod
-    if (m_attacker->getMod(Mod::AUGMENTS_SA) > 0 && saDmgBonus && m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_SNEAK_ATTACK))
+    if (m_attacker->getMod(Mod::AUGMENTS_SA) > 0 && CheckHadSneakAttack() && m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_SNEAK_ATTACK))
     {
         m_damage += (int32)(m_damage * ((100 + (m_attacker->getMod(Mod::AUGMENTS_SA))) / 100.0f));
     }
 
     // Apply Trick Attack Augment Mod
-    if (m_attacker->getMod(Mod::AUGMENTS_TA) > 0 && taDmgBonus && m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_TRICK_ATTACK))
+    if (m_attacker->getMod(Mod::AUGMENTS_TA) > 0 && CheckHadTrickAttack() && m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_TRICK_ATTACK))
     {
         m_damage += (int32)(m_damage * ((100 + (m_attacker->getMod(Mod::AUGMENTS_TA))) / 100.0f));
     }

--- a/src/map/attack.h
+++ b/src/map/attack.h
@@ -92,6 +92,8 @@ public:
     bool                      IsAnticipated() const;
     bool                      IsDeflected() const;
     bool                      CheckAnticipated();
+    bool                      CheckHadSneakAttack() const;
+    bool                      CheckHadTrickAttack() const;
     bool                      IsCountered() const;
     bool                      CheckCounter();
     bool                      IsCovered() const; // Returns the covered flag.
@@ -115,6 +117,8 @@ private:
     bool                      m_isCountered{ false };
     bool                      m_isCovered{ false }; // Flag: Is someone covering the victim?
     bool                      m_anticipated{ false };
+    bool                      m_isSA{ false };                // Attack had a valid SA proc
+    bool                      m_isTA{ false };                // Attack had a valid TA proc
     bool                      m_isFirstSwing{ false };        // Flag: Is this attack the first swing?
     float                     m_damageRatio{ false };         // The damage ratio.
     int32                     m_damage{ 0 };                  // The damage for this attack.

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2570,7 +2570,7 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
         if ((actionTarget.reaction & REACTION::MISS) == REACTION::NONE && attack.GetAttackType() != PHYSICAL_ATTACK_TYPE::DAKEN)
         {
             battleutils::HandleEnspell(this, PTarget, &actionTarget, attack.IsFirstSwing(), (CItemWeapon*)this->m_Weapons[attack.GetWeaponSlot()],
-                                       attack.GetDamage());
+                                       attack.GetDamage(), attack);
             battleutils::HandleSpikesDamage(this, PTarget, &actionTarget, attack.GetDamage());
         }
 

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1455,7 +1455,7 @@ namespace battleutils
 
                 if (PAttacker->objtype == TYPE_PC && PAttacker->PParty != nullptr)
                 {
-                    if (auto* PChar = dynamic_cast<CCharEntity*>(PAttacker))
+                    if (PChar)
                     {
                         // clang-format off
                         PChar->ForPartyWithTrusts([&](CBattleEntity* PMember)
@@ -1470,10 +1470,10 @@ namespace battleutils
                 }
                 else if (PAttacker->objtype == TYPE_TRUST)
                 {
-                    if (auto* PChar = dynamic_cast<CCharEntity*>(PAttacker->PMaster))
+                    if (auto* PMaster = dynamic_cast<CCharEntity*>(PAttacker->PMaster))
                     {
                         // clang-format off
-                        PChar->ForPartyWithTrusts([&](CBattleEntity* PMember)
+                        PMaster->ForPartyWithTrusts([&](CBattleEntity* PMember)
                         {
                             if (attackerID == PMember->id)
                             {

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1121,7 +1121,7 @@ namespace battleutils
      *                                                                       *
      ************************************************************************/
 
-    void HandleEnspell(CBattleEntity* PAttacker, CBattleEntity* PDefender, actionTarget_t* Action, bool isFirstSwing, CItemWeapon* weapon, int32 finaldamage)
+    void HandleEnspell(CBattleEntity* PAttacker, CBattleEntity* PDefender, actionTarget_t* Action, bool isFirstSwing, CItemWeapon* weapon, int32 finaldamage, CAttack& attack)
     {
         CCharEntity* PChar = nullptr;
 
@@ -1156,14 +1156,34 @@ namespace battleutils
 
                     float procRate = 0.04f / std::pow<float>(2.f, std::max<int16>(0, THdiff)); // Numbers below diff of -1 (i.e. TH 10 vs mobs TH8 level) are not known. Assume no extra bonus for now.
 
-                    // Impossible to tell if SA or TA was used currently. Allegedly it gives a 10x(!) multiplicative bonus.
-                    // TODO: fix that
                     // Not known if Feint and Gifts are multiplicative or additive. Currently assuming additive
                     // The mob has an evasion down from feint that applies this mod.
-                    // The player has job point gifts that apply thsi mod.
+                    // The player has job point gifts that apply this mod.
                     float procRateBonus = 1.f + (PChar->getMod(Mod::TREASURE_HUNTER_PROC) + PMob->getMod(Mod::TREASURE_HUNTER_PROC)) / 100.f;
 
                     procRate *= procRateBonus;
+
+                    // It's unlikely that SATA bonus is multiplicative SA * TA bonus -- the rate would be astronomically higher if it was
+                    // Add the two together if they exist
+                    float sneakAttackTrickAttackBonus = 0.f;
+
+                    // BG wiki claims 10x bonus for SA
+                    if (attack.CheckHadSneakAttack())
+                    {
+                        sneakAttackTrickAttackBonus += 10.f;
+                    }
+
+                    // BG wiki claims 10x bonus for TA
+                    if (attack.CheckHadTrickAttack())
+                    {
+                        sneakAttackTrickAttackBonus += 10.f;
+                    }
+
+                    // way greater than epsilon just in case...
+                    if (sneakAttackTrickAttackBonus > 1.f)
+                    {
+                        procRateBonus *= sneakAttackTrickAttackBonus;
+                    }
 
                     if (xirand::GetRandomNumber<float>(0.f, 1.f) <= procRate)
                     {

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -32,6 +32,7 @@
 #include "entities/battleentity.h"
 
 class CAbility;
+class CAttack;
 class CItemWeapon;
 class CMobSkill;
 class CPetSkill;
@@ -171,7 +172,7 @@ namespace battleutils
     bool  HandleParrySpikesDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, actionTarget_t* Action, int32 damage);
     bool  HandleSpikesEquip(CBattleEntity* PAttacker, CBattleEntity* PDefender, actionTarget_t* Action, uint8 damage, SUBEFFECT spikesType, uint8 chance);
     void  HandleSpikesStatusEffect(CBattleEntity* PAttacker, CBattleEntity* PDefender, actionTarget_t* Action);
-    void  HandleEnspell(CBattleEntity* PAttacker, CBattleEntity* PDefender, actionTarget_t* Action, bool isFirstSwing, CItemWeapon* weapon, int32 damage);
+    void  HandleEnspell(CBattleEntity* PAttacker, CBattleEntity* PDefender, actionTarget_t* Action, bool isFirstSwing, CItemWeapon* weapon, int32 damage, CAttack& attack);
     uint8 GetRangedHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool isBarrage);
     uint8 GetRangedHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool isBarrage, int16 accBonus);
     int32 CalculateEnspellDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, uint8 Tier, uint8 element);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implement SA/TA th proc bonuses
Add setting to disable TH procs in general
Fix some shadowed variables in HandleEnspell

Probably better to review by commit
## Steps to test these changes

Breakpoint on SA/TA melee procs, check if the bonuses are being applied
Disable TH procs and see the code isn't being checked via breakpoint
