### PR TITLE
Set idle despawn time on spawn to avoid needing to be disengaged

### DIFF
--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -643,6 +643,13 @@ void CMobEntity::Spawn()
 
     m_DespawnTimer = timer::time_point::min();
     luautils::OnMobSpawn(this);
+
+    // Set the despawn time if the mob has a non-zero idle despawn time modifier.
+    // This is used to despawn mobs that are not engaged in combat after a certain time.
+    if (getMobMod(MOBMOD_IDLE_DESPAWN) > 0)
+    {
+        SetDespawnTime(std::chrono::seconds(getMobMod(MOBMOD_IDLE_DESPAWN)));
+    }
 }
 
 void CMobEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& action)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

At the moment when we call `mob:setMobMod(xi.mobMod.IDLE_DESPAWN, time value)` it doesn't actually set the despawn time unless the mob has been disengaged. This is done in the `mobentity.cpp` file:

```
void CMobEntity::OnDisengage(CAttackState& state)
{
    ..........

    if (getMobMod(MOBMOD_IDLE_DESPAWN))
    {
        SetDespawnTime(std::chrono::seconds(getMobMod(MOBMOD_IDLE_DESPAWN)));
    }
    
    ..........
}
```

However, there are certain mobs such as Lumber Jack and Cemetery Cherry that should despawn after a certain idle time, regardless of whether they have been disengaged or have just been idle since spawning. By adding the same logic to the `Spawn` function these mobs will despawn after their idle despawn time without needing to disengage first.

## Steps to test these changes

`SpawnMob(17207302)`  to spawn Weeping Willow.

In the `scripts\zones\Batallia_Downs\mobs\Lumber_Jack.lua` fiile inside `entity.onMobInitialize` change `mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 600)` to 60 seconds. Inside `entity.onMobDespawn` change `GetMobByID(mob:getID() -6):setRespawnTime(1800)` to 60 seconds to make sure Weeping Willow spawns 60 seconds after Lumber Jack is left idle for 60 secs and despawns by itself.
