### PR TITLE
Fix the discontinuity in craft skillup formula

### DIFF
--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -693,7 +693,7 @@ namespace synthutils
 
             if (settings::get<bool>("map.CRAFT_MODERN_SYSTEM"))
             {
-                if (baseDiff > 0)
+                if (baseDiff > 1)
                 {
                     skillUpChance = (double)baseDiff * craftChanceMultiplier * (3 - (log(1.2 + charSkill / 100))) / 5; // Original skill up equation with "x2 chance" applied.
                 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The formula LSB uses to calculate the chance a player will increase their crafting skill with a synth is piecewise when using the "Modern System." This means if the server variable CRAFT_MODERN_SYSTEM is set to true, a separate skillup formula is used for crafts _above_ a player's skill level versus crafts _below_ their skill level. The formula appears to be designed such that players should have a lower chance to skill up on crafts below their skill level, which makes sense.

_Edit: I realized after posting this that all of these percentages are assuming CRAFT_CHANCE_MULTIPLIER = 2. With default settings, you can cut all those numbers in half. My point still stands, though._

However, a problem arises when a player's skill level is fractional, such as 108.9. If such a player were attempting to craft a level 109 item, their chance to skill up would be only 2%. If instead they attempted a level 108 or level 110 synth, their chance to skill up would be much higher: 14.7% or 22.3% respectively. This discontinuity in the curve is counterintuitive.

My suggestion is to simply change the baseDiff check in doSynthSkillUp from `if (baseDiff > 0)` to `if (baseDiff > 1)`. This change would have no impact at all on the curve if a player's synth level was a round number. But in the above case, a player with 108.9 skill attempting a level 109 craft would have a 17.2% to skill up, a number that cleanly sits between 14.7% and 22.3%. 

The charts below show skill-up rates for the following player craft levels: 50.0, 50.5, 50.9, 108.0, 108.5, and 108.9. You can see the dip in skill-up rate occurs whenever the craft level is not a round number, but this suggested fix smooths the curve in those cases.

![image](https://github.com/user-attachments/assets/46843a16-e744-453d-8be2-e860ffcc9349)

![image](https://github.com/user-attachments/assets/1be646b3-74ee-440a-ad3f-1ccf9f3db406)

![image](https://github.com/user-attachments/assets/da262c4a-6e0b-456f-ad6b-f975949aa2b4)

![image](https://github.com/user-attachments/assets/09e617dd-e7bd-47be-8b9c-d92898c7d141)

![image](https://github.com/user-attachments/assets/6cf73948-22ed-43bf-9c14-1a2229414d4f)

![image](https://github.com/user-attachments/assets/e4fbc5ae-1edb-41fe-a9c8-3a0b82705647)

Thanks to @ariel-logos for bringing my attention to this issue.

## Steps to test these changes

Attempt a craft with craft level 0.1 higher than your skill level; repeat with 1 level below or 1 level above, and the difference is apparent.
