### PR TITLE
[sql] add module to adjust skill level for first weapon skills for each job

### DIFF
--- a/modules/era/sql/tier_one_weapon_skills.sql
+++ b/modules/era/sql/tier_one_weapon_skills.sql
@@ -1,0 +1,22 @@
+-- Until early 2010 the first weapon skill for each weapon was added at skill level 10 for that weapon. Retail changed the skill level to 5 sometime in early 2010.
+-- It should be noted that the tutorial will still tell players that they will get their weapon skill at skill level 5 for their respective weapon.
+UPDATE weapon_skills
+SET
+    skilllevel = 10
+WHERE
+    name IN (
+        "combo",
+        "wasp_sting",
+        "fast_blade",
+        "hard_slash",
+        "raging_axe",
+        "shield_break",
+        "slice",
+        "double_thrust",
+        "blade_rin",
+        "tachi_enpi",
+        "shining_strike",
+        "heavy_swing",
+        "flaming_arrow",
+        "hot_shot"
+    );


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR will add a module that sets the initial skill level for every jobs first weapon skill to level 10. This is what's listed in the OFFICIAL guide: https://cloud.atavismxi.com/s/7G9F4994NLeoPj3

You can search for "double thrust" or "wasp sting" and levels should be listed in tabled titled "Dagger Skills" or "Polearm Skills" etc.

Sometime in early 2010 the skill level for initial weapon skills was changed to 5 but I can't find that info.

## Steps to test these changes

Add this sql file to init.txt and run db tool.
