### PR TITLE
DB: Don't support directly using enums yet

### DIFF
--- a/src/common/database.h
+++ b/src/common/database.h
@@ -194,6 +194,21 @@ namespace db
         template <typename T>
         inline constexpr bool is_blob_v = is_blob<T>;
 
+        template <typename T, bool = std::is_enum_v<T>>
+        struct enum_decay_impl
+        {
+            using type = std::decay_t<T>;
+        };
+
+        template <typename T>
+        struct enum_decay_impl<T, true>
+        {
+            using type = std::underlying_type_t<T>;
+        };
+
+        template <typename T>
+        using enum_decay_t = typename enum_decay_impl<T>::type;
+
         struct State final
         {
             void reset()
@@ -290,7 +305,8 @@ namespace db
                     return T{};
                 }
 
-                using UnderlyingT = std::decay_t<T>;
+                // TODO: First-class support for enum types
+                using UnderlyingT = enum_decay_t<T>;
 
                 UnderlyingT value{};
 
@@ -463,7 +479,8 @@ namespace db
         {
             TracyZoneScoped;
 
-            using UnderlyingT = std::decay_t<T>;
+            // TODO: First-class support for enum types
+            using UnderlyingT = enum_decay_t<T>;
 
             if constexpr (!is_blob_v<UnderlyingT>)
             {

--- a/src/map/ability.cpp
+++ b/src/map/ability.cpp
@@ -390,12 +390,13 @@ namespace ability
                     continue;
                 }
 
-                const auto abilityId = rset->get<uint16>("abilityId");
-                auto       PAbility  = std::make_unique<CAbility>(abilityId);
+                const auto abilityId    = rset->get<uint16>("abilityId");
+                PAbilityList[abilityId] = std::make_unique<CAbility>(abilityId);
+                const auto& PAbility    = PAbilityList[abilityId];
 
                 PAbility->setMobSkillID(rset->get<uint16>("mobskillId"));
                 PAbility->setName(rset->get<std::string>("name"));
-                PAbility->setJob(rset->get<JOBTYPE>("job"));
+                PAbility->setJob(static_cast<JOBTYPE>(rset->get<uint8>("job")));
                 PAbility->setLevel(rset->get<uint8>("level"));
                 PAbility->setValidTarget(rset->get<uint16>("validTarget"));
                 PAbility->setRecastTime(rset->get<uint16>("recastTime"));
@@ -404,7 +405,7 @@ namespace ability
                 PAbility->setAnimationID(rset->get<uint16>("animation"));
                 PAbility->setAnimationTime(std::chrono::milliseconds(rset->get<uint16>("animationTime")));
                 PAbility->setCastTime(std::chrono::milliseconds(rset->get<uint16>("castTime")));
-                PAbility->setActionType(rset->get<ACTIONTYPE>("actionType"));
+                PAbility->setActionType(static_cast<ACTIONTYPE>(rset->get<uint8>("actionType")));
                 PAbility->setRange(rset->get<float>("range"));
                 PAbility->setAOE(rset->get<uint8>("isAOE"));
                 PAbility->setRecastId(rset->get<uint16>("recastId"));
@@ -413,15 +414,14 @@ namespace ability
                 PAbility->setMeritModID(rset->get<uint16>("meritModID"));
                 PAbility->setAddType(rset->get<uint16>("addType"));
 
+                PAbilitiesByJob[PAbility->getJob()].emplace_back(PAbility.get());
+
                 auto filename = fmt::format("./scripts/actions/abilities/{}.lua", PAbility->getName());
                 if (PAbility->isPetAbility())
                 {
                     filename = fmt::format("./scripts/actions/abilities/pets/{}.lua", PAbility->getName());
                 }
                 luautils::CacheLuaObjectFromFile(filename);
-
-                PAbilitiesByJob[PAbility->getJob()].emplace_back(PAbility.get());
-                PAbilityList[PAbility->getID()] = std::move(PAbility);
             }
         }
 
@@ -432,7 +432,7 @@ namespace ability
             {
                 auto PCharge        = std::make_unique<Charge_t>();
                 PCharge->ID         = rset2->get<uint16>("recastId");
-                PCharge->job        = rset2->get<JOBTYPE>("job");
+                PCharge->job        = static_cast<JOBTYPE>(rset2->get<uint8>("job"));
                 PCharge->level      = rset2->get<uint8>("level");
                 PCharge->maxCharges = rset2->get<uint8>("maxCharges");
                 PCharge->chargeTime = rset2->get<uint32>("chargeTime");

--- a/src/map/utils/trustutils.cpp
+++ b/src/map/utils/trustutils.cpp
@@ -262,7 +262,7 @@ void BuildTrustData(uint32 TrustID)
             data->m_MobSkillList = rset->get<uint16>("skill_list_id");
 
             data->radius    = rset->get<uint8>("mobradius");
-            data->EcoSystem = rset->get<ECOSYSTEM>("ecosystemID");
+            data->EcoSystem = static_cast<ECOSYSTEM>(rset->get<uint8>("ecosystemID"));
             data->HPscale   = rset->get<float>("HP");
             data->MPscale   = rset->get<float>("MP");
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

As it turns out, my db code isn't _that_ smart, and it tried to interpret directly using enums as blobs - which meant numbers took on their ASCII numeric values instead of actual numeric values (0 -> 49, or whatever). This rolls back those changes and puts in a block so you can't directly use enums without manually casting until I get around to fixing it.

- Log in as lv10 WAR
- Have no abilities

After fix: Have abilities

Fixes: https://github.com/LandSandBoat/server/issues/7350