### PR TITLE
Convert !addallspells to batch job

### DIFF
--- a/scripts/commands/addalltrusts.lua
+++ b/scripts/commands/addalltrusts.lua
@@ -1,6 +1,7 @@
 -----------------------------------
 -- func: addalltrusts
 -- desc: Adds all trust spells to the given target. If no target then to the current player.
+--       utilizes !addallspells to not duplicate complex logic
 -----------------------------------
 ---@type TCommand
 local commandObj = {}
@@ -34,25 +35,20 @@ commandObj.onTrigger = function(player, target)
     else
         targ = GetPlayerByName(target)
         if targ == nil then
-            error(player, string.format('Player named "%s" not found!', target))
+            error(player, fmt('Player named "{}" not found!', target))
             return
         end
     end
 
-    -- add all spells
-    local save = true
-    local silent = true -- Hide message
-    local sendUpdate = false -- Prevent packet spam
-    for i = 1, #validSpells do
-        if i == #validSpells then
-            silent = false
-            sendUpdate = true
-        end
-
-        targ:addSpell(validSpells[i], silent, save, sendUpdate)
+    if
+        xi.commands.addallspells and
+        type(xi.commands.addallspells.onTrigger) == 'function'
+    then
+        player:printToPlayer(fmt('Queuing unlock of all trust spells for {}', targ:getName()), xi.msg.channel.SYSTEM_3)
+        xi.commands.addallspells.onTrigger(player, target, validSpells)
+    else
+        player:printToPlayer(fmt('An error occurred calling !addallspells to learn all trusts'))
     end
-
-    player:printToPlayer(string.format('%s now has all trusts.', targ:getName()))
 end
 
 return commandObj


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Converts `!addallspells` and `!addalltrusts` to batch the learning of spells so it doesn't cause watchdog timeouts on the map server when the player knows no/few spells

Also fixes a bug where `!addallspells` and `!addalltrusts` wouldn't refresh the spell list if the last spell in the `validSpells` table was already known

example from before the change:
<img width="1105" height="58" alt="image" src="https://github.com/user-attachments/assets/e5caac00-7ef2-47f9-b20d-9e53a53d153d" />

This map server isn't loaded with all zones, so it's not as bad but I've most certainly had the watchdog crash the map server when using `!addallspells`

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
test with and without a target to ensure it functions as expected
also check the timestamps of messages to see how it's protecting from triggering the watchdog

- this is from a fresh char and a fresh startup of mariadb
   - <img width="508" height="244" alt="image" src="https://github.com/user-attachments/assets/a95cbee1-0d05-4555-b838-2c1c2839ecbe" />
   - note that we get a small warning in the map server: 
   - <img width="1090" height="47" alt="image" src="https://github.com/user-attachments/assets/e1840edc-0a4c-4121-b294-afc6736a7390" />
- and this is after all spells are already known
  - <img width="538" height="487" alt="image" src="https://github.com/user-attachments/assets/439d448f-263a-41d4-aa11-0e05ea42bb5c" />
- and if `!addallspells` gets renamed:
  - <img width="549" height="61" alt="image" src="https://github.com/user-attachments/assets/2e97e96a-cb18-4ba0-ad4e-fc23732e6e13" />
- also for science, running the command 4 times back to back:
  - <img width="514" height="529" alt="image" src="https://github.com/user-attachments/assets/9cc18aa7-7182-48f0-8dd5-0b414125eaf0" />

Edit: looks like i fundamentally misunderstood what `target` was in the command. Should be sorted now to both give proper messages and not fail CI

<img width="513" height="405" alt="image" src="https://github.com/user-attachments/assets/6103b65f-ea7f-407b-81cf-f2cc284c64cd" />
