### PR TITLE
[lua] KB Meteor formula

### DIFF
--- a/scripts/actions/spells/black/meteor.lua
+++ b/scripts/actions/spells/black/meteor.lua
@@ -30,7 +30,11 @@ spellObject.onSpellCast = function(caster, target, spell)
         caster:getFamily() == 51 or
         caster:getFamily() == 479
     then
-        dmg = 14 + caster:getMainLvl() * 30
+        -- Not entirely accurate until mobspell skills are reworked. #7222
+        -- TODO: + dINT *2 until dINT +13. When dINT is negative, dINT / 2 until unknown floor.
+        -- TODO: Account for all mitigation sources.
+        -- TODO: Account for rage.
+        dmg = caster:getMainLvl() * 15.5
     else
         dmg = ((100 + caster:getMod(xi.mod.MATT)) / (100 + target:getMod(xi.mod.MDEF))) * (caster:getStat(xi.mod.INT) + (caster:getMaxSkillLevel(caster:getMainLvl(), xi.job.BLM, xi.skill.ELEMENTAL_MAGIC)) / 6) * 9.4
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

KB Meteor is using a formula that comes from Monstrosity currently, resulting in large values that do not match expectations. Frank got in touch with jimmayus/aether and they spent some time figuring it out.

It's half baked because some mechanics for calculations are missing (#7222) but I've documented what's missing to the best of my ability.

Credits: 
jimmayus / Aether for collecting the data - not sure what are your GitHub handles for co-author.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
