### PR TITLE
Move auto-attack damage out to lua

### DIFF
--- a/scripts/enum/physical_attack_type.lua
+++ b/scripts/enum/physical_attack_type.lua
@@ -1,0 +1,20 @@
+-----------------------------------
+-- Physical Attack Type
+-----------------------------------
+xi = xi or {}
+
+---@enum xi.physicalAttackType
+xi.physicalAttackType =
+{
+    NORMAL     = 0,
+    DOUBLE     = 1,
+    TRIPLE     = 2,
+    ZANSHIN    = 3,
+    KICK       = 4,
+    RANGED     = 5,
+    RAPID_SHOT = 6,
+    SAMBA      = 7,
+    QUAD       = 8,
+    DAKEN      = 9,
+    FOLLOWUP   = 10,
+}

--- a/scripts/globals/combat/effect_utilities.lua
+++ b/scripts/globals/combat/effect_utilities.lua
@@ -1,0 +1,71 @@
+xi = xi or {}
+xi.combat = xi.combat or {}
+xi.combat.effect = xi.combat.effect or {}
+
+xi.combat.effect.handleStoneskin = function(defender, damage)
+    -- Stoneskin
+    local skin = defender:getMod(xi.mod.STONESKIN)
+    if damage > 0 and skin > 0 then
+        if skin > damage then
+            defender:delMod(xi.mod.STONESKIN, damage)
+            return 0
+        end
+            
+        defender:delStatusEffect(xi.effect.STONESKIN)
+        return damage - skin
+    end
+
+    return damage
+end
+
+xi.combat.effect.handleScarletDelirium = function(defender, damage)
+    -- Check for Scarlet Delirium and update Effect Power with bonus from damage
+    if defender:hasStatusEffect(xi.effect.SCARLET_DELIRIUM) then
+        local effect = defender:getStatusEffect(xi.effect.SCARLET_DELIRIUM)
+
+        -- Damage bonus calculation, update Effect Power
+        if effect:getPower() == 0 then
+            -- Damage to Max HP Ratio
+            local bonus = math.floor(damage * 100 / defender:getMaxHP() / 2)
+            local duration = 90 + effect:getSubPower()
+
+            -- Convert status effect from "Absorb damage" mode to "Provide damage bonus" mode
+            defender:delStatusEffectSilent(xi.effect.SCARLET_DELIRIUM)
+            defender:addStatusEffect(xi.effect.SCARLET_DELIRIUM_1, xi.effect.SCARLET_DELIRIUM_1, bonus, 0, duration)
+        end
+    end
+end
+
+xi.combat.effect.handleConsumeMana = function(player)
+    local damage = 0
+
+    if player:hasStatusEffect(xi.effect.CONSUME_MANA) then
+        damage = damage + math.floor(player.getHP() / 10)
+        player:setHP(0)
+        player:delStatusEffect(xi.effect.CONSUME_MANA)
+    end
+
+    return damage
+end
+
+xi.combat.effect.handleSoulEater = function(player, damage)
+    if player:hasStatusEffect(xi.effect.SOULEATER) then
+        -- Souleater's HP consumed is 10% (base) + x% from gear (only highest) + x% from gear augments.
+        local souleaterBonus = player:getMaxGearMod(xi.mod.SOULEATER_EFFECT) * 0.01
+        local souleaterBonusII = player:getMod(xi.mod.SOULEATER_EFFECT_II) * 0.01
+        local stalwartSoulBonus = 1 - player:getMod(xi.mod.STALWART_SOUL) / 100
+        local bonusDamage = player:getHP() * (0.1 + souleaterBonus + souleaterBonusII)
+
+        if bonusDamage >= 1 then
+            player:addHP(-handleStoneskin(player, math.floor(bonusDamage * stalwartSoulBonus)))
+
+            if player:getMainJob() == xi.job.DRK then
+                damage = math.floor(damage + bonusDamage)
+            else
+                damage = math.floor(damage + (bonusDamage / 2))
+            end
+        end
+    end
+
+    return damage
+end

--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -104,6 +104,300 @@ local elementalBelt = -- Ordered by element.
     xi.item.SHADOW_BELT
 }
 
