### PR TITLE
[lua] Implement AUGMENTS_ABSORB_TP

### DIFF
--- a/scripts/globals/spells/absorb_spell.lua
+++ b/scripts/globals/spells/absorb_spell.lua
@@ -216,6 +216,7 @@ xi.spells.absorb.doAbsorbTPSpell = function(caster, target, spell)
     local elementalStaffBonus  = xi.spells.damage.calculateElementalStaffBonus(caster, xi.element.DARK)
     local dayAndWeather        = xi.spells.damage.calculateDayAndWeather(caster, xi.element.DARK, false)
     local absorbMultiplier     = 1 + caster:getMod(xi.mod.AUGMENTS_ABSORB) / 100
+    local absorbTpMultiplier   = 1 + caster:getMod(xi.mod.AUGMENTS_ABSORB_TP) / 100 -- TODO: Additive with aug abs or multiplicative?
     local liberatorMultiplier  = 1 + caster:getMod(xi.mod.AUGMENTS_ABSORB_LIBERATOR) / 100
 
     -- Operations.
@@ -225,6 +226,7 @@ xi.spells.absorb.doAbsorbTPSpell = function(caster, target, spell)
     finalDamage = math.floor(finalDamage * elementalStaffBonus)
     finalDamage = math.floor(finalDamage * dayAndWeather)
     finalDamage = math.floor(finalDamage * absorbMultiplier)
+    finalDamage = math.floor(finalDamage * absorbTpMultiplier)
     finalDamage = math.floor(finalDamage * liberatorMultiplier)
 
     -- Clamp


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

Implements AUGMENTS_ABSORB_TP, a mod found on items such as Bale Gauntlets +1. I implemented this such that it applied multiplicatively with AUGMENTS_ABSORB (e.g. erra pendant, chuparrosa mantle) like most other similar mods that enhance potency, but testing data is a bit sparse for this one since Absorb TP on retail has been tweaked so many times.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

!changejob DRK 99
!additem 11211 (bale gauntlets +1, 5% bonus to absorb TP)

Perform an Absorb-TP on a mob with and without the gauntlets, at approximately the same level of Mob TP. Alternatively, just add a print statement to display the multiplier. You should see the final amount of TP absorbed increase by 5%.
