### PR TITLE
Knocking on Forbidden Doors mannequin fixes

### DIFF
--- a/scripts/quests/otherAreas/Knocking_on_Forbidden_Doors.lua
+++ b/scripts/quests/otherAreas/Knocking_on_Forbidden_Doors.lua
@@ -204,10 +204,11 @@ quest.sections =
                     for itemId = xi.item.HUME_M_MANNEQUIN, xi.item.GALKA_MANNEQUIN do
                         if npcUtil.tradeHasExactly(trade, itemId) then
                             tradedMannequin = itemId
+                            break
                         end
                     end
 
-                    if tradedMannequin then
+                    if tradedMannequin ~= 0 then
                         return quest:progressEvent(319, { [0] = 2,
                             [1] = xi.mannequin.getMannequins(player), -- Player Mannequin List
                             [2] = xi.mannequin.cost.PURCHASE,
@@ -258,12 +259,16 @@ quest.sections =
                     then
                         player:confirmTrade()
                         npcUtil.giveItem(player, xi.item.HUME_M_MANNEQUIN + option - 1)
+                        local race = ((option - 1) % 8) + 1
+                        xi.mannequin.setMannequinPose(player, race, 0)
                     end
                 end,
 
                 [321] = function(player, csid, option, npc)
                     -- If the transaction failed, the option is nil.
-                    if
+                    if player:getFreeSlotsCount() == 0 then
+                        player:messageSpecial(mhauraID.text.ITEM_CANNOT_BE_OBTAINED, xi.item.HUME_M_MANNEQUIN + option - 1)
+                    elseif
                         -- Purchase the mannequin.  Option = race (1-8)
                         option >= 1 and
                         option <= 8 and
@@ -271,6 +276,8 @@ quest.sections =
                     then
                         player:messageSpecial(mhauraID.text.ITEM_OBTAINED, xi.item.HUME_M_MANNEQUIN + option - 1)
                         player:addItem(xi.item.HUME_M_MANNEQUIN + option - 1)
+                        local race = ((option - 1) % 8) + 1
+                        xi.mannequin.setMannequinPose(player, race, 0)
                     elseif
                         option >= 10 and
                         player:delGil(xi.mannequin.cost.POSE)

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -18772,7 +18772,7 @@ void CLuaBaseEntity::setMannequinPose(uint16 itemID, uint8 race, uint8 pose)
 
                         const char* fmtQuery = "UPDATE char_inventory "
                                                "SET extra = ? "
-                                               "WHERE charid = ? AND itemId = ?"
+                                               "WHERE charid = ? AND itemId = ? "
                                                "LIMIT 1";
 
                         if (!db::preparedStmt(fmtQuery, PMannequin->m_extra, PChar->id, PMannequin->getID()))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

1. Mannequins obtained through trade or purchase from Fyi Chalmwoh are now the correct race and can be equipped with items
2. Fixes the issue where players could obtain a mannequin through trade without it being removed from their inventory
3. Purchasing a mannequin with a full inventory will no longer take the player's gil and not give the item
4. Fixes an SQL error when calling setMannequinPose

## Steps to test these changes
!completequest 4 29
!completequest 4 77
!completequest 4 78
!addkeyitem 713
!setgil 1000000
!pos -39.273 -16.000 70.126 249
!zone 238
<!-- Clear and detailed steps to test your changes here -->
