### PR TITLE
[lua][command] !mobskill

### DIFF
--- a/scripts/commands/mobskill.lua
+++ b/scripts/commands/mobskill.lua
@@ -1,0 +1,60 @@
+-----------------------------------
+-- func: mobskill
+-- desc: Forces an entity to do a skill
+-----------------------------------
+---@type TCommand
+local commandObj = {}
+
+commandObj.cmdprops =
+{
+    permission = 1,
+    parameters = 'iii'
+}
+
+local function error(player, msg)
+    player:printToPlayer(msg)
+    player:printToPlayer('!mobskill <skillID> {mob} {tp}')
+end
+
+commandObj.onTrigger = function(player, skillID, target, tp)
+    if skillID == nil or skillID < 0 then
+        error(player, 'You must provide a correct skill ID.')
+        return
+    end
+
+    if tp == nil or tp < 1000 then
+        tp = 1000
+    end
+
+    local targ
+    local zone = player:getZone()
+
+    if not zone then
+        return
+    end
+
+    if target == nil then
+        targ = player:getCursorTarget()
+    elseif zone and zone:getTypeMask() == xi.zoneType.INSTANCED then
+        local instance = player:getInstance()
+
+        if not instance then
+            return
+        end
+
+        targ = GetMobByID(target, instance)
+    else
+        targ = GetMobByID(target)
+    end
+
+    if targ == nil or targ:isPC() then
+        error(player, 'You must either provide a mobID or target a mob.')
+        return
+    end
+
+    -- use skill
+    targ:setTP(tp)
+    targ:useMobAbility(skillID)
+end
+
+return commandObj


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

command to force skills upon entites
!mobskill <skillID> optional<target id> optional<tp amount>

can use cursor target so id is optional
can add a tp amount to test skills with variance to tp amounts, defaults at 1000 tp for use

works in instanced content as well

## Steps to test these changes

find a mob use command, prosper
