### PR TITLE
C2S Validation [Linkshell/Mog House/Events]

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -892,16 +892,17 @@ timer::duration CCharEntity::GetPlayTime(bool needUpdate)
     return m_PlayTime;
 }
 
-CItemEquipment* CCharEntity::getEquip(SLOTTYPE slot)
+auto CCharEntity::getEquip(const SLOTTYPE slot) const -> CItemEquipment*
 {
-    uint8           loc  = equip[slot];
-    uint8           est  = equipLoc[slot];
+    const uint8     loc  = equip[slot];
+    const uint8     est  = equipLoc[slot];
     CItemEquipment* item = nullptr;
 
     if (loc != 0)
     {
-        item = (CItemEquipment*)getStorage(est)->GetItem(loc);
+        item = static_cast<CItemEquipment*>(getStorage(est)->GetItem(loc));
     }
+
     return item;
 }
 
@@ -3224,7 +3225,7 @@ void CCharEntity::clearTriggerAreas()
     charTriggerAreaIDs.clear();
 }
 
-bool CCharEntity::isInEvent()
+auto CCharEntity::isInEvent() const -> bool
 {
     return currentEvent->eventId != -1;
 }

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -561,7 +561,7 @@ public:
     void            SetPlayTime(timer::duration playTime); // Set playtime
     timer::duration GetPlayTime(bool needUpdate = true);   // Get playtime
 
-    CItemEquipment* getEquip(SLOTTYPE slot);
+    auto getEquip(SLOTTYPE slot) const -> CItemEquipment*;
 
     bool requestedInfoSync = false;
 
@@ -611,7 +611,7 @@ public:
     void onTriggerAreaLeave(uint32 triggerAreaId);
     void clearTriggerAreas();
 
-    bool isInEvent();
+    auto isInEvent() const -> bool;
     bool isNpcLocked();
     void queueEvent(EventInfo* eventToQueue);
     void endCurrentEvent();

--- a/src/map/packets/c2s/0x05b_eventend.cpp
+++ b/src/map/packets/c2s/0x05b_eventend.cpp
@@ -1,0 +1,73 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "0x05b_eventend.h"
+
+#include "entities/baseentity.h"
+#include "entities/charentity.h"
+#include "lua/luautils.h"
+#include "packets/release.h"
+
+auto GP_CLI_COMMAND_EVENTEND::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
+{
+    return PacketValidator()
+        .oneOf<GP_CLI_COMMAND_EVENTEND_MODE>(Mode)
+        .isInEvent(PChar, EventPara);
+}
+
+void GP_CLI_COMMAND_EVENTEND::process(MapSession* PSession, CCharEntity* PChar) const
+{
+    auto       result  = EndPara;
+    const auto eventId = EventPara;
+
+    if (PChar->currentEvent->option != 0)
+    {
+        result = PChar->currentEvent->option;
+    }
+
+    switch (static_cast<GP_CLI_COMMAND_EVENTEND_MODE>(Mode))
+    {
+        case GP_CLI_COMMAND_EVENTEND_MODE::UpdatePending:
+        {
+            // If optional cutscene is started, we check to see if the selected option should lock the player
+            if (result != -1 && PChar->currentEvent->hasCutsceneOption(result))
+            {
+                PChar->setLocked(true);
+            }
+
+            luautils::OnEventUpdate(PChar, eventId, result);
+        }
+        break;
+        case GP_CLI_COMMAND_EVENTEND_MODE::End:
+        {
+            luautils::OnEventFinish(PChar, eventId, result);
+            // reset if this event did not initiate another event
+            if (PChar->currentEvent->eventId == eventId)
+            {
+                PChar->endCurrentEvent();
+            }
+        }
+        break;
+    }
+
+    PChar->pushPacket<CReleasePacket>(PChar, RELEASE_TYPE::EVENT);
+    PChar->updatemask |= UPDATE_HP;
+}

--- a/src/map/packets/c2s/0x05b_eventend.h
+++ b/src/map/packets/c2s/0x05b_eventend.h
@@ -1,0 +1,41 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include "base.h"
+
+enum class GP_CLI_COMMAND_EVENTEND_MODE : uint16_t
+{
+    End           = 0,
+    UpdatePending = 1,
+};
+
+// https://github.com/atom0s/XiPackets/tree/main/world/client/0x005B
+// This packet is sent by the client when ending an event or updating a pending event status.
+GP_CLI_PACKET(GP_CLI_COMMAND_EVENTEND,
+              uint32_t UniqueNo;  // PS2: UniqueNo
+              uint32_t EndPara;   // PS2: EndPara
+              uint16_t ActIndex;  // PS2: ActIndex
+              uint16_t Mode;      // PS2: Mode
+              uint16_t EventNum;  // PS2: EventNum
+              uint16_t EventPara; // PS2: EventPara
+);

