### PR TITLE
Separate Steal and Despoil lockout

### DIFF
--- a/scripts/globals/job_utils/thief.lua
+++ b/scripts/globals/job_utils/thief.lua
@@ -213,24 +213,24 @@ xi.job_utils.thief.useDespoil = function(player, target, ability, action)
         player:addTP(tpSteal)
     end
 
-    local stolen = target:getDespoilItem()
+    local despoiled = target:getDespoilItem()
 
     if
         target:isMob() and
         math.random(1, 100) <= despoilChance and
-        stolen ~= 0
+        despoiled ~= 0
     then
         if player:getObjType() == xi.objType.TRUST then
             player:getMaster():addItem(stolen)
         else
-            player:addItem(stolen)
+            player:addItem(despoiled)
         end
 
-        target:itemStolen()
+        target:itemDespoiled()
 
         -- Attempt to grab the debuff from the DB
         -- If there isn't a debuff assigned to the item stolen, select one at random
-        local debuff = player:getDespoilDebuff(stolen)
+        local debuff = player:getDespoilDebuff(despoiled)
 
         if not debuff then
             debuff = despoilDebuffs[math.random(#despoilDebuffs)]
@@ -244,7 +244,7 @@ xi.job_utils.thief.useDespoil = function(player, target, ability, action)
         ability:setMsg(xi.msg.basic.STEAL_FAIL) -- Failed
     end
 
-    return stolen
+    return despoiled
 end
 
 xi.job_utils.thief.useFeint = function(player, target, ability)

--- a/scripts/globals/job_utils/thief.lua
+++ b/scripts/globals/job_utils/thief.lua
@@ -221,7 +221,7 @@ xi.job_utils.thief.useDespoil = function(player, target, ability, action)
         despoiled ~= 0
     then
         if player:getObjType() == xi.objType.TRUST then
-            player:getMaster():addItem(stolen)
+            player:getMaster():addItem(despoiled)
         else
             player:addItem(despoiled)
         end

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -3993,6 +3993,11 @@ function CBaseEntity:itemStolen()
 end
 
 ---@nodiscard
+---@return boolean
+function CBaseEntity:itemDespoiled()
+end
+
+---@nodiscard
 ---@return integer
 function CBaseEntity:getTHlevel()
 end

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -134,6 +134,7 @@ CMobEntity::CMobEntity()
 , m_HiPartySize(0)
 , m_THLvl(0)
 , m_ItemStolen(false)
+, m_ItemDespoiled(false)
 , m_Family(0)
 , m_SuperFamily(0)
 , m_MobSkillList(0)
@@ -593,13 +594,14 @@ void CMobEntity::Spawn()
 {
     TracyZoneScoped;
     CBattleEntity::Spawn();
-    m_giveExp      = true;
-    m_HiPCLvl      = 0;
-    m_HiPartySize  = 0;
-    m_THLvl        = 0;
-    m_ItemStolen   = false;
-    m_DropItemTime = 1000;
-    animationsub   = (uint8)getMobMod(MOBMOD_SPAWN_ANIMATIONSUB);
+    m_giveExp       = true;
+    m_HiPCLvl       = 0;
+    m_HiPartySize   = 0;
+    m_THLvl         = 0;
+    m_ItemStolen    = false;
+    m_ItemDespoiled = false;
+    m_DropItemTime  = 1000;
+    animationsub    = (uint8)getMobMod(MOBMOD_SPAWN_ANIMATIONSUB);
     SetCallForHelpFlag(false);
 
     PEnmityContainer->Clear();

--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -238,14 +238,15 @@ public:
     position_t m_SpawnPoint; // spawn point of mob
 
     uint8  m_Element;
-    uint8  m_HiPCLvl;     // Highest Level of Player Character that hit the Monster
-    uint8  m_HiPartySize; // Largest party size that hit the Monster
-    int16  m_THLvl;       // Highest Level of Treasure Hunter that apply to drops
-    bool   m_ItemStolen;  // if true, mob has already been robbed. reset on respawn. also used for thf maat fight
+    uint8  m_HiPCLvl;       // Highest Level of Player Character that hit the Monster
+    uint8  m_HiPartySize;   // Largest party size that hit the Monster
+    int16  m_THLvl;         // Highest Level of Treasure Hunter that apply to drops
+    bool   m_ItemStolen;    // if true, mob has already been robbed. reset on respawn. also used for thf maat fight
+    bool   m_ItemDespoiled; // if true, mob has already been despoiled. reset on respawn.
     uint16 m_Family;
     uint16 m_SuperFamily;
-    uint16 m_MobSkillList; // Mob skill list defined from mob_pools
-    uint32 m_Pool;         // pool the mob came from
+    uint16 m_MobSkillList;  // Mob skill list defined from mob_pools
+    uint32 m_Pool;          // pool the mob came from
 
     CMobSpellList*           m_SpellListContainer; // The spells list container for this mob
     std::map<uint16, uint16> m_UsedSkillIds;       // mob skill ids used (key) along with mob level (value)

--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -245,8 +245,8 @@ public:
     bool   m_ItemDespoiled; // if true, mob has already been despoiled. reset on respawn.
     uint16 m_Family;
     uint16 m_SuperFamily;
-    uint16 m_MobSkillList;  // Mob skill list defined from mob_pools
-    uint32 m_Pool;          // pool the mob came from
+    uint16 m_MobSkillList; // Mob skill list defined from mob_pools
+    uint32 m_Pool;         // pool the mob came from
 
     CMobSpellList*           m_SpellListContainer; // The spells list container for this mob
     std::map<uint16, uint16> m_UsedSkillIds;       // mob skill ids used (key) along with mob level (value)

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -18324,7 +18324,7 @@ uint16 CLuaBaseEntity::getDespoilItem()
 
     DropList_t* PDropList = itemutils::GetDropList(PMob->m_DropID);
 
-    if (PDropList && !PMob->m_ItemStolen)
+    if (PDropList && !PMob->m_ItemDespoiled)
     {
         std::vector<DropItem_t> despoilableItems;
 
@@ -18361,7 +18361,7 @@ uint16 CLuaBaseEntity::getDespoilDebuff(uint16 itemID)
  *  Function: itemStolen()
  *  Purpose : Flags a mob's item as stolen, returns true upon update
  *  Example : target:itemStolen()
- *  Notes   : Used in scripts/actions/abilities/steal.lua
+ *  Notes   : Used in scripts/globals/job_utils/thief.lua
  ************************************************************************/
 
 bool CLuaBaseEntity::itemStolen()
@@ -18373,6 +18373,25 @@ bool CLuaBaseEntity::itemStolen()
     }
 
     static_cast<CMobEntity*>(m_PBaseEntity)->m_ItemStolen = true;
+    return true;
+}
+
+/************************************************************************
+ *  Function: itemDespoiled()
+ *  Purpose : Flags a mob's item as despoiled, returns true upon update
+ *  Example : target:itemDespoiled()
+ *  Notes   : Used in scripts/globals/job_utils/thief.lua
+ ************************************************************************/
+
+bool CLuaBaseEntity::itemDespoiled()
+{
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to flag despoiled item for invalid entity type (%s).", m_PBaseEntity->getName());
+        return false;
+    }
+
+    static_cast<CMobEntity*>(m_PBaseEntity)->m_ItemDespoiled = true;
     return true;
 }
 
@@ -19800,6 +19819,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("getDespoilItem", CLuaBaseEntity::getDespoilItem);
     SOL_REGISTER("getDespoilDebuff", CLuaBaseEntity::getDespoilDebuff);
     SOL_REGISTER("itemStolen", CLuaBaseEntity::itemStolen);
+    SOL_REGISTER("itemDespoiled", CLuaBaseEntity::itemDespoiled);
     SOL_REGISTER("getTHlevel", CLuaBaseEntity::getTHlevel);
     SOL_REGISTER("setTHlevel", CLuaBaseEntity::setTHlevel);
 

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -911,6 +911,7 @@ public:
     uint16 getDespoilItem();                // gets ItemID of droplist despoil item from mob (steal item if no despoil item)
     uint16 getDespoilDebuff(uint16 itemID); // gets the status effect id to apply to the mob on successful despoil
     bool   itemStolen();                    // sets mob's ItemStolen var = true
+    bool   itemDespoiled();                 // sets mob's ItemDespoiled var = true
     int16  getTHlevel();                    // Returns the Monster's current Treasure Hunter Tier
     void   setTHlevel(int16 newLevel);      // Sets the Monster's current Treasure Hunter Tier
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This change resolves #7352, creating a separate "isDespoiled" tracker for despoiled items versus stolen ones. Now you can steal and despoil from the same mob.

## Steps to test these changes

!changejob THF 99

!exec player:setMod(xi.mod.STEAL, 50)
!exec player:setMod(xi.mod.DESPOIL, 50)

Find some goblins in labyrinth of onzozo and try stealing and despoiling; you should be able to get two items.