+-- WARNING: This function is used in src/map/entities/battleentity.cpp "OnAttack" function.
+-- If you update these parameters, update them there as well.
+---@param player CBaseEntity
+---@param target CBaseEntity
+---@param attack CAttack
+---@param skilltype xi.skill
+xi.combat.physical.calculateCounterDamage = function(player, target, skilltype, isCritical)
+    local naturalH2hDamage = 0
+    if skilltype == xi.skill.HAND_TO_HAND or (target:isMob() and target:getMainJob() == xi.job.MNK) then
+        naturalH2hDamage = math.floor(target:getSkillLevel(xi.skill.HAND_TO_HAND) * 0.11) + 3
+    end
+
+    local attackBonus = 1
+    if target:isPC() and target:getMainJob() == xi.job.MNK and target:hasStatusEffect(xi.effect.COUNTERSTANCE) then
+        attackBonus = math.floor(attackBonus + (target:getMod(xi.mod.DEX) / 100) * target:getJobPointLevel(xi.jp.COUNTERSTANCE_EFFECT))
+    end
+
+    local damageRatio = xi.combat.physical.calculateMeleePDIF(target, player, skilltype, attackBonus, isCritical, xi.combat.levelCorrection.isLevelCorrectedZone(target), false, 0, false, xi.slot.Main, false)
+    local damage = math.floor((target:getWeaponDmg() + naturalH2hDamage + xi.combat.physical.calculateMeleeStatFactor(target, player)) * damageRatio)
+
+    return damage
+end
+
+-- WARNING: This function is used in src/map/attack.cpp "ProcessDamage" function.
+-- If you update these parameters, update them there as well.
+---@param attack CAttack
+xi.combat.physical.calculateAttackDamage = function(attacker, victim, slot, physicalAttackType, isH2H, isFirstSwing, isSA, isTA, damageRatio, baseDamage)
+    local bonusBasePhysicalDamage = 0
+    local damage = 0
+    
+    -- Sneak Attack
+    if isSA then
+        bonusBasePhysicalDamage = bonusBasePhysicalDamage + math.floor((attacker.getStat(xi.mod.DEX) * (1 + attacker.getMod(xi.mod.SNEAK_ATK_DEX) / 100)))
+    end
+
+    -- Trick Attack
+    if isTA then
+        bonusBasePhysicalDamage = bonusBasePhysicalDamage + math.floor((attacker:getStat(xi.mod.AGI) * (1 + attacker:getMod(xi.mod.TRICK_ATK_AGI) / 100)))
+    end
+
+    -- Consume Mana
+    if attacker:isPC() then
+        bonusBasePhysicalDamage = bonusBasePhysicalDamage + xi.combat.effect.handleConsumeMana(attacker)
+    end
+
+    if isH2H then
+        local naturalH2hDamage = math.floor(attacker:getSkillLevel(xi.skill.HAND_TO_HAND) * 0.11) + 3
+        damage = math.floor(damageRatio * (baseDamage + naturalH2hDamage + bonusBasePhysicalDamage + xi.combat.physical.calculateMeleeStatFactor(attacker, victim)))
+    elseif slot == xi.slot.MAIN then
+        damage = math.floor(damageRatio * (baseDamage + bonusBasePhysicalDamage + xi.combat.physical.calculateMeleeStatFactor(attacker, victim)))
+    elseif slot == xi.slot.AMMO then
+        damage = math.floor(damageRatio * (baseDamage + xi.combat.physical.calculateMeleeStatFactor(attacker, victim)))
+    end
+
+    -- Scarlet Delirium
+    -- SCARLET_DELIRIUM_1 is only active after damage has been dealt to the DRK and SCARLET_DELIRIUM has been removed.
+    if attacker:hasStatusEffect(xi.effect.SCARLET_DELIRIUM_1) then
+        local effectPower = 1 + (attacker:getStatusEffect(xi.effect.SCARLET_DELIRIUM_1):getPower() / 100)
+        damage = math.floor(damage * effectPower)
+    end
+
+    -- Double Attack and Triple Attack
+    if physicalAttackType == xi.physicalAttackType.DOUBLE and attacker:isPC() then
+        damage = math.floor(damage * ((100 + attacker:getMod(xi.mod.DOUBLE_ATTACK_DMG)) / 100))
+    elseif physicalAttackType == xi.physicalAttackType.TRIPLE and attacker:isPC() then
+        damage = math.floor(damage * ((100 + attacker:getMod(xi.mod.TRIPLE_ATTACK_DMG)) / 100))
+    end
+
+    -- Soul Eater
+    if attacker:isPC() then
+        damage = xi.combat.effect.handleSoulEater(attacker, damage)
+    end
+
+    -- Damage multipliers
+    damage = xi.combat.physical.calculateDamageMultiplier(attacker, slot, damage, physicalAttackType, isFirstSwing)
+
+    -- Sneak Attack Augment
+    if attacker:getMod(xi.mod.AUGMENTS_SA) > 0 and isSA and attacker:hasStatusEffect(xi.effect.SNEAK_ATTACK) then
+        damage = damage + math.floor(damage * ((100 + attacker:getMod(xi.mod.AUGMENTS_SA)) / 100))
+    end
+
+    -- Trick Attack Augment
+    if attacker:getMod(xi.mod.AUGMENTS_TA) > 0 and isTA and attacker:hasStatusEffect(xi.effect.TRICK_ATTACK) then
+        damage = damage + math.floor(damage * ((100 + attacker:getMod(xi.mod.AUGMENTS_TA)) / 100))
+    end
+
+    --- Low level mobs can get negative fSTR so low they crater their (base weapon damage + fstr) to below 0.
+    --- TODO: Find out proper fSTR calc for low level mobs when your VIT is ridiculously high. It's likely that this is slightly wrong (possibly you'd get more hits for 0 than you should)
+    --- However, there are legitimate strategies on retail with 1 dmg weapons and negative fSTR ranks that result in all auto attacks hitting for 0 but using enspells for damage so no TP is fed.
+    --- Absorption isn't possible at this point in the calculation, so zero it.
+    if damage < 0 then
+        damage = 0
+    end
+
+    -- Apply Restraint Weaponskill Damage
+    if isFirstSwing and attacker:hasStatusEffect(xi.effect.RESTRAINT) then
+        local effect = attacker:getStatusEffect(xi.effect.RESTRAINT)
+        local power = effect:getPower()
+
+        if effect:getPower() < 30 then
+            local jpBonus = 0
+
+            if attacker:isPC() then
+                jpBonus = attacker:getJobPointLevel(xi.jp.RESTRAINT) * 2
+            end
+
+            -- Convert weapon delay and divide
+            -- Pull remainder of previous hit's value from Effect Sub Power
+            local boostPerRound = ((attacker:getBaseDelay() / 1000) * 60) / 385
+            local remainder = effect:getSubPower() / 100
+
+            -- Calculate bonuses from Enhances Restraint, Job Point upgrades, and remainder from previous hit
+            boostPerRound = (boostPerRound * (1 + attacker:getMod(xi.Mod.ENHANCES_RESTRAINT) / 100) * (1 + jpBonus / 100)) + remainder
+
+            -- Calculate new remainder and multiply by 100 so significant digits aren't lost
+            remainder = math.floor((1 - (math.ceil(boostPerRound) - boostPerRound)) * 100)
+            boostPerRound = math.floor(boostPerRound)
+
+            -- Cap total power to +30% WSD
+            if power + boostPerRound > 30 then
+                boostPerRound = 30 - power
+            end
+
+            effect:setPower(power + boostPerRound)
+            effect:setSubPower(remainder)
+            attacker:setMod(xi.mod.ALL_WSDMG_FIRST_HIT, boostPerRound)
+        end
+    end
+    
+    return damage
+end
+
+-- WARNING: This function is used in src/utils/battleutils.cpp "TakePhysicalDamage" function.
+-- If you update these parameters, update them there as well.
+---@param attacker CBaseEntity
+---@param defender CBaseEntity
+---@param physicalAttackType PHYSICAL_ATTACK_TYPE
+---@param damage integer
+---@param isBlocked boolean
+---@param slot xi.slot
+---@param tpMultiplier integer
+---@param taChar CBaseEntity
+---@param giveTPtoVictim boolean
+---@param giveTPtoAttacker boolean
+---@param isCounter boolean
+---@param isCovered boolean
+---@param originalTarget CBaseEntity
+xi.combat.physical.takePhysicalDamage = function(attacker, defender, physicalAttackType, damage, isBlocked,
+                                                slot, tpMultiplier, taChar, giveTPtoVictim, giveTPtoAttacker, 
+                                                isCounter, isCovered, originalTarget)
+
+    local giveTPtoAttacker = giveTPtoAttacker and not attacker:hasStatusEffect(xi.effect.MEIKYO_SHISUI)
+    local giveTPtoVictim = giveTPtoVictim and physicalAttackType ~= xi.physicalAttackType.DAKEN
+    local isRanged = slot == xi.slot.AMMO or slot == xi.slot.RANGED
+    local baseDamage = damage
+    local attackType = xi.attackType.PHYSICAL
+    local damageType = xi.damageType.NONE
+
+    if attacker:hasStatusEffect(xi.effect.FORMLESS_STRIKES) and not isCounter then
+        attackType = xi.attackType.SPECIAL
+        local formlessMod = 55
+
+        -- https://www.bg-wiki.com/ffxi/Formless_Strikes
+        -- Merit value of 1 is +5%, so 60% normal power
+        if attacker:isPC() then
+            formlessMod = formlessMod + attacker:getMerit(xi.merit.FORMLESS_STRIKES)
+        end
+
+        damage = math.floor(damage * formlessMod / 100)
+        damage = target:breathDmgTaken(damage)
+    else
+        damageType = attacker:getWeaponDamageType(slot)
+
+        if isRanged then
+            attackType = xi.attackType.RANGED
+            damage = defender:rangedDmgTaken(damage, damageType, isCovered)
+        else
+            damage = defender:physicalDmgTaken(damage, damageType, isCovered)
+        end
+
+        -- absorb mods are handled in the above functions, but they do not affect counters
+        -- this is a little hacky, but will work for now
+        if damage < 0 and isCounter then
+            damage = -damage
+        end
+
+        -- counters are always considered blunt (assuming h2h) damage, except retaliation (which is the only counter
+        -- that gives TP to the attacker)
+        if not isCounter or giveTPtoAttacker then
+            if damageType == xi.damageType.PIERCING then
+                damage = math.floor(damage * (1 + defender:getMod(xi.mod.PIERCE_SDT) / 10000))
+            elseif damageType == xi.damageType.SLASHING then
+                damage = math.floor(damage * (1 + defender:getMod(xi.mod.SLASH_SDT) / 10000))
+            elseif damageType == xi.damageType.IMPACT then
+                damage = math.floor(damage * (1 + defender:getMod(xi.mod.IMPACT_SDT) / 10000))
+            elseif damageType == xi.damageType.HTH then
+                damage = math.floor(damage * (1 + defender:getMod(xi.mod.HTH_SDT) / 10000))
+            end
+        else
+            damage = math.floor(damage * (1 + defender:getMod(xi.mod.HTH_SDT) / 10000))
+        end
+
+        if isBlocked then
+            local absorb = 100
+            
+            -- shield def bonus is a flat raw damage reduction that occurs before absorb
+            -- however do not reduce below 0 or if damage is negative
+            if damage > 0 then
+                damage = math.max(0, damage - defender:getMod(xi.mod.SHIELD_DEF_BONUS))
+            end
+            
+            if defender:isPC() then
+                local slotSub = defender:getEquippedItem(xi.slot.SUB)
+                if slotSub:isShield() then
+                    absorb = utils.clamp(100 - slotSub:getShieldAbsorptionRate(), 0, 100)
+
+                    -- Shield Mastery
+                    if math.max(damage - defender:getMod(xi.mod.PHALANX) + defender:getMod(xi.mod.STONESKIN), 0) > 0 and defender:getMod(xi.mod.SHIELD_MASTERY_TP) then
+                        -- If the player blocked with a shield and has shield mastery, add shield mastery TP bonus
+                        -- unblocked damage (before block but as if affected by stoneskin/phalanx) must be greater than zero
+                        defender:addTP(defender:getMod(xi.mod.SHIELD_MASTERY_TP))
+                    end
+                end
+            elseif defender:isPet() or defender:isTrust() then
+                absorb = 50
+
+                -- Shield Mastery
+                if math.max(damage - defender:getMod(xi.mod.PHALANX) + defender:getMod(xi.mod.STONESKIN), 0) > 0 and defender:getMod(xi.mod.SHIELD_MASTERY_TP) then
+                    -- If the pet or trust blocked with a shield and has shield mastery, add shield mastery TP bonus
+                    -- unblocked damage (before block but as if affected by stoneskin/phalanx) must be greater than zero
+                    defender:addTP(defender:getMod(xi.mod.SHIELD_MASTERY_TP))
+                end
+            else
+                absorb = 50
+            end
+
+            -- Reprisal
+            if damage > 0 and defender:hasStatusEffect(xi.effect.REPRISAL) then
+                -- Reflect a portion of the blocked damage back. This is calculated before Stoneskin, Phalanx, Sentinel or Invincible
+                local spikesBonus = 1 + defender:getMod(xi.mod.REPRISAL_SPIKES_BONUS) / 100
+                local effectPower = math.floor(defender:getStatusEffect(xi.effect.REPRISAL):getPower() * spikesBonus)
+                local blockedDamage = math.floor((damage * (100 - absorb)) / 100)
+
+                if defender:hasStatusEffect(xi.effect.INVINCIBLE) or defender:hasStatusEffect(xi.effect.SENTINEL) then
+                    blockedDamage = math.floor((baseDamage * (100 - absorb)) / 100)
+                end
+
+                local spikesDamage = math.floor(blockedDamage * (effectPower / 100))
+                defender:setMod(xi.mod.SPIKES_DMG, spikesDamage)
+            end
+
+            damage = math.floor((damage * absorb) / 100)
+        end
+    end
+
+    if damage > 0 then
+        damage = math.floor(math.max(damage - defender:getMod(xi.mod.PHALANX), 0))
+
+        damage = xi.combat.effect.handleStoneskin(defender, damage)
+        defender:handleAfflatusMiseryDamage(damage)
+    end
+
+    damage = utils.clamp(damage, -99999, 99999)
+    damage = defender:checkDamageCap(damage)
+    xi.combat.effect.handleScarletDelirium(defender, damage)
+
+    local corrected = defender:takeDamage(damage, attacker, attackType, damageType)
+    if damage < 0 then
+        damage = -corrected
+    end
+
+    local delay = 0
+    if isRanged then
+        delay = attacker:getBaseRangedDelay()
+    else
+        delay = attacker:getBaseDelay()
+    end
+
+    if giveTPtoAttacker then
+        if isRanged then
+            attacker:addTP(xi.combat.tp.getSingleRangedHitTPReturn(attacker, defender, delay))
+        else
+            local isZanshin = attacker:isPC() and physicalAttackType == xi.physicalAttackType.ZANSHIN
+            attacker:addTP(xi.combat.tp.getSingleMeleeHitTPReturn(attacker, defender, isZanshin, delay))
+        end
+    end
+    
+    if giveTPtoVictim then
+        defender:addTP(xi.combat.tp.calculateTPGainOnPhysicalDamage(damage, delay, attacker, defender))
+    end
+
+    return damage
+end
+
 -- 'fSTR' in English Wikis. 'SV function' in JP wiki and Studio Gobli.
 -- BG wiki: https://www.bg-wiki.com/ffxi/FSTR
 -- Gobli Wiki: https://w-atwiki-jp.translate.goog/studiogobli/pages/14.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp
