### PR TITLE
Add zone checks to entity based draw in

### DIFF
--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Minotaur.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Minotaur.lua
@@ -18,7 +18,9 @@ entity.onMobFight = function(mob, target)
     }
     if drawInTable.conditions[1] then
         for _, member in ipairs(target:getAlliance()) do
-            utils.drawIn(member, drawInTable)
+            if member:getZone() == mob:getZone() then
+                utils.drawIn(member, drawInTable)
+            end
         end
     end
 end

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -17896,7 +17896,7 @@ void CLuaBaseEntity::drawIn(sol::variadic_args va)
     CBaseEntity*   PBaseEntity = PLuaBaseEntity->m_PBaseEntity;
     CBattleEntity* PTarget     = nullptr;
 
-    if (PBaseEntity)
+    if (PBaseEntity && PBaseEntity->getZone() == m_PBaseEntity->getZone())
     {
         PTarget = dynamic_cast<CBattleEntity*>(PBaseEntity);
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes #7111 

`utils.drawIn` isn't necessarily tied to an entity, so I added the zone check to the Minotaur script. Zone safety was added to the entity binding, which is used on alliance members with King Vinegarroon.

## Steps to test these changes

See #7111 

Also spawn KV (17289575, may need to comment out the despawn bit in its script) and give it `!tp 3000` until it eventually draws in alliance members in the zone.
