### PR TITLE
[core] Don't cancel spell during cast for being out of range

### DIFF
--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -121,7 +121,7 @@ bool CMagicState::Update(time_point tick)
     auto isTargetValid = [&]()
     {
         // m_PEntity->IsValidTarget checks if the target is dead and returns nullptr if so, so we don't need to duplicate it here.
-        if (!PTarget || m_errorMsg || !CanCastSpell(PTarget, true) ||
+        if (!PTarget || m_errorMsg ||
             (HasMoved() && (m_PEntity->objtype != TYPE_PET || static_cast<CPetEntity*>(m_PEntity)->getPetType() != PET_TYPE::AUTOMATON)))
         {
             return false;
@@ -157,7 +157,8 @@ bool CMagicState::Update(time_point tick)
 
     if (tick > GetEntryTime() + m_castTime && !IsCompleted())
     {
-        if (!isTargetValid())
+        // CanCastSpell also does a range check which we don't want to check during midcast - mobs don't cancel spells during casting for being out of range
+        if (!isTargetValid() || !CanCastSpell(PTarget, true))
         {
             m_PEntity->OnCastInterrupted(*this, action, msg, false);
             m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Don't cancel spell during cast for being out of range

## Steps to test these changes

Aggro a mob, zoom out of range, zoom back, still get the spell landed on you