### PR TITLE
[build] Load nested module CMakeLists.txt if present

### DIFF
--- a/src/map/CMakeLists.txt
+++ b/src/map/CMakeLists.txt
@@ -153,12 +153,18 @@ set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${CMAKE_SOURCE_D
 
 # Search for module directories
 set(module_include_dirs "")
+set(cmakelist_include_paths "")
 file(STRINGS ${CMAKE_SOURCE_DIR}/modules/init.txt INIT_FILE_ENTRIES REGEX "^[^#\n].*")
 foreach(entry ${INIT_FILE_ENTRIES})
     if (${entry} STREQUAL "")
         continue()
     endif()
     if (IS_DIRECTORY "${CMAKE_SOURCE_DIR}/modules/${entry}")
+        if (EXISTS "${CMAKE_SOURCE_DIR}/modules/${entry}/CMakeLists.txt")
+            list(APPEND cmakelist_include_paths "${CMAKE_SOURCE_DIR}/modules/${entry}/CMakeLists.txt")
+            message(STATUS "Adding module CMakeLists.txt to build: ${CMAKE_SOURCE_DIR}/modules/${entry}/CMakeLists.txt")
+            continue()
+        endif()
         file(GLOB_RECURSE module_files
             "${CMAKE_SOURCE_DIR}/modules/${entry}/*.cpp"
             "${CMAKE_SOURCE_DIR}/modules/${entry}/*.h")
@@ -174,6 +180,13 @@ endforeach()
 add_executable(xi_map
     ${SOURCES}
     ${resource})
+
+foreach(entry ${cmakelist_include_paths})
+    if (${entry} STREQUAL "")
+        continue()
+    endif()
+    include("${entry}")
+endforeach()
 
 if(WIN32)
     set_target_properties(xi_map PROPERTIES OUTPUT_NAME xi_map)


### PR DESCRIPTION
Allow modules to manipulate the build process for xi_map

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Building a module that needs to link libraries and realized there was no easy way to change the build process without dirtying the main CMakeLists.

This makes the map process CMakeLists check if the module has a CMakeList.txt at the root and include it if so.

Not a CMake expert, open to other ideas.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

Add a CMakeList.txt in a module, reconfigure cmake, see it get included.

<!-- Clear and detailed steps to test your changes here -->