@@ -1084,4 +1378,67 @@ xi.combat.physical.isGuarded = function(defender, attacker)
     end
 
     return guarded
+end
+
+xi.combat.physical.calculateDamageMultiplier = function(player, slot, damage, physicalAttackType, isFirstSwing)
+    local weapon = player:getEquippedItem(slot)
+
+    if weapon == nil then
+        return damage
+    end
+
+    local baseDamage = damage
+    local occ_do_triple_dmg = 0
+    local occ_do_double_dmg = 0
+
+    if physicalAttackType == xi.physicalAttackType.RAPID_SHOT then
+        occ_do_triple_dmg = math.floor(player:getMod(xi.mod.REM_OCC_DO_TRIPLE_DMG_RANGED) / 10)
+        occ_do_double_dmg = math.floor(player:getMod(xi.mod.REM_OCC_DO_DOUBLE_DMG_RANGED) / 10)
+    elseif physicalAttackType == xi.physicalAttackType.NORMAL then
+        if slot == xi.slot.MAIN then
+            occ_do_triple_dmg = math.floor(player:getMod(xi.mod.REM_OCC_DO_TRIPLE_DMG) / 10)
+            occ_do_double_dmg = math.floor(player:getMod(xi.mod.REM_OCC_DO_DOUBLE_DMG) / 10)
+        end
+    end
+
+    local occ_extra_dmg = xi.combat.utils.getScaledItemModifier(player, weapon, xi.mod.OCC_DO_EXTRA_DMG) / 100
+    local occ_extra_dmg_chance = math.floor(xi.combat.utils.getScaledItemModifier(player, weapon, xi.mod.EXTRA_DMG_CHANCE) / 10)
+
+    if isFirstSwing then
+        if occ_extra_dmg > 3 and occ_extra_dmg_chance > 0 and (1 + math.random(1, 100)) <= occ_extra_dmg_chance then
+            return math.floor(damage * occ_extra_dmg)
+        elseif occ_do_triple_dmg > 0 and (1 + math.random(1, 100)) <= occ_do_triple_dmg then
+            return math.floor(damage * 3)
+        elseif occ_extra_dmg > 2 and occ_extra_dmg_chance > 0 and (1 + math.random(1, 100)) <= occ_extra_dmg_chance then
+            return math.floor(damage * occ_extra_dmg)
+        elseif occ_do_double_dmg > 0 and (1 + math.random(1, 100)) <= occ_do_double_dmg then
+            return math.floor(damage * 2)
+        elseif occ_extra_dmg > 0 and occ_extra_dmg_chance > 0 and (1 + math.random(1, 100)) <= occ_extra_dmg_chance then
+            return math.floor(damage * occ_extra_dmg)
+        end
+    end
+
+    if physicalAttackType == xi.physicalAttackType.ZANSHIN then
+        if math.random(1, 100) < player:getMod(xi.mod.ZANSHIN_DOUBLE_DAMAGE) then
+            return baseDamage * 2
+        end
+    elseif physicalAttackType == xi.physicalAttackType.TRIPLE then
+        if math.random(1, 100) < player:getMod(xi.mod.TA_TRIPLE_DMG_RATE) then
+            return baseDamage * 3
+        end
+    elseif physicalAttackType == xi.physicalAttackType.DOUBLE then
+        if math.random(1, 100) < player:getMod(xi.mod.DA_DOUBLE_DMG_RATE) then
+            return baseDamage * 2
+        end
+    elseif physicalAttackType == xi.physicalAttackType.RAPID_SHOT then
+        if math.random(1, 100) < player.getMod(xi.mod.RAPID_SHOT_DOUBLE_DAMAGE) then
+            return baseDamage * 2
+        end
+    elseif physicalAttackType == xi.physicalAttackType.SAMBA then
+        if math.random(1, 100) < player.getMod(xi.mod.SAMBA_DOUBLE_DAMAGE) then
+            return baseDamage * 2
+        end
+    end
+
+    return baseDamage
 end

