### PR TITLE
[core] getMobHP binding for mobskills

### DIFF
--- a/src/map/lua/lua_mobskill.cpp
+++ b/src/map/lua/lua_mobskill.cpp
@@ -118,6 +118,12 @@ float CLuaMobSkill::getTP()
     return static_cast<float>(m_PLuaMobSkill->getTP());
 }
 
+// Retrieves the Monsters HP as it was at the start of mobskill
+auto CLuaMobSkill::getMobHP() const -> int32
+{
+    return m_PLuaMobSkill->getHP();
+}
+
 // Retrieves the Monsters HP% as it was at the start of mobskill
 uint8 CLuaMobSkill::getMobHPP()
 {
@@ -141,6 +147,7 @@ void CLuaMobSkill::Register()
     SOL_REGISTER("getTotalTargets", CLuaMobSkill::getTotalTargets);
     SOL_REGISTER("getPrimaryTargetID", CLuaMobSkill::getPrimaryTargetID);
     SOL_REGISTER("getTP", CLuaMobSkill::getTP);
+    SOL_REGISTER("getMobHP", CLuaMobSkill::getMobHP);
     SOL_REGISTER("getMobHPP", CLuaMobSkill::getMobHPP);
 }
 

--- a/src/map/lua/lua_mobskill.h
+++ b/src/map/lua/lua_mobskill.h
@@ -42,6 +42,7 @@ public:
     friend std::ostream& operator<<(std::ostream& out, const CLuaMobSkill& mobskill);
 
     float  getTP();
+    auto   getMobHP() const -> int32;
     uint8  getMobHPP();
     uint16 getID();
     int16  getParam();

--- a/src/map/mobskill.cpp
+++ b/src/map/mobskill.cpp
@@ -37,6 +37,7 @@ CMobSkill::CMobSkill(uint16 id)
 , m_ActivationTime(0s)
 , m_Message(0)
 , m_TP(0)
+, m_HP(0)
 , m_HPP(0)
 , m_knockback(0)
 , m_primarySkillchain(0)
@@ -158,6 +159,12 @@ void CMobSkill::setTP(int16 tp)
     m_TP = tp;
 }
 
+// Stores the Monsters HP as it was at the start of mobskill
+auto CMobSkill::setHP(int32 hp) -> void
+{
+    m_HP = hp;
+}
+
 // Stores the Monsters HP% as it was at the start of mobskill
 void CMobSkill::setHPP(uint8 hpp)
 {
@@ -192,6 +199,12 @@ uint16 CMobSkill::getAnimationID() const
 int16 CMobSkill::getTP() const
 {
     return m_TP;
+}
+
+// Retrieves the Monsters HP as it was at the start of mobskill
+auto CMobSkill::getHP() const -> int32
+{
+    return m_HP;
 }
 
 // Retrieves the Monsters HP% as it was at the start of mobskill

--- a/src/map/mobskill.h
+++ b/src/map/mobskill.h
@@ -76,6 +76,7 @@ public:
     uint16          getAoEMsg() const;
     uint16          getValidTargets() const;
     int16           getTP() const;
+    auto            getHP() const -> int32;
     uint8           getHPP() const;
     auto            getTargets() const -> const std::vector<CBattleEntity*>&;
     uint16          getTotalTargets() const;
@@ -101,6 +102,7 @@ public:
     void setMsg(uint16 msg);
     void setValidTargets(uint16 targ);
     void setTP(int16 tp);
+    auto setHP(int32 hp) -> void;
     void setHPP(uint8 hpp);
     void setTargets(const std::vector<CBattleEntity*>& targets);
     void setTotalTargets(uint16 targets);
@@ -129,6 +131,7 @@ private:
     timer::duration m_ActivationTime; // how long the mob prepares the tp move for
     uint16          m_Message;        // message param, scripters can edit this depending on self/resist/etc.
     int16           m_TP;             // the tp at the time of finish readying (for scripts)
+    int32           m_HP;             // HP at the time of using mob skill (for scripts)
     uint8           m_HPP;            // HPP at the time of using mob skill (for scripts)
     uint8           m_knockback;      // knockback value (0-7)
     uint8           m_primarySkillchain;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds binding `getMobHP` binding for use in mobskill scripts. This retrieves the mob's HP when it firsts attempts to use the skill(Beginning of prepare time).

Use case: Many suicide skills use the mobs current HP(at the time it first started casting) for damage calculations.

## Steps to test these changes
Currently not used, just ground work for upcoming PRs. You can test with prints.

* Add a print in a **onMobWeaponSkill**(within a mobskill script) with the new binding: `skill:getMobHP()`
* Force the mob to use the skill you edited with `!tp 3000` when engaged or !exec `target:useMobAbility(AbilityID, player)`
* See print returns mobs HP as it was on skill prepare rather than at time of execution.
