### PR TITLE
Proper mounts rendering, Noble Chocobo fix, Kraklaw mount

### DIFF
--- a/scripts/commands/chocobo.lua
+++ b/scripts/commands/chocobo.lua
@@ -22,36 +22,37 @@ local chocobo = {}
 
 chocobo.color =
 {
-    yellow = 0x0000,
-    black  = 0x0200,
-    blue   = 0x0400,
-    red    = 0x0600,
-    green  = 0x0800,
-}
-
-chocobo.look =
-{
-    head = 0x0001, -- enlarged beak and crest (discernment)
-    feet = 0x0008, -- bigger feet and talons  (strength)
-    tail = 0x0040, -- extra tail feathers     (endurance)
+    yellow = xi.chocobo.color.YELLOW,
+    black  = xi.chocobo.color.BLACK,
+    blue   = xi.chocobo.color.BLUE,
+    red    = xi.chocobo.color.RED,
+    green  = xi.chocobo.color.GREEN,
 }
 
 commandObj.onTrigger = function(player, arg, arg2, arg3, arg4)
-    local look = tonumber(arg) or chocobo.color[arg] or 0
+    local color = tonumber(arg) or chocobo.color[arg] or xi.chocobo.YELLOW
+    local traits =
+    {
+        largeBeak   = false,
+        fullTail    = false,
+        largeTalons = false,
+    }
 
-    if chocobo.look[arg2] then
-        look = look + chocobo.look[arg2]
+    local traitArgs = { arg2, arg3, arg4 }
+
+    for _, traitArg in ipairs(traitArgs) do
+        if traitArg then
+            if traitArg == 'head' then
+                traits.largeBeak = true
+            elseif traitArg == 'tail' then
+                traits.fullTail = true
+            elseif traitArg == 'feet' then
+                traits.largeTalons = true
+            end
+        end
     end
 
-    if chocobo.look[arg3] then
-        look = look + chocobo.look[arg3]
-    end
-
-    if chocobo.look[arg4] then
-        look = look + chocobo.look[arg4]
-    end
-
-    player:registerChocobo(look)
+    player:registerChocobo(color, traits)
 
     player:delStatusEffectSilent(xi.effect.MOUNTED)
     player:addStatusEffectEx(xi.effect.MOUNTED, xi.effect.MOUNTED, xi.mount.CHOCOBO, 0, 1800, 0, 64, true)

--- a/scripts/effects/mounted.lua
+++ b/scripts/effects/mounted.lua
@@ -5,11 +5,13 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
+    local mountId = effect:getPower()
     -- Retail sends a music change packet (packet ID 0x5F) in both cases.
 
-    -- TODO: This isn't quite right. The IDs we use for mounts vs what we use for power etc.
-    -- seem to be off-by-one.
-    if effect:getPower() < 2 then
+    if
+        mountId == xi.mount.CHOCOBO or
+        mountId == xi.mount.NOBLE_CHOCOBO
+    then
         target:changeMusic(4, 212)
         target:setAnimation(xi.anim.CHOCOBO)
     else

--- a/scripts/enum/chocobo.lua
+++ b/scripts/enum/chocobo.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- Personal Chocobo
+-----------------------------------
+xi = xi or {}
+
+xi.chocobo = xi.chocobo or {}
+
+---@enum xi.chocobo.color
+xi.chocobo.color =
+{
+    YELLOW = 0,
+    BLACK  = 2,
+    BLUE   = 4,
+    RED    = 6,
+    GREEN  = 8,
+}

--- a/scripts/enum/key_item.lua
+++ b/scripts/enum/key_item.lua
@@ -3007,7 +3007,8 @@ xi.keyItem =
     BYAKKO_COMPANION                         = 3104,
     NOBLE_CHOCOBO_COMPANION                  = 3105,
     IXION_COMPANION                          = 3106,
-
+    PHUABO_COMPANION                         = 3107,
+    CRAKLAW_COMPANION                        = 3108,
     SHEET_OF_SHADOW_LORD_TUNES               = 3136,
     MYSTICAL_CANTEEN                         = 3137,
     YGNASS_INSIGNIA                          = 3138,

