### PR TITLE
[core] Zero-initialize LearnedWeaponskills bitset

### DIFF
--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -284,7 +284,7 @@ public:
     uint8            m_TitleList[143]{};       // List of obtained titles
     uint8            m_Abilities[64]{};        // List of current abilities
     uint8            m_LearnedAbilities[49]{}; // Learnable abilities (corsair rolls)
-    xi::bitset<64>   m_LearnedWeaponskills;    // Learnable Weaponskills
+    xi::bitset<64>   m_LearnedWeaponskills{};  // Learnable Weaponskills
     uint8            m_TraitList[18]{};        // List of active job traits in the form of a bit mask
     uint8            m_PetCommands[64]{};
     uint8            m_WeaponSkills[32]{};


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Random unlockable weaponskills are showing to characters with a NULL weaponskills BLOB in their database entry.
i.e. Requiescat, Chant du Cygne on a RDM75 with 0 unlocked weapons

This is happening because the rset->extractBlob does not touch the destination field in such cases and then the weaponskills checks happen against garbage data.

This PR zero-initializes the underlying bitset in the CCharEntity object.

I tried to make a wider change (because I suspect this is happening in other cases) and have the underlying `xi::bitset` to be zero initialized but then promptly learned what 'trivial' meant in that context, as the Binder was unable to work with such types (specifically the PChar->keys representing key items)

Next best option would be to modify `extractBlob` but there is this comment which I am not sure how to interpret

https://github.com/LandSandBoat/server/blob/3ba3962aa757e61067e24c7581d4d871f1f4e1d2/src/common/database.h#L767-L769

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
- NULL the weaponskills field of your character
- Ensure random unlockable WS don't show up in your menu.

<!-- Clear and detailed steps to test your changes here -->
