### PR TITLE
[core] Abort spellcasting if target is no longer eligible

### DIFF
--- a/src/map/ai/controllers/mob_controller.h
+++ b/src/map/ai/controllers/mob_controller.h
@@ -60,6 +60,7 @@ public:
     void         SetFollowTarget(CBaseEntity* PTarget, FollowType followType);
     bool         HasFollowTarget();
     void         ClearFollowTarget();
+    bool         CheckHide(CBattleEntity* PTarget);
 
     void OnCastStopped(CMagicState& state, action_t& action);
 
@@ -69,7 +70,6 @@ protected:
     virtual void TryLink();
     bool         CanDetectTarget(CBattleEntity* PTarget, bool forceSight = false);
     bool         CanPursueTarget(CBattleEntity* PTarget);
-    bool         CheckHide(CBattleEntity* PTarget);
     bool         CheckLock(CBattleEntity* PTarget);
     bool         CheckDetection(CBattleEntity* PTarget);
     virtual bool CanCastSpells();

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -113,15 +113,38 @@ CMagicState::CMagicState(CBattleEntity* PEntity, uint16 targid, SpellID spellid,
 
 bool CMagicState::Update(time_point tick)
 {
-    if (tick > GetEntryTime() + m_castTime && !IsCompleted())
+    action_t    action;
+    auto*       PTarget = m_PEntity->IsValidTarget(m_targid, m_PSpell->getValidTarget(), m_errorMsg);
+    MSGBASIC_ID msg     = MSGBASIC_IS_INTERRUPTED;
+
+    auto isTargetValid = [&]()
     {
-        auto*       PTarget = m_PEntity->IsValidTarget(m_targid, m_PSpell->getValidTarget(), m_errorMsg);
-        MSGBASIC_ID msg     = MSGBASIC_IS_INTERRUPTED;
-
-        action_t action;
-
+        // m_PEntity->IsValidTarget checks if the target is dead and returns nullptr if so, so we don't need to duplicate it here.
         if (!PTarget || m_errorMsg || !CanCastSpell(PTarget, true) ||
             (HasMoved() && (m_PEntity->objtype != TYPE_PET || static_cast<CPetEntity*>(m_PEntity)->getPetType() != PET_TYPE::AUTOMATON)))
+        {
+            return false;
+        }
+        return true;
+    };
+
+    // Check if target is still valid during mid-cast (mostly to check if the target has died and to cancel.)
+    if (!IsCompleted())
+    {
+        if (!isTargetValid())
+        {
+            // guessed, but cancels correctly.
+            m_PEntity->OnCastInterrupted(*this, action, msg, false);
+            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
+
+            Complete();
+            return false;
+        }
+    }
+
+    if (tick > GetEntryTime() + m_castTime && !IsCompleted())
+    {
+        if (!isTargetValid())
         {
             m_PEntity->OnCastInterrupted(*this, action, msg, false);
             m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -22,6 +22,7 @@
 #include "magic_state.h"
 
 #include "ai/ai_container.h"
+#include "ai/controllers/pet_controller.h"
 #include "ai/states/inactive_state.h"
 #include "common/utils.h"
 #include "enmity_container.h"
@@ -124,6 +125,18 @@ bool CMagicState::Update(time_point tick)
             (HasMoved() && (m_PEntity->objtype != TYPE_PET || static_cast<CPetEntity*>(m_PEntity)->getPetType() != PET_TYPE::AUTOMATON)))
         {
             return false;
+        }
+
+        // Check hide if we're a mob and the target isn't ourselves
+        if (PTarget && PTarget->id != m_PEntity->id && m_PEntity->objtype == TYPE_MOB)
+        {
+            if (auto petController = dynamic_cast<CMobController*>(m_PEntity->PAI->GetController()))
+            {
+                if (petController->CheckHide(PTarget)) // Returns true if cant detect target
+                {
+                    return false;
+                }
+            }
         }
         return true;
     };


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Abort spellcasting if target is no longer eligible to be casted on

this PR will fix that for dying and hide

## Steps to test these changes
see videos
[2025-02-26 22-34-48.webm](https://github.com/user-attachments/assets/26cc3eaf-8d05-451a-96d6-4bb642d5f809)
[2025-02-26 23-05-15.webm](https://github.com/user-attachments/assets/78005140-00cc-4b1b-b629-fb334a3a9ab2)

