### PR TITLE
[lua] Vampiric Root steals status effects

### DIFF
--- a/scripts/actions/mobskills/vampiric_lash.lua
+++ b/scripts/actions/mobskills/vampiric_lash.lua
@@ -4,7 +4,7 @@
 -- Type: Magical
 -- Utsusemi/Blink absorb: 1 shadow
 -- Range: Melee
--- Notes: In ToAU zones, this has an additional effect of absorbing all status effects, including food.
+-- Notes: (Unverified) In ToAU zones, this has an additional effect of absorbing all status effects, including food.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}

--- a/scripts/actions/mobskills/vampiric_root.lua
+++ b/scripts/actions/mobskills/vampiric_root.lua
@@ -1,10 +1,10 @@
 -----------------------------------
 -- Vampiric Root
--- Deals dark damage to a single target. Additional effect: Drain
+-- Steals HP from a single target and absorbs positive status effects.
 -- Type: Magical
 -- Utsusemi/Blink absorb: 1 shadow
 -- Range: Melee
--- Notes: If used against undead, it will simply do damage and not drain HP.
+-- Notes: (Unverified) If used against undead, it will simply do damage and not drain HP.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -20,6 +20,13 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, xi.mobskills.shadowBehavior.NUMSHADOWS_1)
 
     skill:setMsg(xi.mobskills.mobPhysicalDrainMove(mob, target, skill, xi.mobskills.drainType.HP, damage))
+
+    -- Absorb ALL positive status effects
+    -- Note: Some sources claim this includes food and reraise which has been proven to be false
+    local result = mob:stealStatusEffect(target)
+    while result ~= 0 do
+        result = mob:stealStatusEffect(target)
+    end
 
     return damage
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds logic to steal all status effects from target upon use.

Note that wikis claim this is supposed to steal Reraise and Food, which I have proven to be false, _at least on base Ameretat mobs_

This move isn't in any skill list currently but I've tested it on my upcoming Einherjar Morbol boss.

Ameretats need a thorough audit (and possibly the whole Morbol family), I've found so many conflicting or downright wrong claims on the wikis that I can't trust any of the data there. 

Related to #7405 

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
