### PR TITLE
Fix Erlene behavior (SCH AF1)

### DIFF
--- a/scripts/quests/crystalWar/A_Little_Knowledge.lua
+++ b/scripts/quests/crystalWar/A_Little_Knowledge.lua
@@ -182,8 +182,10 @@ quest.sections =
             {
                 onTrigger = function(player, npc)
                     if
-                        player:canLearnSpell(xi.magic.spell.EMBRAVA) and
-                        player:canLearnSpell(xi.magic.spell.KAUSTRA)
+                        player:getMainJob() == xi.job.SCH and
+                        player:getMainLvl() >= 5 and
+                        not player:hasSpell(xi.magic.spell.EMBRAVA) and
+                        not player:hasSpell(xi.magic.spell.KAUSTRA)
                     then
                         return quest:progressEvent(47)
                     else

--- a/scripts/quests/crystalWar/SCH_AF2_Downward_Helix.lua
+++ b/scripts/quests/crystalWar/SCH_AF2_Downward_Helix.lua
@@ -18,6 +18,7 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_AVAILABLE and
+                player:hasCompletedQuest(xi.questLog.CRYSTAL_WAR, xi.quest.id.crystalWar.ON_SABBATICAL) and
                 xi.quest.getVar(player, xi.questLog.CRYSTAL_WAR, xi.quest.id.crystalWar.ON_SABBATICAL, 'Timer') <= VanadielUniqueDay() and
                 player:getMainJob() == xi.job.SCH and
                 player:getMainLvl() >= xi.settings.main.AF2_QUEST_LEVEL


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR fixes two issues with the NPC Erlene in Eldieme [S]. 

1. Corrects the logic for triggering the event in which she teaches the spells Embrava and Kaustra. `player:canLearnSpell()` returns 0 if the player can learn the spell, and 96 or 95 otherwise, so this was triggering every time any player spoke to Erlene after unlocking SCH. And in the case of Embrava and Kaustra, the function still won't return 0 anyway unless the player has Tabula Rasa active. Instead, checking the player's main job, level, and whether they have the spells is a better approach.
2. Added a check to see if the player had completed the AF1 quest before the AF2 quest could begin. Otherwise, if the player was higher than level 50, they could not complete AF1.

## Steps to test these changes

* Talk to Erlene as a job with main level >= 30, complete the SCH unlock quest. Zone, !changejob sch 1, return to Erlene; she should not give you Embrava and Kaustra. !changejob sch 5, now she should give you the spells. She will not give you the spells again and again each time you talk to her. 
* Complete the quests AF1 and begin AF2 as expected.
