### PR TITLE
[Fix] Wrong avatar being displayed as learnt (Cloister of Tremors)

### DIFF
--- a/scripts/battlefields/Cloister_of_Tremors/trial-size_trial_by_earth.lua
+++ b/scripts/battlefields/Cloister_of_Tremors/trial-size_trial_by_earth.lua
@@ -29,7 +29,7 @@ end
 function content:onEventFinishWin(player, csid, option, npc)
     if not player:hasSpell(xi.magic.spell.TITAN) then
         player:addSpell(xi.magic.spell.TITAN)
-        player:messageSpecial(cloisterOfTremorsID.text.TITAN_UNLOCKED, 0, 0, 2)
+        player:messageSpecial(cloisterOfTremorsID.text.TITAN_UNLOCKED, 0, 0, 1)
     end
 
     if not player:hasItem(xi.item.SCROLL_OF_INSTANT_WARP) then


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

As title sais. Makes Titan display instead of Leviathan.

## Steps to test these changes

None
