### PR TITLE
[Core] Add Sol bindings for CLuaLootContainer class

### DIFF
--- a/src/map/lua/sol_bindings.cpp
+++ b/src/map/lua/sol_bindings.cpp
@@ -90,6 +90,10 @@ SOL_BIND_DEF_SUB(CLuaItem, CItem, CItemShop);
 SOL_BIND_DEF_SUB(CLuaItem, CItem, CItemUsable);
 SOL_BIND_DEF_SUB(CLuaItem, CItem, CItemWeapon);
 
+#include "utils/itemutils.h"
+#include "lua_loot.h"
+SOL_BIND_DEF(CLuaLootContainer, LootContainer);
+
 #include "mobskill.h"
 #include "lua_mobskill.h"
 SOL_BIND_DEF(CLuaMobSkill, CMobSkill);

--- a/src/map/lua/sol_bindings.h
+++ b/src/map/lua/sol_bindings.h
@@ -124,6 +124,10 @@ SOL_BIND_DEC_SUB(CLuaItem, CItem, CItemShop);
 SOL_BIND_DEC_SUB(CLuaItem, CItem, CItemUsable);
 SOL_BIND_DEC_SUB(CLuaItem, CItem, CItemWeapon);
 
+class CLuaLootContainer;
+struct LootContainer;
+SOL_BIND_DEC(CLuaLootContainer, LootContainer);
+
 class CLuaMobSkill;
 class CMobSkill;
 SOL_BIND_DEC(CLuaMobSkill, CMobSkill);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Currently Listener "ITEM_DROPS" is unable to be used as the the second arg that is suppose to be the LootContainer is not being converted resulting in the error "attempt to index local 'loot' (a userdata value)"
This PR re adds the sol binding for LootContainer to CLuaLootContainer
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Add a Listener "ITEM_DROPS" to a mob
Kill mob
No error in the script and items added via the listener can be rolled
<!-- Clear and detailed steps to test your changes here -->
