### PR TITLE
[Fix] Coronach Aftermath

### DIFF
--- a/scripts/actions/weaponskills/coronach.lua
+++ b/scripts/actions/weaponskills/coronach.lua
@@ -30,9 +30,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doRangedWeaponskill(player, target, wsID, params, tp, action, primary)
 
     -- Apply aftermath
-    if damage > 0 then
-        xi.aftermath.addStatusEffect(player, tp, xi.slot.RANGED, xi.aftermath.type.RELIC)
-    end
+    xi.aftermath.addStatusEffect(player, tp, xi.slot.RANGED, xi.aftermath.type.RELIC)
 
     return tpHits, extraHits, criticalHit, damage
 end


### PR DESCRIPTION
Coronach now grants aftermath even on a zero damage hit or a miss.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Coronach should grant aftermath even on a miss or zero damage hit. 

## Steps to test these changes

!changejob rng 75
!additem 18336 (Annihilator)
!additem 17343 (Bronze Bullet)
!tp 3000 <me> 
Fire at any mob without already having aftermath, miss should grant AM. 

## Retail Capture
[Coronach miss still grants AM - Video Proof](https://youtu.be/X_JvtCxoSC4)
[Coronach miss still grants AM - Capture Data](https://drive.google.com/drive/folders/1tSC-lralvkcNZnZpyti_p_64CRDcwN4P?usp=drive_link)