### PR TITLE
[core] Clear mob targetID when BST use Leave

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2724,6 +2724,10 @@ bool CBattleEntity::hasEnmityEXPENSIVE() const
         // clang-format off
         loc.zone->ForEachMob([&](CMobEntity* PMob)
         {
+            if (!PMob->isAlive())
+            {
+                return;
+            }
             // Account for charmed mobs attacking normal mobs, etc
             if (PMob->GetBattleTargetID() == targid && PMob->allegiance != allegiance)
             {

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1292,6 +1292,7 @@ namespace petutils
                 if ((state && state->GetAbility()->getID() == ABILITY_LEAVE) || PChar->loc.zoning || PChar->isDead())
                 {
                     PMob->PEnmityContainer->Clear();
+                    PMob->SetBattleTargetID(0);
                     PMob->m_OwnerID.clean();
                     PMob->updatemask |= UPDATE_STATUS;
                 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
2 for 1

**Clear target ID for mobs released with Leave**
When a BST uses Leave, sets the released mob target ID to 0. 

This ensures any subsequent hasEnmity (hasEnmityEXPENSIVE) check will not return true for the now passive monster.

This was blocking BST from calling Trusts after releasing a charmed mob.

**Don't consider dead/despawned mobs for hasEnmityEXPENSIVE**

For some reason, all of the zone mobs were being checked against when performing enmity checks. With this change, mobs in such conditions will not be considered.

This was blocking BST from calling Trusts even after the released mob was gone.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

- !changejob BST 99
- Charm a monster
- Use Leave
- Attempt to summon trust
  - Before PR: Cannot summon Trusts due to enmity
  - With PR: Trust is summoned

<!-- Clear and detailed steps to test your changes here -->
