### PR TITLE
[lua] Fix geo potency formula with missing y-axis initial condition

### DIFF
--- a/scripts/globals/job_utils/geomancer.lua
+++ b/scripts/globals/job_utils/geomancer.lua
@@ -103,38 +103,40 @@ local indiData =
     [xi.magic.spell.INDI_GRAVITY]    = { visualEffect = indiVisualEffect.WIND.ENEMIES,    effect = xi.effect.GEO_WEIGHT,              targetType = xi.auraTarget.ENEMIES },
 }
 
+-- "minPotency" is potency as zero combined skill
+-- "maxSkill" is the combined skill where you reach maxPotency
 local potencyData =
 {
-    [xi.effect.GEO_REGEN]               = { divisor =  20.00, minPotency = 1.0, maxPotency = 30.0, geoModMultiplier = 2.0 },
-    [xi.effect.GEO_POISON]              = { divisor =  20.00, minPotency = 1.0, maxPotency = 30.0, geoModMultiplier = 3.0 },
-    [xi.effect.GEO_REFRESH]             = { divisor = 150.00, minPotency = 1.0, maxPotency =  6.0, geoModMultiplier = 1.0 },
-    [xi.effect.GEO_STR_BOOST]           = { divisor =  36.00, minPotency = 1.0, maxPotency = 25.0, geoModMultiplier = 2.0 },
-    [xi.effect.GEO_DEX_BOOST]           = { divisor =  36.00, minPotency = 1.0, maxPotency = 25.0, geoModMultiplier = 2.0 },
-    [xi.effect.GEO_VIT_BOOST]           = { divisor =  36.00, minPotency = 1.0, maxPotency = 25.0, geoModMultiplier = 2.0 },
-    [xi.effect.GEO_AGI_BOOST]           = { divisor =  36.00, minPotency = 1.0, maxPotency = 25.0, geoModMultiplier = 2.0 },
-    [xi.effect.GEO_INT_BOOST]           = { divisor =  36.00, minPotency = 1.0, maxPotency = 25.0, geoModMultiplier = 2.0 },
-    [xi.effect.GEO_MND_BOOST]           = { divisor =  36.00, minPotency = 1.0, maxPotency = 25.0, geoModMultiplier = 2.0 },
-    [xi.effect.GEO_CHR_BOOST]           = { divisor =  36.00, minPotency = 1.0, maxPotency = 25.0, geoModMultiplier = 2.0 },
-    [xi.effect.GEO_ATTACK_BOOST]        = { divisor =  25.93, minPotency = 4.6, maxPotency = 34.7, geoModMultiplier = 2.7 },
-    [xi.effect.GEO_DEFENSE_BOOST]       = { divisor =  22.61, minPotency = 9.7, maxPotency = 39.8, geoModMultiplier = 4.6 },
-    [xi.effect.GEO_MAGIC_ATK_BOOST]     = { divisor =  60.00, minPotency = 3.0, maxPotency = 15.0, geoModMultiplier = 3.0 },
-    [xi.effect.GEO_MAGIC_DEF_BOOST]     = { divisor =  45.00, minPotency = 5.0, maxPotency = 20.0, geoModMultiplier = 4.0 },
-    [xi.effect.GEO_ACCURACY_BOOST]      = { divisor =  18.00, minPotency = 1.0, maxPotency = 50.0, geoModMultiplier = 5.0 },
-    [xi.effect.GEO_EVASION_BOOST]       = { divisor =  13.84, minPotency = 1.0, maxPotency = 65.0, geoModMultiplier = 5.0 },
-    [xi.effect.GEO_MAGIC_ACC_BOOST]     = { divisor =  18.00, minPotency = 1.0, maxPotency = 50.0, geoModMultiplier = 5.0 },
-    [xi.effect.GEO_MAGIC_EVASION_BOOST] = { divisor =  13.84, minPotency = 1.0, maxPotency = 65.0, geoModMultiplier = 6.0 },
-    [xi.effect.GEO_ATTACK_DOWN]         = { divisor =  36.00, minPotency = 4.6, maxPotency = 25.0, geoModMultiplier = 4.6 },
-    [xi.effect.GEO_DEFENSE_DOWN]        = { divisor =  60.81, minPotency = 2.7, maxPotency = 14.8, geoModMultiplier = 2.7 },
-    [xi.effect.GEO_MAGIC_ATK_DOWN]      = { divisor =  45.00, minPotency = 5.0, maxPotency = 20.0, geoModMultiplier = 4.0 },
-    [xi.effect.GEO_MAGIC_DEF_DOWN]      = { divisor =  60.00, minPotency = 3.0, maxPotency = 15.0, geoModMultiplier = 3.0 },
-    [xi.effect.GEO_ACCURACY_DOWN]       = { divisor =  13.84, minPotency = 1.0, maxPotency = 65.0, geoModMultiplier = 6.0 },
-    [xi.effect.GEO_EVASION_DOWN]        = { divisor =  18.00, minPotency = 1.0, maxPotency = 50.0, geoModMultiplier = 5.0 },
-    [xi.effect.GEO_MAGIC_ACC_DOWN]      = { divisor =  13.84, minPotency = 1.0, maxPotency = 65.0, geoModMultiplier = 6.0 },
-    [xi.effect.GEO_MAGIC_EVASION_DOWN]  = { divisor =  18.00, minPotency = 1.0, maxPotency = 50.0, geoModMultiplier = 5.0 },
-    [xi.effect.GEO_SLOW]                = { divisor =  60.4,  minPotency = 0.9, maxPotency = 14.9, geoModMultiplier = 0.5 },
-    [xi.effect.GEO_PARALYSIS]           = { divisor =  60.00, minPotency = 1.0, maxPotency = 15.0, geoModMultiplier = 1.0 },
-    [xi.effect.GEO_WEIGHT]              = { divisor =  45.22, minPotency = 3.9, maxPotency = 19.9, geoModMultiplier = 1.1 },
-    [xi.effect.GEO_HASTE]               = { divisor =  30.1,  minPotency = 2.4, maxPotency = 29.9, geoModMultiplier = 1.1 },
+    [xi.effect.GEO_REGEN]               = { maxSkill = 600, minPotency = 1.0, maxPotency = 30.0, geoModMultiplier = 2.0 },
+    [xi.effect.GEO_POISON]              = { maxSkill = 600, minPotency = 1.0, maxPotency = 30.0, geoModMultiplier = 3.0 },
+    [xi.effect.GEO_REFRESH]             = { maxSkill = 900, minPotency = 1.0, maxPotency =  6.0, geoModMultiplier = 1.0 },
+    [xi.effect.GEO_STR_BOOST]           = { maxSkill = 900, minPotency = 1.0, maxPotency = 25.0, geoModMultiplier = 2.0 },
+    [xi.effect.GEO_DEX_BOOST]           = { maxSkill = 900, minPotency = 1.0, maxPotency = 25.0, geoModMultiplier = 2.0 },
+    [xi.effect.GEO_VIT_BOOST]           = { maxSkill = 900, minPotency = 1.0, maxPotency = 25.0, geoModMultiplier = 2.0 },
+    [xi.effect.GEO_AGI_BOOST]           = { maxSkill = 900, minPotency = 1.0, maxPotency = 25.0, geoModMultiplier = 2.0 },
+    [xi.effect.GEO_INT_BOOST]           = { maxSkill = 900, minPotency = 1.0, maxPotency = 25.0, geoModMultiplier = 2.0 },
+    [xi.effect.GEO_MND_BOOST]           = { maxSkill = 900, minPotency = 1.0, maxPotency = 25.0, geoModMultiplier = 2.0 },
+    [xi.effect.GEO_CHR_BOOST]           = { maxSkill = 900, minPotency = 1.0, maxPotency = 25.0, geoModMultiplier = 2.0 },
+    [xi.effect.GEO_ATTACK_BOOST]        = { maxSkill = 900, minPotency = 4.6, maxPotency = 34.7, geoModMultiplier = 2.7 },
+    [xi.effect.GEO_DEFENSE_BOOST]       = { maxSkill = 900, minPotency = 9.7, maxPotency = 39.8, geoModMultiplier = 4.6 },
+    [xi.effect.GEO_MAGIC_ATK_BOOST]     = { maxSkill = 900, minPotency = 3.0, maxPotency = 15.0, geoModMultiplier = 3.0 },
+    [xi.effect.GEO_MAGIC_DEF_BOOST]     = { maxSkill = 900, minPotency = 5.0, maxPotency = 20.0, geoModMultiplier = 4.0 },
+    [xi.effect.GEO_ACCURACY_BOOST]      = { maxSkill = 900, minPotency = 1.0, maxPotency = 50.0, geoModMultiplier = 5.0 },
+    [xi.effect.GEO_EVASION_BOOST]       = { maxSkill = 900, minPotency = 1.0, maxPotency = 65.0, geoModMultiplier = 5.0 },
+    [xi.effect.GEO_MAGIC_ACC_BOOST]     = { maxSkill = 900, minPotency = 1.0, maxPotency = 50.0, geoModMultiplier = 5.0 },
+    [xi.effect.GEO_MAGIC_EVASION_BOOST] = { maxSkill = 900, minPotency = 1.0, maxPotency = 65.0, geoModMultiplier = 6.0 },
+    [xi.effect.GEO_ATTACK_DOWN]         = { maxSkill = 900, minPotency = 4.6, maxPotency = 25.0, geoModMultiplier = 4.6 },
+    [xi.effect.GEO_DEFENSE_DOWN]        = { maxSkill = 900, minPotency = 2.7, maxPotency = 14.8, geoModMultiplier = 2.7 },
+    [xi.effect.GEO_MAGIC_ATK_DOWN]      = { maxSkill = 900, minPotency = 5.0, maxPotency = 20.0, geoModMultiplier = 4.0 },
+    [xi.effect.GEO_MAGIC_DEF_DOWN]      = { maxSkill = 900, minPotency = 3.0, maxPotency = 15.0, geoModMultiplier = 3.0 },
+    [xi.effect.GEO_ACCURACY_DOWN]       = { maxSkill = 900, minPotency = 1.0, maxPotency = 65.0, geoModMultiplier = 6.0 },
+    [xi.effect.GEO_EVASION_DOWN]        = { maxSkill = 900, minPotency = 1.0, maxPotency = 50.0, geoModMultiplier = 5.0 },
+    [xi.effect.GEO_MAGIC_ACC_DOWN]      = { maxSkill = 900, minPotency = 1.0, maxPotency = 65.0, geoModMultiplier = 6.0 },
+    [xi.effect.GEO_MAGIC_EVASION_DOWN]  = { maxSkill = 900, minPotency = 1.0, maxPotency = 50.0, geoModMultiplier = 5.0 },
+    [xi.effect.GEO_SLOW]                = { maxSkill = 900, minPotency = 0.9, maxPotency = 14.9, geoModMultiplier = 0.5 },
+    [xi.effect.GEO_PARALYSIS]           = { maxSkill = 900, minPotency = 1.0, maxPotency = 15.0, geoModMultiplier = 1.0 },
+    [xi.effect.GEO_WEIGHT]              = { maxSkill = 900, minPotency = 3.9, maxPotency = 19.9, geoModMultiplier = 1.1 },
+    [xi.effect.GEO_HASTE]               = { maxSkill = 900, minPotency = 2.4, maxPotency = 29.9, geoModMultiplier = 1.1 },
 }
 
 local function getLuopan(player)
