### PR TITLE
[fix] AH Announcements, AH timer issue

### DIFF
--- a/modules/custom/cpp/ah_announcement.cpp
+++ b/modules/custom/cpp/ah_announcement.cpp
@@ -23,6 +23,7 @@
 #include "map/item_container.h"
 #include "map/map_session.h"
 #include "map/zone.h"
+#include "utils/auctionutils.h"
 
 #include <functional>
 #include <numeric>
@@ -47,153 +48,59 @@ class AHAnnouncementModule : public CPPModule
             const auto action = data.ref<uint8>(0x04);
             if (action == 0x0E)
             {
-                // !!!
-                // NOTE: This is almost the exact same code as the original, with the annoucement attached to the end.
-                //     : If the original code changes, this will have to change too!
-                // !!!
-
                 const uint32 price    = data.ref<uint32>(0x08);
                 const uint16 itemid   = data.ref<uint16>(0x0C);
                 const uint8  quantity = data.ref<uint8>(0x10);
 
-                if (PChar->getStorage(LOC_INVENTORY)->GetFreeSlotsCount() == 0)
+                CItem* PItem = itemutils::GetItemPointer(itemid);
+                if (PItem)
                 {
-                    PChar->pushPacket<CAuctionHousePacket>(action, 0xE5, 0, 0, 0, 0);
-                }
-                else
-                {
-                    CItem* PItem = itemutils::GetItemPointer(itemid);
-                    if (PItem != nullptr)
+                    if (auctionutils::PurchasingItems(PChar, action, price, itemid, quantity))
                     {
-                        if (PItem->getFlag() & ITEM_FLAG_RARE)
+                        // clang-format off
+                        const auto sellerId = [&]() -> uint32
                         {
-                            for (uint8 LocID = 0; LocID < CONTAINER_ID::MAX_CONTAINER_ID; ++LocID)
+                            uint32 sellerId = 0;
+
+                            const auto rset = db::preparedStmt("SELECT seller "
+                                                               "FROM auction_house WHERE "
+                                                               "buyer_name = ? AND "
+                                                               "sale = ? AND "
+                                                               "itemid = ? AND "
+                                                               "stack = ? "
+                                                               "ORDER BY sell_date DESC LIMIT 1",
+                                                               PChar->getName(), price, itemid, quantity == 0);
+
+                            FOR_DB_SINGLE_RESULT(rset)
                             {
-                                if (PChar->getStorage(LocID)->SearchItem(itemid) != ERROR_SLOTID)
-                                {
-                                    PChar->pushPacket<CAuctionHousePacket>(action, 0xE5, 0, 0, 0, 0);
-                                    return;
-                                }
+                                sellerId = rset->get<uint32>("seller");
                             }
-                        }
 
-                        CItem* gil = PChar->getStorage(LOC_INVENTORY)->GetItem(0);
+                            return sellerId;
+                        }();
 
-                        if (gil != nullptr && gil->isType(ITEM_CURRENCY) && gil->getQuantity() >= price && gil->getReserve() == 0)
+                        if (sellerId)
                         {
-                            bool itemPurchasedSuccessfully = false;
-
-                            // clang-format off
-                            const auto success = db::transaction([&]()
+                            // Sanitize name
+                            std::string name  = PItem->getName();
+                            auto        parts = split(name, "_");
+                            name              = "";
+                            name += std::accumulate(std::begin(parts), std::end(parts), std::string(),
+                            [](std::string const& ss, std::string const& s)
                             {
-                                // Get the row id of the item we're buying
-                                const auto rowId = [&]() -> uint32
-                                {
-                                    const auto rset = db::preparedStmt(R"(
-                                        SELECT id
-                                        FROM auction_house
-                                        WHERE itemid = ?
-                                        AND buyer_name IS NULL
-                                        AND stack = ?
-                                        AND price <= ?
-                                        ORDER BY price
-                                        LIMIT 1;
-                                        )",
-                                        itemid, quantity == 0, price);
-
-                                    FOR_DB_SINGLE_RESULT(rset)
-                                    {
-                                        return rset->get<uint32>("id");
-                                    }
-
-                                    return 0;
-                                }();
-
-                                // Now that we have the row id, we can use it to update the purchase information
-                                const auto successfulUpdate = [&]() -> bool
-                                {
-                                    const auto rset = db::preparedStmt("UPDATE auction_house "
-                                        "SET buyer_name = ?, sale = ?, sell_date = ? "
-                                        "WHERE id = ? "
-                                        "LIMIT 1 ",
-                                        PChar->getName(), price, (uint32)time(nullptr), rowId);
-
-                                    return rset && rset->rowsAffected();
-                                }();
-
-                                // If the update was successful we can now add the item to the buyer's inventory
-                                if (successfulUpdate)
-                                {
-                                    uint8 SlotID = charutils::AddItem(PChar, LOC_INVENTORY, itemid, (quantity == 0 ? PItem->getStackSize() : 1));
-                                    if (SlotID != ERROR_SLOTID)
-                                    {
-                                        charutils::UpdateItem(PChar, LOC_INVENTORY, 0, -(int32)(price));
-
-                                        PChar->pushPacket<CAuctionHousePacket>(action, 0x01, itemid, price, quantity, PItem->getStackSize());
-                                        PChar->pushPacket<CInventoryFinishPacket>();
-
-                                        // Now that the item is in the buyer's inventory we can send the message to the seller
-                                        const auto sellerId = [&]() -> uint32
-                                        {
-                                            uint32 sellerId = 0;
-
-                                            const auto rset = db::preparedStmt(R"(
-                                                SELECT seller
-                                                FROM auction_house
-                                                WHERE id = ?;
-                                                )",
-                                                rowId);
-
-                                            FOR_DB_SINGLE_RESULT(rset)
-                                            {
-                                                sellerId = rset->get<uint32>("seller");
-                                            }
-
-                                            return sellerId;
-                                        }();
-
-                                        if (sellerId)
-                                        {
-                                            // Sanitize name
-                                            std::string name  = PItem->getName();
-                                            auto        parts = split(name, "_");
-                                            name              = "";
-                                            name += std::accumulate(std::begin(parts), std::end(parts), std::string(),
-                                            [](std::string const& ss, std::string const& s)
-                                            {
-                                                return ss.empty() ? s : ss + " " + s;
-                                            });
-                                            name[0] = std::toupper(name[0]);
-
-                                            // Send message to seller!
-                                            message::send(ipc::ChatMessageCustom{
-                                                .recipientId = sellerId,
-                                                .senderName  = "",
-                                                .message     = fmt::format("Your '{}' has sold to {} for {} gil!", name, PChar->getName(), price),
-                                                .messageType = MESSAGE_SYSTEM_3,
-                                            });
-                                        }
-
-                                        itemPurchasedSuccessfully = true;
-                                    }
-                                }
+                                return ss.empty() ? s : ss + " " + s;
                             });
-                            if (itemPurchasedSuccessfully && success)
-                            {
-                                return;
-                            }
+                            name[0] = std::toupper(name[0]);
+
+                            // Send message to seller!
+                            message::send(ipc::ChatMessageCustom{
+                                .recipientId = sellerId,
+                                .senderName  = "",
+                                .message     = fmt::format("Your '{}' has sold to {} for {} gil!", name, PChar->getName(), price),
+                                .messageType = MESSAGE_SYSTEM_3,
+                            });
                             // clang-format on
                         }
-                    }
-
-                    // You were unable to buy the {qty} {item}
-                    if (PItem)
-                    {
-                        PChar->pushPacket<CAuctionHousePacket>(action, 0xC5, itemid, price, quantity, PItem->getStackSize());
-                    }
-                    else
-                    {
-                        PChar->pushPacket<CAuctionHousePacket>(action, 0xC5, itemid, price, quantity, 0);
                     }
                 }
             }

