### PR TITLE
Chore: Tidy SQL usage in login, search, and world servers

### DIFF
--- a/sql/synergy_recipes.sql
+++ b/sql/synergy_recipes.sql
@@ -65,8 +65,8 @@ SET @RANK_GRANDMASTER = 14;
 SET @RANK_LEGEND      = 15;
 
 DELIMITER $$
-DROP TRIGGER IF EXISTS ensure_ingredients_are_ordered;
-CREATE TRIGGER ensure_ingredients_are_ordered
+DROP TRIGGER IF EXISTS ensure_synergy_ingredients_are_ordered;
+CREATE TRIGGER ensure_synergy_ingredients_are_ordered
      BEFORE INSERT ON synergy_recipes FOR EACH ROW BEGIN
           IF NEW.ingredient2 > 0 AND NEW.ingredient1 > NEW.ingredient2
           THEN

--- a/sql/synth_recipes.sql
+++ b/sql/synth_recipes.sql
@@ -52,8 +52,8 @@ CREATE TABLE `synth_recipes` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 DELIMITER $$
-DROP TRIGGER IF EXISTS ensure_ingredients_are_ordered;
-CREATE TRIGGER ensure_ingredients_are_ordered
+DROP TRIGGER IF EXISTS ensure_synth_ingredients_are_ordered;
+CREATE TRIGGER ensure_synth_ingredients_are_ordered
      BEFORE INSERT ON synth_recipes FOR EACH ROW BEGIN
           IF NEW.Ingredient2 > 0 AND NEW.Ingredient1 > NEW.Ingredient2
           THEN

--- a/src/common/logging.h
+++ b/src/common/logging.h
@@ -64,15 +64,31 @@ namespace logging
 
 // clang-format off
 
-// Helper to allow pointers to numeric types to be formatted
-// as strings.
-// TODO: All need for this should eventually be removed!
-// TODO: Any place we use this it is indicating some smelly and unsafe code.
-//     : When replacing, the surrounding code should be audited!
 template <typename T>
-std::string str(T v)
+std::string asStringFromUntrustedSource(const T* ptr)
 {
-    return std::string(reinterpret_cast<const char*>(v));
+    if (!ptr)
+    {
+        return "";
+    }
+
+    static constexpr size_t MAX_STRING_LENGTH = 1024;
+
+    const auto str = reinterpret_cast<const char*>(ptr);
+    return std::string(str, strnlen(str, MAX_STRING_LENGTH));
+}
+
+template <typename T>
+std::string asStringFromUntrustedSource(const T* ptr, size_t max_size)
+{
+    if (!ptr)
+    {
+        return "";
+    }
+
+    const auto str = reinterpret_cast<const char*>(ptr);
+    const auto len = strnlen(str, max_size);
+    return std::string(str, len);
 }
 
 // Helper for allowing `enum` and `enum class` types to be formatted

--- a/src/common/socket.cpp
+++ b/src/common/socket.cpp
@@ -321,7 +321,9 @@ std::string ip2str(uint32 ip)
     uint32 reversed_ip = htonl(ip);
     char   address[INET_ADDRSTRLEN];
     inet_ntop(AF_INET, &reversed_ip, address, INET_ADDRSTRLEN);
-    return fmt::format("{}", str(address));
+
+    // This is internal, so we can trust it.
+    return fmt::format("{}", asStringFromUntrustedSource(address));
 }
 
 uint32 str2ip(const char* ip_str)
@@ -332,12 +334,6 @@ uint32 str2ip(const char* ip_str)
     return ntohl(ip);
 }
 
