### PR TITLE
Fixing/removing redundant std::move() in ipc.h and adding a reference to a ipc_client.cpp as a result

### DIFF
--- a/src/common/ipc.h
+++ b/src/common/ipc.h
@@ -98,7 +98,7 @@ namespace ipc
             return std::nullopt;
         }
 
-        return std::move(object);
+        return object;
     }
 
     template <typename T>
@@ -124,6 +124,6 @@ namespace ipc
             return std::nullopt;
         }
 
-        return std::move(object);
+        return object;
     }
 } // namespace ipc

--- a/src/map/ipc_client.cpp
+++ b/src/map/ipc_client.cpp
@@ -678,7 +678,7 @@ void IPCClient::handleMessage_KillSession(const IPP& ipp, const ipc::KillSession
 
     map_session_data_t* sessionToDelete = nullptr;
 
-    for (const auto [_, session] : map_session_list)
+    for (const auto &[_, session] : map_session_list)
     {
         if (session->charID == message.victimId)
         {

--- a/src/map/ipc_client.cpp
+++ b/src/map/ipc_client.cpp
@@ -678,7 +678,7 @@ void IPCClient::handleMessage_KillSession(const IPP& ipp, const ipc::KillSession
 
     map_session_data_t* sessionToDelete = nullptr;
 
-    for (const auto &[_, session] : map_session_list)
+    for (const auto& [_, session] : map_session_list)
     {
         if (session->charID == message.victimId)
         {


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixing/removing redundant std::move() in ipc.h and adding a reference to a ipc_client.cpp as a result
Closes #7165

## Steps to test these changes
Compile server on a debian or debian-fork (not ubuntu) distro
or
Compile server with -Werror=redundant-move on.