### PR TITLE
[ToAU] Audit follwup: Fix a few event parameters

### DIFF
--- a/scripts/missions/toau/21_Finders_Keepers.lua
+++ b/scripts/missions/toau/21_Finders_Keepers.lua
@@ -25,7 +25,7 @@ mission.sections =
             onTriggerAreaEnter =
             {
                 [3] = function(player, triggerArea)
-                    return mission:progressEvent(3093, 1, 1, 0, 0, 0, 0, 0, 0, 0)
+                    return mission:progressEvent(3093, 1, 1, 0, 0, 0, 0, 0, 0)
                 end,
             },
 

--- a/scripts/missions/toau/23_Social_Graces.lua
+++ b/scripts/missions/toau/23_Social_Graces.lua
@@ -24,7 +24,7 @@ mission.sections =
             onTriggerAreaEnter =
             {
                 [3] = function(player, triggerArea)
-                    return mission:progressEvent(3095, 0, 1, 0, 0, 0, 0, 0, 4, 0)
+                    return mission:progressEvent(3095, 0, 1, 0, 0, 0, 0, 0, 4)
                 end,
             },
 
@@ -32,7 +32,7 @@ mission.sections =
             {
                 [3095] = function(player, csid, option, npc)
                     if option == 1 then
-                        player:updateEvent(1, 1, 0, 0, 0, 0, 0, 0, 0)
+                        player:updateEvent(1, 1, 0, 0, 0, 0, 0, 0)
                     end
                 end,
             },

--- a/scripts/missions/toau/37_Path_of_Blood.lua
+++ b/scripts/missions/toau/37_Path_of_Blood.lua
@@ -24,7 +24,7 @@ mission.sections =
             onTriggerAreaEnter =
             {
                 [3] = function(player, triggerArea)
-                    return mission:progressEvent(3131)
+                    return mission:progressEvent(3131, 0, 1, 0, 0, 0, 0, 0)
                 end,
             },
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

As title sais. Because of how this events work, they, sometimes, require a ninth argument and sometimes they dont.

## Steps to test these changes

!exec player:startEvent(evert id, paramters) or run the missions and have the CSs play properly.
Note that this would have not prevented mission progression
