### PR TITLE
[core] Status Effect subType cleanup, sourceType DB fields/OriginID added

### DIFF
--- a/scripts/effects/allies_roll.lua
+++ b/scripts/effects/allies_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.ALLIES_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/aria.lua
+++ b/scripts/effects/aria.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.ARIA
+-- TODO: Song: Aria of Passion. Obtained when Loughnashade is equipped.
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/aspir_daze.lua
+++ b/scripts/effects/aspir_daze.lua
@@ -1,5 +1,8 @@
 -----------------------------------
 -- xi.effect.ASPIR_DAZE
+-- Notes:
+-- Debuff applied to an entity when hit by an another entity's party that have a corresponding Samba effect active.
+-- subType for Daze effects stores the ID of the attacker. See battleutils.cpp "HandleEnspell"
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/atma.lua
+++ b/scripts/effects/atma.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.ATMA
+-- Notes: Effect subType = Atma slot.  See: scripts/globals/abyssea/atma.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/aubade.lua
+++ b/scripts/effects/aubade.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.AUBADE
+-- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/avengers_roll.lua
+++ b/scripts/effects/avengers_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.AVENGERS_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/ballad.lua
+++ b/scripts/effects/ballad.lua
@@ -2,7 +2,8 @@
 -- xi.effect.BALLAD
 -- getPower returns the TIER (e.g. 1, 2, 3, 4)
 -- DO NOT ALTER ANY OF THE EFFECT VALUES! DO NOT ALTER EFFECT POWER!
--- Todo: Find a better way of doing this. Need to account for varying modifiers + CASTER's skill (not target)
+-- TODO: Find a better way of doing this. Need to account for varying modifiers + CASTER's skill (not target)
+-- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/battlefield.lua
+++ b/scripts/effects/battlefield.lua
@@ -1,5 +1,9 @@
 -----------------------------------
 -- xi.effect.BATTLEFIELD
+-- Notes: Effect parameters:
+-- power: Stores battlefield ID.
+-- subType: stores charIDs
+-- subPower: stores battlefield area (Which "arena" within the battlefield if not an instanced zone)
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/beast_roll.lua
+++ b/scripts/effects/beast_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.BEAST_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/blitzers_roll.lua
+++ b/scripts/effects/blitzers_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.BLITZERS_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/bolters_roll.lua
+++ b/scripts/effects/bolters_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.BOLTERS_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/capriccio.lua
+++ b/scripts/effects/capriccio.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.CAPRICCIO
+-- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/carol.lua
+++ b/scripts/effects/carol.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.CAROL
+-- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/casters_roll.lua
+++ b/scripts/effects/casters_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.CASTERS_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/chaos_roll.lua
+++ b/scripts/effects/chaos_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.CHAOS_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/choral_roll.lua
+++ b/scripts/effects/choral_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.CHORAL_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/companions_roll.lua
+++ b/scripts/effects/companions_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.COMPANIONS_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/corsairs_roll.lua
+++ b/scripts/effects/corsairs_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.CORSAIRS_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/coursers_roll.lua
+++ b/scripts/effects/coursers_roll.lua
@@ -1,5 +1,7 @@
 -----------------------------------
 -- xi.effect.COURSERS_ROLL
+-- TODO: Enable modifier and define power in job_utils/corsair.lua
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/dancers_roll.lua
+++ b/scripts/effects/dancers_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.DANCERS_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/dirge.lua
+++ b/scripts/effects/dirge.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.DIRGE
+-- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/double-up_chance.lua
+++ b/scripts/effects/double-up_chance.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.DOUBLE_UP_CHANCE
+-- Notes: Effect's subType stores abilityID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/drachen_roll.lua
+++ b/scripts/effects/drachen_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.DRACHEN_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/drain_daze.lua
+++ b/scripts/effects/drain_daze.lua
@@ -1,5 +1,8 @@
 -----------------------------------
 -- xi.effect.DRAIN_DAZE
