### PR TITLE
[regimes] Add Cipher selections to field manual finishOpts

### DIFF
--- a/scripts/globals/regimes.lua
+++ b/scripts/globals/regimes.lua
@@ -66,6 +66,8 @@ local regimeInfo =
             [133] = { act = 'SALTED_FISH',     cost = 50, discounted = 25, food = true },
             [149] = { act = 'HARD_COOKIE',     cost = 50, discounted = 25, food = true },
             [165] = { act = 'INSTANT_NOODLES', cost = 50, discounted = 25, food = true },
+            [181] = { act = 'CIPHER_KORU',     cost = 300, discounted = 300 },
+            [197] = { act = 'CIPHER_SAKURA',   cost = 300, discounted = 300 },
 
             -- TODO: implement elite training
             -- ELITE_INTRO     =  36,
@@ -76,8 +78,6 @@ local regimeInfo =
             -- ELITE_CHAP5     = 116,
             -- ELITE_CHAP6     = 132,
             -- ELITE_CHAP7     = 148,
-
-            -- TODO: implement Trust: Sakura and Trust: Koru-Moru (Alter Ego Extravaganza)
         },
         zone =
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Simply adds the missing finishOptions to the outdoor books: Field Manual

Noticed it was missing while messing with the event options for something else

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Go to field manual and check field support menu while `xi.settings.main.ENABLE_TRUST_ALTER_EGO_EXTRAVAGANZA == 3`

the Ciphers should be present in the list (due to the server variable), and choosing them should reward the cipher item (previously did nothing).

This functionality was already in Grounds Tomes