--- a/scripts/globals/combat/tp.lua
+++ b/scripts/globals/combat/tp.lua
@@ -6,10 +6,10 @@ xi.combat.tp = xi.combat.tp or {}
 -----------------------------------
 
 -- returns a single melee hit's TP return
-xi.combat.tp.getSingleMeleeHitTPReturn = function(actor, target, isZanshin)
+xi.combat.tp.getSingleMeleeHitTPReturn = function(actor, target, isZanshin, delay)
     isZanshin = isZanshin or false -- optional input, defaults to false.
 
-    local delay        = actor:getBaseDelay()
+    local delay        = delay or actor:getBaseDelay()
     local attackOutput = xi.combat.tp.getModifiedDelayAndCanZanshin(actor, delay)
     local tpReturn     = xi.combat.tp.calculateTPReturn(actor, attackOutput.modifiedDelay)
 
@@ -20,6 +20,19 @@ xi.combat.tp.getSingleMeleeHitTPReturn = function(actor, target, isZanshin)
     local storeTPModifier = (100 + actor:getMod(xi.mod.STORETP)) / 100
 
     return math.floor(tpReturn * storeTPModifier)
+end
+
+-- returns a single ranged hit's TP return
+xi.combat.tp.getSingleRangedHitTPReturn = function(actor, target, delay)
+    local delay = delay or actor:getBaseRangedDelay() -- there do not appear to be any delay modifiers for ranged attacks, snapshot does not seem to effect this
+
+    if delay > 0 then
+        local storeTPModifier = (100 + actor:getMod(xi.mod.STORETP)) / 100
+
+        return math.floor(xi.combat.tp.calculateTPReturn(actor, delay) * storeTPModifier)
+    end
+
+    return 0
 end
 
 -- returns a PC weapon slot's TP return for a single hit
@@ -68,19 +81,6 @@ xi.combat.tp.getModifiedDelayAndCanZanshin = function(actor, delay)
     modifiedDelay = modifiedDelay * math.max((100 + actor:getMod(xi.mod.DELAYP)) / 100, 0.85) -- minimum cap of -15% https://www.bg-wiki.com/ffxi/Attack_Speed. Undocumented if 15% + Claymore Grip goes above 15%.
 
     return ({ canZanshin = canZanshin , modifiedDelay = math.floor(modifiedDelay) })
