### PR TITLE
Manage CCharEntity::PMeritPoints with unique_ptr

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -364,7 +364,6 @@ CCharEntity::~CCharEntity()
     destroy(Container);
     destroy(UContainer);
     destroy(CraftContainer);
-    destroy(PMeritPoints);
     destroy(PJobPoints);
     destroy(PLatentEffectContainer);
 

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -456,13 +456,13 @@ public:
 
     virtual void HandleErrorMessage(std::unique_ptr<CBasicPacket>&) override;
 
-    CLinkshell*    PLinkshell1;
-    CLinkshell*    PLinkshell2;
-    CUnityChat*    PUnityChat;
-    CTreasurePool* PTreasurePool;
-    CMeritPoints*  PMeritPoints;
-    CJobPoints*    PJobPoints;
-    bool           MeritMode;
+    CLinkshell*                   PLinkshell1;
+    CLinkshell*                   PLinkshell2;
+    CUnityChat*                   PUnityChat;
+    CTreasurePool*                PTreasurePool;
+    std::unique_ptr<CMeritPoints> PMeritPoints;
+    CJobPoints*                   PJobPoints;
+    bool                          MeritMode;
 
     CLatentEffectContainer* PLatentEffectContainer;
     bool                    retriggerLatents; // used to retrigger all latent effects if some event requires them to be retriggered

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -813,7 +813,7 @@ namespace charutils
         }
 
         // TODO: Remove raw new's
-        PChar->PMeritPoints = new CMeritPoints(PChar);
+        PChar->PMeritPoints = std::make_unique<CMeritPoints>(PChar);
         PChar->PMeritPoints->SetMeritPoints(meritPoints);
         PChar->PMeritPoints->SetLimitPoints(limitPoints);
         PChar->PJobPoints = new CJobPoints(PChar);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Contributes to #5171 by converting PMeritPoints raw pointer to unique_ptr.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

Test1: Added merits to a test character and observed their effect being applied in stats menu.

Test2: Logged in and /shutdown to trigger CCharEntity::~CCharEntity() to observe change of destruction timing for PMeritPoints doesn't impact anything.

<!-- Clear and detailed steps to test your changes here -->
