### PR TITLE
Fix GCC compile warning

### DIFF
--- a/src/map/utils/blueutils.cpp
+++ b/src/map/utils/blueutils.cpp
@@ -102,34 +102,33 @@ namespace blueutils
         }
 
         std::vector<CCharEntity*> PBlueMages;
+        auto                      AddBlueMages = [&PMob, &PBlueMages](const CParty* PParty)
+        {
+            for (const auto& member : PParty->members)
+            {
+                auto* PMember = dynamic_cast<CCharEntity*>(member);
+                if (PMember &&
+                    PMember->GetMJob() == JOB_BLU &&
+                    PMember->getZone() == PMob->getZone())
+                {
+                    PBlueMages.emplace_back(PMember);
+                }
+            }
+        };
 
         // populate PBlueMages
         if (PChar->PParty != nullptr)
         {
-            std::vector<CParty*> parties;
-
             if (PChar->PParty->m_PAlliance)
             {
-                parties = PChar->PParty->m_PAlliance->partyList;
+                for (const auto* party : PChar->PParty->m_PAlliance->partyList)
+                {
+                    AddBlueMages(party);
+                }
             }
             else
             {
-                parties.emplace_back(PChar->PParty);
-            }
-
-            for (const auto* party : parties)
-            {
-                for (auto& member : party->members)
-                {
-                    auto* PMember = dynamic_cast<CCharEntity*>(member);
-
-                    if (PMember &&
-                        PMember->GetMJob() == JOB_BLU &&
-                        PMember->getZone() == PMob->getZone())
-                    {
-                        PBlueMages.emplace_back(PMember);
-                    }
-                }
+                AddBlueMages(PChar->PParty);
             }
         }
         else if (PChar->GetMJob() == JOB_BLU)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes this warning:
```
[100%] Linking CXX executable /home/runner/work/server/server/xi_map
In member function ‘deallocate’,
    inlined from ‘deallocate’ at /usr/include/c++/14/bits/allocator.h:208:0,
    inlined from ‘deallocate’ at /usr/include/c++/14/bits/alloc_traits.h:513:0,
    inlined from ‘_M_deallocate’ at /usr/include/c++/14/bits/stl_vector.h:389:0,
    inlined from ‘_M_deallocate’ at /usr/include/c++/14/bits/stl_vector.h:385:7,
    inlined from ‘__dt_base ’ at /usr/include/c++/14/bits/stl_vector.h:368:15,
    inlined from ‘__dt_base ’ at /usr/include/c++/14/bits/stl_vector.h:738:7,
    inlined from ‘TryLearningSpells’ at /home/runner/work/server/server/src/map/utils/blueutils.cpp:134:9,
    inlined from ‘DistributeRewards’ at /home/runner/work/server/server/src/map/entities/mobentity.cpp:678:41,
    inlined from ‘operator()’ at /home/runner/work/server/server/src/map/entities/mobentity.cpp:1182:30,
    inlined from ‘__invoke_impl’ at /usr/include/c++/14/bits/invoke.h:61:36,
    inlined from ‘__invoke_r’ at /usr/include/c++/14/bits/invoke.h:111:28,
    inlined from ‘_M_invoke’ at /usr/include/c++/14/bits/std_function.h:290:30:
/usr/include/c++/14/bits/new_allocator.h:172: warning: ‘operator delete’ called on pointer ‘_345’ with nonzero offset [1, 9223372036854775800] [-Wfree-nonheap-object]
  172 |         _GLIBCXX_OPERATOR_DELETE(_GLIBCXX_SIZED_DEALLOC(__p, __n));
In member function ‘allocate’,
    inlined from ‘allocate’ at /usr/include/c++/14/bits/allocator.h:196:40,
    inlined from ‘allocate’ at /usr/include/c++/14/bits/alloc_traits.h:478:28,
    inlined from ‘_M_allocate’ at /usr/include/c++/14/bits/stl_vector.h:380:33,
    inlined from ‘_M_allocate_and_copy’ at /usr/include/c++/14/bits/stl_vector.h:1621:40,
    inlined from ‘operator=’ at /usr/include/c++/14/bits/vector.tcc:238:44,
    inlined from ‘TryLearningSpells’ at /home/runner/work/server/server/src/map/utils/blueutils.cpp:113:55,
    inlined from ‘DistributeRewards’ at /home/runner/work/server/server/src/map/entities/mobentity.cpp:678:41,
    inlined from ‘operator()’ at /home/runner/work/server/server/src/map/entities/mobentity.cpp:1182:30,
    inlined from ‘__invoke_impl’ at /usr/include/c++/14/bits/invoke.h:61:36,
    inlined from ‘__invoke_r’ at /usr/include/c++/14/bits/invoke.h:111:28,
    inlined from ‘_M_invoke’ at /usr/include/c++/14/bits/std_function.h:290:30:
/usr/include/c++/14/bits/new_allocator.h:151: note: returned from ‘operator new’
  151 |         return static_cast<_Tp*>(_GLIBCXX_OPERATOR_NEW(__n * sizeof(_Tp)));
[100%] Built target xi_map
```

## Steps to test these changes

Build with gcc and don't get a warning. Should be functionally the same game-wise.