--- a/src/map/packets/c2s/0x05c_eventendxzy.cpp
+++ b/src/map/packets/c2s/0x05c_eventendxzy.cpp
@@ -1,0 +1,71 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "0x05c_eventendxzy.h"
+
+#include "entities/charentity.h"
+#include "lua/luautils.h"
+#include "packets/cs_position.h"
+#include "packets/release.h"
+
+auto GP_CLI_COMMAND_EVENTENDXZY::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
+{
+    return PacketValidator()
+        .mustEqual(Mode, 1, "Mode not 1")
+        .isInEvent(PChar, EventPara);
+}
+
+void GP_CLI_COMMAND_EVENTENDXZY::process(MapSession* PSession, CCharEntity* PChar) const
+{
+    const auto result  = EndPara;
+    const auto eventId = EventPara;
+
+    bool updatePosition = false;
+
+    // TODO: Currently the return value for onEventUpdate in Interaction Framework is not received.  Remove
+    // the localVar check when this is resolved.
+
+    const int32  updateResult     = luautils::OnEventUpdate(PChar, eventId, result);
+    const uint32 noPositionUpdate = PChar->GetLocalVar("noPosUpdate");
+    updatePosition                = noPositionUpdate == 0 ? updateResult == 1 : false;
+
+    PChar->SetLocalVar("noPosUpdate", 0);
+
+    if (updatePosition)
+    {
+        position_t newPos = {
+            x,
+            y,
+            z,
+            0,
+            static_cast<uint8_t>(dir),
+        };
+
+        PChar->pushPacket<CCSPositionPacket>(PChar, newPos, POSMODE::EVENT);
+        PChar->pushPacket<CPositionPacket>(PChar, newPos, POSMODE::NORMAL);
+    }
+    else
+    {
+        PChar->pushPacket<CCSPositionPacket>(PChar, PChar->loc.p, POSMODE::CLEAR);
+    }
+
+    PChar->pushPacket<CReleasePacket>(PChar, RELEASE_TYPE::EVENT);
+}

--- a/src/map/packets/c2s/0x05c_eventendxzy.h
+++ b/src/map/packets/c2s/0x05c_eventendxzy.h
@@ -1,0 +1,39 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include "base.h"
+
+// https://github.com/atom0s/XiPackets/tree/main/world/client/0x005C
+// This packet is sent by the client when updating an event that involves the clients position. (ie. Requesting to warp between telepoints.)
+GP_CLI_PACKET(GP_CLI_COMMAND_EVENTENDXZY,
+              float    x;         // PS2: x
+              float    y;         // PS2: y
+              float    z;         // PS2: z
+              uint32_t UniqueNo;  // PS2: UniqueNo
+              uint32_t EndPara;   // PS2: EndPara
+              uint16_t EventNum;  // PS2: EventNum
+              uint16_t EventPara; // PS2: EventPara
+              uint16_t ActIndex;  // PS2: ActIndex
+              uint8_t  Mode;      // PS2: Mode
+              int8_t   dir;       // PS2: dir
+);

--- a/src/map/packets/c2s/0x060_passwards.cpp
+++ b/src/map/packets/c2s/0x060_passwards.cpp
@@ -1,0 +1,43 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "0x060_passwards.h"
+
+#include "common/logging.h"
+#include "entities/charentity.h"
+#include "lua/luautils.h"
+#include "packets/release.h"
+
+auto GP_CLI_COMMAND_PASSWARDS::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
+{
+    return PacketValidator()
+        .isInEvent(PChar);
+}
+
+void GP_CLI_COMMAND_PASSWARDS::process(MapSession* PSession, CCharEntity* PChar) const
+{
+    // !cs 199 in zone 245
+    const auto updateString = asStringFromUntrustedSource(String);
+    luautils::OnEventUpdate(PChar, updateString);
+
+    PChar->pushPacket<CReleasePacket>(PChar, RELEASE_TYPE::EVENT);
+    PChar->pushPacket<CReleasePacket>(PChar, RELEASE_TYPE::PLAYERINPUT);
+}

