### PR TITLE
Base implementation of barrage turbine

### DIFF
--- a/scripts/actions/abilities/pets/attachments/barrage_turbine.lua
+++ b/scripts/actions/abilities/pets/attachments/barrage_turbine.lua
@@ -1,0 +1,31 @@
+-----------------------------------
+-- Attachment: Barrage Turbine
+-----------------------------------
+---@type TAttachment
+local attachmentObject = {}
+
+attachmentObject.onEquip = function(pet)
+    pet:addListener('AUTOMATON_ATTACHMENT_CHECK', 'ATTACHMENT_BARRAGE_TURBINE', function(automaton, target)
+        local master = automaton:getMaster()
+
+        if
+            not automaton:hasRecast(xi.recast.ABILITY, xi.automaton.abilities.BARRAGE_TURBINE) and
+            master and
+            master:countEffect(xi.effect.WIND_MANEUVER) > 0
+        then
+            automaton:useMobAbility(xi.automaton.abilities.BARRAGE_TURBINE, target)
+        end
+    end)
+end
+
+attachmentObject.onUnequip = function(pet)
+    pet:removeListener('ATTACHMENT_BARRAGE_TURBINE')
+end
+
+attachmentObject.onManeuverGain = function(pet, maneuvers)
+end
+
+attachmentObject.onManeuverLose = function(pet, maneuvers)
+end
+
+return attachmentObject

--- a/scripts/actions/abilities/pets/automaton/barrage_turbine.lua
+++ b/scripts/actions/abilities/pets/automaton/barrage_turbine.lua
@@ -1,0 +1,49 @@
+-----------------------------------
+-- Barrage Turbine
+-- https://www.bg-wiki.com/ffxi/Barrage_Turbine
+-- https://wiki.ffo.jp/html/23698.html
+-----------------------------------
+---@type TAbilityAutomaton
+local abilityObject = {}
+
+abilityObject.onAutomatonAbilityCheck = function(target, automaton, skill)
+    return 0
+end
+
+abilityObject.onAutomatonAbility = function(target, automaton, skill, master, action)
+    automaton:addRecast(xi.recast.ABILITY, skill:getID(), 60 * 3)
+
+    -- Apply overload.
+    -- TODO: This is a placeholder that adds zero overload for now.
+    --       For reference, the full maneuver handling is xi.automaton.onUseManeuver.
+    -- local overload = automaton:addBurden(xi.element.WIND - 1, 0)
+
+    local windManeuvers = master:countEffect(xi.effect.WIND_MANEUVER)
+    windManeuvers = utils.clamp(windManeuvers, 0, 3)
+
+    -- Shots per wind maneuver.
+    local shotCount =
+    {
+        [1] = 4,
+        [2] = 6,
+        [3] = 9,
+    }
+
+    -- Barrage set up and execution.
+    local params =
+    {
+        numHits   = shotCount[windManeuvers],
+        isBarrage = true,
+        atkmulti  = 1.5,
+        ftpMod    = { 1.0, 1.0, 1.0 },
+        str_wsc   = 0.5,
+        dex_wsc   = 0.25,
+    }
+
+    -- TODO: Remove/adjust the 8 hit weaponskill cap; tweak damage and TP return.
+    local damage = xi.autows.doAutoRangedWeaponskill(automaton, target, 0, params, 1000, true, skill, action)
+
+    return damage
+end
+
+return abilityObject

--- a/scripts/globals/automaton.lua
+++ b/scripts/globals/automaton.lua
@@ -29,6 +29,7 @@ xi.automaton.abilities =
     STRING_SHREDDER = 2743,
     ARMOR_SHATTERER = 2744,
     HEAT_CAPACITOR  = 2745,
+    BARRAGE_TURBINE = 2746,
     DISRUPTOR       = 2747,
 }
 

--- a/scripts/globals/pets/automaton.lua
+++ b/scripts/globals/pets/automaton.lua
@@ -13,6 +13,9 @@ xi.pets.automaton.onMobSpawn = function(mob)
             automaton:setLocalVar('MANEUVER_DURATION', math.min(dur + 3, 300))
         end
     end)
