### PR TITLE
[lua] ZM7: Start event when clicking last pedestal

### DIFF
--- a/scripts/missions/rotz/07_The_Chamber_of_Oracles.lua
+++ b/scripts/missions/rotz/07_The_Chamber_of_Oracles.lua
@@ -25,7 +25,7 @@ local function handleActiveOnTrigger(player, keyItemId, statusIncrease)
         player:setMissionStatus(xi.mission.log_id.ZILART, missionStatus + statusIncrease)
         player:messageSpecial(oraclesID.text.YOU_PLACE_THE, keyItemId)
 
-        if missionStatus == 255 then
+        if player:getMissionStatus(xi.mission.log_id.ZILART) == 255 then
             return mission:event(1)
         end
     elseif missionStatus == 255 then -- Execute cutscene if the player is interrupted.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Noticed while porting Eden ZM tests. The missionStatus value is not being refreshed after being updated, so you have to click again on another pedestal after the last one to trigger the CS. 

Capture showing event is supposed to start when clicking last pedestal https://youtu.be/BqbmmbygGBU?t=1885
credits: @siknoz 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