--- a/src/map/packets/c2s/0x060_passwards.h
+++ b/src/map/packets/c2s/0x060_passwards.h
@@ -1,0 +1,33 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include "base.h"
+
+// https://github.com/atom0s/XiPackets/tree/main/world/client/0x0060
+// This packet is sent by the client when interacting with an event that expects the client to give an input string. (ie. Passwords)
+GP_CLI_PACKET(GP_CLI_COMMAND_PASSWARDS,
+              uint32_t UniqueNo;   // PS2: UniqueNo
+              uint16_t ActIndex;   // PS2: ActIndex
+              uint16_t padding00;  // PS2: dammy
+              uint8_t  String[16]; // PS2: String
+);

--- a/src/map/packets/c2s/0x0c3_group_comlink_make.cpp
+++ b/src/map/packets/c2s/0x0c3_group_comlink_make.cpp
@@ -1,0 +1,66 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "0x0c3_group_comlink_make.h"
+
+#include "entities/charentity.h"
+#include "items.h"
+#include "items/item_linkshell.h"
+#include "utils/charutils.h"
+#include "utils/itemutils.h"
+
+auto GP_CLI_COMMAND_GROUP_COMLINK_MAKE::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
+{
+    return PacketValidator()
+        .mustEqual(State, 0, "State not 0")
+        .oneOf<GP_CLI_COMMAND_GROUP_COMLINK_MAKE_LINKSHELLID>(LinkshellId)
+        .hasLinkshellRank(PChar, LinkshellId, LSTYPE_PEARLSACK);
+}
+
+void GP_CLI_COMMAND_GROUP_COMLINK_MAKE::process(MapSession* PSession, CCharEntity* PChar) const
+{
+    const CItemLinkshell* PItemLinkshell = nullptr;
+
+    switch (static_cast<GP_CLI_COMMAND_GROUP_COMLINK_MAKE_LINKSHELLID>(LinkshellId))
+    {
+        case GP_CLI_COMMAND_GROUP_COMLINK_MAKE_LINKSHELLID::Linkshell1:
+            PItemLinkshell = reinterpret_cast<CItemLinkshell*>(PChar->getEquip(SLOT_LINK1));
+            break;
+        case GP_CLI_COMMAND_GROUP_COMLINK_MAKE_LINKSHELLID::Linkshell2:
+            PItemLinkshell = reinterpret_cast<CItemLinkshell*>(PChar->getEquip(SLOT_LINK2));
+            break;
+    }
+
+    if (!PItemLinkshell)
+    {
+        return;
+    }
+
+    // Make a new Linkpearl
+    auto* PItemLinkPearl = static_cast<CItemLinkshell*>(itemutils::GetItem(ITEMID::LINKPEARL));
+    if (PItemLinkPearl)
+    {
+        PItemLinkPearl->setQuantity(1);
+        std::memcpy(PItemLinkPearl->m_extra, PItemLinkshell->m_extra, 24);
+        PItemLinkPearl->SetLSType(LSTYPE_LINKPEARL);
+        charutils::AddItem(PChar, LOC_INVENTORY, PItemLinkPearl);
+    }
+}

--- a/src/map/packets/c2s/0x0c3_group_comlink_make.h
+++ b/src/map/packets/c2s/0x0c3_group_comlink_make.h
@@ -1,0 +1,37 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include "base.h"
+
+enum class GP_CLI_COMMAND_GROUP_COMLINK_MAKE_LINKSHELLID : uint8_t
+{
+    Linkshell1 = 1,
+    Linkshell2 = 2,
+};
+
+// https://github.com/atom0s/XiPackets/tree/main/world/client/0x00C3
+// This packet is sent by the client when requesting to create a link pearl for an equipped linkshell.
+GP_CLI_PACKET(GP_CLI_COMMAND_GROUP_COMLINK_MAKE,
+              uint8_t State;       // PS2: State
+              uint8_t LinkshellId; // PS2: (New; did not exist.)
+);

