### PR TITLE
AH: Show stack amount in history when selling

### DIFF
--- a/src/search/data_loader.cpp
+++ b/src/search/data_loader.cpp
@@ -159,19 +159,11 @@ ahItem CDataLoader::GetAHItemFromItemID(uint16 ItemID)
                                  "LEFT JOIN item_weapon ON item_basic.itemid = item_weapon.itemid "
                                  "WHERE item_basic.itemid = ?",
                                  ItemID);
-    if (rset && rset->rowsCount())
+    FOR_DB_SINGLE_RESULT(rset)
     {
-        while (rset->next())
-        {
-            CAHItem.Category     = rset->get<uint16>("aH");
-            CAHItem.SingleAmount = rset->getOrDefault<uint32>("COUNT(*)-SUM(stack)", 0);
-            CAHItem.StackAmount  = rset->getOrDefault<uint32>("SUM(stack)", 0);
-
-            if (rset->getOrDefault<uint32>("COUNT(*)-SUM(stack)", 0) == 1)
-            {
-                CAHItem.StackAmount = 0;
-            }
-        }
+        CAHItem.Category     = rset->get<uint16>("aH");
+        CAHItem.SingleAmount = rset->getOrDefault<uint32>("COUNT(*)-SUM(stack)", 0);
+        CAHItem.StackAmount  = rset->getOrDefault<uint32>("SUM(stack)", 0);
     }
     return CAHItem;
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Don't know what was the intent behind that if block but it's forcing the returned stacks quantity to always be set to 0 when selling an item on the AH. 

![image](https://github.com/user-attachments/assets/7615f013-b25f-4f86-83e8-099779092333)

Tested without it and behavior is now correct. Tested on items with history and without etc.

Also gets rid of the loop, since this query returns a single row.

## Steps to test these changes
List stacks of a certain item. Purchase at least one of them so there's some history.
Try listing a new stack, the quantity indicator should now correctly reflect the correct amount of stacks on the AH.

![image](https://github.com/user-attachments/assets/d25deb21-12ad-47f6-9a19-11b8a4fbbe3b)

<!-- Clear and detailed steps to test your changes here -->
