### PR TITLE
[Interaction] Implement "Limit break" 8 minigame and revise LB 6, 7 and 8 event paramters

### DIFF
--- a/scripts/missions/rotz/08_Return_to_Delkfutts_Tower.lua
+++ b/scripts/missions/rotz/08_Return_to_Delkfutts_Tower.lua
@@ -80,9 +80,10 @@ mission.sections =
         [xi.zone.STELLAR_FULCRUM] =
         {
             onZoneIn = function(player, prevZone)
-                if not mission:isVarBitsSet(player, 'Option', 2) then
+                local missionStatus = player:getMissionStatus(mission.areaId)
+                if missionStatus == 0 then
                     return 0 -- Pre-Battle.
-                elseif player:getMissionStatus(mission.areaId) == 2 then
+                elseif missionStatus == 2 then
                     return 17 -- Post-Battle. Mission complete event.
                 elseif player:getPreviousZone() == xi.zone.UPPER_DELKFUTTS_TOWER then
                     return 7 -- Ensure regular entering CS plays.

--- a/scripts/quests/jeuno/LB07_Expanding_Horizons.lua
+++ b/scripts/quests/jeuno/LB07_Expanding_Horizons.lua
@@ -11,7 +11,7 @@ local quest = Quest:new(xi.questLog.JEUNO, xi.quest.id.jeuno.EXPANDING_HORIZONS)
 
 quest.reward =
 {
-    fame = 50,
+    fame     = 50,
     fameArea = xi.fameArea.JEUNO,
 }
 
@@ -21,9 +21,7 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_AVAILABLE and
-                player:getMainLvl() >= 76 and
-                player:getLevelCap() == 80 and
-                xi.settings.main.MAX_LEVEL >= 85
+                player:getLevelCap() == 80
         end,
 
         [xi.zone.RULUDE_GARDENS] =
@@ -31,7 +29,23 @@ quest.sections =
             ['Nomad_Moogle'] =
             {
                 onTrigger = function(player, npc)
-                    return quest:progressEvent(10045, 0, 1, 2, 0) -- Confirmed.
+                    local playerLevel     = player:getMainLvl()
+                    local limitBreaker    = player:hasKeyItem(xi.ki.LIMIT_BREAKER) and 1 or 2
+                    local lastQuestNumber = 0
+                    local lastQuestStage  = 0
+                    if
+                        xi.settings.main.MAX_LEVEL > 80 and
+                        limitBreaker == 1
+                    then
+                        if playerLevel > 75 then
+                            lastQuestNumber = 2
+                        elseif playerLevel == 75 then
+                            lastQuestNumber = 1
+                            lastQuestStage  = 2
+                        end
+                    end
+
+                    return quest:progressEvent(10045, playerLevel, limitBreaker, lastQuestNumber, lastQuestStage)
                 end,
             },
 
@@ -56,10 +70,6 @@ quest.sections =
         {
             ['Nomad_Moogle'] =
             {
-                onTrigger = function(player, npc)
-                    return quest:event(10045, 0, 1, 2, 1)
-                end,
-
                 onTrade = function(player, npc, trade)
                     if
                         npcUtil.tradeHasExactly(trade, { { xi.item.KINDREDS_CREST, 5 } }) and
@@ -67,6 +77,15 @@ quest.sections =
                     then
                         return quest:progressEvent(10136)
                     end
+                end,
+
+                onTrigger = function(player, npc)
+                    local playerLevel     = player:getMainLvl()
+                    local limitBreaker    = player:hasKeyItem(xi.ki.LIMIT_BREAKER) and 1 or 2
+                    local lastQuestNumber = 2
+                    local lastQuestStage  = 1
+
+                    return quest:event(10045, playerLevel, limitBreaker, lastQuestNumber, lastQuestStage)
                 end,
             },
 

--- a/scripts/quests/jeuno/LB08_Beyond_the_Stars.lua
+++ b/scripts/quests/jeuno/LB08_Beyond_the_Stars.lua
@@ -26,9 +26,7 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_AVAILABLE and
-                player:getMainLvl() >= 81 and
                 player:getLevelCap() == 85 and
-                xi.settings.main.MAX_LEVEL >= 90
         end,
 
         [xi.zone.RULUDE_GARDENS] =
@@ -36,7 +34,23 @@ quest.sections =
             ['Nomad_Moogle'] =
             {
                 onTrigger = function(player, npc)
-                    return quest:progressEvent(10045, 0, 1, 3, 0)
+                    local playerLevel     = player:getMainLvl()
+                    local limitBreaker    = player:hasKeyItem(xi.ki.LIMIT_BREAKER) and 1 or 2
+                    local lastQuestNumber = 0
+                    local lastQuestStage  = 0
+                    if
+                        xi.settings.main.MAX_LEVEL > 85 and
+                        limitBreaker == 1
+                    then
+                        if playerLevel > 80 then
+                            lastQuestNumber = 3
+                        elseif playerLevel == 80 then
+                            lastQuestNumber = 2
+                            lastQuestStage  = 2
+                        end
+                    end
+
+                    return quest:progressEvent(10045, playerLevel, limitBreaker, lastQuestNumber, lastQuestStage)
                 end,
             },
 
@@ -61,22 +75,28 @@ quest.sections =
         {
             ['Nomad_Moogle'] =
             {
-                onTrigger = function(player, npc)
-                    if quest:getVar(player, 'Prog') == 1 then
-                        -- Rock, Paper, Scissor Minigame starting event.
-                        -- NOT CODED. WAITING FOR CAPS.
-                        return quest:progressEvent(10161)
-                    else
-                        return quest:event(10045, 0, 1, 3, 1)
-                    end
-                end,
-
                 onTrade = function(player, npc, trade)
                     if
                         npcUtil.tradeHasExactly(trade, { { xi.item.KINDREDS_CREST, 10 } }) and
                         player:getMeritCount() > 4
                     then
                         return quest:progressEvent(10137)
+                    end
+                end,
+
+                onTrigger = function(player, npc)
+                    -- Rock, Paper, Scissor Minigame.
+                    if quest:getVar(player, 'Prog') == 1 then
+                        return quest:progressEvent(10161)
+
+                    -- Reminder
+                    else
+                        local playerLevel     = player:getMainLvl()
+                        local limitBreaker    = player:hasKeyItem(xi.ki.LIMIT_BREAKER) and 1 or 2
+                        local lastQuestNumber = 3
+                        local lastQuestStage  = 1
+
+                        return quest:event(10045, playerLevel, limitBreaker, lastQuestNumber, lastQuestStage)
                     end
                 end,
             },

--- a/scripts/quests/jeuno/LB08_Beyond_the_Stars.lua
+++ b/scripts/quests/jeuno/LB08_Beyond_the_Stars.lua
@@ -26,7 +26,7 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_AVAILABLE and
-                player:getLevelCap() == 85 and
+                player:getLevelCap() == 85
         end,
 
         [xi.zone.RULUDE_GARDENS] =
@@ -85,27 +85,54 @@ quest.sections =
                 end,
 
                 onTrigger = function(player, npc)
+                    local playerLevel     = player:getMainLvl()
+                    local limitBreaker    = player:hasKeyItem(xi.ki.LIMIT_BREAKER) and 1 or 2
+                    local lastQuestNumber = 3
+                    local lastQuestStage  = 1
+
                     -- Rock, Paper, Scissor Minigame.
                     if quest:getVar(player, 'Prog') == 1 then
-                        return quest:progressEvent(10161)
+                        return quest:progressEvent(10161, playerLevel, 0)
 
                     -- Reminder
                     else
-                        local playerLevel     = player:getMainLvl()
-                        local limitBreaker    = player:hasKeyItem(xi.ki.LIMIT_BREAKER) and 1 or 2
-                        local lastQuestNumber = 3
-                        local lastQuestStage  = 1
-
                         return quest:event(10045, playerLevel, limitBreaker, lastQuestNumber, lastQuestStage)
                     end
                 end,
             },
 
-            -- onEventUpdate =
-            -- {
-                -- [10161] = function(player, csid, option, npc)
-                -- end,
-            -- },
+            onEventUpdate =
+            {
+                [10161] = function(player, csid, option, npc)
+                    -- Maat move choice.
+                    local maatMove = 0
+                    if option == 21 then
+                        maatMove = 0 -- Red.
+                    elseif option == 22 then
+                        maatMove = 1 -- Blue.
+                    elseif option == 23 then
+                        maatMove = 2 -- Green.
+                    end
+
+                    -- Degenhard move choice.
+                    local degenhardMove = math.random(0, 2)
+
+                    -- Rock-Paper-Scissors: Red beats Blue; Blue beats Green; Green beats Red.
+                    local clashOutcome = 1 -- Assume Degenhard wins
+                    if maatMove == degenhardMove then
+                        clashOutcome = 2 -- Draw
+                    elseif
+                        (maatMove == 0 and degenhardMove == 1) or
+                        (maatMove == 1 and degenhardMove == 2) or
+                        (maatMove == 2 and degenhardMove == 0)
+                    then
+                        clashOutcome = 0
+                    end
+
+                    local eventBitmask = maatMove + degenhardMove * 4 + clashOutcome * 16 -- Controls moves chosen by Maat and Degenhard, and who wins the round.
+                    player:updateEvent(eventBitmask)
+                end,
+            },
 
             onEventFinish =
             {
@@ -116,7 +143,8 @@ quest.sections =
                 end,
 
                 [10161] = function(player, csid, option, npc)
-                    if quest:complete(player) then
+                    if option == 254 then
+                        quest:complete(player)
                         player:setLevelCap(90)
                         player:messageSpecial(ruludeID.text.YOUR_LEVEL_LIMIT_IS_NOW_90)
                     end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Implements a simple and useless minigame that wasnt implemented. The event does most of the work, curiously.
- Fixes parameters used in main LB 6,7,8 event (10045)
- Fixes variable check in ZM8

## Steps to test these changes

Do LB 6, 7 and 8.
Play LB 8 minigame.
Do ZM8 from begining to end.
