### PR TITLE
[cpp] Explicitly truncate status effect sub power in lua binding

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -13299,7 +13299,7 @@ bool CLuaBaseEntity::addStatusEffect(sol::variadic_args va)
 
         // Optional
         auto subType         = va[4].is<uint32>() ? va[4].as<uint32>() : 0;
-        auto subPower        = va[5].is<uint16>() ? va[5].as<uint16>() : 0;
+        auto subPower        = va[5].is<double>() ? static_cast<uint16>(va[5].as<double>()) : 0;
         auto tier            = va[6].is<uint16>() ? va[6].as<uint16>() : 0;
         auto sourceType      = va[7].is<EffectSourceType>() ? va[7].as<EffectSourceType>() : EffectSourceType::SOURCE_NONE;
         auto sourceTypeParam = va[8].is<uint16>() ? va[8].as<uint16>() : 0;
@@ -13366,7 +13366,7 @@ bool CLuaBaseEntity::addStatusEffectEx(sol::variadic_args va)
 
     // Optional
     auto subType    = va[5].is<uint32>() ? va[5].as<uint32>() : 0;
-    auto subPower   = va[6].is<uint16>() ? va[6].as<uint16>() : 0;
+    auto subPower   = va[6].is<double>() ? static_cast<uint16>(va[6].as<double>()) : 0;
     auto tier       = va[7].is<uint16>() ? va[7].as<uint16>() : 0;
     auto effectFlag = va[8].is<uint32>() ? va[8].as<uint32>() : 0;
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Resolves #7809 

More I thought about it the more it seemed to really be that simple. 

Simply changed the saving of subPower to be default 0 if lua parameter isn't a number, and if it's a number static cast it instead of using `.as<uint16>` which apparently rounds.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

testing is verified simply with a map print command, as the aura doesn't provide an effect if you don't set the tier and effectFlag. But the issue boils down to rounding subpower, so confirming that is truncated instead should be sufficient

original reported command in the `addStatusEffectEx` binding
<img width="910" height="228" alt="image" src="https://github.com/user-attachments/assets/50c26984-3377-4214-b4ce-b0de9c819d41" />

and without a subpower
<img width="889" height="223" alt="image" src="https://github.com/user-attachments/assets/d7a7ef68-5d04-4532-862f-7db219368e7d" />


same command in the `addStatusEffect` binding
<img width="881" height="209" alt="image" src="https://github.com/user-attachments/assets/52e9b5d5-f856-483d-a1de-8b2fac504ce1" />

and without a subpower
<img width="898" height="221" alt="image" src="https://github.com/user-attachments/assets/921aac10-77c0-4c8c-b1a6-5ada722bb430" />
