### PR TITLE
[ci] Fail on duplicate core calls in same condition

### DIFF
--- a/scripts/zones/Sacrarium/mobs/Mariselles_Pupil.lua
+++ b/scripts/zones/Sacrarium/mobs/Mariselles_Pupil.lua
@@ -19,10 +19,12 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobFight = function(mob, target)
-    local teleTime = mob:getLocalVar('teleTime')
+    local teleTime   = mob:getLocalVar('teleTime')
+    local battleTime = mob:getBattleTime()
+
     if
-        mob:getBattleTime() - teleTime > 30 and
-        mob:getBattleTime() > 59 and
+        battleTime - teleTime > 30 and
+        battleTime > 59 and
         not xi.combat.behavior.isEntityBusy(mob)
     then
         local profLocation = mob:getLocalVar('spawnLocation')

--- a/scripts/zones/Sacrarium/mobs/Old_Professor_Mariselle.lua
+++ b/scripts/zones/Sacrarium/mobs/Old_Professor_Mariselle.lua
@@ -24,10 +24,11 @@ end
 
 entity.onMobFight = function(mob, target)
     local opMariselle = mob:getID()
+    local battleTime  = mob:getBattleTime()
 
     if
-        mob:getBattleTime() % 30 < 3 and
-        mob:getBattleTime() > 3
+        battleTime % 30 < 3 and
+        battleTime > 3
     then
         local xPos = mob:getXPos()
         local yPos = mob:getYPos()
@@ -51,16 +52,18 @@ entity.onMobFight = function(mob, target)
         end
     end
 
-    local teleTime = mob:getLocalVar('teleTime')
+    local teleTime   = mob:getLocalVar('teleTime')
+    local battleTime = mob:getBattleTime()
+
     if
-        mob:getBattleTime() - teleTime > 30 and
-        mob:getBattleTime() > 59 and
+        battleTime - teleTime > 30 and
+        battleTime > 59 and
         not xi.combat.behavior.isEntityBusy(mob)
     then
         local profLocation = mob:getLocalVar('spawnLocation')
         local randomPosition = math.random(1, 9)
         utils.mobTeleport(mob, 2000, professorTables.locations[profLocation][randomPosition])
-        mob:setLocalVar('teleTime', mob:getBattleTime())
+        mob:setLocalVar('teleTime', battleTime)
     end
 
     -- If players wander too far from professor and his teleport room he deaggros --

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Defender.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Defender.lua
@@ -21,10 +21,12 @@ entity.onMobFight = function(mob, target)
     -- TODO: Casting animation for before summons. When he spawns them isn't exactly retail accurate.
     -- Defenders can also still spawn the Aura Gears while sleeping, etc.
     -- Maximum number of pets Defender can spawn is 5
+    local battleTime = mob:getBattleTime()
+
     if
         petCount <= 5 and
-        mob:getBattleTime() % 15 < 3 and
-        mob:getBattleTime() > 3 and
+        battleTime % 15 < 3 and
+        battleTime > 3 and
         not auraGear:isSpawned()
     then
         auraGear:setSpawn(mob:getXPos() + 1, mob:getYPos(), mob:getZPos() + 1)

--- a/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
@@ -221,12 +221,13 @@ entity.onMobWeaponSkill = function(target, mob, skill)
     end
 
     -- Below 25% Jorm can Horrid Roar 3x
-    local roarCount = mob:getLocalVar('roarCount')
+    local roarCount       = mob:getLocalVar('roarCount')
+    local mobAnimationSub = mob:getAnimationSub()
 
     if
         mob:getHPP() <= 25 and
         skill:getID() == 1296 and -- Check for Horrid Roar
-        (mob:getAnimationSub() == 0 or mob:getAnimationSub() == 2) -- If it flies during horrid roar cancel the remainders
+        (mobAnimationSub == 0 or mobAnimationSub == 2) -- If it flies during horrid roar cancel the remainders
     then
         if roarCount < 2 then
             if not target:isBehind(mob, 96) then

--- a/scripts/zones/Valley_of_Sorrows/mobs/Aspidochelone.lua
+++ b/scripts/zones/Valley_of_Sorrows/mobs/Aspidochelone.lua
@@ -72,14 +72,15 @@ entity.onMobFight = function(mob, target)
         mob:getHP() <= changeHP
     then
         mob:setLocalVar('dmgToChange', 0)
+        local mobAnimationSub = mob:getAnimationSub()
 
-        if mob:getAnimationSub() == 1 then
+        if mobAnimationSub == 1 then
             outOfShell(mob)
             mob:setAnimationSub(2)
             mob:setTP(3000) -- Immediately TPs coming out of shell
         elseif