--- a/modules/custom/cpp/ah_pagination.cpp
+++ b/modules/custom/cpp/ah_pagination.cpp
@@ -60,7 +60,7 @@ class AHPaginationModule : public CPPModule
             if (action == 0x05)
             {
                 const timer::time_point curTick = timer::now();
-                if (curTick - PChar->m_AHHistoryTimestamp > 1500ms)
+                if (curTick > PChar->m_AHHistoryTimestamp + 1500ms)
                 {
                     // Not const, because we're going to increment it below
                     // This will get wiped on zoning

--- a/src/map/utils/auctionutils.cpp
+++ b/src/map/utils/auctionutils.cpp
@@ -154,7 +154,7 @@ void auctionutils::OpenListOfSales(CCharEntity* PChar, uint8 action, uint16 item
 
     const auto curTick = timer::now();
 
-    if (curTick - PChar->m_AHHistoryTimestamp > 5s)
+    if (curTick > PChar->m_AHHistoryTimestamp + 5s)
     {
         PChar->m_ah_history.clear();
         PChar->m_AHHistoryTimestamp = curTick;
@@ -278,7 +278,7 @@ void auctionutils::ProofOfPurchase(CCharEntity* PChar, uint8 action, uint32 pric
     }
 }
 
-void auctionutils::PurchasingItems(CCharEntity* PChar, uint8 action, uint32 price, uint16 itemid, uint8 quantity)
+bool auctionutils::PurchasingItems(CCharEntity* PChar, uint8 action, uint32 price, uint16 itemid, uint8 quantity)
 {
     TracyZoneScoped;
 
@@ -299,7 +299,7 @@ void auctionutils::PurchasingItems(CCharEntity* PChar, uint8 action, uint32 pric
                     if (PChar->getStorage(LocID)->SearchItem(itemid) != ERROR_SLOTID)
                     {
                         PChar->pushPacket<CAuctionHousePacket>(action, 0xE5, 0, 0, 0, 0);
-                        return;
+                        return false;
                     }
                 }
             }
@@ -320,8 +320,9 @@ void auctionutils::PurchasingItems(CCharEntity* PChar, uint8 action, uint32 pric
 
                         PChar->pushPacket<CAuctionHousePacket>(action, 0x01, itemid, price, quantity, PItem->getStackSize());
                         PChar->pushPacket<CInventoryFinishPacket>();
+
+                        return true;
                     }
-                    return;
                 }
             }
         }
