### PR TITLE
[Interaction] Add missing event in LB5 and edit battlefield entry requirement

### DIFF
--- a/scripts/battlefields/Balgas_Dais/shattering_stars_mnk.lua
+++ b/scripts/battlefields/Balgas_Dais/shattering_stars_mnk.lua
@@ -19,9 +19,12 @@ local content = Battlefield:new({
 })
 
 function content:entryRequirement(player, npc, isRegistrant, trade)
-    return player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS) >= xi.questStatus.QUEST_ACCEPTED and
-        player:getMainJob() == xi.job.MNK and
-        player:getMainLvl() >= 66
+    local jobRequirement   = player:getMainJob() == xi.job.MNK
+    local levelRequirement = player:getMainLvl() >= 66
+    local questStatus      = player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS)
+    local questRequirement = questStatus == xi.questStatus.QUEST_COMPLETED or (questStatus == xi.questStatus.QUEST_ACCEPTED and player:getCharVar('Quest[3][132]tradedTestimony') == 1)
+
+    return jobRequirement and levelRequirement and questRequirement
 end
 
 content.groups =

--- a/scripts/battlefields/Balgas_Dais/shattering_stars_smn.lua
+++ b/scripts/battlefields/Balgas_Dais/shattering_stars_smn.lua
@@ -19,9 +19,12 @@ local content = Battlefield:new({
 })
 
 function content:entryRequirement(player, npc, isRegistrant, trade)
-    return player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS) >= xi.questStatus.QUEST_ACCEPTED and
-        player:getMainJob() == xi.job.SMN and
-        player:getMainLvl() >= 66
+    local jobRequirement   = player:getMainJob() == xi.job.SMN
+    local levelRequirement = player:getMainLvl() >= 66
+    local questStatus      = player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS)
+    local questRequirement = questStatus == xi.questStatus.QUEST_COMPLETED or (questStatus == xi.questStatus.QUEST_ACCEPTED and player:getCharVar('Quest[3][132]tradedTestimony') == 1)
+
+    return jobRequirement and levelRequirement and questRequirement
 end
 
 content.groups =

--- a/scripts/battlefields/Balgas_Dais/shattering_stars_whm.lua
+++ b/scripts/battlefields/Balgas_Dais/shattering_stars_whm.lua
@@ -19,9 +19,12 @@ local content = Battlefield:new({
 })
 
 function content:entryRequirement(player, npc, isRegistrant, trade)
-    return player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS) >= xi.questStatus.QUEST_ACCEPTED and
-        player:getMainJob() == xi.job.WHM and
-        player:getMainLvl() >= 66
+    local jobRequirement   = player:getMainJob() == xi.job.WHM
+    local levelRequirement = player:getMainLvl() >= 66
+    local questStatus      = player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS)
+    local questRequirement = questStatus == xi.questStatus.QUEST_COMPLETED or (questStatus == xi.questStatus.QUEST_ACCEPTED and player:getCharVar('Quest[3][132]tradedTestimony') == 1)
+
+    return jobRequirement and levelRequirement and questRequirement
 end
 
 content.groups =

--- a/scripts/battlefields/Chamber_of_Oracles/shattering_stars_drg.lua
+++ b/scripts/battlefields/Chamber_of_Oracles/shattering_stars_drg.lua
@@ -19,9 +19,12 @@ local content = Battlefield:new({
 })
 
 function content:entryRequirement(player, npc, isRegistrant, trade)
-    return player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS) >= xi.questStatus.QUEST_ACCEPTED and
-        player:getMainJob() == xi.job.DRG and
-        player:getMainLvl() >= 66
+    local jobRequirement   = player:getMainJob() == xi.job.DRG
+    local levelRequirement = player:getMainLvl() >= 66
+    local questStatus      = player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS)
+    local questRequirement = questStatus == xi.questStatus.QUEST_COMPLETED or (questStatus == xi.questStatus.QUEST_ACCEPTED and player:getCharVar('Quest[3][132]tradedTestimony') == 1)
+
+    return jobRequirement and levelRequirement and questRequirement
 end
 
 content.groups =

--- a/scripts/battlefields/Chamber_of_Oracles/shattering_stars_nin.lua
+++ b/scripts/battlefields/Chamber_of_Oracles/shattering_stars_nin.lua
@@ -19,9 +19,12 @@ local content = Battlefield:new({
 })
 
 function content:entryRequirement(player, npc, isRegistrant, trade)
