### PR TITLE
[claimshield] notify player of participation

### DIFF
--- a/modules/custom/lua/claim_shield.lua
+++ b/modules/custom/lua/claim_shield.lua
@@ -123,6 +123,20 @@ local timerFunc = function(mob)
 
             member:printToPlayer(str, xi.msg.channel.SYSTEM_3, '')
 
+            -- Check if this player was in the entries list
+            local wasInEntries = false
+            for _, entity in pairs(entries) do
+                if entity:getID() == member:getID() then
+                    wasInEntries = true
+                    break
+                end
+            end
+
+            -- Inform player they were on the lottery list if they were in entries
+            if wasInEntries then
+                member:printToPlayer('You were on the lottery list.', xi.msg.channel.SYSTEM_3, '')
+            end
+
             -- Remove from entries table
             local pos = tableFindPosByID(entries, member)
             if pos then
@@ -135,10 +149,13 @@ local timerFunc = function(mob)
         for _, member in pairs(entries) do
             local str = string.format('Your group was not successful in the lottery for %s. (out of %i players)', mob:getPacketName(), numEntries)
             if #alliance == 1 then
-                str = string.format('Your were not successful in the lottery for %s. (out of %i players)', mob:getPacketName(), numEntries)
+                str = string.format('You were not successful in the lottery for %s. (out of %i players)', mob:getPacketName(), numEntries)
             end
 
             member:printToPlayer(str, xi.msg.channel.SYSTEM_3, '')
+
+            -- Players in the entries list were definitely on the lottery list
+            member:printToPlayer('You were on the lottery list.', xi.msg.channel.SYSTEM_3, '')
             mob:clearEnmityForEntity(member)
         end
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [ ] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
This PR adds a simple message to the player letting them know they were on the list for the claimshield. Relevant in an alliance since the notify message will let all players in said alliance know, this will let a player know if they made it on the list or not. 

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
I haven't tested locally as I don't have a dev environment, Figured I'd raise this at least for discussion while I get that sorted out.