### PR TITLE
[cpp/sql] Adds nyzul vigil weapons latent adds_weaponskill effect

### DIFF
--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -35645,6 +35645,15 @@ INSERT INTO `item_mods` VALUES (17739,5,10); -- MP: 10
 -- Steel Kilij +1
 INSERT INTO `item_mods` VALUES (17740,5,15); -- MP: 15
 
+-- Vorpal Sword
+INSERT INTO `item_mods` VALUES (17742,355,44); -- ADDS_WEAPONSKILL: 44
+
+-- Wightslayer
+INSERT INTO `item_mods` VALUES (17743,355,46); -- ADDS_WEAPONSKILL: 46
+
+-- Brave Blade
+INSERT INTO `item_mods` VALUES (17744,355,45); -- ADDS_WEAPONSKILL: 45
+
 -- Hofud
 INSERT INTO `item_mods` VALUES (17745,3,3);    -- HPP: 3
 INSERT INTO `item_mods` VALUES (17745,13,5);   -- MND: 5
@@ -36063,6 +36072,9 @@ INSERT INTO `item_mods` VALUES (17949,15,8); -- FIRE_MEVA: 8
 -- Zoraal Jas Axe
 INSERT INTO `item_mods` VALUES (17953,364,10); -- REWARD_HP_BONUS: 10
 
+-- Double Axe
+INSERT INTO `item_mods` VALUES (17956,355,74); -- ADDS_WEAPONSKILL: 74
+
 -- Iron Ram Pick
 INSERT INTO `item_mods` VALUES (17958,23,10); -- ATT: 10
 INSERT INTO `item_mods` VALUES (17958,248,2); -- CURSERES: 2
@@ -36181,6 +36193,9 @@ INSERT INTO `item_mods` VALUES (18000,14,1); -- CHR: 1
 
 -- Perseuss Harpe
 INSERT INTO `item_mods` VALUES (18002,246,2); -- PETRIFYRES: 2
+
+-- Swordbreaker
+INSERT INTO `item_mods` VALUES (18003,355,27); -- ADDS_WEAPONSKILL: 27
 
 -- Trailers Kukri
 INSERT INTO `item_mods` VALUES (18004,26,14); -- RACC: 14
@@ -36309,6 +36324,9 @@ INSERT INTO `item_mods` VALUES (18033,501,15);  -- ITEM_ADDEFFECT_CHANCE: 15
 INSERT INTO `item_mods` VALUES (18033,951,148); -- ITEM_ADDEFFECT_STATUS: 148
 INSERT INTO `item_mods` VALUES (18033,952,10);  -- ITEM_ADDEFFECT_POWER: 10
 INSERT INTO `item_mods` VALUES (18033,953,60);  -- ITEM_ADDEFFECT_DURATION: 60
+
+-- Dancing Dagger
+INSERT INTO `item_mods` VALUES (18034,355,28); -- ADDS_WEAPONSKILL: 28
 
 -- Deathbone Knife
 INSERT INTO `item_mods` VALUES (18035,21,-5); -- LIGHT_MEVA: -5
@@ -36520,6 +36538,9 @@ INSERT INTO `item_mods` VALUES (18119,501,15);  -- ITEM_ADDEFFECT_CHANCE: 15
 INSERT INTO `item_mods` VALUES (18119,951,148); -- ITEM_ADDEFFECT_STATUS: 148
 INSERT INTO `item_mods` VALUES (18119,952,10);  -- ITEM_ADDEFFECT_POWER: 10
 INSERT INTO `item_mods` VALUES (18119,953,30);  -- ITEM_ADDEFFECT_DURATION: 30
+
+-- Radiant Lance
+INSERT INTO `item_mods` VALUES (18120,355,122); -- ADDS_WEAPONSKILL: 122
 
 -- Valkyries Fork
 INSERT INTO `item_mods` VALUES (18121,73,3);  -- STORETP: 3
@@ -37522,6 +37543,9 @@ INSERT INTO `item_mods` VALUES (18423,23,3); -- ATT: 3
 -- Izayoi +1
 INSERT INTO `item_mods` VALUES (18424,23,5); -- ATT: 5
 
+-- Sasuke Katana
+INSERT INTO `item_mods` VALUES (18426,355,138); -- ADDS_WEAPONSKILL: 138
+
 -- Shusui
 INSERT INTO `item_mods` VALUES (18429,2,-20); -- HP: -20
 INSERT INTO `item_mods` VALUES (18429,9,3);   -- DEX: 3
