### PR TITLE
Move auto attack damage to lua

### DIFF
--- a/scripts/enum/physical_attack_type.lua
+++ b/scripts/enum/physical_attack_type.lua
@@ -1,0 +1,20 @@
+-----------------------------------
+-- Physical Attack Type
+-----------------------------------
+xi = xi or {}
+
+---@enum xi.physicalAttackType
+xi.physicalAttackType =
+{
+    NORMAL     = 0,
+    DOUBLE     = 1,
+    TRIPLE     = 2,
+    ZANSHIN    = 3,
+    KICK       = 4,
+    RANGED     = 5,
+    RAPID_SHOT = 6,
+    SAMBA      = 7,
+    QUAD       = 8,
+    DAKEN      = 9,
+    FOLLOWUP   = 10,
+}

--- a/scripts/globals/combat/effect_utilities.lua
+++ b/scripts/globals/combat/effect_utilities.lua
@@ -1,0 +1,77 @@
+xi = xi or {}
+xi.combat = xi.combat or {}
+xi.combat.effect = xi.combat.effect or {}
+
+xi.combat.effect.handleConsumeMana = function(player)
+    local damage = 0
+
+    if player:hasStatusEffect(xi.effect.CONSUME_MANA) then
+        damage = damage + math.floor(player:getMP() / 10)
+        player:setMP(0)
+        player:delStatusEffect(xi.effect.CONSUME_MANA)
+    end
+
+    return damage
+end
+
+xi.combat.effect.handleSoulEater = function(player, damage)
+    if player:hasStatusEffect(xi.effect.SOULEATER) then
+        -- Souleater's HP consumed is 10% (base) + x% from gear (only highest) + x% from gear augments.
+        local souleaterBonus = player:getMaxGearMod(xi.mod.SOULEATER_EFFECT) * 0.01
+        local souleaterBonusII = player:getMod(xi.mod.SOULEATER_EFFECT_II) * 0.01
+        local stalwartSoulBonus = 1 - player:getMod(xi.mod.STALWART_SOUL) / 100
+        local bonusDamage = player:getHP() * (0.1 + souleaterBonus + souleaterBonusII)
+
+        if bonusDamage >= 1 then
+            player:addHP(-utils.stoneskin(player, math.floor(bonusDamage * stalwartSoulBonus)))
+
+            if player:getMainJob() == xi.job.DRK then
+                damage = math.floor(damage + bonusDamage)
+            else
+                damage = math.floor(damage + (bonusDamage / 2))
+            end
+        end
+    end
+
+    return damage
+end
+
+xi.combat.effect.handleRestraint = function(player)
+    if player:hasStatusEffect(xi.effect.RESTRAINT) then
+        local effect = player:getStatusEffect(xi.effect.RESTRAINT)
+        if effect == nil then
+            return
+        end
+
+        local power = effect:getPower()
+
+        if effect:getPower() < 30 then
+            local jpBonus = 0
+
+            if player:isPC() then
+                jpBonus = player:getJobPointLevel(xi.jp.RESTRAINT) * 2
+            end
+
+            -- Convert weapon delay and divide
+            -- Pull remainder of previous hit's value from Effect Sub Power
+            local boostPerRound = ((player:getBaseDelay() / 1000) * 60) / 385
+            local remainder = effect:getSubPower() / 100
+
+            -- Calculate bonuses from Enhances Restraint, Job Point upgrades, and remainder from previous hit
+            boostPerRound = (boostPerRound * (1 + player:getMod(xi.Mod.ENHANCES_RESTRAINT) / 100) * (1 + jpBonus / 100)) + remainder
+
+            -- Calculate new remainder and multiply by 100 so significant digits aren't lost
+            remainder = math.floor((1 - (math.ceil(boostPerRound) - boostPerRound)) * 100)
+            boostPerRound = math.floor(boostPerRound)
+
+            -- Cap total power to +30% WSD
+            if power + boostPerRound > 30 then
+                boostPerRound = 30 - power
+            end
+
+            effect:setPower(power + boostPerRound)
+            effect:setSubPower(remainder)
+            player:setMod(xi.mod.ALL_WSDMG_FIRST_HIT, boostPerRound)
+        end
+    end
+end

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -3266,6 +3266,11 @@ end
 function CBaseEntity:getWeaponHitCount(offhand)
 end
 
