### PR TITLE
[Chore] Improve "Banishing Gate" behavior

### DIFF
--- a/scripts/zones/Garlaige_Citadel/npcs/_5k0.lua
+++ b/scripts/zones/Garlaige_Citadel/npcs/_5k0.lua
@@ -9,18 +9,22 @@ local ID = zones[xi.zone.GARLAIGE_CITADEL]
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    if player:hasKeyItem(xi.ki.POUCH_OF_WEIGHTED_STONES) then
-        -- Door opens from both sides.
-        GetNPCByID(npc:getID()):openDoor(30)
+    if npc:getAnimation() == xi.animation.CLOSE_DOOR then
+        if player:hasKeyItem(xi.ki.POUCH_OF_WEIGHTED_STONES) then
+            -- Only the left side displays a message when interacting.
+            if player:getXPos() < -201 then
+                player:messageSpecial(ID.text.THE_GATE_OPENS_FOR_YOU, xi.ki.POUCH_OF_WEIGHTED_STONES)
+            end
 
-        -- Only the left side displays a message when interacting.
-        if player:getXPos() < -201 then
-            player:messageSpecial(ID.text.THE_GATE_OPENS_FOR_YOU, xi.ki.POUCH_OF_WEIGHTED_STONES)
-        end
-    else
-        -- Left side regular interaction.
-        if player:getXPos() < -201 then
-            player:messageSpecial(ID.text.YOU_COULD_OPEN_THE_GATE, xi.ki.POUCH_OF_WEIGHTED_STONES)
+            -- Door opens from both sides. There's a short delay.
+            npc:timer(1500, function(npcArg)
+                npcArg:openDoor(15)
+            end)
+        else
+            -- Left side regular interaction.
+            if player:getXPos() < -201 then
+                player:messageSpecial(ID.text.YOU_COULD_OPEN_THE_GATE, xi.ki.POUCH_OF_WEIGHTED_STONES)
+            end
         end
     end
 end

--- a/scripts/zones/Garlaige_Citadel/npcs/_5k9.lua
+++ b/scripts/zones/Garlaige_Citadel/npcs/_5k9.lua
@@ -9,18 +9,22 @@ local ID = zones[xi.zone.GARLAIGE_CITADEL]
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    if player:hasKeyItem(xi.ki.POUCH_OF_WEIGHTED_STONES) then
-        -- Door opens from both sides.
-        GetNPCByID(npc:getID()):openDoor(30)
+    if npc:getAnimation() == xi.animation.CLOSE_DOOR then
+        if player:hasKeyItem(xi.ki.POUCH_OF_WEIGHTED_STONES) then
+            -- Only the north side displays a message when interacting.
+            if player:getZPos() > 80.5 then
+                player:messageSpecial(ID.text.THE_GATE_OPENS_FOR_YOU, xi.ki.POUCH_OF_WEIGHTED_STONES)
+            end
 
-        -- Only the north side displays a message when interacting.
-        if player:getZPos() > 80.5 then
-            player:messageSpecial(ID.text.THE_GATE_OPENS_FOR_YOU, xi.ki.POUCH_OF_WEIGHTED_STONES)
-        end
-    else
-        -- North side regular interaction.
-        if player:getZPos() > 80.5 then
-            player:messageSpecial(ID.text.YOU_COULD_OPEN_THE_GATE, xi.ki.POUCH_OF_WEIGHTED_STONES)
+            -- Door opens from both sides. There's a short delay.
+            npc:timer(1500, function(npcArg)
+                npcArg:openDoor(15)
+            end)
+        else
+            -- North side regular interaction.
+            if player:getZPos() > 80.5 then
+                player:messageSpecial(ID.text.YOU_COULD_OPEN_THE_GATE, xi.ki.POUCH_OF_WEIGHTED_STONES)
+            end
         end
     end
 end

--- a/scripts/zones/Garlaige_Citadel/npcs/_5ki.lua
+++ b/scripts/zones/Garlaige_Citadel/npcs/_5ki.lua
@@ -9,21 +9,22 @@ local ID = zones[xi.zone.GARLAIGE_CITADEL]
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    if player:hasKeyItem(xi.ki.POUCH_OF_WEIGHTED_STONES) then
-        -- Door opens from both sides.
-        GetNPCByID(npc:getID()):openDoor(30)
+    if npc:getAnimation() == xi.animation.CLOSE_DOOR then
+        if player:hasKeyItem(xi.ki.POUCH_OF_WEIGHTED_STONES) then
+            -- Only the south side SHOULD display a message when interacting.
+            if player:getZPos() < 359 then
+                player:messageSpecial(ID.text.THE_GATE_OPENS_FOR_YOU, xi.ki.POUCH_OF_WEIGHTED_STONES)
+            end
 
-        -- NOTE: In retail, this door doesn't display any messages.
-        -- "Better than retail" case, considering how the other 2 gates behave.
-
-        -- Only the south side SHOULD display a message when interacting.
-        if player:getZPos() < 359 then
-            player:messageSpecial(ID.text.THE_GATE_OPENS_FOR_YOU, xi.ki.POUCH_OF_WEIGHTED_STONES)
-        end
-    else
-        -- South side EXPECTED regular interaction.
-        if player:getZPos() < 359 then
-            player:messageSpecial(ID.text.YOU_COULD_OPEN_THE_GATE, xi.ki.POUCH_OF_WEIGHTED_STONES)
+            -- Door opens from both sides. There's a short delay.
+            npc:timer(1500, function(npcArg)
+                npcArg:openDoor(15)
+            end)
+        else
+            -- South side EXPECTED regular interaction.
+            if player:getZPos() < 359 then
+                player:messageSpecial(ID.text.YOU_COULD_OPEN_THE_GATE, xi.ki.POUCH_OF_WEIGHTED_STONES)
+            end
         end
     end
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?


As title sais:
- Adds a check for gate already open, so it doesn't return messages while open.
- Adjust time gates stay open.
- Adds a short delay to mimic retail.
- Removes reduntant "Get npc id, to get npc we already had" logic

## Steps to test these changes

None.
