### PR TITLE
Change loop counter to remove incorrect mob IDs

### DIFF
--- a/scripts/zones/King_Ranperres_Tomb/mobs/Cemetery_Cherry.lua
+++ b/scripts/zones/King_Ranperres_Tomb/mobs/Cemetery_Cherry.lua
@@ -14,7 +14,7 @@ mixins =
 local entity = {}
 
 local function spawnSaplings()
-    for i = ID.mob.CHERRY_SAPLING_OFFSET, ID.mob.CHERRY_SAPLING_OFFSET + 12 do
+    for i = ID.mob.CHERRY_SAPLING_OFFSET, ID.mob.CHERRY_SAPLING_OFFSET + 8 do
         local mob = GetMobByID(i)
         if mob ~= nil and mob:getName() == 'Cherry_Sapling' and not mob:isSpawned() then
             SpawnMob(i)

--- a/scripts/zones/King_Ranperres_Tomb/mobs/Cherry_Sapling.lua
+++ b/scripts/zones/King_Ranperres_Tomb/mobs/Cherry_Sapling.lua
@@ -10,7 +10,7 @@ local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     local allSaplingsDead = true
-    for i = ID.mob.CHERRY_SAPLING_OFFSET, ID.mob.CHERRY_SAPLING_OFFSET + 12 do
+    for i = ID.mob.CHERRY_SAPLING_OFFSET, ID.mob.CHERRY_SAPLING_OFFSET + 8 do
         local mobObj = GetMobByID(i)
         if
             mobObj ~= nil and


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Changes the loop counter to 8 to remove 4 mobs that are incorrectly added to these calculations. The loop is using the first offset and then 12 more IDs however as you can see by the pasted `mob_spawn_points.sql` values below there are 8 saplings + Cemetery Cherry. The other 4 should not be included.

INSERT INTO `mob_spawn_points` VALUES (17555748,'Cherry_Sapling','Cherry Sapling',34,43.824,-0.600,-282.762,53);
INSERT INTO `mob_spawn_points` VALUES (17555749,'Cherry_Sapling','Cherry Sapling',34,36.356,-0.600,-276.178,32);
INSERT INTO `mob_spawn_points` VALUES (17555750,'Cherry_Sapling','Cherry Sapling',34,43.242,-0.600,-272.295,127);
INSERT INTO `mob_spawn_points` VALUES (17555751,'Cherry_Sapling','Cherry Sapling',34,-2.604,-0.600,-274.021,127);
INSERT INTO `mob_spawn_points` VALUES (17555752,'Cherry_Sapling','Cherry Sapling',34,0.936,-0.600,-286.576,127);
INSERT INTO `mob_spawn_points` VALUES (17555753,'Cherry_Sapling','Cherry Sapling',34,-4.388,-0.600,-279.671,110);
INSERT INTO `mob_spawn_points` VALUES (17555754,'Cemetery_Cherry','Cemetery Cherry',35,33.000,-0.600,-287.000,127);
INSERT INTO `mob_spawn_points` VALUES (17555755,'Cherry_Sapling','Cherry Sapling',34,25.484,-0.600,-260.549,127);
INSERT INTO `mob_spawn_points` VALUES (17555756,'Cherry_Sapling','Cherry Sapling',34,45.287,-0.600,-259.305,127);
INSERT INTO `mob_spawn_points` VALUES (17555757,'Hati','Hati',30,226.236,7.778,-287.226,127);
INSERT INTO `mob_spawn_points` VALUES (17555758,'Spartoi_Warrior','Spartoi Warrior',31,197.653,7.113,-317.833,127);
INSERT INTO `mob_spawn_points` VALUES (17555759,'Spartoi_Sorcerer','Spartoi Sorcerer',32,231.449,7.430,-277.359,103);
INSERT INTO `mob_spawn_points` VALUES (17555760,'Hati','Hati',30,228.725,6.994,-310.425,221);


## Steps to test these changes

Spawned all mobs using the current looping count and then removed the 4 unnecessary values to make sure it works as intended.
