### PR TITLE
[Listener][Cpp] adds listener for items going into treasure pool

### DIFF
--- a/documentation/AI_Events.txt
+++ b/documentation/AI_Events.txt
@@ -28,6 +28,7 @@ DEATH - Entity, Killer?
 DEFEATED_MOB - Mob, Attacker, optParams (Note: optParams is the same table in onMobDeath)
 EXPERIENCE_POINTS - Entity, exp
 ITEM_DROPS - Entity, Loot
+TREASUREPOOL - Entity, Target, ItemID
 DESPAWN - Entity
 
 TAKE_DAMAGE - Entity, amount, optionalAttacker, attackType, damageType

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -689,6 +689,7 @@ void CMobEntity::DropItems(CCharEntity* PChar)
     auto AddItemToPool = [this, PChar](uint16 ItemID)
     {
         PChar->PTreasurePool->AddItem(ItemID, this);
+        PAI->EventHandler.triggerListener("TREASUREPOOL", CLuaBaseEntity(this), CLuaBaseEntity(PChar), ItemID);
     };
 
     DropList_t* dropList = itemutils::GetDropList(m_DropID);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

can add a listener for items going into a treasure pool to make changes
Used in salvage for adding drops and most likely in other content as well.
Useful for mobs that drop multiples of an item IF they drop.
Example:
Mob in Salvage can drop a cell at a Common rate but if it does drop it always drop 3 more of the same cell.

This mixin can be used to see what is being put into the treasure pool and then used to player:addTreasure(item, mob) to duplicate.

updated AI_Events page for Listener

test showing me adding 3 more of every drop if it happens to supply an incoming item
![image](https://github.com/user-attachments/assets/b3415357-261e-439b-8c9d-140f04051803)


## Steps to test these changes

map still builds error free
