### PR TITLE
[Fix] Cardinal Chant missing divisor

### DIFF
--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -258,8 +258,8 @@ local function cardinalChantBonus(actor, target, direction, spellId, skillType)
     local gearFactor = 1 + actor:getMod(xi.mod.CARDINAL_CHANT_BONUS) / 100
 
     -- Calculate angle %
-    local angle        = utils.getWorldRotation(actor:getPos(), target:getPos())
-    local angleFactor  = 0
+    local angle       = utils.getWorldRotation(actor:getPos(), target:getPos())
+    local angleFactor = 0
 
     switch (direction) : caseof
     {
@@ -944,7 +944,7 @@ xi.spells.damage.calculateIfMagicBurstBonus = function(caster, target, spellId, 
     cappedBonus = utils.clamp(cappedBonus, 0, 0.4)
 
     -- BLM Job Point: Magic Burst Damage and GEO cardinal chant.
-    uncappedBonus = uncappedBonus + caster:getJobPointLevel(xi.jp.MAGIC_BURST_DMG_BONUS) / 100 + cardinalChantBonus(caster, target, xi.direction.WEST, spellId, skillType)
+    uncappedBonus = uncappedBonus + caster:getJobPointLevel(xi.jp.MAGIC_BURST_DMG_BONUS) / 100 + cardinalChantBonus(caster, target, xi.direction.WEST, spellId, skillType) / 100
 
     -- Get final multiplier
     magicBurstBonus = magicBurstBonus + cappedBonus + uncappedBonus


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fix oversight with Cardinal Chant Magic Burst Bonus missing a divisor due to being a different scale.

## Steps to test these changes

Use a GEO and magic burst. See boosted, but not busted, damage.
