### PR TITLE
[SQL] Adjust DRK trait "Resist Paralyze" acquisition level

### DIFF
--- a/sql/traits.sql
+++ b/sql/traits.sql
@@ -335,7 +335,7 @@ INSERT INTO `traits` VALUES (49,'resist poison',11,60,3,241,20,NULL,0);
 INSERT INTO `traits` VALUES (49,'resist poison',11,81,4,241,25,NULL,0);
 INSERT INTO `traits` VALUES (50,'resist paralyze',8,20,1,242,10,NULL,0);
 INSERT INTO `traits` VALUES (50,'resist paralyze',8,40,2,242,15,NULL,0);
-INSERT INTO `traits` VALUES (50,'resist paralyze',8,50,3,242,20,NULL,0);
+INSERT INTO `traits` VALUES (50,'resist paralyze',8,60,3,242,20,NULL,0);
 INSERT INTO `traits` VALUES (50,'resist paralyze',8,75,4,242,25,NULL,0);
 INSERT INTO `traits` VALUES (50,'resist paralyze',8,81,5,242,30,'ABYSSEA',0);
 INSERT INTO `traits` VALUES (50,'resist paralyze',17,5,1,242,10,'TOAU',0);


### PR DESCRIPTION


**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The trait `Resist Paralyze` had the wrong content_tag set for Corsair/Dark Knight as well as the wrong level for tier 3 on Dark Knight.

Source: https://ffxiclopedia.fandom.com/wiki/Resist_Paralyze?diff=503918&oldid=499472

## Steps to test these changes

N/A
