### PR TITLE
Fix issue with GetBestAgainstTargetWeakness (#6974)

### DIFF
--- a/src/map/mob_spell_container.cpp
+++ b/src/map/mob_spell_container.cpp
@@ -346,18 +346,61 @@ std::optional<SpellID> CMobSpellContainer::GetBestAgainstTargetWeakness(CBattleE
     // clang-format on
 
     std::size_t weakestIndex = std::distance(resistances.begin(), std::min_element(resistances.begin(), resistances.end()));
-
-    // TODO: Figure this out properly:
+    std::optional<SpellID> choice     = std::nullopt;
     auto Weakness_Element = weakestIndex + 1;
-    auto Spell_Element    = spell::GetSpell(spellId)->getElement();
-    if (Spell_Element == Weakness_Element)
+    if (spell::GetSpell(spellId) != 0)
     {
-        return spellId;
+    	auto Spell_Element    = spell::GetSpell(spellId)->getElement();
+    	if (Spell_Element == Weakness_Element)
+    	{
+            return spellId;
+    	}
     }
-    else
+    switch (Weakness_Element) // Adjust to ignore ELEMENT_NONE
     {
-        return std::nullopt;
+    	case ELEMENT_FIRE:
+    	{
+    	    choice = GetBestAvailable(SPELLFAMILY_FIRE);
+    	    break;
+        }
+        case ELEMENT_ICE:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_BLIZZARD);
+            break;
+        }
+        case ELEMENT_WIND:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_AERO);
+            break;
+        }
+        case ELEMENT_EARTH:
+        {
+           choice = GetBestAvailable(SPELLFAMILY_STONE);
+           break;
+        }
+        case ELEMENT_THUNDER:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_THUNDER);
+            break;
+        }
+        case ELEMENT_WATER:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_WATER);
+            break;
+        }
+        case ELEMENT_LIGHT:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_BANISH);
+            break;
+        }
+        case ELEMENT_DARK:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_DRAIN);
+            break;
+        }
     }
+    // If all else fails, just cast the best you have!
+    return !choice ? GetBestAvailable(SPELLFAMILY_NONE) : choice;
 }
 
 std::optional<SpellID> CMobSpellContainer::EnSpellAgainstTargetWeakness(CBattleEntity* PTarget)

--- a/src/map/mob_spell_container.cpp
+++ b/src/map/mob_spell_container.cpp
@@ -345,23 +345,23 @@ std::optional<SpellID> CMobSpellContainer::GetBestAgainstTargetWeakness(CBattleE
     };
     // clang-format on
 
-    std::size_t weakestIndex = std::distance(resistances.begin(), std::min_element(resistances.begin(), resistances.end()));
-    std::optional<SpellID> choice     = std::nullopt;
-    auto Weakness_Element = weakestIndex + 1;
+    std::size_t            weakestIndex     = std::distance(resistances.begin(), std::min_element(resistances.begin(), resistances.end()));
+    std::optional<SpellID> choice           = std::nullopt;
+    auto                   Weakness_Element = weakestIndex + 1;
     if (spell::GetSpell(spellId) != 0)
     {
-    	auto Spell_Element    = spell::GetSpell(spellId)->getElement();
-    	if (Spell_Element == Weakness_Element)
-    	{
+        auto Spell_Element = spell::GetSpell(spellId)->getElement();
+        if (Spell_Element == Weakness_Element)
+        {
             return spellId;
-    	}
+        }
     }
     switch (Weakness_Element) // Adjust to ignore ELEMENT_NONE
     {
-    	case ELEMENT_FIRE:
-    	{
-    	    choice = GetBestAvailable(SPELLFAMILY_FIRE);
-    	    break;
+        case ELEMENT_FIRE:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_FIRE);
+            break;
         }
         case ELEMENT_ICE:
         {
@@ -375,8 +375,8 @@ std::optional<SpellID> CMobSpellContainer::GetBestAgainstTargetWeakness(CBattleE
         }
         case ELEMENT_EARTH:
         {
-           choice = GetBestAvailable(SPELLFAMILY_STONE);
-           break;
+            choice = GetBestAvailable(SPELLFAMILY_STONE);
+            break;
         }
         case ELEMENT_THUNDER:
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
map server crashing as per bug report 
Closes #6974
will now work if spell id is given or not
## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
summon a trust with best against target gambit with no spell id, will cast best spell against target or best spell if cant find any weakness