-    return player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS) >= xi.questStatus.QUEST_ACCEPTED and
-        player:getMainJob() == xi.job.NIN and
-        player:getMainLvl() >= 66
+    local jobRequirement   = player:getMainJob() == xi.job.NIN
+    local levelRequirement = player:getMainLvl() >= 66
+    local questStatus      = player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS)
+    local questRequirement = questStatus == xi.questStatus.QUEST_COMPLETED or (questStatus == xi.questStatus.QUEST_ACCEPTED and player:getCharVar('Quest[3][132]tradedTestimony') == 1)
+
+    return jobRequirement and levelRequirement and questRequirement
 end
 
 content.groups =

--- a/scripts/battlefields/Chamber_of_Oracles/shattering_stars_sam.lua
+++ b/scripts/battlefields/Chamber_of_Oracles/shattering_stars_sam.lua
@@ -19,9 +19,12 @@ local content = Battlefield:new({
 })
 
 function content:entryRequirement(player, npc, isRegistrant, trade)
-    return player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS) >= xi.questStatus.QUEST_ACCEPTED and
-        player:getMainJob() == xi.job.SAM and
-        player:getMainLvl() >= 66
+    local jobRequirement   = player:getMainJob() == xi.job.SAM
+    local levelRequirement = player:getMainLvl() >= 66
+    local questStatus      = player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS)
+    local questRequirement = questStatus == xi.questStatus.QUEST_COMPLETED or (questStatus == xi.questStatus.QUEST_ACCEPTED and player:getCharVar('Quest[3][132]tradedTestimony') == 1)
+
+    return jobRequirement and levelRequirement and questRequirement
 end
 
 content.groups =

--- a/scripts/battlefields/Horlais_Peak/shattering_stars_blm.lua
+++ b/scripts/battlefields/Horlais_Peak/shattering_stars_blm.lua
@@ -19,9 +19,12 @@ local content = Battlefield:new({
 })
 
 function content:entryRequirement(player, npc, isRegistrant, trade)
-    return player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS) >= xi.questStatus.QUEST_ACCEPTED and
-        player:getMainJob() == xi.job.BLM and
-        player:getMainLvl() >= 66
+    local jobRequirement   = player:getMainJob() == xi.job.BLM
+    local levelRequirement = player:getMainLvl() >= 66
+    local questStatus      = player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS)
+    local questRequirement = questStatus == xi.questStatus.QUEST_COMPLETED or (questStatus == xi.questStatus.QUEST_ACCEPTED and player:getCharVar('Quest[3][132]tradedTestimony') == 1)
+
+    return jobRequirement and levelRequirement and questRequirement
 end
 
 content.groups =

--- a/scripts/battlefields/Horlais_Peak/shattering_stars_rng.lua
+++ b/scripts/battlefields/Horlais_Peak/shattering_stars_rng.lua
@@ -19,9 +19,12 @@ local content = Battlefield:new({
 })
 
 function content:entryRequirement(player, npc, isRegistrant, trade)
-    return player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS) >= xi.questStatus.QUEST_ACCEPTED and
-        player:getMainJob() == xi.job.RNG and
-        player:getMainLvl() >= 66
+    local jobRequirement   = player:getMainJob() == xi.job.RNG
+    local levelRequirement = player:getMainLvl() >= 66
+    local questStatus      = player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS)
+    local questRequirement = questStatus == xi.questStatus.QUEST_COMPLETED or (questStatus == xi.questStatus.QUEST_ACCEPTED and player:getCharVar('Quest[3][132]tradedTestimony') == 1)
+
+    return jobRequirement and levelRequirement and questRequirement
 end
 
 content.groups =

--- a/scripts/battlefields/Horlais_Peak/shattering_stars_war.lua
+++ b/scripts/battlefields/Horlais_Peak/shattering_stars_war.lua
@@ -19,9 +19,12 @@ local content = Battlefield:new({
 })
 
 function content:entryRequirement(player, npc, isRegistrant, trade)
-    return player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS) >= xi.questStatus.QUEST_ACCEPTED and
-        player:getMainJob() == xi.job.WAR and
-        player:getMainLvl() >= 66
+    local jobRequirement   = player:getMainJob() == xi.job.WAR
+    local levelRequirement = player:getMainLvl() >= 66
+    local questStatus      = player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS)
+    local questRequirement = questStatus == xi.questStatus.QUEST_COMPLETED or (questStatus == xi.questStatus.QUEST_ACCEPTED and player:getCharVar('Quest[3][132]tradedTestimony') == 1)
+
+    return jobRequirement and levelRequirement and questRequirement
 end
 
 content.groups =

