### PR TITLE
[core] Adjust getAvailableTrickAttackChar for compiler warning

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4260,42 +4260,32 @@ namespace battleutils
 
         if (taUser->PParty != nullptr)
         {
-            std::vector<CParty*> taPartyList;
-            if (taUser->PParty->m_PAlliance != nullptr)
-            {
-                taPartyList = taUser->PParty->m_PAlliance->partyList;
-            }
-            else
-            {
-                taPartyList.emplace_back(taUser->PParty);
-            }
-
             // Collect all potential TA targets who are closer to the mob than the TA user
-            for (auto&& party : taPartyList)
-            {
-                for (auto&& PMember : party->members)
-                {
-                    float distTAtarget = distance(PMember->loc.p, PMob->loc.p);
-                    // require closer target not be closer than .5 yalms (.5*.5=.25 distsquared) to mob
-                    if (distTAtarget >= worldAngleMinDistance && distTAtarget < distTAmob)
-                    {
-                        taTargetList.emplace_back(distTAtarget, PMember);
-                    }
 
-                    if (auto* PChar = dynamic_cast<CCharEntity*>(PMember))
+            // clang-format off
+            taUser->ForAlliance([&PMob, distTAmob, &taTargetList](CBattleEntity* PMember)
+            {
+                float distTAtarget = distance(PMember->loc.p, PMob->loc.p);
+                // require closer target not be closer than .5 yalms (.5*.5=.25 distsquared) to mob
+                if (distTAtarget >= worldAngleMinDistance && distTAtarget < distTAmob)
+                {
+                    taTargetList.emplace_back(distTAtarget, PMember);
+                }
+
+                if (auto* PChar = dynamic_cast<CCharEntity*>(PMember))
+                {
+                    for (auto* PTrust : PChar->PTrusts)
                     {
-                        for (auto* PTrust : PChar->PTrusts)
+                        distTAtarget = distance(PTrust->loc.p, PMob->loc.p);
+                        // require closer target not be closer than .5 yalms (.5*.5=.25 distsquared) to mob
+                        if (distTAtarget >= worldAngleMinDistance && distTAtarget < distTAmob)
                         {
-                            float distTAtarget = distance(PTrust->loc.p, PMob->loc.p);
-                            // require closer target not be closer than .5 yalms (.5*.5=.25 distsquared) to mob
-                            if (distTAtarget >= worldAngleMinDistance && distTAtarget < distTAmob)
-                            {
-                                taTargetList.emplace_back(distTAtarget, PTrust);
-                            }
+                            taTargetList.emplace_back(distTAtarget, PTrust);
                         }
                     }
                 }
-            }
+            });
+            // clang-format on
         }
 
         // Check TA user's fellow


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

gcc was complaining about this:

```
In member function ‘deallocate’,
    inlined from ‘deallocate’ at /usr/include/c++/14/bits/allocator.h:208:0,
    inlined from ‘deallocate’ at /usr/include/c++/14/bits/alloc_traits.h:513:0,
    inlined from ‘_M_deallocate’ at /usr/include/c++/14/bits/stl_vector.h:389:0,
    inlined from ‘_M_deallocate’ at /usr/include/c++/14/bits/stl_vector.h:385:7,
    inlined from ‘__dt_base ’ at /usr/include/c++/14/bits/stl_vector.h:368:15,
    inlined from ‘__dt_base ’ at /usr/include/c++/14/bits/stl_vector.h:738:7,
    inlined from ‘getAvailableTrickAttackChar’ at /home/casey/dev/server/src/map/utils/battleutils.cpp:4300:9:
/usr/include/c++/14/bits/new_allocator.h:172: warning: ‘operator delete’ called on pointer ‘_214’ with nonzero offset [1, 9223372036854775800] [-Wfree-nonheap-object]
  172 |         _GLIBCXX_OPERATOR_DELETE(_GLIBCXX_SIZED_DEALLOC(__p, __n));
In member function ‘allocate’,
    inlined from ‘allocate’ at /usr/include/c++/14/bits/allocator.h:196:40,
    inlined from ‘allocate’ at /usr/include/c++/14/bits/alloc_traits.h:478:28,
    inlined from ‘_M_allocate’ at /usr/include/c++/14/bits/stl_vector.h:380:33,
    inlined from ‘_M_allocate_and_copy’ at /usr/include/c++/14/bits/stl_vector.h:1621:40,
    inlined from ‘operator=’ at /usr/include/c++/14/bits/vector.tcc:238:44,
    inlined from ‘getAvailableTrickAttackChar’ at /home/casey/dev/server/src/map/utils/battleutils.cpp:4267:60:
/usr/include/c++/14/bits/new_allocator.h:151: note: returned from ‘operator new’
  151 |         return static_cast<_Tp*>(_GLIBCXX_OPERATOR_NEW(__n * sizeof(_Tp)));
  ```
  
  There was probably some bad juju occuring here:
  ```
             std::vector<CParty*> taPartyList;
            if (taUser->PParty->m_PAlliance != nullptr)
            {
                taPartyList = taUser->PParty->m_PAlliance->partyList; <--- copies a pointer(?)
            }
            else
            {
                taPartyList.emplace_back(taUser->PParty);
            }
```

## Steps to test these changes

Check that TA works on trusts/players
