### PR TITLE
[lua, quest ]fix cs in quest The Brugaire Consortium

### DIFF
--- a/scripts/quests/sandoria/The_Brugaire_Consortium.lua
+++ b/scripts/quests/sandoria/The_Brugaire_Consortium.lua
@@ -116,7 +116,7 @@ quest.sections =
                         quest:getVar(player, 'Prog') == 1 and
                         npcUtil.tradeHasExactly(trade, xi.item.PARCEL_FOR_THE_AUCTION_HOUSE)
                     then
-                        return quest:progressEvent(535)
+                        return quest:progressEvent(540)
                     end
                 end,
             },


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes #6965. I confirmed the NPC Apstaule gives dialogue from the NPC Regine. This code fixes it so that when you get to Apstaule in the quest the dialogue comes from him.

## Steps to test these changes

1. Talk to Fontoumant at the port of Sandoria (H-10) and receive an offer.
2. Trade “Magic Shop Parcel” to Regine.
3. Talk to Fontoumant
4. Trade “Auction Parcel” to Apstaule.
5. A cutscene of NPC “Apstaule” will be activated.
