### PR TITLE
[fix] Always save unlocked PUP attachments

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -16073,8 +16073,8 @@ bool CLuaBaseEntity::hasAttachment(uint16 itemID)
 
 /************************************************************************
  *  Function: getAutomatonName()
- *  Purpose : Returns the string name of the automation pet
- *  Example : local name = pet:getAutomatonName()
+ *  Purpose : Returns the string name of the player's automaton
+ *  Example : local name = player:getAutomatonName()
  *  Notes   :
  ************************************************************************/
 
@@ -16088,7 +16088,7 @@ auto CLuaBaseEntity::getAutomatonName() -> std::string
 
     const auto rset = db::preparedStmt("SELECT name FROM "
                                        "char_pet LEFT JOIN pet_name ON automatonid = id "
-                                       "WHERE charid = %u LIMIT 1",
+                                       "WHERE charid = ? LIMIT 1",
                                        m_PBaseEntity->id);
 
     if (rset && rset->rowsCount() && rset->next())

--- a/src/map/utils/puppetutils.cpp
+++ b/src/map/utils/puppetutils.cpp
@@ -119,15 +119,22 @@ namespace puppetutils
         }
     }
 
+    void SaveAttachments(CCharEntity* PChar)
+    {
+        db::preparedStmt("UPDATE char_pet SET "
+                         "unlocked_attachments = ? "
+                         "WHERE charid = ? LIMIT 1",
+                         PChar->m_unlockedAttachments, PChar->id);
+    }
+
     void SaveAutomaton(CCharEntity* PChar)
     {
         if (PChar->GetMJob() == JOBTYPE::JOB_PUP || PChar->GetSJob() == JOBTYPE::JOB_PUP)
         {
             db::preparedStmt("UPDATE char_pet SET "
-                             "unlocked_attachments = ?, "
                              "equipped_attachments = ? "
                              "WHERE charid = ? LIMIT 1",
-                             PChar->m_unlockedAttachments, PChar->automatonInfo.m_Equip, PChar->id);
+                             PChar->automatonInfo.m_Equip, PChar->id);
         }
     }
 
@@ -146,7 +153,7 @@ namespace puppetutils
         {
             if (addBit(id & 0xFF, (uint8*)PChar->m_unlockedAttachments.attachments, sizeof(PChar->m_unlockedAttachments.attachments)))
             {
-                SaveAutomaton(PChar);
+                SaveAttachments(PChar);
                 PChar->pushPacket<CCharJobExtraPacket>(PChar, PChar->GetMJob() == JOB_PUP);
                 return true;
             }
@@ -156,7 +163,7 @@ namespace puppetutils
         {
             if (addBit(id & 0x0F, &PChar->m_unlockedAttachments.frames, sizeof(PChar->m_unlockedAttachments.frames)))
             {
-                SaveAutomaton(PChar);
+                SaveAttachments(PChar);
                 PChar->pushPacket<CCharJobExtraPacket>(PChar, PChar->GetMJob() == JOB_PUP);
                 return true;
             }
@@ -166,7 +173,7 @@ namespace puppetutils
         {
             if (addBit(id & 0x0F, &PChar->m_unlockedAttachments.heads, sizeof(PChar->m_unlockedAttachments.heads)))
             {
-                SaveAutomaton(PChar);
+                SaveAttachments(PChar);
                 PChar->pushPacket<CCharJobExtraPacket>(PChar, PChar->GetMJob() == JOB_PUP);
                 return true;
             }

--- a/src/map/utils/puppetutils.h
+++ b/src/map/utils/puppetutils.h
@@ -29,6 +29,7 @@
 namespace puppetutils
 {
     void   LoadAutomaton(CCharEntity* PChar);
+    void   SaveAttachments(CCharEntity* PChar);
     void   SaveAutomaton(CCharEntity* PChar);
     bool   UnlockAttachment(CCharEntity* PChar, CItem* PItem);
     bool   HasAttachment(CCharEntity* PChar, CItem* PItem);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

With some of the recent PUP changes, the query to save newly unlocked attachments was gated behind a main/sub job check for PUP, but that does not work for two reasons:
- When you unlock PUP, you are on another job. Therefore the default unlocked frames Harlequin Frame and Head are not saved on quest completion.
  - There is a fallback in the LoadAutomaton part of the code to force equip them if no frame/head are found, but that stops working as soon as you equip any other unlocked frame/head, and then the Harlequin pieces are gone forever.
- Tateeya accepts attachments trades on any job
  - This leads to Tateeya eating the item but not unlocking it.

This PR splits the saving of unlocked attachments and equipped attachments in two different functions.

There was also a small issue in the Automaton name query, which led to the returned automaton name to be empty when queried from lua.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
- Complete "No Strings Attached" to unlock PUP, verify Harlequin Frame and Harlequin Head show up in your list of attachments (and not _just_ equipped)
- Trade Tateeya attachments as non-PUP and check as PUP that they were saved

<!-- Clear and detailed steps to test your changes here -->
