### PR TITLE
[Lua, SQL] Fix bugs in confrontation, add IDs to valkurm

### DIFF
--- a/scripts/missions/amk/06_An_Errand_The_Professors_Price.lua
+++ b/scripts/missions/amk/06_An_Errand_The_Professors_Price.lua
@@ -64,11 +64,14 @@ local beginCardianFight = function(player, npc)
         table.insert(cardianIds, cardianId)
     end
 
+    local params = {}
+    params.winFunc = function(wPlayer)
+        npcUtil.giveKeyItem(wPlayer, xi.keyItem.RIPE_STARFRUIT)
+        npcUtil.giveKeyItem(wPlayer, xi.keyItem.PEACH_CORAL_KEY)
+    end
+
     -- Spawn mobs and start battle
-    xi.confrontation.start(player, npc, cardianIds, function(playerArg)
-        npcUtil.giveKeyItem(playerArg, xi.keyItem.RIPE_STARFRUIT)
-        npcUtil.giveKeyItem(playerArg, xi.keyItem.PEACH_CORAL_KEY)
-    end)
+    xi.confrontation.start(player, npc, cardianIds, params)
 
     -- Apply mods
     for _, mobId in pairs(cardianIds) do

--- a/scripts/zones/Outer_Horutoto_Ruins/IDs.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/IDs.lua
@@ -26,7 +26,17 @@ zones[xi.zone.OUTER_HORUTOTO_RUINS] =
         DOOR_FIRMLY_SHUT              = 7272,  -- The door is firmly shut.
         ALL_G_ORBS_ENERGIZED          = 7275,  -- The six Mana Orbs have been successfully energized with magic!
         CHEST_UNLOCKED                = 7298,  -- You unlock the chest!
+        IF_HAD_ORBS                   = 7356,  -- You sense that if you had <keyitem>, <keyitem>, <keyitem>, or <keyitem>, something might happen.
         CANNOT_ENTER_BATTLEFIELD      = 7359,  -- You cannot enter this battlefield with the key item: <keyitem> in your possession.
+        MUST_WAIT_LONGER              = 7360,  -- It appears you must wait longer to commence the battle.
+        COMMENCING_EXPERIMENT         = 7361,  -- CoMM-eN-cInG*Ex-PE-rI-MeNt.
+        INITIATING_TRANSMISSION       = 7362,  -- INi-TiAT-iNG*TRAnS-miSS-IOn*TO*PRo-FeSS-oR...
+        VENTURED_TOO_FAR              = 7363,  -- You have ventured too far from the field of battle.\nThe Confrontation will automatically disengage if you do not return.
+        CONFRONTATION_DISENGAGED      = 7364,  -- You have ventured too far from the field of battle.\n The Confrotation has been disengaged.
+        RETURNED_TO_BATTLE            = 7365,  -- You have returned to the field of battle.
+        YOU_HAVE_X_MINUTES_LEFT       = 7366,  -- You have <number> minutes (Earth time) to complete the battle.
+        YOU_HAVE_ONLY_X_SECONDS_LEFT  = 7367,  -- You have only <number> seconds (Earth time) remaining.
+        CONFRONTATION_TIME_UP         = 7369,  -- Your time for this confrontation is up...
         PLAYER_OBTAINS_ITEM           = 8275,  -- <name> obtains <item>!
         UNABLE_TO_OBTAIN_ITEM         = 8276,  -- You were unable to obtain the item.
         PLAYER_OBTAINS_TEMP_ITEM      = 8277,  -- <name> obtains the temporary item: <item>!
@@ -34,15 +44,16 @@ zones[xi.zone.OUTER_HORUTOTO_RUINS] =
         NO_COMBINATION                = 8283,  -- You were unable to enter a combination.
         REGIME_REGISTERED             = 10361, -- New training regime registered!
     },
