### PR TITLE
Search: Ensure handler session lives long enough to see checkDeadline()

### DIFF
--- a/src/search/search_handler.h
+++ b/src/search/search_handler.h
@@ -91,7 +91,7 @@ private:
     // Deadline timer to drop a read
     asio::steady_timer deadline_;
 
-    void checkDeadline();
+    void checkDeadline(std::shared_ptr<search_handler> self);
 
     uint16_t getNumSessionsInUse(std::string const& ipAddressStr);
     void     addToUsedIPAddresses(std::string const& ipAddressStr);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Pushes a shared_ptr to the search_handler into the deadline timer, so it's guaranteed to be there if/when the timer goes off. This is standard ASIO operating procedure. We don't do this anywhere else in the code!

## Steps to test these changes

You can force this error by setting: `if (length != ref<uint16>(data_, 0x00) || length < 28)` to `if (true)`.

Then when you crash, you can look at the stacktrace and see that `checkDeadline` is called, but the session is gone, and `fmt` is trying to log an IP address that isn't there (a negative uninit'd number).
