### PR TITLE
fix: Can move any type of item in MOGSAFE2, proper flag in 0x67 packet

### DIFF
--- a/src/map/packets/c2s/0x029_item_move.cpp
+++ b/src/map/packets/c2s/0x029_item_move.cpp
@@ -29,6 +29,17 @@
 
 namespace
 {
+    const std::set wardrobeContainers = {
+        LOC_WARDROBE,
+        LOC_WARDROBE2,
+        LOC_WARDROBE3,
+        LOC_WARDROBE4,
+        LOC_WARDROBE5,
+        LOC_WARDROBE6,
+        LOC_WARDROBE7,
+        LOC_WARDROBE8,
+    };
+
     // List of containers valid for character current status
     // Note: When sharing Mog House, client restricts menu but retail honors injected packets.
     //       However, you do not get access to your own Safe, Locker or Storage.
@@ -120,7 +131,7 @@ namespace
         }
 
         // Only equipment and weapons can be moved to the wardrobe.
-        if (to >= LOC_WARDROBE && to <= LOC_WARDROBE8)
+        if (wardrobeContainers.contains(to))
         {
             if (!PItem->isType(ITEM_EQUIPMENT) && !PItem->isType(ITEM_WEAPON))
             {

--- a/src/map/packets/char_sync.cpp
+++ b/src/map/packets/char_sync.cpp
@@ -58,9 +58,5 @@ CCharSyncPacket::CCharSyncPacket(CCharEntity* PChar)
     }
 
     ref<uint8>(0x25) = PChar->jobs.job[PChar->GetMJob()];
-
-    // Moghouse menu flags?
-    auto mhflag             = PChar->profile.mhflag;
-    bool enableChangeFloors = (mhflag & 0x04) && (mhflag & 0x02) && (mhflag & 0x01) ? 0x01 : 0x00;
-    ref<uint8>(0x27)        = enableChangeFloors;
+    ref<uint8>(0x27) = PChar->profile.mhflag & 0x20 ? 1 : 0; // MogExpansionFlag - Is 2nd floor unlocked.
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- MOGSAFE2 enum is in the middle of WARDROBE and WARDROBE2 and got caught in a range check, letting only equipment items be moved in it
- Sets the flag properly in the 0x067 S2C packet so that the client knows not to enable Mog safe 2 until MH2F unlock has been completed (cutscene obtained)

~~Draft while I verify there isn't another bug with the MH2F cutscene unlock.~~

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
