### PR TITLE
[fix] Einherjar: Apply Poroggo mixin to Ariri Samariri

### DIFF
--- a/scripts/zones/Hazhalm_Testing_Grounds/mobs/Ariri_Samariri.lua
+++ b/scripts/zones/Hazhalm_Testing_Grounds/mobs/Ariri_Samariri.lua
@@ -13,6 +13,7 @@
 mixins =
 {
     require('scripts/mixins/draw_in'),
+    require('scripts/mixins/families/poroggo'),
 }
 -----------------------------------
 ---@type TMobEntity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

I uh... may have forgotten to apply the mixin. 

Ariri is wrecking havoc spamming Death with 0 delay after Providence since the mixin is missing.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
- !pos 1 1 1 78
- !spawnmob 17096718
- Watch it use Providence and use one special Poroggo spell once
- MAGIC_COOL mobmod should go back to 35 after the cast and it should no longer cast any special spell.

<!-- Clear and detailed steps to test your changes here -->
