### PR TITLE
Support overlapping TriggerAreas

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -464,6 +464,15 @@
         "__split_buffer": "cpp",
         "__threading_support": "cpp",
         "__tree": "cpp",
-        "print": "cpp"
+        "print": "cpp",
+        "__bits": "cpp",
+        "__debug": "cpp",
+        "__errc": "cpp",
+        "__functional_base": "cpp",
+        "__mutex_base": "cpp",
+        "__nullptr": "cpp",
+        "__std_stream": "cpp",
+        "__string": "cpp",
+        "__tuple": "cpp"
     },
 }

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -725,9 +725,27 @@ end
 function CBaseEntity:isInMogHouse()
 end
 
----@nodiscard
----@return integer
-function CBaseEntity:getPlayerTriggerAreaInZone()
+---@param triggerAreaId integer
+---@return boolean
+function CBaseEntity:isPlayerInTriggerArea(triggerAreaId)
+end
+
+---@return nil
+function CBaseEntity:isPlayerInAnyTriggerArea()
+end
+
+---@param triggerAreaId integer
+---@return nil
+function CBaseEntity:onPlayerTriggerAreaEnter(triggerAreaId)
+end
+
+---@param triggerAreaId integer
+---@return nil
+function CBaseEntity:onPlayerTriggerAreaLeave(triggerAreaId)
+end
+
+---@return nil
+function CBaseEntity:clearPlayerTriggerAreas()
 end
 
 ---@param statusID integer

--- a/scripts/zones/Port_Bastok/npcs/_6kt.lua
+++ b/scripts/zones/Port_Bastok/npcs/_6kt.lua
@@ -35,7 +35,7 @@ entity.onTimeTrigger = function(npc, triggerID)
 
         --If a player is on the bridge, kick them off
         for _, player in pairs(players) do
-            if player:getPlayerTriggerAreaInZone() == 2 then
+            if player:isPlayerInTriggerArea(2) then
                 player:startEvent(70)
             end
         end

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -181,17 +181,16 @@ CCharEntity::CCharEntity()
 
     m_PMonstrosity = nullptr;
 
-    m_Costume             = 0;
-    m_Costume2            = 0;
-    m_hasTractor          = 0;
-    m_hasRaise            = 0;
-    m_weaknessLvl         = 0;
-    m_hasArise            = false;
-    m_InsideTriggerAreaID = 0;
-    m_LevelRestriction    = 0;
-    m_lastBcnmTimePrompt  = 0;
-    m_AHHistoryTimestamp  = 0;
-    m_DeathTimestamp      = 0;
+    m_Costume            = 0;
+    m_Costume2           = 0;
+    m_hasTractor         = 0;
+    m_hasRaise           = 0;
+    m_weaknessLvl        = 0;
+    m_hasArise           = false;
+    m_LevelRestriction   = 0;
+    m_lastBcnmTimePrompt = 0;
+    m_AHHistoryTimestamp = 0;
+    m_DeathTimestamp     = 0;
 
     m_EquipFlag         = 0;
     m_EquipBlock        = 0;
@@ -3096,6 +3095,26 @@ bool CCharEntity::OnAttackError(CAttackState& state)
         return true;
     }
     return false;
+}
+
+bool CCharEntity::isInTriggerArea(uint32 triggerAreaID)
+{
+    return charTriggerAreaIDs.find(triggerAreaID) != charTriggerAreaIDs.end();
+}
+
+void CCharEntity::onTriggerAreaEnter(uint32 triggerAreaID)
+{
+    charTriggerAreaIDs.insert(triggerAreaID);
+}
+
+void CCharEntity::onTriggerAreaLeave(uint32 triggerAreaID)
+{
+    charTriggerAreaIDs.erase(triggerAreaID);
+}
+
+void CCharEntity::clearTriggerAreas()
+{
+    charTriggerAreaIDs.clear();
 }
 
 bool CCharEntity::isInEvent()

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -479,8 +479,7 @@ public:
 
     std::unique_ptr<monstrosity::MonstrosityData_t> m_PMonstrosity;
 
-    uint32     m_InsideTriggerAreaID; // The ID of the trigger area the character is inside
-    uint8      m_LevelRestriction;    // Character level limit
+    uint8      m_LevelRestriction; // Character level limit
     uint16     m_Costume;
     uint16     m_Costume2;
     uint32     m_AHHistoryTimestamp;
