### PR TITLE
Scaffolding for onTransportEvent to trigger NPCs and mobs.

### DIFF
--- a/scripts/zones/Aht_Urhgan_Whitegate/Zone.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/Zone.lua
@@ -82,10 +82,12 @@ zoneObject.onTriggerAreaLeave = function(player, triggerArea)
 end
 
 zoneObject.onTransportEvent = function(player, transport)
-    if transport == 46 or transport == 47 then
-        player:startEvent(200)
-    elseif transport == 58 or transport == 59 then
-        player:startEvent(203)
+    if player:getObjType() == xi.objType.PC then
+        if transport == 46 or transport == 47 then
+            player:startEvent(200)
+        elseif transport == 58 or transport == 59 then
+            player:startEvent(203)
+        end
     end
 end
 

--- a/scripts/zones/Bastok-Jeuno_Airship/Zone.lua
+++ b/scripts/zones/Bastok-Jeuno_Airship/Zone.lua
@@ -17,8 +17,11 @@ zoneObject.onZoneIn = function(player, prevZone)
     return cs
 end
 
-zoneObject.onTransportEvent = function(player, transport)
-    player:startEvent(100)
+zoneObject.onTransportEvent = function(entity, transport)
+    if entity:getObjType() == xi.objType.PC then
+        entity:startEvent(100)
+--    elseif entity:getObjType() == xi.objType.NPC then
+    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Bibiki_Bay/Zone.lua
+++ b/scripts/zones/Bibiki_Bay/Zone.lua
@@ -40,7 +40,9 @@ zoneObject.onTriggerAreaLeave = function(player, triggerArea)
 end
 
 zoneObject.onTransportEvent = function(player, transport)
-    xi.manaclipper.onTransportEvent(player, transport)
+    if player:getObjType() == xi.objType.PC then
+        xi.manaclipper.onTransportEvent(player, transport)
+    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Kazham-Jeuno_Airship/Zone.lua
+++ b/scripts/zones/Kazham-Jeuno_Airship/Zone.lua
@@ -17,8 +17,11 @@ zoneObject.onZoneIn = function(player, prevZone)
     return cs
 end
 
-zoneObject.onTransportEvent = function(player, transport)
-    player:startEvent(10)
+zoneObject.onTransportEvent = function(entity, transport)
+    if entity:getObjType() == xi.objType.PC then
+        entity:startEvent(10)
+--    elseif entity:getObjType() == xi.objType.NPC then
+    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Kazham/Zone.lua
+++ b/scripts/zones/Kazham/Zone.lua
@@ -32,7 +32,9 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.onTransportEvent = function(player, transport)
-    player:startEvent(10000)
+    if player:getObjType() == xi.objType.PC then
+        player:startEvent(10000)
+    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Manaclipper/Zone.lua
+++ b/scripts/zones/Manaclipper/Zone.lua
@@ -42,8 +42,12 @@ zoneObject.onZoneIn = function(player, prevZone)
     return cs
 end
 
-zoneObject.onTransportEvent = function(player, transport)
-    player:startEvent(100)
+zoneObject.onTransportEvent = function(entity, transport)
+    if entity:getObjType() == xi.objType.PC then
+        entity:startEvent(100)
+--    elseif entity:getObjType() == xi.objType.NPC then
+--    elseif entity:getObjType() == xi.objType.MOB then
+    end
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)

--- a/scripts/zones/Mhaura/Zone.lua
+++ b/scripts/zones/Mhaura/Zone.lua
@@ -52,18 +52,20 @@ zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranki
 end
 
 zoneObject.onTransportEvent = function(player, transport)
-    if transport == 47 or transport == 46 then
-        if
-            not player:hasKeyItem(xi.ki.BOARDING_PERMIT) or
-            xi.settings.main.ENABLE_TOAU == 0
-        then
-            player:setPos(8.200, -1.363, 3.445, 192)
-            player:messageSpecial(ID.text.DO_NOT_POSSESS, xi.ki.BOARDING_PERMIT)
+    if player:getObjType() == xi.objType.PC then
+        if transport == 47 or transport == 46 then
+            if
+                not player:hasKeyItem(xi.ki.BOARDING_PERMIT) or
+                xi.settings.main.ENABLE_TOAU == 0
+            then
+                player:setPos(8.200, -1.363, 3.445, 192)
+                player:messageSpecial(ID.text.DO_NOT_POSSESS, xi.ki.BOARDING_PERMIT)
+            else
+                player:startEvent(200)
+            end
         else
             player:startEvent(200)
         end
-    else
-        player:startEvent(200)
     end
 end
 

