### PR TITLE
Refresh potency affects battery charge

### DIFF
--- a/scripts/actions/spells/blue/battery_charge.lua
+++ b/scripts/actions/spells/blue/battery_charge.lua
@@ -21,7 +21,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local power = 3 -- 10%
+    local power = 3 + caster:getMod(xi.mod.ENHANCES_REFRESH)
     local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 300)
 
     if not target:addStatusEffect(xi.effect.REFRESH, power, 0, duration) then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

When a character casts the blue mage spell Battery Charge, the caster's "ENHANCES_REFRESH" mod (increased by gear such as [Amalric Coif](https://www.bg-wiki.com/ffxi/Amalric_Coif)) is added to the spell's potency.

## Steps to test these changes

`!changejob BLU 99`

Cast the spell Battery Charge with Amalric Coif equipped (`!additem 25615`), and see that your amount of MP recovered per tic goes from +3 to +4.
