### PR TITLE
[lua] Move pdif calculations out of weaponskills.lua

### DIFF
--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -396,28 +396,30 @@ xi.combat.physical.calculateMeleePDIF = function(actor, target, weaponType, wsAt
     -- Step 1: Attack / Defense Ratio
     ----------------------------------------
     local baseRatio     = 0
-    local actorAttack   = math.max(1, math.floor(actor:getStat(xi.mod.ATT, weaponSlot) * wsAttackMod))
+    local actorAttack   = 0
     local targetDefense = math.max(1, target:getStat(xi.mod.DEF))
+    local flourishBonus = 1.0
 
     -- Actor Weaponskill Specific Attack modifiers.
     if isWeaponskill then
-        if actor:hasStatusEffect(xi.effect.BUILDING_FLOURISH) then
-            local flourishEffect = actor:getStatusEffect(xi.effect.BUILDING_FLOURISH)
+        local flourishEffect = actor:getStatusEffect(xi.effect.BUILDING_FLOURISH)
 
-            if flourishEffect and flourishEffect:getPower() >= 2 then -- 2 or more Finishing Moves used.
-                actorAttack = math.floor(actorAttack * (125 + flourishEffect:getSubPower()) / 100)
-            end
+        if flourishEffect and flourishEffect:getPower() >= 2 then -- 2 or more Finishing Moves used.
+            local meritCount = flourishEffect:getSubPower()
+
+            flourishBonus = 1.25 + 0.01 * meritCount -- +1% attack bonus per merit -- TODO: do the merits apply even when FMs are < 2?
         end
     end
 
+    -- TODO: it is unknown if ws attack mod and flourish bonus are additive or multiplicative
+    actorAttack = math.max(1, math.floor(actor:getStat(xi.mod.ATT, weaponSlot) * wsAttackMod * flourishBonus))
+
     -- Target Defense Modifiers.
-    local ignoreDefenseFactor = 1
-
     if tpIgnoresDefense then
-        ignoreDefenseFactor = 1 - tpFactor
-    end
+        local ignoreDefenseFactor = 1 - tpFactor
 
-    targetDefense = math.floor(targetDefense * ignoreDefenseFactor)
+        targetDefense = math.floor(targetDefense * ignoreDefenseFactor)
+    end
 
     -- Actor Attack / Target Defense ratio
     baseRatio = actorAttack / targetDefense
@@ -519,21 +521,24 @@ xi.combat.physical.calculateRangedPDIF = function(actor, target, weaponType, wsA
     -- Step 1: Attack / Defense Ratio
     ----------------------------------------
     local baseRatio     = 0
-    local actorAttack   = math.max(1, math.floor(actor:getStat(xi.mod.RATT) * wsAttackMod))
+    local actorAttack   = 0
     local targetDefense = math.max(1, target:getStat(xi.mod.DEF))
+    local flourishBonus = 1.0
 
-    -- Actor Weaponskill Specific Ranged Attack modifiers.
+    -- Actor Weaponskill Specific Attack modifiers.
+    -- TODO: verify this actually works on ranged WS
     if isWeaponskill then
-        -- TODO: verify this actually works on ranged WS.
-        -- This is a real concern now that RNG/DNC and COR/DNC can actually get level 50 subs through master levels.
-        if actor:hasStatusEffect(xi.effect.BUILDING_FLOURISH) then
-            local flourishEffect = actor:getStatusEffect(xi.effect.BUILDING_FLOURISH)
+        local flourishEffect = actor:getStatusEffect(xi.effect.BUILDING_FLOURISH)
 
-            if flourishEffect and flourishEffect:getPower() >= 2 then -- 2 or more Finishing Moves used.
-                actorAttack = math.floor(actorAttack * (125 + flourishEffect:getSubPower()) / 100)
-            end
+        if flourishEffect and flourishEffect:getPower() >= 2 then -- 2 or more Finishing Moves used.
+            local meritCount = flourishEffect:getSubPower()
+
+            flourishBonus = 1.25 + 0.01 * meritCount -- +1% attack bonus per merit -- TODO: do the merits apply even when FMs are < 2?
         end
     end
+
+    -- TODO: it is unknown if ws attack mod and flourish bonus are additive or multiplicative
+    actorAttack = math.max(1, math.floor(actor:getStat(xi.mod.RATT) * wsAttackMod * flourishBonus))
 
     -- Target Defense Modifiers.
     local ignoreDefenseFactor = 1

--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -379,6 +379,16 @@ end
 
 -- WARNING: This function is used in src/utils/battleutils.cpp "GetDamageRatio" function.
 -- If you update this parameters, update them there aswell.
+---@param actor CBaseEntity
+---@param target CBaseEntity
+---@param weaponType xi.skill
+---@param wsAttackMod number
+---@param isCritical boolean
+---@param applyLevelCorrection boolean
+---@param tpIgnoresDefense boolean
+---@param tpFactor number
+---@param isWeaponskill boolean
+---@param weaponSlot xi.slot
 xi.combat.physical.calculateMeleePDIF = function(actor, target, weaponType, wsAttackMod, isCritical, applyLevelCorrection, tpIgnoresDefense, tpFactor, isWeaponskill, weaponSlot)
     local pDif = 0
 
@@ -493,6 +503,15 @@ xi.combat.physical.calculateMeleePDIF = function(actor, target, weaponType, wsAt
     return pDif
 end
 
+---@param actor CBaseEntity
+---@param target CBaseEntity
+---@param weaponType xi.skill
+---@param wsAttackMod number
+---@param isCritical boolean
+---@param applyLevelCorrection boolean
+---@param tpIgnoresDefense boolean
+---@param tpFactor number
+---@param isWeaponskill boolean
 xi.combat.physical.calculateRangedPDIF = function(actor, target, weaponType, wsAttackMod, isCritical, applyLevelCorrection, tpIgnoresDefense, tpFactor, isWeaponskill)
     local pDif = 0
 

--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -394,7 +394,7 @@ xi.combat.physical.calculateMeleePDIF = function(actor, target, weaponType, wsAt
         if actor:hasStatusEffect(xi.effect.BUILDING_FLOURISH) then
             local flourishEffect = actor:getStatusEffect(xi.effect.BUILDING_FLOURISH)
 
-            if flourishEffect:getPower() >= 2 then -- 2 or more Finishing Moves used.
+            if flourishEffect and flourishEffect:getPower() >= 2 then -- 2 or more Finishing Moves used.
                 actorAttack = math.floor(actorAttack * (125 + flourishEffect:getSubPower()) / 100)
             end
         end
@@ -510,7 +510,7 @@ xi.combat.physical.calculateRangedPDIF = function(actor, target, weaponType, wsA
         if actor:hasStatusEffect(xi.effect.BUILDING_FLOURISH) then
             local flourishEffect = actor:getStatusEffect(xi.effect.BUILDING_FLOURISH)
 
-            if flourishEffect:getPower() >= 2 then -- 2 or more Finishing Moves used.
+            if flourishEffect and flourishEffect:getPower() >= 2 then -- 2 or more Finishing Moves used.
                 actorAttack = math.floor(actorAttack * (125 + flourishEffect:getSubPower()) / 100)
             end
         end

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -913,7 +913,7 @@ uint16 CBattleEntity::RATT(uint8 skill, uint16 bonusSkill)
     uint16 baseSkill = skill == SKILL_FISHING ? 0 : GetSkill(skill);
     int32  RATT      = 8 + baseSkill + bonusSkill + m_modStat[Mod::RATT] + battleutils::GetRangedAttackBonuses(this) + STR();
     // use max to prevent any underflow
-    return std::max(0, RATT + (RATT * m_modStat[Mod::RATTP] / 100) + std::min<int16>((RATT * m_modStat[Mod::FOOD_RATTP] / 100), m_modStat[Mod::FOOD_RATT_CAP]));
+    return std::max(1, RATT + (RATT * m_modStat[Mod::RATTP] / 100) + std::min<int16>((RATT * m_modStat[Mod::FOOD_RATTP] / 100), m_modStat[Mod::FOOD_RATT_CAP]));
 }
 
 uint16 CBattleEntity::RACC(uint8 skill, uint16 bonusSkill)

--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -573,25 +573,28 @@ void CTrustEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& act
 
             if (primary)
             {
-                if (PBattleTarget->health.hp > 0 && PWeaponSkill->getPrimarySkillchain() != 0)
+                if ((actionTarget.reaction & REACTION::MISS) == REACTION::NONE)
                 {
-                    // NOTE: GetSkillChainEffect is INSIDE this if statement because it
-                    //  ALTERS the state of the resonance, which misses and non-elemental skills should NOT do.
-                    SUBEFFECT effect = battleutils::GetSkillChainEffect(PBattleTarget, PWeaponSkill->getPrimarySkillchain(),
-                                                                        PWeaponSkill->getSecondarySkillchain(), PWeaponSkill->getTertiarySkillchain());
-                    if (effect != SUBEFFECT_NONE)
+                    if (PBattleTarget->health.hp > 0 && PWeaponSkill->getPrimarySkillchain() != 0)
                     {
-                        actionTarget.addEffectParam = battleutils::TakeSkillchainDamage(this, PBattleTarget, damage, taChar);
-                        if (actionTarget.addEffectParam < 0)
+                        // NOTE: GetSkillChainEffect is INSIDE this if statement because it
+                        //  ALTERS the state of the resonance, which misses and non-elemental skills should NOT do.
+                        SUBEFFECT effect = battleutils::GetSkillChainEffect(PBattleTarget, PWeaponSkill->getPrimarySkillchain(),
+                                                                            PWeaponSkill->getSecondarySkillchain(), PWeaponSkill->getTertiarySkillchain());
+                        if (effect != SUBEFFECT_NONE)
                         {
-                            actionTarget.addEffectParam   = -actionTarget.addEffectParam;
-                            actionTarget.addEffectMessage = 384 + effect;
+                            actionTarget.addEffectParam = battleutils::TakeSkillchainDamage(this, PBattleTarget, damage, taChar);
+                            if (actionTarget.addEffectParam < 0)
+                            {
+                                actionTarget.addEffectParam   = -actionTarget.addEffectParam;
+                                actionTarget.addEffectMessage = 384 + effect;
+                            }
+                            else
+                            {
+                                actionTarget.addEffectMessage = 287 + effect;
+                            }
+                            actionTarget.additionalEffect = effect;
                         }
-                        else
-                        {
-                            actionTarget.addEffectMessage = 287 + effect;
-                        }
-                        actionTarget.additionalEffect = effect;
                     }
                 }
             }

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -14202,6 +14202,29 @@ uint16 CLuaBaseEntity::getStat(uint16 statId, sol::variadic_args va)
             value               = PEntity->ATT(weaponSlot);
         }
         break;
+        case Mod::RATT:
+        {
+            SKILLTYPE skill = SKILL_NONE;
+
+            if (PEntity->objtype == TYPE_PET && static_cast<CPetEntity*>(PEntity)->getPetType() == PET_TYPE::AUTOMATON)
+            {
+                skill = SKILLTYPE::SKILL_AUTOMATON_RANGED;
+                value = PEntity->RATT(skill);
+            }
+            else
+            {
+                CItemWeapon* PWeapon = dynamic_cast<CItemWeapon*>(PEntity->m_Weapons[SLOTTYPE::SLOT_RANGED]);
+                if (PWeapon)
+                {
+                    value = PEntity->RATT(PWeapon->getSkillType());
+                }
+                else
+                {
+                    value = PEntity->RATT(SKILL_MARKSMANSHIP); // TODO: does this edge case exist? will mobs or trusts hit this?
+                }
+            }
+        }
+        break;
         case Mod::DEF:
             value = PEntity->DEF();
             break;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Move pdif calculations out of weaponskills.lua, to use the physical utilities ones that already exist
Trusts can't SC anymore if they miss

Misc fixes to make the pdif junk work

## Steps to test these changes

Apply this patch;
check ranged ws such as hot shot (hybrid), split shot (def ignore), detonator (attack bonus)
check physical ws such as blade: chi (hybrid), wheeling thrust (def ignore), howling fist (attack bonus)
finally, check viper bite on dancer with building flourish (2+ FMs)

viper bite with 2x FMs + 2 merits:
![image](https://github.com/user-attachments/assets/dd9fdf07-cecc-41b0-b677-7634d8a697e6)

Make sure your ratt matches the debug prints:
![image](https://github.com/user-attachments/assets/5ebd420b-08a7-4492-bb36-751b3909985a)

```diff
diff --git a/scripts/globals/combat/physical_utilities.lua b/scripts/globals/combat/physical_utilities.lua
index 897e02561c..c5a40f97d0 100644
--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -414,13 +414,28 @@ xi.combat.physical.calculateMeleePDIF = function(actor, target, weaponType, wsAt
     -- TODO: it is unknown if ws attack mod and flourish bonus are additive or multiplicative
     actorAttack = math.max(1, math.floor(actor:getStat(xi.mod.ATT, weaponSlot) * wsAttackMod * flourishBonus))
 
+    if isWeaponskill then
+        print("===")
+        print(string.format("tpIgnoresDefense: %s, tpFactor %f", tpIgnoresDefense and "true" or "false", tpFactor))
+        print(string.format("Base attack: %d, wsAttackMod: %f, flourishBonus: %f, post modifier attack: %f", actor:getStat(xi.mod.ATT, weaponSlot), wsAttackMod, flourishBonus, actorAttack))
+    end
+
     -- Target Defense Modifiers.
     if tpIgnoresDefense then
         local ignoreDefenseFactor = 1 - tpFactor
 
+        print(string.format("targetDef before: %d, ignoreDefenseFactor: %f", targetDefense, ignoreDefenseFactor))
+
         targetDefense = math.floor(targetDefense * ignoreDefenseFactor)
     end
 
+
+    if isWeaponskill then
+        print(string.format("targetDef after: %d", targetDefense))
+
+        print("===")
+    end
+
     -- Actor Attack / Target Defense ratio
     baseRatio = actorAttack / targetDefense
 
@@ -540,15 +555,30 @@ xi.combat.physical.calculateRangedPDIF = function(actor, target, weaponType, wsA
     -- TODO: it is unknown if ws attack mod and flourish bonus are additive or multiplicative
     actorAttack = math.max(1, math.floor(actor:getStat(xi.mod.RATT) * wsAttackMod * flourishBonus))
 
+    print(actorAttack)
+    if isWeaponskill then
+        print("===")
+        print(string.format("tpIgnoresDefense: %s, tpFactor %f", tpIgnoresDefense and "true" or "false", tpFactor))
+        print(string.format("Base attack: %d, wsAttackMod: %f, flourishBonus: %f, post modifier attack: %f", actor:getStat(xi.mod.RATT), wsAttackMod, flourishBonus, actorAttack))
+    end
+
     -- Target Defense Modifiers.
     local ignoreDefenseFactor = 1
 
     if tpIgnoresDefense then
         ignoreDefenseFactor = 1 - tpFactor
+
+         print(string.format("targetDef before: %d, ignoreDefenseFactor: %f", targetDefense, ignoreDefenseFactor))
     end
 
     targetDefense = math.floor(targetDefense * ignoreDefenseFactor)
 
+    if isWeaponskill then
+        print(string.format("targetDef after: %d", targetDefense))
+
+        print("===")
+    end
+
     baseRatio = actorAttack / targetDefense
 
     -- Apply cap to baseRatio.
```
