### PR TITLE
Check effective level for gearsets

### DIFF
--- a/scripts/globals/gear_sets.lua
+++ b/scripts/globals/gear_sets.lua
@@ -2472,16 +2472,24 @@ xi.gear_sets.itemToSetId = xi.gear_sets.createItemToSetId()
 -- core on equip and unequip of an item.
 xi.gear_sets.checkForGearSet = function(player)
     player:clearGearSetMods()
+    local playerCurrentLevel = player:getMainLvl()
 
     -- Build a table containing equipped Set IDs, and the count for each one.
     local equippedSets = {}
     for equipmentSlot = 0, xi.MAX_SLOTID do
-        local equipId = player:getEquipID(equipmentSlot)
-        local setId   = xi.gear_sets.itemToSetId[equipId]
+        local equip = player:getEquippedItem(equipmentSlot)
+        if equip then
+            local equipId    = equip:getID()
+            local equipLevel = equip:getReqLvl()
+            local setId      = xi.gear_sets.itemToSetId[equipId]
 
-        if setId then
-            for _, v in ipairs(setId) do
-                equippedSets[v] = equippedSets[v] and (equippedSets[v] + 1) or 1
+            if
+                setId and
+                playerCurrentLevel >= equipLevel -- Player may be under Level Sync/Cap
+            then
+                for _, v in ipairs(setId) do
+                    equippedSets[v] = equippedSets[v] and (equippedSets[v] + 1) or 1
+                end
             end
         end
     end

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -6929,6 +6929,7 @@ uint8 CLuaBaseEntity::levelRestriction(sol::object const& level)
             charutils::BuildingCharTraitsTable(PChar);
             charutils::BuildingCharAbilityTable(PChar);
             charutils::CheckValidEquipment(PChar);
+            luautils::CheckForGearSet(PChar);
 
             PChar->updatemask |= UPDATE_HP;
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Checks that character current effective level (sync/cap) is meeting required level for item before applying gear sets bonuses
- Re-checks anytime restriction is applied/lifted

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!additem lavas_ring
!additem kushas_ring
!addeffect level_restriction 54 << no effect
!addeffect level_restriction 55 << effects granted

<!-- Clear and detailed steps to test your changes here -->
