### PR TITLE
[sql] Fix Kick Out Skill to Rear Conal

### DIFF
--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -644,7 +644,7 @@ INSERT INTO `mob_skills` VALUES (626,437,'vulture_3',0,0.0,7.0,2000,0,1,0,0,0,0,
 INSERT INTO `mob_skills` VALUES (627,438,'vulture_4',0,0.0,7.0,2000,0,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (628,372,'wild_horn',4,0.0,10.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (629,373,'thunderbolt',1,0.0,30.0,2000,1500,4,8,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (630,374,'kick_out',4,0.0,10.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (630,374,'kick_out',8,0.0,10.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (631,375,'shock_wave',4,0.0,7.0,2000,1500,4,0,0,2,0,0,0);
 INSERT INTO `mob_skills` VALUES (632,376,'flame_armor',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (633,377,'howl',1,0.0,20.0,2000,1500,1,0,0,0,0,0,0); -- Behemoth family Howl


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
- Corrects the `mob_skill_aoe` flag for Kick Out to be Rear-Conal.
- The skill was incorrectly flagged as a frontal-cone but is a rear-conal ([Source](https://www.bg-wiki.com/ffxi/Category:Behemoth))
- The skill would only fire while the character is behind the mob, but then would fail because the conal check was configured to check in front of the mob:
`[map][debug] Could not add original target in CTargetFind::findWithinArea (CTargetFind::findWithinArea:116)`

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - `!spawnmob 17297440` to spawn Behemoth
2 - `!gotoid 17297440`
3 - Position your character behind Behemoth
4 - `!exec target:useMobAbility(630)`

NOTE: Behemoth now properly uses Kick Out while standing behind the mob instead of failing.