+-- Notes:
+-- Debuff applied to an entity when hit by an another entity's party that have a corresponding Samba effect active.
+-- subType for Daze effects stores the ID of the attacker. See battleutils.cpp "HandleEnspell"
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/enchantment.lua
+++ b/scripts/effects/enchantment.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.ENCHANTMENT
+-- Notes: Effect subType is used to store itemID of source item. See: CStatusEffectContainer::SetEffectParams
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/etude.lua
+++ b/scripts/effects/etude.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.ETUDE
+-- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/evokers_roll.lua
+++ b/scripts/effects/evokers_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.EVOKERS_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/fantasia.lua
+++ b/scripts/effects/fantasia.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.FANTASIA
+-- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/fighters_roll.lua
+++ b/scripts/effects/fighters_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.FIGHTERS_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/food.lua
+++ b/scripts/effects/food.lua
@@ -1,5 +1,7 @@
 -----------------------------------
 -- xi.effect.FOOD
+-- Notes: Effect subType is used to store itemID of usable food item. See: CStatusEffectContainer::SetEffectParams
+-- Effect subType of 0 allows effect to use the effect script below.
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/fugue.lua
+++ b/scripts/effects/fugue.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.FUGUE
+-- Notes: May be related to Cactuar Fugue (Currently unobtaiable BRD song)
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/gallants_roll.lua
+++ b/scripts/effects/gallants_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.GALLANTS_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/gavotte.lua
+++ b/scripts/effects/gavotte.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.GAVOTTE
+-- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/haste_daze.lua
+++ b/scripts/effects/haste_daze.lua
@@ -1,5 +1,8 @@
 -----------------------------------
 -- xi.effect.HASTE_DAZE
+-- Notes:
+-- Debuff applied to an entity when hit by an another entity's party that have a corresponding Samba effect active.
+-- subType for Daze effects stores the ID of the attacker. See battleutils.cpp "HandleEnspell"
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/healers_roll.lua
+++ b/scripts/effects/healers_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.HEALERS_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/hum.lua
+++ b/scripts/effects/hum.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.HUM
+-- Notes: Might be related to Chocobo Hum (Currently unobtainable BRD song)
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/hunters_roll.lua
+++ b/scripts/effects/hunters_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.HUNTERS_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/hymnus.lua
+++ b/scripts/effects/hymnus.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.HYMNUS
+-- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/madrigal.lua
+++ b/scripts/effects/madrigal.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.MADRIGAL
+-- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -- getPower returns the TIER (e.g. 1, 2, 3, 4)
 -----------------------------------
 ---@type TEffect

--- a/scripts/effects/maguss_roll.lua
+++ b/scripts/effects/maguss_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.MAGUSS_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/mambo.lua
+++ b/scripts/effects/mambo.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.MAMBO
+-- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/march.lua
+++ b/scripts/effects/march.lua
@@ -1,8 +1,9 @@
 -----------------------------------
 -- xi.effect.MARCH
+-- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -- getPower returns the TIER (e.g. 1, 2, 3, 4)
 -- DO NOT ALTER ANY OF THE EFFECT VALUES! DO NOT ALTER EFFECT POWER!
--- Todo: Find a better way of doing this. Need to account for varying modifiers + CASTER's skill (not target)
+-- TODO: Find a better way of doing this. Need to account for varying modifiers + CASTER's skill (not target)
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/mazurka.lua
+++ b/scripts/effects/mazurka.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.MAZURKA
+-- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/minne.lua
+++ b/scripts/effects/minne.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.MINNE
+-- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/minuet.lua
+++ b/scripts/effects/minuet.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.MINUET
+-- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/misers_roll.lua
+++ b/scripts/effects/misers_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.MISERS_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/monks_roll.lua
+++ b/scripts/effects/monks_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.MONKS_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/naturalists_roll.lua
+++ b/scripts/effects/naturalists_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.NATURALISTS_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/ninja_roll.lua
+++ b/scripts/effects/ninja_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.NINJA_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/operetta.lua
+++ b/scripts/effects/operetta.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.OPERETTA
+-- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/paeon.lua
+++ b/scripts/effects/paeon.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.PAEON
+-- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/pastoral.lua
+++ b/scripts/effects/pastoral.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.PASTORAL
+-- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/prelude.lua
+++ b/scripts/effects/prelude.lua
@@ -1,5 +1,7 @@
 -----------------------------------
 -- xi.effect.PRELUDE