@@ -336,6 +337,8 @@ void auctionutils::PurchasingItems(CCharEntity* PChar, uint8 action, uint32 pric
             PChar->pushPacket<CAuctionHousePacket>(action, 0xC5, itemid, price, quantity, 0);
         }
     }
+
+    return false;
 }
 
 void auctionutils::CancelSale(CCharEntity* PChar, uint8 action, uint8 slotid)

--- a/src/map/utils/auctionutils.h
+++ b/src/map/utils/auctionutils.h
@@ -36,7 +36,7 @@ namespace auctionutils
     void OpenListOfSales(CCharEntity* PChar, uint8 action, uint16 itemid);
     void RetrieveListOfItemsSoldByPlayer(CCharEntity* PChar);
     void ProofOfPurchase(CCharEntity* PChar, uint8 action, uint32 price, uint8 slot, uint8 quantity);
-    void PurchasingItems(CCharEntity* PChar, uint8 action, uint32 price, uint16 itemid, uint8 quantity);
+    bool PurchasingItems(CCharEntity* PChar, uint8 action, uint32 price, uint16 itemid, uint8 quantity);
     void CancelSale(CCharEntity* PChar, uint8 action, uint8 slotid);
     void UpdateSaleListByPlayer(CCharEntity* PChar, uint8 action, uint8 slotid);
 }; // namespace auctionutils


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

2 for 1

- Reworks ah_announcement module to defer the bulk of the logic to auctionutils, so it stops breaking every other day. Closes #7485
  - auctionutils::PurchasingItems returns a boolean, indicating if a sale went through

- Fixes the check for user throttling when they check list of sales, as it is currently defaulting to the "Try again later" state
  - Since `m_AHHistoryTimestamp` is initialized to `timer::time_point::min()` (min value of a long long), the existing check no longer works.

![Screenshot 2025-05-07 185929](https://github.com/user-attachments/assets/c14602da-4dde-4e7c-b6f1-63904c03e256)


<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

Without modules enabled:
- Open Auction House
- Check Sales Status
- Ensure items for sale show up
- Try again during the 5s cooldown, ensure "Please try again" shows up
- Ensure items can be listed and purchased

With modules enabled:
- Ensure pagination on Sales Status works, along with the 1.5s cooldown
- Ensure a message is received when purchasing one of your own item


<!-- Clear and detailed steps to test your changes here -->
