### PR TITLE
[lua] Bug Fix Quest "To Cure a Cough"

### DIFF
--- a/scripts/zones/Southern_San_dOria/npcs/Amaura.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Amaura.lua
@@ -11,7 +11,7 @@ entity.onTrigger = function(player, npc)
     local toCureaCough = player:getQuestStatus(xi.questLog.SANDORIA, xi.quest.id.sandoria.TO_CURE_A_COUGH)
 
     if
-        player:getCharVar('DiaryPage') == 3 or
+        player:getCharVar('DiaryPage') >= 3 or
         toCureaCough == xi.questStatus.QUEST_ACCEPTED
     then
         if


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a bug where if the player reads the 4th page of the diary the quest gets hard locked and the player is unable to progress.

## Steps to test these changes

Complete Quest "The Trader in the Forest" ``!completequest 0 7``
Complete Quest "The Medicine Woman" ``!compeltequest 0 30``
Complete the quest as normal. When reading the diary read up to page 4 and continue the quest.
