### PR TITLE
[interaction] SoA "Balamors Ruse" onMobDeath additional safety and fixes

### DIFF
--- a/scripts/missions/soa/4_6_0_Balamors_Ruse.lua
+++ b/scripts/missions/soa/4_6_0_Balamors_Ruse.lua
@@ -16,16 +16,18 @@ mission.reward =
 local keyItemOnMobDeath =
 {
     onMobDeath = function(mob, player, optParams)
-        -- TODO: Mobs that grant this KI and the rate in which it drops needs to be measured further.  This
-        -- is currently set to a lower value than observed in capture.
-
-        if math.random(1, 100) <= 20 then
-            local playerZoneID = player:getZoneID()
+        -- TODO: Mobs that grant this KI and the rate in which it drops needs to be measured further.
+        if
+            player and                                     -- We need it to fetch the party.
+            (optParams.isKiller or optParams.noKiller) and -- Only run once, not once per party member
+            math.random(1, 100) <= 20                      -- This is currently set to a lower value than observed in capture.
+        then
+            local zoneID = mob:getZoneID() -- Fetch the zoneId of the mob to ensure correct zone in case of no killer.
 
             for _, partyMember in ipairs(player:getParty()) do
                 if
-                    partyMember:getZoneID() == playerZoneID and
-                    partyMember:getCurrentMission(xi.mission.log_id.SOA) == xi.mission.id.soa.THE_CHARLATAN
+                    partyMember:getZoneID() == zoneID and
+                    partyMember:getCurrentMission(xi.mission.log_id.SOA) == xi.mission.id.soa.BALAMORS_RUSE
                 then
                     npcUtil.giveKeyItem(partyMember, xi.ki.CONSUMMATE_SIMULACRUM)
                 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Fix mission checked from `THE_CHARLATAN` to `BALAMORS_RUSE`
- Ensure the logic is only run once and not once per entity in hate list. Adjust logic to account for it.

## Steps to test these changes

Do mission with several members.
