### PR TITLE
[lua] Hazhalm dialog IDs

### DIFF
--- a/scripts/zones/Hazhalm_Testing_Grounds/IDs.lua
+++ b/scripts/zones/Hazhalm_Testing_Grounds/IDs.lua
@@ -15,8 +15,32 @@ zones[xi.zone.HAZHALM_TESTING_GROUNDS] =
         LOGIN_CAMPAIGN_UNDERWAY       = 7002, -- The [/January/February/March/April/May/June/July/August/September/October/November/December] <number> Login Campaign is currently underway!
         LOGIN_NUMBER                  = 7003, -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.
         MEMBERS_LEVELS_ARE_RESTRICTED = 7023, -- Your party is unable to participate because certain members' levels are restricted.
+        GATE_FIRMLY_CLOSED            = 7226, -- The gate is firmly closed...
         PARTY_MEMBERS_HAVE_FALLEN     = 7611, -- All party members have fallen in battle. Now leaving the battlefield.
         THE_PARTY_WILL_BE_REMOVED     = 7618, -- If all party members' HP are still zero after # minute[/s], the party will be removed from the battlefield.
+        STAGNANT_AURA_CLEARED         = 7995, -- The chamber's stagnant aura has somewhat cleared...
+        CREATURES_CALMED              = 7996, -- The creatures lurking in the shadows have calmed...
+        CREATURES_RESTLESS            = 7997, -- The creatures lurking in the shadows have become restless...
+        FEATHERS_CONSUMED             = 8053, -- All of the valkyrie feathers in your possession are consumed!
+        ENTRY_PROHIBITED              = 8054, -- Entry to the chambers is prohibited for # more Vana'dielian [day/days].
+        MIN_LEVEL_ENTRY               = 8055, -- Adventurers who have yet to reach level <number> will not be permitted entry to the training grounds.
+        RESERVATION_LOCKOUT           = 8056, -- Chamber reservation is prohibited for # more Vana'dielian [day/days].
+        MIN_LEVEL_RESERVATION         = 8057, -- Adventurers who have yet to reach level <number> will not be permitted to make reservations within the training grounds.
+        CHAMBER_OCCUPIED              = 8061, -- Currently, another expedition is occupying [/Rossweisse's Chamber/Grimgerde's Chamber/Siegrune's Chamber/Helmwige's Chamber/Schwertleite's Chamber/Waltraute's Chamber/Ortlinde's Chamber/Gerhilde's Chamber/Brunhilde's Chamber/Odin's Chamber/Odin's Chamber].
+        GLOWING_LAMP_OBTAINED         = 8062, -- Time and destination have been recorded on your <item>.
+        MISSING_FEATHERS              = 8063, -- You do not possess the items required for entry.
+        REQUIREMENTS_UNMET            = 8064, -- You do not meet the requirements for entry.
+        LAMP_POWER_FADED              = 8065, -- he power of the % has faded. You may no longer occupy this chamber.
+        TOO_MANY_ADVENTURERS          = 8067, -- There are too many adventurers in the chamber.
+        TIMEOUT_WARNING               = 8068, -- ---== Warning! ==---- Your reservation of this chamber will end in # [minute/minutes].
+        TIMEOUT_WARNING_SECONDS       = 8069, -- ---== Warning! ==---- Your reservation of this chamber will end in # [second/seconds].
+        EXPEDITION_INCAPACITATED_WARN = 8070, -- All expedition members have been incapacitated. Commencing emergency teleportation in # [minute/minutes].
+        EXPEDITION_INCAPACITATED      = 8071, -- All expedition members have been incapacitated. Commencing emergency teleportation.
+        CHAMBER_CLEARED               = 8074, -- [Rossweisse's Chamber/Grimgerde's Chamber/Siegrune's Chamber/Helmwige's Chamber/Schwertleite's Chamber/Waltraute's Chamber/Ortlinde's Chamber/Gerhilde's Chamber/Brunhilde's Chamber/Odin's Chamber/Odin's Chamber] has been cleared. Commencing teleportation in # [minute/minutes].
+        MEMBERS_ENGAGED_IN_BATTLE     = 8075, -- Other members currently engaged in battle. Entry denied.
+        AMPOULES_OBTAINED             = 8076, -- You obtain <number> ampoule[/s] of viscous therion ichor.
+        GROUP_LEADER_NOT_YET_ENTERED  = 8077, -- The group leader has not yet entered the chamber. Entry denied.
+        CLAIM_RELINQUISH              = 8079, -- Note that your claim over the area through your <item> will be relinquished if over <number> more minute[/s] pass from this point with no one inside.
     },
     mob =
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Daily Einherjar PR. Adds all relevant dialog IDs for Einherjar to Hazhalm.

Ran it through UpdateExtractor several times.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
