### PR TITLE
Ancestry Moogle (Race change service)

### DIFF
--- a/scripts/commands/racechange.lua
+++ b/scripts/commands/racechange.lua
@@ -1,0 +1,48 @@
+-----------------------------------
+-- func: racechange <player>
+-- desc: Make player eligible for Ancestry Moogle Race Change service.
+-----------------------------------
+---@type TCommand
+local commandObj = {}
+
+commandObj.cmdprops =
+{
+    permission = 3,
+    parameters = 's'
+}
+
+local function error(player, msg)
+    player:printToPlayer(msg)
+    player:printToPlayer('!racechange (player)')
+end
+
+commandObj.onTrigger = function(player, arg1)
+    local target
+
+    if arg1 ~= nil then
+        target = GetPlayerByName(arg1)
+        if target == nil then
+            error(player, string.format('Player named "%s" not found!', arg1))
+            return
+        end
+    else
+        target = player:getCursorTarget()
+        if target and not target:isPC() then
+            error(player, 'Target is not a PC')
+            return
+        end
+
+        if target == nil then
+            target = player
+        end
+    end
+
+    target:setCharVar('[RaceChange]Eligible', os.time() + 1209600, os.time() + 1209600)
+    target:setCharVar('[RaceChange]Last', 0)
+
+    player:printToPlayer(string.format(
+        '%s is now eligible for race change service at Ancestry Moogle. Eligibility will expire in 14 days.',
+        target:getName()))
+end
+
+return commandObj

