### PR TITLE
[cpp] Add pre-spawn hook to delay spawn

### DIFF
--- a/scripts/specs/types/MobEntity.lua
+++ b/scripts/specs/types/MobEntity.lua
@@ -20,6 +20,7 @@
 ---@field onMobFight? fun(mob: CBaseEntity, target: CBaseEntity)
 ---@field onCriticalHit? fun(mob: CBaseEntity, attacker: CBaseEntity?)
 ---@field onMobDeath? fun(mob: CBaseEntity, killer: CBaseEntity?, optParams: { isKiller: boolean, noKiller: boolean, isWeaponSkillKill: boolean, weaponskillUsed: xi.weaponskill, weaponskillDamage: integer })
+---@field onMobSpawnCheck? fun(mob: CBaseEntity): integer
 ---@field onMobSpawn? fun(mob: CBaseEntity)
 ---@field onMobRoamAction? fun(mob: CBaseEntity)
 ---@field onMobRoam? fun(mob: CBaseEntity)

--- a/scripts/zones/Grauberg_[S]/mobs/Vasiliceratops.lua
+++ b/scripts/zones/Grauberg_[S]/mobs/Vasiliceratops.lua
@@ -11,8 +11,7 @@ local entity = {}
 entity.phList =
 {
     [ID.mob.VASILICERATOPS - 3] = ID.mob.VASILICERATOPS,
-    -- [ID.mob.VASILICERATOPS - 67] = ID.mob.VASILICERATOPS,
-    -- TODO: Add shared spawning for the PH. Only one PH is alive at a time. Spawns in either spot.
+    [ID.mob.VASILICERATOPS - 67] = ID.mob.VASILICERATOPS,
 }
 
 entity.onMobInitialize = function(mob)

--- a/scripts/zones/Grauberg_[S]/mobs/Wivre.lua
+++ b/scripts/zones/Grauberg_[S]/mobs/Wivre.lua
@@ -2,17 +2,81 @@
 -- Area: Grauberg [S]
 --  Mob: Wivre
 -- Note: PH for Vasiliceratops
+--       Mutually exclusive spawning of PHs is somewhat complex but re-usable to any number of mobs in the wivreSharedSpawns table
 -----------------------------------
 local ID = zones[xi.zone.GRAUBERG_S]
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
+local wivreSharedSpawns =
+set{
+    ID.mob.VASILICERATOPS - 3,
+    ID.mob.VASILICERATOPS - 67,
+}
+
+entity.onMobInitialize = function(mob)
+    -- despawn normally if not a PH
+    if not wivreSharedSpawns[mob:getID()] then
+        return
+    end
+
+    -- instead of immediately spawning on zone init, enter respawn state and process onMobSpawnCheck to decide when to spawn
+    mob:setRespawnTime(1)
+end
+
+entity.onMobSpawnCheck = function(mob)
+    -- spawn normally if not a PH
+    if not wivreSharedSpawns[mob:getID()] then
+        return 0
+    end
+
+    -- only one of the PHs can be up at a time
+    for phId, _ in pairs(wivreSharedSpawns) do
+        local phMob = GetMobByID(phId)
+        if
+            (phMob and phMob:isSpawned()) or
+            mob:getLocalVar('blockNextSpawn') == 1
+        then
+            -- delay this mob from spawning for a full cycle
+            mob:setLocalVar('blockNextSpawn', 0)
+            return 330
+        end
+    end
+
+    return 0
+end
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
     xi.mob.phOnDespawn(mob, ID.mob.VASILICERATOPS, 10, 5400) -- 1.5 hour
+
+    -- despawn normally if not a PH
+    if not wivreSharedSpawns[mob:getID()] then
+        return
+    end
+
+    local phChoice, _ = utils.randomEntryIdx(wivreSharedSpawns)
+    for phId, _ in pairs(wivreSharedSpawns) do
+        local phMob = GetMobByID(phId)
+        if phMob then
+            -- block next spawn for all except the chosen PH
+            -- unless NM was set to spawn by this despawn, then it's a free-for-all on next spawn
+            if phChoice ~= phId and mob:getRespawnTime() ~= 0 then
+                phMob:setLocalVar('blockNextSpawn', 1)
+            else
+                phMob:setLocalVar('blockNextSpawn', 0)
+            end
+
+            -- do not undo disabled spawn when vasiliceratops is primed
+            if phMob:getRespawnTime() ~= 0 then
+                -- reset respawn timer to keep all mobs in sync
+                phMob:setRespawnTime(330)
+            end
+        end
+    end
 end
 
 return entity

