### PR TITLE
Add xi::lazy template

### DIFF
--- a/src/common/xi.h
+++ b/src/common/xi.h
@@ -21,11 +21,19 @@
 
 #pragma once
 
+#include <array>
+#include <functional>
+#include <memory>
+#include <mutex>
 #include <optional>
+#include <string>
+#include <tuple>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 #include "earth_time.h"
+#include "tracy.h"
 
 // The purpose of this namespace IS NOT to replace the C++ standard library.
 //
@@ -392,4 +400,101 @@ namespace xi
         }
     };
 
+    // For easy lazy initialization of objects.
+    // Most suitable for Parent->lazy<ChildType> relationships.
+    // NOTE: We capture the constructor arguments in a lambda for use during initialization later on.
+    //     : Therefore you need to ensure the child outlives the parent!
+    template <typename T>
+    class lazy
+    {
+    public:
+        lazy()
+        : constructFn_([]
+                       { return T{}; })
+        {
+        }
+
+        DISALLOW_COPY_AND_MOVE(lazy);
+
+        //
+        // Factory function to create a lazy instance with captured arguments
+        //
+
+        template <typename... Args>
+        static auto with_args(Args&&... args) -> lazy<T>
+        {
+            auto args_tuple = std::make_tuple(std::forward<Args>(args)...);
+            return lazy(std::move(args_tuple));
+        }
+
+        auto get() -> T&
+        {
+            auto lock = std::unique_lock<LockableBase(std::mutex)>(mutex_);
+            LockMark(mutex_);
+
+            if (!instance_)
+            {
+                instance_.emplace(constructFn_());
+            }
+
+            return *instance_;
+        }
+
+        bool is_constructed() const noexcept
+        {
+            return instance_.has_value();
+        }
+
+        void reset() noexcept
+        {
+            instance_.reset();
+        }
+
+        //
+        // Implicit conversion operators
+        //
+
+        operator T&()
+        {
+            return get();
+        }
+
+        auto operator->() -> T*
+        {
+            return &get();
+        }
+
+        auto operator*() -> T&
+        {
+            return get();
+        }
+
+    private:
+        //
+        // Private constructor used by factory
+        //
+
+        template <typename Tuple>
+        explicit lazy(Tuple&& args_tuple)
+        {
+            constructFn_ = [args_tuple = std::forward<Tuple>(args_tuple)]() mutable -> T
+            {
+                return std::apply(
+                    [](auto&&... unpacked)
+                    {
+                        return T(std::forward<decltype(unpacked)>(unpacked)...);
+                    },
+                    std::move(args_tuple));
+            };
+        }
+
+        //
+        // Members
+        //
+
+        mutable TracyLockable(std::mutex, mutex_);
+
+        std::optional<T>   instance_;
+        std::function<T()> constructFn_;
+    };
 } // namespace xi

--- a/src/map/aman.cpp
+++ b/src/map/aman.cpp
@@ -65,15 +65,6 @@ namespace
 CAMANContainer::CAMANContainer(CCharEntity* PChar)
 : m_player(PChar)
 {
-}
-
-auto CAMANContainer::isInitialized() const -> bool
-{
-    return m_isInitialized;
-}
-
-void CAMANContainer::init()
-{
     const auto fmtQuery = "SELECT "
                           "mentor, "
                           "DATEDIFF(CURRENT_TIMESTAMP, last_logout) AS days_since_logout, "
@@ -87,7 +78,6 @@ void CAMANContainer::init()
         const auto logoutDiff = rset->get<uint32>("days_since_logout");
         m_mentorUnlocked      = rset->get<uint32>("mentor") > 0;
         m_isMuted             = rset->get<bool>("muted");
-        m_isInitialized       = true;
 
         if (!settings::get<bool>("main.ASSIST_CHANNEL_ENABLED"))
         {

--- a/src/map/aman.h
+++ b/src/map/aman.h
@@ -28,8 +28,6 @@ class CAMANContainer
 {
 public:
     CAMANContainer(CCharEntity* PChar);
-    auto isInitialized() const -> bool; // Has the container been initialized with the character data?
-    void init();                        // Must be called explicitly once the character is fully loaded.
 
     auto isAssistChannelEligible() const -> bool; // Can the player participate in the Assist Channel?
     auto onZoneIn() const -> void;                // Displays the Assist Channel eligibility message when the player zones in.
@@ -62,6 +60,5 @@ private:
     bool         m_assistChannelEligible{ false };
     uint32_t     m_assistChannelPlaytimeExpiry{ 0 };
     bool         m_notifyExpired{ false };
-    bool         m_isInitialized{ false };
     CCharEntity* m_player;
 };

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -96,7 +96,7 @@
 
 CCharEntity::CCharEntity()
 : m_PlayTime(0s)
-, m_AMAN(this)
+, m_AMAN(xi::lazy<CAMANContainer>::with_args(this))
 {
     TracyZoneScoped;
     objtype     = TYPE_PC;
@@ -765,11 +765,6 @@ auto CCharEntity::getStorage(const uint8 locationId) const -> CItemContainer*
 
 auto CCharEntity::aman() -> CAMANContainer&
 {
-    if (!m_AMAN.isInitialized())
-    {
-        m_AMAN.init();
-    }
-
     return m_AMAN;
 }
 

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -664,7 +664,7 @@ protected:
     void TrackArrowUsageForScavenge(CItemWeapon* PAmmo);
 
 private:
-    CAMANContainer m_AMAN;
+    xi::lazy<CAMANContainer> m_AMAN;
 
     std::unique_ptr<CItemContainer> m_Inventory;
     std::unique_ptr<CItemContainer> m_Mogsafe;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Moves the initialisation of lazy objects out into a thread-safe helper, supporting default and argument forwarding construction. 
