### PR TITLE
[fix] GP daily points tracking expiring var

### DIFF
--- a/scripts/globals/crafting/crafting_guild_points.lua
+++ b/scripts/globals/crafting/crafting_guild_points.lua
@@ -354,7 +354,8 @@ xi.crafting.guildPointOnEventFinish = function(player, option, guildId)
             player:messageSpecial(ID.text.GUILD_NEW_CONTRACT, guildId)
         else
             player:messageSpecial(ID.text.GUILD_TERMINATE_CONTRACT, guildId, oldGuild)
-            player:setCharVar('[GUILD]daily_points', 1)
+            -- Restrict player ability to turn in GP items until next day.
+            player:setCharVar('[GUILD]daily_points', 1, JstMidnight())
         end
     end
 end

--- a/src/map/guild.cpp
+++ b/src/map/guild.cpp
@@ -22,6 +22,7 @@
 #include "guild.h"
 #include "entities/charentity.h"
 #include "items/item.h"
+#include "lua/luautils.h"
 
 #include "utils/charutils.h"
 #include "utils/itemutils.h"
@@ -76,42 +77,46 @@ void CGuild::updateGuildPointsPattern(uint8 pattern)
     }
 }
 
-std::pair<uint8, int16> CGuild::addGuildPoints(CCharEntity* PChar, CItem* PItem)
+auto CGuild::addGuildPoints(CCharEntity* PChar, const CItem* PItem) const -> std::pair<uint8, int16>
 {
     uint8 rank = PChar->RealSkills.rank[m_id + 48];
 
-    rank = std::clamp<uint8>(rank, 3, 9);
+    rank                   = std::clamp<uint8>(rank, 3, 9);
+    const uint16 curPoints = PChar->getCharVar("[GUILD]daily_points");
+
+    if (curPoints == 1)
+    {
+        // curPoints set to 1 means the player is not eligible for points
+        // due to changing guilds recently.
+        return { 0, 0 };
+    }
 
     if (PItem)
     {
-        uint16 curPoints = PChar->getCharVar("[GUILD]daily_points");
-        if (curPoints != 1)
+        for (auto& GPItem : m_GPItems[rank - 3])
         {
-            for (auto& GPItem : m_GPItems[rank - 3])
+            if (GPItem.item->getID() == PItem->getID())
             {
-                if (GPItem.item->getID() == PItem->getID())
+                // if a player ranks up to a new pattern whose maxpoints are fewer than the player's current daily points
+                // then we'd be trying to push a negative number into quantity. our edit to CGuild::getDailyGPItem should
+                // prevent this, but let's be doubly sure.
+                uint16 quantity    = std::min<uint16>((((GPItem.maxpoints - std::clamp<uint16>(curPoints, 0, GPItem.maxpoints)) / GPItem.points) + 1), PItem->getReserve());
+                uint16 pointsToAdd = GPItem.points * quantity;
+
+                if (curPoints <= GPItem.maxpoints)
                 {
-                    // if a player ranks up to a new pattern whose maxpoints are fewer than the player's current daily points
-                    // then we'd be trying to push a negative number into quantity. our edit to CGuild::getDailyGPItem should
-                    // prevent this, but let's be doubly sure.
-                    uint16 quantity    = std::min<uint16>((((GPItem.maxpoints - std::clamp<uint16>(curPoints, 0, GPItem.maxpoints)) / GPItem.points) + 1), PItem->getReserve());
-                    uint16 pointsToAdd = GPItem.points * quantity;
-
-                    if (curPoints <= GPItem.maxpoints)
-                    {
-                        pointsToAdd = std::clamp<uint16>(pointsToAdd, 0, GPItem.maxpoints - curPoints);
-                    }
-                    else
-                    {
-                        pointsToAdd = 0;
-                    }
-
-                    charutils::AddPoints(PChar, pointsName.c_str(), pointsToAdd);
-
-                    PChar->setCharVar("[GUILD]daily_points", curPoints + pointsToAdd);
-
-                    return { quantity, pointsToAdd };
+                    pointsToAdd = std::clamp<uint16>(pointsToAdd, 0, GPItem.maxpoints - curPoints);
                 }
+                else
+                {
+                    pointsToAdd = 0;
+                }
+
+                charutils::AddPoints(PChar, pointsName.c_str(), pointsToAdd);
+                // Tally of earned points expire at JST midnight.
+                PChar->setCharVar("[GUILD]daily_points", curPoints + pointsToAdd, luautils::JstMidnight());
+
+                return { quantity, pointsToAdd };
             }
         }
     }
@@ -119,24 +124,23 @@ std::pair<uint8, int16> CGuild::addGuildPoints(CCharEntity* PChar, CItem* PItem)
     return { 0, 0 };
 }
 
