### PR TITLE
[Lua] Bodyguard Follow Behavior Fix

### DIFF
--- a/scripts/globals/follow.lua
+++ b/scripts/globals/follow.lua
@@ -99,3 +99,34 @@ xi.follow.assignLeaderMod = function(mob, leaders, maxDistance)
         end
     end
 end
+
+-- This function causes the followers to organize in a column, and not
+-- stack upon one another. Must be called in leading mob's onMobRoam in
+-- order to maintain continuity of mob ordering in the line.
+--
+-- @param Original mob that leads the line of followers
+-- @param The amount of followers (assumed to be adjacent to origin mob's ID)
+-----------------------------------
+xi.follow.followLine = function(mob, numFollowers)
+    local mobID = mob:getID()
+
+    if
+        mob and
+        mob:isAlive()
+    then
+        for indexFollower = mobID + numFollowers, mobID + 1, -1 do
+            local follower = GetMobByID(indexFollower)
+
+            if follower and follower:isAlive() then
+                for indexLeader = indexFollower - 1, mobID, -1 do
+                    local newLeader = GetMobByID(indexLeader)
+
+                    if newLeader and newLeader:isAlive() then
+                        xi.follow.follow(follower, newLeader)
+                        break
+                    end
+                end
+            end
+        end
+    end
+end

--- a/scripts/mixins/rotz_bodyguarded_nm.lua
+++ b/scripts/mixins/rotz_bodyguarded_nm.lua
@@ -11,13 +11,11 @@ g_mixins.bodyguard = function(bodyguardedNM)
     -- function for bodyguard roaming logic
     local bodyGuardRoam = function(mob)
         -- if bodyguarded NM is missing or dead then despawn the bodyguard
-        if not bodyguardedNM or (bodyguardedNM and bodyguardedNM:isDead()) then
-            DespawnMob(mob:getID())
-        -- else if bodyguard not following then follow NM
-        elseif
-            not mob:hasFollowTarget() and bodyguardedNM
+        if
+            not bodyguardedNM or
+            (bodyguardedNM and bodyguardedNM:isDead())
         then
-            mob:follow(bodyguardedNM, xi.followType.ROAM)
+            DespawnMob(mob:getID())
         end
     end
 
@@ -47,13 +45,16 @@ g_mixins.bodyguard = function(bodyguardedNM)
 
                     guard:setSpawn(nmSpawnPos.x - spawnPosOffset[index], nmSpawnPos.y, nmSpawnPos.z)
                     guard:spawn()
-                    guard:follow(mob, xi.followType.ROAM)
                     guard:addListener('ROAM_TICK', 'ROTZ_BODYGUARD_ROAM', bodyGuardRoam)
                     guard:addListener('DESPAWN', 'ROTZ_BODYGUARD_DESPAWN', bodyGuardDespawn)
                     guard:setMobMod(xi.mobMod.NO_DESPAWN, 1)
                 end
             end
         end
+    end)
+
+    bodyguardedNM:addListener('ROAM_TICK', 'ROTZ_NM_ROAM_TICK', function(mob)
+        xi.follow.followLine(mob, 2)
     end)
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- This PR adds a new method of following a target as a train of mobs. The added function goes through the list all possible followers, adjacent to a mob's ID, and has each mob follow the next mob that is 1 ID closer to the leader - giving the behavior of a column following order. Should a mob in the middle of the train die, or not be spawned, it will follow the next mob in order.
- This behavior is used in a plethora of content and not only the ROTZ overworld NMs that spawn with x2 bodyguards. This PR intends to build the framework for future needed content.
- Side note: Previous behavior of the ROTZ overworld mixin caused the mobs to path inside one another

Links to captures with proof of follow behavior in ROTZ overworld NMs
https://www.youtube.com/watch?v=spfDvNUIUWM
https://www.youtube.com/watch?v=CV7WNt6vaWU
https://www.youtube.com/watch?v=wDdv3Ditz1U

## Steps to test these changes
!zone {Eastern Altepa Desert}
!spawnmob 17244372
!exec player:setPos(GetMobByID(17244372):getPos())
Observe behavior
Kill mob between NM and final mob and view adjustment behavior