### PR TITLE
Fixes SQL query when DISABLE_MOB_NPC_CHAR_NAMES is true

### DIFF
--- a/src/login/view_session.cpp
+++ b/src/login/view_session.cpp
@@ -224,20 +224,20 @@ void view_session::read_func()
                 if (settings::get<bool>("login.DISABLE_MOB_NPC_CHAR_NAMES"))
                 {
                     const auto query =
-                        "WITH results AS "
-                        "( "
-                        "    SELECT polutils_name AS `name` FROM npc_list "
-                        "    UNION "
-                        "    SELECT packet_name AS `name` FROM mob_pools "
-                        ") "
-                        "SELECT * FROM results WHERE REPLACE(REPLACE(UPPER(`name`), '-', ''), '_', '') LIKE REPLACE(REPLACE(UPPER(?), '-', ''), '_', '')";
+                        "SELECT polutils_name AS `name` FROM npc_list "
+                        "WHERE REPLACE(REPLACE(UPPER(polutils_name), '-', ''), '_', '') "
+                        "LIKE REPLACE(REPLACE(UPPER(?), '-', ''), '_', '') "
+                        "UNION "
+                        "SELECT packet_name AS `name` FROM mob_pools "
+                        "WHERE REPLACE(REPLACE(UPPER(packet_name), '-', ''), '_', '') "
+                        "LIKE REPLACE(REPLACE(UPPER(?), '-', ''), '_', '')";
 
-                    const auto rset1 = db::preparedStmt(query, nameStr);
+                    const auto rset1 = db::preparedStmt(query, nameStr, nameStr);
                     if (!rset1)
                     {
                         invalidNameReason = "Internal entity name query failed";
                     }
-                    else if (rset1 && rset1->rowsCount() != 0)
+                    else if (rset1->rowsCount() != 0)
                     {
                         invalidNameReason = "Name already in use.";
                     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Removes unsupported CTE from SQL query when creating a character with DISABLE_MOB_NPC_CHAR_NAMES set to true

Closes: https://github.com/LandSandBoat/server/issues/7391
## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
login.lua
DISABLE_MOB_NPC_CHAR_NAMES = true

create a new character