### PR TITLE
AH Announcements module sends bid failure packet

### DIFF
--- a/modules/custom/cpp/ah_announcement.cpp
+++ b/modules/custom/cpp/ah_announcement.cpp
@@ -81,6 +81,8 @@ class AHAnnouncementModule : public CPPModule
 
                         if (gil != nullptr && gil->isType(ITEM_CURRENCY) && gil->getQuantity() >= price && gil->getReserve() == 0)
                         {
+                            bool itemPurchasedSuccessfully = false;
+
                             // clang-format off
                             const auto success = db::transaction([&]()
                             {
@@ -173,10 +175,12 @@ class AHAnnouncementModule : public CPPModule
                                                 .messageType = MESSAGE_SYSTEM_3,
                                             });
                                         }
+
+                                        itemPurchasedSuccessfully = true;
                                     }
                                 }
                             });
-                            if (success)
+                            if (itemPurchasedSuccessfully && success)
                             {
                                 return;
                             }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
AH announcements module transaction wrapper always returns true, even if no SQL transaction happened. 
  - Really the logic should be changed so it doesn't even attempt to perform one, since rowId is 0 but that's for another day.

This ensures the correct conditions are verified so it goes into the block that sends the bid failure message.

Without it, the client is left stuck on "Downloading Data" waiting for any result.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
- Attempt to buy an item for a price that doesn't get any result
- Client receives bid failure message

<!-- Clear and detailed steps to test your changes here -->
