### PR TITLE
[core] Allow Physical and Ranged Damage Nullification during WS

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2426,6 +2426,16 @@ namespace battleutils
             damage = 0;
         }
 
+        // Handle damage nullification.
+        if (attackType == ATTACK_TYPE::RANGED && xirand::GetRandomNumber(100) < PDefender->getMod(Mod::NULL_RANGED_DAMAGE))
+        {
+            damage = 0;
+        }
+        else if (attackType == ATTACK_TYPE::PHYSICAL && xirand::GetRandomNumber(100) < PDefender->getMod(Mod::NULL_PHYSICAL_DAMAGE))
+        {
+            damage = 0;
+        }
+
         if (damage > 0)
         {
             damage = std::max(damage - PDefender->getMod(Mod::PHALANX), 0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR allows Damage Nullification to occur during Physical/Ranged Weaponskills, which in turn allows `Shadow Mantle` to block physical damage from Weaponskills.


**Here is retail testing showing the ability for `Shadow Mantle` to block Physical Weaponskills:**


![image](https://github.com/user-attachments/assets/d08c8b36-b04b-4567-84b8-c5c7a703d896)
![image](https://github.com/user-attachments/assets/f38b7f10-10fd-4bc1-9542-1d3740dc58b2)
![image](https://github.com/user-attachments/assets/65ad42f3-f629-4e94-bbf8-34a36173aa06)

![image](https://github.com/user-attachments/assets/e31fd65b-a419-43a2-9b15-f51589556359)
![image](https://github.com/user-attachments/assets/903f9fcc-bf05-4657-945d-58452c43d6d5)
![image](https://github.com/user-attachments/assets/9b341c4f-56b4-49a6-bdc0-bedfc52aa54b)
![image](https://github.com/user-attachments/assets/4b0d8cea-2d20-4ee2-b21f-17e3d5f24a1c)
![image](https://github.com/user-attachments/assets/ed081264-8268-4f54-b103-4873de5e93a2)
![image](https://github.com/user-attachments/assets/5045067f-87a5-4241-910e-e7d74f135c45)
![image](https://github.com/user-attachments/assets/ad2a088a-1d5f-4838-9de4-6374df2aa3d1)



## Steps to test these changes

- `!additem shadow_mantle`
- Equip Shadow Mantle
- Find a mob with physical weaponskills, such as a Raptor in Uleguerand Range
- `!tp 3000` them
- 6% of the time you should take 0 damage from their physical weaponskills

## Test Screenshots

![image](https://github.com/user-attachments/assets/5823e6ab-0d4a-4218-b908-b244933a4510)
