### PR TITLE
Send new timer packet when battlefield time limit is adjusted

### DIFF
--- a/scripts/commands/setbattlefieldtime.lua
+++ b/scripts/commands/setbattlefieldtime.lua
@@ -1,0 +1,29 @@
+-----------------------------------
+-- func: setbattlefieldtime
+-- desc: Set time limit for an active battlefield
+-----------------------------------
+---@type TCommand
+local commandObj = {}
+
+commandObj.cmdprops =
+{
+    permission = 4,
+    parameters = 'i'
+}
+
+local function error(player, msg)
+    player:printToPlayer(msg)
+    player:printToPlayer('!setbattlefieldtime <minutes>')
+end
+
+commandObj.onTrigger = function(player, minutes)
+    local battlefield = player:getBattlefield()
+    if not battlefield then
+        error(player, 'This command can only be used while inside a battlefield.')
+        return
+    end
+
+    battlefield:setTimeLimit(minutes * 60)
+end
+
+return commandObj

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -203,6 +203,14 @@ void CBattlefield::SetTimeLimit(duration time)
 {
     m_TimeLimit      = time;
     m_LastPromptTime = time;
+
+    if (m_showTimer)
+    {
+        for (auto player : m_EnteredPlayers)
+        {
+            charutils::SendTimerPacket(GetZone()->GetCharByID(player), GetRemainingTime());
+        }
+    }
 }
 
 void CBattlefield::SetWipeTime(time_point time)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Resolves issue #911 

## Steps to test these changes

1. Enter a BCNM (I used Treasures and Tribulations)
2. Use setbattlefieldtime GM command to edit the time limit on the battlefield
3. Countdown clock now shifts with changes to the battlefield time limit