--- a/src/map/ai/states/state.cpp
+++ b/src/map/ai/states/state.cpp
@@ -60,6 +60,17 @@ timer::time_point CState::GetEntryTime() const
     return m_entryTime;
 }
 
+bool CState::WasExitDelayed()
+{
+    return m_wasDelayed;
+}
+
+void CState::DelayExitTime(std::chrono::milliseconds delayMilliseconds)
+{
+    m_entryTime += delayMilliseconds;
+    m_wasDelayed = true;
+}
+
 void CState::ResetEntryTime()
 {
     m_entryTime = timer::now();

--- a/src/map/ai/states/state.h
+++ b/src/map/ai/states/state.h
@@ -80,6 +80,8 @@ protected:
     uint16            GetTargetID() const;
     void              Complete();
     timer::time_point GetEntryTime() const;
+    bool              WasExitDelayed();
+    void              DelayExitTime(std::chrono::milliseconds delayMilliseconds);
 
     std::unique_ptr<CBasicPacket> m_errorMsg;
 
@@ -89,6 +91,7 @@ protected:
 private:
     CBaseEntity*      m_PTarget{ nullptr };
     bool              m_completed{ false };
+    bool              m_wasDelayed{ false };
     timer::time_point m_entryTime{ timer::now() };
 };
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -3448,6 +3448,27 @@ namespace luautils
         }
     }
 
+    int32 OnMobSpawnCheck(CBaseEntity* PMob)
+    {
+        TracyZoneScoped;
+
+        auto onMobSpawnCheck = getEntityCachedFunction(PMob, "onMobSpawnCheck");
+        if (!onMobSpawnCheck.valid())
+        {
+            return 0;
+        }
+
+        auto result = onMobSpawnCheck(PMob);
+        if (!result.valid())
+        {
+            sol::error err = result;
+            ShowError("luautils::onMobSpawnCheck: %s", err.what());
+            return 0;
+        }
+
+        return result.get_type(0) == sol::type::number ? result.get<int32>(0) : 0;
+    }
+
     void OnMobSpawn(CBaseEntity* PMob)
     {
         TracyZoneScoped;

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -347,6 +347,7 @@ namespace luautils
     void OnMobInitialize(CBaseEntity* PMob);
     void ApplyMixins(CBaseEntity* PMob);
     void ApplyZoneMixins(CBaseEntity* PMob);
+    auto OnMobSpawnCheck(CBaseEntity* PMob) -> int32;
     void OnMobSpawn(CBaseEntity* PMob);
     void OnMobRoamAction(CBaseEntity* PMob); // triggers when event mob is ready for a custom roam action
     void OnMobRoam(CBaseEntity* PMob);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Adds a new luautils hook before `->Spawn()` is called in the `respawn` state, following the format of onMagicCastingCheck, onAbilityCheck, etc
- `return 0` is the default "everything is good to continue" state
- allows delaying the spawn of a mob based on logic in in the mob's `onMobSpawnCheck` function
  - This logic can utilize localvars on the mob since it happens before spawn
  - returning a positive integer delays the spawn by X seconds

The primary reason for making this hook is to create a better claimshield that doesn't have a million and one different ways to exploit it, but I can see it being useful for other things that might need to change values about a mob before it spawns and loses its localvars.

(There's also potential for creating a spawn slot system fully within lua that checks the spawn position of other mobs nearby and spawned, but that's mostly a fever dream in my head at this point)

An example use is implemented for spawn-slot behavior of Vasiliceratops' pair of PHs (they are mutually exclusive)

Note: `onMobPreSpawn` is now a separate functionality, and is [implemented here](https://github.com/LandSandBoat/server/pull/7933) with an example for Despot

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Apologies for the impossible-to-follow original description. Here we'll test the simple use-case added to this PR
- Adjust the respawn time to 10s of the Wivres, ph cooldown to 1, set timers on spawn for the wivre and vasiliceratops
- watch the logs to see the behavior
  - <img width="667" height="482" alt="image" src="https://github.com/user-attachments/assets/90989fab-105c-461b-baa8-2f7b55cb7a63" />
