### PR TITLE
More Gambit Conditions For Trusts

### DIFF
--- a/scripts/globals/gambits.lua
+++ b/scripts/globals/gambits.lua
@@ -113,6 +113,9 @@ ai.select =
     BEST_INDI           = 10,
     STORM_DAY           = 11,
     HELIX_DAY           = 12,
+    EN_MOB_WEAKNESS     = 13,
+    STORM_MOB_WEAKNESS  = 14,
+    HELIX_MOB_WEAKNESS  = 15,
 }
 ai.s = ai.select
 

--- a/src/map/ai/helpers/gambits_container.cpp
+++ b/src/map/ai/helpers/gambits_container.cpp
@@ -327,7 +327,7 @@ namespace gambits
                     }
                     else if (action.select == G_SELECT::BEST_AGAINST_TARGET)
                     {
-                    	auto spell_to_cast = static_cast<SpellID>(action.select_arg);
+                        auto spell_to_cast = static_cast<SpellID>(action.select_arg);
                         auto spell_id      = POwner->SpellContainer->GetBestAgainstTargetWeakness(target, spell_to_cast);
                         if (spell_id.has_value())
                         {

--- a/src/map/ai/helpers/gambits_container.cpp
+++ b/src/map/ai/helpers/gambits_container.cpp
@@ -328,7 +328,7 @@ namespace gambits
                     else if (action.select == G_SELECT::BEST_AGAINST_TARGET)
                     {
                     	auto spell_to_cast = static_cast<SpellID>(action.select_arg);
-                        auto spell_id = POwner->SpellContainer->GetBestAgainstTargetWeakness(target, spell_to_cast);
+                        auto spell_id      = POwner->SpellContainer->GetBestAgainstTargetWeakness(target, spell_to_cast);
                         if (spell_id.has_value())
                         {
                             controller->Cast(target->targid, spell_id.value());

--- a/src/map/ai/helpers/gambits_container.cpp
+++ b/src/map/ai/helpers/gambits_container.cpp
@@ -371,7 +371,7 @@ namespace gambits
                         auto spell_id = POwner->SpellContainer->StormDayAgainstTargetWeakness(target);
                         if (spell_id.has_value())
                         {
-                            controller->Cast(POwner->targid, spell_id.value());
+                            controller->Cast(target->targid, spell_id.value());
                         }
                     }
                     else if (action.select == G_SELECT::RANDOM)

--- a/src/map/ai/helpers/gambits_container.cpp
+++ b/src/map/ai/helpers/gambits_container.cpp
@@ -327,7 +327,8 @@ namespace gambits
                     }
                     else if (action.select == G_SELECT::BEST_AGAINST_TARGET)
                     {
-                        auto spell_id = POwner->SpellContainer->GetBestAgainstTargetWeakness(target);
+                    	auto spell_to_cast = static_cast<SpellID>(action.select_arg);
+                        auto spell_id = POwner->SpellContainer->GetBestAgainstTargetWeakness(target, spell_to_cast);
                         if (spell_id.has_value())
                         {
                             controller->Cast(target->targid, spell_id.value());
@@ -347,6 +348,30 @@ namespace gambits
                         if (spell_id.has_value())
                         {
                             controller->Cast(target->targid, spell_id.value());
+                        }
+                    }
+                    else if (action.select == G_SELECT::EN_MOB_WEAKNESS)
+                    {
+                        auto spell_id = POwner->SpellContainer->EnSpellAgainstTargetWeakness(target);
+                        if (spell_id.has_value())
+                        {
+                            controller->Cast(POwner->targid, spell_id.value());
+                        }
+                    }
+                    else if (action.select == G_SELECT::STORM_MOB_WEAKNESS)
+                    {
+                        auto spell_id = POwner->SpellContainer->StormDayAgainstTargetWeakness(target);
+                        if (spell_id.has_value())
+                        {
+                            controller->Cast(POwner->targid, spell_id.value());
+                        }
+                    }
+                    else if (action.select == G_SELECT::HELIX_MOB_WEAKNESS)
+                    {
+                        auto spell_id = POwner->SpellContainer->StormDayAgainstTargetWeakness(target);
+                        if (spell_id.has_value())
+                        {
+                            controller->Cast(POwner->targid, spell_id.value());
                         }
                     }
                     else if (action.select == G_SELECT::RANDOM)

--- a/src/map/ai/helpers/gambits_container.h
+++ b/src/map/ai/helpers/gambits_container.h
@@ -91,6 +91,9 @@ namespace gambits
         BEST_INDI           = 10,
         STORM_DAY           = 11,
         HELIX_DAY           = 12,
+        EN_MOB_WEAKNESS     = 13,
+        STORM_MOB_WEAKNESS  = 14,
+        HELIX_MOB_WEAKNESS  = 15,
     };
 
     enum class G_TP_TRIGGER : uint16

--- a/src/map/mob_spell_container.cpp
+++ b/src/map/mob_spell_container.cpp
@@ -349,15 +349,15 @@ std::optional<SpellID> CMobSpellContainer::GetBestAgainstTargetWeakness(CBattleE
 
     // TODO: Figure this out properly:
     auto Weakness_Element = weakestIndex + 1;
-    auto Spell_Element = spell::GetSpell(spellId)->getElement();
+    auto Spell_Element    = spell::GetSpell(spellId)->getElement();
     if (Spell_Element == Weakness_Element)
 	{
-		return spellId;
-	}
-	else
-	{
-		return std::nullopt;
-	}
+        return spellId;
+    }
+    else
+    {
+        return std::nullopt;
+    }
 }
 
 std::optional<SpellID> CMobSpellContainer::EnSpellAgainstTargetWeakness(CBattleEntity* PTarget)

--- a/src/map/mob_spell_container.cpp
+++ b/src/map/mob_spell_container.cpp
@@ -328,7 +328,39 @@ std::optional<SpellID> CMobSpellContainer::GetBestEntrustedSpell(CBattleEntity* 
     return choice;
 }
 
-std::optional<SpellID> CMobSpellContainer::GetBestAgainstTargetWeakness(CBattleEntity* PTarget)
+std::optional<SpellID> CMobSpellContainer::GetBestAgainstTargetWeakness(CBattleEntity* PTarget, SpellID spellId)
+{
+    // Look up what the target has the _least resistance to_:
+    // clang-format off
+    std::vector<int16> resistances
+    {
+        PTarget->getMod(Mod::FIRE_RES_RANK),
+        PTarget->getMod(Mod::ICE_RES_RANK),
+        PTarget->getMod(Mod::WIND_RES_RANK),
+        PTarget->getMod(Mod::EARTH_RES_RANK),
+        PTarget->getMod(Mod::THUNDER_RES_RANK),
+        PTarget->getMod(Mod::WATER_RES_RANK),
+        PTarget->getMod(Mod::LIGHT_RES_RANK),
+        PTarget->getMod(Mod::DARK_RES_RANK),
+    };
+    // clang-format on
+
+    std::size_t weakestIndex = std::distance(resistances.begin(), std::min_element(resistances.begin(), resistances.end()));
+
+    // TODO: Figure this out properly:
+    auto Weakness_Element = weakestIndex + 1;
+    auto Spell_Element = spell::GetSpell(spellId)->getElement();
+    if (Spell_Element == Weakness_Element)
+	{
+		return spellId;
+	}
+	else
+	{
+		return std::nullopt;
+	}
+}
+
+std::optional<SpellID> CMobSpellContainer::EnSpellAgainstTargetWeakness(CBattleEntity* PTarget)
 {
     // Look up what the target has the _least resistance to_:
     // clang-format off
@@ -353,48 +385,170 @@ std::optional<SpellID> CMobSpellContainer::GetBestAgainstTargetWeakness(CBattleE
     {
         case ELEMENT_FIRE:
         {
-            choice = GetBestAvailable(SPELLFAMILY_FIRE);
+            choice = GetBestAvailable(SPELLFAMILY_ENFIRE);
             break;
         }
         case ELEMENT_ICE:
         {
-            choice = GetBestAvailable(SPELLFAMILY_BLIZZARD);
+            choice = GetBestAvailable(SPELLFAMILY_ENBLIZZARD);
             break;
         }
         case ELEMENT_WIND:
         {
-            choice = GetBestAvailable(SPELLFAMILY_AERO);
+            choice = GetBestAvailable(SPELLFAMILY_ENAERO);
             break;
         }
         case ELEMENT_EARTH:
         {
-            choice = GetBestAvailable(SPELLFAMILY_STONE);
+            choice = GetBestAvailable(SPELLFAMILY_ENSTONE);
             break;
         }
         case ELEMENT_THUNDER:
         {
-            choice = GetBestAvailable(SPELLFAMILY_THUNDER);
+            choice = GetBestAvailable(SPELLFAMILY_ENTHUNDER);
             break;
         }
         case ELEMENT_WATER:
         {
-            choice = GetBestAvailable(SPELLFAMILY_WATER);
+            choice = GetBestAvailable(SPELLFAMILY_ENWATER);
+            break;
+        }
+    }
+     return choice;
+}
+
+std::optional<SpellID> CMobSpellContainer::StormDayAgainstTargetWeakness(CBattleEntity* PTarget)
+{
+    // Look up what the target has the _least resistance to_:
+    // clang-format off
+    std::vector<int16> resistances
+    {
+        PTarget->getMod(Mod::FIRE_RES_RANK),
+        PTarget->getMod(Mod::ICE_RES_RANK),
+        PTarget->getMod(Mod::WIND_RES_RANK),
+        PTarget->getMod(Mod::EARTH_RES_RANK),
+        PTarget->getMod(Mod::THUNDER_RES_RANK),
+        PTarget->getMod(Mod::WATER_RES_RANK),
+        PTarget->getMod(Mod::LIGHT_RES_RANK),
+        PTarget->getMod(Mod::DARK_RES_RANK),
+    };
+    // clang-format on
+
+    std::size_t weakestIndex = std::distance(resistances.begin(), std::min_element(resistances.begin(), resistances.end()));
+
+    // TODO: Figure this out properly:
+    std::optional<SpellID> choice = std::nullopt;
+    switch (weakestIndex + 1) // Adjust to ignore ELEMENT_NONE
+    {
+      case ELEMENT_FIRE:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_FIRESTORM);
+            break;
+        }
+        case ELEMENT_ICE:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_HAILSTORM);
+            break;
+        }
+        case ELEMENT_WIND:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_WINDSTORM);
+            break;
+        }
+        case ELEMENT_EARTH:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_SANDSTORM);
+            break;
+        }
+        case ELEMENT_THUNDER:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_THUNDERSTORM);
+            break;
+        }
+        case ELEMENT_WATER:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_RAINSTORM);
             break;
         }
         case ELEMENT_LIGHT:
         {
-            choice = GetBestAvailable(SPELLFAMILY_BANISH);
+            choice = GetBestAvailable(SPELLFAMILY_AURORASTORM);
             break;
         }
         case ELEMENT_DARK:
         {
-            choice = GetBestAvailable(SPELLFAMILY_DRAIN);
+            choice = GetBestAvailable(SPELLFAMILY_VOIDSTORM);
             break;
         }
     }