-end
-
--- returns a single melee hit's TP return
-xi.combat.tp.getSingleRangedHitTPReturn = function(actor, target)
-    local delay = actor:getBaseRangedDelay() -- there do not appear to be any delay modifiers for ranged attacks, snapshot does not seem to effect this
-
-    if delay > 0 then
-        local storeTPModifier = (100 + actor:getMod(xi.mod.STORETP)) / 100
-
-        return math.floor(xi.combat.tp.calculateTPReturn(actor, delay) * storeTPModifier)
-    end
-
-    return 0
 end
 
 -- https://www.bg-wiki.com/ffxi/Tactical_Points

--- a/scripts/globals/combat/utilities.lua
+++ b/scripts/globals/combat/utilities.lua
@@ -1,0 +1,25 @@
+xi = xi or {}
+xi.combat = xi.combat or {}
+xi.combat.utils = xi.combat.utils or {}
+
+xi.combat.utils.getScaledItemModifier = function(entity, item, mod)
+    local reqLevel = item:getReqLvl()
+    if entity:GetMLevel() < reqLevel then
+        local modAmount = item:getModifier(mod)
+
+        if mod == xi.mod.RANGED_DMG_RATING then
+            modAmount = modAmount * 3
+            modAmount = math.floor(modAmount / 4)
+        elseif mod == xi.mod.MP then
+            modAmount = math.floor(modAmount / 2)
+        elseif mod == xi.mod.MACC then
+            modAmount = math.floor(modAmount / 3)
+        end
+        
+        return math.floor(modAmount / reqLevel)
+    else
+        return item.getMod(mod)
+    end
+
+    return 0
+end

--- a/scripts/specs/core/CAttack.lua
+++ b/scripts/specs/core/CAttack.lua
@@ -6,7 +6,7 @@ local CAttack = {}
 
 ---@nodiscard
 ---@return boolean
-function CAttack:getCritical()
+function CAttack:isCritical()
 end
 
 ---@param critical boolean

--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -98,6 +98,9 @@ xi.settings.map =
     -- Disables Treasure Hunter procs (Era behavior wants this true)
     DISABLE_TREASURE_HUNTER_PROCS = false,
 
+    -- Enable auto attack damage calculations in Lua
+    ENABLE_AUTO_ATTACK_LUA = true,
+
     -- Weaponskill point base (before skillchain) for breaking latent - whole numbers only. retail is 1.
     WS_POINTS_BASE = 1,
 

--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -30,7 +30,7 @@
 
 /************************************************************************
  *                                                                      *
- *  Constructor.                                                            *
+ *  Constructor.                                                        *
  *                                                                      *
  ************************************************************************/
 CAttack::CAttack(CBattleEntity* attacker, CBattleEntity* defender, PHYSICAL_ATTACK_TYPE type, PHYSICAL_ATTACK_DIRECTION direction, CAttackRound* attackRound)
@@ -47,17 +47,17 @@ CAttack::CAttack(CBattleEntity* attacker, CBattleEntity* defender, PHYSICAL_ATTA
  *  Returns the attack direction.                                       *
  *                                                                      *
  ************************************************************************/
-PHYSICAL_ATTACK_DIRECTION CAttack::GetAttackDirection()
+PHYSICAL_ATTACK_DIRECTION CAttack::GetAttackDirection() const
 {
     return m_attackDirection;
 }
 
 /************************************************************************
  *                                                                      *
- *  Returns the attack type.                                                *
+ *  Returns the attack type.                                            *
  *                                                                      *
  ************************************************************************/
-PHYSICAL_ATTACK_TYPE CAttack::GetAttackType()
+PHYSICAL_ATTACK_TYPE CAttack::GetAttackType() const
 {
     return m_attackType;
 }
@@ -74,7 +74,7 @@ void CAttack::SetAttackType(PHYSICAL_ATTACK_TYPE type)
 
 /************************************************************************
  *                                                                      *
- *  Returns the isCritical flag.                                            *
+ *  Returns the isCritical flag.                                        *
  *                                                                      *
  ************************************************************************/
 bool CAttack::IsCritical() const
@@ -459,12 +459,12 @@ bool CAttack::CheckAnticipated()
     }
 }
 
-bool CAttack::CheckHadSneakAttack() const
+bool CAttack::IsSA() const
 {
     return m_isSA;
 }
 
-bool CAttack::CheckHadTrickAttack() const
+bool CAttack::IsTA() const
 {
     return m_isTA;
 }
@@ -566,11 +566,71 @@ bool CAttack::CheckCover()
 
 /************************************************************************
  *                                                                      *
- *  Processes the damage for this swing.                                    *
+ *  Processes the damage for this swing.                                *
  *                                                                      *
  ************************************************************************/
 void CAttack::ProcessDamage()
 {
+    if (settings::get<bool>("map.ENABLE_AUTO_ATTACK_LUA"))
+    {
+        // Sneak attack.
+        if (m_attacker->GetMJob() == JOB_THF && m_isFirstSwing && m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_SNEAK_ATTACK) &&
+            (behind(m_attacker->loc.p, m_victim->loc.p, 64) || m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_HIDE) ||
+            m_victim->StatusEffectContainer->HasStatusEffect(EFFECT_DOUBT)))
+        {
+            m_isSA = true;
+        }
+
+        // Trick attack.
+        if (m_attacker->GetMJob() == JOB_THF && m_isFirstSwing && m_attackRound->GetTAEntity() != nullptr)
+        {
+            m_isTA = true;
+        }
+
+        auto calculateAttackDamage = lua["xi"]["combat"]["physical"]["calculateAttackDamage"];
+        auto result = calculateAttackDamage(m_attacker, m_victim, GetWeaponSlot(), m_attackType, m_attackRound->IsH2H(), m_isFirstSwing, m_isSA, m_isTA, m_damageRatio, m_attacker->GetMainWeaponDmg());
+        if (result.valid())
+        {
+            m_damage = result.get<int32>(0);
+
+            // Set attack type to Samba if the attack type is normal.  Don't overwrite other types.  Used for Samba double damage.
+            if (m_attackType == PHYSICAL_ATTACK_TYPE::NORMAL && (m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_DRAIN_SAMBA) ||
+                                                                m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_ASPIR_SAMBA) || m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_HASTE_SAMBA)))
+            {
+                SetAttackType(PHYSICAL_ATTACK_TYPE::SAMBA);
+            }
+
+            // Try skill up.
+            if (m_damage > 0)
+            {
+                if (m_attacker->objtype == TYPE_PC)
+                {
+                    if (m_attackType == PHYSICAL_ATTACK_TYPE::DAKEN)
+                    {
+                        charutils::TrySkillUP((CCharEntity*)m_attacker, SKILLTYPE::SKILL_THROWING, m_victim->GetMLevel());
+                    }
+                    else if (auto* weapon = dynamic_cast<CItemWeapon*>(m_attacker->m_Weapons[(SLOTTYPE)GetWeaponSlot()]))
+                    {
+                        charutils::TrySkillUP((CCharEntity*)m_attacker, (SKILLTYPE)weapon->getSkillType(), m_victim->GetMLevel());
+                    }
+                }
+                else if (m_attacker->objtype == TYPE_PET && m_attacker->PMaster && m_attacker->PMaster->objtype == TYPE_PC &&
+                        static_cast<CPetEntity*>(m_attacker)->getPetType() == PET_TYPE::AUTOMATON)
+                {
+                    puppetutils::TrySkillUP((CAutomatonEntity*)m_attacker, SKILL_AUTOMATON_MELEE, m_victim->GetMLevel());
+                }
+            }
+            m_isBlocked = attackutils::IsBlocked(m_attacker, m_victim);
+        }
+        else
+        {
+            sol::error err = result;
+            ShowError("attack.cpp::ProcessDamage(): %s", err.what());
+        }
+
+        return;
+    }
+
     // Sneak attack.
     if (m_attacker->GetMJob() == JOB_THF && m_isFirstSwing && m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_SNEAK_ATTACK) &&
         (behind(m_attacker->loc.p, m_victim->loc.p, 64) || m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_HIDE) ||
