### PR TITLE
fix: Capture correct field on position updates for moving animation

### DIFF
--- a/src/map/packets/c2s/0x015_pos.cpp
+++ b/src/map/packets/c2s/0x015_pos.cpp
@@ -33,6 +33,11 @@ auto GP_CLI_COMMAND_POS::validate(MapSession* PSession, const CCharEntity* PChar
 
 void GP_CLI_COMMAND_POS::process(MapSession* PSession, CCharEntity* PChar) const
 {
+    if (PChar->pendingPositionUpdate)
+    {
+        return;
+    }
+
     const float  newX        = x;
     const float  newY        = z; // Not a typo.
     const float  newZ        = y; // Not a typo.
@@ -57,7 +62,7 @@ void GP_CLI_COMMAND_POS::process(MapSession* PSession, CCharEntity* PChar) const
         PChar->loc.p.y = newY;
         PChar->loc.p.z = newZ;
 
-        PChar->loc.p.moving   = MovTime;
+        PChar->loc.p.moving   = MoveFlame;
         PChar->loc.p.rotation = newRotation;
 
         PChar->m_TargID = newTargID;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Adds a missing conditional
- Capture MoveFlame instead of MovTime when receiving a position update from clients. 
  - This is causing the server to broadcast bad run/move animations to other PCs, making it appear as if they are rubberbanding. 
  - Re-verified the old handler was capturing this field and I was off by 4 bytes when updating this packet.

> MovTime
> Unused.
> 
> The client does not use this value.
> 
> MoveFlame
> The clients current animation time.
https://github.com/atom0s/XiPackets/blob/main/world/client/0x0015/README.md

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