--- a/scripts/zones/Nashmau/Zone.lua
+++ b/scripts/zones/Nashmau/Zone.lua
@@ -34,8 +34,10 @@ zoneObject.onTriggerAreaLeave = function(player, triggerArea)
 end
 
 zoneObject.onTransportEvent = function(player, transport)
-    if transport == 59 then
-        player:startEvent(200)
+    if player:getObjType() == xi.objType.PC then
+        if transport == 59 then
+            player:startEvent(200)
+        end
     end
 end
 

--- a/scripts/zones/Open_sea_route_to_Al_Zahbi/Zone.lua
+++ b/scripts/zones/Open_sea_route_to_Al_Zahbi/Zone.lua
@@ -24,9 +24,13 @@ zoneObject.onZoneIn = function(player, prevZone)
     return cs
 end
 
-zoneObject.onTransportEvent = function(player, transport)
-    player:startEvent(1028)
-    player:messageSpecial(ID.text.DOCKING_IN_AL_ZAHBI)
+zoneObject.onTransportEvent = function(entity, transport)
+    if entity:getObjType() == xi.objType.PC then
+        entity:startEvent(1028)
+        entity:messageSpecial(ID.text.DOCKING_IN_AL_ZAHBI)
+--    elseif entity:getObjType() == xi.objType.NPC then
+--    elseif entity:getObjType() == xi.objType.MOB then
+    end
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)

--- a/scripts/zones/Open_sea_route_to_Mhaura/Zone.lua
+++ b/scripts/zones/Open_sea_route_to_Mhaura/Zone.lua
@@ -24,9 +24,13 @@ zoneObject.onZoneIn = function(player, prevZone)
     return cs
 end
 
-zoneObject.onTransportEvent = function(player, transport)
-    player:startEvent(1028)
-    player:messageSpecial(ID.text.DOCKING_IN_MHAURA)
+zoneObject.onTransportEvent = function(entity, transport)
+    if entity:getObjType() == xi.objType.PC then
+        entity:startEvent(1028)
+        entity:messageSpecial(ID.text.DOCKING_IN_MHAURA)
+--    elseif entity:getObjType() == xi.objType.NPC then
+--    elseif entity:getObjType() == xi.objType.MOB then
+    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Port_Bastok/Zone.lua
+++ b/scripts/zones/Port_Bastok/Zone.lua
@@ -41,7 +41,9 @@ zoneObject.onTriggerAreaLeave = function(player, triggerArea)
 end
 
 zoneObject.onTransportEvent = function(player, transport)
-    player:startEvent(71)
+    if player:getObjType() == xi.objType.PC then
+        player:startEvent(71)
+    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Port_Jeuno/Zone.lua
+++ b/scripts/zones/Port_Jeuno/Zone.lua
@@ -53,14 +53,16 @@ zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranki
 end
 
 zoneObject.onTransportEvent = function(player, transport)
-    if transport == 223 then
-        player:startEvent(10010)
-    elseif transport == 224 then
-        player:startEvent(10012)
-    elseif transport == 225 then
-        player:startEvent(10011)
-    elseif transport == 226 then
-        player:startEvent(10013)
+    if player:getObjType() == xi.objType.PC then
+        if transport == 223 then
+            player:startEvent(10010)
+        elseif transport == 224 then
+            player:startEvent(10012)
+        elseif transport == 225 then
+            player:startEvent(10011)
+        elseif transport == 226 then
+            player:startEvent(10013)
+        end
     end
 end
 

--- a/scripts/zones/Port_San_dOria/Zone.lua
+++ b/scripts/zones/Port_San_dOria/Zone.lua
@@ -41,7 +41,9 @@ zoneObject.onTriggerAreaLeave = function(player, triggerArea)
 end
 
 zoneObject.onTransportEvent = function(player, transport)
-    player:startEvent(700)
+    if player:getObjType() == xi.objType.PC then
+        player:startEvent(700)
+    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Port_Windurst/Zone.lua
+++ b/scripts/zones/Port_Windurst/Zone.lua
@@ -35,7 +35,9 @@ zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranki
 end
 
 zoneObject.onTransportEvent = function(player, transport)
-    player:startEvent(10002)
+    if player:getObjType() == xi.objType.PC then
+        player:startEvent(10002)
+    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/San_dOria-Jeuno_Airship/Zone.lua
+++ b/scripts/zones/San_dOria-Jeuno_Airship/Zone.lua
@@ -17,8 +17,11 @@ zoneObject.onZoneIn = function(player, prevZone)
     return cs
 end
 
