### PR TITLE
[lua] Fix Final Sting playing death animation twice

### DIFF
--- a/scripts/actions/mobskills/final_sting.lua
+++ b/scripts/actions/mobskills/final_sting.lua
@@ -34,6 +34,10 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     mob:setHP(0)
 
+    if mob:isDead() then
+        mob:setAnimationSub(1) -- Don't die twice
+    end
+
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT, 0, 0, 0)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

animsub is 1 with hpp% @ 0
![image](https://github.com/user-attachments/assets/4985459e-825c-4dee-b31a-7b896205a2be)
![1739332985128.webm](https://github.com/user-attachments/assets/a601d26a-3f1b-4b52-a3fb-350caba611e6)


## Steps to test these changes
claim bee, !exec target:useMobAbility(336), dont see double death animation when it dies
