### PR TITLE
[core] Improve Error Condition in CPartyEffectsPacket

### DIFF
--- a/src/map/packets/party_effects.cpp
+++ b/src/map/packets/party_effects.cpp
@@ -24,23 +24,31 @@
 #include "party.h"
 #include "status_effect_container.h"
 
-CPartyEffectsPacket::CPartyEffectsPacket()
+void CPartyEffectsPacket::AddMemberEffects(std::size_t partyIndex, CCharEntity* PMember)
 {
-    this->setType(0x76);
-    this->setSize(0xF4);
-}
-
-void CPartyEffectsPacket::AddMemberEffects(CBattleEntity* PMember)
-{
-    if (members == 5)
+    // Check for valid party size to prevent buffer being overrun (244 bytes).
+    // When using multiple map processess across different IPs, the latency
+    // in communication combined with players joining/leaving at the same time
+    // can cause the party size to be larger than the packet size.
+    if (partyIndex >= 5)
     {
         ShowWarning("Member count exceeds packet maximum.");
         return;
     }
 
-    ref<uint32>(members * 0x30 + 0x04) = PMember->id;
-    ref<uint16>(members * 0x30 + 0x08) = PMember->targid;
-    ref<uint64>(members * 0x30 + 0x0C) = PMember->StatusEffectContainer->m_Flags;
-    std::memcpy(buffer_.data() + (members * 0x30 + 0x14), PMember->StatusEffectContainer->m_StatusIcons, 32);
-    ++members;
+    ref<uint32>(partyIndex * 0x30 + 0x04) = PMember->id;
+    ref<uint16>(partyIndex * 0x30 + 0x08) = PMember->targid;
+    ref<uint64>(partyIndex * 0x30 + 0x0C) = PMember->StatusEffectContainer->m_Flags;
+    std::memcpy(buffer_.data() + (partyIndex * 0x30 + 0x14), PMember->StatusEffectContainer->m_StatusIcons, 32);
+}
+
+CPartyEffectsPacket::CPartyEffectsPacket(const std::vector<CCharEntity*>& membersList)
+{
+    this->setType(0x76);
+    this->setSize(0xF4);
+
+    for (std::size_t idx = 0; idx < membersList.size(); ++idx)
+    {
+        AddMemberEffects(idx, membersList[idx]);
+    }
 }

--- a/src/map/packets/party_effects.h
+++ b/src/map/packets/party_effects.h
@@ -23,6 +23,7 @@
 #define _CPARTYEFFECTSPACKET_H
 
 #include "common/cbasetypes.h"
+#include "entities/charentity.h"
 
 #include "basic.h"
 
@@ -31,12 +32,9 @@ class CBattleEntity;
 class CPartyEffectsPacket : public CBasicPacket
 {
 public:
-    CPartyEffectsPacket();
-    void AddMemberEffects(CBattleEntity* PMember);
+    explicit CPartyEffectsPacket(const std::vector<CCharEntity*>& membersList);
+    void AddMemberEffects(std::size_t partyIndex, CCharEntity* PMember);
     void AddMemberEffects(uint32 id);
-
-private:
-    int members{ 0 };
 };
 
 #endif

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -1226,8 +1226,9 @@ void CParty::PushEffectsPacket()
 
         for (auto& PMember : members)
         {
-            auto* PMemberChar = static_cast<CCharEntity*>(PMember);
-            auto  effects     = std::make_unique<CPartyEffectsPacket>();
+            auto*                     PMemberChar = static_cast<CCharEntity*>(PMember);
+            std::vector<CCharEntity*> sameZoneMembers;
+
             for (auto& memberinfo : info)
             {
                 if (memberinfo.partyid == m_PartyID && memberinfo.id != PMemberChar->id)
@@ -1235,11 +1236,13 @@ void CParty::PushEffectsPacket()
                     auto* PPartyMember = zoneutils::GetChar(memberinfo.id);
                     if (PPartyMember && PPartyMember->getZone() == PMemberChar->getZone())
                     {
-                        effects->AddMemberEffects(PPartyMember);
+                        sameZoneMembers.push_back(PPartyMember);
                     }
                 }
             }
-            PMemberChar->pushPacket(std::move(effects));
+
+            // Make and send packet for PMemberChar
+            PMemberChar->pushPacket<CPartyEffectsPacket>(sameZoneMembers);
         }
         m_EffectsChanged = false;
     }


### PR DESCRIPTION
Adds in additional checks into AddMemberEffects to account for negatives and values above 5.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Improves error catching logic in `CPartyEffectsPacket`
- Previously, it only accounted for if `members == 5`, but not if the count ever exceeded 5.
- The `members` private member is also a regular `int` type, so added a ` < 0 ` check as a safeguard to prevent it from ever handling a negative number.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
NOTE: This would be extremely difficult to test in practice by ones self.
The goal here is to break the party interface and get an extra player into the party to exceed the 5 member limit specified in the code.  If you successfully exceed >5 members, the error check logic would fail because it was previously only checking for 5.

1 - Login with 8 characters
2 - Fill the party with 5 members
3 - Send out pending invites on players 6-8
4 - Attempt to join Players 6-8 at the same time

NOTE: Even with a bugged party size, the error checking still kicks in.

_Side Note: This was an issue on Horizon that was observed and fixed.  This seemed to be possibly related to slight delays in communication across clustered map server processes on different IPs and the communication between them._