### PR TITLE
[Fix] Error when calculating skill value at level over 99 (lua)

### DIFF
--- a/scripts/globals/combat/skill_ranks.lua
+++ b/scripts/globals/combat/skill_ranks.lua
@@ -119,5 +119,5 @@ xi.combat.skillLevel.getSkillCap = function(actorLevel, skillRank)
     local rankToCheck  = skillRank or xi.skillRank.G -- Assume rank G
 
     -- Going to assume levels over 99 give 1 skill level, just like master levels.
-    return xi.combat.skillLevel.dataTable[levelToCheck][rankToCheck] + utils.clamp(levelToCheck - 99, 0, 156)
+    return xi.combat.skillLevel.dataTable[utils.clamp(levelToCheck, 0, 99)][rankToCheck] + utils.clamp(levelToCheck - 99, 0, 156)
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes bad math in lua function for skill value

## Steps to test these changes
Fisht any mob over lvl 99 that can use magical skills.
