### PR TITLE
[Magic] Improve blue enfeebling spells logic

### DIFF
--- a/scripts/actions/spells/blue/actinic_burst.lua
+++ b/scripts/actions/spells/blue/actinic_burst.lua
@@ -22,16 +22,16 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
-    params.ecosystem = xi.ecosystem.LUMINION
-    params.effect = xi.effect.FLASH
-    local power = 200
-    local tick = 0
-    local duration = 16
-    local resistThreshold = 0.25
-    local isGaze = false
-    local isConal = false
+    params.ecosystem       = xi.ecosystem.LUMINION
+    params.effect          = xi.effect.FLASH
+    params.power           = 200
+    params.tick            = 0
+    params.duration        = 16
+    params.resistThreshold = 0.25
+    params.isGaze          = false
+    params.isConal         = false
 
-    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params, power, tick, duration, resistThreshold, isGaze, isConal)
+    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params)
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/awful_eye.lua
+++ b/scripts/actions/spells/blue/awful_eye.lua
@@ -21,16 +21,16 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
-    params.ecosystem = xi.ecosystem.LIZARD
-    params.effect = xi.effect.STR_DOWN
-    local power = 30
-    local tick = 1
-    local duration = 30
-    local resistThreshold = 0.5
-    local isGaze = true
-    local isConal = true
+    params.ecosystem       = xi.ecosystem.LIZARD
+    params.effect          = xi.effect.STR_DOWN
+    params.power           = 30
+    params.tick            = 1
+    params.duration        = 30
+    params.resistThreshold = 0.5
+    params.isGaze          = true
+    params.isConal         = true
 
-    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params, power, tick, duration, resistThreshold, isGaze, isConal)
+    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params)
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/chaotic_eye.lua
+++ b/scripts/actions/spells/blue/chaotic_eye.lua
@@ -21,16 +21,16 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
-    params.ecosystem = xi.ecosystem.BEAST
-    params.effect = xi.effect.SILENCE
-    local power = 1
-    local tick = 0
-    local duration = 120
-    local resistThreshold = 0.5
-    local isGaze = true
-    local isConal = false
+    params.ecosystem       = xi.ecosystem.BEAST
+    params.effect          = xi.effect.SILENCE
+    params.power           = 1
+    params.tick            = 0
+    params.duration        = 120
+    params.resistThreshold = 0.5
+    params.isGaze          = true
+    params.isConal         = false
 
-    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params, power, tick, duration, resistThreshold, isGaze, isConal)
+    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params)
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/cimicine_discharge.lua
+++ b/scripts/actions/spells/blue/cimicine_discharge.lua
@@ -21,16 +21,16 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
-    params.ecosystem = xi.ecosystem.VERMIN
-    params.effect = xi.effect.SLOW
-    local power = 2000
-    local tick = 0
-    local duration = 90
-    local resistThreshold = 0.5
-    local isGaze = false
-    local isConal = false
+    params.ecosystem       = xi.ecosystem.VERMIN
+    params.effect          = xi.effect.SLOW
+    params.power           = 2000
+    params.tick            = 0
+    params.duration        = 90
+    params.resistThreshold = 0.5
+    params.isGaze          = false
+    params.isConal         = false
 
-    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params, power, tick, duration, resistThreshold, isGaze, isConal)
+    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params)
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/filamented_hold.lua
+++ b/scripts/actions/spells/blue/filamented_hold.lua
@@ -21,16 +21,16 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
-    params.ecosystem = xi.ecosystem.VERMIN
-    params.effect = xi.effect.SLOW
-    local power = 2500
-    local tick = 0
-    local duration = 90
-    local resistThreshold = 0.5
-    local isGaze = false
-    local isConal = true
+    params.ecosystem       = xi.ecosystem.VERMIN
+    params.effect          = xi.effect.SLOW
+    params.power           = 2500
+    params.tick            = 0
+    params.duration        = 90
+    params.resistThreshold = 0.5
+    params.isGaze          = false
+    params.isConal         = true
 
-    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params, power, tick, duration, resistThreshold, isGaze, isConal)
+    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params)
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/frightful_roar.lua
+++ b/scripts/actions/spells/blue/frightful_roar.lua
@@ -21,16 +21,16 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
-    params.ecosystem = xi.ecosystem.DEMON
-    params.effect = xi.effect.DEFENSE_DOWN
-    local power = 10
-    local tick = 0
-    local duration = 180
-    local resistThreshold = 0.5
-    local isGaze = false
-    local isConal = false
+    params.ecosystem       = xi.ecosystem.DEMON
+    params.effect          = xi.effect.DEFENSE_DOWN
+    params.power           = 10
+    params.tick            = 0
+    params.duration        = 180
+    params.resistThreshold = 0.5
+    params.isGaze          = false
+    params.isConal         = false
 
