### PR TITLE
[sql] Fixes Seawolf Cudgel Attack Stat

### DIFF
--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -37288,7 +37288,7 @@ INSERT INTO `item_mods` VALUES (18394,71,2); -- MPHEAL: 2
 
 -- Seawolf Cudgel
 INSERT INTO `item_mods` VALUES (18395,8,5);   -- STR: 5
-INSERT INTO `item_mods` VALUES (18395,23,5);  -- ATT: 5
+INSERT INTO `item_mods` VALUES (18395,23,-5); -- ATT: -5
 INSERT INTO `item_mods` VALUES (18395,25,15); -- ACC: 15
 
 -- Sea Robber Cudgel


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Changes the attack stat of Seawolf Cudgel from +5 to -5.
This matches all wikis including the JP wiki and the .dat

![image](https://github.com/user-attachments/assets/a0d37549-86b0-460b-9e70-35e105ccb384)


## Steps to test these changes

1. ``!changejob whm 75``
2. ``!additem seawolf_cudgel``
3. Target self !getstats 3 note attack stat
4. Equip Cudgel
5. Target self !getstats 3 note attack stat

## Sources
.dat 
![image](https://github.com/user-attachments/assets/86541922-4fc1-4cf0-b270-2c95455010fc)

Wikis:
https://wiki.ffo.jp/html/4096.html
https://ffxiclopedia.fandom.com/wiki/Seawolf_Cudgel
https://www.bg-wiki.com/ffxi/Seawolf_Cudgel
https://www.ffxidb.com/items/18395
