### PR TITLE
[Fix] H2H weapon dealy being counted twice

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -445,7 +445,7 @@ bool CBattleEntity::Rest(float rate)
 uint16 CBattleEntity::GetWeaponDelay(bool tp)
 {
     TracyZoneScoped;
-    uint16 finalDelay = 9999;
+    uint16 finalDelay = 8000; // 480 (base) * 1000 / 60 (milisecond conversion)
 
     if (auto* weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_MAIN]))
     {
@@ -462,7 +462,6 @@ uint16 CBattleEntity::GetWeaponDelay(bool tp)
         // H2H
         if (weapon->isHandToHand())
         {
-            weaponDelay = weaponDelay + 8000;                    // (480) base * (1000 / 60) milisecond conversion
             martialArts = getMod(Mod::MARTIAL_ARTS) * 1000 / 60; // TODO: Job points?
         }
 
@@ -478,7 +477,7 @@ uint16 CBattleEntity::GetWeaponDelay(bool tp)
         if (!tp && StatusEffectContainer->HasStatusEffect(EFFECT_HUNDRED_FISTS))
         {
             finalDelay = std::clamp<uint16>(weaponDelay - martialArts, 1600, 8000);
-            finalDelay = finalDelay * 0.25;
+            finalDelay = finalDelay * 0.25f;
 
             return finalDelay;
         }


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR fixes the base delay (8000) being added a second time for H2H weapons.

One would think H2H weapons would add to the base delay of 8000, since they add damage and delay in their description, unlike other weapons.
But they dont. `getDelay()` already accounts for the base unarmed delay for H2H weapons. 

## Steps to test these changes

Equip a H2H weapon and attack something. You may even attack sometime in the next year now.
