### PR TITLE
[core] Set m_TimeType at server startup, call TOTD change on startup

### DIFF
--- a/src/common/vana_time.cpp
+++ b/src/common/vana_time.cpp
@@ -214,6 +214,51 @@ void CVanaTime::setCustomEpoch(int32 epoch)
 {
     m_customEpoch = epoch;
     m_TimeType    = SyncTime();
+
+    if (m_TimeType == TIME_NONE) // SyncTime wasn't on an exact hour, calculate current m_TimeType
+    {
+        switch (m_vHour)
+        {
+            case 23:
+            case 22:
+            case 21:
+            case 20:
+                m_TimeType = TIME_NIGHT;
+                break;
+            case 19:
+            case 18:
+                m_TimeType = TIME_EVENING;
+                break;
+            case 17:
+                m_TimeType = TIME_DUSK;
+                break;
+            case 16:
+            case 15:
+            case 14:
+            case 13:
+            case 12:
+            case 11:
+            case 10:
+            case 9:
+            case 8:
+            case 7:
+                m_TimeType = TIME_DAY;
+                break;
+            case 6:
+                m_TimeType = TIME_DAWN;
+                break;
+            case 5:
+            case 4:
+                m_TimeType = TIME_NEWDAY;
+                break;
+            case 3:
+            case 2:
+            case 1:
+            case 0:
+                m_TimeType = TIME_MIDNIGHT;
+                break;
+        }
+    }
 }
 
 TIMETYPE CVanaTime::GetCurrentTOTD()

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -336,6 +336,8 @@ int32 do_init(int32 argc, char** argv)
     CTaskMgr::getInstance()->AddTask("garbage_collect", server_clock::now(), nullptr, CTaskMgr::TASK_INTERVAL, 15min, map_garbage_collect);
     CTaskMgr::getInstance()->AddTask("persist_server_vars", server_clock::now(), nullptr, CTaskMgr::TASK_INTERVAL, 1min, serverutils::PersistVolatileServerVars);
 
+    zoneutils::TOTDChange(CVanaTime::getInstance()->GetCurrentTOTD()); // This tells the zones to spawn stuff based on time of day conditions (such as undead at night)
+
     ShowInfo("do_init: Removing expired database variables");
     uint32 currentTimestamp = CVanaTime::getInstance()->getSysTime();
     _sql->Query("DELETE FROM char_vars WHERE expiry > 0 AND expiry <= %d", currentTimestamp);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

m_TimeType is not set on startup which could cause issues with mob scripts that check TOTD.
Call TOTD change on startup so mobs that should spawn at certain times do (such as undead)
Note: time_server is normally what calls that, but it's delayed by 2.4 seconds so as far as I know this wouldn't result in TOTD change being called twice with the same time type.

## Steps to test these changes

start server @ night
!zone konschtat highlands
!gotoname Wolf_Zombie 1

See zombie there