### PR TITLE
dbtool: Don't launch server processes with port 0

### DIFF
--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -1068,6 +1068,9 @@ def launch_using_zone_settings():
 
     ports = result.stdout.split("\n")[1:-1]
 
+    # Strip out any '0' entries from ports
+    ports = [port for port in ports if port.strip() != '0']
+
     print(f"ZoneIP: {zoneip}, Ports: {ports}\n")
 
     xi_connect_executable = from_server_path(f"xi_connect{exe}")
@@ -1087,9 +1090,8 @@ def launch_using_zone_settings():
     time.sleep(1)
 
     for port in ports:
-        if port != "0":
-            print(f"Launching {xi_map_executable} --log log/map-server-{port}.log --ip {zoneip} --port {port}")
-            launch_process_in_background([xi_map_executable, "--log", f"log/map-server-{port}.log", "--ip", zoneip, "--port", port])
+        print(f"Launching {xi_map_executable} --log log/map-server-{port}.log --ip {zoneip} --port {port}")
+        launch_process_in_background([xi_map_executable, "--log", f"log/map-server-{port}.log", "--ip", zoneip, "--port", port])
 
 def update_submodules():
     # fmt: off

--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -1087,8 +1087,9 @@ def launch_using_zone_settings():
     time.sleep(1)
 
     for port in ports:
-        print(f"Launching {xi_map_executable} --log log/map-server-{port}.log --ip {zoneip} --port {port}")
-        launch_process_in_background([xi_map_executable, "--log", f"log/map-server-{port}.log", "--ip", zoneip, "--port", port])
+        if port != "0":
+            print(f"Launching {xi_map_executable} --log log/map-server-{port}.log --ip {zoneip} --port {port}")
+            launch_process_in_background([xi_map_executable, "--log", f"log/map-server-{port}.log", "--ip", zoneip, "--port", port])
 
 def update_submodules():
     # fmt: off


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Addresses #7666 by changing dbtool so it skips over zones that have been assigned port 0 in xidb.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1. Default xidb
2. build xi_*
3. Run `py -3 dbtool.py`
4. l (launch server)
5. Observe only a single instance of xi_map is started:

```
Launching D:\Projects\LandSandBoatAJBats\server\xi_connect.exe --log log/connect-server.log
Launching D:\Projects\LandSandBoatAJBats\server\xi_search.exe --log log/search-server.log
Launching D:\Projects\LandSandBoatAJBats\server\xi_world.exe --log log/world-server.log
Launching D:\Projects\LandSandBoatAJBats\server\xi_map.exe --log log/map-server-54230.log --ip 127.0.0.1 --port 54230
```
