### PR TITLE
Implement Bst JAs: Spur and Run WIld

### DIFF
--- a/scripts/actions/abilities/run_wild.lua
+++ b/scripts/actions/abilities/run_wild.lua
@@ -1,0 +1,21 @@
+-----------------------------------
+-- Ability: Run Wild
+-- Your familiar will gain heightened powers, but will disappear when the effect expires.
+-- Obtained: Beastmaster Level 93
+-- Recast Time: 15 Minutes
+-- Duration: 5:00
+-- Notes: despawns your pet when the effect wears
+-----------------------------------
+---@type TAbility
+local abilityObject = {}
+
+abilityObject.onAbilityCheck = function(player, target, ability)
+    -- same requirements as snarl: pet exists and is attacking a target
+    return xi.job_utils.beastmaster.onAbilityCheckSnarl(player, target, ability)
+end
+
+abilityObject.onUseAbility = function(player, target, ability, action)
+    return xi.job_utils.beastmaster.onUseAbilityRunWild(player, target, ability, action)
+end
+
+return abilityObject

--- a/scripts/actions/abilities/spur.lua
+++ b/scripts/actions/abilities/spur.lua
@@ -1,0 +1,20 @@
+-----------------------------------
+-- Ability: Spur
+-- Grants "Store TP" effect to pets.
+-- Obtained: Beastmaster Level 83
+-- Recast Time: 3 Minutes
+-- Duration: 1:30
+-----------------------------------
+---@type TAbility
+local abilityObject = {}
+
+abilityObject.onAbilityCheck = function(player, target, ability)
+    -- same requirements as snarl: pet exists and is attacking a target
+    return xi.job_utils.beastmaster.onAbilityCheckSnarl(player, target, ability)
+end
+
+abilityObject.onUseAbility = function(player, target, ability, action)
+    return xi.job_utils.beastmaster.onUseAbilitySpur(player)
+end
+
+return abilityObject

--- a/scripts/effects/spur.lua
+++ b/scripts/effects/spur.lua
@@ -5,6 +5,8 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
+    effect:addMod(xi.mod.STORETP, effect:getPower())
+    effect:addMod(xi.mod.ATT, effect:getSubPower())
 end
 
 effectObject.onEffectTick = function(target, effect)

--- a/scripts/enum/mod.lua
+++ b/scripts/enum/mod.lua
@@ -524,6 +524,7 @@ xi.mod =
     TANDEM_STRIKE_POWER             = 271,  -- Grants a bonus to your and your pet's accuracy and magic accuracy when you and your pet are attacking the same target.
     TANDEM_BLOW_POWER               = 272,  -- Reduces amount of TP gained by enemies when striking them if you and your pet are attacking the same target.
     ENHANCES_MONSTER_CORRELATION    = 1155, -- Grants acc +X and attp +X% against a weaker opposing ecosystem. Typically applied to pet, not owner (item_mods_pet.sql)
+    ENHANCES_SPUR                   = 1157, -- Increases Store TP bonus by the mod amount when using job ability Spur
 
     -- Samurai
     SENGIKORI_SC_DMG_DEBUFF         = 1088, -- % Increase to closing skillchain damage. Applied to defender.

--- a/scripts/globals/job_utils/beastmaster.lua
+++ b/scripts/globals/job_utils/beastmaster.lua
@@ -675,3 +675,12 @@ xi.job_utils.beastmaster.attemptCharm = function(charmer, target)
 
     return xi.msg.basic.CHARM_FAIL
 end
+
+xi.job_utils.beastmaster.onUseAbilitySpur = function(player)
+    local power = 20 + player:getMod(xi.mod.ENHANCES_SPUR)-- bonus STORETP
+    local subpower = player:getJobPointLevel(xi.jp.SPUR_EFFECT) * 3 -- bonus attack
+    local pet = player:getPet()
+    if pet then
+        pet:addStatusEffect(xi.effect.SPUR, power, 0, 90, 0, subpower)
+    end
+end

--- a/scripts/globals/job_utils/beastmaster.lua
+++ b/scripts/globals/job_utils/beastmaster.lua
@@ -684,3 +684,29 @@ xi.job_utils.beastmaster.onUseAbilitySpur = function(player)
         pet:addStatusEffect(xi.effect.SPUR, power, 0, 90, 0, subpower)
     end
 end
