### PR TITLE
[core][lua] Allow effect subTypes greater than 0 for more effects

### DIFF
--- a/scripts/enum/effect_source_type.lua
+++ b/scripts/enum/effect_source_type.lua
@@ -6,8 +6,19 @@ xi = xi or {}
 ---@enum xi.effectSourceType
 xi.effectSourceType =
 {
-    NONE           = 0,
-    EQUIPPED_ITEM  = 1,
-    TEMPORARY_ITEM = 2,
-    MOD            = 3,
+    NONE           = 0,  -- Default or None.
+    ITEM           = 1,  -- Effect came from an item.
+    EQUIPPED_ITEM  = 2,  -- Effect came from an enchantment or similar effect from equipped items.
+    TEMPORARY_ITEM = 3,  -- Effect came from a temporary item.
+    MOB_SCRIPT     = 4,  -- Effect came from a mob's script(Mechanics, Aura, etc)
+    MOB_ATTACK     = 5,  -- Effect came from an additional effect attached to a mob's attack.
+    MOB_SKILL      = 6,  -- Effect came from a mob skill.
+    FOOD           = 7,  -- Effect came from a food item.
+    MAGIC_WHITE    = 8,  -- Effect came from a white magic spell.
+    MAGIC_BLACK    = 9,  -- Effect came from a black magic spell.
+    MAGIC_BLUE     = 10, -- Effect came from a blue magic spell.
+    MAGIC_SONG     = 11, -- Effect came from a song.
+    ABILITY        = 12, -- Effect came from an ability.
+    WEAPONSKILL    = 13, -- Effect came from a weaponskill.
+    ENVIRONMENT    = 14, -- Effect came from an enviromental source such as a trap or hazard.
 }

