### PR TITLE
[fix] Marvelous Cheer lockstyle

### DIFF
--- a/src/map/items.h
+++ b/src/map/items.h
@@ -104,5 +104,6 @@ enum ITEMID : uint16
     DREAM_BELL_P1       = 18864,
     LADY_BELL           = 18868,
     LADY_BELL_P1        = 18869,
+    MARVELOUS_CHEER     = 22283,
     GIL                 = 65535,
 };

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -76,6 +76,7 @@
 #include "grades.h"
 #include "ipc_client.h"
 #include "item_container.h"
+#include "items.h"
 #include "latent_effect_container.h"
 #include "linkshell.h"
 #include "map_networking.h"
@@ -2296,6 +2297,13 @@ namespace charutils
 
             CItemWeapon* PWeapon = dynamic_cast<CItemWeapon*>(PItem);
             CItemWeapon* AWeapon = dynamic_cast<CItemWeapon*>(AItem);
+
+            // Marvelous Cheer special case
+            // It is not technically a Wind Instrument, but it can lockstyle one.
+            if (AItem->getID() == MARVELOUS_CHEER && PWeapon->getSkillType() == SKILL_WIND_INSTRUMENT)
+            {
+                return HasItem(PChar, AItem->getID());
+            }
 
             if (PWeapon && AWeapon && PWeapon->getSkillType() == AWeapon->getSkillType())
             {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Marvelous Cheer is a little bit of a special case: it has no skill in DB because it doesn't provide Wind skill. See #5420
This led to one lockstyle check failing since the skillType didn't match the other item skillType.

This carves out an exception before the check in question. I hate to add a special case on the C++ side but it is pretty unique in that regard.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!additem marvelous_cheer
!additem gjallarhorn_75

Equip ghorn and lockstyle Marvelous Cheer, sing, profit.