+
+xi.job_utils.beastmaster.onUseAbilityRunWild = function(player, target, ability, action)
+    -- all but regen are a 25% bonus
+    local power = 25
+    local pet = player:getPet()
+    if pet then
+        -- mods aren't tied to an effect, just applied to the pet. They leave when the pet dies or despawns
+        pet:addMod(xi.mod.ATTP, power)
+        pet:addMod(xi.mod.ACC, pet:getACC() * power / 100)
+        -- Yep, it's an MAB % addition
+        -- "If you have no sources of Magic Attack Bonus while using the slug pet, then Run Wild actually makes his innate MAB penalty even more negative, thus reducing damage."
+        pet:addMod(xi.mod.MATT, pet:getMod(xi.mod.MATT) * power / 100)
+        pet:addMod(xi.mod.EVA, pet:getEVA() * power / 100)
+        pet:addMod(xi.mod.DEFP, power)
+        -- TODO find out this potency, but appears to be consistently 1% per tick with hare familiar at lvl 99
+        pet:addMod(xi.mod.REGEN, 0.01 * pet:getMaxHP())
+
+        -- After 5 minutes, the pet just despawns
+        pet:setJugRemainingTime(300)
+    end
+
+    -- seems to display nothing in console, but this it the msg id from capture
+    ability:setMsg(154)
+
+    return ability:getID()
+end

