### PR TITLE
[lua] add module for pre TOAU signet

### DIFF
--- a/modules/era/lua/cop_signet.lua
+++ b/modules/era/lua/cop_signet.lua
@@ -1,0 +1,47 @@
+-----------------------------------
+-- Pre TOAU Signet effect
+-- Pre 8 March 2007
+-- https://www.bg-wiki.com/ffxi/The_History_of_Final_Fantasy_XI/2007
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('cop_signet')
+
+m:addOverride('xi.effects.signet.onEffectGain', function(target, effect)
+    target:addLatent(xi.latent.SIGNET_BONUS, 0, xi.mod.DEF, 0)
+    target:addLatent(xi.latent.SIGNET_BONUS, 0, xi.mod.EVA, 0)
+end)
+
+m:addOverride('xi.effects.healing.onEffectTick', function(target, effect)
+    local healtime = effect:getTickCount()
+
+    if healtime > 2 then
+        -- curse II also known as "zombie"
+        if
+            not target:hasStatusEffect(xi.effect.DISEASE) and
+            not target:hasStatusEffect(xi.effect.PLAGUE) and
+            not target:hasStatusEffect(xi.effect.CURSE_II)
+        then
+            local healHP = 0
+
+            target:addTP(xi.settings.main.HEALING_TP_CHANGE)
+            healHP = 10 + (healtime - 2) + target:getMod(xi.mod.HPHEAL)
+
+            -- Records of Eminence: Heal Without Using Magic
+            if
+                target:getObjType() == xi.objType.PC and
+                target:getEminenceProgress(4) and
+                healHP > 0 and
+                target:getHPP() < 100
+            then
+                xi.roe.onRecordTrigger(target, 4)
+            end
+
+            target:addHPLeaveSleeping(healHP)
+            target:updateEnmityFromCure(target, healHP)
+            target:addMP(12 + ((healtime - 2) * (1 + target:getMod(xi.mod.CLEAR_MIND))) + target:getMod(xi.mod.MPHEAL))
+        end
+    end
+end)
+
+return m


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR remove the def and evasion bonus signet had added to the player since 2007. Also, player will heal for less and lose TP when healing with signet. There is a link at top of each lua file.  If you open link and search for "signet" you will see the changes.

Destined to be wildly popular

## Steps to test these changes

Add the following to init.txt
```
 era/lua/cop_signet.lua
era/lua/cop_signet_healing.lua
```

Get signet from gate guard
Attack monster that's an even match or higher in region under your nations control. Your def shouldn't change.
!tp 2000
!hp 1
/heal
Should loose tp when healing.
