### PR TITLE
[lua] Implement enfeebling magic duration mod

### DIFF
--- a/scripts/globals/spells/enfeebling_spell.lua
+++ b/scripts/globals/spells/enfeebling_spell.lua
@@ -324,6 +324,8 @@ xi.spells.enfeebling.calculateDuration = function(caster, target, spellId, spell
                 duration = duration + caster:getJobPointLevel(xi.jp.STYMIE_EFFECT)
             end
         end
+
+        duration = math.floor(duration * (1 + caster:getMod(xi.mod.ENF_MAG_DURATION) / 100))
     end
 
     ---@cast duration integer


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements the "ENF_MAG_DURATION" mod, which extends the duration of enfeebling magic by a percentage, calculated after all the additive duration extensions from merits and job points.

## Steps to test these changes

!changejob RDM 99
!additem 25827 (regal cuffs, enfeeb magic duration +20%)

Add a print in xi.spells.enfeebling.calculatePotency for duration just before the return at the end of the function. Cast the spell Paralyze on a mob, and see the duration is 120 seconds. Equip the regal cuffs and cast Paralyze again, and you'll see the duration increase to 144 seconds (a 20% increase).
