### PR TITLE
SQL: Fix issues with wildcards and debug logging

### DIFF
--- a/src/common/database.cpp
+++ b/src/common/database.cpp
@@ -168,12 +168,15 @@ auto db::detail::validateQueryLeadingKeyword(std::string const& query) -> Result
 
 auto db::detail::validateQueryContent(std::string const& query) -> bool
 {
+    // NOTE: We shouldn't be checking for the presence of '%', as this
+    //     : is the SQL wildcard character.
+
     if (query.find("{}") != std::string::npos)
     {
         return false;
     }
 
-    if (query.find(";") != std::string::npos)
+    if (query.find(';') != std::string::npos)
     {
         return false;
     }
@@ -260,7 +263,7 @@ auto db::queryStr(std::string const& rawQuery) -> std::unique_ptr<db::detail::Re
         {
             auto stmt = state.connection->createStatement();
 
-            DebugSQL(fmt::format("query: {}", rawQuery));
+            DebugSQLFmt("query: {}", rawQuery);
             const auto queryTimer = detail::timer(rawQuery);
 
             if (queryType == detail::ResultSetType::Select)

--- a/src/common/database.h
+++ b/src/common/database.h
@@ -511,7 +511,7 @@ namespace db
 
             if constexpr (!is_blob_v<UnderlyingT>)
             {
-                DebugSQL(fmt::format("binding {}: {}", counter, value));
+                DebugSQLFmt("binding {}: {}", counter, value);
             }
 
             if constexpr (std::is_enum_v<UnderlyingT>)
@@ -580,7 +580,7 @@ namespace db
                 const auto blobWrapper = BlobWrapper::create(value);
                 blobs.push_back(blobWrapper);
 
-                DebugSQL(fmt::format("binding {}: {}", counter, blobWrapper->toString()));
+                DebugSQLFmt("binding {}: {}", counter, blobWrapper->toString());
 
                 stmt->setBlob(counter, &blobWrapper->istream);
             }
@@ -688,7 +688,7 @@ namespace db
                     state.lazyPreparedStatements[rawQuery] = std::unique_ptr<sql::PreparedStatement>(state.connection->prepareStatement(rawQuery.c_str()));
                 }
 
-                DebugSQL(fmt::format("preparedStmt: {}", rawQuery));
+                DebugSQLFmt("preparedStmt: {}", rawQuery);
 
                 // NOTE: Everything is 1-indexed, but we're going to increment right away insider binder!
                 auto counter = 0;

--- a/src/common/logging.h
+++ b/src/common/logging.h
@@ -106,77 +106,77 @@ inline auto format_as(type v) \
     try                     \
     {
 
-#define END_CATCH_HANDLER                                                                                         \
-    }                                                                                                            \
+#define END_CATCH_HANDLER(File, Line)                                                                             \
+    }                                                                                                             \
     catch (std::exception const& ex)                                                                              \
     {                                                                                                             \
         SPDLOG_LOGGER_ERROR(spdlog::get("error"), fmt::sprintf("Encountered logging exception!: %s", ex.what())); \
-        SPDLOG_LOGGER_ERROR(spdlog::get("error"), fmt::sprintf("%s:%i", __FILE__, __LINE__));                     \
+        SPDLOG_LOGGER_ERROR(spdlog::get("error"), fmt::sprintf("%s:%i", File, Line));                             \
     }                                                                                                             \
     catch (...)                                                                                                   \
     {                                                                                                             \
         SPDLOG_LOGGER_ERROR(spdlog::get("error"), fmt::sprintf("Encountered unhandled logging exception!"));      \
-        SPDLOG_LOGGER_ERROR(spdlog::get("error"), fmt::sprintf("%s:%i", __FILE__, __LINE__));                     \
+        SPDLOG_LOGGER_ERROR(spdlog::get("error"), fmt::sprintf("%s:%i", File, Line));                             \
     } STATEMENT_CLOSE
 
