### PR TITLE
Check isSpawned before attempting to spawn Bayawak

### DIFF
--- a/scripts/zones/Yuhtunga_Jungle/Zone.lua
+++ b/scripts/zones/Yuhtunga_Jungle/Zone.lua
@@ -88,7 +88,10 @@ zoneObject.onZoneWeatherChange = function(weather)
             DisallowRespawn(bayawak:getID(), false)
 
             -- Spawn if respawn is up
-            if os.time() > bayawak:getLocalVar('respawn') then
+            if
+                os.time() > bayawak:getLocalVar('respawn') and
+                not bayawak:isSpawned()
+            then
                 SpawnMob(bayawak:getID())
             end
         else


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Checks to see if Bayawak is spawned before attempting to spawn when conditions met.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Watch map process until conditions are met, and ensure the following error does not occur:
```
[04/14/25 11:11:11:043][map][debug] SpawnMob: 17281388 <Bayawak> is already spawned (luautils::SpawnMob:1749)
```
<!-- Clear and detailed steps to test your changes here -->
