### PR TITLE
[lua] Add more msg Enums

### DIFF
--- a/scripts/actions/mobskills/cosmic_elucidation.lua
+++ b/scripts/actions/mobskills/cosmic_elucidation.lua
@@ -21,7 +21,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     damage = math.min(0, damage) -- Cosmic Elucidation does not have an absorb message
 
     target:takeDamage(damage, mob, xi.attackType.SPECIAL, xi.damageType.ELEMENTAL)
-    skill:setMsg(302)
+    skill:setMsg(xi.msg.basic.SKILLCHAIN_COSMIC_ELUCIDATION)
 
     return damage
 end

--- a/scripts/effects/doom.lua
+++ b/scripts/effects/doom.lua
@@ -15,7 +15,7 @@ effectObject.onEffectTick = function(target, effect)
     local remainingTicks = 1 + (effect:getTimeRemaining() / 1000) / 3
 
     -- doom counter
-    target:messagePublic(112, target, remainingTicks, remainingTicks)
+    target:messagePublic(xi.msg.basic.DOOM_COUNTER, target, remainingTicks, remainingTicks)
 end
 
 effectObject.onEffectLose = function(target, effect)

--- a/scripts/enum/msg.lua
+++ b/scripts/enum/msg.lua
@@ -65,8 +65,10 @@ xi.msg.area =
 ---@enum xi.basic
 xi.msg.basic =
 {
-    NONE                            = 0, -- Display nothing
-    HIT_DMG                         = 1, -- <actor> hits <target> for <amount> points of damage.
+    NONE                            = 0,  -- Display nothing
+    HIT_DMG                         = 1,  -- <actor> hits <target> for <amount> points of damage.
+    HIT_MISS                        = 15, -- <actor> misses <target>.
+    HIT_CRIT                        = 67, -- <actor> scores a critical hit! <target> takes <amount> points of damage.
 
     -- Magic
     MAGIC_DMG                       = 2,   -- <caster> casts <spell>. <target> takes <amount> damage.
@@ -311,20 +313,24 @@ xi.msg.basic =
     RECOVERS_MP                     = 25,  -- <target> recovers <number> MP.
     RECOVERS_HP_AND_MP              = 26,  -- <target> recovers <number> HP and MP.
     IS_PARALYZED_2                  = 84,  -- <target> is paralyzed.
+    DOOM_COUNTER                    = 112, -- <target's> doom counter is now down to <param>.
     IS_STATUS                       = 203, -- <target> is <status>.
     IS_NO_LONGER_STATUS             = 204, -- <target> is no longer <status>.
     GAINS_EFFECT_OF_STATUS          = 205, -- <target> gains the effect of <status>.
     STATUS_WEARS_OFF                = 206, -- <target>'s <status> effect wears off.
     ABOUT_TO_WEAR_OFF               = 251, -- The effect of <status> is about to wear off.
     ALL_ABILITIES_RECHARGED         = 361, -- All of <target>'s abilities are recharged.
+    PETRIFICATION_COUNTER           = 530, -- <target's> petrification counter is now down to <param>.
 
     -- Battlefield
     UNABLE_TO_ACCESS_SJ             = 107, -- <player> is temporarily unable to access support job abilities
     TIME_LEFT                       = 202, -- Time left: (0:00:00)
+    SKILLCHAIN_COSMIC_ELUCIDATION   = 302, -- Skillchain: Cosmic Elucidation. <target> takes <number> points of damage.
 
     -- Dynamis
     TIME_DYNAMIS_EXTENDED           = 448, -- Time allowed in Dynamis has been extended by <param> minutes
     TIME_DYNAMIS_REMAINING          = 449, -- ----== WARNING ==----Time remaining in Dynamis: <param> minutes.
+
     -- Charm
     CHARM_SUCCESS                   = 136, -- <actor> uses charm. <target> is now under the <actor>'s control.
     CHARM_FAIL                      = 137, -- <actor> uses charm. <actor> fails to charm <target>.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds some more msg enums and utilizes them in a couple places (Doom, Tenzen Skillchain).

## Steps to test these changes

Should not observe any new changes. To test:

1. Get hit with doom, see counter still work same as before.
2. Run Tenzen airship fight, fail it by letting Tenzen finish his skill chains. See that Cosmic Elucidation message still works.
