### PR TITLE
[lua] Charm Effect subPower: Damage over time

### DIFF
--- a/scripts/effects/charm.lua
+++ b/scripts/effects/charm.lua
@@ -5,6 +5,9 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
+    if effect:getSubPower() > 0 then -- Chariots have a DOT on charm from Brainjack skill.
+        effect:addMod(xi.mod.REGEN_DOWN, effect:getSubPower())
+    end
 end
 
 effectObject.onEffectTick = function(target, effect)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a REGEN_DOWN modifier that is defined by the effect's subPower and when it is greater than 0.

Use case: Mobskill "Brainjack" used by Chariot family has a Damage over time(DOT) effect on the charmed players. (Mobskill edits will be added in a later PR).

## Steps to test these changes
1. Edit an existing charm mobskill to have a subPower of 1 or greater and tick set to at least 3.
2. Get a mob to use that charm skill on you by using `!exec target:useMobAbility(AbilityIDHere, player)`
3. See that you now take damage over time while charmed and that it stops when uncharmed.