-            mob:getAnimationSub() == 2 or
-            mob:getAnimationSub() == 0
+            mobAnimationSub == 2 or
+            mobAnimationSub == 0
         then
             intoShell(mob)
         end

--- a/scripts/zones/VeLugannon_Palace/mobs/Detector.lua
+++ b/scripts/zones/VeLugannon_Palace/mobs/Detector.lua
@@ -58,10 +58,12 @@ entity.onMobFight = function(mob, target)
     -- Detectors can also still spawn the mobToSpawns while sleeping, moving, etc.
     -- Maximum number of pets Detector can spawn is 5
 
+    local mobBattleTime = mob:getBattleTime()
+
     if
         petCount <= 5 and
-        mob:getBattleTime() % 15 < 3 and
-        mob:getBattleTime() > 3 and
+        mobBattleTime % 15 < 3 and
+        mobBattleTime > 3 and
         not mobToSpawn:isSpawned()
     then
         mobToSpawn:setSpawn(mob:getXPos() + 1, mob:getYPos(), mob:getZPos() + 1)

--- a/tools/ci/lua_stylecheck.py
+++ b/tools/ci/lua_stylecheck.py
@@ -99,7 +99,7 @@ class LuaStyleCheck:
             print(f"{error_string}: {self.filename}:{self.counter}")
 
             if not suppress_line_ref:
-                print(f"{self.lines[self.counter - 1].strip()}                              <-- HERE")
+                print(f"{self.lines[self.counter - 1].strip()}                              <-- HERE");
 
             print("")
 
@@ -349,6 +349,17 @@ class LuaStyleCheck:
             if len(paramList) != 2:
                 self.error(f"math.random() calls should have upper and lower bounds ({randString.group(0)}).")
 
+    def check_duplicate_function_calls_in_condition(self, condition_str):
+        """Detects duplicate method/function calls with identical targets and parameters in a condition string."""
+        # Match method or function calls: target:func(params) or target.func(params)
+        func_calls = re.findall(r'(\w+(?::|\.)\w+\s*\([^\)]*\))', condition_str)
+        seen = set()
+        for call in func_calls:
+            if call in seen:
+                self.error(f"Duplicate function call in condition: {call}")
+            else:
+                seen.add(call)
+
     def run_style_check(self):
         if self.filename is None:
             print("ERROR: No filename provided to LuaStyleCheck class.")
@@ -359,6 +370,7 @@ class LuaStyleCheck:
             in_block_comment    = False
             in_condition        = False
             full_condition      = ""
+            full_condition_original = ""
             uses_id             = False
             has_id_ref          = False
 
@@ -448,8 +460,10 @@ class LuaStyleCheck:
                 # If nothing is left on the line after removing, then the string breaks rules
                 # TODO: If we have a string inside parentheses, make sure it has and/or in the string
 
+                # Condition block handling
                 if contains_word('if')(code_line) or contains_word('elseif')(code_line) or in_condition:
                     full_condition += code_line
+                    full_condition_original += line.rstrip('\n')
 
                     match = re.search(r"\bthen\b\s*(.*)", code_line)
                     if match and match.group(1):
@@ -457,7 +471,7 @@ class LuaStyleCheck:
 
                     if contains_word('then')(code_line):
                         condition_str = full_condition.replace('elseif','').replace('if','').replace('then','').strip()
-                        paren_regex = regex.compile(r"\((([^\)\(]+)|(?R))*+\)", re.S)
+                        paren_regex = regex.compile(r"\((?:[^()]+|(?R))*\)", re.S)
                         removed_paren_str = regex.sub(paren_regex, "", condition_str)
 
                         if removed_paren_str == "":
@@ -469,8 +483,12 @@ class LuaStyleCheck:
                         if not in_condition and len(re.findall(r" and | or ", condition_str)) > 0 and len(condition_str) > 72:
                             self.error("Multiline conditional format required")
 
+                        # Use the original, unmodified condition string for duplicate function call check
+                        self.check_duplicate_function_calls_in_condition(full_condition_original)
+
                         in_condition   = False
                         full_condition = ""
+                        full_condition_original = ""
 
                     # Multiline conditions
                     else:


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Disallows duplicate function calls in the same conditional with no change in parameter as a part of CI.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Example:
```
    if
        petCount <= 5 and
        mob:getBattleTime() % 15 < 3 and
        mob:getBattleTime() > 3 and
        not mobToSpawn:isSpawned()
    then
 ```
    This should fail on change.