-#define LOGGER_BODY(LOG_TYPE_MACRO, LogStringName, ...) \
-    BEGIN_CATCH_HANDLER const auto _msgStr = fmt::sprintf(__VA_ARGS__); TracyZoneScoped; TracyMessageStr(_msgStr); logging::AddBacktrace(_msgStr); LOG_TYPE_MACRO(spdlog::get(LogStringName), _msgStr); END_CATCH_HANDLER
+#define LOGGER_BODY(LOG_TYPE_MACRO, LogStringName, File, Line, ...) \
+    BEGIN_CATCH_HANDLER const auto _msgStr = fmt::sprintf(__VA_ARGS__); TracyZoneScoped; TracyMessageStr(_msgStr); logging::AddBacktrace(_msgStr); LOG_TYPE_MACRO(spdlog::get(LogStringName), _msgStr); END_CATCH_HANDLER(File, Line)
 
-#define LOGGER_BODY_CONDITIONAL(LOG_TYPE_MACRO, LogStringName, LogConditionStr, ...) \
-    BEGIN_CATCH_HANDLER const auto _msgStr = fmt::sprintf(__VA_ARGS__); TracyZoneScoped; TracyMessageStr(_msgStr); logging::AddBacktrace(_msgStr); if (settings::get<bool>(LogConditionStr)) { LOG_TYPE_MACRO(spdlog::get(LogStringName), _msgStr); } END_CATCH_HANDLER
+#define LOGGER_BODY_CONDITIONAL(LOG_TYPE_MACRO, LogStringName, LogConditionStr, File, Line, ...) \
+    BEGIN_CATCH_HANDLER const auto _msgStr = fmt::sprintf(__VA_ARGS__); TracyZoneScoped; TracyMessageStr(_msgStr); logging::AddBacktrace(_msgStr); if (settings::get<bool>(LogConditionStr)) { LOG_TYPE_MACRO(spdlog::get(LogStringName), _msgStr); } END_CATCH_HANDLER(File, Line)
 
-#define LOGGER_BODY_FMT(LOG_TYPE_MACRO, LogStringName, ...) \
-    BEGIN_CATCH_HANDLER const auto _msgStr = fmt::format(__VA_ARGS__); TracyZoneScoped; TracyMessageStr(_msgStr); logging::AddBacktrace(_msgStr); LOG_TYPE_MACRO(spdlog::get(LogStringName), _msgStr); END_CATCH_HANDLER
+#define LOGGER_BODY_FMT(LOG_TYPE_MACRO, LogStringName, File, Line, ...) \
+    BEGIN_CATCH_HANDLER const auto _msgStr = fmt::format(__VA_ARGS__); TracyZoneScoped; TracyMessageStr(_msgStr); logging::AddBacktrace(_msgStr); LOG_TYPE_MACRO(spdlog::get(LogStringName), _msgStr); END_CATCH_HANDLER(File, Line)
 
-#define LOGGER_BODY_CONDITIONAL_FMT(LOG_TYPE_MACRO, LogStringName, LogConditionStr, ...) \
-    BEGIN_CATCH_HANDLER const auto _msgStr = fmt::format(__VA_ARGS__); TracyZoneScoped; TracyMessageStr(_msgStr); logging::AddBacktrace(_msgStr); if (settings::get<bool>(LogConditionStr)) { LOG_TYPE_MACRO(spdlog::get(LogStringName), _msgStr); } END_CATCH_HANDLER
+#define LOGGER_BODY_CONDITIONAL_FMT(LOG_TYPE_MACRO, LogStringName, LogConditionStr, File, Line, ...) \
+    BEGIN_CATCH_HANDLER const auto _msgStr = fmt::format(__VA_ARGS__); TracyZoneScoped; TracyMessageStr(_msgStr); logging::AddBacktrace(_msgStr); if (settings::get<bool>(LogConditionStr)) { LOG_TYPE_MACRO(spdlog::get(LogStringName), _msgStr); } END_CATCH_HANDLER(File, Line)
 
 // Regular Loggers
 // NOTE 1: Trace is not for logging to screen or file; it's for filling the backtrace buffer and reporting to Tracy.
 // NOTE 2: It isn't possible (or a good idea) to allow the user to disable TRACE, ERROR, or CRITICAL logging.
