### PR TITLE
Add DA/TA to physical Blood Pact

### DIFF
--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -110,6 +110,16 @@ xi.summon.avatarPhysicalMove = function(avatar, target, skill, numberofhits, acc
     local acc = avatar:getACC() + xi.summon.getSummoningSkillOverCap(avatar)
     local eva = target:getEVA()
 
+    -- Handle double/triple attack
+    local bonusHits    = 0
+    local doubleRate   = avatar:getMod(xi.mod.DOUBLE_ATTACK)
+    local tripleRate   = avatar:getMod(xi.mod.TRIPLE_ATTACK)
+    if math.random(1, 100) <= tripleRate then
+        bonusHits = bonusHits + 2
+    elseif math.random(1, 100) <= doubleRate then
+        bonusHits = bonusHits + 1
+    end
+
     -- Level correction does not happen in Adoulin zones, Legion, or zones in Escha/Reisenjima
     -- https://www.bg-wiki.com/bg/PDIF#Level_Correction_Function_.28cRatio.29
     local shouldApplyLevelCorrection = xi.combat.levelCorrection.isLevelCorrectedZone(avatar)
@@ -159,7 +169,7 @@ xi.summon.avatarPhysicalMove = function(avatar, target, skill, numberofhits, acc
         numHitsLanded  = numHitsLanded + 1
     end
 
-    while numHitsProcessed < numberofhits do
+    while numHitsProcessed < (numberofhits + bonusHits) do
         if math.random() < hitrateSubsequent then
             numHitsLanded = numHitsLanded + 1
         end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a check for avatar "double attack" and "triple attack" mod, and adds additional attacks to physical Blood Pacts when those mods trigger. The logic is the same as what is used for physical weaponskills.

## Steps to test these changes

!changejob SMN 99
!additem 28418 (incarnation sash, pet double attack +4%)

When you perform a blood pact rage with the sash, you should see a 4% chance to add an additional hit.