### PR TITLE
[lua] Unity NPC use the right CharVar for calculations

### DIFF
--- a/scripts/globals/unity.lua
+++ b/scripts/globals/unity.lua
@@ -148,7 +148,7 @@ function xi.unity.onEventUpdate(player, csid, option, npc)
     local zoneId               = player:getZoneID()
     local ID                   = zones[zoneId]
     local accolades            = player:getCurrency('unity_accolades')
-    local weeklyAccoladesSpent = player:getCharVar('weekly_sparks_spent')
+    local weeklyAccoladesSpent = player:getCharVar('weekly_accolades_spent')
     local remainingLimit       = xi.settings.main.WEEKLY_EXCHANGE_LIMIT - player:getCharVar('weekly_accolades_spent')
     local category             = bit.band(option, 0xF)
     local selection            = bit.band(bit.rshift(option, 5), 0xFF)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Unity NPCs are looking up the wrong CharVar when performing unity accolades calculations, leading to players ending up in negative if they had spent sparks with RoE NPCs.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

!addcurrency unity_accolades 100000
!pos -88 1 -48 230
Buy items from Urbiolaine in South San d'Oria, verify the math checks out.

<!-- Clear and detailed steps to test your changes here -->
fixes #3426 