### PR TITLE
[core] Check for throwing weapons in baseentity getStat

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -14402,7 +14402,15 @@ uint16 CLuaBaseEntity::getStat(uint16 statId, sol::variadic_args va)
                 }
                 else
                 {
-                    value = PEntity->RATT(SKILL_MARKSMANSHIP); // TODO: does this edge case exist? will mobs or trusts hit this?
+                    PWeapon = dynamic_cast<CItemWeapon*>(PEntity->m_Weapons[SLOTTYPE::SLOT_AMMO]);
+                    if (PWeapon)
+                    {
+                        value = PEntity->RATT(PWeapon->getSkillType());
+                    }
+                    else
+                    {
+                        value = PEntity->RATT(SKILL_MARKSMANSHIP); // TODO: does this edge case exist? will mobs or trusts hit this?
+                    }
                 }
             }
         }

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -14409,6 +14409,7 @@ uint16 CLuaBaseEntity::getStat(uint16 statId, sol::variadic_args va)
                     }
                     else
                     {
+                        ShowError("CLuaBaseEntity::getStat(): Ranged attack with no ranged weapon or ammo, defaulting to marksmanship");
                         value = PEntity->RATT(SKILL_MARKSMANSHIP); // TODO: does this edge case exist? will mobs or trusts hit this?
                     }
                 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do? 

PR #7450 fixed the bug where ranged PDIF was based on marksmanship skill when using a thrown weapon, but the damage dealt was still based on marksmanship skill, not throwing skill. This PR fixes that issue.

## Steps to test these changes

On base branch, `!setskill MARKSMANSHIP 0`, then throw a shuriken at a mob. It will do very little damage. Then, `!setskill MARKSMANSHIP 300`, throw another shuriken, and you'll see a large increase in damage.

Do the same experiment with this PR and you'll see shuriken/boomerang/dart/pebble damage should depend only on throwing skill.