@@ -586,6 +585,11 @@ public:
     int32 GetTimeCreated();
     uint8 getHighestJobLevel();
 
+    bool isInTriggerArea(uint32 triggerAreaId);
+    void onTriggerAreaEnter(uint32 tiggerAreaId);
+    void onTriggerAreaLeave(uint32 triggerAreaId);
+    void clearTriggerAreas();
+
     bool isInEvent();
     bool isNpcLocked();
     void queueEvent(EventInfo* eventToQueue);
@@ -659,6 +663,7 @@ private:
 
     std::unordered_map<std::string, std::pair<int32, uint32>> charVarCache;
     std::unordered_set<std::string>                           charVarChanges;
+    std::unordered_set<uint32>                                charTriggerAreaIDs; // Holds any TriggerArea IDs that the player is currently within the bounds of
 
     uint8      dataToPersist = 0;
     time_point nextDataPersistTime;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -2799,13 +2799,12 @@ bool CLuaBaseEntity::isInMogHouse()
 }
 
 /************************************************************************
-*  Function: getPlayerTriggerAreaInZone
-*  Purpose : Returns the player's current trigger area inside the zone
-*  Example : local triggerAreaID = player:getPlayerTriggerAreaInZone()
-*  Notes   : This refers to trigger areas added via the registerTriggerArea function
-             Currently only used for port bastok drawbridge
-************************************************************************/
-uint32 CLuaBaseEntity::getPlayerTriggerAreaInZone()
+ *  Function: isPlayerInTriggerArea
+ *  Purpose : Returns a boolean indiciating if the player is within the provided TriggerAreaID
+ *  Example : local isInTriggerArea = player:isPlayerInTriggerArea(1)
+ *  Notes   : This refers to trigger areas added via the registerTriggerArea function
+ ************************************************************************/
+bool CLuaBaseEntity::isPlayerInTriggerArea(uint32 TriggerAreaID)
 {
     if (m_PBaseEntity->objtype != TYPE_PC)
     {
@@ -2814,7 +2813,61 @@ uint32 CLuaBaseEntity::getPlayerTriggerAreaInZone()
     }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
-    return PChar->m_InsideTriggerAreaID;
+    return PChar->isInTriggerArea(TriggerAreaID);
+}
+
+/************************************************************************
+ *  Function: onPlayerTriggerAreaEnter
+ *  Purpose : Returns a boolean indiciating if the player is within the provided TriggerAreaID
+ *  Example : player:onPlayerTriggerAreaEnter(1)
+ *  Notes   : This refers to trigger areas added via the registerTriggerArea function
+ ************************************************************************/
+void CLuaBaseEntity::onPlayerTriggerAreaEnter(uint32 TriggerAreaID)
+{
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->getName());
+        return;
+    }
+
+    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
+    PChar->onTriggerAreaEnter(TriggerAreaID);
+}
+
+/************************************************************************
+ *  Function: onPlayerTriggerAreaLeave
+ *  Purpose : Returns a boolean indiciating if the player is within the provided TriggerAreaID
+ *  Example : player:onPlayerTriggerAreaLeave(1)
+ *  Notes   : This refers to trigger areas added via the registerTriggerArea function
+ ************************************************************************/
+void CLuaBaseEntity::onPlayerTriggerAreaLeave(uint32 TriggerAreaID)
+{
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->getName());
+        return;
+    }
+
+    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
+    PChar->onTriggerAreaLeave(TriggerAreaID);
+}
+
+/************************************************************************
+ *  Function: clearPlayerTriggerAreas
+ *  Purpose : Returns a boolean indiciating if the player is within the provided TriggerAreaID
+ *  Example : player:clearPlayerTriggerAreas(1)
+ *  Notes   : This refers to trigger areas added via the registerTriggerArea function
+ ************************************************************************/
+void CLuaBaseEntity::clearPlayerTriggerAreas()
+{
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->getName());
+        return;
+    }
+
+    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
+    PChar->clearTriggerAreas();
 }
 
 /************************************************************************
@@ -19645,7 +19698,12 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("getTHlevel", CLuaBaseEntity::getTHlevel);
     SOL_REGISTER("setTHlevel", CLuaBaseEntity::setTHlevel);
 
-    SOL_REGISTER("getPlayerTriggerAreaInZone", CLuaBaseEntity::getPlayerTriggerAreaInZone);
+    // TriggerArea management
+    SOL_REGISTER("isPlayerInTriggerArea", CLuaBaseEntity::isPlayerInTriggerArea);
+    SOL_REGISTER("onPlayerTriggerAreaEnter", CLuaBaseEntity::onPlayerTriggerAreaEnter);
+    SOL_REGISTER("onPlayerTriggerAreaLeave", CLuaBaseEntity::onPlayerTriggerAreaLeave);
+    SOL_REGISTER("clearPlayerTriggerAreas", CLuaBaseEntity::clearPlayerTriggerAreas);
+
     SOL_REGISTER("updateToEntireZone", CLuaBaseEntity::updateToEntireZone);
     SOL_REGISTER("sendEntityUpdateToPlayer", CLuaBaseEntity::sendEntityUpdateToPlayer);
     SOL_REGISTER("sendEmptyEntityUpdateToPlayer", CLuaBaseEntity::sendEmptyEntityUpdateToPlayer);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -187,9 +187,12 @@ public:
     uint8  getContinentID();
     bool   isInMogHouse();
 
-    uint32 getPlayerTriggerAreaInZone();
-    void   updateToEntireZone(uint8 statusID, uint8 animation, sol::object const& matchTime); // Forces an update packet to update the NPC entity zone-wide
+    bool isPlayerInTriggerArea(uint32 triggerAreaId);
+    void onPlayerTriggerAreaEnter(uint32 triggerAreaId);
+    void onPlayerTriggerAreaLeave(uint32 triggerAreaId);
+    void clearPlayerTriggerAreas();
 
+    void updateToEntireZone(uint8 statusID, uint8 animation, sol::object const& matchTime); // Forces an update packet to update the NPC entity zone-wide
     void sendEntityUpdateToPlayer(CLuaBaseEntity* entityToUpdate, uint8 entityUpdate, uint8 updateMask);
     void sendEmptyEntityUpdateToPlayer(CLuaBaseEntity* entityToUpdate);
 

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -1040,10 +1040,10 @@ void CZone::CharZoneIn(CCharEntity* PChar)
 {
     TracyZoneScoped;
 
-    PChar->loc.zone              = this;
-    PChar->loc.zoning            = false;
-    PChar->loc.destination       = 0;
-    PChar->m_InsideTriggerAreaID = 0;
+    PChar->loc.zone        = this;
+    PChar->loc.zoning      = false;
+    PChar->loc.destination = 0;
+    PChar->clearTriggerAreas();
 
     if (PChar->isMounted() && !CanUseMisc(MISC_MOUNT))
     {
@@ -1149,7 +1149,7 @@ void CZone::CharZoneOut(CCharEntity* PChar)
     TracyZoneScoped;
     for (const auto& triggerArea : m_triggerAreaList)
     {
-        if (triggerArea->GetTriggerAreaID() == PChar->m_InsideTriggerAreaID)
+        if (PChar->isInTriggerArea(triggerArea->GetTriggerAreaID()))
         {
             luautils::OnTriggerAreaLeave(PChar, triggerArea);
             break;
@@ -1235,29 +1235,25 @@ void CZone::CheckTriggerAreas()
         // TODO: When we start to use octrees or spatial hashing to split up zones,
         //     : use them here to make the search domain smaller.
 
-        uint32 triggerAreaID = 0;
         for (const auto& triggerArea : m_triggerAreaList)
         {
+            auto triggerAreaID = triggerArea->GetTriggerAreaID();
             if (triggerArea->isPointInside(PChar->loc.p))
             {
-                triggerAreaID = triggerArea->GetTriggerAreaID();
-
-                if (triggerArea->GetTriggerAreaID() != PChar->m_InsideTriggerAreaID)
+                if (!PChar->isInTriggerArea(triggerAreaID))
                 {
+                    // Add the TriggerArea to the players cache of current TriggerAreas
+                    PChar->onTriggerAreaEnter(triggerAreaID);
                     luautils::OnTriggerAreaEnter(PChar, triggerArea);
                 }
-
-                if (PChar->m_InsideTriggerAreaID == 0)
-                {
-                    break;
-                }
             }
-            else if (triggerArea->GetTriggerAreaID() == PChar->m_InsideTriggerAreaID)
+            else if (PChar->isInTriggerArea(triggerAreaID))
             {
+                // Remove the TriggerArea from the players cache of current TriggerAreas
+                PChar->onTriggerAreaLeave(triggerAreaID);
                 luautils::OnTriggerAreaLeave(PChar, triggerArea);
             }
         }
-        PChar->m_InsideTriggerAreaID = triggerAreaID;
     });
     // clang-format on
 }

--- a/src/map/zone_instance.cpp
+++ b/src/map/zone_instance.cpp
@@ -443,29 +443,25 @@ void CZoneInstance::CheckTriggerAreas()
             // TODO: When we start to use octrees or spatial hashing to split up zones,
             //     : use them here to make the search domain smaller.
 
-            uint32 triggerAreaID = 0;
             for (const auto& triggerArea : m_triggerAreaList)
             {
+                auto triggerAreaID = triggerArea->GetTriggerAreaID();
                 if (triggerArea->isPointInside(PChar->loc.p))
                 {
-                    triggerAreaID = triggerArea->GetTriggerAreaID();
-
-                    if (triggerArea->GetTriggerAreaID() != PChar->m_InsideTriggerAreaID)
+                    if (!PChar->isInTriggerArea(triggerAreaID))
                     {
+                        // Add the TriggerArea to the players cache of current TriggerAreas
+                        PChar->onTriggerAreaEnter(triggerAreaID);
                         luautils::OnTriggerAreaEnter(PChar, triggerArea);
                     }
-
-                    if (PChar->m_InsideTriggerAreaID == 0)
-                    {
-                        break;
-                    }
                 }
-                else if (triggerArea->GetTriggerAreaID() == PChar->m_InsideTriggerAreaID)
+                else if (PChar->isInTriggerArea(triggerAreaID))
                 {
+                    // Remove the TriggerArea from the players cache of current TriggerAreas
+                    PChar->onTriggerAreaLeave(triggerAreaID);
                     luautils::OnTriggerAreaLeave(PChar, triggerArea);
                 }
             }
-            PChar->m_InsideTriggerAreaID = triggerAreaID;
         });
         // clang-format on
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes https://github.com/LandSandBoat/server/issues/6894
Replaces https://github.com/LandSandBoat/server/pull/6940
Potentially obviates some of the work in https://github.com/LandSandBoat/server/pull/3978

The current logic for handling being inside of a TriggerArea presumes you'll only ever be inside of a single one at a time, which causes issues for quests like Flyers for Regine. In that quest, multiple pairs of NPCs are close enough to have their trigger areas invoked at once, which causes the issue described in that bug (the last area in the list that you've entered will be recorded, but all prior trigger areas will fire on repeat until you leave them, since their debounce fails).

This change pivots m_InsideTriggerAreaID to be an unordered set instead of a single value, which allows us to store and arbitrary number of TriggerAreaIDs on a character. The datatype was recommended by one of the core maintainers here as having largely good performance characteristics.

I've also moved to a private section alongside some other unordered_set/maps, as the logic to handle the data should always be going through the helper methods and callers should not interact with the list itself. Additionally, i changed the name to `charTriggerAreaIDs` to be more in-keeping with its new neighbors.

This also adds methods for interacting with charTriggerAreaIDs so that all the logic for manipulating areas is kept in one place, and I removed a lot of extraneous logic from zone/zone instance and pushed tracking the triggered area into the luatils method as that seemed to do all the real heavy lifting, and now when the method exits all the logic to invoke the trigger area (including recording it on the player) is in one place as well.

## Steps to test these changes

- Accept the quest "[Flyers For Regine](https://www.bg-wiki.com/ffxi/Flyers_for_Regine)" in Port Sandoria
- Exit to Northern Sandoria
- Approach Villion (V) from below (F3, up on a balcony)
- Enter his TriggerArea
- Move slightly, notice it only writes 1 log line for V, and does not loop
- Slowly move towards Guilberdrier (G) (F3, on the lower level)
- Trigger Gs TriggerArea, while still being within Vs
- Notice it only writes 1 log line for G and does not repeat Vs

Leaving and reentering the trigger areas cause them to fire again as normal.

I've also tested the Bastok Bridge area, as that one got a special call out in some older comments, and it also worked as expected.

## Notes

I've verified that the test case from my original PR still works, but have not checked every triggerarea.
