### PR TITLE
Improve settings packet handling/saving

### DIFF
--- a/src/map/packets/zone_in.cpp
+++ b/src/map/packets/zone_in.cpp
@@ -85,6 +85,7 @@ struct GP_MYROOM_DANCER_PKT
 };
 
 // PS2: SAVE_CONF
+// Seems to be a truncated version of SAVE_CONF missing PvpFlg and AreaCode?
 struct SAVE_CONF_PKT
 {
     uint32_t unknown00[3]; // PS2: (Multiple fields; bits.)
@@ -352,7 +353,7 @@ CZoneInPacket::CZoneInPacket(CCharEntity* PChar, const EventInfo* currentEvent)
     ref<uint32>(0xEC) = PChar->GetMaxMP();
     // ref<uint8>(0xEF) = TODO: implement flag of 1 = high for "has unlocked sub and can change jobs"
 
-    std::memcpy(&buffer_[offsetof(GP_SERV_LOGIN, ConfData)], &PChar->playerConfig, sizeof(SAVE_CONF));
+    std::memcpy(&buffer_[offsetof(GP_SERV_LOGIN, ConfData)], &PChar->playerConfig, sizeof(SAVE_CONF_PKT));
 
     ref<uint8>(0x100) = 0x01; // observed: RoZ = 3, CoP = 5, ToAU = 9, WoTG = 11, SoA/original areas = 1
 

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -626,11 +626,13 @@ void CParty::AddMember(CBattleEntity* PEntity)
             PChar->updatemask |= UPDATE_HP;
 
             charutils::SaveCharStats(PChar);
+            charutils::SavePlayerSettings(PChar);
 
             PChar->pushPacket<CMenuConfigPacket>(PChar);
             PChar->pushPacket<CCharUpdatePacket>(PChar);
             PChar->pushPacket<CCharSyncPacket>(PChar);
         }
+
         PChar->PTreasurePool->UpdatePool(PChar);
 
         // Apply level sync if the party is level synced


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Apparently C2S 0x0DC packet handling was very close but not quite right. This PR fixes that
Bonus if you can wrap your head around why 0x1 = = on and 0x2 == off
When you /join a party, apparently, the client does not inform the server that the /inv flag has changed so it was never updated in the db. Now we update it immediately on join

## Steps to test these changes

Use commands that modify settings, see no changes