+    return choice;
+}
 
-    // If all else fails, just cast the best you have!
-    return !choice ? GetBestAvailable(SPELLFAMILY_NONE) : choice;
+std::optional<SpellID> CMobSpellContainer::HelixAgainstTargetWeakness(CBattleEntity* PTarget)
+{
+    // Look up what the target has the _least resistance to_:
+    // clang-format off
+    std::vector<int16> resistances
+    {
+        PTarget->getMod(Mod::FIRE_RES_RANK),
+        PTarget->getMod(Mod::ICE_RES_RANK),
+        PTarget->getMod(Mod::WIND_RES_RANK),
+        PTarget->getMod(Mod::EARTH_RES_RANK),
+        PTarget->getMod(Mod::THUNDER_RES_RANK),
+        PTarget->getMod(Mod::WATER_RES_RANK),
+        PTarget->getMod(Mod::LIGHT_RES_RANK),
+        PTarget->getMod(Mod::DARK_RES_RANK),
+    };
+    // clang-format on
+
+    std::size_t weakestIndex = std::distance(resistances.begin(), std::min_element(resistances.begin(), resistances.end()));
+
+    // TODO: Figure this out properly:
+    std::optional<SpellID> choice = std::nullopt;
+    switch (weakestIndex + 1) // Adjust to ignore ELEMENT_NONE
+    {
+      case ELEMENT_FIRE:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_PYROHELIX);
+            break;
+        }
+        case ELEMENT_ICE:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_CRYOHELIX);
+            break;
+        }
+        case ELEMENT_WIND:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_ANEMOHELIX);
+            break;
+        }
+        case ELEMENT_EARTH:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_GEOHELIX);
+            break;
+        }
+        case ELEMENT_THUNDER:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_IONOHELIX);
+            break;
+        }
+        case ELEMENT_WATER:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_HYDROHELIX);
+            break;
+        }
+        case ELEMENT_LIGHT:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_LUMINOHELIX);
+            break;
+        }
+        case ELEMENT_DARK:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_NOCTOHELIX);
+            break;
+        }
+    }
+    return choice;
 }
 
 std::optional<SpellID> CMobSpellContainer::GetStormDay()

