### PR TITLE
[core] Implement retail accurate gilfinder

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -1189,8 +1189,9 @@ auto CMobController::Disengage() -> bool
     PMob->SetCallForHelpFlag(false);
     PMob->animation = ANIMATION_NONE;
     // https://www.bluegartr.com/threads/108198-Random-Facts-Thread-Traits-and-Stats-(Player-and-Monster)?p=5670209&viewfull=1#post5670209
-    PMob->m_THLvl = 0;
-    m_mobHealTime = m_Tick;
+    PMob->m_THLvl          = 0;
+    PMob->m_GilfinderLevel = 0; // Assumed to work like TH
+    m_mobHealTime          = m_Tick;
     return CController::Disengage();
 }
 

--- a/src/map/enmity_container.cpp
+++ b/src/map/enmity_container.cpp
@@ -171,6 +171,7 @@ void CEnmityContainer::UpdateEnmity(CBattleEntity* PEntity, int32 CE, int32 VE, 
     if (directAction)
     {
         int16 THlevel = std::min<int16>(8, PEntity->getMod(Mod::TREASURE_HUNTER));
+        int16 GFlevel = PEntity->getMod(Mod::GILFINDER); // Is there a cap? Theoretical GF level cap could be GF 8 for 128/256 + 8*16 = 256/256
 
         // Enforce TH8 as max for THF main and TH4 as non-THF main
         if (PEntity->GetMJob() != JOB_THF)
@@ -181,6 +182,11 @@ void CEnmityContainer::UpdateEnmity(CBattleEntity* PEntity, int32 CE, int32 VE, 
         if (m_EnmityHolder->m_THLvl < THlevel)
         {
             m_EnmityHolder->m_THLvl = THlevel;
+        }
+
+        if (m_EnmityHolder->m_GilfinderLevel < GFlevel)
+        {
+            m_EnmityHolder->m_GilfinderLevel = GFlevel;
         }
     }
 

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -3132,13 +3132,15 @@ void CCharEntity::changeMoghancement(uint16 moghancementID, bool isAdding)
             }
             break;
         case MOGHANCEMENT_MONEY:
-            addModifier(Mod::GILFINDER, 10 * multiplier);
+            // TODO: this is NOT gilfinder
+            // addModifier(Mod::GILFINDER, 10 * multiplier);
             break;
         case MOGHANCEMENT_CAMPAIGN:
             addModifier(Mod::CAMPAIGN_BONUS, 5 * multiplier);
             break;
         case MOGHANCEMENT_MONEY_II:
-            addModifier(Mod::GILFINDER, 15 * multiplier);
+            // TODO: this is NOT gilfinder
+            // addModifier(Mod::GILFINDER, 15 * multiplier);
             break;
         case MOGHANCEMENT_SKILL_GAINS:
             // NOTE: Exact value is unknown but considering this only granted by a newish item it makes sense SE made it fairly strong

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -133,6 +133,7 @@ CMobEntity::CMobEntity()
 , m_HiPCLvl(0)
 , m_HiPartySize(0)
 , m_THLvl(0)
+, m_GilfinderLevel(0)
 , m_ItemStolen(false)
 , m_ItemDespoiled(false)
 , m_Family(0)
@@ -594,14 +595,15 @@ void CMobEntity::Spawn()
 {
     TracyZoneScoped;
     CBattleEntity::Spawn();
-    m_giveExp       = true;
-    m_HiPCLvl       = 0;
-    m_HiPartySize   = 0;
-    m_THLvl         = 0;
-    m_ItemStolen    = false;
-    m_ItemDespoiled = false;
-    m_DropItemTime  = 1000ms;
-    animationsub    = (uint8)getMobMod(MOBMOD_SPAWN_ANIMATIONSUB);
+    m_giveExp        = true;
+    m_HiPCLvl        = 0;
+    m_HiPartySize    = 0;
+    m_THLvl          = 0;
+    m_GilfinderLevel = 0;
+    m_ItemStolen     = false;
+    m_ItemDespoiled  = false;
+    m_DropItemTime   = 1000ms;
+    animationsub     = (uint8)getMobMod(MOBMOD_SPAWN_ANIMATIONSUB);
     SetCallForHelpFlag(false);
 
     PEnmityContainer->Clear();
@@ -1188,7 +1190,9 @@ void CMobEntity::Die()
 
             DistributeRewards();
             m_OwnerID.clean();
-            m_THLvl = 0;
+
+            m_THLvl          = 0;
+            m_GilfinderLevel = 0;
         }
     }));
     // clang-format on

