### PR TITLE
Fix Rycharde the Chef quest event not starting

### DIFF
--- a/scripts/quests/otherAreas/RQ1_Rycharde_the_Chef.lua
+++ b/scripts/quests/otherAreas/RQ1_Rycharde_the_Chef.lua
@@ -32,9 +32,9 @@ quest.sections =
             {
                 onTrigger = function(player, npc)
                     if quest:getVar(player, 'Prog') == 2 then
-                        quest:progressEvent(70, xi.item.SLICE_OF_DHALMEL_MEAT)
+                        return quest:progressEvent(70, xi.item.SLICE_OF_DHALMEL_MEAT)
                     elseif quest:getVar(player, 'Prog') > 2 then
-                        quest:progressEvent(71, xi.item.SLICE_OF_DHALMEL_MEAT)
+                        return quest:progressEvent(71, xi.item.SLICE_OF_DHALMEL_MEAT)
                     end
                 end,
             },
@@ -43,9 +43,9 @@ quest.sections =
             {
                 onTrigger = function(player, npc)
                     if quest:getVar(player, 'Prog') == 1 then
-                        quest:progressEvent(60)
+                        return quest:progressEvent(60)
                     elseif quest:getVar(player, 'Prog') > 1 then
-                        quest:event(68)
+                        return quest:event(68)
                     end
                 end,
             },

--- a/scripts/quests/outlands/You_Call_That_a_Knife.lua
+++ b/scripts/quests/outlands/You_Call_That_a_Knife.lua
@@ -158,7 +158,7 @@ quest.sections =
         {
             ['Mhebi_Juhbily'] = quest:progressEvent(133),
 
-            ['Vah_Keshura'] =  quest:event(132),
+            ['Vah_Keshura'] = quest:event(132),
 
             onEventFinish =
             {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes issue with quest event not starting (and a random extra space that I found while searching this issue).

## Steps to test these changes

`!gotoid 17797137`, talk to Numi, ask for work, `!gotoid 17797128`, talk to Take, progress the quest.