### PR TITLE
Core: If inserted zone entity is a char check for moghouse status

### DIFF
--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -462,6 +462,7 @@ public:
     //     : disambiguate between entities who have been rebuilt (players, dynamic entities) and have the same ID.
     xi::optional<EntityID_t> WideScanTarget;
 
+    // NOTE: These are all keyed by id
     SpawnIDList_t SpawnPCList;    // list of visible characters
     SpawnIDList_t SpawnMOBList;   // list of visible monsters
     SpawnIDList_t SpawnPETList;   // list of visible pets

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -162,8 +162,14 @@ void CZoneEntities::TryAddToNearbySpawnLists(CBaseEntity* PEntity)
             {
                 case TYPE_PC:
                 {
+                    auto* PChar = static_cast<CCharEntity*>(PEntity);
+                    if (PChar->m_moghouseID != PCurrentChar->m_moghouseID)
+                    {
+                        continue;
+                    }
+
                     PCurrentChar->SpawnPCList[PEntity->id] = PEntity;
-                    PCurrentChar->updateCharPacket(static_cast<CCharEntity*>(PEntity), ENTITY_SPAWN, UPDATE_ALL_CHAR);
+                    PCurrentChar->updateCharPacket(PChar, ENTITY_SPAWN, UPDATE_ALL_CHAR);
                     break;
                 }
                 case TYPE_NPC:
@@ -178,7 +184,6 @@ void CZoneEntities::TryAddToNearbySpawnLists(CBaseEntity* PEntity)
                     PCurrentChar->updateEntityPacket(PEntity, ENTITY_SPAWN, UPDATE_ALL_MOB);
                     break;
                 }
-
                 case TYPE_PET:
                 {
                     PCurrentChar->SpawnPETList[PEntity->id] = PEntity;
@@ -213,7 +218,6 @@ void CZoneEntities::InsertPC(CCharEntity* PChar)
     m_charTargIds.insert(PChar->targid);
     m_charList[PChar->targid] = PChar;
 
-    // TODO: Do we need to force-add the entity to spawn lists? It'll happen on a char's next update anyway?
     TryAddToNearbySpawnLists(PChar);
 
     ShowDebug("CZone:: %s IncreaseZoneCounter <%u> %s", m_zone->getName(), m_charList.size(), PChar->getName());
@@ -228,7 +232,6 @@ void CZoneEntities::InsertAlly(CBaseEntity* PMob)
         PMob->loc.zone           = m_zone;
         m_allyList[PMob->targid] = PMob;
 
-        // TODO: Do we need to force-add the entity to spawn lists? It'll happen on a char's next update anyway?
         TryAddToNearbySpawnLists(PMob);
     }
 }
@@ -244,7 +247,6 @@ void CZoneEntities::InsertMOB(CBaseEntity* PMob)
         FindPartyForMob(PMob);
         m_mobList[PMob->targid] = PMob;
 
-        // TODO: Do we need to force-add the entity to spawn lists? It'll happen on a char's next update anyway?
         TryAddToNearbySpawnLists(PMob);
     }
 }
@@ -276,7 +278,6 @@ void CZoneEntities::InsertNPC(CBaseEntity* PNpc)
             m_npcList[PNpc->targid] = PNpc;
         }
 
-        // TODO: Do we need to force-add the entity to spawn lists? It'll happen on a char's next update anyway?
         TryAddToNearbySpawnLists(PNpc);
     }
 }
@@ -291,7 +292,6 @@ void CZoneEntities::InsertPET(CBaseEntity* PPet)
 
         m_petList[PPet->targid] = PPet;
 
-        // TODO: Do we need to force-add the entity to spawn lists? It'll happen on a char's next update anyway?
         TryAddToNearbySpawnLists(PPet);
 
         PPet->spawnAnimation = SPAWN_ANIMATION::NORMAL; // Turn off special spawn animation
@@ -310,7 +310,6 @@ void CZoneEntities::InsertTRUST(CBaseEntity* PTrust)
         m_zone->GetZoneEntities()->AssignDynamicTargIDandLongID(PTrust);
         m_trustList[PTrust->targid] = PTrust;
 
-        // TODO: Do we need to force-add the entity to spawn lists? It'll happen on a char's next update anyway?
         TryAddToNearbySpawnLists(PTrust);
 
         PTrust->spawnAnimation = SPAWN_ANIMATION::NORMAL; // Turn off special spawn animation

--- a/src/map/zone_entities.h
+++ b/src/map/zone_entities.h
@@ -102,6 +102,7 @@ public:
 private:
     CZone* m_zone;
 
+    // NOTE: These are all keyed by targid
     EntityList_t m_allyList;
     EntityList_t m_mobList;
     EntityList_t m_petList;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

Bug repro:

- Both be in MH in the same area
- One of you !goto "me"
- Other person will see the first person flash in for 1 400ms tick, and then disappear

Visible before, not visible after fix.

Also checked you can still see other players outside of MH.