### PR TITLE
C2S Packets Validation [0x104 - 0x110]

### DIFF
--- a/src/map/item_container.cpp
+++ b/src/map/item_container.cpp
@@ -182,12 +182,13 @@ uint8 CItemContainer::InsertItem(CItem* PItem, uint8 SlotID)
     return ERROR_SLOTID;
 }
 
-CItem* CItemContainer::GetItem(uint8 SlotID)
+CItem* CItemContainer::GetItem(uint8 slotID) const
 {
-    if (SlotID <= m_size)
+    if (slotID <= m_size)
     {
-        return m_ItemList[SlotID];
+        return m_ItemList[slotID];
     }
+
     return nullptr;
 }
 

--- a/src/map/item_container.h
+++ b/src/map/item_container.h
@@ -77,7 +77,7 @@ public:
     uint32            SortingPacket; // number of sort requests per clock
     timer::time_point LastSortingTime;
 
-    CItem* GetItem(uint8 slotID); // get a pointer to the object located in the specified cell.
+    CItem* GetItem(uint8 slotID) const; // get a pointer to the object located in the specified cell.
     void   Clear();               // remove all items from container
 
     template <typename F, typename... Args>

--- a/src/map/item_container.h
+++ b/src/map/item_container.h
@@ -78,7 +78,7 @@ public:
     timer::time_point LastSortingTime;
 
     CItem* GetItem(uint8 slotID) const; // get a pointer to the object located in the specified cell.
-    void   Clear();               // remove all items from container
+    void   Clear();                     // remove all items from container
 
     template <typename F, typename... Args>
     void ForEachItem(F func, Args&&... args)

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -88,6 +88,7 @@
 #include "packets/c2s/0x058_recipe.h"
 #include "packets/c2s/0x105_bazaar_list.h"
 #include "packets/c2s/0x10f_currencies_1.h"
+#include "packets/c2s/0x110_fishing_2.h"
 #include "packets/c2s/0x113_sitchair.h"
 #include "packets/c2s/0x114_map_markers.h"
 #include "packets/c2s/0x115_currencies_2.h"
@@ -3172,21 +3173,6 @@ void SmallPacket0x064(MapSession* const PSession, CCharEntity* const PChar, CBas
     }
 
     charutils::SaveKeyItems(PChar);
-}
-
-/************************************************************************
- *                                                                       *
- *  Fishing (Action) [Old fishing method packet! Still used.]            *
- *                                                                       *
- ************************************************************************/
-
-void SmallPacket0x066(MapSession* const PSession, CCharEntity* const PChar, CBasicPacket& data)
-{
-    TracyZoneScoped;
-    if (settings::get<bool>("map.FISHING_ENABLE") && PChar->GetMLevel() >= settings::get<uint8>("map.FISHING_MIN_LEVEL"))
-    {
-        fishingutils::HandleFishingAction(PChar, data);
-    }
 }
 
 /************************************************************************
@@ -7263,21 +7249,6 @@ void SmallPacket0x10E(MapSession* const PSession, CCharEntity* const PChar, CBas
 }
 
 /************************************************************************
- *                                                                       *
- *  Fishing (New)                                                        *
- *                                                                       *
- ************************************************************************/
-
-void SmallPacket0x110(MapSession* const PSession, CCharEntity* const PChar, CBasicPacket& data)
-{
-    TracyZoneScoped;
-    if (settings::get<bool>("map.FISHING_ENABLE") && PChar->GetMLevel() >= settings::get<uint8>("map.FISHING_MIN_LEVEL"))
-    {
-        fishingutils::HandleFishingAction(PChar, data);
-    }
-}
-
-/************************************************************************
  *                                                                        *
  *  Roe Quest Log Request                                                 *
  *                                                                        *
@@ -7384,7 +7355,7 @@ void PacketParserInitialize()
     PacketSize[0x061] = 0x04; PacketParser[0x061] = &SmallPacket0x061;
     PacketSize[0x063] = 0x00; PacketParser[0x063] = &SmallPacket0x063;
     PacketSize[0x064] = 0x26; PacketParser[0x064] = &SmallPacket0x064;
-    PacketSize[0x066] = 0x0A; PacketParser[0x066] = &SmallPacket0x066;
+    PacketSize[0x066] = 0x0A; PacketParser[0x066] = &ValidatedPacketHandler<GP_CLI_COMMAND_FISHING_2>;
     PacketSize[0x06E] = 0x06; PacketParser[0x06E] = &SmallPacket0x06E;
     PacketSize[0x06F] = 0x00; PacketParser[0x06F] = &SmallPacket0x06F;
     PacketSize[0x070] = 0x00; PacketParser[0x070] = &SmallPacket0x070;
@@ -7450,7 +7421,7 @@ void PacketParserInitialize()
     PacketSize[0x10D] = 0x04; PacketParser[0x10D] = &SmallPacket0x10D;
     PacketSize[0x10E] = 0x04; PacketParser[0x10E] = &SmallPacket0x10E;
     PacketSize[0x10F] = 0x02; PacketParser[0x10F] = &ValidatedPacketHandler<GP_CLI_COMMAND_CURRENCIES_1>;
-    PacketSize[0x110] = 0x0A; PacketParser[0x110] = &SmallPacket0x110;
+    PacketSize[0x110] = 0x0A; PacketParser[0x110] = &ValidatedPacketHandler<GP_CLI_COMMAND_FISHING_2>;
     PacketSize[0x111] = 0x00; PacketParser[0x111] = &SmallPacket0xFFF_DEPRECATED;
     PacketSize[0x112] = 0x00; PacketParser[0x112] = &SmallPacket0x112;
     PacketSize[0x113] = 0x06; PacketParser[0x113] = &ValidatedPacketHandler<GP_CLI_COMMAND_SITCHAIR>;

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -246,6 +246,17 @@ void SmallPacket0xFFF_NOT_IMPLEMENTED(MapSession* const PSession, CCharEntity* c
 
 /************************************************************************
  *                                                                       *
+ *  Deprecated Packet                                                    *
+ *                                                                       *
+ ************************************************************************/
+
+void SmallPacket0xFFF_DEPRECATED(MapSession* const PSession, CCharEntity* const PChar, CBasicPacket& data)
+{
+    ShowWarning("parse: SmallPacket is deprecated Type<%03hX>", (data.ref<uint16>(0) & 0x1FF));
+}
+
+/************************************************************************
+ *                                                                       *
  *  Log Into Zone                                                        *
  *                                                                       *
  *  Update session key and client port between zone transitions.         *
@@ -7268,19 +7279,6 @@ void SmallPacket0x110(MapSession* const PSession, CCharEntity* const PChar, CBas
 
 /************************************************************************
  *                                                                        *
- *  Lock Style Request                                                    *
- *                                                                        *
- ************************************************************************/
-
-void SmallPacket0x111(MapSession* const PSession, CCharEntity* const PChar, CBasicPacket& data)
-{
-    TracyZoneScoped;
-    charutils::SetStyleLock(PChar, data.ref<uint8>(0x04));
-    PChar->pushPacket<CCharAppearancePacket>(PChar);
-}
-
-/************************************************************************
- *                                                                        *
  *  Roe Quest Log Request                                                 *
  *                                                                        *
  ************************************************************************/
@@ -7453,7 +7451,7 @@ void PacketParserInitialize()
     PacketSize[0x10E] = 0x04; PacketParser[0x10E] = &SmallPacket0x10E;
     PacketSize[0x10F] = 0x02; PacketParser[0x10F] = &ValidatedPacketHandler<GP_CLI_COMMAND_CURRENCIES_1>;
     PacketSize[0x110] = 0x0A; PacketParser[0x110] = &SmallPacket0x110;
-    PacketSize[0x111] = 0x00; PacketParser[0x111] = &SmallPacket0x111;
+    PacketSize[0x111] = 0x00; PacketParser[0x111] = &SmallPacket0xFFF_DEPRECATED;
     PacketSize[0x112] = 0x00; PacketParser[0x112] = &SmallPacket0x112;
     PacketSize[0x113] = 0x06; PacketParser[0x113] = &ValidatedPacketHandler<GP_CLI_COMMAND_SITCHAIR>;
     PacketSize[0x114] = 0x00; PacketParser[0x114] = &ValidatedPacketHandler<GP_CLI_COMMAND_MAP_MARKERS>;

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -88,6 +88,8 @@
 #include "packets/c2s/0x058_recipe.h"
 #include "packets/c2s/0x066_fishing.h"
 #include "packets/c2s/0x105_bazaar_list.h"
+#include "packets/c2s/0x10c_roe_start.h"
+#include "packets/c2s/0x10d_roe_remove.h"
 #include "packets/c2s/0x10e_roe_claim.h"
 #include "packets/c2s/0x10f_currencies_1.h"
 #include "packets/c2s/0x110_fishing_2.h"
