### PR TITLE
[sql] add sublink for archaic families

### DIFF
--- a/sql/mob_family_mods.sql
+++ b/sql/mob_family_mods.sql
@@ -208,6 +208,9 @@ INSERT INTO `mob_family_mods` VALUES (61,389,-25,0); -- UDMGMAGIC: -25
 -- Cerberus
 INSERT INTO `mob_family_mods` VALUES (62,36,50,1); -- ROAM_COOL: 50
 
+-- Chariot
+INSERT INTO `mob_family_mods` VALUES (63,10,15,1); -- SUBLINK: 15
+
 -- Cluster
 INSERT INTO `mob_family_mods` VALUES (68,36,40,1); -- ROAM_COOL: 40
 INSERT INTO `mob_family_mods` VALUES (68,51,2,1);  -- ROAM_TURNS: 2
@@ -379,6 +382,10 @@ INSERT INTO `mob_family_mods` VALUES (115,54,100,1);  -- GIL_BONUS: 100
 INSERT INTO `mob_family_mods` VALUES (116,31,15,1); -- ROAM_DISTANCE: 15
 INSERT INTO `mob_family_mods` VALUES (116,36,60,1); -- ROAM_COOL: 60
 INSERT INTO `mob_family_mods` VALUES (116,52,30,1); -- ROAM_RATE: 30
+
+-- Gear
+INSERT INTO `mob_family_mods` VALUES (119,10,15,1); -- SUBLINK: 15
+INSERT INTO `mob_family_mods` VALUES (120,10,15,1); -- SUBLINK: 15
 
 -- Ghost
 INSERT INTO `mob_family_mods` VALUES (121,36,50,1);   -- ROAM_COOL: 50
@@ -634,6 +641,9 @@ INSERT INTO `mob_family_mods` VALUES (208,36,60,1);  -- ROAM_COOL: 60
 INSERT INTO `mob_family_mods` VALUES (208,52,30,1);  -- ROAM_RATE: 30
 INSERT INTO `mob_family_mods` VALUES (208,62,10,0);  -- ATTP: 10
 INSERT INTO `mob_family_mods` VALUES (208,63,20,0);  -- DEFP: 20
+
+-- Rampart
+INSERT INTO `mob_family_mods` VALUES (209,10,15,1); -- SUBLINK: 15
 
 -- Raptor
 INSERT INTO `mob_family_mods` VALUES (210,31,30,1);  -- ROAM_DISTANCE: 30


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

adds value 15 sublink value for ramparts, gear, gears, and chariot families

## Steps to test these changes

DB builds
mobs can now link together
