### PR TITLE
[lua] Fix superlinking on rank 2 mission bcnms

### DIFF
--- a/scripts/battlefields/Balgas_Dais/rank_2_mission.lua
+++ b/scripts/battlefields/Balgas_Dais/rank_2_mission.lua
@@ -3,8 +3,6 @@
 -- Name: Mission Rank 2
 -- !pos 299 -123 345 146
 -----------------------------------
-local balgasID = zones[xi.zone.BALGAS_DAIS]
------------------------------------
 
 local content = Battlefield:new({
     zoneId        = xi.zone.BALGAS_DAIS,
@@ -39,20 +37,6 @@ function content:checkSkipCutscene(player)
         ))
 end
 
-content.groups =
-{
-    {
-        mobIds =
-        {
-            { balgasID.mob.BLACK_DRAGON,     balgasID.mob.BLACK_DRAGON + 1 },
-            { balgasID.mob.BLACK_DRAGON + 2, balgasID.mob.BLACK_DRAGON + 3 },
-            { balgasID.mob.BLACK_DRAGON + 4, balgasID.mob.BLACK_DRAGON + 5 },
-        },
-
-        allDeath = function(battlefield, mob)
-            battlefield:setStatus(xi.battlefield.status.WON)
-        end,
-    },
-}
+content:addEssentialMobs({ 'Black_Dragon', 'Searcher' })
 
 return content:register()

--- a/scripts/battlefields/Horlais_Peak/rank_2_mission.lua
+++ b/scripts/battlefields/Horlais_Peak/rank_2_mission.lua
@@ -2,8 +2,6 @@
 -- Rank 2 Final Mission
 -- Horlais Peak mission battlefield
 -----------------------------------
-local horlaisID = zones[xi.zone.HORLAIS_PEAK]
------------------------------------
 
 local content = Battlefield:new({
     zoneId        = xi.zone.HORLAIS_PEAK,
@@ -38,20 +36,6 @@ function content:checkSkipCutscene(player)
         ))
 end
 
-content.groups =
-{
-    {
-        mobIds =
-        {
-            { horlaisID.mob.DREAD_DRAGON,     horlaisID.mob.DREAD_DRAGON + 1 },
-            { horlaisID.mob.DREAD_DRAGON + 2, horlaisID.mob.DREAD_DRAGON + 3 },
-            { horlaisID.mob.DREAD_DRAGON + 4, horlaisID.mob.DREAD_DRAGON + 5 },
-        },
-
-        allDeath = function(battlefield, mob)
-            battlefield:setStatus(xi.battlefield.status.WON)
-        end,
-    },
-}
+content:addEssentialMobs({ 'Dread_Dragon', 'Spotter' })
 
 return content:register()

--- a/scripts/battlefields/Waughroon_Shrine/rank_2_mission.lua
+++ b/scripts/battlefields/Waughroon_Shrine/rank_2_mission.lua
@@ -3,8 +3,6 @@
 -- Waughroon Shrine mission battlefield
 -- !pos -345 104 -260 144
 -----------------------------------
-local waughroonID = zones[xi.zone.WAUGHROON_SHRINE]
------------------------------------
 
 local content = Battlefield:new({
     zoneId        = xi.zone.WAUGHROON_SHRINE,
@@ -39,20 +37,6 @@ function content:checkSkipCutscene(player)
         ))
 end
 
-content.groups =
-{
-    {
-        mobIds =
-        {
-            { waughroonID.mob.DARK_DRAGON,     waughroonID.mob.DARK_DRAGON + 1 },
-            { waughroonID.mob.DARK_DRAGON + 2, waughroonID.mob.DARK_DRAGON + 3 },
-            { waughroonID.mob.DARK_DRAGON + 4, waughroonID.mob.DARK_DRAGON + 5 },
-        },
-
-        allDeath = function(battlefield, mob)
-            battlefield:setStatus(xi.battlefield.status.WON)
-        end,
-    },
-}
+content:addEssentialMobs({ 'Dark_Dragon', 'Seeker' })
 
 return content:register()

--- a/scripts/zones/Balgas_Dais/IDs.lua
+++ b/scripts/zones/Balgas_Dais/IDs.lua
@@ -49,7 +49,6 @@ zones[xi.zone.BALGAS_DAIS] =
     mob =
     {
         ATORI_TUTORI            = GetFirstID('Atori-Tutori_qm'),
-        BLACK_DRAGON            = GetFirstID('Black_Dragon'),
         BUU_XOLO_THE_BLOODFACED = GetFirstID('Buu_Xolo_the_Bloodfaced'),
         DVOROVOI                = GetFirstID('Dvorovoi'),
         GILAGOGE_TLUGVI         = GetFirstID('Gilagoge_Tlugvi'),

--- a/scripts/zones/Horlais_Peak/IDs.lua
+++ b/scripts/zones/Horlais_Peak/IDs.lua
@@ -56,7 +56,6 @@ zones[xi.zone.HORLAIS_PEAK] =
         ARMSMASTER_DEKBUK       = GetFirstID('Armsmaster_Dekbuk'),
         ATORI_TUTORI            = GetFirstID('Atori-Tutori_qm'),
         DAROKBOK_OF_CLAN_REAPER = GetFirstID('Darokbok_of_Clan_Reaper'),
-        DREAD_DRAGON            = GetFirstID('Dread_Dragon'),
         HELLTAIL_HARRY          = GetFirstID('Helltail_Harry'),
         MAAT                    = GetFirstID('Maat'),
     },

--- a/scripts/zones/Waughroon_Shrine/IDs.lua
+++ b/scripts/zones/Waughroon_Shrine/IDs.lua
@@ -54,7 +54,6 @@ zones[xi.zone.WAUGHROON_SHRINE] =
     mob =
     {
         ATORI_TUTORI      = GetFirstID('Atori-Tutori_qm'),
-        DARK_DRAGON       = GetFirstID('Dark_Dragon'),
         FLAYER_FRANZ      = GetFirstID('Flayer_Franz'),
         GAKI              = GetFirstID('Gaki'),
         KUJHU_GRANITESKIN = GetFirstID('KuJhu_Graniteskin'),


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Broke out the rank 2 mission superlinking from #7832 since it ended up being unrelated to party building

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- Test by giving yourself the rank2 mission in each dungeon based on [this file](https://github.com/LandSandBoat/server/blob/base/scripts/battlefields/Horlais_Peak/rank_2_mission.lua) and [this file](https://github.com/LandSandBoat/server/blob/base/scripts/battlefields/Waughroon_Shrine/rank_2_mission.lua) entry requirements
- enter battlefield
- check mob parties, before the changes in this PR they were each in their own party, addEssentialMobs puts them in the same superlink group/party
- <img width="524" height="129" alt="image" src="https://github.com/user-attachments/assets/42602f8e-c301-4848-a603-ca7bfaa54510" />
- ensure completing the battleground still continues the mission