### PR TITLE
[fix] CLinkshell::ChangeMemberRank crash

### DIFF
--- a/src/map/linkshell.cpp
+++ b/src/map/linkshell.cpp
@@ -196,6 +196,7 @@ void CLinkshell::ChangeMemberRank(const std::string& MemberName, uint8 toSack)
                     uint8 SlotID     = PItemLinkshell->getSlotID();
                     destroy(PItemLinkshell);
 
+                    PItemLinkshell = newShellItem;
                     PMember->getStorage(LocationID)->InsertItem(PItemLinkshell, SlotID);
                     db::preparedStmt("UPDATE char_inventory SET itemid = ?, extra = ? WHERE charid = ? AND location = ? AND slot = ? LIMIT 1",
                                      PItemLinkshell->getID(), PItemLinkshell->m_extra, PMember->id, LocationID, SlotID);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

When promoting a linkpearl to a sack, the original linkpearl is destroyed and then accessed by the subsequent query which causes the map server to crash inconditionally.

Line was removed in #7322 

## Steps to test these changes
- Give pearl to 2nd char
- Promote pearl to sack
- No crash

<!-- Clear and detailed steps to test your changes here -->
