### PR TITLE
[lua] Correct RangedPDIF Level Correction

### DIFF
--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -574,7 +574,7 @@ xi.combat.physical.calculateRangedPDIF = function(actor, target, weaponType, wsA
     local levelDifFactor = 0
 
     if applyLevelCorrection then
-        levelDifFactor = (actor:getMainLvl() - target:getMainLvl()) * 0.05
+        levelDifFactor = (actor:getMainLvl() - target:getMainLvl()) * 0.025
     end
 
     -- Only players suffer from negative level difference.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The calculateRangedPDIF function was using the melee level correction values `0.05` instead of `0.025`

https://www.bg-wiki.com/ffxi/PDIF#Level_Correction_Function_(cRatio)
https://ffxiclopedia.fandom.com/wiki/Level_Correction_Function_and_pDIF

## Steps to test these changes

Shoot mobs that are higher level than you with a ranged weapon.

Player should receive less of a level difference penalty when using ranged attacks on mobs higher level than them.

<!-- Clear and detailed steps to test your changes here -->
