### PR TITLE
[core] Only join messageThread if it is joinable

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -465,7 +465,10 @@ void do_final(int code)
     trustutils::FreeTrustList();
     zoneutils::FreeZoneList();
 
-    messageThread.join();
+    if (messageThread.joinable())
+    {
+        messageThread.join();
+    }
 
     CTaskMgr::delInstance();
     CVanaTime::delInstance();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

trying to join a thread that is not joinable crashes, so check if the thread is joinable first

## Steps to test these changes

start xi_map, `exit` in commandline, see it not crash