### PR TITLE
[lua/cpp] Fixes for !addallweaponskills, !delallinventory

### DIFF
--- a/scripts/commands/delallweaponskills.lua
+++ b/scripts/commands/delallweaponskills.lua
@@ -1,6 +1,6 @@
 -----------------------------------
--- func: addallweaponskills
--- desc: Adds all learned weaponskills to the given target. If no target then to the current player.
+-- func: delallweaponskills
+-- desc: Removes all learned weaponskills to the given target. If no target then to the current player.
 -----------------------------------
 ---@type TCommand
 local commandObj = {}
@@ -13,7 +13,7 @@ commandObj.cmdprops =
 
 local function error(player, msg)
     player:printToPlayer(msg)
-    player:printToPlayer('!addallweaponskills (player)')
+    player:printToPlayer('!delallweaponskills (player)')
 end
 
 commandObj.onTrigger = function(player, target)
@@ -31,10 +31,10 @@ commandObj.onTrigger = function(player, target)
 
     -- add all learned weaponskills
     for _, wsUnlockId in pairs(xi.wsUnlock) do
-        targ:addLearnedWeaponskill(wsUnlockId)
+        targ:delLearnedWeaponskill(wsUnlockId)
     end
 
-    player:printToPlayer(string.format('%s now has all learned weaponskills.', targ:getName()))
+    player:printToPlayer(string.format('%s now has zero learned weaponskills.', targ:getName()))
 end
 
 return commandObj

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -4267,6 +4267,17 @@ bool CLuaBaseEntity::delContainerItems(sol::object const& containerID)
     auto* PItemContainer = PChar->getStorage(location);
     uint8 containerSize  = PItemContainer->GetSize();
 
+    // ensure we unequip equipped items before deletion
+    for (uint8 equipmentSlot = 0; equipmentSlot <= 15; equipmentSlot++)
+    {
+        if (PChar->equipLoc[equipmentSlot] == location)
+        {
+            // UnequipItem doesn't consider SLOT_MAIN removing SLOT_SUB, so we say to Equip nothing in this equipment slot
+            // this is the same thing that equipset_set packet does to remove a slot
+            charutils::EquipItem(PChar, 0, equipmentSlot, 0);
+        }
+    }
+
     for (uint8 i = 1; i <= containerSize; ++i)
     {
         auto* PItem = PItemContainer->GetItem(i);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

- `!addallweaponskills` Iterate enum for learned ws
- do the same for new `!delallweaponskills`
- and fix crash in `!delallinventory`/`!delcontaineritems`
  - map server crashed if you ran the above while having an item in that container equipped
  - was decided to unequip the items before purging the container, rather than preserve items that were equipped
  - `PChar->equipLoc` stores the container that the equipped item lives in, so we can just loop over all equipment slots to pre-emptively unequip items

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- use all 4 gm commands and see they work as intended
- additional testing of delcontaineritems lua binding
  - equip something from the container X in main hand
  - equip something from another container in offhand
  - `!delcontaineritems X` and see that the offhand is unequipped properly
  - example:
    - <img width="514" height="331" alt="image" src="https://github.com/user-attachments/assets/04cec41f-35ea-47a6-ac9d-b06bc24d3369" />
    - <img width="530" height="558" alt="image" src="https://github.com/user-attachments/assets/ecb9d994-e7a4-4027-8e04-020c5952c4f5" />

