### PR TITLE
[core] Bazaar displays item exdata

### DIFF
--- a/src/map/packets/bazaar_item.cpp
+++ b/src/map/packets/bazaar_item.cpp
@@ -55,7 +55,9 @@ CBazaarItemPacket::CBazaarItemPacket(CItem* PItem, uint8 SlotID, uint16 Tax)
             ref<uint32>(0x15) = nextUseTime;
             ref<uint32>(0x19) = ((CItemUsable*)PItem)->getUseDelay() + currentTime;
         }
-        // 12? characters? seems a bit short. TODO: research this.
-        std::memcpy(buffer_.data() + 0x1D, PItem->getSignature().c_str(), std::min<size_t>(PItem->getSignature().size(), 12));
+        else
+        {
+            std::memcpy(buffer_.data() + 0x11, PItem->m_extra, std::min<size_t>(CItem::extra_size, 24));
+        }
     }
 }

--- a/src/map/packets/trade_update.cpp
+++ b/src/map/packets/trade_update.cpp
@@ -49,7 +49,7 @@ CTradeUpdatePacket::CTradeUpdatePacket(CItem* PItem, uint8 SlotID)
             ref<uint8>(0x0F) = ((CItemUsable*)PItem)->getCurrentCharges();
         }
     }
-    if (PItem->isType(ITEM_LINKSHELL))
+    else if (PItem->isType(ITEM_LINKSHELL))
     {
         ref<uint32>(0x0E) = ((CItemLinkshell*)PItem)->GetLSID();
         ref<uint16>(0x14) = ((CItemLinkshell*)PItem)->GetLSRawColor();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Same as #7247, send the whole m_extra array in Bazaar Item packets.
Also fixes the TradeUpdate packet to not overwrite exdata for charged items.

![Screenshot 2025-03-17 053441](https://github.com/user-attachments/assets/6759f5fb-f963-4a21-95c3-ce109033c006)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

![Screenshot 2025-03-17 204019](https://github.com/user-attachments/assets/9f85c2c1-30b8-4a8a-9680-002fb9597e86)
![Screenshot 2025-03-17 204026](https://github.com/user-attachments/assets/b0444861-4800-4f1f-a55c-4e724b2b8857)
![Screenshot 2025-03-17 204032](https://github.com/user-attachments/assets/517951eb-0306-4455-805a-3078c0495bdf)
![Screenshot 2025-03-17 204038](https://github.com/user-attachments/assets/32086873-904c-4df0-b389-f6aab0d0ba07)

<!-- Clear and detailed steps to test your changes here -->
