### PR TITLE
[core][lua] Hook up core parry checks to existing lua function

### DIFF
--- a/scripts/enum/mod.lua
+++ b/scripts/enum/mod.lua
@@ -1025,6 +1025,8 @@ xi.mod =
 
     DESPAWN_TIME_REDUCTION = 1134, -- Reduction in seconds. 1 = 1 second less to despawn.
 
+    PARRY_HP_RECOVERY = 1135, -- Recover <Mod Value> HP on successful parry.
+
     -- IF YOU ADD ANY NEW MODIFIER HERE, ADD IT IN src/map/modifier.h ASWELL!
 
     -- The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.

--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -707,7 +707,7 @@ xi.combat.physical.criticalRateFromFencer = function(actor)
 end
 
 -- Critical rate from Building Flourish.
--- TODO: Study case were if we can attach modifiers to the effect itself, both this and the effect may need refactoring.
+-- TODO: Study case where if we can attach modifiers to the effect itself, both this and the effect may need refactoring.
 xi.combat.physical.criticalRateFromFlourish = function(actor)
     local buildingFlourishBonus = 0
 
@@ -1031,13 +1031,31 @@ xi.combat.physical.isParried = function(defender, attacker)
         xi.combat.physical.calculateParryRate(defender, attacker) > math.random(1, 100)
     then
         parried = true
+
+        -- https://www.bg-wiki.com/ffxi/Turms_Mittens
+        if
+            defender:getMod(xi.mod.PARRY_HP_RECOVERY) > 0 and
+            not defender:hasStatusEffect(xi.effect.CURSE_II)
+        then
+            local recoveryValue = defender:getMod(xi.mod.PARRY_HP_RECOVERY)
+            defender:addHP(recoveryValue)
+        end
+
         if defender:isPC() then
-            -- TODO: implement Turms mod here (when that mod is added to LSB)
-            defender:trySkillUp(xi.skill.PARRY, attacker:getMainLvl())
             -- handle tactical parry
             if defender:hasTrait(xi.trait.TACTICAL_PARRY) then
                 defender:addTP(defender:getMod(xi.mod.TACTICAL_PARRY))
             end
+        end
+    end
+
+    -- Handle skill ups.
+    if defender:isPC() then
+        if
+            parried or -- We parried
+            not xi.settings.map.PARRY_OLD_SKILLUP_STYLE -- Old style skillup is not enabled
+        then
+            defender:trySkillUp(xi.skill.PARRY, attacker:getMainLvl())
         end
     end
 

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2527,13 +2527,6 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                     }
                 }
 
-                if (attack.IsParried() || !settings::get<bool>("map.PARRY_OLD_SKILLUP_STYLE"))
-                {
-                    if (battleutils::GetParryRate(this, PTarget) > 0)
-                    {
-                        charutils::TrySkillUP((CCharEntity*)PTarget, SKILL_PARRY, GetMLevel());
-                    }
-                }
                 if (!attack.IsCountered() && !attack.IsParried())
                 {
                     charutils::TrySkillUP((CCharEntity*)PTarget, SKILL_EVASION, GetMLevel());

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
   Copyright (c) 2010-2015 Darkstar Dev Teams
   This program is free software: you can redistribute it and/or modify
@@ -1070,12 +1070,14 @@ enum class Mod
 
     DESPAWN_TIME_REDUCTION = 1134, // Reduction in seconds. 1 = 1 second less to despawn.
 
+    PARRY_HP_RECOVERY = 1135, // Recover <Mod Value> HP on successful parry.
+
     // IF YOU ADD ANY NEW MODIFIER HERE, ADD IT IN scripts/enum/mod.lua ASWELL!
 
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     // 570 through 825 used by WS DMG mods these are not spares.
     //
-    // SPARE IDs: 1135 and onward
+    // SPARE IDs: 1136 and onward
 };
 
 // temporary workaround for using enum class as unordered_map key until compilers support it

--- a/src/map/utils/attackutils.cpp
+++ b/src/map/utils/attackutils.cpp
@@ -24,6 +24,7 @@
 #include "battleutils.h"
 #include "common/utils.h"
 #include "items/item_weapon.h"
+#include "lua/luautils.h"
 #include "status_effect_container.h"
 
 namespace attackutils
@@ -232,10 +233,26 @@ namespace attackutils
 
     bool IsParried(CBattleEntity* PAttacker, CBattleEntity* PDefender)
     {
-        if (facing(PDefender->loc.p, PAttacker->loc.p, 64))
+        auto isParriedFunc = lua["xi"]["combat"]["physical"]["isParried"];
+
+        if (isParriedFunc.valid())
         {
-            return (xirand::GetRandomNumber(100) < battleutils::GetParryRate(PAttacker, PDefender));
+            try
+            {
+                bool result = isParriedFunc(PDefender, PAttacker);
+                return result;
+            }
+            catch (const sol::error& err)
+            {
+                ShowError("attackutils::IsParried(): %s", err.what());
+                return false;
+            }
         }
+        else
+        {
+            ShowError("attackutils::IsParried() failed to run Lua function");
+        }
+
         return false;
     }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Replaces core parry logic to use the existing lua function in physical_utilities.lua.

Adds modifier: `PARRY_HP_RECOVERY` to support HP recovery on parry. Used for: https://www.bg-wiki.com/ffxi/Turms_Mittens_+1

## Steps to test these changes

Compare values in functions:
`battleutils.cpp` (Line 1959)
`uint8 GetParryRate(CBattleEntity* PAttacker, CBattleEntity* PDefender)`

`physical_utilities.lua` (Line 799)
`xi.combat.physical.calculateParryRate = function(defender, attacker)`

Find a mob, attack it/keep your weapon out. See that you can get parried attacks and skill ups like normal.

Set your settings/map: PARRY_OLD_SKILLUP_STYLE to true and see that it behaves as expected  (Only skill ups on successful parry)

`!setmod PARRY_HP_RECOVERY 100` then parry a mob attack. See that you gain 100 HP back after a parry.

Delete or modify name of isParried function in physical_utilities.lua. See that it supplies an error.