### PR TITLE
[core] Fix crash in Latent Effect Container

### DIFF
--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -659,15 +659,18 @@ void CLatentEffectContainer::CheckLatentsWeather()
 void CLatentEffectContainer::CheckLatentsWeather(uint16 weather)
 {
     ProcessLatentEffects([this, weather](CLatentEffect& latent) {
-        if (latent.GetConditionsID() == LATENT::WEATHER_ELEMENT)
+        if (auto owner = dynamic_cast<CBattleEntity*>(m_POwner))
         {
-            auto element = zoneutils::GetWeatherElement(battleutils::GetWeather((CBattleEntity*)m_POwner, false, weather));
-            return ApplyLatentEffect(latent, latent.GetConditionsValue() == element);
-        }
-        else if (latent.GetConditionsID() == LATENT::WEATHER_CONDITION)
-        {
-            auto element = battleutils::GetWeather((CBattleEntity*)m_POwner, false, weather);
-            return ApplyLatentEffect(latent, latent.GetConditionsValue() == element);
+            if (latent.GetConditionsID() == LATENT::WEATHER_ELEMENT)
+            {
+                const auto element = zoneutils::GetWeatherElement(battleutils::GetWeather(owner, false, weather));
+                return ApplyLatentEffect(latent, latent.GetConditionsValue() == element);
+            }
+            else if (latent.GetConditionsID() == LATENT::WEATHER_CONDITION)
+            {
+                const auto element = battleutils::GetWeather(owner, false, weather);
+                return ApplyLatentEffect(latent, latent.GetConditionsValue() == element);
+            }
         }
         return false;
     });


### PR DESCRIPTION
Adds a null check on m_POwner and removes the implicit casts that was happening.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Prevents a crash in latent effect container that can happen if m_POwner becomes null (during zoning, logout, etc)
- Adds `nullptr` check before before triggering latents.
- Removes implicit casts on `m_POwner`

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - Login with a two characters
2 - Equip one character with a weather-based latent effect
3 - Move both characters to an outside zone
4 - Start logging out with one character
5 - Right as the first character is about to logout, use `!setweather` to change the weather to whatever matches the latent
NOTE: The map process no longer crashes trying to call `ApplyLatentEffect()`