### PR TITLE
Core: Convert more uses of legacy SQL (and fix retreat/release CE/VE)

### DIFF
--- a/sql/abilities.sql
+++ b/sql/abilities.sql
@@ -105,8 +105,8 @@ INSERT INTO `abilities` VALUES (85,'call_beast',9,23,1,300,104,0,0,83,2000,0,6,1
 INSERT INTO `abilities` VALUES (86,'unlimited_shot',11,51,1,180,126,0,0,90,2000,0,6,20.0,0,1,300,1030,0,NULL);
 INSERT INTO `abilities` VALUES (87,'dismiss',14,1,1,300,161,0,0,94,2000,0,6,20.0,0,0,0,0,4,NULL);
 INSERT INTO `abilities` VALUES (88,'assault',15,1,4,5,170,0,0,94,2000,0,6,20.0,0,0,0,0,256,NULL);
-INSERT INTO `abilities` VALUES (89,'retreat',15,1,1,5,171,0,0,94,2000,0,6,20.0,0,-10,0,0,256,NULL);
-INSERT INTO `abilities` VALUES (90,'release',15,1,1,5,172,0,0,94,2000,0,6,20.0,0,-10,0,0,256,NULL);
+INSERT INTO `abilities` VALUES (89,'retreat',15,1,1,5,171,0,0,94,2000,0,6,20.0,0,10,0,0,256,NULL);
+INSERT INTO `abilities` VALUES (90,'release',15,1,1,5,172,0,0,94,2000,0,6,20.0,0,10,0,0,256,NULL);
 INSERT INTO `abilities` VALUES (91,'blood_pact_rage',15,1,1,60,173,0,0,0,2000,0,6,20.0,0,1,300,0,256,NULL);
 INSERT INTO `abilities` VALUES (92,'rampart',7,62,1,300,77,0,0,91,2000,0,6,20.0,1,320,320,776,0,NULL);
 INSERT INTO `abilities` VALUES (93,'azure_lore',16,0,1,3600,0,0,0,142,2000,0,6,20.0,0,1,300,0,0,'TOAU');

--- a/sql/abilities.sql
+++ b/sql/abilities.sql
@@ -105,8 +105,8 @@ INSERT INTO `abilities` VALUES (85,'call_beast',9,23,1,300,104,0,0,83,2000,0,6,1
 INSERT INTO `abilities` VALUES (86,'unlimited_shot',11,51,1,180,126,0,0,90,2000,0,6,20.0,0,1,300,1030,0,NULL);
 INSERT INTO `abilities` VALUES (87,'dismiss',14,1,1,300,161,0,0,94,2000,0,6,20.0,0,0,0,0,4,NULL);
 INSERT INTO `abilities` VALUES (88,'assault',15,1,4,5,170,0,0,94,2000,0,6,20.0,0,0,0,0,256,NULL);
-INSERT INTO `abilities` VALUES (89,'retreat',15,1,1,5,171,0,0,94,2000,0,6,20.0,0,10,0,0,256,NULL);
-INSERT INTO `abilities` VALUES (90,'release',15,1,1,5,172,0,0,94,2000,0,6,20.0,0,10,0,0,256,NULL);
+INSERT INTO `abilities` VALUES (89,'retreat',15,1,1,5,171,0,0,94,2000,0,6,20.0,0,-10,0,0,256,NULL);
+INSERT INTO `abilities` VALUES (90,'release',15,1,1,5,172,0,0,94,2000,0,6,20.0,0,-10,0,0,256,NULL);
 INSERT INTO `abilities` VALUES (91,'blood_pact_rage',15,1,1,60,173,0,0,0,2000,0,6,20.0,0,1,300,0,256,NULL);
 INSERT INTO `abilities` VALUES (92,'rampart',7,62,1,300,77,0,0,91,2000,0,6,20.0,1,320,320,776,0,NULL);
 INSERT INTO `abilities` VALUES (93,'azure_lore',16,0,1,3600,0,0,0,142,2000,0,6,20.0,0,1,300,0,0,'TOAU');

--- a/src/common/database.h
+++ b/src/common/database.h
@@ -362,6 +362,10 @@ namespace db
                 {
                     extractFromBlob(&*this, key, value);
                 }
+                else if constexpr (std::is_same_v<UnderlyingT, size_t>)
+                {
+                    value = static_cast<T>(resultSet_->getUInt(key.c_str()));
+                }
                 else
                 {
                     static_assert(always_false_v<T>, "Trying to extract unsupported type from ResultSetWrapper");
@@ -531,6 +535,10 @@ namespace db
                 DebugSQL(fmt::format("binding {}: {}", counter, blobWrapper->toString()));
 
                 stmt->setBlob(counter, &blobWrapper->istream);
+            }
+            else if constexpr (std::is_same_v<UnderlyingT, size_t>)
+            {
+                stmt->setUInt(counter, value);
             }
             else
             {

--- a/src/map/ability.cpp
+++ b/src/map/ability.cpp
@@ -233,22 +233,22 @@ void CAbility::setRecastId(uint16 recastId)
     m_recastId = recastId;
 }
 
-void CAbility::setCE(uint16 CE)
+void CAbility::setCE(int32 CE)
 {
     m_CE = CE;
 }
 
-uint16 CAbility::getCE() const
+int32 CAbility::getCE() const
 {
     return m_CE;
 }
 
-void CAbility::setVE(uint16 VE)
+void CAbility::setVE(int32 VE)
 {
     m_VE = VE;
 }
 
-uint16 CAbility::getVE() const
+int32 CAbility::getVE() const
 {
     return m_VE;
 }
@@ -408,8 +408,8 @@ namespace ability
                 PAbility->setRange(rset->get<float>("range"));
                 PAbility->setAOE(rset->get<uint8>("isAOE"));
                 PAbility->setRecastId(rset->get<uint16>("recastId"));
-                PAbility->setCE(rset->get<uint16>("CE"));
-                PAbility->setVE(rset->get<uint16>("VE"));
+                PAbility->setCE(rset->get<int32>("CE"));
+                PAbility->setVE(rset->get<int32>("VE"));
                 PAbility->setMeritModID(rset->get<uint16>("meritModID"));
                 PAbility->setAddType(rset->get<uint16>("addType"));
 

--- a/src/map/ability.h
+++ b/src/map/ability.h
@@ -716,8 +716,8 @@ public:
     uint16     getAoEMsg() const;
     uint16     getRecastTime() const;
     uint16     getRecastId() const;
-    uint16     getCE() const;
-    uint16     getVE() const;
+    int32      getCE() const;
+    int32      getVE() const;
     uint16     getMeritModID() const;
     ACTIONTYPE getActionType();
     EFFECT     getPostActionEffectCleanup();
@@ -736,8 +736,8 @@ public:
     void setMessage(uint16 message);
     void setRecastTime(uint16 recastTime);
     void setRecastId(uint16 recastId);
-    void setCE(uint16 CE);
-    void setVE(uint16 VE);
+    void setCE(int32 CE);
+    void setVE(int32 VE);
     void setMeritModID(uint16 value);
     void setActionType(ACTIONTYPE type);
     void setPostActionEffectCleanup(EFFECT effectToCleanup);
@@ -759,8 +759,8 @@ private:
     uint16      m_message;
     uint16      m_recastTime;
     uint16      m_recastId;
-    uint16      m_CE;
-    uint16      m_VE;
+    int32       m_CE;
+    int32       m_VE;
     uint16      m_meritModID;
     std::string m_name;
     uint16      m_mobskillId;

--- a/src/map/ability.h
+++ b/src/map/ability.h
@@ -777,7 +777,6 @@ private:
 namespace ability
 {
     void LoadAbilitiesList();
-    void CleanupAbilitiesList();
 
     CAbility* GetAbility(uint16 AbilityID);
 

--- a/src/map/ai/controllers/automaton_controller.cpp
+++ b/src/map/ai/controllers/automaton_controller.cpp
@@ -469,9 +469,9 @@ bool CAutomatonController::TryHeal(const CurrentManeuvers& maneuvers)
         }
         else
         {
-            uint16 selfEnmity   = selfEnmity_obj->second.CE + selfEnmity_obj->second.VE;
-            uint16 masterEnmity = masterEnmity_obj->second.CE + masterEnmity_obj->second.VE;
-            haveHate            = selfEnmity > masterEnmity;
+            int32 selfEnmity   = selfEnmity_obj->second.CE + selfEnmity_obj->second.VE;
+            int32 masterEnmity = masterEnmity_obj->second.CE + masterEnmity_obj->second.VE;
+            haveHate           = selfEnmity > masterEnmity;
         }
     }
 

--- a/src/map/enmity_container.cpp
+++ b/src/map/enmity_container.cpp
@@ -317,10 +317,10 @@ void CEnmityContainer::LowerEnmityByPercent(CBattleEntity* PEntity, uint8 percen
     {
         float mod = ((float)(percent) / 100.0f);
 
-        auto CEValue = (int16)(enmity_obj->second.CE * mod);
+        auto CEValue = (int32)(enmity_obj->second.CE * mod);
         enmity_obj->second.CE -= (CEValue < 0 ? 0 : CEValue);
 
-        auto VEValue = (int16)(enmity_obj->second.VE * mod);
+        auto VEValue = (int32)(enmity_obj->second.VE * mod);
         enmity_obj->second.VE -= (VEValue < 0 ? 0 : VEValue);
 
         // transfer hate if HateReceiver not nullptr

--- a/src/map/lua/lua_ability.cpp
+++ b/src/map/lua/lua_ability.cpp
@@ -86,22 +86,22 @@ void CLuaAbility::setRecast(uint16 recastTime)
     m_PLuaAbility->setRecastTime(recastTime);
 }
 
-uint16 CLuaAbility::getCE()
+int32 CLuaAbility::getCE()
 {
     return m_PLuaAbility->getCE();
 }
 
-void CLuaAbility::setCE(uint16 ce)
+void CLuaAbility::setCE(int32 ce)
 {
     m_PLuaAbility->setCE(ce);
 }
 
-uint16 CLuaAbility::getVE()
+int32 CLuaAbility::getVE()
 {
     return m_PLuaAbility->getVE();
 }
 
-void CLuaAbility::setVE(uint16 ve)
+void CLuaAbility::setVE(int32 ve)
 {
     m_PLuaAbility->setVE(ve);
 }

--- a/src/map/lua/lua_ability.h
+++ b/src/map/lua/lua_ability.h
@@ -50,15 +50,15 @@ public:
     uint16 getAnimation();
     uint16 getAddType(); // see map/ability.h for definitions. These can tell if the ability is a Merit ability, Astral Flow only ability, etc
 
-    void   setMsg(uint16 messageID);
-    void   setAnimation(uint16 animationID);
-    void   setRecast(uint16 recastTime);
-    uint16 getCE();
-    void   setCE(uint16 ce);
-    uint16 getVE();
-    void   setVE(uint16 ve);
-    void   setRange(float range);
-    void   setPostActionCleanupEffect(EFFECT effectToCleanup);
+    void  setMsg(uint16 messageID);
+    void  setAnimation(uint16 animationID);
+    void  setRecast(uint16 recastTime);
+    int32 getCE();
+    void  setCE(int32 ce);
+    int32 getVE();
+    void  setVE(int32 ve);
+    void  setRange(float range);
+    void  setPostActionCleanupEffect(EFFECT effectToCleanup);
 
     bool operator==(const CLuaAbility& other) const
     {

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1886,11 +1886,11 @@ namespace luautils
      *                                                                       *
      ************************************************************************/
 
-    bool IsContentEnabled(const char* contentTag)
+    bool IsContentEnabled(const std::string& contentTag)
     {
         TracyZoneScoped;
 
-        if (contentTag == nullptr || std::strlen(contentTag) == 0)
+        if (contentTag.empty())
         {
             return true;
         }

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -278,7 +278,7 @@ namespace luautils
     void  Terminate();                                                                                   // Logs off all characters and terminates the server
 
     int32 GetTextIDVariable(uint16 ZoneID, const char* variable); // Load the value of the TextID variable of the specified zone
-    bool  IsContentEnabled(const char* content);
+    bool  IsContentEnabled(const std::string& content);
 
     void OnGameDay(CZone* PZone);
     void OnGameHour(CZone* PZone);

--- a/src/map/map_server.cpp
+++ b/src/map/map_server.cpp
@@ -390,7 +390,6 @@ void MapServer::do_final()
 {
     TracyZoneScoped;
 
-    ability::CleanupAbilitiesList();
     itemutils::FreeItemList();
     battleutils::FreeWeaponSkillsList();
     battleutils::FreeMobSkillList();

--- a/src/map/spell.cpp
+++ b/src/map/spell.cpp
@@ -563,10 +563,10 @@ namespace spell
             }
         }
 
-        const char* blueQuery = "SELECT blue_spell_list.spellid, blue_spell_list.mob_skill_id, blue_spell_list.set_points, \
-                                blue_spell_list.trait_category, blue_spell_list.trait_category_weight, blue_spell_list.primary_sc, \
-                                blue_spell_list.secondary_sc, blue_spell_list.tertiary_sc, spell_list.content_tag \
-                             FROM blue_spell_list JOIN spell_list on blue_spell_list.spellid = spell_list.spellid";
+        const char* blueQuery = "SELECT blue_spell_list.spellid, blue_spell_list.mob_skill_id, blue_spell_list.set_points, "
+                                "blue_spell_list.trait_category, blue_spell_list.trait_category_weight, blue_spell_list.primary_sc, "
+                                "blue_spell_list.secondary_sc, blue_spell_list.tertiary_sc, spell_list.content_tag "
+                                "FROM blue_spell_list JOIN spell_list on blue_spell_list.spellid = spell_list.spellid";
 
         ret = _sql->Query(blueQuery);
 
@@ -574,7 +574,8 @@ namespace spell
         {
             while (_sql->NextRow() == SQL_SUCCESS)
             {
-                char* contentTag = (char*)_sql->GetData(8);
+                // const auto contentTag = rset->getOrDefault<std::string>("content_tag", "");
+                const auto contentTag = _sql->GetStringData(8);
                 if (!luautils::IsContentEnabled(contentTag))
                 {
                     continue;
@@ -623,7 +624,8 @@ namespace spell
         {
             while (_sql->NextRow() == SQL_SUCCESS)
             {
-                char* contentTag = (char*)_sql->GetData(2);
+                // const auto contentTag = rset->getOrDefault<std::string>("content_tag", "");
+                const auto contentTag = _sql->GetStringData(2);
                 if (!luautils::IsContentEnabled(contentTag))
                 {
                     continue;

--- a/src/map/spell.cpp
+++ b/src/map/spell.cpp
@@ -352,12 +352,12 @@ void CSpell::setElement(uint16 element)
     m_element = element;
 }
 
-void CSpell::setCE(uint16 ce)
+void CSpell::setCE(int32 ce)
 {
     m_CE = ce;
 }
 
-uint16 CSpell::getCE() const
+int32 CSpell::getCE() const
 {
     return m_CE;
 }
@@ -367,12 +367,12 @@ void CSpell::setRadius(float radius)
     m_radius = radius;
 }
 
-void CSpell::setVE(uint16 ve)
+void CSpell::setVE(int32 ve)
 {
     m_VE = ve;
 }
 
-uint16 CSpell::getVE() const
+int32 CSpell::getVE() const
 {
     return m_VE;
 }

--- a/src/map/spell.h
+++ b/src/map/spell.h
@@ -1072,8 +1072,8 @@ public:
     uint16             getMessage() const;
     uint16             getDefaultMessage();
     uint16             getMagicBurstMessage() const;
-    uint16             getCE() const;
-    uint16             getVE() const;
+    int32              getCE() const;
+    int32              getVE() const;
     uint32             getModifiedRecast() const;
     float              getRadius() const;
     uint16             getAoEMessage() const; // returns the single target message for AoE moves
@@ -1116,8 +1116,8 @@ public:
     void setModifier(MODIFIER modifier); // set Spell modifier message, MUST reset the modifier on use otherwise it will be stale
     void setPrimaryTargetID(uint32);
 
-    void setCE(uint16 ce);
-    void setVE(uint16 ve);
+    void setCE(int32 ce);
+    void setVE(int32 ve);
     void setRequirements(uint8 requirements);
     void setMeritId(uint16 meritId);
     void setModifiedRecast(uint32 mrec);
@@ -1156,8 +1156,8 @@ private:
     uint16      m_message{};                       // message id
     uint16      m_MagicBurstMessage{};             // Message used for magic bursts.
     MODIFIER    m_MessageModifier{};               // Message modifier, "Cover!", "Resist!" or "Immunobreak!"
-    uint16      m_CE{};                            // cumulative enmity of spell
-    uint16      m_VE{};                            // volatile enmity of spell
+    int32       m_CE{};                            // cumulative enmity of spell
+    int32       m_VE{};                            // volatile enmity of spell
     std::string m_name;                            // spell name
     uint32      m_modifiedRecastTime{};            // recast time after modifications
     uint8       m_requirements{};                  // requirements before being able to cast spell

--- a/src/map/trait.cpp
+++ b/src/map/trait.cpp
@@ -54,10 +54,10 @@ namespace traits
      ************************************************************************/
     void LoadTraitsList()
     {
-        const char* Query = "SELECT traitid, job, level, rank, modifier, value, content_tag, meritid \
-                             FROM traits \
-                             WHERE traitid < %u \
-                             ORDER BY job, traitid ASC, rank DESC";
+        const char* Query = "SELECT traitid, job, level, rank, modifier, value, content_tag, meritid "
+                            "FROM traits "
+                            "WHERE traitid < %u "
+                            "ORDER BY job, traitid ASC, rank DESC";
 
         int32 ret = _sql->Query(Query, MAX_TRAIT_ID);
 
@@ -65,9 +65,8 @@ namespace traits
         {
             while (_sql->NextRow() == SQL_SUCCESS)
             {
-                char* contentTag = nullptr;
-                _sql->GetData(6, &contentTag, nullptr);
-
+                // const auto contentTag = rset->getOrDefault<std::string>("content_tag", "");
+                const auto contentTag = _sql->GetStringData(6);
                 if (!luautils::IsContentEnabled(contentTag))
                 {
                     continue;

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -413,12 +413,12 @@ namespace battleutils
      *                                                                       *
      ************************************************************************/
 
-    int16 GetEnmityModDamage(int16 level)
+    int32 GetEnmityModDamage(int16 level)
     {
         return level * 31 / 50 + 6;
     }
 
-    int16 GetEnmityModCure(int16 level)
+    int32 GetEnmityModCure(int16 level)
     {
         if (level <= 10)
         {
@@ -4379,7 +4379,7 @@ namespace battleutils
     }
 
     // Generate enmity for all targets in range
-    void GenerateInRangeEnmity(CBattleEntity* PSource, int16 CE, int16 VE)
+    void GenerateInRangeEnmity(CBattleEntity* PSource, int32 CE, int32 VE)
     {
         if (PSource == nullptr)
         {

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -178,13 +178,13 @@ namespace battleutils
     uint8 GetRangedHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool isBarrage, int16 accBonus);
     int32 CalculateEnspellDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, uint8 Tier, uint8 element);
 
-    int16 GetEnmityModDamage(int16 level);
-    int16 GetEnmityModCure(int16 level);
+    int32 GetEnmityModDamage(int16 level);
+    int32 GetEnmityModCure(int16 level);
     bool  isValidSelfTargetWeaponskill(int wsid);
     bool  CanUseWeaponskill(CCharEntity* PChar, CWeaponSkill* PSkill);
     int16 CalculateBaseTP(int32 delay);
     void  GenerateCureEnmity(CBattleEntity* PSource, CBattleEntity* PTarget, int32 amount, int32 fixedCE = 0, int32 fixedVE = 0);
-    void  GenerateInRangeEnmity(CBattleEntity* PSource, int16 CE, int16 VE);
+    void  GenerateInRangeEnmity(CBattleEntity* PSource, int32 CE, int32 VE);
 
     CItemWeapon*    GetEntityWeapon(CBattleEntity* PEntity, SLOTTYPE Slot);
     CItemEquipment* GetEntityArmor(CBattleEntity* PEntity, SLOTTYPE Slot);

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -302,7 +302,7 @@ namespace synthutils
         {
             const auto& recipe = synthRecipes[possibleRecipeKey];
 
-            if (!luautils::IsContentEnabled(recipe.ContentTag.c_str()))
+            if (!luautils::IsContentEnabled(recipe.ContentTag))
             {
                 PChar->pushPacket<CSynthMessagePacket>(PChar, SYNTH_BADRECIPE);
                 return false;

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -314,14 +314,14 @@ namespace zoneutils
                 {
                     while (rset->next())
                     {
-                        // If there is no content tag, always load the NPC
-                        const auto contentTagFound = !rset->isNull("content_tag");
-                        if (contentTagFound && !luautils::IsContentEnabled(rset->get<std::string>("content_tag").c_str()))
+                        // If there is no content tag, the NPC will always be loaded
+                        const auto contentTag = rset->getOrDefault<std::string>("content_tag", "");
+                        if (!luautils::IsContentEnabled(contentTag))
                         {
                             continue;
                         }
 
-                        uint32 NpcID = rset->get<uint32>("npcid");
+                        const auto NpcID = rset->get<uint32>("npcid");
 
                         if (!(PZone->GetTypeMask() & ZONE_TYPE::INSTANCED))
                         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

It also turns out we've _never_ been honouring negative values for CE or VE from spells or abilities. Now we do. Retreat and release at your leisure! 