### PR TITLE
Create menuType enum to support CLuaBaseEntity::sendMenu() parameter

### DIFF
--- a/scripts/commands/ah.lua
+++ b/scripts/commands/ah.lua
@@ -12,7 +12,7 @@ commandObj.cmdprops =
 }
 
 commandObj.onTrigger = function(player)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 return commandObj

--- a/scripts/enum/menu_type.lua
+++ b/scripts/enum/menu_type.lua
@@ -1,0 +1,9 @@
+xi = xi or {}
+
+---@enum xi.menuType
+xi.menuType =
+{
+    MOOGLE  = 1,
+    SHOP    = 2,
+    AUCTION = 3,
+}

--- a/scripts/globals/moghouse.lua
+++ b/scripts/globals/moghouse.lua
@@ -265,7 +265,7 @@ xi.moghouse.moogleTrigger = function(player, npc)
             end
         end
 
-        player:sendMenu(1)
+        player:sendMenu(xi.menuType.MOOGLE)
     end
 end
 

--- a/scripts/globals/shop.lua
+++ b/scripts/globals/shop.lua
@@ -42,7 +42,7 @@ xi.shop =
             player:addShopItem(stock[i], stock[i + 1] * priceMultiplier)
         end
 
-        player:sendMenu(2)
+        player:sendMenu(xi.menuType.SHOP)
     end,
 
     -- send general guild shop dialog to player (Added on June 2014 QoL)
@@ -57,7 +57,7 @@ xi.shop =
             player:addShopItem(stock[i], stock[i + 1], guildSkillId, stock[i + 2])
         end
 
-        player:sendMenu(2)
+        player:sendMenu(xi.menuType.SHOP)
     end,
 
     -- send curio vendor moogle shop shop dialog to player
@@ -74,7 +74,7 @@ xi.shop =
             end
         end
 
-        player:sendMenu(2)
+        player:sendMenu(xi.menuType.SHOP)
     end,
 
     -- send nation shop dialog to player

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -605,7 +605,7 @@ end
 function CBaseEntity:changeMusic(blockID, musicTrackID)
 end
 
----@param menu integer
+---@param menu xi.menuType
 ---@return nil
 function CBaseEntity:sendMenu(menu)
 end

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Auction_Counter.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Auction_Counter.lua
@@ -9,7 +9,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Al_Zahbi/npcs/Goyuyu.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Goyuyu.lua
@@ -9,7 +9,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Al_Zahbi/npcs/Sojan-Tamjan.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Sojan-Tamjan.lua
@@ -9,7 +9,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Al_Zahbi/npcs/Yando-Memondo.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Yando-Memondo.lua
@@ -9,7 +9,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Bastok_Markets/npcs/Auction_Counter.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Auction_Counter.lua
@@ -12,7 +12,7 @@ end
 
 entity.onTrigger = function(player, npc)
     xi.tutorial.onAuctionTrigger(player)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Bastok_Mines/npcs/Auction_Counter.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Auction_Counter.lua
@@ -9,7 +9,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Eastern_Adoulin/npcs/Auction_Counter.lua
+++ b/scripts/zones/Eastern_Adoulin/npcs/Auction_Counter.lua
@@ -9,7 +9,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Kazham/npcs/Cha_Chalco.lua
+++ b/scripts/zones/Kazham/npcs/Cha_Chalco.lua
@@ -9,7 +9,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Kazham/npcs/Cophi_Ricuub.lua
+++ b/scripts/zones/Kazham/npcs/Cophi_Ricuub.lua
@@ -9,7 +9,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Kazham/npcs/Nomad_Moogle.lua
+++ b/scripts/zones/Kazham/npcs/Nomad_Moogle.lua
@@ -12,7 +12,7 @@ end
 
 entity.onTrigger = function(player, npc)
     player:showText(npc, ID.text.NOMAD_MOOGLE_DIALOG)
-    player:sendMenu(1)
+    player:sendMenu(xi.menuType.MOOGLE)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Kazham/npcs/Sulo_Mouzho.lua
+++ b/scripts/zones/Kazham/npcs/Sulo_Mouzho.lua
@@ -9,7 +9,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Lower_Jeuno/npcs/Auction_Counter.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Auction_Counter.lua
@@ -9,7 +9,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Mhaura/npcs/Nomad_Moogle.lua
+++ b/scripts/zones/Mhaura/npcs/Nomad_Moogle.lua
@@ -12,7 +12,7 @@ end
 
 entity.onTrigger = function(player, npc)
     player:showText(npc, ID.text.NOMAD_MOOGLE_DIALOG)
