### PR TITLE
[lua] BST mobs pets despawn if not aggresive on master death

### DIFF
--- a/scripts/actions/mobskills/call_beast.lua
+++ b/scripts/actions/mobskills/call_beast.lua
@@ -13,10 +13,23 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
+local onMasterDeath = function(mob)
+    if mob:hasPet() then
+        local pet = mob:getPet()
+        if pet ~= nil then
+            if not pet:isEngaged() then
+                DespawnMob(pet:getID(), 2)
+            end
+        end
+    end
+end
+
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     mob:spawnPet()
 
     skill:setMsg(xi.msg.basic.NONE)
+    mob:addListener('DEATH', 'BEASTMASTER_DEATH', onMasterDeath)
+    mob:addListener('DESPAWN', 'BEASTMASTER_DESPAWN', onMasterDeath)
 
     return 0
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Attaches listeners on mobskill "Call Beast" usage, ensuring their pet gets despawned if not aggressive at the time of master death/despawn. See [retail example](https://www.youtube.com/watch?v=QXeJlAviSiA)

This ensures pets are not "orphaned" if the master was killed in one hit or despawned due to other conditions (Fomor Beastmaster in Wajaom disappearing during the day, for example)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

https://www.youtube.com/watch?v=RJwZFLgiVFs

- Aggro a BST mob and kill it, pet should not despawn
- One shot or !despawnmob a BST mob, the pet should despawn


<!-- Clear and detailed steps to test your changes here -->
