### PR TITLE
Core: Rollback pending packet changes to raw ptr forms

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -422,11 +422,11 @@ void CCharEntity::pushPacket(std::unique_ptr<CBasicPacket>&& packet)
     {
         if (PendingPositionPacket)
         {
-            PendingPositionPacket = packet->copy();
+            PendingPositionPacket = packet.get();
         }
         else
         {
-            PendingPositionPacket = packet->copy();
+            PendingPositionPacket = packet.get();
             PacketList.emplace_back(std::move(packet));
         }
     }
@@ -442,13 +442,17 @@ void CCharEntity::updateCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint8 
     if (existing == PendingCharPackets.end())
     {
         // No existing packet update for the given char, so we push new packet
-        PacketList.emplace_back(std::make_unique<CCharPacket>(PChar, type, updatemask));
-        PendingCharPackets.emplace(PChar->id, std::make_unique<CCharPacket>(PChar, type, updatemask));
+        auto packet = std::make_unique<CCharPacket>(PChar, type, updatemask);
+        PendingCharPackets.emplace(PChar->id, packet.get());
+        PacketList.emplace_back(std::move(packet));
     }
     else
     {
-        // Found existing packet update for the given char, so we update it instead of pushing new
-        existing->second->updateWith(PChar, type, updatemask);
+        if (existing->second != nullptr)
+        {
+            // Found existing packet update for the given char, so we update it instead of pushing new
+            existing->second->updateWith(PChar, type, updatemask);
+        }
     }
 }
 
@@ -458,13 +462,17 @@ void CCharEntity::updateEntityPacket(CBaseEntity* PEntity, ENTITYUPDATE type, ui
     if (existing == PendingEntityPackets.end())
     {
         // No existing packet update for the given entity, so we push new packet
-        PacketList.emplace_back(std::make_unique<CEntityUpdatePacket>(PEntity, type, updatemask));
-        PendingEntityPackets.emplace(PEntity->id, std::make_unique<CEntityUpdatePacket>(PEntity, type, updatemask));
+        auto packet = std::make_unique<CEntityUpdatePacket>(PEntity, type, updatemask);
+        PendingEntityPackets.emplace(PEntity->id, packet.get());
+        PacketList.emplace_back(std::move(packet));
     }
     else
     {
-        // Found existing packet update for the given entity, so we update it instead of pushing new
-        existing->second->updateWith(PEntity, type, updatemask);
+        if (existing->second != nullptr)
+        {
+            // Found existing packet update for the given entity, so we update it instead of pushing new
+            existing->second->updateWith(PEntity, type, updatemask);
+        }
     }
 }
 

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -542,7 +542,8 @@ public:
 
     CItemEquipment* getEquip(SLOTTYPE slot);
 
-    std::unique_ptr<CBasicPacket> PendingPositionPacket = nullptr;
+    // TODO: Don't use raw ptrs for this, but don't duplicate whole packets with unique_ptr either.
+    CBasicPacket* PendingPositionPacket = nullptr;
 
     bool requestedInfoSync = false;
 
@@ -663,9 +664,11 @@ private:
     uint8      dataToPersist = 0;
     time_point nextDataPersistTime;
 
-    std::deque<std::unique_ptr<CBasicPacket>>                        PacketList;           // The list of packets to be sent to the character during the next network cycle
-    std::unordered_map<uint32, std::unique_ptr<CCharPacket>>         PendingCharPackets;   // Keep track of which char packets are queued up for this char, such that they can be updated
-    std::unordered_map<uint32, std::unique_ptr<CEntityUpdatePacket>> PendingEntityPackets; // Keep track of which entity update packets are queued up for this char, such that they can be updated
+    std::deque<std::unique_ptr<CBasicPacket>> PacketList; // The list of packets to be sent to the character during the next network cycle
+
+    // TODO: Don't use raw ptrs for this, but don't duplicate whole packets with unique_ptr either.
+    std::unordered_map<uint32, CCharPacket*>         PendingCharPackets;   // Keep track of which char packets are queued up for this char, such that they can be updated
+    std::unordered_map<uint32, CEntityUpdatePacket*> PendingEntityPackets; // Keep track of which entity update packets are queued up for this char, such that they can be updated
 };
 
 #endif


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Might fix https://github.com/LandSandBoat/server/issues/6778

The lifetimes for these were tight before my changes, but they weren't well-defined. This sets them back to what they were, but I'm not happy about it ;_;

Not tested yet, I have a lot of work-work on before the weekend