### PR TITLE
[fix] Consider vertical distance when adding PC to spawnlist

### DIFF
--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -1100,7 +1100,7 @@ void CZoneEntities::SpawnPCs(CCharEntity* PChar)
             }
 
             float charDistance = distance(PChar->loc.p, PCurrentChar->loc.p);
-            if (charDistance > CHARACTER_SYNC_DISTANCE)
+            if (charDistance > CHARACTER_SYNC_DISTANCE || !isWithinVerticalDistance(PChar, PCurrentChar))
             {
                 continue;
             }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Bit of an odd bug that's been happening for some time.

STR
- With two chars, head to Eldieme Necropolis, near the drop: !pos 58 -26.6 8.8 195
- Drop one char
- Drop second char

-> Chars will be invisible to each other

Took some time to go reproduce on retail and then check the packets and realized that when having one char at the top and one char at the bottom, LSB would keep sending malformed UPDATE_PC packets (basically all flags incl. DESPAWN set but without the correct informations)

It turns out, the gap between the top and the bottom is 28 yalms, which matches both the vertical rendering limit (20 yalms) to remove a character from your spawn list and _also_ match the 50 yalms range making you eligible to be added. 

This meant that on every tick, the character would get removed, then added. Since there is a "buffering" logic for UPDATE_PC packets, both updates would conflict leading to malformed packets.

When the 2nd char finally dropped, the client would be in a bad state, leading to the emission of a CHARREQ2 packet requesting an update, however that handler is _not implemented_ at the moment.

As a fix, we will simply add the vertical check when considering PCs to add to the spawnlist, which resolves the issue. 

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
With 2 chars:
!pos 58 -26.6 8.8 195
Drop one, then the other down the hole
Both chars are visible

<!-- Clear and detailed steps to test your changes here -->
