### PR TITLE
Update CSPositionPacket

### DIFF
--- a/src/map/packets/cs_position.h
+++ b/src/map/packets/cs_position.h
@@ -25,13 +25,14 @@
 #include "common/cbasetypes.h"
 
 #include "basic.h"
+#include "position.h"
 
 class CCharEntity;
 
 class CCSPositionPacket : public CBasicPacket
 {
 public:
-    CCSPositionPacket(CCharEntity* PChar);
+    CCSPositionPacket(CBaseEntity* PEntity, position_t position, POSMODE mode = POSMODE::NORMAL);
 };
 
 #endif


### PR DESCRIPTION
CSPositionPacket is identical to PositionPacket.
Update and fix packet handling for incoming packet 0x05C (event update with position).

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Follows up on #6902 by updating [the other position packet, 0x065](https://github.com/atom0s/XiPackets/blob/main/world/server/0x0065/README.md). Basically a copy/paste of CPositionPacket.

This capture was helpful in figuring out how 0x065 is used:
https://drive.google.com/file/d/12zdCSIEmHCw47s6G4DF_GsYdOSZkox6I/view

When selecting a battlefield, the client sends a [warp request (C2S 0x05C)](https://github.com/atom0s/XiPackets/blob/main/world/client/0x005C/README.md). If the server says the request is denied (like when a battlefield arena is occupied), it sends 0x065 with mode 2 to the client without changing the player position. The client then sends a warp request for the next arena and so on and if all arenas are full the cutscene ends without any actual position changes. If a request succeeds the server sends 0x065 with mode 1, and a matching 0x05B with mode 0 (a normal position update).

Fixes #7325

SmallPacket0x05E should behave as it did previously, with the exception that it now calls `PChar->setLocked(false)` as part of the mode 5 (reset).

## Steps to test these changes

```
!pos -342.69 104 -259 144
!additem moon_orb
```
Do this with 4 characters, all solo.
Have the first 2 characters enter any BCNM.
With the last 2 characters, trade the orb to the entrance so both characters have the BCNM selection menu open.
Attempt to enter a BCNM with both characters.

One of the last 2 characters should be denied entry, and the screen should fade back in. This character will still be in the lobby, while the other 3 should be in different arenas.
