### PR TITLE
Relocate triggerarea zoning check

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2001,12 +2001,6 @@ namespace luautils
     {
         TracyZoneScoped;
 
-        // Do not enter trigger areas while loading in. Set in xi.player.onGameIn
-        if (PChar->GetLocalVar("ZoningIn") > 0)
-        {
-            return;
-        }
-
         std::string                 filename;
         std::optional<CLuaInstance> optInstance = std::nullopt;
         if (PChar->PInstance)

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -1224,6 +1224,12 @@ void CZone::CheckTriggerAreas()
         // TODO: When we start to use octrees or spatial hashing to split up zones,
         //     : use them here to make the search domain smaller.
 
+        // Do not enter trigger areas while loading in. Set in xi.player.onGameIn
+        if (PChar->GetLocalVar("ZoningIn") > 0)
+        {
+            return;
+        }
+
         for (const auto& triggerArea : m_triggerAreaList)
         {
             const auto triggerAreaID = triggerArea->getTriggerAreaID();

--- a/src/map/zone_instance.cpp
+++ b/src/map/zone_instance.cpp
@@ -423,6 +423,12 @@ void CZoneInstance::CheckTriggerAreas()
             // TODO: When we start to use octrees or spatial hashing to split up zones,
             //     : use them here to make the search domain smaller.
 
+            // Do not enter trigger areas while loading in. Set in xi.player.onGameIn
+            if (PChar->GetLocalVar("ZoningIn") > 0)
+            {
+                return;
+            }
+
             for (const auto& triggerArea : m_triggerAreaList)
             {
                 const auto triggerAreaID = triggerArea->getTriggerAreaID();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Follows up on [this](https://github.com/LandSandBoat/server/pull/6946#issuecomment-2636440177) outstanding issue from PR https://github.com/LandSandBoat/server/pull/6946

## Steps to test these changes

Login while having logged out in a trigger zone
Notice that the trigger zone takes effect once you have "zoned in"
Ex: NPCs for the [Flyers for Regine](https://www.bg-wiki.com/ffxi/Flyers_for_Regine) quest will look at you upon logging in

Prior to this, after the changes in the original PR, the lua would not have run but your character would still be marked as being inside the trigger area.

# Notes

Following up here: [here](https://github.com/LandSandBoat/server/pull/6946#issuecomment-2636450338)

Zoning into Abyssea - Konschtat has the visitant status message appear.
Logging out and back in also has the message appear.