### PR TITLE
[Fix] ZM8 battlefield entrance requirement

### DIFF
--- a/scripts/battlefields/Stellar_Fulcrum/return_to_delkfutts_tower.lua
+++ b/scripts/battlefields/Stellar_Fulcrum/return_to_delkfutts_tower.lua
@@ -21,7 +21,7 @@ local content = BattlefieldMission:new({
     missionArea           = xi.mission.log_id.ZILART,
     mission               = xi.mission.id.zilart.RETURN_TO_DELKFUTTS_TOWER,
     missionStatusArea     = xi.mission.log_id.ZILART,
-    requiredMissionStatus = 2,
+    requiredMissionStatus = 1,
     title                 = xi.title.DESTROYER_OF_ANTIQUITY,
 })
 

--- a/scripts/missions/rotz/08_Return_to_Delkfutts_Tower.lua
+++ b/scripts/missions/rotz/08_Return_to_Delkfutts_Tower.lua
@@ -20,7 +20,6 @@ mission.reward =
 -- Bits
 -- 0 -> Lower Jeuno Aldo interaction. Optional.
 -- 1 -> Lower Delkfutt tower Zone-in cutscene. Optional. Yes. Really.
--- 2 -> Stellar Fulcrum pre-battle cutscene. Can't miss it.
 
 mission.sections =
 {
@@ -83,7 +82,7 @@ mission.sections =
             onZoneIn = function(player, prevZone)
                 if not mission:isVarBitsSet(player, 'Option', 2) then
                     return 0 -- Pre-Battle.
-                elseif player:getMissionStatus(mission.areaId) == 1 then
+                elseif player:getMissionStatus(mission.areaId) == 2 then
                     return 17 -- Post-Battle. Mission complete event.
                 elseif player:getPreviousZone() == xi.zone.UPPER_DELKFUTTS_TOWER then
                     return 7 -- Ensure regular entering CS plays.
@@ -102,7 +101,7 @@ mission.sections =
             onEventFinish =
             {
                 [0] = function(player, csid, option, npc)
-                    mission:setVarBit(player, 'Option', 2)
+                    player:setMissionStatus(mission.areaId, 1)
                 end,
 
                 [17] = function(player, csid, option, npc)
@@ -111,7 +110,7 @@ mission.sections =
 
                 [32001] = function(player, csid, option, npc)
                     if player:getLocalVar('battlefieldWin') == xi.battlefield.id.RETURN_TO_DELKFUTTS_TOWER then
-                        player:setMissionStatus(mission.areaId, 1)
+                        player:setMissionStatus(mission.areaId, 2)
                         player:setPos(-519.99, 1.076, -19.943, 64, xi.zone.STELLAR_FULCRUM)
                     end
                 end,


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

When I made the Lower Delkfutt Tower CS optional, I forgot to update the battlefield mission status entry requirement.

## Steps to test these changes

Be on mission and be able to enter.