+-- Notes:
+-- Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -- getPower returns the TIER (e.g. 1, 2, 3, 4)
 -----------------------------------
 ---@type TEffect

--- a/scripts/effects/puppet_roll.lua
+++ b/scripts/effects/puppet_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.PUPPET_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/rhapsody.lua
+++ b/scripts/effects/rhapsody.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.RHAPSODY
+-- TODO: Identify what this effect is used for.
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/rogues_roll.lua
+++ b/scripts/effects/rogues_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.ROGUES_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/round.lua
+++ b/scripts/effects/round.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.ROUND
+-- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/samurai_roll.lua
+++ b/scripts/effects/samurai_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.SAMURAI_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/scherzo.lua
+++ b/scripts/effects/scherzo.lua
@@ -1,6 +1,7 @@
 -----------------------------------
 -- xi.effect.SCHERZO
 -- TODO: MOD_CRITICAL_DAMAGE_REDUCTION
+-- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/scholars_roll.lua
+++ b/scripts/effects/scholars_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.SCHOLARS_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/serenade.lua
+++ b/scripts/effects/serenade.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.SERENADE
+-- Notes: May be related to Devotee Serenade (Currently unobtainable BRD Song)
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/sirvente.lua
+++ b/scripts/effects/sirvente.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.SIRVENTE
+-- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/tacticians_roll.lua
+++ b/scripts/effects/tacticians_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.TACTICIANS_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/warlocks_roll.lua
+++ b/scripts/effects/warlocks_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.WARLOCKS_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/wizards_roll.lua
+++ b/scripts/effects/wizards_roll.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- xi.effect.WIZARDS_ROLL
+-- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -13301,8 +13301,9 @@ bool CLuaBaseEntity::addStatusEffect(sol::variadic_args va)
         auto subType         = va[4].is<uint32>() ? va[4].as<uint32>() : 0;
         auto subPower        = va[5].is<uint16>() ? va[5].as<uint16>() : 0;
         auto tier            = va[6].is<uint16>() ? va[6].as<uint16>() : 0;
