### PR TITLE
[core] Always use rank C meva for mobs, rank G for trusts

### DIFF
--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -106,8 +106,16 @@ namespace mobutils
 
     uint16 GetMagicEvasion(CMobEntity* PMob)
     {
-        uint8 mEvaRank = PMob->evaRank;
-        return GetBaseSkill(PMob, mEvaRank);
+        uint8 mlvl = std::min<uint8>(PMob->GetMLevel(), 99);
+
+        // Assume trusts have G rank meva like players
+        if (PMob->objtype == TYPE_TRUST)
+        {
+            return battleutils::GetMaxSkill(12, mlvl);
+        }
+
+        // Mobs have rank C magic evasion
+        return battleutils::GetMaxSkill(7, mlvl);
     }
 
     /************************************************************************

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1111,8 +1111,8 @@ namespace petutils
 
     void FinalizePetStatistics(CBattleEntity* PMaster, CPetEntity* PPet)
     {
-        // set C magic evasion
-        PPet->setModifier(Mod::MEVA, battleutils::GetMaxSkill(SKILL_ELEMENTAL_MAGIC, JOB_RDM, PPet->GetMLevel() > 99 ? 99 : PPet->GetMLevel()));
+        // set C magic evasion, add MEVA that may have come from other sources (Automaton, Wyvern, Avatar bonus meva in their respective CalculateXStats function)
+        PPet->setModifier(Mod::MEVA, battleutils::GetMaxSkill(7, std::min<uint8>(99, PPet->GetMLevel())) + PPet->getMod(Mod::MEVA));
         PPet->health.tp = 0;
         PMaster->applyPetModifiers(PPet);
         PPet->UpdateHealth();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Apparently, meva was based off the evasion rank of the mob, which was wrong. Now we force calculate rank C for all mobs meva

Set trusts to rank G meva (I dont have any proof for or against this FYI)

Fix a mod not working for pets

## Steps to test these changes

lvl 99 wyvern:
![image](https://github.com/user-attachments/assets/dc5f60e8-26bd-4f83-bcfe-82318b6c0513)
matches level 76 rank c
![image](https://github.com/user-attachments/assets/19d13c68-527d-4759-b396-e24614d09588)
makes level 99 rank g
![image](https://github.com/user-attachments/assets/3e747be4-47ff-4d9e-bda2-438570a01bab)


