### PR TITLE
[Fix] Elemental Syphon day/weather bonuses and add JP effect

### DIFF
--- a/scripts/globals/job_utils/rune_fencer.lua
+++ b/scripts/globals/job_utils/rune_fencer.lua
@@ -518,7 +518,7 @@ local function getSwipeLungeDamageMultipliers(player, target, element, bonusMacc
     multipliers.magianAffinity      = xi.spells.damage.calculateMagianAffinity() -- Presumed but untested.
     multipliers.SDT                 = xi.spells.damage.calculateSDT(target, element)
     multipliers.resist              = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, element, 0, 0, bonusMacc)
-    multipliers.dayAndWeather       = xi.spells.damage.calculateDayAndWeather(player, 0, element)
+    multipliers.dayAndWeather       = xi.spells.damage.calculateDayAndWeather(player, element, false)
     multipliers.magicBonusDiff      = xi.spells.damage.calculateMagicBonusDiff(player, target, 0, 0, element)
     multipliers.TMDA                = xi.spells.damage.calculateTMDA(target, element)
     multipliers.nukeAbsorbOrNullify = xi.spells.damage.calculateNukeAbsorbOrNullify(target, element)

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -161,7 +161,7 @@ function getCureFinal(caster, spell, basecure, minCure, isBlueMagic)
     local curePot         = math.min(caster:getMod(xi.mod.CURE_POTENCY), 50) / 100 -- caps at 50%
     local curePotII       = math.min(caster:getMod(xi.mod.CURE_POTENCY_II), 30) / 100 -- caps at 30%
     local potency         = 1 + curePot + curePotII
-    local dayWeatherBonus = xi.spells.damage.calculateDayAndWeather(caster, spell:getID(), spell:getElement())
+    local dayWeatherBonus = xi.spells.damage.calculateDayAndWeather(caster, spell:getElement(), false)
     local dSeal           = 1
 
     if caster:hasStatusEffect(xi.effect.DIVINE_SEAL) then
@@ -333,7 +333,7 @@ function addBonuses(caster, spell, target, dmg, params)
     local ele             = spell:getElement()
     local affinityBonus   = xi.spells.damage.calculateElementalStaffBonus(caster, ele)
     local magicDefense    = xi.spells.damage.calculateSDT(target, ele)
-    local dayWeatherBonus = xi.spells.damage.calculateDayAndWeather(caster, spell:getID(), ele)
+    local dayWeatherBonus = xi.spells.damage.calculateDayAndWeather(caster, ele, false)
     local casterJob       = caster:getMainJob()
 
     params = params or {}
@@ -410,7 +410,7 @@ function addBonusesAbility(caster, ele, target, dmg, params)
     local magicDefense = xi.spells.damage.calculateSDT(target, ele)
     dmg = math.floor(dmg * magicDefense)
 
-    local dayWeatherBonus = xi.spells.damage.calculateDayAndWeather(caster, 0, ele)
+    local dayWeatherBonus = xi.spells.damage.calculateDayAndWeather(caster, ele, false)
     dmg = math.floor(dmg * dayWeatherBonus)
 
     local mab = 1

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -283,7 +283,7 @@ xi.mobskills.mobMagicalMove = function(actor, target, action, baseDamage, action
     -- Multipliers.
     local sdt                         = xi.spells.damage.calculateSDT(target, actionElement)
     local resist                      = xi.mobskills.applyPlayerResistance(actor, nil, target, actor:getStat(xi.mod.INT) - target:getStat(xi.mod.INT), petAccBonus, actionElement)
-    local dayAndWeather               = xi.spells.damage.calculateDayAndWeather(actor, 0, actionElement)
+    local dayAndWeather               = xi.spells.damage.calculateDayAndWeather(actor, actionElement, false)
     local magicBonusDiff              = xi.spells.damage.calculateMagicBonusDiff(actor, target, 0, 0, actionElement)
     local targetMagicDamageAdjustment = xi.spells.damage.calculateTMDA(target, actionElement)
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Changes how the day/weather function works so we can force the bonus to happen directly.
- Fixes several issues with elemental Siphon.
  - Skill cap wasnt accounted for
  - Skill wasnt being multiplied by * 1.05 nor was it recieving the proper penalty.
  - Job points werent affecting elemental syphon
  - The spirit was being fed to the weather/day function instead of the player.

https://www.bg-wiki.com/ffxi/Elemental_Siphon

Close #6599 

## Steps to test these changes

Use elemental syphon. Numbers should match better with retail.
