### PR TITLE
Core: Party system rewrite

### DIFF
--- a/src/map/packets/party_define.cpp
+++ b/src/map/packets/party_define.cpp
@@ -27,9 +27,9 @@
 #include "entities/trustentity.h"
 #include "utils/zoneutils.h"
 
-const char* partyQuery = "SELECT chars.charid, partyflag, pos_zone, pos_prevzone FROM accounts_parties \
-                                        LEFT JOIN chars ON accounts_parties.charid = chars.charid WHERE \
-                                        IF (allianceid <> 0, allianceid = %d, partyid = %d) ORDER BY partyflag & %u, timestamp";
+const char* partyQuery = "SELECT chars.charid, partyflag, pos_zone, pos_prevzone FROM accounts_parties "
+                         "LEFT JOIN chars ON accounts_parties.charid = chars.charid WHERE "
+                         "IF (allianceid <> 0, allianceid = %d, partyid = %d) ORDER BY partyflag & %u, timestamp";
 
 CPartyDefinePacket::CPartyDefinePacket(CParty* PParty, bool loadTrust)
 {

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -48,19 +48,6 @@
 #include "packets/party_effects.h"
 #include "packets/party_member_update.h"
 
-// should have brace-or-equal initializers when MSVC supports it
-struct CParty::partyInfo_t
-{
-    uint32      id         = {};
-    uint32      partyid    = {};
-    uint32      allianceid = {};
-    std::string name       = {};
-    uint16      flags      = {};
-    uint16      zone       = {};
-    uint16      prev_zone  = {};
-};
-
-// Constructor
 CParty::CParty(CBattleEntity* PEntity)
 : m_PartyID(0)
 , m_PartyType(PARTY_MOBS)

--- a/src/map/party.h
+++ b/src/map/party.h
@@ -52,15 +52,20 @@ enum PARTYFLAG : uint16
 };
 DECLARE_FORMAT_AS_UNDERLYING(PARTYFLAG);
 
-/************************************************************************
- *                                                                      *
- *  Character group class                                               *
- *                                                                      *
- ************************************************************************/
-
 class CParty
 {
 public:
+    struct partyInfo_t
+    {
+        uint32      id{};
+        uint32      partyid{};
+        uint32      allianceid{};
+        std::string name{};
+        uint16      flags{};
+        uint16      zone{};
+        uint16      prev_zone{};
+    };
+
     CParty(CBattleEntity* PEntity);
     CParty(uint32 id);
     ~CParty();

--- a/src/map/party_proxy.h
+++ b/src/map/party_proxy.h
@@ -1,0 +1,123 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include "common/cbasetypes.h"
+
+//
+// Proxy Structures
+//
+
+// TODO: Verify exactly what's needed by the client to populate CPartyDefinePacket, CPartyMemberUpdatePacket, and others
+
+/*
+CPartyDefinePacket:
+
+    const char* partyQuery = "SELECT chars.charid, partyflag, pos_zone, pos_prevzone FROM accounts_parties "
+                            "LEFT JOIN chars ON accounts_parties.charid = chars.charid WHERE "
+                            "IF (allianceid <> 0, allianceid = %d, partyid = %d) ORDER BY partyflag & %u, timestamp";
+
+    uint16       targid = 0;
+    CCharEntity* PChar  = zoneutils::GetChar(_sql->GetUIntData(0));
+    if (PChar)
+    {
+        targid = PChar->targid;
+    }
+    ref<uint32>(12 * i + 0x08) = _sql->GetUIntData(0);
+    ref<uint16>(12 * i + 0x0C) = targid;
+    ref<uint16>(12 * i + 0x0E) = _sql->GetUIntData(1);
+    ref<uint16>(12 * i + 0x10) = _sql->GetUIntData(2) ? _sql->GetUIntData(2) : _sql->GetUIntData(3);
+    i++;
+
+Then the same loop for local trusts.
+
+This is the sort of logic for "resolving" the party members before sending updates to the client:alignas
+
+    CCharEntity* PPartyMember = zoneutils::GetChar(memberinfo.id);
+    if (PPartyMember)
+    {
+        PChar->pushPacket<CPartyMemberUpdatePacket>(PPartyMember, j, memberinfo.flags, PChar->getZone());
+    }
+    else
+    {
+        uint16 zoneid = memberinfo.zone == 0 ? memberinfo.prev_zone : memberinfo.zone;
+        PChar->pushPacket<CPartyMemberUpdatePacket>(memberinfo.id, memberinfo.name, memberinfo.flags, j, zoneid);
+    }
+*/
+
+struct MemberProxy
+{
+    uint32                id{};
+    std::array<uint8, 15> name{};
+    uint16                flags{};
+    uint16                zone{};
+    uint16                prev_zone{};
+
+    bool dirty{};
+};
+constexpr size_t MemberProxySize = sizeof(MemberProxy); // 28 bytes maximum
+
+struct PartyProxy
+{
+    uint32 partyLeaderId;
+
+    // TODO: Type information about the party
+
+    std::array<MemberProxy, 6> members;
+
+    bool dirty{};
+};
+constexpr size_t PartyProxySize = sizeof(PartyProxy); // 172 bytes maximum
+
+struct AllianceProxy
+{
+    uint32 allianceLeaderId;
+
+    // TODO: Type information about the alliance
+
+    std::array<PartyProxy, 3> parties;
+
+    bool dirty{};
+};
+constexpr size_t AllianceProxySize = sizeof(AllianceProxy); // 520 bytes maximum
+
+//
+// Helpers
+//
+
+auto resolveMember(uint32 memberId) -> CCharEntity*
+{
+    // TODO: Use the memberId to collect the member from
+    //     : the respective on-process zone
+}
+
+auto resolveParty(uint32 partyId) -> std::vector<CCharEntity*>
+{
+    // TODO: Use the partyId to collect the party members from
+    //     : their respective on-process zones
+}
+
+auto resolveAlliance(uint32 allianceId) -> std::vector<CCharEntity*>
+{
+    // TODO: Use the allianceId to collect the alliance members from
+    //     : their respective on-process zones
+}


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

My notes and thoughts are in `party_proxy.h`

The skinny is: The map process really don't need much to populate the packets that go to players. Only the content of `partyInfo_t` per member. If we were to serialize a whole alliance update/redefinition - it would only be 520 bytes, chump change for ZMQ and our serialization system.

So, each process that has a party on will have a `PartyProxy`, which will always be kept in line with what's on the world server through complete updates. By asking the party proxy "is this character in the same zone as me" we can swap out the proxy information for the actual entity information. 

Ideas:
- Mob parties and players parties don't need to be the same thing. `MobGroup` as an abstraction makes more sense than trying to jam them into `Party` and `PartyProxy` etc. `MobGroup` is overloaded in the db, so maybe just `MobParty` and `PlayerParty` are unrelated classes with similar names? I suppose the point is that `CBattleEntity*` knows about what "party" an entity is in. What does it need here?
- These flags are probably still useful, could we keep the exact same db layout?
```
enum PARTYFLAG : uint16
{
    PARTY_SECOND    = 0x0001,
    PARTY_THIRD     = 0x0002,
    PARTY_LEADER    = 0x0004,
    ALLIANCE_LEADER = 0x0008,
    PARTY_QM        = 0x0010,
    PARTY_SYNC      = 0x0100,
};
```
- Time member joined
- Leader, SyncTarget, Quartermaster
- PartyNumber, Alliance, PartyLeader, AllianceLeader
- Party EffectFlags packet (easy)
- Interaction with treasurepool

TODO: Better name for party_proxy. 