### PR TITLE
[fix] Alexander/Odin don't bodyguard

### DIFF
--- a/src/map/ai/controllers/mob_controller.h
+++ b/src/map/ai/controllers/mob_controller.h
@@ -19,11 +19,9 @@
 ===========================================================================
 */
 
-#ifndef _MOB_CONTROLLER_H
-#define _MOB_CONTROLLER_H
+#pragma once
 
 #include "controller.h"
-#include "entities/mobentity.h"
 
 enum class FollowType : uint8
 {
@@ -35,57 +33,57 @@ enum class FollowType : uint8
 class CMobController : public CController
 {
 public:
-    CMobController(CMobEntity* PMob);
+    CMobController(CMobEntity* PEntity);
 
     virtual void Tick(timer::time_point tick) override;
-    virtual bool Disengage() override;
-    virtual bool Engage(uint16 targid) override;
+    virtual auto Disengage() -> bool override;
+    virtual auto Engage(uint16 targid) -> bool override;
     virtual void Despawn() override;
     virtual void Reset() override;
 
-    virtual bool MobSkill(uint16 targid, uint16 wsid);
-    virtual bool Ability(uint16 targid, uint16 abilityid) override
+    virtual auto MobSkill(uint16 targid, uint16 wsid) -> bool;
+    virtual auto Ability(uint16 targid, uint16 abilityid) -> bool override
     {
         return false;
     }
-    bool MobSkill(int list = 0);
-    bool TryCastSpell();
-    bool TrySpecialSkill();
+    auto MobSkill(int listId = 0) -> bool;
+    auto TryCastSpell() -> bool;
+    auto TrySpecialSkill() -> bool;
 
-    bool         CanFollowTarget(CBattleEntity*);
-    bool         CanAggroTarget(CBattleEntity*);
+    auto         CanFollowTarget(CBattleEntity*) const -> bool;
+    auto         CanAggroTarget(CBattleEntity*) const -> bool;
     void         TapDeaggroTime();
     void         TapDeclaimTime();
-    virtual bool Cast(uint16 targid, SpellID spellid) override;
+    virtual auto Cast(uint16 targid, SpellID spellid) -> bool override;
     void         SetFollowTarget(CBaseEntity* PTarget, FollowType followType);
-    bool         HasFollowTarget();
+    auto         HasFollowTarget() const -> bool;
     void         ClearFollowTarget();
-    bool         CheckHide(CBattleEntity* PTarget);
+    auto         CheckHide(const CBattleEntity* PTarget) const -> bool;
 
     void OnCastStopped(CMagicState& state, action_t& action);
 
 protected:
-    virtual bool TryDeaggro();
+    virtual auto TryDeaggro() -> bool;
 
     virtual void TryLink();
-    bool         CanDetectTarget(CBattleEntity* PTarget, bool forceSight = false);
-    bool         CanPursueTarget(CBattleEntity* PTarget);
-    bool         CheckLock(CBattleEntity* PTarget);
-    bool         CheckDetection(CBattleEntity* PTarget);
-    virtual bool CanCastSpells();
+    auto         CanDetectTarget(CBattleEntity* PTarget, bool forceSight = false) const -> bool;
+    auto         CanPursueTarget(const CBattleEntity* PTarget) const -> bool;
+    auto         CheckLock(CBattleEntity* PTarget) const -> bool;
+    auto         CheckDetection(CBattleEntity* PTarget) -> bool;
+    virtual auto CanCastSpells() -> bool;
     void         CastSpell(SpellID spellid);
     virtual void Move();
 
     virtual void DoCombatTick(timer::time_point tick);
-    void         FaceTarget(uint16 targid = 0);
+    void         FaceTarget(uint16 targid = 0) const;
     virtual void HandleEnmity();
 
     virtual void DoRoamTick(timer::time_point tick);
     void         Wait(timer::duration _duration);
     void         FollowRoamPath();
-    bool         CanMoveForward(float currentDistance);
-    bool         IsSpecialSkillReady(float currentDistance);
-    bool         IsSpellReady(float currentDistance);
+    auto         CanMoveForward(float currentDistance) -> bool;
+    auto         IsSpecialSkillReady(float currentDistance) const -> bool;
+    auto         IsSpellReady(float currentDistance) const -> bool;
 
     CBattleEntity* PTarget{ nullptr };
 
@@ -110,5 +108,3 @@ private:
     bool              m_firstSpell{ true };
     timer::time_point m_LastRoamScript{ timer::time_point::min() };
 };
-
-#endif // _AI_CONTROLLER_H


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Missed the bit of logic that auto-engages avatars when master is attacked. 
This was causing Alexander to attack aggroed mobs.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
- Aggro a mob
- Cast Alexander
- Alexander should remain passive (other than executing PD) and not engage the mob

<!-- Clear and detailed steps to test your changes here -->
