### PR TITLE
Implement tandem strike + tandem blow

### DIFF
--- a/scripts/globals/combat/magic_hit_rate.lua
+++ b/scripts/globals/combat/magic_hit_rate.lua
@@ -318,6 +318,21 @@ local function magicAccuracyFromWeatherElement(actor, actionElement)
     return magicAcc
 end
 
+-- Magic Accuracy from Tandem Strike (BST trait).
+local function magicAccuracyFromTandemStrike(actor)
+    local magicAcc = 0
+
+    if actor:isTandemActive() then
+        if actor:getMaster() ~= nil and actor:getMaster():isPC() then
+            magicAcc = actor:getMaster():getMod(xi.mod.TANDEM_STRIKE_POWER)
+        else
+            magicAcc = actor:getMod(xi.mod.TANDEM_STRIKE_POWER)
+        end
+    end
+
+    return magicAcc
+end
+
 -- Magic Accuracy from Food.
 local function magicAccuracyFromFoodMultiplier(actor)
     local magicAcc          = 1
@@ -369,13 +384,14 @@ xi.combat.magicHitRate.calculateActorMagicAccuracy = function(actor, target, spe
     local magicAccBurst     = magicAccuracyFromMagicBurst(target, actionElement, statUsed)
     local magicAccDay       = magicAccuracyFromDayElement(actor, actionElement)
     local magicAccWeather   = magicAccuracyFromWeatherElement(actor, actionElement)
+    local magicAccTandem    = magicAccuracyFromTandemStrike(actor)
 
     -- Multipliers
     local magicAccFoodFactor      = magicAccuracyFromFoodMultiplier(actor)
     local magicAccSoulVoiceFactor = magicAccuracyFromSoulVoiceMultiplier(actor, skillType, effectId)
 
     -- Add up food magic accuracy.
-    finalMagicAcc = magicAccBase + magicAccSkill + magicAccElement + magicAccStatDiff + magicAccEffects + magicAccMerits + magicAccJobPoints + magicAccBurst + magicAccDay + magicAccWeather + bonusMacc
+    finalMagicAcc = magicAccBase + magicAccSkill + magicAccElement + magicAccStatDiff + magicAccEffects + magicAccMerits + magicAccJobPoints + magicAccBurst + magicAccDay + magicAccWeather + magicAccTandem + bonusMacc
     finalMagicAcc = math.floor(finalMagicAcc * magicAccFoodFactor * magicAccSoulVoiceFactor)
 
     return finalMagicAcc

--- a/scripts/globals/combat/tp.lua
+++ b/scripts/globals/combat/tp.lua
@@ -121,6 +121,20 @@ xi.combat.tp.calculateTPReturn = function(gainee, delay)
     return math.floor(tpReturn)
 end
 
+-- Bonus subtle blow II from Tandem Blow (BST trait)
+xi.combat.tp.getTandemBlowBonus = function(actor)
+    local tandemBlowBonus = 0
+    if actor:isTandemActive() then
+        if actor:getMaster() ~= nil and actor:getMaster():isPC() then
+            tandemBlowBonus = actor:getMaster():getMod(xi.mod.TANDEM_BLOW_POWER)
+        else
+            tandemBlowBonus = actor:getMod(xi.mod.TANDEM_BLOW_POWER)
+        end
+    end
+
+    return tandemBlowBonus
+end
+
 -- TODO: does Ikishoten factor into this as a bonus to baseTPGain if it procs on the hit? Needs verification.
 xi.combat.tp.calculateTPGainOnPhysicalDamage = function(totalDamage, delay, actor, target)
     -- TODO: does dAGI penalty work against/for Trusts/Pets? Nothing is documented for this. Currently assuming mob only.
@@ -132,7 +146,8 @@ xi.combat.tp.calculateTPGainOnPhysicalDamage = function(totalDamage, delay, acto
         local dAGIModifier       = utils.clamp(200 - (dAGI + 30) / 200, 1.0, 0.5)                    -- 50% reduction at +70 dAGI: https://www.bg-wiki.com/ffxi/Monster_TP_gain
         local subtleBlowMerits   = actor:getMerit(xi.merit.SUBTLE_BLOW_EFFECT)
         local subtleBlowI        = math.min(actor:getMod(xi.mod.SUBTLE_BLOW) + subtleBlowMerits, 50) -- cap of 50% https://www.bg-wiki.com/ffxi/Subtle_Blow
-        local subtleBlowII       = actor:getMod(xi.mod.SUBTLE_BLOW_II)                               -- no known cap
+        local tandemBlowBonus    = xi.combat.tp.getTandemBlowBonus(actor)
+        local subtleBlowII       = actor:getMod(xi.mod.SUBTLE_BLOW_II) + tandemBlowBonus             -- no known cap
         local subtleBlowModifier = math.max((100 - subtleBlowI + subtleBlowII) / 100, 0.25)          -- combined cap of 75% reduction: https://www.bg-wiki.com/ffxi/Subtle_Blow
         local storeTPModifier    = (100 + target:getMod(xi.mod.STORETP)) / 100
 
@@ -164,7 +179,8 @@ xi.combat.tp.calculateTPGainOnMagicalDamage = function(totalDamage, actor, targe
         local dAGIModifier       = utils.clamp(200 - (dAGI + 30) / 200, 1.0, 0.5)                    -- 50% reduction at +70 dAGI: https://www.bg-wiki.com/ffxi/Monster_TP_gain
         local subtleBlowMerits   = actor:getMerit(xi.merit.SUBTLE_BLOW_EFFECT)
         local subtleBlowI        = math.min(actor:getMod(xi.mod.SUBTLE_BLOW) + subtleBlowMerits, 50) -- cap of 50% https://www.bg-wiki.com/ffxi/Subtle_Blow
-        local subtleBlowII       = actor:getMod(xi.mod.SUBTLE_BLOW_II)                               -- no known cap
+        local tandemBlowBonus    = xi.combat.tp.getTandemBlowBonus(actor)
+        local subtleBlowII       = actor:getMod(xi.mod.SUBTLE_BLOW_II) + tandemBlowBonus             -- no known cap
         local subtleBlowModifier = math.max((100 - subtleBlowI + subtleBlowII) / 100, 0.25)          -- combined cap of 75% reduction: https://www.bg-wiki.com/ffxi/Subtle_Blow
         local storeTPModifier    = (100 + target:getMod(xi.mod.STORETP)) / 100
 

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -3090,6 +3090,11 @@ function CBaseEntity:uncharm()
 end
 
 ---@nodiscard
+---@return boolean
+function CBaseEntity:isTandemActive()
+end
+
+---@nodiscard
 ---@param element integer
 ---@param burden integer
 ---@return integer

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1024,6 +1024,11 @@ uint16 CBattleEntity::ACC(uint8 attackNumber, uint16 offsetAccuracy)
             ACC += this->getMod(Mod::ENSPELL_DMG);
         }
 
+        if (petutils::IsTandemActive(this))
+        {
+            ACC += this->getMod(Mod::TANDEM_STRIKE_POWER);
+        }
+
         auto* PChar = dynamic_cast<CCharEntity*>(this);
         if (PChar)
         {
@@ -1045,6 +1050,14 @@ uint16 CBattleEntity::ACC(uint8 attackNumber, uint16 offsetAccuracy)
             ACC += this->getMod(Mod::ENSPELL_DMG);
         }
 
+        if (petutils::IsTandemActive(this))
+        {
+            if (this->PMaster && this->PMaster->objtype == TYPE_PC)
+            {
+                ACC += this->PMaster->getMod(Mod::TANDEM_STRIKE_POWER);
+            }
+        }
+
         ACC = ACC + std::min<int16>((ACC * m_modStat[Mod::FOOD_ACCP] / 100), m_modStat[Mod::FOOD_ACC_CAP]);
         return std::max<int16>(0, ACC);
     }
@@ -1055,6 +1068,14 @@ uint16 CBattleEntity::ACC(uint8 attackNumber, uint16 offsetAccuracy)
         if (this->StatusEffectContainer->HasStatusEffect(EFFECT_ENLIGHT))
         {
             ACC += this->getMod(Mod::ENSPELL_DMG);
+        }
+
+        if (petutils::IsTandemActive(this))
+        {
+            if (this->PMaster && this->PMaster->objtype == TYPE_PC)
+            {
+                ACC += this->PMaster->getMod(Mod::TANDEM_STRIKE_POWER);
+            }
         }
 
         ACC = ACC + std::min<int16>((ACC * m_modStat[Mod::FOOD_ACCP] / 100), m_modStat[Mod::FOOD_ACC_CAP]) + DEX() / 2; // Account for food mods here for Snatch Morsel

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -14286,6 +14286,24 @@ void CLuaBaseEntity::uncharm()
 }
 
 /************************************************************************
+ *  Function: isTandemActive()
+ *  Purpose : If entity is pet or master, checks to see if both are fighting same target
+ *  Example : player:isTandemActive()
+ *  Notes   : used for BST traits Tandem Strike / Tandem Blow
+ ************************************************************************/
+
+bool CLuaBaseEntity::isTandemActive()
+{
+    auto* PBattle = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
+    if (!PBattle)
+    {
+        ShowError("Invalid entity type calling function (%s).", m_PBaseEntity->getName());
+        return false;
+    }
+    return petutils::IsTandemActive(static_cast<CBattleEntity*>(m_PBaseEntity));
+}
+
+/************************************************************************
  *  Function: addBurden()
  *  Purpose : Adds a Burden to a Target
  *  Example : local overload = target:addBurden(xi.magic.ele.EARTH - 1, burden)
@@ -19615,6 +19633,7 @@ void CLuaBaseEntity::Register()
     // BST
     SOL_REGISTER("charm", CLuaBaseEntity::charm);
     SOL_REGISTER("uncharm", CLuaBaseEntity::uncharm);
+    SOL_REGISTER("isTandemActive", CLuaBaseEntity::isTandemActive);
 
     // PUP
     SOL_REGISTER("addBurden", CLuaBaseEntity::addBurden);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -708,6 +708,7 @@ public:
 
     void charm(CLuaBaseEntity const* target, sol::object const& p0);
     void uncharm();
+    bool isTandemActive();
 
     uint8 addBurden(uint8 element, uint8 burden);
     uint8 getOverloadChance(uint8 element);

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2400,9 +2400,23 @@ namespace battleutils
                     sBlowMerit = PChar->PMeritPoints->GetMeritValue(MERIT_TYPE::MERIT_SUBTLE_BLOW_EFFECT, PChar);
                 }
 
+                // Check for Tandem Blow bonus while pet+master are fighting same target
+                int32 tandemBlowBonus = 0;
+                if (petutils::IsTandemActive(PAttacker))
+                {
+                    if (PAttacker->PMaster && PAttacker->PMaster->objtype == TYPE_PC)
+                    {
+                        tandemBlowBonus = PAttacker->PMaster->getMod(Mod::TANDEM_BLOW_POWER);
+                    }
+                    else
+                    {
+                        tandemBlowBonus = PAttacker->getMod(Mod::TANDEM_BLOW_POWER);
+                    }
+                }
+
                 // account for attacker's subtle blow which reduces the baseTP gain for the defender
                 float sBlow1    = std::clamp((float)(PAttacker->getMod(Mod::SUBTLE_BLOW) + sBlowMerit), -50.0f, 50.0f);
-                float sBlow2    = std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW_II), -50.0f, 50.0f);
+                float sBlow2    = std::clamp((float)(PAttacker->getMod(Mod::SUBTLE_BLOW_II) + tandemBlowBonus), -50.0f, 50.0f);
                 float sBlowMult = ((100.0f - std::clamp(sBlow1 + sBlow2, -75.0f, 75.0f)) / 100.0f);
 
                 // mobs hit get basetp+30 whereas pcs hit get basetp/3
@@ -2571,9 +2585,23 @@ namespace battleutils
                 sBlowMerit = PChar->PMeritPoints->GetMeritValue(MERIT_TYPE::MERIT_SUBTLE_BLOW_EFFECT, PChar);
             }
 
+            // Check for Tandem Blow bonus while pet+master are fighting same target
+            int32 tandemBlowBonus = 0;
+            if (petutils::IsTandemActive(PAttacker))
+            {
+                if (PAttacker->PMaster && PAttacker->PMaster->objtype == TYPE_PC)
+                {
+                    tandemBlowBonus = PAttacker->PMaster->getMod(Mod::TANDEM_BLOW_POWER);
+                }
+                else
+                {
+                    tandemBlowBonus = PAttacker->getMod(Mod::TANDEM_BLOW_POWER);
+                }
+            }
+
             // account for attacker's subtle blow which reduces the baseTP gain for the defender
             float sBlow1    = std::clamp((float)(PAttacker->getMod(Mod::SUBTLE_BLOW) + sBlowMerit), -50.0f, 50.0f);
-            float sBlow2    = std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW_II), -50.0f, 50.0f);
+            float sBlow2    = std::clamp((float)(PAttacker->getMod(Mod::SUBTLE_BLOW_II) + tandemBlowBonus), -50.0f, 50.0f);
             float sBlowMult = (100.0f - std::clamp(sBlow1 + sBlow2, -75.0f, 75.0f)) / 100.0f;
 
             // mobs hit get basetp+30 whereas pcs hit get basetp/3

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1916,6 +1916,40 @@ namespace petutils
         return false;
     }
 
+    bool IsTandemActive(CBattleEntity* PAttacker)
+    {
+        /*  This is used for Tandem Strike (acc/m.acc+) and Tandem Blow (subtle blow II+).
+            To get the bonus, both pet and master must be engaged in combat with the same target.
+            Inspired by TiberonKalkaz's approach in ASB.
+            https://github.com/AirSkyBoat/AirSkyBoat/pull/3134/files#diff-dea0a7c8d005d1e7507dcb2370aff3a46df84ab53d87ba50beeab376c3082621
+        */
+        CBattleEntity* tandemPartner;
+        if (PAttacker->objtype == TYPE_PC)
+        {
+            if (PAttacker->PPet == nullptr)
+                return false;
+
+            tandemPartner = PAttacker->PPet;
+        }
+        else
+        {
+            if (PAttacker->PMaster == nullptr || PAttacker->PMaster->objtype != TYPE_PC)
+                return false;
+
+            tandemPartner = PAttacker->PMaster;
+        }
+
+        if (
+            tandemPartner->PAI->IsEngaged() &&
+            tandemPartner->GetBattleTarget() != nullptr &&
+            tandemPartner->GetBattleTargetID() == PAttacker->GetBattleTargetID())
+        {
+            return true;
+        }
+
+        return false;
+    }
+
     Pet_t* GetPetInfo(uint32 PetID)
     {
         for (Pet_t* info : g_PPetList)

--- a/src/map/utils/petutils.h
+++ b/src/map/utils/petutils.h
@@ -214,6 +214,7 @@ namespace petutils
     void SetupPetWithMaster(CBattleEntity* PMaster, CPetEntity* PPet);
 
     bool CheckPetModType(CBattleEntity* PPet, PetModType petmod);
+    bool IsTandemActive(CBattleEntity* PAttacker);
 
     Pet_t* GetPetInfo(uint32 PetID);
 }; // namespace petutils


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