@@ -650,13 +710,13 @@ void CAttack::ProcessDamage()
         attackutils::CheckForDamageMultiplier((CCharEntity*)m_attacker, dynamic_cast<CItemWeapon*>(m_attacker->m_Weapons[slot]), m_damage, m_attackType, slot, m_isFirstSwing);
 
     // Apply Sneak Attack Augment Mod
-    if (m_attacker->getMod(Mod::AUGMENTS_SA) > 0 && CheckHadSneakAttack() && m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_SNEAK_ATTACK))
+    if (m_attacker->getMod(Mod::AUGMENTS_SA) > 0 && IsSA() && m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_SNEAK_ATTACK))
     {
         m_damage += (int32)(m_damage * ((100 + (m_attacker->getMod(Mod::AUGMENTS_SA))) / 100.0f));
     }
 
     // Apply Trick Attack Augment Mod
-    if (m_attacker->getMod(Mod::AUGMENTS_TA) > 0 && CheckHadTrickAttack() && m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_TRICK_ATTACK))
+    if (m_attacker->getMod(Mod::AUGMENTS_TA) > 0 && IsTA() && m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_TRICK_ATTACK))
     {
         m_damage += (int32)(m_damage * ((100 + (m_attacker->getMod(Mod::AUGMENTS_TA))) / 100.0f));
     }

--- a/src/map/attack.h
+++ b/src/map/attack.h
@@ -70,11 +70,12 @@ class CAttack
 public:
     CAttack(CBattleEntity* attacker, CBattleEntity* defender, PHYSICAL_ATTACK_TYPE type, PHYSICAL_ATTACK_DIRECTION direction, CAttackRound* attackRound);
 
-    uint16                    GetAnimationID();                     // Returns the animation ID.
-    PHYSICAL_ATTACK_TYPE      GetAttackType();                      // Returns the attack type (Double, Triple, Zanshin ect).
-    PHYSICAL_ATTACK_DIRECTION GetAttackDirection();                 // Returns the attack direction.
-    uint8                     GetWeaponSlot();                      // Returns the attacking slot.
-    uint8                     GetHitRate();                         // Returns the hitrate for this swing.
+    uint16                    GetAnimationID();                         // Returns the animation ID.
+    PHYSICAL_ATTACK_TYPE      GetAttackType() const;                    // Returns the attack type (Double, Triple, Zanshin ect).
+    void                      SetAttackType(PHYSICAL_ATTACK_TYPE type); // Sets the attack type.
+    PHYSICAL_ATTACK_DIRECTION GetAttackDirection() const;               // Returns the attack direction.
+    uint8                     GetWeaponSlot();                          // Returns the attacking slot.
+    uint8                     GetHitRate();                             // Returns the hitrate for this swing.
     int32                     GetDamage() const;                    // Returns the damage for this attack.
     void                      SetDamage(int32);                     // Sets the damage for this attack.
     bool                      IsCritical() const;                   // Returns the isCritical flag.
@@ -92,15 +93,13 @@ public:
     bool                      IsAnticipated() const;
     bool                      IsDeflected() const;
     bool                      CheckAnticipated();
-    bool                      CheckHadSneakAttack() const;
-    bool                      CheckHadTrickAttack() const;
+    bool                      IsSA() const;
+    bool                      IsTA() const;
     bool                      IsCountered() const;
     bool                      CheckCounter();
     bool                      IsCovered() const; // Returns the covered flag.
     bool                      CheckCover();      // Sets the covered flag and returns it.
     void                      ProcessDamage();   // Processes the damage for this swing.
-
-    void SetAttackType(PHYSICAL_ATTACK_TYPE type); // Sets the attack type.
 
 private:
     CBattleEntity*            m_attacker;            // The attacker.
@@ -115,7 +114,7 @@ private:
     bool                      m_isBlocked{ false };  // Flag: Is this attack blocked by the victim?
     bool                      m_isEvaded{ false };   // Flag: Is this attack evaded by the victim?
     bool                      m_isCountered{ false };
-    bool                      m_isCovered{ false }; // Flag: Is someone covering the victim?
+    bool                      m_isCovered{ false };  // Flag: Is someone covering the victim?
     bool                      m_anticipated{ false };
     bool                      m_isSA{ false };                // Attack had a valid SA proc
     bool                      m_isTA{ false };                // Attack had a valid TA proc

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2415,30 +2415,47 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                             }
                         }
 
-                        if (skilltype == SKILLTYPE::SKILL_HAND_TO_HAND || (PTarget->objtype == TYPE_MOB && PTarget->GetMJob() == JOB_MNK))
+                        int32 damage = 0;
+                        if (settings::get<bool>("map.ENABLE_AUTO_ATTACK_LUA"))
                         {
-                            naturalh2hDMG = (int16)((PTarget->GetSkill(SKILL_HAND_TO_HAND) * 0.11f) + 3);
+                            auto calculateCounterDamage = lua["xi"]["combat"]["physical"]["calculateCounterDamage"];
+                            auto result = calculateCounterDamage(this, PTarget, skilltype, attack.IsCritical());
+                            if (result.valid())
+                            {
+                                damage = result.get<int32>(0);
+                            }
+                            else
+                            {
+                                sol::error err = result;
+                                ShowError("battleentity.cpp::OnAttack(): %s", err.what());
+                            }
                         }
