### PR TITLE
[lua] "In a Stew" quest bug fix

### DIFF
--- a/scripts/quests/windurst/In_a_Stew.lua
+++ b/scripts/quests/windurst/In_a_Stew.lua
@@ -84,7 +84,7 @@ quest.sections =
                 [239] = function(player, csid, option, npc)
                     if quest:complete(player) then
                         quest:setMustZone(player)
-                        player:delKeyItem(xi.ki.RIVERNEWORT)
+                        player:delKeyItem(xi.ki.RANPI_MONPIS_SPECIAL_STEW)
                         quest:setVar(player, 'Wait', NextConquestTally())
                     end
                 end,


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Corrects the key item being deleted upon quest completion.

## Steps to test these changes

Complete quest like normal.
