### PR TITLE
[Bug] Bastok 7 1 mission QM2 in Ro'Maeve not moving

### DIFF
--- a/scripts/missions/bastok/7_1_The_Final_Image.lua
+++ b/scripts/missions/bastok/7_1_The_Final_Image.lua
@@ -132,12 +132,9 @@ mission.sections =
                         if mission:getLocalVar(player, 'nmDefeated') == 1 then
                             player:setMissionStatus(mission.areaId, 2)
                             return mission:keyItem(xi.ki.REINFORCED_CERMET)
-                        elseif
-                            -- TODO: xi.settings default (300s) is used to hide this QM on spawn.  Verify if this is accurate since we're moving the QM
+                        else
                             npcUtil.popFromQM(player, npc, { romaeveID.mob.MOKKURKALFI, romaeveID.mob.MOKKURKALFI + 1 }, { claim = false, look = true, radius = 2 })
-                        then
-                            local newPosition = npcUtil.pickNewPosition(npc:getID(), romaeveID.npc.BASTOK_7_1_QM_POS, true)
-                            npcUtil.queueMove(npc, newPosition)
+                            npc:hideNPC(0)
                             return mission:messageSpecial(romaeveID.text.A_CHILL_RUNS_DOWN_SPINE)
                         end
                     end

--- a/scripts/zones/RoMaeve/Zone.lua
+++ b/scripts/zones/RoMaeve/Zone.lua
@@ -72,7 +72,7 @@ zoneObject.onGameHour = function(zone)
         vanadielHour == 12 or
         vanadielHour == 18
     then
-        npcUtil.queueMove(qm2, newPosition, 100)
+        npcUtil.queueMove(qm2, newPosition)
     end
 end
 

--- a/scripts/zones/RoMaeve/Zone.lua
+++ b/scripts/zones/RoMaeve/Zone.lua
@@ -36,7 +36,8 @@ zoneObject.onGameHour = function(zone)
     local vanadielHour = VanadielHour()
     local moongate1 = GetNPCByID(ID.npc.MOONGATE_OFFSET)
     local moongate2 = GetNPCByID(ID.npc.MOONGATE_OFFSET + 1)
-
+    local qm2 = GetNPCByID(ID.npc.BASTOK_7_1_QM)
+    local newPosition = npcUtil.pickNewPosition(ID.npc.BASTOK_7_1_QM, ID.npc.BASTOK_7_1_QM_POS, false)
     -- Make Ro'Maeve come to life between 6pm and 6am during a full moon
     if moongate1 and moongate2 then
         if IsMoonFull() and (vanadielHour >= 18 or vanadielHour < 6) then
@@ -63,6 +64,15 @@ zoneObject.onGameHour = function(zone)
                 moongate1:setLocalVar('romaeveActive', 0) -- Make loop available again
             end
         end
+    end
+
+    if
+        vanadielHour == 0 or
+        vanadielHour == 6 or
+        vanadielHour == 12 or
+        vanadielHour == 18
+    then
+        npcUtil.queueMove(qm2, newPosition, 100)
     end
 end
 

--- a/scripts/zones/RoMaeve/Zone.lua
+++ b/scripts/zones/RoMaeve/Zone.lua
@@ -65,12 +65,12 @@ zoneObject.onGameHour = function(zone)
             end
         end
     end
-    
-    if 
-        vanadielHour == 0 or 
-        vanadielHour == 6 or 
-        vanadielHour == 12 or 
-        vanadielHour == 18 
+
+    if
+        vanadielHour == 0 or
+        vanadielHour == 6 or
+        vanadielHour == 12 or
+        vanadielHour == 18
     then
         npcUtil.queueMove(qm2, newPosition, 100)
     end

--- a/scripts/zones/RoMaeve/Zone.lua
+++ b/scripts/zones/RoMaeve/Zone.lua
@@ -36,7 +36,8 @@ zoneObject.onGameHour = function(zone)
     local vanadielHour = VanadielHour()
     local moongate1 = GetNPCByID(ID.npc.MOONGATE_OFFSET)
     local moongate2 = GetNPCByID(ID.npc.MOONGATE_OFFSET + 1)
-
+    local qm2 = GetNPCByID(ID.npc.BASTOK_7_1_QM)
+    local newPosition = npcUtil.pickNewPosition(ID.npc.BASTOK_7_1_QM, ID.npc.BASTOK_7_1_QM_POS, false)
     -- Make Ro'Maeve come to life between 6pm and 6am during a full moon
     if moongate1 and moongate2 then
         if IsMoonFull() and (vanadielHour >= 18 or vanadielHour < 6) then
@@ -63,6 +64,15 @@ zoneObject.onGameHour = function(zone)
                 moongate1:setLocalVar('romaeveActive', 0) -- Make loop available again
             end
         end
+    end
+    
+    if 
+        vanadielHour == 0 or 
+        vanadielHour == 6 or 
+        vanadielHour == 12 or 
+        vanadielHour == 18 
+    then
+        npcUtil.queueMove(qm2, newPosition, 100)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
The QM that spawns Mokkurkalfi was not moving around the zone every 15mins like it should

would always default to table pos 1.
issue with npcUtil.pickNewPosition, passing true to the function seems to not allow it to move?  setting it to false generates a new position.  
Since this should move every 15 mins real time (1hour = 2.4mins 15mins ish = 6 hours), it doesnt make sense to move the QM every time the ontrigger happens?  so i moved the logic to the Ro'Maeve zone file.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
use gm command !addmission 1 12
talk to Cid
go to Ro'Maeve, QM will now move from spot to spot like it should every 15 mins real time