### PR TITLE
Make Royal Savior better

### DIFF
--- a/scripts/actions/mobskills/royal_savior.lua
+++ b/scripts/actions/mobskills/royal_savior.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Royal Savior
--- Grants effect of Protect
+-- Grants effects of Sentinel and Stoneskin
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -10,9 +10,18 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.PROTECT, 175, 0, 300))
+    -- Unsure if this is the correct value for enmity gain. The Wikis say it is stronger than Sentinel.
+    -- Sentinel is 900, Provoke is 1800
+    local power = 1300
 
-    return xi.effect.PROTECT
+    -- No data for how strong the stoneskin effect is from Royal Savior. Stoneskin cap is 350 without bonuses. This will make it 300 for level 99.
+    local amount = mob:getMainLvl() * 3 + 3
+
+    target:addEnmity(mob, 1, power)
+    mob:addStatusEffect(xi.effect.STONESKIN, amount, 0, 300)
+    skill:setMsg(xi.msg.basic.SKILL_GAIN_EFFECT)
+
+    return xi.effect.SENTINEL
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/royal_savior.lua
+++ b/scripts/actions/mobskills/royal_savior.lua
@@ -10,6 +10,8 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    xi.trust.message(mob,xi.trust.messageOffset.SPECIAL_MOVE_1)
+
     -- Unsure if this is the correct value for enmity gain. The Wikis say it is stronger than Sentinel.
     -- Sentinel is 900, Provoke is 1800
     local power = 1300
@@ -21,7 +23,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     mob:addStatusEffect(xi.effect.STONESKIN, amount, 0, 300)
     skill:setMsg(xi.msg.basic.SKILL_GAIN_EFFECT)
 
-    return xi.effect.SENTINEL
+    return xi.effect.DEFENSE_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/royal_savior.lua
+++ b/scripts/actions/mobskills/royal_savior.lua
@@ -10,8 +10,6 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    xi.trust.message(mob,xi.trust.messageOffset.SPECIAL_MOVE_1)
-
     -- Unsure if this is the correct value for enmity gain. The Wikis say it is stronger than Sentinel.
     -- Sentinel is 900, Provoke is 1800
     local power = 1300

--- a/scripts/actions/spells/trust/trion.lua
+++ b/scripts/actions/spells/trust/trion.lua
@@ -24,6 +24,13 @@ spellObject.onMobSpawn = function(mob)
     mob:addGambit(ai.t.TARGET, { ai.c.NOT_STATUS, xi.effect.FLASH }, { ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.FLASH })
 
     mob:addGambit(ai.t.PARTY, { ai.c.HPP_LT, 75 }, { ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.CURE })
+
+    mob:addListener('WEAPONSKILL_USE', 'TRION_WEAPONSKILL_USE', function(mobArg, target, wsid, tp, action)
+        if wsid == 3194 then -- Royal Savior
+            --  O Great kings of the noble line of d'Oraguille, shield me from harm!
+            xi.trust.message(mobArg, xi.trust.messageOffset.SPECIAL_MOVE_1)
+        end
+    end)
 end
 
 spellObject.onMobDespawn = function(mob)


### PR DESCRIPTION
Royal Savior should not cast Protect on mobs. It grants Trion the effects of Sentinel and Stoneskin.

**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

There is little to no data on these effects that I can find. The wikis each say the `Sentinel` effect granted by Royal Savior is stronger than regular `Sentinel`, but probably not the same power as `Provoke`, so this settles somewhere in between. I couldn't find much on the `Stoneskin` effect, so I made up some math to make `Stoneskin` have an amount of 300 HP at level 99. Its surely not retail accurate but seems like an improvement. Open to suggestions.

## Steps to test these changes

Summon Trion, let him get enough TP to use Royal Savior.
