### PR TITLE
[quest, lua] fix quest The Trader In The Forest to remove batagreens when traded

### DIFF
--- a/scripts/quests/sandoria/The_Trader_in_the_Forest.lua
+++ b/scripts/quests/sandoria/The_Trader_in_the_Forest.lua
@@ -81,7 +81,9 @@ quest.sections =
             onEventFinish =
             {
                 [525] = function(player, csid, option, npc)
-                    quest:complete(player)
+                    if quest:complete(player) then
+                        player:confirmTrade()
+                    end
                 end,
 
                 [593] = function(player, csid, option, npc)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a part of #6897. When you trade batagreens to the NPC Abeaule they stay in your inventory. 

## Steps to test these changes

Complete the quest The Trade In The Forest