--- a/scripts/enum/mount.lua
+++ b/scripts/enum/mount.lua
@@ -40,9 +40,10 @@ xi.mount =
     RED_RAPTOR     = 31,
     IRON_GIANT     = 32,
     BYAKKO         = 33,
-    NOBLE_CHOCOBO  = 34, -- NOTE: This is currently blank, probably needs additional packets sent
+    NOBLE_CHOCOBO  = 34, -- NOTE: This uses Chocobo animation
     IXION          = 35,
     PHUABO         = 36,
+    CRACKLAW       = 37,
     --
-    MOUNT_MAX      = 37,
+    MOUNT_MAX      = 38,
 }

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -3444,9 +3444,10 @@ end
 function CBaseEntity:setPetName(pType, value, arg2)
 end
 
----@param value integer
+---@param color xi.chocobo.color
+---@param traits table
 ---@return nil
-function CBaseEntity:registerChocobo(value)
+function CBaseEntity:registerChocobo(color, traits)
 end
 
 ---@nodiscard

--- a/sql/item_basic.sql
+++ b/sql/item_basic.sql
@@ -7622,6 +7622,7 @@ INSERT INTO `item_basic` VALUES (10080,0,'♪byakko','♪byakko',1,61504,@NONE,1
 INSERT INTO `item_basic` VALUES (10081,0,'♪noble_chocobo','♪noble_chocobo',1,61504,@NONE,1,0);
 INSERT INTO `item_basic` VALUES (10082,0,'♪ixion','♪ixion',1,61504,@NONE,1,0);
 INSERT INTO `item_basic` VALUES (10083,0,'♪phuabo','♪phuabo',1,61504,@NONE,1,0);
+INSERT INTO `item_basic` VALUES (10084,0,'♪craklaw','♪craklaw',1,61504,@NONE,1,0);
 INSERT INTO `item_basic` VALUES (10112,906,'cipher_of_zeids_alter_ego','cipher_zeid',1,61504,@NONE,0,0);
 INSERT INTO `item_basic` VALUES (10113,907,'cipher_of_lions_alter_ego','cipher_lion',1,61504,@NONE,0,0);
 INSERT INTO `item_basic` VALUES (10114,908,'cipher_of_tenzens_alter_ego','cipher_tenzen',1,61504,@NONE,0,0);

--- a/src/map/entities/baseentity.h
+++ b/src/map/entities/baseentity.h
@@ -144,11 +144,12 @@ enum MOUNTTYPE : uint8
     MOUNT_RED_RAPTOR     = 31,
     MOUNT_IRON_GIANT     = 32,
     MOUNT_BYAKKO         = 33,
-    MOUNT_NOBLE_CHOCOBO  = 34, // NOTE: This is currently blank, probably needs additional packets sent
+    MOUNT_NOBLE_CHOCOBO  = 34, // NOTE: This uses Chocobo animation, and CustomProperties[1] set to 1
     MOUNT_IXION          = 35,
     MOUNT_PHUABO         = 36,
+    MOUNT_CRACKLAW       = 37,
     //
-    MOUNT_MAX = 37,
+    MOUNT_MAX = 38,
 };
 
 enum class ALLEGIANCE_TYPE : uint8

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -343,6 +343,7 @@ public:
     std::array<uint8, 20> m_SetBlueSpells{}; // The 0x200 offsetted blue magic spell IDs which the user has set. (1 byte per spell)
 
     uint32 m_FieldChocobo{};
+    uint8  m_mountId{}; // Do not reset to 0. Only update when the mount changes.
     uint32 m_claimedDeeds[5]{};
     uint32 m_uniqueEvents[5]{};
 

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -28,6 +28,7 @@
 #include "packets/position.h"
 #include "utils/charutils.h"
 
+enum class ChocoboColor : uint8_t;
 class CBaseEntity;
 class CCharEntity;
 class CLuaBattlefield;
