### PR TITLE
[sql] Fixes dropid for Goblin Trader

### DIFF
--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -8056,7 +8056,7 @@ INSERT INTO `mob_groups` VALUES (22,1511,111,'Ghast_blm',330,0,953,0,0,40,40,0);
 INSERT INTO `mob_groups` VALUES (23,2447,111,'Lugat',330,0,264,0,0,39,42,0);
 INSERT INTO `mob_groups` VALUES (24,2919,111,'Nue',0,32,1827,0,0,41,42,0);
 INSERT INTO `mob_groups` VALUES (25,1701,111,'Goblin_Poacher',330,0,1138,0,0,40,43,0);
-INSERT INTO `mob_groups` VALUES (26,1741,111,'Goblin_Trader',330,0,2864,0,0,40,43,0);
+INSERT INTO `mob_groups` VALUES (26,1741,111,'Goblin_Trader',330,0,1179,0,0,40,43,0);
 INSERT INTO `mob_groups` VALUES (27,1709,111,'Goblin_Robber',330,0,1145,0,0,40,43,0);
 INSERT INTO `mob_groups` VALUES (28,1705,111,'Goblin_Reaper',330,0,1142,0,0,40,43,0);
 INSERT INTO `mob_groups` VALUES (29,3781,111,'Stone_Golem',330,0,505,0,0,40,42,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This Goblin Trader belongs to Zone 111 (Beaucedine Glacier) in `mob_droplist` and has the wrong dropid in `mob_groups`.
```sql
-- ZoneID: 111 - Goblin Trader
...
INSERT INTO `mob_droplist` VALUES (1179,0,0,1000,511,@RARE);  -- Goblin Mask (Rare, 5%)
...
```

## Steps to test these changes
Goblin Traders in Beaucedine Glacier will no longer drop the wrong items.
