### PR TITLE
[lua] Implement ENHANCES_ELEMENTAL_SEAL

### DIFF
--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -710,6 +710,22 @@ xi.spells.damage.calculateDivineEmblemMultiplier = function(caster, skillType)
     return divineEmblemMultiplier
 end
 
+-- Elemental seal applies its own multiplier to spells when Laevateinn is equipped,
+-- or some other source of ENHANCES_ELEMENTAL_SEAL is available to the caster.
+xi.spells.damage.calculateEnhancedElementalSealMultiplier = function(caster, skillType, spellElement)
+    local eleSealMultiplier = 1
+
+    if
+        caster:hasStatusEffect(xi.effect.ELEMENTAL_SEAL) and
+        spellElement >= xi.element.FIRE and -- TODO: Test impact and meteor.
+        skillType == xi.skill.ELEMENTAL_MAGIC
+    then
+        eleSealMultiplier = 1 + caster:getMod(xi.mod.ENHANCES_ELEMENTAL_SEAL) / 100
+    end
+
+    return eleSealMultiplier
+end
+
 -- Ebullience applies an entirely separate multiplier to Black Magic.
 xi.spells.damage.calculateEbullienceMultiplier = function(caster, spellGroup)
     local ebullienceMultiplier = 1
@@ -1070,6 +1086,7 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
     local magicBonusDiff            = xi.spells.damage.calculateMagicBonusDiff(caster, target, spellId, skillType, spellElement)
     local divineSealMultiplier      = xi.spells.damage.calculateDivineSealMultiplier(caster, skillType)
     local divineEmblemMultiplier    = xi.spells.damage.calculateDivineEmblemMultiplier(caster, skillType)
+    local eleSealMultiplier         = xi.spells.damage.calculateEnhancedElementalSealMultiplier(caster, skillType, spellElement)
     local ebullienceMultiplier      = xi.spells.damage.calculateEbullienceMultiplier(caster, spellGroup)
     local skillTypeMultiplier       = xi.spells.damage.calculateSkillTypeMultiplier(skillType)
     local ninSkillBonus             = xi.spells.damage.calculateNinSkillBonus(caster, spellId, skillType)
@@ -1092,6 +1109,7 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
     finalDamage = math.floor(finalDamage * targetMagicDamageAdjustment)
     finalDamage = math.floor(finalDamage * divineSealMultiplier)
     finalDamage = math.floor(finalDamage * divineEmblemMultiplier)
+    finalDamage = math.floor(finalDamage * eleSealMultiplier)
     finalDamage = math.floor(finalDamage * ebullienceMultiplier)
     finalDamage = math.floor(finalDamage * skillTypeMultiplier)
     finalDamage = math.floor(finalDamage * ninSkillBonus)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements the item mod ENHANCES_ELEMENTAL_SEAL, seen on the mythic weapon Laevateinn, which adds bonus damage to elemental spells cast under the effect of Elemental Seal.

## Steps to test these changes

!changejob BLM 99
!additem 18994 (laevateinn lv75, ele seal +10)

Put a print statement in xi.spells.damage.calculateEleSealMultiplier for eleSealMultiplier. When casting a nuke without Laevateinn equipped, with or without Elemental Seal active, the multiplier should be 1. With Laevateinn equipped and Elemental Seal active, the multiplier should be 1.1.
