### PR TITLE
[core] BLU Triple Attack overwrites Double Attack

### DIFF
--- a/src/map/utils/blueutils.cpp
+++ b/src/map/utils/blueutils.cpp
@@ -484,9 +484,11 @@ namespace blueutils
                                         break;
                                     }
                                 }
-                                else if (PTrait->getMod() == Mod::DOUBLE_ATTACK && iter->getMod() == Mod::TRIPLE_ATTACK)
+                                else if ((PTrait->getMod() == Mod::DOUBLE_ATTACK && iter->getMod() == Mod::TRIPLE_ATTACK) ||
+                                         (PTrait->getMod() == Mod::GILFINDER && iter->getMod() == Mod::TREASURE_HUNTER))
                                 {
                                     // Triple Attack (16 pts) overwrites Double Attack (8 pts)
+                                    // Treasure Hunter (18 pts) overwrites Gilfinder (12 pts)
                                     add = false;
                                     break;
                                 }

--- a/src/map/utils/blueutils.cpp
+++ b/src/map/utils/blueutils.cpp
@@ -484,6 +484,12 @@ namespace blueutils
                                         break;
                                     }
                                 }
+                                else if (PTrait->getMod() == Mod::DOUBLE_ATTACK && iter->getMod() == Mod::TRIPLE_ATTACK)
+                                {
+                                    // Triple Attack (16 pts) overwrites Double Attack (8 pts)
+                                    add = false;
+                                    break;
+                                }
                             }
 
                             if (add)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Setting 4 BLU spells with `Double Attack` currently grants both `Double Attack` and `Triple Attack`.

Only `Triple Attack` is supposed to be set in this condition. Double Attack can still be obtained independently from a WAR subjob.

> Setting only one tier will result in the [Double Attack](https://www.bg-wiki.com/ffxi/Double_Attack) Job Trait instead.
> https://www.bg-wiki.com/ffxi/Triple_Attack

> Setting two tiers will result in the [Triple Attack](https://www.bg-wiki.com/ffxi/Triple_Attack) Job Trait instead.
> https://www.bg-wiki.com/ffxi/Double_Attack

>     Set 8 trait points for double attack and 16 for triple attack.
>     Setting triple attack removes the double attack trait, but it can be regained through subbing warrior which provides a higher double attack rate than the spell trait does.
> https://www.bg-wiki.com/ffxi/Blue_Mage_Job_Traits#Double_Attack_&_Triple_Attack

> Rank1 can be acquired when the attribute value is 8 or above . Furthermore, when the attribute value reaches 16 or above, the attribute changes to Triple Attack
> https://wiki.ffo.jp/html/1904.html

This PR adds a special condition when the check is performed. 

As far as I can tell this is the only case where a trait overwrite a different one, hence the direct change to `blueutils::CalculateTraits`

There might be something smarter to be done as this could break if the following query ever returned the traits in a different order.

https://github.com/LandSandBoat/server/blob/f1a5d793dc0b504a54e3a4eed03f5db6646ea72e/src/map/trait.cpp#L89-L92

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

- Change to BLU 99 with a non WAR subjob
- Equip the following spells
![image](https://github.com/user-attachments/assets/c238090c-71ba-41eb-ba8a-5fce6585647e)
- Verify only Triple Attack is present

- Unequip one of the spells
- Verify only Double Attack is present

- Repeat first test with a /WAR subjob and verify both Triple Attack and Double Attack are present


<!-- Clear and detailed steps to test your changes here -->
