### PR TITLE
[lua, quest] Correct mob ID of Mahjlaef the Paintorn for RoE

### DIFF
--- a/scripts/globals/roe_records.lua
+++ b/scripts/globals/roe_records.lua
@@ -6278,7 +6278,7 @@ xi.roe.records =
     [809] =
     { -- Subjugation: Mahjlaef the Paintorn
         trigger = xi.roeTrigger.DEFEAT_MOB,
-        reqs = { mobID = set { 17101204 } },
+        reqs = { mobID = set { 17101200 } },
         flags = set { 'repeat' },
         reward = { sparks = 300, exp = 1500, accolades = 30 },
     },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Fixed the "Mahjlaef the Paintorn" ZNM Record of Eminence quest by correcting the mob ID of the target. Before it was a random Merrow Typhoondancer.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

- Activate the RoE
- Spawn and kill the ZNM