### PR TITLE
[core] Handle std::optional spell OnMobMagicPrepare

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2845,7 +2845,13 @@ namespace luautils
             return {};
         }
 
-        auto result = onMobMagicPrepare(PCaster, PTarget, spell::GetSpell(startingSpellId.value()));
+        CSpell* PSpell = nullptr;
+        if (startingSpellId.has_value())
+        {
+            PSpell = spell::GetSpell(startingSpellId.value());
+        }
+
+        auto result = onMobMagicPrepare(PCaster, PTarget, PSpell);
         if (!result.valid())
         {
             sol::error err = result;

--- a/src/map/mob_spell_container.cpp
+++ b/src/map/mob_spell_container.cpp
@@ -843,7 +843,7 @@ std::optional<SpellID> CMobSpellContainer::GetDebuffSpell()
 
 std::optional<SpellID> CMobSpellContainer::GetHealSpell()
 {
-    if (m_PMob->m_EcoSystem == ECOSYSTEM::UNDEAD || m_healList.empty())
+    if (m_healList.empty())
     {
         return {};
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Resolves a crash when the initial spellId is nullopt. Seen in a custom CE script.

Exact steps to reproduce elude me right now, but the cause was fairly obvious.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