+
     mob =
     {
-        DESMODONT                  = GetFirstID('Desmodont'),
         AH_PUCH                    = GetFirstID('Ah_Puch'),
-        BALLOON_NM_OFFSET          = GetTableOfIDs('Balloon')[2], -- TODO: NM Needs audit. This only uses 2 of the NMs
-        FULL_MOON_FOUNTAIN_OFFSET  = GetFirstID('Jack_of_Cups'),
-        JESTER_WHOD_BE_KING_OFFSET = GetFirstID('Queen_of_Swords'),
         APPARATUS_ELEMENTAL        = GetFirstID('Thunder_Elemental'),
         CUSTOM_CARDIAN_OFFSET      = GetFirstID('Custom_Cardian'),
+        BALLOON_NM_OFFSET          = GetTableOfIDs('Balloon')[2], -- TODO: NM Needs audit. This only uses 2 of the NMs
+        DESMODONT                  = GetFirstID('Desmodont'),
+        FULL_MOON_FOUNTAIN_OFFSET  = GetFirstID('Jack_of_Cups'),
+        JESTER_WHOD_BE_KING_OFFSET = GetFirstID('Queen_of_Swords'),
     },
     npc =
     {

--- a/scripts/zones/Valkurm_Dunes/IDs.lua
+++ b/scripts/zones/Valkurm_Dunes/IDs.lua
@@ -51,14 +51,19 @@ zones[xi.zone.VALKURM_DUNES] =
         REGIME_REGISTERED              = 10278, -- New training regime registered!
         COMMON_SENSE_SURVIVAL          = 12332, -- It appears that you have arrived at a new survival guide provided by the Adventurers' Mutual Aid Network. Common sense dictates that you should now be able to teleport here from similar tomes throughout the world.
     },
+
     mob =
     {
-        VALKURM_EMPEROR = GetFirstID('Valkurm_Emperor'),
-        GOLDEN_BAT      = GetFirstID('Golden_Bat'),
-        MARCHELUTE      = GetFirstID('Marchelute'),
-        DOMAN           = GetFirstID('Doman'),
-        ONRYO           = GetFirstID('Onryo'),
+        BEACH_MONK          = GetFirstID('Beach_Monk'),
+        DOMAN               = GetFirstID('Doman'),
+        GOLDEN_BAT          = GetFirstID('Golden_Bat'),
+        HEIKE_CRAB          = GetFirstID('Heike_Crab'),
+        HOUU_THE_SHOALWADER = GetFirstID('Houu_the_Shoalwader'),
+        MARCHELUTE          = GetFirstID('Marchelute'),
+        ONRYO               = GetFirstID('Onryo'),
+        VALKURM_EMPEROR     = GetFirstID('Valkurm_Emperor'),
     },
+
     npc =
     {
         SUNSAND_QM    = GetFirstID('qm1'),

--- a/sql/status_effects.sql
+++ b/sql/status_effects.sql
@@ -305,7 +305,7 @@ INSERT INTO `status_effects` VALUES (272,'aftermath_lv3',288,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (273,'aftermath',288,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (274,'enlight',41,94,51,0,0,0,7,0,0);
 INSERT INTO `status_effects` VALUES (275,'auspice',4194336,94,51,0,0,0,7,0,0);
-INSERT INTO `status_effects` VALUES (276,'confrontation',8912928,0,0,0,0,0,0,0,0);
+INSERT INTO `status_effects` VALUES (276,'confrontation',8913184,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (277,'enfire_ii',41,94,51,0,0,0,1,0,0);
 INSERT INTO `status_effects` VALUES (278,'enblizzard_ii',41,94,51,0,0,0,2,0,0);
 INSERT INTO `status_effects` VALUES (279,'enaero_ii',41,94,51,0,0,0,3,0,0);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Improves a number of things required for confrontations to work properly
1) Add function annotations
2) Addresses some edge case bugs that cause confrontation to break down when players re-enter the zone without confrontation effect
3) Add time limit functionality to confrontations
4) Prepare player list for appropriate enmity list management on pop (To be added to npcUtil.lua)
5) Update confrontation effect flag to include xi.effectFlag.ON_ZONE
6) Add some mob IDs to valkurm IDs.lua for pirates chart quest
7) Add some text IDs to outer horutoto ruins IDs.lua

## Steps to test these changes
Setup some dummy confrontation somewhere, such as qm4 in valkurm dunes (!pos -168 4 -131 103, id = 17199740)
Test out numerous edge cases for wins and losses.  
Player can still force win with multiple players because hate list doesn't autopopulate all alliance members.  So spawning player can pop mobs, then zone.  Mobs will then despawn, and because valid player count > 0, win condition triggers.  This can be fixed by adjusting the logic in npcUtil.lua to include the enmity player list logic.  To be handled in separate PR.



coauthor: TracentEden <92269743+TracentEden@users.noreply.github.com>
github.com/AirSkyBoat/AirSkyBoat 0c8cb7e7fa7a28106acaf06fb85eb7fd878eeaa6
github.com/AirSkyBoat/AirSkyBoat 3881abe4437a6f428cfbb6ada9efda24e7d6ed61