### PR TITLE
Xolotl pet resummon and combat logic

### DIFF
--- a/scripts/zones/Attohwa_Chasm/mobs/Xolotl.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Xolotl.lua
@@ -4,6 +4,75 @@
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
+local isSummoning = false
+
+local summonPet = function(mob, pet, spawnPos)
+    if not pet or not mob then
+        return
+    end
+
+    isSummoning = true
+    -- Fake a Summoning animation
+    mob:entityAnimationPacket(xi.animationString.CAST_SUMMONER_START)
+    mob:timer(5000, function(mob)
+        mob:entityAnimationPacket(xi.animationString.CAST_SUMMONER_STOP)
+        pet:setSpawn(spawnPos.x + 2, spawnPos.y, spawnPos.z, spawnPos.rot)
+        pet:spawn()
+        if mob:isEngaged() then
+            pet:updateEnmity(mob:getTarget())
+        end
+        pet:follow(mob, xi.followType.ROAM)
+        isSummoning = false
+    end)
+end
+
+local handlePetCooldown = function(mob)
+    local xolotlID = mob:getID()
+
+    if not GetMobByID(xolotlID + 1):isSpawned() and not isSummoning then
+        if GetSystemTime() >= mob:getLocalVar("[XOLOTL]HoundCooldown") then
+            summonPet(mob, GetMobByID(xolotlID + 1), mob:getPos())
+        end
+    end
+
+    if not GetMobByID(xolotlID + 2):isSpawned() and not isSummoning then
+        if GetSystemTime() >= mob:getLocalVar("[XOLOTL]SacrificeCooldown") then
+            summonPet(mob, GetMobByID(xolotlID + 2), mob:getPos())
+        end
+    end
+end
+
+local handleGroupAggro = function(xolotlID)
+    -- This function needs the Xolotl ID as mobid to loop through the group
+    local pickedTarget -- find the best suitable attack target, prioritizing Xolotl's target
+
+    for i = xolotlID + 2, xolotlID, -1 do
+        local mob = GetMobByID(i)
+        if mob and mob:getTarget() then
+            if mob:getTarget():isPC() then
+                pickedTarget = mob:getTarget()
+            end
+        end
+    end
+
+    -- If Xolotl or pet are roaming, but any of the others have PC target, update enmity to the picked target
+    for i = xolotlID, xolotlID + 2 do
+        local mob = GetMobByID(i)
+        if pickedTarget and mob and mob:getCurrentAction() == xi.act.ROAMING then
+            mob:updateEnmity(pickedTarget)
+        end
+    end
+end
+
+entity.onMobFight = function(mob)
+    handlePetCooldown(mob)
+    handleGroupAggro(mob:getID())
+end
+
+entity.onMobRoam = function(mob)
+    handlePetCooldown(mob)
+    handleGroupAggro(mob:getID())
+end
 
 entity.onMobSpawn = function(mob)
     mob:setRespawnTime(0)

--- a/scripts/zones/Attohwa_Chasm/mobs/Xolotls_Hound_Warrior.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Xolotls_Hound_Warrior.lua
@@ -10,4 +10,22 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.SUPERLINK, 32)
 end
 
+entity.onMobDespawn = function(mob)
+    local xolotlID = mob:getID() - 1
+    GetMobByID(xolotlID):setLocalVar("[XOLOTL]HoundCooldown", GetSystemTime() + math.random(30, 120))
+end
+
+entity.onMobRoam = function(mob)
+    local xolotlID = mob:getID() - 1
+    local xolotl = GetMobByID(xolotlID)
+
+    if xolotl then
+        if not xolotl:isSpawned() then
+            DespawnMob(mob:getID())
+        else
+            mob:follow(xolotl, xi.followType.ROAM)
+        end
+    end
+end
+
 return entity

--- a/scripts/zones/Attohwa_Chasm/mobs/Xolotls_Sacrifice.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Xolotls_Sacrifice.lua
@@ -10,4 +10,22 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.SUPERLINK, 32)
 end
 
+entity.onMobDespawn = function(mob)
+    local xolotlID = mob:getID() - 2
+    GetMobByID(xolotlID):setLocalVar("[XOLOTL]SacrificeCooldown", GetSystemTime() + math.random(30, 120))
+end
+
+entity.onMobRoam = function(mob)
+    local xolotlID = mob:getID() - 2
+    local xolotl = GetMobByID(xolotlID)
+
+    if xolotl then
+        if not xolotl:isSpawned() then
+            DespawnMob(mob:getID())
+        else
+            mob:follow(xolotl, xi.followType.ROAM)
+        end
+    end
+end
+
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Handles Xolotl's faked "pet" summons, aggro and despawn logic. (Pet in quotation marks as they are not true pets)

- Stores pets TODs + randomized cooldown timer in Xolotls localVarChar and tries to resummon them 30s-120s after despawn, faking a Summoning animation
- Pets follow Xolotl around
- Despawns pets if roaming and Xolotl is not up
- If Xolotl or Pet is aggrod while roaming, will engage roaming enemies on same target
- If Pet is resummoned, will engage on Xolotl's current target

Related captures: https://1drv.ms/u/c/87e665e10555c452/EVLEVQXhZeYggIfKAAAAAAABKIw1q91QND6xemN6H-i3RQ?e=CqEPYW
Related Footage: https://youtu.be/q2avBzJ93Mc
Related Footage (old/blurry, showing approx 120s pet repop): https://www.youtube.com/watch?v=O9gFQ4C_4Cw

## Steps to test these changes

!zone <Attohwa Chasm>
!gotoname Xolotl
if not up: !spawnmob 16806215

While roaming, Xolotl should summon his pets, 30s-120s cooldown after a pet dies.
While engaged, Xolotl should summon his pets, 30s-120s cooldown after a pet dies.
While Xolotl is roaming, pets should follow around Xolotl.
Engage on Xolotl, !hp 0 to kill it, the pets should still be engaging on you.
!goto <me> to reset enmity. Pets should despawn if roaming and Xolotl is not up.

!spawnmob 16806215
Wait for daybreak (0400). Xolotl should despawn as normal, and pets should despawn on next roam tick.

!spawnmob 16806215
Provoke on Hound Warrior or Sacrifice. All three mobs should engage on same target.