-#define ShowTrace(...)    logging::AddBacktrace(fmt::sprintf(__VA_ARGS__))
-#define ShowDebug(...)    LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_DEBUG, "debug", "logging.LOG_DEBUG", __VA_ARGS__)
-#define ShowInfo(...)     LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_INFO, "info", "logging.LOG_INFO", __VA_ARGS__)
-#define ShowWarning(...)  LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_WARN, "warn", "logging.LOG_WARNING", __VA_ARGS__); logging::tapWarningOrError()
-#define ShowLua(...)      LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_INFO, "lua", "logging.LOG_LUA", __VA_ARGS__); logging::tapWarningOrError()
-#define ShowError(...)    LOGGER_BODY(SPDLOG_LOGGER_ERROR, "error", __VA_ARGS__); logging::tapWarningOrError()
-#define ShowCritical(...) LOGGER_BODY(SPDLOG_LOGGER_CRITICAL, "critical", __VA_ARGS__); logging::tapWarningOrError()
+#define ShowTrace(...)    logging::AddBacktrace(fmt::format("{}:{}: {}", __FILE__, __LINE__, fmt::sprintf(__VA_ARGS__)))
+#define ShowDebug(...)    LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_DEBUG, "debug", "logging.LOG_DEBUG", __FILE__, __LINE__, __VA_ARGS__)
+#define ShowInfo(...)     LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_INFO, "info", "logging.LOG_INFO", __FILE__, __LINE__, __VA_ARGS__)
+#define ShowWarning(...)  LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_WARN, "warn", "logging.LOG_WARNING", __FILE__, __LINE__, __VA_ARGS__); logging::tapWarningOrError()
+#define ShowLua(...)      LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_INFO, "lua", "logging.LOG_LUA", __FILE__, __LINE__, __VA_ARGS__); logging::tapWarningOrError()
+#define ShowError(...)    LOGGER_BODY(SPDLOG_LOGGER_ERROR, "error", __FILE__, __LINE__, __VA_ARGS__); logging::tapWarningOrError()
+#define ShowCritical(...) LOGGER_BODY(SPDLOG_LOGGER_CRITICAL, "critical", __FILE__, __LINE__, __VA_ARGS__); logging::tapWarningOrError()
 
 // Regular Loggers fmt variants
-#define ShowTraceFmt(...)    logging::AddBacktrace(fmt::format(__VA_ARGS__))
-#define ShowDebugFmt(...)    LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_DEBUG, "debug", "logging.LOG_DEBUG", __VA_ARGS__)
-#define ShowInfoFmt(...)     LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_INFO, "info", "logging.LOG_INFO", __VA_ARGS__)
-#define ShowWarningFmt(...)  LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_WARN, "warn", "logging.LOG_WARNING", __VA_ARGS__); logging::tapWarningOrError()
-#define ShowLuaFmt(...)      LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_INFO, "lua", "logging.LOG_LUA", __VA_ARGS__); logging::tapWarningOrError()
-#define ShowErrorFmt(...)    LOGGER_BODY_FMT(SPDLOG_LOGGER_ERROR, "error", __VA_ARGS__); logging::tapWarningOrError()
-#define ShowCriticalFmt(...) LOGGER_BODY_FMT(SPDLOG_LOGGER_CRITICAL, "critical", __VA_ARGS__); logging::tapWarningOrError()
+#define ShowTraceFmt(...)    logging::AddBacktrace(fmt::format("{}:{}: {}", __FILE__, __LINE__, fmt::format(__VA_ARGS__)))
+#define ShowDebugFmt(...)    LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_DEBUG, "debug", "logging.LOG_DEBUG", __FILE__, __LINE__, __VA_ARGS__)
+#define ShowInfoFmt(...)     LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_INFO, "info", "logging.LOG_INFO", __FILE__, __LINE__, __VA_ARGS__)
+#define ShowWarningFmt(...)  LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_WARN, "warn", "logging.LOG_WARNING", __FILE__, __LINE__, __VA_ARGS__); logging::tapWarningOrError()
+#define ShowLuaFmt(...)      LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_INFO, "lua", "logging.LOG_LUA", __FILE__, __LINE__, __VA_ARGS__); logging::tapWarningOrError()
+#define ShowErrorFmt(...)    LOGGER_BODY_FMT(SPDLOG_LOGGER_ERROR, "error", __FILE__, __LINE__, __VA_ARGS__); logging::tapWarningOrError()
+#define ShowCriticalFmt(...) LOGGER_BODY_FMT(SPDLOG_LOGGER_CRITICAL, "critical", __FILE__, __LINE__, __VA_ARGS__); logging::tapWarningOrError()
 
 // Debug Loggers
