### PR TITLE
[lua] [core] Chi Blast: fix xi.ability.adjustDamage param fix, rename xi.ability.adjustDamage params, add safety to UpdateEnmityFromDamage

### DIFF
--- a/scripts/globals/ability.lua
+++ b/scripts/globals/ability.lua
@@ -4,7 +4,7 @@
 xi = xi or {}
 xi.ability = xi.ability or {}
 
-xi.ability.adjustDamage = function(dmg, mob, skill, target, skilltype, skillparam, shadowbehav) -- seems to only be used for Wyvern breaths and chi blast
+xi.ability.adjustDamage = function(dmg, attacker, skill, target, skilltype, skillparam, shadowbehav) -- seems to only be used for Wyvern breaths and chi blast
     -- physical attack missed, skip rest
     local msg = skill:getMsg()
     if
@@ -89,7 +89,7 @@ xi.ability.adjustDamage = function(dmg, mob, skill, target, skilltype, skillpara
 
     if dmg > 0 then
         target:wakeUp()
-        target:updateEnmityFromDamage(mob, dmg)
+        target:updateEnmityFromDamage(attacker, dmg)
     end
 
     return dmg

--- a/scripts/globals/job_utils/monk.lua
+++ b/scripts/globals/job_utils/monk.lua
@@ -83,7 +83,7 @@ xi.job_utils.monk.useChiBlast = function(player, target, ability)
 
     local dmg = math.floor(player:getStat(xi.mod.MND) * (0.5 + (math.random() / 2))) * multiplier
 
-    dmg = xi.ability.adjustDamage(dmg, target, ability, target, xi.attackType.BREATH, nil, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
+    dmg = xi.ability.adjustDamage(dmg, player, ability, target, xi.attackType.BREATH, nil, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, player, xi.attackType.BREATH, xi.damageType.ELEMENTAL)
     target:updateClaim(player)
     player:delStatusEffect(xi.effect.BOOST)

--- a/src/map/enmity_container.cpp
+++ b/src/map/enmity_container.cpp
@@ -392,17 +392,27 @@ void CEnmityContainer::SetVE(CBattleEntity* PEntity, const int32 amount)
 void CEnmityContainer::UpdateEnmityFromDamage(CBattleEntity* PEntity, int32 Damage)
 {
     TracyZoneScoped;
-    Damage          = (Damage < 1 ? 1 : Damage);
-    int16 damageMod = battleutils::GetEnmityModDamage(m_EnmityHolder->GetMLevel());
 
-    int32 CE = (int32)(80.f / damageMod * Damage);
-    int32 VE = (int32)(240.f / damageMod * Damage);
-
-    UpdateEnmity(PEntity, CE, VE);
-
-    if (m_EnmityHolder && m_EnmityHolder->m_HiPCLvl < PEntity->GetMLevel())
+    if (PEntity && m_EnmityHolder)
     {
-        m_EnmityHolder->m_HiPCLvl = PEntity->GetMLevel();
+        // Don't add enmity to yourself
+        if (m_EnmityHolder->id == PEntity->id)
+        {
+            return;
+        }
+
+        Damage          = (Damage < 1 ? 1 : Damage);
+        int16 damageMod = battleutils::GetEnmityModDamage(m_EnmityHolder->GetMLevel());
+
+        int32 CE = (int32)(80.f / damageMod * Damage);
+        int32 VE = (int32)(240.f / damageMod * Damage);
+
+        UpdateEnmity(PEntity, CE, VE);
+
+        if (m_EnmityHolder->m_HiPCLvl < PEntity->GetMLevel())
+        {
+            m_EnmityHolder->m_HiPCLvl = PEntity->GetMLevel();
+        }
     }
 }
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -12879,6 +12879,12 @@ void CLuaBaseEntity::updateEnmityFromDamage(CLuaBaseEntity* PEntity, int32 damag
 {
     auto* PBaseMob = static_cast<CMobEntity*>(m_PBaseEntity);
 
+    if (m_PBaseEntity->id == PEntity->getID())
+    {
+        ShowWarning(fmt::format("updateEnmityFromDamage(): Attempting to add enmity from damage to self ({}, {})!", PEntity->getName(), PEntity->getID()));
+        return;
+    }
+
     // This is a mob attacking a target and losing enmity from doing damage
     if (m_PBaseEntity->objtype == TYPE_PC || m_PBaseEntity->objtype == TYPE_PET || (m_PBaseEntity->objtype == TYPE_MOB && PBaseMob->isCharmed))
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Apparently Chi Blast was adding the mob to it's own enmity list from damage instead of the player. This fixes that and adds safety so that can't happen again

## Steps to test these changes

Chi Blast a mob, see !exec print(tostring(target:getEnmityList())) doesnt contain the mob itself