### PR TITLE
[core] Implement Kick Attack damage in autoattacks

### DIFF
--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -593,7 +593,16 @@ void CAttack::ProcessDamage()
     {
         m_naturalH2hDamage = (int32)(m_attacker->GetSkill(SKILL_HAND_TO_HAND) * 0.11f) + 3;
         m_baseDamage       = m_attacker->GetMainWeaponDmg();
-        m_damage           = (uint32)(((m_baseDamage + m_naturalH2hDamage + m_bonusBasePhysicalDamage + battleutils::GetFSTR(m_attacker, m_victim, slot)) * m_damageRatio));
+
+        if (m_attackType == PHYSICAL_ATTACK_TYPE::KICK)
+        {
+            int32 kickDamage = m_naturalH2hDamage + m_attacker->getMod(Mod::KICK_DMG); // KICK_DMG includes weapon dmg if footwork is active
+            m_damage         = (uint32)(((kickDamage + m_bonusBasePhysicalDamage + battleutils::GetFSTR(m_attacker, m_victim, slot)) * m_damageRatio));
+        }
+        else
+        {
+            m_damage = (uint32)(((m_baseDamage + m_naturalH2hDamage + m_bonusBasePhysicalDamage + battleutils::GetFSTR(m_attacker, m_victim, slot)) * m_damageRatio));
+        }
     }
     else if (slot == SLOT_MAIN)
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Currently, kick attack damage is not treated any differently than ordinary H2H attacks during attack rounds. This means that when kick attacks trigger during auto attacks, weapon damage is incorrectly applied to them, and "kick damage" buffs are incorrectly _not_ applied to them. This PR resolves this issue.

## Steps to test these changes

For testing, compile with `ShowDebug("kickDamage: %u", kickDamage);` in attack.cpp ProcessDamage().

```
!changejob MNK 99
!setskill HAND_TO_HAND 400
!exec player:setMod(xi.mod.KICK_ATTACK_RATE, 100)
!additem dune_boots
!additem dumuzis
```

At h2h skill 400, base kick damage should be 400*.11 + 3 = 47.
Dune boots provide Kick Damage +30.
Dumuzis provide weapon damage +36.

**No footwork**

**Nothing equipped:** Kick damage = 47 ✓
**Dumuzis equipped, no boots:** Kick damage = 47 ✓
**No weapon, dune boots equipped:** Kick damage = 77 (47+30 from boots) ✓
**Dumuzis + dune boots equipped:** Kick damage = 77 ✓

**With footwork**
(Note: adding weapon dmg to kicks is applied *when Footwork is used*, and lasts the duration of Footwork effect even if the weapon is unequipped.)

**Nothing equipped:** Kick damage = 67 (47+20) ✓
**Dumuzis equipped (when JA used), no boots:** Kick damage = 103 (47+20+36) ✓
**No weapon, dune boots equipped:** Kick damage = 97 (47+20+30) ✓
**Dumuzis + dune boots equipped:** Kick damage = 133 (47+20+30+36) ✓
