### PR TITLE
[Misc] Add mapping for survival guide mog tablet discount and fix Tenzen being unavailable during "Dawn"

### DIFF
--- a/scripts/globals/rhapsodies.lua
+++ b/scripts/globals/rhapsodies.lua
@@ -384,9 +384,18 @@ xi.rhapsodies.requiredCharacters =
 xi.rhapsodies.charactersAvailable = function(player)
     local rovMission = player:getCurrentMission(xi.mission.log_id.ROV)
     for _, char in pairs(xi.rhapsodies.requiredCharacters[rovMission]) do
-        local expansionMission = player:getCurrentMission(xi.rhapsodies.expansion[char])
+        local expansionLog     = xi.rhapsodies.expansion[char]
+        local expansionMission = player:getCurrentMission(expansionLog)
+
         if xi.rhapsodies.unavailability[char][expansionMission] then
-            return false
+            -- CoP "Dawn" exception. TODO: Maybe add support for mission status checks in the future.
+            if
+                expansionLog ~= xi.mission.log_id.COP or       -- Mission log isn't CoP -> false
+                expansionMission ~= xi.mission.id.cop.DAWN or  -- Mission log is CoP, but mission isn't "Dawn" -> false
+                player:getCharVar('Mission[6][828]Status') < 4 -- Mission log is CoP and mission is "Dawn", but status for "Dawn" is under 4 -> false
+            then
+                return false -- Character is unavailable.
+            end
         end
     end
 

--- a/scripts/missions/acp/01_A_Crystalline_Prophecy.lua
+++ b/scripts/missions/acp/01_A_Crystalline_Prophecy.lua
@@ -36,8 +36,10 @@ mission.sections =
                         local noVerena = 0
                         local noSibyl  = 0
 
-                        -- TODO: Fact check this.
-                        if player:hasCompletedMission(xi.mission.log_id.ZILART, xi.mission.id.zilart.WELCOME_TNORG) then
+                        if
+                            player:getCurrentMission(xi.mission.log_id.ZILART) >= xi.mission.id.zilart.RETURN_TO_DELKFUTTS_TOWER and -- Verena is kidnapped and then in plot coma.
+                            player:getCurrentMission(xi.mission.log_id.ZILART) < xi.mission.id.zilart.AWAKENING                      -- Verena appears in Tenshodo cutscene, recovered.
+                        then
                             noVerena = 1
                         end
 

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Survival_Guide.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Survival_Guide.lua
@@ -5,7 +5,7 @@
 ---@type TNpcEntity
 local entity = {}
 
-entity.onTrigger = function(player, targetNpc)
+entity.onTrigger = function(player, npc)
     xi.survivalGuide.onTrigger(player)
 end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds the logic to display the "free ride" text in survival guides. Doesnt actually implement mog tablets, obviously.
- The NPC fixes for Verena are confirmed in retail and proper, but the Tenzen fix will require an actual rewrite of the system to support mission stages checking, when more use-cases are found.

## Steps to test these changes
None.
