### PR TITLE
[lua] Fixed Saurumugue Zone pos

### DIFF
--- a/scripts/zones/Sauromugue_Champaign/Zone.lua
+++ b/scripts/zones/Sauromugue_Champaign/Zone.lua
@@ -25,7 +25,7 @@ zoneObject.onZoneIn = function(player, prevZone)
         player:getYPos() == 0 and
         player:getZPos() == 0
     then
-        player:setPos(-571, 1, 339, 7)
+        player:setPos(-574.647, 2.3231, 399.974, 7)
     end
 
     if quests.rainbow.onZoneIn(player) then


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Changes the zone in position when using GM command !zone from inside a rock to zone line.

## Steps to test these changes

!zone 120

Old:
![xiloader_QPyuhhXugE](https://github.com/user-attachments/assets/1672052b-d177-4f75-8e85-18ad9c238cc1)
![xiloader_98Ogyx7FlB](https://github.com/user-attachments/assets/4ba60a9b-5fd0-4c2c-bb1a-0e4103a45ec6)

New:

![xiloader_xAKZxBL8hA](https://github.com/user-attachments/assets/38f6404c-0db1-4856-ae46-d455d37c014c)
![xiloader_5O9XpH7kQh](https://github.com/user-attachments/assets/1ca50d18-16ea-4932-abb1-3e45e7d38219)

