### PR TITLE
[lua] Add Guarding Rate Boost effect script

### DIFF
--- a/scripts/effects/guarding_rate_boost.lua
+++ b/scripts/effects/guarding_rate_boost.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- xi.effect.GUARDING_RATE_BOOST
+-----------------------------------
+---@type TEffect
+local effectObject = {}
+
+effectObject.onEffectGain = function(target, effect)
+    effect:addMod(xi.mod.ADDITIVE_GUARD, effect:getPower())
+end
+
+effectObject.onEffectTick = function(target, effect)
+end
+
+effectObject.onEffectLose = function(target, effect)
+end
+
+return effectObject

--- a/sql/status_effects.sql
+++ b/sql/status_effects.sql
@@ -633,6 +633,7 @@ INSERT INTO `status_effects` VALUES (610,'negate_charm',289,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (611,'magic_evasion_boost_ii',32,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (612,'colure_active',9437440,0,0,3,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (619,'spirit_bond',5243177,0,0,0,0,0,0,0,0);
+INSERT INTO `status_effects` VALUES (622,'guarding_rate_boost',41,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (623,'rampart',5243168,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (625,'sirens_favor',32,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (768,'abyssea_str',256,0,0,0,0,0,1,0,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds missing script and status_effects.sql entry for "Guarding Rate Boost"(ID: 622).

Use cases: Used for Raaz mobskill "Zealous Snort". Also applied to BST players with Raaz pets.

## Steps to test these changes

(Not currently used for anything)
1. !exec target:addStatusEffect(xi.effect.GUARDING_RATE_BOOST, 10, 0, 60)
2. Use "!getmod ADDITIVE_GUARD" on target, see that mod was added.

<!-- Clear and detailed steps to test your changes here -->