@@ -787,7 +788,7 @@ public:
 
     auto getPetName() -> const std::string;
     void setPetName(uint8 pType, uint16 value, sol::object const& arg2);
-    void registerChocobo(uint32 value);
+    void registerChocobo(ChocoboColor color, sol::table const& traits) const;
 
     void petAttack(CLuaBaseEntity* PEntity);
     void petAbility(uint16 abilityID); // Function exists, but is not implemented.  Warning will be displayed.

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -718,6 +718,8 @@ void SmallPacket0x01A(MapSession* const PSession, CCharEntity* const PChar, CBas
                     return;
                 }
 
+                // Rendering packets need to send MountIndex even after char is unmounted.
+                PChar->m_mountId = MountID ? MountID + 1 : 0;
                 PChar->StatusEffectContainer->AddStatusEffect(new CStatusEffect(
                                                                   EFFECT_MOUNTED,
                                                                   EFFECT_MOUNTED,

--- a/src/map/packets/char_status.cpp
+++ b/src/map/packets/char_status.cpp
@@ -33,6 +33,7 @@
 #include "item_container.h"
 #include "status_effect_container.h"
 #include "utils/itemutils.h"
+#include "utils/mountutils.h"
 
 // https://github.com/atom0s/XiPackets/tree/main/world/server/0x0037
 
@@ -267,8 +268,9 @@ CCharStatusPacket::CCharStatusPacket(CCharEntity* PChar)
 
     if (auto* effect = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_MOUNTED))
     {
-        packet->mount_id     = effect->GetPower();
-        flags0.Chocobo_Index = effect->GetSubPower();
+        const auto [ChocoboIndex, CustomProperties] = mountutils::packetDefinition(PChar);
+        packet->mount_id                            = effect->GetPower();
+        flags0.Chocobo_Index                        = ChocoboIndex;
     }
 
     // flags 1 starts at 0x2C

--- a/src/map/packets/char_sync.cpp
+++ b/src/map/packets/char_sync.cpp
@@ -23,6 +23,7 @@
 
 #include "entities/charentity.h"
 #include "status_effect_container.h"
+#include "utils/mountutils.h"
 
 CCharSyncPacket::CCharSyncPacket(CCharEntity* PChar)
 {
@@ -50,8 +51,10 @@ CCharSyncPacket::CCharSyncPacket(CCharEntity* PChar)
 
     if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_MOUNTED))
     {
-        ref<uint16>(0x13) = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_MOUNTED)->GetSubPower();
-        ref<uint32>(0x18) = PChar->m_FieldChocobo;
+        const auto [ChocoboIndex, CustomProperties] = mountutils::packetDefinition(PChar);
+        ref<uint16>(0x13)                           = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_MOUNTED)->GetSubPower();
+        ref<uint32>(0x18)                           = CustomProperties[0]; // Personal Chocobo model
+        ref<uint32>(0x1C)                           = CustomProperties[1]; // Noble Chocobo
     }
 
     ref<uint8>(0x25) = PChar->jobs.job[PChar->GetMJob()];