--- a/src/map/packets/c2s/0x0c4_group_comlink_active.cpp
+++ b/src/map/packets/c2s/0x0c4_group_comlink_active.cpp
@@ -1,0 +1,215 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "0x0c4_group_comlink_active.h"
+
+#include "entities/charentity.h"
+#include "item_container.h"
+#include "items.h"
+#include "items/item_linkshell.h"
+#include "linkshell.h"
+#include "packets/char_status.h"
+#include "packets/inventory_assign.h"
+#include "packets/inventory_finish.h"
+#include "packets/inventory_item.h"
+#include "packets/linkshell_equip.h"
+#include "utils/charutils.h"
+#include "utils/itemutils.h"
+
+namespace
+{
+    const auto createLinkshell = [](CCharEntity* PChar, CItemLinkshell* PItemLinkshell, const GP_CLI_COMMAND_GROUP_COMLINK_ACTIVE& data)
+    {
+        uint32_t       linkshellId    = 0;
+        const uint16_t linkshellColor = (data.a << 12) | (data.b << 8) | (data.g << 4) | data.r;
+
+        char DecodedName[DecodeStringLength]    = {};
+        char EncodedName[LinkshellStringLength] = {};
+
+        const auto encodedRawName = asStringFromUntrustedSource(data.sComLinkName, sizeof(data.sComLinkName));
+
+        DecodeStringLinkshell(encodedRawName, DecodedName);
+        EncodeStringLinkshell(DecodedName, EncodedName);
+
+        const auto safeName = db::escapeString(DecodedName);
+        linkshellId         = linkshell::RegisterNewLinkshell(safeName, linkshellColor);
+
+        if (linkshellId != 0)
+        {
+            destroy(PItemLinkshell);
+            PItemLinkshell = static_cast<CItemLinkshell*>(itemutils::GetItem(ITEMID::LINKSHELL));
+            if (PItemLinkshell == nullptr)
+            {
+                return;
+            }
+
+            PItemLinkshell->setQuantity(1);
+            PChar->getStorage(data.Category)->InsertItem(PItemLinkshell, data.ItemIndex);
+            PItemLinkshell->SetLSID(linkshellId);
+            PItemLinkshell->SetLSType(LSTYPE_LINKSHELL);
+            PItemLinkshell->setSignature(EncodedName); // because apparently the format from the packet isn't right, and is missing terminators
+            PItemLinkshell->SetLSColor(linkshellColor);
+
+            const auto rset = db::preparedStmt("UPDATE char_inventory SET signature = ?, extra = ?, itemId = 513 WHERE charid = ? AND location = ? AND slot = ? LIMIT 1",
+                                               safeName, PItemLinkshell->m_extra, PChar->id, data.Category, data.ItemIndex);
+            if (rset && rset->rowsAffected())
+            {
+                PChar->pushPacket<CInventoryItemPacket>(PItemLinkshell, data.Category, data.ItemIndex);
+            }
+        }
+        else
+        {
+            PChar->pushPacket<CMessageStandardPacket>(MsgStd::LinkshellUnavailable);
+        }
+    };
+
+    const auto equipLinkshell = [](CCharEntity* PChar, CItemLinkshell* PItemLinkshell, const GP_CLI_COMMAND_GROUP_COMLINK_ACTIVE& data)
+    {
+        // Capture existing LS so we can unequip it
+        SLOTTYPE          slot         = SLOT_LINK1;
+        const CLinkshell* oldLinkshell = PChar->PLinkshell1;
+        if (data.LinkshellId == 2)
+        {
+            slot         = SLOT_LINK2;
+            oldLinkshell = PChar->PLinkshell2;
+        }
+
+        // If the linkshell has been broken, break the item
+        const auto rset = db::preparedStmt("SELECT broken FROM linkshells WHERE linkshellid = ? LIMIT 1", PItemLinkshell->GetLSID());
+        if (rset && rset->rowsCount() && rset->next() && rset->get<uint8>("broken") == 1)
+        {
+            PItemLinkshell->SetLSType(LSTYPE_BROKEN);
+
+            db::preparedStmt("UPDATE char_inventory SET extra = ? WHERE charid = ? AND location = ? AND slot = ? LIMIT 1",
+                             PItemLinkshell->m_extra, PChar->id, PItemLinkshell->getLocationID(), PItemLinkshell->getSlotID());
+
+            PChar->pushPacket<CInventoryItemPacket>(PItemLinkshell, PItemLinkshell->getLocationID(), PItemLinkshell->getSlotID());
+            PChar->pushPacket<CInventoryFinishPacket>();
+            PChar->pushPacket<CMessageStandardPacket>(MsgStd::LinkshellNoLongerExists);
+
+            return;
+        }
+
+        if (PItemLinkshell->GetLSID() == 0)
+        {
+            PChar->pushPacket<CMessageStandardPacket>(MsgStd::LinkshellNoLongerExists);
+
+            return;
+        }
+
+        // Unequip old linkshell
+        if (oldLinkshell)
+        {
+            auto* POldItemLinkshell = reinterpret_cast<CItemLinkshell*>(PChar->getEquip(slot));
+
+            if (POldItemLinkshell && POldItemLinkshell->isType(ITEM_LINKSHELL))
+            {
+                linkshell::DelOnlineMember(PChar, POldItemLinkshell);
+
+                POldItemLinkshell->setSubType(ITEM_UNLOCKED);
+                PChar->pushPacket<CInventoryAssignPacket>(POldItemLinkshell, INV_NORMAL);
+            }
+        }
+
+        // Now equip the new linkshell
+        linkshell::AddOnlineMember(PChar, PItemLinkshell, data.LinkshellId);
+        PItemLinkshell->setSubType(ITEM_LOCKED);
+        PChar->equip[SLOT_BACK + data.LinkshellId]    = data.ItemIndex;
+        PChar->equipLoc[SLOT_BACK + data.LinkshellId] = data.Category;
+        if (data.LinkshellId == 1)
+        {
+            PChar->updatemask |= UPDATE_HP;
+        }
+
+        PChar->pushPacket<CInventoryAssignPacket>(PItemLinkshell, INV_LINKSHELL);
+        charutils::SaveCharStats(PChar);
+        charutils::SaveCharEquip(PChar);
+
+        PChar->pushPacket<CLinkshellEquipPacket>(PChar, data.LinkshellId);
+        PChar->pushPacket<CInventoryItemPacket>(PItemLinkshell, data.Category, data.ItemIndex);
+    };
+
+    const auto unequipLinkshell = [](CCharEntity* PChar, CItemLinkshell* PItemLinkshell, const GP_CLI_COMMAND_GROUP_COMLINK_ACTIVE& data)
+    {
+        linkshell::DelOnlineMember(PChar, PItemLinkshell);
+        PItemLinkshell->setSubType(ITEM_UNLOCKED);
+        PChar->equip[SLOT_BACK + data.LinkshellId]    = 0;
+        PChar->equipLoc[SLOT_BACK + data.LinkshellId] = 0;
+        if (data.LinkshellId == 1)
+        {
+            PChar->updatemask |= UPDATE_HP;
+        }
+
+        PChar->pushPacket<CInventoryAssignPacket>(PItemLinkshell, INV_NORMAL);
+        charutils::SaveCharStats(PChar);
+        charutils::SaveCharEquip(PChar);
+
+        PChar->pushPacket<CLinkshellEquipPacket>(PChar, data.LinkshellId);
+        PChar->pushPacket<CInventoryItemPacket>(PItemLinkshell, data.Category, data.ItemIndex);
+    };
+} // namespace
+
+auto GP_CLI_COMMAND_GROUP_COMLINK_ACTIVE::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
+{
+    return PacketValidator()
+        .range("r", r, 0, 15)
+        .range("g", g, 0, 15)
+        .range("b", b, 0, 15)
+        .mustEqual(a, 15, "a not 15")
+        .oneOf<GP_CLI_COMMAND_GROUP_COMLINK_ACTIVE_ACTIVEFLG>(ActiveFlg)
+        .oneOf<GP_CLI_COMMAND_GROUP_COMLINK_ACTIVE_LINKSHELLID>(LinkshellId);
+}
+
+void GP_CLI_COMMAND_GROUP_COMLINK_ACTIVE::process(MapSession* PSession, CCharEntity* PChar) const
+{
+    auto* PItemLinkshell = static_cast<CItemLinkshell*>(PChar->getStorage(Category)->GetItem(ItemIndex));
+
+    if (!PItemLinkshell || !PItemLinkshell->isType(ITEM_LINKSHELL))
+    {
+        return;
+    }
+
+    switch (static_cast<GP_CLI_COMMAND_GROUP_COMLINK_ACTIVE_ACTIVEFLG>(ActiveFlg))
+    {
+        case GP_CLI_COMMAND_GROUP_COMLINK_ACTIVE_ACTIVEFLG::EquipOrCreate:
+        {
+            if (PItemLinkshell->getID() == ITEMID::NEW_LINKSHELL)
+            {
+                // Case 1. New Linkshell, create it.
+                createLinkshell(PChar, PItemLinkshell, *this);
+            }
+            else
+            {
+                // Case 2. Existing LS, equip it.
+                equipLinkshell(PChar, PItemLinkshell, *this);
+            }
+        }
+        break;
+        case GP_CLI_COMMAND_GROUP_COMLINK_ACTIVE_ACTIVEFLG::Unequip:
+        {
+            unequipLinkshell(PChar, PItemLinkshell, *this);
+        }
+        break;
+    }
+
+    PChar->pushPacket<CInventoryFinishPacket>();
+    PChar->pushPacket<CCharStatusPacket>(PChar);
+}