--- a/scripts/battlefields/QuBia_Arena/shattering_stars_brd.lua
+++ b/scripts/battlefields/QuBia_Arena/shattering_stars_brd.lua
@@ -19,9 +19,12 @@ local content = Battlefield:new({
 })
 
 function content:entryRequirement(player, npc, isRegistrant, trade)
-    return player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS) >= xi.questStatus.QUEST_ACCEPTED and
-        player:getMainJob() == xi.job.BRD and
-        player:getMainLvl() >= 66
+    local jobRequirement   = player:getMainJob() == xi.job.BRD
+    local levelRequirement = player:getMainLvl() >= 66
+    local questStatus      = player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS)
+    local questRequirement = questStatus == xi.questStatus.QUEST_COMPLETED or (questStatus == xi.questStatus.QUEST_ACCEPTED and player:getCharVar('Quest[3][132]tradedTestimony') == 1)
+
+    return jobRequirement and levelRequirement and questRequirement
 end
 
 content.groups =

--- a/scripts/battlefields/QuBia_Arena/shattering_stars_drk.lua
+++ b/scripts/battlefields/QuBia_Arena/shattering_stars_drk.lua
@@ -19,9 +19,12 @@ local content = Battlefield:new({
 })
 
 function content:entryRequirement(player, npc, isRegistrant, trade)
-    return player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS) >= xi.questStatus.QUEST_ACCEPTED and
-        player:getMainJob() == xi.job.DRK and
-        player:getMainLvl() >= 66
+    local jobRequirement   = player:getMainJob() == xi.job.DRK
+    local levelRequirement = player:getMainLvl() >= 66
+    local questStatus      = player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS)
+    local questRequirement = questStatus == xi.questStatus.QUEST_COMPLETED or (questStatus == xi.questStatus.QUEST_ACCEPTED and player:getCharVar('Quest[3][132]tradedTestimony') == 1)
+
+    return jobRequirement and levelRequirement and questRequirement
 end
 
 content.groups =

--- a/scripts/battlefields/QuBia_Arena/shattering_stars_pld.lua
+++ b/scripts/battlefields/QuBia_Arena/shattering_stars_pld.lua
@@ -19,9 +19,12 @@ local content = Battlefield:new({
 })
 
 function content:entryRequirement(player, npc, isRegistrant, trade)
-    return player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS) >= xi.questStatus.QUEST_ACCEPTED and
-        player:getMainJob() == xi.job.PLD and
-        player:getMainLvl() >= 66
+    local jobRequirement   = player:getMainJob() == xi.job.PLD
+    local levelRequirement = player:getMainLvl() >= 66
+    local questStatus      = player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS)
+    local questRequirement = questStatus == xi.questStatus.QUEST_COMPLETED or (questStatus == xi.questStatus.QUEST_ACCEPTED and player:getCharVar('Quest[3][132]tradedTestimony') == 1)
+
+    return jobRequirement and levelRequirement and questRequirement
 end
 
 content.groups =

--- a/scripts/battlefields/Waughroon_Shrine/shattering_stars_bst.lua
+++ b/scripts/battlefields/Waughroon_Shrine/shattering_stars_bst.lua
@@ -19,9 +19,12 @@ local content = Battlefield:new({
 })
 
 function content:entryRequirement(player, npc, isRegistrant, trade)
-    return player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS) >= xi.questStatus.QUEST_ACCEPTED and
-        player:getMainJob() == xi.job.BST and
-        player:getMainLvl() >= 66
+    local jobRequirement   = player:getMainJob() == xi.job.BST
+    local levelRequirement = player:getMainLvl() >= 66
+    local questStatus      = player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS)
+    local questRequirement = questStatus == xi.questStatus.QUEST_COMPLETED or (questStatus == xi.questStatus.QUEST_ACCEPTED and player:getCharVar('Quest[3][132]tradedTestimony') == 1)
+
+    return jobRequirement and levelRequirement and questRequirement
 end
 
 content.groups =

--- a/scripts/battlefields/Waughroon_Shrine/shattering_stars_rdm.lua
+++ b/scripts/battlefields/Waughroon_Shrine/shattering_stars_rdm.lua
@@ -19,9 +19,12 @@ local content = Battlefield:new({
 })
 
 function content:entryRequirement(player, npc, isRegistrant, trade)
