### PR TITLE
[lua] Added Unique Events for Mathilde and Ramona

### DIFF
--- a/scripts/enum/unique_event.lua
+++ b/scripts/enum/unique_event.lua
@@ -15,4 +15,6 @@ xi.uniqueEvent =
 {
     EKOKOKO_INTRODUCTION = 0,
     RECEIVED_NEXUS_CAPE  = 1,
+    MET_MATHILDES_SON = 2,
+    RAMONA_INTRODUCTION = 3,
 }

--- a/scripts/zones/Selbina/DefaultActions.lua
+++ b/scripts/zones/Selbina/DefaultActions.lua
@@ -19,7 +19,6 @@ return {
     ['Pacomart']     = { event = 180 },
     ['Pascaut']      = { event = 26 },
     ['Pomulus']      = { event = 700 },
-    ['Ramona']       = { event = 170 },
     ['Thunder_Hawk'] = { event = 84 },
     ['Valgeir']      = { event = 140 },
     ['Velema']       = { event = 10 },

--- a/scripts/zones/Selbina/npcs/Ramona.lua
+++ b/scripts/zones/Selbina/npcs/Ramona.lua
@@ -1,27 +1,26 @@
 -----------------------------------
 -- Area: Selbina
---  NPC: Mathilde
--- Involved in Quest: Riding on the Clouds
--- !pos 12.578 -8.287 -7.576 248
+--  NPC: Ramona
+-- !pos 15.1869 -7.2878 -1.1016 171
 -----------------------------------
 ---@type TNpcEntity
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    if player:getRank(player:getNation()) >= 6 then
-        if not player:hasCompletedUniqueEvent(xi.uniqueEvent.MET_MATHILDES_SON) then
-            player:startEvent(173)
-        else
-            player:startEvent(174)
-        end
+    if not player:hasCompletedUniqueEvent(xi.uniqueEvent.RAMONA_INTRODUCTION) then
+        player:startEvent(172)
     else
-        player:startEvent(171)
+        if not player:hasCompletedUniqueEvent(xi.uniqueEvent.MET_MATHILDES_SON) then
+            player:startEvent(170)
+        else
+            player:startEvent(175)
+        end
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    if csid == 173 then
-        player:setUniqueEvent(xi.uniqueEvent.MET_MATHILDES_SON)
+    if csid == 172 then
+        player:setUniqueEvent(xi.uniqueEvent.RAMONA_INTRODUCTION)
     end
 end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes #6765 
Some clarification though:  The issue suggests that events 173 and 174 are able to be played upon first meeting with NPC Mathilde, but I found in retail that that isn't exactly the case.  These events only appear after a player has reached Rank 6.  Footage of these events in retail can be found [here](https://www.youtube.com/watch?v=hyUKY57ielg).  
Likewise, the NPC Ramona should be playing events that are directly related, one of which does happen upon the players first interaction, so I decided to add similar logic for her to play her events.


## Steps to test these changes

!setrank 1
Speak to Mathilde, see event 171
Speak to Ramona, see event 172
Speak to Ramona again, see event 170
!setrank 6
Speak to Mathilde, see event 173
Speak to Mathilde again, see event 174
Speak to Ramona, see event 175

If you need to reset the unique events, you can run:
!exec player:delUniqueEvent(xi.uniqueEvent.RAMONA_INTRODUCTION)
!exec player:delUniqueEvent(xi.uniqueEvent.MET_MATHILDES_SON)
