### PR TITLE
Use PacketList directly when sending

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -396,6 +396,11 @@ bool CCharEntity::isPacketListEmpty()
     return PacketList.empty();
 }
 
+auto CCharEntity::getPacketList() const -> const std::deque<std::unique_ptr<CBasicPacket>>&
+{
+    return PacketList;
+}
+
 void CCharEntity::clearPacketList()
 {
     while (!PacketList.empty())
@@ -438,41 +443,39 @@ void CCharEntity::pushPacket(std::unique_ptr<CBasicPacket>&& packet)
 
 void CCharEntity::updateCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint8 updatemask)
 {
-    auto existing = PendingCharPackets.find(PChar->id);
-    if (existing == PendingCharPackets.end())
+    auto       itr              = PendingCharPackets.find(PChar->id);
+    const bool hasPendingPacket = itr != PendingCharPackets.end() && itr->second != nullptr;
+    if (hasPendingPacket)
     {
-        // No existing packet update for the given char, so we push new packet
-        auto packet = std::make_unique<CCharPacket>(PChar, type, updatemask);
-        PendingCharPackets.emplace(PChar->id, packet.get());
-        PacketList.emplace_back(std::move(packet));
+        // Found existing packet update for the given char, so we update it instead of pushing new
+        auto& packet = itr->second;
+        packet->updateWith(PChar, type, updatemask);
     }
     else
     {
-        if (existing->second != nullptr)
-        {
-            // Found existing packet update for the given char, so we update it instead of pushing new
-            existing->second->updateWith(PChar, type, updatemask);
-        }
+        // No existing packet update for the given char, so we push new packet
+        auto packet                   = std::make_unique<CCharPacket>(PChar, type, updatemask);
+        PendingCharPackets[PChar->id] = packet.get();
+        PacketList.emplace_back(std::move(packet));
     }
 }
 
 void CCharEntity::updateEntityPacket(CBaseEntity* PEntity, ENTITYUPDATE type, uint8 updatemask)
 {
-    auto existing = PendingEntityPackets.find(PEntity->id);
-    if (existing == PendingEntityPackets.end())
+    auto       itr              = PendingEntityPackets.find(PEntity->id);
+    const bool hasPendingPacket = itr != PendingEntityPackets.end() && itr->second != nullptr;
+    if (hasPendingPacket)
     {
-        // No existing packet update for the given entity, so we push new packet
-        auto packet = std::make_unique<CEntityUpdatePacket>(PEntity, type, updatemask);
-        PendingEntityPackets.emplace(PEntity->id, packet.get());
-        PacketList.emplace_back(std::move(packet));
+        // Found existing packet update for the given entity, so we update it instead of pushing new
+        auto& packet = itr->second;
+        packet->updateWith(PEntity, type, updatemask);
     }
     else
     {
-        if (existing->second != nullptr)
-        {
-            // Found existing packet update for the given entity, so we update it instead of pushing new
-            existing->second->updateWith(PEntity, type, updatemask);
-        }
+        // No existing packet update for the given entity, so we push new packet
+        auto packet                       = std::make_unique<CEntityUpdatePacket>(PEntity, type, updatemask);
+        PendingEntityPackets[PEntity->id] = packet.get();
+        PacketList.emplace_back(std::move(packet));
     }
 }
 
@@ -498,16 +501,6 @@ auto CCharEntity::popPacket() -> std::unique_ptr<CBasicPacket>
     }
 
     return PPacket;
-}
-
-auto CCharEntity::getPacketListCopy() -> std::deque<std::unique_ptr<CBasicPacket>>
-{
-    std::deque<std::unique_ptr<CBasicPacket>> PacketListCopy;
-    for (const auto& packet : PacketList)
-    {
-        PacketListCopy.emplace_back(std::make_unique<CBasicPacket>(packet));
-    }
-    return PacketListCopy;
 }
 
 size_t CCharEntity::getPacketCount()

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -415,6 +415,7 @@ public:
 
     uint8 GetGender();
 
+    auto getPacketList() const -> const std::deque<std::unique_ptr<CBasicPacket>>&;
     void clearPacketList();
 
     template <typename T, typename... Args>
@@ -428,8 +429,7 @@ public:
     void   updateCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint8 updatemask);     // Push or update a char packet
     void   updateEntityPacket(CBaseEntity* PEntity, ENTITYUPDATE type, uint8 updatemask); // Push or update an entity update packet
     bool   isPacketListEmpty();
