### PR TITLE
[Interaction] LB9: Fix parameters, adjust minigame and add missing event update

### DIFF
--- a/scripts/quests/jeuno/LB06_New_Worlds_Await.lua
+++ b/scripts/quests/jeuno/LB06_New_Worlds_Await.lua
@@ -23,7 +23,7 @@ quest.reward =
 
 quest.sections =
 {
-    -- Section: Quest accepted.
+    -- Section: Quest accepted. There is no quest pre-requisite.
     {
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_AVAILABLE and

--- a/scripts/quests/jeuno/LB07_Expanding_Horizons.lua
+++ b/scripts/quests/jeuno/LB07_Expanding_Horizons.lua
@@ -21,6 +21,7 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_AVAILABLE and
+                player:hasCompletedQuest(xi.questLog.JEUNO, xi.quest.id.jeuno.NEW_WORLDS_AWAIT) and
                 player:getLevelCap() == 80
         end,
 

--- a/scripts/quests/jeuno/LB08_Beyond_the_Stars.lua
+++ b/scripts/quests/jeuno/LB08_Beyond_the_Stars.lua
@@ -26,6 +26,7 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_AVAILABLE and
+                player:hasCompletedQuest(xi.questLog.JEUNO, xi.quest.id.jeuno.EXPANDING_HORIZONS) and
                 player:getLevelCap() == 85
         end,
 
@@ -44,7 +45,7 @@ quest.sections =
                     then
                         if playerLevel > 80 then
                             lastQuestNumber = 3
-                        elseif playerLevel == 80 then
+                        elseif playerLevel >= 75 then
                             lastQuestNumber = 2
                             lastQuestStage  = 2
                         end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds missing event update where Atori-Tutori recognices your character.
- Fixes certain event paramters.
- Adds functionality to reject the quest.
- Adjust minigame timing, paramters used and remove unneeded variable usage.

## Steps to test these changes
Accept and complete LB9
