### PR TITLE
PDIF level correction adjustments, move ranged PDIF to lua

### DIFF
--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -321,7 +321,7 @@ local function getSingleHitDamage(attacker, target, dmg, ftp, wsParams, calcPara
     if calcParams.attackType == xi.attackType.PHYSICAL then
         calcParams.pdif = xi.combat.physical.calculateMeleePDIF(attacker, target, calcParams.attackInfo.weaponType, atkMultiplier, criticalHit, applyLevelCorrection, ignoresDefense, ignoreDefMultiplier, true, calcParams.attackInfo.slot)
     else
-        calcParams.pdif = xi.combat.physical.calculateRangedPDIF(attacker, target, calcParams.skillType, atkMultiplier, criticalHit, applyLevelCorrection, ignoresDefense, ignoreDefMultiplier, true)
+        calcParams.pdif = xi.combat.physical.calculateRangedPDIF(attacker, target, calcParams.skillType, atkMultiplier, criticalHit, applyLevelCorrection, ignoresDefense, ignoreDefMultiplier, true, 0)
     end
 
     hitDamage = (dmg + consumeManaBonus(attacker)) * ftp * calcParams.pdif


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

I moved ranged PDIF to lua calls, and tested it. I noticed I was getting positive level correction vs mobs below me which is wrong. Players should only get penalized (or neutral), and mobs should only get positive (or neutral) correction.

I changed how its calculated to be more human readable, the way it was done looked strange and was likely why we had this bug.

I added an input to ranged pdif so it would be compatible with the C++ function for Sange since it adds static attack.

Probably better to review by commit and read the whole function in GetRangedDamageRatio, it looks like a mess but it's basically a total replacement.

## Steps to test these changes

Use /ra, barrage, etc with no errors and see it work.
Use melee/ranged attacks and don't get positive level correction vs mobs below you


