### PR TITLE
Add CI check for GetPool magic numbers

### DIFF
--- a/scripts/actions/mobskills/blood_drain.lua
+++ b/scripts/actions/mobskills/blood_drain.lua
@@ -13,8 +13,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local damage = mob:getWeaponDmg() * 2
     local shadow = xi.mobskills.shadowBehavior.NUMSHADOWS_1
 
-    -- Asanbosam (pool id 256) uses a modified blood drain that ignores shadows
-    if mob:getPool() == 256 then
+    -- Asanbosam uses a modified blood drain that ignores shadows
+    if mob:getPool() == xi.mobPools.ASANBOSAM then
         shadow = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
     end
 

--- a/scripts/actions/mobskills/decussate.lua
+++ b/scripts/actions/mobskills/decussate.lua
@@ -11,7 +11,10 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getPool() == 1846 and mob:getHP() < mob:getMaxHP() / 100 * 35 then
+    if
+        mob:getPool() == xi.mobPools.GULOOL_JA_JA and
+        mob:getHP() < mob:getMaxHP() / 100 * 35
+    then
         return 0
     else
         return 1

--- a/scripts/actions/mobskills/dread_shriek.lua
+++ b/scripts/actions/mobskills/dread_shriek.lua
@@ -23,7 +23,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     end
 
     -- Cyranuce M Cutauleon
-    if mob:getPool() == 884 then
+    if mob:getPool() == xi.mobPools.CYRANUCE_M_CUTAULEON then
         power = 100 -- yes, really
     end
 

--- a/scripts/actions/mobskills/drop_hammer.lua
+++ b/scripts/actions/mobskills/drop_hammer.lua
@@ -25,7 +25,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
 
-    if mob:getPool() == 6750 then  -- Fahrafahr the Bloodied
+    if mob:getPool() == xi.mobPools.FAHRAFAHR_THE_BLOODIED then  -- Fahrafahr the Bloodied
         mob:resetEnmity(target)
     end
 

--- a/scripts/actions/mobskills/entangle.lua
+++ b/scripts/actions/mobskills/entangle.lua
@@ -16,7 +16,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    if mob:getName() == 'Cernunnos' then
+    if mob:getPool() == xi.mobPools.CERNUNNOS then
         local numhits = 3
         local accmod = 1
         local ftp    = 2.0
@@ -28,7 +28,10 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill,  xi.effect.BIND, 1, 0, 30)
 
         return dmg
-    elseif mob:getPool() == 671 or mob:getPool() == 1346 then -- Cemetery Cherry and leafless Jidra
+    elseif
+        mob:getPool() == xi.mobPools.CEMETERY_CHERRY or
+        mob:getPool() == xi.mobPools.LEAFLESS_JIDRA
+    then -- Cemetery Cherry and leafless Jidra
         local numhits = 3
         local accmod = 1
         local ftp    = 2.0

--- a/scripts/actions/mobskills/flat_blade.lua
+++ b/scripts/actions/mobskills/flat_blade.lua
@@ -10,7 +10,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getPool() ~= 4006 then
+    if mob:getPool() ~= xi.mobPools.QUBIA_ARENA_TRION then
         mob:messageBasic(xi.msg.basic.READIES_WS, 0, 35)
     end
 
@@ -18,7 +18,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    if mob:getPool() == 4006 then -- Trion@Qubia_Arena only
+    if mob:getPool() == xi.mobPools.QUBIA_ARENA_TRION then
         target:showText(mob, zones[xi.zone.QUBIA_ARENA].text.FLAT_LAND)
     end
 

--- a/scripts/actions/mobskills/flying_hip_press.lua
+++ b/scripts/actions/mobskills/flying_hip_press.lua
@@ -17,7 +17,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local cap = 300
 
     -- Bugbear Matman has stronger Flying Hip Press
-    if mob:getPool() == 562 then
+    if mob:getPool() == xi.mobPools.BUGBEAR_MATMAN then
         cap = math.random(300, 700)
     end
 

--- a/scripts/actions/mobskills/heavy_armature.lua
+++ b/scripts/actions/mobskills/heavy_armature.lua
@@ -6,7 +6,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getPool() == 243 then
+    if mob:getPool() == xi.mobPools.ARMED_GEARS then
         return 0
     else
         return 1

--- a/scripts/actions/mobskills/hurricane_wing.lua
+++ b/scripts/actions/mobskills/hurricane_wing.lua
@@ -27,7 +27,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     target:takeDamage(damage, mob, xi.attackType.MAGICAL, xi.damageType.WIND)
 
-    if mob:getPool() == 2840 then -- Nidhogg
+    if mob:getPool() == xi.mobPool.NIDHOGG then
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 160, 0, 30)
     else
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 100, 0, 30)

