### PR TITLE
[packets] Don't send custom name on door NPC spawn-in

### DIFF
--- a/src/map/packets/entity_update.cpp
+++ b/src/map/packets/entity_update.cpp
@@ -559,6 +559,16 @@ void CEntityUpdatePacket::updateWith(CBaseEntity* PEntity, ENTITYUPDATE type, ui
     // Otherwise it will revert to it's default name (if applicable).
     else if (PEntity->isRenamed)
     {
+        if (type == ENTITY_SPAWN && PEntity->look.size == MODEL_DOOR)
+        {
+            // Doors won't function properly if they spawn in with a custom packetname
+            // Don't extend this packet, but send a small UPDATE_HP packet afterwards to update the name
+            // SpawnNPCs(PChar) function updated to send the player an UPDATE_HP packet later
+            // other places where NPCs are inserted are likely not relevant as this only affects doors
+
+            return;
+        }
+
         updatemask |= UPDATE_NAME;
         ref<uint8>(0x0A) |= updatemask;
 

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -913,6 +913,20 @@ void CZoneEntities::SpawnNPCs(CCharEntity* PChar)
             {
                 spawnList.insert(itr, SpawnIDList_t::value_type(id, PCurrentEntity));
                 PChar->updateEntityPacket(PCurrentEntity, ENTITY_SPAWN, UPDATE_ALL_MOB);
+                if (PCurrentEntity->isRenamed && PCurrentEntity->look.size == MODEL_DOOR)
+                {
+                    // Doors won't function properly if they spawn in with a custom packetname
+                    // Previous ENTITY_SPAWN didn't include the name, so now we send a small UPDATE_HP packet to fix the name
+                    PChar->PAI->QueueAction(queueAction_t(std::chrono::seconds(1), false,
+                                                          [PChar, PCurrentEntity](auto* _)
+                                                          {
+                                                              // Ensure NPC still exists
+                                                              if (PCurrentEntity)
+                                                              {
+                                                                  PChar->updateEntityPacket(PCurrentEntity, ENTITY_UPDATE, UPDATE_HP);
+                                                              }
+                                                          }));
+                }
             }
         };
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Resolves a weird edge case with the lua binding `:renameEntity()` and inserting an NPC into a player's spawn list. When the NPC is in range (or player logs into zone within range), a full update spawn packet is sent. When that packet includes the extra information from `->isRenamed` within the `CEntityUpdatePacket::updateWith` function, animation updates simply aren't displayed in the client. Of course the door's animation on the server side, but something about the game client instantiating an NPC with the custom name bugs out.

The updated code simply doesn't append the custom name information when a DOOR is doing a full ENTITY_SPAWN packet, then queues the UPDATE_HP packet for the player that was moving within range of the NPC.

It feels like a workaround and I'm open to a better solution. It's also very possible that retail never uses the custom name portion of a packet for door NPCs and that's why the strange behavior exists. Note that the changes in the PR in that situation simply makes no changes, as it only flags on npc ENTITY_SPAWN packets with `isRenamed == true`

FWIW, i tested other types of NPCs and couldn't find another type that had issues with animations with a renamed displayname

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

This is easily replicated by adding this to Ulegrand's Zone.lua
<img width="484" height="197" alt="image" src="https://github.com/user-attachments/assets/4de9c99e-2ef3-4107-bc99-f1ef590890f1" />

When the map server inits the zone, weather change is executed and the NPC becomes targetable and has a custom name.

changing the weather with `!setweather 1` and `!setweather 13` will toggle the animation of the door on the server, but game clients won't render the change

With this PR compiled, it functions as normal