@@ -221,10 +223,13 @@ local function getEffectPotency(player, effect)
     end
 
     local combinedSkillLevel = utils.clamp(handbellSkill + geoSkill, 0, 900)
-    local divisor            = potencyData[effect].divisor
+    local maxSkill           = potencyData[effect].maxSkill
     local minPotency         = potencyData[effect].minPotency
     local maxPotency         = potencyData[effect].maxPotency
-    local potency            = utils.clamp(combinedSkillLevel / divisor, minPotency, maxPotency)
+    -- TODO find the real scaling formula?
+    -- linear regression to find divisor based on minPotency at 0 skill and maxPotency at "maxSkill"
+    local divisor            = maxSkill / (maxPotency - minPotency)
+    local potency            = utils.clamp(minPotency + combinedSkillLevel / divisor, minPotency, maxPotency)
 
     if geomancyMod > 0 and not player:hasStatusEffect(xi.effect.ENTRUST) then
         -- Geomancy bonus is a mod value * the multiplier then added to the final potency of the effect


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

see https://github.com/LandSandBoat/server/pull/4979/commits/24350e73a9cde5d3baf299ae3eb8ed08dd422bb9

The other PR was attempting to put the spell/effect tables into the global table for easier module manipulation, but the core reason for the PR was very simple. This PR is sticking to the bugfix specifically.

