### PR TITLE
[core] Proper type for SQL-retrieved mob behavior flag

### DIFF
--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -477,7 +477,7 @@ namespace zoneutils
                             mainWeapon->setDelay((rset->get<uint16>("cmbDelay") * 1000) / 60);
                             mainWeapon->setBaseDelay((rset->get<uint16>("cmbDelay") * 1000) / 60);
 
-                            PMob->m_Behavior    = static_cast<BEHAVIOR>(rset->get<uint8>("behavior"));
+                            PMob->m_Behavior    = rset->get<uint16>("behavior");
                             PMob->m_Link        = rset->get<uint32>("links");
                             PMob->m_Type        = static_cast<MOBTYPE>(rset->get<uint32>("mobType"));
                             PMob->m_Immunity    = rset->get<uint32>("immunity");


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Ensures we get behavior from mob_pools as a uint16 instead of uint8 cast to BEHAVIOR

```
enum BEHAVIOR : uint16
{
    BEHAVIOR_NONE         = 0x000,
    BEHAVIOR_NO_DESPAWN   = 0x001, // mob does not despawn on death
    BEHAVIOR_STANDBACK    = 0x002, // mob will standback forever
    BEHAVIOR_RAISABLE     = 0x004, // mob can be raised via Raise spells
    BEHAVIOR_NOHELP       = 0x008, // mob can not be targeted by helpful magic from players (cure, protect, etc)
    BEHAVIOR_AGGRO_AMBUSH = 0x200, // mob aggroes by ambush
    BEHAVIOR_NO_TURN      = 0x400  // mob does not turn to face target
};
```

Noticed large mobs (Nidhogg/KB) with BEHAVIOR_NO_TURN were always facing the player and discovered the flag was never correctly set. Probably fixes a whole lot of other bugs!

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Spawn Nidhogg, ensure Nidhogg does not turn, inspect m_Behavior

<!-- Clear and detailed steps to test your changes here -->
