### PR TITLE
Fix issue with status timers

### DIFF
--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1722,9 +1722,10 @@ void CStatusEffectContainer::SaveStatusEffects(bool logout)
             continue;
         }
 
-        auto realduration = PStatusEffect->GetStartTime() + PStatusEffect->GetDuration() - timer::now();
+        const auto durationSeconds     = timer::count_seconds(PStatusEffect->GetDuration());
+        const auto realDurationSeconds = timer::count_seconds(PStatusEffect->GetStartTime() + PStatusEffect->GetDuration() - timer::now());
 
-        if (realduration > 0s || PStatusEffect->GetDuration() == 0s)
+        if (realDurationSeconds > 0 || durationSeconds == 0)
         {
             const char* Query = "INSERT INTO char_effects (charid, effectid, icon, power, tick, duration, subid, subpower, tier, flags, timestamp) "
                                 "VALUES(%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u)";
@@ -1743,20 +1744,19 @@ void CStatusEffectContainer::SaveStatusEffects(bool logout)
                 PStatusEffect->SetPower(m_POwner->getMod(Mod::STONESKIN));
             }
 
-            uint32 tick     = static_cast<uint32>(timer::count_seconds(PStatusEffect->GetTickTime()));
             uint32 duration = 0;
 
-            if (PStatusEffect->GetDuration() > 0s)
+            if (durationSeconds > 0)
             {
                 if (PStatusEffect->HasEffectFlag(EFFECTFLAG_OFFLINE_TICK))
                 {
-                    duration = static_cast<uint32>(timer::count_seconds(PStatusEffect->GetDuration()));
+                    duration = static_cast<uint32>(durationSeconds);
                 }
                 else
                 {
-                    if (realduration > 0s)
+                    if (realDurationSeconds > 0)
                     {
-                        duration = static_cast<uint32>(timer::count_seconds(realduration));
+                        duration = static_cast<uint32>(realDurationSeconds);
                     }
                     else
                     {
@@ -1764,7 +1764,10 @@ void CStatusEffectContainer::SaveStatusEffects(bool logout)
                     }
                 }
             }
-            auto timestamp = earth_time::timestamp(timer::to_utc(PStatusEffect->GetStartTime()));
+
+            uint32 tick      = static_cast<uint32>(timer::count_seconds(PStatusEffect->GetTickTime()));
+            auto   timestamp = earth_time::timestamp(timer::to_utc(PStatusEffect->GetStartTime()));
+
             _sql->Query(Query, m_POwner->id, PStatusEffect->GetStatusID(), PStatusEffect->GetIcon(), PStatusEffect->GetPower(), tick, duration,
                         PStatusEffect->GetSubID(), PStatusEffect->GetSubPower(), PStatusEffect->GetTier(), PStatusEffect->GetEffectFlags(),
                         timestamp);


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Database uses seconds so cast before any checks or comparisons.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