Geo potency data in the table was assumed correct for the previous PR. I've spot checked it and everything appears correct, except for `divisor`. This was calculated as `900 / maxPotency` across the board, except for geo-regen and geo-poison, as they cap at 600 skill. I took the original table and threw some quick excel math at it

<img width="1418" height="721" alt="image" src="https://github.com/user-attachments/assets/ea3b1e42-7eb6-4e3e-bdaa-2762761b8b17" />

Old formula was a simple linear function, using divisor described above as the slope, but then `utils.clamp` was applied with the minPotency and maxPotency. This mean that your potency was floored at the minimum until you got past the initial amount (most noticable on things like Def boost, attack down, def down)

New formula has static data that is easier for a human to read (skill where you reach maxPotency), and calculates `divisor` based on that

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- `!changejob geo 99`
- don't equip a handbell
- `!setskill geomancy 0`
- to set a "combined skill", just use the `geomancy_skill` mod. Note that skill mods don't take effect until you change equipment, so after `!setmod geomancy_skill X` you need to set or remove a piece of equipment (check magic skill menu to confirm)
- with 0 of the mod, cast indi-regen and see you get potency 1
  - <img width="597" height="208" alt="image" src="https://github.com/user-attachments/assets/bbb41fb3-3fe8-4ecd-94a9-08376f0fc4f1" />
