### PR TITLE
Fix Fiendish Tome drop: Chapter 1 -> Chapter 11, ID 3404 -> 3414

### DIFF
--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -19973,7 +19973,7 @@ INSERT INTO `mob_droplist` VALUES (2509,0,0,1000,896,@ALWAYS);   -- Scorpion She
 INSERT INTO `mob_droplist` VALUES (2509,0,0,1000,901,@VRARE);    -- Venomous Claw (Very Rare, 1%)
 
 -- ZoneID: 187 - Tzee Xicu Idol
-INSERT INTO `mob_droplist` VALUES (2510,0,0,1000,3404,@ALWAYS);   -- Fiendish Tome Chapter 1 (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (2510,0,0,1000,3414,@ALWAYS);   -- Fiendish Tome Chapter 11 (Always, 100%)
 INSERT INTO `mob_droplist` VALUES (2510,0,0,1000,1474,@UNCOMMON); -- Infinity Core (Uncommon, 10%)
 INSERT INTO `mob_droplist` VALUES (2510,0,0,1000,748,@VRARE);     -- Gold Beastcoin (Very Rare, 1%)
 INSERT INTO `mob_droplist` VALUES (2510,0,0,1000,749,@RARE);      -- Mythril Beastcoin (Rare, 1%)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes incorrect item drop for Tzee Xicu Idol (ZoneID 187). Changes drop from Fiendish Tome Chapter 1 (ID 3404) to Fiendish Tome Chapter 11 (ID 3414).

## Steps to test these changes

1. Spawned Tzee Xicu Idol mob (ID 17543169)
2. Killed the mob and verified it drops Fiendish Tome Chapter 11 (3414) instead of Chapter 1 (3404)
3. Verified the drop rate remains 100% as intended by carrying steps 1. and 2. out three additional times.