### PR TITLE
[core] Fix crash on Fishing Bait Loss

### DIFF
--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -1361,17 +1361,24 @@ namespace fishingutils
                 return false;
             }
 
-            if (PChar->hookedFish->successtype != FISHINGSUCCESSTYPE_CATCHITEM)
+            if (PChar->hookedFish == nullptr)
             {
-                if (PBait->getQuantity() == 1)
+                ShowWarning("PChar->hookedFish was null.");
+            }
+            else
+            {
+                if (PChar->hookedFish->successtype != FISHINGSUCCESSTYPE_CATCHITEM)
                 {
-                    charutils::UnequipItem(PChar, SLOT_AMMO, false);
-                }
-                charutils::UpdateItem(PChar, PBait->getLocationID(), PBait->getSlotID(), -1);
+                    if (PBait->getQuantity() == 1)
+                    {
+                        charutils::UnequipItem(PChar, SLOT_AMMO, false);
+                    }
+                    charutils::UpdateItem(PChar, PBait->getLocationID(), PBait->getSlotID(), -1);
 
-                if (SendUpdate)
-                {
-                    PChar->pushPacket<CInventoryFinishPacket>();
+                    if (SendUpdate)
+                    {
+                        PChar->pushPacket<CInventoryFinishPacket>();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes crash on hookedFish in BaitLoss where hookedFish is deref'd before checking for null

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Fixes a crash in `BaitLoss()`
- `PChar->hookedFish` was not checked for null before being accessed in the `PChar->hookedFish->successType` comparison, leading to a crash.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - Go fishing with bait
2 - Try and trigger the following messages related to stamina checking:
```cpp
case FISHACTION_FINISH:
    ...
    else if (stamina <= 0x14)  // Lack of Skill!
                {
                    // you lost the catch due to lack of skill
                    // lose bait but keep lure
                    PChar->animation = ANIMATION_FISHING_LINE_BREAK;
                    PChar->updatemask |= UPDATE_HP;
                    BaitLoss(PChar, false, true);
                    PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_LOST_LOWSKILL);

                    if (PChar->hookedFish)
                    {
                        PChar->hookedFish->successtype = FISHINGSUCCESSTYPE_NONE;
                    }
                }
    else if (stamina <= 0x64)  // Line Breaks!
        ...
    else if (stamina <= 0x100) // You give up!
        ...
    else // implied (stamina > 0x100) // Lost catch!
        ...
```
In the above cases, `BaitLoss()` was called before the `if(PChar->hookedFish)` checks
3 - Repeat the steps above to check the remaining cases

NOTE: Under any of the above conditions, no crash is experienced when `BaitLoss()` is called.