-    auto   popPacket() -> std::unique_ptr<CBasicPacket>;                     // Get first packet from PacketList
-    auto   getPacketListCopy() -> std::deque<std::unique_ptr<CBasicPacket>>; // Return a COPY of packet list
+    auto   popPacket() -> std::unique_ptr<CBasicPacket>; // Get first packet from PacketList
     size_t getPacketCount();
     void   erasePackets(uint8 num); // Erase num elements from front of packet list
     bool   isPacketFiltered(std::unique_ptr<CBasicPacket>& packet);
@@ -541,9 +541,6 @@ public:
     uint32 GetPlayTime(bool needUpdate = true); // Get playtime
 
     CItemEquipment* getEquip(SLOTTYPE slot);
-
-    // TODO: Don't use raw ptrs for this, but don't duplicate whole packets with unique_ptr either.
-    CBasicPacket* PendingPositionPacket = nullptr;
 
     bool requestedInfoSync = false;
 
@@ -664,9 +661,9 @@ private:
     uint8      dataToPersist = 0;
     time_point nextDataPersistTime;
 
-    std::deque<std::unique_ptr<CBasicPacket>> PacketList; // The list of packets to be sent to the character during the next network cycle
-
     // TODO: Don't use raw ptrs for this, but don't duplicate whole packets with unique_ptr either.
+    std::deque<std::unique_ptr<CBasicPacket>>        PacketList; // The list of packets to be sent to the character during the next network cycle
+    CBasicPacket*                                    PendingPositionPacket = nullptr;
     std::unordered_map<uint32, CCharPacket*>         PendingCharPackets;   // Keep track of which char packets are queued up for this char, such that they can be updated
     std::unordered_map<uint32, CEntityUpdatePacket*> PendingEntityPackets; // Keep track of which entity update packets are queued up for this char, such that they can be updated
 };

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1049,14 +1049,13 @@ int32 send_parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_da
     {
         do
         {
-            *buffsize       = FFXI_HEADER_SIZE;
-            auto packetList = PChar->getPacketListCopy();
-            packets         = 0;
+            *buffsize        = FFXI_HEADER_SIZE;
+            auto& packetList = PChar->getPacketList();
+            packets          = 0;
 
-            while (!packetList.empty() && *buffsize + packetList.front()->getSize() < MAX_BUFFER_SIZE && static_cast<size_t>(packets) < PacketCount)
+            while (!PChar->isPacketListEmpty() && *buffsize + packetList.front()->getSize() < MAX_BUFFER_SIZE && static_cast<size_t>(packets) < PacketCount)
             {
-                PSmallPacket = std::move(packetList.front());
-                packetList.pop_front();
+                PSmallPacket = PChar->popPacket();
 
                 PSmallPacket->setSequence(map_session_data->server_packet_id);
                 auto type = PSmallPacket->getType();
@@ -1131,7 +1130,6 @@ int32 send_parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_da
             }
         }
     } while (PacketSize == static_cast<uint32>(-1));
-    PChar->erasePackets(packets);
     TotalPacketsSentPerTick += packets;
     TracyZoneString(fmt::format("Sending {} packets", packets));
 
@@ -1188,7 +1186,7 @@ int32 send_parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_da
 
     *buffsize = PacketSize + FFXI_HEADER_SIZE;
 
-    auto remainingPackets = PChar->getPacketListCopy().size();
+    auto remainingPackets = PChar->getPacketCount();
     TotalPacketsDelayedPerTick += static_cast<uint32>(remainingPackets);
 
     if (settings::get<bool>("logging.DEBUG_PACKET_BACKLOG"))

--- a/src/map/packet_guard.cpp
+++ b/src/map/packet_guard.cpp
@@ -104,7 +104,7 @@ namespace PacketGuard
     {
         // Count packets in queue
         std::map<std::string, uint32> packetCounterMap;
-        for (auto& entry : PChar->getPacketListCopy())
+        for (auto& entry : PChar->getPacketList())
         {
             auto packetStr = fmt::format("0x{:4X}", entry->getType());
             packetCounterMap[packetStr]++;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Couple edge case fixes if a pending packet ends up being null. Mainly though this makes it so we use the PacketList directly when preparing packets to send instead of making a copy and using that. We currently make a copy of the packet list, process those copies, then delete the real packets. This apparently causes some sync issues (#6829) that should be fixed now.

I'm not sure why exactly this issue seems to be consistent, so this may require some further review, but this seems to fix it.

## Steps to test these changes

Log in with 2 characters, go to the same zone, both characters can see each other.
