### PR TITLE
[ci] Add check_format parameter to LLS argument to restore json output

### DIFF
--- a/tools/ci/lua_lang_server.py
+++ b/tools/ci/lua_lang_server.py
@@ -159,7 +159,7 @@ log_path = os.path.abspath(log_path)
 scripts_path = os.path.abspath(scripts_path)
 modules_path = os.path.abspath(modules_path)
 
-check_command = f'{lua_server_path} --loglevel="trace" --logpath="{log_path}" --configpath="{config_path}" --checklevel="Information" --check="{scripts_path}"'
+check_command = f'{lua_server_path} --loglevel="trace" --logpath="{log_path}" --check_format="json" --configpath="{config_path}" --checklevel="Information" --check="{scripts_path}"'
 
 if args.force and os.path.exists("./check.json"):
     print("Force flag is enabled, removing existing check.json.")


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
With recent LLS changes, the default output format was changed in cases where a new parameter (`check_format`) was added, and we do not explicitly set `check_out_path` (see: https://github.com/LuaLS/lua-language-server/pull/3051)

Adds `check_format` parameter to LLS call in CI to move back to json output and fixes CI failures.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
CI should not fail on non-existing file.
<!-- Clear and detailed steps to test your changes here -->
