### PR TITLE
Fix application of MOUNT_MOVE mod

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -319,7 +319,7 @@ uint8 CBattleEntity::UpdateSpeed(bool run)
     if (isMounted())
     {
         outputSpeed = settings::get<uint8>("map.MOUNT_SPEED") / 2;
-        outputSpeed *= (100 + getMod(Mod::MOUNT_MOVE)) / 100;
+        outputSpeed *= 1.0f + static_cast<float>(getMod(Mod::MOUNT_MOVE)) / 100.0f;
     }
     else if (baseSpeed == 0 || getMod(Mod::MOVE_SPEED_OVERRIDE) < 0)
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The MOUNT_MOVE mod should increase mount movement speed similar to MOVE_SPEED_GEAR_BONUS does when on foot. However, because of the integer division that happens in the line where it is applied, only increments of 100% make any impact on mount movement speed; everything else floors to a multiplier of 1. This PR fixes the issue.

## Steps to test these changes

Unfortunately player:getSpeed() shows you your character's unmounted speed. So here's what I did to test:

* Logged in as two characters
* `!setmod MOUNT_MOVE 15` on Character A
* `!chocobo` on both characters
* Have Character B /follow Character A
* Character A rides off, and outpaces Character B as expected

Before this change, even with the MOUNT_MOVE mod applied, characters A and B had the same speed and would keep pace.
