### PR TITLE
Fix daily tally limit type

### DIFF
--- a/src/world/daily_tally.cpp
+++ b/src/world/daily_tally.cpp
@@ -30,8 +30,8 @@ namespace dailytally
 {
     void UpdateDailyTallyPoints()
     {
-        uint16 dailyTallyLimit  = settings::get<uint16>("main.DAILY_TALLY_LIMIT");
-        uint16 dailyTallyAmount = settings::get<uint16>("main.DAILY_TALLY_AMOUNT");
+        int32 dailyTallyLimit  = std::clamp<int32>(settings::get<int32>("main.DAILY_TALLY_LIMIT"), std::numeric_limits<uint16>::min(), std::numeric_limits<uint16>::max());
+        int32 dailyTallyAmount = std::clamp<int32>(settings::get<int32>("main.DAILY_TALLY_AMOUNT"), std::numeric_limits<uint16>::min(), std::numeric_limits<uint16>::max());
 
         if (!db::preparedStmt("UPDATE char_points "
                               "SET char_points.daily_tally = LEAST(?, char_points.daily_tally + ?) "


### PR DESCRIPTION
Need to fit 50,000 into a signed int to compare to -1.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes #7092

Default `DAILY_TALLY_LIMIT` is 50k, -1 is the uninitialized state before you unlock it. When comparing to -1, 50k is treated as a negative signed integer so the update query was producing incorrect results.

## Steps to test these changes

If `char_points.daily_tally` is negative, talk to one of the gobs and it should set it to 50, then either wait till JP midnight or what I did was add `dailytally::UpdateDailyTallyPoints();` in the hourly update [here](https://github.com/LandSandBoat/server/blob/f1a5d793dc0b504a54e3a4eed03f5db6646ea72e/src/world/time_server.cpp#L64). See daily tally correctly increase.
