### PR TITLE
[lua] Implement ELEMENTAL_DEBUFF_EFFECT

### DIFF
--- a/scripts/enum/mod.lua
+++ b/scripts/enum/mod.lua
@@ -471,6 +471,8 @@ xi.mod =
     AUGMENTS_IMPETUS                = 1097, -- see https://www.bg-wiki.com/ffxi/Impetus, adds Crit Hit Damage & Accuracy for Impetus
 
     -- Black Mage
+    ENHANCES_ELEMENTAL_SEAL         = 1149, -- Bonus magic damage when using Elemental Seal (percent)
+    ELEMENTAL_DEBUFF_EFFECT         = 1150, -- Increase stat reduction by N, and DoT by N/2 HP per tick
 
     -- Paladin
     ENHANCES_CHIVALRY               = 1061, -- Enhances "Chivalry" effect (increases the base TP modifier by the provided value / 100, e.g. mod value 5 = +0.05)
@@ -516,6 +518,7 @@ xi.mod =
 
     -- Ninja
     ENHANCES_SANGE                  = 1091, -- 1 = +1 attack for Daken during Sange per Sange merit (i.e. 20 with 5 merits = +100 attack during Sange)
+    ENHANCES_FUTAE                  = 1148, -- Adds to the +50% bonus damage to elemental ninjutsu provided by Futae (percent)
 
     -- Dragoon
     WYVERN_LVL_BONUS                = 1043, -- Wyvern: Lv.+ (Increases wyvern's base level above 99)
@@ -1049,9 +1052,6 @@ xi.mod =
     PARRY_HP_RECOVERY = 1135, -- Recover <Mod Value> HP on successful parry.
 
     -- TODO: These mods are not yet implemented.
-    ENHANCES_FUTAE                  = 1148, -- TODO: Adds to the +50% bonus damage to elemental ninjutsu provided by Futae (percent)
-    ENHANCES_ELEMENTAL_SEAL         = 1149, -- TODO: Bonus magic damage when using Elemental Seal (percent)
-    ELEMENTAL_DEBUFF_EFFECT         = 1150, -- TODO: Increase stat reduction by +N, and DoT by N/2 HP per tick
     ENF_MAG_DURATION                = 1151, -- TODO: Increase enfeebling spell duration (percent)
     REWARD_RECAST                   = 1152, -- TODO: Reduces Reward recast time (seconds)
     AUGMENTS_ABSORB_TP              = 1153, -- TODO: Increases absorb-TP potency, stacks with AUGMENTS_ABSORB

--- a/scripts/globals/spells/enfeebling_spell.lua
+++ b/scripts/globals/spells/enfeebling_spell.lua
@@ -131,7 +131,7 @@ local function getElementalDebuffPotency(caster, statUsed)
         potency = potency + 1
     end
 
-    potency = potency + caster:getMerit(xi.merit.ELEMENTAL_DEBUFF_EFFECT) -- TODO: Add BLM Toban gear effect (potency) here.
+    potency = potency + caster:getMerit(xi.merit.ELEMENTAL_DEBUFF_EFFECT) + caster:getMod(xi.mod.ELEMENTAL_DEBUFF_EFFECT) / 2
 
     return potency
 end

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -432,9 +432,11 @@ enum class Mod
     REGEN_BONUS      = 989, // Increases the amount of HP restored by Regen
 
     // Black Mage
-    CLEAR_MIND             = 295,  // Used in conjunction with HEALMP to increase amount between tics
-    CONSERVE_MP            = 296,  // Percent chance
-    ELEMENTAL_MAGIC_RECAST = 1146, // Recast time for elemental magic spells (percent, usually negative)
+    CLEAR_MIND              = 295,  // Used in conjunction with HEALMP to increase amount between tics
+    CONSERVE_MP             = 296,  // Percent chance
+    ELEMENTAL_MAGIC_RECAST  = 1146, // Recast time for elemental magic spells (percent, usually negative)
+    ENHANCES_ELEMENTAL_SEAL = 1149, // Bonus magic damage when using Elemental Seal (percent)
+    ELEMENTAL_DEBUFF_EFFECT = 1150, // Increase stat reduction by N, and DoT by N/2 HP per tick
 
     // Red Mage
     BLINK             = 299, // Tracks blink shadows
@@ -578,6 +580,7 @@ enum class Mod
     DAKEN                = 911, // chance to throw a shuriken without consuming it
     NINJUTSU_DURATION    = 1000,
     ENHANCES_SANGE       = 1091, // 1 = +1 attack for Daken during Sange per Sange merit (i.e. 20 with 5 merits = +100 attack during Sange)
+    ENHANCES_FUTAE       = 1148, // Adds to the +50% bonus damage to elemental ninjutsu provided by Futae (percent)
 
     // Dragoon
     ANCIENT_CIRCLE_DURATION    = 859,  // Ancient Circle extended duration in seconds
@@ -1085,12 +1088,9 @@ enum class Mod
     PARRY_HP_RECOVERY = 1135, // Recover <Mod Value> HP on successful parry.
 
     // TODO: These mods are not yet implemented.
-    ENHANCES_FUTAE          = 1148, // TODO: Adds to the +50% bonus damage to elemental ninjutsu provided by Futae (percent)
-    ENHANCES_ELEMENTAL_SEAL = 1149, // TODO: Bonus magic damage when using Elemental Seal (percent)
-    ELEMENTAL_DEBUFF_EFFECT = 1150, // TODO: Increase stat reduction by +N, and DoT by N/2 HP per tick
-    ENF_MAG_DURATION        = 1151, // TODO: Increase enfeebling spell duraiton (percent)
-    REWARD_RECAST           = 1152, // TODO: Reward recast time reduction (seconds)
-    AUGMENTS_ABSORB_TP      = 1153, // TODO: Increases absorb-TP potency, stacks with AUGMENTS_ABSORB
+    ENF_MAG_DURATION   = 1151, // TODO: Increase enfeebling spell duration (percent)
+    REWARD_RECAST      = 1152, // TODO: Reward recast time reduction (seconds)
+    AUGMENTS_ABSORB_TP = 1153, // TODO: Increases absorb-TP potency, stacks with AUGMENTS_ABSORB
 
     // IF YOU ADD ANY NEW MODIFIER HERE, ADD IT IN scripts/enum/mod.lua ASWELL!
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements the ELEMENTAL_DEBUFF_EFFECT item mod on items such as the Archmage's Sabots +3 and Agwu's Slops. This mod adds additional potency to spells such as Burn and Frost.

This PR also reorganizes some item mods from the "not implemented" section to their associated job section in the enum files.

## Steps to test these changes

!changejob BLM 99
!additem 23780 (Agwu's Slops, elemental debuff effect +5)

Cast the spell Burn on a mob, and observe the amount of stat reduction and DoT (place a print in scripts/effects/burn.lua, inside onEffectGain). Once it wears off, equip the Agwu's Slops and cast Burn again. You should see the DoT go up by 5, and the stat reduction go up by 10. The item also has a sizable bonus to INT, so you may bump up to the next dINT tier and see +1 potency than you'd normally expect (+1 DoT and +2 stat reduction).
