### PR TITLE
[SQL] add 5 snapshot bonus to Commodore Gants (+1)

### DIFF
--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -25137,12 +25137,14 @@ INSERT INTO `item_mods` VALUES (15028,1,14); -- DEF: 14
 INSERT INTO `item_mods` VALUES (15028,2,12); -- HP: 12
 INSERT INTO `item_mods` VALUES (15028,11,2); -- AGI: 2
 INSERT INTO `item_mods` VALUES (15028,26,5); -- RACC: 5
+INSERT INTO `item_mods` VALUES (15028,365,5); -- SNAPSHOT: 5
 
 -- Commodore Gants +1
 INSERT INTO `item_mods` VALUES (15029,1,15); -- DEF: 15
 INSERT INTO `item_mods` VALUES (15029,2,15); -- HP: 15
 INSERT INTO `item_mods` VALUES (15029,11,3); -- AGI: 3
 INSERT INTO `item_mods` VALUES (15029,26,5); -- RACC: 5
+INSERT INTO `item_mods` VALUES (15029,365,5); -- SNAPSHOT: 5
 
 -- Puppetry Dastanas +1
 INSERT INTO `item_mods` VALUES (15030,1,13);  -- DEF: 13


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds missing 5 "Snapshot" mod to `Commodore Gants (+1)`
Source
- Lists that it enhances Snapshot effect: https://ffxiclopedia.fandom.com/wiki/Commodore_Gants?oldid=739857, https://www.ffxiah.com/item/15028/commodore-gants, 
- Lists the value: https://www.bg-wiki.com/ffxi/Commodore_Gants

## Steps to test these changes

N/A
