### PR TITLE
[lua] Save Survival Guide TP menu user choice

### DIFF
--- a/scripts/globals/teleports/survival_guide.lua
+++ b/scripts/globals/teleports/survival_guide.lua
@@ -115,7 +115,7 @@ xi.survivalGuide.onEventUpdate = function(player, csid, option, npc)
             elseif choice == optionMap.REPLACE_FAVORITE then
                 favorites[bit.rshift(option, 24) + 1] = index
             elseif choice == optionMap.SET_MENU_LAYOUT then
-                favorites[10] = (bit.rshift(option, 16) and 1) or 0
+                favorites[10] = (bit.rshift(option, 16))
             end
 
             player:setTeleportMenu(xi.teleport.type.SURVIVAL, favorites)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

When attempting to change the way the Survival Guide teleport menu presents options (either by region or content), the flag is always saved as 1 in char_unlocks, regardless of the selected option in the menu. This PR resolves the issue.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

Use a "Survival Guide"
- "Other Mysteries"
- "Select by region/content"

Back out of the menu, use the "Survival Guide" again and confirm it's displaying teleports according to your choice.
<!-- Clear and detailed steps to test your changes here -->
