### PR TITLE
[c++] Add support for unusual despawn times

### DIFF
--- a/scripts/enum/mod.lua
+++ b/scripts/enum/mod.lua
@@ -1023,6 +1023,8 @@ xi.mod =
     MAGIC_BURST_BONUS_CAPPED   = 487, -- Magic Burst Bonus I from gear, Ancient Magic Merits, Atmas. Cap at 40% bonus (1.4 multiplier)
     MAGIC_BURST_BONUS_UNCAPPED = 274, -- Magic Burst Bonus II from gear, JP Gifts, BLM JPs and Job traits. No known cap.
 
+    DESPAWN_TIME_REDUCTION = 1134, -- Reduction in seconds. 1 = 1 second less to despawn.
+
     -- IF YOU ADD ANY NEW MODIFIER HERE, ADD IT IN src/map/modifier.h ASWELL!
 
     -- The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.

--- a/scripts/globals/promyvion.lua
+++ b/scripts/globals/promyvion.lua
@@ -205,6 +205,7 @@ end
 xi.promyvion.receptacleOnMobInitialize = function(mob)
     mob:setAutoAttackEnabled(false) -- Receptacles only use TP moves.
     mob:addMod(xi.mod.DEF, 55)
+    -- mob:setMod(xi.mod.DESPAWN_TIME_REDUCTION, 10) -- TODO: Properly time in retail and then adjust timers for portal opening, decorations, etc...
 end
 
 xi.promyvion.receptacleOnMobSpawn = function(mob)

--- a/src/map/ai/states/death_state.cpp
+++ b/src/map/ai/states/death_state.cpp
@@ -51,24 +51,32 @@ CDeathState::CDeathState(CBattleEntity* PEntity, duration death_time)
 
 bool CDeathState::Update(time_point tick)
 {
+    // It's completed
     if (IsCompleted() || m_PEntity->animation != ANIMATION_DEATH)
     {
         return true;
     }
-    else if (tick > GetEntryTime() + m_deathTime && !IsCompleted())
+
+    // It's not completed
+    else
     {
-        Complete();
-        m_PEntity->OnDeathTimer();
-    }
-    else if (m_PEntity->objtype == TYPE_PC && tick > m_raiseTime && !IsCompleted() && !m_raiseSent && m_PEntity->isDead())
-    {
-        auto* PChar = static_cast<CCharEntity*>(m_PEntity);
-        if (PChar->m_hasRaise)
+        auto time = GetEntryTime() + m_deathTime - std::chrono::seconds(m_PEntity->getMod(Mod::DESPAWN_TIME_REDUCTION));
+        if (tick > time)
         {
-            PChar->pushPacket<CRaiseTractorMenuPacket>(PChar, TYPE_RAISE);
-            m_raiseSent = true;
+            Complete();
+            m_PEntity->OnDeathTimer();
+        }
+        else if (m_PEntity->objtype == TYPE_PC && tick > m_raiseTime && !m_raiseSent && m_PEntity->isDead())
+        {
+            auto* PChar = static_cast<CCharEntity*>(m_PEntity);
+            if (PChar->m_hasRaise)
+            {
+                PChar->pushPacket<CRaiseTractorMenuPacket>(PChar, TYPE_RAISE);
+                m_raiseSent = true;
+            }
         }
     }
+
     return false;
 }
 

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -1070,12 +1070,14 @@ enum class Mod
     MAGIC_BURST_BONUS_CAPPED   = 487, // Magic Burst Bonus I from gear, Ancient Magic Merits, Innin merits and Atmas. Cap at 40% bonus (1.4 multiplier)
     MAGIC_BURST_BONUS_UNCAPPED = 274, // Magic Burst Bonus II from gear, JP Gifts, BLM JPs and Job traits. No known cap.
 
+    DESPAWN_TIME_REDUCTION = 1134, // Reduction in seconds. 1 = 1 second less to despawn.
+
     // IF YOU ADD ANY NEW MODIFIER HERE, ADD IT IN scripts/enum/mod.lua ASWELL!
 
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     // 570 through 825 used by WS DMG mods these are not spares.
     //
-    // SPARE IDs: 1134 and onward
+    // SPARE IDs: 1135 and onward
 };
 
 // temporary workaround for using enum class as unordered_map key until compilers support it


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
In retail, Memory receptacles in Promyvion despawn very fast after death.
This adds support to dynamically allow certain entities to despawn faster (or slower) via modifier.

Promyvion portal timings and such will require a different PR, for proper timing adjustments.

## Steps to test these changes

Unused.
