### PR TITLE
add module for pre 2007 absorb spell cast times

### DIFF
--- a/modules/era/sql/original_absorb_casting_time.sql
+++ b/modules/era/sql/original_absorb_casting_time.sql
@@ -1,0 +1,17 @@
+-- The update on December 19th 2006 changed the absorb spell casting times from four seconds to two seconds: http://www.playonline.com/pcd/update/ff11us/20061219WH3cX1/detail.html
+-- It should be noted that the current game client will say the spells have a two second cast time
+
+UPDATE spell_list
+SET
+  castTime = 4000
+WHERE
+  name IN (
+    "absorb-str",
+    "absorb-dex",
+    "absorb-vit",
+    "absorb-agi",
+    "absorb-int",
+    "absorb-mnd",
+    "absorb-chr",
+    "absorb-tp"
+  );


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a module to use pre 2007 cast times for dark knight absorb spells

http://www.playonline.com/pcd/update/ff11us/20061219WH3cX1/detail.html
(search for " The casting time for all Absorb spells has been reduced from four seconds to two.")

## Steps to test these changes

Add era/sql/original_absorb_casting_time.sql to init.txt
Run dbtool
Run:
```
SELECT castTime FROM spell_list
WHERE name LIKE "absorb-%" 
AND (content_tag IS null OR content_tag = "TOAU")
```

