### PR TITLE
[core] Reintroduce messageType support over IPC chat msg

### DIFF
--- a/src/common/ipc_structs.h
+++ b/src/common/ipc_structs.h
@@ -72,22 +72,24 @@ namespace ipc
 
     struct ChatMessageParty
     {
-        uint32      partyId{};
-        uint32      senderId{};
-        std::string senderName{};
-        std::string message{};
-        uint16      zoneId{};
-        uint8       gmLevel{};
+        uint32            partyId{};
+        uint32            senderId{};
+        std::string       senderName{};
+        std::string       message{};
+        uint16            zoneId{};
+        uint8             gmLevel{};
+        CHAT_MESSAGE_TYPE messageType{ MESSAGE_PARTY };
     };
 
     struct ChatMessageAlliance
     {
-        uint32      allianceId{};
-        uint32      senderId{};
-        std::string senderName{};
-        std::string message{};
-        uint16      zoneId{};
-        uint8       gmLevel{};
+        uint32            allianceId{};
+        uint32            senderId{};
+        std::string       senderName{};
+        std::string       message{};
+        uint16            zoneId{};
+        uint8             gmLevel{};
+        CHAT_MESSAGE_TYPE messageType{ MESSAGE_PARTY };
     };
 
     struct ChatMessageLinkshell
@@ -102,30 +104,33 @@ namespace ipc
 
     struct ChatMessageUnity
     {
-        uint32      unityLeaderId{};
-        uint32      senderId{};
-        std::string senderName{};
-        std::string message{};
-        uint16      zoneId{};
-        uint8       gmLevel{};
+        uint32            unityLeaderId{};
+        uint32            senderId{};
+        std::string       senderName{};
+        std::string       message{};
+        uint16            zoneId{};
+        uint8             gmLevel{};
+        CHAT_MESSAGE_TYPE messageType{ MESSAGE_UNITY };
     };
 
     struct ChatMessageYell
     {
-        uint32      senderId{};
-        std::string senderName{};
-        std::string message{};
-        uint16      zoneId{};
-        uint8       gmLevel{};
+        uint32            senderId{};
+        std::string       senderName{};
+        std::string       message{};
+        uint16            zoneId{};
+        uint8             gmLevel{};
+        CHAT_MESSAGE_TYPE messageType{ MESSAGE_YELL };
     };
 
     struct ChatMessageServerMessage
     {
-        uint32      senderId{};
-        std::string senderName{};
-        std::string message{};
-        uint16      zoneId{};
-        uint8       gmLevel{};
+        uint32            senderId{};
+        std::string       senderName{};
+        std::string       message{};
+        uint16            zoneId{};
+        uint8             gmLevel{};
+        CHAT_MESSAGE_TYPE messageType{ MESSAGE_SYSTEM_1 };
     };
 
     struct ChatMessageCustom

--- a/src/map/ipc_client.cpp
+++ b/src/map/ipc_client.cpp
@@ -233,7 +233,7 @@ void IPCClient::handleMessage_ChatMessageParty(const IPP& ipp, const ipc::ChatMe
     });
     if (PParty)
     {
-        PParty->PushPacket(message.senderId, 0, std::make_unique<CChatMessagePacket>(message.senderName, message.zoneId, MESSAGE_PARTY, message.message, message.gmLevel));
+        PParty->PushPacket(message.senderId, 0, std::make_unique<CChatMessagePacket>(message.senderName, message.zoneId, message.messageType, message.message, message.gmLevel));
     }
     // clang-format on
 }
@@ -268,7 +268,7 @@ void IPCClient::handleMessage_ChatMessageAlliance(const IPP& ipp, const ipc::Cha
     {
         for (const auto& currentParty : PAlliance->partyList)
         {
-            currentParty->PushPacket(message.senderId, 0, std::make_unique<CChatMessagePacket>(message.senderName, message.zoneId, MESSAGE_PARTY, message.message, message.gmLevel));
+            currentParty->PushPacket(message.senderId, 0, std::make_unique<CChatMessagePacket>(message.senderName, message.zoneId, message.messageType, message.message, message.gmLevel));
         }
     }
     // clang-format on
@@ -291,7 +291,7 @@ void IPCClient::handleMessage_ChatMessageUnity(const IPP& ipp, const ipc::ChatMe
 
     if (CUnityChat* PUnityChat = unitychat::GetUnityChat(message.unityLeaderId))
     {
-        PUnityChat->PushPacket(message.senderId, std::make_unique<CChatMessagePacket>(message.senderName, message.zoneId, MESSAGE_UNITY, message.message, message.gmLevel));
+        PUnityChat->PushPacket(message.senderId, std::make_unique<CChatMessagePacket>(message.senderName, message.zoneId, message.messageType, message.message, message.gmLevel));
     }
 }
 
@@ -309,7 +309,7 @@ void IPCClient::handleMessage_ChatMessageYell(const IPP& ipp, const ipc::ChatMes
                 // Don't push to sender
                 if (PChar->id != message.senderId)
                 {
-                    PChar->pushPacket(std::make_unique<CChatMessagePacket>(message.senderName, message.zoneId, MESSAGE_YELL, message.message, message.gmLevel));
+                    PChar->pushPacket(std::make_unique<CChatMessagePacket>(message.senderName, message.zoneId, message.messageType, message.message, message.gmLevel));
                 }
             });
         }
