### PR TITLE
move CS 98 from Gilgamesh to Oaken Door

### DIFF
--- a/scripts/missions/bastok/6_2_The_Pirates_Cove.lua
+++ b/scripts/missions/bastok/6_2_The_Pirates_Cove.lua
@@ -11,16 +11,16 @@
 -- qm4        : !pos 171 0 -25 205
 -- Gilgamesh  : !pos 122.452 -9.009 -12.052 252
 -----------------------------------
-local bastokMarketsID  = zones[xi.zone.BASTOK_MARKETS]
-local bastokMinesID    = zones[xi.zone.BASTOK_MINES]
-local ifritsCauldronID = zones[xi.zone.IFRITS_CAULDRON]
-local metalworksID     = zones[xi.zone.METALWORKS]
-local portBastokID     = zones[xi.zone.PORT_BASTOK]
+local bastokMarketsID     = zones[xi.zone.BASTOK_MARKETS]
+local bastokMinesID       = zones[xi.zone.BASTOK_MINES]
+local ifritsCauldronID    = zones[xi.zone.IFRITS_CAULDRON]
+local metalworksID        = zones[xi.zone.METALWORKS]
+local portBastokID        = zones[xi.zone.PORT_BASTOK]
 -----------------------------------
 
-local mission = Mission:new(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_PIRATES_COVE)
+local mission             = Mission:new(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_PIRATES_COVE)
 
-mission.reward =
+mission.reward            =
 {
     gil = 40000,
     rank = 7,
@@ -33,7 +33,7 @@ local handleAcceptMission = function(player, csid, option, npc)
     end
 end
 
-mission.sections =
+mission.sections          =
 {
     {
         check = function(player, currentMission, missionStatus, vars)
@@ -125,6 +125,15 @@ mission.sections =
 
         [xi.zone.NORG] =
         {
+            ['_700'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:getMissionStatus(mission.areaId) == 1 then
+                        return mission:progressEvent(98)
+                    end
+                end,
+            },
+
             ['Gilgamesh'] =
             {
                 onTrade = function(player, npc, trade)
@@ -133,12 +142,6 @@ mission.sections =
                         npcUtil.tradeHasExactly(trade, xi.item.FRAG_ROCK)
                     then
                         return mission:progressEvent(99)
-                    end
-                end,
-
-                onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) == 1 then
-                        return mission:progressEvent(98)
                     end
                 end,
             },


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes #7617

CS 98 is activated by clicking a "Oaken Door" instead of Gilgamesh.

## Steps to test these changes

1.  !addmission 1 17
2. !gotoid 17748013 (I think this was the Naji in Metal Works - there are so many)
3. Talk to Naji
4. !zone 252
5. Travel to Oaken Door
6. Click oaken Door for mission CS(98).

