### PR TITLE
Fix status effect ticking

### DIFF
--- a/scripts/actions/mobskills/emetic_discharge.lua
+++ b/scripts/actions/mobskills/emetic_discharge.lua
@@ -28,7 +28,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
             local statusEffect = mob:getStatusEffect(effect)
 
             if statusEffect then
-                target:addStatusEffect(effect, statusEffect:getPower(), statusEffect:getTickCount(), statusEffect:getDuration())
+                target:addStatusEffect(effect, statusEffect:getPower(), statusEffect:getTick(), statusEffect:getDuration())
                 mob:delStatusEffect(effect)
             end
         end

--- a/scripts/actions/spells/white/sacrifice.lua
+++ b/scripts/actions/spells/white/sacrifice.lua
@@ -19,7 +19,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
             -- only add it to me if I don't have it
             if not caster:hasStatusEffect(effect) then
-                caster:addStatusEffect(effect, statusEffect:getPower(), statusEffect:getTickCount(), statusEffect:getDuration())
+                caster:addStatusEffect(effect, statusEffect:getPower(), statusEffect:getTick(), statusEffect:getDuration())
             end
 
             target:delStatusEffect(effect)

--- a/scripts/effects/healing.lua
+++ b/scripts/effects/healing.lua
@@ -57,7 +57,7 @@ end
 effectObject.onEffectTick = function(target, effect)
     local healtime = effect:getTickCount()
 
-    if healtime > 2 then
+    if healtime > 1 then
         -- Avatars cancel healing on first healing tick if summoned
         local pet = target:getPet()
         if pet ~= nil then

--- a/scripts/effects/leavegame.lua
+++ b/scripts/effects/leavegame.lua
@@ -38,10 +38,11 @@ effectObject.onEffectTick = function(target, effect)
     -- Logout to Shutdown or vice versa.
     -- This has no bearing on the way the player gets disconnected
     -- but it does change the message displayed.
-    if effect:getTickCount() > 5 then
+    local elapsedTicks = effect:getTickCount()
+    if elapsedTicks > 5 then
         target:leaveGame()
     else
-        target:messageSystem(messages[effect:getPower()], 30 - effect:getTickCount() * 5)
+        target:messageSystem(messages[effect:getPower()], 30 - elapsedTicks * 5)
     end
 end
 

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -2017,7 +2017,7 @@ void CStatusEffectContainer::TickEffects(timer::time_point tick)
         for (const auto& PStatusEffect : m_StatusEffectSet)
         {
             if (PStatusEffect->GetTickTime() != 0s &&
-                PStatusEffect->GetElapsedTickCount() <= (tick - PStatusEffect->GetStartTime()) / PStatusEffect->GetTickTime())
+                PStatusEffect->GetElapsedTickCount() < (tick - PStatusEffect->GetStartTime()) / PStatusEffect->GetTickTime())
             {
                 if (PStatusEffect->HasEffectFlag(EFFECTFLAG_AURA))
                 {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Effects are checked if they need ticking every 3s, which results in the first call to OnEffectTick happening 0-3s after the effect is applied. This changes it to start ticking the effect only after the first tick period of the effect has passed.

Also fixes a few issues where some effects were being set with a tick period as the amount of ticks that have passed.

It looks like almost everything uses 0-3s ticks so there shouldn't be a noticeable difference because of the global 3s tick syncing (see `m_EffectCheckTime`). Sneak, invisible, deodorize have 10s ticks used to give the wearing off warnings. Avatar's Favor also has a 10s tick I assume is for the same thing, since the actual effect is handled by `TickRegen` on a 3s tick.

The most noticeable change will be proper time messaging while logging out, as it currently immediately (0-3s) goes from 302 to 25s.

I'm not sure if that synced 3s ticking is correct but is how it's been, this is mostly about fixing the logout messaging.

## Steps to test these changes

- `/logout` should take ~30s, messaging is properly delayed.
- Use a helix spell, note initial elemental damage, then a DoT tick ~10s later.
- Use spectral jig, note 3 "wearing off" warnings at ~25s, ~15s, ~5s remaining.
