### PR TITLE
[Magic] Fix aborb spell function missing a comparator

### DIFF
--- a/scripts/globals/spells/absorb_spell.lua
+++ b/scripts/globals/spells/absorb_spell.lua
@@ -98,7 +98,7 @@ xi.spells.absorb.doDrainingSpell = function(caster, target, spell)
     end
 
     -- Early return: Target absorbs or nullifies dark.
-    if xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.DARK) then
+    if xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.DARK) ~= 1 then
         spell:setMsg(xi.msg.basic.MAGIC_RESIST)
         return finalDamage
     end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

As title sais. Function returns an int, not a bool, so it needs to be compared to an int

## Steps to test these changes
Use drain spells.
