### PR TITLE
Fix 'stuck under docks in Whitegate' bug

### DIFF
--- a/scripts/zones/Aht_Urhgan_Whitegate/Zone.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/Zone.lua
@@ -29,13 +29,13 @@ zoneObject.onZoneIn = function(player, prevZone)
         player:getZPos() == 0
     then
         if prevZone == xi.zone.OPEN_SEA_ROUTE_TO_AL_ZAHBI then
-            player:setPos(-11, 5, -142, 192)
+            player:setPos(-11, 2, -142, 192)
             cs = 201
         elseif
             prevZone == xi.zone.SILVER_SEA_ROUTE_TO_AL_ZAHBI or
             prevZone == xi.zone.SILVER_SEA_ROUTE_TO_NASHMAU
         then
-            player:setPos(11, 5, 142, 64)
+            player:setPos(11, 2, 142, 64)
             cs = 204
         else
             -- MOG HOUSE EXIT


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The y-coordinate for zoning into Whitegate from either boat is below the floor. Sometimes the client seems to be able to handle this and place you in the right spot, but in some cases it doesn't do this, such as when a player gets the cutscene for the RoV mission Desert Winds. This PR fixes the zone-in y-coordinate.

## Steps to test these changes

* `!addmission 13 54` (RoV "Desert Winds")
* `!zone [Open sea route to Al Zahbi]`
* When boat arrives, see that you don't get stuck under the dock.

You can also confirm these coordinates are correct simply by zoning to Whitegate, standing on the dock and checking !pos.
