### PR TITLE
[Lua] [Sql] Update sources of player pdt to also give ranged dt

### DIFF
--- a/scripts/effects/sentinel.lua
+++ b/scripts/effects/sentinel.lua
@@ -12,6 +12,7 @@ effectObject.onEffectGain = function(target, effect)
     end
 
     target:addMod(xi.mod.UDMGPHYS, -effect:getPower())
+    target:addMod(xi.mod.UDMGRANGE, -effect:getPower())
     target:addMod(xi.mod.ENMITY, enmityBonus)
     target:addMod(xi.mod.ENMITY_LOSS_REDUCTION, effect:getSubPower())
 end
@@ -32,6 +33,7 @@ effectObject.onEffectTick = function(target, effect)
 
         effect:setPower(power - decayby)
         target:delMod(xi.mod.UDMGPHYS, -decayby)
+        target:delMod(xi.mod.UDMGRANGE, -decayby)
     end
 end
 
@@ -43,6 +45,7 @@ effectObject.onEffectLose = function(target, effect)
     end
 
     target:delMod(xi.mod.UDMGPHYS, -effect:getPower())
+    target:delMod(xi.mod.UDMGRANGE, -effect:getPower())
     target:delMod(xi.mod.ENMITY, enmityBonus)
     target:delMod(xi.mod.ENMITY_LOSS_REDUCTION, effect:getSubPower())
 end

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -104,6 +104,7 @@ INSERT INTO `item_latents` VALUES(11405,25,20,13,406); -- +20 accuracy during Fo
 
 -- Louhi's Mask
 INSERT INTO `item_latents` VALUES (11474,161,-300,26,0);   -- Daytime: Physical damage taken -3%
+INSERT INTO `item_latents` VALUES (11474,164,-300,26,0);   -- Daytime: Ranged damage taken -3%
 INSERT INTO `item_latents` VALUES (11474,163,-300,26,1);   -- Nighttime: Magic damage taken -3%
 
 -- Diana Corona
@@ -418,15 +419,18 @@ INSERT INTO `item_latents` VALUES (13425,168,30,2,25);   -- Spell interruption r
 
 -- Slayer's Earring
 INSERT INTO `item_latents` VALUES (13426,161,-2000,2,25);  -- Physical damage taken -20% while HP <=25% and TP <=100%
+INSERT INTO `item_latents` VALUES (13426,164,-2000,2,25);  -- Ranged damage taken -20% while HP <=25% and TP <=100%
 
 -- Tamer's Earring
 INSERT INTO `item_latents` VALUES (13427,304,5,2,25);    -- "Tame" success rate  while HP <=25% and TP <=100%
 
 -- Minstrel's Earring
 INSERT INTO `item_latents` VALUES (13428,161,-3000,2,25);  -- Physical damage taken -30% while HP <=25% and TP <=100%
+INSERT INTO `item_latents` VALUES (13428,164,-3000,2,25);  -- Ranged damage taken -30% while HP <=25% and TP <=100%
 
 -- Tracker's Earring
 INSERT INTO `item_latents` VALUES (13429,161,-3000,2,25);  -- Physical damage taken -30% while HP <=25% and TP <=100%
+INSERT INTO `item_latents` VALUES (13429,164,-3000,2,25);  -- Ranged damage taken -30% while HP <=25% and TP <=100%
 
 -- Ronin Earring
 INSERT INTO `item_latents` VALUES (13430,163,-2000,2,25);  -- Magic damage taken -20% while HP <=25% and TP <=100%
@@ -497,11 +501,17 @@ INSERT INTO `item_latents` VALUES (13565,296,15,30,0);   -- +15 "Conserve MP" on
 INSERT INTO `item_latents` VALUES (13572,1,10,26,0);     -- Daytime: DEF +10
 INSERT INTO `item_latents` VALUES (13572,27,3,26,1);     -- Nighttime: Enmity +3
 
--- Cheviot/Umbra Cape (physical damage reduction doubled at night)
+-- Cheviot Cape (physical/ranged damage reduction doubled at night)
 INSERT INTO `item_latents` VALUES (13651,161,-500,26,1);
+INSERT INTO `item_latents` VALUES (13651,164,-500,26,1);
 
+-- Umbra Cape (physical/ranged damage reduction doubled at night)
 INSERT INTO `item_latents` VALUES (13652,161,-600,26,1);
+INSERT INTO `item_latents` VALUES (13652,164,-600,26,1);
+
+-- Sand Mantle
 INSERT INTO `item_latents` VALUES (13655,161,-2000,13,7);
+INSERT INTO `item_latents` VALUES (13655,164,-2000,13,7);
 
 -- Shadow Mantle
 INSERT INTO `item_latents` VALUES (13658,10,20,32,0);    -- Darksday: VIT+20
@@ -1446,6 +1456,7 @@ INSERT INTO `item_latents` VALUES (16057,944,3,52,8);    -- conserve tp+6 during
 
 -- Colossus's Earring
 INSERT INTO `item_latents` VALUES (16058,161,-100,52,7);   -- physical damage -2% during light weather (has -1% normally)
