### PR TITLE
[xi_test] Lua bindings (getItems, getCrystalElement, equipItem, isCharmed, isMobType)

### DIFF
--- a/scripts/globals/magicburst.lua
+++ b/scripts/globals/magicburst.lua
@@ -21,7 +21,7 @@ local matches = -- [element id][resonance id]
     { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, -- (13) BLU - Physical Slashing
 }
 
--- Returns a boolean if the spell's element matches the resonace given
+-- Returns a boolean if the spell's element matches the resonance given
 local function doesSpellElementMatchResonance(ele, resonance)
     local isMatch = matches[ele + 1][resonance:getPower() + 1]
     return (isMatch ~= nil and isMatch > 0)

--- a/scripts/globals/missions.lua
+++ b/scripts/globals/missions.lua
@@ -3,6 +3,7 @@ require('scripts/globals/utils')
 xi = xi or {}
 xi.mission = xi.mission or {}
 
+---@enum xi.mission.log_id
 xi.mission.log_id =
 {
     SANDORIA    =  0,
@@ -565,7 +566,7 @@ xi.mission.id =
     {
         RHAPSODIES_OF_VANADIEL          = 0,   -- ±
         -- CREATION_AND_REBIRTH         =  -- Category
-        RESONACE                        = 2,   -- ±
+        RESONANCE                       = 2,   -- ±
         EMISSARY_FROM_THE_SEAS          = 3,   -- ±
         SET_FREE                        = 4,   -- ±
         THE_BEGINNING                   = 6,   -- ±

--- a/scripts/missions/rov/1_01_Rhapsodies_of_Vanadiel.lua
+++ b/scripts/missions/rov/1_01_Rhapsodies_of_Vanadiel.lua
@@ -10,7 +10,7 @@ local mission = Mission:new(xi.mission.log_id.ROV, xi.mission.id.rov.RHAPSODIES_
 
 mission.reward =
 {
-    nextMission = { xi.mission.log_id.ROV, xi.mission.id.rov.RESONACE },
+    nextMission = { xi.mission.log_id.ROV, xi.mission.id.rov.RESONANCE },
 }
 
 local rovEntryZones =

--- a/scripts/missions/rov/1_02_Resonance.lua
+++ b/scripts/missions/rov/1_02_Resonance.lua
@@ -5,7 +5,7 @@
 -- !addmission 13 2
 -----------------------------------
 
-local mission = Mission:new(xi.mission.log_id.ROV, xi.mission.id.rov.RESONACE)
+local mission = Mission:new(xi.mission.log_id.ROV, xi.mission.id.rov.RESONANCE)
 
 mission.reward =
 {

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -1003,6 +1003,12 @@ end
 function CBaseEntity:findItems(itemID, location)
 end
 
+---@nodiscard
+---@param location integer?
+---@return CItem[]
+function CBaseEntity:getItems(location)
+end
+
 ---@param size integer
 ---@param arg1 integer?
 ---@return nil
@@ -1089,8 +1095,9 @@ end
 
 ---@param itemID integer
 ---@param container integer?
+---@param slot integer?
 ---@return nil
-function CBaseEntity:equipItem(itemID, container)
+function CBaseEntity:equipItem(itemID, container, slot)
 end
 
 ---@param itemID integer
@@ -3114,6 +3121,11 @@ end
 
 ---@nodiscard
 ---@return boolean
+function CBaseEntity:isCharmed()
+end
+
+---@nodiscard
+---@return boolean
 function CBaseEntity:isTandemActive()
 end
 
@@ -3849,6 +3861,11 @@ end
 ---@nodiscard
 ---@return integer
 function CBaseEntity:getBattleTime()
+end
+
+---@nodiscard
+---@return integer
+function CBaseEntity:getCrystalElement()
 end
 
 ---@nodiscard

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -26,6 +26,7 @@
 #include "luautils.h"
 #include "packets/message_standard.h"
 #include "packets/position.h"
+#include "utils/battleutils.h"
 #include "utils/charutils.h"
 
 enum class ChocoboColor : uint8_t;
@@ -246,6 +247,7 @@ public:
     uint8  incrementItemWear(uint16 itemID);                               // Increment the item's worn value and returns it
     auto   findItem(uint16 itemID, sol::object const& location) -> CItem*; // Like hasItem, but returns the item object (nil if not found)
     auto   findItems(uint16 itemID, sol::object const& location) -> sol::table;
+    auto   getItems(sol::object const& location) -> sol::table;
 
     void createShop(uint8 size, sol::object const& arg1);
     void addShopItem(uint16 itemID, double rawPrice, sol::object const& arg2, sol::object const& arg3);
@@ -265,7 +267,7 @@ public:
 
     // Equipping
     bool canEquipItem(uint16 itemID, sol::object const& chkLevel);
-    void equipItem(uint16 itemID, sol::object const& container);
+    void equipItem(uint16 itemID, sol::object const& container, sol::object const& equipSlot) const;
     void unequipItem(uint8 slotID);
 
     void setEquipBlock(uint16 equipBlock);
@@ -713,6 +715,7 @@ public:
 
     void charm(CLuaBaseEntity const* target, sol::object const& p0);
     void uncharm();
+    auto isCharmed() const -> bool;
     bool isTandemActive();
 
     uint8 addBurden(uint8 element, uint8 burden);
@@ -830,7 +833,7 @@ public:
     uint8  getEcosystem();
     uint16 getSuperFamily();
     uint16 getFamily();
-    bool   isMobType(uint8 mobType); // True if mob is of type passed to function
+    auto   isMobType(uint8 mobType) const -> bool; // True if mob is of type passed to function
     bool   isUndead();
     bool   isNM();
 
@@ -880,6 +883,7 @@ public:
     void  delMobMod(uint16 mobModID, int16 value);
 
     uint32 getBattleTime();
+    auto   getCrystalElement() const -> ELEMENT;
 
     uint16 getBehavior();
     void   setBehavior(uint16 behavior);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a handful of bindings to the Map side. I feel like they could be useful in the future so I don't believe they need to be restricted to just xi_test.
- getItems(): Returns a table of items in a given container
  - This is used by the Treasure Hunter test case to calculate drop rates
- getCrystalElement(): Returns the crystal element of a given monster
  - This is used by the Crystal drop test case to check dropped crystals match mob element.
- isCharmed() - Is a battle entity currently charmed
  - This is used by a handful of BST test cases 

Resolves 2 issues-ish with existing bindings:
- equipItem: Accepts an optional slot. This is relevant for equipping weapons in the SUB slot. The default logic tries to force them in the MAIN slot.
  - The treasure hunter test case uses it to equip Thief's Knife as a sub weapon. Eden code has this extra parameter.
- getMobType: Checking if a mob is NORMAL fails the existing check since the enum equals 0
  - I don't recall why this is needed exactly but I came across it while porting Eden tests.

Also includes a typo fix for RoV 1-2 mission, RESONACE -> RESONANCE.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
!exec print(player:getItems())
!exec print(target:isCharmed())
!exec print(target:getElement())
!exec print(target:isMobType(0))
!exec player:equipItem(XXXX, 0, 1) -- sub slot