### PR TITLE
Fix item enchantments, add Haste Belt and Regen Collar

### DIFF
--- a/scripts/items/haste_belt.lua
+++ b/scripts/items/haste_belt.lua
@@ -10,14 +10,22 @@ itemObject.onItemCheck = function(target, item, param, caster)
     return 0
 end
 
+itemObject.onItemUnequip = function(target, item)
+    target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HASTE_BELT)
+end
+
 itemObject.onItemUse = function(target)
     if target:hasEquipped(xi.item.HASTE_BELT) then
-        if not target:hasStatusEffect(xi.effect.HASTE) then
-            target:addStatusEffect(xi.effect.HASTE, 1000, 0, 180, 0, 0, 0, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HASTE_BELT)
-        else
-            target:messageBasic(xi.msg.basic.NO_EFFECT)
-        end
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HASTE_BELT)
     end
+end
+
+itemObject.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.HASTE_GEAR, 1000)
+end
+
+itemObject.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.HASTE_GEAR, 1000)
 end
 
 return itemObject

--- a/scripts/items/regen_collar.lua
+++ b/scripts/items/regen_collar.lua
@@ -10,14 +10,22 @@ itemObject.onItemCheck = function(target, item, param, caster)
     return 0
 end
 
+itemObject.onItemUnequip = function(target, item)
+    target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.REGEN_COLLAR)
+end
+
 itemObject.onItemUse = function(target)
     if target:hasEquipped(xi.item.REGEN_COLLAR) then
-        if not target:hasStatusEffect(xi.effect.REGEN) then
-            target:addStatusEffect(xi.effect.REGEN, 1, 3, 120, 0, 0, 0, xi.effectSourceType.EQUIPPED_ITEM, xi.item.REGEN_COLLAR)
-        else
-            target:messageBasic(xi.msg.basic.NO_EFFECT)
-        end
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 120, 0, 0, 0, xi.effectSourceType.EQUIPPED_ITEM, xi.item.REGEN_COLLAR)
     end
+end
+
+itemObject.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.REGEN, 1)
+end
+
+itemObject.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.REGEN, 1)
 end
 
 return itemObject

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1547,7 +1547,7 @@ void CStatusEffectContainer::SetEffectParams(CStatusEffect* StatusEffect)
             if (PItem != nullptr)
             {
                 // get the item lua script and check if it has valid functions
-                auto itemName     = "globals/items/" + PItem->getName();
+                auto itemName     = "items/" + PItem->getName();
                 auto itemFullName = fmt::format("./scripts/{}.lua", itemName);
                 auto cacheEntry   = luautils::GetCacheEntryFromFilename(itemFullName);
                 auto onEffectGain = cacheEntry["onEffectGain"].get<sol::function>();
@@ -1565,17 +1565,17 @@ void CStatusEffectContainer::SetEffectParams(CStatusEffect* StatusEffect)
     }
 
     // Determine if this is a BRD Song or COR Effect.
-    if (subType == 0 ||
-        ((subType > 20000 ||
-          (effect >= EFFECT_REQUIEM && effect <= EFFECT_NOCTURNE) ||
-          (effect >= EFFECT_DOUBLE_UP_CHANCE && effect <= EFFECT_NATURALISTS_ROLL) ||
-          effect == EFFECT_RUNEISTS_ROLL ||
-          effect == EFFECT_DRAIN_DAZE ||
-          effect == EFFECT_ASPIR_DAZE ||
-          effect == EFFECT_HASTE_DAZE ||
-          effect == EFFECT_ATMA ||
-          effect == EFFECT_BATTLEFIELD) &&
-         !effectFromItemEnchant))
+    if (!effectFromItemEnchant &&
+        (subType == 0 ||
+         subType > 20000 ||
+         (effect >= EFFECT_REQUIEM && effect <= EFFECT_NOCTURNE) ||
+         (effect >= EFFECT_DOUBLE_UP_CHANCE && effect <= EFFECT_NATURALISTS_ROLL) ||
+         effect == EFFECT_RUNEISTS_ROLL ||
+         effect == EFFECT_DRAIN_DAZE ||
+         effect == EFFECT_ASPIR_DAZE ||
+         effect == EFFECT_HASTE_DAZE ||
+         effect == EFFECT_ATMA ||
+         effect == EFFECT_BATTLEFIELD))
     {
         name.insert(0, "effects/");
         name.insert(name.size(), effects::EffectsParams[effect].Name);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Fixes a path variable and condition in CStatusEffectContainer::SetEffectParams that prevented item enchantments from working.

Haste Belt now gives enchantment haste instead spell haste. This effect will stack with the spell haste. Effect is removed when belt is unequipped.

Regen Collar now gives enchantment regen instead spell regen. This effect will stack with the spell regen. Effect is removed when collar is unequipped.

Closes: https://github.com/LandSandBoat/server/issues/5768
## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
!additem 15526
!getmod 370

!additem 15290
!getmod 384