--- a/src/map/packets/c2s/0x0c4_group_comlink_active.h
+++ b/src/map/packets/c2s/0x0c4_group_comlink_active.h
@@ -1,0 +1,51 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include "base.h"
+
+enum class GP_CLI_COMMAND_GROUP_COMLINK_ACTIVE_ACTIVEFLG : uint8_t
+{
+    Unequip       = 0,
+    EquipOrCreate = 1,
+};
+
+enum class GP_CLI_COMMAND_GROUP_COMLINK_ACTIVE_LINKSHELLID : uint8_t
+{
+    Linkshell1 = 1,
+    Linkshell2 = 2,
+};
+
+// https://github.com/atom0s/XiPackets/tree/main/world/client/0x00C4
+// This packet is sent by the client when requesting to create a linkshell or when equipping/unequipping a linkshell item.
+GP_CLI_PACKET(GP_CLI_COMMAND_GROUP_COMLINK_ACTIVE,
+              uint16_t r : 4;            // PS2: r
+              uint16_t g : 4;            // PS2: g
+              uint16_t b : 4;            // PS2: b
+              uint16_t a : 4;            // PS2: a
+              uint8_t  ItemIndex;        // PS2: ItemIndex
+              uint8_t  Category;         // PS2: (New; did not exist.)
+              uint8_t  ActiveFlg;        // PS2: ActiveFlg
+              uint8_t  padding00[3];     // PS2: (New; did not exist.)
+              uint8_t  sComLinkName[15]; // PS2: sComLinkName
+              uint8_t  LinkshellId;      // PS2: (New; did not exist.)
+);

