### PR TITLE
[core] Fix Potential Underflow in Guild Points

### DIFF
--- a/src/map/guild.cpp
+++ b/src/map/guild.cpp
@@ -81,7 +81,7 @@ std::pair<uint8, int16> CGuild::addGuildPoints(CCharEntity* PChar, CItem* PItem)
 
     if (PItem)
     {
-        int32 curPoints = PChar->getCharVar("[GUILD]daily_points");
+        uint16 curPoints = PChar->getCharVar("[GUILD]daily_points");
         if (curPoints != 1)
         {
             for (auto& GPItem : m_GPItems[rank - 3])
@@ -91,20 +91,23 @@ std::pair<uint8, int16> CGuild::addGuildPoints(CCharEntity* PChar, CItem* PItem)
                     // if a player ranks up to a new pattern whose maxpoints are fewer than the player's current daily points
                     // then we'd be trying to push a negative number into quantity. our edit to CGuild::getDailyGPItem should
                     // prevent this, but let's be doubly sure.
-                    uint16 quantity = std::max<uint16>(0, std::min<uint16>((((GPItem.maxpoints - curPoints) / GPItem.points) + 1), PItem->getReserve()));
-                    uint16 points   = GPItem.points * quantity;
-                    if (points > GPItem.maxpoints - curPoints)
+                    uint16 quantity    = std::min<uint16>((((GPItem.maxpoints - std::clamp<uint16>(curPoints, 0, GPItem.maxpoints)) / GPItem.points) + 1), PItem->getReserve());
+                    uint16 pointsToAdd = GPItem.points * quantity;
+
+                    if (curPoints <= GPItem.maxpoints)
                     {
-                        points = GPItem.maxpoints - curPoints;
+                        pointsToAdd = std::clamp<uint16>(pointsToAdd, 0, GPItem.maxpoints - curPoints);
+                    }
+                    else
+                    {
+                        pointsToAdd = 0;
                     }
 
-                    charutils::AddPoints(PChar, pointsName.c_str(), points);
+                    charutils::AddPoints(PChar, pointsName.c_str(), pointsToAdd);
 
-                    PChar->setCharVar("[GUILD]daily_points", curPoints + points);
+                    PChar->setCharVar("[GUILD]daily_points", curPoints + pointsToAdd);
 
-                    return {
-                        std::clamp<uint8>(quantity, 0, std::numeric_limits<uint8>::max()), points
-                    };
+                    return { quantity, pointsToAdd };
                 }
             }
         }
@@ -131,6 +134,6 @@ std::pair<uint16, uint16> CGuild::getDailyGPItem(CCharEntity* PChar)
         // a rank-up can land player in a new pattern that rewards fewer max points than they
         // have traded in today. we prevent remainingPoints from going negative here so that
         // we don't later calculate a negative quantity in CGuild::addGuildPoints
-        return std::make_pair(GPItem[0].item->getID(), std::max<uint16>(0, (GPItem[0].maxpoints - curPoints)));
+        return std::make_pair(GPItem[0].item->getID(), GPItem[0].maxpoints - std::clamp<uint16>(curPoints, 0, GPItem[0].maxpoints));
     }
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
- currPoints was declared as int32 but then redeclared as uint16 
- prevents an underflow where subtracting curPoints from GPItem.maxpoints could result in large value from wraparound

Ex:
```
curPoints = 5000
maxPoints = 1000
GPItem.points = 100
PItem->getReserve() = 10

1000 - 5000 = -4000
-4000 (as uint16) becomes 65536 - 4000 = 61536
(61536 / 100) + 1 = 616
quantity = min(616, 10) = 10 (despite having curPoints > GPItem.maxPoints)
```

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - Check guild patterns and find one where a rank 4+ turn in has a lower cap than the rank before it
2 - Turn in GP item at the lower rank until you exceed the cap of the next rank item's cap
3 - Bump your rank up to the next rank and turn in the GP item again
4 - Try to trade GP Items for your new rank
NOTE: You will not be able to continue receiving extra GP
