### PR TITLE
Add the acrolith family of skills

### DIFF
--- a/scripts/actions/mobskills/detonating_grip.lua
+++ b/scripts/actions/mobskills/detonating_grip.lua
@@ -1,0 +1,36 @@
+-----------------------------------
+--  Detonating Grip
+--  Family: Acrolith
+--  Type: Physical
+--  Can be dispelled: N/A
+--  Utsusemi/Blink absorb: Ignores shadows
+--  Range: Aoe on target, TODO capture
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    if mob:getHPP() > 35 then
+        return 1
+    end
+
+    if mob:getLocalVar('lost_r_arm') == 1 then
+        -- Lost right arm, filtering out Detonating grip!
+        return 1
+    end
+
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    local numhits = 1
+    local accmod = 10
+    local ftp    = 1
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
+    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.NONE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
+
+    target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.NONE)
+    return dmg
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/dire_straight.lua
+++ b/scripts/actions/mobskills/dire_straight.lua
@@ -1,0 +1,32 @@
+-----------------------------------
+--  Dire Straight
+--  Family: Acrolith
+--  Type: Physical
+--  Can be dispelled: N/A
+--  Utsusemi/Blink absorb: Wipe shadows
+--  Range: Single Target TODO Capture
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    if mob:getLocalVar('lost_r_arm') == 1 then
+        -- Lost right arm, filtering out Detonating grip!
+        return 1
+    end
+
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    local numhits = 1
+    local accmod = 1
+    local ftp    = 1
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
+    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.NONE, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
+
+    target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.NONE)
+    return dmg
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/dismemberment.lua
+++ b/scripts/actions/mobskills/dismemberment.lua
@@ -1,0 +1,36 @@
+-----------------------------------
+--  Dismemberment
+--  Family: Acrolith
+--  Type: Physical
+--  Can be dispelled: N/A
+--  Utsusemi/Blink absorb: Ignore shadows
+--  Range: Single Target TODO Capture
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    if mob:getHPP() > 35 then
+        return 1
+    end
+
+    if mob:getLocalVar('lost_r_arm') == 1 then
+        -- I have never observed acrolith use Dismemberment with right arm lost
+        return 1
+    end
+
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    local numhits = 1
+    local accmod = 1
+    local ftp    = 1
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
+    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.NONE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
+
+    target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.NONE)
+    return dmg
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/earth_shatter.lua
+++ b/scripts/actions/mobskills/earth_shatter.lua
@@ -1,0 +1,31 @@
+-----------------------------------
+--  Earth Shatter
+--  Family: Acrolith
+--  Type: Physical
+--  Can be dispelled: N/A
+--  Utsusemi/Blink absorb: Wipes shadows
+--  Range: Aoe on mob, TODO Capture
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    if mob:getLocalVar('lost_r_arm') == 1 then
+        -- I have never observed acrolith use earth shatter with right arm lost
+        return 1
+    end
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    local numhits = 1
+    local accmod = 1
+    local ftp    = 1
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
+    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.NONE, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
+
+    target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.NONE)
+    return dmg
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/sinker_drill.lua
+++ b/scripts/actions/mobskills/sinker_drill.lua
@@ -1,0 +1,32 @@
+-----------------------------------
+--  Sinker Drill
+--  Family: Acrolith
+--  Type: Physical
+--  Can be dispelled: N/A
+--  Utsusemi/Blink absorb: Up to 5 shadows
+--  Range: Single Target TODO Capture
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    if mob:getLocalVar('lost_body') == 1 then
+        -- Lost body, filtering out Sinker Drill!
+        return 1
+    end
+
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    local numhits = 5
+    local accmod = 1
+    local ftp    = 1
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
+    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.NONE, info.hitslanded)
+
+    target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.NONE)
+    return dmg
+end
+
+return mobskillObject

--- a/scripts/enum/mob_skills.lua
+++ b/scripts/enum/mob_skills.lua
@@ -211,6 +211,12 @@ xi.mobSkill =
 
     BOREAS_MANTLE            = 1980, -- Unique entry.
 
+    DISMEMBERMENT            = 2070,
+    DIRE_STRAIGHT            = 2071,
+    EARTH_SHATTER            = 2072,
+    SINKER_DRILL             = 2073,
+    DETONATING_GRIP          = 2074,
+
     NOCTURNAL_SERVITUDE      = 2112,
 
     HELLSNAP                 = 2113,

