### PR TITLE
[xi_test] Controlled weather, lazy-loaded zones

### DIFF
--- a/scripts/globals/interaction/interaction_lookup.lua
+++ b/scripts/globals/interaction/interaction_lookup.lua
@@ -197,9 +197,7 @@ end
 -- Add handlers from a container, if the handler is in a zone in the valid zone table
 function InteractionLookup:addContainer(container, validZoneTable)
     if self.containers[container.id] then
-        -- Container already added, need to remove it first to re-add.
-        printf('Can\'t add a container that is already a loaded. Need to remove it first: ' .. container.id)
-        return
+        self:removeContainer(container)
     end
 
     if container.id == nil then

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1226,19 +1226,12 @@ namespace luautils
         return PNpc;
     }
 
-    void InitInteractionGlobal()
+    void InitInteractionGlobal(const std::vector<uint16>& zoneIds)
     {
         auto initZones = lua["InteractionGlobal"]["initZones"];
+        auto table     = sol::as_table(zoneIds);
 
-        std::vector<uint16> zoneIds;
-        // clang-format off
-        zoneutils::ForEachZone([&zoneIds](CZone* PZone)
-        {
-            zoneIds.emplace_back(PZone->GetID());
-        });
-        // clang-format on
-
-        auto result = initZones(zoneIds);
+        auto result = initZones(table);
 
         if (!result.valid())
         {

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -211,7 +211,7 @@ namespace luautils
     void PopulateIDLookupsByZone(std::optional<uint16> maybeZoneId = std::nullopt);
 
     void SendEntityVisualPacket(uint32 npcid, const char* command);
-    void InitInteractionGlobal();
+    void InitInteractionGlobal(const std::vector<uint16>& zoneIds);
     auto GetZone(uint16 zoneId) -> CZone*;
     auto GetItemByID(uint32 itemId) -> CItem*;
     auto GetNPCByID(uint32 npcid, sol::object const& instanceObj) -> CBaseEntity*;

--- a/src/map/map_engine.h
+++ b/src/map/map_engine.h
@@ -44,6 +44,9 @@ struct MapConfig final
 {
     IPP  ipp{};
     bool inCI{ false };
+    bool isTestServer{ false };      // Disables watchdog and certain recurring tasks when ticks are externally managed.
+    bool lazyZones{ false };         // Load zones when first accessed
+    bool controlledWeather{ false }; // Disables automated weather
 };
 
 //

--- a/src/map/utils/zoneutils.h
+++ b/src/map/utils/zoneutils.h
@@ -32,30 +32,32 @@ class CNpcEntity;
 
 namespace zoneutils
 {
+    void LoadZones(const std::vector<uint16>& zoneIds);
     void LoadZoneList(IPP mapIPP);
     void FreeZoneList();
     void InitializeWeather();
     void TOTDChange(vanadiel_time::TOTD TOTD);
     void SavePlayTime();
 
-    REGION_TYPE    GetCurrentRegion(uint16 ZoneID);
-    CONTINENT_TYPE GetCurrentContinent(uint16 ZoneID);
+    auto GetCurrentRegion(uint16 zoneId) -> REGION_TYPE;
+    auto GetCurrentContinent(uint16 zoneId) -> CONTINENT_TYPE;
 
-    int GetWeatherElement(WEATHER weather);
+    auto GetWeatherElement(WEATHER weather) -> int;
 
-    CZone*       GetZone(uint16 ZoneID);
-    CNpcEntity*  GetTrigger(uint16 TargID, uint16 ZoneID);
-    CBaseEntity* GetEntity(uint32 ID, uint8 filter = -1);
-    CCharEntity* GetCharByName(std::string const& name);
-    auto         GetCharFromWorld(uint32 charid, uint16 targid) -> CCharEntity*; // returns pointer to character by id and target id
-    CCharEntity* GetChar(uint32 id);                                             // returns pointer to character by id
-    CCharEntity* GetCharToUpdate(uint32 primary, uint32 ternary);                // returns pointer to preferred char to update for party changes
-    auto         GetZonesAssignedToThisProcess(IPP mapIPP) -> std::vector<uint16>;
-    bool         IsZoneAssignedToThisProcess(IPP mapIPP, ZONEID zoneId);
-    void         ForEachZone(const std::function<void(CZone*)>& func);
-    uint64       GetZoneIPP(uint16 zoneid);                      // returns IPP for zone ID
-    bool         IsResidentialArea(CCharEntity*);                // returns whether or not the area is a residential zone
-    bool         IsAlwaysOutOfNationControl(REGION_TYPE region); // returns true if a region should never trigger "in areas outside own nation's control" latent effect; false otherwise.
+    auto GetZone(uint16 zoneId) -> CZone*;
+    auto GetTrigger(uint16 targId, uint16 zoneId) -> CNpcEntity*;
+    auto GetEntity(uint32 id, uint8 filter = -1) -> CBaseEntity*;
+    auto GetCharByName(std::string const& name) -> CCharEntity*;
+    auto GetCharFromWorld(uint32 charId, uint16 targId) -> CCharEntity*;  // returns pointer to character by id and target id
+    auto GetChar(uint32 charId) -> CCharEntity*;                          // returns pointer to character by id
+    auto GetCharToUpdate(uint32 primary, uint32 ternary) -> CCharEntity*; // returns pointer to preferred char to update for party changes
+    auto GetZonesAssignedToThisProcess(IPP mapIPP) -> std::vector<uint16>;
+    auto IsZoneAssignedToThisProcess(IPP mapIPP, ZONEID zoneId) -> bool;
+    void ForEachZone(const std::function<void(CZone*)>& func);
+    void ForEachZone(const std::vector<uint16>& zoneIds, const std::function<void(CZone*)>& func);
+    auto GetZoneIPP(uint16 zoneId) -> uint64;                    // returns IPP for zone ID
+    auto IsResidentialArea(const CCharEntity* PChar) -> bool;    // returns whether or not the area is a residential zone
+    auto IsAlwaysOutOfNationControl(REGION_TYPE region) -> bool; // returns true if a region should never trigger "in areas outside own nation's control" latent effect; false otherwise.
 
     void AfterZoneIn(CBaseEntity* PEntity); // triggers after a player has finished zoning in
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Introduces a handful of booleans in MapEngine config struct
- Disable certain code paths when they are equal to true
  - **lazyZones**: Disables the automatic loading of zones, instances and transports matching IPP on MapEngine construction
    - Instead of relying on LoadZoneList, xi_test will directly call LoadZones which has been modified to take a vector of zone IDs
    - The default case (current behavior) still relies on LoadZoneList but it has been modified to simply translate the IPP into zoneIds and pass it to LoadZones. 
    - The underlying LoadMOB/LoadNPC are also modified to operate on a subset of explicit zone IDs.
    - IF initialization code has been slightly modified to be able to support partial loads
      - I also removed the piece that blocked reloading a container. I've gone back and forth multiple times on this and do not see a better way at this point. Guidance welcome
    - I tried to expose this as an optional feature for development purposes but zoneutils needs refactoring into a stateful container to support this properly in my opinion.
 - **controlledWeather**: Disables the initialization of weather in zones. 
 - **isTestServer**: Disables watchdog initialization and certain recurring tasks which do not play well with the future time/tick manipulation

Everything is set to **false by default** and **not exposed**, there should be 0 behavior change once merged.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

- [x] JIT zone loading when lazyZones true (with some extra code to force the load in LoadChar)
- [x] No weather with controlledWeather true
- [x] Retested IF

<!-- Clear and detailed steps to test your changes here -->