--- a/scripts/globals/ancestry_moogle.lua
+++ b/scripts/globals/ancestry_moogle.lua
@@ -1,0 +1,262 @@
+-----------------------------------
+-- Ancestry Moogle (Race Change)
+--
+-- Player must have CharVar '[RaceChange]Eligible' set to a non-zero value to use the service.
+-----------------------------------
+
+xi = xi or {}
+xi.ancestryMoogle = {}
+
+local settings =
+{
+    -- Interactions disabled if set to false.
+    enabled  = xi.settings.main.RACE_CHANGE_ENABLED or true,
+
+    -- The time in seconds that the player has to wait before they can use the service again.
+    -- Default is 14 days (1209600 seconds).
+    cooldown = xi.settings.main.RACE_CHANGE_COOLDOWN or 1209600,
+}
+
+local csidKey =
+{
+    NOT_ELIGIBLE = 1,
+    RACE_CHANGE  = 2,
+}
+
+local csidLookup =
+{
+    [xi.zone.PORT_BASTOK]    = { 480, 479 },
+    [xi.zone.PORT_SAN_DORIA] = { 833, 832 },
+    [xi.zone.WINDURST_WALLS] = { 580, 579 },
+}
+
+local swappableItems =
+{
+    [0] = -- Female trading Male gear
+    {
+        xi.item.DANCERS_TIARA_M,
+        xi.item.DANCERS_CASAQUE_M,
+        xi.item.DANCERS_BANGLES_M,
+        xi.item.DANCERS_TIGHTS_M,
+        xi.item.DANCERS_TOE_SHOES_M,
+
+        xi.item.DANCERS_TIARA_M_P1,
+        xi.item.DANCERS_CASAQUE_M_P1,
+        xi.item.DANCERS_BANGLES_M_P1,
+        xi.item.DANCERS_TIGHTS_M_P1,
+        xi.item.DANCERS_TOE_SHOES_M_P1,
+
+        xi.item.MAXIXI_TIARA_M,
+        xi.item.MAXIXI_CASAQUE_M,
+        xi.item.MAXIXI_BANGLES_M,
+        xi.item.MAXIXI_TIGHTS_M,
+        xi.item.MAXIXI_TOE_SHOES_M,
+
+        xi.item.MAXIXI_TIARA_M_P1,
+        xi.item.MAXIXI_CASAQUE_M_P1,
+        xi.item.MAXIXI_BANGLES_M_P1,
+        xi.item.MAXIXI_TIGHTS_M_P1,
+        xi.item.MAXIXI_TOE_SHOES_M_P1,
+
+        xi.item.MAXIXI_TIARA_M_P2,
+        xi.item.MAXIXI_CASAQUE_M_P2,
+        xi.item.MAXIXI_BANGLES_M_P2,
+        xi.item.MAXIXI_TIGHTS_M_P2,
+        xi.item.MAXIXI_TOE_SHOES_M_P2,
+
+        xi.item.MAXIXI_TIARA_M_P3,
+        xi.item.MAXIXI_CASAQUE_M_P3,
+        xi.item.MAXIXI_BANGLES_M_P3,
+        xi.item.MAXIXI_TIGHTS_M_P3,
+        xi.item.MAXIXI_TOE_SHOES_M_P3,
+    },
+
+    [1] = -- Male trading Female gear
+    {
+        xi.item.DANCERS_TIARA_F,
+        xi.item.DANCERS_CASAQUE_F,
+        xi.item.DANCERS_BANGLES_F,
+        xi.item.DANCERS_TIGHTS_F,
+        xi.item.DANCERS_TOE_SHOES_F,
+
+        xi.item.DANCERS_TIARA_F_P1,
+        xi.item.DANCERS_CASAQUE_F_P1,
+        xi.item.DANCERS_BANGLES_F_P1,
+        xi.item.DANCERS_TIGHTS_F_P1,
+        xi.item.DANCERS_TOE_SHOES_F_P1,
+
+        xi.item.MAXIXI_TIARA_F,
+        xi.item.MAXIXI_CASAQUE_F,
+        xi.item.MAXIXI_BANGLES_F,
+        xi.item.MAXIXI_TIGHTS_F,
+        xi.item.MAXIXI_TOE_SHOES_F,
+
+        xi.item.MAXIXI_TIARA_F_P1,
+        xi.item.MAXIXI_CASAQUE_F_P1,
+        xi.item.MAXIXI_BANGLES_F_P1,
+        xi.item.MAXIXI_TIGHTS_F_P1,
+        xi.item.MAXIXI_TOE_SHOES_F_P1,
+
+        xi.item.MAXIXI_TIARA_F_P2,
+        xi.item.MAXIXI_CASAQUE_F_P2,
+        xi.item.MAXIXI_BANGLES_F_P2,
+        xi.item.MAXIXI_TIGHTS_F_P2,
+        xi.item.MAXIXI_TOE_SHOES_F_P2,
+
+        xi.item.MAXIXI_TIARA_F_P3,
+        xi.item.MAXIXI_CASAQUE_F_P3,
+        xi.item.MAXIXI_BANGLES_F_P3,
+        xi.item.MAXIXI_TIGHTS_F_P3,
+        xi.item.MAXIXI_TOE_SHOES_F_P3,
+    },
+}
+
+xi.ancestryMoogle.onTrade = function(player, npc, trade)
+    if not settings.enabled then
+        return
+    end
+
+    local confirmedItems = {}
+
+    for slotId = 0, 7 do
+        local item = trade:getItem(slotId)
+        if item then
+            local itemId = item:getID()
+            if utils.contains(itemId, swappableItems[player:getGender()]) then
+                print('Item eligible for swap: ' .. itemId)
+                -- Player submitted an eligible item from the opposite gender.
+                table.insert(confirmedItems, itemId)
+            end
+        end
+    end
+
+    for _, v in ipairs(confirmedItems) do
+        -- Give new item. Item ID + 1 for MtoF, -1 for FtoM.
+        -- getGender returns 0 for F and 1 for M.
+        if npcUtil.giveItem(player, player:getGender() == 1 and v - 1 or v + 1) then
+            trade:confirmItem(v, 1)
+        end
+    end
+
+    player:confirmTrade()
+    return true
+end
+
+xi.ancestryMoogle.onTrigger = function(player, npc)
+    if not settings.enabled then
+        return
+    end
+
+    local zoneID           = player:getZoneID()
+    local raceChangeLast   = player:getCharVar('[RaceChange]Last')
+    local raceChangeExpiry = player:getCharVar('[RaceChange]Eligible')
+
+    -- If the player is on cooldown, show a message and exit.
+    if raceChangeLast + settings.cooldown >= os.time() then
+        player:startEvent(csidLookup[zoneID][csidKey.NOT_ELIGIBLE],
+            236,
+            0, -- unknown, seen 0
+            0, -- unknown, seen 0
+            0, -- unknown, seen 0
+            0, -- unknown, time remaining for an unknown variant of the event
+            5, -- 0 is message when service not purchased, 1+ when on cooldown.
+            1, -- 1+ displays "Thank you for using the service!". Capture shows misc values.
+            0  -- unknown, seen random values.
+        )
+        return
+    end
+
+    -- Player must have "purchased" the service and have enough time left to use it.
+    if
+        raceChangeExpiry == 0 or          -- Expired charvar
+        raceChangeExpiry - os.time() <= 0 -- If the charvar is set but expired.
+    then
+        player:startEvent(csidLookup[zoneID][csidKey.NOT_ELIGIBLE], 236)
+        player:setCharVar('[RaceChange]Eligible', 0)
+        return
+    end
+
+    -- The upcoming event need the Previous_Race NPC set to the player current race/face.
+    -- The Previous_Race NPC is 2 IDs higher than the Ancestry Moogle NPC.
+    local previousRaceNpc = GetNPCByID(npc:getID() + 2)
+    if previousRaceNpc then
+        previousRaceNpc:setLook({ race = player:getRace(), face = player:getFace() })
+        player:sendEntityUpdateToPlayer(previousRaceNpc, xi.entityUpdate.ENTITY_UPDATE, xi.updateType.UPDATE_ALL_CHAR)
+    end
+
+    player:startEvent(csidLookup[zoneID][csidKey.RACE_CHANGE],
+        player:getRace(),                -- current race
+        bit.rshift(player:getFace(), 1), -- current face, flattened from 0-15 to 0-7
+        player:getSize(),                -- current size
+        player:getFace() % 2,            -- current hair color (face variant)
+        raceChangeExpiry - os.time(),    -- Time left to use the service, in seconds.
+        0,                               -- unknown, seen 0
+        0,                               -- unknown, seen random values
+        0                                -- unknown, seen random values
+    )
+end
+
+xi.ancestryMoogle.onEventFinish = function(player, csid, option, npc)
+    if not settings.enabled then
+        return
+    end
+
+    local zoneID = player:getZoneID()
+    local raceChangeExpiry = player:getCharVar('[RaceChange]Eligible')
+
+    if
+        csid == csidLookup[zoneID][csidKey.RACE_CHANGE] and
+        option ~= utils.EVENT_CANCELLED_OPTION
+    then
+        -- If timer expired between the event start and finish, reset
+        if
+            raceChangeExpiry == 0 or          -- Expired charvar
+            raceChangeExpiry - os.time() <= 0 -- If the charvar is set but expired.
+        then
+            player:messageSpecial(zones[zoneID].text.UNABLE_RACE_CHANGE)
+            -- Must rezone character to exit the special event.
+            player:forceRezone()
+            return
+        end
+
+        -- Bits 8-11:  Race ID (4 bits, values 1-8)
+        -- Bits 12-15: Face/Hair combination (4 bits, values 0-15)
+        -- Bits 16-17: Size (2 bits, values 0(small)-2(large))
+        local newRace = bit.band(bit.rshift(option, 8), 0xF)
+        local newFace = bit.band(bit.rshift(option, 12), 0xF)
+        local newSize = bit.band(bit.rshift(option, 16), 0x3)
+
+        -- Sanity checks
+        if
+            (not newRace or not newFace or not newSize) or
+            (newRace < xi.race.HUME_M or newRace > xi.race.GALKA) or
+            (newFace > 15) or -- 1A (0) to 8B (15)
+            (newSize > 2)     -- 0 (small) to 2 (large)
+        then
+            printf('bad race change data: player=%s, newRace=%d, newFace=%d, newSize=%d',
+                player:getName(), newRace, newFace, newSize)
+            player:messageSpecial(zones[zoneID].text.UNABLE_RACE_CHANGE)
+            -- Must rezone character to exit the special event.
+            player:forceRezone()
+            return
+        end
+
+        printf('race change: player=%s, race %d -> %d, face %d -> %d, size %d -> %d',
+            player:getName(),
+            player:getRace(), newRace,
+            player:getFace(), newFace,
+            player:getSize(), newSize)
+
+        -- Set the timer to 0 so the player can't use the service again
+        -- This is done before the actual race change since it will teleport the player
+        -- and player may no longer be valid
+        player:setCharVar('[RaceChange]Eligible', 0)
+        player:setCharVar('[RaceChange]Last', os.time())
+
+        if not player:raceChange(newRace, newFace, newSize) then
+            player:messageSpecial(zones[zoneID].text.UNABLE_RACE_CHANGE)
+            -- Must rezone character to exit the special event.
+            player:forceRezone()
+        end
+    end
+end

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -1177,7 +1177,25 @@ end
 
 ---@nodiscard
 ---@return integer
