### PR TITLE
Mob roam casting cleanup/battlefield start retail partiy

### DIFF
--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -1104,6 +1104,24 @@ function Battlefield:onBattlefieldEnter(player, battlefield)
         end
     end
 
+    -- Handle mob initial spell casts (blaze spikes, protect, etc)
+    if player:getID() == initiatorId then
+        local mobs = battlefield:getMobs(true, true)
+        for _, mob in pairs(mobs) do
+            if mob:isSpawned() then
+                -- wait until initiator is out of cutscene
+                mob:addListener('ROAM_TICK', 'FIRST_CAST', function(mobArg)
+                    local firstPlayer = GetPlayerByID(initiatorId)
+                    if firstPlayer and not firstPlayer:isInEvent() then
+                        mobArg:castSpell()
+
+                        mobArg:removeListener('FIRST_CAST')
+                    end
+                end)
+            end
+        end
+    end
+
     local ID = zones[self.zoneId]
     player:messageSpecial(ID.text.ENTERING_THE_BATTLEFIELD_FOR, 0, self.index)
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

the real reason for the PR is to trigger `:castSpell()` after a player finishes their entry cutscene. For most battlefields this is a short camera pan onto the player, but some missions/quests will take longer
- this PR adds a self-destructing ROAM listener on all mobs that start off in the battlefield spawned, and triggers `:castSpell()` once after the initiator PC is finished with their cutscene
- mobs without buff spells will quietly do nothing from this call

In doing that, I stumbled upon a weird one-off with the `:castSpell()` binding.
- if you don't pass a spellid, it triggers `->TryCastSpell()`, which should contain all the logic to... try to cast a spell
- the issue is that this was randomizing _all_ spells and attempting the one it got. So if the mob is out of combat, it would randomly select an offensive spell most of the time, so the mob would do nothing.
- The implication of this bug wasn't far-reaching, as there was special roam logic to attempt buff spells specifically while roaming
- This PR cleans up the `TryCastSpell` logic to consider if a mob is engaged or not and updates the roam logic to be simplified as well
- also, summoner mobs cast their pets via a "buff" spell, and the special logic for that was firing on the first roam tick (before the player was finished with their cutscene), so this adds a little complexity to that check 
  - the logic is unchanged if a mob is not in a battlefield
  - the logic is unchanged if a mob is in a battlefield but the battlefield is locked (which happens when a mob is engaged)
  - otherwise, it fails back to the 20% chance to cast a spell
    - I didn't want to add complexity here, but to truly get perfection we'd need something near the `xirand::GetRandomNumber(10) < 3` conditional to not even attempt to cast if the player is still in a cutscene.
    - I couldn't think of the simplest way to do this, so this PR still has a small chance to have mobs cast buffs before the player is out of their cutscene, and thus not get the initial action packet
      - if the cutscene is quick enough you still see the casting animation and get the finish
      - <img width="650" height="107" alt="image" src="https://github.com/user-attachments/assets/68c3dd2d-88dc-44be-9bfa-8170b7a4b2ea" />



## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
First off, the fix in `battlefield.lua` in action. Playe receives the spell packets:
<img width="685" height="495" alt="image" src="https://github.com/user-attachments/assets/c50c7d88-78cf-49fc-bf26-d5d3fa4d3e4c" />

Other situations that should have no regression
- Ensure mob roam casting works as expected in and outside of battlefields
- ensure `:castSpell()` still works if passing an expclit spellid (untouched), and reliably casts a buff if the mob is out of combat

here's some screenshots of various conditions still working as expected
ran into davoi to catch random mobs buffing out of combat
<img width="498" height="56" alt="image" src="https://github.com/user-attachments/assets/83cc1daf-164a-44ad-9f0d-6e68dfb98343" />

ran to xarc to see non-battlefield demons spawning their elementals out of combat
<img width="371" height="251" alt="image" src="https://github.com/user-attachments/assets/a7e6434f-4991-4c55-94d4-b12b498e5cb4" />

ensured mobs in combat still cast spells/summon a new pet
<img width="495" height="139" alt="image" src="https://github.com/user-attachments/assets/c9f8d0ca-31e0-4058-aad2-c0a329d5f63d" />
