### PR TITLE
[Fix] Sublimation/Refresh interaction and Drain2/3 HP bonus

### DIFF
--- a/scripts/actions/abilities/sublimation.lua
+++ b/scripts/actions/abilities/sublimation.lua
@@ -14,38 +14,33 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    local sublimationComplete = player:getStatusEffect(xi.effect.SUBLIMATION_COMPLETE)
-    local sublimationCharging = player:getStatusEffect(xi.effect.SUBLIMATION_ACTIVATED)
-    local mp                  = 0
+    local mp        = 0
+    local maxMP     = player:getMaxMP()
+    local currentMP = player:getMP()
 
-    if sublimationComplete ~= nil then
-        mp           = sublimationComplete:getPower()
-        local maxmp  = player:getMaxMP()
-        local currmp = player:getMP()
+    if player:hasStatusEffect(xi.effect.SUBLIMATION_COMPLETE) then
+        mp = player:getStatusEffect(xi.effect.SUBLIMATION_COMPLETE):getPower()
 
-        if mp + currmp > maxmp then
-            mp = maxmp - currmp
+        if mp + currentMP > maxMP then
+            mp = maxMP - currentMP
         end
 
         player:addMP(mp)
         player:delStatusEffectSilent(xi.effect.SUBLIMATION_COMPLETE)
         ability:setMsg(xi.msg.basic.JA_RECOVERS_MP)
-    elseif sublimationCharging ~= nil then
-        mp           = sublimationCharging:getPower()
-        local maxmp  = player:getMaxMP()
-        local currmp = player:getMP()
+    elseif player:hasStatusEffect(xi.effect.SUBLIMATION_ACTIVATED) then
+        mp = player:getStatusEffect(xi.effect.SUBLIMATION_ACTIVATED):getPower()
 
-        if mp + currmp > maxmp then
-            mp = maxmp - currmp
+        if mp + currentMP > maxMP then
+            mp = maxMP - currentMP
         end
 
         player:addMP(mp)
         player:delStatusEffectSilent(xi.effect.SUBLIMATION_ACTIVATED)
         ability:setMsg(xi.msg.basic.JA_RECOVERS_MP)
     else
-        local refresh = player:getStatusEffect(xi.effect.REFRESH)
-
-        if refresh == nil or refresh:getSubPower() < 3 then
+        local refreshTier = player:hasStatusEffect(xi.effect.REFRESH) and player:getStatusEffect(xi.effect.REFRESH):getTier() or 0
+        if refreshTier < 3 then
             player:delStatusEffect(xi.effect.REFRESH)
             player:addStatusEffect(xi.effect.SUBLIMATION_ACTIVATED, 0, 3, 7200)
         else

--- a/scripts/effects/max_hp_boost.lua
+++ b/scripts/effects/max_hp_boost.lua
@@ -5,14 +5,14 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.HPP, effect:getPower())
+    effect:addMod(xi.mod.HPP, effect:getPower())   -- % HP bonus to max HP
+    effect:addMod(xi.mod.HP, effect:getSubPower()) -- Flat HP bonus to max HP
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.HPP, effect:getPower())
 end
 
 return effectObject

--- a/scripts/effects/refresh.lua
+++ b/scripts/effects/refresh.lua
@@ -5,14 +5,18 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.REFRESH, effect:getPower())
+    if effect:getTier() >= 3 then
+        target:delStatusEffect(xi.effect.SUBLIMATION_ACTIVATED)
+        target:delStatusEffect(xi.effect.SUBLIMATION_COMPLETE)
+    end
+
+    effect:addMod(xi.mod.REFRESH, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.REFRESH, effect:getPower())
 end
 
 return effectObject

--- a/scripts/effects/sublimation_activated.lua
+++ b/scripts/effects/sublimation_activated.lua
@@ -5,6 +5,7 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
+    target:delStatusEffect(xi.effect.REFRESH)
 end
 
 effectObject.onEffectTick = function(target, effect)

--- a/scripts/effects/sublimation_complete.lua
+++ b/scripts/effects/sublimation_complete.lua
@@ -5,6 +5,7 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
+    target:delStatusEffect(xi.effect.REFRESH)
 end
 
 effectObject.onEffectTick = function(target, effect)

--- a/scripts/globals/monstrosity.lua
+++ b/scripts/globals/monstrosity.lua
@@ -1505,9 +1505,7 @@ xi.monstrosity.teyrnonOnEventFinish = function(player, csid, option, npc)
                 end
 
                 player:delStatusEffectSilent(xi.effect.REFRESH)
-                player:delStatusEffect(xi.effect.SUBLIMATION_COMPLETE)
-                player:delStatusEffect(xi.effect.SUBLIMATION_ACTIVATED)
-                player:addStatusEffect(xi.effect.REFRESH, 1, 3, 3600, 0, 3)
+                player:addStatusEffect(xi.effect.REFRESH, 1, 3, 3600) -- Does indeed get overwriten by regular refresh.
             end,
 
             -- 4: Protect

--- a/scripts/globals/regimes.lua
+++ b/scripts/globals/regimes.lua
@@ -1225,9 +1225,7 @@ xi.regime.bookOnEventFinish = function(player, option, regimeType)
 
             ['REFRESH'] = function()
                 player:delStatusEffectSilent(xi.effect.REFRESH)
-                player:delStatusEffect(xi.effect.SUBLIMATION_COMPLETE)
-                player:delStatusEffect(xi.effect.SUBLIMATION_ACTIVATED)
-                player:addStatusEffect(xi.effect.REFRESH, 1, 3, 3600, 0, 3)
+                player:addStatusEffect(xi.effect.REFRESH, 1, 3, 3600) -- Does indeed get overwriten by regular refresh.
             end,
 
             ['PROTECT'] = function()

--- a/scripts/globals/spells/enhancing_spell.lua
+++ b/scripts/globals/spells/enhancing_spell.lua
@@ -497,8 +497,8 @@ xi.spells.enhancing.useEnhancingSpell = function(caster, target, spell)
     -- Refresh
     elseif spellEffect == xi.effect.REFRESH then
         if
-            target:hasStatusEffect(xi.effect.SUBLIMATION_ACTIVATED) or
-            target:hasStatusEffect(xi.effect.SUBLIMATION_COMPLETE)
+            tier < 3 and
+            (target:hasStatusEffect(xi.effect.SUBLIMATION_ACTIVATED) or target:hasStatusEffect(xi.effect.SUBLIMATION_COMPLETE))
         then
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
             return 0


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Should fix instances of sublimation/refresh weird interactions.
- Closes #7600
- Fixes weird interactions between Drain 2/3 hp bonus when used under certain situations.

## Steps to test these changes

Review by commit.
Try to have refresh (actual refresh, not ballad, rolls, etc) and sublimation at the same time.
Use Drain II and Drain III. Have max HP effect be applied only when it has to.
