### PR TITLE
Command: Update !quest to use getVarPrefix()

### DIFF
--- a/scripts/commands/quest.lua
+++ b/scripts/commands/quest.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 -- func: quest <logid> <questid> optional <player-name>, logid and quest ids work by numbers or string.format
 -- desc: quest command built with menu control, can add/delete/complete quests, see status,
--- see vars in the IF format of 'Prog', 'Option', 'Stage', 'Wait'.
+-- see vars in the IF format of 'Prog', 'Option', 'Stage', 'Wait', 'Timer', etc.
 -- Can clear vars in the IF format
 -----------------------------------
 local logIdHelpers = require('scripts/globals/log_ids')
@@ -132,10 +132,7 @@ commandObj.onTrigger = function(player, logId, questId, target)
             {
                 'Clear Vars',
                 function(playerArg)
-                    xi.quest.setVar(targ, logId, questId, 'Prog', 0)
-                    xi.quest.setVar(targ, logId, questId, 'Stage', 0)
-                    xi.quest.setVar(targ, logId, questId, 'Option', 0)
-                    xi.quest.setVar(targ, logId, questId, 'Wait', 0)
+                    targ:clearVarsWithPrefix(xi.quest.getVarPrefix(logId, questId))
                     playerArg:printToPlayer(string.format('Player %s variables for %s Quest %i are cleared', targ:getName(), logName, questId), xi.msg.channel.NS_LINKSHELL3)
                 end,
             },

--- a/scripts/globals/missions.lua
+++ b/scripts/globals/missions.lua
@@ -804,6 +804,8 @@ local function getVarPrefix(areaId, missionId)
     return string.format('Mission[%d][%d]', areaId, missionId)
 end
 
+xi.mission.getVarPrefix = getVarPrefix
+
 xi.mission.incrementVar = function(player, areaId, missionId, name, value)
     return player:incrementCharVar(getVarPrefix(areaId, missionId) .. name, value)
 end

--- a/scripts/globals/quests.lua
+++ b/scripts/globals/quests.lua
@@ -1215,6 +1215,8 @@ local function getVarPrefix(areaId, questId)
     return string.format('Quest[%d][%d]', areaId, questId)
 end
 
+xi.quest.getVarPrefix = getVarPrefix
+
 -- Interaction Framework Helper Functions
 xi.quest.incrementVar = function(player, areaId, questId, name, value)
     return player:incrementCharVar(getVarPrefix(areaId, questId) .. name, value)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

I saw that we have some variance in how we assign vars to quests, so I hooked this up to make sure _everything_ gets cleared if we clear.