-
-                        // Calculate attack bonus for Counterstance Effect Job Points
-                        // Needs verification, as there appears to be conflicting information regarding an attack bonus based on DEX
-                        // vs a base damage increase.
-                        float attBonus = 1.0f;
-                        if (PTarget->objtype == TYPE_PC && PTarget->GetMJob() == JOB_MNK && PTarget->StatusEffectContainer->HasStatusEffect(EFFECT_COUNTERSTANCE))
+                        else
                         {
-                            auto*  PChar        = static_cast<CCharEntity*>(PTarget);
-                            uint8  csJpModifier = PChar->PJobPoints->GetJobPointValue(JP_COUNTERSTANCE_EFFECT) * 2;
-                            uint16 targetDex    = PTarget->DEX();
+                            if (skilltype == SKILLTYPE::SKILL_HAND_TO_HAND || (PTarget->objtype == TYPE_MOB && PTarget->GetMJob() == JOB_MNK))
+                            {
+                                naturalh2hDMG = (int16)((PTarget->GetSkill(SKILL_HAND_TO_HAND) * 0.11f) + 3);
+                            }
 
-                            attBonus += ((static_cast<float>(targetDex) / 100) * csJpModifier);
+                            // Calculate attack bonus for Counterstance Effect Job Points
+                            // Needs verification, as there appears to be conflicting information regarding an attack bonus based on DEX
+                            // vs a base damage increase.
+                            float attBonus = 1.0f;
+                            if (PTarget->objtype == TYPE_PC && PTarget->GetMJob() == JOB_MNK && PTarget->StatusEffectContainer->HasStatusEffect(EFFECT_COUNTERSTANCE))
+                            {
+                                auto*  PChar        = static_cast<CCharEntity*>(PTarget);
+                                uint8  csJpModifier = PChar->PJobPoints->GetJobPointValue(JP_COUNTERSTANCE_EFFECT) * 2;
+                                uint16 targetDex    = PTarget->DEX();
+
+                                attBonus += ((static_cast<float>(targetDex) / 100) * csJpModifier);
+                            }
+
+                            float DamageRatio = battleutils::GetDamageRatio(PTarget, this, attack.IsCritical(), attBonus, skilltype, SLOT_MAIN, false);
+                            damage            = (int32)((PTarget->GetMainWeaponDmg() + naturalh2hDMG + battleutils::GetFSTR(PTarget, this, SLOT_MAIN)) * DamageRatio);
                         }
-
-                        float DamageRatio = battleutils::GetDamageRatio(PTarget, this, attack.IsCritical(), attBonus, skilltype, SLOT_MAIN, false);
-                        auto  damage      = (int32)((PTarget->GetMainWeaponDmg() + naturalh2hDMG + battleutils::GetFSTR(PTarget, this, SLOT_MAIN)) * DamageRatio);
-
-                        actionTarget.spikesParam =
-                            battleutils::TakePhysicalDamage(PTarget, this, attack.GetAttackType(), damage, false, SLOT_MAIN, 1, nullptr, true, false, true);
+                        actionTarget.spikesParam = battleutils::TakePhysicalDamage(PTarget, this, attack.GetAttackType(), damage, false, SLOT_MAIN, 1, nullptr, true, false, true);
                         actionTarget.spikesMessage = 33;
+
                         if (PTarget->objtype == TYPE_PC)
                         {
                             charutils::TrySkillUP((CCharEntity*)PTarget, skilltype, GetMLevel());

--- a/src/map/lua/lua_attack.cpp
+++ b/src/map/lua/lua_attack.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
   Copyright (c) 2023 LandSandBoat Dev Teams
@@ -32,7 +32,7 @@ CLuaAttack::CLuaAttack(CAttack* attack)
     }
 }
 
-bool CLuaAttack::getCritical() const
+bool CLuaAttack::isCritical() const
 {
     return m_PLuaAttack->IsCritical();
 }
@@ -47,9 +47,10 @@ void CLuaAttack::setCritical(bool critical)
 void CLuaAttack::Register()
 {
     SOL_USERTYPE("CAttack", CLuaAttack);
-    SOL_REGISTER("getCritical", CLuaAttack::getCritical);
+
+    SOL_REGISTER("isCritical", CLuaAttack::isCritical);
     SOL_REGISTER("setCritical", CLuaAttack::setCritical);
-};
+}
 
 std::ostream& operator<<(std::ostream& os, const CLuaAttack& attack)
 {

--- a/src/map/lua/lua_attack.h
+++ b/src/map/lua/lua_attack.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
   Copyright (c) 2023 LandSandBoat Dev Teams
@@ -23,13 +23,13 @@
 
 #include "common/cbasetypes.h"
 #include "luautils.h"
+#include "utils/attackutils.h"
 
 class CAttack;
 
 class CLuaAttack
 {
     CAttack* m_PLuaAttack;
-
 public:
     CLuaAttack(CAttack*);
 
@@ -38,7 +38,7 @@ public:
         return m_PLuaAttack;
     }
 
-    bool getCritical() const;
+    bool isCritical() const;
     void setCritical(bool critical);
 
     friend std::ostream& operator<<(std::ostream& out, const CLuaAttack& action);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -14613,8 +14613,9 @@ int32 CLuaBaseEntity::physicalDmgTaken(double damage, sol::variadic_args va)
     }
 
     DAMAGE_TYPE damageType = va[0].is<uint32>() ? va[0].as<DAMAGE_TYPE>() : DAMAGE_TYPE::NONE;
+    bool isCovered = va[1].as<bool>();
 
