### PR TITLE
Only sleep zones after mobs have pathed home

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -970,10 +970,12 @@ void CMobController::DoRoamTick(time_point tick)
             }
 
             // if I just disengaged check if I should despawn
+            PMob->m_IsPathingHome = false;
             if (!PMob->getMobMod(MOBMOD_DONT_ROAM_HOME) && PMob->IsFarFromHome())
             {
                 if (PMob->CanRoamHome())
                 {
+                    PMob->m_IsPathingHome = true;
                     // walk back to spawn if too far away
                     if (!PMob->PAI->PathFind->IsFollowingPath() && !PMob->PAI->PathFind->PathTo(PMob->m_SpawnPoint))
                     {

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -110,6 +110,11 @@ bool CBattleEntity::isAlive()
     return !isDead();
 }
 
+bool CBattleEntity::isFullyHealed()
+{
+    return (isAlive() && health.hp >= health.maxhp && health.mp >= health.maxmp);
+}
+
 bool CBattleEntity::isInDynamis()
 {
     auto* PZone = loc.zone == nullptr ? zoneutils::GetZone(loc.destination) : loc.zone;

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -112,7 +112,14 @@ bool CBattleEntity::isAlive()
 
 bool CBattleEntity::isFullyHealed()
 {
-    return (isAlive() && health.hp >= health.maxhp && health.mp >= health.maxmp);
+    if (isAlive())
+    {
+        if (health.hp >= health.maxhp && health.mp >= health.maxmp)
+        {
+            return true;
+        }
+    }
+    return false;
 }
 
 bool CBattleEntity::isInDynamis()

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -566,6 +566,7 @@ public:
 
     bool isDead();
     bool isAlive();
+    bool isFullyHealed();
     bool isInAdoulin();
     bool isInAssault();
     bool isInDynamis();

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -112,6 +112,7 @@ CMobEntity::CMobEntity()
 , m_unk2(0)
 , m_CallForHelpBlocked(false)
 , m_IsClaimable(true)
+, m_IsPathingHome(false)
 {
     TracyZoneScoped;
     objtype     = ENTITYTYPE::TYPE_MOB;

--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -255,6 +255,7 @@ public:
     CMobSpellContainer* SpellContainer;
 
     bool m_IsClaimable;
+    bool m_IsPathingHome;
 
     static constexpr float sound_range{ 8.f };
     static constexpr float sight_range{ 15.f };

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -937,6 +937,14 @@ void CZone::ZoneServer(time_point tick)
     {
         m_BattlefieldHandler->HandleBattlefields(tick);
     }
+
+    while (!zoneTimersAsleepAndRunning.empty())
+    {
+        std::string zoneName = zoneTimersAsleepAndRunning.front();
+        zoneTimersAsleepAndRunning.pop();
+
+        CTaskMgr::getInstance()->RemoveTask(zoneName + "_empty_timer");
+    }
 }
 void CZone::SleepZone()
 {
@@ -947,6 +955,8 @@ void CZone::SleepZone()
 
         ZoneTimerTriggerAreas->m_type = CTaskMgr::TASK_REMOVE;
         ZoneTimerTriggerAreas         = nullptr;
+
+        zoneTimersAsleepAndRunning.push(m_zoneName);
     }
 }
 

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -695,21 +695,20 @@ void CZone::UpdateWeather()
 void CZone::CheckMobsPathedBack()
 {
     // clang-format off
-    CTaskMgr::getInstance()->AddTask("zone_empty_timer", server_clock::now(), this, CTaskMgr::TASK_INTERVAL, 5s,
+    CTaskMgr::getInstance()->AddTask(m_zoneName + "_empty_timer", server_clock::now(), this, CTaskMgr::TASK_INTERVAL, 5s,
     [](time_point tick, CTaskMgr::CTask* PTask)
     {
         bool allMobsHomeAndHealed = true;
-        // if the timer runs out, check if all the mobs have pathed home
         CZone* PZone = std::any_cast<CZone*>(PTask->m_data);
-        if (PZone && PZone->GetZoneEntities())
+        // if the timer runs out, check if all the mobs have pathed home
+        if (PZone && PZone->GetZoneEntities() && PZone->GetZoneEntities()->GetMobList().size() > 0)
         {
             EntityList_t mobListMap = PZone->GetZoneEntities()->GetMobList();
             for (const auto& pair : mobListMap)
             {
                 CMobEntity* mob = dynamic_cast<CMobEntity*>(pair.second);
-
-                // if the mob is not fully healed OR ((the mob can rome home AND is far from home) OR the mob can't rome home)
-                if (mob && !mob->isFullyHealed() || ((mob->CanRoamHome() && mob->IsFarFromHome()) || !mob->CanRoamHome()))
+                // if the mob is (not dead/despawned AND it is not fully healed) OR it is pathing home
+                if (mob && ((!mob->isDead() && !mob->isFullyHealed()) || mob->m_IsPathingHome))
                 {
                     // at least one mob is away from home or not fully healed
                     allMobsHomeAndHealed = false;
@@ -718,7 +717,7 @@ void CZone::CheckMobsPathedBack()
             }
         }
 
-        // if all mobs home and healed up, sleep the zone @todo and stop timer?
+        // if all mobs home and healed up, sleep the zone
         if (allMobsHomeAndHealed)
         {
             PZone->SleepZone();
@@ -784,9 +783,6 @@ void CZone::IncreaseZoneCounter(CCharEntity* PChar)
     if (!ZoneTimer && !m_zoneEntities->CharListEmpty())
     {
         createZoneTimers();
-
-        // the zone is active again, remove the timer, if its still going
-        CTaskMgr::getInstance()->RemoveTask("zone_empty_timer");
     }
 
     PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_ON_ZONE_PATHOS, true);

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -692,20 +692,39 @@ void CZone::UpdateWeather()
     // clang-format on
 }
 
-void CZone::SetKeepAlive()
+void CZone::CheckMobsPathedBack()
 {
-    // create timer to keep zone alive for 15 minutes
-    CTaskMgr::getInstance()->AddTask("zone_empty_timer", server_clock::now(), this, CTaskMgr::TASK_ONCE, 15min,
+    // clang-format off
+    CTaskMgr::getInstance()->AddTask("zone_empty_timer", server_clock::now(), this, CTaskMgr::TASK_INTERVAL, 5s,
     [](time_point tick, CTaskMgr::CTask* PTask)
     {
-        // if the timer runs out, sleep the zone
+        bool allMobsHome = true;
+        // if the timer runs out, check if all the mobs have pathed home
         CZone* PZone = std::any_cast<CZone*>(PTask->m_data);
-        if (PZone)
+        if (PZone && PZone->GetZoneEntities())
+        {
+            EntityList_t mobListMap = PZone->GetZoneEntities()->GetMobList();
+            for (const auto& pair : mobListMap)
+            {
+                CMobEntity* mob = dynamic_cast<CMobEntity*>(pair.second);
+                if (mob && mob->IsFarFromHome())
+                {
+                    // at least one mob is away from home
+                    allMobsHome = false;
+                    break;
+                }
+            }
+        }
+
+        // if all mobs home, sleep the zone, @todo and stop timer?
+        if (allMobsHome)
         {
             PZone->SleepZone();
         }
+
         return 0;
     });
+    // clang-format on
 }
 
 /************************************************************************
@@ -722,7 +741,7 @@ void CZone::DecreaseZoneCounter(CCharEntity* PChar)
 
     if (m_zoneEntities->CharListEmpty())
     {
-        SetKeepAlive();
+        CheckMobsPathedBack();
     }
     else
     {

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -692,40 +692,26 @@ void CZone::UpdateWeather()
     // clang-format on
 }
 
-void CZone::CheckMobsPathedBack()
+bool CZone::CheckMobsPathedBack()
 {
-    // clang-format off
-    CTaskMgr::getInstance()->AddTask(m_zoneName + "_empty_timer", server_clock::now(), this, CTaskMgr::TASK_INTERVAL, 5s,
-    [](time_point tick, CTaskMgr::CTask* PTask)
+    bool allMobsHomeAndHealed = true;
+    if (m_zoneEntities && m_zoneEntities->GetMobList().size() > 0)
     {
-        bool allMobsHomeAndHealed = true;
-        CZone* PZone = std::any_cast<CZone*>(PTask->m_data);
-        // if the timer runs out, check if all the mobs have pathed home
-        if (PZone && PZone->GetZoneEntities() && PZone->GetZoneEntities()->GetMobList().size() > 0)
+        EntityList_t mobListMap = m_zoneEntities->GetMobList();
+        for (const auto& pair : mobListMap)
         {
-            EntityList_t mobListMap = PZone->GetZoneEntities()->GetMobList();
-            for (const auto& pair : mobListMap)
+            CMobEntity* mob = dynamic_cast<CMobEntity*>(pair.second);
+            // if the mob is (not dead/despawned AND it is not fully healed) OR it is pathing home
+            if (mob && ((!mob->isDead() && !mob->isFullyHealed()) || mob->m_IsPathingHome))
             {
-                CMobEntity* mob = dynamic_cast<CMobEntity*>(pair.second);
-                // if the mob is (not dead/despawned AND it is not fully healed) OR it is pathing home
-                if (mob && ((!mob->isDead() && !mob->isFullyHealed()) || mob->m_IsPathingHome))
-                {
-                    // at least one mob is away from home or not fully healed
-                    allMobsHomeAndHealed = false;
-                    break;
-                }
+                // at least one mob is away from home or not fully healed
+                allMobsHomeAndHealed = false;
+                break;
             }
         }
+    }
 
-        // if all mobs home and healed up, sleep the zone
-        if (allMobsHomeAndHealed)
-        {
-            PZone->SleepZone();
-        }
-
-        return 0;
-    });
-    // clang-format on
+    return allMobsHomeAndHealed;
 }
 
 /************************************************************************
@@ -742,7 +728,7 @@ void CZone::DecreaseZoneCounter(CCharEntity* PChar)
 
     if (m_zoneEntities->CharListEmpty())
     {
-        CheckMobsPathedBack();
+        m_timeZoneEmpty = server_clock::now();
     }
     else
     {
@@ -938,25 +924,13 @@ void CZone::ZoneServer(time_point tick)
         m_BattlefieldHandler->HandleBattlefields(tick);
     }
 
-    while (!zoneTimersAsleepAndRunning.empty())
-    {
-        std::string zoneName = zoneTimersAsleepAndRunning.front();
-        zoneTimersAsleepAndRunning.pop();
-
-        CTaskMgr::getInstance()->RemoveTask(zoneName + "_empty_timer");
-    }
-}
-void CZone::SleepZone()
-{
-    if (ZoneTimer && m_zoneEntities->CharListEmpty())
+    if (ZoneTimer && m_zoneEntities->CharListEmpty() && m_timeZoneEmpty + 5s < server_clock::now() && CheckMobsPathedBack())
     {
         ZoneTimer->m_type = CTaskMgr::TASK_REMOVE;
         ZoneTimer         = nullptr;
 
         ZoneTimerTriggerAreas->m_type = CTaskMgr::TASK_REMOVE;
         ZoneTimerTriggerAreas         = nullptr;
-
-        zoneTimersAsleepAndRunning.push(m_zoneName);
     }
 }
 

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -692,6 +692,22 @@ void CZone::UpdateWeather()
     // clang-format on
 }
 
+void CZone::SetKeepAlive()
+{
+    // create timer to keep zone alive for 15 minutes
+    CTaskMgr::getInstance()->AddTask("zone_empty_timer", server_clock::now(), this, CTaskMgr::TASK_ONCE, 15min,
+    [](time_point tick, CTaskMgr::CTask* PTask)
+    {
+        // if the timer runs out, sleep the zone
+        CZone* PZone = std::any_cast<CZone*>(PTask->m_data);
+        if (PZone)
+        {
+            PZone->SleepZone();
+        }
+        return 0;
+    });
+}
+
 /************************************************************************
  *                                                                       *
  *  Remove a character from the zone. If ZoneServer and character are    *
@@ -706,7 +722,7 @@ void CZone::DecreaseZoneCounter(CCharEntity* PChar)
 
     if (m_zoneEntities->CharListEmpty())
     {
-        m_timeZoneEmpty = server_clock::now();
+        SetKeepAlive();
     }
     else
     {
@@ -747,6 +763,9 @@ void CZone::IncreaseZoneCounter(CCharEntity* PChar)
     if (!ZoneTimer && !m_zoneEntities->CharListEmpty())
     {
         createZoneTimers();
+
+        // the zone is active again, remove the timer, if its still going
+        CTaskMgr::getInstance()->RemoveTask("zone_empty_timer");
     }
 
     PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_ON_ZONE_PATHOS, true);
@@ -901,8 +920,10 @@ void CZone::ZoneServer(time_point tick)
     {
         m_BattlefieldHandler->HandleBattlefields(tick);
     }
-
-    if (ZoneTimer && m_zoneEntities->CharListEmpty() && m_timeZoneEmpty + 5s < server_clock::now())
+}
+void CZone::SleepZone()
+{
+    if (ZoneTimer && m_zoneEntities->CharListEmpty())
     {
         ZoneTimer->m_type = CTaskMgr::TASK_REMOVE;
         ZoneTimer         = nullptr;

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -698,7 +698,7 @@ void CZone::CheckMobsPathedBack()
     CTaskMgr::getInstance()->AddTask("zone_empty_timer", server_clock::now(), this, CTaskMgr::TASK_INTERVAL, 5s,
     [](time_point tick, CTaskMgr::CTask* PTask)
     {
-        bool allMobsHome = true;
+        bool allMobsHomeAndHealed = true;
         // if the timer runs out, check if all the mobs have pathed home
         CZone* PZone = std::any_cast<CZone*>(PTask->m_data);
         if (PZone && PZone->GetZoneEntities())
@@ -707,17 +707,19 @@ void CZone::CheckMobsPathedBack()
             for (const auto& pair : mobListMap)
             {
                 CMobEntity* mob = dynamic_cast<CMobEntity*>(pair.second);
-                if (mob && mob->IsFarFromHome())
+
+                // if the mob is not fully healed OR ((the mob can rome home AND is far from home) OR the mob can't rome home)
+                if (mob && !mob->isFullyHealed() || ((mob->CanRoamHome() && mob->IsFarFromHome()) || !mob->CanRoamHome()))
                 {
-                    // at least one mob is away from home
-                    allMobsHome = false;
+                    // at least one mob is away from home or not fully healed
+                    allMobsHomeAndHealed = false;
                     break;
                 }
             }
         }
 
-        // if all mobs home, sleep the zone, @todo and stop timer?
-        if (allMobsHome)
+        // if all mobs home and healed up, sleep the zone @todo and stop timer?
+        if (allMobsHomeAndHealed)
         {
             PZone->SleepZone();
         }
@@ -949,8 +951,6 @@ void CZone::SleepZone()
 
         ZoneTimerTriggerAreas->m_type = CTaskMgr::TASK_REMOVE;
         ZoneTimerTriggerAreas         = nullptr;
-
-        m_zoneEntities->HealAllMobs();
     }
 }
 

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -30,7 +30,6 @@
 #include <list>
 #include <map>
 #include <unordered_map>
-#include <queue>
 
 #include "battlefield_handler.h"
 #include "campaign_handler.h"
@@ -584,7 +583,7 @@ public:
     bool CanUseMisc(uint16 misc) const;
     void SetWeather(WEATHER weatherCondition);
     void UpdateWeather();
-    void CheckMobsPathedBack();
+    bool CheckMobsPathedBack();
     void SleepZone();
 
     virtual void SpawnPCs(CCharEntity* PChar);
@@ -652,8 +651,6 @@ public:
     void LoadNavMesh();
     void LoadZoneLos();
 
-    std::queue<std::string> zoneTimersAsleepAndRunning;
-
 private:
     ZONEID         m_zoneID;
     ZONE_TYPE      m_zoneType;
@@ -684,6 +681,8 @@ private:
     void LoadZoneWeather();
 
     CTreasurePool* m_TreasurePool;
+
+    time_point m_timeZoneEmpty; // The time point when the last player left the zone
 
     std::unordered_map<std::string, QueryByNameResult_t> m_queryByNameResults;
 

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -583,7 +583,7 @@ public:
     bool CanUseMisc(uint16 misc) const;
     void SetWeather(WEATHER weatherCondition);
     void UpdateWeather();
-    void SetKeepAlive();
+    void CheckMobsPathedBack();
     void SleepZone();
 
     virtual void SpawnPCs(CCharEntity* PChar);

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -583,6 +583,8 @@ public:
     bool CanUseMisc(uint16 misc) const;
     void SetWeather(WEATHER weatherCondition);
     void UpdateWeather();
+    void SetKeepAlive();
+    void SleepZone();
 
     virtual void SpawnPCs(CCharEntity* PChar);
     virtual void SpawnMOBs(CCharEntity* PChar);
@@ -679,8 +681,6 @@ private:
     void LoadZoneWeather();
 
     CTreasurePool* m_TreasurePool;
-
-    time_point m_timeZoneEmpty; // The time point when the last player left the zone
 
     std::unordered_map<std::string, QueryByNameResult_t> m_queryByNameResults;
 

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -584,7 +584,6 @@ public:
     void SetWeather(WEATHER weatherCondition);
     void UpdateWeather();
     bool CheckMobsPathedBack();
-    void SleepZone();
 
     virtual void SpawnPCs(CCharEntity* PChar);
     virtual void SpawnMOBs(CCharEntity* PChar);

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -30,6 +30,7 @@
 #include <list>
 #include <map>
 #include <unordered_map>
+#include <queue>
 
 #include "battlefield_handler.h"
 #include "campaign_handler.h"
@@ -650,6 +651,8 @@ public:
 
     void LoadNavMesh();
     void LoadZoneLos();
+
+    std::queue<std::string> zoneTimersAsleepAndRunning;
 
 private:
     ZONEID         m_zoneID;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This is an attempt to fix #5910.  All zones with mobs stay alive until the mob fully paths back and/or restores its own hp/mp, then it sleeps that zone.

## Steps to test these changes
I have run this on my own client/server setup and examined print statements when I exit the zone.  I was able to determine we needed to add the "isDead" call to weed out mobs that are fished up, only spawn at night, or have other uncertain pop conditions.
