### PR TITLE
Search: Fix condition where nullptr might get printed

### DIFF
--- a/src/search/search_handler.cpp
+++ b/src/search/search_handler.cpp
@@ -780,7 +780,8 @@ search_req search_handler::_HandleSearchRequest()
         }
     }
 
-    ShowInfoFmt("Name: {} Job: {} Lvls: {} ~ {}", (nameLen > 0 ? name : nullptr), jobid, minLvl, maxLvl);
+    const auto printableName = nameLen > 0 ? name : "<empty>";
+    ShowInfoFmt("Name: {} Job: {} Lvls: {} ~ {}", printableName, jobid, minLvl, maxLvl);
 
     search_req sr;
     sr.jobid  = jobid;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

fmt doesn't like it when you try to give it a nullptr, maybe I'll git it a specialisation for that one day