--- a/src/map/packets/c2s/0x0cb_myroom_is.cpp
+++ b/src/map/packets/c2s/0x0cb_myroom_is.cpp
@@ -1,0 +1,131 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "0x0cb_myroom_is.h"
+
+#include "entities/charentity.h"
+#include "utils/charutils.h"
+
+namespace
+{
+    const std::map<uint8, GP_CLI_COMMAND_MYROOM_IS_PARAM2> default2fStyles = {
+        { NATION_SANDORIA, GP_CLI_COMMAND_MYROOM_IS_PARAM2::SandorianStyle },
+        { NATION_BASTOK, GP_CLI_COMMAND_MYROOM_IS_PARAM2::BastokanStyle },
+        { NATION_WINDURST, GP_CLI_COMMAND_MYROOM_IS_PARAM2::WindurstianStyle },
+    };
+
+    const auto isRentARoom = [](const CCharEntity* PChar)
+    {
+        switch (PChar->profile.nation)
+        {
+            case NATION_SANDORIA:
+                return PChar->loc.zone->GetRegionID() != REGION_TYPE::SANDORIA;
+            case NATION_BASTOK:
+                return PChar->loc.zone->GetRegionID() != REGION_TYPE::BASTOK;
+            case NATION_WINDURST:
+                return PChar->loc.zone->GetRegionID() != REGION_TYPE::WINDURST;
+            default:
+                return true;
+        }
+    };
+} // namespace
+
+auto GP_CLI_COMMAND_MYROOM_IS::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
+{
+    return PacketValidator()
+        .mustEqual(PChar->m_moghouseID, PChar->id, "Character not in their mog house")
+        .oneOf<GP_CLI_COMMAND_MYROOM_IS_KIND>(Kind)
+        .oneOf<GP_CLI_COMMAND_MYROOM_IS_PARAM2>(Param2);
+}
+
+void GP_CLI_COMMAND_MYROOM_IS::process(MapSession* PSession, CCharEntity* PChar) const
+{
+    // Note: If you're in a Rent-a-Room, these commands are not available to the client.
+    // However, retail will honor each of them if injected.
+    if (isRentARoom(PChar))
+    {
+        ShowWarning(fmt::format("Player {} modifying Rent-a-Room state.", PChar->getName()));
+    }
+
+    switch (static_cast<GP_CLI_COMMAND_MYROOM_IS_KIND>(Kind))
+    {
+        case GP_CLI_COMMAND_MYROOM_IS_KIND::Open:
+            // Not implemented
+            // NOTE: If you zone or move floors while in the MH and you have someone visiting, they will be booted.
+            // NOTE: When you zone or move floors your "open MH" flag will be reset.
+            break;
+        case GP_CLI_COMMAND_MYROOM_IS_KIND::Close:
+            // Not implemented
+            break;
+        case GP_CLI_COMMAND_MYROOM_IS_KIND::Remodel:
+        {
+            auto newStyle = Param2;
+
+            // Retail forces you to nation default style on invalid Param2.
+            auto default2fStyle = GP_CLI_COMMAND_MYROOM_IS_PARAM2::SandorianStyle;
+            if (default2fStyles.contains(PChar->profile.nation))
+            {
+                default2fStyle = default2fStyles.at(PChar->profile.nation);
+            }
+
+            if (!(PChar->profile.mhflag & 0x0020))
+            {
+                ShowWarning(fmt::format("Player {} remodeling MH2F without it unlocked.", PChar->getName()));
+            }
+
+            if (Param2 == static_cast<uint16_t>(GP_CLI_COMMAND_MYROOM_IS_PARAM2::MogPatio) && !charutils::hasKeyItem(PChar, KeyItem::MOG_PATIO_DESIGN_DOCUMENT))
+            {
+                ShowWarning(fmt::format("Player {} remodeling MH2F to Patio without owning the KI to unlock it.", PChar->getName()));
+                newStyle = static_cast<uint16_t>(default2fStyle);
+            }
+
+            // 0x0080: This bit and the next track which 2F decoration style is being used (0: SANDORIA, 1: BASTOK, 2: WINDURST, 3: PATIO)
+            // 0x0100: ^ As above
+
+            // Extract original model and add 615 so it's in line with what comes in with the packet.
+            const uint16 oldType = static_cast<uint16_t>(((PChar->profile.mhflag & 0x0100) + (PChar->profile.mhflag & 0x0080)) >> 7) + 615;
+
+            // Clear bits first
+            PChar->profile.mhflag &= ~(0x0080);
+            PChar->profile.mhflag &= ~(0x0100);
+
+            // Write new model bits
+            PChar->profile.mhflag |= ((newStyle - 615) << 7);
+            charutils::SaveCharStats(PChar);
+
+            // Note: The forced zone may bypass this message.
+            PChar->pushPacket<CMessageStandardPacket>(MsgStd::SuccessfulRemodel);
+
+            // If the model changes AND you're on MH2F; force a rezone so the model change can take effect.
+            if (Param2 != oldType && PChar->profile.mhflag & 0x0040)
+            {
+                const auto zoneid = PChar->getZone();
+
+                PChar->loc.destination = zoneid;
+                PChar->status          = STATUS_TYPE::DISAPPEAR;
+
+                PChar->clearPacketList();
+                charutils::SendToZone(PChar, zoneid);
+            }
+        }
+        break;
+    }
+}

