### PR TITLE
[quest, lua] fix quest The Rescue to remove Quadav Charm item when traded

### DIFF
--- a/scripts/quests/otherAreas/The_Rescue.lua
+++ b/scripts/quests/otherAreas/The_Rescue.lua
@@ -93,6 +93,7 @@ quest.sections =
             onEventFinish =
             {
                 [1000] = function(player, csid, option, npc)
+                    player:confirmTrade()
                     npcUtil.giveKeyItem(player, xi.ki.TRADERS_SACK)
                 end,
             },


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes the last issue with #6897

With these changes when I do the quest "The Rescue" the Quadav Charm item is removed from my inventory when I trade it

## Steps to test these changes

!gotoid17793026
Speak to Thunder Hawk to get quest
!additem 495 to get Quadav Charm
!gotoid 17379626 to get close to destination
Go to door at I8.
Trade Quadav Charm to door.
It should be removed from your inventory.
