### PR TITLE
fix: Use correct item field for lockstyle

### DIFF
--- a/src/map/packets/c2s/0x053_lockstyle.cpp
+++ b/src/map/packets/c2s/0x053_lockstyle.cpp
@@ -81,7 +81,7 @@ void GP_CLI_COMMAND_LOCKSTYLE::process(MapSession* PSession, CCharEntity* PChar)
                 uint16_t    itemId = item.ItemNo;
 
                 // Skip non-visible items
-                if (item.ItemIndex > SLOT_FEET)
+                if (item.EquipKind > SLOT_FEET)
                 {
                     continue;
                 }
@@ -91,12 +91,12 @@ void GP_CLI_COMMAND_LOCKSTYLE::process(MapSession* PSession, CCharEntity* PChar)
                 {
                     itemId = 0;
                 }
-                else if ((PItem->getEquipSlotId() & (1 << item.ItemIndex)) == 0) // item doesn't fit in slot
+                else if ((PItem->getEquipSlotId() & (1 << item.EquipKind)) == 0) // item doesn't fit in slot
                 {
                     itemId = 0;
                 }
 
-                PChar->styleItems[item.ItemIndex] = itemId;
+                PChar->styleItems[item.EquipKind] = itemId;
             }
 
             // Check if we need to remove conflicting slots. Essentially, packet injection shenanigan detector.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Was using the wrong field from the lockstyle item structure. (Inventory slot ID instead of equipment slot)

## Steps to test these changes
- Make an equipset
- /lockstyleset 1

<!-- Clear and detailed steps to test your changes here -->
