### PR TITLE
Use getMaxGearMod for Phantom Roll bonus

### DIFF
--- a/scripts/globals/job_utils/corsair.lua
+++ b/scripts/globals/job_utils/corsair.lua
@@ -50,30 +50,6 @@ local corsairRollMods =
     [xi.jobAbility.AVENGERS_ROLL   ] = { {   2,   2,    3,  12,    4,    5,   6,    1,    7,    9,   18,   6 },   1,   0, xi.effect.AVENGERS_ROLL,    xi.mod.COUNTER,                 xi.job.NONE },
 }
 
--- Check for xi.mod.PHANTOM_ROLL Value and apply non-stack logic.
-local function phantombuffMultiple(caster)
-    local phantomValue = caster:getMod(xi.mod.PHANTOM_ROLL)
-    local phantomBuffMultiplier = 0
-
-    if phantomValue == 3 then
-        phantomBuffMultiplier = 3
-    elseif
-        phantomValue == 5 or
-        phantomValue == 8
-    then
-        phantomBuffMultiplier = 5
-    elseif
-        phantomValue == 7 or
-        phantomValue == 10 or
-        phantomValue == 12 or
-        phantomValue == 15
-    then
-        phantomBuffMultiplier = 7
-    end
-
-    return phantomBuffMultiplier
-end
-
 -- Sets local var if party contains specified job
 local function checkForJobBonus(caster, job)
     local jobBonus = 0
@@ -181,7 +157,8 @@ local function applyRoll(caster, target, inAbility, action, total, isDoubleup, c
 
     -- Apply Additional Phantom Roll+ Buff
     local phantomBase = corsairRollMods[abilityId][2] -- Base increment buff
-    effectpower       = effectpower + (phantomBase * phantombuffMultiple(caster))
+    local phantomMult = caster:getMaxGearMod(xi.mod.PHANTOM_ROLL)
+    effectpower       = effectpower + (phantomBase * phantomMult)
 
     -- Effect Power varies depending on COR level (Main vs Sub)
     local actorLevel  = utils.getActiveJobLevel(caster, xi.job.COR)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The logic in corsair.lua to apply the Phantom Roll bonus has unusual logic for retrieving the maximum gear bonus, instead of using getMaxGearMod. As a result, any PHANTOM_ROLL value other than 3, 5, or 7 will return unexpected results (usually zero). This PR simply replaces that logic with getMaxGearMod, which is used in other places where the maximum gear mod is all that counts, like Souleater bonuses.

## Steps to test these changes

Test the difference in roll potency with and without Regal necklace (item ID 26038) equipped. Then, 
change that item's mod value in item_mods.sql to something like 6 or 20, update your db, and run the test again. You should see phantom roll bonuses other than 3, 5, or 7 work as expected.