@@ -37571,6 +37595,9 @@ INSERT INTO `item_mods` VALUES (18440,12,3); -- INT: 3
 -- Taimakuniyuki +1
 INSERT INTO `item_mods` VALUES (18442,9,5);  -- DEX: 5
 INSERT INTO `item_mods` VALUES (18442,23,5); -- ATT: 5
+
+-- Windslicer
+INSERT INTO `item_mods` VALUES (18443,355,154); -- ADDS_WEAPONSKILL: 154
 
 -- Pachipachio
 INSERT INTO `item_mods` VALUES (18446,23,12); -- ATT: 12
@@ -37710,6 +37737,9 @@ INSERT INTO `item_mods` VALUES (18489,245,2); -- VIRUSRES: 2
 
 -- Dark Amood +1
 INSERT INTO `item_mods` VALUES (18490,245,3); -- VIRUSRES: 3
+
+-- Sturdy Axe
+INSERT INTO `item_mods` VALUES (18492,355,90); -- ADDS_WEAPONSKILL: 90
 
 -- Fourth Division Toporok
 INSERT INTO `item_mods` VALUES (18494,23,10); -- ATT: 10
@@ -38002,8 +38032,17 @@ INSERT INTO `item_mods` VALUES (18585,72,2); -- HPHEAL: 2
 INSERT INTO `item_mods` VALUES (18587,5,50);   -- MP: 50
 INSERT INTO `item_mods` VALUES (18587,374,10); -- CURE_POTENCY: 10
 
+-- Mages Staff
+INSERT INTO `item_mods` VALUES (18589,355,186); -- ADDS_WEAPONSKILL: 186
+
+-- Scepter Staff
+INSERT INTO `item_mods` VALUES (18590,355,187); -- ADDS_WEAPONSKILL: 187
+
 -- Pastoral Staff
 INSERT INTO `item_mods` VALUES (18591,23,4); -- ATT: 4
+
+-- Elder Staff
+INSERT INTO `item_mods` VALUES (18592,355,188); -- ADDS_WEAPONSKILL: 188
 
 -- Alkalurops
 INSERT INTO `item_mods` VALUES (18593,2,-10); -- HP: -10
@@ -38655,6 +38694,12 @@ INSERT INTO `item_mods` VALUES (18715,26,3); -- RACC: 3
 -- Marss Hexagun +1
 INSERT INTO `item_mods` VALUES (18716,26,5); -- RACC: 5
 
+-- Killer Bow
+INSERT INTO `item_mods` VALUES (18719,355,217); -- ADDS_WEAPONSKILL: 217
+
+-- Quicksilver
+INSERT INTO `item_mods` VALUES (18720,355,218); -- ADDS_WEAPONSKILL: 218
+
 -- Peiste Dart
 INSERT INTO `item_mods` VALUES (18726,8,1);  -- STR: 1
 INSERT INTO `item_mods` VALUES (18726,11,1); -- AGI: 1
@@ -38734,6 +38779,12 @@ INSERT INTO `item_mods` VALUES (18751,107,5); -- GUARD: 5
 INSERT INTO `item_mods` VALUES (18752,25,3);   -- ACC: 3
 INSERT INTO `item_mods` VALUES (18752,68,-10); -- EVA: -10
 INSERT INTO `item_mods` VALUES (18752,291,5);  -- COUNTER: 5
+
+-- Burning Fists
+INSERT INTO `item_mods` VALUES (18753,355,11); -- ADDS_WEAPONSKILL: 11
+
+-- Inferno Claws
+INSERT INTO `item_mods` VALUES (18754,355,12); -- ADDS_WEAPONSKILL: 12
 
 -- Noble Himantes
 INSERT INTO `item_mods` VALUES (18755,25,3); -- ACC: 3
@@ -39018,7 +39069,7 @@ INSERT INTO `item_mods` VALUES (18849,5,-31); -- MP: -31
 INSERT INTO `item_mods` VALUES (18849,10,6);  -- VIT: 6
 
 -- Werebuster
-INSERT INTO `item_mods` VALUES (18851,8,8); -- STR: 8
+INSERT INTO `item_mods` VALUES (18851,355,171); -- ADDS_WEAPONSKILL: 171
 
 -- Spirit Maul
 INSERT INTO `item_mods` VALUES (18853,13,2);   -- MND: 2
@@ -39262,6 +39313,9 @@ INSERT INTO `item_mods` VALUES (18915,238,5); -- LUMINION_KILLER: 5
 INSERT INTO `item_mods` VALUES (18916,3,5);   -- HPP: 5
 INSERT INTO `item_mods` VALUES (18916,13,10); -- MND: 10
 INSERT INTO `item_mods` VALUES (18916,14,10); -- CHR: 10
