### PR TITLE
[core] Check for throwing weapons when calculating pDIF

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1659,7 +1659,19 @@ namespace battleutils
         float pDIF = 1.0;
 
         auto* targ_weapon = dynamic_cast<CItemWeapon*>(PAttacker->m_Weapons[SLOT_RANGED]);
-        uint8 weaponType  = targ_weapon ? targ_weapon->getSkillType() : static_cast<uint8>(SKILL_MARKSMANSHIP); // TODO: does the no-weapon case actually hit?
+        if (!targ_weapon)
+        {
+            // No ranged weapon, check ammo slot for throwing
+            targ_weapon = dynamic_cast<CItemWeapon*>(PAttacker->m_Weapons[SLOT_AMMO]);
+
+            if (!targ_weapon)
+            {
+                ShowError("battleutils::GetRangedDamageRatio(): No ranged weapon or ammo");
+                return pDIF;
+            }
+        }
+
+        uint8 weaponType = targ_weapon->getSkillType();
 
         auto levelCorrectionFunc = lua["xi"]["combat"]["levelCorrection"]["isLevelCorrectedZone"];
         auto rangedPDIFFunc      = lua["xi"]["combat"]["physical"]["calculateRangedPDIF"];


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Checks the ammo slot for Throwing Weapons if no ranged weapon was found. 
Without it, Shurikens (and other Throwing weapons) are defaulting to Marksmanship, leading to inaccurate calculations.

Also made it explicitely log should the "no weapons case" occur, instead of defaulting to Marksmanship.

Credits to JudgeMack, Deft, Sakiro, Integrity, Koca (@lumokai), MadMike (@madmikeblvd), Fabfury (and probably missed a few) for testing and providing steps to reproduce.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!changejob NIN 99
!additem shuriken 99

Breakpoint and throw, see skill type used.

<!-- Clear and detailed steps to test your changes here -->