-std::pair<uint16, uint16> CGuild::getDailyGPItem(CCharEntity* PChar)
+auto CGuild::getDailyGPItem(CCharEntity* PChar) const -> std::pair<uint16, uint16>
 {
     uint8 rank = PChar->RealSkills.rank[m_id + 48];
 
     rank = std::clamp<uint8>(rank, 3, 9);
 
-    auto GPItem    = m_GPItems[rank - 3];
-    auto curPoints = (uint16)PChar->getCharVar("[GUILD]daily_points");
+    const auto GPItem    = m_GPItems[rank - 3];
+    const auto curPoints = static_cast<uint16>(PChar->getCharVar("[GUILD]daily_points"));
 
-    if (curPoints == 1) // char_var set to 1 in crafting.lua file when done getting points forthe day. Deleted in guildutils.cpp
+    // curPoints set to 1 means the player recently changed guild and is barred from trading for the day.
+    if (curPoints == 1)
     {
         return std::make_pair(GPItem[0].item->getID(), 0);
     }
-    else
-    {
-        // a rank-up can land player in a new pattern that rewards fewer max points than they
-        // have traded in today. we prevent remainingPoints from going negative here so that
-        // we don't later calculate a negative quantity in CGuild::addGuildPoints
-        return std::make_pair(GPItem[0].item->getID(), GPItem[0].maxpoints - std::clamp<uint16>(curPoints, 0, GPItem[0].maxpoints));
-    }
+
+    // a rank-up can land player in a new pattern that rewards fewer max points than they
+    // have traded in today. we prevent remainingPoints from going negative here so that
+    // we don't later calculate a negative quantity in CGuild::addGuildPoints
+    return std::make_pair(GPItem[0].item->getID(), GPItem[0].maxpoints - std::clamp<uint16>(curPoints, 0, GPItem[0].maxpoints));
 }

--- a/src/map/guild.h
+++ b/src/map/guild.h
@@ -56,8 +56,8 @@ public:
     uint8 id() const;
 
     void updateGuildPointsPattern(uint8 pattern);
-    auto addGuildPoints(CCharEntity* PChar, CItem* PItem) -> std::pair<uint8, int16>;
-    auto getDailyGPItem(CCharEntity* PChar) -> std::pair<uint16, uint16>;
+    auto addGuildPoints(CCharEntity* PChar, const CItem* PItem) const -> std::pair<uint8, int16>;
+    auto getDailyGPItem(CCharEntity* PChar) const -> std::pair<uint16, uint16>;
 
 private:
     uint8       m_id;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -4589,20 +4589,18 @@ void CLuaBaseEntity::addShopItem(uint16 itemID, double rawPrice, sol::object con
  *  Notes   :
  ************************************************************************/
 
-auto CLuaBaseEntity::getCurrentGPItem(uint8 guildID) -> std::tuple<uint16, uint16>
+auto CLuaBaseEntity::getCurrentGPItem(const uint8 guildId) const -> std::tuple<uint16, uint16>
 {
-    if (m_PBaseEntity->objtype != TYPE_PC)
+    if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
     {
-        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->getName());
-        return { 0, 0 };
+        const CGuild* PGuild           = guildutils::GetGuild(guildId);
+        auto [itemId, remainingPoints] = PGuild->getDailyGPItem(PChar);
+
+        return { itemId, remainingPoints };
     }
 
-    CGuild*      PGuild = guildutils::GetGuild(guildID);
-    CCharEntity* PChar  = static_cast<CCharEntity*>(m_PBaseEntity);
-
-    auto GPItem = PGuild->getDailyGPItem(PChar);
-
-    return { GPItem.first, GPItem.second };
+    ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->getName());
+    return { 0, 0 };
 }
 
 /************************************************************************
@@ -9619,20 +9617,18 @@ void CLuaBaseEntity::delAssaultPoint(uint8 region, int32 points)
  *  Notes   :
  ************************************************************************/
 
