### PR TITLE
Implement status resist in mob status moves

### DIFF
--- a/scripts/globals/combat/status_effect_tables.lua
+++ b/scripts/globals/combat/status_effect_tables.lua
@@ -35,7 +35,7 @@ local column =
 xi.combat.statusEffect.dataTable =
 {
     [xi.effect.ADDLE        ] = { 0,               xi.effect.NOCTURNE, xi.element.FIRE,    xi.immunity.ADDLE,      xi.mod.SLOWRES,     0, 0,                    xi.mod.ADDLE_IMMUNOBREAK    }, -- Addle cant be immunobroken?
-    [xi.effect.AMNESIA      ] = { 0,               0,                  xi.element.FIRE,    xi.immunity.AMNESIA,    xi.mod.AMNESIARES,  0, xi.mod.AMNESIA_MEVA,  0                           },
+    [xi.effect.AMNESIA      ] = { 0,               0,                  xi.element.FIRE,    0,                      xi.mod.AMNESIARES,  0, xi.mod.AMNESIA_MEVA,  0                           },
     [xi.effect.BIND         ] = { 0,               0,                  xi.element.ICE,     xi.immunity.BIND,       xi.mod.BINDRES,     0, xi.mod.BIND_MEVA,     xi.mod.BIND_IMMUNOBREAK     },
     [xi.effect.BLINDNESS    ] = { 0,               0,                  xi.element.DARK,    xi.immunity.BLIND,      xi.mod.BLINDRES,    0, xi.mod.BLIND_MEVA,    xi.mod.BLIND_IMMUNOBREAK    },
     [xi.effect.BURN         ] = { xi.effect.DROWN, 0,                  xi.element.FIRE,    0,                      0,                  0, 0,                    0                           },

--- a/scripts/globals/combat/status_effect_tables.lua
+++ b/scripts/globals/combat/status_effect_tables.lua
@@ -35,6 +35,7 @@ local column =
 xi.combat.statusEffect.dataTable =
 {
     [xi.effect.ADDLE        ] = { 0,               xi.effect.NOCTURNE, xi.element.FIRE,    xi.immunity.ADDLE,      xi.mod.SLOWRES,     0, 0,                    xi.mod.ADDLE_IMMUNOBREAK    }, -- Addle cant be immunobroken?
+    [xi.effect.AMNESIA      ] = { 0,               0,                  xi.element.FIRE,    xi.immunity.AMNESIA,    xi.mod.AMNESIARES,  0, xi.mod.AMNESIA_MEVA,  0                           },
     [xi.effect.BIND         ] = { 0,               0,                  xi.element.ICE,     xi.immunity.BIND,       xi.mod.BINDRES,     0, xi.mod.BIND_MEVA,     xi.mod.BIND_IMMUNOBREAK     },
     [xi.effect.BLINDNESS    ] = { 0,               0,                  xi.element.DARK,    xi.immunity.BLIND,      xi.mod.BLINDRES,    0, xi.mod.BLIND_MEVA,    xi.mod.BLIND_IMMUNOBREAK    },
     [xi.effect.BURN         ] = { xi.effect.DROWN, 0,                  xi.element.FIRE,    0,                      0,                  0, 0,                    0                           },

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -629,9 +629,14 @@ end
 -- Adds a status effect to a target
 xi.mobskills.mobStatusEffectMove = function(mob, target, typeEffect, power, tick, duration, subType, subPower, tier)
     if target:canGainStatusEffect(typeEffect, power) then
-        local statmod = xi.mod.INT
-        local element = mob:getStatusEffectElement(typeEffect)
-        local resist  = xi.mobskills.applyPlayerResistance(mob, typeEffect, target, mob:getStat(statmod)-target:getStat(statmod), 0, element)
+        local statmod    = xi.mod.INT
+        local element    = mob:getStatusEffectElement(typeEffect)
+        local fullResist = xi.combat.statusEffect.isTargetResistant(mob, target, typeEffect)
+        local resist     = xi.mobskills.applyPlayerResistance(mob, typeEffect, target, mob:getStat(statmod)-target:getStat(statmod), 0, element)
+
+        if fullResist then
+            return xi.msg.basic.SKILL_MISS -- resist !
+        end
 
         if resist >= 0.25 then
             local totalDuration = utils.clamp(duration * resist, 1)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This change adds a consideration for "Resist [x]" status-effect resistance traits and gear mods into mobskills.mobStatusEffectMove, which is called during mob weaponskills that apply a status. Currently, equipping "Resist Charm" gear doesn't help you at all against, say, a yovra's Luminous Drape. Resist traits only come into play when the mob is casting a spell or singing an enfeebling song. But with this change, mob weaponskills also check for these traits.

Because of the way "isTargetResistant" works in combat/status_effect_tables.lua, this means all mob weaponskill status effect moves will now fail at least 5% of the time (2% if the mob is an NM).

This change also adds amnesia to the table in status_effect_tables.lua, along with its element (fire), resistance mod (AMNESIARES), and magic eva mod (AMNESIA_MEVA).

## Steps to test these changes

You can test both of the above changes by changing to a job with innate resist amnesia:

!changejob BST 85

Then find a qiqirn and hit it until it uses Kibosh on you. You can see that 5 + 25% of the time (5% minimum), you will fully resist amnesia.
