### PR TITLE
Correct the bonus granted by the Heatsink

### DIFF
--- a/scripts/globals/automaton.lua
+++ b/scripts/globals/automaton.lua
@@ -86,7 +86,7 @@ local attachmentModifiers =
     ['galvanizer']          = { { xi.mod.COUNTER,                     {    10,    20,    35,    50 }, true  }, },
     ['hammermill']          = { { xi.mod.SHIELD_BASH,                 {    15,    25,    50,   100 }, true  },
                                 { xi.mod.AUTO_SHIELD_BASH_SLOW,       {     0,    12,    19,    25 }, true  }, },
-    ['heatsink']            = { { xi.mod.BURDEN_DECAY,                {     2,     4,     5,     6 }, true  }, },
+    ['heatsink']            = { { xi.mod.BURDEN_DECAY,                {     1,     3,     4,     5 }, true  }, },
     ['inhibitor']           = { { xi.mod.STORETP,                     {     5,    15,    25,    40 }, true  },
                                 { xi.mod.AUTO_TP_EFFICIENCY,          {   900,   900,   900,   900 }, false }, },
     ['inhibitor_ii']        = { { xi.mod.STORETP,                     {    10,    25,    40,    65 }, true  },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The automaton attachment Heatsink is granting a higher bonus than it should. The attachment was coded according to the total new burden decay value instead of the bonus that should be provided due how the page [was written on the wiki](https://www.bg-wiki.com/ffxi/Heatsink).

The burden from maneuvers decays at a rate of 1 degree per tick. Adding the Heatsink increases this to 2 degress per tick (+1) without a maneuver but is coded as +2 degrees for a total of 3. Each tier is 1 higher than it should be.

- [Burden section on BG](https://www.bg-wiki.com/ffxi/Category:Maneuver#Burden_and_Overloading)
- [Heatsink testing by Byrth](https://www.ffxiah.com/forum/topic/38369/automaton-research-thread/6/#2358787)

## Steps to test these changes

Changed values.