--- a/src/map/packets/c2s/0x0cb_myroom_is.h
+++ b/src/map/packets/c2s/0x0cb_myroom_is.h
@@ -1,0 +1,57 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include "base.h"
+#include <magic_enum/magic_enum.hpp>
+
+enum class GP_CLI_COMMAND_MYROOM_IS_PARAM2 : uint16_t
+{
+    Unk1             = 0,   // When opening the mog house
+    Unk2             = 1,   // When closing the mog house
+    SandorianStyle   = 615, // Remodel
+    BastokanStyle    = 616,
+    WindurstianStyle = 617,
+    MogPatio         = 618,
+};
+
+template <>
+struct magic_enum::customize::enum_range<GP_CLI_COMMAND_MYROOM_IS_PARAM2>
+{
+    static constexpr int min = 0;
+    static constexpr int max = 618;
+};
+
+enum class GP_CLI_COMMAND_MYROOM_IS_KIND : uint8_t
+{
+    Open    = 1,
+    Close   = 2,
+    Remodel = 5,
+};
+
+// https://github.com/atom0s/XiPackets/tree/main/world/client/0x00CB
+// This packet is sent by the client when interacting with different mog house functionality.
+GP_CLI_PACKET(GP_CLI_COMMAND_MYROOM_IS,
+              uint8_t  Kind;   // The packet kind.
+              uint8_t  Param1; // The packet parameter. (1)
+              uint16_t Param2; // The packet parameter. (2)
+);

