### PR TITLE
[core] Extend flexibility of Dynamic Entities

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -94,6 +94,7 @@
 #include "los/zone_los.h"
 #include "map_networking.h"
 #include "map_server.h"
+#include "mob_modifier.h"
 #include "mobskill.h"
 #include "monstrosity.h"
 #include "navmesh.h"
@@ -5494,6 +5495,56 @@ namespace luautils
                     sol::error err = result;
                     ShowError("applyMixins: %s: %s", PMob->name.c_str(), err.what());
                 }
+            }
+
+            // Allow for overrides of defaults on TYPE_MOB
+            // If no value is specified, mob_groups.sql values are used
+            const auto minLevel = table["minLevel"].get_or<uint8>(0);
+            if (minLevel > 0)
+            {
+                PMob->m_minLevel = minLevel;
+            }
+
+            const auto maxLevel = table["maxLevel"].get_or<uint8>(0);
+            if (maxLevel > 0)
+            {
+                PMob->m_maxLevel = maxLevel;
+            }
+
+            const auto dropId = table["dropId"].get_or<uint16>(0);
+            if (dropId > 0)
+            {
+                PMob->m_DropID = dropId;
+            }
+
+            const auto skillList = table["skillList"].get_or<uint16>(0);
+            if (skillList > 0)
+            {
+                PMob->m_MobSkillList = skillList;
+                PMob->setMobMod(MOBMOD_SKILL_LIST, skillList);
+            }
+
+            const auto spellList = table["spellList"].get_or<uint16>(0);
+            if (spellList > 0)
+            {
+                mobutils::SetSpellList(PMob, spellList);
+            }
+
+            const auto respawn = table["respawn"].get_or<uint32>(0);
+            if (respawn > 0)
+            {
+                PMob->m_RespawnTime  = respawn * 1000;
+                PMob->m_AllowRespawn = true;
+            }
+            else
+            {
+                PMob->m_AllowRespawn = false;
+            }
+
+            const auto spawnType = table["spawnType"].get_or<uint16>(0);
+            if (spawnType > 0)
+            {
+                PMob->m_SpawnType = (SPAWNTYPE)spawnType;
             }
 
             luautils::OnEntityLoad(PMob);


### PR DESCRIPTION
Adds in optional table values to modify mob level, drops, skills, spells, respawn, and timed spawns.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Extends the flexibility of Dynamic Entities for `TYPE_MOB` to allow for modifying the following:
- Minimum Level
- Maximum Level
- Drop ID
- Skill List
- Spell List
- Respawn Times
- Spawn Type (Normal, Night, Lottery, Windowed, Scripted, etc..)

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - Use the following script to create a command to spawn a DE Mob:
_NOTE: This script is crude and strictly for testing this PR_
```lua
---@type TCommand
local commandObj = {}

commandObj.cmdprops =
{
    permission = 1,
    parameters = ""
}

commandObj.onTrigger = function(player)
    local zone = player:getZone()

    if not zone then
        return
    end

    local mob = zone:insertDynamicEntity({
        objtype = xi.objType.MOB,
        name = "Test DE Mob",
        x = player:getXPos(),
        y = player:getYPos(),
        z = player:getZPos(),
        rotation = player:getRotPos(),
        groupId = 1,
        groupZoneId = zone:getID(),
        look = 357,
        minLevel = 10,  -- Set Min Level
        maxLevel = 20,  -- Set Max Level
        dropId = 805,   -- Modify to Fafnir Drop Table
        skillList = 48, -- Set custom skills (Bee)
        spellList = 79, -- Set custom Spell List (King Arthro)
        respawn = 60,   -- 60 Second Respawn
        spawnType = 0,  -- SPAWNTYPE_NORMAL (00:00 - 23:59)
    })

    if not mob then
        return
    end

    mob:setSpawn(player:getXPos(), player:getYPos(), player:getZPos(), player:getRotPos())
    mob:spawn()
end

return commandObj
```
2 - Use the new command to trigger a DE spawn with the added settings
3 - Check the Following Conditions:
- Mob Level (Variable between 10 to 20)
- Mob Drops on Death (Set to Fafnir Drops)
- Mob Spells (Should be Water Spells)
- Mob Skills (Should be Bee TP Moves)  _..and enjoy the distorted animations of a bee on a crab.._
- Check Respawn (Should be 1 Minute)

NOTE: You are now able to further modify Dynamic Entities from the Table Data when spawning a DE.