--- a/scripts/actions/mobskills/leafstorm.lua
+++ b/scripts/actions/mobskills/leafstorm.lua
@@ -13,9 +13,9 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     if
-        mob:getName() == 'Cernunnos' or
-        mob:getPool() == 671 or
-        mob:getPool() == 1346
+        mob:getPool() == xi.mobPool.CERNUNNOS or
+        mob:getPool() == xi.mobPool.CEMETERY_CHERRY or
+        mob:getPool() == xi.mobPool.LEAFLESS_JIDRA
     then
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 128, 3, 120)
 

--- a/scripts/actions/mobskills/pinecone_bomb.lua
+++ b/scripts/actions/mobskills/pinecone_bomb.lua
@@ -14,7 +14,11 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 1
     local accmod  = 1
     local ftp     = 1
-    if mob:getPool() == 671 or mob:getPool() == 1346 then -- Cemetery Cherry and leafless Jidra
+
+    if
+        mob:getPool() == xi.mobPools.CEMETERY_CHERRY or
+        mob:getPool() == xi.mobPools.LEAFLESS_JIDRA
+    then
         ftp = 3
     else
         ftp = 2.3
@@ -24,7 +28,10 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
 
-    if mob:getPool() ~= 671 and mob:getPool() ~= 1346 then
+    if
+        mob:getPool() ~= xi.mobPools.CEMETERY_CHERRY and
+        mob:getPool() ~= xi.mobPools.LEAFLESS_JIDRA
+    then
         xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.SLEEP_I, 1, 0, 30)
     end
 

--- a/scripts/actions/mobskills/pit_ambush.lua
+++ b/scripts/actions/mobskills/pit_ambush.lua
@@ -9,7 +9,10 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getPool() == 1318 and mob:getLocalVar('AMBUSH') == 1 then
+    if
+        mob:getPool() == xi.mobPools.FEELER_ANTLION and
+        mob:getLocalVar('AMBUSH') == 1
+    then
         return 1
     else
         return 0

--- a/scripts/actions/mobskills/qn_aern_rdm.lua
+++ b/scripts/actions/mobskills/qn_aern_rdm.lua
@@ -6,7 +6,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getPool() == 3269 and mob:getHPP() <= 70 then
+    if mob:getPool() == xi.mobPool.QNAERN_RDM and mob:getHPP() <= 70 then
         return 0
     else
         return 1

--- a/scripts/actions/mobskills/qn_aern_whm.lua
+++ b/scripts/actions/mobskills/qn_aern_whm.lua
@@ -6,7 +6,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getPool() == 4651 and mob:getHPP() <= 50 then
+    if mob:getPool() == xi.mobPools.QNAERN_WHM and mob:getHPP() <= 50 then
         return 0
     else
         return 1

--- a/scripts/actions/mobskills/red_lotus_blade.lua
+++ b/scripts/actions/mobskills/red_lotus_blade.lua
@@ -10,7 +10,10 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getPool() ~= 4006 and mob:getPool() ~= 4249 then
+    if
+        mob:getPool() ~= xi.mobPools.QUBIA_ARENA_TRION and
+        mob:getPool() ~= xi.mobPools.THRONE_ROOM_VOLKER
+    then
         mob:messageBasic(xi.msg.basic.READIES_WS, 0, 34)
     end
 
@@ -18,9 +21,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    if mob:getPool() == 4006 then -- Trion: uBia_Arena only
+    if mob:getPool() == xi.mobPools.QUBIA_ARENA_TRION then -- Trion: uBia_Arena only
         target:showText(mob, zones[xi.zone.QUBIA_ARENA].text.RLB_LAND)
-    elseif mob:getPool() == 4249 then -- Volker: Throne_Room only
+    elseif mob:getPool() == xi.mobPools.THRONE_ROOM_VOLKER then -- Volker: Throne_Room only
         target:showText(mob, zones[xi.zone.THRONE_ROOM].text.FEEL_MY_PAIN)
     end
 

--- a/scripts/actions/mobskills/restoral.lua
+++ b/scripts/actions/mobskills/restoral.lua
@@ -16,7 +16,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     So math.random() for now!
     ]]
     local heal = math.random(900, 1400)
-    if mob:getPool() == 243 then
+    if mob:getPool() == xi.mobPools.ARMED_GEARS then
         heal = heal * 2.5
     end
 

--- a/scripts/actions/mobskills/sand_blast.lua
+++ b/scripts/actions/mobskills/sand_blast.lua
@@ -13,7 +13,10 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 20, 0, 120))
 