-    return battleutils::PhysicalDmgTaken(static_cast<CBattleEntity*>(m_PBaseEntity), static_cast<int32>(damage), damageType);
+    return battleutils::PhysicalDmgTaken(static_cast<CBattleEntity*>(m_PBaseEntity), static_cast<int32>(damage), damageType, isCovered);
 }
 
 /************************************************************************
@@ -14653,8 +14654,9 @@ int32 CLuaBaseEntity::rangedDmgTaken(double damage, sol::variadic_args va)
     }
 
     DAMAGE_TYPE damageType = va[0].is<uint32>() ? va[0].as<DAMAGE_TYPE>() : DAMAGE_TYPE::NONE;
+    bool isCovered = va[1].as<bool>();
 
-    return battleutils::RangedDmgTaken(static_cast<CBattleEntity*>(m_PBaseEntity), static_cast<int32>(damage), damageType);
+    return battleutils::RangedDmgTaken(static_cast<CBattleEntity*>(m_PBaseEntity), static_cast<int32>(damage), damageType, isCovered);
 }
 
 /************************************************************************

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1170,13 +1170,13 @@ namespace battleutils
                         float sneakAttackTrickAttackBonus = 0.f;
 
                         // BG wiki claims 10x bonus for SA
-                        if (attack.CheckHadSneakAttack())
+                        if (attack.IsSA())
                         {
                             sneakAttackTrickAttackBonus += 10.f;
                         }
 
                         // BG wiki claims 10x bonus for TA
-                        if (attack.CheckHadTrickAttack())
+                        if (attack.IsTA())
                         {
                             sneakAttackTrickAttackBonus += 10.f;
                         }
@@ -2073,6 +2073,108 @@ namespace battleutils
                              uint8 slot, uint16 tpMultiplier, CBattleEntity* taChar, bool giveTPtoVictim, bool giveTPtoAttacker, bool isCounter, bool isCovered,
                              CBattleEntity* POriginalTarget)
     {
+        if (settings::get<bool>("map.ENABLE_AUTO_ATTACK_LUA"))
+        {
+            auto takePhysicalDamage = lua["xi"]["combat"]["physical"]["takePhysicalDamage"];
+            auto result = takePhysicalDamage(PAttacker, PDefender, physicalAttackType, damage, isBlocked, 
+                                            slot, tpMultiplier, taChar, giveTPtoVictim, giveTPtoAttacker, 
+                                            isCounter, isCovered, POriginalTarget);
+            if (result.valid())
+            {
+                damage = result.get<int32>(0);
+
+                bool isRanged = (slot == SLOT_AMMO || slot == SLOT_RANGED);
+                battleutils::ClaimMob(PDefender, PAttacker);
+
+                if (damage > 0)
+                {
+                    PDefender->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DAMAGE);
+
+                    // Check for bind breaking
+                    BindBreakCheck(PAttacker, PDefender);
+
+                    switch (PDefender->objtype)
+                    {
+                        case TYPE_MOB:
+                            if (taChar == nullptr)
+                            {
+                                ((CMobEntity*)PDefender)->PEnmityContainer->UpdateEnmityFromDamage(PAttacker, damage);
+                            }
+                            else
+                            {
+                                ((CMobEntity*)PDefender)->PEnmityContainer->UpdateEnmityFromDamage(taChar, damage);
+                            }
+
+                            if (((CMobEntity*)PDefender)->m_HiPCLvl < PAttacker->GetMLevel())
+                            {
+                                ((CMobEntity*)PDefender)->m_HiPCLvl = PAttacker->GetMLevel();
+                            }
+
+                            // if the mob is charmed by player
+                            if (PDefender->PMaster != nullptr && PDefender->PMaster->objtype == TYPE_PC)
+                            {
+                                ((CPetEntity*)PDefender)
+                                    ->loc.zone->UpdateEntityPacket(PDefender, ENTITY_UPDATE, UPDATE_COMBAT);
+
+                                if (PAttacker->objtype == TYPE_MOB)
+                                {
+                                    // charmed mob should lose enmity from normal attacks
+                                    ((CMobEntity*)PAttacker)->PEnmityContainer->UpdateEnmityFromAttack(PDefender, damage);
+                                }
+                            }
+                            break;
+
+                        case TYPE_PET:
+                            ((CPetEntity*)PDefender)->loc.zone->UpdateEntityPacket(PDefender, ENTITY_UPDATE, UPDATE_COMBAT);
+
+                            if (PAttacker->objtype == TYPE_MOB)
+                            {
+                                // pets should lose enmity from normal attacks
+                                ((CMobEntity*)PAttacker)->PEnmityContainer->UpdateEnmityFromAttack(PDefender, damage);
+                            }
+                            break;
+                        case TYPE_PC:
+                            if (PAttacker->objtype == TYPE_MOB)
+                            {
+                                if (isCovered)
+                                {
+                                    ((CMobEntity*)PAttacker)->PEnmityContainer->UpdateEnmityFromCover(POriginalTarget, PDefender);
+                                }
+                                else
+                                {
+                                    ((CMobEntity*)PAttacker)->PEnmityContainer->UpdateEnmityFromAttack(PDefender, damage);
+                                }
+                            }
+                            break;
+                        default:
+                            break;
+                    }
+
+                    // try to interrupt spell if not a ranged attack and not blocked by Shield Mastery
+                    if ((!isRanged) && !((isBlocked) && (PDefender->objtype == TYPE_PC) && (charutils::hasTrait((CCharEntity*)PDefender, TRAIT_SHIELD_MASTERY))))
+                    {
+                        PDefender->TryHitInterrupt(PAttacker);
+                    }
+                }
+                else if (PDefender->objtype == TYPE_MOB)
+                {
+                    ((CMobEntity*)PDefender)->PEnmityContainer->UpdateEnmityFromDamage(PAttacker, 0);
+                }
+
+                if (PAttacker->objtype == TYPE_PC && !isRanged && !isCounter)
+                {
+                    PAttacker->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_ATTACK);
+                }
+            }
+            else
+            {
+                sol::error err = result;
+                ShowError("battleentity::TakePhysicalDamage(): %s", err.what());
+            }
+
+            return damage;
+        }
+
         auto* weapon           = GetEntityWeapon(PAttacker, (SLOTTYPE)slot);
         giveTPtoAttacker       = giveTPtoAttacker && !PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_MEIKYO_SHISUI);
         giveTPtoVictim         = giveTPtoVictim && physicalAttackType != PHYSICAL_ATTACK_TYPE::DAKEN;
@@ -2383,13 +2485,13 @@ namespace battleutils
                     PDefender->addTP(
                         (int16)(tpMultiplier * ((baseTp / 3) * sBlowMult *
                                                 (1.0f + 0.01f * (float)((PDefender->getMod(Mod::STORETP) +
-                                                                         getStoreTPbonusFromMerit(PAttacker))))))); // yup store tp counts on hits taken too!
+                                                                        getStoreTPbonusFromMerit(PAttacker))))))); // yup store tp counts on hits taken too!
                 }
                 else
                 {
                     PDefender->addTP((uint16)(tpMultiplier *
-                                              ((baseTp + 30) * sBlowMult *
-                                               (1.0f + 0.01f * (float)PDefender->getMod(Mod::STORETP))))); // subtle blow also reduces the "+30" on mob tp gain
+                                            ((baseTp + 30) * sBlowMult *
+                                            (1.0f + 0.01f * (float)PDefender->getMod(Mod::STORETP))))); // subtle blow also reduces the "+30" on mob tp gain
                 }
             }
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Moves damage calculations from C++ to Lua conditioned on ENABLE_AUTO_ATTACK_LUA in map.lua

I am going to split this into many smaller PRs.

https://github.com/LandSandBoat/server/issues/4949

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