-    return player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS) >= xi.questStatus.QUEST_ACCEPTED and
-        player:getMainJob() == xi.job.RDM and
-        player:getMainLvl() >= 66
+    local jobRequirement   = player:getMainJob() == xi.job.RDM
+    local levelRequirement = player:getMainLvl() >= 66
+    local questStatus      = player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS)
+    local questRequirement = questStatus == xi.questStatus.QUEST_COMPLETED or (questStatus == xi.questStatus.QUEST_ACCEPTED and player:getCharVar('Quest[3][132]tradedTestimony') == 1)
+
+    return jobRequirement and levelRequirement and questRequirement
 end
 
 content.groups =

--- a/scripts/battlefields/Waughroon_Shrine/shattering_stars_thf.lua
+++ b/scripts/battlefields/Waughroon_Shrine/shattering_stars_thf.lua
@@ -19,9 +19,12 @@ local content = Battlefield:new({
 })
 
 function content:entryRequirement(player, npc, isRegistrant, trade)
-    return player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS) >= xi.questStatus.QUEST_ACCEPTED and
-        player:getMainJob() == xi.job.THF and
-        player:getMainLvl() >= 66
+    local jobRequirement   = player:getMainJob() == xi.job.THF
+    local levelRequirement = player:getMainLvl() >= 66
+    local questStatus      = player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS)
+    local questRequirement = questStatus == xi.questStatus.QUEST_COMPLETED or (questStatus == xi.questStatus.QUEST_ACCEPTED and player:getCharVar('Quest[3][132]tradedTestimony') == 1)
+
+    return jobRequirement and levelRequirement and questRequirement
 end
 
 content.groups =

--- a/scripts/quests/jeuno/LB05_1_Shattering_Stars.lua
+++ b/scripts/quests/jeuno/LB05_1_Shattering_Stars.lua
@@ -11,9 +11,9 @@ local quest = Quest:new(xi.questLog.JEUNO, xi.quest.id.jeuno.SHATTERING_STARS)
 
 quest.reward =
 {
-    fame = 80,
+    fame     = 80,
     fameArea = xi.fameArea.JEUNO,
-    title = xi.title.STAR_BREAKER,
+    title    = xi.title.STAR_BREAKER,
 }
 
 local maatBattlefieldIds =
@@ -95,22 +95,27 @@ quest.sections =
         {
             ['Maat'] =
             {
-                onTrigger = function(player, npc)
-                    if quest:getVar(player, 'Prog') >= 1 then
-                        return quest:progressEvent(93) -- Complete quest.
-                    elseif quest:getVar(player, 'Prog') == 0 then
-                        return quest:event(91, player:getMainJob())
-                    end
-                end,
-
                 onTrade = function(player, npc, trade)
-                    local properTestimony = xi.item.WARRIORS_TESTIMONY + player:getMainJob() - 1
+                    local playerJob       = player:getMainJob()
+                    local properTestimony = xi.item.WARRIORS_TESTIMONY + playerJob - 1
 
                     if
                         npcUtil.tradeHasExactly(trade, properTestimony) and
                         quest:getVar(player, 'Prog') == 0
                     then
-                        return quest:progressEvent(64, player:getMainJob())
+                        return quest:progressEvent(64, playerJob)
+                    end
+                end,
+
+                onTrigger = function(player, npc)
+                    local playerJob = player:getMainJob()
+
+                    if quest:getVar(player, 'Prog') >= 1 then
+                        return quest:progressEvent(93) -- Complete quest.
+                    elseif quest:getVar(player, 'tradedTestimony') == 0 then
+                        return quest:event(91, playerJob) -- Testimony never traded.
+                    else
+                        return quest:event(63, playerJob) -- Testimony traded at least once.
                     end
                 end,
             },
@@ -118,6 +123,9 @@ quest.sections =
             onEventFinish =
             {
                 [64] = function(player, csid, option, npc)
+                    quest:setVar(player, 'tradedTestimony', 1)
+
+                    -- Accept teleport.
                     if option == 1 then
                         local mJob = player:getMainJob()
                         if mJob == xi.job.MNK or mJob == xi.job.WHM or mJob == xi.job.SMN then


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds missing event when speaking with maat after trading him the testimony.
So either:
- Tell him you arent ready in the trade event.
- Get teleported to the BCNM by the event and then teleport back without completing the battlefield.

With this, we also edit the battlefield entry requirements so it requires trading him the testimony the very first time (meaning we cant just trigger the quest, and head to the bcnm directly)

## Steps to test these changes

Run LB5
