### PR TITLE
Fixed Ramponneau placeholder to match retail (16D).

### DIFF
--- a/scripts/zones/West_Sarutabaruta_[S]/mobs/Toad.lua
+++ b/scripts/zones/West_Sarutabaruta_[S]/mobs/Toad.lua
@@ -10,7 +10,7 @@ local entity = {}
 
 local ramponneauPHTable =
 {
-    [ID.mob.RAMPONNEAU - 1] = ID.mob.RAMPONNEAU, -- 78.836 -0.109 -199.204
+    [ID.mob.RAMPONNEAU - 4] = ID.mob.RAMPONNEAU, -- 78.836 -0.109 -199.204
 }
 
 entity.onMobDeath = function(mob, player, optParams)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixed Ramponneau placeholder to match retail (16D).

## Steps to test these changes

Utilized addons (renamer & hxui) to confirm which is the correct placeholder. The current/incorrect placeholder spawns at (F-10) in a pack of 10 toads instead of at (I-9)/(I-10) in a pack of 3 toads (one toad appears to be missing?). Once the current/incorrect placeholder is defeated at (F-10) the NM still spawns in its expected location of (I-9)/(I-10), making for a weird experience.
