### PR TITLE
[core] Don't apply augments with modId 0

### DIFF
--- a/src/map/items/item_equipment.cpp
+++ b/src/map/items/item_equipment.cpp
@@ -451,6 +451,12 @@ void CItemEquipment::SetAugmentMod(uint16 type, uint8 value)
         // check if we should be adding to or taking away from the mod power (handle scripted augments properly)
         modValue = (modValue > 0 ? modValue + value : modValue - value) * (multiplier > 1 ? multiplier : 1);
 
+        // Skip unimplemented augments modifiers
+        if (modId == Mod::NONE)
+        {
+            continue;
+        }
+
         if (!isPet)
         {
             addModifier(CModifier(modId, modValue));


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Checks the augment modId and skips it if 0. 
Resolves an issue where values were mistakenly applied to modId 0, and songs duration/potency calculations used it, leading to reduced durations.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Sing Mazurka/Nocturne, get full duration.

<!-- Clear and detailed steps to test your changes here -->
