### PR TITLE
Correct event priority in A_Hard_Days_Knight

### DIFF
--- a/scripts/quests/otherAreas/A_Hard_Days_Knight.lua
+++ b/scripts/quests/otherAreas/A_Hard_Days_Knight.lua
@@ -51,7 +51,7 @@ quest.sections =
                     local questProgress = quest:getVar(player, 'Prog')
 
                     if questProgress == 0 then
-                        return quest:progressEvent(120)
+                        return quest:event(120)
                     elseif questProgress == 1 then
                         return quest:progressEvent(121)
                     end


### PR DESCRIPTION
Fixes return quest:progressEvent(120) to                         return quest:event(120) to prep for The Search for Goldmane.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Corrects progressEvent(120) to event(120) to prep for the NPC dialog sharing event(397) during The Search for Goldmane. 

## Steps to test these changes

Zone to Tavnazia - !zone 26
Approach Quelveuiat - !pos 1.066 -22.750 -25.077
Selection option 1 in the dialog to accept "A Hard Days Knight" -OR- add the quest - !addquest 4 64
Speak to Quelveuiat to get event 120. 
