### PR TITLE
[Fix] Remove incorrect missionStatus check in ToAU 46

### DIFF
--- a/scripts/missions/toau/46_Imperial_Coronation.lua
+++ b/scripts/missions/toau/46_Imperial_Coronation.lua
@@ -29,7 +29,6 @@ mission.sections =
                     local properlyDressed = whitegateShared.doRoyalPalaceArmorCheck(player) and 1 or 0
 
                     if
-                        player:getMissionStatus(mission.areaId) == 2 and
                         player:getEquipID(xi.slot.MAIN) == 0 and
                         player:getEquipID(xi.slot.SUB) == 0 and
                         properlyDressed == 1


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
As title sais. Bad copy/paste.

## Steps to test these changes
Interact with Whitegate door and mission 46 properly dressed and have it react.