-    if mob:getPool() == 1318 and mob:getLocalVar('SAND_BLAST') == 1 then -- Feeler Anltion
+    if
+        mob:getPool() == xi.mobPools.FEELER_ANTLION and
+        mob:getLocalVar('SAND_BLAST') == 1
+    then
         local alastorId = mob:getID() + 6
         local alastor = GetMobByID(alastorId)
         if alastor and not alastor:isSpawned() then -- Alastor Antlion

--- a/scripts/actions/mobskills/savage_blade.lua
+++ b/scripts/actions/mobskills/savage_blade.lua
@@ -10,7 +10,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getPool() ~= 4006 then
+    if mob:getPool() ~= xi.mobPools.QUBIA_ARENA_TRION then
         mob:messageBasic(xi.msg.basic.READIES_WS, 0, 42)
     end
 
@@ -18,7 +18,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    if mob:getPool() == 4006 then -- Trion@QuBia_Arena only
+    if mob:getPool() == xi.mobPools.QUBIA_ARENA_TRION then -- Trion@QuBia_Arena only
         target:showText(mob, zones[xi.zone.QUBIA_ARENA].text.SAVAGE_LAND)
     end
 

--- a/scripts/actions/mobskills/soothing_aroma.lua
+++ b/scripts/actions/mobskills/soothing_aroma.lua
@@ -8,7 +8,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getHPP() >= 50 and mob:getPool() == 3326 then
+    if mob:getHPP() >= 50 and mob:getPool() == xi.mobPools.RASKOVNIK then
         -- Raskovnik doesn't use this for the 1st half of its HP.
         return 1
     end

--- a/scripts/actions/mobskills/spirits_within.lua
+++ b/scripts/actions/mobskills/spirits_within.lua
@@ -10,7 +10,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getPool() ~= 4249 then
+    if mob:getPool() ~= xi.mobPools.THRONE_ROOM_VOLKER then
         mob:messageBasic(xi.msg.basic.READIES_WS, 0, 39)
     end
 
@@ -18,7 +18,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    if mob:getPool() == 4249 then -- Volker@Throne_Room only
+    if mob:getPool() == xi.mobPools.THRONE_ROOM_VOLKER then -- Volker@Throne_Room only
         target:showText(mob, zones[xi.zone.THRONE_ROOM].text.RETURN_TO_THE_DARKNESS)
     end
 

--- a/scripts/actions/mobskills/vorpal_blade.lua
+++ b/scripts/actions/mobskills/vorpal_blade.lua
@@ -24,7 +24,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
         else
             return 1
         end
-    elseif mob:getPool() ~= 4249 then
+    elseif mob:getPool() ~= xi.mobPools.THRONE_ROOM_VOLKER then
         mob:messageBasic(xi.msg.basic.READIES_WS, 0, 40)
     end
 
@@ -32,7 +32,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    if mob:getPool() == 4249 then -- Volker@Throne_Room only
+    if mob:getPool() == xi.mobPools.THRONE_ROOM_VOLKER then -- Volker@Throne_Room only
         target:showText(mob, zones[xi.zone.THRONE_ROOM].text.BLADE_ANSWER)
     end
 

--- a/scripts/actions/mobskills/wild_rage.lua
+++ b/scripts/actions/mobskills/wild_rage.lua
@@ -10,7 +10,6 @@
 ---@type TMobSkill
 local mobskillObject = {}
 
-local platoonScorpionPoolID  = 3157
 local wildRageDamageIncrease = 0.10
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
@@ -23,7 +22,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local ftp    = 2.1
 
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
-    if mob:getPool() == platoonScorpionPoolID then
+    if mob:getPool() == xi.mobPools.PLATOON_SCORPION then
         -- should not have to verify because platoon scorps only in battlefield
         local numScorpsDead = mob:getBattlefield():getLocalVar('[ODS]NumScorpsDead')
 
@@ -34,8 +33,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, xi.mobskills.shadowBehavior.NUMSHADOWS_3)
 
-    -- king vinegrroon
-    if mob:getPool() == 2262 then
+    if mob:getPool() == xi.mobPools.KING_VINEGARROON then
         xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.POISON, 25, 3, 60)
     end
 

--- a/scripts/actions/spells/black/sleepga.lua
+++ b/scripts/actions/spells/black/sleepga.lua
@@ -10,7 +10,7 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     if caster:isMob() then
-        if caster:getPool() == 5310 then -- Amnaf (Flayer)
+        if caster:getPool() == xi.mobPools.AMNAF_PSYCHEFLAYER then
             caster:resetEnmity(target)
         end
 

