### PR TITLE
Items that are "EX" and "ALT" can now be sent to characters on the same account

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -712,7 +712,7 @@ namespace charutils
             }
         }
         const auto [_, accid] = charutils::getCharIdAndAccountIdFromName(PChar->getName());
-        PChar->accid = accid;
+        PChar->accid          = accid;
 
         db::query(fmt::format("UPDATE char_stats SET zoning = 0 WHERE charid = {}", PChar->id));
 

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -711,6 +711,8 @@ namespace charutils
                 PChar->clearCharVarsWithPrefix("jugpet-");
             }
         }
+        const auto [_, accid] = charutils::getCharIdAndAccountIdFromName(PChar->getName());
+        PChar->accid = accid;
 
         db::query(fmt::format("UPDATE char_stats SET zoning = 0 WHERE charid = {}", PChar->id));
 

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -365,6 +365,7 @@ namespace charutils
                                "pos_z, "
                                "moghouse, "
                                "boundary, "
+                               "accid, "
                                "home_zone, "
                                "home_rot, "
                                "home_x, "
@@ -409,6 +410,7 @@ namespace charutils
             PChar->loc.p.z         = rset->get<float>("pos_z");
             PChar->m_moghouseID    = rset->get<uint32>("moghouse");
             PChar->loc.boundary    = rset->get<uint16>("boundary");
+            PChar->accid           = rset->get<uint32>("accid");
 
             PChar->profile.home_point.destination = rset->get<uint16>("home_zone");
             PChar->profile.home_point.p.rotation  = rset->get<uint8>("home_rot");
@@ -711,8 +713,6 @@ namespace charutils
                 PChar->clearCharVarsWithPrefix("jugpet-");
             }
         }
-        const auto [_, accid] = charutils::getCharIdAndAccountIdFromName(PChar->getName());
-        PChar->accid          = accid;
 
         db::query(fmt::format("UPDATE char_stats SET zoning = 0 WHERE charid = {}", PChar->id));
 

--- a/src/map/utils/dboxutils.cpp
+++ b/src/map/utils/dboxutils.cpp
@@ -282,8 +282,9 @@ void dboxutils::AddItemsToBeSent(CCharEntity* PChar, uint8 action, uint8 boxtype
                     return;
                 }
 
+                const auto [_, senderAccid] = charutils::getCharIdAndAccountIdFromName(PChar->getName());
                 // Different accounts
-                if (PChar->accid != recvAccid)
+                if (senderAccid != recvAccid)
                 {
                     return;
                 }

--- a/src/map/utils/dboxutils.cpp
+++ b/src/map/utils/dboxutils.cpp
@@ -282,9 +282,8 @@ void dboxutils::AddItemsToBeSent(CCharEntity* PChar, uint8 action, uint8 boxtype
                     return;
                 }
 
-                const auto [_, senderAccid] = charutils::getCharIdAndAccountIdFromName(PChar->getName());
                 // Different accounts
-                if (senderAccid != recvAccid)
+                if (PChar->accid != recvAccid)
                 {
                     return;
                 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Closes issue #7047.


## Steps to test these changes
Do !additem 13566 to generate an item that can be sent between characters on the same account (or to yourself) that is also EX.  Verify the item can be sent and the "Communication seems congested" error does not appear on screen.
