### PR TITLE
[lua] Curaga Earring Bug Fix

### DIFF
--- a/scripts/items/curaga_earring.lua
+++ b/scripts/items/curaga_earring.lua
@@ -12,18 +12,20 @@ end
 
 itemObject.onItemUse = function(target)
     target:forMembersInRange(30, function(member)
-        local healAmount = math.random(60, 90)
+        if member:isAlive() then
+            local healAmount = math.random(60, 90)
 
-        healAmount = healAmount + (healAmount * (member:getMod(xi.mod.CURE_POTENCY_RCVD) / 100))
-        healAmount = healAmount * xi.settings.main.CURE_POWER
+            healAmount = healAmount + (healAmount * (member:getMod(xi.mod.CURE_POTENCY_RCVD) / 100))
+            healAmount = healAmount * xi.settings.main.CURE_POWER
 
-        local diff = (member:getMaxHP() - member:getHP())
-        if healAmount > diff then
-            healAmount = diff
+            local diff = (member:getMaxHP() - member:getHP())
+            if healAmount > diff then
+                healAmount = diff
+            end
+
+            member:addHP(healAmount)
+            member:messageBasic(xi.msg.basic.RECOVERS_HP, 0, healAmount)
         end
-
-        member:addHP(healAmount)
-        member:messageBasic(xi.msg.basic.RECOVERS_HP, 0, healAmount)
     end)
 end
 


### PR DESCRIPTION
Adds extra check on curaga earring to prevent adding HP to dead players.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Fixes an issue with Curaga Earring script that allowed dead players to receive HP.
This had two unintended effects:
- If the player received HP from the earring, and the changed zones (relogging, warp, teleport, etc), they would be alive again on entering the next zone with no weakness.
- It placed the player in a bugged state where they could not be raised, but also can't move (without a zone change)

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - Login with 2 characters
2 - Make a party with both characters
3 - `!hp 0` one character
4 - `!changejob whm 99` on the second character
5 - `!additem curaga_earring`
6 - Equip the earring and then use it while standing next to the dead character

Result: The dead player no longer receives a heal from the earring.