-        auto sourceType      = va[7].is<EffectSourceType>() ? va[7].as<EffectSourceType>() : EffectSourceType::SOURCE_NONE;
-        auto sourceTypeParam = va[8].is<uint16>() ? va[8].as<uint16>() : 0;
+        auto sourceType      = va[7].is<uint16>() ? va[7].as<uint16>() : 0;
+        auto sourceTypeParam = va[8].is<uint32>() ? va[8].as<uint32>() : 0;
+        auto originID        = va[9].is<uint32>() ? va[9].as<uint32>() : 0;
 
         CStatusEffect* PEffect = new CStatusEffect(effectID,
                                                    effectIcon,
@@ -13317,6 +13318,9 @@ bool CLuaBaseEntity::addStatusEffect(sol::variadic_args va)
         {
             PEffect->SetSource(sourceType, sourceTypeParam);
         }
+
+        // Set the originID. This is the original source of the effect(Usually an entity)
+        PEffect->SetOriginID(originID);
 
         if (PEffect->GetStatusID() == EFFECT_FOOD)
         {

--- a/src/map/lua/lua_statuseffect.cpp
+++ b/src/map/lua/lua_statuseffect.cpp
@@ -144,7 +144,7 @@ void CLuaStatusEffect::setIcon(uint16 icon)
 
 //======================================================//
 
-void CLuaStatusEffect::setSource(EffectSourceType sourceType, uint16 sourceTypeParam)
+void CLuaStatusEffect::setSource(EffectSourceType sourceType, uint32 sourceTypeParam)
 {
     m_PLuaStatusEffect->SetSource(sourceType, sourceTypeParam);
 }
@@ -162,6 +162,11 @@ void CLuaStatusEffect::setSubPower(uint16 subpower)
 void CLuaStatusEffect::setTier(uint16 tier)
 {
     m_PLuaStatusEffect->SetTier(tier);
+}
+
+auto CLuaStatusEffect::setOriginID(uint32 originid) -> void
+{
+    m_PLuaStatusEffect->SetOriginID(originid);
 }
 
 //======================================================//
@@ -231,14 +236,19 @@ uint16 CLuaStatusEffect::getIcon()
     return m_PLuaStatusEffect->GetIcon();
 }
 
-EffectSourceType CLuaStatusEffect::getSourceType()
+uint16 CLuaStatusEffect::getSourceType()
 {
     return m_PLuaStatusEffect->GetSourceType();
 }
 
-uint16 CLuaStatusEffect::getSourceTypeParam()
+uint32 CLuaStatusEffect::getSourceTypeParam()
 {
     return m_PLuaStatusEffect->GetSourceTypeParam();
+}
+
+auto CLuaStatusEffect::getOriginID() -> uint32
+{
+    return m_PLuaStatusEffect->GetOriginID();
 }
 
 //======================================================//
@@ -250,6 +260,8 @@ void CLuaStatusEffect::Register()
     SOL_REGISTER("getSubType", CLuaStatusEffect::getSubType);
     SOL_REGISTER("getSourceType", CLuaStatusEffect::getSourceType);
     SOL_REGISTER("getSourceTypeParam", CLuaStatusEffect::getSourceTypeParam);
+    SOL_REGISTER("getOriginID", CLuaStatusEffect::getOriginID);
+    SOL_REGISTER("setOriginID", CLuaStatusEffect::setOriginID);
     SOL_REGISTER("setSource", CLuaStatusEffect::setSource);
     SOL_REGISTER("setIcon", CLuaStatusEffect::setIcon);
     SOL_REGISTER("getPower", CLuaStatusEffect::getPower);

--- a/src/map/lua/lua_statuseffect.h
+++ b/src/map/lua/lua_statuseffect.h
@@ -41,23 +41,25 @@ public:
 
     friend std::ostream& operator<<(std::ostream& out, const CStatusEffect& effect);
 
-    uint32           getEffectType();
-    uint32           getSubType();
-    EffectSourceType getSourceType();
-    uint16           getSourceTypeParam();
-    uint16           getPower();
-    uint16           getSubPower();
-    uint16           getTier();
-    uint32           getDuration();
-    uint32           getStartTime();
-    uint32           getLastTick();
-    uint32           getTimeRemaining();
-    uint32           getTickCount();
-    uint32           getTick();
-    uint16           getIcon();
+    uint32 getEffectType();
+    uint32 getSubType();
+    uint16 getSourceType();
+    uint32 getSourceTypeParam();
+    auto   getOriginID() -> uint32;
+    uint16 getPower();
+    uint16 getSubPower();
+    uint16 getTier();
+    uint32 getDuration();
+    uint32 getStartTime();
+    uint32 getLastTick();
+    uint32 getTimeRemaining();
+    uint32 getTickCount();
+    uint32 getTick();
+    uint16 getIcon();
 
     void setIcon(uint16 icon);
-    void setSource(EffectSourceType sourceType, uint16 sourceTypeParam);
+    void setSource(EffectSourceType sourceType, uint32 sourceTypeParam);
+    auto setOriginID(uint32 originid) -> void;
     void setPower(uint16 power);
     void setSubPower(uint16 subpower);
     void setTier(uint16 tier);

--- a/src/map/status_effect.cpp
+++ b/src/map/status_effect.cpp
@@ -27,7 +27,7 @@
 #include "status_effect_container.h"
 #include <utility>
 
-CStatusEffect::CStatusEffect(EFFECT id, uint16 icon, uint16 power, timer::duration tick, timer::duration duration, uint32 subid, uint16 subPower, uint16 tier, uint32 flags)
+CStatusEffect::CStatusEffect(EFFECT id, uint16 icon, uint16 power, timer::duration tick, timer::duration duration, uint32 subid, uint16 subPower, uint16 tier, uint32 flags, uint16 sourceType, uint32 sourceTypeParam, uint32 originID)
 : m_StatusID(id)
 , m_SubID(subid)
 , m_Icon(icon)
@@ -35,6 +35,9 @@ CStatusEffect::CStatusEffect(EFFECT id, uint16 icon, uint16 power, timer::durati
 , m_SubPower(subPower)
 , m_Tier(tier)
 , m_Flags(flags)
+, m_OriginID(originID)
+, m_SourceType(sourceType)
+, m_SourceTypeParam(sourceTypeParam)
 , m_TickTime(tick)
 , m_Duration(duration)
 {
@@ -71,14 +74,19 @@ uint32 CStatusEffect::GetSubID() const
     return m_SubID;
 }
 
-EffectSourceType CStatusEffect::GetSourceType() const
+auto CStatusEffect::GetSourceType() const -> uint16
 {
     return m_SourceType;
 }
 
-uint16 CStatusEffect::GetSourceTypeParam() const
+auto CStatusEffect::GetSourceTypeParam() const -> uint32
 {
     return m_SourceTypeParam;
+}
+
+auto CStatusEffect::GetOriginID() const -> uint32
+{
+    return m_OriginID;
 }
 
 uint16 CStatusEffect::GetEffectType() const
@@ -172,10 +180,15 @@ void CStatusEffect::SetIcon(uint16 Icon)
     m_POwner->StatusEffectContainer->UpdateStatusIcons();
 }
 
-void CStatusEffect::SetSource(EffectSourceType sourceType, uint16 sourceTypeParam)
+auto CStatusEffect::SetSource(uint16 sourceType, uint32 sourceTypeParam) -> void
 {
     m_SourceType      = sourceType;
     m_SourceTypeParam = sourceTypeParam;
+}
+
+auto CStatusEffect::SetOriginID(uint32 originID) -> void
+{
+    m_OriginID = originID;
 }
 
 void CStatusEffect::SetEffectType(uint16 Type)

--- a/src/map/status_effect.h
+++ b/src/map/status_effect.h
@@ -781,17 +781,18 @@ enum EffectSourceType : uint8_t
 class CStatusEffect
 {
 public:
-    EFFECT           GetStatusID();
-    uint32           GetSubID() const;
-    EffectSourceType GetSourceType() const;
-    uint16           GetSourceTypeParam() const;
-    uint16           GetIcon() const;
-    uint16           GetPower() const;
-    uint16           GetSubPower() const;
-    uint16           GetTier() const;
-    uint32           GetEffectFlags() const;
-    uint16           GetEffectType() const;
-    uint8            GetEffectSlot() const;
+    EFFECT GetStatusID();
+    uint32 GetSubID() const;
+    auto   GetSourceType() const -> uint16;
+    auto   GetSourceTypeParam() const -> uint32;
+    auto   GetOriginID() const -> uint32;
+    uint16 GetIcon() const;
+    uint16 GetPower() const;
+    uint16 GetSubPower() const;
+    uint16 GetTier() const;
+    uint32 GetEffectFlags() const;
+    uint16 GetEffectType() const;
+    uint8  GetEffectSlot() const;
 
     timer::duration   GetTickTime() const;
     timer::duration   GetDuration() const;
@@ -806,13 +807,14 @@ public:
     void SetEffectType(uint16 Type);
     void SetEffectSlot(uint8 Slot);
     void SetIcon(uint16 Icon);
-    void SetSource(EffectSourceType SourceType, uint16 SourceTypeParam);
+    auto SetSource(uint16 sourceType, uint32 sourceTypeParam) -> void;
     void SetPower(uint16 Power);
     void SetSubPower(uint16 subPower);
     void SetTier(uint16 tier);
     void SetDuration(timer::duration Duration);
     void SetOwner(CBattleEntity* Owner);
     void SetTickTime(timer::duration tick);
+    auto SetOriginID(uint32 originID) -> void;
 
     void IncrementElapsedTickCount();
     void SetStartTime(timer::time_point StartTime);
@@ -827,24 +829,25 @@ public:
     std::vector<CModifier> modList; // List of modifiers
     bool                   deleted{ false };
 
-    CStatusEffect(EFFECT id, uint16 icon, uint16 power, timer::duration tick, timer::duration duration, uint32 subid = 0, uint16 subPower = 0, uint16 tier = 0, uint32 flags = 0);
+    CStatusEffect(EFFECT id, uint16 icon, uint16 power, timer::duration tick, timer::duration duration, uint32 subid = 0, uint16 subPower = 0, uint16 tier = 0, uint32 flags = 0, uint16 sourceType = EffectSourceType::SOURCE_NONE, uint32 sourceTypeParam = 0, uint32 originID = 0);
 
     ~CStatusEffect();
 
 private:
     CBattleEntity* m_POwner{ nullptr };
 
-    EFFECT           m_StatusID{ EFFECT_NONE };                     // Main effect type
-    uint32           m_SubID{ 0 };                                  // Additional effect type
-    EffectSourceType m_SourceType{ EffectSourceType::SOURCE_NONE }; // The effect's source type
-    uint16           m_SourceTypeParam{ 0 };                        // The effect's source ID
-    uint16           m_Icon{ 0 };                                   // Effect icon
-    uint16           m_Power{ 0 };                                  // Strength of effect
-    uint16           m_SubPower{ 0 };                               // Secondary power of the effect
-    uint16           m_Tier{ 0 };                                   // Tier of the effect
-    uint32           m_Flags{ 0 };                                  // Effect flags (conditions for its disappearance)
-    uint16           m_Type{ 0 };                                   // Used to enforce only one
-    uint8            m_Slot{ 0 };                                   // Used to determine slot order for songs/rolls
+    EFFECT m_StatusID{ EFFECT_NONE }; // Main effect type
+    uint32 m_SubID{ 0 };              // Additional effect type
+    uint16 m_Icon{ 0 };               // Effect icon
+    uint16 m_Power{ 0 };              // Strength of effect
+    uint16 m_SubPower{ 0 };           // Secondary power of the effect
+    uint16 m_Tier{ 0 };               // Tier of the effect
+    uint32 m_Flags{ 0 };              // Effect flags (conditions for its disappearance)
+    uint32 m_OriginID{ 0 };           // The effect's origin ID. (This is usually the ID of the entity that created the effect)
+    uint16 m_SourceType{ 0 };         // The effect's source type
+    uint32 m_SourceTypeParam{ 0 };    // The effect's source ID
+    uint16 m_Type{ 0 };               // Used to enforce only one
+    uint8  m_Slot{ 0 };               // Used to determine slot order for songs/rolls
 
     timer::duration   m_TickTime{ 0ms }; // Effect repetition time
     timer::duration   m_Duration{ 0ms }; // Duration of effect

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1609,16 +1609,19 @@ void CStatusEffectContainer::LoadStatusEffects()
     }
 
     const char* Query = "SELECT "
-                        "effectid,"
-                        "icon,"
-                        "power,"
-                        "tick,"
-                        "duration,"
-                        "subid,"
-                        "subpower,"
+                        "effectid, "
+                        "icon, "
+                        "power, "
+                        "tick, "
+                        "duration, "
+                        "subid, "
+                        "subpower, "
                         "tier, "
                         "flags, "
-                        "timestamp "
+                        "timestamp, "
+                        "sourcetype, "
+                        "sourcetypeparam, "
+                        "originid "
                         "FROM char_effects "
                         "WHERE charid = ?";
 
@@ -1664,7 +1667,10 @@ void CStatusEffectContainer::LoadStatusEffects()
                                   rset->get<uint16>("subid"),
                                   rset->get<uint16>("subpower"),
                                   rset->get<uint16>("tier"),
-                                  flags);
+                                  flags,
+                                  rset->get<uint16>("sourcetype"),
+                                  rset->get<uint32>("sourcetypeparam"),
+                                  rset->get<uint32>("originid"));
 
             PEffectList.emplace_back(PStatusEffect);
 
