### PR TITLE
fix: Set DE look before inserting in zone

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -5448,6 +5448,18 @@ namespace luautils
             }
         }
 
+        // Look must be set _before_ inserting the entity into the zone,
+        // else equipped NPCs/Mobs will be invisible.
+        if (table["look"].get_type() == sol::type::number)
+        {
+            PEntity->SetModelId(table.get<uint16>("look"));
+        }
+        else if (table["look"].get_type() == sol::type::string)
+        {
+            auto lookStr  = table.get<std::string>("look");
+            PEntity->look = stringToLook(lookStr);
+        }
+
         if (auto* PNpc = dynamic_cast<CNpcEntity*>(PEntity))
         {
             PNpc->namevis     = table.get_or<uint8>("namevis", 0);
@@ -5559,16 +5571,6 @@ namespace luautils
             }
 
             PZone->InsertMOB(PMob);
-        }
-
-        if (table["look"].get_type() == sol::type::number)
-        {
-            PEntity->SetModelId(table.get<uint16>("look"));
-        }
-        else if (table["look"].get_type() == sol::type::string)
-        {
-            auto lookStr  = table.get<std::string>("look");
-            PEntity->look = stringToLook(lookStr);
         }
 
         PEntity->updatemask |= UPDATE_ALL_CHAR;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Ensures DE model is set before inserting into the zone. DEs "mobs-but-actually-NPCs" with custom models were spawning invisible to clients in Garrison..

I need to take the time to do a write up, this was a swiss cheese of a clusterfuck to debug.

Given the conditions required and the limited subset of content using DEs, this likely only affects Garrison.

## Steps to test these changes

!garrison start

<!-- Clear and detailed steps to test your changes here -->
