### PR TITLE
Lua: Lower Jeuno Gobbie box shouldn't show Tenshodo Coffer options

### DIFF
--- a/scripts/zones/Lower_Jeuno/npcs/Treasure_Coffer.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Treasure_Coffer.lua
@@ -1871,7 +1871,16 @@ local argumentKeyItems =
     },
 }
 
+local isTenshodoCoffer = function(player)
+    local distance = player:checkDistance(41.169, 3.899, -51.005)
+    return distance < 6.0
+end
+
 entity.onTrigger = function(player, npc)
+    if not isTenshodoCoffer(player) then
+        return
+    end
+
     -- determines if server/player is eligible to receive a nexus cape
     local eligibleNexusCape = xi.settings.main.ENABLE_ACP == 1 and
                             xi.settings.main.ENABLE_AMK == 1 and


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

They're named the same, so this is a quick patch to stop the inert gobbie box coffer showing the hidden tenshodo box options