-#define DebugSockets(...)     LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_SOCKETS", __VA_ARGS__)
-#define DebugIPC(...)         LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_IPC", __VA_ARGS__)
-#define DebugNavmesh(...)     LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_NAVMESH",__VA_ARGS__)
-#define DebugPackets(...)     LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_PACKETS",__VA_ARGS__)
-#define DebugActions(...)     LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_ACTIONS", __VA_ARGS__)
-#define DebugSQL(...)         LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_SQL", __VA_ARGS__)
-#define DebugIDLookup(...)    LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_ID_LOOKUP", __VA_ARGS__)
-#define DebugModules(...)     LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_MODULES", __VA_ARGS__)
-#define DebugAuctions(...)    LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_AUCTIONS", __VA_ARGS__)
-#define DebugDeliveryBox(...) LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_DELIVERY_BOX", __VA_ARGS__)
-#define DebugBazaars(...)     LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_BAZAARS", __VA_ARGS__)
-#define DebugPerformance(...) LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_PERFORMANCE", __VA_ARGS__)
+#define DebugSockets(...)     LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_SOCKETS", __FILE__, __LINE__, __VA_ARGS__)
+#define DebugIPC(...)         LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_IPC", __FILE__, __LINE__, __VA_ARGS__)
+#define DebugNavmesh(...)     LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_NAVMESH",__FILE__, __LINE__, __VA_ARGS__)
+#define DebugPackets(...)     LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_PACKETS",__FILE__, __LINE__, __VA_ARGS__)
+#define DebugActions(...)     LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_ACTIONS", __FILE__, __LINE__, __VA_ARGS__)
+#define DebugSQL(...)         LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_SQL", __FILE__, __LINE__, __VA_ARGS__)
+#define DebugIDLookup(...)    LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_ID_LOOKUP", __FILE__, __LINE__, __VA_ARGS__)
+#define DebugModules(...)     LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_MODULES", __FILE__, __LINE__, __VA_ARGS__)
+#define DebugAuctions(...)    LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_AUCTIONS", __FILE__, __LINE__, __VA_ARGS__)
+#define DebugDeliveryBox(...) LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_DELIVERY_BOX", __FILE__, __LINE__, __VA_ARGS__)
+#define DebugBazaars(...)     LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_BAZAARS", __FILE__, __LINE__, __VA_ARGS__)
+#define DebugPerformance(...) LOGGER_BODY_CONDITIONAL(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_PERFORMANCE", __FILE__, __LINE__, __VA_ARGS__)
 
 // Debug Loggers fmt variants
