### PR TITLE
[sql] Add beastmen drop desynths

### DIFF
--- a/sql/synth_recipes.sql
+++ b/sql/synth_recipes.sql
@@ -4763,6 +4763,17 @@ INSERT INTO `synth_recipes` VALUES (75536,1,0,0,0,69,0,0,0,0,0,4100,4242,16618,0
 INSERT INTO `synth_recipes` VALUES (75537,1,0,0,0,45,0,0,0,0,0,4100,4242,14790,0,0,0,0,0,0,0,653,653,653,653,1,2,2,2,'Reraise Earring (desynth)','COP'); -- FFXIclopedia
 INSERT INTO `synth_recipes` VALUES (75538,1,0,0,0,0,0,0,82,0,0,4100,4242,13171,0,0,0,0,0,0,0,850,850,850,887,1,1,1,1,'Reraise Gorget (desynth)','COP'); -- FFXIclopedia
 INSERT INTO `synth_recipes` VALUES (75539,1,0,0,0,86,0,0,0,0,0,4100,4242,17065,0,0,0,0,0,0,0,652,652,745,746,1,1,1,1,'Platinum Rod (desynth)',NULL); -- FFXIclopedia
+INSERT INTO `synth_recipes` VALUES (75540,1,0,0,0,25,0,0,0,0,0,4098,4240,1625,0,0,0,0,0,0,0,661,661,661,752,1,1,1,1,'Moblin Helm (desynth)',NULL); -- FFXIclopedia and JP Wiki
+INSERT INTO `synth_recipes` VALUES (75541,1,0,0,0,26,0,0,0,0,0,4098,4240,1632,0,0,0,0,0,0,0,661,661,661,752,2,2,2,1,'Moblin Mail (desynth)',NULL); -- BGwiki
+INSERT INTO `synth_recipes` VALUES (75542,1,0,0,95,0,0,0,0,0,0,4100,4242,2504,0,0,0,0,0,0,0,652,653,654,1711,1,1,1,1,'Heavy Quadav Chestplate (desynth)',NULL); -- BGwiki
+INSERT INTO `synth_recipes` VALUES (75543,1,0,0,95,0,0,0,0,0,0,4100,4242,2505,0,0,0,0,0,0,0,652,653,654,659,2,2,2,2,'Heavy Quadav Backplate (desynth)',NULL); -- BGwiki
+INSERT INTO `synth_recipes` VALUES (75544,1,0,0,47,0,0,0,0,0,0,4100,4242,2510,0,0,0,0,0,0,0,651,652,1629,1629,2,2,1,1,'Orc Helmet (desynth)',NULL); -- BGwiki and JP Wiki
+INSERT INTO `synth_recipes` VALUES (75545,1,0,0,43,0,0,0,0,0,0,4100,4242,2511,0,0,0,0,0,0,0,651,652,1629,1629,1,1,1,1,'Orc Pauldron (desynth)',NULL); -- BGwiki and JP Wiki
+INSERT INTO `synth_recipes` VALUES (75546,1,0,0,0,0,0,44,0,0,0,4098,4240,2519,0,0,0,0,0,0,0,1629,2529,676,2006,1,1,1,1,'Yagudo Osode (desynth)',NULL); -- BGwiki
+INSERT INTO `synth_recipes` VALUES (75547,1,0,0,0,0,0,44,0,0,0,4098,4240,2520,0,0,0,0,0,0,0,1629,2529,666,676,1,1,2,3,'Yagudo Kote (desynth)',NULL); -- BGwiki, FFXIclopedia and JP wiki (highest level used)
+INSERT INTO `synth_recipes` VALUES (75548,1,0,0,69,0,0,0,0,0,0,4100,4242,2652,0,0,0,0,0,0,0,651,651,653,1615,2,2,1,1,'Gigas Helm (desynth)',NULL); -- BGwiki and JP Wiki
+INSERT INTO `synth_recipes` VALUES (75549,1,0,0,77,0,0,0,0,0,0,4100,4242,2653,0,0,0,0,0,0,0,651,651,654,1629,1,1,1,1,'Gigas Gauntlets (desynth)',NULL); -- BGwiki and JP Wiki
+INSERT INTO `synth_recipes` VALUES (75550,1,0,0,96,0,0,0,0,0,0,4100,4242,16166,0,0,0,0,0,0,0,2303,2303,2303,2303,1,1,2,2,'Januwiyah -1 (desynth)',NULL); -- BGwiki
 -- -----------
 -- RECIPES END
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Adds missing beastmen related drop desynth recipes based off BGwiki and JP wiki entries:
- Moblin Mail/Helm Wind crystal desynths
- Heavy Quadav Chestplate
- Heavy Quadav Backplate
- Orc Helmet
- Orc Pauldron
- Yagudo Osode
- Yagudo Kote
- Gigas Helm
- Gigas Gauntlets
- Januwiyah -1

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

`!additem 4098 12` (thunder crystal)
`!additem itemID` 
Desynth the items and see they follow the wiki results