--- a/scripts/mixins/families/acrolith.lua
+++ b/scripts/mixins/families/acrolith.lua
@@ -1,0 +1,56 @@
+-- Acrolith family mixin
+-- Customization:
+--   Acrolith family of mobs have a behavior of losing body parts based on what skills
+--   they perform. All acrolith type mobs can mix in this lua. This was sourced from
+--   bg wiki which had the most detail: https://www.bg-wiki.com/ffxi/Category:Acrolith
+
+require('scripts/globals/mixins')
+
+g_mixins = g_mixins or {}
+g_mixins.families = g_mixins.families or {}
+
+g_mixins.families.acrolith = function(acrolithMob)
+    acrolithMob:addListener('WEAPONSKILL_USE', 'ACROLITH_WEAPONSKILL_USE', function(mob, target, wsid, tp, action)
+        if wsid == xi.mobSkill.DETONATING_GRIP then
+            mob:setLocalVar('lost_r_arm', 1)
+            return
+        end
+
+        if wsid == xi.mobSkill.DISMEMBERMENT then
+            -- Dismemberment takes right arm first
+            if mob:getLocalVar('lost_r_arm') == 0 then
+                mob:setLocalVar('lost_r_arm', 1)
+                return
+            end
+        end
+    end)
+
+    acrolithMob:addListener('WEAPONSKILL_STATE_EXIT', 'ACROLITH_WEAPONSKILL_STATE_EXIT', function(mob, skillID)
+        if skillID == xi.mobSkill.DETONATING_GRIP then
+            mob:setAnimationSub(5)
+        end
+
+        if skillID == xi.mobSkill.DISMEMBERMENT then            
+            mob:setAnimationSub(5)
+        end
+    end)
+
+    -- TODO find rate of fall apart crit event
+    acrolithMob:addListener('CRITICAL_TAKE', 'ACROLITH_CRITICAL_TAKE', function(mob)
+        local random = math.random(1, 100)
+
+        if
+            random <= 20 and
+            mob:getLocalVar('lost_r_arm') == 1 and
+            mob:getLocalVar('lost_body') == 0
+        then
+            -- Fall apart
+            mob:setAnimationSub(6)
+            mob:setAutoAttackEnabled(false)
+            mob:setLocalVar('lost_r_arm', 1)
+            mob:setLocalVar('lost_body', 1)            
+        end
+    end)
+end
+
+return g_mixins.families.acrolith

--- a/scripts/zones/Al_Zahbi/mobs/Acrolith.lua
+++ b/scripts/zones/Al_Zahbi/mobs/Acrolith.lua
@@ -1,0 +1,13 @@
+-----------------------------------
+-- Area: Al Zahbi
+--  Mob: Acrolith
+-----------------------------------
+mixins = { require('scripts/mixins/families/acrolith') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobDeath = function(mob, player, optParams)
+end
+
+return entity

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -21,7 +21,11 @@ CREATE TABLE IF NOT EXISTS `mob_skill_lists` (
 -- Contenu de la table `mob_skill_lists`
 --
 
--- 1: Acrolith
+INSERT INTO `mob_skill_lists` VALUES ('Acrolith',1,2070);
+INSERT INTO `mob_skill_lists` VALUES ('Acrolith',1,2071);
+INSERT INTO `mob_skill_lists` VALUES ('Acrolith',1,2072);
+INSERT INTO `mob_skill_lists` VALUES ('Acrolith',1,2073);
+INSERT INTO `mob_skill_lists` VALUES ('Acrolith',1,2074);
 INSERT INTO `mob_skill_lists` VALUES ('Adamantoise',2,804);
 INSERT INTO `mob_skill_lists` VALUES ('Adamantoise',2,805);
 INSERT INTO `mob_skill_lists` VALUES ('Adamantoise',2,806);

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -2088,7 +2088,7 @@ INSERT INTO `mob_skills` VALUES (2070,1411,'dismemberment',0,0.0,7.0,2000,1000,4
 INSERT INTO `mob_skills` VALUES (2071,1412,'dire_straight',0,0.0,7.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2072,1413,'earth_shatter',1,0.0,15.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2073,1414,'sinker_drill',0,0.0,7.0,2000,1000,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (2074,1415,'detonating_grip',0,0.0,7.0,2000,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (2074,1415,'detonating_grip',2,0.0,7.0,2000,1000,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (2075,1819,'overthrow',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (2076,1820,'rock_smash',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (2077,1821,'diamondhide',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Addresses #5494 by adding the acrolith family skills. There are TODOs left where more capture is needed.
There are still some capture TODOs:
- Follow up adding acrolith.lua mixin to every acrolith type mob in the game. This change starts with just the one in Al Zahbi besieged.
- Verify all of the ranges and AOE ranges of these abilities.
- Tune skill power
- Use the correct animation id for left arm and body dismemberment anims.

Existential TODOs:
- How does a client zoning in know the disassembled state of an Acrolith that it wasn't present to witness?

## Steps to test these changes
!zone al zahbi
!spawnmob 16974118 (spawns near the gate to outside)
Feed TP until debug logging reports all of the limbs have been exhausted (Only way to do this since we still need to capture the proper limb falling animations)
Acrolith will only do earthshatter with no limbs or body left.
