### PR TITLE
[Lua] Add enmityPlayerList logic to npcUtil.popFromQM

### DIFF
--- a/scripts/globals/confrontation.lua
+++ b/scripts/globals/confrontation.lua
@@ -159,15 +159,13 @@ xi.confrontation.start = function(player, npc, mobIds, params)
     mobIds = mobs
 
     -- Tag alliance members with the confrontation effect
-    local registeredPlayerIds = {}
-    local registeredPlayers = {}
     local alliance = player:getAlliance()
+    local registeredPlayerIds = {}
 
     for _, member in ipairs(alliance) do
         -- Using the pop npc's ID as the 'key'
         member:addStatusEffect(xi.effect.CONFRONTATION, lookupKey, 0, 0)
         table.insert(registeredPlayerIds, member:getID())
-        table.insert(registeredPlayers, member)
     end
 
     -- Tag mobs with the confrontation effect
@@ -200,8 +198,7 @@ xi.confrontation.start = function(player, npc, mobIds, params)
 
     -- Pop!
     if params.allRegPlayerEnmity then
-        -- TODO: Add enmityPlayerList functionality to npcUtil.popFromQM
-        npcUtil.popFromQM(player, npc, mobIds, { look = true, claim = true, hide = 1, enmityPlayerList = registeredPlayers })
+        npcUtil.popFromQM(player, npc, mobIds, { look = true, claim = true, hide = 1, enmityPlayerList = alliance })
     else
         npcUtil.popFromQM(player, npc, mobIds, { look = true, claim = true, hide = 1 })
     end

--- a/scripts/globals/npc_util.lua
+++ b/scripts/globals/npc_util.lua
@@ -56,19 +56,20 @@ function npcUtil.popFromQM(player, qm, mobId, params)
     end
 
     -- get list of mobs to pop
-    local mobs = {}
+    local mobIds = {}
     if type(mobId) == 'number' then
-        table.insert(mobs, mobId)
+        table.insert(mobIds, mobId)
     elseif type(mobId) == 'table' then
         for _, v in pairs(mobId) do
             if type(v) == 'number' then
-                table.insert(mobs, v)
+                table.insert(mobIds, v)
             end
         end
     end
 
-    -- make sure none are spawned
-    for k, v in pairs(mobs) do
+    -- make sure none are spawned, translate table from integers to CLuaBaseEntities
+    local mobs = {}
+    for k, v in pairs(mobIds) do
         local mob = GetMobByID(v)
         if mob == nil or mob:isSpawned() then
             return false
@@ -99,6 +100,16 @@ function npcUtil.popFromQM(player, qm, mobId, params)
         -- claim
         if params.claim then
             mob:updateClaim(player)
+        end
+
+        -- Distribute enmity
+        if type(params.enmityPlayerList) == 'table' then
+            -- Add 1 CE to ensure mobs go after spawner first in case params.claim == false
+            mob:addEnmity(player, 1, 0)
+
+            for _, member in ipairs(params.enmityPlayerList) do
+                mob:addEnmity(member, 1, 0)
+            end
         end
 
         -- look


### PR DESCRIPTION

**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Add functionality to npcUtil.popFromQM for alliance hate on spawn.
- Ensures the table `mobs` in that file will only ever contain CLuaBaseEntities, instead of integers first, then entities.
- Remove creation of redundant `registeredPlayers` table in confrontation.lua

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