+
+-- Death Sickle
+INSERT INTO `item_mods` VALUES (18944,355,106); -- ADDS_WEAPONSKILL: 106
 
 -- Fourth Division Zaghnal
 INSERT INTO `item_mods` VALUES (18946,25,7);  -- ACC: 7
@@ -39878,6 +39932,9 @@ INSERT INTO `item_mods` VALUES (19099,355,188); -- ADDS_WEAPONSKILL: 188
 INSERT INTO `item_mods` VALUES (19100,2,16);  -- HP: 16
 INSERT INTO `item_mods` VALUES (19100,5,16);  -- MP: 16
 INSERT INTO `item_mods` VALUES (19100,248,2); -- CURSERES: 2
+
+-- Main Gauche
+INSERT INTO `item_mods` VALUES (19102,355,29); -- ADDS_WEAPONSKILL: 29
 
 -- Darksteel Jambiya
 INSERT INTO `item_mods` VALUES (19103,25,1); -- ACC: 1

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3048,7 +3048,8 @@ namespace charutils
             {
                 PItem = dynamic_cast<CItemWeapon*>(PChar->m_Weapons[std::get<0>(slot)]);
 
-                if (PItem)
+                // As of writing, the only unlockable weapons are: wsnm, ksnm, nyzul vigil weapons
+                if (PItem && (!PItem->isUnlockable() || PItem->isUnlocked()))
                 {
                     std::get<1>(slot) = battleutils::GetScaledItemModifier(PChar, PItem, Mod::ADDS_WEAPONSKILL);
                     std::get<2>(slot) = battleutils::GetScaledItemModifier(PChar, PItem, Mod::ADDS_WEAPONSKILL_DYN);
@@ -6864,8 +6865,10 @@ namespace charutils
             if (PWeapon->addWsPoints(wspoints))
             {
                 // weapon is now broken
+                charutils::BuildingCharWeaponSkills(PChar);
                 PChar->PLatentEffectContainer->CheckLatentsWeaponBreak(slotid);
                 PChar->pushPacket<CCharStatsPacket>(PChar);
+                PChar->pushPacket<CCharAbilitiesPacket>(PChar);
             }
 
             db::preparedStmt("UPDATE char_inventory SET extra = ? WHERE charid = ? AND location = ? AND slot = ? LIMIT 1",


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Prereq for #7848 to fully work like retail. (opted to remove the erroneous werebuster mod here and remove any changes to `item_mods.sql` in that PR)

The `ADDS_WEAPONSKILL` mod is a weird one, one of the few  (if not only) that stores an enum value in the mod. I.E. if two items have this mod, the _player's_ value for the mod is a useless sum of the two. The mods are only looked at if the mod is applied to a weapon in either the main or ranged slots.

This means that adding the mod via a latent won't work properly, as latent mods aren't applied to the item, but the player.

There is perhaps some way to update the latent container to apply mods to the item, but it seems like there might be some confusing logic/order of operations with unequipping an item. 

I chose the simpler route of having the vigil weapons apply the mod similar to completed relics, then adding a check where the ws is granted to see if a weapon is unlockable via ws points. As of writing, there are only 3 types of weapons that are unlockable, and none of them require granting a ws full-time (only when "broken" via ws points. i.e. "unlocked")

TL;DR - After this PR, this shows that the only weapons affected are these vigil weapons
<img width="1102" height="576" alt="image" src="https://github.com/user-attachments/assets/aad0b121-e341-4973-bb9c-5a76cae63074" />

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- first, ensure relic weapons still give their ws properly
  - <img width="358" height="347" alt="image" src="https://github.com/user-attachments/assets/d43102b5-828f-4f98-b4a4-a793a793d381" />
- then ensure your char doesn't know any learned weaponskills
- add each vigil weapon
- equip it
- see ws list doesn't contain the nyzul ws
  - <img width="219" height="209" alt="image" src="https://github.com/user-attachments/assets/adeb38a8-2f46-4494-bb4b-b43139227fbd" />
- grant 250 ws points
- see that ws list is updated to include the nyzul ws
  - <img width="513" height="357" alt="image" src="https://github.com/user-attachments/assets/230bc208-b74e-4be0-9bad-bdaa27aec111" />
- equip a different item of the same type and see you no longer have the nyzul ws
  - <img width="216" height="205" alt="image" src="https://github.com/user-attachments/assets/5ce2c470-86f3-434c-ba6b-b5b7401ebd25" />