This PR implements the actual effects of the BST traits Tandem Strike and Tandem Blow. When both beastmaster and pet are engaged in combat to the same enemy, these effects should grant bonus acc/m.acc, or subtle blow II, respectively.

https://www.bg-wiki.com/ffxi/Tandem_Strike
https://www.bg-wiki.com/ffxi/Tandem_Blow

My approach was inspired in part by [TiberonKalkaz's approach in ASB](https://github.com/AirSkyBoat/AirSkyBoat/pull/3134/files#diff-dea0a7c8d005d1e7507dcb2370aff3a46df84ab53d87ba50beeab376c3082621).


## Steps to test these changes

`!changejob BST 85`

Add your favorite jug pet. I used ambusher allie, so `!additem 17888`.

Summon your pet, engage the enemy.

`!exec player:printToPlayer(''..player:getACC())`
`!exec player:printToPlayer(''..player:getPet():getACC())`

Then, `/pet Fight <t>`.

`!exec player:printToPlayer(''..player:getACC())`
`!exec player:printToPlayer(''..player:getPet():getACC())`

You should see your acc and your pet's acc have gone up by 40, which is the correct amount for Tandem Strike IV.

For testing magic acc and subtle blow, add a print in `xi.combat.tp.calculateTPGainOnMagicalDamage` that prints subtleBlowII after tandemBlowBonus, and add a print in `xi.combat.magicHitRate.calculateResistRate` that prints magicAcc. Then cast a spell on the enemy (`!changesjob BLM 40`, and cast Stone). You should see magic accuracy increase by 40 while you and your pet are engaged in combat, and store TP II increase by 15.
