### PR TITLE
WS Points - May 2025 update values

### DIFF
--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -98,12 +98,11 @@ xi.settings.map =
     -- Disables Treasure Hunter procs (Era behavior wants this true)
     DISABLE_TREASURE_HUNTER_PROCS = false,
 
-    -- Weaponskill point base (before skillchain) for breaking latent - whole numbers only. retail is 1.
-    WS_POINTS_BASE = 1,
+    -- Weaponskill point base (before skillchain) for breaking latent - whole numbers only. retail is 5.
+    WS_POINTS_BASE = 5,
 
-    -- Weaponskill points per skillchain element - whole numbers only, retail is 1
-    -- (tier 3 sc's have 4 elements, plus 1 for the ws itself, giving 5 points to the closer).
-    WS_POINTS_SKILLCHAIN = 1,
+    -- Weaponskill points per skillchain level - whole numbers only, retail is 2
+    WS_POINTS_SKILLCHAIN = 2,
 
     -- Enable/disable jobs other than BST and RNG having widescan
     ALL_JOBS_WIDESCAN = true,

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1612,23 +1612,27 @@ void CCharEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& acti
 
                             actionTarget.additionalEffect = effect;
 
-                            // Despite appearances, ws_points_skillchain is not a multiplier it is just an amount "per element"
-                            auto wsPointsSkillchain = settings::get<uint8>("map.WS_POINTS_SKILLCHAIN");
+                            // Despite appearances, ws_points_skillchain is not a multiplier it is just an amount "per skillchain level"
+                            const auto wsPointsSkillchain = settings::get<uint8>("map.WS_POINTS_SKILLCHAIN");
                             if (effect >= 7 && effect < 15)
                             {
-                                wspoints += (1 * wsPointsSkillchain); // 1 element
+                                wspoints += (1 * wsPointsSkillchain); // Level 1
                             }
                             else if (effect >= 3)
                             {
-                                wspoints += (2 * wsPointsSkillchain); // 2 elements
+                                wspoints += (2 * wsPointsSkillchain); // Level 2
                             }
                             else
                             {
-                                wspoints += (4 * wsPointsSkillchain); // 4 elements
+                                wspoints += (3 * wsPointsSkillchain); // Level 3
                             }
                         }
                     }
                     // check for ws points
+                    // TODO: As a general rule, mobs not granting EXP do not give WSP
+                    // The following exceptions apply:
+                    // - PC targeted weaponskills always give WSP
+                    // - A handful of content: Besieged, DI
                     if (charutils::CheckMob(this->GetMLevel(), PTarget->GetMLevel()) > EMobDifficulty::TooWeak)
                     {
                         charutils::AddWeaponSkillPoints(this, damslot, wspoints);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Changes weaponskill points obtained for breaking latents and various quests from 1,2,3,5 to 5,7,9,11

> The number of times you need to activate a weapon skill in order to learn it has been reduced for the following quests.
> The Walls of Your Mind / Cloak and Dagger / Old Wounds / Inheritance / Axe the Competition /
> The Weight of Your Limits / Souls in Shadow / Methods Create Madness / Bugi Soden / The Potential Within /
> Orastery Woes / Blood and Glory / From Saplings Grow / Shoot First, Ask Questions Later /
> Unlocking a Myth / Rune Fencing the Night Away / Geomancerrific
> 
> The number of times you need to activate a weapon skill in order to unlock the latent ability of the following weapons has been reduced.
> Destroyers / Heart Snatcher / Dissector / Subduer / Retributor /
> Rampager / Gravedigger / Gondo-Shizunori / Senjuinrikio / Michishiba /
> Morgenstern / Thyrsusstab / Expunger / Coffinmaker
https://forum.square-enix.com/ffxi/threads/62737-May-12-2025-%28JST%29-Version-Update

https://www.bg-wiki.com/ffxi/Category:WSNM
https://wiki-ffo-jp.translate.goog/html/920.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp

## Steps to test these changes
- !additem axe_of_trials
- Skillchain some crabs with a debugger or check exdata
<!-- Clear and detailed steps to test your changes here -->
