### PR TITLE
Core: Add bit_reference to xi::bitset

### DIFF
--- a/src/common/cbasetypes.h
+++ b/src/common/cbasetypes.h
@@ -23,16 +23,18 @@
 
 #include <algorithm>
 #include <cctype>
+#include <chrono>
 #include <climits>
 #include <cstddef>
 #include <cstdint>
+#include <queue>
 #include <span>
 #include <utility>
 #include <vector>
 
 #include "macros.h"
+#include "tracy.h"
 
-// typedef/using
 using int8  = std::int8_t;
 using int16 = std::int16_t;
 using int32 = std::int32_t;
@@ -70,8 +72,6 @@ inline void destroy_arr(T*& ptr)
     ptr = nullptr;
 }
 
-#include <chrono>
-
 using namespace std::literals::chrono_literals;
 using server_clock = std::chrono::system_clock;
 using time_point   = server_clock::time_point;
@@ -81,8 +81,6 @@ using duration     = server_clock::duration;
 // using hires_clock      = std::chrono::high_resolution_clock;
 // using hires_time_point = hires_clock::time_point;
 // using hires_duration   = hires_clock::duration;
-
-#include <queue>
 
 template <class T>
 using MinHeap = std::priority_queue<T, std::vector<T>, std::greater<T>>;
@@ -98,5 +96,3 @@ struct PtrGreater
 
 template <class T>
 using MinHeapPtr = std::priority_queue<T, std::vector<T>, PtrGreater<T>>;
-
-#include "tracy.h"

--- a/src/common/xi.h
+++ b/src/common/xi.h
@@ -198,8 +198,45 @@ namespace xi
         return final_action<std::decay_t<F>>{ std::forward<F>(f) };
     }
 
+    class bit_reference
+    {
+    public:
+        bit_reference(uint8& byte, size_t bit)
+        : byte_(byte)
+        , bit_(bit)
+        {
+        }
+
+        operator bool() const
+        {
+            return (byte_ & (1 << bit_)) != 0;
+        }
+
+        bit_reference& operator=(bool value)
+        {
+            if (value)
+            {
+                byte_ |= (1 << bit_);
+            }
+            else
+            {
+                byte_ &= ~(1 << bit_);
+            }
+            return *this;
+        }
+
+        bit_reference& operator=(const bit_reference& other)
+        {
+            return *this = static_cast<bool>(other);
+        }
+
+    private:
+        uint8& byte_;
+        size_t bit_;
+    };
+
     // std::bitset is not trivial, so we need to create our own bitset
-    // that is for use with the database
+    // for use with the database
     template <std::size_t N>
     struct bitset
     {
@@ -279,9 +316,9 @@ namespace xi
             return *this;
         }
 
-        bool& operator[](std::size_t pos)
+        bit_reference operator[](std::size_t pos)
         {
-            return reinterpret_cast<bool&>(data[pos / 8] |= (1 << (pos % 8)));
+            return bit_reference(data[pos / 8], pos % 8);
         }
 
         bool operator[](std::size_t pos) const

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -280,7 +280,7 @@ public:
     uint16          styleItems[16]{};      // Item IDs for items that are style locked.
 
     uint8            m_ZonesVisitedList[38]{}; // List of zones visited by the character
-    xi::bitset<1024> m_SpellList;              // List of learned spells
+    xi::bitset<1024> m_SpellList{};            // List of learned spells
     uint8            m_TitleList[143]{};       // List of obtained titles
     uint8            m_Abilities[64]{};        // List of current abilities
     uint8            m_LearnedAbilities[49]{}; // Learnable abilities (corsair rolls)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

I fell foul to a common issue when writing a bitset and interacting with the underlying bits. Added a bit_reference type to help.

```
xi::bitset<1024> bs;
bs[23]; // Would return 128

// After changes, will return 0 (default value, because of underlying std::array)
```

Fixes: https://github.com/LandSandBoat/server/issues/7346