- with mod 20, combined skill is 20, and you get potency 2
  - <img width="649" height="341" alt="image" src="https://github.com/user-attachments/assets/c03b0194-b3f9-4434-8466-2cb9d24b5027" />
- with mod 200, combined skill 200, potency is `1 + ( 30 - 1 ) * 200/600 = 10.6`
  - <img width="643" height="208" alt="image" src="https://github.com/user-attachments/assets/2fff5b7a-c149-4b0b-a7eb-084236d384be" />
- with mod 500, combined skill 500, potency is `1 + ( 30 - 1 ) * 500/600 = 25.1`
  - <img width="661" height="191" alt="image" src="https://github.com/user-attachments/assets/50a2fc20-2e82-4190-8285-72bcfb870669" />
- finally, with mod 600, we should reach max potency
  - <img width="671" height="211" alt="image" src="https://github.com/user-attachments/assets/894dd288-a3ca-4aa9-8fdc-7a6549f33f5e" />

similarly, for skills that cap at 900:
precision, skill 0, min bonus 1:
<img width="641" height="162" alt="image" src="https://github.com/user-attachments/assets/b92b96e9-f821-4924-89a3-6bd71e4ddf06" />

precision, skill 600: `1 + (50 - 1) * 600 / 900 = 33.6`
<img width="523" height="245" alt="image" src="https://github.com/user-attachments/assets/60ba4e94-7870-41ad-91f1-6a8199ecbbcb" />

precision, skill 900: `1 + (50 - 1) * 900 / 900 = 50`
<img width="641" height="248" alt="image" src="https://github.com/user-attachments/assets/dd7f344e-d79c-4db4-be65-26c2d59b37f4" />
