### PR TITLE
ZM8: Make cutscene in lower delkfutt tower optional

### DIFF
--- a/scripts/missions/rotz/08_Return_to_Delkfutts_Tower.lua
+++ b/scripts/missions/rotz/08_Return_to_Delkfutts_Tower.lua
@@ -17,6 +17,11 @@ mission.reward =
     nextMission = { xi.mission.log_id.ZILART, xi.mission.id.zilart.ROMAEVE },
 }
 
+-- Bits
+-- 0 -> Lower Jeuno Aldo interaction. Optional.
+-- 1 -> Lower Delkfutt tower Zone-in cutscene. Optional. Yes. Really.
+-- 2 -> Stellar Fulcrum pre-battle cutscene. Can't miss it.
+
 mission.sections =
 {
     -- Section: Mission Active
@@ -25,12 +30,28 @@ mission.sections =
             return currentMission == mission.missionId
         end,
 
+        [xi.zone.LOWER_DELKFUTTS_TOWER] =
+        {
+            onZoneIn = function(player, prevZone)
+                if not mission:isVarBitsSet(player, 'Option', 1) then
+                    return 15
+                end
+            end,
+
+            onEventFinish =
+            {
+                [15] = function(player, csid, option, npc)
+                    mission:setVarBit(player, 'Option', 1)
+                end,
+            },
+        },
+
         [xi.zone.LOWER_JEUNO] =
         {
             ['Aldo'] =
             {
                 onTrigger = function(player, npc)
-                    if mission:getVar(player, 'Option') == 0 then
+                    if not mission:isVarBitsSet(player, 'Option', 0) then
                         return mission:progressEvent(104, 0, 1, 255, 0, 12590582, 95569, 4095, 1)
                     else
                         return mission:event(68)
@@ -41,7 +62,7 @@ mission.sections =
             onEventFinish =
             {
                 [104] = function(player, csid, option, npc)
-                    mission:setVar(player, 'Option', 1)
+                    mission:setVarBit(player, 'Option', 0)
                 end,
             },
         },
@@ -50,39 +71,15 @@ mission.sections =
         {
             ['Gilgamesh'] = mission:event(13),
         },
-    },
-
-    -- Section: Mission Active and missionStatus == 0
-    {
-        check = function(player, currentMission, missionStatus, vars)
-            return currentMission == mission.missionId and missionStatus == 0
-        end,
-
-        [xi.zone.LOWER_DELKFUTTS_TOWER] =
-        {
-            onZoneIn = function(player, prevZone)
-                return 15
-            end,
-
-            onEventFinish =
-            {
-                [15] = function(player, csid, option, npc)
-                    player:setMissionStatus(mission.areaId, 1)
-                end,
-            },
-        },
-    },
-
-    -- Section: Mission Active and missionStatus == 1
-    {
-        check = function(player, currentMission, missionStatus, vars)
-            return currentMission == mission.missionId and missionStatus == 1
-        end,
 
         [xi.zone.STELLAR_FULCRUM] =
         {
             onZoneIn = function(player, prevZone)
-                return 0
+                if not mission:isVarBitsSet(player, 'Option', 2) then
+                    return 0 -- Pre-Battle.
+                elseif player:getMissionStatus(mission.areaId) == 1 then
+                    return 17 -- Post-Battle. Mission complete event.
+                end
             end,
 
             onEventUpdate =
@@ -97,35 +94,16 @@ mission.sections =
             onEventFinish =
             {
                 [0] = function(player, csid, option, npc)
-                    player:setMissionStatus(mission.areaId, 2)
+                    mission:setVarBit(player, 'Option', 2)
                 end,
-            },
-        },
-    },
 
-    -- Section: Mission Active and missionStatus == 2
-    {
-        check = function(player, currentMission, missionStatus, vars)
-            return currentMission == mission.missionId and missionStatus >= 2
-        end,
-
-        [xi.zone.STELLAR_FULCRUM] =
-        {
-            onZoneIn = function(player, prevZone)
-                if player:getMissionStatus(mission.areaId) == 3 then
-                    return 17
-                end
-            end,
-
-            onEventFinish =
-            {
                 [17] = function(player, csid, option, npc)
                     mission:complete(player)
                 end,
 
                 [32001] = function(player, csid, option, npc)
                     if player:getLocalVar('battlefieldWin') == xi.battlefield.id.RETURN_TO_DELKFUTTS_TOWER then
-                        player:setMissionStatus(mission.areaId, 3)
+                        player:setMissionStatus(mission.areaId, 1)
                         player:setPos(-519.99, 1.076, -19.943, 64, xi.zone.STELLAR_FULCRUM)
                     end
                 end,

--- a/scripts/missions/rotz/08_Return_to_Delkfutts_Tower.lua
+++ b/scripts/missions/rotz/08_Return_to_Delkfutts_Tower.lua
@@ -33,8 +33,14 @@ mission.sections =
         [xi.zone.LOWER_DELKFUTTS_TOWER] =
         {
             onZoneIn = function(player, prevZone)
-                if not mission:isVarBitsSet(player, 'Option', 1) then
-                    return 15
+                local previousZone = player:getPreviousZone()
+                if
+                    previousZone == xi.zone.QUFIM_ISLAND and
+                    not mission:isVarBitsSet(player, 'Option', 1)
+                then
+                    return 15 -- Optional cutscene. Only triggers from qufim entrance.
+                elseif previousZone == xi.zone.MIDDLE_DELKFUTTS_TOWER then
+                    return 14 -- Ensure regular entering CS plays.
                 end
             end,
 
@@ -79,6 +85,8 @@ mission.sections =
                     return 0 -- Pre-Battle.
                 elseif player:getMissionStatus(mission.areaId) == 1 then
                     return 17 -- Post-Battle. Mission complete event.
+                elseif player:getPreviousZone() == xi.zone.UPPER_DELKFUTTS_TOWER then
+                    return 7 -- Ensure regular entering CS plays.
                 end
             end,
 

--- a/scripts/zones/Lower_Delkfutts_Tower/Zone.lua
+++ b/scripts/zones/Lower_Delkfutts_Tower/Zone.lua
@@ -15,6 +15,16 @@ end
 
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
+    if prevZone == xi.zone.MIDDLE_DELKFUTTS_TOWER then
+        cs = 14 -- Teleport.
+    -- BORN OF HER NIGHTMARES
+    -- TODO: Convert to interaction.
+    elseif
+        prevZone == xi.zone.QUFIM_ISLAND and
+        player:getCurrentMission(xi.mission.log_id.ACP) == xi.mission.id.acp.BORN_OF_HER_NIGHTMARES
+    then
+        cs = 34
+    end
 
     if
         player:getXPos() == 0 and
@@ -22,14 +32,6 @@ zoneObject.onZoneIn = function(player, prevZone)
         player:getZPos() == 0
     then
         player:setPos(460.022, -1.77, -103.442, 188)
-    end
-
-    -- BORN OF HER NIGHTMARES
-    if
-        player:getCurrentMission(xi.mission.log_id.ACP) == xi.mission.id.acp.BORN_OF_HER_NIGHTMARES and
-        prevZone == xi.zone.QUFIM_ISLAND
-    then
-        cs = 34
     end
 
     return cs

--- a/scripts/zones/Middle_Delkfutts_Tower/Zone.lua
+++ b/scripts/zones/Middle_Delkfutts_Tower/Zone.lua
@@ -26,6 +26,12 @@ end
 
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
+    if
+        prevZone == xi.zone.LOWER_DELKFUTTS_TOWER or
+        prevZone == xi.zone.UPPER_DELKFUTTS_TOWER
+    then
+        cs = 13 -- Teleport.
+    end
 
     if
         player:getXPos() == 0 and

--- a/scripts/zones/Stellar_Fulcrum/Zone.lua
+++ b/scripts/zones/Stellar_Fulcrum/Zone.lua
@@ -5,8 +5,8 @@
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
-    zone:registerCuboidTriggerArea(1, -522, -2, -49,  -517, -1, -43) -- To Upper Delkfutt's Tower
-    zone:registerCuboidTriggerArea(2, 318, -3, 2,  322, 1, 6) -- Exit BCNM to ?
+    zone:registerCuboidTriggerArea(1, -522, -2, -49, -517, -1, -43) -- To Upper Delkfutt's Tower
+    zone:registerCuboidTriggerArea(2,  318, -3,   2,  322,  1,   6) -- Exit BCNM to ?
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
@@ -15,6 +15,9 @@ end
 
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
+    if prevZone == xi.zone.UPPER_DELKFUTTS_TOWER then
+        cs = 7 -- Teleport.
+    end
 
     if
         player:getXPos() == 0 and

--- a/scripts/zones/Stellar_Fulcrum/mobs/Kamlanaut.lua
+++ b/scripts/zones/Stellar_Fulcrum/mobs/Kamlanaut.lua
@@ -16,6 +16,12 @@ local skillToAbsorb =
     [828] = xi.mod.WATER_ABSORB, -- water_blade
 }
 
+entity.onMobInitialize = function(mob)
+    mob:addImmunity(xi.immunity.SILENCE)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+end
+
 entity.onMobEngage = function(mob, target)
     mob:setLocalVar('nextEnSkill', os.time() + 10)
 end
@@ -30,7 +36,7 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onMobWeaponSkill = function(target, mob, skill)
-    local skillId = skill:getID()
+    local skillId  = skill:getID()
     local absorbId = skillToAbsorb[skillId]
 
     if absorbId then
@@ -52,9 +58,6 @@ entity.onMobWeaponSkill = function(target, mob, skill)
         -- return TP
         mob:setTP(mob:getLocalVar('currentTP'))
     end
-end
-
-entity.onMobDeath = function(mob, player, optParams)
 end
 
 return entity

--- a/scripts/zones/Upper_Delkfutts_Tower/Zone.lua
+++ b/scripts/zones/Upper_Delkfutts_Tower/Zone.lua
@@ -17,6 +17,12 @@ end
 
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
+    if
+        prevZone == xi.zone.MIDDLE_DELKFUTTS_TOWER or
+        prevZone == xi.zone.STELLAR_FULCRUM
+    then
+        cs = 14 -- Teleport.
+    end
 
     if
         player:getXPos() == 0 and


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This goes against logic, narrative coherence and hurts me deeply. But it's true.
Simplified logic while I was there, using the Option variable to track events as a bitmask

## Steps to test these changes

1. Start ZM8.
2. Go to Stellar Fulcrum. Watch cutscene.
3. Exit and zone to lower delkfutt tower.

Watch the cutscene play and make absolutely no sense.