### PR TITLE
[lua, quest] add module for era quest reward for Northward

### DIFF
--- a/modules/era/lua/northward.lua
+++ b/modules/era/lua/northward.lua
@@ -1,0 +1,22 @@
+-----------------------------------
+-- Module to remove exp and gil from 'Northward' quest reward.
+-- Gil and exp were added to the quest reward in 2017 so they are removed here. https://ffxiclopedia.fandom.com/wiki/Northward
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_northward')
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/jeuno/Northward', function(quest)
+        quest.reward = {
+            fame     = 30,
+            fameArea = xi.fameArea.JEUNO,
+            keyItem  = xi.ki.MAP_OF_CASTLE_ZVAHL,
+            title    = xi.title.ENVOY_TO_THE_NORTH,
+        }
+    end)
+end)
+
+return m


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

In 2017 gil and exp were added to the quest reward for Northward (https://ffxiclopedia.fandom.com/wiki/Northward). This PR just adds a module that removes int he gil and exp from the reward

## Steps to test these changes

Open modules/init.txt and add this line:` /era/lua/`