+---@nodiscard
+---@return integer
+function CBaseEntity:addDamageFromMultipliers(damage, attackType, weaponSlot, allowProc)
+end
+
 ---@return nil
 function CBaseEntity:removeAmmo()
 end

--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -98,6 +98,9 @@ xi.settings.map =
     -- Disables Treasure Hunter procs (Era behavior wants this true)
     DISABLE_TREASURE_HUNTER_PROCS = false,
 
+    -- Enable auto attack damage calculations in Lua
+    ENABLE_AUTO_ATTACK_LUA = false,
+
     -- Weaponskill point base (before skillchain) for breaking latent - whole numbers only. retail is 5.
     WS_POINTS_BASE = 5,
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -15051,6 +15051,24 @@ uint16 CLuaBaseEntity::getWeaponHitCount(bool offhand)
 }
 
 /************************************************************************
+ *  Function: addDamageFromMultipliers()
+ *  Purpose : Adds damage multipliers from relics, etc.
+ *  Example : damage = attacker:addDamageFromMultipliers(damage, physicalAttackType, slot, isFirstSwing)
+ ************************************************************************/
+
+uint32 CLuaBaseEntity::addDamageFromMultipliers(uint32 damage, PHYSICAL_ATTACK_TYPE attackType, uint8 weaponSlot, bool allowProc)
+{
+    if (CCharEntity* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
+    {
+        CItemWeapon* PWeapon = dynamic_cast<CItemWeapon*>(PChar->getEquip((SLOTTYPE)weaponSlot));
+
+        return attackutils::CheckForDamageMultiplier(PChar, PWeapon, damage, attackType, weaponSlot, allowProc);
+    }
+
+    return damage;
+}
+
+/************************************************************************
  *  Function: removeAmmo()
  *  Purpose : Expends one item in the ammo slot (arrow,bullet, etc)
  *  Example : player:removeAmmo()
@@ -19899,6 +19917,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("getRangedDmgRank", CLuaBaseEntity::getRangedDmgRank);
     SOL_REGISTER("getAmmoDmg", CLuaBaseEntity::getAmmoDmg);
     SOL_REGISTER("getWeaponHitCount", CLuaBaseEntity::getWeaponHitCount);
+    SOL_REGISTER("addDamageFromMultipliers", CLuaBaseEntity::addDamageFromMultipliers);
 
     SOL_REGISTER("removeAmmo", CLuaBaseEntity::removeAmmo);
 

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -747,6 +747,7 @@ public:
     uint16 getRangedDmgRank();              // Get ranged weapond DMG rating used for calculating rank
     uint16 getAmmoDmg();                    // Get ammo DMG rating
     uint16 getWeaponHitCount(bool offhand); // Get PC weapon hit count (Occasionally Attacks N times weapons)
+    uint32 addDamageFromMultipliers(uint32 damage, PHYSICAL_ATTACK_TYPE attackType, uint8 weaponSlot, bool allowProc);
 
     void removeAmmo();
 

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -38,6 +38,7 @@ extern sol::state lua;
 
 #include "common/xi.h"
 
+#include "attack.h"
 #include "items/item_equipment.h"
 #include "spell.h"
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Everything is conditioned on ENABLE_AUTO_ATTACK_LUA in map.lua
- Moves damage calculations from CAttack::ProcessDamage() to lua
- Adds lua versions of doConsumeMana and doSoulEater
- Adds lua binding for attackutils::CheckForDamageMultiplier

The first pull request working towards a version of https://github.com/LandSandBoat/server/pull/7461

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Observe auto attack damage under the various affected conditions.