--- a/src/map/packets/c2s/CMakeLists.txt
+++ b/src/map/packets/c2s/CMakeLists.txt
@@ -58,6 +58,12 @@ set(PACKET_C2S_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/0x059_effectend.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x05a_reqconquest.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x05a_reqconquest.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x05b_eventend.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x05b_eventend.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x05c_eventendxzy.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x05c_eventendxzy.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x060_passwards.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x060_passwards.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x061_clistatus.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x061_clistatus.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x063_dig.cpp
@@ -99,6 +105,12 @@ set(PACKET_C2S_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/0x0bf_job_points_spend.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x0c0_job_points_req.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x0c0_job_points_req.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x0c3_group_comlink_make.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x0c3_group_comlink_make.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x0c4_group_comlink_active.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x0c4_group_comlink_active.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x0cb_myroom_is.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x0cb_myroom_is.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x0d2_map_group.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x0d2_map_group.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x0d3_faq_gmcall.cpp

--- a/src/map/packets/c2s/validation.h
+++ b/src/map/packets/c2s/validation.h
@@ -23,6 +23,7 @@
 
 #include "magic_enum/magic_enum.hpp"
 
+enum LSTYPE : std::uint8_t;
 class CCharEntity;
 class PacketValidationResult
 {
@@ -174,6 +175,10 @@ public:
     auto isNotPreventedAction(const CCharEntity* PChar) -> PacketValidator&;
     // Character is not assuming a Monstrosity form
     auto isNotMonstrosity(const CCharEntity* PChar) -> PacketValidator&;
+    // Character must be in a valid event state, with optional eventId check.
+    auto isInEvent(const CCharEntity* PChar, std::optional<uint16_t> eventId = std::nullopt) -> PacketValidator&;
+    // Character must have necessary rank in the linkshell in the given slot
+    auto hasLinkshellRank(const CCharEntity* PChar, uint8_t slot, LSTYPE rank) -> PacketValidator&;
 
     // Custom validation function
     template <typename Func>

--- a/src/map/packets/message_standard.h
+++ b/src/map/packets/message_standard.h
@@ -129,6 +129,7 @@ enum class MsgStd : uint16
     PollProposalLinkshell2       = 289, // Player Name's proposal to the linkshell group (cast vote with command: "/vote ?"):
     CurrentPollResultsLinkshell2 = 290, // Player Name's proposal - Current poll results:
     FinalPollResultsLinkshell2   = 291, // Player Name's proposal - Final poll results:
+    SuccessfulRemodel            = 293, // Your second floor has been successfully remodeled.
     TrustCannotLFP               = 296, // You cannot use Trust magic while seeking a party.
     WaitParty                    = 297, // While inviting a party member, you must wait a while before using Trust magic.
     TrustMaximumNumber           = 298, // You have called forth your maximum number of alter egos.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

6 more.

Noteworthy:
- GP_CLI_COMMAND_GROUP_COMLINK_ACTIVE
  -  Will create new linkshell in the container the "New Linkshell" is, mirroring retail behavior.
  - Closes #7668 by performing the string escaping on the post-decompress value
- GP_CLI_COMMAND_MYROOM_IS:
  - Proper IDs for the Mog House models, they may have shifted at some point. 615-618 are the correct values today.
  - Removed certain early returns when characters attempt to remodel without proper Key Item (Patio) or unlocks (2F), to mirror retail behavior. In exchange, there is an increased amount of logging when such cases occur.
    - Note for the future: retail will happily let you open a rent-a-room to your friends, assuming there is an NPC to sets their entry flag. 
  - Adds retail accurate remodel message

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- [x] GP_CLI_COMMAND_EVENTEND
- [x] GP_CLI_COMMAND_EVENTENDXZY
- [x] GP_CLI_COMMAND_PASSWARDS
- [x] GP_CLI_COMMAND_GROUP_COMLINK_MAKE
- [x] GP_CLI_COMMAND_GROUP_COMLINK_ACTIVE
- [x] GP_CLI_COMMAND_MYROOM_IS
- [x] Mog Remodel