-    player:sendMenu(1)
+    player:sendMenu(xi.menuType.MOOGLE)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Mog_Garden/npcs/Green_Thumb_Moogle.lua
+++ b/scripts/zones/Mog_Garden/npcs/Green_Thumb_Moogle.lua
@@ -31,7 +31,7 @@ entity.onEventFinish = function(player, csid, option, npc)
         end
 
         -- Show the mog house menu
-        player:sendMenu(1)
+        player:sendMenu(xi.menuType.MOOGLE)
 
     elseif csid == 1016 and option == 0xFFE00FF then -- Buy/Sell Things
         local stock =

--- a/scripts/zones/Nashmau/npcs/Momoroon.lua
+++ b/scripts/zones/Nashmau/npcs/Momoroon.lua
@@ -6,7 +6,7 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 return entity

--- a/scripts/zones/Nashmau/npcs/Nomad_Moogle.lua
+++ b/scripts/zones/Nashmau/npcs/Nomad_Moogle.lua
@@ -9,7 +9,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     player:showText(npc, ID.text.NOMAD_MOOGLE_DIALOG)
-    player:sendMenu(1)
+    player:sendMenu(xi.menuType.MOOGLE)
 end
 
 return entity

--- a/scripts/zones/Nashmau/npcs/Pupuroon.lua
+++ b/scripts/zones/Nashmau/npcs/Pupuroon.lua
@@ -6,7 +6,7 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 return entity

--- a/scripts/zones/Norg/npcs/Agatsum.lua
+++ b/scripts/zones/Norg/npcs/Agatsum.lua
@@ -6,7 +6,7 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 return entity

--- a/scripts/zones/Norg/npcs/Atrevaux.lua
+++ b/scripts/zones/Norg/npcs/Atrevaux.lua
@@ -6,7 +6,7 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 return entity

--- a/scripts/zones/Norg/npcs/Gofufu.lua
+++ b/scripts/zones/Norg/npcs/Gofufu.lua
@@ -6,7 +6,7 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 return entity

--- a/scripts/zones/Norg/npcs/Nomad_Moogle.lua
+++ b/scripts/zones/Norg/npcs/Nomad_Moogle.lua
@@ -9,7 +9,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     player:showText(npc, ID.text.NOMAD_MOOGLE_DIALOG)
-    player:sendMenu(1)
+    player:sendMenu(xi.menuType.MOOGLE)
 end
 
 return entity

--- a/scripts/zones/Norg/npcs/Zoldba.lua
+++ b/scripts/zones/Norg/npcs/Zoldba.lua
@@ -6,7 +6,7 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 return entity

--- a/scripts/zones/Port_Jeuno/npcs/Basmus.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Basmus.lua
@@ -6,7 +6,7 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 return entity

--- a/scripts/zones/Port_Jeuno/npcs/Kouang.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Kouang.lua
@@ -6,7 +6,7 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 return entity

--- a/scripts/zones/Port_Jeuno/npcs/Rilve-Hitolve.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Rilve-Hitolve.lua
@@ -6,7 +6,7 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 return entity

--- a/scripts/zones/Port_Jeuno/npcs/Sapladrepoin.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Sapladrepoin.lua
@@ -6,7 +6,7 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 return entity

--- a/scripts/zones/Port_San_dOria/npcs/Auction_Counter.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Auction_Counter.lua
@@ -6,7 +6,7 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 return entity

--- a/scripts/zones/Rabao/npcs/Cavalgrinne.lua
+++ b/scripts/zones/Rabao/npcs/Cavalgrinne.lua
@@ -6,7 +6,7 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 return entity

--- a/scripts/zones/Rabao/npcs/Hyesun.lua
+++ b/scripts/zones/Rabao/npcs/Hyesun.lua
@@ -6,7 +6,7 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 return entity

--- a/scripts/zones/Rabao/npcs/Nomad_Moogle.lua
+++ b/scripts/zones/Rabao/npcs/Nomad_Moogle.lua
@@ -9,7 +9,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     player:showText(npc, ID.text.NOMAD_MOOGLE_DIALOG)
-    player:sendMenu(1)
+    player:sendMenu(xi.menuType.MOOGLE)
 end
 
 return entity

