### PR TITLE
[core] BLU can learn spells in alliance, disable learning while in different zone

### DIFF
--- a/src/map/utils/blueutils.cpp
+++ b/src/map/utils/blueutils.cpp
@@ -104,11 +104,29 @@ namespace blueutils
         // populate PBlueMages
         if (PChar->PParty != nullptr)
         {
-            for (auto& member : PChar->PParty->members)
+            std::vector<CParty*> parties;
+
+            if (PChar->PParty->m_PAlliance)
             {
-                if (member->GetMJob() == JOB_BLU && member->objtype == TYPE_PC)
+                parties = PChar->PParty->m_PAlliance->partyList;
+            }
+            else
+            {
+                parties.emplace_back(PChar->PParty);
+            }
+
+            for (const auto* party : parties)
+            {
+                for (auto& member : party->members)
                 {
-                    PBlueMages.emplace_back((CCharEntity*)member);
+                    auto* PMember = dynamic_cast<CCharEntity*>(member);
+
+                    if (PMember &&
+                        PMember->GetMJob() == JOB_BLU &&
+                        PMember->getZone() == PMob->getZone())
+                    {
+                        PBlueMages.emplace_back(PMember);
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Allows BLU to learn spells when killer is part of a different party in the alliance, as is the case on retail.

> The Blue Mage does not need to be the target of the spell or affect the enemy in any way to learn blue magic. [...] and that the Blue Mage's party/alliance delivers the killing blow to the enemy. 
> https://ffxiclopedia.fandom.com/wiki/Category:Blue_Magic


> In effect, you or a party or alliance member must deliver the final blow to the enemy.
> https://wiki.ffo.jp/html/2329.html


Adds a zone check as it is currently possible to learn spells while in another zone (but around the same position)

 
![Screenshot 2025-02-28 005548](https://github.com/user-attachments/assets/68721eaa-4d7d-4834-91fb-7d2193f20627)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

Try learning BLU spells in an alliance.