### PR TITLE
[lua] GEO check for Entrust when casting Indi

### DIFF
--- a/scripts/globals/job_utils/geomancer.lua
+++ b/scripts/globals/job_utils/geomancer.lua
@@ -353,7 +353,10 @@ end
 -- Magic Casting Checks
 -----------------------------------
 xi.job_utils.geomancer.indiOnMagicCastingCheck = function(caster, target, spell)
-    -- No checks known as of yet
+    if caster ~= target and not caster:hasStatusEffect(xi.effect.ENTRUST) then
+        return xi.msg.basic.MAGIC_CANNOT_BE_CAST
+    end
+
     return 0
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Currently possible to cast Indi- spells on Trusts without Entrust.
This adds an explicit check to all Indi- spells, returning retail message.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

Use shorthand or < stpc> to try and cast Indi spells on trusts.
They should return a message such as "Indi-Refresh cannot be cast on Shantotto" with the PR.
