### PR TITLE
[cpp] Mob party after init (make superlinking more sane)

### DIFF
--- a/scripts/zones/Attohwa_Chasm/mobs/Xolotl.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Xolotl.lua
@@ -5,9 +5,12 @@
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.SUPERLINK, 32)
+end
+
 entity.onMobSpawn = function(mob)
     mob:setRespawnTime(0)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 32)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Attohwa_Chasm/mobs/Xolotls_Hound_Warrior.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Xolotls_Hound_Warrior.lua
@@ -6,7 +6,7 @@
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.SUPERLINK, 32)
 end
 

--- a/scripts/zones/Attohwa_Chasm/mobs/Xolotls_Sacrifice.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Xolotls_Sacrifice.lua
@@ -6,7 +6,7 @@
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.SUPERLINK, 32)
 end
 

--- a/scripts/zones/Ghelsba_Outpost/mobs/Kalamainu.lua
+++ b/scripts/zones/Ghelsba_Outpost/mobs/Kalamainu.lua
@@ -10,7 +10,6 @@ entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.SLEEP_MEVA, 100)
     mob:setMod(xi.mod.LULLABY_MEVA, 100)
     mob:setMobMod(xi.mobMod.NO_MOVE, 1) -- lock from moving
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobEngage = function(mob, target)

--- a/scripts/zones/Ghelsba_Outpost/mobs/Kilioa.lua
+++ b/scripts/zones/Ghelsba_Outpost/mobs/Kilioa.lua
@@ -10,7 +10,6 @@ entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.SLEEP_MEVA, 100)
     mob:setMod(xi.mod.LULLABY_MEVA, 100)
     mob:setMobMod(xi.mobMod.NO_MOVE, 1) -- lock from moving
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobEngage = function(mob, target)

--- a/src/map/instance_loader.cpp
+++ b/src/map/instance_loader.cpp
@@ -289,6 +289,7 @@ CInstance* CInstanceLoader::LoadInstance()
         m_PInstance->ForEachMob([&](CMobEntity* PMob)
         {
             luautils::OnMobInitialize(PMob);
+            m_PInstance->FindPartyForMob(PMob);
             luautils::ApplyMixins(PMob);
             ((CMobEntity*)PMob)->saveModifiers();
             ((CMobEntity*)PMob)->saveMobModifiers();

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2952,6 +2952,7 @@ namespace luautils
         return result.get_type(0) == sol::type::boolean ? result.get<bool>(0) : true;
     }
 
+    // Party building is performed after this, so it's safe to set link/superlink behavior in onMobInitialize
     void OnMobInitialize(CBaseEntity* PMob)
     {
         TracyZoneScoped;
@@ -5583,6 +5584,14 @@ namespace luautils
             luautils::OnEntityLoad(PMob);
 
             luautils::OnMobInitialize(PMob);
+            if (PInstance)
+            {
+                PInstance->FindPartyForMob(PMob);
+            }
+            else
+            {
+                PZone->FindPartyForMob(PMob);
+            }
             luautils::ApplyMixins(PMob);
             luautils::ApplyZoneMixins(PMob);
 

--- a/src/map/mob_modifier.h
+++ b/src/map/mob_modifier.h
@@ -54,7 +54,7 @@ enum MOBMODIFIER : int
     MOBMOD_IMMUNITY               = 23, // immune to set status effects. This only works from the db, not scripts
     MOBMOD_GRADUAL_RAGE           = 24, // (!) TODO: NOT YET IMPLEMENTED -- gradually rages
     MOBMOD_BUILD_RESIST           = 25, // (!) TODO: NOT YET IMPLEMENTED -- builds resistance to given effects
-    MOBMOD_SUPERLINK              = 26, // super link group. Only use this in scripts!
+    MOBMOD_SUPERLINK              = 26, // super link group. Only use this in scripts! Must be defined in onMobInitialize if relevant mobs are different families
     MOBMOD_SPELL_LIST             = 27, // set spell list
     MOBMOD_EXP_BONUS              = 28, // bonus exp (bonus / 100) negative values reduce exp.
     MOBMOD_ASSIST                 = 29, // mobs will assist me

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -1699,6 +1699,10 @@ namespace mobutils
                 luautils::OnEntityLoad(PMob);
 
                 luautils::OnMobInitialize(PMob);
+                if (CZone* PZone = zoneutils::GetZone(zoneID))
+                {
+                    PZone->FindPartyForMob(PMob);
+                }
                 luautils::ApplyMixins(PMob);
                 luautils::ApplyZoneMixins(PMob);
 

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -658,11 +658,13 @@ namespace zoneutils
                 luautils::OnEntityLoad(PMob);
             });
 
