### PR TITLE
[lua] Use new pdif function in utils for violent flourish

### DIFF
--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -415,17 +415,18 @@ xi.job_utils.dancer.useViolentFlourishAbility = function(player, target, ability
             bonus     = 50 - target:getMod(xi.mod.STUNRES) + player:getMod(xi.mod.VFLOURISH_MACC) + player:getJobPointLevel(xi.jp.FLOURISH_I_EFFECT),
         }
 
-        -- Apply WSC
         local weaponDamage = player:getWeaponDmg()
+        local weaponType   = player:getWeaponSkillType(xi.slot.MAIN)
         if player:getWeaponSkillType(xi.slot.MAIN) == xi.skill.HAND_TO_HAND then
             local h2hSkill = player:getSkillLevel(xi.skill.HAND_TO_HAND) * 0.11 + 3
 
             weaponDamage = weaponDamage - 3 + h2hSkill
         end
 
-        local baseDmg   = weaponDamage + xi.weaponskills.fSTR(player:getStat(xi.mod.STR), target:getStat(xi.mod.VIT), player:getWeaponDmgRank())
-        local cRatio, _ = xi.weaponskills.cMeleeRatio(player, target, params, 0, 1000)
-        local dmg       = baseDmg * xi.weaponskills.generatePdif(cRatio[1], cRatio[2], true)
+        local applyLevelCorrection = xi.combat.levelCorrection.isLevelCorrectedZone(player)
+        local baseDmg              = weaponDamage + xi.weaponskills.fSTR(player:getStat(xi.mod.STR), target:getStat(xi.mod.VIT), player:getWeaponDmgRank())
+        local pdif                 = xi.combat.physical.calculateMeleePDIF(player, target, weaponType, 1.0, false, applyLevelCorrection, false, 0.0, false, xi.slot.MAIN, false)
+        local dmg                  = baseDmg * pdif
 
         if applyResistanceEffect(player, target, spell, params) > 0.25 then
             target:addStatusEffect(xi.effect.STUN, 1, 0, 2)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Use new pdif function in utils for violent flourish
Closes #6998

## Steps to test these changes

Use violent flourish with no errors