@@ -7202,40 +7204,6 @@ void SmallPacket0x10B(MapSession* const PSession, CCharEntity* const PChar, CBas
 
 /************************************************************************
  *                                                                        *
- *  Eminence Record Start                                                  *
- *                                                                        *
- ************************************************************************/
-
-void SmallPacket0x10C(MapSession* const PSession, CCharEntity* const PChar, CBasicPacket& data)
-{
-    TracyZoneScoped;
-    if (settings::get<bool>("main.ENABLE_ROE"))
-    {
-        uint16 recordID = data.ref<uint32>(0x04);
-        roeutils::AddEminenceRecord(PChar, recordID);
-        PChar->pushPacket<CRoeSparkUpdatePacket>(PChar);
-        roeutils::onRecordTake(PChar, recordID);
-    }
-}
-
-/************************************************************************
- *                                                                        *
- *  Eminence Record Drop                                                  *
- *                                                                        *
- ************************************************************************/
-
-void SmallPacket0x10D(MapSession* const PSession, CCharEntity* const PChar, CBasicPacket& data)
-{
-    TracyZoneScoped;
-    if (settings::get<bool>("main.ENABLE_ROE"))
-    {
-        roeutils::DelEminenceRecord(PChar, data.ref<uint32>(0x04));
-        PChar->pushPacket<CRoeSparkUpdatePacket>(PChar);
-    }
-}
-
-/************************************************************************
- *                                                                        *
  *  Roe Quest Log Request                                                 *
  *                                                                        *
  ************************************************************************/
@@ -7403,8 +7371,8 @@ void PacketParserInitialize()
     PacketSize[0x109] = 0x00; PacketParser[0x109] = &SmallPacket0x109;
     PacketSize[0x10A] = 0x06; PacketParser[0x10A] = &SmallPacket0x10A;
     PacketSize[0x10B] = 0x00; PacketParser[0x10B] = &SmallPacket0x10B;
-    PacketSize[0x10C] = 0x04; PacketParser[0x10C] = &SmallPacket0x10C;
-    PacketSize[0x10D] = 0x04; PacketParser[0x10D] = &SmallPacket0x10D;
+    PacketSize[0x10C] = 0x04; PacketParser[0x10C] = &ValidatedPacketHandler<GP_CLI_COMMAND_ROE_START>;
+    PacketSize[0x10D] = 0x04; PacketParser[0x10D] = &ValidatedPacketHandler<GP_CLI_COMMAND_ROE_REMOVE>;
     PacketSize[0x10E] = 0x04; PacketParser[0x10E] = &ValidatedPacketHandler<GP_CLI_COMMAND_ROE_CLAIM>;
     PacketSize[0x10F] = 0x02; PacketParser[0x10F] = &ValidatedPacketHandler<GP_CLI_COMMAND_CURRENCIES_1>;
     PacketSize[0x110] = 0x0A; PacketParser[0x110] = &ValidatedPacketHandler<GP_CLI_COMMAND_FISHING_2>;

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -88,6 +88,7 @@
 #include "packets/c2s/0x058_recipe.h"
 #include "packets/c2s/0x066_fishing.h"
 #include "packets/c2s/0x105_bazaar_list.h"
+#include "packets/c2s/0x10b_bazaar_close.h"
 #include "packets/c2s/0x10c_roe_start.h"
 #include "packets/c2s/0x10d_roe_remove.h"
 #include "packets/c2s/0x10e_roe_claim.h"
@@ -7176,34 +7177,6 @@ void SmallPacket0x10A(MapSession* const PSession, CCharEntity* const PChar, CBas
 
 /************************************************************************
  *                                                                        *
- *  Opening "Set Prices" in bazaar-menu, closing the bazaar                 *
- *                                                                        *
- ************************************************************************/
-
-void SmallPacket0x10B(MapSession* const PSession, CCharEntity* const PChar, CBasicPacket& data)
-{
-    TracyZoneScoped;
-    for (std::size_t i = 0; i < PChar->BazaarCustomers.size(); ++i)
-    {
-        CCharEntity* PCustomer = (CCharEntity*)PChar->GetEntity(PChar->BazaarCustomers[i].targid, TYPE_PC);
-
-        if (PCustomer != nullptr && PCustomer->id == PChar->BazaarCustomers[i].id)
-        {
-            PCustomer->pushPacket<CBazaarClosePacket>(PChar);
-
-            DebugBazaarsFmt("Bazaar Interaction [Leave Bazaar] - Buyer: {}, Seller: {}", PCustomer->name, PChar->name);
-        }
-    }
-    PChar->BazaarCustomers.clear();
-
-    PChar->isSettingBazaarPrices = true;
-    PChar->updatemask |= UPDATE_HP;
-
-    DebugBazaarsFmt("Bazaar Interaction [Setting Prices] - Character: {}", PChar->name);
-}
-
-/************************************************************************
- *                                                                        *
  *  Roe Quest Log Request                                                 *
  *                                                                        *
  ************************************************************************/
@@ -7370,7 +7343,7 @@ void PacketParserInitialize()
     PacketSize[0x106] = 0x06; PacketParser[0x106] = &SmallPacket0x106;
     PacketSize[0x109] = 0x00; PacketParser[0x109] = &SmallPacket0x109;
     PacketSize[0x10A] = 0x06; PacketParser[0x10A] = &SmallPacket0x10A;
-    PacketSize[0x10B] = 0x00; PacketParser[0x10B] = &SmallPacket0x10B;
+    PacketSize[0x10B] = 0x00; PacketParser[0x10B] = &ValidatedPacketHandler<GP_CLI_COMMAND_BAZAAR_CLOSE>;
     PacketSize[0x10C] = 0x04; PacketParser[0x10C] = &ValidatedPacketHandler<GP_CLI_COMMAND_ROE_START>;
     PacketSize[0x10D] = 0x04; PacketParser[0x10D] = &ValidatedPacketHandler<GP_CLI_COMMAND_ROE_REMOVE>;
     PacketSize[0x10E] = 0x04; PacketParser[0x10E] = &ValidatedPacketHandler<GP_CLI_COMMAND_ROE_CLAIM>;

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -88,6 +88,7 @@
 #include "packets/c2s/0x058_recipe.h"
 #include "packets/c2s/0x066_fishing.h"
 #include "packets/c2s/0x105_bazaar_list.h"
+#include "packets/c2s/0x109_bazaar_open.h"
 #include "packets/c2s/0x10a_bazaar_itemset.h"
 #include "packets/c2s/0x10b_bazaar_close.h"
 #include "packets/c2s/0x10c_roe_start.h"
@@ -7104,23 +7105,6 @@ void SmallPacket0x106(MapSession* const PSession, CCharEntity* const PChar, CBas
 }
 
 /************************************************************************
- *                                                                       *
- *  Bazaar (Exit Price Setting)                                          *
- *                                                                       *
- ************************************************************************/
-
-void SmallPacket0x109(MapSession* const PSession, CCharEntity* const PChar, CBasicPacket& data)
-{
-    TracyZoneScoped;
-
-    if (PChar->isSettingBazaarPrices)
-    {
-        PChar->isSettingBazaarPrices = false;
-        PChar->updatemask |= UPDATE_HP;
-    }
-}
-
-/************************************************************************
  *                                                                        *
  *  Roe Quest Log Request                                                 *
  *                                                                        *
@@ -7286,7 +7270,7 @@ void PacketParserInitialize()
     PacketSize[0x104] = 0x02; PacketParser[0x104] = &SmallPacket0x104;
     PacketSize[0x105] = 0x06; PacketParser[0x105] = &ValidatedPacketHandler<GP_CLI_COMMAND_BAZAAR_LIST>;
     PacketSize[0x106] = 0x06; PacketParser[0x106] = &SmallPacket0x106;
-    PacketSize[0x109] = 0x00; PacketParser[0x109] = &SmallPacket0x109;
+    PacketSize[0x109] = 0x00; PacketParser[0x109] = &ValidatedPacketHandler<GP_CLI_COMMAND_BAZAAR_OPEN>;
     PacketSize[0x10A] = 0x06; PacketParser[0x10A] = &ValidatedPacketHandler<GP_CLI_COMMAND_BAZAAR_ITEMSET>;
     PacketSize[0x10B] = 0x00; PacketParser[0x10B] = &ValidatedPacketHandler<GP_CLI_COMMAND_BAZAAR_CLOSE>;
     PacketSize[0x10C] = 0x04; PacketParser[0x10C] = &ValidatedPacketHandler<GP_CLI_COMMAND_ROE_START>;

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -77,12 +77,12 @@
 #include "lua/luautils.h"
 
 #include "packets/basic.h"
-#include "packets/bazaar_check.h"
 #include "packets/bazaar_message.h"
 #include "packets/blacklist_edit_response.h"
 #include "packets/c2s/0x041_trophy_entry.h"
 #include "packets/c2s/0x058_recipe.h"
 #include "packets/c2s/0x066_fishing.h"
+#include "packets/c2s/0x104_bazaar_exit.h"
 #include "packets/c2s/0x105_bazaar_list.h"
 #include "packets/c2s/0x106_bazaar_buy.h"
 #include "packets/c2s/0x109_bazaar_open.h"
@@ -6902,37 +6902,6 @@ void SmallPacket0x102(MapSession* const PSession, CCharEntity* const PChar, CBas
 
 /************************************************************************
  *                                                                        *
- *  Closing the "View wares", sending a message to the bazaar            *
- *  that you have left the shop                                            *
- *                                                                        *
- ************************************************************************/
-
-void SmallPacket0x104(MapSession* const PSession, CCharEntity* const PChar, CBasicPacket& data)
-{
-    TracyZoneScoped;
-    CCharEntity* PTarget = (CCharEntity*)PChar->GetEntity(PChar->BazaarID.targid, TYPE_PC);
-
-    if (PTarget != nullptr && PTarget->id == PChar->BazaarID.id)
-    {
-        for (std::size_t i = 0; i < PTarget->BazaarCustomers.size(); ++i)
-        {
-            if (PTarget->BazaarCustomers[i].id == PChar->id)
-            {
-                PTarget->BazaarCustomers.erase(PTarget->BazaarCustomers.begin() + i--);
-            }
-        }
-        if (!PChar->m_isGMHidden || (PChar->m_isGMHidden && PTarget->m_GMlevel >= PChar->m_GMlevel))
-        {
-            PTarget->pushPacket<CBazaarCheckPacket>(PChar, BAZAAR_LEAVE);
-        }
-
-        DebugBazaarsFmt("Bazaar Interaction [Leave Bazaar] - Buyer: {}, Seller: {}", PChar->name, PTarget->name);
-    }
-    PChar->BazaarID.clean();
-}
-
-/************************************************************************
- *                                                                        *
  *  Roe Quest Log Request                                                 *
  *                                                                        *
  ************************************************************************/
@@ -7094,7 +7063,7 @@ void PacketParserInitialize()
     PacketSize[0x0FF] = 0x00; PacketParser[0x0FF] = &SmallPacket0x0FF;
     PacketSize[0x100] = 0x04; PacketParser[0x100] = &SmallPacket0x100;
     PacketSize[0x102] = 0x52; PacketParser[0x102] = &SmallPacket0x102;
-    PacketSize[0x104] = 0x02; PacketParser[0x104] = &SmallPacket0x104;
+    PacketSize[0x104] = 0x02; PacketParser[0x104] = &ValidatedPacketHandler<GP_CLI_COMMAND_BAZAAR_EXIT>;
     PacketSize[0x105] = 0x06; PacketParser[0x105] = &ValidatedPacketHandler<GP_CLI_COMMAND_BAZAAR_LIST>;
     PacketSize[0x106] = 0x06; PacketParser[0x106] = &ValidatedPacketHandler<GP_CLI_COMMAND_BAZAAR_BUY>;
     PacketSize[0x109] = 0x00; PacketParser[0x109] = &ValidatedPacketHandler<GP_CLI_COMMAND_BAZAAR_OPEN>;

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -88,6 +88,7 @@
 #include "packets/c2s/0x058_recipe.h"
 #include "packets/c2s/0x066_fishing.h"
 #include "packets/c2s/0x105_bazaar_list.h"
+#include "packets/c2s/0x10e_roe_claim.h"
 #include "packets/c2s/0x10f_currencies_1.h"
 #include "packets/c2s/0x110_fishing_2.h"
 #include "packets/c2s/0x113_sitchair.h"
@@ -7235,22 +7236,6 @@ void SmallPacket0x10D(MapSession* const PSession, CCharEntity* const PChar, CBas
 
 /************************************************************************
  *                                                                        *
- *  Claim completed eminence record                                       *
- *                                                                        *
- ************************************************************************/
-
-void SmallPacket0x10E(MapSession* const PSession, CCharEntity* const PChar, CBasicPacket& data)
-{
-    TracyZoneScoped;
-    if (settings::get<bool>("main.ENABLE_ROE"))
-    {
-        uint16 recordID = data.ref<uint16>(0x04);
-        roeutils::onRecordClaim(PChar, recordID);
-    }
-}
-
-/************************************************************************
- *                                                                        *
  *  Roe Quest Log Request                                                 *
  *                                                                        *
  ************************************************************************/
@@ -7420,7 +7405,7 @@ void PacketParserInitialize()
     PacketSize[0x10B] = 0x00; PacketParser[0x10B] = &SmallPacket0x10B;
     PacketSize[0x10C] = 0x04; PacketParser[0x10C] = &SmallPacket0x10C;
     PacketSize[0x10D] = 0x04; PacketParser[0x10D] = &SmallPacket0x10D;
-    PacketSize[0x10E] = 0x04; PacketParser[0x10E] = &SmallPacket0x10E;
+    PacketSize[0x10E] = 0x04; PacketParser[0x10E] = &ValidatedPacketHandler<GP_CLI_COMMAND_ROE_CLAIM>;
     PacketSize[0x10F] = 0x02; PacketParser[0x10F] = &ValidatedPacketHandler<GP_CLI_COMMAND_CURRENCIES_1>;
     PacketSize[0x110] = 0x0A; PacketParser[0x110] = &ValidatedPacketHandler<GP_CLI_COMMAND_FISHING_2>;
     PacketSize[0x111] = 0x00; PacketParser[0x111] = &SmallPacket0xFFF_DEPRECATED;

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -86,6 +86,7 @@
 #include "packets/blacklist_edit_response.h"
 #include "packets/c2s/0x041_trophy_entry.h"
 #include "packets/c2s/0x058_recipe.h"
+#include "packets/c2s/0x066_fishing.h"
 #include "packets/c2s/0x105_bazaar_list.h"
 #include "packets/c2s/0x10f_currencies_1.h"
 #include "packets/c2s/0x110_fishing_2.h"
@@ -7355,7 +7356,7 @@ void PacketParserInitialize()
     PacketSize[0x061] = 0x04; PacketParser[0x061] = &SmallPacket0x061;
     PacketSize[0x063] = 0x00; PacketParser[0x063] = &SmallPacket0x063;
     PacketSize[0x064] = 0x26; PacketParser[0x064] = &SmallPacket0x064;
-    PacketSize[0x066] = 0x0A; PacketParser[0x066] = &ValidatedPacketHandler<GP_CLI_COMMAND_FISHING_2>;
+    PacketSize[0x066] = 0x0A; PacketParser[0x066] = &ValidatedPacketHandler<GP_CLI_COMMAND_FISHING>;
     PacketSize[0x06E] = 0x06; PacketParser[0x06E] = &SmallPacket0x06E;
     PacketSize[0x06F] = 0x00; PacketParser[0x06F] = &SmallPacket0x06F;
     PacketSize[0x070] = 0x00; PacketParser[0x070] = &SmallPacket0x070;

--- a/src/map/packets/c2s/0x041_trophy_entry.cpp
+++ b/src/map/packets/c2s/0x041_trophy_entry.cpp
@@ -23,7 +23,7 @@
 
 #include "entities/charentity.h"
 
-PacketValidationResult GP_CLI_COMMAND_TROPHY_ENTRY::validate(MapSession* PSession, const CCharEntity* PChar) const
+auto GP_CLI_COMMAND_TROPHY_ENTRY::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
     return PacketValidator()
         .mustNotEqual(PChar->PTreasurePool, nullptr, "Character does not have a treasure pool")

--- a/src/map/packets/c2s/0x058_recipe.cpp
+++ b/src/map/packets/c2s/0x058_recipe.cpp
@@ -25,7 +25,7 @@
 #include "packets/synth_suggestion.h"
 #include "validation.h"
 
-PacketValidationResult GP_CLI_COMMAND_RECIPE::validate(MapSession* PSession, const CCharEntity* PChar) const
+auto GP_CLI_COMMAND_RECIPE::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
     return PacketValidator()
         .range("skill", skill, 0x01, 0x08) // Fishing 0x00 to Digging 0x0A. 0x00, 0x09, and 0x0A are not implemented

--- a/src/map/packets/c2s/0x066_fishing.cpp
+++ b/src/map/packets/c2s/0x066_fishing.cpp
@@ -19,29 +19,29 @@
 ===========================================================================
 */
 
-#include "0x110_fishing_2.h"
+#include "0x066_fishing.h"
 
 #include "entities/charentity.h"
 
-auto GP_CLI_COMMAND_FISHING_2::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
+auto GP_CLI_COMMAND_FISHING::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
     return PacketValidator()
         .mustEqual(settings::get<bool>("map.FISHING_ENABLE"), true, "Fishing is disabled")
         .mustEqual(PChar->GetMLevel() >= settings::get<uint8>("map.FISHING_MIN_LEVEL"), true, "Character below fishing minimum level")
         .mustEqual(UniqueNo, PChar->id, "Character id mismatch")
         .mustEqual(ActIndex, PChar->targid, "Character targid mismatch")
-        .range("mode", mode, GP_CLI_COMMAND_FISHING_2_MODE::RequestCheckHook, GP_CLI_COMMAND_FISHING_2_MODE::RequestPotentialTimeout)
+        .range("mode", mode, GP_CLI_COMMAND_FISHING_MODE::RequestCheckHook, GP_CLI_COMMAND_FISHING_MODE::RequestPotentialTimeout)
         .custom([&](PacketValidator& v)
                 {
                     // clang-format off
-                    switch (static_cast<GP_CLI_COMMAND_FISHING_2_MODE>(mode))
+                    switch (static_cast<GP_CLI_COMMAND_FISHING_MODE>(mode))
                     {
-                        case GP_CLI_COMMAND_FISHING_2_MODE::RequestCheckHook:
+                        case GP_CLI_COMMAND_FISHING_MODE::RequestCheckHook:
                             // para and para2 are both 0 for RequestCheckHook
                             v.mustEqual(para, 0, "para must be 0")
                                 .mustEqual(para2, 0, "para2 must be 0");
                             break;
-                        case GP_CLI_COMMAND_FISHING_2_MODE::RequestEndMiniGame:
+                        case GP_CLI_COMMAND_FISHING_MODE::RequestEndMiniGame:
                             // para has various values depending on the reason
                             // - Equals to 300 when client fails to catch a fish
                             // - Equals to 200 when client force exits the mini game
@@ -58,12 +58,12 @@ auto GP_CLI_COMMAND_FISHING_2::validate(MapSession* PSession, const CCharEntity*
                                 }
                             }
                             break;
-                        case GP_CLI_COMMAND_FISHING_2_MODE::RequestRelease:
+                        case GP_CLI_COMMAND_FISHING_MODE::RequestRelease:
                             // para and para2 are both 0 for RequestRelease
                             v.mustEqual(para, 0, "para must be 0")
                                 .mustEqual(para2, 0, "para2 must be 0");
                             break;
-                        case GP_CLI_COMMAND_FISHING_2_MODE::RequestPotentialTimeout:
+                        case GP_CLI_COMMAND_FISHING_MODE::RequestPotentialTimeout:
                             // para is set to time remaining, para2 is always 0
                             // todo: unknown actual range, this parameter is currently unused
                             v.range("para", para, 0, 10)
@@ -74,7 +74,7 @@ auto GP_CLI_COMMAND_FISHING_2::validate(MapSession* PSession, const CCharEntity*
                 });
 }
 
-void GP_CLI_COMMAND_FISHING_2::process(MapSession* PSession, CCharEntity* PChar) const
+void GP_CLI_COMMAND_FISHING::process(MapSession* PSession, CCharEntity* PChar) const
 {
-    fishingutils::FishingAction(PChar, static_cast<GP_CLI_COMMAND_FISHING_2_MODE>(mode), para, para2);
+    fishingutils::FishingAction(PChar, static_cast<GP_CLI_COMMAND_FISHING_MODE>(mode), para, para2);
 }

--- a/src/map/packets/c2s/0x066_fishing.h
+++ b/src/map/packets/c2s/0x066_fishing.h
@@ -20,11 +20,25 @@
 */
 
 #pragma once
+#include "base.h"
 
-struct GP_CLI_COMMAND_FISHING;
+enum class GP_CLI_COMMAND_FISHING_MODE : uint8_t
+{
+    RequestCheckHook        = 2,
+    RequestEndMiniGame      = 3,
+    RequestRelease          = 4,
+    RequestPotentialTimeout = 5,
+};
 
-// https://github.com/atom0s/XiPackets/tree/main/world/client/0x0110
+// https://github.com/atom0s/XiPackets/tree/main/world/client/0x0066
 // This packet is sent by the client when interacting with the fishing mini-game system.
 // Note: 0x066 handles the old fishing system, while 0x110 handles the new fishing mini-game.
 // However, both packets use the exact same structure and are processed the same way.
-using GP_CLI_COMMAND_FISHING_2 = GP_CLI_COMMAND_FISHING;
+GP_CLI_PACKET(GP_CLI_COMMAND_FISHING,
+              uint32_t UniqueNo;  // PS2: UniqueNo
+              int32_t  para;      // PS2: para
+              uint16_t ActIndex;  // PS2: ActIndex
+              int8_t   mode;      // PS2: mode
+              uint8_t  unknown00; // PS2: dammy
+              int32_t  para2;     // PS2: (New; did not exist.)
+);

--- a/src/map/packets/c2s/0x066_fishing.h
+++ b/src/map/packets/c2s/0x066_fishing.h
@@ -20,25 +20,12 @@
 */
 
 #pragma once
-#include "base.h"
 
-enum class GP_CLI_COMMAND_FISHING_MODE : uint8_t
-{
-    RequestCheckHook        = 2,
-    RequestEndMiniGame      = 3,
-    RequestRelease          = 4,
-    RequestPotentialTimeout = 5,
-};
+struct GP_CLI_COMMAND_FISHING_2;
 
 // https://github.com/atom0s/XiPackets/tree/main/world/client/0x0066
 // This packet is sent by the client when interacting with the fishing mini-game system.
 // Note: 0x066 handles the old fishing system, while 0x110 handles the new fishing mini-game.
 // However, both packets use the exact same structure and are processed the same way.
-GP_CLI_PACKET(GP_CLI_COMMAND_FISHING,
-              uint32_t UniqueNo;  // PS2: UniqueNo
-              int32_t  para;      // PS2: para
-              uint16_t ActIndex;  // PS2: ActIndex
-              int8_t   mode;      // PS2: mode
-              uint8_t  unknown00; // PS2: dammy
-              int32_t  para2;     // PS2: (New; did not exist.)
-);
+// There is a strong chance that this packet is deprecated and not legitimately usable by the client.
+using GP_CLI_COMMAND_FISHING = GP_CLI_COMMAND_FISHING_2;

--- a/src/map/packets/c2s/0x104_bazaar_exit.cpp
+++ b/src/map/packets/c2s/0x104_bazaar_exit.cpp
@@ -1,0 +1,59 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "0x104_bazaar_exit.h"
+
+#include "entities/charentity.h"
+#include "packets/bazaar_check.h"
+
+auto GP_CLI_COMMAND_BAZAAR_EXIT::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
+{
+    // No parameters to validate.
+    return PacketValidator();
+}
+
+void GP_CLI_COMMAND_BAZAAR_EXIT::process(MapSession* PSession, CCharEntity* PChar) const
+{
+    auto* PEntity = PChar->GetEntity(PChar->BazaarID.targid, TYPE_PC);
+    if (!PEntity)
+    {
+        return;
+    }
+
+    if (auto* PTarget = static_cast<CCharEntity*>(PEntity); PTarget->id == PChar->BazaarID.id)
+    {
+        for (std::size_t i = 0; i < PTarget->BazaarCustomers.size(); ++i)
+        {
+            if (PTarget->BazaarCustomers[i].id == PChar->id)
+            {
+                PTarget->BazaarCustomers.erase(PTarget->BazaarCustomers.begin() + i--);
+            }
+        }
+        if (!PChar->m_isGMHidden || (PChar->m_isGMHidden && PTarget->m_GMlevel >= PChar->m_GMlevel))
+        {
+            PTarget->pushPacket<CBazaarCheckPacket>(PChar, BAZAAR_LEAVE);
+        }
+
+        DebugBazaarsFmt("Bazaar Interaction [Leave Bazaar] - Buyer: {}, Seller: {}", PChar->name, PTarget->name);
+    }
+
+    PChar->BazaarID.clean();
+}

--- a/src/map/packets/c2s/0x104_bazaar_exit.h
+++ b/src/map/packets/c2s/0x104_bazaar_exit.h
@@ -19,18 +19,9 @@
 ===========================================================================
 */
 
-#include "0x109_bazaar_open.h"
+#pragma once
+#include "base.h"
 
-#include "entities/charentity.h"
-
-auto GP_CLI_COMMAND_BAZAAR_OPEN::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
-{
-    return PacketValidator()
-        .mustEqual(PChar->isSettingBazaarPrices, true, "isSettingBazaarPrices not true");
-}
-
-void GP_CLI_COMMAND_BAZAAR_OPEN::process(MapSession* PSession, CCharEntity* PChar) const
-{
-    PChar->isSettingBazaarPrices = false;
-    PChar->updatemask |= UPDATE_HP;
-}
+// https://github.com/atom0s/XiPackets/tree/main/world/client/0x0104
+// This packet is sent by the client when exiting a bazaar.
+GP_CLI_PACKET(GP_CLI_COMMAND_BAZAAR_EXIT);

--- a/src/map/packets/c2s/0x105_bazaar_list.cpp
+++ b/src/map/packets/c2s/0x105_bazaar_list.cpp
@@ -25,7 +25,7 @@
 #include "packets/bazaar_check.h"
 #include "packets/bazaar_item.h"
 
-PacketValidationResult GP_CLI_COMMAND_BAZAAR_LIST::validate(MapSession* PSession, const CCharEntity* PChar) const
+auto GP_CLI_COMMAND_BAZAAR_LIST::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
     return PacketValidator()
         .mustEqual(PChar->BazaarID.id, 0, "Character already has a Bazaar ID")

--- a/src/map/packets/c2s/0x106_bazaar_buy.cpp
+++ b/src/map/packets/c2s/0x106_bazaar_buy.cpp
@@ -1,0 +1,204 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "0x106_bazaar_buy.h"
+
+#include "common/async.h"
+#include "entities/charentity.h"
+#include "packets/bazaar_close.h"
+#include "packets/bazaar_confirmation.h"
+#include "packets/bazaar_item.h"
+#include "packets/bazaar_purchase.h"
+#include "packets/inventory_finish.h"
+#include "packets/inventory_item.h"
+#include "utils/charutils.h"
+#include "utils/itemutils.h"
+
+auto GP_CLI_COMMAND_BAZAAR_BUY::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
+{
+    // TODO: Short-circuit PV so we can bring all the other checks into this function
+    return PacketValidator()
+        .range("BuyNum", BuyNum, 1, 99);
+}
+
+void GP_CLI_COMMAND_BAZAAR_BUY::process(MapSession* PSession, CCharEntity* PChar) const
+{
+    auto* PEntity = PChar->GetEntity(PChar->BazaarID.targid, TYPE_PC);
+    if (!PEntity)
+    {
+        return;
+    }
+
+    auto* PTarget = static_cast<CCharEntity*>(PEntity);
+    if (PTarget->id != PChar->BazaarID.id)
+    {
+        return;
+    }
+
+    CItemContainer* PBazaar         = PTarget->getStorage(LOC_INVENTORY);
+    CItemContainer* PBuyerInventory = PChar->getStorage(LOC_INVENTORY);
+    if (PBazaar == nullptr || PBuyerInventory == nullptr)
+    {
+        return;
+    }
+
+    CItem* PBazaarItem = PBazaar->GetItem(BazaarItemIndex);
+    if (PBazaarItem == nullptr || PBazaarItem->getReserve() > 0)
+    {
+        return;
+    }
+
+    if (PChar->id == PTarget->id || PBuyerInventory->GetFreeSlotsCount() == 0)
+    {
+        PChar->pushPacket<CBazaarPurchasePacket>(PTarget, false);
+
+        if (settings::get<bool>("logging.DEBUG_BAZAARS") && PChar->id == PTarget->id)
+        {
+            if (PChar->id == PTarget->id)
+            {
+                DebugBazaarsFmt("Bazaar Interaction [Purchase Failed / Self Bazaar] - Character: {}, Item: {}", PChar->name, PBazaarItem->getName());
+            }
+            if (PBuyerInventory->GetFreeSlotsCount() == 0)
+            {
+                DebugBazaarsFmt("Bazaar Interaction [Purchase Failed / Inventory Full] - Buyer: {}, Seller: {}, Item: {}", PChar->name, PTarget->name, PBazaarItem->getName());
+            }
+        }
+
+        return;
+    }
+
+    // Obtain the players gil
+    const CItem* PCharGil = PBuyerInventory->GetItem(0);
+    if (PCharGil == nullptr || !PCharGil->isType(ITEM_CURRENCY) || PCharGil->getReserve() > 0)
+    {
+        // Player has no gil
+        PChar->pushPacket<CBazaarPurchasePacket>(PTarget, false);
+        return;
+    }
+
+    if ((PBazaarItem->getCharPrice() != 0) && (PBazaarItem->getQuantity() >= BuyNum))
+    {
+        const uint32 Price        = (PBazaarItem->getCharPrice() * BuyNum);
+        uint32       PriceWithTax = (PChar->loc.zone->GetTax() * Price) / 10000 + Price;
+
+        // Validate this player can afford said item
+        if (PCharGil->getQuantity() < PriceWithTax)
+        {
+            PChar->pushPacket<CBazaarPurchasePacket>(PTarget, false);
+
+            // Exploit attempt
+            ShowWarningFmt("Bazaar Interaction [Insufficient Gil] - Buyer: {}, Seller: {}, Buyer Gil: {}, Price: {}", PChar->name, PTarget->name, PCharGil->getQuantity(), PriceWithTax);
+
+            return;
+        }
+
+        CItem* PItem = itemutils::GetItem(PBazaarItem);
+
+        PItem->setCharPrice(0);
+        PItem->setQuantity(BuyNum);
+        PItem->setSubType(ITEM_UNLOCKED);
+
+        if (charutils::AddItem(PChar, LOC_INVENTORY, PItem) == ERROR_SLOTID)
+        {
+            return;
+        }
+
+        if (settings::get<bool>("map.AUDIT_PLAYER_BAZAAR"))
+        {
+            Async::getInstance()->submit(
+                [itemID        = PItem->getID(),
+                 quantity      = BuyNum,
+                 sellerID      = PTarget->id,
+                 sellerName    = PTarget->getName(),
+                 purchaserID   = PChar->id,
+                 purchaserName = PChar->getName(),
+                 price         = PriceWithTax,
+                 date          = earth_time::timestamp()]
+                {
+                    const auto query = "INSERT INTO audit_bazaar(itemid, quantity, seller, seller_name, purchaser, purchaser_name, price, date) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+                    if (!db::preparedStmt(query, itemID, quantity, sellerID, sellerName, purchaserID, purchaserName, price, date))
+                    {
+                        ShowErrorFmt("Failed to log bazaar purchase (ItemID: {}, Quantity: {}, Seller: {}, Purchaser: {}, Price: {})", itemID, quantity, sellerName, purchaserName, price);
+                    }
+                });
+        }
+
+        charutils::UpdateItem(PChar, LOC_INVENTORY, 0, -static_cast<int32>(PriceWithTax));
+        charutils::UpdateItem(PTarget, LOC_INVENTORY, 0, Price);
+
+        PChar->pushPacket<CBazaarPurchasePacket>(PTarget, true);
+
+        PTarget->pushPacket<CBazaarConfirmationPacket>(PChar, PItem);
+
+        charutils::UpdateItem(PTarget, LOC_INVENTORY, BazaarItemIndex, -static_cast<int32>(BuyNum));
+
+        PTarget->pushPacket<CInventoryItemPacket>(PBazaar->GetItem(BazaarItemIndex), LOC_INVENTORY, BazaarItemIndex);
+        PTarget->pushPacket<CInventoryFinishPacket>();
+
+        DebugBazaarsFmt("Bazaar Interaction [Purchase Successful] - Buyer: {}, Seller: {}, Item: {}, Qty: {}, Cost: {}", PChar->name, PTarget->name, PItem->getName(), BuyNum, PriceWithTax);
+
+        bool BazaarIsEmpty = true;
+
+        for (uint8 BazaarSlotID = 1; BazaarSlotID <= PBazaar->GetSize(); ++BazaarSlotID)
+        {
+            PItem = PBazaar->GetItem(BazaarSlotID);
+
+            if ((PItem != nullptr) && (PItem->getCharPrice() != 0))
+            {
+                BazaarIsEmpty = false;
+                break;
+            }
+        }
+        for (std::size_t i = 0; i < PTarget->BazaarCustomers.size(); ++i)
+        {
+            PEntity = PTarget->GetEntity(PTarget->BazaarCustomers[i].targid, TYPE_PC);
+            if (!PEntity)
+            {
+                continue;
+            }
+
+            if (auto* PCustomer = static_cast<CCharEntity*>(PEntity); PCustomer->id == PTarget->BazaarCustomers[i].id)
+            {
+                if (PCustomer->id != PChar->id)
+                {
+                    PCustomer->pushPacket<CBazaarConfirmationPacket>(PChar, BazaarItemIndex, BuyNum);
+                }
+                PCustomer->pushPacket<CBazaarItemPacket>(PBazaar->GetItem(BazaarItemIndex), BazaarItemIndex, PChar->loc.zone->GetTax());
+
+                if (BazaarIsEmpty)
+                {
+                    PCustomer->pushPacket<CBazaarClosePacket>(PTarget);
+
+                    DebugBazaarsFmt("Bazaar Interaction [Bazaar Emptied] - Buyer: {}, Seller: {}", PChar->name, PTarget->name);
+                }
+            }
+        }
+
+        if (BazaarIsEmpty)
+        {
+            PTarget->updatemask |= UPDATE_HP;
+        }
+
+        return;
+    }
+
+    PChar->pushPacket<CBazaarPurchasePacket>(PTarget, false);
+}

--- a/src/map/packets/c2s/0x106_bazaar_buy.h
+++ b/src/map/packets/c2s/0x106_bazaar_buy.h
@@ -1,0 +1,31 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+#include "base.h"
+
+// https://github.com/atom0s/XiPackets/tree/main/world/client/0x0106
+// This packet is sent by the client when requesting to purchase an item from a bazaar.
+GP_CLI_PACKET(GP_CLI_COMMAND_BAZAAR_BUY,
+              uint8_t  BazaarItemIndex; // PS2: BazaarItemIndex
+              uint8_t  padding00[3];    // PS2: Dammy
+              uint32_t BuyNum;          // PS2: BuyNum
+);

--- a/src/map/packets/c2s/0x109_bazaar_open.cpp
+++ b/src/map/packets/c2s/0x109_bazaar_open.cpp
@@ -19,13 +19,19 @@
 ===========================================================================
 */
 
-#pragma once
-#include "base.h"
+#include "0x109_bazaar_open.h"
 
-// https://github.com/atom0s/XiPackets/tree/main/world/client/0x010A
-// This packet is sent by the client when setting an items sale price within the players personal bazaar.
-GP_CLI_PACKET(GP_CLI_COMMAND_BAZAAR_ITEMSET,
-              uint8_t  ItemIndex;    // PS2: ItemIndex
-              uint8_t  padding00[3]; // PS2: Dammy
-              uint32_t Price;        // PS2: Price
-);
+#include "entities/charentity.h"
+
+
+auto GP_CLI_COMMAND_BAZAAR_OPEN::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
+{
+    return PacketValidator()
+        .mustEqual(PChar->isSettingBazaarPrices, true, "isSettingBazaarPrices not true");
+}
+
+void GP_CLI_COMMAND_BAZAAR_OPEN::process(MapSession* PSession, CCharEntity* PChar) const
+{
+    PChar->isSettingBazaarPrices = false;
+    PChar->updatemask |= UPDATE_HP;
+}

--- a/src/map/packets/c2s/0x109_bazaar_open.h
+++ b/src/map/packets/c2s/0x109_bazaar_open.h
@@ -22,10 +22,6 @@
 #pragma once
 #include "base.h"
 
-// https://github.com/atom0s/XiPackets/tree/main/world/client/0x010A
-// This packet is sent by the client when setting an items sale price within the players personal bazaar.
-GP_CLI_PACKET(GP_CLI_COMMAND_BAZAAR_ITEMSET,
-              uint8_t  ItemIndex;    // PS2: ItemIndex
-              uint8_t  padding00[3]; // PS2: Dammy
-              uint32_t Price;        // PS2: Price
-);
+// https://github.com/atom0s/XiPackets/tree/main/world/client/0x0109
+// This packet is sent by the client when exiting the bazaar 'Set Prices' menu with at least one item having a sale price set.
+GP_CLI_PACKET(GP_CLI_COMMAND_BAZAAR_OPEN);

--- a/src/map/packets/c2s/0x10a_bazaar_itemset.cpp
+++ b/src/map/packets/c2s/0x10a_bazaar_itemset.cpp
@@ -1,0 +1,69 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "0x10a_bazaar_itemset.h"
+
+#include "entities/charentity.h"
+#include "packets/bazaar_check.h"
+#include "packets/inventory_finish.h"
+#include "packets/inventory_item.h"
+
+auto GP_CLI_COMMAND_BAZAAR_ITEMSET::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
+{
+    // TODO: Need PV to support short-circuiting so we can nest null checks and move the PStorage/PItem checks here
+    return PacketValidator()
+        .range("Price", Price, 0, 99999999); // Bazaar max sell price is 99,999,999 gil
+}
+
+void GP_CLI_COMMAND_BAZAAR_ITEMSET::process(MapSession* PSession, CCharEntity* PChar) const
+{
+    const auto* PStorage = PChar->getStorage(LOC_INVENTORY);
+    if (PStorage == nullptr)
+    {
+        return;
+    }
+
+    CItem* PItem = PStorage->GetItem(ItemIndex);
+    if (PItem == nullptr)
+    {
+        return;
+    }
+
+    if (PItem->getReserve() > 0)
+    {
+        ShowError("Player %s trying to bazaar a RESERVED item! [Item: %i | Slot ID: %i] ", PChar->getName(), PItem->getID(),
+                  ItemIndex);
+        return;
+    }
+
+    if (!(PItem->getFlag() & ITEM_FLAG_EX) && (!PItem->isSubType(ITEM_LOCKED) || PItem->getCharPrice() != 0))
+    {
+        db::preparedStmt("UPDATE char_inventory SET bazaar = ? WHERE charid = ? AND location = 0 AND slot = ?", Price, PChar->id, ItemIndex);
+
+        PItem->setCharPrice(Price);
+        PItem->setSubType((Price == 0 ? ITEM_UNLOCKED : ITEM_LOCKED));
+
+        PChar->pushPacket<CInventoryItemPacket>(PItem, LOC_INVENTORY, ItemIndex);
+        PChar->pushPacket<CInventoryFinishPacket>();
+
+        DebugBazaarsFmt("Bazaar Interaction [Price Set] - Character: {}, Item: {}, Price: {}", PChar->name, PItem->getName(), Price);
+    }
+}

--- a/src/map/packets/c2s/0x10a_bazaar_itemset.h
+++ b/src/map/packets/c2s/0x10a_bazaar_itemset.h
@@ -1,0 +1,31 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+#include "base.h"
+
+// https://github.com/atom0s/XiPackets/tree/main/world/client/0x010B
+// This packet is sent by the client when setting an items sale price within the players personal bazaar.
+GP_CLI_PACKET(GP_CLI_COMMAND_BAZAAR_ITEMSET,
+              uint8_t  ItemIndex;    // PS2: ItemIndex
+              uint8_t  padding00[3]; // PS2: Dammy
+              uint32_t Price;        // PS2: Price
+);

--- a/src/map/packets/c2s/0x10b_bazaar_close.cpp
+++ b/src/map/packets/c2s/0x10b_bazaar_close.cpp
@@ -1,0 +1,58 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "0x10b_bazaar_close.h"
+
+#include "entities/charentity.h"
+#include "packets/bazaar_check.h"
+#include "packets/bazaar_close.h"
+
+auto GP_CLI_COMMAND_BAZAAR_CLOSE::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
+{
+    return PacketValidator()
+        .mustEqual(AllListClearFlg, 0, "AllListClearFlg not 0"); // Always 0
+}
+
+void GP_CLI_COMMAND_BAZAAR_CLOSE::process(MapSession* PSession, CCharEntity* PChar) const
+{
+    for (std::size_t i = 0; i < PChar->BazaarCustomers.size(); ++i)
+    {
+        auto* PEntity = PChar->GetEntity(PChar->BazaarCustomers[i].targid, TYPE_PC);
+        if (!PEntity)
+        {
+            continue;
+        }
+
+        if (auto* PCustomer = static_cast<CCharEntity*>(PEntity); PCustomer->id == PChar->BazaarCustomers[i].id)
+        {
+            PCustomer->pushPacket<CBazaarClosePacket>(PChar);
+
+            DebugBazaarsFmt("Bazaar Interaction [Leave Bazaar] - Buyer: {}, Seller: {}", PCustomer->name, PChar->name);
+        }
+    }
+
+    PChar->BazaarCustomers.clear();
+
+    PChar->isSettingBazaarPrices = true;
+    PChar->updatemask |= UPDATE_HP;
+
+    DebugBazaarsFmt("Bazaar Interaction [Setting Prices] - Character: {}", PChar->name);
+}

--- a/src/map/packets/c2s/0x10b_bazaar_close.h
+++ b/src/map/packets/c2s/0x10b_bazaar_close.h
@@ -1,0 +1,29 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+#include "base.h"
+
+// https://github.com/atom0s/XiPackets/tree/main/world/client/0x010B
+// This packet is sent by the client when entering the bazaar 'Set Prices' menu.
+GP_CLI_PACKET(GP_CLI_COMMAND_BAZAAR_CLOSE,
+              uint32_t AllListClearFlg; // PS2: AllListClearFlg
+);

--- a/src/map/packets/c2s/0x10c_roe_start.cpp
+++ b/src/map/packets/c2s/0x10c_roe_start.cpp
@@ -1,0 +1,43 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "0x10c_roe_start.h"
+
+#include "entities/charentity.h"
+#include "packets/roe_sparkupdate.h"
+#include "roe.h"
+
+auto GP_CLI_COMMAND_ROE_START::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
+{
+    return PacketValidator()
+        .mustEqual(settings::get<bool>("main.ENABLE_ROE"), true, "RoE is disabled")
+        .range("ObjectiveId", ObjectiveId, 0, 4096)
+        .mustEqual(roeutils::RoeSystem.TimedRecords.test(ObjectiveId), false, "Cannot start a timed record")
+        .mustEqual(roeutils::GetEminenceRecordCompletion(PChar, ObjectiveId) && !roeutils::RoeSystem.RepeatableRecords.test(ObjectiveId),
+                   false, "Cannot start a completed record that is not repeatable");
+}
+
+void GP_CLI_COMMAND_ROE_START::process(MapSession* PSession, CCharEntity* PChar) const
+{
+    roeutils::AddEminenceRecord(PChar, ObjectiveId);
+    PChar->pushPacket<CRoeSparkUpdatePacket>(PChar);
+    roeutils::onRecordTake(PChar, ObjectiveId);
+}

--- a/src/map/packets/c2s/0x10c_roe_start.h
+++ b/src/map/packets/c2s/0x10c_roe_start.h
@@ -1,0 +1,30 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+#include "base.h"
+
+// https://github.com/atom0s/XiPackets/tree/main/world/client/0x010C
+// This packet is sent by the client when requesting to start a Records of Eminence objective.
+GP_CLI_PACKET(GP_CLI_COMMAND_ROE_START,
+              uint16_t ObjectiveId; // The Records of Eminence object id.
+              uint16_t padding00;   // Padding; unused.
+);

--- a/src/map/packets/c2s/0x10d_roe_remove.cpp
+++ b/src/map/packets/c2s/0x10d_roe_remove.cpp
@@ -1,0 +1,39 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "0x10d_roe_remove.h"
+
+#include "entities/charentity.h"
+#include "packets/roe_sparkupdate.h"
+#include "roe.h"
+
+auto GP_CLI_COMMAND_ROE_REMOVE::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
+{
+    return PacketValidator()
+        .mustEqual(settings::get<bool>("main.ENABLE_ROE"), true, "RoE is disabled")
+        .range("ObjectiveId", ObjectiveId, 0, 4096);
+}
+
+void GP_CLI_COMMAND_ROE_REMOVE::process(MapSession* PSession, CCharEntity* PChar) const
+{
+    roeutils::DelEminenceRecord(PChar, ObjectiveId);
+    PChar->pushPacket<CRoeSparkUpdatePacket>(PChar);
+}

--- a/src/map/packets/c2s/0x10d_roe_remove.h
+++ b/src/map/packets/c2s/0x10d_roe_remove.h
@@ -1,0 +1,30 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+#include "base.h"
+
+// https://github.com/atom0s/XiPackets/tree/main/world/client/0x010D
+// This packet is sent by the client when requesting to remove an active Records of Eminence objective.
+GP_CLI_PACKET(GP_CLI_COMMAND_ROE_REMOVE,
+              uint16_t ObjectiveId; // The Records of Eminence object id.
+              uint16_t padding00;   // Padding; unused.
+);

--- a/src/map/packets/c2s/0x10e_roe_claim.cpp
+++ b/src/map/packets/c2s/0x10e_roe_claim.cpp
@@ -1,0 +1,39 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "0x10e_roe_claim.h"
+
+#include "entities/charentity.h"
+#include "packets/currency1.h"
+#include "roe.h"
+
+auto GP_CLI_COMMAND_ROE_CLAIM::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
+{
+    return PacketValidator()
+        .mustEqual(settings::get<bool>("main.ENABLE_ROE"), true, "RoE is disabled")
+        .range("ObjectiveId", ObjectiveId, 0, 4096);
+}
+
+void GP_CLI_COMMAND_ROE_CLAIM::process(MapSession* PSession, CCharEntity* PChar) const
+{
+    roeutils::onRecordClaim(PChar, ObjectiveId);
+    PChar->pushPacket<CCurrencyPacket1>(PChar);
+}

--- a/src/map/packets/c2s/0x10e_roe_claim.h
+++ b/src/map/packets/c2s/0x10e_roe_claim.h
@@ -1,0 +1,30 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+#include "base.h"
+
+// https://github.com/atom0s/XiPackets/tree/main/world/client/0x010E
+// This packet is sent by the client when requesting to claim a completed Records of Eminence objectives reward.
+GP_CLI_PACKET(GP_CLI_COMMAND_ROE_CLAIM,
+              uint16_t ObjectiveId; // The Records of Eminence object id.
+              uint16_t padding00;   // Padding; unused.
+);

--- a/src/map/packets/c2s/0x10f_currencies_1.cpp
+++ b/src/map/packets/c2s/0x10f_currencies_1.cpp
@@ -24,7 +24,7 @@
 #include "entities/charentity.h"
 #include "packets/currency1.h"
 
-PacketValidationResult GP_CLI_COMMAND_CURRENCIES_1::validate(MapSession* PSession, const CCharEntity* PChar) const
+auto GP_CLI_COMMAND_CURRENCIES_1::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
     // No parameters to validate for this packet.
     return PacketValidator();

--- a/src/map/packets/c2s/0x110_fishing_2.cpp
+++ b/src/map/packets/c2s/0x110_fishing_2.cpp
@@ -1,0 +1,80 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "0x110_fishing_2.h"
+
+#include "entities/charentity.h"
+
+auto GP_CLI_COMMAND_FISHING_2::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
+{
+    return PacketValidator()
+        .mustEqual(settings::get<bool>("map.FISHING_ENABLE"), true, "Fishing is disabled")
+        .mustEqual(PChar->GetMLevel() >= settings::get<uint8>("map.FISHING_MIN_LEVEL"), true, "Character below fishing minimum level")
+        .mustEqual(UniqueNo, PChar->id, "Character id mismatch")
+        .mustEqual(ActIndex, PChar->targid, "Character targid mismatch")
+        .range("mode", mode, GP_CLI_COMMAND_FISHING_2_MODE::RequestCheckHook, GP_CLI_COMMAND_FISHING_2_MODE::RequestPotentialTimeout)
+        .custom([&](PacketValidator& v)
+                {
+                    // clang-format off
+                    switch (static_cast<GP_CLI_COMMAND_FISHING_2_MODE>(mode))
+                    {
+                        case GP_CLI_COMMAND_FISHING_2_MODE::RequestCheckHook:
+                            // para and para2 are both 0 for RequestCheckHook
+                            v.mustEqual(para, 0, "para must be 0")
+                                .mustEqual(para2, 0, "para2 must be 0");
+                            break;
+                        case GP_CLI_COMMAND_FISHING_2_MODE::RequestEndMiniGame:
+                            // para has various values depending on the reason
+                            // - Equals to 300 when client fails to catch a fish
+                            // - Equals to 200 when client force exits the mini game
+                            // - Equals to 0 when client successfully catches a fish
+                            // - Else it is equal to the fish remaining stamina
+                            v.range("para", para, 0, 300);
+
+                            // if para2 is non-zero, it must equal current hooked fish special
+                            if (para2 != 0)
+                            {
+                                if (PChar->hookedFish)
+                                {
+                                    v.mustEqual(para2, PChar->hookedFish->special, "para2 not equal to current hooked fish special");
+                                }
+                            }
+                            break;
+                        case GP_CLI_COMMAND_FISHING_2_MODE::RequestRelease:
+                            // para and para2 are both 0 for RequestRelease
+                            v.mustEqual(para, 0, "para must be 0")
+                                .mustEqual(para2, 0, "para2 must be 0");
+                            break;
+                        case GP_CLI_COMMAND_FISHING_2_MODE::RequestPotentialTimeout:
+                            // para is set to time remaining, para2 is always 0
+                            // todo: unknown actual range, this parameter is currently unused
+                            v.range("para", para, 0, 10)
+                                .mustEqual(para2, 0, "para2 must be 0");
+                            break;
+                    }
+                    // clang-format on
+                });
+}
+
+void GP_CLI_COMMAND_FISHING_2::process(MapSession* PSession, CCharEntity* PChar) const
+{
+    fishingutils::FishingAction(PChar, static_cast<GP_CLI_COMMAND_FISHING_2_MODE>(mode), para, para2);
+}

--- a/src/map/packets/c2s/0x110_fishing_2.cpp
+++ b/src/map/packets/c2s/0x110_fishing_2.cpp
@@ -19,29 +19,29 @@
 ===========================================================================
 */
 
-#include "0x066_fishing.h"
+#include "0x110_fishing_2.h"
 
 #include "entities/charentity.h"
 
-auto GP_CLI_COMMAND_FISHING::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
+auto GP_CLI_COMMAND_FISHING_2::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
     return PacketValidator()
         .mustEqual(settings::get<bool>("map.FISHING_ENABLE"), true, "Fishing is disabled")
         .mustEqual(PChar->GetMLevel() >= settings::get<uint8>("map.FISHING_MIN_LEVEL"), true, "Character below fishing minimum level")
         .mustEqual(UniqueNo, PChar->id, "Character id mismatch")
         .mustEqual(ActIndex, PChar->targid, "Character targid mismatch")
-        .range("mode", mode, GP_CLI_COMMAND_FISHING_MODE::RequestCheckHook, GP_CLI_COMMAND_FISHING_MODE::RequestPotentialTimeout)
+        .range("mode", mode, GP_CLI_COMMAND_FISHING_2_MODE::RequestCheckHook, GP_CLI_COMMAND_FISHING_2_MODE::RequestPotentialTimeout)
         .custom([&](PacketValidator& v)
                 {
                     // clang-format off
-                    switch (static_cast<GP_CLI_COMMAND_FISHING_MODE>(mode))
+                    switch (static_cast<GP_CLI_COMMAND_FISHING_2_MODE>(mode))
                     {
-                        case GP_CLI_COMMAND_FISHING_MODE::RequestCheckHook:
+                        case GP_CLI_COMMAND_FISHING_2_MODE::RequestCheckHook:
                             // para and para2 are both 0 for RequestCheckHook
                             v.mustEqual(para, 0, "para must be 0")
                                 .mustEqual(para2, 0, "para2 must be 0");
                             break;
-                        case GP_CLI_COMMAND_FISHING_MODE::RequestEndMiniGame:
+                        case GP_CLI_COMMAND_FISHING_2_MODE::RequestEndMiniGame:
                             // para has various values depending on the reason
                             // - Equals to 300 when client fails to catch a fish
                             // - Equals to 200 when client force exits the mini game
@@ -58,12 +58,12 @@ auto GP_CLI_COMMAND_FISHING::validate(MapSession* PSession, const CCharEntity* P
                                 }
                             }
                             break;
-                        case GP_CLI_COMMAND_FISHING_MODE::RequestRelease:
+                        case GP_CLI_COMMAND_FISHING_2_MODE::RequestRelease:
                             // para and para2 are both 0 for RequestRelease
                             v.mustEqual(para, 0, "para must be 0")
                                 .mustEqual(para2, 0, "para2 must be 0");
                             break;
-                        case GP_CLI_COMMAND_FISHING_MODE::RequestPotentialTimeout:
+                        case GP_CLI_COMMAND_FISHING_2_MODE::RequestPotentialTimeout:
                             // para is set to time remaining, para2 is always 0
                             // todo: unknown actual range, this parameter is currently unused
                             v.range("para", para, 0, 10)
@@ -74,7 +74,7 @@ auto GP_CLI_COMMAND_FISHING::validate(MapSession* PSession, const CCharEntity* P
                 });
 }
 
-void GP_CLI_COMMAND_FISHING::process(MapSession* PSession, CCharEntity* PChar) const
+void GP_CLI_COMMAND_FISHING_2::process(MapSession* PSession, CCharEntity* PChar) const
 {
-    fishingutils::FishingAction(PChar, static_cast<GP_CLI_COMMAND_FISHING_MODE>(mode), para, para2);
+    fishingutils::FishingAction(PChar, static_cast<GP_CLI_COMMAND_FISHING_2_MODE>(mode), para, para2);
 }

--- a/src/map/packets/c2s/0x110_fishing_2.h
+++ b/src/map/packets/c2s/0x110_fishing_2.h
@@ -1,0 +1,43 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+#include "base.h"
+
+enum class GP_CLI_COMMAND_FISHING_2_MODE : uint8_t
+{
+    RequestCheckHook        = 2,
+    RequestEndMiniGame      = 3,
+    RequestRelease          = 4,
+    RequestPotentialTimeout = 5,
+};
+
+// https://github.com/atom0s/XiPackets/tree/main/world/client/0x0110
+// This packet is sent by the client when interacting with the fishing mini-game system.
+// Note: 0x066 handles the old fishing system, while 0x110 handles the new fishing mini-game.
+GP_CLI_PACKET(GP_CLI_COMMAND_FISHING_2,
+              uint32_t UniqueNo;  // The local clients server id.
+              int32_t  para;      // The fishing parameter.
+              uint16_t ActIndex;  // The local clients target index.
+              int8_t   mode;      // The fishing mode.
+              uint8_t  padding00; // Padding; unused.
+              int32_t  para2;     // The fishing parameter (2).
+);

--- a/src/map/packets/c2s/0x110_fishing_2.h
+++ b/src/map/packets/c2s/0x110_fishing_2.h
@@ -20,11 +20,26 @@
 */
 
 #pragma once
+#include "base.h"
 
-struct GP_CLI_COMMAND_FISHING;
+enum class GP_CLI_COMMAND_FISHING_2_MODE : uint8_t
+{
+    RequestCheckHook        = 2,
+    RequestEndMiniGame      = 3,
+    RequestRelease          = 4,
+    RequestPotentialTimeout = 5,
+};
 
 // https://github.com/atom0s/XiPackets/tree/main/world/client/0x0110
 // This packet is sent by the client when interacting with the fishing mini-game system.
 // Note: 0x066 handles the old fishing system, while 0x110 handles the new fishing mini-game.
 // However, both packets use the exact same structure and are processed the same way.
-using GP_CLI_COMMAND_FISHING_2 = GP_CLI_COMMAND_FISHING;
+// Note that 0x066 packet is aliased to this struct.
+GP_CLI_PACKET(GP_CLI_COMMAND_FISHING_2,
+              uint32_t UniqueNo;  // PS2: UniqueNo
+              int32_t  para;      // PS2: para
+              uint16_t ActIndex;  // PS2: ActIndex
+              int8_t   mode;      // PS2: mode
+              uint8_t  unknown00; // PS2: dammy
+              int32_t  para2;     // PS2: (New; did not exist.)
+);

--- a/src/map/packets/c2s/0x113_sitchair.cpp
+++ b/src/map/packets/c2s/0x113_sitchair.cpp
@@ -26,7 +26,7 @@
 #include "utils/charutils.h"
 #include "validation.h"
 
-PacketValidationResult GP_CLI_COMMAND_SITCHAIR::validate(MapSession* PSession, const CCharEntity* PChar) const
+auto GP_CLI_COMMAND_SITCHAIR::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
     return PacketValidator()
         .mustEqual(PChar->status, STATUS_TYPE::NORMAL, "Character abnormal status")

--- a/src/map/packets/c2s/0x114_map_markers.cpp
+++ b/src/map/packets/c2s/0x114_map_markers.cpp
@@ -24,7 +24,7 @@
 #include "entities/charentity.h"
 #include "packets/map_marker.h"
 
-PacketValidationResult GP_CLI_COMMAND_MAP_MARKERS::validate(MapSession* PSession, const CCharEntity* PChar) const
+auto GP_CLI_COMMAND_MAP_MARKERS::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
     // No parameters to validate for this packet.
     return PacketValidator();

--- a/src/map/packets/c2s/0x115_currencies_2.cpp
+++ b/src/map/packets/c2s/0x115_currencies_2.cpp
@@ -24,7 +24,7 @@
 #include "entities/charentity.h"
 #include "packets/currency2.h"
 
-PacketValidationResult GP_CLI_COMMAND_CURRENCIES_2::validate(MapSession* PSession, const CCharEntity* PChar) const
+auto GP_CLI_COMMAND_CURRENCIES_2::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
     // No parameters to validate for this packet.
     return PacketValidator();

--- a/src/map/packets/c2s/0x116_unity_menu.cpp
+++ b/src/map/packets/c2s/0x116_unity_menu.cpp
@@ -25,7 +25,7 @@
 #include "packets/menu_unity.h"
 #include "packets/roe_sparkupdate.h"
 
-PacketValidationResult GP_CLI_COMMAND_UNITY_MENU::validate(MapSession* PSession, const CCharEntity* PChar) const
+auto GP_CLI_COMMAND_UNITY_MENU::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
     return PacketValidator()
         .range("Kind", Kind, 0x0, 0x1); // Kind 0 = First set of 32 packets, Kind 1 = Second set of 32 packets

--- a/src/map/packets/c2s/0x117_unity_quest.cpp
+++ b/src/map/packets/c2s/0x117_unity_quest.cpp
@@ -25,7 +25,7 @@
 #include "packets/menu_unity.h"
 #include "packets/roe_sparkupdate.h"
 
-PacketValidationResult GP_CLI_COMMAND_UNITY_QUEST::validate(MapSession* PSession, const CCharEntity* PChar) const
+auto GP_CLI_COMMAND_UNITY_QUEST::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
     return PacketValidator()
         .mustEqual(Kind, 0x0, "Kind not 0x0"); // Client always sends 0x0 despite possibly supporting 0x1, 0x2

--- a/src/map/packets/c2s/0x118_unity_toggle.cpp
+++ b/src/map/packets/c2s/0x118_unity_toggle.cpp
@@ -24,7 +24,7 @@
 #include "entities/charentity.h"
 #include "unitychat.h"
 
-PacketValidationResult GP_CLI_COMMAND_UNITY_TOGGLE::validate(MapSession* PSession, const CCharEntity* PChar) const
+auto GP_CLI_COMMAND_UNITY_TOGGLE::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
     return PacketValidator()
         .range("Mode", Mode, GP_CLI_COMMAND_UNITY_TOGGLE_MODE::Inactive, GP_CLI_COMMAND_UNITY_TOGGLE_MODE::Active);

--- a/src/map/packets/c2s/0x119_emote_list.cpp
+++ b/src/map/packets/c2s/0x119_emote_list.cpp
@@ -24,7 +24,7 @@
 #include "entities/charentity.h"
 #include "packets/char_emote_list.h"
 
-PacketValidationResult GP_CLI_COMMAND_EMOTE_LIST::validate(MapSession* PSession, const CCharEntity* PChar) const
+auto GP_CLI_COMMAND_EMOTE_LIST::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
     // No input validation is needed for this packet.
     return PacketValidator();

--- a/src/map/packets/c2s/0x11b_mastery_display.cpp
+++ b/src/map/packets/c2s/0x11b_mastery_display.cpp
@@ -25,7 +25,7 @@
 #include "packets/char_status.h"
 #include "utils/charutils.h"
 
-PacketValidationResult GP_CLI_COMMAND_MASTERY_DISPLAY::validate(MapSession* PSession, const CCharEntity* PChar) const
+auto GP_CLI_COMMAND_MASTERY_DISPLAY::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
     return PacketValidator()
         .range("Mode", Mode, GP_CLI_COMMAND_MASTERY_DISPLAY_MODE::Off, GP_CLI_COMMAND_MASTERY_DISPLAY_MODE::On);

--- a/src/map/packets/c2s/0x11d_jump.cpp
+++ b/src/map/packets/c2s/0x11d_jump.cpp
@@ -25,7 +25,7 @@
 #include "packets/char_emotion_jump.h"
 #include "utils/jailutils.h"
 
-PacketValidationResult GP_CLI_COMMAND_JUMP::validate(MapSession* PSession, const CCharEntity* PChar) const
+auto GP_CLI_COMMAND_JUMP::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
     return PacketValidator()
         .mustEqual(UniqueNo, PChar->id, "Character ID mismatch")

--- a/src/map/packets/c2s/CMakeLists.txt
+++ b/src/map/packets/c2s/CMakeLists.txt
@@ -9,6 +9,8 @@ set(PACKET_C2S_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/0x066_fishing.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x105_bazaar_list.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x105_bazaar_list.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x10b_bazaar_close.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x10b_bazaar_close.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x10c_roe_start.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x10c_roe_start.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x10d_roe_remove.cpp

--- a/src/map/packets/c2s/CMakeLists.txt
+++ b/src/map/packets/c2s/CMakeLists.txt
@@ -5,7 +5,6 @@ set(PACKET_C2S_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/0x041_trophy_entry.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x058_recipe.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x058_recipe.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/0x066_fishing.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x066_fishing.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x104_bazaar_exit.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x104_bazaar_exit.h
@@ -27,6 +26,7 @@ set(PACKET_C2S_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/0x10e_roe_claim.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x10f_currencies_1.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x10f_currencies_1.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x110_fishing_2.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x110_fishing_2.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x113_sitchair.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x113_sitchair.h

--- a/src/map/packets/c2s/CMakeLists.txt
+++ b/src/map/packets/c2s/CMakeLists.txt
@@ -9,6 +9,8 @@ set(PACKET_C2S_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/0x066_fishing.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x105_bazaar_list.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x105_bazaar_list.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x106_bazaar_buy.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x106_bazaar_buy.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x109_bazaar_open.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x109_bazaar_open.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x10a_bazaar_itemset.cpp

--- a/src/map/packets/c2s/CMakeLists.txt
+++ b/src/map/packets/c2s/CMakeLists.txt
@@ -9,6 +9,8 @@ set(PACKET_C2S_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/0x066_fishing.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x105_bazaar_list.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x105_bazaar_list.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x10e_roe_claim.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x10e_roe_claim.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x10f_currencies_1.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x10f_currencies_1.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x110_fishing_2.h

--- a/src/map/packets/c2s/CMakeLists.txt
+++ b/src/map/packets/c2s/CMakeLists.txt
@@ -9,6 +9,10 @@ set(PACKET_C2S_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/0x066_fishing.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x105_bazaar_list.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x105_bazaar_list.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x10c_roe_start.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x10c_roe_start.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x10d_roe_remove.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x10d_roe_remove.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x10e_roe_claim.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x10e_roe_claim.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x10f_currencies_1.cpp

--- a/src/map/packets/c2s/CMakeLists.txt
+++ b/src/map/packets/c2s/CMakeLists.txt
@@ -7,6 +7,8 @@ set(PACKET_C2S_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/0x058_recipe.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x066_fishing.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x066_fishing.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x104_bazaar_exit.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x104_bazaar_exit.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x105_bazaar_list.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x105_bazaar_list.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x106_bazaar_buy.cpp

--- a/src/map/packets/c2s/CMakeLists.txt
+++ b/src/map/packets/c2s/CMakeLists.txt
@@ -9,6 +9,8 @@ set(PACKET_C2S_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/0x105_bazaar_list.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x10f_currencies_1.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x10f_currencies_1.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x110_fishing_2.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x110_fishing_2.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x113_sitchair.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x113_sitchair.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x114_map_markers.cpp

--- a/src/map/packets/c2s/CMakeLists.txt
+++ b/src/map/packets/c2s/CMakeLists.txt
@@ -9,6 +9,8 @@ set(PACKET_C2S_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/0x066_fishing.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x105_bazaar_list.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x105_bazaar_list.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x10a_bazaar_itemset.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x10a_bazaar_itemset.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x10b_bazaar_close.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x10b_bazaar_close.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x10c_roe_start.cpp

--- a/src/map/packets/c2s/CMakeLists.txt
+++ b/src/map/packets/c2s/CMakeLists.txt
@@ -5,11 +5,12 @@ set(PACKET_C2S_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/0x041_trophy_entry.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x058_recipe.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x058_recipe.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x066_fishing.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x066_fishing.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x105_bazaar_list.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x105_bazaar_list.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x10f_currencies_1.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x10f_currencies_1.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/0x110_fishing_2.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x110_fishing_2.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x113_sitchair.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x113_sitchair.h

--- a/src/map/packets/c2s/CMakeLists.txt
+++ b/src/map/packets/c2s/CMakeLists.txt
@@ -9,6 +9,8 @@ set(PACKET_C2S_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/0x066_fishing.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x105_bazaar_list.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x105_bazaar_list.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x109_bazaar_open.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x109_bazaar_open.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x10a_bazaar_itemset.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x10a_bazaar_itemset.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x10b_bazaar_close.cpp

--- a/src/map/packets/c2s/validation.h
+++ b/src/map/packets/c2s/validation.h
@@ -35,7 +35,7 @@ public:
         setValid(false);
     }
 
-    bool valid() const
+    auto valid() const -> bool
     {
         return m_Valid;
     }
@@ -45,7 +45,7 @@ public:
         m_Valid = valid;
     }
 
-    std::string errorString() const
+    auto errorString() const -> std::string
     {
         std::string errorMessages;
         for (const auto& error : m_Errors)
@@ -73,7 +73,7 @@ public:
 
     // Left value must equal right value
     template <typename T1, typename T2>
-    PacketValidator& mustEqual(T1 left, T2 right, const std::string& errMsg)
+    auto mustEqual(T1 left, T2 right, const std::string& errMsg) -> PacketValidator&
     {
         const auto rightVal = static_cast<T1>(right);
         if (left != rightVal)
@@ -86,7 +86,7 @@ public:
 
     // Left value must not equal right value
     template <typename T1, typename T2>
-    PacketValidator& mustNotEqual(T1 left, T2 right, const std::string& errMsg)
+    auto mustNotEqual(T1 left, T2 right, const std::string& errMsg) -> PacketValidator&
     {
         const auto rightVal = static_cast<T1>(right);
         if (left == rightVal)
@@ -99,7 +99,7 @@ public:
 
     // Inclusive range check
     template <typename T, typename MinT, typename MaxT>
-    PacketValidator& range(const std::string& fieldName, T value, MinT min, MaxT max)
+    auto range(const std::string& fieldName, T value, MinT min, MaxT max) -> PacketValidator&
     {
         const auto val    = value;
         const auto minVal = static_cast<T>(min);
@@ -116,7 +116,7 @@ public:
 
     // Value must be a multiple of divisor
     template <typename T, typename DivT>
-    PacketValidator& multipleOf(const std::string& fieldName, T value, DivT divisor)
+    auto multipleOf(const std::string& fieldName, T value, DivT divisor) -> PacketValidator&
     {
         const auto divVal = static_cast<T>(divisor);
         if (value % divVal != 0)
@@ -129,7 +129,7 @@ public:
 
     // Custom validation function
     template <typename Func>
-    PacketValidator& custom(Func customValidation)
+    auto custom(Func customValidation) -> PacketValidator&
     {
         customValidation(*this);
         return *this;

--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -260,11 +260,11 @@ namespace roeutils
         charutils::SaveEminenceData(PChar);
     }
 
-    bool GetEminenceRecordCompletion(CCharEntity* PChar, uint16 recordID)
+    bool GetEminenceRecordCompletion(const CCharEntity* PChar, uint16 recordID)
     {
         TracyZoneScoped;
-        uint16 page = recordID / 8;
-        uint8  bit  = recordID % 8;
+        const uint16 page = recordID / 8;
+        const uint8  bit  = recordID % 8;
         return PChar->m_eminenceLog.complete[page] & (1 << bit);
     }
 
@@ -304,17 +304,7 @@ namespace roeutils
             return false;
         }
 
-        // Prevent packet-injection for re-taking completed records which aren't marked repeatable.
-        if (roeutils::GetEminenceRecordCompletion(PChar, recordID) && !roeutils::RoeSystem.RepeatableRecords.test(recordID))
-        {
-            return false;
-        }
-
-        // Prevent packet-injection from taking timed records as normal ones.
-        if (roeutils::RoeSystem.TimedRecords.test(recordID))
-        {
-            return false;
-        }
+        // There used to be packet injection prevention code here, but it is now part of the packet handler
 
         for (int i = 0; i < 30; i++)
         {

--- a/src/map/roe.h
+++ b/src/map/roe.h
@@ -143,7 +143,7 @@ namespace roeutils
     bool event(ROE_EVENT eventID, CCharEntity* PChar, const RoeDatagram& payload);
 
     void   SetEminenceRecordCompletion(CCharEntity* PChar, uint16 recordID, bool newStatus);
-    bool   GetEminenceRecordCompletion(CCharEntity* PChar, uint16 recordID);
+    bool   GetEminenceRecordCompletion(const CCharEntity* PChar, uint16 recordID);
     uint16 GetNumEminenceCompleted(CCharEntity* PChar);
     bool   AddEminenceRecord(CCharEntity* PChar, uint16 recordID);
     bool   DelEminenceRecord(CCharEntity* PChar, uint16 recordID);

--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -28,6 +28,7 @@
 #include "common/utils.h"
 #include "common/vana_time.h"
 
+#include "packets/c2s/0x066_fishing.h"
 #include "packets/caught_fish.h"
 #include "packets/caught_monster.h"
 #include "packets/char_skills.h"
@@ -57,7 +58,6 @@
 #include "item_container.h"
 #include "itemutils.h"
 #include "mob_modifier.h"
-#include "packets/c2s/0x110_fishing_2.h"
 #include "status_effect_container.h"
 #include "trade_container.h"
 #include "universal_container.h"
@@ -2657,7 +2657,7 @@ namespace fishingutils
         return catchResponse;
     }
 
-    void FishingAction(CCharEntity* PChar, const GP_CLI_COMMAND_FISHING_2_MODE mode, const uint32 para, const uint32 para2)
+    void FishingAction(CCharEntity* PChar, const GP_CLI_COMMAND_FISHING_MODE mode, const uint32 para, const uint32 para2)
     {
         const uint32 stamina = para;
         const uint32 special = para2;
@@ -2675,7 +2675,7 @@ namespace fishingutils
 
         switch (mode)
         {
-            case GP_CLI_COMMAND_FISHING_2_MODE::RequestCheckHook:
+            case GP_CLI_COMMAND_FISHING_MODE::RequestCheckHook:
             {
                 if (vanaTime < PChar->lastCastTime + PChar->hookDelay - 2)
                 {
@@ -2746,7 +2746,7 @@ namespace fishingutils
             }
             break;
 
-            case GP_CLI_COMMAND_FISHING_2_MODE::RequestEndMiniGame:
+            case GP_CLI_COMMAND_FISHING_MODE::RequestEndMiniGame:
             {
                 if (stamina <= 4)
                 {
@@ -2861,7 +2861,7 @@ namespace fishingutils
             }
             break;
 
-            case GP_CLI_COMMAND_FISHING_2_MODE::RequestPotentialTimeout:
+            case GP_CLI_COMMAND_FISHING_MODE::RequestPotentialTimeout:
             {
                 // message: "You don't know how much longer you can keep this one on the line..."
                 PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_WARNING);
@@ -2870,7 +2870,7 @@ namespace fishingutils
             break;
 
             default:
-            case GP_CLI_COMMAND_FISHING_2_MODE::RequestRelease:
+            case GP_CLI_COMMAND_FISHING_MODE::RequestRelease:
             {
                 if (PChar->hookedFish != nullptr)
                 {

--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -58,6 +58,7 @@
 #include "item_container.h"
 #include "itemutils.h"
 #include "mob_modifier.h"
+#include "packets/c2s/0x110_fishing_2.h"
 #include "status_effect_container.h"
 #include "trade_container.h"
 #include "universal_container.h"
@@ -2657,7 +2658,7 @@ namespace fishingutils
         return catchResponse;
     }
 
-    void FishingAction(CCharEntity* PChar, const GP_CLI_COMMAND_FISHING_MODE mode, const uint32 para, const uint32 para2)
+    void FishingAction(CCharEntity* PChar, const GP_CLI_COMMAND_FISHING_2_MODE mode, const uint32 para, const uint32 para2)
     {
         const uint32 stamina = para;
         const uint32 special = para2;
@@ -2675,7 +2676,7 @@ namespace fishingutils
 
         switch (mode)
         {
-            case GP_CLI_COMMAND_FISHING_MODE::RequestCheckHook:
+            case GP_CLI_COMMAND_FISHING_2_MODE::RequestCheckHook:
             {
                 if (vanaTime < PChar->lastCastTime + PChar->hookDelay - 2)
                 {
@@ -2746,7 +2747,7 @@ namespace fishingutils
             }
             break;
 
-            case GP_CLI_COMMAND_FISHING_MODE::RequestEndMiniGame:
+            case GP_CLI_COMMAND_FISHING_2_MODE::RequestEndMiniGame:
             {
                 if (stamina <= 4)
                 {
@@ -2861,7 +2862,7 @@ namespace fishingutils
             }
             break;
 
-            case GP_CLI_COMMAND_FISHING_MODE::RequestPotentialTimeout:
+            case GP_CLI_COMMAND_FISHING_2_MODE::RequestPotentialTimeout:
             {
                 // message: "You don't know how much longer you can keep this one on the line..."
                 PChar->pushPacket<CMessageTextPacket>(PChar, MessageOffset + FISHMESSAGEOFFSET_WARNING);
@@ -2870,7 +2871,7 @@ namespace fishingutils
             break;
 
             default:
-            case GP_CLI_COMMAND_FISHING_MODE::RequestRelease:
+            case GP_CLI_COMMAND_FISHING_2_MODE::RequestRelease:
             {
                 if (PChar->hookedFish != nullptr)
                 {

--- a/src/map/utils/fishingutils.h
+++ b/src/map/utils/fishingutils.h
@@ -29,6 +29,7 @@
 #include <map>
 #include <vector>
 
+enum class GP_CLI_COMMAND_FISHING_2_MODE : uint8_t;
 struct lsbret_t
 { // lose/snap/break return values
     uint8 failReason;
@@ -508,14 +509,6 @@ enum FISHPOOLFLAGS : uint32
     FISHPOOL_REMOVE  = 0x200
 };
 
-enum FISHACTION : uint8
-{
-    FISHACTION_CHECK   = 2, // This is always the first 0x110 packet.
-    FISHACTION_FINISH  = 3, // This is the next 0x110 after 0x115.
-    FISHACTION_END     = 4, // This is sent when the fishing session ends completely
-    FISHACTION_WARNING = 5  // This is the 0x110 packet if the time is going on too long.
-};
-
 enum FISHMESSAGEOFFSET : uint8
 {
     FISHMESSAGEOFFSET_NOROD                    = 0x01, // You can't fish without a rod in your hands.
@@ -925,10 +918,9 @@ class CItemWeapon;
 namespace fishingutils
 {
     // Catch Pools
-    void   ReduceFishPool(uint16 zoneId, uint8 areaId, uint16 fishId);
-    void   RestockFishingAreas();
-    void   CreateFishingPools();
-    uint32 HandleFishingAction(CCharEntity* PChar, CBasicPacket& data);
+    void ReduceFishPool(uint16 zoneId, uint8 areaId, uint16 fishId);
+    void RestockFishingAreas();
+    void CreateFishingPools();
 
     // Calculations
     uint8               GetMoonPhase();
@@ -1003,7 +995,7 @@ namespace fishingutils
     uint8            UnhookMob(CCharEntity* PChar, bool lost);
     fishresponse_t*  FishingCheck(CCharEntity* PChar, uint8 fishingSkill, rod_t* rod, bait_t* bait, fishingarea_t* area);
     catchresponse_t* ReelCheck(CCharEntity* PChar, fishresponse_t* response, rod_t* rod);
-    void             FishingAction(CCharEntity* PChar, FISHACTION action, uint16 stamina, uint32 special);
+    void             FishingAction(CCharEntity* PChar, GP_CLI_COMMAND_FISHING_2_MODE mode, uint32 para, uint32 para2);
     CItemFish*       GetFish(uint16 itemid); // creates a `new` CItemFish if possible
 
     // Initialization

--- a/src/map/utils/fishingutils.h
+++ b/src/map/utils/fishingutils.h
@@ -29,7 +29,7 @@
 #include <map>
 #include <vector>
 
-enum class GP_CLI_COMMAND_FISHING_MODE : uint8_t;
+enum class GP_CLI_COMMAND_FISHING_2_MODE : uint8_t;
 struct lsbret_t
 { // lose/snap/break return values
     uint8 failReason;
@@ -995,7 +995,7 @@ namespace fishingutils
     uint8            UnhookMob(CCharEntity* PChar, bool lost);
     fishresponse_t*  FishingCheck(CCharEntity* PChar, uint8 fishingSkill, rod_t* rod, bait_t* bait, fishingarea_t* area);
     catchresponse_t* ReelCheck(CCharEntity* PChar, fishresponse_t* response, rod_t* rod);
-    void             FishingAction(CCharEntity* PChar, GP_CLI_COMMAND_FISHING_MODE mode, uint32 para, uint32 para2);
+    void             FishingAction(CCharEntity* PChar, GP_CLI_COMMAND_FISHING_2_MODE mode, uint32 para, uint32 para2);
     CItemFish*       GetFish(uint16 itemid); // creates a `new` CItemFish if possible
 
     // Initialization

--- a/src/map/utils/fishingutils.h
+++ b/src/map/utils/fishingutils.h
@@ -29,7 +29,7 @@
 #include <map>
 #include <vector>
 
-enum class GP_CLI_COMMAND_FISHING_2_MODE : uint8_t;
+enum class GP_CLI_COMMAND_FISHING_MODE : uint8_t;
 struct lsbret_t
 { // lose/snap/break return values
     uint8 failReason;
@@ -995,7 +995,7 @@ namespace fishingutils
     uint8            UnhookMob(CCharEntity* PChar, bool lost);
     fishresponse_t*  FishingCheck(CCharEntity* PChar, uint8 fishingSkill, rod_t* rod, bait_t* bait, fishingarea_t* area);
     catchresponse_t* ReelCheck(CCharEntity* PChar, fishresponse_t* response, rod_t* rod);
-    void             FishingAction(CCharEntity* PChar, GP_CLI_COMMAND_FISHING_2_MODE mode, uint32 para, uint32 para2);
+    void             FishingAction(CCharEntity* PChar, GP_CLI_COMMAND_FISHING_MODE mode, uint32 para, uint32 para2);
     CItemFish*       GetFish(uint16 itemid); // creates a `new` CItemFish if possible
 
     // Initialization


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Convert C2S packets code to trailing returns
- Deprecates 0x111 packet entirely (old lockstyle)
- Port 9 packets over. Fishing, RoE, Bazaar.

Notes:
- Skipped 0x112 because it does not match XiPackets at all, I need to spend some time looking at captures.
- 0x110_GP_CLI_COMMAND_FISHING_2 (new fishing) is aliased to 0x066_GP_CLI_COMMAND_FISHING (old fishing) because they are the same structure and go through the same handlers. Not even sure we still need to support 0x066.

## Steps to test these changes
- [x] GP_CLI_COMMAND_BAZAAR_EXIT
- [x] GP_CLI_COMMAND_BAZAAR_BUY
- [x] GP_CLI_COMMAND_BAZAAR_OPEN
- [x] GP_CLI_COMMAND_BAZAAR_ITEMSET
- [x] GP_CLI_COMMAND_BAZAAR_CLOSE
- [x] GP_CLI_COMMAND_ROE_START
- [x] GP_CLI_COMMAND_ROE_CLAIM
- [x] GP_CLI_COMMAND_FISHING

<!-- Clear and detailed steps to test your changes here -->