--- a/src/map/utils/CMakeLists.txt
+++ b/src/map/utils/CMakeLists.txt
@@ -31,6 +31,8 @@ set(UTIL_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/mobutils.h
     ${CMAKE_CURRENT_SOURCE_DIR}/moduleutils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/moduleutils.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/mountutils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mountutils.h
     ${CMAKE_CURRENT_SOURCE_DIR}/petutils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/petutils.h
     ${CMAKE_CURRENT_SOURCE_DIR}/puppetutils.cpp

--- a/src/map/utils/mountutils.cpp
+++ b/src/map/utils/mountutils.cpp
@@ -1,0 +1,80 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "mountutils.h"
+
+#include "entities/baseentity.h"
+#include "entities/charentity.h"
+#include "status_effect.h"
+#include "status_effect_container.h"
+
+namespace mountutils
+{
+    // ChocoboIndex is a field (0-7) used in various packets.
+    // While it has little incidence for mounts, it is extremely important for custom chocobos.
+    // CustomProperties[0] sets the Personal Chocobo model.
+    // CustomProperties[1] is used for Noble Chocobo, and is set to 1.
+    auto packetDefinition(const CCharEntity* PChar) -> MountPacketDefinition
+    {
+        const auto* effect = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_MOUNTED);
+        if (!effect)
+        {
+            return MountPacketDefinition{
+                .ChocoboIndex = 0,
+            };
+        }
+
+        switch (const auto mount = effect->GetPower())
+        {
+            case MOUNT_CHOCOBO:
+            {
+                // Customized chocobos need ChocoboIndex 2
+                if (PChar->m_FieldChocobo)
+                {
+                    return MountPacketDefinition{
+                        .ChocoboIndex     = 2,
+                        .CustomProperties = { PChar->m_FieldChocobo, 0 },
+                    };
+                }
+
+                // Regular Chocobos use 1
+                return MountPacketDefinition{
+                    .ChocoboIndex = 1,
+                };
+            }
+            case MOUNT_NOBLE_CHOCOBO:
+            {
+                // Noble Chocobo is a special case, it should return 3
+                // if following other mounts logic, however captures show it uses 4, likely to indicate it is a Chocobo.
+                // It also needs 1 in CustomProperties[1]
+                return MountPacketDefinition{
+                    .ChocoboIndex     = static_cast<uint8_t>((mount % 8) + 2),
+                    .CustomProperties = { 0, 1 },
+                };
+            }
+            default:
+                // All other mounts return the remainder + 1
+                return MountPacketDefinition{
+                    .ChocoboIndex = static_cast<uint8_t>((mount % 8) + 1),
+                };
+        }
+    }
+}; // namespace mountutils

--- a/src/map/utils/mountutils.h
+++ b/src/map/utils/mountutils.h
@@ -1,0 +1,73 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+class CCharEntity;
+
+struct MountPacketDefinition
+{
+    uint8_t  ChocoboIndex;
+    uint32_t CustomProperties[2];
+};
+
+// Odd values work but will force short tail, even if the bit is set in traits.
+enum class ChocoboColor : uint8_t
+{
+    Yellow = 0,
+    Black  = 2,
+    Blue   = 4,
+    Red    = 6,
+    Green  = 8,
+};
+
+struct ChocoboPhysicalTraits
+{
+    uint8_t largeBeak : 1;
+    uint8_t unknown1 : 1;
+    uint8_t unknown2 : 1;
+    uint8_t largeTalons : 1;
+    uint8_t unknown4 : 1;
+    uint8_t unknown5 : 1;
+    uint8_t fullTail : 1;
+    uint8_t unknown7 : 1; // Gives an unknown purple tail variant on yellow chocobos
+};
+
+struct ChocoboCustomProperties
+{
+    union
+    {
+        uint32_t properties;
+        struct
+        {
+            ChocoboPhysicalTraits traits;
+            ChocoboColor          color;
+
+            uint8_t unknown8; // Might be personal chocobo statistics.
+            uint8_t unknown9; // Might be personal chocobo statistics.
+        };
+    };
+};
+
+namespace mountutils
+{
+    auto packetDefinition(const CCharEntity* PChar) -> MountPacketDefinition;
+}; // namespace mountutils


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

### Craklaw mount
Adds the new Craklaw mount (Item + Key Item + Mount ID). Yes it is spelled **Craklaw** and **Cracklaw** in several places and this is not a typo. 
The game menu shows it as Cracklaw, yet the key items and items are named Craklaw.

### Enables proper personal chocobo rendering

I have taken the time to map out the exact struct representing a custom chocobo model (and discovered several hours later that this was sort of documented in chocobo.lua). 

While it's not very useful right now, at least it's there for when Chocobo Raising is added. chocobo.lua and the associated binding are updated to make use of it, until raising is added.

### Noble Chocobo
Carved out exceptions in several places for **Noble Chocobo** as despite being a mount, it requires the animation to be set to **CHOCOBO** and **CustomProperties[1]** to be set to 1. This enables it to render properly.