-            PZone->ForEachMob([](CMobEntity* PMob)
+            PZone->ForEachMob([&PZone](CMobEntity* PMob)
             {
                 mobutils::AddSqlModifiers(PMob);
 
                 luautils::OnMobInitialize(PMob);
+                PZone->FindPartyForMob(PMob);
+
                 luautils::ApplyMixins(PMob);
                 luautils::ApplyZoneMixins(PMob);
 

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -246,7 +246,6 @@ void CZoneEntities::InsertMOB(CBaseEntity* PMob)
     {
         PMob->loc.zone = m_zone;
 
-        FindPartyForMob(PMob);
         m_mobList[PMob->targid] = PMob;
 
         TryAddToNearbySpawnLists(PMob);
@@ -368,7 +367,7 @@ void CZoneEntities::FindPartyForMob(CBaseEntity* PEntity)
 
             int16 sublink = PMob->getMobMod(MOBMOD_SUBLINK);
 
-            if (PCurrentMob->allegiance == PMob->allegiance &&
+            if (PCurrentMob->PParty && PCurrentMob->allegiance == PMob->allegiance &&
                 (forceLink || PCurrentMob->m_Family == PMob->m_Family || (sublink && sublink == PCurrentMob->getMobMod(MOBMOD_SUBLINK))))
             {
                 if (PCurrentMob->PMaster == nullptr || PCurrentMob->PMaster->objtype == TYPE_MOB)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Superlinking works by checking if mobs in the mob's party and (if the superlink groups match) linking works from any distance in the zone. This of course hinges on the mobs being in the same party. By default, mobs with linking enabled are put into parties by family (or if superlink mobmod is set, added to the same party). 

This of course means that if a skeleton is in superlink group with a lizard, and you pull the lizard from across the zone, the skeleton will assist, then link any lizards along the way (since they're in the same group).

It's a bit imperfect of a system, but superlink is not used often enough to matter too much on that front. The point is, superlink relies on mobs being in the same group

This means that there's currently no LUA way to make mobs superlink. We can set mob pooll mods in the db and make things be in the same superlink group, and that does work, but things like this PR #7726 are attempting to fix mob behavior and imo it's moving backwards to go and insert the proper data into the db.

This PR does the following:
- rearranges the party building to happen after `OnMobInitialize`
  - `InsertMOB` function has the `FindPartyForMob` removed
  - every instance of `OnMobInitialize` has a partner call to it
  - I looked for every call of `InsertMOB` and I believe i updated the flow to call party building properly after `OnMobInitialize`
  - I had to add a check for `PCurrentMob->PParty` in the party builder function because previously it was only inserting a mob into the zone's moblist after executing, so it was guaranteed that every mob had a party, where that isn't true anymore
- This solves 2 things with mob linking:
  - you can define mob behavior in `onMobInitialize` and the party building will happen afterwards 
    - (things like [cactuars that shouldn't link, but need to be in a one-way link relationship with cactro rapido](https://github.com/LandSandBoat/server/pull/3790/files) can be done fully in lua)
    - setting `xi.mobMod.SUPERLINK` works as expected
- I've updated Xolotl and his pets to function properly with linking (I didn't mess with the rest of their combat/spawn logic)
  - test by going to the chasm, and `!gotoname Xolotl`, then spawn his pet (increment mob id by 1), pull it way back, then spawn him
  - see that he assists
  - also print their party to the map server log: `!exec print(target:getParty())`
- I scanned the `scripts` folder for other instances of `SUPERLINK` mobmod to see if anything that is currently broken existed. Most things that use it are the same family
  - I removed the unnecessary mobmod on petrifying pair as the `addEssentialMobs` handles that
    - test by going into bcnm, setting sight and hearing range to 1 of both mobs: `!setmobmod 4 1`, `!setmobmod 5 1`
    - aggro one and see the other links
    - This is typical battlefield behavior that has worked for a while
  - I found that rank 2 mission was not using `addEssentialMobs` and thus the eye and dragon were not linking with eachother
    - Test by giving yourself the rank2 mission in each dungeon based on [this file](https://github.com/LandSandBoat/server/blob/base/scripts/battlefields/Horlais_Peak/rank_2_mission.lua) and [this file](https://github.com/LandSandBoat/server/blob/base/scripts/battlefields/Waughroon_Shrine/rank_2_mission.lua) entry requirements
    - enter battlefield
    - check mob parties, before the changes in this PR they were each in their own party, `addEssentialMobs` puts them in the same superlink group/party 
    - <img width="524" height="129" alt="image" src="https://github.com/user-attachments/assets/2481bfe8-1b05-4ab6-98ce-4f6f6fabe1ac" />
    - ensure completing the battleground still continues the mission
- There are perhaps other instances of SUPERLINK not being set properly, but the rabbit hole started by knowing for sure rank2 mission mobs and xolotl didn't link

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Sorry, test notes listed above, but TL;DR is `!exec print(target:getParty())` to ensure party building is working as expected