### PR TITLE
Core: Improve logging from watchdog

### DIFF
--- a/settings/default/logging.lua
+++ b/settings/default/logging.lua
@@ -44,7 +44,6 @@ xi.settings.logging =
     LOG_LUA     = true, -- Prints from Lua using `print()`
 
     -- Specific Debug loggers
-    -- NOTE: None of these will print unless you also have the above LOG_DEBUG setting set to true!
     DEBUG_SOCKETS        = false, -- Calls in C++: DebugSockets(...)
     DEBUG_IPC            = false, -- Calls in C++: DebugIPC(...)
     DEBUG_NAVMESH        = false, -- Calls in C++: DebugNavmesh(...)

--- a/src/common/console_service.cpp
+++ b/src/common/console_service.cpp
@@ -150,6 +150,12 @@ ConsoleService::ConsoleService()
         crash();
     });
 
+    RegisterCommand("throw", "Throw an exception from the console worker thread",
+    [](std::vector<std::string>& inputs)
+    {
+        throw std::runtime_error("Exception thrown from console command (from worker thread)");
+    });
+
     RegisterCommand("db", "Run both a query and a prepared statement to test the database connection",
     [](std::vector<std::string>& inputs)
     {

--- a/src/common/macros.h
+++ b/src/common/macros.h
@@ -102,3 +102,8 @@
 #define _gmtime_s(a, b)    gmtime_s(a, b)
 #define _localtime_s(a, b) localtime_s(a, b)
 #endif
+
+// MSVC doesn't have __PRETTY_FUNCTION__ so we use an equivalent
+#if defined(_MSC_VER)
+#define __PRETTY_FUNCTION__ __FUNCSIG__
+#endif

--- a/src/map/navmesh.cpp
+++ b/src/map/navmesh.cpp
@@ -262,6 +262,8 @@ std::vector<pathpoint_t> CNavMesh::findPath(const position_t& start, const posit
         return {};
     }
 
+    DebugNavmesh("CNavMesh::findPath (%f, %f, %f) -> (%f, %f, %f) (%u)", start.x, start.y, start.z, end.x, end.y, end.z, m_zoneID);
+
     std::vector<pathpoint_t> ret{};
     dtStatus                 status = 0;
 
@@ -363,6 +365,8 @@ std::pair<int16, position_t> CNavMesh::findRandomPosition(const position_t& star
         return {};
     }
 
+    DebugNavmesh("CNavMesh::findRandomPosition (%f, %f, %f) (%u)", start.x, start.y, start.z, m_zoneID);
+
     dtStatus status = 0;
 
     float spos[3];
@@ -435,6 +439,8 @@ bool CNavMesh::validPosition(const position_t& position)
         return true;
     }
 
+    DebugNavmesh("CNavMesh::validPosition (%f, %f, %f) (%u)", position.x, position.y, position.z, m_zoneID);
+
     float spos[3];
     CNavMesh::ToDetourPos(&position, spos);
 
@@ -465,6 +471,8 @@ bool CNavMesh::findClosestValidPoint(const position_t& position, float* validPoi
         return true;
     }
 
+    DebugNavmesh("CNavMesh::findClosestValidPoint (%f, %f, %f) (%u)", position.x, position.y, position.z, m_zoneID);
+
     float spos[3];
     CNavMesh::ToDetourPos(&position, spos);
 
@@ -493,6 +501,8 @@ bool CNavMesh::findFurthestValidPoint(const position_t& startPosition, const pos
     {
         return true;
     }
+
+    DebugNavmesh("CNavMesh::findFurthestValidPoint (%f, %f, %f) -> (%f, %f, %f) (%u)", startPosition.x, startPosition.y, startPosition.z, endPosition.x, endPosition.y, endPosition.z, m_zoneID);
 
     float spos[3];
     CNavMesh::ToDetourPos(&startPosition, spos);
@@ -536,6 +546,8 @@ void CNavMesh::snapToValidPosition(position_t& position)
         return;
     }
 
+    DebugNavmesh("CNavMesh::snapToValidPosition (%f, %f, %f) (%u)", position.x, position.y, position.z, m_zoneID);
+
     float spos[3];
     CNavMesh::ToDetourPos(&position, spos);
 
@@ -573,6 +585,8 @@ bool CNavMesh::onSameFloor(const position_t& start, float* spos, const position_
     {
         return true;
     }
+
+    DebugNavmesh("CNavMesh::onSameFloor (%f, %f, %f) -> (%f, %f, %f) (%u)", start.x, start.y, start.z, end.x, end.y, end.z, m_zoneID);
 
     float verticalDistance = abs(start.y - end.y);
     if (verticalDistance > 2 * verticalLimit)
@@ -641,6 +655,8 @@ bool CNavMesh::raycast(const position_t& start, const position_t& end)
     {
         return true;
     }
+
+    DebugNavmesh("CNavMesh::raycast (%f, %f, %f) -> (%f, %f, %f) (%u)", start.x, start.y, start.z, end.x, end.y, end.z, m_zoneID);
 
     dtStatus status = 0;
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- ALL logging reports to the backtrace ALL the time.
- Console service is set up before modules, so you can add commands now if you want
- More debug logging in navmesh, to catch if that's the cause of watchdog crashes
- Gets rid of `std::raise(SIGKILL);`, since it's called from the non-main thread and results in unhandled death on Windows

## Steps to test these changes

Inject thread sleeps, see the watchdog fire and produce more logging.