+
+    -- Barrage Turbine cannot be used unless the automaton has been active for at least 3 minutes.
+    mob:addRecast(xi.recast.ABILITY, xi.automaton.abilities.BARRAGE_TURBINE, 60 * 3)
 end
 
 xi.pets.automaton.onMobDeath = function(mob)

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -637,6 +637,8 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
         -- Needs better verification
         if calcParams.extraOffhandHit and hitsDone == 1 then
             calcParams.tpHitsLanded = calcParams.tpHitsLanded + calcParams.hitsLanded
+        elseif wsParams.isBarrage then
+            calcParams.tpHitsLanded = calcParams.tpHitsLanded + calcParams.hitsLanded
         else -- Otherwise, add a hit to the "extra" hits which is 10 tp each
             calcParams.mainHitsLanded = calcParams.mainHitsLanded + calcParams.hitsLanded
         end

--- a/sql/automaton_abilities.sql
+++ b/sql/automaton_abilities.sql
@@ -54,6 +54,7 @@ INSERT INTO `automaton_abilities` VALUES (2301,'magic_mortar',23,225);
 INSERT INTO `automaton_abilities` VALUES (2743,'string_shredder',21,324);
 INSERT INTO `automaton_abilities` VALUES (2744,'armor_shatterer',22,324);
 INSERT INTO `automaton_abilities` VALUES (2745,'heat_capacitor',0,0);
