### PR TITLE
[xi_test] Time manipulation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -288,7 +288,7 @@
         "VanadielMoonDirection",
         "VanadielRSERace",
         "VanadielRSELocation",
-        "SetVanadielTimeOffset",
+        "SetTimeOffset",
         "IsMoonNew",
         "IsMoonFull",
         "RunElevator",

--- a/scripts/commands/addtime.lua
+++ b/scripts/commands/addtime.lua
@@ -1,0 +1,35 @@
+-----------------------------------
+-- func: addtime
+-- desc: Resets and then adds offset (in seconds) to earth clock.
+--
+-- Vana'Diel time is indirectly impacted by this command.
+-- Use to adjust time to test timed conditions on quests and other.
+--
+-- Use with caution!
+-----------------------------------
+---@type TCommand
+local commandObj = {}
+
+commandObj.cmdprops =
+{
+    permission = 5,
+    parameters = 'i'
+}
+
+local function error(player)
+    player:printToPlayer('!addtime <offset_in_seconds>')
+end
+
+commandObj.onTrigger = function(player, offset)
+    -- validate offset
+    if offset == nil then
+        error(player)
+        return
+    end
+
+    SetTimeOffset(offset)
+    -- Runs !time command to show the updated time.
+    xi.commands.time.onTrigger(player)
+end
+
+return commandObj

--- a/src/common/earth_time.h
+++ b/src/common/earth_time.h
@@ -33,16 +33,18 @@ namespace earth_time
     using duration   = clock::duration;
     using time_point = clock::time_point;
 
+    inline duration time_offset{ 0 };
+
     // Unix time of the Vana'diel epoch
     static constexpr earth_time::time_point vanadiel_epoch{ 1009810800s };
 
     // Earth time = UTC
     inline time_point now()
     {
-        return clock::now();
+        return clock::now() + time_offset;
     }
 
-    inline std::tm to_utc_tm(const time_point& tp = clock::now())
+    inline std::tm to_utc_tm(const time_point& tp = now())
     {
         std::time_t time_t_val = clock::to_time_t(tp);
         std::tm     utc_tm{};
@@ -50,12 +52,22 @@ namespace earth_time
         return utc_tm;
     }
 
-    inline std::tm to_local_tm(const time_point& tp = clock::now())
+    inline std::tm to_local_tm(const time_point& tp = now())
     {
         std::time_t time_t_val = clock::to_time_t(tp);
         std::tm     local_tm{};
         _localtime_s(&local_tm, &time_t_val);
         return local_tm;
+    }
+
+    inline void add_offset(const duration& additional_offset)
+    {
+        time_offset += additional_offset;
+    }
+
+    inline void reset_offset()
+    {
+        time_offset = duration{ 0 };
     }
 
     namespace utc

--- a/src/common/timer.h
+++ b/src/common/timer.h
@@ -37,10 +37,11 @@ namespace timer
     using time_point = clock::time_point;
 
     inline const time_point start_time = clock::now();
+    inline duration         time_offset{ 0 };
 
     inline time_point now()
     {
-        return clock::now();
+        return clock::now() + time_offset;
     }
 
     inline duration get_uptime()
@@ -51,17 +52,27 @@ namespace timer
     // https://stackoverflow.com/questions/35282308/convert-between-c11-clocks/35282833#35282833
     inline earth_time::time_point to_utc(const time_point& timer_tp = now())
     {
-        auto utc_now   = earth_time::now();
-        auto timer_now = clock::now();
+        const auto utc_now   = earth_time::now();
+        const auto timer_now = timer::now();
         return std::chrono::time_point_cast<earth_time::duration>(timer_tp - timer_now + utc_now);
     };
 
     inline time_point from_utc(const earth_time::time_point& utc_tp = earth_time::now())
     {
-        auto timer_now = clock::now();
-        auto utc_now   = earth_time::now();
+        const auto timer_now = timer::now();
+        const auto utc_now   = earth_time::now();
         return utc_tp - utc_now + timer_now;
     };
+
+    inline void add_offset(const duration& additional_offset)
+    {
+        time_offset += additional_offset;
+    }
+
+    inline void reset_offset()
+    {
+        time_offset = duration{ 0 };
+    }
 
     // Gets the Earth milliseconds of a duration.
     template <typename Rep, typename Period>

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -282,6 +282,7 @@ namespace luautils
         lua.set_function("VanadielMoonDirection", &luautils::VanadielMoonDirection);
         lua.set_function("VanadielRSERace", &luautils::VanadielRSERace);
         lua.set_function("VanadielRSELocation", &luautils::VanadielRSELocation);
+        lua.set_function("SetTimeOffset", &luautils::SetTimeOffset);
         lua.set_function("IsMoonNew", &luautils::IsMoonNew);
         lua.set_function("IsMoonFull", &luautils::IsMoonFull);
         lua.set_function("RunElevator", &luautils::StartElevator);
@@ -1627,6 +1628,14 @@ namespace luautils
     {
         TracyZoneScoped;
         return vanadiel_time::rse::get_location();
+    }
+
+    void SetTimeOffset(const int32 offset)
+    {
+        TracyZoneScoped;
+
+        earth_time::reset_offset();
+        earth_time::add_offset(std::chrono::seconds(offset));
     }
 
     bool IsMoonNew()

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -269,6 +269,7 @@ namespace luautils
     uint8  VanadielMoonDirection();
     uint8  VanadielRSERace();
     uint8  VanadielRSELocation();
+    void   SetTimeOffset(int32 offset); // Manipulate earth time forward or backward by offset seconds. Affects Vana'Diel time.
     bool   IsMoonNew();
     bool   IsMoonFull();
     void   StartElevator(uint32 ElevatorID);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Modifies the steady clock and earth_time clock to accept and account for an optional offset duration.
  - xi_test needs to modify the steady clock for moving ticks forward and the earth clock to test JP Midnights, Vanadiel days etc.
- Reintroduces the bindings to change time from lua (earth_time only!) that was removed with #7500
- Introduce "!addtime <seconds>" making use of said binding to reintroduce the ability to manipulate time for **development purposes**

@cocosolos 

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!addtime 3600

<!-- Clear and detailed steps to test your changes here -->
