### PR TITLE
Replace last lingering 'magianAffinity' in swipe/lunge damage multipliers

### DIFF
--- a/scripts/globals/job_utils/rune_fencer.lua
+++ b/scripts/globals/job_utils/rune_fencer.lua
@@ -515,7 +515,7 @@ local function getSwipeLungeDamageMultipliers(player, target, element, bonusMacc
     local multipliers = {}
 
     multipliers.eleStaffBonus       = xi.spells.damage.calculateElementalStaffBonus(player, element)
-    multipliers.magianAffinity      = xi.spells.damage.calculateMagianAffinity() -- Presumed but untested.
+    multipliers.eleAffinityBonus    = xi.spells.damage.calculateElementalAffinityBonus(player, element)
     multipliers.SDT                 = xi.spells.damage.calculateSDT(target, element)
     multipliers.resist              = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, element, 0, 0, bonusMacc)
     multipliers.dayAndWeather       = xi.spells.damage.calculateDayAndWeather(player, element, false)
@@ -541,7 +541,7 @@ local function calculateSwipeLungeDamage(player, target, skillModifier, gearBonu
     damage = damage + player:getMod(xi.mod.MAGIC_DAMAGE) -- add mdamage to base damage
 
     damage = math.floor(damage * multipliers.eleStaffBonus)
-    damage = math.floor(damage * multipliers.magianAffinity)
+    damage = math.floor(damage * multipliers.eleAffinityBonus)
     damage = math.floor(damage * multipliers.SDT)
     damage = math.floor(damage * multipliers.resist)
     damage = math.floor(damage * multipliers.magicBurst)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Replaces the reference to "calculateMagianAffinity" in rune_fencer.lua with the updated "calculateElementalAffinityBonus", as it was updated in 1bce68cba1d31af0a0afd58e7f1de1cf2d331c91

## Steps to test these changes

Perform a swipe or lunge, deal more than 0 damage and no errors in log