--- a/sql/abilities.sql
+++ b/sql/abilities.sql
@@ -294,8 +294,8 @@ INSERT INTO `abilities` VALUES (277,'sepulcher',7,87,4,300,41,100,0,253,2000,0,6
 INSERT INTO `abilities` VALUES (278,'palisade',7,95,1,300,42,100,0,253,2000,0,6,20.0,0,900,1800,0,0,NULL);
 INSERT INTO `abilities` VALUES (279,'arcane_crest',8,87,4,300,43,100,0,250,2000,0,6,20.0,0,1,80,0,0,NULL); -- needs animation
 INSERT INTO `abilities` VALUES (280,'scarlet_delirium',8,95,1,90,44,100,0,250,2000,0,6,20.0,0,1,80,0,0,NULL);
--- INSERT INTO `abilities` VALUES (281,'spur',9,83,1,180,45,100,0,255,2000,0,6,20.0,0,0,0,0,0,NULL);
--- INSERT INTO `abilities` VALUES (282,'run_wild',9,93,1,900,46,100,0,255,2000,0,6,20.0,0,0,0,0,0,NULL); -- needs animation
+INSERT INTO `abilities` VALUES (281,'spur',9,83,1,180,45,100,0,255,2000,0,6,20.0,0,0,0,0,0,NULL);
+INSERT INTO `abilities` VALUES (282,'run_wild',9,93,1,900,46,100,0,247,2000,0,6,20.0,0,0,0,0,0,NULL);
 INSERT INTO `abilities` VALUES (283,'tenuto',10,83,1,5,47,0,0,257,2000,0,6,20.0,0,0,0,0,0,'ABYSSEA');
 INSERT INTO `abilities` VALUES (284,'marcato',10,95,1,600,48,0,0,251,2000,0,6,20.0,0,0,0,0,0,'ABYSSEA');
 INSERT INTO `abilities` VALUES (285,'bounty_shot',11,87,4,60,51,100,0,189,2000,0,3,21.0,0,0,0,0,0,NULL);
@@ -335,7 +335,7 @@ INSERT INTO `abilities` VALUES (327,'stymie',5,96,1,3600,254,100,0,275,2000,0,6,
 INSERT INTO `abilities` VALUES (328,'larceny',6,96,4,3600,254,453,0,181,2000,0,3,4.0,0,0,0,0,0,NULL);
 INSERT INTO `abilities` VALUES (329,'intervene',7,96,4,3600,254,110,0,120,2000,0,3,4.0,0,0,340,0,0,NULL);
 INSERT INTO `abilities` VALUES (330,'soul_enslavement',8,96,1,3600,254,100,0,278,2000,0,6,0.0,0,0,0,0,0,NULL);
-INSERT INTO `abilities` VALUES (331,'unleash',9,96,1,3600,254,100,0,279,2000,0,6,0.0,0,0,0,0,0,NULL); -- check animation
+INSERT INTO `abilities` VALUES (331,'unleash',9,96,1,3600,254,100,0,279,2000,0,6,0.0,0,0,0,0,0,NULL);
 INSERT INTO `abilities` VALUES (332,'clarion_call',10,96,1,3600,254,100,0,280,2000,0,6,0.0,0,0,0,0,0,NULL); -- check animation
 INSERT INTO `abilities` VALUES (333,'overkill',11,96,1,3600,254,100,0,281,2000,0,6,0.0,0,0,0,0,0,NULL);
 INSERT INTO `abilities` VALUES (334,'yaegasumi',12,96,1,3600,254,100,0,282,2000,0,6,0.0,0,0,0,0,0,NULL); -- check animation

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -5329,11 +5329,12 @@ INSERT INTO `item_mods` VALUES (11151,30,8);   -- MACC: 8
 INSERT INTO `item_mods` VALUES (11151,902,25); -- OCCULT_ACUMEN: 25
 
 -- Ferine Ocreae +2
-INSERT INTO `item_mods` VALUES (11152,1,25);  -- DEF: 25
-INSERT INTO `item_mods` VALUES (11152,8,7);   -- STR: 7
-INSERT INTO `item_mods` VALUES (11152,9,7);   -- DEX: 7
-INSERT INTO `item_mods` VALUES (11152,25,8);  -- ACC: 8
-INSERT INTO `item_mods` VALUES (11152,288,3); -- DOUBLE_ATTACK: 3
+INSERT INTO `item_mods` VALUES (11152,1,25);    -- DEF: 25
+INSERT INTO `item_mods` VALUES (11152,8,7);     -- STR: 7
+INSERT INTO `item_mods` VALUES (11152,9,7);     -- DEX: 7
+INSERT INTO `item_mods` VALUES (11152,25,8);    -- ACC: 8
+INSERT INTO `item_mods` VALUES (11152,288,3);   -- DOUBLE_ATTACK: 3
+INSERT INTO `item_mods` VALUES (11152,1157,10); -- ENHANCES_SPUR: 10
 
 -- Aoidos Cothurnes +2
 INSERT INTO `item_mods` VALUES (11153,1,18);   -- DEF: 18
@@ -6021,11 +6022,12 @@ INSERT INTO `item_mods` VALUES (11251,30,6);   -- MACC: 6
 INSERT INTO `item_mods` VALUES (11251,902,15); -- OCCULT_ACUMEN: 15
 
 -- Ferine Ocreae +1
-INSERT INTO `item_mods` VALUES (11252,1,23);  -- DEF: 23
-INSERT INTO `item_mods` VALUES (11252,8,5);   -- STR: 5
-INSERT INTO `item_mods` VALUES (11252,9,5);   -- DEX: 5
-INSERT INTO `item_mods` VALUES (11252,25,5);  -- ACC: 5
-INSERT INTO `item_mods` VALUES (11252,288,2); -- DOUBLE_ATTACK: 2
+INSERT INTO `item_mods` VALUES (11252,1,23);   -- DEF: 23
+INSERT INTO `item_mods` VALUES (11252,8,5);    -- STR: 5
+INSERT INTO `item_mods` VALUES (11252,9,5);    -- DEX: 5
+INSERT INTO `item_mods` VALUES (11252,25,5);   -- ACC: 5
+INSERT INTO `item_mods` VALUES (11252,288,2);  -- DOUBLE_ATTACK: 2
+INSERT INTO `item_mods` VALUES (11252,1157,5); -- ENHANCES_SPUR: 5
 
 -- Aoidos Cothurnes +1
 INSERT INTO `item_mods` VALUES (11253,1,16);   -- DEF: 16
@@ -53567,8 +53569,8 @@ INSERT INTO `item_mods` VALUES (23361,31,120);  -- MEVA: 120
 INSERT INTO `item_mods` VALUES (23361,68,95);   -- EVA:  95
 INSERT INTO `item_mods` VALUES (23361,288,5);   -- DOUBLE_ATTACK: 5
 INSERT INTO `item_mods` VALUES (23361,384,300); -- HASTE_GEAR: 3%
+INSERT INTO `item_mods` VALUES (23361,1157,18); -- ENHANCES_SPUR: 18
 -- TODO: Physical damage limit +7%
--- TODO: "Spur"+18
 
 -- Fili Cothurnes +2
 INSERT INTO `item_mods` VALUES (23362,1,86);    -- DEF: 86
@@ -72361,6 +72363,7 @@ INSERT INTO `item_mods` VALUES (27427,31,54);   -- MEVA: 54
 INSERT INTO `item_mods` VALUES (27427,68,25);   -- EVA: 25
 INSERT INTO `item_mods` VALUES (27427,288,3);   -- DOUBLE_ATTACK: 3
 INSERT INTO `item_mods` VALUES (27427,384,300); -- HASTE_GEAR: 300
+INSERT INTO `item_mods` VALUES (27427,1157,12); -- ENHANCES_SPUR: 12
 
 -- Nukumi Ocreae +1
 INSERT INTO `item_mods` VALUES (27428,1,71);    -- DEF: 71
@@ -72376,6 +72379,7 @@ INSERT INTO `item_mods` VALUES (27428,31,80);   -- MEVA: 80
 INSERT INTO `item_mods` VALUES (27428,68,55);   -- EVA: 55
 INSERT INTO `item_mods` VALUES (27428,288,4);   -- DOUBLE_ATTACK: 4
 INSERT INTO `item_mods` VALUES (27428,384,300); -- HASTE_GEAR: 300
+INSERT INTO `item_mods` VALUES (27428,1157,15); -- ENHANCES_SPUR: 15
 
 -- Fili Cothurnes
 INSERT INTO `item_mods` VALUES (27429,1,46);    -- DEF: 46

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -15654,6 +15654,27 @@ void CLuaBaseEntity::despawnPet()
 }
 
 /************************************************************************
+ *  Function: setJugRemainingTime()
+ *  Purpose : Sets remaining jug pet duration
+ *  Example : pet:setJugRemainingTime(300)
+ ************************************************************************/
+
+void CLuaBaseEntity::setJugRemainingTime(uint32 remainingSeconds)
+{
+    auto* PPetEntity = dynamic_cast<CPetEntity*>(m_PBaseEntity);
+
+    if (!PPetEntity || PPetEntity->getPetType() != PET_TYPE::JUG_PET)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->getName());
+        return;
+    }
+
+    auto previousJugLifetime = timer::now() - PPetEntity->getJugSpawnTime();
+
+    PPetEntity->setJugDuration(previousJugLifetime + std::chrono::seconds(remainingSeconds));
+}
+
+/************************************************************************
  *  Function: hasValidJugPetItem()
  *  Purpose : Returns true if subSkill Type is of sufficient value
  *  Example : if player:hasValidJugPetItem() then
@@ -19798,6 +19819,7 @@ void CLuaBaseEntity::Register()
     // Pets and Automations
     SOL_REGISTER("spawnPet", CLuaBaseEntity::spawnPet);
     SOL_REGISTER("despawnPet", CLuaBaseEntity::despawnPet);
+    SOL_REGISTER("setJugRemainingTime", CLuaBaseEntity::setJugRemainingTime);
 
     SOL_REGISTER("hasValidJugPetItem", CLuaBaseEntity::hasValidJugPetItem);
 

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -763,6 +763,7 @@ public:
     // Pets and Automations
     void spawnPet(sol::object const& arg0);
     void despawnPet();
+    void setJugRemainingTime(uint32 remainingSeconds);
 
     auto   spawnTrust(uint16 trustId) -> CBaseEntity*;
     void   clearTrusts();

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -527,6 +527,7 @@ enum class Mod
     TANDEM_STRIKE_POWER          = 271,  // Grants a bonus to your and your pet's accuracy and magic accuracy when you and your pet are attacking the same target.
     TANDEM_BLOW_POWER            = 272,  // Reduces amount of TP gained by enemies when striking them if you and your pet are attacking the same target.
     ENHANCES_MONSTER_CORRELATION = 1155, // Grants your pet acc +X and attp +X% against a weaker opposing ecosystem. Typically applied to pet, not owner (item_mods_pet.sql)
+    ENHANCES_SPUR                = 1157, // Increases Store TP bonus by the mod amount when using job ability Spur
 
     // Bard
     MINNE_EFFECT           = 433,  //
@@ -1101,7 +1102,7 @@ enum class Mod
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     // 570 through 825 used by WS DMG mods these are not spares.
     //
-    // SPARE IDs: 1157 and onward
+    // SPARE IDs: 1158 and onward
 };
 
 // temporary workaround for using enum class as unordered_map key until compilers support it


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Came across these abilities in the captures I'm parsing to convert jug pet ready skills. Figured I'd code them as they're pretty simple, were just missing specific behavior/animations

Added a new binding to set the pet's total duration to how long it's been out + a number of seconds. The core logic determines when a jug pet disappears, this piggybacks off that.

Also note that if the player zones/logs this persists

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

- Use a jug pet
- use spur
- see it reports pet cannot use that
- tell pet to fight a mob
- use [spur](https://www.bg-wiki.com/ffxi/Spur)
- see pet has bonus store tp and effect wears off in 90s
- use [Run Wild](https://www.bg-wiki.com/ffxi/Run_Wild)
- see pet has ridic bonus status
  - +25% bonus to Pet: Attack, Accuracy, Magic Attack Bonus, Evasion, and Defense bonus and adds a Regen effect, but the pet disappears after 5 minutes
