### PR TITLE
[Synthesis] Separate both craft failing types

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -7212,8 +7212,7 @@ namespace charutils
         // interrupted in some way, such as by being attacked or moving to another area (e.g. ship docking).
 
         ShowWarning("%s: %s attempting to zone in the middle of a synth, failing their synth!", sourceFunction, PChar->getName());
-        PChar->setModifier(Mod::SYNTH_MATERIAL_LOSS, -1000); // Force crit fail
-        synthutils::doSynthFail(PChar, true);
+        synthutils::doSynthCriticalFail(PChar);
 
         PChar->CraftContainer->Clean(); // Clean to reset m_ItemCount to 0
     }

--- a/src/map/utils/synthutils.h
+++ b/src/map/utils/synthutils.h
@@ -58,7 +58,8 @@ namespace synthutils
     void  LoadSynthRecipes();
     int32 startSynth(CCharEntity* PChar);
     int32 sendSynthDone(CCharEntity* PChar);
-    void  doSynthFail(CCharEntity* PChar, bool isCriticalFail);
+    void  doSynthFail(CCharEntity* PChar);
+    void  doSynthCriticalFail(CCharEntity* PChar);
 }; // namespace synthutils
 
 #endif


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The purpose of this PR is to avoid setting a modifier on the character and making unnecesary calculations when all materials are going to be broken anyway. It also removes the need of a bool parameter and the need to choose between messages.

## Steps to test these changes

Craft. Fail. Craft in MH, DC inside, loose everything
