### PR TITLE
Kill PAutomaton

### DIFF
--- a/sql/item_equipment.sql
+++ b/sql/item_equipment.sql
@@ -11343,6 +11343,7 @@ INSERT INTO `item_equipment` VALUES (23282,'horos_tights_+2',99,119,262144,304,0
 INSERT INTO `item_equipment` VALUES (23283,'peda._pants_+2',99,119,524288,215,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23284,'bagua_pants_+2',99,119,1048576,310,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23285,'futhark_trousers_+2',99,119,2097152,339,0,0,128,0,0,0);
+INSERT INTO `item_equipment` VALUES (23303,'kara._pantaloni_+2',99,119,131072,299,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23308,'pumm._calligae_+2',99,119,1,64,0,0,256,0,0,0);
 INSERT INTO `item_equipment` VALUES (23309,'anch._gaiters_+2',99,119,2,66,0,0,256,0,0,0);
 INSERT INTO `item_equipment` VALUES (23310,'theo._duckbills_+2',99,119,4,68,0,0,256,0,0,0);

--- a/src/map/entities/automatonentity.cpp
+++ b/src/map/entities/automatonentity.cpp
@@ -49,29 +49,14 @@ CAutomatonEntity::~CAutomatonEntity()
     TracyZoneScoped;
 }
 
-void CAutomatonEntity::setFrame(AUTOFRAMETYPE frame)
-{
-    m_Equip.Frame = frame;
-}
-
 AUTOFRAMETYPE CAutomatonEntity::getFrame() const
 {
     return (AUTOFRAMETYPE)m_Equip.Frame;
 }
 
-void CAutomatonEntity::setHead(AUTOHEADTYPE head)
-{
-    m_Equip.Head = head;
-}
-
 AUTOHEADTYPE CAutomatonEntity::getHead() const
 {
     return (AUTOHEADTYPE)m_Equip.Head;
-}
-
-void CAutomatonEntity::setAttachment(uint8 slotid, uint8 id)
-{
-    m_Equip.Attachments[slotid] = id;
 }
 
 uint8 CAutomatonEntity::getAttachment(uint8 slotid)
@@ -91,45 +76,14 @@ bool CAutomatonEntity::hasAttachment(uint8 attachment)
     return false;
 }
 
-void CAutomatonEntity::setElementMax(uint8 element, uint8 max)
-{
-    m_ElementMax[element] = max;
-}
-
 uint8 CAutomatonEntity::getElementMax(uint8 element)
 {
     return m_ElementMax[element];
 }
 
-void CAutomatonEntity::addElementCapacity(uint8 element, int8 value)
-{
-    m_ElementEquip[element] += value;
-}
-
 uint8 CAutomatonEntity::getElementCapacity(uint8 element)
 {
     return m_ElementEquip[element];
-}
-
-uint8 CAutomatonEntity::getElementalCapacityBonus()
-{
-    return m_elementalCapacityBonus;
-}
-
-void CAutomatonEntity::setElementalCapacityBonus(uint8 bonus)
-{
-    if (bonus == m_elementalCapacityBonus)
-    {
-        return;
-    }
-
-    int8 difference = static_cast<int8>(bonus) - m_elementalCapacityBonus;
-    for (size_t i = 0; i < m_ElementMax.size(); ++i)
-    {
-        m_ElementMax[i] += difference;
-    }
-
-    m_elementalCapacityBonus = bonus;
 }
 
 void CAutomatonEntity::burdenTick()

--- a/src/map/entities/automatonentity.h
+++ b/src/map/entities/automatonentity.h
@@ -62,13 +62,6 @@ public:
     std::array<uint8, 8> m_ElementMax{};
     std::array<uint8, 8> m_ElementEquip{};
 
-    void setFrame(AUTOFRAMETYPE frame);
-    void setHead(AUTOHEADTYPE head);
-    void setAttachment(uint8 slot, uint8 id);
-
-    void setElementMax(uint8 element, uint8 max);
-    void addElementCapacity(uint8 element, int8 value);
-
     AUTOFRAMETYPE getFrame() const;
     AUTOHEADTYPE  getHead() const;
     uint8         getAttachment(uint8 slot);
@@ -76,9 +69,6 @@ public:
 
     uint8 getElementMax(uint8 element);
     uint8 getElementCapacity(uint8 element);
-
-    uint8 getElementalCapacityBonus();
-    void  setElementalCapacityBonus(uint8 bonus);
 
     void  burdenTick();
     auto  getBurden() -> std::array<uint8, 8>;
@@ -99,7 +89,6 @@ public:
 
 private:
     std::array<uint8, 8> m_Burden{};
-    uint8                m_elementalCapacityBonus = 0;
 };
 
 #endif

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -220,7 +220,6 @@ CCharEntity::CCharEntity()
     PUnityChat    = nullptr;
     PTreasurePool = nullptr;
 
-    PAutomaton             = nullptr;
     PClaimedMob            = nullptr;
     PRecastContainer       = std::make_unique<CCharRecastContainer>(this);
     PLatentEffectContainer = new CLatentEffectContainer(this);
@@ -356,11 +355,6 @@ CCharEntity::~CCharEntity()
     if (PParty)
     {
         PParty->PopMember(this);
-    }
-
-    if (PAutomaton)
-    {
-        PAutomaton->PMaster = nullptr;
     }
 
     charutils::WriteHistory(this);
@@ -643,6 +637,83 @@ bool CCharEntity::shouldPetPersistThroughZoning()
            petType == PET_TYPE::AVATAR ||
            petType == PET_TYPE::AUTOMATON ||
            (petType == PET_TYPE::JUG_PET && settings::get<bool>("map.KEEP_JUGPET_THROUGH_ZONING"));
