### PR TITLE
[sql] Remove Indigo Memosphere drop from Promyvion-Vahzl Gorger

### DIFF
--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -9984,7 +9984,6 @@ INSERT INTO `mob_droplist` VALUES (1208,0,0,1000,1611,@UNCOMMON); -- Remnant Of 
 INSERT INTO `mob_droplist` VALUES (1208,0,0,1000,1612,@UNCOMMON); -- Remnant Of A Radiant Memory (Uncommon, 10%)
 INSERT INTO `mob_droplist` VALUES (1208,0,0,1000,1613,@UNCOMMON); -- Remnant Of A Malevolent Memory (Uncommon, 10%)
 INSERT INTO `mob_droplist` VALUES (1208,0,0,1000,1689,80);        -- Recollection Of Guilt (8.0%)
-INSERT INTO `mob_droplist` VALUES (1208,0,0,1000,1722,80);        -- Indigo Memosphere (8.0%)
 INSERT INTO `mob_droplist` VALUES (1208,0,0,1000,1723,80);        -- White Memosphere (8.0%)
 
 -- ZoneID:  40 - Gosspix Blabberlips


### PR DESCRIPTION
Indigo Memosphere is for the Promyvion-Mea Map Quest and should not drop in Promy Vahzl

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
It removes indigo memosphere as a drop from promyvion-vahzl gorgers. This item is for the promy-mea map quest and should not drop in Vahzl.
Sources:
https://wiki.ffo.jp/html/16069.html
https://ffxiclopedia.fandom.com/wiki/Indigo_Memosphere
https://www.bg-wiki.com/ffxi/Indigo_Memosphere
https://ffxi.allakhazam.com/db/item.html?fitem=8443
http://ffxi.somepage.com/questdb/513

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Just removes an erroneous drop.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
