### PR TITLE
[core, lua] SPAWN listener after onMobSpawn

### DIFF
--- a/modules/custom/lua/claim_shield.lua
+++ b/modules/custom/lua/claim_shield.lua
@@ -145,7 +145,7 @@ local timerFunc = function(mob)
 end
 
 -- Called on entity onMobSpawn, sets up timerFunc
-local spawnFunc = function(mob)
+local listenerFunc = function(mob)
     print(string.format('Applying Claimshield to %s for %ims', mob:getPacketName(), claimshieldTime))
 
     mob:setMobMod(xi.mobMod.CLAIM_TYPE, xi.claimType.UNCLAIMABLE)
@@ -158,16 +158,16 @@ end
 
 -- Main entrypoint of each override
 local overrideFunc = function(mob)
-    spawnFunc(mob)
+    mob:addListener('SPAWN', string.format('%s_CS_SPAWN', mob:getPacketName()), listenerFunc)
 
-    -- Call original onMobSpawn
+    -- Call original onMobInitialize
     super(mob)
 end
 
 -- NOTE: At the time we iterate over these entries, the Lua zone and mob objects won't be ready,
 --     : so we deal with everything as strings for now.
 for _, entry in pairs(nmsToShield) do
-    m:addOverride(string.format('xi.zones.%s.mobs.%s.onMobSpawn', entry[1], entry[2]), overrideFunc)
+    m:addOverride(string.format('xi.zones.%s.mobs.%s.onMobInitialize', entry[1], entry[2]), overrideFunc)
 end
 
 return m

--- a/src/map/entities/baseentity.cpp
+++ b/src/map/entities/baseentity.cpp
@@ -75,7 +75,6 @@ void CBaseEntity::Spawn()
     updatemask |= UPDATE_HP;
     ResetLocalVars();
     PAI->Reset();
-    PAI->EventHandler.triggerListener("SPAWN", this);
 }
 
 void CBaseEntity::FadeOut()

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -3486,6 +3486,8 @@ namespace luautils
             sol::error err = result;
             ShowError("luautils::onMobSpawn: %s", err.what());
         }
+
+        PMob->PAI->EventHandler.triggerListener("SPAWN", PMob);
     }
 
     void OnMobRoamAction(CBaseEntity* PMob)

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -412,7 +412,7 @@ namespace zoneutils
 
                 auto* PZone = g_PZoneList[zoneId];
 
-                const auto query = "SELECT mobname, mobid, pos_rot, pos_x, pos_y, pos_z, "
+                const auto query = "SELECT mobname, packet_name, mobid, pos_rot, pos_x, pos_y, pos_z, "
                     "respawntime, spawntype, dropid, mob_groups.HP, mob_groups.MP, minLevel, maxLevel, "
                     "modelid, mJob, sJob, cmbSkill, cmbDmgMult, cmbDelay, behavior, links, mobType, immunity, "
                     "ecosystemID, mobradius, speed, "
@@ -445,6 +445,7 @@ namespace zoneutils
                             CMobEntity* PMob = new CMobEntity;
 
                             PMob->name = rset->get<std::string>("mobname");
+                            PMob->packetName = rset->get<std::string>("packet_name");
                             PMob->id   = rset->get<uint32>("mobid");
 
                             PMob->targid = static_cast<uint16>(PMob->id & 0x0FFF);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This is a change I've been meaning to make since #7246 

Currently the SPAWN listeners are executed very early in the entity lifecycle - before mods are applied/force reset, claim cleaned up etc.

This leads to the SPAWN listener being generally useless when you need to change anything of value. Furthermore, unlike other listeners it runs before the sister lua method (onMobSpawn) which is incredibly confusing.

- This PR executes the listeners _after_ onMobSpawn has been completed.
  - Any change performed within the listener will now correctly persist as expected
- Reverts the claim shield to how it was before #7246 
- Also fixes the packetName not being obtained from DB for regular mobs, which has led to the claim shield reporting empty names.

I believe this closes #7796 - I also believe this now allows performing the function of #7791 in a SPAWN listener instead of customizing the C++ side.

## Steps to test these changes

I have retested the claim shield - unfortunately this is the only piece in the codebase making use of this listener so I might have missed other use cases.

- Enable claim shield lua module
- !zone Mount Zhayolm
- !gotoid 17027458
- !spawnmob 17027458