-    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params, power, tick, duration, resistThreshold, isGaze, isConal)
+    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params)
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/infrasonics.lua
+++ b/scripts/actions/spells/blue/infrasonics.lua
@@ -21,16 +21,16 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
-    params.ecosystem = xi.ecosystem.LIZARD
-    params.effect = xi.effect.EVASION_DOWN
-    local power = 20
-    local tick = 0
-    local duration = 60
-    local resistThreshold = 0.5
-    local isGaze = false
-    local isConal = true
+    params.ecosystem       = xi.ecosystem.LIZARD
+    params.effect          = xi.effect.EVASION_DOWN
+    params.power           = 20
+    params.tick            = 0
+    params.duration        = 60
+    params.resistThreshold = 0.5
+    params.isGaze          = false
+    params.isConal         = true
 
-    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params, power, tick, duration, resistThreshold, isGaze, isConal)
+    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params)
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/jettatura.lua
+++ b/scripts/actions/spells/blue/jettatura.lua
@@ -21,16 +21,16 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
-    params.ecosystem = xi.ecosystem.BIRD
-    params.effect = xi.effect.TERROR
-    local power = 1
-    local tick = 0
-    local duration = 5
-    local resistThreshold = 0.5
-    local isGaze = true
-    local isConal = true
+    params.ecosystem       = xi.ecosystem.BIRD
+    params.effect          = xi.effect.TERROR
+    params.power           = 1
+    params.tick            = 0
+    params.duration        = 5
+    params.resistThreshold = 0.5
+    params.isGaze          = true
+    params.isConal         = true
 
-    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params, power, tick, duration, resistThreshold, isGaze, isConal)
+    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params)
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/lowing.lua
+++ b/scripts/actions/spells/blue/lowing.lua
@@ -21,16 +21,16 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
-    params.ecosystem = xi.ecosystem.BEAST
-    params.effect = xi.effect.PLAGUE
-    local power = 5
-    local tick = 0
-    local duration = 60
-    local resistThreshold = 0.5
-    local isGaze = false
-    local isConal = false
+    params.ecosystem       = xi.ecosystem.BEAST
+    params.effect          = xi.effect.PLAGUE
+    params.power           = 5
+    params.tick            = 0
+    params.duration        = 60
+    params.resistThreshold = 0.5
+    params.isGaze          = false
+    params.isConal         = false
 
-    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params, power, tick, duration, resistThreshold, isGaze, isConal)
+    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params)
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/sandspray.lua
+++ b/scripts/actions/spells/blue/sandspray.lua
@@ -21,16 +21,16 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
-    params.ecosystem = xi.ecosystem.BEASTMEN
-    params.effect = xi.effect.BLINDNESS
-    local power = 25
-    local tick = 0
-    local duration = 120
-    local resistThreshold = 0.5
-    local isGaze = false
-    local isConal = true
+    params.ecosystem       = xi.ecosystem.BEASTMEN
+    params.effect          = xi.effect.BLINDNESS
+    params.power           = 25
+    params.tick            = 0
+    params.duration        = 120
+    params.resistThreshold = 0.5
+    params.isGaze          = false
+    params.isConal         = true
 
-    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params, power, tick, duration, resistThreshold, isGaze, isConal)
+    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params)
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/sheep_song.lua
+++ b/scripts/actions/spells/blue/sheep_song.lua
@@ -22,16 +22,16 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
-    params.ecosystem = xi.ecosystem.BEAST
-    params.effect = xi.effect.SLEEP_I
-    local power = 1
-    local tick = 0
-    local duration = 60
-    local resistThreshold = 0.50
-    local isGaze = false
-    local isConal = false
+    params.ecosystem       = xi.ecosystem.BEAST
+    params.effect          = xi.effect.SLEEP_I
+    params.power           = 1
+    params.tick            = 0
+    params.duration        = 60
+    params.resistThreshold = 0.50
+    params.isGaze          = false
+    params.isConal         = false
 
-    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params, power, tick, duration, resistThreshold, isGaze, isConal)
+    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params)
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/soporific.lua
+++ b/scripts/actions/spells/blue/soporific.lua
@@ -22,16 +22,16 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
-    params.ecosystem = xi.ecosystem.PLANTOID
-    params.effect = xi.effect.SLEEP_II
-    local power = 2
-    local tick = 0
-    local duration = 90
-    local resistThreshold = 0.50
-    local isGaze = false
-    local isConal = false
+    params.ecosystem       = xi.ecosystem.PLANTOID
+    params.effect          = xi.effect.SLEEP_I
+    params.power           = 2
+    params.tick            = 0
+    params.duration        = 90
+    params.resistThreshold = 0.50
+    params.isGaze          = false
+    params.isConal         = false
 
