### PR TITLE
Prevent position saving if character is in disappear/zoning

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -5207,6 +5207,11 @@ namespace charutils
     {
         TracyZoneScoped;
 
+        if (PChar->status == STATUS_TYPE::DISAPPEAR)
+        {
+            return;
+        }
+
         const char* Query = "UPDATE chars "
                             "SET "
                             "pos_rot = %u,"


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Saw this PR'd to Eden, seems like a no-brainer

```
Do not save player position to database if it has Disappear status, which is used for zoning.
```