### PR TITLE
fixed SATA adjustment on TH procs

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1163,8 +1163,6 @@ namespace battleutils
                         // The player has job point gifts that apply this mod.
                         float procRateBonus = 1.f + (PChar->getMod(Mod::TREASURE_HUNTER_PROC) + PMob->getMod(Mod::TREASURE_HUNTER_PROC)) / 100.f;
 
-                        procRate *= procRateBonus;
-
                         // It's unlikely that SATA bonus is multiplicative SA * TA bonus -- the rate would be astronomically higher if it was
                         // Add the two together if they exist
                         float sneakAttackTrickAttackBonus = 0.f;
@@ -1186,6 +1184,8 @@ namespace battleutils
                         {
                             procRateBonus *= sneakAttackTrickAttackBonus;
                         }
+
+                        procRate *= procRateBonus;
 
                         if (xirand::GetRandomNumber<float>(0.f, 1.f) <= procRate)
                         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Fixes the modification to treasure hunter proc rate based on sneak attack / trick attack added in PR #6791 

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

Apply SA/TA and attempt to proc TH