### PR TITLE
[cpp] effect mod improvements

### DIFF
--- a/scripts/globals/job_utils/rune_fencer.lua
+++ b/scripts/globals/job_utils/rune_fencer.lua
@@ -297,8 +297,7 @@ local function applyVallationValianceSDTMods(target, SDTTypes, power, effect, du
         local newEffect = target:getStatusEffect(effect)
 
         for _, SDT in ipairs(SDTTypes) do
-            target:addMod(SDT, -power)
-            newEffect:addMod(SDT, -power) -- due to order of events, this only adds mods to the container, not to the owner of the effect.
+            newEffect:addMod(SDT, -power)
         end
     end
 end
@@ -310,8 +309,7 @@ local function applyGambitSDTMods(target, SDTTypes, power, effect, duration) -- 
         local newEffect = target:getStatusEffect(effect)
 
         for _, SDT in ipairs(SDTTypes) do
-            target:addMod(SDT, -power)
-            newEffect:addMod(SDT, -power) -- due to order of events, this only adds mods to the container, not to the owner of the effect.
+            newEffect:addMod(SDT, -power)
         end
     end
 end
@@ -782,8 +780,7 @@ xi.job_utils.rune_fencer.useRayke = function(player, target, ability, action)
             local element    = getRaykeElement(rune)
 
             raykeElements = raykeElements + bit.lshift(element, 4 * i) -- pack 4 bit damage type into 16 bit int
-            target:addMod(resRankMod, -1)
-            effect:addMod(resRankMod, -1) -- Status effect handles removing the mods
+            effect:addMod(resRankMod, -1)
 
             i = i + 1
         end

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2613,8 +2613,7 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                         auto PEffect = PTarget->StatusEffectContainer->GetStatusEffect(EFFECT_EVASION_DOWN);
 
                         // When Feint's evasion down effect is on, the target can get "debuffed" with TREASURE_HUNTER_PROC +25% * level above first on Feint
-                        PEffect->addMod(Mod::TREASURE_HUNTER_PROC, PFeintEffect->GetSubPower());      // Remove TREASURE_HUNTER_PROC debuff on effect wearing off. This isnt added to the mob directly.
-                        PTarget->addModifier(Mod::TREASURE_HUNTER_PROC, PFeintEffect->GetSubPower()); // Add TREASURE_HUNTER_PROC debuff immediately to mob
+                        PEffect->addMod(Mod::TREASURE_HUNTER_PROC, PFeintEffect->GetSubPower());
                     }
                     StatusEffectContainer->DelStatusEffect(EFFECT_FEINT);
                 }

--- a/src/map/status_effect.cpp
+++ b/src/map/status_effect.cpp
@@ -240,6 +240,13 @@ void CStatusEffect::addMod(Mod modType, int16 amount)
         }
     }
     modList.emplace_back(modType, amount);
+
+    // Since an effect's mod list is only applied to entity when adding the effect
+    // we need to add the mod to the entity manually if the effect is already applied
+    if (m_POwner)
+    {
+        m_POwner->addModifier(modType, amount);
+    }
 }
 
 void CStatusEffect::setMod(Mod modType, int16 value)
@@ -248,9 +255,23 @@ void CStatusEffect::setMod(Mod modType, int16 value)
     {
         if (i.getModID() == modType)
         {
+            // Since an effect's mod list is only applied to entity when adding the effect
+            // we need to add the mod to the entity manually if the effect is already applied
+            if (m_POwner)
+            {
+                m_POwner->addModifier(modType, value - i.getModAmount());
+            }
+
             i.setModAmount(value);
             return;
         }
     }
     modList.emplace_back(modType, value);
+
+    // Since an effect's mod list is only applied to entity when adding the effect
+    // we need to add the mod to the entity manually if the effect is already applied
+    if (m_POwner)
+    {
+        m_POwner->addModifier(modType, value);
+    }
 }

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -3835,9 +3835,6 @@ namespace battleutils
 
             Mod resistanceRankMods[] = { Mod::FIRE_RES_RANK, Mod::ICE_RES_RANK, Mod::WIND_RES_RANK, Mod::EARTH_RES_RANK, Mod::THUNDER_RES_RANK, Mod::ICE_RES_RANK, Mod::LIGHT_RES_RANK, Mod::DARK_RES_RANK };
 
-            // Reset any resistance rank mods on the defender
-            PDefender->delModifiers(&PSCEffect->modList);
-
             // Reset the effects resistance rank mods
             for (auto& resistanceRank : resistanceRankMods)
             {
@@ -3859,9 +3856,6 @@ namespace battleutils
                     Mod resistanceRankMod = GetResistanceRankModFromElement(element);
                     PSCEffect->setMod(resistanceRankMod, -1);
                 }
-
-                // Add the mods back to the player (effect cleanup will destroy the mods for us later)
-                PDefender->addModifiers(&PSCEffect->modList);
 
                 return (SUBEFFECT)GetSkillchainSubeffect(skillchain);
             }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
when an effect is created, `onEffectGain` is executed. This function handles logic on which mods to apply to the effect. After this, the mods are stacked onto the entity.

later calls to `statusEffect->addMod(` and `setMod(` are added to the effect's `modList` but not added to the entity.

This PR resolves that and cleans up all instances I can find of duplicate code that was working around the issue.
- dragoon job utils was adjusting mods on effects that were already on the player
- skillchain resistance rank mods were being adjusted without reapplying the skillbound effect

This is a smaller (and better for the addMod portion) version of what I was doing in https://github.com/LandSandBoat/server/pull/5743 . 

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Give yourself an effect, see that it has mods on it and the player gets the mods
add a mod to the effect
see that your player has that mod 
remove the effect
see all the mods are gone

<img width="662" height="412" alt="image" src="https://github.com/user-attachments/assets/58d3d4c9-7fb8-41da-9f5b-bba03c441abb" />
