### PR TITLE
[Lua] Castle Zvahl Teleporters

### DIFF
--- a/scripts/zones/Castle_Zvahl_Keep/IDs.lua
+++ b/scripts/zones/Castle_Zvahl_Keep/IDs.lua
@@ -34,6 +34,14 @@ zones[xi.zone.CASTLE_ZVAHL_KEEP] =
     {
         TREASURE_CHEST = GetFirstID('Treasure_Chest'),
         CRAGGY_PILLAR  = GetTableOfIDs('Craggy_Pillar'),
+        TELE_CENTER    = GetFirstID('_4iy'),
+        TELE_NW        = GetFirstID('_4iu'),
+        TELE_SW        = GetFirstID('_4iv'),
+        TELE_NE        = GetFirstID('_4iw'),
+        TELE_SE        = GetFirstID('_4ix'),
+        TELE_N         = GetFirstID('_4is'),
+        TELE_S         = GetFirstID('_4ir'),
+        TELE_HIDDEN    = GetFirstID('_4it'),
     },
 }
 

--- a/scripts/zones/Castle_Zvahl_Keep/Zone.lua
+++ b/scripts/zones/Castle_Zvahl_Keep/Zone.lua
@@ -1,21 +1,53 @@
 -----------------------------------
 -- Zone: Castle_Zvahl_Keep (162)
 -----------------------------------
+local ID = zones[xi.zone.CASTLE_ZVAHL_KEEP]
+-----------------------------------
 ---@type TZone
 local zoneObject = {}
 
+local teleportTable =
+{
+    [1] = { npc = ID.npc.TELE_CENTER, event = 0, }, -- Teleports player to far NE corner
+    [2] = { npc = ID.npc.TELE_NE,     event = 2, }, -- Teleports player to far SE corner
+    [3] = { npc = ID.npc.TELE_SE,     event = 3, }, -- Teleports player to far SW corner (from middle-SE porter)
+    [4] = { npc = ID.npc.TELE_NW,     event = 1, }, -- Teleports player to far SW corner (from middle-NW porter)
+    [5] = { npc = ID.npc.TELE_SW,     event = 4, }, -- Teleports player to the top of the stairs on map 4
+    [6] = { npc = ID.npc.TELE_N,      event = 6, }, -- Teleports player to position to one of several random positions
+    [7] = { npc = ID.npc.TELE_S,      event = 7, }, -- Teleports player to position to one of several random positions
+    [8] = { npc = ID.npc.TELE_HIDDEN, event = 5, }, -- Teleports player to H-7 on map 4 platform near the ore door (south or north part randomly)
+}
+
 zoneObject.onInitialize = function(zone)
-    -- TODO: Change these trigger areas to radials except 8, which already is.
-    zone:registerTriggerArea(1, -301, -50, -22, -297, -49, -17)    -- central porter on map 3
-    zone:registerTriggerArea(2, -275, -54,   3, -271, -53,   7)    -- NE porter on map 3
-    zone:registerTriggerArea(3, -275, -54, -47, -271, -53, -42)    -- SE porter on map 3
-    zone:registerTriggerArea(4, -330, -54,   3, -326, -53,   7)    -- NW porter on map 3
-    zone:registerTriggerArea(5, -328, -54, -47, -324, -53, -42)    -- SW porter on map 3
-    zone:registerTriggerArea(6, -528, -74,  84, -526, -73,  89)    -- N porter on map 4
-    zone:registerTriggerArea(7, -528, -74,  30, -526, -73,  36)    -- S porter on map 4
-    zone:registerTriggerArea(8, -459.9908, 2.5, 60.1056,  0, 0, 0) -- Hidden room porter on map 4
+    zone:registerTriggerArea(1, -300, 3, -20, 0, 0, 0) -- central porter on map 3
+    zone:registerTriggerArea(2, -273, 3,   5, 0, 0, 0) -- NE porter on map 3
+    zone:registerTriggerArea(3, -273, 3, -45, 0, 0, 0) -- SE porter on map 3
+    zone:registerTriggerArea(4, -327, 3,   5, 0, 0, 0) -- NW porter on map 3
+    zone:registerTriggerArea(5, -327, 3, -45, 0, 0, 0) -- SW porter on map 3
+    zone:registerTriggerArea(6, -527, 3,  87, 0, 0, 0) -- N porter on map 4
+    zone:registerTriggerArea(7, -527, 3,  33, 0, 0, 0) -- S porter on map 4
+    zone:registerTriggerArea(8, -460, 3,  60, 0, 0, 0) -- Hidden room porter on map 4
 
     xi.treasure.initZone(zone)
