### PR TITLE
[Lua] Fix Haste Spell Level

### DIFF
--- a/scripts/globals/spells/enhancing_spell.lua
+++ b/scripts/globals/spells/enhancing_spell.lua
@@ -123,7 +123,7 @@ local pTable =
     [xi.magic.spell.GAIN_CHR     ] = { 1, xi.effect.CHR_BOOST,      1,    5,  300, true,  false, 0 },
 
     -- Haste
-    [xi.magic.spell.HASTE        ] = { 1, xi.effect.HASTE,         48, 1465,  180, true,  false, 0 },
+    [xi.magic.spell.HASTE        ] = { 1, xi.effect.HASTE,         40, 1465,  180, true,  false, 0 },
     [xi.magic.spell.HASTE_II     ] = { 2, xi.effect.HASTE,         96, 2998,  180, true,  false, 0 },
     [xi.magic.spell.HASTEGA      ] = { 1, xi.effect.HASTE,         48, 1494,  180, false, false, 0 },
     -- [xi.magic.spell.HASTEGA_II   ] = { 2, xi.effect.HASTE,         99, 2998,  180, false, false, 0 },


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Updates the Spell Level of `Haste` so that when a WHM40 casts it, it doesn't receive a duration penalty. The spell is incorrectly set to 48, which is the level RDM gains access to haste, rather than 40 which is when WHM gains access.

![image](https://github.com/user-attachments/assets/f0b7e454-9f14-4fff-86ba-84edad7b0287)

## Steps to test these changes

Change job to WHM40. Cast haste on yourself. Verify that the buff lasts for `180s (full duration)` and not `150s (level penalty duration)`

## Testing Results
| Before | After |
|-|-|
| ![image](https://github.com/user-attachments/assets/68eadf4f-4d25-43d4-ab2f-ff4be24a741c) | ![image](https://github.com/user-attachments/assets/06f85feb-9497-46f9-bccf-b81a7e9c6d49) |
| ![image](https://github.com/user-attachments/assets/14c526df-5a74-4ac3-8296-20e3461e4cd8) | ![image](https://github.com/user-attachments/assets/75d44bca-acce-4b99-935c-3527d91d8c4b) |