-zoneObject.onTransportEvent = function(player, transport)
-    player:startEvent(100)
+zoneObject.onTransportEvent = function(entity, transport)
+    if entity:getObjType() == xi.objType.PC then
+        entity:startEvent(100)
+--    elseif entity:getObjType() == xi.objType.NPC then
+    end
 end
 
 zoneObject.onGameHour = function(zone)

--- a/scripts/zones/Selbina/Zone.lua
+++ b/scripts/zones/Selbina/Zone.lua
@@ -55,7 +55,9 @@ zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranki
 end
 
 zoneObject.onTransportEvent = function(player, transport)
-    player:startEvent(200)
+    if player:getObjType() == xi.objType.PC then
+        player:startEvent(200)
+    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Ship_bound_for_Mhaura/Zone.lua
+++ b/scripts/zones/Ship_bound_for_Mhaura/Zone.lua
@@ -22,8 +22,12 @@ zoneObject.onZoneIn = function(player, prevZone)
     return cs
 end
 
-zoneObject.onTransportEvent = function(player, transport)
-    player:startEvent(512)
+zoneObject.onTransportEvent = function(entity, transport)
+    if entity:getObjType() == xi.objType.PC then
+        entity:startEvent(512)
+--    elseif entity:getObjType() == xi.objType.NPC then
+--    elseif entity:getObjType() == xi.objType.MOB then
+    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Ship_bound_for_Mhaura_Pirates/Zone.lua
+++ b/scripts/zones/Ship_bound_for_Mhaura_Pirates/Zone.lua
@@ -22,8 +22,12 @@ zoneObject.onZoneIn = function(player, prevZone)
     return cs
 end
 
-zoneObject.onTransportEvent = function(player, transport)
-    player:startEvent(512)
+zoneObject.onTransportEvent = function(entity, transport)
+    if entity:getObjType() == xi.objType.PC then
+        entity:startEvent(512)
+--    elseif entity:getObjType() == xi.objType.NPC then
+--    elseif entity:getObjType() == xi.objType.MOB then
+    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Ship_bound_for_Selbina/Zone.lua
+++ b/scripts/zones/Ship_bound_for_Selbina/Zone.lua
@@ -32,8 +32,12 @@ zoneObject.onZoneIn = function(player, prevZone)
     return cs
 end
 
-zoneObject.onTransportEvent = function(player, transport)
-    player:startEvent(255)
+zoneObject.onTransportEvent = function(entity, transport)
+    if entity:getObjType() == xi.objType.PC then
+        entity:startEvent(255)
+--    elseif entity:getObjType() == xi.objType.NPC then
+--    elseif entity:getObjType() == xi.objType.MOB then
+    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Ship_bound_for_Selbina_Pirates/Zone.lua
+++ b/scripts/zones/Ship_bound_for_Selbina_Pirates/Zone.lua
@@ -22,8 +22,12 @@ zoneObject.onZoneIn = function(player, prevZone)
     return cs
 end
 
-zoneObject.onTransportEvent = function(player, transport)
-    player:startEvent(255)
+zoneObject.onTransportEvent = function(entity, transport)
+    if entity:getObjType() == xi.objType.PC then
+        entity:startEvent(255)
+--    elseif entity:getObjType() == xi.objType.NPC then
+--    elseif entity:getObjType() == xi.objType.MOB then
+    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Silver_Sea_route_to_Al_Zahbi/Zone.lua
+++ b/scripts/zones/Silver_Sea_route_to_Al_Zahbi/Zone.lua
@@ -16,8 +16,12 @@ end
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)
 end
 
-zoneObject.onTransportEvent = function(player, transport)
-    player:startEvent(1025)
+zoneObject.onTransportEvent = function(entity, transport)
+    if entity:getObjType() == xi.objType.PC then
+        entity:startEvent(1025)
+--    elseif entity:getObjType() == xi.objType.NPC then
+--    elseif entity:getObjType() == xi.objType.MOB then
+    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Silver_Sea_route_to_Nashmau/Zone.lua
+++ b/scripts/zones/Silver_Sea_route_to_Nashmau/Zone.lua
@@ -13,8 +13,12 @@ zoneObject.onZoneIn = function(player, prevZone)
     return cs
 end
 
-zoneObject.onTransportEvent = function(player, transport)
-    player:startEvent(1025)
+zoneObject.onTransportEvent = function(entity, transport)
+    if entity:getObjType() == xi.objType.PC then
+        entity:startEvent(1025)
+--    elseif entity:getObjType() == xi.objType.NPC then
+--    elseif entity:getObjType() == xi.objType.MOB then
+    end
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)

