### PR TITLE
fix: CLuaStatusEffect::getTimeRemaining wraparound

### DIFF
--- a/src/map/lua/lua_statuseffect.cpp
+++ b/src/map/lua/lua_statuseffect.cpp
@@ -113,7 +113,7 @@ uint32 CLuaStatusEffect::getTimeRemaining()
     if (m_PLuaStatusEffect->GetDuration() > 0s)
     {
         auto duration = m_PLuaStatusEffect->GetStartTime() - timer::now() + m_PLuaStatusEffect->GetDuration();
-        remaining     = static_cast<uint32>(timer::count_milliseconds(duration));
+        remaining     = static_cast<uint32>(std::max<int64>(timer::count_milliseconds(duration), 0));
     }
 
     return remaining;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Reintroduce the std::max call that used to be here, otherwise the result wraps around when a negative result is cast to uint

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
