### PR TITLE
[core] Fix nullptr crash in Packet 0x02D

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -5281,9 +5281,13 @@ void SmallPacket0x0D2(MapSession* const PSession, CCharEntity* const PChar, CBas
     // clang-format off
     PChar->ForAlliance([PChar](CBattleEntity* PPartyMember)
     {
-        if (PPartyMember->getZone() == PChar->getZone() && ((CCharEntity*)PPartyMember)->m_moghouseID == PChar->m_moghouseID)
+        if (PPartyMember)
         {
-            PChar->pushPacket<CPartyMapPacket>((CCharEntity*)PPartyMember);
+            auto* partyMember = static_cast<CCharEntity*>(PPartyMember);
+            if (partyMember->getZone() == PChar->getZone() && partyMember->m_moghouseID == PChar->m_moghouseID)
+            {
+                PChar->pushPacket<CPartyMapPacket>(partyMember);
+            }
         }
     });
     // clang-format on


### PR DESCRIPTION
Fixes a crash that can occur if PPartyMember is null and adds type-safety cast.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Fixes a crash that can occur in Packet 0x0D2 during the `ForAlliance()` call
- `PPartyMember` is never checked for null before being accessed
- Swapped to a static cast pointer of PPartyMember for type safety
- Changed associated checks to `partyMember`

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - Create a party with at least 2 members
2 - Trigger the map marker update by opening the map
3 - Force a nullptr scenario (such as force closing one players client before the map loads, particularly while the second player is zoning, logging out, etc.).

NOTE: The map process no longer crashes trying to access a nullptr in `ForAlliance()`