--- a/src/map/mob_spell_container.cpp
+++ b/src/map/mob_spell_container.cpp
@@ -414,7 +414,7 @@ std::optional<SpellID> CMobSpellContainer::EnSpellAgainstTargetWeakness(CBattleE
             break;
         }
     }
-     return choice;
+    return choice;
 }
 
 std::optional<SpellID> CMobSpellContainer::StormDayAgainstTargetWeakness(CBattleEntity* PTarget)
@@ -440,7 +440,7 @@ std::optional<SpellID> CMobSpellContainer::StormDayAgainstTargetWeakness(CBattle
     std::optional<SpellID> choice = std::nullopt;
     switch (weakestIndex + 1) // Adjust to ignore ELEMENT_NONE
     {
-      case ELEMENT_FIRE:
+        case ELEMENT_FIRE:
         {
             choice = GetBestAvailable(SPELLFAMILY_FIRESTORM);
             break;
@@ -507,7 +507,7 @@ std::optional<SpellID> CMobSpellContainer::HelixAgainstTargetWeakness(CBattleEnt
     std::optional<SpellID> choice = std::nullopt;
     switch (weakestIndex + 1) // Adjust to ignore ELEMENT_NONE
     {
-      case ELEMENT_FIRE:
+        case ELEMENT_FIRE:
         {
             choice = GetBestAvailable(SPELLFAMILY_PYROHELIX);
             break;

--- a/src/map/mob_spell_container.cpp
+++ b/src/map/mob_spell_container.cpp
@@ -351,7 +351,7 @@ std::optional<SpellID> CMobSpellContainer::GetBestAgainstTargetWeakness(CBattleE
     auto Weakness_Element = weakestIndex + 1;
     auto Spell_Element    = spell::GetSpell(spellId)->getElement();
     if (Spell_Element == Weakness_Element)
-	{
+    {
         return spellId;
     }
     else

--- a/src/map/mob_spell_container.h
+++ b/src/map/mob_spell_container.h
@@ -67,7 +67,10 @@ public:
     std::optional<SpellID> GetBestAvailable(SPELLFAMILY family);
     std::optional<SpellID> GetBestIndiSpell(CBattleEntity* PMaster);
     std::optional<SpellID> GetBestEntrustedSpell(CBattleEntity* PMaster);
-    std::optional<SpellID> GetBestAgainstTargetWeakness(CBattleEntity* PTarget);
+    std::optional<SpellID> GetBestAgainstTargetWeakness(CBattleEntity* PTarget, SpellID spellId);
+    std::optional<SpellID> EnSpellAgainstTargetWeakness(CBattleEntity* PTarget);
+    std::optional<SpellID> StormDayAgainstTargetWeakness(CBattleEntity* PTarget);
+    std::optional<SpellID> HelixAgainstTargetWeakness(CBattleEntity* PTarget);
     std::optional<SpellID> GetStormDay();
     std::optional<SpellID> GetHelixDay();
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Added more gambits to properly select the correct en/helix/storm spells based on enemy weakness for Adelheid and Rainemard like trusts.


## Steps to test these changes

adding something along the lines of 
mob:addGambit(ai.t.TARGET, {ai.c.ALWAYS, 0}, {ai.r.MA, ai.s.STORM_MOB_WEAKNESS, 0}
for adel will properly cast the correct storm spell on her based on enemy weaknesses.

adding something along the lines of 
mob:addGambit(ai.t.TARGET,{ ai.c.ALWAYS, 0}, {ai.r.MA, ai.s.EN_MOB_WEAKNESS, 0})
for Rainemard will properly cast the correct enspell on himself based on enemy weaknesses

changed BEST_AGAINST_TARGET gambit to accept a spell ID and not bound to only specific spell families.