+INSERT INTO `automaton_abilities` VALUES (2746,'barrage_turbine',22,0);
 INSERT INTO `automaton_abilities` VALUES (2747,'disruptor',0,0);
 
 /*!40000 ALTER TABLE `automaton_abilities` ENABLE KEYS */;

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -2758,7 +2758,7 @@ INSERT INTO `mob_skills` VALUES (2740,1890,'silent_storm',0,0.0,7.0,2000,1500,4,
 INSERT INTO `mob_skills` VALUES (2743,1509,'string_shredder',0,0.0,7.0,2000,1,4,0,324,0,10,4,0);
 INSERT INTO `mob_skills` VALUES (2744,1510,'armor_shatterer',0,0.0,7.0,2000,1,4,0,324,0,11,8,0);
 INSERT INTO `mob_skills` VALUES (2745,433,'heat_capacitor',0,0.0,7.0,2000,0,16,4,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (2746,434,'barrage_turbine',0,0.0,7.0,2000,0,16,4,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (2746,16,'barrage_turbine',0,0.0,25.0,2000,0,4,4,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2747,439,'disruptor',0,0.0,7.0,2000,0,4,4,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (2748,1922,'mantid_melee_double',0,0.0,7.0,2000,0,4,4,0,0,0,0,0); -- kaggan melee specials
 -- INSERT INTO `mob_skills` VALUES (2749,1923,'mantid_melee_slice',0,0.0,7.0,2000,0,4,4,0,0,0,0,0);  -- kaggan melee specials


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Closes #4822

## Background
### Automaton Attachments
1. Upon equipping an ability attachment (like Flashbulb which is implemented), the attachment is subscribed to the `AUTOMATON_ATTACHMENT_CHECK` event listener with a function to execute when the event occurs.
2. `/src/map/ai/controllers/automaton_controller.cpp` -> `DoCombatTick` has a `TryAction` block that calls `TryAttachment`.
3. `TryAttachment` calls any listeners currently subscribed to `AUTOMATON_ATTACHMENT_CHECK`.
4. The subscribed function gets executed and checks various things like ability recast, number of active maneuvers, etc.
5. If all of the checks pass then the ability is used via `useMobAbility` from `/src/map/lua/lua_baseentity.cpp`.
6. The `onAutomatonAbility` function in `/scripts/actions/abilities/pets/automaton` catches this and actually performs the ability.

### Automaton Ranged Attack
1. Automaton ranged attacks are treated as weaponskills.
2. The setup function `xi.autows.doAutoRangedWeaponskill` is used to carry out the ranged attack. It sets up some necessary variables and then calls in to standard weaponskill functions `xi.weaponskills.calculateRawWSDmg` and `xi.weaponskills.takeWeaponskillDamage`.
3. Standard weaponskills can have multiple hits with (I believe) a cap of `8` hits. And this is how the code is setup up within `xi.weaponskills.calculateRawWSDmg`.
4. The TP from a PUP ranged attack is applied in `/src/map/utils/battleutils.cpp` `TakeWeaponskillDamage()`.

## General Implementation
### List Adjustments
 `automaton_abilities.sql` 
* Added barrage turbine to with `reqframe = 22` and `skilllevel = 0`.
`mob_skills.sql` for barrage turbine (2746)
* Changed `mob_skill_distance` to `25.0` (previously 7.0) to match the regular ranged attack
* Changed `mob_valid_targets` to `4` (previously 16). Without the latter change barrage turbine will only be able to do damage to the automaton instead of the enemy.
* Changed mob_anim_id to 16 (previously 434). There isn't a noticeably special animation for barrage turbine. It has the same animation as the regular automaton ranged attack.
4. Added `BARRAGE_TURBINE` to the `xi.automaton.abilities` list in `/scripts/globals/automaton.lua`. The ID is 2746.

Do NOT add to `mob_skill_lists.sql` because Barrage Turbine is not a TP move in the traditional sense and we don't want it mixed in with the automaton's weaponskill lineup.

![Image](https://github.com/user-attachments/assets/23d248de-80de-4be2-94a0-d06ffbd30d09)
_Barrage Turbine Capture_

### `onEquip` Listener
1. I chose to not include a distance check to mirror the regular automaton ranged attack.
2. There needs to be a time in zone check before using `useMobAbility`.

### `onAutomatonAbility`
1. I confirmed that the delay is `180 seconds` (3 minutes) between barrage turbine activation.
2. Add overload. The amount of overload to add isn't well understood so I'm just leaving a placeholder adding zero to `xi.element.WIND` for now. The burden handling may require a bit more (future) thought as all of the actions in the standard xi.automaton.onUseManeuver handling may not be appropriate for the burden added by barrage turbine. For example, barrage turbine does not come with an overload chance message and I've never seen barrage turbine cause an overload (can it?).
3. Get the number of active wind maneuvers since the number of shots scale with the number of maneuvers.
4. Execute the barrage. I leveraged the existing automaton ranged attack handling to do this. See Barrage Implementation for more information on that.

## Barrage Implementation
As automaton ranged attacks are considered weaponskills, and a barrage is a series of ranged attacks, it would be prudent to take advantage of the existing automaton ranged attack code, `xi.autows.doAutoRangedWeaponskill`, to perform the barrage. This works generally, but there is the matter of damage and TP gain.

I needed to create a new element, `isBarrage`, within the parameter table passed into `xi.autows.doAutoRangedWeaponskill`. I used that new element within the remaining hits `while` loop of `xi.weaponskills.calculateRawWSDmg` to increase the amount of `tpHitsLanded`. I needed to use `tpHitsLanded` because it's used in `TakeWeaponskillDamage()` which calculates the return TP. The other option was `extraHitsLanded`, but those hits only get multipied by `10` instead of the `baseTp`,

### Problem # 1
The max number of shots in the barrage is 9. The multi-hit weaponskill cap is 8. So, as-is I cannot generate a 9 shot hit. If I remove the cap in the remaining hits `while` loop within `xi.weaponskills.calculateRawWSDmg` I am able to get the correct amount of hits, but I didn't want to perform too much surgery.

### Problem # 2
Retail testing shows that the TP gained from Barrage Turbine is nice multiples of the base ranged attack TP proportional to the number of active maneuvers. My implementation is close, but not quite perfect. They are just a bit shy of the expected value. The existing TP calculations, perhaps in `battleutils.cpp`, may need to be adjusted to better handle the TP return of weaponskill based barrage. Or maybe a net new handler needs to implemented somewhere.

## Testing
The same sample size was 5 tests for each set (5 ranged, 5 with one maneuver, etc.). Not an extensive sample size, but it does take three minutes between each barrage on retail. The data spread seemed like 5 tests should be good enough.

### TP Return
This Implementation
| Action    | Hits     | TP     | ~Ranged Attacks |
|--------------|--------------|--------------|--------------|
| Ranged | 1 | 93 | ~ |
| 1 Maneuver | 4 | 342 | 3.67 |
| 2 Maneuvers | 6 | 508 | 5.46 |
| 3 Maneuvers | 8 | 716 | 7.69 |

\* Note that 3 maneuvers is 8 because of the weaponskill multi-hit cap instead of the expected 9.

Retail
| Action    | Hits     | TP     | ~Ranged Attacks |
|--------------|--------------|--------------|--------------|
| Ranged | 1 | 105 |  ~ |
| 1 Maneuver | 4 | 420 | 4 |
| 2 Maneuvers | 6 | 630 | 6 |
| 3 Maneuvers | 9 | 945 | 9 |

### Damage
In this implementation the individual barrage hits _outperform_ the the regular ranged hits a bit.
| Action    | Hits    | Average Damage   | ~Ranged Attacks |
|--------------|--------------|--------------|--------------|
| Ranged | 1 | 266 | ~ |
| 1 Maneuver | 4 | 1191 | 4.48 |
| 2 Maneuvers | 6 | 1708 | 6.42 |
| 3 Maneuvers | 8 | 2197 | 8.26 |

\* Note that 3 maneuvers is 8 because of the weaponskill multi-hit cap instead of the expected 9.

In Retail the individual barrage hits _underperform_ regular ranged hits a bit.
| Action    | Hits    | Average Damage   | ~Ranged Attacks |
|--------------|--------------|--------------|--------------|
| Ranged | 1 | 617.4 | ~ |
| 1 Maneuver | 4 | 2259 | 3.66 |
| 2 Maneuvers | 6 | 3555 | 5.76 |
| 3 Maneuvers | 9 | 5492 | 8.89 |

### Barrage Turbine Delay
I did some testing on how long it takes before the initial barrage turbine can be used. After several different scenarios I can say this about the delay:
1. Consistently takes 3 minutes between barrage turbines.
2. Can be used immediately upon engaging a mob as long as a wind maneuver is active.
3. Letting maneuvers completely fall off does not reset any counters.
4. **The automaton needs to be active for at least 3 minutes before use.**

Battle Scenario Testing
| Time Stamp | Event    |
|--------------|--------------|
| 12:21:56 | Barrage Turbine on mob # 1 |
| 12:23:56 | Mob # 1 defeated |
| 12:24:09 | Engage mob # 2 with melee damage |
| 12:24:21 | Deploy automaton |
| 12:24:55 | Redeploy automaton because it was engaged but not doing anything. It shoots the mob |
| 12:28:01 | Barrage Turbine on mob # 2 |
| ~ | Let maneuvers wear off |
| 12:35:47 | Add wind maneuver |
| 12:35:49 | Barrage Turbine on mob # 2 |
| 12:37:06 | Retrieve (automaton stops engaging mob # 2) |
| 12:38:15 | Deploy |
| 12:37:06 | Deploy again (automaton starts engaging mob # 2) |
| 12:41:53 | Barrage Turbine on mob # 2 |
| 12:44:54 | Barrage Turbine on mob # 2 |
| 12:47:54 | Barrage Turbine on mob # 2 |
| 12:48:27 | Mob # 2 defeated |
| 12:53:05 | Engaged mob # 3 |
| 12:53:14 | Deploy |
| 12:53:14 | Barrage Turbine on mob # 3 (instant) |
| 12:56:17 | Barrage Turbine on mob # 3 |
| 12:56:44 | Zone out and back in |
| ~ | Wait >3 minutes |
| 01:02:19 | Add wind maneuver |
| 01:03:01 | Engaged mob # 4 |
| 01:03:09 | Deploy (automaton engages) |
| 01:03:09 | Barrage Turbine on mob # 4 |
| 01:06:18 | Zone out and back in |
| 01:07:24 | Engaged mob # 5 |
| 01:07:39 | Add wind maneuver |
| 01:07:49 | Deploy (automaton engages) |
| 01:08:55 | Add wind maneuver |
| 01:09:23 | Barrage Turbine on mob # 5) |

Initial Delay Testing (Zone vs. Activation)
| Time Stamp | Event    |
|--------------|--------------|
| 11:00:25 | Zone in |
| 11:01:44 | Activate automaton |
| 11:02:10 | Deploy (automaton engages) |
| 11:02:15 | Wind maneuver |
| 11:02:50 | Wind maneuver |
| 11:03:44 | Wind maneuver |
| 11:04:46 | Barrage Turbine |

\* Barrage turbine occurs 3 minutes after activation.

## TODOs
1. Flesh out the burden application.
2. Tune the damage and TP return to be more in line with retail.
3. Expand the remaining hits `while` loop of `xi.weaponskills.calculateRawWSDmg` (or some other strategy) to allow for 9 hits. Right now it's capped at 8.