### PR TITLE
[core] Add more entity directional Lua bindings

### DIFF
--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -144,12 +144,16 @@ uint8 relativeAngle(uint8 world, int16 diff)
 
 int16 angleDifference(uint8 worldAngleA, uint8 worldAngleB)
 {
-    int16 degreeDiff   = worldAngleA - worldAngleB;
-    uint8 absoluteDiff = abs(degreeDiff);
-    if (absoluteDiff > 128)
+    int16 degreeDiff = worldAngleA - worldAngleB;
+    if (degreeDiff > 128)
     {
-        degreeDiff = 256 - absoluteDiff;
+        degreeDiff -= 256;
     }
+    else if (degreeDiff < -128)
+    {
+        degreeDiff += 256;
+    }
+
     return degreeDiff;
 }
 
@@ -183,6 +187,20 @@ bool beside(const position_t& A, const position_t& B, uint8 coneAngle)
     uint8 facingDiff = abs(facingAngle(B, A));
     uint8 halfAngle  = static_cast<uint8>(coneAngle / 2);
     return (facingDiff > 64 - halfAngle) && (facingDiff < 64 + halfAngle);
+}
+
+auto toEntitysLeft(const position_t& A, const position_t& B, uint8 coneAngle) -> bool
+{
+    int16 diff      = facingAngle(B, A);
+    uint8 halfAngle = static_cast<uint8>(coneAngle / 2);
+    return (diff < 0) && (abs(diff) > (64 - halfAngle)) && (abs(diff) < (64 + halfAngle));
+}
+
+auto toEntitysRight(const position_t& A, const position_t& B, uint8 coneAngle) -> bool
+{
+    int16 diff      = facingAngle(B, A);
+    uint8 halfAngle = static_cast<uint8>(coneAngle / 2);
+    return (diff > 0) && (abs(diff) > (64 - halfAngle)) && (abs(diff) < (64 + halfAngle));
 }
 
 /**

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -117,15 +117,17 @@ int32      intpow32(int32 base, int32 exponent); // Exponential power of integer
 void       getMSB(uint32* result, uint32 value); // fast Most Significant Byte search under GCC or MSVC. Fallback included.
 float      rotationToRadian(uint8 rotation);
 uint8      radianToRotation(float radian);
-uint8      worldAngle(const position_t& A, const position_t& B);               // А - the main entity, B - target entity (vector projection onto the X-axis)
-uint8      relativeAngle(uint8 world, int16 diff);                             // Returns a new world angle which is diff degrees in a given (signed) direction
-int16      angleDifference(uint8 worldAngleA, uint8 aworldAngleB);             // Returns difference between two world angles (0~128), sign indicates direction
-int16      facingAngle(const position_t& A, const position_t& B);              // А - the main entity, B - target entity
-bool       facing(const position_t& A, const position_t& B, uint8 coneAngle);  // true if A is facing B within coneAngle degrees
-bool       infront(const position_t& A, const position_t& B, uint8 coneAngle); // true if A is infront of B within coneAngle degrees
-bool       behind(const position_t& A, const position_t& B, uint8 coneAngle);  // true if A is behind of B within coneAngle degrees
-bool       beside(const position_t& A, const position_t& B, uint8 coneAngle);  // true if A is to a side of B within coneAngle degrees
-position_t nearPosition(const position_t& A, float offset, float radian);      // Returns a position near the given position
+uint8      worldAngle(const position_t& A, const position_t& B);                              // А - the main entity, B - target entity (vector projection onto the X-axis)
+uint8      relativeAngle(uint8 world, int16 diff);                                            // Returns a new world angle which is diff degrees in a given (signed) direction
+int16      angleDifference(uint8 worldAngleA, uint8 worldAngleB);                             // Returns difference between two world angles (0~128), sign indicates direction
+int16      facingAngle(const position_t& A, const position_t& B);                             // А - the main entity, B - target entity
+bool       facing(const position_t& A, const position_t& B, uint8 coneAngle);                 // true if A is facing B within coneAngle degrees
+bool       infront(const position_t& A, const position_t& B, uint8 coneAngle);                // true if A is infront of B within coneAngle degrees
+bool       behind(const position_t& A, const position_t& B, uint8 coneAngle);                 // true if A is behind of B within coneAngle degrees
+bool       beside(const position_t& A, const position_t& B, uint8 coneAngle);                 // true if A is to a side of B within coneAngle degrees
+auto       toEntitysLeft(const position_t& A, const position_t& B, uint8 coneAngle) -> bool;  // true if A is to the left side of B within coneAngle degrees (from perspective of B)
+auto       toEntitysRight(const position_t& A, const position_t& B, uint8 coneAngle) -> bool; // true if A is to the right side of B within coneAngle degrees (from perspective of B)
+position_t nearPosition(const position_t& A, float offset, float radian);                     // Returns a position near the given position
 
 int32 hasBit(uint16 value, const uint8* BitArray, uint32 size); // Check for the presence of a bit in the array
 int32 addBit(uint16 value, uint8* BitArray, uint32 size);       // Adds a bit to the array

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -2734,6 +2734,34 @@ bool CLuaBaseEntity::isBeside(CLuaBaseEntity const* target, sol::object const& a
 }
 
 /************************************************************************
+ *  Function: isToEntitysLeft()
+ *  Purpose : Returns true if an entityA is to the left side of entityB (From EntityB's perspective)
+ *  Example : if attacker:isToEntitysLeft(target) then
+ *  Notes   : Can specify angle for wider/narrower ranges
+ ************************************************************************/
+
+auto CLuaBaseEntity::isToEntitysLeft(CLuaBaseEntity const* target, sol::object const& angleArg) -> bool
+{
+    uint8 angle = (angleArg != sol::lua_nil) ? angleArg.as<uint8>() : 64;
+
+    return toEntitysLeft(m_PBaseEntity->loc.p, target->GetBaseEntity()->loc.p, angle);
+}
+
+/************************************************************************
+ *  Function: isToEntitysRight()
+ *  Purpose : Returns true if an entityA is to the right side of entityB (From EntityB's perspective)
+ *  Example : if entityA:isToEntitysRight(EntityB) then
+ *  Notes   : Can specify angle for wider/narrower ranges
+ ************************************************************************/
+
+auto CLuaBaseEntity::isToEntitysRight(CLuaBaseEntity const* target, sol::object const& angleArg) -> bool
+{
+    uint8 angle = (angleArg != sol::lua_nil) ? angleArg.as<uint8>() : 64;
+
+    return toEntitysRight(m_PBaseEntity->loc.p, target->GetBaseEntity()->loc.p, angle);
+}
+
+/************************************************************************
  *  Function: getZone(isZoning)
  *  Purpose : Returns a pointer to a zone object?
  *  Example : if player:getZone() == mob:getZone() then
@@ -19252,6 +19280,8 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("isInfront", CLuaBaseEntity::isInfront);
     SOL_REGISTER("isBehind", CLuaBaseEntity::isBehind);
     SOL_REGISTER("isBeside", CLuaBaseEntity::isBeside);
+    SOL_REGISTER("isToEntitysLeft", CLuaBaseEntity::isToEntitysLeft);
+    SOL_REGISTER("isToEntitysRight", CLuaBaseEntity::isToEntitysRight);
 
     SOL_REGISTER("getZone", CLuaBaseEntity::getZone);
     SOL_REGISTER("getZoneID", CLuaBaseEntity::getZoneID);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -175,12 +175,14 @@ public:
     void sendEmote(CLuaBaseEntity* target, uint8 emID, uint8 emMode);
 
     // Location and Positioning
-    int16 getWorldAngle(sol::variadic_args va);                                 // return angle (rot) between two points (vector from a to b), aligned to absolute cardinal degree
-    int16 getFacingAngle(CLuaBaseEntity const* target);                         // return angle between entity rot and target pos, aligned to number of degrees of difference
-    bool  isFacing(CLuaBaseEntity const* target, sol::object const& angleArg);  // true if you are facing the target
-    bool  isInfront(CLuaBaseEntity const* target, sol::object const& angleArg); // true if you're infront of the input target
-    bool  isBehind(CLuaBaseEntity const* target, sol::object const& angleArg);  // true if you're behind the input target
-    bool  isBeside(CLuaBaseEntity const* target, sol::object const& angleArg);  // true if you're to the side of the input target
+    int16 getWorldAngle(sol::variadic_args va);                                                // return angle (rot) between two points (vector from a to b), aligned to absolute cardinal degree
+    int16 getFacingAngle(CLuaBaseEntity const* target);                                        // return angle between entity rot and target pos, aligned to number of degrees of difference
+    bool  isFacing(CLuaBaseEntity const* target, sol::object const& angleArg);                 // true if you are facing the target
+    bool  isInfront(CLuaBaseEntity const* target, sol::object const& angleArg);                // true if you're infront of the input target
+    bool  isBehind(CLuaBaseEntity const* target, sol::object const& angleArg);                 // true if you're behind the input target
+    bool  isBeside(CLuaBaseEntity const* target, sol::object const& angleArg);                 // true if you're to the side of the input target
+    auto  isToEntitysLeft(CLuaBaseEntity const* target, sol::object const& angleArg) -> bool;  // true if you're to the left side of the input target (from target's perspective)
+    auto  isToEntitysRight(CLuaBaseEntity const* target, sol::object const& angleArg) -> bool; // true if you're to the right side of the input target (from target's perspective)
 
     auto   getZone(sol::object const& arg0) -> CZone*;
     uint16 getZoneID();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds two new Lua bindings to detect position on an entity(EntityA) in relation to another(EntityB) depending on if they are on the left or the right side of entityB.


`isToEntitysLeft()`

`isToEntitysRight()`

Use Case: Some mobskills exist that trigger specifically from only the left or only right side of a mob.

## Steps to test these changes
1. Add this to a mob script before server start. 64 on the 256 rotational scale. = 90 Degree angle

```
entity.onMobFight = function(mob, target)
    print('isFront', target:isInfront(mob, 64))
    print('isBeside', target:isBeside(mob, 64))
    print('isBehind', target:isBehind(mob, 64))
    print('isToEntitysLeft', target:isToEntitysLeft(mob, 64))
    print('isToEntitysRight', target:isToEntitysRight(mob, 64))
end
```

2. Aggro the mob, Use !stun on it, then proceed to move around the mob while checking map log. See that each print returns true when you are on the corresponding side for each binding.
