### PR TITLE
Fix rounding issue with recasts

### DIFF
--- a/src/map/ai/controllers/player_controller.cpp
+++ b/src/map/ai/controllers/player_controller.cpp
@@ -133,8 +133,9 @@ bool CPlayerController::Ability(uint16 targid, uint16 abilityid)
                 currentRecast -= recast->chargeTime * (recast->maxCharges - 1);
             }
 
+            currentRecast = std::chrono::ceil<std::chrono::seconds>(currentRecast);
             PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, 0, 0, MSGBASIC_UNABLE_TO_USE_JA2);
-            PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, timer::count_seconds(currentRecast), 0, MSGBASIC_TIME_LEFT);
+            PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, static_cast<uint32>(std::max<int64>(timer::count_seconds(currentRecast), 0)), 0, MSGBASIC_TIME_LEFT);
             return false;
         }
         if (auto target = PChar->GetEntity(targid); target && target->PAI->IsUntargetable())

--- a/src/map/packets/char_recast.cpp
+++ b/src/map/packets/char_recast.cpp
@@ -39,7 +39,8 @@ CCharRecastPacket::CCharRecastPacket(CCharEntity* PChar)
 
     for (auto&& recast : *RecastList)
     {
-        uint32 recastSeconds = static_cast<uint32>(timer::count_seconds(recast.RecastTime == 0s ? 0s : (recast.TimeStamp - timer::now() + recast.RecastTime)));
+        const auto remaining     = recast.RecastTime == 0s ? 0s : std::chrono::ceil<std::chrono::seconds>(recast.TimeStamp - timer::now() + recast.RecastTime);
+        const auto recastSeconds = static_cast<uint32>(std::max<int64>(timer::count_seconds(remaining), 0));
 
         if (recast.ID == 256) // borrowing this id for mount recast
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

#7687 

> Delay when JA come off cooldown
>When a JA cooldown goes to 0 (as reported in-game) and you attempt to use it, the server denies the action and reports odd values as Time left, i.e. (Time Left: (0:00:4294967295)).
>
>You then have to repeat the action which leads to an effective 1sec+ delay every time you use a JA, which is very obvious on JA-heavy jobs such as PUP/DNC/DRG.
>
>STR:
>
>DNC99
>Use Flourishes or some other quick CD JAs

`static_cast` and `max` to make sure the recast we're sending is the correct size and in bounds, `chrono::ceil` to the second to make sure the client doesn't show stuff as off cooldown before it's ready.

## Steps to test these changes

Select an ability from the menu, spam enter to see that it correctly fires as soon as it becomes available.
Spam an ability text command (`/ja "Box Step" <t>`), see correct recast displayed.