+INSERT INTO `item_latents` VALUES (16058,164,-100,52,7);   -- ranged damage -2% during light weather (has -1% normally)
 
 INSERT INTO `item_latents` VALUES (16071,48,5,13,5);
 INSERT INTO `item_latents` VALUES (16071,165,5,13,5);

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -131,6 +131,7 @@ INSERT INTO `item_mods` VALUES (10272,10,9);     -- VIT: 9
 INSERT INTO `item_mods` VALUES (10272,23,15);    -- ATT: 15
 INSERT INTO `item_mods` VALUES (10272,27,6);     -- ENMITY: 6
 INSERT INTO `item_mods` VALUES (10272,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (10272,164,-400); -- DMGRANGE: -400
 
 -- Dux Scale Mail +1
 INSERT INTO `item_mods` VALUES (10273,1,69);     -- DEF: 69
@@ -139,6 +140,7 @@ INSERT INTO `item_mods` VALUES (10273,10,10);    -- VIT: 10
 INSERT INTO `item_mods` VALUES (10273,23,16);    -- ATT: 16
 INSERT INTO `item_mods` VALUES (10273,27,7);     -- ENMITY: 7
 INSERT INTO `item_mods` VALUES (10273,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (10273,164,-500); -- DMGRANGE: -500
 
 -- Chelona Blazer
 INSERT INTO `item_mods` VALUES (10274,1,57);   -- DEF: 57
@@ -348,6 +350,7 @@ INSERT INTO `item_mods` VALUES (10313,2,50);     -- HP: 50
 INSERT INTO `item_mods` VALUES (10313,10,15);    -- VIT: 15
 INSERT INTO `item_mods` VALUES (10313,29,2);     -- MDEF: 2
 INSERT INTO `item_mods` VALUES (10313,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (10313,164,-400); -- DMGRANGE: -400
 
 -- Aneirins Gloves
 INSERT INTO `item_mods` VALUES (10314,1,25);   -- DEF: 25
@@ -370,6 +373,7 @@ INSERT INTO `item_mods` VALUES (10316,10,4);     -- VIT: 4
 INSERT INTO `item_mods` VALUES (10316,25,10);    -- ACC: 10
 INSERT INTO `item_mods` VALUES (10316,27,4);     -- ENMITY: 4
 INSERT INTO `item_mods` VALUES (10316,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (10316,164,-200); -- DMGRANGE: -200
 
 -- Dux Finger Gauntlets +1
 INSERT INTO `item_mods` VALUES (10317,1,33);     -- DEF: 33
@@ -377,6 +381,7 @@ INSERT INTO `item_mods` VALUES (10317,10,5);     -- VIT: 5
 INSERT INTO `item_mods` VALUES (10317,25,11);    -- ACC: 11
 INSERT INTO `item_mods` VALUES (10317,27,5);     -- ENMITY: 5
 INSERT INTO `item_mods` VALUES (10317,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (10317,164,-300); -- DMGRANGE: -300
 
 -- Chelona Gloves
 INSERT INTO `item_mods` VALUES (10318,1,26);  -- DEF: 26
@@ -555,6 +560,7 @@ INSERT INTO `item_mods` VALUES (10346,8,7);      -- STR: 7
 INSERT INTO `item_mods` VALUES (10346,23,11);    -- ATT: 11
 INSERT INTO `item_mods` VALUES (10346,27,5);     -- ENMITY: 5
 INSERT INTO `item_mods` VALUES (10346,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (10346,164,-400); -- DMGRANGE: -400
 
 -- Dux Cuisses +1
 INSERT INTO `item_mods` VALUES (10347,1,56);     -- DEF: 56
@@ -562,6 +568,7 @@ INSERT INTO `item_mods` VALUES (10347,8,8);      -- STR: 8
 INSERT INTO `item_mods` VALUES (10347,23,12);    -- ATT: 12
 INSERT INTO `item_mods` VALUES (10347,27,6);     -- ENMITY: 6
 INSERT INTO `item_mods` VALUES (10347,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (10347,164,-500); -- DMGRANGE: -500
 
 -- Chelona Trousers
 INSERT INTO `item_mods` VALUES (10348,1,46);   -- DEF: 46
@@ -617,6 +624,7 @@ INSERT INTO `item_mods` VALUES (10363,10,5);     -- VIT: 5
 INSERT INTO `item_mods` VALUES (10363,25,9);     -- ACC: 9
 INSERT INTO `item_mods` VALUES (10363,27,4);     -- ENMITY: 4
 INSERT INTO `item_mods` VALUES (10363,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (10363,164,-300); -- DMGRANGE: -300
 
 -- Dux Greaves +1
 INSERT INTO `item_mods` VALUES (10364,1,31);     -- DEF: 31
@@ -624,6 +632,7 @@ INSERT INTO `item_mods` VALUES (10364,10,6);     -- VIT: 6
 INSERT INTO `item_mods` VALUES (10364,25,10);    -- ACC: 10
 INSERT INTO `item_mods` VALUES (10364,27,5);     -- ENMITY: 5
 INSERT INTO `item_mods` VALUES (10364,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (10364,164,-400); -- DMGRANGE: -400
 
 -- Chelona Boots
 INSERT INTO `item_mods` VALUES (10365,1,23);  -- DEF: 23
@@ -693,6 +702,7 @@ INSERT INTO `item_mods` VALUES (10371,384,200); -- HASTE_GEAR: 200
 INSERT INTO `item_mods` VALUES (10372,1,49);     -- DEF: 49
 INSERT INTO `item_mods` VALUES (10372,75,-20);   -- MOVE_SPEED_STACKABLE: -20
 INSERT INTO `item_mods` VALUES (10372,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (10372,164,-500); -- DMGRANGE: -500
 
 -- Ocular Boots
 INSERT INTO `item_mods` VALUES (10373,1,22);   -- DEF: 22
@@ -918,6 +928,7 @@ INSERT INTO `item_mods` VALUES (10434,8,5);      -- STR: 5
 INSERT INTO `item_mods` VALUES (10434,23,13);    -- ATT: 13
 INSERT INTO `item_mods` VALUES (10434,27,3);     -- ENMITY: 3
 INSERT INTO `item_mods` VALUES (10434,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (10434,164,-300); -- DMGRANGE: -300
 
 -- Dux Visor +1
 INSERT INTO `item_mods` VALUES (10435,1,41);     -- DEF: 41
@@ -925,6 +936,7 @@ INSERT INTO `item_mods` VALUES (10435,8,6);      -- STR: 6
 INSERT INTO `item_mods` VALUES (10435,23,14);    -- ATT: 14
 INSERT INTO `item_mods` VALUES (10435,27,4);     -- ENMITY: 4
 INSERT INTO `item_mods` VALUES (10435,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (10435,164,-400); -- DMGRANGE: -400
 
 -- Chelona Hat
 INSERT INTO `item_mods` VALUES (10436,1,32);  -- DEF: 32
@@ -1902,6 +1914,7 @@ INSERT INTO `item_mods` VALUES (10569,1,39);     -- DEF: 39
 INSERT INTO `item_mods` VALUES (10569,2,40);     -- HP: 40
 INSERT INTO `item_mods` VALUES (10569,29,2);     -- MDEF: 2
 INSERT INTO `item_mods` VALUES (10569,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (10569,164,-300); -- DMGRANGE: -300
 
 -- Huginn Hose
 INSERT INTO `item_mods` VALUES (10570,1,52);  -- DEF: 52
@@ -1943,6 +1956,7 @@ INSERT INTO `item_mods` VALUES (10574,1,40);     -- DEF: 40
 INSERT INTO `item_mods` VALUES (10574,2,50);     -- HP: 50
 INSERT INTO `item_mods` VALUES (10574,29,5);     -- MDEF: 5
 INSERT INTO `item_mods` VALUES (10574,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (10574,164,-400); -- DMGRANGE: -400
 
 -- Ugol Brayettes
 INSERT INTO `item_mods` VALUES (10575,1,51);  -- DEF: 51
@@ -1996,6 +2010,7 @@ INSERT INTO `item_mods` VALUES (10581,5,40);     -- MP: 40
 INSERT INTO `item_mods` VALUES (10581,27,-4);    -- ENMITY: -4
 INSERT INTO `item_mods` VALUES (10581,28,6);     -- MATT: 6
 INSERT INTO `item_mods` VALUES (10581,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (10581,164,-400); -- DMGRANGE: -400
 
 -- Gardyloo Trousers
 INSERT INTO `item_mods` VALUES (10582,1,46);    -- DEF: 46
@@ -2155,22 +2170,26 @@ INSERT INTO `item_mods` VALUES (10615,384,300); -- HASTE_GEAR: 300
 -- Rheic Schuhs
 INSERT INTO `item_mods` VALUES (10616,1,26);     -- DEF: 26
 INSERT INTO `item_mods` VALUES (10616,161,-300); -- DMGPHYS: -3%
+INSERT INTO `item_mods` VALUES (10616,164,-300); -- DMGRANGE: -3%
 
 -- Rheic Schuhs +1
 INSERT INTO `item_mods` VALUES (10617,1,26);     -- DEF: 26
 INSERT INTO `item_mods` VALUES (10617,25,8);     -- ACC: 8
 INSERT INTO `item_mods` VALUES (10617,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (10617,164,-300); -- DMGRANGE: -300
 
 -- Rheic Schuhs +2
 INSERT INTO `item_mods` VALUES (10618,1,27);     -- DEF: 27
 INSERT INTO `item_mods` VALUES (10618,25,8);     -- ACC: 8
 INSERT INTO `item_mods` VALUES (10618,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (10618,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (10618,288,1);    -- DOUBLE_ATTACK: 1
 
 -- Rheic Schuhs +3
 INSERT INTO `item_mods` VALUES (10619,1,27);     -- DEF: 27
 INSERT INTO `item_mods` VALUES (10619,25,10);    -- ACC: 10
 INSERT INTO `item_mods` VALUES (10619,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (10619,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (10619,288,2);    -- DOUBLE_ATTACK: 2
 
 -- Phorcys Schuhs
@@ -2279,6 +2298,7 @@ INSERT INTO `item_mods` VALUES (10633,24,12);    -- RATT: 12
 INSERT INTO `item_mods` VALUES (10633,26,15);    -- RACC: 15
 INSERT INTO `item_mods` VALUES (10633,27,-4);    -- ENMITY: -4
 INSERT INTO `item_mods` VALUES (10633,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (10633,164,-200); -- DMGRANGE: -200
 
 -- Auspex Nails
 INSERT INTO `item_mods` VALUES (10634,1,28);   -- DEF: 28
@@ -2316,6 +2336,7 @@ INSERT INTO `item_mods` VALUES (10638,24,15);    -- RATT: 15
 INSERT INTO `item_mods` VALUES (10638,26,18);    -- RACC: 18
 INSERT INTO `item_mods` VALUES (10638,27,-7);    -- ENMITY: -7
 INSERT INTO `item_mods` VALUES (10638,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (10638,164,-300); -- DMGRANGE: -300
 
 -- Spurrina Nails
 INSERT INTO `item_mods` VALUES (10639,1,29);   -- DEF: 29
@@ -2701,6 +2722,7 @@ INSERT INTO `item_mods` VALUES (10690,8,7);      -- STR: 7
 INSERT INTO `item_mods` VALUES (10690,10,7);     -- VIT: 7
 INSERT INTO `item_mods` VALUES (10690,23,17);    -- ATT: 17
 INSERT INTO `item_mods` VALUES (10690,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (10690,164,-300); -- DMGRANGE: -300
 
 -- Melee Gloves +2
 INSERT INTO `item_mods` VALUES (10691,1,20);    -- DEF: 20
@@ -2908,6 +2930,7 @@ INSERT INTO `item_mods` VALUES (10716,8,7);      -- STR: 7
 INSERT INTO `item_mods` VALUES (10716,10,7);     -- VIT: 7
 INSERT INTO `item_mods` VALUES (10716,27,6);     -- ENMITY: 6
 INSERT INTO `item_mods` VALUES (10716,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (10716,164,-400); -- DMGRANGE: -400
 
 -- Abyss Flanchard +2
 INSERT INTO `item_mods` VALUES (10717,1,49);   -- DEF: 49
@@ -3243,10 +3266,12 @@ INSERT INTO `item_mods` VALUES (10767,288,1); -- DOUBLE_ATTACK: 1
 
 -- Gelatinous Ring
 INSERT INTO `item_mods` VALUES (10768,161,-600); -- DMGPHYS: -600
+INSERT INTO `item_mods` VALUES (10768,164,-600); -- DMGRANGE: -600
 INSERT INTO `item_mods` VALUES (10768,163,200);  -- DMGMAGIC: 200
 
 -- Gelatinous Ring +1
 INSERT INTO `item_mods` VALUES (10769,161,-700); -- DMGPHYS: -700
+INSERT INTO `item_mods` VALUES (10769,164,-700); -- DMGRANGE: -700
 INSERT INTO `item_mods` VALUES (10769,163,100);  -- DMGMAGIC: 100
 
 -- Cacoethic Ring
@@ -3277,6 +3302,7 @@ INSERT INTO `item_mods` VALUES (10774,12,5);     -- INT: 5
 INSERT INTO `item_mods` VALUES (10774,13,5);     -- MND: 5
 INSERT INTO `item_mods` VALUES (10774,30,5);     -- MACC: 5
 INSERT INTO `item_mods` VALUES (10774,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (10774,164,-200); -- DMGRANGE: -200
 
 -- Gaiardas Ring
 INSERT INTO `item_mods` VALUES (10775,8,5); -- STR: 5
@@ -3406,6 +3432,7 @@ INSERT INTO `item_mods` VALUES (10804,384,200); -- HASTE_GEAR: 200
 INSERT INTO `item_mods` VALUES (10805,1,35);     -- DEF: 35
 INSERT INTO `item_mods` VALUES (10805,10,10);    -- VIT: 10
 INSERT INTO `item_mods` VALUES (10805,161,-700); -- DMGPHYS: -700
+INSERT INTO `item_mods` VALUES (10805,164,-700); -- DMGRANGE: -700
 INSERT INTO `item_mods` VALUES (10805,384,-200); -- HASTE_GEAR: -200
 
 -- Adamas
@@ -3463,6 +3490,7 @@ INSERT INTO `item_mods` VALUES (10818,288,3); -- DOUBLE_ATTACK: 3
 -- Flume Belt
 INSERT INTO `item_mods` VALUES (10819,1,12);     -- DEF: 12
 INSERT INTO `item_mods` VALUES (10819,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (10819,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (10819,516,2);    -- ABSORB_DMG_TO_MP: 2
 
 -- Bishops Sash
@@ -3684,6 +3712,7 @@ INSERT INTO `item_mods` VALUES (10874,1,42);     -- DEF: 42
 INSERT INTO `item_mods` VALUES (10874,10,7);     -- VIT: 7
 INSERT INTO `item_mods` VALUES (10874,68,-7);    -- EVA: -7
 INSERT INTO `item_mods` VALUES (10874,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (10874,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (10874,384,400);  -- HASTE_GEAR: 400
 
 -- Snowman Cap
@@ -4016,6 +4045,7 @@ INSERT INTO `item_mods` VALUES (10929,246,2); -- PETRIFYRES: 2
 
 -- Veisa Collar
 INSERT INTO `item_mods` VALUES (10930,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (10930,164,-400); -- DMGRANGE: -400
 
 -- Rancor Collar
 INSERT INTO `item_mods` VALUES (10931,25,6); -- ACC: 6
@@ -4023,6 +4053,7 @@ INSERT INTO `item_mods` VALUES (10931,25,6); -- ACC: 6
 -- Oneiros Torque
 INSERT INTO `item_mods` VALUES (10932,68,5);     -- EVA: 5
 INSERT INTO `item_mods` VALUES (10932,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (10932,164,-200); -- DMGRANGE: -200
 
 -- Mujin Necklace
 INSERT INTO `item_mods` VALUES (10933,8,5);   -- STR: 5
@@ -4041,6 +4072,7 @@ INSERT INTO `item_mods` VALUES (10935,27,-7); -- ENMITY: -7
 
 -- Wiglen Gorget
 INSERT INTO `item_mods` VALUES (10936,161,-600); -- DMGPHYS: -600
+INSERT INTO `item_mods` VALUES (10936,164,-600); -- DMGRANGE: -600
 INSERT INTO `item_mods` VALUES (10936,163,600);  -- DMGMAGIC: 600
 INSERT INTO `item_mods` VALUES (10936,370,3);    -- REGEN: 3
 
@@ -5142,6 +5174,7 @@ INSERT INTO `item_mods` VALUES (11130,1,58);     -- DEF: 58
 INSERT INTO `item_mods` VALUES (11130,2,50);     -- HP: 50
 INSERT INTO `item_mods` VALUES (11130,82,7);     -- SWORD: 7
 INSERT INTO `item_mods` VALUES (11130,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (11130,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (11130,384,400);  -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (11130,427,1);    -- ENMITY_LOSS_REDUCTION: 1
 
@@ -5833,6 +5866,7 @@ INSERT INTO `item_mods` VALUES (11229,896,3);   -- DESPOIL: 3
 INSERT INTO `item_mods` VALUES (11230,1,56);     -- DEF: 56
 INSERT INTO `item_mods` VALUES (11230,2,30);     -- HP: 30
 INSERT INTO `item_mods` VALUES (11230,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (11230,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (11230,384,300);  -- HASTE_GEAR: 300
 INSERT INTO `item_mods` VALUES (11230,427,1);    -- ENMITY_LOSS_REDUCTION: 1
 
@@ -6956,6 +6990,7 @@ INSERT INTO `item_mods` VALUES (11420,12,-4);    -- INT: -4
 INSERT INTO `item_mods` VALUES (11420,13,-4);    -- MND: -4
 INSERT INTO `item_mods` VALUES (11420,27,3);     -- ENMITY: 3
 INSERT INTO `item_mods` VALUES (11420,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (11420,164,-300); -- DMGRANGE: -300
 
 -- Missile Boots
 INSERT INTO `item_mods` VALUES (11421,1,21); -- DEF: 21
@@ -6995,6 +7030,7 @@ INSERT INTO `item_mods` VALUES (11426,12,-4);    -- INT: -4
 INSERT INTO `item_mods` VALUES (11426,23,8);     -- ATT: 8
 INSERT INTO `item_mods` VALUES (11426,27,3);     -- ENMITY: 3
 INSERT INTO `item_mods` VALUES (11426,161,-100); -- DMGPHYS: -100
+INSERT INTO `item_mods` VALUES (11426,164,-100); -- DMGRANGE: -100
 
 -- Versa Sollerets +1
 INSERT INTO `item_mods` VALUES (11427,1,25);     -- DEF: 25
@@ -7002,6 +7038,7 @@ INSERT INTO `item_mods` VALUES (11427,12,-3);    -- INT: -3
 INSERT INTO `item_mods` VALUES (11427,23,9);     -- ATT: 9
 INSERT INTO `item_mods` VALUES (11427,27,4);     -- ENMITY: 4
 INSERT INTO `item_mods` VALUES (11427,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (11427,164,-200); -- DMGRANGE: -200
 
 -- Lore Sabots
 INSERT INTO `item_mods` VALUES (11428,1,11);     -- DEF: 11
@@ -7168,6 +7205,7 @@ INSERT INTO `item_mods` VALUES (11454,1,22);     -- DEF: 22
 INSERT INTO `item_mods` VALUES (11454,8,5);      -- STR: 5
 INSERT INTO `item_mods` VALUES (11454,10,5);     -- VIT: 5
 INSERT INTO `item_mods` VALUES (11454,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (11454,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (11454,288,2);    -- DOUBLE_ATTACK: 2
 
 -- Menhit Leggings
@@ -7698,6 +7736,7 @@ INSERT INTO `item_mods` VALUES (11550,73,2); -- STORETP: 2
 INSERT INTO `item_mods` VALUES (11551,1,11);     -- DEF: 11
 INSERT INTO `item_mods` VALUES (11551,68,-15);   -- EVA: -15
 INSERT INTO `item_mods` VALUES (11551,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (11551,164,-400); -- DMGRANGE: -400
 
 -- Libeccio Mantle
 INSERT INTO `item_mods` VALUES (11552,1,10);  -- DEF: 10
@@ -8719,6 +8758,7 @@ INSERT INTO `item_mods` VALUES (11780,12,-6);    -- INT: -6
 INSERT INTO `item_mods` VALUES (11780,23,8);     -- ATT: 8
 INSERT INTO `item_mods` VALUES (11780,27,5);     -- ENMITY: 5
 INSERT INTO `item_mods` VALUES (11780,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (11780,164,-200); -- DMGRANGE: -200
 
 -- Versa Celata +1
 INSERT INTO `item_mods` VALUES (11781,1,49);     -- DEF: 49
@@ -8726,6 +8766,7 @@ INSERT INTO `item_mods` VALUES (11781,12,-5);    -- INT: -5
 INSERT INTO `item_mods` VALUES (11781,23,9);     -- ATT: 9
 INSERT INTO `item_mods` VALUES (11781,27,6);     -- ENMITY: 6
 INSERT INTO `item_mods` VALUES (11781,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (11781,164,-300); -- DMGRANGE: -300
 
 -- Lore Hat
 INSERT INTO `item_mods` VALUES (11782,1,13);     -- DEF: 13
@@ -8948,6 +8989,7 @@ INSERT INTO `item_mods` VALUES (11817,1,30);     -- DEF: 30
 INSERT INTO `item_mods` VALUES (11817,10,9);     -- VIT: 9
 INSERT INTO `item_mods` VALUES (11817,68,-14);   -- EVA: -14
 INSERT INTO `item_mods` VALUES (11817,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (11817,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (11817,75,-5);    -- MOVE_SPEED_STACKABLE: -5
 
 -- Oneiros Headgear
@@ -9039,6 +9081,7 @@ INSERT INTO `item_mods` VALUES (11830,13,-4);    -- MND: -4
 INSERT INTO `item_mods` VALUES (11830,23,14);    -- ATT: 14
 INSERT INTO `item_mods` VALUES (11830,27,5);     -- ENMITY: 5
 INSERT INTO `item_mods` VALUES (11830,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (11830,164,-300); -- DMGRANGE: -300
 
 -- Versa Hauberk +1
 INSERT INTO `item_mods` VALUES (11831,1,63);     -- DEF: 63
@@ -9047,6 +9090,7 @@ INSERT INTO `item_mods` VALUES (11831,13,-3);    -- MND: -3
 INSERT INTO `item_mods` VALUES (11831,23,15);    -- ATT: 15
 INSERT INTO `item_mods` VALUES (11831,27,6);     -- ENMITY: 6
 INSERT INTO `item_mods` VALUES (11831,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (11831,164,-400); -- DMGRANGE: -400
 
 -- Lore Robe
 INSERT INTO `item_mods` VALUES (11832,1,40);     -- DEF: 40
@@ -9119,6 +9163,7 @@ INSERT INTO `item_mods` VALUES (11843,20,-10);   -- WATER_MEVA: -10
 INSERT INTO `item_mods` VALUES (11843,21,-10);   -- LIGHT_MEVA: -10
 INSERT INTO `item_mods` VALUES (11843,22,-10);   -- DARK_MEVA: -10
 INSERT INTO `item_mods` VALUES (11843,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (11843,164,-500); -- DMGRANGE: -500
 
 -- Alcides Harness
 INSERT INTO `item_mods` VALUES (11844,1,50);  -- DEF: 50
@@ -9276,6 +9321,7 @@ INSERT INTO `item_mods` VALUES (11864,519,10); -- CURE_CAST_TIME: 10
 INSERT INTO `item_mods` VALUES (11865,1,68);     -- DEF: 68
 INSERT INTO `item_mods` VALUES (11865,10,15);    -- VIT: 15
 INSERT INTO `item_mods` VALUES (11865,161,-700); -- DMGPHYS: -700
+INSERT INTO `item_mods` VALUES (11865,164,-700); -- DMGRANGE: -700
 INSERT INTO `item_mods` VALUES (11865,426,1);    -- ABSORB_PHYSDMG_TO_MP: 1
 
 -- Tocis Harness
@@ -9314,6 +9360,7 @@ INSERT INTO `item_mods` VALUES (11870,519,12); -- CURE_CAST_TIME: 12
 INSERT INTO `item_mods` VALUES (11871,1,69);     -- DEF: 69
 INSERT INTO `item_mods` VALUES (11871,10,16);    -- VIT: 16
 INSERT INTO `item_mods` VALUES (11871,161,-800); -- DMGPHYS: -800
+INSERT INTO `item_mods` VALUES (11871,164,-800); -- DMGRANGE: -800
 
 -- Aces Mail
 INSERT INTO `item_mods` VALUES (11872,8,18);    -- STR: 18
@@ -9382,6 +9429,7 @@ INSERT INTO `item_mods` VALUES (11880,13,-5);    -- MND: -5
 INSERT INTO `item_mods` VALUES (11880,23,6);     -- ATT: 6
 INSERT INTO `item_mods` VALUES (11880,27,4);     -- ENMITY: 4
 INSERT INTO `item_mods` VALUES (11880,161,-100); -- DMGPHYS: -100
+INSERT INTO `item_mods` VALUES (11880,164,-100); -- DMGRANGE: -100
 
 -- Versa Mufflers +1
 INSERT INTO `item_mods` VALUES (11881,1,26);     -- DEF: 26
@@ -9389,6 +9437,7 @@ INSERT INTO `item_mods` VALUES (11881,13,-4);    -- MND: -4
 INSERT INTO `item_mods` VALUES (11881,23,7);     -- ATT: 7
 INSERT INTO `item_mods` VALUES (11881,27,5);     -- ENMITY: 5
 INSERT INTO `item_mods` VALUES (11881,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (11881,164,-200); -- DMGRANGE: -200
 
 -- Lore Cuffs
 INSERT INTO `item_mods` VALUES (11882,1,13);     -- DEF: 13
@@ -9645,12 +9694,14 @@ INSERT INTO `item_mods` VALUES (11919,116,15); -- DARK: 15
 INSERT INTO `item_mods` VALUES (11920,1,19);     -- DEF: 19
 INSERT INTO `item_mods` VALUES (11920,13,3);     -- MND: 3
 INSERT INTO `item_mods` VALUES (11920,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (11920,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (11920,225,5);    -- BIRD_KILLER: 5
 
 -- Magma Gauntlets
 INSERT INTO `item_mods` VALUES (11921,1,34);     -- DEF: 34
 INSERT INTO `item_mods` VALUES (11921,15,30);    -- FIRE_MEVA: 30
 INSERT INTO `item_mods` VALUES (11921,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (11921,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (11921,499,1);    -- ITEM_SUBEFFECT: 1
 INSERT INTO `item_mods` VALUES (11921,500,20);   -- ITEM_ADDEFFECT_DMG: 20
 INSERT INTO `item_mods` VALUES (11921,501,15);   -- ITEM_ADDEFFECT_CHANCE: 15
@@ -9709,6 +9760,7 @@ INSERT INTO `item_mods` VALUES (11930,13,-5);    -- MND: -5
 INSERT INTO `item_mods` VALUES (11930,23,10);    -- ATT: 10
 INSERT INTO `item_mods` VALUES (11930,27,3);     -- ENMITY: 3
 INSERT INTO `item_mods` VALUES (11930,161,-100); -- DMGPHYS: -100
+INSERT INTO `item_mods` VALUES (11930,164,-100); -- DMGRANGE: -100
 
 -- Versa Breeches +1
 INSERT INTO `item_mods` VALUES (11931,1,39);     -- DEF: 39
@@ -9716,6 +9768,7 @@ INSERT INTO `item_mods` VALUES (11931,13,-4);    -- MND: -4
 INSERT INTO `item_mods` VALUES (11931,23,11);    -- ATT: 11
 INSERT INTO `item_mods` VALUES (11931,27,4);     -- ENMITY: 4
 INSERT INTO `item_mods` VALUES (11931,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (11931,164,-200); -- DMGRANGE: -200
 
 -- Lore Slops
 INSERT INTO `item_mods` VALUES (11932,1,25);     -- DEF: 25
@@ -9948,6 +10001,7 @@ INSERT INTO `item_mods` VALUES (11969,1,55);     -- DEF: 55
 INSERT INTO `item_mods` VALUES (11969,23,20);    -- ATT: 20
 INSERT INTO `item_mods` VALUES (11969,25,20);    -- ACC: 20
 INSERT INTO `item_mods` VALUES (11969,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (11969,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (11969,841,3);    -- ALL_WSDMG_FIRST_HIT: 3
 
 -- Athoss Tights
@@ -10052,6 +10106,7 @@ INSERT INTO `item_mods` VALUES (11984,1,43);     -- DEF: 43
 INSERT INTO `item_mods` VALUES (11984,10,5);     -- VIT: 5
 INSERT INTO `item_mods` VALUES (11984,27,10);    -- ENMITY: 10
 INSERT INTO `item_mods` VALUES (11984,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (11984,164,-200); -- DMGRANGE: -200
 
 -- Tussle Breeches
 INSERT INTO `item_mods` VALUES (11985,1,50);   -- DEF: 50
@@ -10609,6 +10664,7 @@ INSERT INTO `item_mods` VALUES (12114,2,15);     -- HP: 15
 INSERT INTO `item_mods` VALUES (12114,5,15);     -- MP: 15
 INSERT INTO `item_mods` VALUES (12114,27,3);     -- ENMITY: 3
 INSERT INTO `item_mods` VALUES (12114,161,-100); -- DMGPHYS: -100
+INSERT INTO `item_mods` VALUES (12114,164,-100); -- DMGRANGE: -100
 
 -- Furia Galea
 INSERT INTO `item_mods` VALUES (12115,1,33);     -- DEF: 33
@@ -10616,6 +10672,7 @@ INSERT INTO `item_mods` VALUES (12115,2,15);     -- HP: 15
 INSERT INTO `item_mods` VALUES (12115,5,15);     -- MP: 15
 INSERT INTO `item_mods` VALUES (12115,27,3);     -- ENMITY: 3
 INSERT INTO `item_mods` VALUES (12115,161,-100); -- DMGPHYS: -100
+INSERT INTO `item_mods` VALUES (12115,164,-100); -- DMGRANGE: -100
 
 -- Ebur Galea
 INSERT INTO `item_mods` VALUES (12116,1,33);     -- DEF: 33
@@ -10623,6 +10680,7 @@ INSERT INTO `item_mods` VALUES (12116,2,15);     -- HP: 15
 INSERT INTO `item_mods` VALUES (12116,5,15);     -- MP: 15
 INSERT INTO `item_mods` VALUES (12116,27,3);     -- ENMITY: 3
 INSERT INTO `item_mods` VALUES (12116,161,-100); -- DMGPHYS: -100
+INSERT INTO `item_mods` VALUES (12116,164,-100); -- DMGRANGE: -100
 
 -- Ebon Armet
 INSERT INTO `item_mods` VALUES (12117,1,30); -- DEF: 30
@@ -11079,18 +11137,21 @@ INSERT INTO `item_mods` VALUES (12186,1,26);     -- DEF: 26
 INSERT INTO `item_mods` VALUES (12186,10,3);     -- VIT: 3
 INSERT INTO `item_mods` VALUES (12186,27,2);     -- ENMITY: 2
 INSERT INTO `item_mods` VALUES (12186,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (12186,164,-200); -- DMGRANGE: -200
 
 -- Furia Moufles
 INSERT INTO `item_mods` VALUES (12187,1,26);     -- DEF: 26
 INSERT INTO `item_mods` VALUES (12187,10,3);     -- VIT: 3
 INSERT INTO `item_mods` VALUES (12187,27,2);     -- ENMITY: 2
 INSERT INTO `item_mods` VALUES (12187,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (12187,164,-200); -- DMGRANGE: -200
 
 -- Ebur Moufles
 INSERT INTO `item_mods` VALUES (12188,1,26);     -- DEF: 26
 INSERT INTO `item_mods` VALUES (12188,10,3);     -- VIT: 3
 INSERT INTO `item_mods` VALUES (12188,27,2);     -- ENMITY: 2
 INSERT INTO `item_mods` VALUES (12188,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (12188,164,-200); -- DMGRANGE: -200
 
 -- Ebon Gauntlets
 INSERT INTO `item_mods` VALUES (12189,1,24); -- DEF: 24
@@ -11755,6 +11816,7 @@ INSERT INTO `item_mods` VALUES (12296,15,-10);    -- FIRE_MEVA: -10
 INSERT INTO `item_mods` VALUES (12296,18,10);     -- EARTH_MEVA: 10
 INSERT INTO `item_mods` VALUES (12296,68,10);     -- EVA: 10
 INSERT INTO `item_mods` VALUES (12296,161,-1000); -- DMGPHYS: -1000
+INSERT INTO `item_mods` VALUES (12296,164,-1000); -- DMGRANGE: -1000
 
 -- Parana Shield
 INSERT INTO `item_mods` VALUES (12298,1,2);  -- DEF: 2
@@ -12500,6 +12562,7 @@ INSERT INTO `item_mods` VALUES (12452,1,21);     -- DEF: 21
 INSERT INTO `item_mods` VALUES (12452,21,1);     -- LIGHT_MEVA: 1
 INSERT INTO `item_mods` VALUES (12452,22,1);     -- DARK_MEVA: 1
 INSERT INTO `item_mods` VALUES (12452,161,-100); -- DMGPHYS: -100
+INSERT INTO `item_mods` VALUES (12452,164,-100); -- DMGRANGE: -100
 
 -- Coral Cap
 INSERT INTO `item_mods` VALUES (12453,1,21);     -- DEF: 21
@@ -12662,6 +12725,7 @@ INSERT INTO `item_mods` VALUES (12490,168,5); -- SPELLINTERRUPT: 5
 INSERT INTO `item_mods` VALUES (12492,1,27);     -- DEF: 27
 INSERT INTO `item_mods` VALUES (12492,68,12);    -- EVA: 12
 INSERT INTO `item_mods` VALUES (12492,161,-100); -- DMGPHYS: -100
+INSERT INTO `item_mods` VALUES (12492,164,-100); -- DMGRANGE: -100
 
 -- Accord Hat
 INSERT INTO `item_mods` VALUES (12493,1,18);  -- DEF: 18
@@ -13020,6 +13084,7 @@ INSERT INTO `item_mods` VALUES (12565,1,48);     -- DEF: 48
 INSERT INTO `item_mods` VALUES (12565,9,3);      -- DEX: 3
 INSERT INTO `item_mods` VALUES (12565,11,3);     -- AGI: 3
 INSERT INTO `item_mods` VALUES (12565,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (12565,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (12565,163,-300); -- DMGMAGIC: -300
 
 -- Centurions Scale Mail
@@ -13091,6 +13156,7 @@ INSERT INTO `item_mods` VALUES (12580,1,39);     -- DEF: 39
 INSERT INTO `item_mods` VALUES (12580,21,2);     -- LIGHT_MEVA: 2
 INSERT INTO `item_mods` VALUES (12580,22,2);     -- DARK_MEVA: 2
 INSERT INTO `item_mods` VALUES (12580,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (12580,164,-300); -- DMGRANGE: -300
 
 -- Coral Harness
 INSERT INTO `item_mods` VALUES (12581,1,41);     -- DEF: 41
@@ -13258,6 +13324,7 @@ INSERT INTO `item_mods` VALUES (12620,1,65);     -- DEF: 65
 INSERT INTO `item_mods` VALUES (12620,8,16);     -- STR: 16
 INSERT INTO `item_mods` VALUES (12620,23,32);    -- ATT: 32
 INSERT INTO `item_mods` VALUES (12620,161,-600); -- DMGPHYS: -600
+INSERT INTO `item_mods` VALUES (12620,164,-600); -- DMGRANGE: -600
 INSERT INTO `item_mods` VALUES (12620,163,600);  -- DMGMAGIC: 600
 
 -- Scorpion Breastplate
@@ -13693,6 +13760,7 @@ INSERT INTO `item_mods` VALUES (12708,1,14);     -- DEF: 14
 INSERT INTO `item_mods` VALUES (12708,21,1);     -- LIGHT_MEVA: 1
 INSERT INTO `item_mods` VALUES (12708,22,1);     -- DARK_MEVA: 1
 INSERT INTO `item_mods` VALUES (12708,161,-100); -- DMGPHYS: -100
+INSERT INTO `item_mods` VALUES (12708,164,-100); -- DMGRANGE: -100
 
 -- Coral Mittens
 INSERT INTO `item_mods` VALUES (12709,1,14);     -- DEF: 14
@@ -14181,6 +14249,7 @@ INSERT INTO `item_mods` VALUES (12821,1,35);     -- DEF: 35
 INSERT INTO `item_mods` VALUES (12821,9,2);      -- DEX: 2
 INSERT INTO `item_mods` VALUES (12821,10,2);     -- VIT: 2
 INSERT INTO `item_mods` VALUES (12821,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (12821,164,-300); -- DMGRANGE: -300
 
 -- Centurions Cuisses
 INSERT INTO `item_mods` VALUES (12822,1,16); -- DEF: 16
@@ -14253,6 +14322,7 @@ INSERT INTO `item_mods` VALUES (12839,1,28);     -- DEF: 28
 INSERT INTO `item_mods` VALUES (12839,21,2);     -- LIGHT_MEVA: 2
 INSERT INTO `item_mods` VALUES (12839,22,2);     -- DARK_MEVA: 2
 INSERT INTO `item_mods` VALUES (12839,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (12839,164,-200); -- DMGRANGE: -200
 
 -- Sitabaki
 INSERT INTO `item_mods` VALUES (12840,1,5); -- DEF: 5
@@ -14730,6 +14800,7 @@ INSERT INTO `item_mods` VALUES (12949,10,2);     -- VIT: 2
 INSERT INTO `item_mods` VALUES (12949,11,2);     -- AGI: 2
 INSERT INTO `item_mods` VALUES (12949,23,2);     -- ATT: 2
 INSERT INTO `item_mods` VALUES (12949,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (12949,164,-200); -- DMGRANGE: -200
 
 -- Centurions Greaves
 INSERT INTO `item_mods` VALUES (12950,1,7);  -- DEF: 7
@@ -14796,6 +14867,7 @@ INSERT INTO `item_mods` VALUES (12964,1,12);     -- DEF: 12
 INSERT INTO `item_mods` VALUES (12964,21,1);     -- LIGHT_MEVA: 1
 INSERT INTO `item_mods` VALUES (12964,22,1);     -- DARK_MEVA: 1
 INSERT INTO `item_mods` VALUES (12964,161,-100); -- DMGPHYS: -100
+INSERT INTO `item_mods` VALUES (12964,164,-100); -- DMGRANGE: -100
 
 -- Coral Leggings
 INSERT INTO `item_mods` VALUES (12965,1,12);     -- DEF: 12
@@ -15697,6 +15769,7 @@ INSERT INTO `item_mods` VALUES (13185,68,-5); -- EVA: -5
 INSERT INTO `item_mods` VALUES (13186,1,7);      -- DEF: 7
 INSERT INTO `item_mods` VALUES (13186,8,7);      -- STR: 7
 INSERT INTO `item_mods` VALUES (13186,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (13186,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (13186,289,5);    -- SUBTLE_BLOW: 5
 INSERT INTO `item_mods` VALUES (13186,384,1200); -- HASTE_GEAR: 1200
 
@@ -16221,6 +16294,7 @@ INSERT INTO `item_mods` VALUES (13302,5,-10); -- MP: -10
 
 -- Jelly Ring
 INSERT INTO `item_mods` VALUES (13303,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (13303,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (13303,163,500);  -- DMGMAGIC: 500
 
 -- Nimble Ring
@@ -17637,11 +17711,13 @@ INSERT INTO `item_mods` VALUES (13650,68,5);  -- EVA: 5
 INSERT INTO `item_mods` VALUES (13651,1,5);      -- DEF: 5
 INSERT INTO `item_mods` VALUES (13651,22,13);    -- DARK_MEVA: 13
 INSERT INTO `item_mods` VALUES (13651,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (13651,164,-500); -- DMGRANGE: -500
 
 -- Umbra Cape
 INSERT INTO `item_mods` VALUES (13652,1,6);      -- DEF: 6
 INSERT INTO `item_mods` VALUES (13652,22,14);    -- DARK_MEVA: 14
 INSERT INTO `item_mods` VALUES (13652,161,-600); -- DMGPHYS: -600
+INSERT INTO `item_mods` VALUES (13652,164,-600); -- DMGRANGE: -600
 
 -- Desert Mantle
 INSERT INTO `item_mods` VALUES (13653,1,8);  -- DEF: 8
@@ -18115,6 +18191,7 @@ INSERT INTO `item_mods` VALUES (13747,1,49);     -- DEF: 49
 INSERT INTO `item_mods` VALUES (13747,9,4);      -- DEX: 4
 INSERT INTO `item_mods` VALUES (13747,11,4);     -- AGI: 4
 INSERT INTO `item_mods` VALUES (13747,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (13747,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (13747,163,-400); -- DMGMAGIC: -400
 
 -- Vermillion Cloak
@@ -18261,6 +18338,7 @@ INSERT INTO `item_mods` VALUES (13765,1,40);     -- DEF: 40
 INSERT INTO `item_mods` VALUES (13765,21,3);     -- LIGHT_MEVA: 3
 INSERT INTO `item_mods` VALUES (13765,22,3);     -- DARK_MEVA: 3
 INSERT INTO `item_mods` VALUES (13765,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (13765,164,-400); -- DMGRANGE: -400
 
 -- Mermans Harness
 INSERT INTO `item_mods` VALUES (13766,1,42);     -- DEF: 42
@@ -18457,6 +18535,7 @@ INSERT INTO `item_mods` VALUES (13792,1,64);     -- DEF: 64
 INSERT INTO `item_mods` VALUES (13792,8,15);     -- STR: 15
 INSERT INTO `item_mods` VALUES (13792,23,30);    -- ATT: 30
 INSERT INTO `item_mods` VALUES (13792,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (13792,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (13792,163,500);  -- DMGMAGIC: 500
 
 -- Hauberk +1
@@ -18476,6 +18555,7 @@ INSERT INTO `item_mods` VALUES (13794,16,-20); -- ICE_MEVA: -20
 INSERT INTO `item_mods` VALUES (13795,1,38);     -- DEF: 38
 INSERT INTO `item_mods` VALUES (13795,27,3);     -- ENMITY: 3
 INSERT INTO `item_mods` VALUES (13795,161,-600); -- DMGPHYS: -600
+INSERT INTO `item_mods` VALUES (13795,164,-600); -- DMGRANGE: -600
 
 -- Bishops Robe
 INSERT INTO `item_mods` VALUES (13796,1,22); -- DEF: 22
@@ -18513,6 +18593,7 @@ INSERT INTO `item_mods` VALUES (13801,25,4); -- ACC: 4
 INSERT INTO `item_mods` VALUES (13802,1,39);     -- DEF: 39
 INSERT INTO `item_mods` VALUES (13802,27,4);     -- ENMITY: 4
 INSERT INTO `item_mods` VALUES (13802,161,-900); -- DMGPHYS: -900
+INSERT INTO `item_mods` VALUES (13802,164,-900); -- DMGRANGE: -900
 
 -- Shamans Cloak
 INSERT INTO `item_mods` VALUES (13803,1,43);  -- DEF: 43
@@ -18822,6 +18903,7 @@ INSERT INTO `item_mods` VALUES (13863,1,22);     -- DEF: 22
 INSERT INTO `item_mods` VALUES (13863,21,2);     -- LIGHT_MEVA: 2
 INSERT INTO `item_mods` VALUES (13863,22,2);     -- DARK_MEVA: 2
 INSERT INTO `item_mods` VALUES (13863,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (13863,164,-200); -- DMGRANGE: -200
 
 -- Mermans Cap
 INSERT INTO `item_mods` VALUES (13864,1,22);     -- DEF: 22
@@ -18913,6 +18995,7 @@ INSERT INTO `item_mods` VALUES (13880,1,18); -- DEF: 18
 INSERT INTO `item_mods` VALUES (13881,1,19);     -- DEF: 19
 INSERT INTO `item_mods` VALUES (13881,27,1);     -- ENMITY: 1
 INSERT INTO `item_mods` VALUES (13881,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (13881,164,-400); -- DMGRANGE: -400
 
 -- Corsairs Hat
 INSERT INTO `item_mods` VALUES (13882,1,14);  -- DEF: 14
@@ -18944,6 +19027,7 @@ INSERT INTO `item_mods` VALUES (13885,68,5);  -- EVA: 5
 INSERT INTO `item_mods` VALUES (13886,1,20);     -- DEF: 20
 INSERT INTO `item_mods` VALUES (13886,27,2);     -- ENMITY: 2
 INSERT INTO `item_mods` VALUES (13886,161,-600); -- DMGPHYS: -600
+INSERT INTO `item_mods` VALUES (13886,164,-600); -- DMGRANGE: -600
 
 -- Black Sallet
 INSERT INTO `item_mods` VALUES (13887,1,22);    -- DEF: 22
@@ -19571,6 +19655,7 @@ INSERT INTO `item_mods` VALUES (13994,1,15);     -- DEF: 15
 INSERT INTO `item_mods` VALUES (13994,21,2);     -- LIGHT_MEVA: 2
 INSERT INTO `item_mods` VALUES (13994,22,2);     -- DARK_MEVA: 2
 INSERT INTO `item_mods` VALUES (13994,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (13994,164,-200); -- DMGRANGE: -200
 
 -- Mermans Mittens
 INSERT INTO `item_mods` VALUES (13995,1,15);     -- DEF: 15
@@ -20188,6 +20273,7 @@ INSERT INTO `item_mods` VALUES (14110,1,13);     -- DEF: 13
 INSERT INTO `item_mods` VALUES (14110,21,2);     -- LIGHT_MEVA: 2
 INSERT INTO `item_mods` VALUES (14110,22,2);     -- DARK_MEVA: 2
 INSERT INTO `item_mods` VALUES (14110,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (14110,164,-200); -- DMGRANGE: -200
 
 -- Mermans Leggings
 INSERT INTO `item_mods` VALUES (14111,1,13);     -- DEF: 13
@@ -20636,6 +20722,7 @@ INSERT INTO `item_mods` VALUES (14194,10,3);     -- VIT: 3
 INSERT INTO `item_mods` VALUES (14194,11,3);     -- AGI: 3
 INSERT INTO `item_mods` VALUES (14194,23,3);     -- ATT: 3
 INSERT INTO `item_mods` VALUES (14194,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (14194,164,-300); -- DMGRANGE: -300
 
 -- Waders
 INSERT INTO `item_mods` VALUES (14195,1,2);   -- DEF: 2
@@ -20917,6 +21004,7 @@ INSERT INTO `item_mods` VALUES (14234,1,29);     -- DEF: 29
 INSERT INTO `item_mods` VALUES (14234,21,3);     -- LIGHT_MEVA: 3
 INSERT INTO `item_mods` VALUES (14234,22,3);     -- DARK_MEVA: 3
 INSERT INTO `item_mods` VALUES (14234,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (14234,164,-300); -- DMGRANGE: -300
 
 -- Mermans Subligar
 INSERT INTO `item_mods` VALUES (14235,1,30);     -- DEF: 30
@@ -21361,6 +21449,7 @@ INSERT INTO `item_mods` VALUES (14313,1,36);     -- DEF: 36
 INSERT INTO `item_mods` VALUES (14313,9,3);      -- DEX: 3
 INSERT INTO `item_mods` VALUES (14313,10,3);     -- VIT: 3
 INSERT INTO `item_mods` VALUES (14313,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (14313,164,-400); -- DMGRANGE: -400
 
 -- Garrison Hose
 INSERT INTO `item_mods` VALUES (14314,1,9); -- DEF: 9
@@ -22662,6 +22751,7 @@ INSERT INTO `item_mods` VALUES (14537,11,3);     -- AGI: 3
 INSERT INTO `item_mods` VALUES (14537,25,9);     -- ACC: 9
 INSERT INTO `item_mods` VALUES (14537,68,9);     -- EVA: 9
 INSERT INTO `item_mods` VALUES (14537,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (14537,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (14537,163,-300); -- DMGMAGIC: -300
 
 -- Hydra Mail +1
@@ -22671,6 +22761,7 @@ INSERT INTO `item_mods` VALUES (14538,11,4);     -- AGI: 4
 INSERT INTO `item_mods` VALUES (14538,25,10);    -- ACC: 10
 INSERT INTO `item_mods` VALUES (14538,68,10);    -- EVA: 10
 INSERT INTO `item_mods` VALUES (14538,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (14538,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (14538,163,-400); -- DMGMAGIC: -400
 
 -- Kyudogi
@@ -24283,6 +24374,7 @@ INSERT INTO `item_mods` VALUES (14885,1,9); -- DEF: 9
 INSERT INTO `item_mods` VALUES (14886,1,15);     -- DEF: 15
 INSERT INTO `item_mods` VALUES (14886,27,-3);    -- ENMITY: -3
 INSERT INTO `item_mods` VALUES (14886,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (14886,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (14886,384,-300); -- HASTE_GEAR: -300
 
 -- Ocelot Gloves
@@ -28243,6 +28335,7 @@ INSERT INTO `item_mods` VALUES (15615,10,2);     -- VIT: 2
 INSERT INTO `item_mods` VALUES (15615,25,3);     -- ACC: 3
 INSERT INTO `item_mods` VALUES (15615,68,3);     -- EVA: 3
 INSERT INTO `item_mods` VALUES (15615,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (15615,164,-300); -- DMGRANGE: -300
 
 -- Hydra Cuisses +1
 INSERT INTO `item_mods` VALUES (15616,1,37);     -- DEF: 37
@@ -28251,6 +28344,7 @@ INSERT INTO `item_mods` VALUES (15616,10,3);     -- VIT: 3
 INSERT INTO `item_mods` VALUES (15616,25,4);     -- ACC: 4
 INSERT INTO `item_mods` VALUES (15616,68,4);     -- EVA: 4
 INSERT INTO `item_mods` VALUES (15616,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (15616,164,-400); -- DMGRANGE: -400
 
 -- Barbarossas Zerehs
 INSERT INTO `item_mods` VALUES (15617,1,36);    -- DEF: 36
@@ -28449,6 +28543,7 @@ INSERT INTO `item_mods` VALUES (15649,1,35);     -- DEF: 35
 INSERT INTO `item_mods` VALUES (15649,5,28);     -- MP: 28
 INSERT INTO `item_mods` VALUES (15649,27,-4);    -- ENMITY: -4
 INSERT INTO `item_mods` VALUES (15649,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (15649,164,-300); -- DMGRANGE: -300
 
 -- Shock Subligar
 INSERT INTO `item_mods` VALUES (15650,1,22); -- DEF: 22
@@ -28785,6 +28880,7 @@ INSERT INTO `item_mods` VALUES (15703,23,2);     -- ATT: 2
 INSERT INTO `item_mods` VALUES (15703,25,2);     -- ACC: 2
 INSERT INTO `item_mods` VALUES (15703,68,2);     -- EVA: 2
 INSERT INTO `item_mods` VALUES (15703,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (15703,164,-200); -- DMGRANGE: -200
 
 -- Hydra Greaves +1
 INSERT INTO `item_mods` VALUES (15704,1,23);     -- DEF: 23
@@ -28794,6 +28890,7 @@ INSERT INTO `item_mods` VALUES (15704,23,3);     -- ATT: 3
 INSERT INTO `item_mods` VALUES (15704,25,3);     -- ACC: 3
 INSERT INTO `item_mods` VALUES (15704,68,3);     -- EVA: 3
 INSERT INTO `item_mods` VALUES (15704,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (15704,164,-300); -- DMGRANGE: -300
 
 -- Ataractic Solea
 INSERT INTO `item_mods` VALUES (15705,1,14);  -- DEF: 14
@@ -29403,6 +29500,7 @@ INSERT INTO `item_mods` VALUES (15839,122,2); -- BLUE: 2
 
 -- Patronus Ring
 INSERT INTO `item_mods` VALUES (15844,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (15844,164,-200); -- DMGRANGE: -200
 
 -- Matrimony Ring
 INSERT INTO `item_mods` VALUES (15847,276,149); -- RSE (race specific equip)
@@ -29427,6 +29525,7 @@ INSERT INTO `item_mods` VALUES (15851,22,5); -- DARK_MEVA: 5
 
 -- Nasatyas Ring
 INSERT INTO `item_mods` VALUES (15852,161,-100); -- DMGPHYS: -100
+INSERT INTO `item_mods` VALUES (15852,164,-100); -- DMGRANGE: -100
 
 -- Dasras Ring
 INSERT INTO `item_mods` VALUES (15853,163,-100); -- DMGMAGIC: -100
@@ -30128,6 +30227,7 @@ INSERT INTO `item_mods` VALUES (16057,944,3); -- CONSERVE_TP: 3
 INSERT INTO `item_mods` VALUES (16058,2,10);     -- HP: 10
 INSERT INTO `item_mods` VALUES (16058,5,10);     -- MP: 10
 INSERT INTO `item_mods` VALUES (16058,161,-100); -- DMGPHYS: -100
+INSERT INTO `item_mods` VALUES (16058,164,-100); -- DMGRANGE: -100
 
 -- Graiai Earring
 INSERT INTO `item_mods` VALUES (16059,7,45); -- CONVHPTOMP: 45
@@ -31305,6 +31405,7 @@ INSERT INTO `item_mods` VALUES (16306,9,3); -- DEX: 3
 
 -- Repelling Collar
 INSERT INTO `item_mods` VALUES (16307,161,-100); -- DMGPHYS: -100
+INSERT INTO `item_mods` VALUES (16307,164,-100); -- DMGRANGE: -100
 INSERT INTO `item_mods` VALUES (16307,163,100);  -- DMGMAGIC: 100
 
 -- Feud Pendant
@@ -34775,6 +34876,7 @@ INSERT INTO `item_mods` VALUES (17550,556,-3); -- EARTH_AFFINITY_PERP: -3
 INSERT INTO `item_mods` VALUES (17551,10,4);      -- VIT: 4
 INSERT INTO `item_mods` VALUES (17551,19,15);     -- THUNDER_MEVA: 15
 INSERT INTO `item_mods` VALUES (17551,161,-2000); -- DMGPHYS: -2000
+INSERT INTO `item_mods` VALUES (17551,164,-2000); -- DMGRANGE: -2000
 INSERT INTO `item_mods` VALUES (17551,350,2);     -- EARTH_STAFF_BONUS: 2
 INSERT INTO `item_mods` VALUES (17551,351,-2);    -- THUNDER_STAFF_BONUS: -2
 INSERT INTO `item_mods` VALUES (17551,556,2);     -- EARTH_AFFINITY_PERP: 2
@@ -34784,6 +34886,7 @@ INSERT INTO `item_mods` VALUES (17551,557,-2);    -- THUNDER_AFFINITY_PERP: -2
 INSERT INTO `item_mods` VALUES (17552,10,5);      -- VIT: 5
 INSERT INTO `item_mods` VALUES (17552,19,20);     -- THUNDER_MEVA: 20
 INSERT INTO `item_mods` VALUES (17552,161,-2000); -- DMGPHYS: -2000
+INSERT INTO `item_mods` VALUES (17552,164,-2000); -- DMGRANGE: -2000
 INSERT INTO `item_mods` VALUES (17552,350,3);     -- EARTH_STAFF_BONUS: 3
 INSERT INTO `item_mods` VALUES (17552,351,-3);    -- THUNDER_STAFF_BONUS: -3
 INSERT INTO `item_mods` VALUES (17552,556,3);     -- EARTH_AFFINITY_PERP: 3
@@ -35477,6 +35580,7 @@ INSERT INTO `item_mods` VALUES (17736,234,2); -- DEMON_KILLER: 2
 INSERT INTO `item_mods` VALUES (17738,25,7);     -- ACC: 7
 INSERT INTO `item_mods` VALUES (17738,111,8);    -- DIVINE: 8
 INSERT INTO `item_mods` VALUES (17738,161,-700); -- DMGPHYS: -700
+INSERT INTO `item_mods` VALUES (17738,164,-700); -- DMGRANGE: -700
 
 -- Steel Kilij
 INSERT INTO `item_mods` VALUES (17739,5,10); -- MP: 10
@@ -37567,6 +37671,7 @@ INSERT INTO `item_mods` VALUES (18497,25,7); -- ACC: 7
 -- Balestarius
 INSERT INTO `item_mods` VALUES (18498,10,8);     -- VIT: 8
 INSERT INTO `item_mods` VALUES (18498,161,-800); -- DMGPHYS: -800
+INSERT INTO `item_mods` VALUES (18498,164,-800); -- DMGRANGE: -800
 
 -- Alastor
 INSERT INTO `item_mods` VALUES (18499,2,10); -- HP: 10
@@ -38661,6 +38766,7 @@ INSERT INTO `item_mods` VALUES (18787,291,3); -- COUNTER: 3
 INSERT INTO `item_mods` VALUES (18788,8,7);      -- STR: 7
 INSERT INTO `item_mods` VALUES (18788,9,5);      -- DEX: 5
 INSERT INTO `item_mods` VALUES (18788,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (18788,164,-500); -- DMGRANGE: -500
 
 -- Marath Baghnakhs
 INSERT INTO `item_mods` VALUES (18789,8,6);  -- STR: 6
@@ -39118,6 +39224,7 @@ INSERT INTO `item_mods` VALUES (18951,230,2); -- BEAST_KILLER: 2
 
 -- Faucheuse
 INSERT INTO `item_mods` VALUES (18952,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (18952,164,-500); -- DMGRANGE: -500
 
 -- Beluga
 INSERT INTO `item_mods` VALUES (18953,2,12);   -- HP: 12
@@ -39434,6 +39541,7 @@ INSERT INTO `item_mods` VALUES (19049,170,1); -- FASTCAST: 1
 
 -- Eisen Grip
 INSERT INTO `item_mods` VALUES (19050,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (19050,164,-200); -- DMGRANGE: -200
 
 -- Vivid Strap +1
 INSERT INTO `item_mods` VALUES (19051,12,1);  -- INT: 1
@@ -41023,6 +41131,7 @@ INSERT INTO `item_mods` VALUES (19773,73,3); -- STORETP: 3
 
 -- Angha Gem
 INSERT INTO `item_mods` VALUES (19774,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (19774,164,-200); -- DMGRANGE: -200
 
 -- Memoria Sachet
 INSERT INTO `item_mods` VALUES (19775,28,2); -- MATT: 2
@@ -41760,6 +41869,7 @@ INSERT INTO `item_mods` VALUES (20505,288,3); -- DOUBLE_ATTACK: 3
 INSERT INTO `item_mods` VALUES (20506,2,80);     -- HP: 80
 INSERT INTO `item_mods` VALUES (20506,73,10);    -- STORETP: 10
 INSERT INTO `item_mods` VALUES (20506,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (20506,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (20506,289,10);   -- SUBTLE_BLOW: 10
 
 -- Comeuppances
@@ -41840,11 +41950,13 @@ INSERT INTO `item_mods` VALUES (20520,505,40); -- OVERLOAD_THRESH: 40
 -- Emeici
 INSERT INTO `item_mods` VALUES (20521,73,4);     -- STORETP: 4
 INSERT INTO `item_mods` VALUES (20521,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (20521,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (20521,302,2);    -- TRIPLE_ATTACK: 2
 
 -- Emeici +1
 INSERT INTO `item_mods` VALUES (20522,73,5);     -- STORETP: 5
 INSERT INTO `item_mods` VALUES (20522,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (20522,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (20522,302,3);    -- TRIPLE_ATTACK: 3
 
 -- Chastisers
@@ -41935,6 +42047,7 @@ INSERT INTO `item_mods` VALUES (20547,68,4);  -- EVA: 4
 INSERT INTO `item_mods` VALUES (20548,23,26);    -- ATT: 26
 INSERT INTO `item_mods` VALUES (20548,68,27);    -- EVA: 27
 INSERT INTO `item_mods` VALUES (20548,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (20548,164,-300); -- DMGRANGE: -300
 
 -- Vineslash Cesti
 INSERT INTO `item_mods` VALUES (20550,25,10); -- ACC: 10
@@ -42845,6 +42958,7 @@ INSERT INTO `item_mods` VALUES (20860,288,4);  -- DOUBLE_ATTACK: 4
 INSERT INTO `item_mods` VALUES (20861,8,12);     -- STR: 12
 INSERT INTO `item_mods` VALUES (20861,10,12);    -- VIT: 12
 INSERT INTO `item_mods` VALUES (20861,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (20861,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (20861,414,20);   -- RETALIATION: 20
 
 -- Lekboza
@@ -42950,6 +43064,7 @@ INSERT INTO `item_mods` VALUES (20900,23,20);    -- ATT: 20
 INSERT INTO `item_mods` VALUES (20900,25,15);    -- ACC: 15
 INSERT INTO `item_mods` VALUES (20900,30,15);    -- MACC: 15
 INSERT INTO `item_mods` VALUES (20900,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (20900,164,-400); -- DMGRANGE: -400
 
 -- Cronus
 INSERT INTO `item_mods` VALUES (20904,23,15);  -- ATT: 15
@@ -43129,6 +43244,7 @@ INSERT INTO `item_mods` VALUES (20977,345,500); -- TP_BONUS: 500
 INSERT INTO `item_mods` VALUES (20982,27,10);    -- ENMITY: 10
 INSERT INTO `item_mods` VALUES (20982,68,22);    -- EVA: 22
 INSERT INTO `item_mods` VALUES (20982,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (20982,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (20982,170,5);    -- FASTCAST: 5
 INSERT INTO `item_mods` VALUES (20982,291,5);    -- COUNTER: 5
 INSERT INTO `item_mods` VALUES (20982,828,1);    -- FORCE_JUMP_CRIT: 1
@@ -43683,6 +43799,7 @@ INSERT INTO `item_mods` VALUES (21168,23,8);     -- ATT: 8
 INSERT INTO `item_mods` VALUES (21168,25,23);    -- ACC: 23
 INSERT INTO `item_mods` VALUES (21168,27,5);     -- ENMITY: 5
 INSERT INTO `item_mods` VALUES (21168,161,-700); -- DMGPHYS: -700
+INSERT INTO `item_mods` VALUES (21168,164,-700); -- DMGRANGE: -700
 
 -- Keraunos
 INSERT INTO `item_mods` VALUES (21169,12,12);   -- INT: 12
@@ -44689,6 +44806,7 @@ INSERT INTO `item_mods` VALUES (21568,73,3);     -- STORETP: 3
 INSERT INTO `item_mods` VALUES (21568,81,247);   -- DAGGER: 247
 INSERT INTO `item_mods` VALUES (21568,110,247);  -- PARRY: 247
 INSERT INTO `item_mods` VALUES (21568,161,-800); -- DMGPHYS: -800
+INSERT INTO `item_mods` VALUES (21568,164,-800); -- DMGRANGE: -800
 INSERT INTO `item_mods` VALUES (21568,171,201);  -- DELAY: 201
 
 -- Chocobo Knife
@@ -45011,6 +45129,7 @@ INSERT INTO `item_mods` VALUES (21637,25,40);     -- ACC: 40
 INSERT INTO `item_mods` VALUES (21637,28,20);     -- MATT: 20
 INSERT INTO `item_mods` VALUES (21637,30,40);     -- MACC: 40
 INSERT INTO `item_mods` VALUES (21637,161,-1000); -- DMGPHYS: -10%
+INSERT INTO `item_mods` VALUES (21637,164,-1000); -- DMGRANGE: -10%
 INSERT INTO `item_mods` VALUES (21637,170,10);    -- FASTCAST: 10%
 INSERT INTO `item_mods` VALUES (21637,301,5);     -- PHALANX: 5
 INSERT INTO `item_mods` VALUES (21637,311,217);   -- MAGIC_DAMAGE: 217
@@ -45757,6 +45876,7 @@ INSERT INTO `item_mods` VALUES (21926,30,40);    -- MACC: 40
 INSERT INTO `item_mods` VALUES (21926,31,30);    -- MEVA: 30
 INSERT INTO `item_mods` VALUES (21926,68,30);    -- EVA: 30
 INSERT INTO `item_mods` VALUES (21926,161,-800); -- DMGPHYS: -800
+INSERT INTO `item_mods` VALUES (21926,164,-800); -- DMGRANGE: -800
 INSERT INTO `item_mods` VALUES (21926,171,190);  -- DELAY: 190
 
 -- Amanomurakumo
@@ -46501,6 +46621,7 @@ INSERT INTO `item_mods` VALUES (22195,288,1); -- DOUBLE_ATTACK: 1
 INSERT INTO `item_mods` VALUES (22196,27,5);     -- ENMITY: 5
 INSERT INTO `item_mods` VALUES (22196,28,7);     -- MATT: 7
 INSERT INTO `item_mods` VALUES (22196,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (22196,164,-200); -- DMGRANGE: -200
 INSERT INTO `item_mods` VALUES (22196,288,2);    -- DOUBLE_ATTACK: 2
 
 -- Niobid Strap
@@ -46552,10 +46673,12 @@ INSERT INTO `item_mods` VALUES (22207,384,500); -- HASTE_GEAR: 500
 
 -- Mensch Strap
 INSERT INTO `item_mods` VALUES (22208,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (22208,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (22208,370,2);    -- REGEN: 2
 
 -- Mensch Strap +1
 INSERT INTO `item_mods` VALUES (22209,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (22209,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (22209,370,3);    -- REGEN: 3
 
 -- Elan Strap
@@ -46791,6 +46914,7 @@ INSERT INTO `item_mods` VALUES (23040,29,2);     -- MDEF: 2
 INSERT INTO `item_mods` VALUES (23040,31,63);    -- MEVA: 63
 INSERT INTO `item_mods` VALUES (23040,68,46);    -- EVA: 46
 INSERT INTO `item_mods` VALUES (23040,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (23040,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (23040,384,800);  -- HASTE_GEAR: 800
 INSERT INTO `item_mods` VALUES (23040,955,16);   -- AGGRESSOR_DURATION: 16
 
@@ -46910,6 +47034,7 @@ INSERT INTO `item_mods` VALUES (23046,29,2);     -- MDEF: 2
 INSERT INTO `item_mods` VALUES (23046,31,42);    -- MEVA: 42
 INSERT INTO `item_mods` VALUES (23046,68,43);    -- EVA: 43
 INSERT INTO `item_mods` VALUES (23046,161,-600); -- DMGPHYS: -600
+INSERT INTO `item_mods` VALUES (23046,164,-600); -- DMGRANGE: -600
 INSERT INTO `item_mods` VALUES (23046,384,700);  -- HASTE_GEAR: 700
 INSERT INTO `item_mods` VALUES (23046,966,1);    -- COVER_MAGIC_AND_RANGED: 1
 INSERT INTO `item_mods` VALUES (23046,967,9);    -- COVER_DURATION: 9
@@ -47439,6 +47564,7 @@ INSERT INTO `item_mods` VALUES (23072,31,85);    -- MEVA: 85
 INSERT INTO `item_mods` VALUES (23072,68,48);    -- EVA: 48
 INSERT INTO `item_mods` VALUES (23072,119,16);   -- SINGING: 16
 INSERT INTO `item_mods` VALUES (23072,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (23072,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (23072,384,600);  -- HASTE_GEAR: 6%
 
 -- Arcadian Beret +2
@@ -47687,6 +47813,7 @@ INSERT INTO `item_mods` VALUES (23084,30,27);    -- MACC: 27
 INSERT INTO `item_mods` VALUES (23084,31,63);    -- MEVA: 63
 INSERT INTO `item_mods` VALUES (23084,68,54);    -- EVA: 54
 INSERT INTO `item_mods` VALUES (23084,161,-500); -- DMGPHYS: -5%
+INSERT INTO `item_mods` VALUES (23084,164,-500); -- DMGRANGE: -5%
 INSERT INTO `item_mods` VALUES (23084,301,6);    -- PHALANX: 6
 INSERT INTO `item_mods` VALUES (23084,384,800);  -- HASTE_GEAR: 8%
 
@@ -49002,6 +49129,7 @@ INSERT INTO `item_mods` VALUES (23146,30,30);    -- MACC: 30
 INSERT INTO `item_mods` VALUES (23146,31,74);    -- MEVA: 74
 INSERT INTO `item_mods` VALUES (23146,68,59);    -- EVA: 59
 INSERT INTO `item_mods` VALUES (23146,161,-500); -- DMGPHYS: -5%
+INSERT INTO `item_mods` VALUES (23146,164,-500); -- DMGRANGE: -5%
 INSERT INTO `item_mods` VALUES (23146,384,400);  -- HASTE_GEAR: 4%
 INSERT INTO `item_mods` VALUES (23146,220,50);   -- RANDOM_DEAL_BONUS: 50
 
@@ -49041,6 +49169,7 @@ INSERT INTO `item_mods` VALUES (23148,30,30);    -- MACC: 30
 INSERT INTO `item_mods` VALUES (23148,31,74);    -- MEVA: 74
 INSERT INTO `item_mods` VALUES (23148,68,59);    -- EVA: 59
 INSERT INTO `item_mods` VALUES (23148,161,-500); -- DMGPHYS: -5%
+INSERT INTO `item_mods` VALUES (23148,164,-500); -- DMGRANGE: -5%
 INSERT INTO `item_mods` VALUES (23148,253,30);   -- AMNESIARES: 30
 INSERT INTO `item_mods` VALUES (23148,302,3);    -- TRIPLE_ATTACK: 3
 INSERT INTO `item_mods` VALUES (23148,384,400);  -- HASTE_GEAR: 4%
@@ -49615,6 +49744,7 @@ INSERT INTO `item_mods` VALUES (23174,29,2);     -- MDEF: 2
 INSERT INTO `item_mods` VALUES (23174,31,53);    -- MEVA: 53
 INSERT INTO `item_mods` VALUES (23174,68,32);    -- EVA: 32
 INSERT INTO `item_mods` VALUES (23174,161,-600); -- DMGPHYS: -600
+INSERT INTO `item_mods` VALUES (23174,164,-600); -- DMGRANGE: -600
 INSERT INTO `item_mods` VALUES (23174,384,500);  -- HASTE_GEAR: 500
 INSERT INTO `item_mods` VALUES (23174,414,17);   -- RETALIATION: 17
 
@@ -50019,6 +50149,7 @@ INSERT INTO `item_mods` VALUES (23195,31,47);    -- MEVA: 47
 INSERT INTO `item_mods` VALUES (23195,68,32);    -- EVA: 32
 INSERT INTO `item_mods` VALUES (23195,123,17);   -- GEOMANCY_SKILL: 17
 INSERT INTO `item_mods` VALUES (23195,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (23195,164,-200); -- DMGRANGE: -200
 INSERT INTO `item_mods` VALUES (23195,384,300);  -- HASTE_GEAR: 300
 
 -- Runeists Mitons +2
@@ -50038,6 +50169,7 @@ INSERT INTO `item_mods` VALUES (23196,31,57);    -- MEVA: 57
 INSERT INTO `item_mods` VALUES (23196,68,34);    -- EVA: 34
 INSERT INTO `item_mods` VALUES (23196,113,17);   -- ENHANCE: 17
 INSERT INTO `item_mods` VALUES (23196,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (23196,164,-200); -- DMGRANGE: -200
 INSERT INTO `item_mods` VALUES (23196,384,500);  -- HASTE_GEAR: 500
 
 -- Agoge Mufflers +2
@@ -50057,6 +50189,7 @@ INSERT INTO `item_mods` VALUES (23197,30,28);    -- MACC: 28
 INSERT INTO `item_mods` VALUES (23197,31,53);    -- MEVA: 53
 INSERT INTO `item_mods` VALUES (23197,68,32);    -- EVA: 32
 INSERT INTO `item_mods` VALUES (23197,161,-500); -- DMGPHYS: -5%
+INSERT INTO `item_mods` VALUES (23197,164,-500); -- DMGRANGE: -5%
 INSERT INTO `item_mods` VALUES (23197,384,500);  -- HASTE_GEAR: 5%
 INSERT INTO `item_mods` VALUES (23197,956,10);   -- DEFENDER_DURATION: 10
 
@@ -50248,6 +50381,7 @@ INSERT INTO `item_mods` VALUES (23206,31,47);    -- MEVA: 47
 INSERT INTO `item_mods` VALUES (23206,68,34);    -- EVA: 34
 INSERT INTO `item_mods` VALUES (23206,121,13);   -- WIND: 13
 INSERT INTO `item_mods` VALUES (23206,161,-400); -- DMGPHYS: -4%
+INSERT INTO `item_mods` VALUES (23206,164,-400); -- DMGRANGE: -4%
 INSERT INTO `item_mods` VALUES (23206,384,300);  -- HASTE_GEAR: 3%
 
 -- Arcadian bracers +2
@@ -50288,6 +50422,7 @@ INSERT INTO `item_mods` VALUES (23208,31,36);    -- MEVA: 36
 INSERT INTO `item_mods` VALUES (23208,68,32);    -- EVA: 32
 INSERT INTO `item_mods` VALUES (23208,94,8);     -- MEDITATE_DURATION: 8
 INSERT INTO `item_mods` VALUES (23208,161,-500); -- DMGPHYS: -5%
+INSERT INTO `item_mods` VALUES (23208,164,-500); -- DMGRANGE: -5%
 INSERT INTO `item_mods` VALUES (23208,384,400);  -- HASTE_GEAR: 4%
 
 -- Mochizuki Tekko +2
@@ -50992,6 +51127,7 @@ INSERT INTO `item_mods` VALUES (23241,29,4);     -- MDEF: 4
 INSERT INTO `item_mods` VALUES (23241,31,90);    -- MEVA: 90
 INSERT INTO `item_mods` VALUES (23241,68,42);    -- EVA: 42
 INSERT INTO `item_mods` VALUES (23241,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (23241,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (23241,288,8);    -- DOUBLE_ATTACK: 8
 INSERT INTO `item_mods` VALUES (23241,384,600);  -- HASTE_GEAR: 600
 
@@ -51107,6 +51243,7 @@ INSERT INTO `item_mods` VALUES (23247,31,74);    -- MEVA: 74
 INSERT INTO `item_mods` VALUES (23247,68,32);    -- EVA: 32
 INSERT INTO `item_mods` VALUES (23247,113,17);   -- ENHANCE: 17
 INSERT INTO `item_mods` VALUES (23247,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (23247,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (23247,384,500);  -- HASTE_GEAR: 500
 
 -- Ignominy Flanchard +2
@@ -51406,6 +51543,7 @@ INSERT INTO `item_mods` VALUES (23263,31,89);    -- MEVA: 89
 INSERT INTO `item_mods` VALUES (23263,68,48);    -- EVA: 48
 INSERT INTO `item_mods` VALUES (23263,111,17);   -- DIVINE: 17
 INSERT INTO `item_mods` VALUES (23263,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (23263,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (23263,384,600);  -- HASTE_GEAR: 600
 INSERT INTO `item_mods` VALUES (23263,958,8);    -- STATUSRES: 8
 
@@ -51510,6 +51648,7 @@ INSERT INTO `item_mods` VALUES (23268,31,117);   -- MEVA: 117
 INSERT INTO `item_mods` VALUES (23268,68,37);    -- EVA: 37
 INSERT INTO `item_mods` VALUES (23268,115,21);   -- ELEM: 21
 INSERT INTO `item_mods` VALUES (23268,161,-400); -- DMGPHYS: -4%
+INSERT INTO `item_mods` VALUES (23268,164,-400); -- DMGRANGE: -4%
 INSERT INTO `item_mods` VALUES (23268,344,30);   -- SPIKES_DMG: 30
 INSERT INTO `item_mods` VALUES (23268,384,500);  -- HASTE_GEAR: 5%
 
@@ -51551,6 +51690,7 @@ INSERT INTO `item_mods` VALUES (23270,30,29);    -- MACC: 29
 INSERT INTO `item_mods` VALUES (23270,31,74);    -- MEVA: 74
 INSERT INTO `item_mods` VALUES (23270,68,32);    -- EVA: 32
 INSERT INTO `item_mods` VALUES (23270,161,-600); -- DMGPHYS: -6%
+INSERT INTO `item_mods` VALUES (23270,164,-600); -- DMGRANGE: -6%
 INSERT INTO `item_mods` VALUES (23270,168,7);    -- SPELLINTERRUPT: 7
 INSERT INTO `item_mods` VALUES (23270,384,500);  -- HASTE_GEAR: 5%
 
@@ -51611,6 +51751,7 @@ INSERT INTO `item_mods` VALUES (23273,30,42);    -- MACC: 42
 INSERT INTO `item_mods` VALUES (23273,31,117);   -- MEVA: 117
 INSERT INTO `item_mods` VALUES (23273,68,40);    -- EVA: 40
 INSERT INTO `item_mods` VALUES (23273,161,-500); -- DMGPHYS: -5%
+INSERT INTO `item_mods` VALUES (23273,164,-500); -- DMGRANGE: -5%
 INSERT INTO `item_mods` VALUES (23273,384,500);  -- HASTE_GEAR: 5%
 
 -- Arcadian braccae +2
@@ -52936,6 +53077,7 @@ INSERT INTO `item_mods` VALUES (23340,31,117);   -- MEVA: 117
 INSERT INTO `item_mods` VALUES (23340,68,68);    -- EVA: 68
 INSERT INTO `item_mods` VALUES (23340,120,13);   -- STRING: 13
 INSERT INTO `item_mods` VALUES (23340,161,-400); -- DMGPHYS: -4%
+INSERT INTO `item_mods` VALUES (23340,164,-400); -- DMGRANGE: -4%
 INSERT INTO `item_mods` VALUES (23340,384,300);  -- HASTE_GEAR: 3%
 INSERT INTO `item_mods` VALUES (23340,455,9);    -- SONG_SPELLCASTING_TIME: -9%
 
@@ -53072,6 +53214,7 @@ INSERT INTO `item_mods` VALUES (23347,30,26);    -- MACC: 26
 INSERT INTO `item_mods` VALUES (23347,31,79);    -- MEVA: 79
 INSERT INTO `item_mods` VALUES (23347,68,82);    -- EVA:  82
 INSERT INTO `item_mods` VALUES (23347,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (23347,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (23347,384,400);  -- HASTE_GEAR: 4%
 INSERT INTO `item_mods` VALUES (23347,841,5);    -- ALL_WSDMG_FIRST_HIT: 5
 
@@ -53664,6 +53807,7 @@ INSERT INTO `item_mods` VALUES (23375,29,3);     -- MDEF: 3
 INSERT INTO `item_mods` VALUES (23375,31,73);    -- MEVA: 73
 INSERT INTO `item_mods` VALUES (23375,68,56);    -- EVA: 56
 INSERT INTO `item_mods` VALUES (23375,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (23375,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (23375,384,800);  -- HASTE_GEAR: 800
 INSERT INTO `item_mods` VALUES (23375,955,18);   -- AGGRESSOR_DURATION: 18
 
@@ -53783,6 +53927,7 @@ INSERT INTO `item_mods` VALUES (23381,29,3);     -- MDEF: 3
 INSERT INTO `item_mods` VALUES (23381,31,52);    -- MEVA: 52
 INSERT INTO `item_mods` VALUES (23381,68,53);    -- EVA: 53
 INSERT INTO `item_mods` VALUES (23381,161,-700); -- DMGPHYS: -700
+INSERT INTO `item_mods` VALUES (23381,164,-700); -- DMGRANGE: -700
 INSERT INTO `item_mods` VALUES (23381,384,700);  -- HASTE_GEAR: 700
 INSERT INTO `item_mods` VALUES (23381,966,1);    -- COVER_MAGIC_AND_RANGED: 1
 INSERT INTO `item_mods` VALUES (23381,967,10);   -- COVER_DURATION: 10
@@ -54754,6 +54899,7 @@ INSERT INTO `item_mods` VALUES (23509,29,3);     -- MDEF: 3
 INSERT INTO `item_mods` VALUES (23509,31,63);    -- MEVA: 63
 INSERT INTO `item_mods` VALUES (23509,68,42);    -- EVA: 42
 INSERT INTO `item_mods` VALUES (23509,161,-700); -- DMGPHYS: -700
+INSERT INTO `item_mods` VALUES (23509,164,-700); -- DMGRANGE: -700
 INSERT INTO `item_mods` VALUES (23509,384,500);  -- HASTE_GEAR: 500
 INSERT INTO `item_mods` VALUES (23509,414,19);   -- RETALIATION: 19
 
@@ -55158,6 +55304,7 @@ INSERT INTO `item_mods` VALUES (23530,31,57);    -- MEVA: 57
 INSERT INTO `item_mods` VALUES (23530,68,42);    -- EVA: 42
 INSERT INTO `item_mods` VALUES (23530,123,19);   -- GEOMANCY_SKILL: 19
 INSERT INTO `item_mods` VALUES (23530,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (23530,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (23530,384,300);  -- HASTE_GEAR: 300
 
 -- Runeists Mitons +3
@@ -55177,6 +55324,7 @@ INSERT INTO `item_mods` VALUES (23531,31,67);    -- MEVA: 67
 INSERT INTO `item_mods` VALUES (23531,68,44);    -- EVA: 44
 INSERT INTO `item_mods` VALUES (23531,113,19);   -- ENHANCE: 19
 INSERT INTO `item_mods` VALUES (23531,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (23531,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (23531,384,500);  -- HASTE_GEAR: 500
 
 -- Agoge Mufflers +3
@@ -55240,6 +55388,7 @@ INSERT INTO `item_mods` VALUES (23576,29,5);     -- MDEF: 5
 INSERT INTO `item_mods` VALUES (23576,31,100);   -- MEVA: 100
 INSERT INTO `item_mods` VALUES (23576,68,52);    -- EVA: 52
 INSERT INTO `item_mods` VALUES (23576,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (23576,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (23576,288,11);   -- DOUBLE_ATTACK: 11
 INSERT INTO `item_mods` VALUES (23576,384,600);  -- HASTE_GEAR: 600
 
@@ -55356,6 +55505,7 @@ INSERT INTO `item_mods` VALUES (23582,31,84);    -- MEVA: 84
 INSERT INTO `item_mods` VALUES (23582,68,42);    -- EVA: 42
 INSERT INTO `item_mods` VALUES (23582,113,19);   -- ENHANCE: 19
 INSERT INTO `item_mods` VALUES (23582,161,-600); -- DMGPHYS: -600
+INSERT INTO `item_mods` VALUES (23582,164,-600); -- DMGRANGE: -600
 INSERT INTO `item_mods` VALUES (23582,384,500);  -- HASTE_GEAR: 500
 
 -- Ignominy Flanchard +3
@@ -55655,6 +55805,7 @@ INSERT INTO `item_mods` VALUES (23598,31,99);    -- MEVA: 99
 INSERT INTO `item_mods` VALUES (23598,68,58);    -- EVA: 58
 INSERT INTO `item_mods` VALUES (23598,111,19);   -- DIVINE: 19
 INSERT INTO `item_mods` VALUES (23598,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (23598,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (23598,384,600);  -- HASTE_GEAR: 600
 
 -- Agoge Cuisses +3
@@ -56339,6 +56490,7 @@ INSERT INTO `item_mods` VALUES (23675,31,127);   -- MEVA: 127
 INSERT INTO `item_mods` VALUES (23675,68,78);    -- EVA: 78
 INSERT INTO `item_mods` VALUES (23675,120,15);   -- STRING: 15
 INSERT INTO `item_mods` VALUES (23675,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (23675,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (23675,384,300);  -- HASTE_GEAR: 300
 INSERT INTO `item_mods` VALUES (23675,455,10);   -- SONG_SPELLCASTING_TIME: -10
 
@@ -56475,6 +56627,7 @@ INSERT INTO `item_mods` VALUES (23682,30,36);    -- MACC: 36
 INSERT INTO `item_mods` VALUES (23682,31,89);    -- MEVA: 89
 INSERT INTO `item_mods` VALUES (23682,68,92);    -- EVA: 92
 INSERT INTO `item_mods` VALUES (23682,161,-600); -- DMGPHYS: -600
+INSERT INTO `item_mods` VALUES (23682,164,-600); -- DMGRANGE: -600
 INSERT INTO `item_mods` VALUES (23682,384,400);  -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (23682,840,10);   -- ALL_WSDMG_ALL_HITS: 10
 
@@ -56631,6 +56784,7 @@ INSERT INTO `item_mods` VALUES (23712,30,37);    -- MACC: 37
 INSERT INTO `item_mods` VALUES (23712,31,99);    -- MEVA: 99
 INSERT INTO `item_mods` VALUES (23712,68,52);    -- EVA: 52
 INSERT INTO `item_mods` VALUES (23712,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (23712,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (23712,163,-700); -- DMGMAGIC: -700
 INSERT INTO `item_mods` VALUES (23712,288,3);    -- DOUBLE_ATTACK: 3
 INSERT INTO `item_mods` VALUES (23712,370,2);    -- REGEN: 2
@@ -56713,6 +56867,7 @@ INSERT INTO `item_mods` VALUES (23716,30,39);     -- MACC: 39
 INSERT INTO `item_mods` VALUES (23716,31,118);    -- MEVA: 118
 INSERT INTO `item_mods` VALUES (23716,68,60);     -- EVA: 60
 INSERT INTO `item_mods` VALUES (23716,161,-1000); -- DMGPHYS: -1000
+INSERT INTO `item_mods` VALUES (23716,164,-1000); -- DMGRANGE: -1000
 INSERT INTO `item_mods` VALUES (23716,163,-1000); -- DMGMAGIC: -1000
 INSERT INTO `item_mods` VALUES (23716,288,5);     -- DOUBLE_ATTACK: 5
 INSERT INTO `item_mods` VALUES (23716,370,4);     -- REGEN: 4
@@ -56791,6 +56946,7 @@ INSERT INTO `item_mods` VALUES (23720,30,36);    -- MACC: 36
 INSERT INTO `item_mods` VALUES (23720,31,91);    -- MEVA: 91
 INSERT INTO `item_mods` VALUES (23720,68,41);    -- EVA: 41
 INSERT INTO `item_mods` VALUES (23720,161,-600); -- DMGPHYS: -600
+INSERT INTO `item_mods` VALUES (23720,164,-600); -- DMGRANGE: -600
 INSERT INTO `item_mods` VALUES (23720,163,-400); -- DMGMAGIC: -400
 INSERT INTO `item_mods` VALUES (23720,288,3);    -- DOUBLE_ATTACK: 3
 INSERT INTO `item_mods` VALUES (23720,370,2);    -- REGEN: 2
@@ -56870,6 +57026,7 @@ INSERT INTO `item_mods` VALUES (23724,30,38);    -- MACC: 38
 INSERT INTO `item_mods` VALUES (23724,31,137);   -- MEVA: 137
 INSERT INTO `item_mods` VALUES (23724,68,49);    -- EVA: 49
 INSERT INTO `item_mods` VALUES (23724,161,-700); -- DMGPHYS: -700
+INSERT INTO `item_mods` VALUES (23724,164,-700); -- DMGRANGE: -700
 INSERT INTO `item_mods` VALUES (23724,163,-300); -- DMGMAGIC: -300
 INSERT INTO `item_mods` VALUES (23724,288,4);    -- DOUBLE_ATTACK: 4
 INSERT INTO `item_mods` VALUES (23724,370,3);    -- REGEN: 3
@@ -56950,6 +57107,7 @@ INSERT INTO `item_mods` VALUES (23728,30,35);    -- MACC: 35
 INSERT INTO `item_mods` VALUES (23728,31,137);   -- MEVA: 137
 INSERT INTO `item_mods` VALUES (23728,68,70);    -- EVA: 70
 INSERT INTO `item_mods` VALUES (23728,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (23728,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (23728,163,-600); -- DMGMAGIC: -600
 INSERT INTO `item_mods` VALUES (23728,288,3);    -- DOUBLE_ATTACK: 3
 INSERT INTO `item_mods` VALUES (23728,370,2);    -- REGEN: 2
@@ -57001,6 +57159,7 @@ INSERT INTO `item_mods` VALUES (23732,31,123);   -- MEVA: 123
 INSERT INTO `item_mods` VALUES (23732,68,91);    -- EVA: 91
 INSERT INTO `item_mods` VALUES (23732,73,8);     -- STORETP: 8
 INSERT INTO `item_mods` VALUES (23732,161,-600); -- DMGPHYS: -600
+INSERT INTO `item_mods` VALUES (23732,164,-600); -- DMGRANGE: -600
 INSERT INTO `item_mods` VALUES (23732,384,600);  -- HASTE_GEAR: 600
 
 -- Malignance Tabard
@@ -57022,6 +57181,7 @@ INSERT INTO `item_mods` VALUES (23733,31,139);   -- MEVA: 139
 INSERT INTO `item_mods` VALUES (23733,68,102);   -- EVA: 102
 INSERT INTO `item_mods` VALUES (23733,73,11);    -- STORETP: 11
 INSERT INTO `item_mods` VALUES (23733,161,-900); -- DMGPHYS: -900
+INSERT INTO `item_mods` VALUES (23733,164,-900); -- DMGRANGE: -900
 INSERT INTO `item_mods` VALUES (23733,384,400);  -- HASTE_GEAR: 400
 
 -- Malignance Gloves
@@ -57043,6 +57203,7 @@ INSERT INTO `item_mods` VALUES (23734,31,112);   -- MEVA: 112
 INSERT INTO `item_mods` VALUES (23734,68,80);    -- EVA: 80
 INSERT INTO `item_mods` VALUES (23734,73,12);    -- STORETP: 12
 INSERT INTO `item_mods` VALUES (23734,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (23734,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (23734,384,400);  -- HASTE_GEAR: 400
 
 -- Malignance Tights
@@ -57064,6 +57225,7 @@ INSERT INTO `item_mods` VALUES (23735,31,150);   -- MEVA: 150
 INSERT INTO `item_mods` VALUES (23735,68,85);    -- EVA: 85
 INSERT INTO `item_mods` VALUES (23735,73,10);    -- STORETP: 10
 INSERT INTO `item_mods` VALUES (23735,161,-700); -- DMGPHYS: -700
+INSERT INTO `item_mods` VALUES (23735,164,-700); -- DMGRANGE: -700
 INSERT INTO `item_mods` VALUES (23735,384,900);  -- HASTE_GEAR: 900
 
 -- Malignance Boots
@@ -57085,6 +57247,7 @@ INSERT INTO `item_mods` VALUES (23736,31,150);   -- MEVA: 150
 INSERT INTO `item_mods` VALUES (23736,68,119);   -- EVA: 119
 INSERT INTO `item_mods` VALUES (23736,73,10);    -- STORETP: 10
 INSERT INTO `item_mods` VALUES (23736,161,-700); -- DMGPHYS: -700
+INSERT INTO `item_mods` VALUES (23736,164,-700); -- DMGRANGE: -700
 INSERT INTO `item_mods` VALUES (23736,384,300);  -- HASTE_GEAR: 300
 
 -- Heidrek Harness
@@ -57167,6 +57330,7 @@ INSERT INTO `item_mods` VALUES (23758,30,40);    -- MACC: 40
 INSERT INTO `item_mods` VALUES (23758,31,69);    -- MEVA: 69
 INSERT INTO `item_mods` VALUES (23758,68,91);    -- EVA: 91
 INSERT INTO `item_mods` VALUES (23758,161,-700); -- DMGPHYS: -700
+INSERT INTO `item_mods` VALUES (23758,164,-700); -- DMGRANGE: -700
 INSERT INTO `item_mods` VALUES (23758,165,4);    -- CRITHITRATE: 4
 INSERT INTO `item_mods` VALUES (23758,224,2);    -- VERMIN_KILLER: 2
 INSERT INTO `item_mods` VALUES (23758,225,2);    -- BIRD_KILLER: 2
@@ -57230,6 +57394,7 @@ INSERT INTO `item_mods` VALUES (23760,30,40);    -- MACC: 40
 INSERT INTO `item_mods` VALUES (23760,31,123);   -- MEVA: 123
 INSERT INTO `item_mods` VALUES (23760,68,63);    -- EVA: 63
 INSERT INTO `item_mods` VALUES (23760,161,-700); -- DMGPHYS: -700
+INSERT INTO `item_mods` VALUES (23760,164,-700); -- DMGRANGE: -700
 INSERT INTO `item_mods` VALUES (23760,170,10);   -- FASTCAST: 10
 INSERT INTO `item_mods` VALUES (23760,311,30);   -- MAGIC_DAMAGE: 30
 INSERT INTO `item_mods` VALUES (23760,384,600);  -- HASTE_GEAR: 600
@@ -57321,6 +57486,7 @@ INSERT INTO `item_mods` VALUES (23765,30,40);     -- MACC: 40
 INSERT INTO `item_mods` VALUES (23765,31,86);     -- MEVA: 86
 INSERT INTO `item_mods` VALUES (23765,68,102);    -- EVA: 102
 INSERT INTO `item_mods` VALUES (23765,161,-1000); -- DMGPHYS: -1000
+INSERT INTO `item_mods` VALUES (23765,164,-1000); -- DMGRANGE: -1000
 INSERT INTO `item_mods` VALUES (23765,165,7);     -- CRITHITRATE: 7
 INSERT INTO `item_mods` VALUES (23765,224,5);     -- VERMIN_KILLER: 5
 INSERT INTO `item_mods` VALUES (23765,225,5);     -- BIRD_KILLER: 5
@@ -57475,6 +57641,7 @@ INSERT INTO `item_mods` VALUES (23772,30,40);    -- MACC: 40
 INSERT INTO `item_mods` VALUES (23772,31,59);    -- MEVA: 59
 INSERT INTO `item_mods` VALUES (23772,68,80);    -- EVA: 80
 INSERT INTO `item_mods` VALUES (23772,161,-800); -- DMGPHYS: -800
+INSERT INTO `item_mods` VALUES (23772,164,-800); -- DMGRANGE: -800
 INSERT INTO `item_mods` VALUES (23772,165,5);    -- CRITHITRATE: 5
 INSERT INTO `item_mods` VALUES (23772,224,2);    -- VERMIN_KILLER: 2
 INSERT INTO `item_mods` VALUES (23772,225,2);    -- BIRD_KILLER: 2
@@ -57626,6 +57793,7 @@ INSERT INTO `item_mods` VALUES (23779,30,40);    -- MACC: 40
 INSERT INTO `item_mods` VALUES (23779,31,96);    -- MEVA: 96
 INSERT INTO `item_mods` VALUES (23779,68,85);    -- EVA: 85
 INSERT INTO `item_mods` VALUES (23779,161,-900); -- DMGPHYS: -900
+INSERT INTO `item_mods` VALUES (23779,164,-900); -- DMGRANGE: -900
 INSERT INTO `item_mods` VALUES (23779,165,6);    -- CRITHITRATE: 6
 INSERT INTO `item_mods` VALUES (23779,224,5);    -- VERMIN_KILLER: 5
 INSERT INTO `item_mods` VALUES (23779,225,5);    -- BIRD_KILLER: 5
@@ -57752,6 +57920,7 @@ INSERT INTO `item_mods` VALUES (23784,30,40);    -- MACC: 40
 INSERT INTO `item_mods` VALUES (23784,31,112);   -- MEVA: 112
 INSERT INTO `item_mods` VALUES (23784,68,110);   -- EVA: 110
 INSERT INTO `item_mods` VALUES (23784,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (23784,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (23784,165,4);    -- CRITHITRATE: 4
 INSERT INTO `item_mods` VALUES (23784,368,20);   -- REGAIN: 20
 INSERT INTO `item_mods` VALUES (23784,384,300);  -- HASTE_GEAR: 300
@@ -57793,6 +57962,7 @@ INSERT INTO `item_mods` VALUES (23786,30,40);    -- MACC: 40
 INSERT INTO `item_mods` VALUES (23786,31,96);    -- MEVA: 96
 INSERT INTO `item_mods` VALUES (23786,68,119);   -- EVA: 119
 INSERT INTO `item_mods` VALUES (23786,161,-600); -- DMGPHYS: -600
+INSERT INTO `item_mods` VALUES (23786,164,-600); -- DMGRANGE: -600
 INSERT INTO `item_mods` VALUES (23786,165,3);    -- CRITHITRATE: 3
 INSERT INTO `item_mods` VALUES (23786,224,2);    -- VERMIN_KILLER: 2
 INSERT INTO `item_mods` VALUES (23786,225,2);    -- BIRD_KILLER: 2
@@ -58714,6 +58884,7 @@ INSERT INTO `item_mods` VALUES (25575,29,3);     -- MDEF: 3
 INSERT INTO `item_mods` VALUES (25575,31,53);    -- MEVA: 53
 INSERT INTO `item_mods` VALUES (25575,68,49);    -- EVA: 49
 INSERT INTO `item_mods` VALUES (25575,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (25575,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (25575,384,400);  -- HASTE_GEAR: 400
 
 -- Hizamaru Somen +2
@@ -59223,6 +59394,7 @@ INSERT INTO `item_mods` VALUES (25629,29,2);     -- MDEF: 2
 INSERT INTO `item_mods` VALUES (25629,31,48);    -- MEVA: 48
 INSERT INTO `item_mods` VALUES (25629,68,36);    -- EVA: 36
 INSERT INTO `item_mods` VALUES (25629,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (25629,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (25629,384,700);  -- HASTE_GEAR: 700
 
 -- Carbie Cap +1
@@ -59312,6 +59484,7 @@ INSERT INTO `item_mods` VALUES (25661,29,3);     -- MDEF: 3
 INSERT INTO `item_mods` VALUES (25661,31,53);    -- MEVA: 53
 INSERT INTO `item_mods` VALUES (25661,68,49);    -- EVA: 49
 INSERT INTO `item_mods` VALUES (25661,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (25661,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (25661,384,400);  -- HASTE_GEAR: 400
 
 -- Meghanada Visor +1
@@ -59332,6 +59505,7 @@ INSERT INTO `item_mods` VALUES (25662,29,3);     -- MDEF: 3
 INSERT INTO `item_mods` VALUES (25662,31,53);    -- MEVA: 53
 INSERT INTO `item_mods` VALUES (25662,68,49);    -- EVA: 49
 INSERT INTO `item_mods` VALUES (25662,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (25662,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (25662,384,400);  -- HASTE_GEAR: 400
 
 -- Inyanga Tiara
@@ -59478,6 +59652,7 @@ INSERT INTO `item_mods` VALUES (25684,29,4);     -- MDEF: 4
 INSERT INTO `item_mods` VALUES (25684,31,59);    -- MEVA: 59
 INSERT INTO `item_mods` VALUES (25684,68,44);    -- EVA: 44
 INSERT INTO `item_mods` VALUES (25684,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (25684,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (25684,165,4);    -- CRITHITRATE: 4
 INSERT INTO `item_mods` VALUES (25684,384,300);  -- HASTE_GEAR: 300
 
@@ -59497,6 +59672,7 @@ INSERT INTO `item_mods` VALUES (25685,29,4);     -- MDEF: 4
 INSERT INTO `item_mods` VALUES (25685,31,59);    -- MEVA: 59
 INSERT INTO `item_mods` VALUES (25685,68,44);    -- EVA: 44
 INSERT INTO `item_mods` VALUES (25685,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (25685,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (25685,165,5);    -- CRITHITRATE: 5
 INSERT INTO `item_mods` VALUES (25685,384,300);  -- HASTE_GEAR: 300
 
@@ -59684,6 +59860,7 @@ INSERT INTO `item_mods` VALUES (25707,29,4);     -- MDEF: 4
 INSERT INTO `item_mods` VALUES (25707,31,53);    -- MEVA: 53
 INSERT INTO `item_mods` VALUES (25707,68,44);    -- EVA: 44
 INSERT INTO `item_mods` VALUES (25707,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (25707,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (25707,311,15);   -- MAGIC_DAMAGE: 15
 INSERT INTO `item_mods` VALUES (25707,384,300);  -- HASTE_GEAR: 300
 
@@ -59753,6 +59930,7 @@ INSERT INTO `item_mods` VALUES (25747,29,6);     -- MDEF: 6
 INSERT INTO `item_mods` VALUES (25747,31,64);    -- MEVA: 64
 INSERT INTO `item_mods` VALUES (25747,68,55);    -- EVA: 55
 INSERT INTO `item_mods` VALUES (25747,161,-600); -- DMGPHYS: -600
+INSERT INTO `item_mods` VALUES (25747,164,-600); -- DMGRANGE: -600
 INSERT INTO `item_mods` VALUES (25747,165,3);    -- CRITHITRATE: 3
 INSERT INTO `item_mods` VALUES (25747,384,200);  -- HASTE_GEAR: 200
 
@@ -59774,6 +59952,7 @@ INSERT INTO `item_mods` VALUES (25748,29,6);     -- MDEF: 6
 INSERT INTO `item_mods` VALUES (25748,31,64);    -- MEVA: 64
 INSERT INTO `item_mods` VALUES (25748,68,55);    -- EVA: 55
 INSERT INTO `item_mods` VALUES (25748,161,-700); -- DMGPHYS: -700
+INSERT INTO `item_mods` VALUES (25748,164,-700); -- DMGRANGE: -700
 INSERT INTO `item_mods` VALUES (25748,165,5);    -- CRITHITRATE: 5
 INSERT INTO `item_mods` VALUES (25748,384,200);  -- HASTE_GEAR: 200
 
@@ -60216,6 +60395,7 @@ INSERT INTO `item_mods` VALUES (25802,29,2);     -- MDEF: 2
 INSERT INTO `item_mods` VALUES (25802,31,37);    -- MEVA: 37
 INSERT INTO `item_mods` VALUES (25802,68,36);    -- EVA: 36
 INSERT INTO `item_mods` VALUES (25802,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (25802,164,-200); -- DMGRANGE: -200
 INSERT INTO `item_mods` VALUES (25802,384,400);  -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (25802,841,3);    -- ALL_WSDMG_FIRST_HIT: 3
 
@@ -60237,6 +60417,7 @@ INSERT INTO `item_mods` VALUES (25803,29,2);     -- MDEF: 2
 INSERT INTO `item_mods` VALUES (25803,31,37);    -- MEVA: 37
 INSERT INTO `item_mods` VALUES (25803,68,36);    -- EVA: 36
 INSERT INTO `item_mods` VALUES (25803,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (25803,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (25803,384,400);  -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (25803,841,5);    -- ALL_WSDMG_FIRST_HIT: 5
 
@@ -60566,6 +60747,7 @@ INSERT INTO `item_mods` VALUES (25842,31,75);    -- MEVA: 75
 INSERT INTO `item_mods` VALUES (25842,68,62);    -- EVA: 62
 INSERT INTO `item_mods` VALUES (25842,73,4);     -- STORETP: 4
 INSERT INTO `item_mods` VALUES (25842,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (25842,164,-200); -- DMGRANGE: -200
 INSERT INTO `item_mods` VALUES (25842,384,600);  -- HASTE_GEAR: 600
 
 -- Chironic Hose
@@ -60625,6 +60807,7 @@ INSERT INTO `item_mods` VALUES (25860,29,5);     -- MDEF: 5
 INSERT INTO `item_mods` VALUES (25860,31,69);    -- MEVA: 69
 INSERT INTO `item_mods` VALUES (25860,68,41);    -- EVA: 41
 INSERT INTO `item_mods` VALUES (25860,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (25860,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (25860,302,3);    -- TRIPLE_ATTACK: 3
 INSERT INTO `item_mods` VALUES (25860,384,400);  -- HASTE_GEAR: 400
 
@@ -60645,6 +60828,7 @@ INSERT INTO `item_mods` VALUES (25861,29,5);     -- MDEF: 5
 INSERT INTO `item_mods` VALUES (25861,31,69);    -- MEVA: 69
 INSERT INTO `item_mods` VALUES (25861,68,41);    -- EVA: 41
 INSERT INTO `item_mods` VALUES (25861,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (25861,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (25861,302,4);    -- TRIPLE_ATTACK: 4
 INSERT INTO `item_mods` VALUES (25861,384,400);  -- HASTE_GEAR: 400
 
@@ -60928,6 +61112,7 @@ INSERT INTO `item_mods` VALUES (25880,29,5);     -- MDEF: 5
 INSERT INTO `item_mods` VALUES (25880,31,69);    -- MEVA: 69
 INSERT INTO `item_mods` VALUES (25880,68,41);    -- EVA: 41
 INSERT INTO `item_mods` VALUES (25880,161,-600); -- DMGPHYS: -600
+INSERT INTO `item_mods` VALUES (25880,164,-600); -- DMGRANGE: -600
 INSERT INTO `item_mods` VALUES (25880,302,5);    -- TRIPLE_ATTACK: 5
 INSERT INTO `item_mods` VALUES (25880,384,400);  -- HASTE_GEAR: 400
 
@@ -60997,6 +61182,7 @@ INSERT INTO `item_mods` VALUES (25927,29,5);     -- MDEF: 5
 INSERT INTO `item_mods` VALUES (25927,31,69);    -- MEVA: 69
 INSERT INTO `item_mods` VALUES (25927,68,74);    -- EVA: 74
 INSERT INTO `item_mods` VALUES (25927,161,-100); -- DMGPHYS: -100
+INSERT INTO `item_mods` VALUES (25927,164,-100); -- DMGRANGE: -100
 INSERT INTO `item_mods` VALUES (25927,365,5);    -- SNAPSHOT: 5
 INSERT INTO `item_mods` VALUES (25927,384,200);  -- HASTE_GEAR: 200
 
@@ -61017,6 +61203,7 @@ INSERT INTO `item_mods` VALUES (25928,29,5);     -- MDEF: 5
 INSERT INTO `item_mods` VALUES (25928,31,69);    -- MEVA: 69
 INSERT INTO `item_mods` VALUES (25928,68,74);    -- EVA: 74
 INSERT INTO `item_mods` VALUES (25928,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (25928,164,-200); -- DMGRANGE: -200
 INSERT INTO `item_mods` VALUES (25928,365,8);    -- SNAPSHOT: 8
 INSERT INTO `item_mods` VALUES (25928,384,200);  -- HASTE_GEAR: 200
 
@@ -62472,6 +62659,7 @@ INSERT INTO `item_mods` VALUES (26642,31,51);    -- MEVA: 51
 INSERT INTO `item_mods` VALUES (26642,68,17);    -- EVA: 17
 INSERT INTO `item_mods` VALUES (26642,119,12);   -- SINGING: 12
 INSERT INTO `item_mods` VALUES (26642,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (26642,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (26642,384,500);  -- HASTE_GEAR: 500
 
 -- Bihu Roundlet +1
@@ -62492,6 +62680,7 @@ INSERT INTO `item_mods` VALUES (26643,31,75);    -- MEVA: 75
 INSERT INTO `item_mods` VALUES (26643,68,38);    -- EVA: 38
 INSERT INTO `item_mods` VALUES (26643,119,14);   -- SINGING: 14
 INSERT INTO `item_mods` VALUES (26643,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (26643,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (26643,384,600);  -- HASTE_GEAR: 600
 
 -- Arcadian Beret
@@ -63089,6 +63278,7 @@ INSERT INTO `item_mods` VALUES (26698,29,2);     -- MDEF: 2
 INSERT INTO `item_mods` VALUES (26698,31,31);    -- MEVA: 31
 INSERT INTO `item_mods` VALUES (26698,68,17);    -- EVA: 17
 INSERT INTO `item_mods` VALUES (26698,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (26698,164,-200); -- DMGRANGE: -200
 INSERT INTO `item_mods` VALUES (26698,384,800);  -- HASTE_GEAR: 800
 
 -- Gallian Helm +1
@@ -64425,6 +64615,7 @@ INSERT INTO `item_mods` VALUES (26818,31,51);    -- MEVA: 51
 INSERT INTO `item_mods` VALUES (26818,68,17);    -- EVA: 17
 INSERT INTO `item_mods` VALUES (26818,119,12);   -- SINGING: 12
 INSERT INTO `item_mods` VALUES (26818,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (26818,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (26818,384,500);  -- HASTE_GEAR: 500
 
 -- Bihu Justaucorps +1
@@ -64445,6 +64636,7 @@ INSERT INTO `item_mods` VALUES (26819,30,29);    -- MACC: 29
 INSERT INTO `item_mods` VALUES (26819,31,80);    -- MEVA: 80
 INSERT INTO `item_mods` VALUES (26819,68,44);    -- EVA: 44
 INSERT INTO `item_mods` VALUES (26819,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (26819,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (26819,384,300);  -- HASTE_GEAR: 300
 
 -- Arcadian Jerkin
@@ -64692,6 +64884,7 @@ INSERT INTO `item_mods` VALUES (26832,29,3);     -- MDEF: 3
 INSERT INTO `item_mods` VALUES (26832,31,43);    -- MEVA: 43
 INSERT INTO `item_mods` VALUES (26832,68,23);    -- EVA: 23
 INSERT INTO `item_mods` VALUES (26832,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (26832,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (26832,384,400);  -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (26832,220,50);   -- RANDOM_DEAL_BONUS: 50
 
@@ -64713,6 +64906,7 @@ INSERT INTO `item_mods` VALUES (26833,29,6);     -- MDEF: 6
 INSERT INTO `item_mods` VALUES (26833,31,64);    -- MEVA: 64
 INSERT INTO `item_mods` VALUES (26833,68,49);    -- EVA: 49
 INSERT INTO `item_mods` VALUES (26833,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (26833,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (26833,384,400);  -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (26833,220,50);   -- RANDOM_DEAL_BONUS: 50
 
@@ -64763,6 +64957,7 @@ INSERT INTO `item_mods` VALUES (26836,29,3);     -- MDEF: 3
 INSERT INTO `item_mods` VALUES (26836,31,43);    -- MEVA: 43
 INSERT INTO `item_mods` VALUES (26836,68,23);    -- EVA: 23
 INSERT INTO `item_mods` VALUES (26836,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (26836,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (26836,253,20);   -- AMNESIARES: 20
 INSERT INTO `item_mods` VALUES (26836,384,400);  -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (26836,493,35);   -- VFLOURISH_MACC: 35
@@ -64784,6 +64979,7 @@ INSERT INTO `item_mods` VALUES (26837,29,6);     -- MDEF: 6
 INSERT INTO `item_mods` VALUES (26837,31,64);    -- MEVA: 64
 INSERT INTO `item_mods` VALUES (26837,68,49);    -- EVA: 49
 INSERT INTO `item_mods` VALUES (26837,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (26837,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (26837,253,25);   -- AMNESIARES: 25
 INSERT INTO `item_mods` VALUES (26837,384,400);  -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (26837,493,37);   -- VFLOURISH_MACC: 37
@@ -65230,6 +65426,7 @@ INSERT INTO `item_mods` VALUES (26881,29,4);     -- MDEF: 4
 INSERT INTO `item_mods` VALUES (26881,31,53);    -- MEVA: 53
 INSERT INTO `item_mods` VALUES (26881,68,41);    -- EVA: 41
 INSERT INTO `item_mods` VALUES (26881,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (26881,164,-200); -- DMGRANGE: -200
 INSERT INTO `item_mods` VALUES (26881,384,300);  -- HASTE_GEAR: 300
 
 -- Wildheitbrust
@@ -65249,6 +65446,7 @@ INSERT INTO `item_mods` VALUES (26882,29,4);     -- MDEF: 4
 INSERT INTO `item_mods` VALUES (26882,31,53);    -- MEVA: 53
 INSERT INTO `item_mods` VALUES (26882,68,41);    -- EVA: 41
 INSERT INTO `item_mods` VALUES (26882,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (26882,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (26882,384,300);  -- HASTE_GEAR: 300
 
 -- Sombra Harness
@@ -66426,6 +66624,7 @@ INSERT INTO `item_mods` VALUES (26976,29,1);     -- MDEF: 1
 INSERT INTO `item_mods` VALUES (26976,31,29);    -- MEVA: 29
 INSERT INTO `item_mods` VALUES (26976,68,10);    -- EVA: 10
 INSERT INTO `item_mods` VALUES (26976,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (26976,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (26976,384,400);  -- HASTE_GEAR: 400
 
 -- Agoge Mufflers +1
@@ -66443,6 +66642,7 @@ INSERT INTO `item_mods` VALUES (26977,29,2);     -- MDEF: 2
 INSERT INTO `item_mods` VALUES (26977,31,43);    -- MEVA: 43
 INSERT INTO `item_mods` VALUES (26977,68,22);    -- EVA: 22
 INSERT INTO `item_mods` VALUES (26977,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (26977,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (26977,384,500);  -- HASTE_GEAR: 500
 
 -- Hesychasts Gloves
@@ -66746,6 +66946,7 @@ INSERT INTO `item_mods` VALUES (26994,31,25);    -- MEVA: 25
 INSERT INTO `item_mods` VALUES (26994,68,11);    -- EVA: 11
 INSERT INTO `item_mods` VALUES (26994,121,9);    -- WIND: 9
 INSERT INTO `item_mods` VALUES (26994,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (26994,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (26994,384,300);  -- HASTE_GEAR: 300
 
 -- Bihu Cuffs +1
@@ -66765,6 +66966,7 @@ INSERT INTO `item_mods` VALUES (26995,31,37);    -- MEVA: 37
 INSERT INTO `item_mods` VALUES (26995,68,24);    -- EVA: 24
 INSERT INTO `item_mods` VALUES (26995,121,11);   -- WIND: 11
 INSERT INTO `item_mods` VALUES (26995,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (26995,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (26995,384,300);  -- HASTE_GEAR: 300
 
 -- Arcadian Bracers
@@ -66819,6 +67021,7 @@ INSERT INTO `item_mods` VALUES (26998,31,18);    -- MEVA: 18
 INSERT INTO `item_mods` VALUES (26998,68,10);    -- EVA: 10
 INSERT INTO `item_mods` VALUES (26998,94,8);     -- MEDITATE_DURATION: 8
 INSERT INTO `item_mods` VALUES (26998,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (26998,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (26998,384,300);  -- HASTE_GEAR: 300
 
 -- Sakonji Kote +1
@@ -66837,6 +67040,7 @@ INSERT INTO `item_mods` VALUES (26999,31,26);    -- MEVA: 26
 INSERT INTO `item_mods` VALUES (26999,68,22);    -- EVA: 22
 INSERT INTO `item_mods` VALUES (26999,94,8);     -- MEDITATE_DURATION: 8
 INSERT INTO `item_mods` VALUES (26999,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (26999,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (26999,384,400);  -- HASTE_GEAR: 400
 
 -- Mochizuki Tekko
@@ -67364,6 +67568,7 @@ INSERT INTO `item_mods` VALUES (27045,29,1);     -- MDEF: 1
 INSERT INTO `item_mods` VALUES (27045,31,36);    -- MEVA: 36
 INSERT INTO `item_mods` VALUES (27045,68,22);    -- EVA: 22
 INSERT INTO `item_mods` VALUES (27045,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (27045,164,-200); -- DMGRANGE: -200
 INSERT INTO `item_mods` VALUES (27045,384,400);  -- HASTE_GEAR: 400
 
 -- Acro Gauntlets
@@ -68530,6 +68735,7 @@ INSERT INTO `item_mods` VALUES (27140,29,2);     -- MDEF: 2
 INSERT INTO `item_mods` VALUES (27140,31,43);    -- MEVA: 43
 INSERT INTO `item_mods` VALUES (27140,68,41);    -- EVA: 41
 INSERT INTO `item_mods` VALUES (27140,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (27140,164,-200); -- DMGRANGE: -200
 INSERT INTO `item_mods` VALUES (27140,289,5);    -- SUBTLE_BLOW: 5
 INSERT INTO `item_mods` VALUES (27140,302,2);    -- TRIPLE_ATTACK: 2
 INSERT INTO `item_mods` VALUES (27140,384,500);  -- HASTE_GEAR: 500
@@ -68688,6 +68894,7 @@ INSERT INTO `item_mods` VALUES (27160,31,73);    -- MEVA: 73
 INSERT INTO `item_mods` VALUES (27160,68,12);    -- EVA: 12
 INSERT INTO `item_mods` VALUES (27160,115,17);   -- ELEM: 17
 INSERT INTO `item_mods` VALUES (27160,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (27160,164,-200); -- DMGRANGE: -200
 INSERT INTO `item_mods` VALUES (27160,344,30);   -- SPIKES_DMG: 30
 INSERT INTO `item_mods` VALUES (27160,384,400);  -- HASTE_GEAR: 400
 
@@ -68707,6 +68914,7 @@ INSERT INTO `item_mods` VALUES (27161,31,107);   -- MEVA: 107
 INSERT INTO `item_mods` VALUES (27161,68,27);    -- EVA: 27
 INSERT INTO `item_mods` VALUES (27161,115,19);   -- ELEM: 19
 INSERT INTO `item_mods` VALUES (27161,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (27161,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (27161,344,30);   -- SPIKES_DMG: 30
 INSERT INTO `item_mods` VALUES (27161,384,500);  -- HASTE_GEAR: 500
 
@@ -68759,6 +68967,7 @@ INSERT INTO `item_mods` VALUES (27164,29,1);     -- MDEF: 1
 INSERT INTO `item_mods` VALUES (27164,31,43);    -- MEVA: 43
 INSERT INTO `item_mods` VALUES (27164,68,10);    -- EVA: 10
 INSERT INTO `item_mods` VALUES (27164,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (27164,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (27164,384,500);  -- HASTE_GEAR: 500
 
 -- Caballarius Breeches +1
@@ -68776,6 +68985,7 @@ INSERT INTO `item_mods` VALUES (27165,29,3);     -- MDEF: 3
 INSERT INTO `item_mods` VALUES (27165,31,64);    -- MEVA: 64
 INSERT INTO `item_mods` VALUES (27165,68,22);    -- EVA: 22
 INSERT INTO `item_mods` VALUES (27165,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (27165,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (27165,384,500);  -- HASTE_GEAR: 500
 
 -- Fallens Flanchard
@@ -68857,6 +69067,7 @@ INSERT INTO `item_mods` VALUES (27170,30,16);    -- MACC: 16
 INSERT INTO `item_mods` VALUES (27170,31,73);    -- MEVA: 73
 INSERT INTO `item_mods` VALUES (27170,68,14);    -- EVA: 14
 INSERT INTO `item_mods` VALUES (27170,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (27170,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (27170,384,400);  -- HASTE_GEAR: 400
 
 -- Bihu Cannions +1
@@ -68874,6 +69085,7 @@ INSERT INTO `item_mods` VALUES (27171,30,27);    -- MACC: 27
 INSERT INTO `item_mods` VALUES (27171,31,107);   -- MEVA: 107
 INSERT INTO `item_mods` VALUES (27171,68,30);    -- EVA: 30
 INSERT INTO `item_mods` VALUES (27171,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (27171,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (27171,384,400);  -- HASTE_GEAR: 400
 
 -- Arcadian Braccae
@@ -69883,6 +70095,7 @@ INSERT INTO `item_mods` VALUES (27249,29,1);     -- MDEF: 1
 INSERT INTO `item_mods` VALUES (27249,31,58);    -- MEVA: 58
 INSERT INTO `item_mods` VALUES (27249,68,8);     -- EVA: 8
 INSERT INTO `item_mods` VALUES (27249,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (27249,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (27249,384,500);  -- HASTE_GEAR: 500
 INSERT INTO `item_mods` VALUES (27249,427,11);   -- ENMITY_LOSS_REDUCTION: 11
 
@@ -69900,6 +70113,7 @@ INSERT INTO `item_mods` VALUES (27250,29,3);     -- MDEF: 3
 INSERT INTO `item_mods` VALUES (27250,31,86);    -- MEVA: 86
 INSERT INTO `item_mods` VALUES (27250,68,19);    -- EVA: 19
 INSERT INTO `item_mods` VALUES (27250,161,-600); -- DMGPHYS: -600
+INSERT INTO `item_mods` VALUES (27250,164,-600); -- DMGRANGE: -600
 INSERT INTO `item_mods` VALUES (27250,384,500);  -- HASTE_GEAR: 500
 INSERT INTO `item_mods` VALUES (27250,427,12);   -- ENMITY_LOSS_REDUCTION: 12
 
@@ -70356,6 +70570,7 @@ INSERT INTO `item_mods` VALUES (27280,29,6);     -- MDEF: 6
 INSERT INTO `item_mods` VALUES (27280,31,107);   -- MEVA: 107
 INSERT INTO `item_mods` VALUES (27280,68,44);    -- EVA: 44
 INSERT INTO `item_mods` VALUES (27280,161,-700); -- DMGPHYS: -700
+INSERT INTO `item_mods` VALUES (27280,164,-700); -- DMGRANGE: -700
 INSERT INTO `item_mods` VALUES (27280,384,600);  -- HASTE_GEAR: 600
 INSERT INTO `item_mods` VALUES (27280,963,2);    -- INQUARTATA: 2
 
@@ -70965,6 +71180,7 @@ INSERT INTO `item_mods` VALUES (27346,31,73);    -- MEVA: 73
 INSERT INTO `item_mods` VALUES (27346,68,26);    -- EVA: 26
 INSERT INTO `item_mods` VALUES (27346,120,9);    -- STRING: 9
 INSERT INTO `item_mods` VALUES (27346,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (27346,164,-200); -- DMGRANGE: -200
 INSERT INTO `item_mods` VALUES (27346,384,300);  -- HASTE_GEAR: 300
 INSERT INTO `item_mods` VALUES (27346,455,7);    -- SONG_SPELLCASTING_TIME: 7
 
@@ -70985,6 +71201,7 @@ INSERT INTO `item_mods` VALUES (27347,31,107);   -- MEVA: 107
 INSERT INTO `item_mods` VALUES (27347,68,58);    -- EVA: 58
 INSERT INTO `item_mods` VALUES (27347,120,11);   -- STRING: 11
 INSERT INTO `item_mods` VALUES (27347,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (27347,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (27347,384,300);  -- HASTE_GEAR: 300
 INSERT INTO `item_mods` VALUES (27347,455,8);    -- SONG_SPELLCASTING_TIME: 8
 
@@ -71210,6 +71427,7 @@ INSERT INTO `item_mods` VALUES (27360,29,2);     -- MDEF: 2
 INSERT INTO `item_mods` VALUES (27360,31,47);    -- MEVA: 47
 INSERT INTO `item_mods` VALUES (27360,68,33);    -- EVA: 33
 INSERT INTO `item_mods` VALUES (27360,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (27360,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (27360,384,400);  -- HASTE_GEAR: 400
 
 -- Lanun Bottes +1
@@ -71228,6 +71446,7 @@ INSERT INTO `item_mods` VALUES (27361,29,5);     -- MDEF: 5
 INSERT INTO `item_mods` VALUES (27361,31,69);    -- MEVA: 69
 INSERT INTO `item_mods` VALUES (27361,68,72);    -- EVA: 72
 INSERT INTO `item_mods` VALUES (27361,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (27361,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (27361,384,400);  -- HASTE_GEAR: 400
 
 -- Pitre Babouches
@@ -71391,6 +71610,7 @@ INSERT INTO `item_mods` VALUES (27374,29,2);     -- MDEF: 2
 INSERT INTO `item_mods` VALUES (27374,31,86);    -- MEVA: 86
 INSERT INTO `item_mods` VALUES (27374,68,44);    -- EVA: 44
 INSERT INTO `item_mods` VALUES (27374,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (27374,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (27374,301,4);    -- PHALANX: 4
 INSERT INTO `item_mods` VALUES (27374,384,300);  -- HASTE_GEAR: 300
 INSERT INTO `item_mods` VALUES (27374,518,2);    -- SHIELDBLOCKRATE: 2
@@ -71409,6 +71629,7 @@ INSERT INTO `item_mods` VALUES (27375,29,2);     -- MDEF: 2
 INSERT INTO `item_mods` VALUES (27375,31,86);    -- MEVA: 86
 INSERT INTO `item_mods` VALUES (27375,68,44);    -- EVA: 44
 INSERT INTO `item_mods` VALUES (27375,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (27375,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (27375,301,5);    -- PHALANX: 5
 INSERT INTO `item_mods` VALUES (27375,384,300);  -- HASTE_GEAR: 300
 INSERT INTO `item_mods` VALUES (27375,518,3);    -- SHIELDBLOCKRATE: 3
@@ -72478,6 +72699,7 @@ INSERT INTO `item_mods` VALUES (27453,29,2);     -- MDEF: 2
 INSERT INTO `item_mods` VALUES (27453,31,73);    -- MEVA: 73
 INSERT INTO `item_mods` VALUES (27453,68,35);    -- EVA: 35
 INSERT INTO `item_mods` VALUES (27453,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (27453,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (27453,384,400);  -- HASTE_GEAR: 400
 
 -- Erilaz Greaves +1
@@ -72503,6 +72725,7 @@ INSERT INTO `item_mods` VALUES (27454,29,5);     -- MDEF: 5
 INSERT INTO `item_mods` VALUES (27454,31,107);   -- MEVA: 107
 INSERT INTO `item_mods` VALUES (27454,68,77);    -- EVA: 77
 INSERT INTO `item_mods` VALUES (27454,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (27454,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (27454,384,400);  -- HASTE_GEAR: 400
 
 -- Criers Gaiters
@@ -72546,6 +72769,7 @@ INSERT INTO `item_mods` VALUES (27466,62,20);    -- ATTP: 20
 INSERT INTO `item_mods` VALUES (27466,68,49);    -- EVA: 49
 INSERT INTO `item_mods` VALUES (27466,109,13);   -- SHIELD: 13
 INSERT INTO `item_mods` VALUES (27466,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (27466,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (27466,240,15);   -- SLEEPRES: 15
 INSERT INTO `item_mods` VALUES (27466,384,300);  -- HASTE_GEAR: 300
 
@@ -72781,6 +73005,7 @@ INSERT INTO `item_mods` VALUES (27496,30,10);    -- MACC: 10
 INSERT INTO `item_mods` VALUES (27496,31,75);    -- MEVA: 75
 INSERT INTO `item_mods` VALUES (27496,68,80);    -- EVA: 80
 INSERT INTO `item_mods` VALUES (27496,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (27496,164,-200); -- DMGRANGE: -200
 INSERT INTO `item_mods` VALUES (27496,289,6);    -- SUBTLE_BLOW: 6
 INSERT INTO `item_mods` VALUES (27496,302,2);    -- TRIPLE_ATTACK: 2
 INSERT INTO `item_mods` VALUES (27496,384,400);  -- HASTE_GEAR: 400
@@ -72882,6 +73107,7 @@ INSERT INTO `item_mods` VALUES (27537,840,2); -- ALL_WSDMG_ALL_HITS: 2
 INSERT INTO `item_mods` VALUES (27539,1,5);      -- DEF: 5
 INSERT INTO `item_mods` VALUES (27539,10,2);     -- VIT: 2
 INSERT INTO `item_mods` VALUES (27539,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (27539,164,-200); -- DMGRANGE: -200
 INSERT INTO `item_mods` VALUES (27539,291,1);    -- COUNTER: 1
 
 -- Eabani Earring
@@ -72921,6 +73147,7 @@ INSERT INTO `item_mods` VALUES (27553,562,5); -- MAGIC_CRITHITRATE: 5
 
 -- Wardens Ring
 INSERT INTO `item_mods` VALUES (27555,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (27555,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (27555,166,-5);   -- ENEMYCRITRATE: -5
 INSERT INTO `item_mods` VALUES (27555,255,10);   -- DEATHRES: 10
 
@@ -73398,6 +73625,7 @@ INSERT INTO `item_mods` VALUES (27669,29,1);     -- MDEF: 1
 INSERT INTO `item_mods` VALUES (27669,31,21);    -- MEVA: 21
 INSERT INTO `item_mods` VALUES (27669,68,15);    -- EVA: 15
 INSERT INTO `item_mods` VALUES (27669,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (27669,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (27669,384,600);  -- HASTE_GEAR: 600
 INSERT INTO `item_mods` VALUES (27669,966,1);    -- COVER_MAGIC_AND_RANGED: 1
 
@@ -73782,6 +74010,7 @@ INSERT INTO `item_mods` VALUES (27690,29,2);     -- MDEF: 2
 INSERT INTO `item_mods` VALUES (27690,31,32);    -- MEVA: 32
 INSERT INTO `item_mods` VALUES (27690,68,33);    -- EVA: 33
 INSERT INTO `item_mods` VALUES (27690,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (27690,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (27690,384,700);  -- HASTE_GEAR: 700
 INSERT INTO `item_mods` VALUES (27690,966,1);    -- COVER_MAGIC_AND_RANGED: 1
 INSERT INTO `item_mods` VALUES (27690,967,9);    -- COVER_DURATION: 9
@@ -74208,6 +74437,7 @@ INSERT INTO `item_mods` VALUES (27722,29,2);     -- MDEF: 2
 INSERT INTO `item_mods` VALUES (27722,31,32);    -- MEVA: 32
 INSERT INTO `item_mods` VALUES (27722,68,33);    -- EVA: 33
 INSERT INTO `item_mods` VALUES (27722,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (27722,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (27722,384,700);  -- HASTE_GEAR: 700
 INSERT INTO `item_mods` VALUES (27722,499,2);    -- ITEM_SUBEFFECT: 2
 INSERT INTO `item_mods` VALUES (27722,500,20);   -- ITEM_ADDEFFECT_DMG: 20
@@ -74495,6 +74725,7 @@ INSERT INTO `item_mods` VALUES (27744,29,2);     -- MDEF: 2
 INSERT INTO `item_mods` VALUES (27744,31,53);    -- MEVA: 53
 INSERT INTO `item_mods` VALUES (27744,68,36);    -- EVA: 36
 INSERT INTO `item_mods` VALUES (27744,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (27744,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (27744,384,800);  -- HASTE_GEAR: 800
 
 -- Felistris Mask
@@ -76813,6 +77044,7 @@ INSERT INTO `item_mods` VALUES (27917,29,2);     -- MDEF: 2
 INSERT INTO `item_mods` VALUES (27917,31,34);    -- MEVA: 34
 INSERT INTO `item_mods` VALUES (27917,68,21);    -- EVA: 21
 INSERT INTO `item_mods` VALUES (27917,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (27917,164,-300); -- DMGRANGE: -300
 
 -- Manibozho Jerkin
 INSERT INTO `item_mods` VALUES (27918,1,93);    -- DEF: 93
@@ -77819,6 +78051,7 @@ INSERT INTO `item_mods` VALUES (27985,31,37);    -- MEVA: 37
 INSERT INTO `item_mods` VALUES (27985,68,22);    -- EVA: 22
 INSERT INTO `item_mods` VALUES (27985,123,15);   -- GEOMANCY_SKILL: 15
 INSERT INTO `item_mods` VALUES (27985,161,-100); -- DMGPHYS: -100
+INSERT INTO `item_mods` VALUES (27985,164,-100); -- DMGRANGE: -100
 INSERT INTO `item_mods` VALUES (27985,384,300);  -- HASTE_GEAR: 300
 
 -- Gefechthentzes
@@ -78385,6 +78618,7 @@ INSERT INTO `item_mods` VALUES (28038,14,13);    -- CHR: 13
 INSERT INTO `item_mods` VALUES (28038,31,22);    -- MEVA: 22
 INSERT INTO `item_mods` VALUES (28038,68,16);    -- EVA: 16
 INSERT INTO `item_mods` VALUES (28038,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (28038,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (28038,166,-3);   -- ENEMYCRITRATE: -3
 INSERT INTO `item_mods` VALUES (28038,384,300);  -- HASTE_GEAR: 300
 
@@ -78400,6 +78634,7 @@ INSERT INTO `item_mods` VALUES (28039,14,15);    -- CHR: 15
 INSERT INTO `item_mods` VALUES (28039,31,23);    -- MEVA: 23
 INSERT INTO `item_mods` VALUES (28039,68,17);    -- EVA: 17
 INSERT INTO `item_mods` VALUES (28039,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (28039,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (28039,166,-4);   -- ENEMYCRITRATE: -4
 INSERT INTO `item_mods` VALUES (28039,384,300);  -- HASTE_GEAR: 300
 
@@ -78806,6 +79041,7 @@ INSERT INTO `item_mods` VALUES (28066,31,25);    -- MEVA: 25
 INSERT INTO `item_mods` VALUES (28066,68,10);    -- EVA: 10
 INSERT INTO `item_mods` VALUES (28066,123,15);   -- GEOMANCY_SKILL: 15
 INSERT INTO `item_mods` VALUES (28066,161,-100); -- DMGPHYS: -100
+INSERT INTO `item_mods` VALUES (28066,164,-100); -- DMGRANGE: -100
 INSERT INTO `item_mods` VALUES (28066,384,300);  -- HASTE_GEAR: 300
 
 -- Abatteur Subligar
@@ -79043,6 +79279,7 @@ INSERT INTO `item_mods` VALUES (28096,31,43);    -- MEVA: 43
 INSERT INTO `item_mods` VALUES (28096,68,10);    -- EVA: 10
 INSERT INTO `item_mods` VALUES (28096,113,15);   -- ENHANCE: 15
 INSERT INTO `item_mods` VALUES (28096,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (28096,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (28096,384,500);  -- HASTE_GEAR: 500
 
 -- Ignominy Flanchard
@@ -79412,6 +79649,7 @@ INSERT INTO `item_mods` VALUES (28117,31,64);    -- MEVA: 64
 INSERT INTO `item_mods` VALUES (28117,68,22);    -- EVA: 22
 INSERT INTO `item_mods` VALUES (28117,113,15);   -- ENHANCE: 15
 INSERT INTO `item_mods` VALUES (28117,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (28117,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (28117,384,500);  -- HASTE_GEAR: 500
 
 -- Ignominy Flanchard +1
@@ -80150,6 +80388,7 @@ INSERT INTO `item_mods` VALUES (28173,29,4);     -- MDEF: 4
 INSERT INTO `item_mods` VALUES (28173,31,80);    -- MEVA: 80
 INSERT INTO `item_mods` VALUES (28173,68,27);    -- EVA: 27
 INSERT INTO `item_mods` VALUES (28173,161,-200); -- DMGPHYS: -200
+INSERT INTO `item_mods` VALUES (28173,164,-200); -- DMGRANGE: -200
 INSERT INTO `item_mods` VALUES (28173,384,600);  -- HASTE_GEAR: 600
 
 -- Theurgists Slacks
@@ -80214,6 +80453,7 @@ INSERT INTO `item_mods` VALUES (28178,29,2);     -- MDEF: 2
 INSERT INTO `item_mods` VALUES (28178,31,54);    -- MEVA: 54
 INSERT INTO `item_mods` VALUES (28178,68,16);    -- EVA: 16
 INSERT INTO `item_mods` VALUES (28178,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (28178,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (28178,384,500);  -- HASTE_GEAR: 500
 
 -- Shabti Cuisses +1
@@ -80229,6 +80469,7 @@ INSERT INTO `item_mods` VALUES (28179,29,2);     -- MDEF: 2
 INSERT INTO `item_mods` VALUES (28179,31,56);    -- MEVA: 56
 INSERT INTO `item_mods` VALUES (28179,68,17);    -- EVA: 17
 INSERT INTO `item_mods` VALUES (28179,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (28179,164,-500); -- DMGRANGE: -500
 INSERT INTO `item_mods` VALUES (28179,384,500);  -- HASTE_GEAR: 500
 
 -- Haruspex Slops
@@ -80626,6 +80867,7 @@ INSERT INTO `item_mods` VALUES (28207,31,47);    -- MEVA: 47
 INSERT INTO `item_mods` VALUES (28207,68,17);    -- EVA: 17
 INSERT INTO `item_mods` VALUES (28207,111,15);   -- DIVINE: 15
 INSERT INTO `item_mods` VALUES (28207,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (28207,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (28207,384,600);  -- HASTE_GEAR: 600
 INSERT INTO `item_mods` VALUES (28207,958,6);    -- STATUSRES: 6
 
@@ -81787,6 +82029,7 @@ INSERT INTO `item_mods` VALUES (28289,29,2);     -- MDEF: 2
 INSERT INTO `item_mods` VALUES (28289,31,64);    -- MEVA: 64
 INSERT INTO `item_mods` VALUES (28289,68,49);    -- EVA: 49
 INSERT INTO `item_mods` VALUES (28289,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (28289,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (28289,384,300);  -- HASTE_GEAR: 300
 
 -- Shneddick Boots +1
@@ -81836,6 +82079,7 @@ INSERT INTO `item_mods` VALUES (28292,31,69);    -- MEVA: 69
 INSERT INTO `item_mods` VALUES (28292,68,72);    -- EVA: 72
 INSERT INTO `item_mods` VALUES (28292,73,5);     -- STORETP: 5
 INSERT INTO `item_mods` VALUES (28292,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (28292,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (28292,384,400);  -- HASTE_GEAR: 400
 
 -- Umbani Boots
@@ -82293,6 +82537,7 @@ INSERT INTO `item_mods` VALUES (28321,29,2);     -- MDEF: 2
 INSERT INTO `item_mods` VALUES (28321,31,47);    -- MEVA: 47
 INSERT INTO `item_mods` VALUES (28321,68,33);    -- EVA: 33
 INSERT INTO `item_mods` VALUES (28321,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (28321,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (28321,384,400);  -- HASTE_GEAR: 400
 
 -- Orvail Souliers +1
@@ -82353,6 +82598,7 @@ INSERT INTO `item_mods` VALUES (28327,25,13);    -- ACC: 13
 INSERT INTO `item_mods` VALUES (28327,31,37);    -- MEVA: 37
 INSERT INTO `item_mods` VALUES (28327,68,14);    -- EVA: 14
 INSERT INTO `item_mods` VALUES (28327,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (28327,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (28327,384,300);  -- HASTE_GEAR: 300
 
 -- Shneddick Boots
@@ -82622,6 +82868,7 @@ INSERT INTO `item_mods` VALUES (28344,13,14);    -- MND: 14
 INSERT INTO `item_mods` VALUES (28344,14,9);     -- CHR: 9
 INSERT INTO `item_mods` VALUES (28344,31,27);    -- MEVA: 27
 INSERT INTO `item_mods` VALUES (28344,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (28344,164,-300); -- DMGRANGE: -300
 INSERT INTO `item_mods` VALUES (28344,384,300);  -- HASTE_GEAR: 300
 
 -- Karieyh Sollerets
@@ -82838,6 +83085,7 @@ INSERT INTO `item_mods` VALUES (28388,288,-1); -- DOUBLE_ATTACK: -1
 INSERT INTO `item_mods` VALUES (28389,23,5);     -- ATT: 5
 INSERT INTO `item_mods` VALUES (28389,25,8);     -- ACC: 8
 INSERT INTO `item_mods` VALUES (28389,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (28389,164,-400); -- DMGRANGE: -400
 
 -- Fiend Torque
 INSERT INTO `item_mods` VALUES (28390,2,5); -- HP: 5
@@ -83108,6 +83356,7 @@ INSERT INTO `item_mods` VALUES (28436,249,15); -- GRAVITYRES: 15
 -- Flume Belt +1
 INSERT INTO `item_mods` VALUES (28437,1,15);     -- DEF: 15
 INSERT INTO `item_mods` VALUES (28437,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (28437,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (28437,516,2);    -- ABSORB_DMG_TO_MP: 2
 
 -- Chiners Belt +1
@@ -83367,6 +83616,7 @@ INSERT INTO `item_mods` VALUES (28491,14,5); -- CHR: 5
 -- Hibernation Earring
 INSERT INTO `item_mods` VALUES (28492,1,10);     -- DEF: 10
 INSERT INTO `item_mods` VALUES (28492,161,-100); -- DMGPHYS: -100
+INSERT INTO `item_mods` VALUES (28492,164,-100); -- DMGRANGE: -100
 
 -- Neritic Earring
 INSERT INTO `item_mods` VALUES (28493,11,2); -- AGI: 2
@@ -83518,6 +83768,7 @@ INSERT INTO `item_mods` VALUES (28529,2,15);     -- HP: 15
 INSERT INTO `item_mods` VALUES (28529,5,15);     -- MP: 15
 INSERT INTO `item_mods` VALUES (28529,18,10);    -- EARTH_MEVA: 10
 INSERT INTO `item_mods` VALUES (28529,161,-100); -- DMGPHYS: -100
+INSERT INTO `item_mods` VALUES (28529,164,-100); -- DMGRANGE: -100
 
 -- Dumakulems Ring
 INSERT INTO `item_mods` VALUES (28530,9,4);  -- DEX: 4
@@ -83676,6 +83927,7 @@ INSERT INTO `item_mods` VALUES (28577,375,5); -- CURE_POTENCY_RCVD: 5
 -- Patricius Ring
 INSERT INTO `item_mods` VALUES (28578,25,7);     -- ACC: 7
 INSERT INTO `item_mods` VALUES (28578,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (28578,164,-500); -- DMGRANGE: -500
 
 -- Kayres Ring
 INSERT INTO `item_mods` VALUES (28579,2,70); -- HP: 70
@@ -83885,6 +84137,7 @@ INSERT INTO `item_mods` VALUES (28614,1,10);     -- DEF: 10
 INSERT INTO `item_mods` VALUES (28614,10,8);     -- VIT: 8
 INSERT INTO `item_mods` VALUES (28614,18,20);    -- EARTH_MEVA: 20
 INSERT INTO `item_mods` VALUES (28614,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (28614,164,-400); -- DMGRANGE: -400
 INSERT INTO `item_mods` VALUES (28614,462,3);    -- EARTH_ABSORB: 3
 
 -- Toro Cape
@@ -84050,11 +84303,13 @@ INSERT INTO `item_mods` VALUES (28638,25,15);    -- ACC: 15
 INSERT INTO `item_mods` VALUES (28638,28,10);    -- MATT: 10
 INSERT INTO `item_mods` VALUES (28638,68,15);    -- EVA: 15
 INSERT INTO `item_mods` VALUES (28638,161,-300); -- DMGPHYS: -300
+INSERT INTO `item_mods` VALUES (28638,164,-300); -- DMGRANGE: -300
 
 -- Repulse Mantle
 INSERT INTO `item_mods` VALUES (28639,1,17);     -- DEF: 17
 INSERT INTO `item_mods` VALUES (28639,2,30);     -- HP: 30
 INSERT INTO `item_mods` VALUES (28639,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (28639,164,-400); -- DMGRANGE: -400
 
 -- Pahtli Cape
 INSERT INTO `item_mods` VALUES (28640,1,16);  -- DEF: 16
@@ -84209,6 +84464,7 @@ INSERT INTO `item_mods` VALUES (28664,10,10);    -- VIT: 10
 INSERT INTO `item_mods` VALUES (28664,29,5);     -- MDEF: 5
 INSERT INTO `item_mods` VALUES (28664,109,100);  -- SHIELD: 100
 INSERT INTO `item_mods` VALUES (28664,161,-700); -- DMGPHYS: -700
+INSERT INTO `item_mods` VALUES (28664,164,-700); -- DMGRANGE: -700
 
 -- Killedar Shield +1
 INSERT INTO `item_mods` VALUES (28665,1,61);     -- DEF: 61
@@ -84217,6 +84473,7 @@ INSERT INTO `item_mods` VALUES (28665,10,11);    -- VIT: 11
 INSERT INTO `item_mods` VALUES (28665,29,6);     -- MDEF: 6
 INSERT INTO `item_mods` VALUES (28665,109,106);  -- SHIELD: 106
 INSERT INTO `item_mods` VALUES (28665,161,-800); -- DMGPHYS: -800
+INSERT INTO `item_mods` VALUES (28665,164,-800); -- DMGRANGE: -800
 
 -- Coalition Shield
 INSERT INTO `item_mods` VALUES (28666,1,33); -- DEF: 33
@@ -84229,6 +84486,7 @@ INSERT INTO `item_mods` VALUES (28667,10,7);     -- VIT: 7
 INSERT INTO `item_mods` VALUES (28667,13,7);     -- MND: 7
 INSERT INTO `item_mods` VALUES (28667,20,25);    -- WATER_MEVA: 25
 INSERT INTO `item_mods` VALUES (28667,161,-800); -- DMGPHYS: -800
+INSERT INTO `item_mods` VALUES (28667,164,-800); -- DMGRANGE: -800
 
 -- Matamata Shield +1
 INSERT INTO `item_mods` VALUES (28668,1,32);     -- DEF: 32
@@ -84238,6 +84496,7 @@ INSERT INTO `item_mods` VALUES (28668,10,8);     -- VIT: 8
 INSERT INTO `item_mods` VALUES (28668,13,8);     -- MND: 8
 INSERT INTO `item_mods` VALUES (28668,20,26);    -- WATER_MEVA: 26
 INSERT INTO `item_mods` VALUES (28668,161,-900); -- DMGPHYS: -900
+INSERT INTO `item_mods` VALUES (28668,164,-900); -- DMGRANGE: -900
 
 -- Butznar Shield +1
 INSERT INTO `item_mods` VALUES (28669,1,36);     -- DEF: 36
@@ -84246,6 +84505,7 @@ INSERT INTO `item_mods` VALUES (28669,8,8);      -- STR: 8
 INSERT INTO `item_mods` VALUES (28669,10,8);     -- VIT: 8
 INSERT INTO `item_mods` VALUES (28669,13,8);     -- MND: 8
 INSERT INTO `item_mods` VALUES (28669,161,-500); -- DMGPHYS: -500
+INSERT INTO `item_mods` VALUES (28669,164,-500); -- DMGRANGE: -500
 
 -- Leafkin Shield
 INSERT INTO `item_mods` VALUES (28670,1,1); -- DEF: 1
@@ -84257,6 +84517,7 @@ INSERT INTO `item_mods` VALUES (28671,8,7);      -- STR: 7
 INSERT INTO `item_mods` VALUES (28671,10,7);     -- VIT: 7
 INSERT INTO `item_mods` VALUES (28671,13,7);     -- MND: 7
 INSERT INTO `item_mods` VALUES (28671,161,-400); -- DMGPHYS: -400
+INSERT INTO `item_mods` VALUES (28671,164,-400); -- DMGRANGE: -400
 
 -- Kendatsuba Sune-Ate +1
 INSERT INTO `item_mods` VALUES (25959, 1, 81);    -- DEF: 81

--- a/sql/item_mods_pet.sql
+++ b/sql/item_mods_pet.sql
@@ -77,6 +77,7 @@ INSERT INTO `item_mods_pet` VALUES (10915,27,-3,0); -- All Pets - ENMITY: -3
 
 -- Oneiros Cappa
 INSERT INTO `item_mods_pet` VALUES (10972,161,-300,0); -- All Pets - DMGPHYS: -300
+INSERT INTO `item_mods_pet` VALUES (10972,164,-300,0); -- All Pets - DMGRANGE: -300
 
 -- Esper Earring
 INSERT INTO `item_mods_pet` VALUES (11052,126,3,1); -- Avatar - BP_DAMAGE: 3
@@ -324,6 +325,7 @@ INSERT INTO `item_mods_pet` VALUES (16270,2,50,2); -- Wyvern - HP: 50
 
 -- Shepherds Chain
 INSERT INTO `item_mods_pet` VALUES (16297,161,-200,0); -- All Pets - DMGPHYS: -200
+INSERT INTO `item_mods_pet` VALUES (16297,164,-200,0); -- All Pets - DMGRANGE: -200
 
 -- Puppetry Churidars +1
 INSERT INTO `item_mods_pet` VALUES (16351,168,10,3); -- Automaton - SPELLINTERRUPT: 10
@@ -827,6 +829,7 @@ INSERT INTO `item_mods_pet` VALUES (23195,160,-1200,8); -- Luopan - DMG: -1200
 
 -- Ankusa Gloves +2
 INSERT INTO `item_mods_pet` VALUES (23205,161,-500,0); -- Pet: DMGPHYS: -5%
+INSERT INTO `item_mods_pet` VALUES (23205,164,-500,0); -- Pet: DMGRANGE -5%
 
 -- Pteroslaver finger gauntlets +2
 INSERT INTO `item_mods_pet` VALUES (23210,163,-1000,2); -- Wyvern: DMGMAGIC: -1000
@@ -880,6 +883,7 @@ INSERT INTO `item_mods_pet` VALUES (23272,384,500,0); -- Pet: HASTE_GEAR: 5%
 
 -- Pteroslaver brais +2
 INSERT INTO `item_mods_pet` VALUES (23277,161,-1000,2); -- Wyvern: DMGPHYS: -10%
+INSERT INTO `item_mods_pet` VALUES (23277,164,-1000,2); -- Wyvern: DMGRANGE -10%
 
 -- Pteroslaver brais +2
 INSERT INTO `item_mods_pet` VALUES (23278,28,44,1); -- Avatar: MATT: 44
@@ -927,6 +931,7 @@ INSERT INTO `item_mods_pet` VALUES (23325,384,400,3); -- Automaton - HASTE_GEAR:
 -- Ankusa Gaiters +2
 INSERT INTO `item_mods_pet` VALUES (23339,68,28,0);    -- Pet: EVA: 28
 INSERT INTO `item_mods_pet` VALUES (23339,161,-400,0); -- Pet: DMGPHYS: -4%
+INSERT INTO `item_mods_pet` VALUES (23339,164,-400,0); -- Pet: DMGRANGE -4%
 
 -- Pteroslaver greaves +2
 INSERT INTO `item_mods_pet` VALUES (23344,2,260,2); -- Wyvern: HP: 260
@@ -1018,6 +1023,7 @@ INSERT INTO `item_mods_pet` VALUES (23660,384,500,3); -- Automaton - HASTE_GEAR:
 -- Ankusa Gaiters +3
 INSERT INTO `item_mods_pet` VALUES (23674,68,38,0);    -- All Pets - EVA: 38
 INSERT INTO `item_mods_pet` VALUES (23674,161,-500,0); -- All Pets - DMGPHYS: -500
+INSERT INTO `item_mods_pet` VALUES (23674,164,-500,0); -- All Pets - DMGRANGE: -500
 
 -- Pteroslaver Greaves +3
 INSERT INTO `item_mods_pet` VALUES (23679,2,290,2);  -- Wyvern - HP: 290
@@ -1307,9 +1313,11 @@ INSERT INTO `item_mods_pet` VALUES (26927,126,11,1); -- Avatar - BP_DAMAGE: 11
 
 -- Ankusa Gloves
 INSERT INTO `item_mods_pet` VALUES (26992,161,-300,0); -- Pet: DMGPHYS: -3%
+INSERT INTO `item_mods_pet` VALUES (26992,164,-300,0); -- Pet: DMGRANGE -3%
 
 -- Ankusa Gloves +1
 INSERT INTO `item_mods_pet` VALUES (26993,161,-400,0); -- Pet: DMGPHYS: -4%
+INSERT INTO `item_mods_pet` VALUES (26993,164,-400,0); -- Pet: DMGRANGE -4%
 
 -- Glyphic Bracers
 INSERT INTO `item_mods_pet` VALUES (27004,25,20,1);   -- Avatar - ACC: 20
@@ -1396,10 +1404,12 @@ INSERT INTO `item_mods_pet` VALUES (27299,288,5,0); -- All Pets - DOUBLE_ATTACK:
 -- Ankusa Gaiters
 INSERT INTO `item_mods_pet` VALUES (27344,68,15,0);    -- Pet: EVA: 15
 INSERT INTO `item_mods_pet` VALUES (27344,161,-300,0); -- Pet: DMGPHYS: -3%
+INSERT INTO `item_mods_pet` VALUES (27344,164,-300,0); -- Pet: DMGRANGE -3%
 
 -- Ankusa Gaiters +1
 INSERT INTO `item_mods_pet` VALUES (27345,68,18,0);    -- Pet: EVA: 18
 INSERT INTO `item_mods_pet` VALUES (27345,161,-300,0); -- Pet: DMGPHYS: -3%
+INSERT INTO `item_mods_pet` VALUES (27345,164,-300,0); -- Pet: DMGRANGE -3%
 
 -- Glyphic Pigaches
 INSERT INTO `item_mods_pet` VALUES (27356,23,28,1); -- Avatar - ATT: 28
@@ -1607,9 +1617,11 @@ INSERT INTO `item_mods_pet` VALUES (28432,384,500,3); -- Automaton - HASTE_GEAR:
 
 -- Handlers Earring (Checked)
 INSERT INTO `item_mods_pet` VALUES (28490,161,-300,0); -- All Pets - DMGPHYS: -300
+INSERT INTO `item_mods_pet` VALUES (28490,164,-300,0); -- All Pets - DMGRANGE: -300
 
 -- Handlers Earring +1 (Checked)
 INSERT INTO `item_mods_pet` VALUES (28491,161,-400,0); -- All Pets - DMGPHYS: -400
+INSERT INTO `item_mods_pet` VALUES (28491,164,-400,0); -- All Pets - DMGRANGE: -400
 
 -- Rimeice Earring
 INSERT INTO `item_mods_pet` VALUES (28495,27,5,0);    -- All Pets - ENMITY: 5


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This is a reimplementation from downstream at ASB:
https://github.com/AirSkyBoat/AirSkyBoat/commit/9abd2ebdba64a95f51372b04efdaab4e09664e35

It adds -Ranged DT to sources granting -Physical DT (specifically items and Sentinel)

Originally authored by @TiberonKalkaz (added as co-author to this commit)

## Steps to test these changes

- Equip any of the items modified (eg: Cheviot Cape) and confirm that they lower ranged damage taken
- Use Sentinel and confirm that it lowers ranged damage taken
- Alternatively you can use `!getmod DMGRANGE` to see exact values

## Sentinel Testing
![image](https://github.com/user-attachments/assets/18b230c9-3a17-4ef1-b80e-89e2e0b6c3c4)

## Cheviot Cape Testing
| Before | After |
|-|-|
| ![image](https://github.com/user-attachments/assets/9bb54b62-36ad-476f-80fb-3467dc16525d) | ![image](https://github.com/user-attachments/assets/732a4976-e29a-4d1c-9681-08b18883ec85) |