--- a/scripts/zones/Windurst-Jeuno_Airship/Zone.lua
+++ b/scripts/zones/Windurst-Jeuno_Airship/Zone.lua
@@ -17,8 +17,11 @@ zoneObject.onZoneIn = function(player, prevZone)
     return cs
 end
 
-zoneObject.onTransportEvent = function(player, transport)
-    player:startEvent(100)
+zoneObject.onTransportEvent = function(entity, transport)
+    if entity:getObjType() == xi.objType.PC then
+        entity:startEvent(100)
+--    elseif entity:getObjType() == xi.objType.NPC then
+    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -4571,11 +4571,11 @@ namespace luautils
         charutils::ClearCharVarFromAll(varName);
     }
 
-    void OnTransportEvent(CCharEntity* PChar, uint32 TransportID)
+    void OnTransportEvent(CBaseEntity* PEntity, uint32 TransportID)
     {
         TracyZoneScoped;
 
-        auto name = PChar->loc.zone->getName();
+        auto name = PEntity->loc.zone->getName();
 
         auto onTransportEvent = lua["xi"]["zones"][name]["Zone"]["onTransportEvent"];
         if (!onTransportEvent.valid())
@@ -4583,7 +4583,7 @@ namespace luautils
             return;
         }
 
-        auto result = onTransportEvent(PChar, TransportID);
+        auto result = onTransportEvent(PEntity, TransportID);
         if (!result.valid())
         {
             sol::error err = result;

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -292,7 +292,7 @@ namespace luautils
     void OnTriggerAreaEnter(CCharEntity* PChar, std::unique_ptr<ITriggerArea> const& PTriggerArea); // when player enters a trigger area in a zone
     void OnTriggerAreaLeave(CCharEntity* PChar, std::unique_ptr<ITriggerArea> const& PTriggerArea); // when player leaves a trigger area in a zone
 
-    void OnTransportEvent(CCharEntity* PChar, uint32 TransportID);
+    void OnTransportEvent(CBaseEntity* PEntity, uint32 TransportID);
     void OnTimeTrigger(CNpcEntity* PNpc, uint8 triggerID);
     void OnConquestUpdate(CZone* PZone, ConquestUpdate type, uint8 influence, uint8 owner, uint8 ranking, bool isConquestAlliance); // conquest update (hourly or tally)
 

--- a/src/map/transport.cpp
+++ b/src/map/transport.cpp
@@ -89,7 +89,7 @@ void TransportZone_Town::closeDoor(bool sendPacket) const
 
 void TransportZone_Town::depart() const
 {
-    this->ship.dock.zone->TransportDepart(this->ship.npc->loc.boundary, this->ship.npc->loc.prevzone);
+    this->ship.dock.zone->TransportDepart(this->ship.npc->loc.boundary, this->ship.npc->loc.prevzone, false);
 }
 
 void Elevator_t::openDoor(CNpcEntity* npc) const
@@ -331,7 +331,7 @@ void CTransportHandler::TransportTimer()
         }
         else if (zoneIterator->state == STATE_TRANSPORTZONE_EVICT)
         {
-            zoneIterator->voyageZone->TransportDepart(0, zoneIterator->voyageZone->GetID());
+            zoneIterator->voyageZone->TransportDepart(0, zoneIterator->voyageZone->GetID(), true);
             zoneIterator->state = STATE_TRANSPORTZONE_WAIT;
         }
         else if (zoneIterator->state == STATE_TRANSPORTZONE_WAIT)

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -551,9 +551,9 @@ void CZone::FindPartyForMob(CBaseEntity* PEntity)
  *                                                                       *
  ************************************************************************/
 
-void CZone::TransportDepart(uint16 boundary, uint16 zone)
+void CZone::TransportDepart(uint16 boundary, uint16 zone, bool voyageZone)
 {
-    m_zoneEntities->TransportDepart(boundary, zone);
+    m_zoneEntities->TransportDepart(boundary, zone, voyageZone);
 }
 
 void CZone::updateCharLevelRestriction(CCharEntity* PChar)

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -604,8 +604,8 @@ public:
     virtual void InsertTRUST(CBaseEntity* PTrust);
 
     virtual void FindPartyForMob(CBaseEntity* PEntity);