--- a/scripts/enum/mob_pools.lua
+++ b/scripts/enum/mob_pools.lua
@@ -7,6 +7,26 @@ xi = xi or {}
 ---@enum xi.mobPools
 xi.mobPools =
 {
-    PEPPER  = 3116, -- BCNM20 Charming Trio, Absorbing Kiss
-    PHOEDME = 3132, -- BCNM20 Charming Trio, Deep Kiss
+    ARMED_GEARS            = 243,  -- Armed Gears Restoral
+    ASANBOSAM              = 256,  -- Asanbosam's Blood Drain ignores shadows
+    BUGBEAR_MATMAN         = 562,  -- Stronger Flying Hip Press
+    CEMETERY_CHERRY        = 671,  -- Specific variant of Entangle
+    CERNUNNOS              = 682,  -- Specific variant of Entangle
+    CYRANUCE_M_CUTAULEON   = 884,  -- Dread Shriek bonus potency
+    LEAFLESS_JIDRA         = 1346, -- Specific variant of Entangle
+    FEELER_ANTLION         = 1318, -- Needed for Feeler Antlion special behavior
+    GULOOL_JA_JA           = 1846, -- Gulool Ja Ja skill check
+    KING_VINEGARROON       = 2262, -- KV poison on Wild Rage
+    NIDHOGG                = 2840, -- Nidhogg's stronger hurricane wing
+    PEPPER                 = 3116, -- BCNM20 Charming Trio, Absorbing Kiss
+    PHOEDME                = 3132, -- BCNM20 Charming Trio, Deep Kiss
+    PLATOON_SCORPION       = 3157, -- KS30 Platoon Scorpion Wild Rage behavior
+    QNAERN_RDM             = 3269, -- Qn'Aern RDM chainspell check
+    RASKOVNIK              = 3326, -- Raskovnik Soothing Aroma
+    QUBIA_ARENA_TRION      = 4006, -- Qu'Bia Arena Trion
+    THRONE_ROOM_VOLKER     = 4249, -- Throne Room BC, Volker
+    QNAERN_WHM             = 4651, -- Qn'Aern WHM benediction check
+    AMNAF_PSYCHEFLAYER     = 5310, -- Reset enmity on sleepga
+    FAHRAFAHR_THE_BLOODIED = 6750, -- Reset Enmity on Drop Hammer
+    HPEMDE_NO_DIVING       = 7033, -- Hpemde that don't dive, such as those in the north end of Al'Taieu
 }

--- a/scripts/mixins/families/hpemde.lua
+++ b/scripts/mixins/families/hpemde.lua
@@ -13,7 +13,7 @@ local function dive(mob)
     mob:setMobAbilityEnabled(false)
 
     -- Om'hpedme in north half of Al'Taieu do not dive or become untargetable
-    if mob:getPool() ~= 7033 then
+    if mob:getPool() ~= xi.mobPools.HPEMDE_NO_DIVING then
         mob:hideName(true)
         mob:setUntargetable(true)
         mob:setAnimationSub(5)

--- a/scripts/zones/Nyzul_Isle/mobs/Psycheflayer.lua
+++ b/scripts/zones/Nyzul_Isle/mobs/Psycheflayer.lua
@@ -9,9 +9,8 @@ local entity = {}
 entity.onMobSpawn = function(mob)
     xi.nyzul.specifiedEnemySet(mob)
 
-    if mob:getPool() == 8072 then
-        mob:setMobMod(xi.mobMod.CHECK_AS_NM, 1)
-    end
+    -- There was a mob pool check for 8072 here but that doesn't exist anymore so it was removed.
+    -- If I had to guess it was for Nyzul Isle and is now obsolete?
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/tools/ci/lua_stylecheck.py
+++ b/tools/ci/lua_stylecheck.py
@@ -349,6 +349,12 @@ class LuaStyleCheck:
             if len(paramList) != 2:
                 self.error(f"math.random() calls should have upper and lower bounds ({randString.group(0)}).")
 
+    def check_getpool_magic_number(self, line):
+        """Detects usage of :getPool() with any conditional operator and an integer, and triggers an error."""
+        match = re.search(r":getPool\(\)\s*(==|~=|<=|>=|<|>)\s*\d+", line)
+        if match:
+            self.error(":getPool() compared to integer literal (magic number) using a conditional operator is not allowed.")
+
     def run_style_check(self):
         if self.filename is None:
             print("ERROR: No filename provided to LuaStyleCheck class.")
@@ -398,6 +404,7 @@ class LuaStyleCheck:
                 # Checks that apply to all lines
                 self.check_table_formatting(code_line)
                 self.check_parameter_padding(code_line)
+                self.check_getpool_magic_number(code_line)
 
                 # If this is a spec file, allow for uppercase definitions
                 if "/specs/" not in self.filename:


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds getPool magic number check for Lua scripts.  Focuses on ~= and ==.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
~~CI will fail on this~~
CI will pass with tne new commits
<!-- Clear and detailed steps to test your changes here -->