@@ -1724,8 +1730,8 @@ void CStatusEffectContainer::SaveStatusEffects(bool logout)
 
         if (realDurationSeconds > 0 || durationSeconds == 0)
         {
-            const char* Query = "INSERT INTO char_effects (charid, effectid, icon, power, tick, duration, subid, subpower, tier, flags, timestamp) "
-                                "VALUES(%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u)";
+            const char* Query = "INSERT INTO char_effects (charid, effectid, icon, power, tick, duration, subid, subpower, tier, flags, timestamp, sourcetype, sourcetypeparam, originid) "
+                                "VALUES(%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u)";
 
             // save power of utsusemi and blink
             if (PStatusEffect->GetStatusID() == EFFECT_COPY_IMAGE)
@@ -1767,7 +1773,7 @@ void CStatusEffectContainer::SaveStatusEffects(bool logout)
 
             _sql->Query(Query, m_POwner->id, PStatusEffect->GetStatusID(), PStatusEffect->GetIcon(), PStatusEffect->GetPower(), tick, duration,
                         PStatusEffect->GetSubID(), PStatusEffect->GetSubPower(), PStatusEffect->GetTier(), PStatusEffect->GetEffectFlags(),
-                        timestamp);
+                        timestamp, PStatusEffect->GetSourceType(), PStatusEffect->GetSourceTypeParam(), PStatusEffect->GetOriginID());
         }
     }
     DeleteStatusEffects();

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1518,7 +1518,7 @@ void CStatusEffectContainer::RemoveAllStatusEffectsInIDRange(EFFECT start, EFFEC
  *                                                                       *
  ************************************************************************/
 
-void CStatusEffectContainer::SetEffectParams(CStatusEffect* StatusEffect)
+auto CStatusEffectContainer::SetEffectParams(CStatusEffect* StatusEffect) -> void
 {
     if (StatusEffect->GetStatusID() >= MAX_EFFECTID)
     {

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1564,22 +1564,19 @@ void CStatusEffectContainer::SetEffectParams(CStatusEffect* StatusEffect)
         }
     }
 
-    // Determine if this is a BRD Song or COR Effect.
-    if (!effectFromItemEnchant &&
-        (subType == 0 ||
-         subType > 20000 ||
-         (effect >= EFFECT_REQUIEM && effect <= EFFECT_NOCTURNE) ||
-         (effect >= EFFECT_DOUBLE_UP_CHANCE && effect <= EFFECT_NATURALISTS_ROLL) ||
-         effect == EFFECT_RUNEISTS_ROLL ||
-         effect == EFFECT_DRAIN_DAZE ||
-         effect == EFFECT_ASPIR_DAZE ||
-         effect == EFFECT_HASTE_DAZE ||
-         effect == EFFECT_ATMA ||
-         effect == EFFECT_BATTLEFIELD))
+    // Effects that use /server/scripts/effects/ as their lua file source.
+    if (!effectFromItemEnchant &&                                           // The effect is not from an item enchantment (See condition above).
+        effect != EFFECT_ENCHANTMENT &&                                     // The effect is not an enchantment that has an effect source defined currently.
+        StatusEffect->GetSourceType() != EffectSourceType::EQUIPPED_ITEM && // The source is not from an equipped item
+        (effect != EFFECT_FOOD || (subType == 0 && effect == EFFECT_FOOD))) // Exclude food effects with a subType > 0 (See condition below)
     {
         name.insert(0, "effects/");
         name.insert(name.size(), effects::EffectsParams[effect].Name);
     }
+
+    // Is an effect from a usable item not caught above.
+    // Known use cases: Food effects with a subPower > 0 (Food effects from items) and enchantments without an effect source.
+    // Food effects from FoV/Gov Books have a subType of 0 and are handled in the scripts/effects/food.lua
     else
     {
         CItem* Ptem = itemutils::GetItemPointer(subType);

--- a/src/map/status_effect_container.h
+++ b/src/map/status_effect_container.h
@@ -143,7 +143,7 @@ private:
     // void ReplaceStatusEffect(EFFECT effect); //this needs to be implemented
     void RemoveStatusEffect(CStatusEffect* PEffect, EffectNotice notice = EffectNotice::ShowMessage); // We remove the effect by its number in the container
     void DeleteStatusEffects();
-    void SetEffectParams(CStatusEffect* StatusEffect); // We set the effect of the effect
+    auto SetEffectParams(CStatusEffect* StatusEffect) -> void; // We set the effect of the effect
     void HandleAura(CStatusEffect* PStatusEffect);
 
     void OverwriteStatusEffect(CStatusEffect* StatusEffect);

--- a/tools/migrations/047_char_effect_sourceeffect_originid.py
+++ b/tools/migrations/047_char_effect_sourceeffect_originid.py
@@ -1,0 +1,30 @@
+import mariadb
+
+
+def migration_name():
+    return "Adding sourcetype, sourctypeparam, originid columns to char_effects table"
+
+
+def check_preconditions(cur):
+    return
+
+
+def needs_to_run(cur):
+    # Ensure crystal columns exist in char_points
+    cur.execute("SHOW COLUMNS FROM char_effects LIKE 'sourcetype'")
+    if not cur.fetchone():
+        return True
+    return False
+
+
+def migrate(cur, db):
+    try:
+        cur.execute(
+            "ALTER TABLE char_effects \
+        ADD COLUMN `sourcetype` smallint(10) unsigned NOT NULL DEFAULT 0, \
+        ADD COLUMN `sourcetypeparam` int(10) unsigned NOT NULL DEFAULT 0, \
+        ADD COLUMN `originid` int(10) unsigned NOT NULL DEFAULT 0;"
+        )
+        db.commit()
+    except mariadb.Error as err:
+        print("Something went wrong: {}".format(err))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Resolves: https://github.com/LandSandBoat/server/issues/7784

1. Adds documentation notes to effects where subType should not be changed due to it being utilized in/by another function(Example: Song calculations for where the caster's ID stored in the subType).

2. The previous block of conditions as far as I could tell was arbitrarily restrictive. Now, any status effect can utilize the subType parameter in lua as long as its not:
 
  * An enchantment. Enchantments come from items and as such the effect looks to the usable item's script rather than the actual effect's script.
 
  * A food with a subPower > 0 is also handled the same way as above where the item's script is used instead of the effect script. Note: Food from non item sources such as FoV books use a subType of 0 which IS allowed to use the effect script.
  
  **Edit: PR Expanded**
  
  3. Adds fields in char_effects.sql for sourcetype, sourcetypeparams, originid and hooks them up to status effect so that they will be saved/loaded on zoning/logouts. Migration script has also been added for dbtool.
  
  4. Adds OriginID argument in addStatusEffect(). This will eventually store the ID of the entity responsible for the original source of the effect. This will later be used to handle effect messaging better(See Winter's posts below)
  
  5. Converts new and relevant functions/bindings to use trailing return type.
  
  6. TODO: Some lua side scripts are currently utilizing effect subType to store entity IDs or other data. Eventually, this will be migrated out to use sourceType/souceTypeParam instead freeing up subType.
  

## Steps to test these changes

No changes should be observed other than being able to utilize subType in effect scripts.

**Test effect scripts**
1. add `print('subType:', effect:getSubType())` to scripts/effects/poison.lua in onEffectGain.
2. use `!exec player:addStatusEffect(xi.effect.POISON, 10, 3, 10, 1)`
3. See that the effect script now works with a subType greater than 0(Poison ticks and the print displays in log).

**Test Enchantments**
1. Use `!getmod subtle_blow` on self. Note the value
2. `!additem kinkobo 1`
3. Equip staff, wait for timer, then use it.
4. Use `!getmod subtle_blow` on self. See that the value has increased.

**Test Foods**
1. `!additem antacid 2`
2. `!additem 4381 1` (Meat Mithkabob)
3. Eat the Mithkabob, Food effects should apply.
4. Use antacids to delete food effect, Find a FoV/GoV book.
5. Get a field support food. See that food effects apply.

**Test Sambas**
1. `!changejob DNC 75`
2. Pick a samba, then hit a mob. See that samba applied.

**Test BRD Songs**
1. Add a print to a song effect. `print('Caster ID:', effect:getSubType())`
2. Cast songs.
3. Caster ID should reflect the charID of the player that casted.

**Test Battlefields**
1. Enter a BCNM, see that mobs load and you can attack them.
2. Have a party member also join and can join the battle.

**Edit: Extended PR**

**Test New Status Effect Fields**

1. Make sure you have no effects active.
2. `!exec target:addStatusEffect(xi.effect.PROTECT, 10, 0, 3600, 0, 0, 0, 3, 5, target:getID())`
 - This gives:
`Protect, Power:10, Tick:0, Duration: 3600, subType: 0, subPower: 0, Tier: 0, sourceType: 3, sourceTypeParam: 5, originID: YourCharID`
3. Zone or logout/login. See that you still have the effect and its applying 10 DEF modifier.
4. Look at your database, go to char_effects.sql, see that the values for sourcetype, sourcetype param and originid persisted through zoning.
5. Cast a buff spell on yourself, then zone. See that effects persist correctly(Should observe no new change)


