### PR TITLE
[cpp] Fix skillup handling with sch arts active

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3247,6 +3247,82 @@ namespace charutils
         }
     }
 
+    // determines if this player has bonus for this skill based on the active sch arts
+    bool isArtsBonusActive(CCharEntity* PChar, SKILLTYPE SkillID)
+    {
+        return (SkillID >= SKILL_DIVINE_MAGIC && SkillID <= SKILL_ENFEEBLING_MAGIC &&
+                PChar->StatusEffectContainer->HasStatusEffect({ EFFECT_LIGHT_ARTS, EFFECT_ADDENDUM_WHITE })) ||
+               (SkillID >= SKILL_ENFEEBLING_MAGIC && SkillID <= SKILL_DARK_MAGIC &&
+                PChar->StatusEffectContainer->HasStatusEffect({ EFFECT_DARK_ARTS, EFFECT_ADDENDUM_BLACK }));
+    }
+
+    // calculates the bonus skill based on active sch arts
+    int16 ArtsBonusSkill(CCharEntity* PChar, SKILLTYPE SkillID)
+    {
+        int16 skillBonus = 0;
+
+        uint16 maxMainSkill = battleutils::GetMaxSkill(SkillID, PChar->GetMJob(), PChar->GetMLevel());
+        uint16 maxSubSkill  = battleutils::GetMaxSkill(SkillID, PChar->GetSJob(), PChar->GetSLevel());
+
+        uint16 artsSkill    = battleutils::GetMaxSkill(SKILL_ENHANCING_MAGIC, JOB_RDM, PChar->GetMLevel());                               // B+ skill
+        uint16 skillCapD    = battleutils::GetMaxSkill(SkillID, JOB_SCH, PChar->GetMLevel());                                             // D skill cap
+        uint16 skillCapE    = battleutils::GetMaxSkill(SKILL_DARK_MAGIC, JOB_RDM, PChar->GetMLevel());                                    // E skill cap
+        auto   currentSkill = std::clamp<uint16>((PChar->RealSkills.skill[(int32)SkillID] / 10), 0, std::max(maxMainSkill, maxSubSkill)); // working skill before bonuses
+        uint16 artsBaseline = 0;                                                                                                          // Level based baseline to which to raise skills
+        uint8  mLevel       = PChar->GetMLevel();
+        if (mLevel < 51)
+        {
+            artsBaseline = (uint16)(5 + 2.7 * (mLevel - 1));
+        }
+        else if (mLevel < 61)
+        {
+            artsBaseline = (uint16)(137 + 4.7 * (mLevel - 50));
+        }
+        else if (mLevel < 71)
+        {
+            artsBaseline = (uint16)(184 + 3.7 * (mLevel - 60));
+        }
+        else if (mLevel < 75)
+        {
+            artsBaseline = (uint16)(221 + 5.0 * (mLevel - 70));
+        }
+        else // >= 75
+        {
+            artsBaseline = skillCapD + 36;
+        }
+
+        if (currentSkill < skillCapE)
+        {
+            // If the player's skill is below the E cap
+            // give enough bonus points to raise it to the arts baseline
+            skillBonus += std::max(artsBaseline - currentSkill, 0);
+        }
+        else if (currentSkill < skillCapD)
+        {
+            // if the skill is at or above the E cap but below the D cap
+            // raise it up to the B+ skill cap minus the difference between the current skill rank and the scholar base skill cap (D)
+            // i.e. give a bonus of the difference between the B+ skill cap and the D skill cap
+            skillBonus += std::max((artsSkill - skillCapD), 0);
+        }
+        else if (currentSkill < artsSkill)
+        {
+            // If the player's skill is at or above the D cap but below the B+ cap
+            // give enough bonus points to raise it to the B+ cap
+            skillBonus += std::max(artsSkill - currentSkill, 0);
+        }
+
+        if (PChar->StatusEffectContainer->HasStatusEffect({ EFFECT_LIGHT_ARTS, EFFECT_ADDENDUM_WHITE }))
+        {
+            skillBonus += PChar->getMod(Mod::LIGHT_ARTS_SKILL);
+        }
+        else
+        {
+            skillBonus += PChar->getMod(Mod::DARK_ARTS_SKILL);
+        }
+
+        return skillBonus;
+    }
+
     /************************************************************************
      *                                                                       *
      *  Collect the work table of the character skills based on real.        *
@@ -3312,64 +3388,9 @@ namespace charutils
             int16  skillBonus   = 0;
 
             // apply arts bonuses
-            if ((i >= SKILL_DIVINE_MAGIC && i <= SKILL_ENFEEBLING_MAGIC && PChar->StatusEffectContainer->HasStatusEffect({ EFFECT_LIGHT_ARTS, EFFECT_ADDENDUM_WHITE })) ||
-                (i >= SKILL_ENFEEBLING_MAGIC && i <= SKILL_DARK_MAGIC && PChar->StatusEffectContainer->HasStatusEffect({ EFFECT_DARK_ARTS, EFFECT_ADDENDUM_BLACK })))
+            if (isArtsBonusActive(PChar, static_cast<SKILLTYPE>(i)))
             {
-                uint16 artsSkill    = battleutils::GetMaxSkill(SKILL_ENHANCING_MAGIC, JOB_RDM, PChar->GetMLevel());                  // B+ skill
-                uint16 skillCapD    = battleutils::GetMaxSkill((SKILLTYPE)i, JOB_SCH, PChar->GetMLevel());                           // D skill cap
-                uint16 skillCapE    = battleutils::GetMaxSkill(SKILL_DARK_MAGIC, JOB_RDM, PChar->GetMLevel());                       // E skill cap
-                auto   currentSkill = std::clamp<uint16>((PChar->RealSkills.skill[i] / 10), 0, std::max(maxMainSkill, maxSubSkill)); // working skill before bonuses
-                uint16 artsBaseline = 0;                                                                                             // Level based baseline to which to raise skills
-                uint8  mLevel       = PChar->GetMLevel();
-                if (mLevel < 51)
-                {
-                    artsBaseline = (uint16)(5 + 2.7 * (mLevel - 1));
-                }
-                else if (mLevel < 61)
-                {
-                    artsBaseline = (uint16)(137 + 4.7 * (mLevel - 50));
-                }
-                else if (mLevel < 71)
-                {
-                    artsBaseline = (uint16)(184 + 3.7 * (mLevel - 60));
-                }
-                else if (mLevel < 75)
-                {
-                    artsBaseline = (uint16)(221 + 5.0 * (mLevel - 70));
-                }
-                else // >= 75
-                {
-                    artsBaseline = skillCapD + 36;
-                }
-
-                if (currentSkill < skillCapE)
-                {
-                    // If the player's skill is below the E cap
-                    // give enough bonus points to raise it to the arts baseline
-                    skillBonus += std::max(artsBaseline - currentSkill, 0);
-                }
-                else if (currentSkill < skillCapD)
-                {
-                    // if the skill is at or above the E cap but below the D cap
-                    // raise it up to the B+ skill cap minus the difference between the current skill rank and the scholar base skill cap (D)
-                    // i.e. give a bonus of the difference between the B+ skill cap and the D skill cap
-                    skillBonus += std::max((artsSkill - skillCapD), 0);
-                }
-                else if (currentSkill < artsSkill)
-                {
-                    // If the player's skill is at or above the D cap but below the B+ cap
-                    // give enough bonus points to raise it to the B+ cap
-                    skillBonus += std::max(artsSkill - currentSkill, 0);
-                }
-
-                if (PChar->StatusEffectContainer->HasStatusEffect({ EFFECT_LIGHT_ARTS, EFFECT_ADDENDUM_WHITE }))
-                {
-                    skillBonus += PChar->getMod(Mod::LIGHT_ARTS_SKILL);
-                }
-                else
-                {
-                    skillBonus += PChar->getMod(Mod::DARK_ARTS_SKILL);
-                }
+                skillBonus += ArtsBonusSkill(PChar, static_cast<SKILLTYPE>(i));
             }
             else if (i >= SKILL_AUTOMATON_MELEE && i <= SKILL_AUTOMATON_MAGIC)
             {
@@ -3688,12 +3709,32 @@ namespace charutils
                     PChar->WorkingSkills.skill[SkillID] |= 0x8000;
                 }
 
+                // check if skillup changed the bonus from sch arts
+                int16 skillBonus = 0;
+                if (isArtsBonusActive(PChar, SkillID))
+                {
+                    skillBonus = ArtsBonusSkill(PChar, SkillID);
+                }
+
                 PChar->RealSkills.skill[SkillID] += SkillAmount;
                 PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, SkillID, SkillAmount, 38);
 
                 if ((CurSkill / 10) < (CurSkill + SkillAmount) / 10) // if gone up a level
                 {
-                    PChar->WorkingSkills.skill[SkillID] += 1;
+                    // Light/Dark Arts artificially boost certain skills
+                    // if skillup happens when real skill is below the base for active arts, don't increment the shown skill
+                    if (isArtsBonusActive(PChar, SkillID))
+                    {
+                        // if the bonus is the same, our real skill was already past the base bonus, so increment the shown skill from skillup
+                        if (skillBonus == ArtsBonusSkill(PChar, SkillID))
+                        {
+                            PChar->WorkingSkills.skill[SkillID] += 1;
+                        }
+                    }
+                    else
+                    {
+                        PChar->WorkingSkills.skill[SkillID] += 1;
+                    }
                     PChar->pushPacket<CCharSkillsPacket>(PChar);
                     PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, SkillID, (CurSkill + SkillAmount) / 10, 53);
 

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -98,12 +98,14 @@ namespace charutils
     void   AddCapacityPoints(CCharEntity* PChar, CBaseEntity* PMob, uint32 capacityPoints, int16 levelDiff = 0, bool isCapacityChain = false);
     void   DistributeCapacityPoints(CCharEntity* PChar, CMobEntity* PMob);
 
-    void TrySkillUP(CCharEntity* PChar, SKILLTYPE SkillID, uint8 lvl, bool forceSkillUp = false, bool useSubSkill = false);
-    void BuildingCharSkillsTable(CCharEntity* PChar);
-    void BuildingCharWeaponSkills(CCharEntity* PChar);
-    void BuildingCharAbilityTable(CCharEntity* PChar);
-    void BuildingCharTraitsTable(CCharEntity* PChar);
-    void BuildingCharPetAbilityTable(CCharEntity* PChar, CPetEntity* PPet, uint32 PetID);
+    void  TrySkillUP(CCharEntity* PChar, SKILLTYPE SkillID, uint8 lvl, bool forceSkillUp = false, bool useSubSkill = false);
+    bool  isArtsBonusActive(CCharEntity* PChar, SKILLTYPE SkillID);
+    int16 ArtsBonusSkill(CCharEntity* PChar, SKILLTYPE SkillID);
+    void  BuildingCharSkillsTable(CCharEntity* PChar);
+    void  BuildingCharWeaponSkills(CCharEntity* PChar);
+    void  BuildingCharAbilityTable(CCharEntity* PChar);
+    void  BuildingCharTraitsTable(CCharEntity* PChar);
+    void  BuildingCharPetAbilityTable(CCharEntity* PChar, CPetEntity* PPet, uint32 PetID);
 
     void DoTrade(CCharEntity* PChar, CCharEntity* PTarget);
     bool CanTrade(CCharEntity* PChar, CCharEntity* PTarget);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Closes https://github.com/LandSandBoat/server/issues/1981 .

See https://github.com/LandSandBoat/server/pull/5827. I went ahead and abstracted the skillBonus into its own function as well to be able to target the specific math and not recalculate all character skills on sch-arts-boosted skillup

Basically, sch arts gives a baseline skill before adding the arts bonus. So if you skillup below that skill, your working skill should not increase. If you skillup after that skill then it should increment your working skill

- The conditional to determine if sch arts affects the current skill id is straight copy/pasted into the `bool` function
- the logic to determine `skillBonus` is straight copy/pasted, then variables updated slightly to work in its own function

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

elemental skill is the easiest to test with
- `!godmode`
- find a mob, and `!exec target:setMobLevel(99)` then `!immortal`
- `!setskill 36 1` to start with 1 elemental skill
- cast on mob until you skill up to 2, see that your magic menu shows 2 skill
- `/ja "dark arts" <me>`
- cast until another skillup, see that you stay at 246
- `!setskill 36 200`
- see that your skill is 246
- cast until a skillup, see that your skill is 247
- `!setskill 36 210`
- see skill is blue and you cannot skillup with or without sch arts

<img width="530" height="586" alt="image" src="https://github.com/user-attachments/assets/8cc195eb-78cd-4281-9274-33134ce24a8a" />

<img width="558" height="576" alt="image" src="https://github.com/user-attachments/assets/e3a7850d-e0fb-45ba-8127-0ae4da6a443d" />

<img width="560" height="581" alt="image" src="https://github.com/user-attachments/assets/7126f1fe-119b-44de-a222-5acef8afd8be" />
