### PR TITLE
Fix objective utility axis

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -12050,7 +12050,7 @@ void CLuaBaseEntity::countdown(sol::object const& secondsObj)
                 strongholdNameOverride = 0
             },
             fence = {
-                pos = {x = 0.000, y = 0.000}, -- center of fence
+                pos = {x = 0.000, z = 0.000}, -- center of fence
                 radius = 25.00, -- radius from pos in yalms
                 render = 25.00, -- distance from fence it becomes visible
                 blue = true -- optional, turns default red fence bars blue
@@ -12137,18 +12137,18 @@ void CLuaBaseEntity::objectiveUtility(sol::object const& obj)
         {
             sol::object fencePosObj = fenceObj.as<sol::table>()["pos"];
             float       posX        = 0.000;
-            float       posY        = 0.000;
+            float       posZ        = 0.000;
             if (fencePosObj.valid() && fencePosObj.is<sol::table>())
             {
                 posX = fencePosObj.as<sol::table>().get<float>("x");
-                posY = fencePosObj.as<sol::table>().get<float>("y");
+                posZ = fencePosObj.as<sol::table>().get<float>("z");
             }
 
             float radius = fenceObj.as<sol::table>().get_or<float>("radius", 0.00);
             float render = fenceObj.as<sol::table>().get_or<float>("render", 25.00);
             bool  blue   = fenceObj.as<sol::table>().get_or<bool, std::string, bool>("blue", false);
 
-            packet->addFence(posX, posY, radius, render, blue);
+            packet->addFence(posX, posZ, radius, render, blue);
         }
 
         sol::object helpObj = obj.as<sol::table>()["help"];

--- a/src/map/packets/objective_utility.cpp
+++ b/src/map/packets/objective_utility.cpp
@@ -79,10 +79,10 @@ void CObjectiveUtilityPacket::addScoreboard(const std::pair<int32, int32>& score
     ref<uint32>(0x44) = data[5];      // Stronghold Name Override - When non-zero, replace Stronghold name with Balamor's Adumbration.
 }
 
-void CObjectiveUtilityPacket::addFence(float x, float y, float radius, float render, bool blue /* = false */)
+void CObjectiveUtilityPacket::addFence(float x, float z, float radius, float render, bool blue /* = false */)
 {
     ref<int32>(0x14)  = static_cast<int32>(x * 1000);
-    ref<int32>(0x18)  = static_cast<int32>(y * 1000);
+    ref<int32>(0x18)  = static_cast<int32>(z * 1000);
     ref<uint32>(0x1C) = static_cast<uint32>(radius * 1000);
     ref<uint32>(0x20) = static_cast<uint32>(render * 1000);
     ref<uint8>(0x24) |= OBJECTIVEUTILITY_FENCE;

--- a/src/map/packets/objective_utility.h
+++ b/src/map/packets/objective_utility.h
@@ -44,6 +44,6 @@ public:
     void addCountdown(uint32 duration, uint32 warning = 0);
     void addBars(std::vector<std::pair<std::string, uint32>>&& bars);
     void addScoreboard(const std::pair<int32, int32>& score, const std::vector<uint32>& data);
-    void addFence(float x, float y, float radius, float render, bool blue = false);
+    void addFence(float x, float z, float radius, float render, bool blue = false);
     void addHelpText(uint16 title, uint16 description);
 };


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

XiPackets calls this FenceY but it aligns with what we use as Z.

## Steps to test these changes

Use this command:
```lua
local commandObj = {}

commandObj.cmdprops =
{
    permission = 1,
    parameters = ''
}

commandObj.onTrigger = function(player)
    local objective = {
        fence = {
            pos = player:getPos(),
            radius = 25,
            render = 25,
        },
    }

    player:objectiveUtility(objective)
end

return commandObj
```
See that it makes a fence centered around your character.