### PR TITLE
[cpp] Resolve issue with gear missing rslotlook value for lockstyles

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -2388,6 +2388,11 @@ namespace charutils
             }
 
             auto removeSlotID = PItem->getRemoveSlotLookId();
+            // Some of the items don't have rslotlook set so we fall back on rslot to know which part to hide
+            if (removeSlotID == 0)
+            {
+                removeSlotID = PItem->getRemoveSlotId();
+            }
             if (removeSlotID > 0)
             {
                 for (auto i = 4u; i <= 8u; i++)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
When the function UpdateRemovedSlotsLookForLockStyle (in charutils.cpp) is called, removeSlotID is 0 for certain cosmetic items that should instead hide the look of certain parts when used for lockstyle.

The function currently fetches the value with  PItem->getRemoveSlotLookId(); from rslotlook in the DB.
With this change, it checks that value first, and if the result is 0 then it checks the rslot value used also in the EquipArmor (here only used to apply the correct look)

In short, if in the DB  rslotlook is 0, it checks in the column rslot which is also used in the function EquipArmor to both remove the "unequippable slot" and the "look", in this case we just remove the look.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- Create a lockstyle set with equip that take more than 1 equipement slot and that have their rslotlook variable set to 0 in the DB.
- Apply the lockstyle and verify that the looks of correct slots are hidden
- Try to change different equipment in the actual equipment window and confirm there are no conflicts or other incorrect displaying.
