### PR TITLE
[sql] Add skill list for Cyranuce M Cutauleon

### DIFF
--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -2306,7 +2306,13 @@ INSERT INTO `mob_skill_lists` VALUES ('Gerjis',497,271); -- razor_fang
 INSERT INTO `mob_skill_lists` VALUES ('Gerjis',497,273); -- claw_cyclone
 INSERT INTO `mob_skill_lists` VALUES ('Gerjis',497,1322); -- gerjis_grip
 -- INSERT INTO `mob_skill_lists` VALUES ('Gerjis',497,1681); -- crossthrash
--- 498: Cyranuce_M_Cutauleon
+INSERT INTO `mob_skill_lists` VALUES ('Cyranuce_M_Cutauleon',498,813); -- Dispelling Wind
+INSERT INTO `mob_skill_lists` VALUES ('Cyranuce_M_Cutauleon',498,814); -- Deadly Drive
+INSERT INTO `mob_skill_lists` VALUES ('Cyranuce_M_Cutauleon',498,815); -- Wind Wall
+INSERT INTO `mob_skill_lists` VALUES ('Cyranuce_M_Cutauleon',498,816); -- Fang Rush
+INSERT INTO `mob_skill_lists` VALUES ('Cyranuce_M_Cutauleon',498,817); -- Dread Shriek
+INSERT INTO `mob_skill_lists` VALUES ('Cyranuce_M_Cutauleon',498,818); -- Tail Crush
+INSERT INTO `mob_skill_lists` VALUES ('Cyranuce_M_Cutauleon',498,822); -- Chaos Breath
 -- 499 to 699: free
 INSERT INTO `mob_skill_lists` VALUES ('Mammet',503,347);
 INSERT INTO `mob_skill_lists` VALUES ('Mammet',503,419);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Add skill list to Cyranuce M Cutauleon, the NM in the BCNM The Holy Crest (DRG unlock quest).
https://www.youtube.com/watch?v=U39y1jHobMQ
Watched several videos of this fight including this one and he used the following:
Chaos Breath, Deadly Drive, Dispelling Wind 
Someone on ffxiclopedia testimonies mentioned him using Dread Shriek as well.
Usually died too quickly to see any TP moves used in other videos but believe it is safe to assume he has all the other Wyvern family TP abilities (Fang Rush, Wind Wall, Tail Crush).

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

Go to Ghelsba Outpost hut with `!togglegm` activated and enter the BCNM The Holy Crest
Use `!tp 3000` on Cyranuce M Cutauleon
See he uses abilities now (previously had none).