-// Reorders bytes from network to little endian (Windows).
-// Neccessary for sending port numbers to the RO client until Gravity notices that they forgot ntohs() calls.
-uint16 ntows(uint16 netshort)
-{
-    return ((netshort & 0xFF) << 8) | ((netshort & 0xFF00) >> 8);
-}
 /*****************************************************************************/
 /*
  *

--- a/src/common/socket.h
+++ b/src/common/socket.h
@@ -155,9 +155,9 @@ int sSocket(int af, int type, int protocol);
 
 #endif
 
-#define TOB(n) ((uint8)((n)&std::numeric_limits<uint8>::max()))
-#define TOW(n) ((uint16)((n)&std::numeric_limits<uint16>::max()))
-#define TOL(n) ((uint32)((n)&std::numeric_limits<uint32>::max()))
+#define TOB(n) ((uint8)((n) & std::numeric_limits<uint8>::max()))
+#define TOW(n) ((uint16)((n) & std::numeric_limits<uint16>::max()))
+#define TOL(n) ((uint32)((n) & std::numeric_limits<uint32>::max()))
 
 enum class socket_type
 {
@@ -186,8 +186,6 @@ void socket_final();
 std::string ip2str(uint32 ip);
 
 uint32 str2ip(const char* ip_str);
-
-uint16 ntows(uint16 netshort);
 
 /************************************************/
 /*

--- a/src/common/sql.cpp
+++ b/src/common/sql.cpp
@@ -275,26 +275,48 @@ int32 SqlConnection::TryPing()
 size_t SqlConnection::EscapeStringLen(char* out_to, const char* from, size_t from_len)
 {
     TracyZoneScoped;
+
     if (self)
     {
-        return mysql_real_escape_string(&self->handle, out_to, from, (uint32)from_len);
+        return mysql_real_escape_string(&self->handle, out_to, from, static_cast<uint32>(from_len));
     }
-    return mysql_escape_string(out_to, from, (uint32)from_len);
+
+    return mysql_escape_string(out_to, from, static_cast<uint32>(from_len));
+}
+
+size_t SqlConnection::EscapeStringLen(char* out_to, std::string_view from)
+{
+    TracyZoneScoped;
+
+    return EscapeStringLen(out_to, from.data(), from.size());
 }
 
 size_t SqlConnection::EscapeString(char* out_to, const char* from)
 {
     TracyZoneScoped;
+
     return EscapeStringLen(out_to, from, strlen(from));
 }
 
-std::string SqlConnection::EscapeString(std::string const& input)
+std::string SqlConnection::EscapeString(std::string_view from)
 {
     TracyZoneScoped;
-    std::string escaped_full_string;
-    escaped_full_string.reserve(input.size() * 2 + 1);
-    EscapeString(escaped_full_string.data(), input.data());
-    return escaped_full_string;
+
+    if (from.empty())
+    {
+        return {};
+    }
+
+    auto buffer = std::vector<char>(from.size() * 2 + 1);
+    auto len    = EscapeStringLen(buffer.data(), from);
+    return std::string(buffer.data(), len);
+}
+
+std::string SqlConnection::EscapeString(const std::string& from)
+{
+    TracyZoneScoped;
+
+    return EscapeString(std::string_view(from));
 }
 
 int32 SqlConnection::QueryStr(const char* query)

--- a/src/common/sql.h
+++ b/src/common/sql.h
@@ -133,16 +133,11 @@ public:
     int32 TryPing();
 
     /// Escapes a string.
-    /// The output buffer must be at least strlen(from)*2+1 in size.
-    ///
-    /// @return The size of the escaped string
-    size_t EscapeString(char* out_to, const char* from);
-    size_t EscapeStringLen(char* out_to, const char* from, size_t from_len);
-
-    /// Escapes a string.
-    ///
-    /// @return The escaped string
-    std::string EscapeString(std::string const& input);
+    auto EscapeStringLen(char* out_to, const char* from, size_t from_len) -> size_t;
+    auto EscapeStringLen(char* out_to, std::string_view from) -> size_t;
+    auto EscapeString(char* out_to, const char* from) -> size_t;
+    auto EscapeString(std::string_view from) -> std::string;
+    auto EscapeString(const std::string& from) -> std::string;
 
     /// Executes a query.
     /// Any previous result is freed.
@@ -265,4 +260,9 @@ private:
 
     std::thread::id m_ThreadId;
 };
+
+//
+// Outside of SQL class/namespace
+//
+
 #endif // _COMMON_SQL_H

--- a/src/common/xi.h
+++ b/src/common/xi.h
@@ -37,7 +37,6 @@
 
 namespace xi
 {
-
     // A wrapper around std::optional to allow usage of object.apply([](auto& obj) { ... });
     // https://en.cppreference.com/w/cpp/utility/optional
     template <typename T>
@@ -45,10 +44,22 @@ namespace xi
     {
     public:
         constexpr optional() = default;
-        constexpr explicit optional(std::nullopt_t) noexcept
+
+        constexpr optional(std::nullopt_t) noexcept
         : m_value(std::nullopt)
         {
         }
+
+        constexpr optional(T&& value)
+        : m_value(std::forward<T>(value))
+        {
+        }
+
+        constexpr optional(const T& value)
+        : m_value(value)
+        {
+        }
+
         constexpr optional(const optional& other)                = default;
         constexpr optional(optional&& other) noexcept            = default;
         constexpr optional& operator=(const optional& other)     = default;
@@ -68,21 +79,23 @@ namespace xi
         }
 
         template <typename F>
-        constexpr void apply(F&& f) &
+        constexpr bool apply(F&& f) &
         {
             if (m_value)
             {
                 f(*m_value);
             }
+            return m_value.has_value();
         }
 
         template <typename F>
-        constexpr void apply(F&& f) const&
+        constexpr bool apply(F&& f) const&
         {
             if (m_value)
             {
                 f(*m_value);
             }
+            return m_value.has_value();
         }
 
         constexpr explicit operator bool() const noexcept
@@ -132,7 +145,7 @@ namespace xi
         }
 
     private:
-        std::optional<T> m_value;
+        std::optional<T> m_value = std::nullopt;
     };
 
     // TODO: A wrapper around std::variant to allow usage of:

--- a/src/login/auth_session.cpp
+++ b/src/login/auth_session.cpp
@@ -156,7 +156,7 @@ void auth_session::read_func()
             // clang-format off
             auto passHash = [&]() -> std::string
             {
-                const auto rset = db::query("SELECT accounts.password FROM accounts WHERE accounts.login = '%s'", username);
+                const auto rset = db::preparedStmt("SELECT accounts.password FROM accounts WHERE accounts.login = ?", username);
                 if (rset && rset->rowsCount() != 0 && rset->next())
                 {
                     return rset->get<std::string>("password");
@@ -180,7 +180,7 @@ void auth_session::read_func()
                 // It's not a BCrypt hash, so we need to use Maria's PASSWORD() to check if the password is actually correct,
                 // and then update the password to a BCrypt hash.
                 const auto passColumn = fmt::sprintf("PASSWORD('%s')", password);
-                const auto rset       = db::query("SELECT %s", passColumn);
+                const auto rset       = db::preparedStmt("SELECT ?", passColumn);
                 if (rset && rset->rowsCount() != 0 && rset->next())
                 {
                     if (rset->get<std::string>(passColumn) != passHash)
@@ -192,7 +192,7 @@ void auth_session::read_func()
                     else
                     {
                         passHash = BCrypt::generateHash(password);
-                        db::query("UPDATE accounts SET accounts.password = '%s' WHERE accounts.login = '%s'", passHash.c_str(), username);
+                        db::preparedStmt("UPDATE accounts SET accounts.password = ? WHERE accounts.login = ?", passHash, username);
                         if (!BCrypt::validatePassword(password, passHash))
                         {
                             ref<uint8>(data_, 0) = LOGIN_ERROR;
@@ -204,7 +204,7 @@ void auth_session::read_func()
             }
 
             // We've validated the password by this point, get account info
-            const auto rset = db::query("SELECT accounts.id, accounts.status FROM accounts WHERE accounts.login = '%s'", username);
+            const auto rset = db::preparedStmt("SELECT accounts.id, accounts.status FROM accounts WHERE accounts.login = ?", username);
             if (rset && rset->rowsCount() != 0 && rset->next())
             {
                 uint32 accountID = rset->get<uint32>("id");
@@ -212,13 +212,13 @@ void auth_session::read_func()
 
                 if (status & ACCOUNT_STATUS_CODE::NORMAL)
                 {
-                    db::query("UPDATE accounts SET accounts.timelastmodify = NULL WHERE accounts.id = %d", accountID);
+                    db::preparedStmt("UPDATE accounts SET accounts.timelastmodify = NULL WHERE accounts.id = ?", accountID);
 
-                    const auto rset = db::query("SELECT charid, server_addr, server_port \
-                                        FROM accounts_sessions JOIN accounts \
-                                        ON accounts_sessions.accid = accounts.id \
-                                        WHERE accounts.id = %d",
-                                                accountID);
+                    const auto rset = db::preparedStmt("SELECT charid, server_addr, server_port "
+                                                       "FROM accounts_sessions JOIN accounts "
+                                                       "ON accounts_sessions.accid = accounts.id "
+                                                       "WHERE accounts.id = ?",
+                                                       accountID);
 
                     if (rset && rset->rowsCount() == 1)
                     {
@@ -248,11 +248,10 @@ void auth_session::read_func()
                     // Not a real problem because the account is locked out when a character is logged in.
 
                     /*
-                    fmtQuery = "SELECT charid \
-                            FROM accounts_sessions \
-                            WHERE accid = %u LIMIT 1";
 
-                    const auto rset = db::query(fmtQuery, accountID);
+                    const auto rset = db::preparedStmt("SELECT charid \
+                            FROM accounts_sessions \
+                            WHERE accid = ? LIMIT 1";, accountID);
                     if (rset && rset->rowsCount() != 0 && rset->next())
                     {
                         // TODO: kick player out of map server if already logged in
@@ -315,7 +314,7 @@ void auth_session::read_func()
             }
 
             // looking for same login
-            const auto rset = db::query("SELECT accounts.id FROM accounts WHERE accounts.login = '%s'", username);
+            const auto rset = db::preparedStmt("SELECT accounts.id FROM accounts WHERE accounts.login = ?", username);
             if (!rset)
             {
                 ref<uint8>(data_, 0) = LOGIN_ERROR_CREATE;
@@ -352,9 +351,9 @@ void auth_session::read_func()
                 char strtimecreate[128];
                 strftime(strtimecreate, sizeof(strtimecreate), "%Y:%m:%d %H:%M:%S", &timecreateinfo);
 
-                const auto rset2 = db::query("INSERT INTO accounts(id,login,password,timecreate,timelastmodify,status,priv) \
-                                VALUES(%d,'%s','%s','%s',NULL,%d,%d)",
-                                             accid, username, BCrypt::generateHash(password), strtimecreate, ACCOUNT_STATUS_CODE::NORMAL, ACCOUNT_PRIVILEGE_CODE::USER);
+                const auto rset2 = db::preparedStmt("INSERT INTO accounts(id,login,password,timecreate,timelastmodify,status,priv) "
+                                                    "VALUES(?, ?, ?, ?, NULL, ?, ?)",
+                                                    accid, username, BCrypt::generateHash(password), strtimecreate, static_cast<uint8>(ACCOUNT_STATUS_CODE::NORMAL), static_cast<uint8>(ACCOUNT_PRIVILEGE_CODE::USER));
                 if (!rset2)
                 {
                     ref<uint8>(data_, 0) = LOGIN_ERROR_CREATE;
@@ -380,7 +379,7 @@ void auth_session::read_func()
             // clang-format off
             auto passHash = [&]() -> std::string
             {
-                const auto rset = db::query("SELECT accounts.password FROM accounts WHERE accounts.login = '%s'", username);
+                const auto rset = db::preparedStmt("SELECT accounts.password FROM accounts WHERE accounts.login = ?", username);
                 if (rset && rset->rowsCount() != 0 && rset->next())
                 {
                     return rset->get<std::string>("password");
@@ -403,7 +402,7 @@ void auth_session::read_func()
             {
                 // It's not a BCrypt hash, so we need to use Maria's PASSWORD() to check if the password is actually correct,
                 // and then update the password to a BCrypt hash.
-                const auto rset = db::query("SELECT PASSWORD('%s')", password);
+                const auto rset = db::preparedStmt("SELECT PASSWORD(?)", password);
                 if (rset && rset->rowsCount() != 0 && rset->next())
                 {
                     if (rset->get<std::string>(0) != passHash)
@@ -415,7 +414,7 @@ void auth_session::read_func()
                     else
                     {
                         passHash = BCrypt::generateHash(password);
-                        db::query("UPDATE accounts SET accounts.password = '%s' WHERE accounts.login = '%s'", passHash.c_str(), username);
+                        db::preparedStmt("UPDATE accounts SET accounts.password = ? WHERE accounts.login = ?", passHash.c_str(), username);
                         if (!BCrypt::validatePassword(password, passHash))
                         {
                             ref<uint8>(data_, 0) = LOGIN_ERROR_CHANGE_PASSWORD;
@@ -426,10 +425,10 @@ void auth_session::read_func()
                 }
             }
 
-            const auto rset = db::query("SELECT accounts.id, accounts.status \
-                                    FROM accounts \
-                                    WHERE accounts.login = '%s'",
-                                        username);
+            const auto rset = db::preparedStmt("SELECT accounts.id, accounts.status "
+                                               "FROM accounts "
+                                               "WHERE accounts.login = ?",
+                                               username);
             if (rset == nullptr || rset->rowsCount() == 0)
             {
                 ShowWarningFmt("login_parse: user <{}> could not be found using the provided information. Aborting.", username);
@@ -457,7 +456,7 @@ void auth_session::read_func()
 
                 if (updated_password == "")
                 {
-                    ShowWarningFmt("login_parse: Empty password; Could not update password for user <{}>.", username);
+                    ShowWarningFmt("login_parse: Empty password: Could not update password for user <{}>.", username);
                     ref<uint8>(data_, 0) = LOGIN_ERROR_CHANGE_PASSWORD;
                     do_write(1);
                     return;
@@ -465,10 +464,10 @@ void auth_session::read_func()
 
                 updated_password = db::escapeString(updated_password);
 
-                db::query("UPDATE accounts SET accounts.timelastmodify = NULL WHERE accounts.id = %d", accid);
+                db::preparedStmt("UPDATE accounts SET accounts.timelastmodify = NULL WHERE accounts.id = ?", accid);
 
-                const auto rset2 = db::query("UPDATE accounts SET accounts.password = '%s' WHERE accounts.id = %d",
-                                             BCrypt::generateHash(updated_password), accid);
+                const auto rset2 = db::preparedStmt("UPDATE accounts SET accounts.password = ? WHERE accounts.id = ?",
+                                                    BCrypt::generateHash(updated_password), accid);
                 if (!rset2)
                 {
                     ShowWarningFmt("login_parse: Error trying to update password in database for user <{}>.", username);

--- a/src/login/auth_session.cpp
+++ b/src/login/auth_session.cpp
@@ -480,14 +480,14 @@ void auth_session::read_func()
                 ref<uint8>(data_, 0) = LOGIN_SUCCESS_CHANGE_PASSWORD;
                 do_write(33);
 
-                ShowInfo("login_parse: password updated for account {} successfully.", accid);
+                ShowInfoFmt("login_parse: password updated for account {} successfully.", accid);
                 return;
             }
         }
         break;
         default:
         {
-            ShowError("Unhandled auth code: {} from {}", code, ipAddress);
+            ShowErrorFmt("Unhandled auth code: {} from {}", code, ipAddress);
         }
         break;
     }

--- a/src/login/cert_helpers.h
+++ b/src/login/cert_helpers.h
@@ -54,7 +54,9 @@ namespace certificateHelpers
 
                     X509_NAME_oneline(X509_get_subject_name(cert), cn, size);
                     X509_NAME_oneline(X509_get_issuer_name(cert), cn, size);
-                    ShowInfo(fmt::format("Found existing login.cert: {}", str(cn)));
+
+                    // This is internal, so we can trust it.
+                    ShowInfo(fmt::format("Found existing login.cert: {}", asStringFromUntrustedSource(cn)));
 
                     // if current time not within the bounds of valid date, note it's expired
                     if (X509_cmp_time(X509_get_notAfter(cert), nullptr) != 1 || X509_cmp_time(X509_get_notBefore(cert), nullptr) != -1)

--- a/src/login/data_session.cpp
+++ b/src/login/data_session.cpp
@@ -59,8 +59,9 @@ void data_session::read_func()
             {
                 session.serverIP = ref<uint32>(data_, 5);
 
-                uint32     numContentIds = 0;
-                const auto rset0         = db::query("SELECT content_ids FROM accounts WHERE id = %u", session.accountID);
+                uint32 numContentIds = 0;
+
+                const auto rset0 = db::preparedStmt("SELECT content_ids FROM accounts WHERE id = ?", session.accountID);
                 if (rset0 && rset0->rowsCount() && rset0->next())
                 {
                     numContentIds = rset0->get<uint32>("content_ids");
@@ -74,20 +75,20 @@ void data_session::read_func()
                     return;
                 }
 
-                const char* pfmtQuery =
-                    "SELECT charid, charname, pos_zone, pos_prevzone, mjob,\
-                        race, face, head, body, hands, legs, feet, main, sub,\
-                        war, mnk, whm, blm, rdm, thf, pld, drk, bst, brd, rng,\
-                        sam, nin, drg, smn, blu, cor, pup, dnc, sch, geo, run, \
-                        gmlevel, nation, size, sjob \
-                    FROM chars \
-                        INNER JOIN char_stats USING(charid) \
-                        INNER JOIN char_look  USING(charid) \
-                        INNER JOIN char_jobs  USING(charid) \
-                        WHERE accid = %i \
-                    LIMIT %u";
+                const auto rset1 = db::preparedStmt("SELECT charid, charname, pos_zone, pos_prevzone, mjob,"
+                                                    "race, face, head, body, hands, legs, feet, main, sub,"
+                                                    "war, mnk, whm, blm, rdm, thf, pld, drk, bst, brd, rng,"
+                                                    "sam, nin, drg, smn, blu, cor, pup, dnc, sch, geo, run, "
+                                                    "gmlevel, nation, size, sjob "
+                                                    "FROM chars "
+                                                    "INNER JOIN char_stats USING(charid) "
+                                                    "INNER JOIN char_look  USING(charid) "
+                                                    "INNER JOIN char_jobs  USING(charid) "
+                                                    "WHERE accid = ? "
+                                                    "LIMIT ?",
+                                                    session.accountID,
+                                                    numContentIds);
 
-                const auto rset1 = db::query(pfmtQuery, session.accountID, numContentIds);
                 if (!rset1)
                 {
                     socket_.lowest_layer().close();
@@ -265,10 +266,10 @@ void data_session::read_func()
             uint16 PrevZone = 0;
             uint16 gmlevel  = 0;
 
-            const auto rset = db::query("SELECT zoneip, zoneport, zoneid, pos_prevzone, gmlevel, accid, charname \
-                                             FROM zone_settings, chars \
-                                             WHERE IF(pos_zone = 0, zoneid = pos_prevzone, zoneid = pos_zone) AND charid = %u AND accid = %u",
-                                        charid, session.accountID);
+            const auto rset = db::preparedStmt("SELECT zoneip, zoneport, zoneid, pos_prevzone, gmlevel, accid, charname "
+                                               "FROM zone_settings, chars "
+                                               "WHERE IF(pos_zone = 0, zoneid = pos_prevzone, zoneid = pos_zone) AND charid = ? AND accid = ?",
+                                               charid, session.accountID);
             if (rset && rset->rowsCount() && rset->next())
             {
                 ZoneID   = rset->get<uint16>("zoneid");
@@ -304,30 +305,31 @@ void data_session::read_func()
                 // Check the number of sessions
                 uint16 sessionCount = 0;
 
-                const auto rset0 = db::query("SELECT COUNT(client_addr) \
-                                FROM accounts_sessions \
-                                WHERE client_addr = %u",
-                                             accountIP);
+                const auto rset0 = db::preparedStmt("SELECT COUNT(client_addr) "
+                                                    "FROM accounts_sessions "
+                                                    "WHERE client_addr = ?",
+                                                    accountIP);
                 if (rset0 && rset0->rowsCount() != 0 && rset0->next())
                 {
                     sessionCount = rset0->get<uint16>("COUNT(client_addr)");
                 }
 
-                bool       hasActiveSession = false;
-                const auto rset1            = db::query("SELECT * \
-                                FROM accounts_sessions \
-                                WHERE accid = %u AND client_port != '0'",
-                                                        session.accountID);
+                bool hasActiveSession = false;
+
+                const auto rset1 = db::preparedStmt("SELECT * "
+                                                    "FROM accounts_sessions "
+                                                    "WHERE accid = ? AND client_port != '0'",
+                                                    session.accountID);
                 if (rset1 && rset1->rowsCount() != 0 && rset1->next())
                 {
                     hasActiveSession = true;
                 }
 
                 // If client was zoning out but was never seen at the destination, wait 30 seconds before allowing login again
-                const auto rset2 = db::query("SELECT * \
-                                FROM accounts_sessions \
-                                WHERE accid = %u AND client_port = '0' AND last_zoneout_time >= SUBTIME(NOW(), \"00:00:30\")",
-                                             session.accountID);
+                const auto rset2 = db::preparedStmt("SELECT * "
+                                                    "FROM accounts_sessions "
+                                                    "WHERE accid = ? AND client_port = '0' AND last_zoneout_time >= SUBTIME(NOW(), \"00:00:30\")",
+                                                    session.accountID);
                 if (rset2 && rset2->rowsCount() != 0 && rset2->next())
                 {
                     hasActiveSession = true;
@@ -335,10 +337,10 @@ void data_session::read_func()
 
                 uint64 exceptionTime = 0;
 
-                const auto rset3 = db::query("SELECT UNIX_TIMESTAMP(exception) \
-                                FROM ip_exceptions \
-                                WHERE accid = %u",
-                                             session.accountID);
+                const auto rset3 = db::preparedStmt("SELECT UNIX_TIMESTAMP(exception) "
+                                                    "FROM ip_exceptions "
+                                                    "WHERE accid = ?",
+                                                    session.accountID);
                 if (rset3 && rset3->rowsCount() != 0 && rset3->next())
                 {
                     exceptionTime = rset3->get<uint64>("UNIX_TIMESTAMP(exception)");
@@ -374,20 +376,21 @@ void data_session::read_func()
                 {
                     if (PrevZone == 0)
                     {
-                        db::query("UPDATE chars SET pos_prevzone = %d WHERE charid = %u", ZoneID, charid);
+                        db::preparedStmt("UPDATE chars SET pos_prevzone = ? WHERE charid = ?", ZoneID, charid);
                     }
                     auto searchPort                       = settings::get<uint16>("network.SEARCH_PORT");
                     characterSelectionResponse.cache_ip   = session.serverIP; // search-server ip
                     characterSelectionResponse.cache_port = searchPort;
 
                     // If the session was not processed by the game server, then it must be deleted.
-                    db::query("DELETE FROM accounts_sessions WHERE accid = %u AND client_port = 0", session.accountID);
+                    db::preparedStmt("DELETE FROM accounts_sessions WHERE accid = ? AND client_port = 0", session.accountID);
 
                     char session_key[sizeof(key3) * 2 + 1];
                     bin2hex(session_key, key3, sizeof(key3));
 
-                    if (!db::query("INSERT INTO accounts_sessions(accid,charid,session_key,server_addr,server_port,client_addr, version_mismatch) "
-                                   "VALUES(%u,%u,x'%s',%u,%u,%u,%u)",
+                    // TODO: Figure out how to encode session_key as a hex string using db::preparedStmt. Encode as a blob?
+                    if (!db::query("INSERT INTO accounts_sessions(accid, charid, session_key, server_addr, server_port, client_addr, version_mismatch) "
+                                   "VALUES(%u, %u, x'%s', %u, %u, %u, %u)",
                                    session.accountID, charid, session_key, ZoneIP, ZonePort, accountIP,
                                    session.versionMismatch ? 1 : 0))
                     {
@@ -400,8 +403,8 @@ void data_session::read_func()
                         }
                     }
 
-                    db::query("UPDATE char_flags SET disconnecting = 0 WHERE charid = %u", charid);
-                    db::query("UPDATE char_stats SET zoning = 2 WHERE charid = %u", charid);
+                    db::preparedStmt("UPDATE char_flags SET disconnecting = 0 WHERE charid = ?", charid);
+                    db::preparedStmt("UPDATE char_stats SET zoning = 2 WHERE charid = ?", charid);
                 }
                 else
                 {
@@ -452,9 +455,9 @@ void data_session::read_func()
                 char timeAndDate[128];
                 strftime(timeAndDate, sizeof(timeAndDate), "%Y:%m:%d %H:%M:%S", &convertedTime);
 
-                if (!db::query("INSERT INTO account_ip_record(login_time,accid,charid,client_ip) \
-                            VALUES ('%s', %u, %u, '%s')",
-                               timeAndDate, session.accountID, charid, loginHelpers::ip2str(accountIP)))
+                if (!db::preparedStmt("INSERT INTO account_ip_record(login_time,accid,charid,client_ip) "
+                                      "VALUES (?, ?, ?, ?)",
+                                      timeAndDate, session.accountID, charid, loginHelpers::ip2str(accountIP)))
                 {
                     ShowError("data_session: Could not write info to account_ip_record.");
                 }

--- a/src/login/login_helpers.cpp
+++ b/src/login/login_helpers.cpp
@@ -52,7 +52,9 @@ namespace loginHelpers
         uint32 reversed_ip = htonl(ip);
         char   address[INET_ADDRSTRLEN];
         inet_ntop(AF_INET, &reversed_ip, address, INET_ADDRSTRLEN);
-        return fmt::format("{}", str(address));
+
+        // This is internal, so we can trust it.
+        return fmt::format("{}", asStringFromUntrustedSource(address));
     }
 
     uint32 str2ip(const char* ip_str)
@@ -142,82 +144,75 @@ namespace loginHelpers
 
     int32 saveCharacter(uint32 accid, uint32 charid, char_mini* createchar)
     {
-        if (!db::query("INSERT INTO chars(charid,accid,charname,pos_zone,nation) VALUES(%u,%u,'%s',%u,%u)",
-                       charid, accid, str(createchar->m_name), createchar->m_zone, createchar->m_nation))
+        const auto charName = asStringFromUntrustedSource(createchar->m_name);
+
+        if (!db::preparedStmt("INSERT INTO chars(charid,accid,charname,pos_zone,nation) VALUES(?, ?, ?, ?, ?)", charid, accid, charName, createchar->m_zone, createchar->m_nation))
         {
-            ShowDebug(fmt::format("lobby_ccsave: char<{}>, accid: {}, charid: {}", str(createchar->m_name), accid, charid));
+            ShowDebug(fmt::format("lobby_ccsave: char<{}>, accid: {}, charid: {}", charName, accid, charid));
             return -1;
         }
 
-        if (!db::query("INSERT INTO char_look(charid,face,race,size) VALUES(%u,%u,%u,%u)",
-                       charid, createchar->m_look.face, createchar->m_look.race, createchar->m_look.size))
+        if (!db::preparedStmt("INSERT INTO char_look(charid,face,race,size) VALUES(?, ?, ?, ?)", charid, createchar->m_look.face, createchar->m_look.race, createchar->m_look.size))
         {
-            ShowDebug(fmt::format("lobby_cLook: char<{}>, charid: {}", str(createchar->m_name), charid));
+            ShowDebug(fmt::format("lobby_cLook: char<{}>, charid: {}", charName, charid));
             return -1;
         }
 
-        if (!db::query("INSERT INTO char_stats(charid,mjob) VALUES(%u,%u)",
-                       charid, createchar->m_mjob))
+        if (!db::preparedStmt("INSERT INTO char_stats(charid,mjob) VALUES(?, ?)", charid, createchar->m_mjob))
         {
             ShowDebug(fmt::format("lobby_cStats: charid: {}", charid));
             return -1;
         }
 
-        if (!db::query("INSERT INTO char_exp(charid) VALUES(%u) ON DUPLICATE KEY UPDATE charid = charid",
-                       charid, createchar->m_mjob))
+        if (!db::preparedStmt("INSERT INTO char_exp(charid) VALUES(?) ON DUPLICATE KEY UPDATE charid = charid", charid))
         {
             return -1;
         }
 
-        if (!db::query("INSERT INTO char_flags(charid) VALUES(%u) ON DUPLICATE KEY UPDATE disconnecting = disconnecting", charid))
+        if (!db::preparedStmt("INSERT INTO char_flags(charid) VALUES(?) ON DUPLICATE KEY UPDATE disconnecting = disconnecting", charid))
         {
             return -1;
         }
 
-        if (!db::query("INSERT INTO char_jobs(charid) VALUES(%u) ON DUPLICATE KEY UPDATE charid = charid",
-                       charid, createchar->m_mjob))
+        if (!db::preparedStmt("INSERT INTO char_jobs(charid) VALUES(?) ON DUPLICATE KEY UPDATE charid = charid", charid))
         {
             return -1;
         }
 
-        if (!db::query("INSERT INTO char_points(charid) VALUES(%u) ON DUPLICATE KEY UPDATE charid = charid",
-                       charid, createchar->m_mjob))
+        if (!db::preparedStmt("INSERT INTO char_points(charid) VALUES(?) ON DUPLICATE KEY UPDATE charid = charid", charid))
         {
             return -1;
         }
 
-        if (!db::query("INSERT INTO char_unlocks(charid) VALUES(%u) ON DUPLICATE KEY UPDATE charid = charid",
-                       charid, createchar->m_mjob))
+        if (!db::preparedStmt("INSERT INTO char_unlocks(charid) VALUES(?) ON DUPLICATE KEY UPDATE charid = charid", charid))
         {
             return -1;
         }
 
-        if (!db::query("INSERT INTO char_profile(charid) VALUES(%u) ON DUPLICATE KEY UPDATE charid = charid",
-                       charid, createchar->m_mjob))
+        if (!db::preparedStmt("INSERT INTO char_profile(charid) VALUES(?) ON DUPLICATE KEY UPDATE charid = charid", charid))
         {
             return -1;
         }
 
-        if (!db::query("INSERT INTO char_storage(charid) VALUES(%u) ON DUPLICATE KEY UPDATE charid = charid",
-                       charid, createchar->m_mjob))
+        if (!db::preparedStmt("INSERT INTO char_storage(charid) VALUES(?) ON DUPLICATE KEY UPDATE charid = charid", charid))
         {
             return -1;
         }
 
-        if (!db::query("DELETE FROM char_inventory WHERE charid = %u", charid))
+        if (!db::preparedStmt("DELETE FROM char_inventory WHERE charid = ?", charid))
         {
             return -1;
         }
 
-        if (!db::query("INSERT INTO char_inventory(charid) VALUES(%u)", charid, createchar->m_mjob))
+        if (!db::preparedStmt("INSERT INTO char_inventory(charid) VALUES(?)", charid))
         {
             return -1;
         }
 
         if (settings::get<bool>("main.NEW_CHARACTER_CUTSCENE"))
         {
-            if (!db::query("INSERT INTO char_vars(charid, varname, value) VALUES(%u, '%s', %u)",
-                           charid, "HQuest[newCharacterCS]notSeen", 1))
+            if (!db::preparedStmt("INSERT INTO char_vars(charid, varname, value) VALUES(?, ?, ?)",
+                                  charid, "HQuest[newCharacterCS]notSeen", 1))
             {
                 return -1;
             }
@@ -231,6 +226,8 @@ namespace loginHelpers
 
         std::memcpy(createchar.m_name, session.requestedNewCharacterName.c_str(), 16);
 
+        const auto charName = db::escapeString(asStringFromUntrustedSource(createchar.m_name));
+
         createchar.m_look.race = ref<uint8>(buf, 48);
         createchar.m_look.size = ref<uint8>(buf, 57);
         createchar.m_look.face = ref<uint8>(buf, 60);
@@ -243,7 +240,7 @@ namespace loginHelpers
         if (mjob != createchar.m_mjob)
         {
             ShowInfo(fmt::format("{} attempted to create invalid starting job {} substituting {}",
-                                 session.requestedNewCharacterName, mjob, createchar.m_mjob));
+                                 charName, mjob, createchar.m_mjob));
         }
 
         createchar.m_nation = ref<uint8>(buf, 54);
@@ -289,31 +286,8 @@ namespace loginHelpers
             return -1;
         }
 
-        ShowDebug(fmt::format("char<{}> successfully saved", str(createchar.m_name)));
+        ShowDebug(fmt::format("char<{}> successfully saved", charName));
         return 0;
-    }
-
-    void PrintPacket(const char* data, uint32 size)
-    {
-        std::string message;
-
-        for (size_t y = 0; y < size; y++)
-        {
-            message.append(fmt::sprintf("%02hhx ", data[y]));
-
-            if (((y + 1) % 16) == 0)
-            {
-                message += "\n";
-                ShowDebug(message);
-                message.clear();
-            }
-        }
-
-        if (message.length() > 0)
-        {
-            message += "\n";
-            ShowDebug(message.c_str());
-        }
     }
 
     std::string getHashFromPacket(std::string const& ip_str, char* data)

--- a/src/map/ai/helpers/gambits_container.cpp
+++ b/src/map/ai/helpers/gambits_container.cpp
@@ -23,7 +23,7 @@ namespace gambits
     // Return a new unique identifier for a gambit
     auto CGambitsContainer::NewGambitIdentifier(Gambit_t const& gambit) const -> std::string
     {
-        return std::format("{}_{}_{}", gambits.size(), gambit.predicate_groups.size(), gambit.actions.size());
+        return fmt::format("{}_{}_{}", gambits.size(), gambit.predicate_groups.size(), gambit.actions.size());
     }
 
     // Validate gambit before it's inserted into the gambit list

--- a/src/map/command_handler.cpp
+++ b/src/map/command_handler.cpp
@@ -277,7 +277,7 @@ int32 CCommandHandler::call(sol::state& lua, CCharEntity* PChar, const std::stri
                 break;
 
             default:
-                ShowError("cmdhandler::call: (%s) undefined type for param; symbol: %s", cmdname.c_str(), *parameter);
+                ShowError("cmdhandler::call: (%s) undefined type for param: symbol: %s", cmdname.c_str(), *parameter);
                 break;
         }
 

--- a/src/map/fishingcontest.cpp
+++ b/src/map/fishingcontest.cpp
@@ -201,8 +201,8 @@ namespace fishingcontest
                 // Set the rank value
                 if (rankGroup > 0)
                 {
-                    const auto query = fmt::format("INSERT INTO char_fishing_contest_history (charid, contest_rank_{}) \
-                                        VALUES ({}, 1) ON DUPLICATE KEY UPDATE contest_rank_{} = contest_rank_{} + 1",
+                    const auto query = fmt::format("INSERT INTO char_fishing_contest_history (charid, contest_rank_{}) "
+                                                   "VALUES ({}, 1) ON DUPLICATE KEY UPDATE contest_rank_{} = contest_rank_{} + 1",
                                                    rankGroup, charID, rankGroup, rankGroup);
 
                     auto rset = db::query(query);
@@ -419,10 +419,10 @@ namespace fishingcontest
         }
 
         // Update the DB with the current contest entries
-        const auto query = fmt::format("REPLACE INTO `fishing_contest_entries` \
-                            (charid, mjob, sjob, mlevel, slevel, race, allegiance, fishRank, score, submitTime, contestRank, share) \
-                            SELECT charid, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {} \
-                            FROM chars WHERE charname = '{}'",
+        const auto query = fmt::format("REPLACE INTO `fishing_contest_entries` "
+                                       "(charid, mjob, sjob, mlevel, slevel, race, allegiance, fishRank, score, submitTime, contestRank, share) "
+                                       "SELECT charid, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {} "
+                                       "FROM chars WHERE charname = '{}'",
                                        entry->mjob,
                                        entry->sjob,
                                        entry->mlvl,

--- a/src/map/linkshell.cpp
+++ b/src/map/linkshell.cpp
@@ -460,16 +460,16 @@ namespace linkshell
 
     bool IsValidLinkshellName(const std::string& name)
     {
-        auto ret = _sql->Query("SELECT linkshellid FROM linkshells WHERE name = '%s' AND broken != 1", name);
-        return ret == SQL_ERROR || _sql->NumRows() == 0;
+        const auto rset = db::preparedStmt("SELECT linkshellid FROM linkshells WHERE name = ? AND broken != 1", name);
+        return !rset || rset->rowsCount() == 0;
     }
 
     uint32 RegisterNewLinkshell(const std::string& name, uint16 color)
     {
         if (IsValidLinkshellName(name))
         {
-            if (_sql->Query("INSERT INTO linkshells (name, color, postrights) VALUES ('%s', %u, %u)", name, color,
-                            static_cast<uint8>(LSTYPE_PEARLSACK)) != SQL_ERROR)
+            if (_sql->Query("INSERT INTO linkshells (name, color, postrights) VALUES ('%s', %u, %u)",
+                            name, color, static_cast<uint8>(LSTYPE_PEARLSACK)) != SQL_ERROR)
             {
                 return LoadLinkshell((uint32)_sql->LastInsertId())->getID();
             }

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -18703,7 +18703,7 @@ auto CLuaBaseEntity::getContestRewardStatus() -> sol::table
         std::string Query = "SELECT contestrank, share "
                             "FROM   fishing_contest_entries "
                             "WHERE  charid = (?) "
-                            "AND    claimed != 1; ";
+                            "AND    claimed != 1";
 
         auto ret = db::preparedStmt(Query, PChar->id);
         if (ret && ret->rowsCount() > 0 && ret->next())

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -5488,6 +5488,7 @@ namespace luautils
 
         if (_sql->SetAutoCommit(false) && _sql->TransactionStart())
         {
+            // NOTE: This will trigger SQL trigger: delivery_box_insert
             const char* Query = "INSERT INTO delivery_box (charid, box, itemid, quantity, senderid, sender) VALUES ("
                                 "%u, "     // Player ID
                                 "1, "      // Box ID == 1

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2186,8 +2186,8 @@ namespace luautils
     {
         TracyZoneScoped;
 
-        ShowTrace("luautils::OnEventUpdate: {} ({}), string: {}",
-                  PChar->getName(), PChar->loc.zone->getName(), updateString);
+        ShowTraceFmt("luautils::OnEventUpdate: {} ({}), string: {}",
+                     PChar->getName(), PChar->loc.zone->getName(), updateString);
 
         EventPrep* previousPrep = PChar->eventPreparation;
         PChar->eventPreparation = PChar->currentEvent;
@@ -4227,7 +4227,7 @@ namespace luautils
         auto name     = PMob->getName();
         auto filename = fmt::format("./scripts/zones/{}/mobs/{}.lua", zone, name);
 
-        ShowTrace("luautils::OnSteal: {} ({}) -> {}", PChar->getName(), zone, name);
+        ShowTraceFmt("luautils::OnSteal: {} ({}) -> {}", PChar->getName(), zone, name);
 
         auto onStealFramework = lua["InteractionGlobal"]["onSteal"];
         auto onSteal          = GetCacheEntryFromFilename(filename)["onSteal"];

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -155,18 +155,17 @@ map_session_data_t* mapsession_createsession(uint32 ip, uint16 port)
 {
     TracyZoneScoped;
 
-    auto ipstr    = ip2str(ip);
-    auto fmtQuery = fmt::format("SELECT charid FROM accounts_sessions WHERE inet_ntoa(client_addr) = '{}' LIMIT 1", ipstr);
+    const auto ipstr = ip2str(ip);
 
-    int32 ret = _sql->Query(fmtQuery.c_str());
+    const auto rset = db::preparedStmt("SELECT charid FROM accounts_sessions WHERE inet_ntoa(client_addr) = ? LIMIT 1", ipstr);
 
-    if (ret == SQL_ERROR)
+    if (rset == nullptr)
     {
         ShowError("SQL query failed in mapsession_createsession!");
         return nullptr;
     }
 
-    if (_sql->NumRows() == 0)
+    if (rset->rowsCount() == 0)
     {
         // This is noisy and not really necessary
         DebugSockets(fmt::format("recv_parse: Invalid login attempt from {}", ipstr));

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -241,10 +241,11 @@ int32 do_init(int32 argc, char** argv)
     ShowInfo("do_init: connecting to database");
     _sql = std::make_unique<SqlConnection>();
 
-    ShowInfo(_sql->GetDatabaseName().c_str());
-    ShowInfo(_sql->GetClientVersion().c_str());
-    ShowInfo(_sql->GetServerVersion().c_str());
-    _sql->CheckCharset();
+    ShowInfo(fmt::format("database name: {}", db::getDatabaseSchema()).c_str());
+    ShowInfo(fmt::format("database server version: {}", db::getDatabaseVersion()).c_str());
+    ShowInfo(fmt::format("database client version: {}", db::getDriverVersion()).c_str());
+    db::checkCharset();
+    db::checkTriggers();
 
     luautils::init(); // Also calls moduleutils::LoadLuaModules();
 
@@ -347,6 +348,8 @@ int32 do_init(int32 argc, char** argv)
     luautils::OnServerStart();
 
     moduleutils::ReportLuaModuleUsage();
+
+    db::enableTimers();
 
     ShowInfo("The map-server is ready to work!");
     ShowInfo("=======================================================================");

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -2625,7 +2625,7 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                     }
 
                     PUBoxItem->setReceiver(recieverName);
-                    PUBoxItem->setSender(PChar->getName().c_str());
+                    PUBoxItem->setSender(PChar->getName());
                     PUBoxItem->setQuantity(quantity);
                     PUBoxItem->setSlotID(PItem->getSlotID());
                     std::memcpy(PUBoxItem->m_extra, PItem->m_extra, sizeof(PUBoxItem->m_extra));

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -214,6 +214,12 @@ void PrintPacket(CBasicPacket& packet)
     }
 }
 
+auto escapeString(const std::string_view str) -> std::string
+{
+    // TODO: Replace with db::escapeString
+    return _sql->EscapeString(str);
+}
+
 /************************************************************************
  *                                                                       *
  *  Unknown Packet                                                       *
@@ -231,7 +237,7 @@ void SmallPacket0x000(map_session_data_t* const PSession, CCharEntity* const PCh
  *                                                                       *
  ************************************************************************/
 
