### PR TITLE
Create enum for item AH categories

### DIFF
--- a/scripts/enum/item_AH_category.lua
+++ b/scripts/enum/item_AH_category.lua
@@ -1,0 +1,75 @@
+-----------------------------------
+-- Item Auction House Category
+-----------------------------------
+xi = xi or {}
+
+---@enum xi.itemAHCategory
+xi.itemAHCategory =
+{
+    NONE         =  0, -- Zero means does not appear in AH at all
+    H2H          =  1, -- Weapons->H2h
+    DAGGER       =  2, -- Weapons->Dagger
+    SWORD        =  3, -- Weapons->Sword
+    GREATSWORD   =  4, -- Weapons->Greatsword
+    AXE          =  5, -- Weapons->Axe
+    GREATAXE     =  6, -- Weapons->Greataxe
+    SCYTHE       =  7, -- Weapons->Scythe
+    POLEARM      =  8, -- Weapons->Polearm
+    KATANA       =  9, -- Weapons->Katana
+    GREATKATANA  = 10, -- Weapons->Greatkatana
+    CLUB         = 11, -- Weapons->Club
+    STAFF        = 12, -- Weapons->Staff
+    BOW          = 13, -- Weapons->Bow
+    INSTRUMENTS  = 14, -- Weapons->Instruments
+    AMMUNITION   = 15, -- Weapons->Ammo&Misc->Ammunition
+    SHIELD       = 16, -- Armor->Shield
+    HEAD         = 17, -- Armor->Head
+    BODY         = 18, -- Armor->Body
+    HANDS        = 19, -- Armor->Hands
+    LEGS         = 20, -- Armor->Legs
+    FEET         = 21, -- Armor->Feet
+    NECK         = 22, -- Armor->Neck
+    WAIST        = 23, -- Armor->Waist
+    EARRINGS     = 24, -- Armor->Earrings
+    RINGS        = 25, -- Armor->Rings
+    BACK         = 26, -- Armor->Back
+    UNUSED       = 27,
+    WHITE_MAGIC  = 28, -- Scrolls->White Magic
+    BLACK_MAGIC  = 29, -- Scrolls->Black Magic
+    SUMMONING    = 30, -- Scrolls->Summoning
+    NINJUTSU     = 31, -- Scrolls->Ninjutsu
+    SONGS        = 32, -- Scrolls->Songs
+    MEDICINES    = 33,
+    FURNISHINGS  = 34,
+    CRYSTALS     = 35,
+    CARDS        = 36, -- Others->Cards
+    CURSED_ITEMS = 37, -- Others->Cursed Items
+    SMITHING     = 38, -- Materials->Smithing
+    GOLDSMITHING = 39, -- Materials->Goldsmithing
+    CLOTHCRAFT   = 40, -- Materials->Clothcraft
+    LEATHERCRAFT = 41, -- Materials->Leathercraft
+    BONECRAFT    = 42, -- Materials->Bonecraft
+    WOODWORKING  = 43, -- Materials->Woodworking
+    ALCHEMY      = 44, -- Materials->Alchemy
+    GEOMANCER    = 45, -- Scrolls->Geomancy
+    MISC         = 46, -- Others->Misc.
+    FISHING_GEAR = 47, -- Weapons->Ammo&Misc->Fishing Gear
+    PET_ITEMS    = 48, -- Weapons->Ammo&Misc->Pet Items
+    NINJA_TOOLS  = 49, -- Others->Ninja Tools
+    BEAST_MADE   = 50, -- Others->Beast-made
+    FISH         = 51, -- Food->Fish
+    MEAT_EGGS    = 52, -- Food->Meals->Meat&Eggs
+    SEAFOOD      = 53, -- Food->Meals->Seafood
+    VEGETABLES   = 54, -- Food->Meals->Vegetables
+    SOUPS        = 55, -- Food->Meals->Soups
+    BREADS_RICE  = 56, -- Food->Meals->Breads&Rice
+    SWEETS       = 57, -- Food->Meals->Sweets
+    DRINKS       = 58, -- Food->Meals->Drinks
+    INGREDIENTS  = 59, -- Food->Ingredients
+    DICE         = 60, -- Scrolls->Dice
+    AUTOMATON    = 61, -- Others->Automaton
+    GRIPS        = 62, -- Weapons->Ammo&Misc->Grips
+    ALCHEMY_2    = 63, -- Materials->Alchemy 2
+    MISC_2       = 64, -- Others->Misc.2
+    MISC_3       = 65, -- Others->Misc.3
+}

--- a/scripts/quests/adoulin/Hunger_Strikes.lua
+++ b/scripts/quests/adoulin/Hunger_Strikes.lua
@@ -52,8 +52,8 @@ quest.sections =
                     local auctionCategory = itemObj:getAHCat()
 
                     if
-                        auctionCategory >= 52 and
-                        auctionCategory <= 57
+                        auctionCategory >= xi.itemAHCategory.MEAT_EGGS and
+                        auctionCategory <= xi.itemAHCategory.SWEETS
                     then
                         return quest:event(2533)
                     end

--- a/scripts/quests/adoulin/The_Starving.lua
+++ b/scripts/quests/adoulin/The_Starving.lua
@@ -52,7 +52,7 @@ quest.sections =
                     local itemObj = trade:getItem(0)
                     local auctionCategory = itemObj:getAHCat()
 
-                    if auctionCategory == 58 then
+                    if auctionCategory == xi.itemAHCategory.DRINKS then
                         return quest:event(3008)
                     else
                         return quest:event(3006)

--- a/scripts/zones/Western_Adoulin/npcs/Westerly_Breeze.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Westerly_Breeze.lua
@@ -20,7 +20,10 @@ entity.onTrade = function(player, npc, trade)
         local itemId = item:getID()
         local ahCategory = item:getAHCat()
 
-        if ahCategory >= 52 and ahCategory <= 57 then
+        if
+            ahCategory >= xi.itemAHCategory.MEAT_EGGS and
+            ahCategory <= xi.itemAHCategory.SWEETS
+        then
             -- We traded him a food item
             if
                 player:getCharVar('ATWTTB_Can_Trade_Gruel') == 1 and


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Creates an enum `xi.itemAHCategory` that can be used when comparing the result of calling `itemObj:getAHCat()`. Replaced integer values with enum entry where `getAHCat()` is called.

## Steps to test these changes

Several calls to `itemObj:getAHCat()` with different items to ensure the correct Boolean value is returned when comparing the various categories. 