-auto CLuaBaseEntity::addGuildPoints(uint8 guildID, uint8 slotID) -> std::tuple<uint8, int16>
+auto CLuaBaseEntity::addGuildPoints(const uint8 guildId, const uint8 slotId) const -> std::tuple<uint8, int16>
 {
-    if (m_PBaseEntity->objtype != TYPE_PC)
+    if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
     {
-        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->getName());
-        return { 0, 0 };
+        const CGuild* PGuild              = guildutils::GetGuild(guildId);
+        auto [itemQuantity, earnedPoints] = PGuild->addGuildPoints(PChar, PChar->TradeContainer->getItem(slotId));
+
+        return { itemQuantity, earnedPoints };
     }
 
-    CGuild* PGuild = guildutils::GetGuild(guildID);
-    auto*   PChar  = static_cast<CCharEntity*>(m_PBaseEntity);
-
-    std::pair<uint8, uint16> gpResult = PGuild->addGuildPoints(PChar, PChar->TradeContainer->getItem(slotID));
-
-    return { gpResult.first, gpResult.second };
+    ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->getName());
+    return { 0, 0 };
 }
 
 /************************************************************************

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -248,7 +248,7 @@ public:
 
     void createShop(uint8 size, sol::object const& arg1);
     void addShopItem(uint16 itemID, double rawPrice, sol::object const& arg2, sol::object const& arg3);
-    auto getCurrentGPItem(uint8 guildID) -> std::tuple<uint16, uint16>;
+    auto getCurrentGPItem(uint8 guildId) const -> std::tuple<uint16, uint16>;
     bool breakLinkshell(std::string const& lsname);
     bool addLinkpearl(std::string const& lsname, bool equip);
 
@@ -478,7 +478,7 @@ public:
     void  addAssaultPoint(uint8 region, int32 points);
     void  delAssaultPoint(uint8 region, int32 points);
 
-    auto addGuildPoints(uint8 guildID, uint8 slotID) -> std::tuple<uint8, int16>;
+    auto addGuildPoints(uint8 guildId, uint8 slotId) const -> std::tuple<uint8, int16>;
 
     // Health and Status
     int32 getHP();

--- a/src/map/utils/guildutils.h
+++ b/src/map/utils/guildutils.h
@@ -19,19 +19,13 @@
 ===========================================================================
 */
 
-#ifndef _GUILDUTILS_H
-#define _GUILDUTILS_H
+#pragma once
 
 #include "common/cbasetypes.h"
 
-/************************************************************************
- *                                                                        *
- *                                                                        *
- *                                                                        *
- ************************************************************************/
-
 class CItemContainer;
 class CGuild;
+class CItemShop;
 
 namespace guildutils
 {
@@ -40,8 +34,8 @@ namespace guildutils
     void UpdateGuildsStock();
     void UpdateGuildPointsPattern();
 
-    CItemContainer* GetGuildShop(uint16 GuildShopID);
-    CGuild*         GetGuild(uint8 GuildID);
-} // namespace guildutils
+    auto GetGuildShop(uint16 guildShopId) -> CItemContainer*;
+    auto GetGuild(uint8 guildId) -> CGuild*;
 
-#endif
+    auto getItemDynamicBasePrice(const CItemShop* PItem) -> uint32;
+} // namespace guildutils


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Should close #7687, since I can't reproduce the last Dynamis issue on stock LSB.

> GP turn-ins patterns are correctly changing at midnight JST but the individual characters charvars are not being reset at the same time.
> 
> This leads to the NPC reporting the character is not eligible for GP turn-ins, however the charvar does reset later during the day and the character is then able to turn in GP items. Haven't yet figured what leads to the discrepancy.
> 
> Briefly looked at the code and I believe it may be easier to just uplift the logic to make use of expiring charvars (set to next midnight JST) as it's using a custom logic from before those existed.

- Removes the custom logic that was removing the GP Item daily points charvar during pattern update, in favor of expiring charvars set to JST midnight
- Updated comments to clarify daily_points is set to 1 when changing guild, making you ineligible for turn ins today.
- Clear the right vector in guildutils
- Cleaned up here and there but it's mostly cosmetic

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Retested:
- Guild shops
- Signing up for GP items
- Turning in GP items until cap
- Played with the timestamp in DB to validate logic, ensured the eligibility returned when timestamp was expired

<!-- Clear and detailed steps to test your changes here -->
