### PR TITLE
[Promyvion] Properly use fast despawn functionality for Memory receptacle decorations and portals

### DIFF
--- a/scripts/zones/Promyvion-Dem/mobs/Memory_Receptacle.lua
+++ b/scripts/zones/Promyvion-Dem/mobs/Memory_Receptacle.lua
@@ -29,10 +29,6 @@ entity.onMobWeaponSkill = function(target, mob, skill)
     xi.promyvion.receptacleOnMobWeaponSkill(mob)
 end
 
-entity.onMobDeath = function(mob, player, optParams)
-    xi.promyvion.receptacleOnMobDeath(mob, optParams)
-end
-
 entity.onMobDespawn = function(mob)
     xi.promyvion.receptacleOnMobDespawn(mob)
 end

--- a/scripts/zones/Promyvion-Holla/mobs/Memory_Receptacle.lua
+++ b/scripts/zones/Promyvion-Holla/mobs/Memory_Receptacle.lua
@@ -29,10 +29,6 @@ entity.onMobWeaponSkill = function(target, mob, skill)
     xi.promyvion.receptacleOnMobWeaponSkill(mob)
 end
 
-entity.onMobDeath = function(mob, player, optParams)
-    xi.promyvion.receptacleOnMobDeath(mob, optParams)
-end
-
 entity.onMobDespawn = function(mob)
     xi.promyvion.receptacleOnMobDespawn(mob)
 end

--- a/scripts/zones/Promyvion-Mea/mobs/Memory_Receptacle.lua
+++ b/scripts/zones/Promyvion-Mea/mobs/Memory_Receptacle.lua
@@ -29,10 +29,6 @@ entity.onMobWeaponSkill = function(target, mob, skill)
     xi.promyvion.receptacleOnMobWeaponSkill(mob)
 end
 
-entity.onMobDeath = function(mob, player, optParams)
-    xi.promyvion.receptacleOnMobDeath(mob, optParams)
-end
-
 entity.onMobDespawn = function(mob)
     xi.promyvion.receptacleOnMobDespawn(mob)
 end

--- a/scripts/zones/Promyvion-Vahzl/mobs/Memory_Receptacle.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Memory_Receptacle.lua
@@ -29,10 +29,6 @@ entity.onMobWeaponSkill = function(target, mob, skill)
     xi.promyvion.receptacleOnMobWeaponSkill(mob)
 end
 
-entity.onMobDeath = function(mob, player, optParams)
-    xi.promyvion.receptacleOnMobDeath(mob, optParams)
-end
-
 entity.onMobDespawn = function(mob)
     xi.promyvion.receptacleOnMobDespawn(mob)
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

As title sais. Simplifies functionality in place to "hack" our way to imitate fast despawns.
Makes receptacle, decoration and portal spawning and despawning imperceptibly smoother.

## Steps to test these changes

None