--- a/src/map/status_effect.h
+++ b/src/map/status_effect.h
@@ -772,10 +772,21 @@ class CBattleEntity;
 
 enum EffectSourceType : uint8_t
 {
-    SOURCE_NONE    = 0,
-    EQUIPPED_ITEM  = 1,
-    TEMPORARY_ITEM = 2,
-    MOB            = 3,
+    SOURCE_NONE           = 0,  // Default or None.
+    SOURCE_ITEM           = 1,  // Effect came from an item.
+    SOURCE_EQUIPPED_ITEM  = 2,  // Effect came from an enchantment or similar effect from equipped items.
+    SOURCE_TEMPORARY_ITEM = 3,  // Effect came from a temporary item.
+    SOURCE_MOB_SCRIPT     = 4,  // Effect came from a mob's script(Mechanics, Aura, etc)
+    SOURCE_MOB_ATTACK     = 5,  // Effect came from an additional effect attached to a mob's attack.
+    SOURCE_MOB_SKILL      = 6,  // Effect came from a mob skill.
+    SOURCE_FOOD           = 7,  // Effect came from a food item.
+    SOURCE_MAGIC_WHITE    = 8,  // Effect came from a white magic spell.
+    SOURCE_MAGIC_BLACK    = 9,  // Effect came from a black magic spell.
+    SOURCE_MAGIC_BLUE     = 10, // Effect came from a blue magic spell.
+    SOURCE_MAGIC_SONG     = 11, // Effect came from a song.
+    SOURCE_ABILITY        = 12, // Effect came from an ability.
+    SOURCE_WEAPONSKILL    = 13, // Effect came from a weaponskill.
+    SOURCE_ENVIRONMENT    = 14, // Effect came from an enviromental source such as a trap or hazard.
 };
 
 class CStatusEffect

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1515,10 +1515,10 @@ void CStatusEffectContainer::RemoveAllStatusEffectsInIDRange(EFFECT start, EFFEC
 /************************************************************************
  *                                                                       *
  *  Install the name of the effect to work with scripts                  *
- *                                                                       *
+ *  TODO: This function could use a clean up in a future PR              *
  ************************************************************************/
 
-void CStatusEffectContainer::SetEffectParams(CStatusEffect* StatusEffect)
+auto CStatusEffectContainer::SetEffectParams(CStatusEffect* StatusEffect) -> void
 {
     if (StatusEffect->GetStatusID() >= MAX_EFFECTID)
     {
@@ -1541,7 +1541,7 @@ void CStatusEffectContainer::SetEffectParams(CStatusEffect* StatusEffect)
     bool effectFromItemEnchant = false;
     if (StatusEffect->GetSourceType() != EffectSourceType::SOURCE_NONE && StatusEffect->GetSourceTypeParam() > 0)
     {
-        if (StatusEffect->GetSourceType() == EffectSourceType::EQUIPPED_ITEM)
+        if (StatusEffect->GetSourceType() == EffectSourceType::SOURCE_EQUIPPED_ITEM)
         {
             auto PItem = itemutils::GetItemPointer(StatusEffect->GetSourceTypeParam());
             if (PItem != nullptr)
@@ -1580,6 +1580,20 @@ void CStatusEffectContainer::SetEffectParams(CStatusEffect* StatusEffect)
         name.insert(0, "effects/");
         name.insert(name.size(), effects::EffectsParams[effect].Name);
     }
+
+    // Other effects that are not BRD Songs, COR Rolls, Food, or effects tied to enchantments/items.
+    else if (!effectFromItemEnchant &&
+             subType > 0 &&
+             StatusEffect->GetSourceType() != EffectSourceType::SOURCE_EQUIPPED_ITEM &&
+             StatusEffect->GetSourceType() != EffectSourceType::SOURCE_TEMPORARY_ITEM &&
+             StatusEffect->GetSourceType() != EffectSourceType::SOURCE_FOOD && // TODO: Asign EFFECT_SOURCE_FOOD to food item scripts.
+             effect != EFFECT_FOOD)                                            // Catch all food effects for now.
+    {
+        name.insert(0, "effects/");
+        name.insert(name.size(), effects::EffectsParams[effect].Name);
+    }
+
+    // This seems to be used for food items currently.
     else
     {
         CItem* Ptem = itemutils::GetItemPointer(subType);

--- a/src/map/status_effect_container.h
+++ b/src/map/status_effect_container.h
@@ -143,7 +143,7 @@ private:
     // void ReplaceStatusEffect(EFFECT effect); //this needs to be implemented
     void RemoveStatusEffect(CStatusEffect* PEffect, EffectNotice notice = EffectNotice::ShowMessage); // We remove the effect by its number in the container
     void DeleteStatusEffects();
-    void SetEffectParams(CStatusEffect* StatusEffect); // We set the effect of the effect
+    auto SetEffectParams(CStatusEffect* StatusEffect) -> void; // We set the effect of the effect
     void HandleAura(CStatusEffect* PStatusEffect);
 
     void OverwriteStatusEffect(CStatusEffect* StatusEffect);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Resolves Issue: https://github.com/LandSandBoat/server/issues/7784

Allows subTypes greater than 0 to be set for effects that are not BRD Songs/COR Rolls/etc.

Previously, if an effect had a subType greater than 0, it would not meet the conditional and would default to the final else statement.

This caused the server to look for name in scripts/items(Currently used for food effects) instead of scripts/effects.
BRD Songs/COR Rolls/Battlefield status, and Daze effects were not affected since they had exceptions already.

Since this was pathing different than user expectations, the effect's onEffectGain/onEffectTick/onEffectLoss were not "Functioning".

With this PR, a new conditional is added to catch cases where the effect is not a food or an active item enchantment(Basically all your common effects) so that subType can be used in effect lua scripts.

Corrected a misspelled enum in effect_source_type.lua (MOD > MOB to match the enum in core)

I also added some more Enums we can use in the future to further differentiate different effect source types. Example:  Telling the difference between a Bind effect from spells vs Bind Effect from abilities/weaponskills for the purposes of immunity.

Added a TODO note to function. I will come back to this soon to assign enums lua side and organize SetEffectParams better.

## Steps to test these changes

Nothing should change other than subTypes functioning for effect lua.

Set subType of a common effect(Example, Poison or Defense Boost) to something greater than 1. See effect script still works.

Cast BRD Spell or use a COR Roll and see that they still work.

Eat Food and see that you gain the correct effects.
