### PR TITLE
add module to revert 2014 skill rank changes

### DIFF
--- a/modules/era/sql/pre_2014_skill_ranks.sql
+++ b/modules/era/sql/pre_2014_skill_ranks.sql
@@ -1,0 +1,10 @@
+-- https://forum.square-enix.com/ffxi/threads/44592?p=527238#post527239
+-- search for "The following jobs have undergone adjustments."
+
+UPDATE `skill_ranks` SET `thf` = 2 WHERE `name` = 'dagger'; -- Down to A(2) from A+(1)
+UPDATE `skill_ranks` SET `bst` = 2 WHERE `name` = 'axe'; -- Down to A(2) from A+(1)
+UPDATE `skill_ranks` SET `nin` = 2 WHERE `name` = 'katana'; -- Down to A(2) from A+(1)
+UPDATE `skill_ranks` SET `nin` = 2 WHERE `name` = 'throwing'; -- Down to A(2) from A+(1)
+UPDATE `skill_ranks` SET `blu` = 2 WHERE `name` = 'sword'; -- Down to A(2) from A+(1)
+UPDATE `skill_ranks` SET `pup` = 3 WHERE `name` = 'hand2hand'; -- Down to B+(3) from A+(1)
+UPDATE `skill_ranks` SET `dnc` = 3 WHERE `name` = 'dagger'; -- Down to B+(3) from A+(1)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adds one module that reverts the skill rank changes listed here: https://www.bg-wiki.com/ffxi/The_History_of_Final_Fantasy_XI/2014.  Search for "Dagger skill has been raised from A to A+." and all changes are in that section. 

THFs dagger skill goes from A+ to A.  BSTs Axe skill goes from A+ to A. Ninjas Katana and Throwing go from A+ to A. BLUs sword skill goes from A+ to A. PUPs H2H goes from A+ to B+. DNCs dagger goes from A+ to B+.

## Steps to test these changes

Add "sql/era/" to init.txt and run dbtool
