### PR TITLE
Add entry.item graceful nil handling

### DIFF
--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -1251,9 +1251,13 @@ function Battlefield:handleLootRolls(battlefield, lootTable, npc)
         if lootGroup then
             local max = 0
 
-            for _, entry in pairs(lootGroup) do
+            for j, entry in pairs(lootGroup) do
                 if type(entry) == 'table' then
                     max = max + entry.weight
+
+                    if entry.item == nil then
+                        print(fmt('[ERROR] Battlefield ({}) has nil item at index {} of lootgroup with index {}', battlefield:getID(), j, i))
+                    end
                 end
             end
 
@@ -1268,7 +1272,7 @@ function Battlefield:handleLootRolls(battlefield, lootTable, npc)
                         current = current + entry.weight
 
                         if current >= roll then
-                            if entry.item == 0 then
+                            if entry.item == 0 or entry.item == nil then
                                 break
                             end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Helps devs out by giving proper messages when an item is not referenced properly in a battlefield `content.loot` table

Example loot table:
```
content.loot =
{
    {
        { item = xi.items.DEMON_HORN, weight = xi.loot.weight.NORMAL },
    },
...
}
```

Note the incorrect use of `xi.items` instead of `xi.item`

Under stock LSB this would result in the following error in the map server:
<img width="1453" height="234" alt="image" src="https://github.com/user-attachments/assets/f8c9b0d3-42c3-49eb-a5f7-2bc76abb427d" />

not impossible to trace down, but with the changes in this PR, here is what you see instead (and other loot is processed properly)

<img width="1143" height="362" alt="image" src="https://github.com/user-attachments/assets/b762eab9-4890-449b-b952-cf0b400fdd43" />

Edit: before the changes in this PR the battlefield exit logic failed early and the player was stuck in the battlefield until triggering the exit npc, also

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Go to any battlefield with an armory crate
complete it
see chest still functions properly
adjust loot to have a nil item somewhere (or make a new group with the only item being nil)
see that it still functions properly, cleanly skips the nil item, and gives a nice error in the log