### Proper values in packets
Note:
 - S2C 0x0D is involved in rendering your mounts to _others_
 - S2C 0x67 and 0x37 are involved in rendering your mount to yourself

I have, thanks to @siknoz , compiled the list of ChocoboIndex field and realized it's just an incrementing value (mountId % 8 + 1) for most mounts.

| Name | ChocoboIndex | MountIndex |
|------|----------|----------|
| Rental Chocobo (regular) | 1 | 0 |
| Rental Chocobo (WOTG) | 1 | 0 |
| Raptor | 3 | 2 |
| Tiger | 4 | 3 |
| Crab | 5 | 4 |
| Red Crab | 6 | 5 |
| Bomb | 7 | 6 |
| Sheep | 0 | 7 |
| Morbol | 1 | 8 |
| Crawler | 2 | 9 |
| Fenrir | 3 | 10 |
| Beetle | 4 | 11 |
| Magic Pot | 6 | 13 |
| Tulfaire | 7 | 14 |
| Warmachine | 0 | 15 |
| Xzomit | 1 | 16 |
| Hippogryf | 2 | 17 |
| Orb | 4 | 19 |
| Omega | 5 | 20 |
| Goobue | 7 | 22 |
| Raaz | 0 | 23 |
| Levitus | 1 | 24 |
| Aspid | 2 | 25 |
| Dhalmel | 3 | 26 |
| Doll | 4 | 27 |
| Gold Bomb | 5 | 28 |
| Wivre | 7 | 30 |
| Red Raptor | 0 | 31 |
| Iron Giant | 1 | 32 |
| Byakko | 2 | 33 |
| Noble Chocobo | 4 | 34 |
| Ixion | 4 | 35 |
| Phuabo | 5 | 36 |
| Cracklaw | 6 | 37 |

The only two exceptions to this rule:
- Noble Chocobo which is 1 higher than the rule above
- Chocobos where 1 is a regular Chocobo, and 2-5 allow custom values. 6 and 7 lead to bugged animations.

I have added a helper to compute this value, and added it to the mentioned packets. 
I have also added the personal chocobo model to CustomProperties[0] and Noble Chocobo special value to CustomProperties[1] (all in the same helper)

### Mount bug
This is what I was originally looking to resolve. 
There's a bug that was supposed to be resolved with #2515 where chars dismounting beyond 50 yalms from another char would disappear.

I have taken the time to go and capture the scenario on retail and compared each packets carefully. While there are a bunch of fields that don't match, the key culprit turned out to be **MountIndex**. 

Retail sends this value **even after you have dismounted**. Furthermore, it will send it to chars zoning in after you have dismounted. 

This leads me to believe that for all these packets, SE is directly serializing 1 or multiple structs attached to the entities and simply masking fields according to flags when the packet is being built/sent. 

On the other hand, LSB builds the packet from scratch every time, which leads MountIndex to be set to 0 when you return in the 50 yalms range and the client really does not like that.

I've added a **m_mountIndex** to the **CCharEntity** so we can send it even if the character is not mounted. I do not consider this to be the proper long term fix but it resolves the issue until I can get to reworking the S2C packets.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Credits:
- @siknoz for [capturing most of the game mounts](https://1drv.ms/u/c/87e665e10555c452/EUzYw2PZ9bpImLlcBANPDaMBwL1MB0xMWPtCVj8MFKM3vQ?e=KzaohY)
- @zach2good for [capturing chocobo whistle quest/testing](https://drive.google.com/open?id=1rb5dN0nxOCXLAYHJ4N85JTggrYFYd0rd)
- @wccbuck for providing the steps to reproduce

## Steps to test these changes

!chocobo red
!chocobo green feet head tail
!addkeyitem craklaw_companion
!addkeyitem noble_chocobo_companion

Dismount past 50 yalms and come back in range of another PC.

<img width="1173" height="752" alt="Screenshot 2025-07-17 001900" src="https://github.com/user-attachments/assets/e63ce4fb-aa5e-4063-83a5-b3791da3e97f" />
