### PR TITLE
Prevent uint16 errors in prepared statements

### DIFF
--- a/src/common/database.h
+++ b/src/common/database.h
@@ -391,7 +391,7 @@ namespace db
             }
             else if constexpr (std::is_same_v<UnderlyingT, uint16>)
             {
-                stmt->setShort(counter, value);
+                stmt->setUInt(counter, value);
             }
             else if constexpr (std::is_same_v<UnderlyingT, int8>)
             {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Sending gil through the delivery box (item ID 65535) errors out with

```
[03/27/25 20:19:51:870][map][error] Query Failed: INSERT INTO delivery_box(charid, charname, box, slot, itemid, itemsubid, quantity, extra, senderid, sender) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?) (db::preparedStmtWithAffectedRows::<lambda_1>::operator ():658)
[03/27/25 20:19:51:870][map][error] (conn=2666) Out of range value for column 'itemid' at row 1 (db::preparedStmtWithAffectedRows::<lambda_1>::operator ():659)
```

Reviewing database logs show the map process sending -1 as the item ID.

Tracked the issue to the binder calling `setShort` for uint16, which deals exclusively with int16 

https://github.com/mariadb-corporation/mariadb-connector-cpp/blob/3370bf1555d242043611f4ab1a33048263dc39f8/src/BasePrepareStatement.cpp#L1308-L1311

To the best of my knowledge, there is no setUInt16, so setUInt is the next best thing but I need a sanity check.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Send yourself some gil through the delivery box


<!-- Clear and detailed steps to test your changes here -->
