### PR TITLE
[fix] Properly initialize points for GP Items

### DIFF
--- a/src/map/guild.cpp
+++ b/src/map/guild.cpp
@@ -67,7 +67,7 @@ void CGuild::updateGuildPointsPattern(uint8 pattern)
                 const auto points    = rset->get<uint16>("points");
                 const auto maxPoints = rset->get<uint16>("max_points");
 
-                m_GPItems[i].emplace_back(itemutils::GetItemPointer(itemId), points, maxPoints);
+                m_GPItems[i].emplace_back(itemutils::GetItemPointer(itemId), maxPoints, points);
             }
         }
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Currently treating the base points of a GP item as the max points, because the arguments were reversed at some point.
This PR simply passes them in the right order.
https://github.com/LandSandBoat/server/blob/502867c824bbc0406b2538b52ea211454c9b7a63/src/map/guild.h#L42-L45

## Steps to test these changes
!pos 118 2 -8 234
!setskill ALCHEMY 100
!setcraftrank ALCHEMY 10
Talk to NPC, sign contract, see the communicated points match the total value on bg-wiki for current item.

<!-- Clear and detailed steps to test your changes here -->
