### PR TITLE
Implement Koschei Crackows pet bonus

### DIFF
--- a/sql/item_mods_pet.sql
+++ b/sql/item_mods_pet.sql
@@ -140,6 +140,10 @@ INSERT INTO `item_mods_pet` VALUES (11388,28,5,3); -- Automaton - MATT: 5
 -- Pantin Babouches +1
 INSERT INTO `item_mods_pet` VALUES (11389,28,5,3); -- Automaton - MATT: 5
 
+-- Koschei Crackows
+INSERT INTO `item_mods_pet` VALUES (11392,23,5,1); -- Avatar - ATT: 5
+INSERT INTO `item_mods_pet` VALUES (11392,1,10,1); -- Avatar - DEF: 10
+
 -- Puppetry Taj +1
 INSERT INTO `item_mods_pet` VALUES (11470,71,3,3); -- Automaton - MPHEAL: 3
 INSERT INTO `item_mods_pet` VALUES (11470,72,3,3); -- Automaton - HPHEAL: 3


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Koschei Crackows should add +5 attack and +10 defense to the user's avatar's stats ([retail confirmation](https://www.bluegartr.com/threads/114636-Monster-Avatar-Pet-damage?p=6033568&viewfull=1#post6033568)). This PR implements those buffs in item_mods_pet.sql.

## Steps to test these changes

Summon an avatar with and without Koschei Crackows equipped (`!additem 11392`), see that your avatar's attack goes up by 5 and defense goes up by 10 when the shoes are equipped.
