### PR TITLE
Remove PChar from zone on force logout

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -6614,6 +6614,8 @@ namespace charutils
         });
 
         PChar->pushPacket<CServerIPPacket>(PChar, 1, IPP());
+
+        removeCharFromZone(PChar);
     }
 
     void ForceLogout(CCharEntity* PChar)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Steps to reproduce:
- Logout as GM
- Watch logs and see DecreaseZoneCounter is not triggered
- See the session hangs until the cleanup task runs

This change ensures we remove the PChar from their zone when going through any `ForceLogout` call, such as when GMs logout. 

https://github.com/LandSandBoat/server/blob/491498a3e4067a46b306eb4448d58def0901c5b4/src/map/packet_system.cpp#L5848-L5852

Before #7243, `removeCharFromZone `was always called (when everything was going through `SendToZone`), this merely reintroduces parity.

https://github.com/LandSandBoat/server/blob/8f65f3c6744a2facb4af0ad35a8afe0f8b4517c0/src/map/utils/charutils.cpp#L6528-L6588

Closes #7390

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Login/logout as GM, see session gets cleaned up immediately

<!-- Clear and detailed steps to test your changes here -->