@@ -326,7 +326,7 @@ void IPCClient::handleMessage_ChatMessageServerMessage(const IPP& ipp, const ipc
     {
         PZone->ForEachChar([&](CCharEntity* PChar)
         {
-            PChar->pushPacket(std::make_unique<CChatMessagePacket>(message.senderName, message.zoneId, MESSAGE_SYSTEM_1, message.message, message.gmLevel));
+            PChar->pushPacket(std::make_unique<CChatMessagePacket>(message.senderName, message.zoneId, message.messageType, message.message, message.gmLevel));
         });
     });
     // clang-format on

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -346,70 +346,64 @@ void CLuaBaseEntity::printToArea(std::string const& message, sol::object const& 
 
     if (messageRange == MESSAGE_AREA_SYSTEM)
     {
-        // TODO: Support messageLook
-
         message::send(ipc::ChatMessageServerMessage{
-            .senderId   = PChar->id,
-            .senderName = name,
-            .message    = message,
+            .senderId    = PChar->id,
+            .senderName  = name,
+            .message     = message,
+            .messageType = messageLook,
         });
     }
     else if (messageRange == MESSAGE_AREA_SAY)
     {
-        PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, std::make_unique<CChatMessagePacket>(PChar, messageLook, message, name));
         PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, std::make_unique<CChatMessagePacket>(PChar, messageLook, message, name));
     }
     else if (messageRange == MESSAGE_AREA_SHOUT)
     {
         PChar->loc.zone->PushPacket(PChar, CHAR_INSHOUT, std::make_unique<CChatMessagePacket>(PChar, messageLook, message, name));
-        PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, std::make_unique<CChatMessagePacket>(PChar, messageLook, message, name));
+        PChar->pushPacket(std::make_unique<CChatMessagePacket>(PChar, messageLook, message, name));
     }
     else if (messageRange == MESSAGE_AREA_PARTY)
     {
-        if (PChar->PParty->m_PAlliance)
+        if (PChar->PParty && PChar->PParty->m_PAlliance)
         {
-            // TODO: Support messageLook
-
             message::send(ipc::ChatMessageAlliance{
-                .allianceId = PChar->PParty->m_PAlliance->m_AllianceID,
-                .senderId   = PChar->id,
-                .senderName = name,
-                .message    = message,
+                .allianceId  = PChar->PParty->m_PAlliance->m_AllianceID,
+                .senderId    = PChar->id,
+                .senderName  = name,
+                .message     = message,
+                .messageType = messageLook,
             });
         }
         else if (PChar->PParty)
         {
-            // TODO: Support messageLook
-
             message::send(ipc::ChatMessageParty{
-                .partyId    = PChar->PParty->GetPartyID(),
-                .senderId   = PChar->id,
-                .senderName = name,
-                .message    = message,
+                .partyId     = PChar->PParty->GetPartyID(),
+                .senderId    = PChar->id,
+                .senderName  = name,
+                .message     = message,
+                .messageType = messageLook,
             });
         }
     }
     else if (messageRange == MESSAGE_AREA_YELL)
     {
-        // TODO: Support messageLook
-
         message::send(ipc::ChatMessageYell{
-            .senderId   = PChar->id,
-            .senderName = name,
-            .message    = message,
+            .senderId    = PChar->id,
+            .senderName  = name,
+            .message     = message,
+            .messageType = messageLook,
         });
 
         PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, std::make_unique<CChatMessagePacket>(PChar, messageLook, message, name));
     }
     else if (messageRange == MESSAGE_AREA_UNITY)
     {
-        // TODO: Support messageLook
-
         message::send(ipc::ChatMessageUnity{
             .unityLeaderId = PChar->id,
             .senderId      = PChar->id,
             .senderName    = name,
             .message       = message,
+            .messageType   = messageLook,
         });
 
         PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, std::make_unique<CChatMessagePacket>(PChar, messageLook, message, name));


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
IPC changes dropped support for specifying messageLook in chat messages.

This is used in player:printToArea to print an arbitrary message type to a specific scope. (i.e. printing a yell message to all members of a party, or printing a SYSTEM_3 msg to all players on server)

Made a couple fixes to the binding while I was at it, one null check was missing and certain packets were duplicated.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

!exec player:printToArea("Test", xi.msg.channel.UNITY, xi.msg.area.SYSTEM)
!exec player:printToArea("Im a real boy!", xi.msg.channel.SHOUT, xi.msg.area.SYSTEM, "Pinocchio")

<!-- Clear and detailed steps to test your changes here -->