-void SmallPacket0xFFF(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket& data)
+void SmallPacket0xFFF_NOT_IMPLEMENTED(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket& data)
 {
     ShowWarning("parse: SmallPacket is not implemented Type<%03hX>", (data.ref<uint16>(0) & 0x1FF));
 }
@@ -2181,36 +2187,28 @@ void SmallPacket0x03D(map_session_data_t* const PSession, CCharEntity* const PCh
 {
     TracyZoneScoped;
 
-    char blacklistedName[PacketNameLength] = {};
-    std::memcpy(&blacklistedName, data[0x08], PacketNameLength - 1);
+    const auto name = escapeString(asStringFromUntrustedSource(data[0x08], 15));
+    const auto cmd  = data.ref<uint8>(0x18);
 
-    std::string name = blacklistedName;
-    uint8       cmd  = data.ref<uint8>(0x18);
+    const auto sendFailPacket = [&]()
+    {
+        PChar->pushPacket<CBlacklistEditResponsePacket>(0, "", 0x02);
+    };
 
     // Attempt to locate the character by their name
-    const char* query = "SELECT charid, accid FROM chars WHERE charname = '%s' LIMIT 1";
-    int32       ret   = _sql->Query(query, name);
-    if (ret == SQL_ERROR || _sql->NumRows() != 1 || _sql->NextRow() != SQL_SUCCESS)
+    const auto rset = db::preparedStmt("SELECT charid, accid FROM chars WHERE charname = ? LIMIT 1", name);
+    if (!rset || rset->rowsCount() != 1 || !rset->next())
     {
-        // Send failed
-        PChar->pushPacket<CBlacklistEditResponsePacket>(0, "", 0x02);
+        sendFailPacket();
         return;
     }
 
-    // Retrieve the data from Sql
-    uint32 charid = _sql->GetUIntData(0);
-    uint32 accid  = _sql->GetUIntData(1);
+    uint32 charid = rset->get<uint32>("charid");
+    uint32 accid  = rset->get<uint32>("accid");
 
     // User is trying to add someone to their blacklist
     if (cmd == 0x00)
     {
-        if (blacklistutils::IsBlacklisted(PChar->id, charid))
-        {
-            // We cannot readd this person, fail to add
-            PChar->pushPacket<CBlacklistEditResponsePacket>(0, "", 0x02);
-            return;
-        }
-
         // Attempt to add this person
         if (blacklistutils::AddBlacklisted(PChar->id, charid))
         {
@@ -2218,20 +2216,11 @@ void SmallPacket0x03D(map_session_data_t* const PSession, CCharEntity* const PCh
         }
         else
         {
-            PChar->pushPacket<CBlacklistEditResponsePacket>(0, "", 0x02);
+            sendFailPacket();
         }
     }
-
-    // User is trying to remove someone from their blacklist
-    else if (cmd == 0x01)
+    else if (cmd == 0x01) // User is trying to remove someone from their blacklist
     {
-        if (!blacklistutils::IsBlacklisted(PChar->id, charid))
-        {
-            // We cannot remove this person, fail to remove
-            PChar->pushPacket<CBlacklistEditResponsePacket>(0, "", 0x02);
-            return;
-        }
-
         // Attempt to remove this person
         if (blacklistutils::DeleteBlacklisted(PChar->id, charid))
         {
@@ -2239,13 +2228,8 @@ void SmallPacket0x03D(map_session_data_t* const PSession, CCharEntity* const PCh
         }
         else
         {
-            PChar->pushPacket<CBlacklistEditResponsePacket>(0, "", 0x02);
+            sendFailPacket();
         }
-    }
-    else
-    {
-        // Send failed
-        PChar->pushPacket<CBlacklistEditResponsePacket>(0, "", 0x02);
     }
 }
 
@@ -2439,6 +2423,7 @@ void SmallPacket0x04B(map_session_data_t* const PSession, CCharEntity* const PCh
 void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket& data)
 {
     TracyZoneScoped;
+
     uint8 action  = data.ref<uint8>(0x04);
     uint8 boxtype = data.ref<uint8>(0x05);
     uint8 slotID  = data.ref<uint8>(0x06);
@@ -2602,10 +2587,9 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
 
             if (PChar->UContainer->IsSlotEmpty(slotID))
             {
-                // TODO: Validate me
-                auto senderName = str(data[0x10]);
+                const auto recieverName = escapeString(asStringFromUntrustedSource(data[0x10], 15));
 
-                auto rset = db::query(fmt::format("SELECT charid, accid FROM chars WHERE charname = '{}' LIMIT 1", senderName));
+                auto rset = db::preparedStmt("SELECT charid, accid FROM chars WHERE charname = ? LIMIT 1", recieverName);
                 if (rset && rset->rowsCount() && rset->next())
                 {
                     uint32 charid = rset->get<uint32>("charid");
@@ -2622,8 +2606,8 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                         // clang-format off
                         auto exists = [&]() -> bool
                         {
-                            auto rset2 = db::query(fmt::format("SELECT COUNT(*) FROM chars WHERE charid = '{}' AND accid = '{}' LIMIT 1", PChar->id, accid));
-                            return rset2 && rset2->next() && rset2->get<uint32>("COUNT(*)") > 0;
+                            auto rset2 = db::preparedStmt("SELECT COUNT(*) FROM chars WHERE charid = ? AND accid = ? LIMIT 1", PChar->id, accid);
+                            return rset2 && rset2->rowsCount() && rset2->next() && rset2->get<uint32>("COUNT(*)");
                         }();
                         if (!exists)
                         {
@@ -2640,10 +2624,8 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                         return;
                     }
 
-                    char receiver[PacketNameLength] = {};
-                    std::memcpy(&receiver, data[0x10], PacketNameLength - 1);
-                    PUBoxItem->setReceiver(receiver);
-                    PUBoxItem->setSender(PChar->getName());
+                    PUBoxItem->setReceiver(recieverName);
+                    PUBoxItem->setSender(PChar->getName().c_str());
                     PUBoxItem->setQuantity(quantity);
                     PUBoxItem->setSlotID(PItem->getSlotID());
                     std::memcpy(PUBoxItem->m_extra, PItem->m_extra, sizeof(PUBoxItem->m_extra));
@@ -2651,10 +2633,11 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                     char extra[sizeof(PItem->m_extra) * 2 + 1];
                     _sql->EscapeStringLen(extra, (const char*)PItem->m_extra, sizeof(PItem->m_extra));
 
+                    // NOTE: This will trigger SQL trigger: delivery_box_insert
                     auto ret = _sql->Query(
-                        "INSERT INTO delivery_box(charid, charname, box, slot, itemid, itemsubid, quantity, extra, senderid, sender) VALUES(%u, "
-                        "'%s', 2, %u, %u, %u, %u, '%s', %u, '%s'); ",
-                        PChar->id, PChar->getName(), slotID, PItem->getID(), PItem->getSubID(), quantity, extra, charid, str(data[0x10]));
+                        "INSERT INTO delivery_box(charid, charname, box, slot, itemid, itemsubid, quantity, extra, senderid, sender) "
+                        "VALUES(%u, '%s', %u, %u, %u, %u, %u, '%s', %u, '%s')",
+                        PChar->id, PChar->getName(), 2, slotID, PItem->getID(), PItem->getSubID(), quantity, extra, charid, recieverName);
 
                     if (ret != SQL_ERROR && _sql->AffectedRows() == 1 && charutils::UpdateItem(PChar, LOC_INVENTORY, invslot, -(int32)quantity))
                     {
@@ -2713,6 +2696,7 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                                 char extra[sizeof(PItem->m_extra) * 2 + 1];
                                 _sql->EscapeStringLen(extra, (const char*)PItem->m_extra, sizeof(PItem->m_extra));
 
+                                // NOTE: This will trigger SQL trigger: delivery_box_insert
                                 ret = _sql->Query(
                                     "INSERT INTO delivery_box(charid, charname, box, itemid, itemsubid, quantity, extra, senderid, sender) "
                                     "VALUES(%u, '%s', 1, %u, %u, %u, '%s', %u, '%s'); ",
@@ -3040,10 +3024,9 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                             _sql->EscapeStringLen(extra, (const char*)PItem->m_extra, sizeof(PItem->m_extra));
 
                             // Insert a return record into delivery_box
-                            ret = _sql->Query("INSERT INTO delivery_box(charid, charname, box, itemid, itemsubid, quantity, extra, senderid, sender) VALUES(%u, "
-                                              "'%s', 1, %u, %u, %u, '%s', %u, '%s'); ",
-                                              senderID, senderName.c_str(), PItem->getID(), PItem->getSubID(), PItem->getQuantity(), extra, PChar->id,
-                                              PChar->getName());
+                            ret = _sql->Query("INSERT INTO delivery_box(charid, charname, box, itemid, itemsubid, quantity, extra, senderid, sender) "
+                                              "VALUES(%u, '%s', %u, %u, %u, %u, '%s', %u, '%s')",
+                                              senderID, senderName, 1, PItem->getID(), PItem->getSubID(), PItem->getQuantity(), extra, PChar->id, PChar->getName());
 
                             if (ret != SQL_ERROR && _sql->AffectedRows() > 0)
                             {
@@ -3064,8 +3047,8 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                     if (!commit || !_sql->TransactionCommit())
                     {
                         _sql->TransactionRollback();
-                        ShowError("Could not finalize delivery return transaction. PlayerID: %d SenderID :%d ItemID: %d Quantity: %d", PChar->id, senderID,
-                                  item_id, quantity);
+                        ShowError("Could not finalize delivery return transaction. PlayerID: %d SenderID :%d ItemID: %d Quantity: %d",
+                                  PChar->id, senderID, item_id, quantity);
                         PChar->pushPacket<CDeliveryBoxPacket>(action, boxtype, PItem, slotID, PChar->UContainer->GetItemsCount(), 0xEB);
                     }
 
@@ -3102,12 +3085,13 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                     int32 ret = SQL_ERROR;
                     if (boxtype == 0x01)
                     {
-                        ret = _sql->Query("DELETE FROM delivery_box WHERE charid = %u AND slot = %u AND box = %u LIMIT 1", PChar->id, slotID, boxtype);
+                        ret = _sql->Query("DELETE FROM delivery_box WHERE charid = %u AND slot = %u AND box = %u LIMIT 1",
+                                          PChar->id, slotID, boxtype);
                     }
                     else if (boxtype == 0x02)
                     {
-                        ret = _sql->Query("DELETE FROM delivery_box WHERE charid = %u AND sent = 0 AND slot = %u AND box = %u LIMIT 1", PChar->id,
-                                          slotID, boxtype);
+                        ret = _sql->Query("DELETE FROM delivery_box WHERE charid = %u AND sent = 0 AND slot = %u AND box = %u LIMIT 1",
+                                          PChar->id, slotID, boxtype);
                     }
 
                     if (ret != SQL_ERROR && _sql->AffectedRows() != 0)
@@ -3168,7 +3152,7 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
             }
             return;
         }
-        // 0x0c - Confirm name before sending
+        // 0x0C - Confirm name before sending
         case 0x0C:
         {
             if (!charutils::isSendBoxOpen(PChar))
@@ -3177,8 +3161,9 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                 return;
             }
 
-            int32 ret = _sql->Query("SELECT accid FROM chars WHERE charname = '%s' LIMIT 1", str(data[0x10]));
+            const auto charName = escapeString(asStringFromUntrustedSource(data[0x10], 15));
 
+            int32 ret = _sql->Query("SELECT accid FROM chars WHERE charname = '%s' LIMIT 1", charName);
             if (ret != SQL_ERROR && _sql->NumRows() > 0 && _sql->NextRow() == SQL_SUCCESS)
             {
                 uint32 accid = _sql->GetUIntData(0);
@@ -3381,6 +3366,7 @@ void SmallPacket0x04E(map_session_data_t* const PSession, CCharEntity* const PCh
                     return;
                 }
 
+                // NOTE: This will trigger SQL trigger: auction_house_list
                 if (!db::preparedStmt("INSERT INTO auction_house(itemid, stack, seller, seller_name, date, price) VALUES(?, ?, ?, ?, ?, ?)",
                                       PItem->getID(), quantity == 0, PChar->id, PChar->getName(), (uint32)time(nullptr), price))
                 {
@@ -3426,6 +3412,7 @@ void SmallPacket0x04E(map_session_data_t* const PSession, CCharEntity* const PCh
 
                     if (gil != nullptr && gil->isType(ITEM_CURRENCY) && gil->getQuantity() >= price && gil->getReserve() == 0)
                     {
+                        // NOTE: This will trigger SQL trigger: auction_house_buy
                         const auto [rset, affectedRows] = db::preparedStmtWithAffectedRows("UPDATE auction_house SET buyer_name = ?, sale = ?, sell_date = ? WHERE itemid = ? AND buyer_name IS NULL "
                                                                                            "AND stack = ? AND price <= ? ORDER BY price LIMIT 1",
                                                                                            PChar->getName(), price, (uint32)time(nullptr), itemid, quantity == 0, price);
@@ -4189,7 +4176,8 @@ void SmallPacket0x060(map_session_data_t* const PSession, CCharEntity* const PCh
 {
     TracyZoneScoped;
 
-    std::string updateString = std::string((char*)data[12]);
+    // TODO: This isn't going near the db, does this need to be escaped? It contains binary data?
+    const auto updateString = asStringFromUntrustedSource(data[0x0C]);
     luautils::OnEventUpdate(PChar, updateString);
 
     PChar->pushPacket<CReleasePacket>(PChar, RELEASE_TYPE::EVENT);
@@ -4283,10 +4271,6 @@ void SmallPacket0x066(map_session_data_t* const PSession, CCharEntity* const PCh
     if (settings::get<bool>("map.FISHING_ENABLE") && PChar->GetMLevel() >= settings::get<uint8>("map.FISHING_MIN_LEVEL"))
     {
         fishingutils::HandleFishingAction(PChar, data);
-    }
-    else
-    {
-        return;
     }
 }
 
@@ -4584,10 +4568,10 @@ void SmallPacket0x071(map_session_data_t* const PSession, CCharEntity* const PCh
     switch (data.ref<uint8>(0x0A))
     {
         case 0: // party - party leader may remove member of his own party
+        {
             if (PChar->PParty && PChar->PParty->GetLeader() == PChar)
             {
-                char charName[PacketNameLength] = {};
-                std::memcpy(&charName, data[0x0C], PacketNameLength - 1);
+                const auto charName = escapeString(asStringFromUntrustedSource(data[0x0C], 15));
 
                 CCharEntity* PVictim = dynamic_cast<CCharEntity*>(PChar->PParty->GetMemberByName(charName));
                 if (PVictim)
@@ -4618,8 +4602,8 @@ void SmallPacket0x071(map_session_data_t* const PSession, CCharEntity* const PCh
                 }
                 else
                 {
-                    char victimName[31]{};
-                    _sql->EscapeStringLen(victimName, (const char*)data[0x0C], std::min<size_t>(strlen((const char*)data[0x0C]), 15));
+                    const auto victimName = escapeString(asStringFromUntrustedSource(data[0x0C], 15));
+
                     int32 ret = _sql->Query("SELECT charid FROM chars WHERE charname = '%s'", victimName);
                     if (ret != SQL_ERROR && _sql->NumRows() == 1 && _sql->NextRow() == SQL_SUCCESS)
                     {
@@ -4627,7 +4611,7 @@ void SmallPacket0x071(map_session_data_t* const PSession, CCharEntity* const PCh
                         if (_sql->Query("DELETE FROM accounts_parties WHERE partyid = %u AND charid = %u", PChar->id, id) == SQL_SUCCESS &&
                             _sql->AffectedRows())
                         {
-                            ShowDebug("%s has removed %s from party", PChar->getName(), str(data[0x0C]));
+                            ShowDebug("%s has removed %s from party", PChar->getName(), victimName);
 
                             uint8 reloadData[4]{};
                             if (PChar->PParty && PChar->PParty->m_PAlliance)
@@ -4648,16 +4632,19 @@ void SmallPacket0x071(map_session_data_t* const PSession, CCharEntity* const PCh
                     }
                 }
             }
-            break;
+        }
+        break;
         case 1: // linkshell
         {
             // Ensure the player has a linkshell equipped
             CItemLinkshell* PItemLinkshell = (CItemLinkshell*)PChar->getEquip(SLOT_LINK1);
             if (PChar->PLinkshell1 && PItemLinkshell)
             {
+                const auto linkshellName = escapeString(asStringFromUntrustedSource(data[0x0C], 20));
+
                 int8 packetData[29]{};
                 ref<uint32>(packetData, 0) = PChar->id;
-                std::memcpy(packetData + 0x04, data[0x0C], 20);
+                std::memcpy(packetData + 0x04, linkshellName.data(), 20);
                 ref<uint32>(packetData, 24) = PChar->PLinkshell1->getID();
                 ref<uint8>(packetData, 28)  = PItemLinkshell->GetLSType();
                 message::send(MSG_LINKSHELL_REMOVE, packetData, sizeof(packetData), nullptr);
@@ -4670,24 +4657,25 @@ void SmallPacket0x071(map_session_data_t* const PSession, CCharEntity* const PCh
             CItemLinkshell* PItemLinkshell = (CItemLinkshell*)PChar->getEquip(SLOT_LINK2);
             if (PChar->PLinkshell2 && PItemLinkshell)
             {
+                const auto linkshellName = escapeString(asStringFromUntrustedSource(data[0x0C], 20));
+
                 int8 packetData[29]{};
                 ref<uint32>(packetData, 0) = PChar->id;
-                std::memcpy(packetData + 0x04, data[0x0C], 20);
+                std::memcpy(packetData + 0x04, linkshellName.data(), 20);
                 ref<uint32>(packetData, 24) = PChar->PLinkshell2->getID();
                 ref<uint8>(packetData, 28)  = PItemLinkshell->GetLSType();
                 message::send(MSG_LINKSHELL_REMOVE, packetData, sizeof(packetData), nullptr);
             }
         }
         break;
-
         case 5: // alliance - alliance leader may kick a party by using that party's leader as kick parameter
+        {
             if (PChar->PParty && PChar->PParty->GetLeader() == PChar && PChar->PParty->m_PAlliance)
             {
                 CCharEntity* PVictim = nullptr;
                 for (std::size_t i = 0; i < PChar->PParty->m_PAlliance->partyList.size(); ++i)
                 {
-                    char charName[PacketNameLength] = {};
-                    std::memcpy(&charName, data[0x0C], PacketNameLength - 1);
+                    const auto charName = escapeString(asStringFromUntrustedSource(data[0x0C], 15));
 
                     PVictim = dynamic_cast<CCharEntity*>(PChar->PParty->m_PAlliance->partyList[i]->GetMemberByName(charName));
                     if (PVictim && PVictim->PParty && PVictim->PParty->m_PAlliance) // victim is in this party
@@ -4713,10 +4701,10 @@ void SmallPacket0x071(map_session_data_t* const PSession, CCharEntity* const PCh
                 }
                 if (!PVictim && PChar->PParty->m_PAlliance->getMainParty() == PChar->PParty)
                 {
-                    char   victimName[31]{};
+                    const auto victimName = escapeString(asStringFromUntrustedSource(data[0x0C], 15));
+
                     uint32 allianceID = PChar->PParty->m_PAlliance->m_AllianceID;
 
-                    _sql->EscapeStringLen(victimName, (const char*)data[0x0C], std::min<size_t>(strlen((const char*)data[0x0C]), 15));
                     int32 ret = _sql->Query("SELECT charid FROM chars WHERE charname = '%s'", victimName);
                     if (ret != SQL_ERROR && _sql->NumRows() == 1 && _sql->NextRow() == SQL_SUCCESS)
                     {
@@ -4731,7 +4719,8 @@ void SmallPacket0x071(map_session_data_t* const PSession, CCharEntity* const PCh
                                             PARTY_SECOND | PARTY_THIRD, partyid) == SQL_SUCCESS &&
                                 _sql->AffectedRows())
                             {
-                                ShowDebug("%s has removed %s party from alliance", PChar->getName(), str(data[0x0C]));
+                                ShowDebug("%s has removed %s party from alliance", PChar->getName(), victimName);
+
                                 // notify party they were removed
                                 uint8 removeData[4]{};
                                 ref<uint32>(removeData, 0) = partyid;
@@ -4745,11 +4734,13 @@ void SmallPacket0x071(map_session_data_t* const PSession, CCharEntity* const PCh
                     }
                 }
             }
-            break;
-
+        }
+        break;
         default:
+        {
             ShowError("SmallPacket0x071 : unknown byte <%.2X>", data.ref<uint8>(0x0A));
-            break;
+        }
+        break;
     }
 }
 
@@ -4771,6 +4762,7 @@ void SmallPacket0x074(map_session_data_t* const PSession, CCharEntity* const PCh
         if (InviteAnswer == 0)
         {
             ShowDebug("%s declined party invite from %s", PChar->getName(), PInviter->getName());
+
             // invitee declined invite
             PInviter->pushPacket<CMessageStandardPacket>(PInviter, 0, 0, MsgStd::InvitationDeclined);
             PChar->InvitePending.clean();
@@ -4784,6 +4776,7 @@ void SmallPacket0x074(map_session_data_t* const PSession, CCharEntity* const PCh
             if (PInviter->PParty->GetLeader() == PInviter && PChar->PParty->GetLeader() == PChar)
             {
                 ShowDebug("%s invited %s to an alliance", PInviter->getName(), PChar->getName());
+
                 // the inviter already has an alliance and wants to add another party - only add if they have room for another party
                 if (PInviter->PParty->m_PAlliance)
                 {
@@ -4856,14 +4849,18 @@ void SmallPacket0x074(map_session_data_t* const PSession, CCharEntity* const PCh
     else
     {
         ShowDebug("(Party)Building invite packet to send to lobby server for %s", PChar->getName());
+
         uint8 packetData[13]{};
         ref<uint32>(packetData, 0)  = PChar->InvitePending.id;
         ref<uint16>(packetData, 4)  = PChar->InvitePending.targid;
         ref<uint32>(packetData, 6)  = PChar->id;
         ref<uint16>(packetData, 10) = PChar->targid;
         ref<uint8>(packetData, 12)  = InviteAnswer;
+
         PChar->InvitePending.clean();
+
         message::send(MSG_PT_INV_RES, packetData, sizeof(packetData), nullptr);
+
         ShowDebug("(Party)Sent invite packet to send to lobby server for %s", PChar->getName());
     }
     PChar->InvitePending.clean();
@@ -4904,11 +4901,11 @@ void SmallPacket0x077(map_session_data_t* const PSession, CCharEntity* const PCh
         {
             if (PChar->PParty != nullptr && PChar->PParty->GetLeader() == PChar)
             {
-                char memberName[PacketNameLength] = {};
-                std::memcpy(&memberName, data[0x04], PacketNameLength - 1);
+                const auto memberName = escapeString(asStringFromUntrustedSource(data[0x04], 15));
+                const auto permission = data.ref<uint8>(0x15);
 
-                ShowDebug(fmt::format("(Party)Altering permissions of {} to {}", str(memberName), str(data[0x15])));
-                PChar->PParty->AssignPartyRole(memberName, data.ref<uint8>(0x15));
+                ShowDebug(fmt::format("(Party)Altering permissions of {} to {}", memberName, permission));
+                PChar->PParty->AssignPartyRole(memberName, permission);
             }
         }
         break;
@@ -4916,11 +4913,14 @@ void SmallPacket0x077(map_session_data_t* const PSession, CCharEntity* const PCh
         {
             if (PChar->PLinkshell1 != nullptr)
             {
+                const auto linkshellName = escapeString(asStringFromUntrustedSource(data[0x04], 20));
+                const auto permission    = data.ref<uint8>(0x15);
+
                 int8 packetData[29]{};
                 ref<uint32>(packetData, 0) = PChar->id;
-                std::memcpy(packetData + 0x04, data[0x04], 20);
+                std::memcpy(packetData + 0x04, linkshellName.data(), 20);
                 ref<uint32>(packetData, 24) = PChar->PLinkshell1->getID();
-                ref<uint8>(packetData, 28)  = data.ref<uint8>(0x15);
+                ref<uint8>(packetData, 28)  = permission;
                 message::send(MSG_LINKSHELL_RANK_CHANGE, packetData, sizeof(packetData), nullptr);
             }
         }
@@ -4929,11 +4929,14 @@ void SmallPacket0x077(map_session_data_t* const PSession, CCharEntity* const PCh
         {
             if (PChar->PLinkshell2 != nullptr)
             {
+                const auto linkshellName = escapeString(asStringFromUntrustedSource(data[0x04], 20));
+                const auto permission    = data.ref<uint8>(0x15);
+
                 int8 packetData[29]{};
                 ref<uint32>(packetData, 0) = PChar->id;
-                std::memcpy(packetData + 0x04, data[0x04], 20);
+                std::memcpy(packetData + 0x04, linkshellName.data(), 20);
                 ref<uint32>(packetData, 24) = PChar->PLinkshell2->getID();
-                ref<uint8>(packetData, 28)  = data.ref<uint8>(0x15);
+                ref<uint8>(packetData, 28)  = permission;
                 message::send(MSG_LINKSHELL_RANK_CHANGE, packetData, sizeof(packetData), nullptr);
             }
         }
@@ -4943,11 +4946,10 @@ void SmallPacket0x077(map_session_data_t* const PSession, CCharEntity* const PCh
             if (PChar->PParty && PChar->PParty->m_PAlliance && PChar->PParty->GetLeader() == PChar &&
                 PChar->PParty->m_PAlliance->getMainParty() == PChar->PParty)
             {
-                char memberName[PacketNameLength] = {};
-                std::memcpy(&memberName, data[0x04], PacketNameLength - 1);
+                const auto memberName = escapeString(asStringFromUntrustedSource(data[0x04], 15));
 
-                ShowDebug(fmt::format("(Alliance)Changing leader to {}", str(memberName)));
-                PChar->PParty->m_PAlliance->assignAllianceLeader(str(data[0x04]).c_str());
+                ShowDebug(fmt::format("(Alliance)Changing leader to {}", memberName));
+                PChar->PParty->m_PAlliance->assignAllianceLeader(memberName.c_str());
 
                 uint8 allianceData[4]{};
                 ref<uint32>(allianceData, 0) = PChar->PParty->m_PAlliance->m_AllianceID;
@@ -5532,7 +5534,7 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
     }
     else if (data.ref<uint8>(0x06) == '#' && PChar->m_GMlevel > 0)
     {
-        message::send(MSG_CHAT_SERVMES, nullptr, 0, std::make_unique<CChatMessagePacket>(PChar, MESSAGE_SYSTEM_1, (const char*)data[7]));
+        message::send(MSG_CHAT_SERVMES, nullptr, 0, std::make_unique<CChatMessagePacket>(PChar, MESSAGE_SYSTEM_1, (const char*)data[0x07]));
     }
     else
     {
@@ -5543,9 +5545,9 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                 if (settings::get<bool>("map.AUDIT_CHAT") && settings::get<uint8>("map.AUDIT_SAY"))
                 {
                     // clang-format off
-                    // NOTE: We capture rawMessage as a std::string because if we cast data[6] into a const char*, the underlying data might
+                    // NOTE: We capture rawMessage as a std::string because if we cast data[0x06] into a const char*, the underlying data might
                     //     : be gone by the time we action this lambda on the worker thread.
-                    Async::getInstance()->submit([name = PChar->getName(), zoneId = PChar->getZone(), rawMessage = std::string((const char*)data[6])]()
+                    Async::getInstance()->submit([name = PChar->getName(), zoneId = PChar->getZone(), rawMessage = std::string((const char*)data[0x06])]()
                     {
                         const auto query = "INSERT INTO audit_chat (speaker, type, zoneid, message, datetime) VALUES(?, 'SAY', ?, ?, current_timestamp())";
                         if (!db::preparedStmt(query, name, zoneId, rawMessage))
@@ -5555,7 +5557,7 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                     });
                     // clang-format on
                 }
-                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, std::make_unique<CChatMessagePacket>(PChar, MESSAGE_SAY, (const char*)data[6]));
+                PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, std::make_unique<CChatMessagePacket>(PChar, MESSAGE_SAY, (const char*)data[0x06]));
             }
             else
             {
@@ -5571,9 +5573,9 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                     if (settings::get<bool>("map.AUDIT_CHAT") && settings::get<uint8>("map.AUDIT_SAY"))
                     {
                         // clang-format off
-                        // NOTE: We capture rawMessage as a std::string because if we cast data[6] into a const char*, the underlying data might
+                        // NOTE: We capture rawMessage as a std::string because if we cast data[0x06] into a const char*, the underlying data might
                         //     : be gone by the time we action this lambda on the worker thread.
-                        Async::getInstance()->submit([name = PChar->getName(), zoneId = PChar->getZone(), rawMessage = std::string((const char*)data[6])]()
+                        Async::getInstance()->submit([name = PChar->getName(), zoneId = PChar->getZone(), rawMessage = std::string((const char*)data[0x06])]()
                         {
                             const auto query = "INSERT INTO audit_chat (speaker, type, zoneid, message, datetime) VALUES(?, 'SAY', ?, ?, current_timestamp())";
                             if (!db::preparedStmt(query, name, zoneId, rawMessage))
@@ -5583,12 +5585,12 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                         });
                         // clang-format on
                     }
-                    PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, std::make_unique<CChatMessagePacket>(PChar, MESSAGE_SAY, (const char*)data[6]));
+                    PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, std::make_unique<CChatMessagePacket>(PChar, MESSAGE_SAY, (const char*)data[0x06]));
                 }
                 break;
                 case MESSAGE_EMOTION:
                 {
-                    PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, std::make_unique<CChatMessagePacket>(PChar, MESSAGE_EMOTION, (const char*)data[6]));
+                    PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, std::make_unique<CChatMessagePacket>(PChar, MESSAGE_EMOTION, (const char*)data[0x06]));
                 }
                 break;
                 case MESSAGE_SHOUT:
@@ -5596,9 +5598,9 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                     if (settings::get<bool>("map.AUDIT_CHAT") && settings::get<uint8>("map.AUDIT_SHOUT"))
                     {
                         // clang-format off
-                        // NOTE: We capture rawMessage as a std::string because if we cast data[6] into a const char*, the underlying data might
+                        // NOTE: We capture rawMessage as a std::string because if we cast data[0x06] into a const char*, the underlying data might
                         //     : be gone by the time we action this lambda on the worker thread.
-                        Async::getInstance()->submit([name = PChar->getName(), zoneId = PChar->getZone(), rawMessage = std::string((const char*)data[6])]()
+                        Async::getInstance()->submit([name = PChar->getName(), zoneId = PChar->getZone(), rawMessage = std::string((const char*)data[0x06])]()
                         {
                             const auto query = "INSERT INTO audit_chat (speaker, type, zoneid, message, datetime) VALUES(?, 'SHOUT', ?, ?, current_timestamp())";
                             if (!db::preparedStmt(query, name, zoneId, rawMessage))
@@ -5608,7 +5610,7 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                         });
                         // clang-format on
                     }
-                    PChar->loc.zone->PushPacket(PChar, CHAR_INSHOUT, std::make_unique<CChatMessagePacket>(PChar, MESSAGE_SHOUT, (const char*)data[6]));
+                    PChar->loc.zone->PushPacket(PChar, CHAR_INSHOUT, std::make_unique<CChatMessagePacket>(PChar, MESSAGE_SHOUT, (const char*)data[0x06]));
                 }
                 break;
                 case MESSAGE_LINKSHELL:
@@ -5619,7 +5621,7 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                         ref<uint32>(packetData, 0) = PChar->PLinkshell1->getID();
                         ref<uint32>(packetData, 4) = PChar->id;
                         message::send(MSG_CHAT_LINKSHELL, packetData, sizeof(packetData),
-                                      std::make_unique<CChatMessagePacket>(PChar, MESSAGE_LINKSHELL, (const char*)data[6]));
+                                      std::make_unique<CChatMessagePacket>(PChar, MESSAGE_LINKSHELL, (const char*)data[0x06]));
 
                         if (settings::get<bool>("map.AUDIT_CHAT") && settings::get<uint8>("map.AUDIT_LINKSHELL"))
                         {
@@ -5627,9 +5629,9 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                             DecodeStringLinkshell(PChar->PLinkshell1->getName(), decodedLinkshellName);
 
                             // clang-format off
-                            // NOTE: We capture rawMessage as a std::string because if we cast data[6] into a const char*, the underlying data might
+                            // NOTE: We capture rawMessage as a std::string because if we cast data[0x06] into a const char*, the underlying data might
                             //     : be gone by the time we action this lambda on the worker thread.
-                            Async::getInstance()->submit([name = PChar->getName(), zoneId = PChar->getZone(), rawMessage = std::string((const char*)data[6]), decodedLinkshellName]()
+                            Async::getInstance()->submit([name = PChar->getName(), zoneId = PChar->getZone(), rawMessage = std::string((const char*)data[0x06]), decodedLinkshellName]()
                             {
                                 const auto query = "INSERT INTO audit_chat (speaker, type, lsName, zoneid, message, datetime) VALUES(?, 'LINKSHELL', ?, ?, ?, current_timestamp())";
                                 if (!db::preparedStmt(query, name, decodedLinkshellName, zoneId, rawMessage))
@@ -5650,7 +5652,7 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                         ref<uint32>(packetData, 0) = PChar->PLinkshell2->getID();
                         ref<uint32>(packetData, 4) = PChar->id;
                         message::send(MSG_CHAT_LINKSHELL, packetData, sizeof(packetData),
-                                      std::make_unique<CChatMessagePacket>(PChar, MESSAGE_LINKSHELL, (const char*)data[6]));
+                                      std::make_unique<CChatMessagePacket>(PChar, MESSAGE_LINKSHELL, (const char*)data[0x06]));
 
                         if (settings::get<bool>("map.AUDIT_CHAT") && settings::get<uint8>("map.AUDIT_LINKSHELL"))
                         {
@@ -5658,9 +5660,9 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                             DecodeStringLinkshell(PChar->PLinkshell2->getName(), decodedLinkshellName);
 
                             // clang-format off
-                            // NOTE: We capture rawMessage as a std::string because if we cast data[6] into a const char*, the underlying data might
+                            // NOTE: We capture rawMessage as a std::string because if we cast data[0x06] into a const char*, the underlying data might
                             //     : be gone by the time we action this lambda on the worker thread.
-                            Async::getInstance()->submit([name = PChar->getName(), zoneId = PChar->getZone(), rawMessage = std::string((const char*)data[6]), decodedLinkshellName]()
+                            Async::getInstance()->submit([name = PChar->getName(), zoneId = PChar->getZone(), rawMessage = std::string((const char*)data[0x06]), decodedLinkshellName]()
                             {
                                 const auto query = "INSERT INTO audit_chat (speaker, type, lsName, zoneid, message, datetime) VALUES(?, 'LINKSHELL', ?, ?, ?, current_timestamp())";
                                 if (!db::preparedStmt(query, name, decodedLinkshellName, zoneId, rawMessage))
@@ -5682,21 +5684,21 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                         {
                             ref<uint32>(packetData, 0) = PChar->PParty->m_PAlliance->m_AllianceID;
                             ref<uint32>(packetData, 4) = PChar->id;
-                            message::send(MSG_CHAT_ALLIANCE, packetData, sizeof(packetData), std::make_unique<CChatMessagePacket>(PChar, MESSAGE_PARTY, (const char*)data[6]));
+                            message::send(MSG_CHAT_ALLIANCE, packetData, sizeof(packetData), std::make_unique<CChatMessagePacket>(PChar, MESSAGE_PARTY, (const char*)data[0x06]));
                         }
                         else
                         {
                             ref<uint32>(packetData, 0) = PChar->PParty->GetPartyID();
                             ref<uint32>(packetData, 4) = PChar->id;
-                            message::send(MSG_CHAT_PARTY, packetData, sizeof(packetData), std::make_unique<CChatMessagePacket>(PChar, MESSAGE_PARTY, (const char*)data[6]));
+                            message::send(MSG_CHAT_PARTY, packetData, sizeof(packetData), std::make_unique<CChatMessagePacket>(PChar, MESSAGE_PARTY, (const char*)data[0x06]));
                         }
 
                         if (settings::get<bool>("map.AUDIT_CHAT") && settings::get<uint8>("map.AUDIT_PARTY"))
                         {
                             // clang-format off
-                            // NOTE: We capture rawMessage as a std::string because if we cast data[6] into a const char*, the underlying data might
+                            // NOTE: We capture rawMessage as a std::string because if we cast data[0x06] into a const char*, the underlying data might
                             //     : be gone by the time we action this lambda on the worker thread.
-                            Async::getInstance()->submit([name = PChar->getName(), zoneId = PChar->getZone(), rawMessage = std::string((const char*)data[6])]()
+                            Async::getInstance()->submit([name = PChar->getName(), zoneId = PChar->getZone(), rawMessage = std::string((const char*)data[0x06])]()
                             {
                                 const auto query = "INSERT INTO audit_chat (speaker, type, zoneid, message, datetime) VALUES(?, 'PARTY', ?, ?, current_timestamp())";
                                 if (!db::preparedStmt(query, name, zoneId, rawMessage))
@@ -5729,14 +5731,14 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                             int8 packetData[4]{};
                             ref<uint32>(packetData, 0) = PChar->id;
 
-                            message::send(MSG_CHAT_YELL, packetData, sizeof(packetData), std::make_unique<CChatMessagePacket>(PChar, MESSAGE_YELL, (const char*)data[6]));
+                            message::send(MSG_CHAT_YELL, packetData, sizeof(packetData), std::make_unique<CChatMessagePacket>(PChar, MESSAGE_YELL, (const char*)data[0x06]));
 
                             if (settings::get<bool>("map.AUDIT_CHAT") && settings::get<uint8>("map.AUDIT_YELL"))
                             {
                                 // clang-format off
-                                // NOTE: We capture rawMessage as a std::string because if we cast data[6] into a const char*, the underlying data might
+                                // NOTE: We capture rawMessage as a std::string because if we cast data[0x06] into a const char*, the underlying data might
                                 //     : be gone by the time we action this lambda on the worker thread.
-                                Async::getInstance()->submit([name = PChar->getName(), zoneId = PChar->getZone(), rawMessage = std::string((const char*)data[6])]()
+                                Async::getInstance()->submit([name = PChar->getName(), zoneId = PChar->getZone(), rawMessage = std::string((const char*)data[0x06])]()
                                 {
                                     const auto query = "INSERT INTO audit_chat (speaker, type, zoneid, message, datetime) VALUES(?, 'YELL', ?, ?, current_timestamp())";
                                     if (!db::preparedStmt(query, name, zoneId, rawMessage))
@@ -5766,16 +5768,16 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                         ref<uint32>(packetData, 0) = PChar->PUnityChat->getLeader();
                         ref<uint32>(packetData, 4) = PChar->id;
                         message::send(MSG_CHAT_UNITY, packetData, sizeof(packetData),
-                                      std::make_unique<CChatMessagePacket>(PChar, MESSAGE_UNITY, (const char*)data[6]));
+                                      std::make_unique<CChatMessagePacket>(PChar, MESSAGE_UNITY, (const char*)data[0x06]));
 
-                        roeutils::event(ROE_EVENT::ROE_UNITY_CHAT, PChar, RoeDatagram("unityMessage", (const char*)data[6]));
+                        roeutils::event(ROE_EVENT::ROE_UNITY_CHAT, PChar, RoeDatagram("unityMessage", (const char*)data[0x06]));
 
                         if (settings::get<bool>("map.AUDIT_CHAT") && settings::get<uint8>("map.AUDIT_UNITY"))
                         {
                             // clang-format off
-                            // NOTE: We capture rawMessage as a std::string because if we cast data[6] into a const char*, the underlying data might
+                            // NOTE: We capture rawMessage as a std::string because if we cast data[0x06] into a const char*, the underlying data might
                             //     : be gone by the time we action this lambda on the worker thread.
-                            Async::getInstance()->submit([name = PChar->getName(), zoneId = PChar->getZone(), unityLeader = PChar->PUnityChat->getLeader(), rawMessage = std::string((const char*)data[6])]()
+                            Async::getInstance()->submit([name = PChar->getName(), zoneId = PChar->getZone(), unityLeader = PChar->PUnityChat->getLeader(), rawMessage = std::string((const char*)data[0x06])]()
                             {
                                 const auto query = "INSERT INTO audit_chat (speaker, type, zoneid, unity, message, datetime) VALUES(?, 'UNITY', ?, ?, ?, current_timestamp())";
                                 if (!db::preparedStmt(query, name, zoneId, unityLeader, rawMessage))
@@ -5810,7 +5812,7 @@ void SmallPacket0x0B6(map_session_data_t* const PSession, CCharEntity* const PCh
         return;
     }
 
-    std::string recipientName = std::string((const char*)data[6], 15);
+    const auto recipientName = escapeString(asStringFromUntrustedSource(data[0x06], 15));
 
     char  message[256]    = {}; // /t messages using "<t>" with a long named NPC targeted caps out at 138 bytes, increasing to the nearest power of 2
     uint8 messagePosition = 0x15;
@@ -5833,7 +5835,7 @@ void SmallPacket0x0B6(map_session_data_t* const PSession, CCharEntity* const PCh
     if (settings::get<bool>("map.AUDIT_CHAT") && settings::get<bool>("map.AUDIT_TELL"))
     {
         // clang-format off
-        // NOTE: We capture rawMessage as a std::string because if we cast data[6] into a const char*, the underlying data might
+        // NOTE: We capture rawMessage as a std::string because if we cast data[0x06] into a const char*, the underlying data might
         //     : be gone by the time we action this lambda on the worker thread.
         Async::getInstance()->submit([name = PChar->getName(), zoneId = PChar->getZone(), recipient = recipientName, message]()
         {
@@ -6023,9 +6025,11 @@ void SmallPacket0x0C4(map_session_data_t* const PSession, CCharEntity* const PCh
             std::memset(&DecodedName, 0, sizeof(DecodedName));
             std::memset(&EncodedName, 0, sizeof(EncodedName));
 
-            char* decodePtr = reinterpret_cast<char*>(data[12]);
-            DecodeStringLinkshell(decodePtr, DecodedName);
+            const auto incomingName = escapeString(asStringFromUntrustedSource(data[0x0C], 20));
+
+            DecodeStringLinkshell(incomingName.data(), DecodedName);
             EncodeStringLinkshell(DecodedName, EncodedName);
+
             // TODO: Check if a linebreak is needed
 
             LinkshellID = linkshell::RegisterNewLinkshell(DecodedName, LinkshellColor);
@@ -6037,6 +6041,7 @@ void SmallPacket0x0C4(map_session_data_t* const PSession, CCharEntity* const PCh
                 {
                     return;
                 }
+
                 PItemLinkshell->setQuantity(1);
                 PChar->getStorage(LocationID)->InsertItem(PItemLinkshell, SlotID);
                 PItemLinkshell->SetLSID(LinkshellID);
@@ -6097,10 +6102,13 @@ void SmallPacket0x0C4(map_session_data_t* const PSession, CCharEntity* const PCh
                     if (ret != SQL_ERROR && _sql->NumRows() != 0 && _sql->NextRow() == SQL_SUCCESS && _sql->GetUIntData(0) == 1)
                     { // if the linkshell has been broken, break the item
                         PItemLinkshell->SetLSType(LSTYPE_BROKEN);
+
                         char extra[sizeof(PItemLinkshell->m_extra) * 2 + 1];
                         _sql->EscapeStringLen(extra, (const char*)PItemLinkshell->m_extra, sizeof(PItemLinkshell->m_extra));
+
                         const char* Query = "UPDATE char_inventory SET extra = '%s' WHERE charid = %u AND location = %u AND slot = %u LIMIT 1";
                         _sql->Query(Query, extra, PChar->id, PItemLinkshell->getLocationID(), PItemLinkshell->getSlotID());
+
                         PChar->pushPacket<CInventoryItemPacket>(PItemLinkshell, PItemLinkshell->getLocationID(), PItemLinkshell->getSlotID());
                         PChar->pushPacket<CInventoryFinishPacket>();
                         PChar->pushPacket<CMessageStandardPacket>(MsgStd::LinkshellNoLongerExists);
@@ -6645,7 +6653,7 @@ void SmallPacket0x0E0(map_session_data_t* const PSession, CCharEntity* const PCh
 {
     TracyZoneScoped;
     char message[256];
-    _sql->EscapeString(message, (const char*)data[4]);
+    _sql->EscapeString(message, (const char*)data[0x04]);
 
     uint8 type = strlen(message) == 0 ? 0 : data.ref<uint8>(data.getSize() - 4);
 
@@ -6724,8 +6732,7 @@ void SmallPacket0x0E2(map_session_data_t* const PSession, CCharEntity* const PCh
             {
                 if (static_cast<uint8>(PItemLinkshell->GetLSType()) <= PChar->PLinkshell1->m_postRights)
                 {
-                    char lsMessage[128] = {};
-                    std::memcpy(&lsMessage, data[16], sizeof(lsMessage));
+                    const auto lsMessage = escapeString(asStringFromUntrustedSource(data[0x10], 128));
                     PChar->PLinkshell1->setMessage(lsMessage, PChar->getName());
                     return;
                 }
@@ -8499,7 +8506,7 @@ void PacketParserInitialize()
     PacketSize[0x03A] = 0x04; PacketParser[0x03A] = &SmallPacket0x03A;
     PacketSize[0x03B] = 0x10; PacketParser[0x03B] = &SmallPacket0x03B;
     PacketSize[0x03C] = 0x00; PacketParser[0x03C] = &SmallPacket0x03C;
-    PacketSize[0x03D] = 0x00; PacketParser[0x03D] = &SmallPacket0x03D; // Blacklist Command
+    PacketSize[0x03D] = 0x00; PacketParser[0x03D] = &SmallPacket0x03D;
     PacketSize[0x041] = 0x00; PacketParser[0x041] = &SmallPacket0x041;
     PacketSize[0x042] = 0x00; PacketParser[0x042] = &SmallPacket0x042;
     PacketSize[0x04B] = 0x00; PacketParser[0x04B] = &SmallPacket0x04B;
@@ -8534,8 +8541,8 @@ void PacketParserInitialize()
     PacketSize[0x085] = 0x04; PacketParser[0x085] = &SmallPacket0x085;
     PacketSize[0x096] = 0x12; PacketParser[0x096] = &SmallPacket0x096;
     PacketSize[0x09B] = 0x00; PacketParser[0x09B] = &SmallPacket0x09B;
-    PacketSize[0x0A0] = 0x00; PacketParser[0x0A0] = &SmallPacket0xFFF;    // not implemented
-    PacketSize[0x0A1] = 0x00; PacketParser[0x0A1] = &SmallPacket0xFFF;    // not implemented
+    PacketSize[0x0A0] = 0x00; PacketParser[0x0A0] = &SmallPacket0xFFF_NOT_IMPLEMENTED;
+    PacketSize[0x0A1] = 0x00; PacketParser[0x0A1] = &SmallPacket0xFFF_NOT_IMPLEMENTED;
     PacketSize[0x0A2] = 0x00; PacketParser[0x0A2] = &SmallPacket0x0A2;
     PacketSize[0x0AA] = 0x00; PacketParser[0x0AA] = &SmallPacket0x0AA;
     PacketSize[0x0AB] = 0x00; PacketParser[0x0AB] = &SmallPacket0x0AB;
@@ -8543,7 +8550,7 @@ void PacketParserInitialize()
     PacketSize[0x0AD] = 0x00; PacketParser[0x0AD] = &SmallPacket0x0AD;
     PacketSize[0x0B5] = 0x00; PacketParser[0x0B5] = &SmallPacket0x0B5;
     PacketSize[0x0B6] = 0x00; PacketParser[0x0B6] = &SmallPacket0x0B6;
-    PacketSize[0x0BE] = 0x00; PacketParser[0x0BE] = &SmallPacket0x0BE;    // merit packet
+    PacketSize[0x0BE] = 0x00; PacketParser[0x0BE] = &SmallPacket0x0BE;
     PacketSize[0x0BF] = 0x00; PacketParser[0x0BF] = &SmallPacket0x0BF;
     PacketSize[0x0C0] = 0x00; PacketParser[0x0C0] = &SmallPacket0x0C0;
     PacketSize[0x0C3] = 0x00; PacketParser[0x0C3] = &SmallPacket0x0C3;
@@ -8551,7 +8558,7 @@ void PacketParserInitialize()
     PacketSize[0x0CB] = 0x04; PacketParser[0x0CB] = &SmallPacket0x0CB;
     PacketSize[0x0D2] = 0x00; PacketParser[0x0D2] = &SmallPacket0x0D2;
     PacketSize[0x0D3] = 0x00; PacketParser[0x0D3] = &SmallPacket0x0D3;
-    PacketSize[0x0D4] = 0x00; PacketParser[0x0D4] = &SmallPacket0xFFF;    // not implemented
+    PacketSize[0x0D4] = 0x00; PacketParser[0x0D4] = &SmallPacket0xFFF_NOT_IMPLEMENTED;
     PacketSize[0x0DB] = 0x00; PacketParser[0x0DB] = &SmallPacket0x0DB;
     PacketSize[0x0DC] = 0x0A; PacketParser[0x0DC] = &SmallPacket0x0DC;
     PacketSize[0x0DD] = 0x08; PacketParser[0x0DD] = &SmallPacket0x0DD;
@@ -8587,7 +8594,7 @@ void PacketParserInitialize()
     PacketSize[0x10E] = 0x04; PacketParser[0x10E] = &SmallPacket0x10E;
     PacketSize[0x10F] = 0x02; PacketParser[0x10F] = &SmallPacket0x10F;
     PacketSize[0x110] = 0x0A; PacketParser[0x110] = &SmallPacket0x110;
-    PacketSize[0x111] = 0x00; PacketParser[0x111] = &SmallPacket0x111; // Lock Style Request
+    PacketSize[0x111] = 0x00; PacketParser[0x111] = &SmallPacket0x111;
     PacketSize[0x112] = 0x00; PacketParser[0x112] = &SmallPacket0x112;
     PacketSize[0x113] = 0x06; PacketParser[0x113] = &SmallPacket0x113;
     PacketSize[0x114] = 0x00; PacketParser[0x114] = &SmallPacket0x114;
@@ -8600,9 +8607,3 @@ void PacketParserInitialize()
     PacketSize[0x11D] = 0x00; PacketParser[0x11D] = &SmallPacket0x11D;
     // clang-format on
 }
-
-/************************************************************************
- *                                                                       *
- *                                                                       *
- *                                                                       *
- ************************************************************************/

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -5885,7 +5885,7 @@ namespace battleutils
                 {
                     if (auto PCharTarget = dynamic_cast<CCharEntity*>(PTarget))
                     {
-                        // Update target's recast state; caster's will be handled in CCharEntity::OnAbility.
+                        // Update target's recast state: caster's will be handled in CCharEntity::OnAbility.
                         PCharTarget->pushPacket<CCharRecastPacket>(PCharTarget);
                     }
                 }
@@ -5916,7 +5916,7 @@ namespace battleutils
             {
                 if (auto PCharTarget = dynamic_cast<CCharEntity*>(PTarget))
                 {
-                    // Update target's recast state; caster's will be handled in CCharEntity::OnAbility.
+                    // Update target's recast state: caster's will be handled in CCharEntity::OnAbility.
                     PCharTarget->pushPacket<CCharRecastPacket>(PCharTarget);
                 }
             }

--- a/src/search/data_loader.h
+++ b/src/search/data_loader.h
@@ -92,7 +92,7 @@ public:
     std::list<SearchEntity*> GetLinkshellList(uint32 LinkshellID);
     std::list<SearchEntity*> GetPlayersList(search_req sr, int* count);
     std::string              GetSearchComment(uint32 playerId);
-    std::vector<ahItem*>     GetAHItemsToCategory(uint8 AHCategoryID, const char* OrderByString);
+    std::vector<ahItem*>     GetAHItemsToCategory(uint8 ahCategoryID, const std::string& orderByString);
     ahItem                   GetAHItemFromItemID(uint16 ItemID);
     void                     ExpireAHItems(uint16 expireAgeInDays);
 };

--- a/src/search/search_handler.cpp
+++ b/src/search/search_handler.cpp
@@ -298,7 +298,8 @@ void search_handler::read_func(uint16_t length)
 void search_handler::handle_error(std::error_code ec, std::shared_ptr<search_handler> self)
 {
     std::ignore = ec;
-    std::ignore = self;
+
+    self = nullptr;
 }
 
 // Mostly copy-pasted DSP era code. It works, so why change it?
@@ -470,7 +471,7 @@ void search_handler::HandleSearchRequest()
 
 void search_handler::HandleAuctionHouseRequest()
 {
-    uint8  AHCatID = ref<uint8>(data_, 0x16);
+    uint8 AHCatID = ref<uint8>(data_, 0x16);
 
     // 2 - level
     // 3 - race
@@ -584,7 +585,7 @@ search_req search_handler::_HandleSearchRequest()
 
     uint32 flags = 0;
 
-    uint8  size = ref<uint8>(data_, 0x10);
+    uint8 size = ref<uint8>(data_, 0x10);
 
     uint16 workloadBits = size * 8;
 

--- a/src/world/conquest_system.cpp
+++ b/src/world/conquest_system.cpp
@@ -186,9 +186,9 @@ bool ConquestSystem::updateInfluencePoints(int points, unsigned int nation, REGI
         return false;
     }
 
-    std::string query = "SELECT sandoria_influence, bastok_influence, windurst_influence, beastmen_influence FROM conquest_system WHERE region_id = %d";
+    std::string query = "SELECT sandoria_influence, bastok_influence, windurst_influence, beastmen_influence FROM conquest_system WHERE region_id = ?";
 
-    auto rset = db::query(query.c_str(), static_cast<uint8>(region));
+    auto rset = db::preparedStmt(query.c_str(), static_cast<uint8>(region));
     if (!rset || rset->rowsCount() == 0 || !rset->next())
     {
         return false;
@@ -221,9 +221,9 @@ bool ConquestSystem::updateInfluencePoints(int points, unsigned int nation, REGI
 
     influences[nation] += lost;
 
-    auto rset2 = db::query("UPDATE conquest_system SET sandoria_influence = %d, bastok_influence = %d, "
-                           "windurst_influence = %d, beastmen_influence = %d WHERE region_id = %u",
-                           influences[0], influences[1], influences[2], influences[3], static_cast<uint8>(region));
+    auto rset2 = db::preparedStmt("UPDATE conquest_system SET sandoria_influence = ?, bastok_influence = ?, "
+                                  "windurst_influence = ?, beastmen_influence = ? WHERE region_id = ?",
+                                  influences[0], influences[1], influences[2], influences[3], static_cast<uint8>(region));
 
     return !rset2;
 }

--- a/src/world/conquest_system.cpp
+++ b/src/world/conquest_system.cpp
@@ -236,13 +236,13 @@ void ConquestSystem::updateWeekConquest()
     sendTallyStartMsg();
 
     // 2- Do the actual db update
-    auto query = "UPDATE conquest_system SET region_control = \
-                            IF(sandoria_influence > bastok_influence AND sandoria_influence > windurst_influence AND \
-                            sandoria_influence > beastmen_influence, 0, \
-                            IF(bastok_influence > sandoria_influence AND bastok_influence > windurst_influence AND \
-                            bastok_influence > beastmen_influence, 1, \
-                            IF(windurst_influence > bastok_influence AND windurst_influence > sandoria_influence AND \
-                            windurst_influence > beastmen_influence, 2, 3)))";
+    auto query = "UPDATE conquest_system SET region_control = "
+                 "IF(sandoria_influence > bastok_influence AND sandoria_influence > windurst_influence AND "
+                 "sandoria_influence > beastmen_influence, 0, "
+                 "IF(bastok_influence > sandoria_influence AND bastok_influence > windurst_influence AND "
+                 "bastok_influence > beastmen_influence, 1, "
+                 "IF(windurst_influence > bastok_influence AND windurst_influence > sandoria_influence AND "
+                 "windurst_influence > beastmen_influence, 2, 3)))";
 
     auto rset = db::preparedStmt(query);
     if (!rset)

--- a/src/world/daily_tally.cpp
+++ b/src/world/daily_tally.cpp
@@ -33,11 +33,10 @@ namespace dailytally
         uint16 dailyTallyLimit  = settings::get<uint16>("main.DAILY_TALLY_LIMIT");
         uint16 dailyTallyAmount = settings::get<uint16>("main.DAILY_TALLY_AMOUNT");
 
-        const char* fmtQuery = "UPDATE char_points \
-            SET char_points.daily_tally = LEAST(%u, char_points.daily_tally + %u) \
-            WHERE char_points.daily_tally > -1";
-
-        if (!db::query(fmtQuery, dailyTallyLimit, dailyTallyAmount))
+        if (!db::preparedStmt("UPDATE char_points "
+                              "SET char_points.daily_tally = LEAST(?, char_points.daily_tally + ?) "
+                              "WHERE char_points.daily_tally > -1",
+                              dailyTallyLimit, dailyTallyAmount))
         {
             ShowError("Failed to update daily tally points");
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Also tidies multiline strings

Testing:
- [x] Make a new character
- [x] Change password
- [x] Delete a character
- [x] Log in
- [x] /sea all
- [x] Send tell
- [x] Join party
- [x] Send party chat
- [x] Add someone to blacklist
- [x] Create and name a linkshell
- [x] Make a linkpearl and trade to someone else
- [x] Both equip linkpearls
- [x] Send linkshell chat - seen by all
- [x] List something on the AH
- [x] Buy something on the AH - get item
- [x] De-list something from the AH
- [x] AH: Price history shows
- [x] AH: Current listings show
- [x] AH: Listing per-item show
- [x] AH: Have someone buy something - gil shows up in dbox
- [x] Send something to another char in the dbox
- [x] Get something from another char in the dbox
- [x] Daily tally
- [x] Conquest
- [x] Cancel dbox sends

