### PR TITLE
[lua] Dread Shriek adjustments per spreadsheet

### DIFF
--- a/scripts/actions/mobskills/dread_shriek.lua
+++ b/scripts/actions/mobskills/dread_shriek.lua
@@ -12,8 +12,22 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
+-- https://docs.google.com/spreadsheets/d/1YBoveP-weMdidrirY-vPDzHyxbEI2ryECINlfCnFkLI/edit?gid=57955395#gid=57955395
+-- TODO: what's the boosted para rate for NMs? needs research
+-- Cyranuce M Cutauleon has a very strong paralyze from this
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 100, 0, 60))
+    local power = 45
+
+    if mob:isNM() then
+        power = 90
+    end
+
+    -- Cyranuce M Cutauleon
+    if mob:getPool() == 884 then
+        power = 100 -- yes, really
+    end
+
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, power, 0, 60))
 
     return xi.effect.PARALYSIS
 end


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Dread Shriek is apparently different from NMs to non NMs:

90% rate is guessed for typical NMs
100% from cyranuce is known from testing


## Steps to test these changes

![image](https://github.com/user-attachments/assets/da27b182-de15-453f-9eaa-44dc891c0b6d)
![image](https://github.com/user-attachments/assets/4bd57e3a-6d14-4413-b8c8-904e7621fb66)
![image](https://github.com/user-attachments/assets/d112ce3f-180b-43c9-b2c2-4672c375e371)

