### PR TITLE
[LUA] Missing Latent Enum Update

### DIFF
--- a/scripts/enum/latent.lua
+++ b/scripts/enum/latent.lua
@@ -64,4 +64,6 @@ xi.latent =
     VS_ECOSYSTEM             = 59, -- Vs. Specific Ecosystem ID (e.g. Vs. Plantoid: Accuracy+3)
     VS_FAMILY                = 60, -- Vs. Specific Family ID (e.g. Vs. Korrigan: Accuracy+3)
     VS_SUPERFAMILY           = 61, -- Vs. Specific Family ID (e.g. Vs. Mandragora: Accuracy+3)
+    MAINJOB                  = 62, -- mainjob - PARAM: JOBTYPE
+    IN_ADOULIN               = 63, -- in adoulin city zone
 }


### PR DESCRIPTION
Adds missing latent effects from latent.h header to the latent.lua enum file.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Add "Main Job" (62) and "In Adoulin" (63) latents to the enum. They are present in the .h file already but were missing from the enum. 

## Steps to test these changes

Should be no testing required. This is already in the functional header, this is just correcting missing data in the enum file.
