### PR TITLE
[lua] Implement BST Ability "Killer Instinct"

### DIFF
--- a/scripts/actions/abilities/killer_instinct.lua
+++ b/scripts/actions/abilities/killer_instinct.lua
@@ -1,0 +1,18 @@
+-----------------------------------
+-- Ability: Killer Instinct
+-- Grants your pet's Killer Effect to party members within area of effect.
+-- Obtained: Beastmaster Level 75 (Merit)
+-- Recast Time: 5:00
+-- Duration: 3:00
+-----------------------------------
+local abilityObject = {}
+
+abilityObject.onAbilityCheck = function(player, target, ability)
+    return xi.job_utils.beastmaster.onAbilityCheckKillerInstinct(player, target, ability)
+end
+
+abilityObject.onUseAbility = function(player, target, ability)
+    return xi.job_utils.beastmaster.onUseAbilityKillerInstinct(player, target, ability)
+end
+
+return abilityObject

--- a/scripts/effects/killer_instinct.lua
+++ b/scripts/effects/killer_instinct.lua
@@ -5,6 +5,25 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
+    -- onUseAbilityKillerInstinct in BST job_utils assigns the pet's ecosystem Enum as the effect subPower.
+    -- subPower is then used to grant the corresponding killer effect.
+    local ecosystemCorrelationMap =
+    {
+        -- Pet Ecosystem(subPower), Corresponding killer modifier
+        [xi.ecosystem.AMORPH]   = xi.mod.BIRD_KILLER,
+        [xi.ecosystem.AQUAN]    = xi.mod.AMORPH_KILLER,
+        [xi.ecosystem.BEAST]    = xi.mod.LIZARD_KILLER,
+        [xi.ecosystem.BIRD]     = xi.mod.AQUAN_KILLER,
+        [xi.ecosystem.LIZARD]   = xi.mod.VERMIN_KILLER,
+        [xi.ecosystem.PLANTOID] = xi.mod.BEAST_KILLER,
+        [xi.ecosystem.VERMIN]   = xi.mod.PLANTOID_KILLER,
+    }
+
+    local mod = ecosystemCorrelationMap[effect:getSubPower()]
+
+    if mod then
+        effect:addMod(mod, effect:getPower())
+    end
 end
 
 effectObject.onEffectTick = function(target, effect)

--- a/scripts/globals/job_utils/beastmaster.lua
+++ b/scripts/globals/job_utils/beastmaster.lua
@@ -508,7 +508,7 @@ xi.job_utils.beastmaster.onAbilityCheckFight = function(player, target, ability)
     return 0, 0
 end
 
--- On Ability Use Stay
+-- On Ability Use Fight
 xi.job_utils.beastmaster.onUseAbilityFight = function(player, target, ability)
     local pet = player:getPet()
 
@@ -519,6 +519,32 @@ xi.job_utils.beastmaster.onUseAbilityFight = function(player, target, ability)
 
         player:petAttack(target)
     end
+end
+
+-- On Ability Check Killer Instinct
+xi.job_utils.beastmaster.onAbilityCheckKillerInstinct = function(player, target, ability)
+    local pet = player:getPet()
+
+    if
+        pet == nil or -- No pet currently spawned
+        (not player:hasJugPet() and pet:getObjType() ~= xi.objType.MOB) -- The pet spawned is not a jug pet or charmed mob
+    then
+        return xi.msg.basic.REQUIRES_A_PET, 0
+    end
+
+    return 0, 0
+end
+
+-- On Ability Use Killer Instinct
+xi.job_utils.beastmaster.onUseAbilityKillerInstinct = function(player, target, ability)
+    -- Notes: Pet ecosystem is assigned to the subPower, then mapped to the correct killer mod in the effect script.
+    local pet          = player:getPet()
+    local petEcosystem = pet:getEcosystem()
+    local power        = 10
+    local duration     = 180 + (player:getMerit(xi.merit.KILLER_INSTINCT) - 10)
+    -- TODO: Is there gear/mods that enhance power/duration?
+
+    target:addStatusEffect(xi.effect.KILLER_INSTINCT, power, 0, duration, 0, petEcosystem)
 end
 
 local function getCharmDuration(charmer, target)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements missing BST Merit ability "Killer Instinct"
https://www.bg-wiki.com/ffxi/Killer_Instinct
https://ffxiclopedia.fandom.com/wiki/Killer_Instinct

Killer Instinct is similar to other job circle abilities. It applies to nearby party members and grants killer effects to them.

For this ability, the killer effect granted depends on the ability caster's current pet(See monster correlation)
https://ffxiclopedia.fandom.com/wiki/Beast_Strength_Chart

If the player has no pet out, the ability can not be used.

If a pet is despawned or killed, the effect does not wear off.

## Steps to test these changes

1. !additem fish_broth
2. !getmod amorph_killer on self.
3. Use Killer Instinct
4. !getmod amorph_killer on self. See increase of mod.
5. Test other pets for other mods and see they grant the corresponding killer mods.
5a. Test on a party member, see party member also gain mods.

<img width="1912" height="1029" alt="image" src="https://github.com/user-attachments/assets/2b0d0af7-7178-4ed7-93fa-8dd49fb1daa5" />