--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -238,11 +238,12 @@ public:
     position_t m_SpawnPoint; // spawn point of mob
 
     uint8  m_Element;
-    uint8  m_HiPCLvl;       // Highest Level of Player Character that hit the Monster
-    uint8  m_HiPartySize;   // Largest party size that hit the Monster
-    int16  m_THLvl;         // Highest Level of Treasure Hunter that apply to drops
-    bool   m_ItemStolen;    // if true, mob has already been robbed. reset on respawn. also used for thf maat fight
-    bool   m_ItemDespoiled; // if true, mob has already been despoiled. reset on respawn.
+    uint8  m_HiPCLvl;        // Highest Level of Player Character that hit the Monster
+    uint8  m_HiPartySize;    // Largest party size that hit the Monster
+    int16  m_THLvl;          // Highest Level of Treasure Hunter that apply to drops
+    int16  m_GilfinderLevel; // Highest Level of Gilfinderthat apply to drops
+    bool   m_ItemStolen;     // if true, mob has already been robbed. reset on respawn. also used for thf maat fight
+    bool   m_ItemDespoiled;  // if true, mob has already been despoiled. reset on respawn.
     uint16 m_Family;
     uint16 m_SuperFamily;
     uint16 m_MobSkillList; // Mob skill list defined from mob_pools

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -4281,6 +4281,16 @@ namespace charutils
             gil += std::clamp<uint32>(gBonus, 1, settings::get<uint32>("map.MAX_GIL_BONUS"));
         }
 
+        // TODO: pin down moghancement money which seems to be a % bonus applied individually?
+        // Gilfinder bonus is 1 + (128 + 0..GF level * 16)/256
+        // https://docs.google.com/spreadsheets/d/134YjiVWoqn9UKOFrJFXZPHZChNa6heWzY0xXOGIteC8/edit
+        if (PMob->m_GilfinderLevel > 0)
+        {
+            double multiplier = 1 + ((128 + xirand::GetRandomNumber<uint16_t>(0, PMob->m_GilfinderLevel * 16)) / 256.);
+
+            gil = gil * multiplier;
+        }
+
         // Distribute gil to player/party/alliance
         if (PChar->PParty != nullptr)
         {
@@ -4290,7 +4300,7 @@ namespace charutils
             // clang-format off
             PChar->ForAlliance([PMob, &members](CBattleEntity* PPartyMember)
             {
-                if (PPartyMember->getZone() == PMob->getZone() && isWithinDistance(PPartyMember->loc.p, PMob->loc.p, 100.f))
+                if (PPartyMember->getZone() == PMob->getZone() && isWithinDistance(PPartyMember->loc.p, PMob->loc.p, 100.f)) // TODO: verify range
                 {
                     members.emplace_back((CCharEntity*)PPartyMember);
                 }
@@ -4300,20 +4310,8 @@ namespace charutils
             // all members might not be in range
             if (!members.empty())
             {
-                // Check for highest gilfinder tier
-                uint16 gilFinderActive = 0;
-
-                for (auto PMember : members)
-                {
-                    if (PMember->getMod(Mod::GILFINDER) > gilFinderActive)
-                    {
-                        gilFinderActive = PMember->getMod(Mod::GILFINDER);
-                    }
-                }
-
                 // Calculate gil for each party member.
                 uint32 gilPerPerson = static_cast<uint32>(gil / members.size());
-                gilPerPerson        = gilPerPerson * (100 + gilFinderActive) / 100;
 
                 for (auto PMember : members)
                 {
@@ -4324,8 +4322,6 @@ namespace charutils
         }
         else if (isWithinDistance(PChar->loc.p, PMob->loc.p, 100.f))
         {
-            // Check for gilfinder
-            gil += gil * PChar->getMod(Mod::GILFINDER) / 100;
             UpdateItem(PChar, LOC_INVENTORY, 0, static_cast<int32>(gil));
             PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, static_cast<int32>(gil), 0, 565);
         }


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements retail-accurate gilfinder which works a lot like treasure hunter
See data at https://docs.google.com/spreadsheets/d/134YjiVWoqn9UKOFrJFXZPHZChNa6heWzY0xXOGIteC8/edit?gid=0#gid=0

the tl;dr is gilfinder is a simple multiplier:  `1 + (128 + random(0, 16 * gilfinder_level))/256`

Moghancement money would be very dangerously broken if not disabled until properly implemented. The same data indicates moghancement money 1 is likely a 1.1x multiplier and likely only effects the gil someone receives but we didn't collect enough data to see how it interacts with gilfinder and have it 100% nailed down.

## Steps to test these changes

Have gilfinder, get gil properly (breakpoint in the code to see the multipliers)