-#define DebugSocketsFmt(...)     LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_SOCKETS", __VA_ARGS__)
-#define DebugIPCFmt(...)         LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_IPC", __VA_ARGS__)
-#define DebugNavmeshFmt(...)     LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_NAVMESH", __VA_ARGS__)
-#define DebugPacketsFmt(...)     LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_PACKETS", __VA_ARGS__)
-#define DebugActionsFmt(...)     LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_ACTIONS", __VA_ARGS__)
-#define DebugSQLFmt(...)         LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_SQL", __VA_ARGS__)
-#define DebugIDLookupFmt(...)    LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_ID_LOOKUP", __VA_ARGS__)
-#define DebugModulesFmt(...)     LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_MODULES", __VA_ARGS__)
-#define DebugAuctionsFmt(...)    LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_AUCTIONS", __VA_ARGS__)
-#define DebugDeliveryBoxFmt(...) LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_DELIVERY_BOX", __VA_ARGS__)
-#define DebugBazaarsFmt(...)     LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_BAZAARS", __VA_ARGS__)
-#define DebugPerformanceFmt(...) LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_PERFORMANCE", __VA_ARGS__)
+#define DebugSocketsFmt(...)     LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_SOCKETS", __FILE__, __LINE__, __VA_ARGS__)
+#define DebugIPCFmt(...)         LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_IPC", __FILE__, __LINE__, __VA_ARGS__)
+#define DebugNavmeshFmt(...)     LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_NAVMESH", __FILE__, __LINE__, __VA_ARGS__)
+#define DebugPacketsFmt(...)     LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_PACKETS", __FILE__, __LINE__, __VA_ARGS__)
+#define DebugActionsFmt(...)     LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_ACTIONS", __FILE__, __LINE__, __VA_ARGS__)
+#define DebugSQLFmt(...)         LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_SQL", __FILE__, __LINE__, __VA_ARGS__)
+#define DebugIDLookupFmt(...)    LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_ID_LOOKUP", __FILE__, __LINE__, __VA_ARGS__)
+#define DebugModulesFmt(...)     LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_MODULES", __FILE__, __LINE__, __VA_ARGS__)
+#define DebugAuctionsFmt(...)    LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_AUCTIONS", __FILE__, __LINE__, __VA_ARGS__)
+#define DebugDeliveryBoxFmt(...) LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_DELIVERY_BOX", __FILE__, __LINE__, __VA_ARGS__)
+#define DebugBazaarsFmt(...)     LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_BAZAARS", __FILE__, __LINE__, __VA_ARGS__)
+#define DebugPerformanceFmt(...) LOGGER_BODY_CONDITIONAL_FMT(SPDLOG_LOGGER_DEBUG, "debug", "logging.DEBUG_PERFORMANCE", __FILE__, __LINE__, __VA_ARGS__)
 
 // clang-format on

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -3333,8 +3333,8 @@ auto CCharEntity::getCharVarsWithPrefix(std::string const& prefix) -> std::vecto
 
     std::vector<std::pair<std::string, int32>> charVars;
 
-    const auto rset = db::preparedStmt("SELECT varname, value, expiry FROM char_vars WHERE charid = ? AND varname LIKE CONCAT(?, '%')",
-                                       this->id, prefix);
+    const auto rset = db::preparedStmt("SELECT varname, value, expiry FROM char_vars WHERE charid = ? AND varname LIKE ?",
+                                       this->id, fmt::format("{}%", prefix));
     if (rset && rset->rowsCount())
     {
         while (rset->next())
@@ -3395,7 +3395,7 @@ void CCharEntity::clearCharVarsWithPrefix(std::string const& prefix)
         ++iter;
     }
 
-    db::preparedStmt("DELETE FROM char_vars WHERE charid = ? AND varname LIKE CONCAT(?, '%')", this->id, prefix);
+    db::preparedStmt("DELETE FROM char_vars WHERE charid = ? AND varname LIKE ?", this->id, fmt::format("{}%", prefix));
 }
 
 bool CCharEntity::startSynth(SKILLTYPE synthSkill)

--- a/src/map/map_server.cpp
+++ b/src/map/map_server.cpp
@@ -153,6 +153,16 @@ void MapServer::loadConsoleCommands()
     {
         mapStatistics_->print();
     });
+
+    consoleService_->registerCommand("backtrace", "Print backtrace",
+    [&](std::vector<std::string>& inputs)
+    {
+        const auto backtrace = logging::GetBacktrace();
+        for (const auto& line : backtrace)
+        {
+            fmt::print("{}\n", line);
+        }
+    });
     // clang-format on
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

There was a logging issue if you had `KEEP_JUGPET_THROUGH_ZONING` enabled, but you didn't have `DEBUG_SQL` enabled. It didn't affect anything, but the logging reported a scary-looking failure.  This should tidy all of that up.

Testing:
- Have KEEP_JUGPET_THROUGH_ZONING on
- BST99
- !additem carrot_broth
- call beast
- zone
- logging is broken before fix
- logging is fixed after fix
- DEBUG_SQL flag doesn't affect anything
- Check `jugpet-` char vars are correctly wiped in SQL workbench