### PR TITLE
[Fix] Sky cermet doors opening on click when they shouldnt

### DIFF
--- a/scripts/zones/The_Shrine_of_RuAvitau/DefaultActions.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/DefaultActions.lua
@@ -1,6 +1,28 @@
 local ID = zones[xi.zone.THE_SHRINE_OF_RUAVITAU]
 
 return {
+    ['_4y0']               = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4y1']               = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4y2']               = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4y3']               = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4y4']               = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4y5']               = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4y6']               = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4y7']               = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4y8']               = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4y9']               = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4ya']               = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4yb']               = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4yc']               = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4yd']               = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4ye']               = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4yf']               = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4yg']               = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4yh']               = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4yi']               = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4yj']               = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4yk']               = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4yl']               = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
     ['blank_divine_might'] = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
     ['qm1']                = { messageSpecial = ID.text.SMALL_HOLE_HERE },
     ['qm2']                = { event = 100 },

--- a/scripts/zones/VeLugannon_Palace/DefaultActions.lua
+++ b/scripts/zones/VeLugannon_Palace/DefaultActions.lua
@@ -1,0 +1,19 @@
+-- local ID = zones[xi.zone.VELUGANNON_PALACE]
+
+return {
+    ['_4x0'] = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4x1'] = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4x2'] = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4x3'] = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4x4'] = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4x5'] = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4x6'] = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4x7'] = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4x8'] = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4x9'] = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4xa'] = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4xb'] = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4xc'] = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4xd'] = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+    ['_4xe'] = { messageSpecial = -1 }, -- [Cermet Door] Prevent from opening on click.
+}


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Doors that arent supposed to open on click need either:
- An empty script with an empty onTrigger function.
- An entry in default actions.
- An entry in an IF script.

## Steps to test these changes

Go to sky. It still sucks.
