### PR TITLE
[Interaction] Fix some WotG mission oversights

### DIFF
--- a/scripts/missions/wotg/04_The_Queen_of_the_Dance.lua
+++ b/scripts/missions/wotg/04_The_Queen_of_the_Dance.lua
@@ -63,10 +63,10 @@ mission.sections =
         },
     },
 
-    -- 2: Come back and use your ticket
+    -- 2+: Come back and use your ticket
     {
         check = function(player, currentMission, missionStatus, vars)
-            return currentMission == mission.missionId and missionStatus == 2
+            return currentMission == mission.missionId and missionStatus >= 2
         end,
 
         [xi.zone.SOUTHERN_SAN_DORIA_S] =
@@ -77,9 +77,9 @@ mission.sections =
                 local missionStatus = player:getMissionStatus(mission.areaId)
 
                 if missionStatus == 3 then
-                    return mission:progressEvent(152)
+                    return 152
                 elseif missionStatus == 4 then
-                    return mission:progressEvent(153)
+                    return 153
                 end
             end,
 

--- a/scripts/missions/wotg/05_While_the_Cat_is_Away.lua
+++ b/scripts/missions/wotg/05_While_the_Cat_is_Away.lua
@@ -33,11 +33,10 @@ mission.sections =
             {
                 [7] = function(player, csid, option, npc)
                     if option == 0 then
-                        local sandyFlag = player:hasCompletedQuest(xi.questLog.CRYSTAL_WAR, xi.quest.id.crystalWar.BURDEN_OF_SUSPICION) and 1 or 0
+                        local sandyFlag  = player:hasCompletedQuest(xi.questLog.CRYSTAL_WAR, xi.quest.id.crystalWar.BURDEN_OF_SUSPICION) and 1 or 0
                         local bastokFlag = player:hasCompletedQuest(xi.questLog.CRYSTAL_WAR, xi.quest.id.crystalWar.WRATH_OF_THE_GRIFFON) and 1 or 0
-                        local windyFlag = player:hasCompletedQuest(xi.questLog.CRYSTAL_WAR, xi.quest.id.crystalWar.A_MANIFEST_PROBLEM) and 1 or 0
-
-                        local rovFlag = player:getCurrentMission(xi.mission.log_id.ROV) >= xi.mission.id.rov.GANGED_UP_ON and 1 or 0
+                        local windyFlag  = player:hasCompletedQuest(xi.questLog.CRYSTAL_WAR, xi.quest.id.crystalWar.A_MANIFEST_PROBLEM) and 1 or 0
+                        local rovFlag    = player:getCurrentMission(xi.mission.log_id.ROV) >= xi.mission.id.rov.GANGED_UP_ON and 1 or 0
 
                         player:updateEvent(sandyFlag, bastokFlag, windyFlag, rovFlag, 0, 7733257, 0, 0)
                     end

--- a/scripts/missions/wotg/07_Purple_The_New_Black.lua
+++ b/scripts/missions/wotg/07_Purple_The_New_Black.lua
@@ -39,7 +39,7 @@ mission.sections =
     -- 1: Enter the BCNM vs Galarhigg
     {
         check = function(player, currentMission, missionStatus, vars)
-            return currentMission == mission.missionId and missionStatus == 1
+            return currentMission == mission.missionId and missionStatus >= 1
         end,
 
         [xi.zone.LA_VAULE_S] =


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- onZoneIn shouldnt use `event()` statements.
- missionStatus check was `==`, making it concrete and crating dead code inside.

Example
![imagen](https://github.com/user-attachments/assets/e6334b60-3fa1-47ab-a54d-39a21b2afed8)


## Steps to test these changes

Run missions
