### PR TITLE
Abyssea tether timer fix

### DIFF
--- a/scripts/globals/abyssea.lua
+++ b/scripts/globals/abyssea.lua
@@ -1206,11 +1206,11 @@ xi.abyssea.searingWardTimer = function(player)
     local tetherTimer = player:getLocalVar('tetherTimer')
 
     if tetherTimer > 1 then
-        if tetherTimer == 11 or tetherTimer <= 6 then
+        player:setLocalVar('tetherTimer', tetherTimer - 1)
+        if tetherTimer <= 6 then
             player:messageSpecial(ID.text.RETURNING_TO_SEARING_IN, tetherTimer - 1)
         end
 
-        player:setLocalVar('tetherTimer', tetherTimer - 1)
         player:timer(1500, function()
             xi.abyssea.searingWardTimer(player)
         end)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This follows up on my [prior PR ](https://github.com/LandSandBoat/server/pull/6963) where I [noticed](https://github.com/LandSandBoat/server/pull/6963#issuecomment-2638567668) that the Abyssea tether timer was double-printing the timer warning for 10 seconds.

I made two changes here:

1. It was sending both `RETURNING_TO_SEARING_IN 7348` and `NO_VISITANT_WARD 7349` due to the way the logic was programmed for `onWardTriggerAreaLeave`, `tetherTimer == 11` and `tetherTimer <=6`. Since the messages are slightly different, I just removed the handling for `== 11`, as that was the cause of the double print in the `searingWardTimer` method.

2. I noticed the timer callback logic, and it seemed a bit curious to me. On a lark, I removed it entirely in favor of relying on `onEffectTick` to see how the timer status would behave, and... it was fine. The `onEffectTick` loop seems to invoke it at about the same cadence (I did not time it, just eyeballed it) and it looked to ultimately behave in the exact same manner. I figure if the outcome is the same, less code and less callbacks is easier to maintain, but i am happy to undo that part of the change if there is some other reason you all prefer that pattern.

## Steps to test these changes

Enter Abyssea Konschtat
Do not receive Vistant Status
Exit through the Searing ward
Watch the timer tick
Notice you only see the warning at 10 seconds, then 5,4,3,2,1
Get warped back inside the staging area

## Notes

While testing this, I noticed that the actual visitant timer which should be ejecting me out of Abyssea is not actually kicking me out. That was happening before I made any changes in this PR, and I can either try to debug and fix as part of this PR, or I could make it a different PR.

After testing this a bit, it seems like the issue is if you enter, do not gain actual visitant status (so, just the hidden temp status), logout, then log back in - the game hits an edge case and does not properly eject you. I'm making a separate branch to confirm the cause + try to put a fix in. I suspect something with `gameLogin` is not getting cleared properly, but I'll open that branch when I know for sure.

It seemingly works fine if you zone in clean, then wait the 5 minutes.

Edit - PR for the visitant status bug here https://github.com/LandSandBoat/server/pull/7000