### PR TITLE
[BUG FIX] Effect add mod order of operations

### DIFF
--- a/scripts/effects/regen.lua
+++ b/scripts/effects/regen.lua
@@ -5,14 +5,13 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.REGEN, effect:getPower())
+    effect:addMod(xi.mod.REGEN, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.REGEN, effect:getPower())
 end
 
 return effectObject

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -502,8 +502,6 @@ bool CStatusEffectContainer::AddStatusEffect(CStatusEffect* PStatusEffect, Effec
         // remove clean up other effects
         OverwriteStatusEffect(PStatusEffect);
 
-        PStatusEffect->SetOwner(m_POwner);
-
         SetEffectParams(PStatusEffect);
 
         // remove effects with same type
@@ -517,6 +515,9 @@ bool CStatusEffectContainer::AddStatusEffect(CStatusEffect* PStatusEffect, Effec
 
         luautils::OnEffectGain(m_POwner, PStatusEffect);
         m_POwner->PAI->EventHandler.triggerListener("EFFECT_GAIN", m_POwner, PStatusEffect);
+
+        // Set owner after triggering all "effect gain" lua actions, to ensure effect:addMod() doesn't double up mod powers on the entity
+        PStatusEffect->SetOwner(m_POwner);
 
         m_POwner->addModifiers(&PStatusEffect->modList);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

[My recent PR](https://github.com/LandSandBoat/server/pull/7799) added logic that said if an effect has an owner, assume it's past the initial `onEffectGain` portion of the flow, but that assumption was incorrect and was only masked by testing multiple effects that didn't use `effect:addMod(` bindings in the `onEffectGain` function.

After that PR merged, any effect that used `effect:addMod(` in the `onEffectGain` function or `EFFECT_GAIN` listener would add the mod to the effect, which would then add the mod to the entity, then `m_POwner->addModifiers(&PStatusEffect->modList);` would run and add the mods again

when the effect wore off it would only remove the base amount:

<img width="656" height="395" alt="image" src="https://github.com/user-attachments/assets/8c8ca13b-2c9d-4911-a535-3a5d70752556" />

This change rearranges the order of operations to apply all functions that call lua functions that can add mods to the effect stack, _THEN_ set the owner of the effect

Each function that is now before the `SetOwner` call is confirmed to not rely on `PStatusEffect->GetOwner()`. they all directly reference `m_POwner`, the owner of the status effect container.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
I've included an updated effect file for regen, berserk is an example of an effect that still uses target:addMod() in the `onEffectGain`

see that mods before gaining and after losing are the same (no doubling up mods)
- `!getmod regen`
- `!addeffect regen`
- `!getmod regen`
- `!deleffect regen`
- `!getmod regen`

same for berserk
- `!getmod attp`
- `!addeffect berserk`
- `!getmod attp`
- `!deleffect berserk`
- `!getmod attp`

<img width="419" height="418" alt="image" src="https://github.com/user-attachments/assets/9af79154-c8b9-43d9-bbbe-d4ef04751d93" />
