### PR TITLE
[lua] Dragon-ish mobskill audit

### DIFF
--- a/scripts/actions/mobskills/bai_wing.lua
+++ b/scripts/actions/mobskills/bai_wing.lua
@@ -19,13 +19,13 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local damage = mob:getWeaponDmg() * 5
+    local damage = mob:getMainLvl() + 2
 
-    damage = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.EARTH, 1, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    damage = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.EARTH, 4, xi.mobskills.magicalTpBonus.NO_EFFECT)
     damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
 
     target:takeDamage(damage, mob, xi.attackType.MAGICAL, xi.damageType.EARTH)
-    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 3000, 0, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 9000, 0, 120)
 
     return damage
 end

--- a/scripts/actions/mobskills/dragon_breath.lua
+++ b/scripts/actions/mobskills/dragon_breath.lua
@@ -22,7 +22,13 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.15, 1.25, xi.element.FIRE, 1596)
+    local breathCap = 1596
+
+    if mob:getPool() == 2840 then -- Nidhogg
+        breathCap = 2000
+    end
+
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.15, 1.25, xi.element.FIRE, breathCap)
     dmgmod = utils.conalDamageAdjustment(mob, target, skill, dmgmod, 0.2)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)

--- a/scripts/actions/mobskills/fiery_breath.lua
+++ b/scripts/actions/mobskills/fiery_breath.lua
@@ -23,7 +23,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.2, 1.25, xi.element.FIRE, 1400)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.2, 1.25, xi.element.FIRE, 2000)
     dmgmod = utils.conalDamageAdjustment(mob, target, skill, dmgmod, 0.9)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)

--- a/scripts/actions/mobskills/geotic_breath.lua
+++ b/scripts/actions/mobskills/geotic_breath.lua
@@ -23,7 +23,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.2, 1.25, xi.element.EARTH, 1400)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, skill, 0.15, 1.25, xi.element.EARTH, 1150)
     dmgmod = utils.conalDamageAdjustment(mob, target, skill, dmgmod, 0.9)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.EARTH, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)

--- a/scripts/actions/mobskills/gigaflare.lua
+++ b/scripts/actions/mobskills/gigaflare.lua
@@ -32,7 +32,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         mob:setBehavior(bit.bor(mob:getBehavior(), xi.behavior.NO_TURN))
     end
 
-    local damage = mob:getWeaponDmg() * 15
+    local damage = mob:getMainLvl() * 14 -- TODO: dINT multiplier * 1.5
 
     damage = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.FIRE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT)
     damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, xi.mobskills.shadowBehavior.WIPE_SHADOWS)

--- a/scripts/actions/mobskills/implosion.lua
+++ b/scripts/actions/mobskills/implosion.lua
@@ -13,7 +13,13 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local damage = mob:getWeaponDmg()
+    local damage = mob:getMainLvl() * 2.75
+
+    -- kinda hacky, need a better control from a mob local var to boost damage
+    -- Boosts when Bahamut is able to use Gigaflare according to jimmy's sheet
+    if mob:getHPP() <= 10 then
+        damage = mob:getMainLvl() * 5.5 
+    end
 
     damage = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.DARK, 1, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)
     damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, xi.mobskills.shadowBehavior.WIPE_SHADOWS)

--- a/scripts/actions/mobskills/megaflare.lua
+++ b/scripts/actions/mobskills/megaflare.lua
@@ -33,7 +33,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     end
 
     -- Damage calculation
-    local damage = mob:getWeaponDmg() * 10
+    local damage = mob:getMainLvl() * 10 -- TODO: dINT multiplier of 1.5x
 
     damage = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.FIRE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT)
     damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, xi.mobskills.shadowBehavior.WIPE_SHADOWS)

--- a/scripts/actions/mobskills/ochre_blast.lua
+++ b/scripts/actions/mobskills/ochre_blast.lua
@@ -19,9 +19,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local damage = mob:getWeaponDmg() * 8
+    local damage = mob:getMainLvl() + 2
 
-    damage = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.EARTH, 1, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    damage = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.EARTH, 3.75, xi.mobskills.magicalTpBonus.NO_EFFECT)
     damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
 
     target:takeDamage(damage, mob, xi.attackType.MAGICAL, xi.damageType.EARTH)

--- a/scripts/actions/mobskills/tempest_wing.lua
+++ b/scripts/actions/mobskills/tempest_wing.lua
@@ -17,8 +17,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     end
 end
 
+-- TODO: Add blind
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local damage = mob:getWeaponDmg() * 4
+    local damage = mob:getMainLvl() * 4.75
 
     damage = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT)
     damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, xi.mobskills.shadowBehavior.WIPE_SHADOWS)

--- a/scripts/actions/mobskills/trample.lua
+++ b/scripts/actions/mobskills/trample.lua
@@ -12,13 +12,14 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
+-- TODO: add bind
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local duration = 30
     xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BIND, 1, 0, duration)
 
     local numhits = 1
     local accmod = 1
-    local ftp    = 3
+    local ftp    = 1.5
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, xi.mobskills.shadowBehavior.NUMSHADOWS_3)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)

--- a/scripts/actions/mobskills/typhoon_wing.lua
+++ b/scripts/actions/mobskills/typhoon_wing.lua
@@ -1,12 +1,10 @@
 -----------------------------------
---  Hurricane Wing
+--  Typhoon Wing
 --
 --  Description: Deals hurricane-force wind damage to enemies within a very wide area of effect. Additional effect: Blind
 --  Type: Magical
 --  Utsusemi/Blink absorb: Wipes shadows
 --  Range: 30' radial.
---  Notes: Used only by Dragua, Fafnir, Nidhogg, Cynoprosopi, Wyrm, and Odzmanouk. The blinding effect does not last long
---                but is very harsh. The attack is wide enough to generally hit an entire alliance.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -22,9 +20,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local damage = mob:getWeaponDmg() * 5
+    local damage = mob:getMainLvl() + 2
 
-    damage = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    damage = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.WIND, 5, xi.mobskills.magicalTpBonus.NO_EFFECT)
     damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
 
     target:takeDamage(damage, mob, xi.attackType.MAGICAL, xi.damageType.WIND)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Audits dragon/dragon adjacent mobskills

## Steps to test these changes

have mobs said skills with no errors (and no oneshotting from Bai wing)
