### PR TITLE
[core] Send item exdata on trade

### DIFF
--- a/src/map/packets/trade_update.cpp
+++ b/src/map/packets/trade_update.cpp
@@ -59,6 +59,6 @@ CTradeUpdatePacket::CTradeUpdatePacket(CItem* PItem, uint8 SlotID)
     }
     else
     {
-        std::memcpy(buffer_.data() + 0x1A, PItem->getSignature().c_str(), std::min<size_t>(PItem->getSignature().size(), 12));
+        std::memcpy(buffer_.data() + 0x0E, PItem->m_extra, std::min<size_t>(CItem::extra_size, 24));
     }
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Sends the full CItem m_extra array in packet when trading. 
Currently only a subset is sent (craft signature), making certain items render improperly on the receiving end.

![Screenshot 2025-03-17 052657](https://github.com/user-attachments/assets/55612ee3-f839-46e8-8fda-65e7bc77c98e)

![Screenshot 2025-03-17 052647](https://github.com/user-attachments/assets/49426fdf-8d20-4d7f-aff3-846c55a5e162)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

![Screenshot 2025-03-17 052252](https://github.com/user-attachments/assets/d9c9e915-96c4-4aaf-982b-1c9f217e63c2)
![Screenshot 2025-03-17 052314](https://github.com/user-attachments/assets/a183b121-5c2a-48c2-ba25-3926d2dc79bb)
![Screenshot 2025-03-17 052300](https://github.com/user-attachments/assets/165e0e6f-4ef0-4e10-8d23-64275004dadc)

<!-- Clear and detailed steps to test your changes here -->