+function CBaseEntity:getFace()
+end
+
+---@nodiscard
+---@return integer
 function CBaseEntity:getGender()
+end
+
+---@nodiscard
+---@return integer
+function CBaseEntity:getSize()
+end
+
+---@nodiscard
+---@param newRace integer
+---@param newFace integer
+---@param newSize integer
+---@return boolean
+function CBaseEntity:raceChange(newRace, newFace, newSize)
 end
 
 ---@nodiscard
@@ -1210,6 +1228,11 @@ end
 ---@param slotObj integer?
 ---@return nil
 function CBaseEntity:setModelId(modelId, slotObj)
+end
+
+---@param look table
+---@return nil
+function CBaseEntity:setLook(look)
 end
 
 ---@nodiscard

--- a/scripts/zones/Aht_Urhgan_Whitegate/DefaultActions.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/DefaultActions.lua
@@ -23,7 +23,6 @@ return {
     ['Hashayra']           = { event = 676 },
     ['Hishahma']           = { event = 571 },
     ['Imperial_Whitegate'] = { messageSpecial = ID.text.GATE_IS_FIRMLY_CLOSED },
-    ['Jarafah']            = { event = 702 },
     ['Jumaaf']             = { event = 243 },
     ['Kabihyam']           = { event = 245 },
     ['Kalimahf']           = { event = 680 },

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Jarafah.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Jarafah.lua
@@ -1,0 +1,19 @@
+-----------------------------------
+-- Area: Aht Urhgan Whitegate
+--  NPC: Jarafah
+--  Item Depository NPC (not implemented)
+--  !pos 14.88 0 -15 50
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    player:startEvent(702)
+end
+
+entity.onEventFinish = function(player, csid, option, npc)
+    -- TODO: Implement
+    -- Must account for race change item swaps. See http://www.playonline.com/ff11eu/envi/racechange/
+end
+
+return entity

--- a/scripts/zones/Port_Bastok/DefaultActions.lua
+++ b/scripts/zones/Port_Bastok/DefaultActions.lua
@@ -16,7 +16,6 @@ return {
     ['Ensetsu']          = { event = 27 },
     ['Evi']              = { event = 21 },
     ['Ferrol']           = { event = 254 },
-    ['Gallagher']        = { event = 349 },
     ['Grin']             = { event = 295 },
     ['Gudav']            = { event = 31 },
     ['Gwinar']           = { event = 365 },

--- a/scripts/zones/Port_Bastok/IDs.lua
+++ b/scripts/zones/Port_Bastok/IDs.lua
@@ -77,6 +77,7 @@ zones[xi.zone.PORT_BASTOK] =
         OBTAINED_GUILD_POINTS         = 12699, -- Obtained: <number> guild points.
         OBTAINED_NUM_KEYITEMS         = 13092, -- Obtained key item: <number> <keyitem>!
         NOT_ACQUAINTED                = 13094, -- I'm sorry, but I don't believe we're acquainted. Please leave me be.
+        UNABLE_RACE_CHANGE            = 14186, -- You were unable to use the specified appearance for your character.
     },
     mob =
     {

--- a/scripts/zones/Port_Bastok/npcs/Ancestry_Moogle.lua
+++ b/scripts/zones/Port_Bastok/npcs/Ancestry_Moogle.lua
@@ -1,0 +1,22 @@
+-----------------------------------
+-- Area: Port Bastok
+--  NPC: Ancestry Moogle
+-- Type: Race Change NPC
+-- !pos 116.080 7.372 -31.820 236
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+    return xi.ancestryMoogle.onTrade(player, npc, trade)
+end
+
+entity.onTrigger = function(player, npc)
+    return xi.ancestryMoogle.onTrigger(player, npc)
+end
+
+entity.onEventFinish = function(player, csid, option, npc)
+    return xi.ancestryMoogle.onEventFinish(player, csid, option, npc)
+end
+
+return entity

--- a/scripts/zones/Port_Bastok/npcs/Gallagher.lua
+++ b/scripts/zones/Port_Bastok/npcs/Gallagher.lua
@@ -1,0 +1,19 @@
+-----------------------------------
+-- Area: Port Bastok
+--  NPC: Gallagher
+--  Item Depository NPC (not implemented)
+--  !pos -33 7.5 -179 236
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    player:startEvent(349)
+end
+
+entity.onEventFinish = function(player, csid, option, npc)
+    -- TODO: Implement
+    -- Must account for race change item swaps. See http://www.playonline.com/ff11eu/envi/racechange/
+end
+
+return entity

--- a/scripts/zones/Port_Jeuno/npcs/Garridan.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Garridan.lua
@@ -1,0 +1,19 @@
+-----------------------------------
+-- Area: Port Jeuno
+--  NPC: Garridan
+--  Item Depository NPC (not implemented)
+--  !pos 19.59 0 -9.9 246
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    player:startEvent(308)
+end
+
+entity.onEventFinish = function(player, csid, option, npc)
+    -- TODO: Implement
+    -- Must account for race change item swaps. See http://www.playonline.com/ff11eu/envi/racechange/
+end
+
+return entity

--- a/scripts/zones/Port_San_dOria/IDs.lua
+++ b/scripts/zones/Port_San_dOria/IDs.lua
@@ -84,6 +84,7 @@ zones[xi.zone.PORT_SAN_DORIA] =
         OBTAINED_NUM_KEYITEMS          = 11562, -- Obtained key item: <number> <keyitem>!
         NOT_ACQUAINTED                 = 11564, -- I'm sorry, but I don't believe we're acquainted. Please leave me be.
         MAP_MARKER_TUTORIAL            = 11912, -- Selecting Map from the main menu opens the map of the area in which you currently reside. Select Markers and press the right arrow key to see all the markers placed on your map.
+        UNABLE_RACE_CHANGE             = 12234, -- You were unable to use the specified appearance for your character.
     },
     mob =
     {

--- a/scripts/zones/Port_San_dOria/npcs/Ancestry_Moogle.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Ancestry_Moogle.lua
@@ -1,0 +1,22 @@
+-----------------------------------
+-- Area: Port San d'Oria
+--  NPC: Ancestry Moogle
+-- Type: Race Change NPC
+-- !pos 73.7 -124 -16 232
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+    return xi.ancestryMoogle.onTrade(player, npc, trade)
+end
+
+entity.onTrigger = function(player, npc)
+    return xi.ancestryMoogle.onTrigger(player, npc)
+end
+
+entity.onEventFinish = function(player, csid, option, npc)
+    return xi.ancestryMoogle.onEventFinish(player, csid, option, npc)
+end
+
+return entity

--- a/scripts/zones/Southern_San_dOria/DefaultActions.lua
+++ b/scripts/zones/Southern_San_dOria/DefaultActions.lua
@@ -38,7 +38,6 @@ return {
     ['Ophelia']              = { event = 751 },
     ['Paouala']              = { event =  82 },
     ['Phillone']             = { event =  29 },
-    ['Poudoruchant']         = { event = 779 },
     ['qm2']                  = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
     ['qm4']                  = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
     ['Rosel']                = { text = ID.text.ROSEL_GREETINGS },

--- a/scripts/zones/Southern_San_dOria/npcs/Poudoruchant.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Poudoruchant.lua
@@ -1,0 +1,19 @@
+-----------------------------------
+-- Area: Southern San d'Oria
+--  NPC: Poudoruchant
+--  Item Depository NPC (not implemented)
+--  !pos -139.56 -2 21.31 230
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    player:startEvent(779)
+end
+
+entity.onEventFinish = function(player, csid, option, npc)
+    -- TODO: Implement
+    -- Must account for race change item swaps. See http://www.playonline.com/ff11eu/envi/racechange/
+end
+
+return entity

--- a/scripts/zones/Windurst_Walls/IDs.lua
+++ b/scripts/zones/Windurst_Walls/IDs.lua
@@ -41,6 +41,7 @@ zones[xi.zone.WINDURST_WALLS] =
         EARNED_ALLIED_NOTES            = 9657,  -- You have earned <number> Allied Note[/s]!
         OBTAINED_GUILD_POINTS          = 9658,  -- Obtained: <number> guild points.
         TEAR_IN_FABRIC_OF_SPACE        = 10870, -- There appears to be a tear in the fabric of space...
+        UNABLE_RACE_CHANGE             = 11470, -- You were unable to use the specified appearance for your character.
     },
     mob =
     {

--- a/scripts/zones/Windurst_Walls/npcs/Ancestry_Moogle.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Ancestry_Moogle.lua
@@ -1,0 +1,22 @@
+-----------------------------------
+-- Area: Windurst Walls
+--  NPC: Ancestry Moogle
+-- Type: Race Change NPC
+-- !pos -220 1 -108 239
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+    return xi.ancestryMoogle.onTrade(player, npc, trade)
+end
+
+entity.onTrigger = function(player, npc)
+    return xi.ancestryMoogle.onTrigger(player, npc)
+end
+
+entity.onEventFinish = function(player, csid, option, npc)
+    return xi.ancestryMoogle.onEventFinish(player, csid, option, npc)
+end
+
+return entity

--- a/scripts/zones/Windurst_Waters/DefaultActions.lua
+++ b/scripts/zones/Windurst_Waters/DefaultActions.lua
@@ -58,7 +58,6 @@ return {
     ['Nine_of_Hearts']   = { event = 277 },
     ['Ohbiru-Dohbiru']   = { event = 344 },
     ['Okaka']            = { event = 574 },
-    ['Olaky-Yayulaky']   = { event = 910 },
     ['Orn']              = { event = 652 },
     ['Pakesse-Myukesse'] = { event = 434 },
     ['Paku-Nakku']       = { event = 431 },

--- a/scripts/zones/Windurst_Waters/npcs/Olaky-Yayulaky.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Olaky-Yayulaky.lua
@@ -1,0 +1,19 @@
+-----------------------------------
+-- Area: Windurst Waters
+--  NPC: Olaky-Yayulaky
+--  Item Depository NPC (not implemented)
+--  !pos -60 -3.5 71 238
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    player:startEvent(910)
+end
+
+entity.onEventFinish = function(player, csid, option, npc)
+    -- TODO: Implement
+    -- Must account for race change item swaps. See http://www.playonline.com/ff11eu/envi/racechange/
+end
+
+return entity

--- a/src/login/data_session.cpp
+++ b/src/login/data_session.cpp
@@ -133,6 +133,7 @@ void data_session::read_func()
                         characterInfo.ffxi_id_world     = charIdMain;
                         characterInfo.worldid           = worldId;
                         characterInfo.status            = 1; // 0 = Invalid/Hidden, 1 = Available, 2 = Disabled (unpaid)
+                        characterInfo.race_change       = 0; // 0 = no race change service, 1 = race change service (gold star icon) (NOT YET SUPPORTED!)
                         characterInfo.renamef           = 0; // 0 = no rename required, 1 = rename required (NOT YET SUPPORTED!)
                         characterInfo.ffxi_id_world_tbl = charIdExtra;
 

--- a/src/login/login_helpers.cpp
+++ b/src/login/login_helpers.cpp
@@ -219,6 +219,24 @@ namespace loginHelpers
         createchar.m_look.size = ref<uint8>(buf, 57);
         createchar.m_look.face = ref<uint8>(buf, 60);
 
+        if (createchar.m_look.race < 1 || createchar.m_look.race > 8) // 1(HumeM) to 8(Galka)
+        {
+            ShowError(fmt::format("{} attempted to create character with invalid race {}", charName, createchar.m_look.race));
+            return -1;
+        }
+
+        if (createchar.m_look.size > 2) // Large
+        {
+            ShowError(fmt::format("{} attempted to create character with invalid size {}", charName, createchar.m_look.size));
+            return -1;
+        }
+
+        if (createchar.m_look.face > 15) // Face 8B
+        {
+            ShowError(fmt::format("{} attempted to create character with invalid face {}", charName, createchar.m_look.face));
+            return -1;
+        }
+
         // Validate that the job is a starting job.
         uint8 mjob        = ref<uint8>(buf, 50);
         createchar.m_mjob = std::clamp<uint8>(mjob, 1, 6);
@@ -231,6 +249,12 @@ namespace loginHelpers
         }
 
         createchar.m_nation = ref<uint8>(buf, 54);
+
+        if (createchar.m_nation > 2) // 0x00 = San d'Oria, 0x01 = Bastok, 0x02 = Windurst
+        {
+            ShowError(fmt::format("{} attempted to create character with invalid nation {}", charName, createchar.m_nation));
+            return -1;
+        }
 
         std::vector<uint32> bastokStartingZones   = { 0xEA, 0xEB, 0xEC };
         std::vector<uint32> sandoriaStartingZones = { 0xE6, 0xE7, 0xE8 };

--- a/src/login/login_packets.h
+++ b/src/login/login_packets.h
@@ -131,7 +131,9 @@ struct lpkt_chr_info_sub2
     uint16_t          ffxi_id_world;      // PS2: ffxi_id_world
     uint16_t          worldid;            // PS2: worldid
     uint16_t          status;             // PS2: status
-    uint8_t           renamef;            // PS2: renamef
+    uint8_t           renamef : 1;        // PS2: renamef
+    uint8_t           race_change : 1;    // PS2: (New; did not exist.)
+    uint8_t           unused : 6;         // PS2: (New; did not exist.)
     uint8_t           ffxi_id_world_tbl;  // PS2: (New; did not exist.)
     char              character_name[16]; // PS2: character_name
     char              world_name[16];     // PS2: world_name

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -214,6 +214,45 @@ enum CHAR_PERSIST : uint8
     EFFECTS  = 0x04,
 };
 
+enum class CharRace : uint8
+{
+    HumeMale       = 1,
+    HumeFemale     = 2,
+    ElvaanMale     = 3,
+    ElvaanFemale   = 4,
+    TarutaruMale   = 5,
+    TarutaruFemale = 6,
+    Mithra         = 7,
+    Galka          = 8,
+};
+
+enum class CharSize : uint8
+{
+    Small  = 0,
+    Medium = 1,
+    Large  = 2,
+};
+
+enum class CharFace : uint8
+{
+    Face1A = 0,
+    Face1B = 1,
+    Face2A = 2,
+    Face2B = 3,
+    Face3A = 4,
+    Face3B = 5,
+    Face4A = 6,
+    Face4B = 7,
+    Face5A = 8,
+    Face5B = 9,
+    Face6A = 10,
+    Face6B = 11,
+    Face7A = 12,
+    Face7B = 13,
+    Face8A = 14,
+    Face8B = 15,
+};
+
 class CBasicPacket;
 class CLinkshell;
 class CUnityChat;

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -287,12 +287,15 @@ public:
     uint8  getRace();
     uint8  getFace();
     uint8  getGender();
+    uint8  getSize();
+    bool   raceChange(CharRace newRace, CharFace newFace, CharSize newSize);
     auto   getName() -> std::string;
     auto   getPacketName() -> std::string;
     void   renameEntity(std::string const& newName, sol::object const& arg2);
     void   hideName(bool isHidden);
     uint16 getModelId();
     void   setModelId(uint16 modelId, sol::object const& slotObj);
+    void   setLook(sol::table const& look);
     uint16 getCostume();
     void   setCostume(uint16 costume);
     uint16 getCostume2();

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -293,6 +293,8 @@ namespace charutils
 
     bool isOrchestrionPlaced(CCharEntity* PChar);
     void updateMannequins(CCharEntity* PChar);
+
+    bool raceChange(CCharEntity* PChar, CharRace newRace, CharFace newFace, CharSize newSize);
 }; // namespace charutils
 
 #endif // _CHARUTILS_H


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds Ancestry Moogle NPC for race changes. 
  - Requires a charvar to be set up through an unspecified process for the NPC to respond.
  - A command script !racechange is provided, to set the charvars
- Adds a handful of supporting Lua bindings 
- Adds DNC AF swaps capability to the Moogle

- Documents unimplemented Item Depository NPC to warn about items that may need to be swapped
- Adds a couple enums for races, faces and character sizes.
- Adds some sanity checks in the login process

Capture
https://drive.google.com/file/d/1o6_9-Wk3iOMZVmNvP1S1HTm0T25Ou6pD/view?usp=sharing
https://www.youtube.com/watch?v=i5IXKNlQn_g

Trade capture
https://drive.google.com/file/d/1ZKlvUcCh-f8qSdnfSs8cWeU_avTC8kJm/view?usp=sharing

## Steps to test these changes

!racechange
!pos 51 8.5 -225 236

To repeat:
!racechange

<!-- Clear and detailed steps to test your changes here -->
