### PR TITLE
[lua, sql] Fix Lamia weapon breaking/weapon skills

### DIFF
--- a/scripts/actions/mobskills/arrow_deluge.lua
+++ b/scripts/actions/mobskills/arrow_deluge.lua
@@ -9,7 +9,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getAnimationSub() == 0 and mob:getMainJob() == xi.job.RNG then
+    if mob:getAnimationSub() ~= 1 and mob:getMainJob() == xi.job.RNG then
         return 0
     else
         return 1

--- a/scripts/actions/mobskills/grim_reaper.lua
+++ b/scripts/actions/mobskills/grim_reaper.lua
@@ -11,7 +11,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getAnimationSub() == 0 then
+    if mob:getAnimationSub() ~= 1 then
         return 0
     end
 

--- a/scripts/actions/mobskills/gusting_gouge.lua
+++ b/scripts/actions/mobskills/gusting_gouge.lua
@@ -10,7 +10,7 @@ local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
     if
-        mob:getAnimationSub() == 0 and
+        mob:getAnimationSub() ~= 1 and
         (
             mob:getMainJob() == xi.job.COR or
             mob:getMainJob() == xi.job.BRD or

--- a/scripts/actions/mobskills/pole_swing.lua
+++ b/scripts/actions/mobskills/pole_swing.lua
@@ -12,7 +12,7 @@ local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
     if
-        mob:getAnimationSub() == 0 and
+        mob:getAnimationSub() ~= 1 and
         (mob:getMainJob() == xi.job.SMN or mob:getMainJob() == xi.job.BLM)
     then
         return 0

--- a/scripts/actions/mobskills/tidal_slash.lua
+++ b/scripts/actions/mobskills/tidal_slash.lua
@@ -9,7 +9,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getAnimationSub() == 0 and mob:getMainJob() == xi.job.SAM then
+    if mob:getAnimationSub() ~= 1 and mob:getMainJob() == xi.job.SAM then
         return 0
     else
         return 1

--- a/scripts/mixins/weapon_break.lua
+++ b/scripts/mixins/weapon_break.lua
@@ -21,7 +21,7 @@ g_mixins.weapon_break = function(weaponBreakMob)
             local animationSub = mob:getAnimationSub()
 
             -- break weapon
-            if animationSub == 0 then
+            if animationSub ~= 1 then
                 mob:setAnimationSub(1)
             end
         end

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -703,7 +703,7 @@ INSERT INTO `mob_skill_lists` VALUES ('Lamiae',171,1761); -- arrow_deluge
 -- INSERT INTO `mob_skill_lists` VALUES ('Lamiae',171,1812); -- pw_pinning_shot
 -- INSERT INTO `mob_skill_lists` VALUES ('Lamiae',171,1813); -- pw_calcifying_deluge
 -- INSERT INTO `mob_skill_lists` VALUES ('Lamiae',171,1814); -- pw_gorgon_dance
--- INSERT INTO `mob_skill_lists` VALUES ('Lamiae',171,1929); -- pole_swing
+INSERT INTO `mob_skill_lists` VALUES ('Lamiae',171,1929); -- pole_swing
 -- INSERT INTO `mob_skill_lists` VALUES ('Lamiae',171,1930); -- tidal_slash
 INSERT INTO `mob_skill_lists` VALUES ('Leech',172,414);
 INSERT INTO `mob_skill_lists` VALUES ('Leech',172,415);

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1943,7 +1943,7 @@ INSERT INTO `mob_skills` VALUES (1925,1269,'stave_toss',0,0.0,15.0,2000,1500,4,0
 -- INSERT INTO `mob_skills` VALUES (1926,1270,'groundburst',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1927,1671,'.',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1928,1672,'.',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1929,1278,'pole_swing',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1929,1278,'pole_swing',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1930,1279,'tidal_slash',4,0.0,10.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1931,1280,'eagle_eye_shot',0,0.0,25.0,2000,0,4,2,0,0,0,0,0); -- lamiae
 INSERT INTO `mob_skills` VALUES (1932,16,'eagle_eye_shot',0,0.0,25.0,2000,0,4,2,0,0,0,0,0); -- swift shot ??


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Changes weapon break mixin to account for mobs that don't have 0 as the default sub anim, changes Lamia WS to be usable regardless of default sub anim so that they use the correct weapon skills before/after breaking weapons. Removed comment from Lamia mob skill list so they correctly use Pole Swing now.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

`!gotoid 16998421`
`!immortal` on the Lamia
`!tp 3000` to the target Lamia
`!addeffect mighty_strikes` (So you crit and break weapon)
`!tp 3000` to the target Lamia
See that the Lamia's weapon breaks and their TP ability usage changes as intended.
