### PR TITLE
[lua] minor fix to tigers teeth quest

### DIFF
--- a/scripts/quests/sandoria/Tigers_Teeth.lua
+++ b/scripts/quests/sandoria/Tigers_Teeth.lua
@@ -2,7 +2,7 @@
 -- Tigers Teeth
 -----------------------------------
 -- LogID: 0 QuestID: 23
--- Taukila : !pos -140 -6 -8 230
+-- Taumila : !pos -140 -6 -8 230
 -----------------------------------
 
 local quest = Quest:new(xi.questLog.SANDORIA, xi.quest.id.sandoria.TIGERS_TEETH)
@@ -48,7 +48,7 @@ quest.sections =
                 onTrade = function(player, npc, trade)
                     if npcUtil.tradeHasExactly(trade, { { xi.item.BLACK_TIGER_FANG, 3 } }) then
                         return quest:progressEvent(572)
-                    elseif npcUtil.tradeHas(trade, xi.item.BLACK_TIGER_FANG) then
+                    else
                         return quest:event(573)
                     end
                 end,
@@ -79,7 +79,7 @@ quest.sections =
                     if npcUtil.tradeHasExactly(trade, { { xi.item.BLACK_TIGER_FANG, 3 } }) then
                         quest:setLocalVar(player, 'Option', 1)
                         return quest:progressEvent(572)
-                    elseif npcUtil.tradeHas(trade, xi.item.BLACK_TIGER_FANG) then
+                    else
                         return quest:event(573)
                     end
                 end,


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

As it was coded the quest used event 573 when less than 3 or more than 3 black tiger fangs were traded to the NPC.  I think that's what it did.... Not 100% on that but according to this capture (https://youtu.be/cgiRAju04ZE?feature=shared&t=60) it looks like when you trade anything besides 3 tiger fangs it uses event 573. 

## Steps to test these changes

Accept quest, trade anything besides 3 tigers fangs to quest giver.

1. !gotoid 17719349
2. !setfamelevel 0 5
3. !additem 884
4. Trade any random item to NPC
5. Should get CS 573
6. Trade 3 tiger fangs to complete quest
