### PR TITLE
[lua] Add mission acceptance text ID for Heaven's Tower

### DIFF
--- a/scripts/zones/Heavens_Tower/IDs.lua
+++ b/scripts/zones/Heavens_Tower/IDs.lua
@@ -22,6 +22,7 @@ zones[xi.zone.HEAVENS_TOWER] =
         MEMBERS_LEVELS_ARE_RESTRICTED = 7193, -- Your party is unable to participate because certain members' levels are restricted.
         YOU_LEARNED_TRUST             = 7195, -- You learned Trust: <name>!
         CALL_MULTIPLE_ALTER_EGO       = 7196, -- You are now able to call multiple alter egos.
+        YOU_ACCEPT_THE_MISSION        = 7332, -- You have accepted the mission.
         FISHING_MESSAGE_OFFSET        = 7385, -- You can't fish here.
         CELEBRATORY_GOODS             = 9118, -- An assortment of celebratory goods is available for purchase.
         OBTAINED_NUM_KEYITEMS         = 9196, -- Obtained key item: <number> <keyitem>!


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds missing text ID for if the player accepts a mission in Heaven's Tower.
![image](https://github.com/user-attachments/assets/8fd6e406-199d-45e4-a1df-ca0aff0b02a4)

Used in all Windurst Missions:
``player:messageSpecial(zones[zoneId].text.YOU_ACCEPT_THE_MISSION)``

## Steps to test these changes

1. ``!zone <Heaven's Tower>``
2. ``!exec player:messageSpecial(zones[xi.zone.HEAVENS_TOWER].text.YOU_ACCEPT_THE_MISSION)``
3. Alternatively, start a Windurst mission in Heaven's Tower