### PR TITLE
[lua][command][quest] all in 1 quest command for IF

### DIFF
--- a/scripts/commands/quest.lua
+++ b/scripts/commands/quest.lua
@@ -1,0 +1,154 @@
+-----------------------------------
+-- func: quest <logid> <questid> optional <player-name>, logid and quest ids work by numbers or string.format
+-- desc: quest command built with menu control, can add/delete/complete quests, see status,
+-- see vars in the IF format of 'Prog', 'Option', 'Stage', 'Wait'.
+-- Can clear vars in the IF format
+-----------------------------------
+local logIdHelpers = require('scripts/globals/log_ids')
+-----------------------------------
+
+---@type TCommand
+local commandObj = {}
+
+commandObj.cmdprops =
+{
+    permission = 1,
+    parameters = 'sss'
+}
+
+local function error(player, msg)
+    player:printToPlayer(msg)
+    player:printToPlayer('!quest <logId> <questId> {player}', xi.msg.channel.NS_LINKSHELL3)
+end
+
+commandObj.onTrigger = function(player, logId, questId, target)
+    -- validate logId
+    local questLog = logIdHelpers.getQuestLogInfo(logId)
+    if questLog == nil then
+        error(player, 'Invalid logID.')
+        return
+    end
+
+    local logName = questLog.full_name
+    logId = questLog.quest_log
+
+    -- validate questId
+    local areaQuestIds = xi.quest.id[xi.quest.area[logId]]
+    if questId ~= nil then
+        questId = tonumber(questId) or areaQuestIds[string.upper(questId)]
+    end
+
+    if questId == nil or questId < 0 then
+        error(player, 'Invalid questID.')
+        return
+    end
+
+    -- validate target
+    local targ
+    if target == nil then
+        targ = player:getCursorTarget()
+        if targ == nil or not targ:isPC() then
+            targ = player
+        end
+    else
+        targ = GetPlayerByName(target)
+        if targ == nil then
+            error(player, string.format('Player named %s not found!', target, xi.msg.channel.NS_LINKSHELL3))
+            return
+        end
+    end
+
+    local status = targ:getQuestStatus(logId, questId)
+
+    local menu =
+    {
+        title = 'Quest Menu',
+        onStart = function(playerArg)
+            local statusName = 'Error'
+            switch (status): caseof
+            {
+                [0] = function(x)
+                    statusName = 'AVAILABLE'
+                end,
+
+                [1] = function(x)
+                    statusName = 'ACCEPTED'
+                end,
+
+                [2] = function(x)
+                    statusName = 'COMPLETED'
+                end,
+            }
+            playerArg:printToPlayer(string.format('Player %s status for %s quest ID %i is: %s', targ:getName(), logName, questId, statusName), xi.msg.channel.NS_LINKSHELL3)
+            playerArg:printToPlayer(string.format('Player %s variables for %s Quest %i are', targ:getName(), logName, questId), xi.msg.channel.NS_LINKSHELL3)
+            playerArg:printToPlayer(string.format('Prog: %i, Stage: %i, Option: %i, Wait %i', xi.quest.getVar(targ, logId, questId, 'Prog'),
+                xi.quest.getVar(targ, logId, questId, 'Stage'), xi.quest.getVar(targ, logId, questId, 'Option'), xi.quest.getVar(targ, logId, questId, 'Wait')), xi.msg.channel.NS_LINKSHELL3)
+        end,
+
+        options =
+        {
+            {
+                'Add Quest',
+                function(playerArg)
+                    if status == xi.questStatus.QUEST_ACCEPTED then
+                        playerArg:printToPlayer(string.format('Quest %s %i is already Accepted on %s', logName, questId, targ:getName()), xi.msg.channel.NS_LINKSHELL3)
+                        return
+                    elseif status == xi.questStatus.QUEST_COMPLETED then
+                        targ:delQuest(logId, questId)
+                        playerArg:printToPlayer(string.format('Quest was in Completed status'), xi.msg.channel.NS_LINKSHELL3)
+                    end
+
+                    targ:addQuest(logId, questId)
+                    playerArg:printToPlayer(string.format('Added %s quest %i to %s.', logName, questId, targ:getName()), xi.msg.channel.NS_LINKSHELL3)
+                end,
+            },
+            {
+                'Complete Quest',
+                function(playerArg)
+                    if status == xi.questStatus.QUEST_COMPLETED then
+                        playerArg:printToPlayer(string.format('Quest %s %i is already Completed', logName, questId), xi.msg.channel.NS_LINKSHELL3)
+                        return
+                    elseif status == xi.questStatus.QUEST_AVAILABLE then
+                        targ:addQuest(logId, questId)
+                        playerArg:printToPlayer(string.format('Quest was in the Available status'), xi.msg.channel.NS_LINKSHELL3)
+                    end
+
+                    targ:completeQuest(logId, questId)
+                    playerArg:printToPlayer(string.format('Completed %s Quest with ID %u for %s', logName, questId, targ:getName()), xi.msg.channel.NS_LINKSHELL3)
+                end,
+            },
+            {
+                'Delete Quest',
+                function(playerArg)
+                    if status == xi.questStatus.QUEST_AVAILABLE then
+                        playerArg:printToPlayer(string.format('Quest %s %i is already in Available status', logName, questId), xi.msg.channel.NS_LINKSHELL3)
+                        return
+                    end
+
+                    targ:delQuest(logId, questId)
+                    playerArg:printToPlayer(string.format('Deleted %s quest %i from %s.', logName, questId, targ:getName()), xi.msg.channel.NS_LINKSHELL3)
+                end,
+            },
+            {
+                'Clear Vars',
+                function(playerArg)
+                    xi.quest.setVar(targ, logId, questId, 'Prog', 0)
+                    xi.quest.setVar(targ, logId, questId, 'Stage', 0)
+                    xi.quest.setVar(targ, logId, questId, 'Option', 0)
+                    xi.quest.setVar(targ, logId, questId, 'Wait', 0)
+                    playerArg:printToPlayer(string.format('Player %s variables for %s Quest %i are cleared', targ:getName(), logName, questId), xi.msg.channel.NS_LINKSHELL3)
+                end,
+            },
+        },
+
+        onCancelled = function(playerArg)
+            playerArg:printToPlayer('Quest Menu Cancelled', xi.msg.channel.NS_LINKSHELL3)
+        end,
+
+        onEnd = function(playerArg)
+        end,
+    }
+    player:customMenu(menu)
+end
+
+return commandObj


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

all in 1 command for quests. With menu!
for IF, reads all vars in the format 'Prog' 'Stage' 'Option' 'Wait' upon use for the quest.
can clears all the vars listed for quest
adds, deletes, completes quests with 1 button, no need to add then complete to go from accepted to complete anymore, same with a completed quest to avail.

![image](https://github.com/user-attachments/assets/e7f40a08-a399-4480-bff7-9d2430a70079)

![image](https://github.com/user-attachments/assets/9fe221c2-5c3e-4026-88b4-e0b46d9f5681)

![image](https://github.com/user-attachments/assets/0a76f7be-018e-4608-80f9-1eb45a8efba3)


## Steps to test these changes

none.
