### PR TITLE
Change kills variable calculation for HQ Beastmen PHs

### DIFF
--- a/scripts/zones/Castle_Oztroja/mobs/Yagudo_Avatar.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Yagudo_Avatar.lua
@@ -21,24 +21,29 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    local nqId = mob:getID()
+    local mobId = mob:getID()
 
-    if nqId == ID.mob.YAGUDO_AVATAR then
-        local hqId        = mob:getID() + 3
-        local timeOfDeath = GetServerVariable('[POP]Tzee_Xicu_the_Manifest')
-        local kills       = GetServerVariable('[PH]Tzee_Xicu_the_Manifest')
-        local popNow      = (math.random(1, 5) == 3 or kills > 6)
+    -- The quest version of this NM doesn't respawn or count toward hq nm.
+    if mobId ~= ID.mob.YAGUDO_AVATAR then
+        return
+    end
 
-        if GetSystemTime() > timeOfDeath and popNow then
-            DisallowRespawn(nqId, true)
-            DisallowRespawn(hqId, false)
-            UpdateNMSpawnPoint(hqId)
-            GetMobByID(hqId):setRespawnTime(math.random(75600, 86400))
-        else
-            UpdateNMSpawnPoint(nqId)
-            mob:setRespawnTime(math.random(75600, 86400))
-            SetServerVariable('[PH]Tzee_Xicu_the_Manifest', kills + 1)
-        end
+     -- Respawn logic.
+    local hqId        = mobId + 3
+    local timeOfDeath = GetServerVariable('[POP]Tzee_Xicu_the_Manifest')
+    local kills       = GetServerVariable('[PH]Tzee_Xicu_the_Manifest') + 1
+    local popNow      = kills >= 7 or (kills >= 2 and math.random(1, 100) <= 20)
+    local respawnTime = 75600 + 1800 * math.random(1, 6)
+
+    if GetSystemTime() > timeOfDeath and popNow then
+        DisallowRespawn(mobId, true)
+        DisallowRespawn(hqId, false)
+        UpdateNMSpawnPoint(hqId)
+        GetMobByID(hqId):setRespawnTime(respawnTime)
+    else
+        UpdateNMSpawnPoint(mobId)
+        mob:setRespawnTime(respawnTime)
+        SetServerVariable('[PH]Tzee_Xicu_the_Manifest', kills)
     end
 end
 

--- a/scripts/zones/Monastic_Cavern/mobs/Orcish_Overlord.lua
+++ b/scripts/zones/Monastic_Cavern/mobs/Orcish_Overlord.lua
@@ -32,25 +32,29 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    local nqId = mob:getID()
+    local mobId = mob:getID()
 
-    -- the quest version of this NM doesn't respawn or count toward hq nm
-    if nqId == ID.mob.ORCISH_OVERLORD then
-        local hqId        = mob:getID() + 1
-        local timeOfDeath = GetServerVariable('[POP]Overlord_Bakgodek')
-        local kills       = GetServerVariable('[PH]Overlord_Bakgodek')
-        local popNow      = math.random(1, 5) == 3 or kills > 6
+    -- The quest version of this NM doesn't respawn or count toward hq nm.
+    if mobId ~= ID.mob.ORCISH_OVERLORD then
+        return
+    end
 
-        if GetSystemTime() > timeOfDeath and popNow then
-            DisallowRespawn(nqId, true)
-            DisallowRespawn(hqId, false)
-            UpdateNMSpawnPoint(hqId)
-            GetMobByID(hqId):setRespawnTime(math.random(75600, 86400))
-        else
-            UpdateNMSpawnPoint(nqId)
-            mob:setRespawnTime(math.random(75600, 86400))
-            SetServerVariable('[PH]Overlord_Bakgodek', kills + 1)
-        end
+    -- Respawn logic.
+    local hqId        = mobId + 1
+    local timeOfDeath = GetServerVariable('[POP]Overlord_Bakgodek')
+    local kills       = GetServerVariable('[PH]Overlord_Bakgodek') + 1
+    local popNow      = kills >= 7 or (kills >= 2 and math.random(1, 100) <= 20)
+    local respawnTime = 75600 + 1800 * math.random(1, 6)
+
+    if GetSystemTime() > timeOfDeath and popNow then
+        DisallowRespawn(mobId, true)
+        DisallowRespawn(hqId, false)
+        UpdateNMSpawnPoint(hqId)
+        GetMobByID(hqId):setRespawnTime(respawnTime)
+    else
+        UpdateNMSpawnPoint(mobId)
+        mob:setRespawnTime(respawnTime)
+        SetServerVariable('[PH]Overlord_Bakgodek', kills)
     end
 end
 

--- a/scripts/zones/Qulun_Dome/mobs/Diamond_Quadav.lua
+++ b/scripts/zones/Qulun_Dome/mobs/Diamond_Quadav.lua
@@ -28,25 +28,29 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    local nqId = mob:getID()
+    local mobId = mob:getID()
 
-    -- the quest version of this NM doesn't respawn or count toward hq nm
-    if nqId == ID.mob.DIAMOND_QUADAV then
-        local hqId = mob:getID() + 1
-        local timeOfDeath = GetServerVariable('[POP]Za_Dha_Adamantking')
-        local kills = GetServerVariable('[PH]Za_Dha_Adamantking')
-        local popNow = (math.random(1, 5) == 3 or kills > 6)
+ -- The quest version of this NM doesn't respawn or count toward hq nm.
+    if mobId ~= ID.mob.DIAMOND_QUADAV then
+        return
+    end
 
-        if GetSystemTime() > timeOfDeath and popNow then
-            DisallowRespawn(nqId, true)
-            DisallowRespawn(hqId, false)
-            UpdateNMSpawnPoint(hqId)
-            GetMobByID(hqId):setRespawnTime(math.random(75600, 86400))
-        else
-            UpdateNMSpawnPoint(nqId)
-            mob:setRespawnTime(math.random(75600, 86400))
-            SetServerVariable('[PH]Za_Dha_Adamantking', kills + 1)
-        end
+    -- Respawn logic.
+    local hqId        = mobId + 1
+    local timeOfDeath = GetServerVariable('[POP]Za_Dha_Adamantking')
+    local kills       = GetServerVariable('[PH]Za_Dha_Adamantking') + 1
+    local popNow      = kills >= 7 or (kills >= 2 and math.random(1, 100) <= 20)
+    local respawnTime = 75600 + 1800 * math.random(1, 6)
+
+    if GetSystemTime() > timeOfDeath and popNow then
+        DisallowRespawn(mobId, true)
+        DisallowRespawn(hqId, false)
+        UpdateNMSpawnPoint(hqId)
+        GetMobByID(hqId):setRespawnTime(respawnTime)
+    else
+        UpdateNMSpawnPoint(mobId)
+        mob:setRespawnTime(respawnTime)
+        SetServerVariable('[PH]Za_Dha_Adamantking', kills)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The current way of counting PH kills for the HQ version pop logic is incorrect. When you kill the NQ NM for the first time the kills variable is set at 0. You then calculate if the HQ should pop based on a 20% chance and the kill variable. Since you don't actually increment it until after this calculation, you will always be 1 kill behind. So after 1 kill its 0, after 2 its 1 after 3 its 2, etc... Also, changed to a minimum of 2 kills b4 hq can pop since it has a 72 hr cooldown anyways, added 30 minute windows for respawns. (Based on most daily HNMs), used nqid for hqid instead of re-fetching mob id.

## Steps to test these changes

Multiple print statements and several rounds of killing PHs and printing out the kills variable to confirm.
