### PR TITLE
[Magic] Fix threnodies elemental MEVA

### DIFF
--- a/scripts/globals/combat/element_tables.lua
+++ b/scripts/globals/combat/element_tables.lua
@@ -42,7 +42,8 @@ xi.combat.element.dataTable =
     [xi.element.DARK   ] = { xi.element.LIGHT,   xi.day.DARKSDAY,     xi.weather.GLOOM,      xi.weather.DARKNESS,      xi.mod.DARK_SDT,    xi.mod.DARK_RES_RANK,    xi.mod.DARK_NULL,  xi.mod.DARK_ABSORB,  xi.mod.DARK_MAB,    xi.mod.DARK_MACC,    xi.mod.DARK_MEVA,    xi.mod.DARK_FTP_BONUS,    xi.mod.DARK_STAFF_BONUS,    xi.mod.FORCE_DARK_DWBONUS,      0,                     0,                                0                                 },
 }
 
-xi.combat.element.getOppositeElement = function(element)
+-- Get element to which the element being checked is weak against.
+xi.combat.element.getElementWeakness = function(element)
     -- Validate fed value.
     local elementToCheck = utils.defaultIfNil(element, 0)
 
@@ -51,6 +52,24 @@ xi.combat.element.getOppositeElement = function(element)
     end
 
     return xi.combat.element.dataTable[elementToCheck][column.ELEMENT_OPPOSED]
+end
+
+-- Get element to which the element being checked is strong against.
+xi.combat.element.getElementStrength = function(element)
+    -- Validate fed value.
+    local elementToCheck = utils.defaultIfNil(element, 0)
+
+    if elementToCheck < xi.element.FIRE or elementToCheck > xi.element.DARK then
+        return 0
+    end
+
+    -- Get element.
+    for i = xi.element.FIRE, xi.element.DARK do
+        local opositeElement = xi.combat.element.dataTable[i][column.ELEMENT_OPPOSED]
+        if opositeElement == elementToCheck then
+            return i
+        end
+    end
 end
 
 -----------------------------------

--- a/scripts/globals/combat/magic_hit_rate.lua
+++ b/scripts/globals/combat/magic_hit_rate.lua
@@ -282,7 +282,7 @@ local function magicAccuracyFromDayElement(actor, actionElement)
             magicAcc = magicAcc + 5
 
         -- Weak day.
-        elseif dayElement == xi.combat.element.getOppositeElement(actionElement) then
+        elseif dayElement == xi.combat.element.getElementWeakness(actionElement) then
             magicAcc = magicAcc - 5
         end
     end

--- a/scripts/globals/pets/avatar.lua
+++ b/scripts/globals/pets/avatar.lua
@@ -63,7 +63,7 @@ local setMagicCastCooldown = function(pet)
     if dayElement == petElement then
         castingCooldown = castingCooldown - 3
     -- Weak day.
-    elseif dayElement == xi.combat.element.getOppositeElement(petElement) then
+    elseif dayElement == xi.combat.element.getElementWeakness(petElement) then
         castingCooldown = castingCooldown + 3
     end
 

--- a/scripts/globals/promyvion.lua
+++ b/scripts/globals/promyvion.lua
@@ -226,14 +226,8 @@ end
 -----------------------------------
 xi.promyvion.emptyOnMobSpawn = function(mob, mobType)
     local element    = math.random(xi.element.FIRE, xi.element.DARK)
-    local opposite   = xi.combat.element.getOppositeElement(element)
-    local complement = xi.element.NONE
-
-    if element == xi.element.WATER then
-        complement = xi.element.FIRE
-    elseif element < xi.element.WATER then
-        complement = element + 1
-    end
+    local opposite   = xi.combat.element.getElementWeakness(element)
+    local complement = xi.combat.element.getElementStrength(element)
 
     -- Setup resistances.
     for i = xi.element.FIRE, xi.element.DARK do

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -555,7 +555,7 @@ xi.spells.damage.calculateDayAndWeather = function(caster, spellElement, alwaysA
             dayAndWeather = dayAndWeather + 0.1 + caster:getMod(xi.mod.DAY_NUKE_BONUS) / 100 -- sorc. tonban(+1)/zodiac ring
 
         -- Weak day.
-        elseif dayElement == xi.combat.element.getOppositeElement(spellElement) then
+        elseif dayElement == xi.combat.element.getElementWeakness(spellElement) then
             dayAndWeather = dayAndWeather - 0.1
         end
     end

--- a/scripts/globals/spells/enfeebling_song.lua
+++ b/scripts/globals/spells/enfeebling_song.lua
@@ -201,7 +201,7 @@ xi.spells.enfeebling.useEnfeeblingSong = function(caster, target, spell)
     local power     = xi.spells.enfeebling.calculateSongPower(caster, spellEffect, pTable[spellId][column.SONG_POWER_BASE], gearBoost) or 0
     local tick      = spellEffect == xi.effect.REQUIEM and 3 or 0
     local duration  = xi.spells.enfeebling.calculateSongDuration(caster, spellEffect, pTable[spellId][column.SONG_DURATION], gearBoost) or 0
-    local subEffect = spellEffect == xi.effect.THRENODY and xi.combat.element.getElementalMEVAModifier(spellElement) or 0
+    local subEffect = spellEffect == xi.effect.THRENODY and xi.combat.element.getElementalMEVAModifier(xi.combat.element.getElementStrength(spellElement)) or 0
 
     -- FClamp and floor.
     power    = math.floor(utils.clamp(power, 0, pTable[spellId][column.SONG_POWER_CAP]))


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

One would think Fire Threnody's element would be fire, but it's water.
https://www.bg-wiki.com/ffxi/Category:Elements

The chart shows that an element defeats another element and its defeated by another one.
Example: Fire defeats Ice and it's defeated by Water.

We already had a method to fetch the element that defeats the checked element (checking fire would return water, since water defeats fire) but we lacked the method for the oposite operation.

This PR creates this method.
Used for threnodies and promyvions aswell, so its not a total waste.

## Steps to test these changes

Cast threnodies and have the mobs be afflicted by the proper elemental meva penalty