+}
+
+void CCharEntity::setAutomatonFrame(AUTOFRAMETYPE frame)
+{
+    automatonInfo.m_Equip.Frame = frame;
+}
+
+void CCharEntity::setAutomatonHead(AUTOHEADTYPE head)
+{
+    automatonInfo.m_Equip.Head = head;
+}
+
+void CCharEntity::setAutomatonAttachment(uint8 slotid, uint8 id)
+{
+    automatonInfo.m_Equip.Attachments[slotid] = id;
+}
+
+void CCharEntity::setAutomatonElementMax(uint8 element, uint8 max)
+{
+    automatonInfo.m_ElementMax[element] = max;
+}
+void CCharEntity::addAutomatonElementCapacity(uint8 element, int8 value)
+{
+    automatonInfo.m_ElementEquip[element] += value;
+}
+
+void CCharEntity::setAutomatonElementalCapacityBonus(uint8 bonus)
+{
+    if (bonus == automatonInfo.m_elementalCapacityBonus)
+    {
+        return;
+    }
+
+    int8 difference = static_cast<int8>(bonus) - automatonInfo.m_elementalCapacityBonus;
+    for (size_t i = 0; i < automatonInfo.m_ElementMax.size(); ++i)
+    {
+        automatonInfo.m_ElementMax[i] += difference;
+    }
+
+    automatonInfo.m_elementalCapacityBonus = bonus;
+}
+
+AUTOFRAMETYPE CCharEntity::getAutomatonFrame() const
+{
+    return static_cast<AUTOFRAMETYPE>(automatonInfo.m_Equip.Frame);
+}
+
+AUTOHEADTYPE CCharEntity::getAutomatonHead() const
+{
+    return static_cast<AUTOHEADTYPE>(automatonInfo.m_Equip.Head);
+}
+
+uint8 CCharEntity::getAutomatonAttachment(uint8 slotid)
+{
+    return automatonInfo.m_Equip.Attachments[slotid];
+}
+
+bool CCharEntity::hasAutomatonAttachment(uint8 attachment)
+{
+    for (auto&& attachmentid : automatonInfo.m_Equip.Attachments)
+    {
+        if (attachmentid == attachment)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+uint8 CCharEntity::getAutomatonElementMax(uint8 element)
+{
+    return automatonInfo.m_ElementMax[element];
+}
+
+uint8 CCharEntity::getAutomatonElementCapacity(uint8 element)
+{
+    return automatonInfo.m_ElementEquip[element];
 }
 
 /************************************************************************

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -41,6 +41,7 @@
 #include "battleentity.h"
 #include "petentity.h"
 
+#include "automatonentity.h"
 #include "utils/fishingutils.h"
 
 #define MAX_QUESTAREA    11
@@ -282,7 +283,6 @@ class CTradeContainer;
 class CItemContainer;
 class CUContainer;
 class CItemEquipment;
-class CAutomatonEntity;
 class CAbilityState;
 class CRangeState;
 class CItemState;
@@ -362,8 +362,40 @@ public:
     uint32 m_claimedDeeds[5]{};
     uint32 m_uniqueEvents[5]{};
 
+    struct
+    {
+        // Store a copy of calculated stats to use when automaton is deactivated for the job info packet (automaton menu)
+        skills_t automatonSkills{};
+        stats_t  automatonStats{};
+        health_t automatonHealth{};
+        look_t   automatonLook{};
+
+        automaton_equip_t    m_Equip{};
+        std::array<uint8, 8> m_ElementMax{};
+        std::array<uint8, 8> m_ElementEquip{};
+        uint8                m_elementalCapacityBonus = 0;
+        std::string          m_automatonName          = "Automaton";
+    } automatonInfo;
+
+    uint8 getAutomatonAttachment(uint8 slot);
+    bool  hasAutomatonAttachment(uint8 attachment);
+
+    uint8 getAutomatonElementMax(uint8 element);
+    uint8 getAutomatonElementCapacity(uint8 element);
+
+    AUTOFRAMETYPE getAutomatonFrame() const;
+    AUTOHEADTYPE  getAutomatonHead() const;
+
+    void setAutomatonFrame(AUTOFRAMETYPE frame);
+    void setAutomatonHead(AUTOHEADTYPE head);
+
+    void setAutomatonAttachment(uint8 slot, uint8 id);
+
+    void setAutomatonElementMax(uint8 element, uint8 max);
+    void addAutomatonElementCapacity(uint8 element, int8 value);
+    void setAutomatonElementalCapacityBonus(uint8 bonus);
+
     UnlockedAttachments_t m_unlockedAttachments{}; // Unlocked Automaton Attachments (1 bit per attachment)
-    CAutomatonEntity*     PAutomaton;              // Automaton statistics
 
     std::vector<CTrustEntity*> PTrusts; // Active trusts
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -14598,7 +14598,8 @@ uint16 CLuaBaseEntity::getWeaponDmg()
 
     // TODO: Determine if trusts and player fellows use mob or player damage formula
     if (m_PBaseEntity->objtype == TYPE_MOB ||
-        m_PBaseEntity->objtype == TYPE_PET)
+        (m_PBaseEntity->objtype == TYPE_PET &&
+         static_cast<CPetEntity*>(m_PBaseEntity)->getPetType() != PET_TYPE::AUTOMATON))
     {
         auto* PMob   = static_cast<CMobEntity*>(m_PBaseEntity);
         weaponDamage = mobutils::GetWeaponDamage(PMob, SLOT_MAIN);

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -6559,6 +6559,7 @@ void SmallPacket0x100(map_session_data_t* const PSession, CCharEntity* const PCh
 
             // If removing RemoveAllEquipment, please add a charutils::CheckUnarmedItem(PChar) if main hand is empty.
             puppetutils::LoadAutomaton(PChar);
+
             if (mjob == JOB_BLU)
             {
                 blueutils::LoadSetSpells(PChar);
@@ -6588,6 +6589,7 @@ void SmallPacket0x100(map_session_data_t* const PSession, CCharEntity* const PCh
 
             charutils::CheckEquipLogic(PChar, SCRIPT_CHANGESJOB, prevsjob);
             puppetutils::LoadAutomaton(PChar);
+
             if (sjob == JOB_BLU)
             {
                 blueutils::LoadSetSpells(PChar);
@@ -6771,8 +6773,14 @@ void SmallPacket0x102(map_session_data_t* const PSession, CCharEntity* const PCh
             }
         }
     }
-    else if ((PChar->GetMJob() == JOB_PUP || PChar->GetSJob() == JOB_PUP) && job == JOB_PUP && PChar->PAutomaton != nullptr && PChar->PPet == nullptr)
+    else if ((PChar->GetMJob() == JOB_PUP || PChar->GetSJob() == JOB_PUP) && job == JOB_PUP)
     {
+        if (dynamic_cast<CAutomatonEntity*>(PChar->PPet))
+        {
+            // Client already prints an error about not being able to do this without our intervention
+            return;
+        }
+
         uint8 attachment = data.ref<uint8>(0x04);
 
         if (attachment == 0x00)
@@ -6791,12 +6799,12 @@ void SmallPacket0x102(map_session_data_t* const PSession, CCharEntity* const PCh
             if (data.ref<uint8>(0x0C) != 0)
             {
                 puppetutils::setHead(PChar, data.ref<uint8>(0x0C));
-                puppetutils::LoadAutomatonStats(PChar);
+                petutils::CalculateAutomatonStats(PChar, PChar->PPet);
             }
             else if (data.ref<uint8>(0x0D) != 0)
             {
                 puppetutils::setFrame(PChar, data.ref<uint8>(0x0D));
-                puppetutils::LoadAutomatonStats(PChar);
+                petutils::CalculateAutomatonStats(PChar, PChar->PPet);
             }
             else
             {
@@ -6809,6 +6817,7 @@ void SmallPacket0x102(map_session_data_t* const PSession, CCharEntity* const PCh
                 }
             }
         }
+
         PChar->pushPacket<CCharJobExtraPacket>(PChar, true);
         PChar->pushPacket<CCharJobExtraPacket>(PChar, false);
         puppetutils::SaveAutomaton(PChar);

--- a/src/map/packets/char_job_extra.cpp
+++ b/src/map/packets/char_job_extra.cpp
@@ -36,15 +36,18 @@ CCharJobExtraPacket::CCharJobExtraPacket(CCharEntity* PChar, bool mjob)
     this->setType(0x44);
     this->setSize(0xA0);
 
-    JOBTYPE job = JOB_NON;
+    JOBTYPE job      = JOB_NON;
+    uint8   jobLevel = 0;
 
     if (mjob)
     {
-        job = PChar->GetMJob();
+        job      = PChar->GetMJob();
+        jobLevel = PChar->GetMLevel();
     }
     else
     {
-        job = PChar->GetSJob();
+        job      = PChar->GetSJob();
+        jobLevel = PChar->GetSLevel();
     }
 
     if (PChar->m_PMonstrosity != nullptr)
@@ -62,22 +65,24 @@ CCharJobExtraPacket::CCharJobExtraPacket(CCharEntity* PChar, bool mjob)
     {
         std::memcpy(buffer_.data() + 0x08, &PChar->m_SetBlueSpells, 20);
     }
-    else if (job == JOB_PUP && PChar->PAutomaton != nullptr)
+    else if (job == JOB_PUP)
     {
-        ref<uint8>(0x08) = PChar->PAutomaton->getHead();
-        ref<uint8>(0x09) = PChar->PAutomaton->getFrame();
-        ref<uint8>(0x0A) = PChar->PAutomaton->getAttachment(0);
-        ref<uint8>(0x0B) = PChar->PAutomaton->getAttachment(1);
-        ref<uint8>(0x0C) = PChar->PAutomaton->getAttachment(2);
-        ref<uint8>(0x0D) = PChar->PAutomaton->getAttachment(3);
-        ref<uint8>(0x0E) = PChar->PAutomaton->getAttachment(4);
-        ref<uint8>(0x0F) = PChar->PAutomaton->getAttachment(5);
-        ref<uint8>(0x10) = PChar->PAutomaton->getAttachment(6);
-        ref<uint8>(0x11) = PChar->PAutomaton->getAttachment(7);
-        ref<uint8>(0x12) = PChar->PAutomaton->getAttachment(8);
-        ref<uint8>(0x13) = PChar->PAutomaton->getAttachment(9);
-        ref<uint8>(0x14) = PChar->PAutomaton->getAttachment(10);
-        ref<uint8>(0x15) = PChar->PAutomaton->getAttachment(11);
+        auto PAutomaton = dynamic_cast<CAutomatonEntity*>(PChar->PPet);
+
+        ref<uint8>(0x08) = PChar->getAutomatonHead();
+        ref<uint8>(0x09) = PChar->getAutomatonFrame();
+        ref<uint8>(0x0A) = PChar->getAutomatonAttachment(0);
+        ref<uint8>(0x0B) = PChar->getAutomatonAttachment(1);
+        ref<uint8>(0x0C) = PChar->getAutomatonAttachment(2);
+        ref<uint8>(0x0D) = PChar->getAutomatonAttachment(3);
+        ref<uint8>(0x0E) = PChar->getAutomatonAttachment(4);
+        ref<uint8>(0x0F) = PChar->getAutomatonAttachment(5);
+        ref<uint8>(0x10) = PChar->getAutomatonAttachment(6);
+        ref<uint8>(0x11) = PChar->getAutomatonAttachment(7);
+        ref<uint8>(0x12) = PChar->getAutomatonAttachment(8);
+        ref<uint8>(0x13) = PChar->getAutomatonAttachment(9);
+        ref<uint8>(0x14) = PChar->getAutomatonAttachment(10);
+        ref<uint8>(0x15) = PChar->getAutomatonAttachment(11);
 
         ref<uint32>(0x18) = PChar->m_unlockedAttachments.heads;
         ref<uint32>(0x1C) = PChar->m_unlockedAttachments.frames;
@@ -92,44 +97,90 @@ CCharJobExtraPacket::CCharJobExtraPacket(CCharEntity* PChar, bool mjob)
         ref<uint32>(0x50) = PChar->m_unlockedAttachments.attachments[6];
         ref<uint32>(0x54) = PChar->m_unlockedAttachments.attachments[7];
 
-        std::memcpy(buffer_.data() + 0x58, PChar->PAutomaton->getName().c_str(), PChar->PAutomaton->getName().size());
+        std::memcpy(buffer_.data() + 0x58, PChar->automatonInfo.m_automatonName.c_str(), PChar->automatonInfo.m_automatonName.size());
 
-        ref<uint16>(0x68) = PChar->PAutomaton->health.hp == 0 ? PChar->PAutomaton->GetMaxHP() : PChar->PAutomaton->health.hp;
-        ref<uint16>(0x6A) = PChar->PAutomaton->GetMaxHP();
-        ref<uint16>(0x6C) = PChar->PAutomaton->health.mp;
-        ref<uint16>(0x6E) = PChar->PAutomaton->GetMaxMP();
+        // Activated automaton
+        if (PAutomaton)
+        {
+            ref<uint16>(0x68) = PAutomaton->health.hp == 0 ? PAutomaton->GetMaxHP() : PAutomaton->health.hp;
+            ref<uint16>(0x6A) = PAutomaton->GetMaxHP();
+            ref<uint16>(0x6C) = PAutomaton->health.mp;
+            ref<uint16>(0x6E) = PAutomaton->GetMaxMP();
+        }
+        else // Deactivated automaton
+        {
+            ref<uint16>(0x68) = PChar->automatonInfo.automatonHealth.maxhp;
+            ref<uint16>(0x6A) = PChar->automatonInfo.automatonHealth.maxhp;
+            ref<uint16>(0x6C) = PChar->automatonInfo.automatonHealth.maxmp;
+            ref<uint16>(0x6E) = PChar->automatonInfo.automatonHealth.maxmp;
+        }
 
-        // TODO: this is a lot of calculations that could be avoided if these were properly initialized in the Automaton when first loading your character
         int32  meritbonus = PChar->PMeritPoints->GetMeritValue(MERIT_AUTOMATON_SKILLS, PChar);
-        uint16 ameCap     = puppetutils::getSkillCap(PChar, SKILL_AUTOMATON_MELEE);
-        uint16 ameBonus   = PChar->getMod(Mod::AUTO_MELEE_SKILL) + meritbonus;
-        ref<uint16>(0x70) = std::min(ameCap, PChar->GetSkill(SKILL_AUTOMATON_MELEE)) + ameBonus;
+        uint16 ameCap     = puppetutils::getSkillCap(PChar, SKILL_AUTOMATON_MELEE, jobLevel);
+        uint16 ameBonus   = PChar->getMod(Mod::AUTO_MELEE_SKILL);
+        uint16 araCap     = puppetutils::getSkillCap(PChar, SKILL_AUTOMATON_RANGED, jobLevel);
+        uint16 araBonus   = PChar->getMod(Mod::AUTO_RANGED_SKILL);
+        uint16 amaCap     = puppetutils::getSkillCap(PChar, SKILL_AUTOMATON_MAGIC, jobLevel);
+        uint16 amaBonus   = PChar->getMod(Mod::AUTO_MAGIC_SKILL);
+
+        ref<uint16>(0x70) = std::min(ameCap, PChar->GetSkill(SKILL_AUTOMATON_MELEE));
         ref<uint16>(0x72) = ameCap + ameBonus;
 
-        uint16 araCap     = puppetutils::getSkillCap(PChar, SKILL_AUTOMATON_RANGED);
-        uint16 araBonus   = PChar->getMod(Mod::AUTO_RANGED_SKILL) + meritbonus;
-        ref<uint16>(0x74) = std::min(araCap, PChar->GetSkill(SKILL_AUTOMATON_RANGED)) + araBonus;
+        ref<uint16>(0x74) = std::min(araCap, PChar->GetSkill(SKILL_AUTOMATON_RANGED));
         ref<uint16>(0x76) = araCap + araBonus;
 
-        uint16 amaCap     = puppetutils::getSkillCap(PChar, SKILL_AUTOMATON_MAGIC);
-        uint16 amaBonus   = PChar->getMod(Mod::AUTO_MAGIC_SKILL) + meritbonus;
-        ref<uint16>(0x78) = std::min(amaCap, PChar->GetSkill(SKILL_AUTOMATON_MAGIC)) + amaBonus;
+        ref<uint16>(0x78) = std::min(amaCap, PChar->GetSkill(SKILL_AUTOMATON_MAGIC));
         ref<uint16>(0x7A) = amaCap + amaBonus;
 
-        ref<uint16>(0x80) = PChar->PAutomaton->stats.STR;
-        ref<uint16>(0x82) = PChar->PAutomaton->getMod(Mod::STR);
-        ref<uint16>(0x84) = PChar->PAutomaton->stats.DEX;
-        ref<uint16>(0x86) = PChar->PAutomaton->getMod(Mod::DEX);
-        ref<uint16>(0x88) = PChar->PAutomaton->stats.VIT;
-        ref<uint16>(0x8A) = PChar->PAutomaton->getMod(Mod::VIT);
-        ref<uint16>(0x8C) = PChar->PAutomaton->stats.AGI;
-        ref<uint16>(0x8E) = PChar->PAutomaton->getMod(Mod::AGI);
-        ref<uint16>(0x90) = PChar->PAutomaton->stats.INT;
-        ref<uint16>(0x92) = PChar->PAutomaton->getMod(Mod::INT);
-        ref<uint16>(0x94) = PChar->PAutomaton->stats.MND;
-        ref<uint16>(0x96) = PChar->PAutomaton->getMod(Mod::MND);
-        ref<uint16>(0x98) = PChar->PAutomaton->stats.CHR;
-        ref<uint16>(0x9A) = PChar->PAutomaton->getMod(Mod::CHR);
+        // No skill rank, so working skills are 0
+        if (puppetutils::getSkillCap(PChar, SKILL_AUTOMATON_MAGIC, jobLevel) == 0)
+        {
+            ref<uint16>(0x78) = amaBonus + meritbonus;
+            ref<uint16>(0x7A) = amaBonus + meritbonus;
+        }
+
+        // No skill rank, so working skills are 0
+        if (puppetutils::getSkillCap(PChar, SKILL_AUTOMATON_RANGED, jobLevel) == 0)
+        {
+            ref<uint16>(0x74) = araBonus + meritbonus;
+            ref<uint16>(0x76) = araBonus + meritbonus;
+        }
+
+        // Activated automaton
+        if (PAutomaton)
+        {
+            ref<uint16>(0x80) = PAutomaton->stats.STR;
+            ref<uint16>(0x82) = PAutomaton->getMod(Mod::STR);
+            ref<uint16>(0x84) = PAutomaton->stats.DEX;
+            ref<uint16>(0x86) = PAutomaton->getMod(Mod::DEX);
+            ref<uint16>(0x88) = PAutomaton->stats.VIT;
+            ref<uint16>(0x8A) = PAutomaton->getMod(Mod::VIT);
+            ref<uint16>(0x8C) = PAutomaton->stats.AGI;
+            ref<uint16>(0x8E) = PAutomaton->getMod(Mod::AGI);
+            ref<uint16>(0x90) = PAutomaton->stats.INT;
+            ref<uint16>(0x92) = PAutomaton->getMod(Mod::INT);
+            ref<uint16>(0x94) = PAutomaton->stats.MND;
+            ref<uint16>(0x96) = PAutomaton->getMod(Mod::MND);
+            ref<uint16>(0x98) = PAutomaton->stats.CHR;
+            ref<uint16>(0x9A) = PAutomaton->getMod(Mod::CHR);
+        }
+        else // Deactivated automaton
+        {
+            ref<uint16>(0x80) = PChar->automatonInfo.automatonStats.STR;
+            ref<uint16>(0x82) = 0;
+            ref<uint16>(0x84) = PChar->automatonInfo.automatonStats.DEX;
+            ref<uint16>(0x86) = 0;
+            ref<uint16>(0x88) = PChar->automatonInfo.automatonStats.VIT;
+            ref<uint16>(0x8A) = 0;
+            ref<uint16>(0x8C) = PChar->automatonInfo.automatonStats.AGI;
+            ref<uint16>(0x8E) = 0;
+            ref<uint16>(0x90) = PChar->automatonInfo.automatonStats.INT;
+            ref<uint16>(0x92) = 0;
+            ref<uint16>(0x94) = PChar->automatonInfo.automatonStats.MND;
+            ref<uint16>(0x96) = 0;
+            ref<uint16>(0x98) = PChar->automatonInfo.automatonStats.CHR;
+            ref<uint16>(0x9A) = 0;
+        }
 
         ref<uint8>(0x9C) = PChar->getMod(Mod::AUTO_ELEM_CAPACITY);
     }

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -846,7 +846,7 @@ namespace charutils
         BuildingCharTraitsTable(PChar);
 
         // Order matters as this uses merits and JP gifts.
-        puppetutils::LoadAutomaton(PChar); // Take care not to reset petZoningInfo with this call
+        puppetutils::LoadAutomaton(PChar);
 
         PChar->animation = (HP == 0 ? ANIMATION_DEATH : ANIMATION_NONE);
 
@@ -3269,10 +3269,8 @@ namespace charutils
             }
             else if (i >= SKILL_AUTOMATON_MELEE && i <= SKILL_AUTOMATON_MAGIC)
             {
-                if (PChar->PAutomaton)
-                {
-                    maxMainSkill = battleutils::GetMaxSkill(1, PChar->GetMLevel()); // A+ capped down to the Automaton's rating
-                }
+                // TODO: does this need to change if you are /PUP?
+                maxMainSkill = battleutils::GetMaxSkill(1, PChar->GetMLevel()); // A+ capped down to the Automaton's rating
             }
 
             skillBonus += PChar->PMeritPoints->GetMeritValue(skillMerit[meritIndex], PChar);
@@ -5113,10 +5111,7 @@ namespace charutils
                     BuildingCharAbilityTable(PChar);
                     BuildingCharTraitsTable(PChar);
                     BuildingCharWeaponSkills(PChar);
-                    if (PChar->PAutomaton != nullptr && PChar->PAutomaton != PChar->PPet)
-                    {
-                        puppetutils::LoadAutomatonStats(PChar);
-                    }
+                    puppetutils::LoadAutomaton(PChar);
                 }
                 PChar->PLatentEffectContainer->CheckLatentsJobLevel();
 

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -399,33 +399,39 @@ namespace petutils
         PMob->stats.CHR = (uint16)((fCHR + mCHR) * 0.9f);
     }
 
-    void LoadAutomatonStats(CCharEntity* PMaster, CPetEntity* PPet, Pet_t* petStats)
+    void LoadAutomatonStats(CCharEntity* PMaster, CPetEntity* PPet, Pet_t* petStats, uint8 mlvl, JOBTYPE mjob, JOBTYPE sjob)
     {
-        PPet->WorkingSkills.automaton_melee  = std::min(puppetutils::getSkillCap(PMaster, SKILL_AUTOMATON_MELEE), PMaster->GetSkill(SKILL_AUTOMATON_MELEE));
-        PPet->WorkingSkills.automaton_ranged = std::min(puppetutils::getSkillCap(PMaster, SKILL_AUTOMATON_RANGED), PMaster->GetSkill(SKILL_AUTOMATON_RANGED));
-        PPet->WorkingSkills.automaton_magic  = std::min(puppetutils::getSkillCap(PMaster, SKILL_AUTOMATON_MAGIC), PMaster->GetSkill(SKILL_AUTOMATON_MAGIC));
+        // temporary, will replace with PChar stored automaton structs eventually
+        skills_t tempSkills = {};
+        stats_t  tempStats  = {};
+        health_t tempHealth = {};
+
+        tempSkills.automaton_melee  = std::min(puppetutils::getSkillCap(PMaster, SKILL_AUTOMATON_MELEE), PMaster->GetSkill(SKILL_AUTOMATON_MELEE));
+        tempSkills.automaton_ranged = std::min(puppetutils::getSkillCap(PMaster, SKILL_AUTOMATON_RANGED), PMaster->GetSkill(SKILL_AUTOMATON_RANGED));
+        tempSkills.automaton_magic  = std::min(puppetutils::getSkillCap(PMaster, SKILL_AUTOMATON_MAGIC), PMaster->GetSkill(SKILL_AUTOMATON_MAGIC));
 
         // Set capped flags
         for (int i = 22; i <= 24; ++i)
         {
-            if (PPet->GetSkill(i) == (puppetutils::getSkillCap(PMaster, (SKILLTYPE)i)))
+            if ((tempSkills.skill[i] & 0x7FFF) == (puppetutils::getSkillCap(PMaster, (SKILLTYPE)i)))
             {
-                PPet->WorkingSkills.skill[i] |= 0x8000;
+                tempSkills.skill[i] |= 0x8000;
             }
         }
 
         // Add mods/merits
         int32 meritbonus = PMaster->PMeritPoints->GetMeritValue(MERIT_AUTOMATON_SKILLS, PMaster);
-        PPet->WorkingSkills.automaton_melee += PMaster->getMod(Mod::AUTO_MELEE_SKILL) + meritbonus;
-        PPet->WorkingSkills.automaton_ranged += PMaster->getMod(Mod::AUTO_RANGED_SKILL) + meritbonus;
+        tempSkills.automaton_melee += PMaster->getMod(Mod::AUTO_MELEE_SKILL) + meritbonus;
+        tempSkills.automaton_ranged += PMaster->getMod(Mod::AUTO_RANGED_SKILL) + meritbonus;
+
         // Share its magic skills to prevent needing separate spells or checks to see which skill to use
-        uint16 amaSkill                     = PPet->WorkingSkills.automaton_magic + PMaster->getMod(Mod::AUTO_MAGIC_SKILL) + meritbonus;
-        PPet->WorkingSkills.automaton_magic = amaSkill;
-        PPet->WorkingSkills.healing         = amaSkill;
-        PPet->WorkingSkills.enhancing       = amaSkill;
-        PPet->WorkingSkills.enfeebling      = amaSkill;
-        PPet->WorkingSkills.elemental       = amaSkill;
-        PPet->WorkingSkills.dark            = amaSkill;
+        uint16 amaSkill            = tempSkills.automaton_magic + PMaster->getMod(Mod::AUTO_MAGIC_SKILL) + meritbonus;
+        tempSkills.automaton_magic = amaSkill;
+        tempSkills.healing         = amaSkill;
+        tempSkills.enhancing       = amaSkill;
+        tempSkills.enfeebling      = amaSkill;
+        tempSkills.elemental       = amaSkill;
+        tempSkills.dark            = amaSkill;
 
         // Declaration of variables needed for calculation.
         float raceStat          = 0; // Final HP for level based on race.
@@ -442,9 +448,6 @@ namespace petutils
 
         uint8 grade = 0;
 
-        uint8   mlvl = PPet->GetMLevel();
-        JOBTYPE mjob = PPet->GetMJob();
-        JOBTYPE sjob = PPet->GetSJob();
         // Calculate HP gain from main job
         int32 mainLevelOver30     = std::clamp(mlvl - 30, 0, 30); // Calculate condition +1HP every lvl after level 30
         int32 mainLevelUpTo60     = (mlvl < 60 ? mlvl - 1 : 59);  // First calculation mode up to level 60 (Used the same for MP)
@@ -475,9 +478,9 @@ namespace petutils
                   (grade::GetHPScale(grade, scaleOver75Column) * mainLevelOver75);
 
         // Calculate Bonus HP
-        bonusStat          = (mainLevelOver10 + mainLevelOver50andUnder60) * 2;
-        PPet->health.maxhp = (int32)((raceStat + jobStat + bonusStat + sJobStat) * petStats->HPscale);
-        PPet->health.hp    = PPet->health.maxhp;
+        bonusStat        = (mainLevelOver10 + mainLevelOver50andUnder60) * 2;
+        tempHealth.maxhp = (int32)((raceStat + jobStat + bonusStat + sJobStat) * petStats->HPscale);
+        tempHealth.hp    = tempHealth.maxhp;
 
         // Start MP calculation
         raceStat = 0;
@@ -510,88 +513,97 @@ namespace petutils
                        grade::GetMPScale(grade, scaleOver60) * mainLevelOver60;
         }
 
-        PPet->health.maxmp = (int32)((raceStat + jobStat + sJobStat) * petStats->MPscale);
-        PPet->health.mp    = PPet->health.maxmp;
+        tempHealth.maxmp = (int32)((raceStat + jobStat + sJobStat) * petStats->MPscale);
+        tempHealth.mp    = tempHealth.maxmp;
 
-        uint16 fSTR = GetBaseToRank(petStats->strRank, PPet->GetMLevel());
-        uint16 fDEX = GetBaseToRank(petStats->dexRank, PPet->GetMLevel());
-        uint16 fVIT = GetBaseToRank(petStats->vitRank, PPet->GetMLevel());
-        uint16 fAGI = GetBaseToRank(petStats->agiRank, PPet->GetMLevel());
-        uint16 fINT = GetBaseToRank(petStats->intRank, PPet->GetMLevel());
-        uint16 fMND = GetBaseToRank(petStats->mndRank, PPet->GetMLevel());
-        uint16 fCHR = GetBaseToRank(petStats->chrRank, PPet->GetMLevel());
+        uint16 slvl = std::floor<uint16>(mlvl / 2);
 
-        uint16 mSTR = GetBaseToRank(grade::GetJobGrade(PPet->GetMJob(), 2), PPet->GetMLevel());
-        uint16 mDEX = GetBaseToRank(grade::GetJobGrade(PPet->GetMJob(), 3), PPet->GetMLevel());
-        uint16 mVIT = GetBaseToRank(grade::GetJobGrade(PPet->GetMJob(), 4), PPet->GetMLevel());
-        uint16 mAGI = GetBaseToRank(grade::GetJobGrade(PPet->GetMJob(), 5), PPet->GetMLevel());
-        uint16 mINT = GetBaseToRank(grade::GetJobGrade(PPet->GetMJob(), 6), PPet->GetMLevel());
-        uint16 mMND = GetBaseToRank(grade::GetJobGrade(PPet->GetMJob(), 7), PPet->GetMLevel());
-        uint16 mCHR = GetBaseToRank(grade::GetJobGrade(PPet->GetMJob(), 8), PPet->GetMLevel());
+        uint16 fSTR = GetBaseToRank(petStats->strRank, mlvl);
+        uint16 fDEX = GetBaseToRank(petStats->dexRank, mlvl);
+        uint16 fVIT = GetBaseToRank(petStats->vitRank, mlvl);
+        uint16 fAGI = GetBaseToRank(petStats->agiRank, mlvl);
+        uint16 fINT = GetBaseToRank(petStats->intRank, mlvl);
+        uint16 fMND = GetBaseToRank(petStats->mndRank, mlvl);
+        uint16 fCHR = GetBaseToRank(petStats->chrRank, mlvl);
 
-        uint16 sSTR = GetBaseToRank(grade::GetJobGrade(PPet->GetSJob(), 2), PPet->GetSLevel());
-        uint16 sDEX = GetBaseToRank(grade::GetJobGrade(PPet->GetSJob(), 3), PPet->GetSLevel());
-        uint16 sVIT = GetBaseToRank(grade::GetJobGrade(PPet->GetSJob(), 4), PPet->GetSLevel());
-        uint16 sAGI = GetBaseToRank(grade::GetJobGrade(PPet->GetSJob(), 5), PPet->GetSLevel());
-        uint16 sINT = GetBaseToRank(grade::GetJobGrade(PPet->GetSJob(), 6), PPet->GetSLevel());
-        uint16 sMND = GetBaseToRank(grade::GetJobGrade(PPet->GetSJob(), 7), PPet->GetSLevel());
-        uint16 sCHR = GetBaseToRank(grade::GetJobGrade(PPet->GetSJob(), 8), PPet->GetSLevel());
+        uint16 mSTR = GetBaseToRank(grade::GetJobGrade(mjob, 2), mlvl);
+        uint16 mDEX = GetBaseToRank(grade::GetJobGrade(mjob, 3), mlvl);
+        uint16 mVIT = GetBaseToRank(grade::GetJobGrade(mjob, 4), mlvl);
+        uint16 mAGI = GetBaseToRank(grade::GetJobGrade(mjob, 5), mlvl);
+        uint16 mINT = GetBaseToRank(grade::GetJobGrade(mjob, 6), mlvl);
+        uint16 mMND = GetBaseToRank(grade::GetJobGrade(mjob, 7), mlvl);
+        uint16 mCHR = GetBaseToRank(grade::GetJobGrade(mjob, 8), mlvl);
 
-        PPet->stats.STR = fSTR + mSTR + sSTR;
-        PPet->stats.DEX = fDEX + mDEX + sDEX;
-        PPet->stats.VIT = fVIT + mVIT + sVIT;
-        PPet->stats.AGI = fAGI + mAGI + sAGI;
-        PPet->stats.INT = fINT + mINT + sINT;
-        PPet->stats.MND = fMND + mMND + sMND;
-        PPet->stats.CHR = fCHR + mCHR + sCHR;
+        uint16 sSTR = GetBaseToRank(grade::GetJobGrade(sjob, 2), slvl);
+        uint16 sDEX = GetBaseToRank(grade::GetJobGrade(sjob, 3), slvl);
+        uint16 sVIT = GetBaseToRank(grade::GetJobGrade(sjob, 4), slvl);
+        uint16 sAGI = GetBaseToRank(grade::GetJobGrade(sjob, 5), slvl);
+        uint16 sINT = GetBaseToRank(grade::GetJobGrade(sjob, 6), slvl);
+        uint16 sMND = GetBaseToRank(grade::GetJobGrade(sjob, 7), slvl);
+        uint16 sCHR = GetBaseToRank(grade::GetJobGrade(sjob, 8), slvl);
 
-        static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setSkillType(SKILL_AUTOMATON_MELEE);
-        static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setDelay((uint16)(floor(1000.0f * (petStats->cmbDelay / 60.0f)))); // every pet should use this eventually
-        static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setBaseDelay((uint16)(floor(1000.0f * (petStats->cmbDelay / 60.0f))));
-        static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setDamage((PPet->GetSkill(SKILL_AUTOMATON_MELEE) / 9) * 2 + 3);
+        tempStats.STR = fSTR + mSTR + sSTR;
+        tempStats.DEX = fDEX + mDEX + sDEX;
+        tempStats.VIT = fVIT + mVIT + sVIT;
+        tempStats.AGI = fAGI + mAGI + sAGI;
+        tempStats.INT = fINT + mINT + sINT;
+        tempStats.MND = fMND + mMND + sMND;
+        tempStats.CHR = fCHR + mCHR + sCHR;
 
-        static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_RANGED])->setSkillType(SKILL_AUTOMATON_RANGED);
-        static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_RANGED])->setDamage((PPet->GetSkill(SKILL_AUTOMATON_RANGED) / 9) * 2 + 3);
-        static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_RANGED])->setDmgType(DAMAGE_TYPE::PIERCING);
-
-        CAutomatonEntity* PAutomaton = static_cast<CAutomatonEntity*>(PPet);
-
-        // Automatons are hard to interrupt
-        PPet->addModifier(Mod::SPELLINTERRUPT, 85);
-
-        switch (PAutomaton->getFrame())
+        if (PPet)
         {
-            default: // case FRAME_HARLEQUIN:
-                PPet->WorkingSkills.evasion = battleutils::GetMaxSkill(2, mlvl > 99 ? 99 : mlvl);
-                PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(10, mlvl > 99 ? 99 : mlvl));
-                break;
-            case FRAME_VALOREDGE:
-                PPet->setModifier(Mod::SHIELDBLOCKRATE, 45);
-                PPet->setMobMod(MOBMOD_CAN_SHIELD_BLOCK, 1);
-                PPet->WorkingSkills.evasion = battleutils::GetMaxSkill(5, mlvl > 99 ? 99 : mlvl);
-                PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(5, mlvl > 99 ? 99 : mlvl));
-                break;
-            case FRAME_SHARPSHOT:
-                PPet->WorkingSkills.evasion = battleutils::GetMaxSkill(1, mlvl > 99 ? 99 : mlvl);
-                PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(11, mlvl > 99 ? 99 : mlvl));
-                break;
-            case FRAME_STORMWAKER:
-                PPet->WorkingSkills.evasion = battleutils::GetMaxSkill(10, mlvl > 99 ? 99 : mlvl);
-                PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(12, mlvl > 99 ? 99 : mlvl));
-                break;
-        }
+            PPet->WorkingSkills = tempSkills;
+            PPet->stats         = tempStats;
+            PPet->health        = tempHealth;
 
-        // Add Job Point Stat Bonuses
-        if (PMaster->GetMJob() == JOB_PUP)
-        {
-            PPet->addModifier(Mod::ATT, PMaster->getMod(Mod::PET_ATK_DEF));
-            PPet->addModifier(Mod::DEF, PMaster->getMod(Mod::PET_ATK_DEF));
-            PPet->addModifier(Mod::ACC, PMaster->getMod(Mod::PET_ACC_EVA));
-            PPet->addModifier(Mod::EVA, PMaster->getMod(Mod::PET_ACC_EVA));
-            PPet->addModifier(Mod::MATT, PMaster->getMod(Mod::PET_MAB_MDB));
-            PPet->addModifier(Mod::MDEF, PMaster->getMod(Mod::PET_MAB_MDB));
-            PPet->addModifier(Mod::MACC, PMaster->getMod(Mod::PET_MACC_MEVA));
-            PPet->addModifier(Mod::MEVA, PMaster->getMod(Mod::PET_MACC_MEVA));
+            static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setSkillType(SKILL_AUTOMATON_MELEE);
+            static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setDelay((uint16)(floor(1000.0f * (petStats->cmbDelay / 60.0f)))); // every pet should use this eventually
+            static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setBaseDelay((uint16)(floor(1000.0f * (petStats->cmbDelay / 60.0f))));
+            static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setDamage((PPet->GetSkill(SKILL_AUTOMATON_MELEE) / 9) * 2 + 3);
+
+            static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_RANGED])->setSkillType(SKILL_AUTOMATON_RANGED);
+            static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_RANGED])->setDamage((PPet->GetSkill(SKILL_AUTOMATON_RANGED) / 9) * 2 + 3);
+            static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_RANGED])->setDmgType(DAMAGE_TYPE::PIERCING);
+
+            CAutomatonEntity* PAutomaton = static_cast<CAutomatonEntity*>(PPet);
+
+            // Automatons are hard to interrupt
+            PPet->addModifier(Mod::SPELLINTERRUPT, 85);
+
+            switch (PAutomaton->getFrame())
+            {
+                default: // case FRAME_HARLEQUIN:
+                    tempSkills.evasion = battleutils::GetMaxSkill(2, mlvl > 99 ? 99 : mlvl);
+                    PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(10, mlvl > 99 ? 99 : mlvl));
+                    break;
+                case FRAME_VALOREDGE:
+                    PPet->setModifier(Mod::SHIELDBLOCKRATE, 45);
+                    PPet->setMobMod(MOBMOD_CAN_SHIELD_BLOCK, 1);
+                    tempSkills.evasion = battleutils::GetMaxSkill(5, mlvl > 99 ? 99 : mlvl);
+                    PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(5, mlvl > 99 ? 99 : mlvl));
+                    break;
+                case FRAME_SHARPSHOT:
+                    tempSkills.evasion = battleutils::GetMaxSkill(1, mlvl > 99 ? 99 : mlvl);
+                    PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(11, mlvl > 99 ? 99 : mlvl));
+                    break;
+                case FRAME_STORMWAKER:
+                    tempSkills.evasion = battleutils::GetMaxSkill(10, mlvl > 99 ? 99 : mlvl);
+                    PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(12, mlvl > 99 ? 99 : mlvl));
+                    break;
+            }
+
+            // Add Job Point Stat Bonuses
+            if (PMaster->GetMJob() == JOB_PUP)
+            {
+                PPet->addModifier(Mod::ATT, PMaster->getMod(Mod::PET_ATK_DEF));
+                PPet->addModifier(Mod::DEF, PMaster->getMod(Mod::PET_ATK_DEF));
+                PPet->addModifier(Mod::ACC, PMaster->getMod(Mod::PET_ACC_EVA));
+                PPet->addModifier(Mod::EVA, PMaster->getMod(Mod::PET_ACC_EVA));
+                PPet->addModifier(Mod::MATT, PMaster->getMod(Mod::PET_MAB_MDB));
+                PPet->addModifier(Mod::MDEF, PMaster->getMod(Mod::PET_MAB_MDB));
+                PPet->addModifier(Mod::MACC, PMaster->getMod(Mod::PET_MACC_MEVA));
+                PPet->addModifier(Mod::MEVA, PMaster->getMod(Mod::PET_MACC_MEVA));
+            }
         }
     }
 
@@ -976,24 +988,27 @@ namespace petutils
 
     void CalculateAutomatonStats(CBattleEntity* PMaster, CPetEntity* PPet)
     {
+        JOBTYPE mjob = JOBTYPE::JOB_NON;
+        JOBTYPE sjob = JOBTYPE::JOB_NON;
+
         CAutomatonEntity* PAutomaton = static_cast<CAutomatonEntity*>(PPet);
         switch (PAutomaton->getFrame())
         {
             default: // case FRAME_HARLEQUIN:
-                PPet->SetMJob(JOB_WAR);
-                PPet->SetSJob(JOB_RDM);
+                mjob = JOB_WAR;
+                sjob = JOB_RDM;
                 break;
             case FRAME_VALOREDGE:
-                PPet->SetMJob(JOB_PLD);
-                PPet->SetSJob(JOB_WAR);
+                mjob = JOB_PLD;
+                sjob = JOB_WAR;
                 break;
             case FRAME_SHARPSHOT:
-                PPet->SetMJob(JOB_RNG);
-                PPet->SetSJob(JOB_PUP);
+                mjob = JOB_RNG;
+                sjob = JOB_PUP;
                 break;
             case FRAME_STORMWAKER:
-                PPet->SetMJob(JOB_RDM);
-                PPet->SetSJob(JOB_WHM);
+                mjob = JOB_RDM;
+                sjob = JOB_WHM;
                 break;
         }
 
@@ -1002,7 +1017,7 @@ namespace petutils
         PPet->SetMLevel(mainLevel);
         PPet->SetSLevel(mainLevel / 2); // Todo: SetSLevel() already reduces the level?
 
-        LoadAutomatonStats(static_cast<CCharEntity*>(PMaster), PPet, g_PPetList.at(PPet->m_PetID)); // temp
+        LoadAutomatonStats(static_cast<CCharEntity*>(PMaster), PPet, g_PPetList.at(PPet->m_PetID), mainLevel, mjob, sjob); // temp
 
         if (PMaster->objtype == TYPE_PC)
         {

--- a/src/map/utils/petutils.h
+++ b/src/map/utils/petutils.h
@@ -207,7 +207,7 @@ namespace petutils
     void CalculateAvatarStats(CBattleEntity* PMaster, CPetEntity* PPet);
     void CalculateWyvernStats(CBattleEntity* PMaster, CPetEntity* PPet);
     void CalculateJugPetStats(CBattleEntity* PMaster, CPetEntity* PPet);
-    void CalculateAutomatonStats(CBattleEntity* PMaster, CPetEntity* PPet);
+    void CalculateAutomatonStats(CBattleEntity* PMaster, CBattleEntity* PPet);
     void CalculateLuopanStats(CBattleEntity* PMaster, CPetEntity* PPet);
     void FinalizePetStatistics(CBattleEntity* PMaster, CPetEntity* PPet);
 

--- a/src/map/utils/puppetutils.cpp
+++ b/src/map/utils/puppetutils.cpp
@@ -48,47 +48,9 @@ namespace puppetutils
         {
             db::extractFromBlob(rset, "unlocked_attachments", PChar->m_unlockedAttachments);
 
-            if (PChar->PAutomaton != nullptr)
-            {
-                // Make sure we don't delete a pet that is active
-                auto* PZone = zoneutils::GetZone(PChar->PAutomaton->getZone());
-                if (PZone == nullptr)
-                {
-                    destroy(PChar->PAutomaton);
-                }
-                else
-                {
-                    if (PChar->PAutomaton->PInstance)
-                    {
-                        if (PChar->PAutomaton->PInstance->GetEntity(PChar->PAutomaton->targid, TYPE_PET) == nullptr)
-                        {
-                            destroy(PChar->PAutomaton);
-                        }
-                        else
-                        {
-                            PChar->PAutomaton->PMaster = nullptr;
-                        }
-                    }
-                    else if (PZone->GetEntity(PChar->PAutomaton->targid, TYPE_PET) == nullptr)
-                    {
-                        destroy(PChar->PAutomaton);
-                    }
-                    else
-                    {
-                        PChar->PAutomaton->PMaster = nullptr;
-                    }
-                }
-
-                PChar->PPet       = nullptr;
-                PChar->PAutomaton = nullptr;
-            }
-
             if (PChar->GetMJob() == JOB_PUP || PChar->GetSJob() == JOB_PUP)
             {
-                PChar->PAutomaton = new CAutomatonEntity();
-                PChar->PAutomaton->saveModifiers();
-
-                PChar->PAutomaton->name = rset->get<std::string>("name");
+                PChar->automatonInfo.m_automatonName = rset->get<std::string>("name");
 
                 automaton_equip_t tempEquip;
                 db::extractFromBlob(rset, "equipped_attachments", tempEquip);
@@ -100,38 +62,39 @@ namespace puppetutils
                     tempEquip.Frame < FRAME_HARLEQUIN ||
                     tempEquip.Frame > FRAME_STORMWAKER)
                 {
-                    PChar->PAutomaton->name = "Automaton";
+                    PChar->PPet->name = "Automaton";
 
-                    PChar->PAutomaton->setHead(HEAD_HARLEQUIN);
+                    PChar->setAutomatonHead(HEAD_HARLEQUIN);
                     tempEquip.Head = HEAD_HARLEQUIN;
-                    PChar->PAutomaton->setFrame(FRAME_HARLEQUIN);
+                    PChar->setAutomatonFrame(FRAME_HARLEQUIN);
                     tempEquip.Frame = FRAME_HARLEQUIN;
-                    for (int i = 0; i < 12; i++)
 
+                    for (int i = 0; i < 12; i++)
                     {
                         tempEquip.Attachments[i] = 0;
                     }
 
                     for (int i = 0; i < 6; i++)
                     {
-                        PChar->PAutomaton->setElementMax(i, 5);
+                        PChar->setAutomatonElementMax(i, 5);
                     }
 
-                    PChar->PAutomaton->setElementMax(6, 3);
-                    PChar->PAutomaton->setElementMax(7, 3);
+                    PChar->setAutomatonElementMax(6, 3);
+                    PChar->setAutomatonElementMax(7, 3);
 
                     for (int i = 0; i < 8; i++)
                     {
-                        PChar->PAutomaton->m_ElementEquip[i] = 0;
+                        PChar->automatonInfo.m_ElementEquip[i] = 0;
                     }
                 }
 
                 // Add the elemental bonus before we set the head and frame
-                PChar->PAutomaton->setElementalCapacityBonus(PChar->getMod(Mod::AUTO_ELEM_CAPACITY));
+                PChar->setAutomatonElementalCapacityBonus(PChar->getMod(Mod::AUTO_ELEM_CAPACITY));
 
                 setHead(PChar, tempEquip.Head);
                 setFrame(PChar, tempEquip.Frame);
-                LoadAutomatonStats(PChar);
+
+                petutils::CalculateAutomatonStats(PChar, PChar->PPet);
 
                 // Always load Optic Fiber and Optic Fiber II first
                 for (int i = 0; i < 12; i++)
@@ -149,23 +112,13 @@ namespace puppetutils
                         setAttachment(PChar, i, tempEquip.Attachments[i]);
                     }
                 }
-
-                // After the Automaton has all attachments set, make sure we update for Optic Fiber
-                puppetutils::UpdateAttachments(PChar);
-
-                // Set burden based on JP
-                PChar->PAutomaton->setAllBurden(30 - PChar->PJobPoints->GetJobPointValue(JP_ACTIVATE_EFFECT));
-
-                PChar->PAutomaton->UpdateHealth();
-                PChar->PAutomaton->health.hp = PChar->PAutomaton->GetMaxHP();
-                PChar->PAutomaton->health.mp = PChar->PAutomaton->GetMaxMP();
             }
         }
     }
 
     void SaveAutomaton(CCharEntity* PChar)
     {
-        if (PChar->PAutomaton)
+        if (PChar->GetMJob() == JOBTYPE::JOB_PUP || PChar->GetSJob() == JOBTYPE::JOB_PUP)
         {
             const char* Query = "UPDATE char_pet SET "
                                 "unlocked_attachments = '%s', "
@@ -177,27 +130,13 @@ namespace puppetutils
             std::memcpy(unlockedAttachments, &PChar->m_unlockedAttachments, sizeof(unlockedAttachments));
             _sql->EscapeStringLen(unlockedAttachmentsEscaped, unlockedAttachments, sizeof(unlockedAttachments));
 
-            char equippedAttachmentsEscaped[sizeof(PChar->PAutomaton->m_Equip) * 2 + 1];
-            char equippedAttachments[sizeof(PChar->PAutomaton->m_Equip)];
-            std::memcpy(equippedAttachments, &PChar->PAutomaton->m_Equip, sizeof(equippedAttachments));
+            char equippedAttachmentsEscaped[sizeof(PChar->automatonInfo.m_Equip) * 2 + 1];
+            char equippedAttachments[sizeof(PChar->automatonInfo.m_Equip)];
+            std::memcpy(equippedAttachments, &PChar->automatonInfo.m_Equip, sizeof(equippedAttachments));
             _sql->EscapeStringLen(equippedAttachmentsEscaped, equippedAttachments, sizeof(equippedAttachments));
 
             _sql->Query(Query, unlockedAttachmentsEscaped, equippedAttachmentsEscaped, PChar->id);
         }
-        else
-        {
-            const char* Query = "UPDATE char_pet SET "
-                                "unlocked_attachments = '%s' "
-                                "WHERE charid = %u";
-
-            char unlockedAttachmentsEscaped[sizeof(PChar->m_unlockedAttachments) * 2 + 1];
-            char unlockedAttachments[sizeof(PChar->m_unlockedAttachments)];
-            std::memcpy(unlockedAttachments, &PChar->m_unlockedAttachments, sizeof(unlockedAttachments));
-            _sql->EscapeStringLen(unlockedAttachmentsEscaped, unlockedAttachments, sizeof(unlockedAttachments));
-
-            _sql->Query(Query, unlockedAttachmentsEscaped, PChar->id);
-        }
-        // TODO: PUP only: save equipped automaton items
     }
 
     bool UnlockAttachment(CCharEntity* PChar, CItem* PItem)
@@ -283,14 +222,14 @@ namespace puppetutils
 
             for (int i = 0; i < 12; i++)
             {
-                if (attachment == PChar->PAutomaton->getAttachment(i))
+                if (attachment == PChar->getAutomatonAttachment(i))
                 {
                     return;
                 }
             }
         }
 
-        uint8 oldAttachment = PChar->PAutomaton->getAttachment(slotId);
+        uint8 oldAttachment = PChar->getAutomatonAttachment(slotId);
         if (attachment != 0 && oldAttachment != 0)
         {
             setAttachment(PChar, slotId, 0);
@@ -303,9 +242,15 @@ namespace puppetutils
             if (PAttachment && PAttachment->getEquipSlot() == ITEM_PUPPET_ATTACHMENT)
             {
                 valid = true;
-                for (int i = 0; i < 8; i++)
+
+                // Iterate through the 8 elements and validate if the attachment actually fits the current automaton head/frame
+                for (int element = 0; element < 8; element++)
                 {
-                    if (PChar->PAutomaton->getElementCapacity(i) + ((PAttachment->getElementSlots() >> (i * 4)) & 0xF) > PChar->PAutomaton->getElementMax(i))
+                    auto currentElementCapacity = PChar->getAutomatonElementCapacity(element);
+                    auto elementMax             = PChar->getAutomatonElementMax(element);
+                    auto attachmentElementPower = ((PAttachment->getElementSlots() >> (element * 4)) & 0xF);
+
+                    if (currentElementCapacity + attachmentElementPower > elementMax)
                     {
                         valid = false;
                         break;
@@ -315,12 +260,12 @@ namespace puppetutils
 
             if (valid)
             {
-                for (int i = 0; i < 8; i++)
+                for (int element = 0; element < 8; element++)
                 {
-                    PChar->PAutomaton->addElementCapacity(i, (PAttachment->getElementSlots() >> (i * 4)) & 0xF);
+                    PChar->addAutomatonElementCapacity(element, (PAttachment->getElementSlots() >> (element * 4)) & 0xF);
                 }
-                luautils::OnAttachmentEquip(PChar->PAutomaton, PAttachment);
-                PChar->PAutomaton->setAttachment(slotId, attachment);
+
+                PChar->setAutomatonAttachment(slotId, attachment);
             }
             else
             {
@@ -329,7 +274,7 @@ namespace puppetutils
         }
         else
         {
-            attachment = PChar->PAutomaton->getAttachment(slotId);
+            attachment = PChar->getAutomatonAttachment(slotId);
 
             if (attachment != 0)
             {
@@ -337,12 +282,12 @@ namespace puppetutils
 
                 if (PAttachment && PAttachment->getEquipSlot() == ITEM_PUPPET_ATTACHMENT)
                 {
-                    for (int i = 0; i < 8; i++)
+                    for (int element = 0; element < 8; element++)
                     {
-                        PChar->PAutomaton->addElementCapacity(i, -(int8)((PAttachment->getElementSlots() >> (i * 4)) & 0xF));
+                        PChar->addAutomatonElementCapacity(element, -(int8)((PAttachment->getElementSlots() >> (element * 4)) & 0xF));
                     }
-                    luautils::OnAttachmentUnequip(PChar->PAutomaton, PAttachment);
-                    PChar->PAutomaton->setAttachment(slotId, 0);
+
+                    PChar->setAutomatonAttachment(slotId, 0);
                 }
             }
         }
@@ -352,73 +297,64 @@ namespace puppetutils
     {
         uint8 tempElementMax[8];
 
-        for (int i = 0; i < 8; i++)
+        for (int element = 0; element < 8; element++)
         {
-            tempElementMax[i] = PChar->PAutomaton->getElementMax(i);
+            tempElementMax[element] = PChar->getAutomatonElementMax(element);
         }
 
-        if (PChar->PAutomaton->getFrame() != 0)
+        if (PChar->getAutomatonFrame() != 0)
         {
-            CItemPuppet* POldFrame = (CItemPuppet*)itemutils::GetItemPointer(0x2000 + PChar->PAutomaton->getFrame());
+            CItemPuppet* POldFrame = (CItemPuppet*)itemutils::GetItemPointer(0x2000 + PChar->getAutomatonFrame());
             if (POldFrame == nullptr || POldFrame->getEquipSlot() != ITEM_PUPPET_FRAME)
             {
                 return;
             }
-            for (int i = 0; i < 8; i++)
+            for (int element = 0; element < 8; element++)
             {
-                tempElementMax[i] -= (POldFrame->getElementSlots() >> (i * 4)) & 0xF;
+                tempElementMax[element] -= (POldFrame->getElementSlots() >> (element * 4)) & 0xF;
             }
         }
+
+        // Check if they actually have the frame
         CItemPuppet* PFrame = (CItemPuppet*)itemutils::GetItemPointer(0x2000 + frame);
         if (PFrame == nullptr || PFrame->getEquipSlot() != ITEM_PUPPET_FRAME || (frame != FRAME_HARLEQUIN && !HasAttachment(PChar, PFrame)))
         {
             return;
         }
-        for (int i = 0; i < 8; i++)
+
+        for (int element = 0; element < 8; element++)
         {
-            tempElementMax[i] += (PFrame->getElementSlots() >> (i * 4)) & 0xF;
+            tempElementMax[element] += (PFrame->getElementSlots() >> (element * 4)) & 0xF;
         }
 
-        bool valid = true;
+        PChar->setAutomatonFrame((AUTOFRAMETYPE)frame);
+        uint8 head                              = PChar->getAutomatonHead();
+        PChar->automatonInfo.automatonLook.race = 0x07;
 
-        for (int i = 0; i < 8; i++)
+        if (head == 3)
         {
-            if (tempElementMax[i] < PChar->PAutomaton->getElementCapacity(i))
-            {
-                valid = false;
-                break;
-            }
+            PChar->automatonInfo.automatonLook.face = 0xBC + ((frame - 32) * 5);
+        }
+        else if (head == 4)
+        {
+            PChar->automatonInfo.automatonLook.face = 0xBB + ((frame - 32) * 5);
+        }
+        else if (head == 5)
+        {
+            PChar->automatonInfo.automatonLook.face = 0xD3 + ((frame - 32));
+        }
+        else if (head == 6)
+        {
+            PChar->automatonInfo.automatonLook.face = 0xD7 + ((frame - 32));
+        }
+        else
+        {
+            PChar->automatonInfo.automatonLook.face = 0xB9 + ((frame - 32) * 5) + (head - 1);
         }
 
-        if (valid)
+        for (int element = 0; element < 8; element++)
         {
-            PChar->PAutomaton->setFrame((AUTOFRAMETYPE)frame);
-            uint8 head                   = PChar->PAutomaton->getHead();
-            PChar->PAutomaton->look.race = 0x07;
-            if (head == 3)
-            {
-                PChar->PAutomaton->look.face = 0xBC + ((frame - 32) * 5);
-            }
-            else if (head == 4)
-            {
-                PChar->PAutomaton->look.face = 0xBB + ((frame - 32) * 5);
-            }
-            else if (head == 5)
-            {
-                PChar->PAutomaton->look.face = 0xD3 + ((frame - 32));
-            }
-            else if (head == 6)
-            {
-                PChar->PAutomaton->look.face = 0xD7 + ((frame - 32));
-            }
-            else
-            {
-                PChar->PAutomaton->look.face = 0xB9 + ((frame - 32) * 5) + (head - 1);
-            }
-            for (int i = 0; i < 8; i++)
-            {
-                PChar->PAutomaton->setElementMax(i, tempElementMax[i]);
-            }
+            PChar->setAutomatonElementMax(element, tempElementMax[element]);
         }
     }
 
@@ -426,84 +362,80 @@ namespace puppetutils
     {
         uint8 tempElementMax[8];
 
-        for (int i = 0; i < 8; i++)
+        for (int element = 0; element < 8; element++)
         {
-            tempElementMax[i] = PChar->PAutomaton->getElementMax(i);
+            tempElementMax[element] = PChar->getAutomatonElementMax(element);
         }
 
-        if (PChar->PAutomaton->getHead() != 0)
+        if (PChar->getAutomatonHead() != 0)
         {
-            CItemPuppet* POldHead = (CItemPuppet*)itemutils::GetItemPointer(0x2000 + PChar->PAutomaton->getHead());
+            CItemPuppet* POldHead = (CItemPuppet*)itemutils::GetItemPointer(0x2000 + PChar->getAutomatonHead());
             if (POldHead == nullptr || POldHead->getEquipSlot() != ITEM_PUPPET_HEAD)
             {
                 return;
             }
-            for (int i = 0; i < 8; i++)
+            for (int element = 0; element < 8; element++)
             {
-                tempElementMax[i] -= (POldHead->getElementSlots() >> (i * 4)) & 0xF;
+                tempElementMax[element] -= (POldHead->getElementSlots() >> (element * 4)) & 0xF;
             }
         }
+
+        // Check if they actually have the head
         CItemPuppet* PHead = (CItemPuppet*)itemutils::GetItemPointer(0x2000 + head);
         if (PHead == nullptr || PHead->getEquipSlot() != ITEM_PUPPET_HEAD || (head != HEAD_HARLEQUIN && !HasAttachment(PChar, PHead)))
         {
             return;
         }
-        for (int i = 0; i < 8; i++)
+
+        for (int element = 0; element < 8; element++)
         {
-            tempElementMax[i] += (PHead->getElementSlots() >> (i * 4)) & 0xF;
+            tempElementMax[element] += (PHead->getElementSlots() >> (element * 4)) & 0xF;
         }
 
-        bool valid = true;
+        PChar->setAutomatonHead((AUTOHEADTYPE)head);
+        uint8 frame                             = PChar->getAutomatonFrame();
+        PChar->automatonInfo.automatonLook.race = 0x07;
 
-        for (int i = 0; i < 8; i++)
+        if (head == 3)
         {
-            if (tempElementMax[i] < PChar->PAutomaton->getElementCapacity(i))
-            {
-                valid = false;
-                break;
-            }
+            PChar->automatonInfo.automatonLook.face = 0xBC + ((frame - 32) * 5);
         }
-
-        if (valid)
+        else if (head == 4)
         {
-            PChar->PAutomaton->setHead((AUTOHEADTYPE)head);
-            uint8 frame                  = PChar->PAutomaton->getFrame();
-            PChar->PAutomaton->look.race = 0x07;
-            if (head == 3)
-            {
-                PChar->PAutomaton->look.face = 0xBC + ((frame - 32) * 5);
-            }
-            else if (head == 4)
-            {
-                PChar->PAutomaton->look.face = 0xBB + ((frame - 32) * 5);
-            }
-            else if (head == 5)
-            {
-                PChar->PAutomaton->look.face = 0xD3 + ((frame - 32));
-            }
-            else if (head == 6)
-            {
-                PChar->PAutomaton->look.face = 0xD7 + ((frame - 32));
-            }
-            else
-            {
-                PChar->PAutomaton->look.face = 0xB9 + ((frame - 32) * 5) + (head - 1);
-            }
-            for (int i = 0; i < 8; i++)
-            {
-                PChar->PAutomaton->setElementMax(i, tempElementMax[i]);
-            }
+            PChar->automatonInfo.automatonLook.face = 0xBB + ((frame - 32) * 5);
+        }
+        else if (head == 5)
+        {
+            PChar->automatonInfo.automatonLook.face = 0xD3 + ((frame - 32));
+        }
+        else if (head == 6)
+        {
+            PChar->automatonInfo.automatonLook.face = 0xD7 + ((frame - 32));
+        }
+        else
+        {
+            PChar->automatonInfo.automatonLook.face = 0xB9 + ((frame - 32) * 5) + (head - 1);
+        }
+        for (int element = 0; element < 8; element++)
+        {
+            PChar->setAutomatonElementMax(element, tempElementMax[element]);
         }
     }
 
     uint16 getSkillCap(CCharEntity* PChar, SKILLTYPE skill, uint8 level)
     {
+        if (PChar == nullptr)
+        {
+            ShowWarning("puppetutils::getSkillCap() - Null PChar passed to function.");
+            return 0;
+        }
+
         int8 rank = 0;
         if (skill < SKILL_AUTOMATON_MELEE || skill > SKILL_AUTOMATON_MAGIC)
         {
             return 0;
         }
-        switch (PChar->PAutomaton->getFrame())
+        switch (PChar->getAutomatonFrame())
         {
             default: // case FRAME_HARLEQUIN:
                 rank = 5;
@@ -536,7 +468,7 @@ namespace puppetutils
                 break;
         }
 
-        switch (PChar->PAutomaton->getHead())
+        switch (PChar->getAutomatonHead())
         {
             case HEAD_VALOREDGE:
                 if (skill == SKILL_AUTOMATON_MELEE)
@@ -576,43 +508,6 @@ namespace puppetutils
         return battleutils::GetMaxSkill(rank, level > 99 ? 99 : level);
     }
 
-    uint16 getSkillCap(CCharEntity* PChar, SKILLTYPE skill)
-    {
-        if (PChar == nullptr)
-        {
-            ShowWarning("puppetutils::getSkillCap() - Null PChar passed to function.");
-            return 0;
-        }
-
-        return getSkillCap(PChar, skill, PChar->PAutomaton->GetMLevel());
-    }
-
-    void LoadAutomatonStats(CCharEntity* PChar)
-    {
-        // Save this since LoadPet() below changes it, but we don't want this changed
-        auto origPetID = PChar->petZoningInfo.petID;
-        switch (PChar->PAutomaton->getFrame())
-        {
-            default: // case FRAME_HARLEQUIN:
-                ShowWarning("puppetutils::LoadAutomatonStats Invalid frame detected for '%s', used Harlequin instead! (%u)",
-                            PChar->getName(), (uint16)PChar->PAutomaton->getFrame());
-            case FRAME_HARLEQUIN:
-                petutils::LoadPet(PChar, PETID_HARLEQUINFRAME, false);
-                break;
-            case FRAME_VALOREDGE:
-                petutils::LoadPet(PChar, PETID_VALOREDGEFRAME, false);
-                break;
-            case FRAME_SHARPSHOT:
-                petutils::LoadPet(PChar, PETID_SHARPSHOTFRAME, false);
-                break;
-            case FRAME_STORMWAKER:
-                petutils::LoadPet(PChar, PETID_STORMWAKERFRAME, false);
-                break;
-        }
-        PChar->PPet                = nullptr; // already saved as PAutomaton, don't need it twice unless it's summoned
-        PChar->petZoningInfo.petID = origPetID;
-    }
-
     void TrySkillUP(CAutomatonEntity* PAutomaton, SKILLTYPE SkillID, uint8 lvl)
     {
         if (!PAutomaton->PMaster || PAutomaton->PMaster->objtype != TYPE_PC)
@@ -622,7 +517,7 @@ namespace puppetutils
         }
 
         CCharEntity* PChar = (CCharEntity*)PAutomaton->PMaster;
-        if (getSkillCap(PChar, SkillID) != 0 && !(PAutomaton->WorkingSkills.skill[SkillID] & 0x8000))
+        if (getSkillCap(PChar, SkillID, PAutomaton->GetMLevel()) != 0 && !(PAutomaton->WorkingSkills.skill[SkillID] & 0x8000))
         {
             uint16 CurSkill = PChar->RealSkills.skill[SkillID];
             uint16 MaxSkill = getSkillCap(PChar, SkillID, std::min(PAutomaton->GetMLevel(), lvl));
@@ -724,7 +619,7 @@ namespace puppetutils
 
     void CheckAttachmentsForManeuver(CCharEntity* PChar, EFFECT maneuver, bool gain)
     {
-        CAutomatonEntity* PAutomaton = PChar->PAutomaton;
+        CAutomatonEntity* PAutomaton = dynamic_cast<CAutomatonEntity*>(PChar->PPet);
 
         if (PAutomaton)
         {
@@ -751,9 +646,28 @@ namespace puppetutils
         }
     }
 
+    void EquipAttachments(CAutomatonEntity* PAutomaton)
+    {
+        if (PAutomaton)
+        {
+            for (uint8 i = 0; i < 12; i++)
+            {
+                if (PAutomaton->getAttachment(i) != 0)
+                {
+                    CItemPuppet* PAttachment = (CItemPuppet*)itemutils::GetItemPointer(0x2100 + PAutomaton->getAttachment(i));
+
+                    if (PAttachment)
+                    {
+                        luautils::OnAttachmentEquip(PAutomaton, PAttachment);
+                    }
+                }
+            }
+        }
+    }
+
     void UpdateAttachments(CCharEntity* PChar)
     {
-        CAutomatonEntity* PAutomaton = PChar->PAutomaton;
+        CAutomatonEntity* PAutomaton = dynamic_cast<CAutomatonEntity*>(PChar->PPet);
 
         if (PAutomaton)
         {
@@ -783,7 +697,8 @@ namespace puppetutils
 
     void PreLevelRestriction(CCharEntity* PChar)
     {
-        CAutomatonEntity* PAutomaton = PChar->PAutomaton;
+        CAutomatonEntity* PAutomaton = dynamic_cast<CAutomatonEntity*>(PChar->PPet);
+
         if (PAutomaton)
         {
             for (int i = 0; i < 12; i++)
@@ -808,7 +723,7 @@ namespace puppetutils
 
     void PostLevelRestriction(CCharEntity* PChar)
     {
-        CAutomatonEntity* PAutomaton = PChar->PAutomaton;
+        CAutomatonEntity* PAutomaton = dynamic_cast<CAutomatonEntity*>(PChar->PPet);
 
         if (PAutomaton)
         {
@@ -831,5 +746,4 @@ namespace puppetutils
             UpdateAttachments(PChar);
         }
     }
-
 } // namespace puppetutils

--- a/src/map/utils/puppetutils.h
+++ b/src/map/utils/puppetutils.h
@@ -36,10 +36,9 @@ namespace puppetutils
     void   setFrame(CCharEntity* PChar, uint8 frame);
     void   setHead(CCharEntity* PChar, uint8 head);
     uint16 getSkillCap(CCharEntity* PChar, SKILLTYPE skill, uint8 level);
-    uint16 getSkillCap(CCharEntity* PChar, SKILLTYPE skill);
     void   TrySkillUP(CAutomatonEntity* PAutomaton, SKILLTYPE SkillID, uint8 lvl);
-    void   LoadAutomatonStats(CCharEntity* PChar);
     void   CheckAttachmentsForManeuver(CCharEntity* PChar, EFFECT maneuver, bool gain);
+    void   EquipAttachments(CAutomatonEntity* PAutomaton);
     void   UpdateAttachments(CCharEntity* PChar);
     void   PreLevelRestriction(CCharEntity* PChar);
     void   PostLevelRestriction(CCharEntity* PChar);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

PAutomaton on CCharEntity must die
see:
https://github.com/LandSandBoat/server/issues/5535
many issues have come up because of PAutomaton being PPet but also not at the same time. It only exists because of the job packet required for the automaton menu. This PR is meant to kill PAutomaton and make that menu work without it.
Closes #6954

## Steps to test these changes

Test a few attachments:
- [x] Magniplug
- [x] Flash Bulb
- [x] Barrage Turbine
- [x] misc stat boosting ones
- [x] regen/refresh

Test some normal cases
- [x] Level sync stat changes
- [x] Level sync + attachments
- [x] Zoning persistence (NOT using !zone)
- [x] skillups

Battlefield cases:
- [x] Instances (e.g. assault)
- [x] BCNMs
- [x] Limbus?