### PR TITLE
[Lua] WSNM Quest Fix

### DIFF
--- a/scripts/quests/bastok/Inheritance.lua
+++ b/scripts/quests/bastok/Inheritance.lua
@@ -132,7 +132,9 @@ quest.sections =
             ['Maharaja'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/bastok/Shoot_First_Ask_Questions_Later.lua
+++ b/scripts/quests/bastok/Shoot_First_Ask_Questions_Later.lua
@@ -136,7 +136,9 @@ quest.sections =
             ['Beet_Leafhopper'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/bastok/The_Walls_of_Your_Mind.lua
+++ b/scripts/quests/bastok/The_Walls_of_Your_Mind.lua
@@ -133,7 +133,9 @@ quest.sections =
             ['Bodach'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/bastok/The_Weight_of_Your_Limits.lua
+++ b/scripts/quests/bastok/The_Weight_of_Your_Limits.lua
@@ -133,7 +133,9 @@ quest.sections =
             ['Greenman'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/jeuno/Axe_the_Competition.lua
+++ b/scripts/quests/jeuno/Axe_the_Competition.lua
@@ -132,7 +132,9 @@ quest.sections =
             ['Yallery_Brown'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/outlands/Bugi_Soden.lua
+++ b/scripts/quests/outlands/Bugi_Soden.lua
@@ -132,7 +132,9 @@ quest.sections =
             ['Megapod_Megalops'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/outlands/Cloak_and_Dagger.lua
+++ b/scripts/quests/outlands/Cloak_and_Dagger.lua
@@ -135,7 +135,9 @@ quest.sections =
             ['Baronial_Bat'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/outlands/The_Potential_Within.lua
+++ b/scripts/quests/outlands/The_Potential_Within.lua
@@ -132,7 +132,9 @@ quest.sections =
             ['Kettenkaefer'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/sandoria/Methods_Create_Madness.lua
+++ b/scripts/quests/sandoria/Methods_Create_Madness.lua
@@ -139,7 +139,9 @@ quest.sections =
             ['Water_Leaper'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/sandoria/Old_Wounds.lua
+++ b/scripts/quests/sandoria/Old_Wounds.lua
@@ -135,7 +135,9 @@ quest.sections =
             ['Girtablulu'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/sandoria/Souls_in_Shadow.lua
+++ b/scripts/quests/sandoria/Souls_in_Shadow.lua
@@ -135,7 +135,9 @@ quest.sections =
             ['Mokumokuren'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/windurst/Blood_and_Glory.lua
+++ b/scripts/quests/windurst/Blood_and_Glory.lua
@@ -135,7 +135,9 @@ quest.sections =
             ['Cailleach_Bheur'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/windurst/From_Saplings_Grow.lua
+++ b/scripts/quests/windurst/From_Saplings_Grow.lua
@@ -134,7 +134,9 @@ quest.sections =
             ['Stolas'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/windurst/Orastery_Woes.lua
+++ b/scripts/quests/windurst/Orastery_Woes.lua
@@ -134,7 +134,9 @@ quest.sections =
             ['Eldhrimnir'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- x ] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes a possible exploit in the quest logic that could allow players to bypass "breaking" their weapons if someone else were to spawn the NM. Added logic to ensure the player has the key item required


## Steps to test these changes
Pop NM according to the quest as a player ready to fight NM.
Be present on a second character with the quest just freshly started.
Kill NM
Witness second character can complete quest.

<!-- Clear and detailed steps to test your changes here -->
