### PR TITLE
[lua] Remove unnecessary require directive

### DIFF
--- a/scripts/mixins/spawn_casket.lua
+++ b/scripts/mixins/spawn_casket.lua
@@ -1,5 +1,4 @@
 -- Casket Mixins
-require('scripts/globals/caskets')
 require('scripts/globals/mixins')
 
 g_mixins = g_mixins or {}


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
All lua scripts in `scripts/global` are executed during `xi_map` startup then modules run. During MOB loads, mixins are read and applied. The `require` directive in the casket mixin was re-reading the `caskets.lua` file from disk, which was undoing any modules that applied overrides to the `xi.caskets` global table. This fixes that by simply letting the process work the way it's supposed to. 

I fully suspect the mixins require statements aren't needed as well, but I didn't go down that rabbit hole.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Load map server, see that caskets still have a chance to spawn from killing mobs
