### PR TITLE
add setting in main.lua to control whether to use original attack modifier or current retails

### DIFF
--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -137,7 +137,7 @@ xi.settings.main =
     DISABLE_PARTY_EXP_PENALTY        = false, -- true/false.
     ENABLE_IMMUNOBREAK               = true,  -- true/false. Allow/Disallow immunobreaks to happen.
     USE_PRE_2013_DEX_MULTIPLIER      = false, -- true/false. False uses 75% of DEX for accuracy calculation. Prior to 2013 50% of DEX was used.
-
+    USE_PRE_2013_STR_MULTIPLIER      = false, -- true/false. False uses STR multiplier of 1.0 for two handed, one handed main, and ranged attacks, 0.75 for H2H, and 0.5 for one handed in sub slot. True uses 0.5 of STR across the board and is how the game was from release to mid 2013.
 
     -- TRUSTS
     ENABLE_TRUST_CASTING           = 1,

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -863,31 +863,31 @@ uint16 CBattleEntity::ATT(SLOTTYPE slot)
 {
     TracyZoneScoped;
     // TODO: consider which weapon!
-    int32 ATT    = 8 + m_modStat[Mod::ATT];
-    auto  ATTP   = m_modStat[Mod::ATTP];
-    auto* weapon = dynamic_cast<CItemWeapon*>(m_Weapons[slot]);
+    int32 ATT           = 8 + m_modStat[Mod::ATT];
+    auto  ATTP          = m_modStat[Mod::ATTP];
+    auto* weapon        = dynamic_cast<CItemWeapon*>(m_Weapons[slot]);
+    float strMultiplier = 0.5;
 
     // https://www.bg-wiki.com/ffxi/Strength
     if (weapon && weapon->isTwoHanded()) // 2-handed weapon
     {
-        ATT += STR();
+        strMultiplier = 1.0;
     }
     else if (weapon && weapon->isHandToHand()) // H2H Weapon
     {
-        ATT += STR() * 3 / 4;
+        strMultiplier = 0.75;
     }
-    else if (slot == SLOT_RANGED || slot == SLOT_AMMO) // Ranged/ammo weapon.
+    else if (slot == SLOT_MAIN || slot == SLOT_RANGED || slot == SLOT_AMMO) // 1-handed weapon in main slot, Ranged or ammo weapon.
     {
-        ATT += STR();
+        strMultiplier = 1.0;
     }
-    else if (slot == SLOT_MAIN) // 1-handed weapon in main slot.
+
+    if (settings::get<bool>("main.USE_PRE_2013_STR_MULTIPLIER"))
     {
-        ATT += STR();
+        strMultiplier = 0.5;
     }
-    else // 1-handed weapon in sub slot.
-    {
-        ATT += STR() / 2;
-    }
+
+    ATT += STR() * strMultiplier;
 
     if (this->StatusEffectContainer->HasStatusEffect(EFFECT_ENDARK))
     {


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adds  a setting to change how strength affects attack. Current retails values will be used by default. Toggling the setting in main.lua will add half of the players strength to their attack as described here: https://forum.square-enix.com/ffxi/threads/35228-July-9-2013-%28JST%29-Version-Update?p=452806&viewfull=1#post452806

## Steps to test these changes

I'm about to test tomorrow!