-    virtual void TransportDepart(uint16 boundary, uint16 zone);  // Collect passengers if ship/boat is departing
-    virtual void updateCharLevelRestriction(CCharEntity* PChar); // Removes the character's level restriction. If the zone has a level restriction, it is applied after it is removed.
+    virtual void TransportDepart(uint16 boundary, uint16 zone, bool voyageZone); // Collect passengers if ship/boat is departing
+    virtual void updateCharLevelRestriction(CCharEntity* PChar);                 // Removes the character's level restriction. If the zone has a level restriction, it is applied after it is removed.
 
     void InsertTriggerArea(std::unique_ptr<ITriggerArea>&& triggerArea); // Add an active area to the zone
 

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -366,7 +366,7 @@ void CZoneEntities::FindPartyForMob(CBaseEntity* PEntity)
     }
 }
 
-void CZoneEntities::TransportDepart(uint16 boundary, uint16 zone)
+void CZoneEntities::TransportDepart(uint16 boundary, uint16 zone, bool voyageZone)
 {
     TracyZoneScoped;
 
@@ -392,6 +392,26 @@ void CZoneEntities::TransportDepart(uint16 boundary, uint16 zone)
             }
 
             luautils::OnTransportEvent(PCurrentChar, zone);
+        }
+    }
+
+    if (voyageZone)
+    {
+        for (EntityList_t::const_iterator it = m_mobList.begin(); it != m_mobList.end(); ++it)
+        {
+            CMobEntity* PCurrentMob = (CMobEntity*)it->second;
+
+            if (PCurrentMob->isAlive())
+            {
+                luautils::OnTransportEvent(PCurrentMob, zone);
+            }
+        }
+
+        for (EntityList_t::const_iterator it = m_npcList.begin(); it != m_npcList.end(); ++it)
+        {
+            CNpcEntity* PCurrentNpc = (CNpcEntity*)it->second;
+
+            luautils::OnTransportEvent(PCurrentNpc, zone);
         }
     }
 }

--- a/src/map/zone_entities.h
+++ b/src/map/zone_entities.h
@@ -70,8 +70,8 @@ public:
     void InsertPET(CBaseEntity* PPet);
     void InsertTRUST(CBaseEntity* PTrust);
 
-    void FindPartyForMob(CBaseEntity* PEntity);         // looking for a party for the monster
-    void TransportDepart(uint16 boundary, uint16 zone); // ship/boat is leaving, passengers need to be collected
+    void FindPartyForMob(CBaseEntity* PEntity);                          // looking for a party for the monster
+    void TransportDepart(uint16 boundary, uint16 zone, bool voyageZone); // ship/boat is leaving, passengers need to be collected
 
     void TOTDChange(TIMETYPE TOTD); // process the world's reactions to changing time of day
     void WeatherChange(WEATHER weather);

--- a/src/map/zone_instance.cpp
+++ b/src/map/zone_instance.cpp
@@ -132,12 +132,12 @@ void CZoneInstance::FindPartyForMob(CBaseEntity* PEntity)
     }
 }
 
-void CZoneInstance::TransportDepart(uint16 boundary, uint16 zone)
+void CZoneInstance::TransportDepart(uint16 boundary, uint16 zone, bool voyageZone)
 {
     TracyZoneScoped;
     for (const auto& PInstance : m_InstanceList)
     {
-        PInstance->TransportDepart(boundary, zone);
+        PInstance->TransportDepart(boundary, zone, voyageZone);
     }
 }
 

--- a/src/map/zone_instance.h
+++ b/src/map/zone_instance.h
@@ -52,8 +52,8 @@ public:
     virtual void InsertPET(CBaseEntity* PPet) override;
     virtual void InsertTRUST(CBaseEntity* PTrust) override;
 
-    virtual void FindPartyForMob(CBaseEntity* PEntity) override;         // looking for a party for the monster
-    virtual void TransportDepart(uint16 boundary, uint16 zone) override; // ship/boat is leaving, passengers need to be collected
+    virtual void FindPartyForMob(CBaseEntity* PEntity) override;                          // looking for a party for the monster
+    virtual void TransportDepart(uint16 boundary, uint16 zone, bool voyageZone) override; // ship/boat is leaving, passengers need to be collected
 
     virtual void TOTDChange(TIMETYPE TOTD) override;                                                           // process the world's reactions to changing time of day
     virtual void PushPacket(CBaseEntity*, GLOBAL_MESSAGE_TYPE, const std::unique_ptr<CBasicPacket>&) override; // send a global package within the zone


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [ ] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds some scaffolding to allow `onTransportEvent` / `TransportDepart` to trigger NPCs and mobs, in addition to players. I'm hoping to use this to work with mobs on the ferry, manaclipper, and barge, as well as NPCs on the barge. Could potentially be used to bootstrap the Discerning Eye quests.

## Steps to test these changes

Board all the boats on all routes and make sure nothing blows up.