### PR TITLE
[search] Don't send reply if there's no reply to be sent

### DIFF
--- a/src/search/search_handler.cpp
+++ b/src/search/search_handler.cpp
@@ -400,7 +400,10 @@ void search_handler::HandleGroupListRequest()
         } while (currentResult < totalResults);
     }
 
-    do_write();
+    if (!searchPackets.empty())
+    {
+        do_write();
+    }
 }
 
 void search_handler::HandleSearchComment()
@@ -466,7 +469,10 @@ void search_handler::HandleSearchRequest()
 
     } while (currentResult < totalResults);
 
-    do_write();
+    if (!searchPackets.empty())
+    {
+        do_write();
+    }
 }
 
 void search_handler::HandleAuctionHouseRequest()
@@ -530,7 +536,10 @@ void search_handler::HandleAuctionHouseRequest()
         searchPackets.emplace_back(PAHPacket.GetData(), length);
     }
 
-    do_write();
+    if (!searchPackets.empty())
+    {
+        do_write();
+    }
 }
 
 void search_handler::HandleAuctionHouseHistory()


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

`searchPackets.front();` crashes if the deque is empty.
Don't send replies if the deque is empty.

## Steps to test these changes

search as normal without error