-    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params, power, tick, duration, resistThreshold, isGaze, isConal)
+    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params)
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/sound_blast.lua
+++ b/scripts/actions/spells/blue/sound_blast.lua
@@ -21,16 +21,16 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
-    params.ecosystem = xi.ecosystem.BIRD
-    params.effect = xi.effect.INT_DOWN
-    local power = 9
-    local tick = 0
-    local duration = 30
-    local resistThreshold = 0.5
-    local isGaze = false
-    local isConal = false
+    params.ecosystem       = xi.ecosystem.BIRD
+    params.effect          = xi.effect.INT_DOWN
+    params.power           = 9
+    params.tick            = 0
+    params.duration        = 30
+    params.resistThreshold = 0.5
+    params.isGaze          = false
+    params.isConal         = false
 
-    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params, power, tick, duration, resistThreshold, isGaze, isConal)
+    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params)
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/stinking_gas.lua
+++ b/scripts/actions/spells/blue/stinking_gas.lua
@@ -20,17 +20,17 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local power           = 10
-    local tick            = 0
-    local duration        = 60
-    local resistThreshold = 0.5
-    local isGaze          = false
-    local isConal         = false
-    local params          = {}
-    params.ecosystem      = xi.ecosystem.UNDEAD
-    params.effect         = xi.effect.VIT_DOWN
+    local params = {}
+    params.ecosystem       = xi.ecosystem.UNDEAD
+    params.effect          = xi.effect.VIT_DOWN
+    params.power           = 10
+    params.tick            = 0
+    params.duration        = 60
+    params.resistThreshold = 0.5
+    params.isGaze          = false
+    params.isConal         = false
 
-    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params, power, tick, duration, resistThreshold, isGaze, isConal)
+    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params)
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/temporal_shift.lua
+++ b/scripts/actions/spells/blue/temporal_shift.lua
@@ -21,16 +21,16 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
-    params.ecosystem = xi.ecosystem.LUMINIAN
-    params.effect = xi.effect.STUN
-    local power = 2
-    local tick = 0
-    local duration = 5
-    local resistThreshold = 0.25
-    local isGaze = false
-    local isConal = false
+    params.ecosystem       = xi.ecosystem.LUMINIAN
+    params.effect          = xi.effect.STUN
+    params.power           = 1
+    params.tick            = 0
+    params.duration        = 5
+    params.resistThreshold = 0.25
+    params.isGaze          = false
+    params.isConal         = false
 
-    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params, power, tick, duration, resistThreshold, isGaze, isConal)
+    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params)
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/venom_shell.lua
+++ b/scripts/actions/spells/blue/venom_shell.lua
@@ -21,16 +21,16 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
-    params.ecosystem = xi.ecosystem.AQUAN
-    params.effect = xi.effect.POISON
-    local power = 6
-    local tick = 0
-    local duration = 60
-    local resistThreshold = 0.5
-    local isGaze = false
-    local isConal = false
+    params.ecosystem       = xi.ecosystem.AQUAN
+    params.effect          = xi.effect.POISON
+    params.power           = 6
+    params.tick            = 0
+    params.duration        = 60
+    params.resistThreshold = 0.5
+    params.isGaze          = false
+    params.isConal         = false
 
-    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params, power, tick, duration, resistThreshold, isGaze, isConal)
+    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params)
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/yawn.lua
+++ b/scripts/actions/spells/blue/yawn.lua
@@ -22,16 +22,16 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
-    params.ecosystem = xi.ecosystem.BIRD
-    params.effect = xi.effect.SLEEP_II
-    local power = 2
-    local tick = 0
-    local duration = 90
-    local resistThreshold = 0.50
-    local isGaze = true
-    local isConal = false
+    params.ecosystem       = xi.ecosystem.BIRD
+    params.effect          = xi.effect.SLEEP_I
+    params.power           = 2
+    params.tick            = 0
+    params.duration        = 90
+    params.resistThreshold = 0.5
+    params.isGaze          = true
+    params.isConal         = false
 
-    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params, power, tick, duration, resistThreshold, isGaze, isConal)
+    return xi.spells.blue.useEnfeeblingSpell(caster, target, spell, params)
 end
 
 return spellObject


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds immunity, resist trait and incompatible effects checks.
- Allows Blue enfeebling spells to magic burst and trigger RoE
- Adds proper messages.
- Audits effects.

## Steps to test these changes

Use blue enfeebling spells. I still feel dirty.