+end
+
+zoneObject.onZoneTick = function(zone)
+    -- Cycle opening Teleporters every 20-60 seconds on individual timers
+    for _, table in pairs(teleportTable) do
+        local teleporter = GetNPCByID(table.npc)
+
+        if teleporter and teleporter:getLocalVar('timer') < os.time() then
+            -- If a player is already on the pad, teleport them
+            for _, player in pairs(zone:getPlayers()) do
+                if player:getLocalVar(string.format('Zvhal_teleporter_%s', table.npc)) == 1 then
+                    player:startCutscene(table.event)
+                end
+            end
+
+            teleporter:openDoor(8)
+            teleporter:setLocalVar('timer', math.random(15, 60) + os.time())
+        end
+    end
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
@@ -36,28 +68,21 @@ zoneObject.onZoneIn = function(player, prevZone)
     return cs
 end
 
-local teleportEventsByArea =
-{
-    [1] = 0, -- Teleports player to far NE corner
-    [2] = 2, -- Teleports player to far SE corner
-    [3] = 1, -- Teleports player to far SW corner (from middle-SE porter)
-    [4] = 3, -- Teleports player to far SW corner (from middle-NW porter)
-    [5] = 4, -- Teleports player to the top of the stairs on map 4
-    [6] = 6, -- Teleports player to position to one of several random positions
-    [7] = 7, -- Teleports player to position to one of several random positions
-    [8] = 5, -- Teleports player to H-7 on map 4 platform near the ore door (south or north part randomly)
-}
-
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)
-    local areaId = triggerArea:GetTriggerAreaID()
+    local table      = teleportTable[triggerArea:GetTriggerAreaID()]
+    local teleporter = GetNPCByID(table.npc)
 
-    -- TODO: these should only work when matching floor spot is animated (beastmen/BCNM symbol)
-    if teleportEventsByArea[areaId] then
-        player:startCutscene(teleportEventsByArea[areaId])
+    player:setLocalVar(string.format('Zvhal_teleporter_%s', table.npc), 1)
+
+    if teleporter and teleporter:getAnimation() == xi.animation.OPEN_DOOR then
+        player:startCutscene(table.event)
     end
 end
 
 zoneObject.onTriggerAreaLeave = function(player, triggerArea)
+    local table = teleportTable[triggerArea:GetTriggerAreaID()]
+
+    player:setLocalVar(string.format('Zvhal_teleporter_%s', table.npc), 0)
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Adds retail accurate functionality to the telepads in Castle Zvahl Keep
- Achieved by running each telepad on an individual timer between 20-50 seconds as witnessed in linked capture. A table was created that ties each npc ID with the appropriate event ID and trigger area. Whenever that portal is opened on its cooldown, the appropriate trigger area checks if said portal is open to allow the player to travel through.
- Implemented an auto-teleport feature that is also evident in retail: The player is automatically teleported if already standing on the telepad. This is achieved by setting a variable on the player. When a portal is triggered it searches for players with the appropriate variable set. If such a player is discovered, the appropriate event is called to teleport them automatically. This variable is unset when player leaves trigger zone.

Captures: https://1drv.ms/f/s!AtUZibtOtozEhoBMroc6yCCkVgliXg?e=bhhaKF
## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Walk into a portal if it appears open, and be teleported to the appropriate location
Walk into a portal if it appears closed
Stand in closed portal and wait for it to open and be teleported without having to re-enter the platform