--- a/scripts/zones/Rabao/npcs/Smiling_Rat.lua
+++ b/scripts/zones/Rabao/npcs/Smiling_Rat.lua
@@ -6,7 +6,7 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 return entity

--- a/scripts/zones/RuLude_Gardens/npcs/Auction_Counter.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Auction_Counter.lua
@@ -6,7 +6,7 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 return entity

--- a/scripts/zones/Selbina/npcs/Nomad_Moogle.lua
+++ b/scripts/zones/Selbina/npcs/Nomad_Moogle.lua
@@ -9,7 +9,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     player:showText(npc, ID.text.NOMAD_MOOGLE_DIALOG)
-    player:sendMenu(1)
+    player:sendMenu(xi.menuType.MOOGLE)
 end
 
 return entity

--- a/scripts/zones/Southern_San_dOria/npcs/Auction_Counter.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Auction_Counter.lua
@@ -9,7 +9,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     xi.tutorial.onAuctionTrigger(player)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 return entity

--- a/scripts/zones/Tavnazian_Safehold/npcs/Eliot.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/Eliot.lua
@@ -8,7 +8,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     if player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.DARKNESS_NAMED) then
-        player:sendMenu(3)
+        player:sendMenu(xi.menuType.AUCTION)
     -- TODO: Else 10916
     end
 end

--- a/scripts/zones/Tavnazian_Safehold/npcs/Ferocious_Artisan.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/Ferocious_Artisan.lua
@@ -8,7 +8,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     if player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.DARKNESS_NAMED) then
-        player:sendMenu(3)
+        player:sendMenu(xi.menuType.AUCTION)
     -- TODO: Else 10917
     end
 end

--- a/scripts/zones/Tavnazian_Safehold/npcs/Nomad_Moogle.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/Nomad_Moogle.lua
@@ -9,7 +9,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     player:showText(npc, ID.text.NOMAD_MOOGLE_DIALOG)
-    player:sendMenu(1)
+    player:sendMenu(xi.menuType.MOOGLE)
 end
 
 return entity

--- a/scripts/zones/Tavnazian_Safehold/npcs/Senvaleget.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/Senvaleget.lua
@@ -8,7 +8,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     if player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.DARKNESS_NAMED) then
-        player:sendMenu(3)
+        player:sendMenu(xi.menuType.AUCTION)
     -- Else 10918
     end
 end

--- a/scripts/zones/Upper_Jeuno/npcs/Indika.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Indika.lua
@@ -6,7 +6,7 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 return entity

--- a/scripts/zones/Upper_Jeuno/npcs/Shama_Pikholo.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Shama_Pikholo.lua
@@ -6,7 +6,7 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 return entity

--- a/scripts/zones/Upper_Jeuno/npcs/Ulesa.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Ulesa.lua
@@ -6,7 +6,7 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 return entity

--- a/scripts/zones/Upper_Jeuno/npcs/Wise_Wolf.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Wise_Wolf.lua
@@ -6,7 +6,7 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 return entity

--- a/scripts/zones/Western_Adoulin/npcs/Auction_Counter.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Auction_Counter.lua
@@ -6,7 +6,7 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 return entity

--- a/scripts/zones/Windurst_Walls/npcs/Auction_Counter.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Auction_Counter.lua
@@ -6,7 +6,7 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 return entity

--- a/scripts/zones/Windurst_Woods/npcs/Auction_Counter.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Auction_Counter.lua
@@ -9,7 +9,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     xi.tutorial.onAuctionTrigger(player)
-    player:sendMenu(3)
+    player:sendMenu(xi.menuType.AUCTION)
 end
 
 return entity

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -2393,7 +2393,7 @@ void CLuaBaseEntity::changeMusic(uint16 blockID, uint16 musicTrackID)
 /************************************************************************
  *  Function: sendMenu()
  *  Purpose : Sends a menu to the PC (Ex: Auction, Mog House, Shop)
- *  Example : player:sendMenu(3)
+ *  Example : player:sendMenu(xi.menuType.AUCTION)
  ************************************************************************/
 
 void CLuaBaseEntity::sendMenu(uint32 menu)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Replaces numeric values in sendMenu calls with enum
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No impact to gameplay
<!-- Clear and detailed steps to test your changes here -->
