### PR TITLE
[core] Add check to prevent Mog House Fishing

### DIFF
--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -1293,6 +1293,12 @@ namespace fishingutils
 
     fishingarea_t* GetFishingArea(CCharEntity* PChar)
     {
+        if (PChar->m_moghouseID > 0)
+        {
+            ShowWarning("fishingutils::GetFishingArea() - Player %s is attempting to fish from Mog House", PChar->name);
+            return nullptr;
+        }
+
         int16        zoneId = PChar->getZone();
         position_t   p      = PChar->loc.p;
         areavector_t loc    = { p.x, p.y, p.z };


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
- Adds a check inside `GetFishingArea()` to check if the player is in their mog house and prevent the action from going through if so.

This can happen through 3rd-party tools that allow for packet-injection.
The checks should cause the player to receive the "Unable to fish here" message.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - Add a fishing pole and some bait and equip them
2 - Zone into the Mog House
3 - Attempt to inject a fishing action packet to the server

NOTE: You are now unable to fish from within your mog house.

_Side Note:  I know Fishing is disabled by default, but on the basis that we should actively be removing these kinds of exploits, we are submitting this upstream._