### PR TITLE
cpp: Style floats and doubles to use (at least) 1 decimal place

### DIFF
--- a/src/common/sql.cpp
+++ b/src/common/sql.cpp
@@ -417,7 +417,7 @@ float SqlConnection::GetFloatData(size_t col)
     {
         if (col < NumColumns())
         {
-            return (self->row[col] ? (float)atof(self->row[col]) : 0.f);
+            return (self->row[col] ? (float)atof(self->row[col]) : 0.0f);
         }
     }
     ShowCritical("Query: %s", self->buf);

--- a/src/map/ai/controllers/automaton_controller.cpp
+++ b/src/map/ai/controllers/automaton_controller.cpp
@@ -445,7 +445,7 @@ bool CAutomatonController::TryHeal(const CurrentManeuvers& maneuvers)
             break;
     }
 
-    threshold                  = std::clamp<float>(threshold + PAutomaton->getMod(Mod::AUTO_HEALING_THRESHOLD), 30.f, 90.f);
+    threshold                  = std::clamp<float>(threshold + PAutomaton->getMod(Mod::AUTO_HEALING_THRESHOLD), 30.0f, 90.0f);
     CBattleEntity* PCastTarget = nullptr;
 
     bool          haveHate   = false;

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -768,7 +768,7 @@ void CMobController::Move()
                             for (auto PSpawnedMob : static_cast<CCharEntity*>(PTarget)->SpawnMOBList)
                             {
                                 if (PSpawnedMob.second != PMob && !PSpawnedMob.second->PAI->PathFind->IsFollowingPath() &&
-                                    distance(PSpawnedMob.second->loc.p, PMob->loc.p) < 1.f)
+                                    distance(PSpawnedMob.second->loc.p, PMob->loc.p) < 1.0f)
                                 {
                                     auto angle = worldAngle(PMob->loc.p, PTarget->loc.p) + 64;
 

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -56,9 +56,9 @@ CPathFind::CPathFind(CBaseEntity* PTarget)
 , m_maxDistance(0.0f)
 , m_carefulPathing(false)
 {
-    m_originalPoint.x        = 0.f;
-    m_originalPoint.y        = 0.f;
-    m_originalPoint.z        = 0.f;
+    m_originalPoint.x        = 0.0f;
+    m_originalPoint.y        = 0.0f;
+    m_originalPoint.z        = 0.0f;
     m_originalPoint.moving   = 0;
     m_originalPoint.rotation = 0;
 
@@ -483,7 +483,7 @@ bool CPathFind::FindRandomPath(const position_t& start, float maxRadius, uint8 m
     auto m_turnLength = static_cast<uint8_t>(xirand::GetRandomNumber<uint32>(maxTurns) + 1);
 
     // Seemingly arbitrary value to pass for maxRadius, all values seem to give similar results, likely due to navmesh polygons being too dense?
-    float      maxRadiusForPolyQuery = maxRadius / 10.f;
+    float      maxRadiusForPolyQuery = maxRadius / 10.0f;
     position_t startPosition         = start;
 
     // find end points for turns, iterate potentially twice as many times to account for erroneous turnPoints

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -451,7 +451,7 @@ void CMagicState::SpendCost()
         {
             CCharEntity* PChar = static_cast<CCharEntity*>(m_PEntity);
 
-            cost = (int16)(cost * (1.f - (float)((PChar->PJobPoints->GetJobPointValue(JP_QUICK_MAGIC_EFFECT) * 2) / 100)));
+            cost = (int16)(cost * (1.0f - (float)((PChar->PJobPoints->GetJobPointValue(JP_QUICK_MAGIC_EFFECT) * 2) / 100)));
         }
 
         // conserve mp
@@ -459,7 +459,7 @@ void CMagicState::SpendCost()
 
         if (xirand::GetRandomNumber(100) < rate)
         {
-            cost = (int16)(cost * (xirand::GetRandomNumber(8.f, 16.f) / 16.0f));
+            cost = (int16)(cost * (xirand::GetRandomNumber(8.0f, 16.0f) / 16.0f));
         }
 
         m_PEntity->addMP(-cost);

--- a/src/map/ai/states/range_state.cpp
+++ b/src/map/ai/states/range_state.cpp
@@ -95,7 +95,7 @@ CRangeState::CRangeState(CBattleEntity* PEntity, uint16 targid)
                     // reduce delay by 2-50%
                     // https://www.bg-wiki.com/ffxi/Rapid_Shot
                     // https://www.ffxiah.com/forum/topic/49806/ranger-firing-range-testing/4/#3233650
-                    delay       = (int16)(delay * (1.f - xirand::GetRandomNumber<uint16>(2, 50) / 100.f));
+                    delay       = (int16)(delay * (1.0f - xirand::GetRandomNumber<uint16>(2, 50) / 100.0f));
                     m_rapidShot = true;
                 }
             }

--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -112,7 +112,7 @@ void CAttack::SetCritical(bool value)
         {
             if (CStatusEffect* footworkEffect = m_attacker->StatusEffectContainer->GetStatusEffect(EFFECT_FOOTWORK))
             {
-                attBonus += (footworkEffect->GetSubPower() / 256.f); // Mod is out of 256
+                attBonus += (footworkEffect->GetSubPower() / 256.0f); // Mod is out of 256
             }
         }
 

--- a/src/map/enmity_container.cpp
+++ b/src/map/enmity_container.cpp
@@ -140,7 +140,7 @@ float CEnmityContainer::CalculateEnmityBonus(CBattleEntity* PEntity)
         }
     }
 
-    float bonus = (100.f + std::clamp(enmityBonus, -50, 100)) / 100.f;
+    float bonus = (100.0f + std::clamp(enmityBonus, -50, 100)) / 100.0f;
 
     return bonus;
 }
@@ -279,7 +279,7 @@ void CEnmityContainer::UpdateEnmityFromCure(CBattleEntity* PEntity, uint8 level,
     int32 CE                     = 0;
     int32 VE                     = 0;
     float bonus                  = CalculateEnmityBonus(PEntity);
-    float tranquilHeartReduction = 1.f - battleutils::HandleTranquilHeart(PEntity);
+    float tranquilHeartReduction = 1.0f - battleutils::HandleTranquilHeart(PEntity);
 
     if (fixedCE > 0 || fixedVE > 0)
     {
@@ -290,8 +290,8 @@ void CEnmityContainer::UpdateEnmityFromCure(CBattleEntity* PEntity, uint8 level,
     {
         CureAmount = (CureAmount < 1 ? 1 : CureAmount);
 
-        CE = (int32)(40.f / battleutils::GetEnmityModCure(level) * CureAmount * bonus * tranquilHeartReduction);
-        VE = (int32)(240.f / battleutils::GetEnmityModCure(level) * CureAmount * bonus * tranquilHeartReduction);
+        CE = (int32)(40.0f / battleutils::GetEnmityModCure(level) * CureAmount * bonus * tranquilHeartReduction);
+        VE = (int32)(240.0f / battleutils::GetEnmityModCure(level) * CureAmount * bonus * tranquilHeartReduction);
     }
 
     auto enmity_obj = m_EnmityList.find(PEntity->id);
@@ -411,8 +411,8 @@ void CEnmityContainer::UpdateEnmityFromDamage(CBattleEntity* PEntity, int32 Dama
         Damage          = (Damage < 1 ? 1 : Damage);
         int16 damageMod = battleutils::GetEnmityModDamage(m_EnmityHolder->GetMLevel());
 
-        int32 CE = (int32)(80.f / damageMod * Damage);
-        int32 VE = (int32)(240.f / damageMod * Damage);
+        int32 CE = (int32)(80.0f / damageMod * Damage);
+        int32 VE = (int32)(240.0f / damageMod * Damage);
 
         UpdateEnmity(PEntity, CE, VE);
 
@@ -434,8 +434,8 @@ void CEnmityContainer::UpdateEnmityFromAttack(CBattleEntity* PEntity, int32 Dama
     TracyZoneScoped;
     if (auto enmity_obj = m_EnmityList.find(PEntity->id); enmity_obj != m_EnmityList.end())
     {
-        float reduction = (100.f - std::min<int16>(PEntity->getMod(Mod::ENMITY_LOSS_REDUCTION), 100)) / 100.f;
-        int32 CE        = (int32)(-1800.f * Damage / PEntity->GetMaxHP() * reduction);
+        float reduction = (100.0f - std::min<int16>(PEntity->getMod(Mod::ENMITY_LOSS_REDUCTION), 100)) / 100.0f;
+        int32 CE        = (int32)(-1800.0f * Damage / PEntity->GetMaxHP() * reduction);
 
         enmity_obj->second.CE = std::clamp(enmity_obj->second.CE + CE, 0, EnmityCap);
     }

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -210,10 +210,10 @@ void CBattleEntity::UpdateHealth()
 {
     TracyZoneScoped;
 
-    float weaknessPower = (100.f + getMod(Mod::WEAKNESS_PCT)) / 100.f;
-    float cursePower    = (100.f + getMod(Mod::CURSE_PCT)) / 100.f;
-    float HPPPower      = (100.f + getMod(Mod::HPP)) / 100.f;
-    float MPPPower      = (100.f + getMod(Mod::MPP)) / 100.f;
+    float weaknessPower = (100.0f + getMod(Mod::WEAKNESS_PCT)) / 100.0f;
+    float cursePower    = (100.0f + getMod(Mod::CURSE_PCT)) / 100.0f;
+    float HPPPower      = (100.0f + getMod(Mod::HPP)) / 100.0f;
+    float MPPPower      = (100.0f + getMod(Mod::MPP)) / 100.0f;
 
     // Calculate "base" hp/mp with weakness, curse, HP mods. Raw HP/MP mods from food are post-curse.
     // Note: Afflictor was noted to use exactly 75/256 for curse power
@@ -274,7 +274,7 @@ uint8 CBattleEntity::GetHPP() const
         return 0;
     }
 
-    return static_cast<uint8>(std::max<uint8>(1, std::floor((static_cast<float>(health.hp) / static_cast<float>(GetMaxHP())) * 100.f)));
+    return static_cast<uint8>(std::max<uint8>(1, std::floor((static_cast<float>(health.hp) / static_cast<float>(GetMaxHP())) * 100.0f)));
 }
 
 int32 CBattleEntity::GetMaxHP() const
@@ -295,7 +295,7 @@ uint8 CBattleEntity::GetMPP() const
         return 0;
     }
 
-    return static_cast<uint8>(std::max<uint8>(1, std::floor((static_cast<float>(health.mp) / static_cast<float>(GetMaxMP())) * 100.f)));
+    return static_cast<uint8>(std::max<uint8>(1, std::floor((static_cast<float>(health.mp) / static_cast<float>(GetMaxMP())) * 100.0f)));
 }
 
 int32 CBattleEntity::GetMaxMP() const
@@ -923,7 +923,7 @@ uint16 CBattleEntity::ATT(SLOTTYPE slot)
             // Smite applies (bonus ATTP) when using 2H or H2H weapons
             if (weapon->isTwoHanded() || weapon->isHandToHand())
             {
-                ATTP += static_cast<int32>(this->getMod(Mod::SMITE) / 256.f * 100); // Divide Smite value by 256
+                ATTP += static_cast<int32>(this->getMod(Mod::SMITE) / 256.0f * 100); // Divide Smite value by 256
             }
         }
     }

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1915,7 +1915,7 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
                         int16 bloodBoonRate = getMod(Mod::BLOOD_BOON);
                         if (xirand::GetRandomNumber(100) < bloodBoonRate)
                         {
-                            mpCost *= xirand::GetRandomNumber(8.f, 16.f) / 16.f;
+                            mpCost *= xirand::GetRandomNumber(8.0f, 16.0f) / 16.0f;
                         }
                     }
 

--- a/src/map/los/zone_los.cpp
+++ b/src/map/los/zone_los.cpp
@@ -104,8 +104,8 @@ auto ZoneLos::Load(uint16 zoneId, std::string const& pathToObj) -> std::unique_p
     ShowDebug("Nodes: %d", stats.nodes);
     ShowDebug("Empty nodes: %d", stats.emptyNodes);
     ShowDebug("Max elements: %d", stats.maxElements);
-    float treeMem    = stats.nodes * sizeof(LosTreeNode) / 1000000.f;
-    float elementMem = (mesh->face_count * sizeof(Triangle) + mesh->face_count * sizeof(int)) / 1000000.f;
+    float treeMem    = stats.nodes * sizeof(LosTreeNode) / 1000000.0f;
+    float elementMem = (mesh->face_count * sizeof(Triangle) + mesh->face_count * sizeof(int)) / 1000000.0f;
     totalMemory += treeMem + elementMem;
     ShowDebug("Tree memory (%db): %.2f mb", sizeof(LosTreeNode), treeMem);
     ShowDebug("Element memory (%db): %.2f mb", sizeof(Triangle), elementMem);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -16538,7 +16538,7 @@ void CLuaBaseEntity::reduceBurden(float percentReduction, sol::object const& int
     {
         uint8 intReduction = (intReductionObj != sol::lua_nil) ? intReductionObj.as<uint8>() : 0;
 
-        burden[i] = (uint8)std::max(0.f, burden[i] * (1 - ((percentReduction / 100) - PEntity->PJobPoints->GetJobPointValue(JP_COOLDOWN_EFFECT))) - intReduction);
+        burden[i] = (uint8)std::max(0.0f, burden[i] * (1 - ((percentReduction / 100) - PEntity->PJobPoints->GetJobPointValue(JP_COOLDOWN_EFFECT))) - intReduction);
     }
 
     PAutomaton->setBurdenArray(burden);

--- a/src/map/utils/attackutils.cpp
+++ b/src/map/utils/attackutils.cpp
@@ -308,26 +308,26 @@ namespace attackutils
                 break;
         }
 
-        float occ_extra_dmg        = battleutils::GetScaledItemModifier(PChar, PWeapon, Mod::OCC_DO_EXTRA_DMG) / 100.f;
+        float occ_extra_dmg        = battleutils::GetScaledItemModifier(PChar, PWeapon, Mod::OCC_DO_EXTRA_DMG) / 100.0f;
         int16 occ_extra_dmg_chance = battleutils::GetScaledItemModifier(PChar, PWeapon, Mod::EXTRA_DMG_CHANCE) / 10;
 
         if (allowProc)
         {
-            if (occ_extra_dmg > 3.f && occ_extra_dmg_chance > 0 && (1 + xirand::GetRandomNumber(100)) <= occ_extra_dmg_chance)
+            if (occ_extra_dmg > 3.0f && occ_extra_dmg_chance > 0 && (1 + xirand::GetRandomNumber(100)) <= occ_extra_dmg_chance)
             {
                 return (uint32)(damage * occ_extra_dmg);
             }
             else if (occ_do_triple_dmg > 0 && (1 + xirand::GetRandomNumber(100)) <= occ_do_triple_dmg)
             {
-                return (uint32)(damage * 3.f);
+                return (uint32)(damage * 3.0f);
             }
-            else if (occ_extra_dmg > 2.f && occ_extra_dmg_chance > 0 && (1 + xirand::GetRandomNumber(100)) <= occ_extra_dmg_chance)
+            else if (occ_extra_dmg > 2.0f && occ_extra_dmg_chance > 0 && (1 + xirand::GetRandomNumber(100)) <= occ_extra_dmg_chance)
             {
                 return (uint32)(damage * occ_extra_dmg);
             }
             else if (occ_do_double_dmg > 0 && (1 + xirand::GetRandomNumber(100)) <= occ_do_double_dmg)
             {
-                return (uint32)(damage * 2.f);
+                return (uint32)(damage * 2.0f);
             }
             else if (occ_extra_dmg > 0 && occ_extra_dmg_chance > 0 && (1 + xirand::GetRandomNumber(100)) <= occ_extra_dmg_chance)
             {

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -770,7 +770,7 @@ namespace battleutils
 
         if (PDefender->getMod(Mod::SPIKES_DMG_BONUS) > 0)
         {
-            damage *= 1 + (PDefender->getMod(Mod::SPIKES_DMG_BONUS) / 100.f);
+            damage *= 1 + (PDefender->getMod(Mod::SPIKES_DMG_BONUS) / 100.0f);
         }
 
         if (static_cast<SPIKES>(Action->spikesEffect) == SPIKES::SPIKE_DREAD)
@@ -833,7 +833,7 @@ namespace battleutils
                 bool crit = battleutils::GetCritHitRate(PDefender, PAttacker, true) > xirand::GetRandomNumber(100);
 
                 // Dmg math.
-                float  DamageRatio = GetDamageRatio(PDefender, PAttacker, crit, 1.f, skilltype, SLOT_MAIN, false);
+                float  DamageRatio = GetDamageRatio(PDefender, PAttacker, crit, 1.0f, skilltype, SLOT_MAIN, false);
                 uint16 dmg         = (uint32)((PDefender->GetMainWeaponDmg() + battleutils::GetFSTR(PDefender, PAttacker, SLOT_MAIN)) * DamageRatio);
                 dmg                = attackutils::CheckForDamageMultiplier(((CCharEntity*)PDefender), dynamic_cast<CItemWeapon*>(PDefender->m_Weapons[SLOT_MAIN]), dmg,
                                                                            PHYSICAL_ATTACK_TYPE::NORMAL, SLOT_MAIN);
@@ -1172,38 +1172,38 @@ namespace battleutils
                             THdiff = PMob->m_THLvl - playerTH;
                         }
 
-                        float procRate = 0.04f / std::pow<float>(2.f, std::max<int16>(0, THdiff)); // Numbers below diff of -1 (i.e. TH 10 vs mobs TH8 level) are not known. Assume no extra bonus for now.
+                        float procRate = 0.04f / std::pow<float>(2.0f, std::max<int16>(0, THdiff)); // Numbers below diff of -1 (i.e. TH 10 vs mobs TH8 level) are not known. Assume no extra bonus for now.
 
                         // Not known if Feint and Gifts are multiplicative or additive. Currently assuming additive
                         // The mob has an evasion down from feint that applies this mod.
                         // The player has job point gifts that apply this mod.
-                        float procRateBonus = 1.f + (PChar->getMod(Mod::TREASURE_HUNTER_PROC) + PMob->getMod(Mod::TREASURE_HUNTER_PROC)) / 100.f;
+                        float procRateBonus = 1.0f + (PChar->getMod(Mod::TREASURE_HUNTER_PROC) + PMob->getMod(Mod::TREASURE_HUNTER_PROC)) / 100.0f;
 
                         // It's unlikely that SATA bonus is multiplicative SA * TA bonus -- the rate would be astronomically higher if it was
                         // Add the two together if they exist
-                        float sneakAttackTrickAttackBonus = 0.f;
+                        float sneakAttackTrickAttackBonus = 0.0f;
 
                         // BG wiki claims 10x bonus for SA
                         if (attack.IsSneakAttack())
                         {
-                            sneakAttackTrickAttackBonus += 10.f;
+                            sneakAttackTrickAttackBonus += 10.0f;
                         }
 
                         // BG wiki claims 10x bonus for TA
                         if (attack.IsTrickAttack())
                         {
-                            sneakAttackTrickAttackBonus += 10.f;
+                            sneakAttackTrickAttackBonus += 10.0f;
                         }
 
                         // way greater than epsilon just in case...
-                        if (sneakAttackTrickAttackBonus > 1.f)
+                        if (sneakAttackTrickAttackBonus > 1.0f)
                         {
                             procRateBonus *= sneakAttackTrickAttackBonus;
                         }
 
                         procRate *= procRateBonus;
 
-                        if (xirand::GetRandomNumber<float>(0.f, 1.f) <= procRate)
+                        if (xirand::GetRandomNumber<float>(0.0f, 1.0f) <= procRate)
                         {
                             PMob->m_THLvl++;
 
@@ -1736,27 +1736,27 @@ namespace battleutils
         int16 x = 1;
         if (delay <= 180)
         {
-            x = (int16)(61 + ((delay - 180) * 63.f) / 360);
+            x = (int16)(61 + ((delay - 180) * 63.0f) / 360);
         }
         else if (delay <= 540)
         {
-            x = (int16)(61 + ((delay - 180) * 88.f) / 360);
+            x = (int16)(61 + ((delay - 180) * 88.0f) / 360);
         }
         else if (delay <= 630)
         {
-            x = (int16)(149 + ((delay - 540) * 20.f) / 360);
+            x = (int16)(149 + ((delay - 540) * 20.0f) / 360);
         }
         else if (delay <= 720)
         {
-            x = (int16)(154 + ((delay - 630) * 28.f) / 360);
+            x = (int16)(154 + ((delay - 630) * 28.0f) / 360);
         }
         else if (delay <= 900)
         {
-            x = (int16)(161 + ((delay - 720) * 24.f) / 360);
+            x = (int16)(161 + ((delay - 720) * 24.0f) / 360);
         }
         else
         {
-            x = (int16)(173 + ((delay - 900) * 28.f) / 360);
+            x = (int16)(173 + ((delay - 900) * 28.0f) / 360);
         }
         return x;
     }
@@ -2252,17 +2252,17 @@ namespace battleutils
 
                     if (reprisalEffect != nullptr)
                     {
-                        float spikesBonus   = 1.f + (PDefender->getMod(Mod::REPRISAL_SPIKES_BONUS) / 100.f);
+                        float spikesBonus   = 1.0f + (PDefender->getMod(Mod::REPRISAL_SPIKES_BONUS) / 100.0f);
                         int16 effectPower   = (int16)(reprisalEffect->GetPower() * spikesBonus);
                         int32 blockedDamage = (damage * (100 - absorb)) / 100;
                         int32 spikesDamage  = 0;
 
                         if (PDefender->StatusEffectContainer->HasStatusEffect({ EFFECT_INVINCIBLE, EFFECT_SENTINEL }))
                         {
-                            blockedDamage = (baseDamage * (100.f - absorb)) / 100.f;
+                            blockedDamage = (baseDamage * (100.0f - absorb)) / 100.0f;
                         }
 
-                        spikesDamage = blockedDamage * (effectPower / 100.f);
+                        spikesDamage = blockedDamage * (effectPower / 100.0f);
 
                         // Set Reprisal spike damage
                         PDefender->setModifier(Mod::SPIKES_DMG, spikesDamage);
@@ -4079,12 +4079,12 @@ namespace battleutils
         auto* PChar = dynamic_cast<CCharEntity*>(PAttacker);
         if (PChar && PChar->StatusEffectContainer->HasStatusEffect(EFFECT_INNIN) && behind(PChar->loc.p, PDefender->loc.p, 64))
         {
-            damage = (int32)(damage * (1.f + PChar->PMeritPoints->GetMeritValue(MERIT_INNIN_EFFECT, PChar) / 100.f));
+            damage = (int32)(damage * (1.0f + PChar->PMeritPoints->GetMeritValue(MERIT_INNIN_EFFECT, PChar) / 100.0f));
         }
 
         if (PDefender->getMod(Mod::SENGIKORI_SC_DMG_DEBUFF) > 0)
         {
-            damage = static_cast<int32>(damage * (1.f + PDefender->getMod(Mod::SENGIKORI_SC_DMG_DEBUFF) / 100.f));
+            damage = static_cast<int32>(damage * (1.0f + PDefender->getMod(Mod::SENGIKORI_SC_DMG_DEBUFF) / 100.0f));
             PDefender->setModifier(Mod::SENGIKORI_SC_DMG_DEBUFF, 0); // Consume the effect
         }
 
@@ -4955,11 +4955,11 @@ namespace battleutils
 
     int32 BreathDmgTaken(CBattleEntity* PDefender, int32 damage)
     {
-        float resist = 1.0f + PDefender->getMod(Mod::UDMGBREATH) / 10000.f;
-        resist       = std::max(resist, 0.f);
+        float resist = 1.0f + PDefender->getMod(Mod::UDMGBREATH) / 10000.0f;
+        resist       = std::max(resist, 0.0f);
         damage       = (int32)(damage * resist);
 
-        resist = 1.0f + PDefender->getMod(Mod::DMGBREATH) / 10000.f + PDefender->getMod(Mod::DMG) / 10000.f;
+        resist = 1.0f + PDefender->getMod(Mod::DMGBREATH) / 10000.0f + PDefender->getMod(Mod::DMG) / 10000.0f;
         resist = std::clamp(resist, 0.5f, 1.5f); // assuming if its floored at .5f its capped at 1.5f but who's stacking +dmgtaken equip anyway???
         damage = (int32)(damage * resist);
 
@@ -5004,14 +5004,14 @@ namespace battleutils
             return (int32)(damage * liement);
         }
 
-        float resist = 1.f + PDefender->getMod(Mod::UDMGMAGIC) / 10000.f;
-        resist       = std::max(resist, 0.f);
+        float resist = 1.0f + PDefender->getMod(Mod::UDMGMAGIC) / 10000.0f;
+        resist       = std::max(resist, 0.0f);
         damage       = (int32)(damage * resist);
 
-        resist = 1.f + PDefender->getMod(Mod::DMGMAGIC) / 10000.f + PDefender->getMod(Mod::DMG) / 10000.f;
+        resist = 1.0f + PDefender->getMod(Mod::DMGMAGIC) / 10000.0f + PDefender->getMod(Mod::DMG) / 10000.0f;
         resist = std::max(resist, 0.5f);
 
-        resist += PDefender->getMod(Mod::DMGMAGIC_II) / 10000.f;
+        resist += PDefender->getMod(Mod::DMGMAGIC_II) / 10000.0f;
         resist = std::max(resist, 0.125f); // Total cap with MDT-% II included is 87.5%
         damage = (int32)(damage * resist);
 
@@ -5047,13 +5047,13 @@ namespace battleutils
 
     int32 PhysicalDmgTaken(CBattleEntity* PDefender, int32 damage, DAMAGE_TYPE damageType, bool IsCovered)
     {
-        float resist = 1.f + PDefender->getMod(Mod::UDMGPHYS) / 10000.f;
-        resist       = std::max(resist, 0.f);
+        float resist = 1.0f + PDefender->getMod(Mod::UDMGPHYS) / 10000.0f;
+        resist       = std::max(resist, 0.0f);
         damage       = (int32)(damage * resist);
 
-        resist = 1.f + PDefender->getMod(Mod::DMGPHYS) / 10000.f + PDefender->getMod(Mod::DMG) / 10000.f;
-        resist = std::max(resist, 0.5f);                        // PDT caps at -50%
-        resist += PDefender->getMod(Mod::DMGPHYS_II) / 10000.f; // Add Burtgang reduction after 50% cap. Extends cap to -68%
+        resist = 1.0f + PDefender->getMod(Mod::DMGPHYS) / 10000.0f + PDefender->getMod(Mod::DMG) / 10000.0f;
+        resist = std::max(resist, 0.5f);                         // PDT caps at -50%
+        resist += PDefender->getMod(Mod::DMGPHYS_II) / 10000.0f; // Add Burtgang reduction after 50% cap. Extends cap to -68%
         damage = (int32)(damage * resist);
 
         if (damage > 0 && PDefender->objtype == TYPE_PET && PDefender->getMod(Mod::AUTO_STEAM_JACKET) > 0)
@@ -5096,11 +5096,11 @@ namespace battleutils
 
     int32 RangedDmgTaken(CBattleEntity* PDefender, int32 damage, DAMAGE_TYPE damageType, bool IsCovered)
     {
-        float resist = 1.0f + PDefender->getMod(Mod::UDMGRANGE) / 10000.f;
-        resist       = std::max(resist, 0.f);
+        float resist = 1.0f + PDefender->getMod(Mod::UDMGRANGE) / 10000.0f;
+        resist       = std::max(resist, 0.0f);
         damage       = (int32)(damage * resist);
 
-        resist = 1.0f + PDefender->getMod(Mod::DMGRANGE) / 10000.f + PDefender->getMod(Mod::DMG) / 10000.f;
+        resist = 1.0f + PDefender->getMod(Mod::DMGRANGE) / 10000.0f + PDefender->getMod(Mod::DMG) / 10000.0f;
         resist = std::max(resist, 0.5f);
         damage = (int32)(damage * resist);
 
@@ -5229,7 +5229,7 @@ namespace battleutils
 
     float HandleTranquilHeart(CBattleEntity* PEntity)
     {
-        float reductionPercent = 0.f;
+        float reductionPercent = 0.0f;
 
         if (PEntity->objtype == TYPE_PC && charutils::hasTrait((CCharEntity*)PEntity, TRAIT_TRANQUIL_HEART))
         {
@@ -5242,7 +5242,7 @@ namespace battleutils
                 reductionPercent = 25;
             }
 
-            reductionPercent = reductionPercent / 100.f;
+            reductionPercent = reductionPercent / 100.0f;
         }
 
         return reductionPercent;
@@ -5964,7 +5964,7 @@ namespace battleutils
             VelocityShotReductionPercent = 15 + battleEntity->getMod(Mod::VELOCITY_SNAPSHOT_BONUS);
         }
 
-        return (int16)(delay * ((100 - SnapShotReductionPercent) / 100.f) * ((100 - VelocityShotReductionPercent) / 100.f));
+        return (int16)(delay * ((100 - SnapShotReductionPercent) / 100.0f) * ((100 - VelocityShotReductionPercent) / 100.0f));
     }
 
     /************************************************************************
@@ -6310,7 +6310,7 @@ namespace battleutils
             uncappedFastCast = std::clamp<int16>(uncappedFastCast + PEntity->getMod(Mod::DIVINE_BENISON), -100, 100);
         }
 
-        float sumFastCast = std::clamp<float>((float)(fastCast + uncappedFastCast + inspirationFastCast), -100.f, 100.f);
+        float sumFastCast = std::clamp<float>((float)(fastCast + uncappedFastCast + inspirationFastCast), -100.0f, 100.0f);
 
         return std::chrono::floor<std::chrono::milliseconds>(cast * ((100.0f - sumFastCast) / 100.0f));
     }
@@ -6508,7 +6508,7 @@ namespace battleutils
             if (PEntity->StatusEffectContainer->HasStatusEffect({ EFFECT_LIGHT_ARTS, EFFECT_ADDENDUM_WHITE }))
             {
                 // Add any "Grimoire: Reduces spellcasting time" bonuses + Light Arts bonus
-                recast = std::chrono::floor<std::chrono::milliseconds>(recast * ((100.f + PEntity->getMod(Mod::WHITE_MAGIC_RECAST) + PEntity->getMod(Mod::GRIMOIRE_SPELLCASTING)) / 100.0f));
+                recast = std::chrono::floor<std::chrono::milliseconds>(recast * ((100.0f + PEntity->getMod(Mod::WHITE_MAGIC_RECAST) + PEntity->getMod(Mod::GRIMOIRE_SPELLCASTING)) / 100.0f));
             }
             else
             {
@@ -6550,7 +6550,7 @@ namespace battleutils
                 CCharEntity* PChar = static_cast<CCharEntity*>(PEntity);
                 if (charutils::hasTrait(PChar, TRAIT_OCCULT_ACUMEN))
                 {
-                    return static_cast<int16>(PSpell->getMPCost() * PChar->getMod(Mod::OCCULT_ACUMEN) / 100.f * (1 + (PChar->getMod(Mod::STORETP) / 100.f)));
+                    return static_cast<int16>(PSpell->getMPCost() * PChar->getMod(Mod::OCCULT_ACUMEN) / 100.0f * (1 + (PChar->getMod(Mod::STORETP) / 100.0f)));
                 }
             }
         }

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3635,11 +3635,11 @@ namespace charutils
             if ((SkillID >= 1 && SkillID <= 12) || (SkillID >= 25 && SkillID <= 31))
             // if should effect automaton replace the above with: (SkillID >= 1 && SkillID <= 31)
             {
-                SkillUpChance *= ((100.f + PChar->getMod(Mod::COMBAT_SKILLUP_RATE)) / 100.f);
+                SkillUpChance *= ((100.0f + PChar->getMod(Mod::COMBAT_SKILLUP_RATE)) / 100.0f);
             }
             else if (SkillID >= 32 && SkillID <= 44)
             {
-                SkillUpChance *= ((100.f + PChar->getMod(Mod::MAGIC_SKILLUP_RATE)) / 100.f);
+                SkillUpChance *= ((100.0f + PChar->getMod(Mod::MAGIC_SKILLUP_RATE)) / 100.0f);
             }
 
             if (Diff > 0 && (random < SkillUpChance || forceSkillUp))
@@ -4301,7 +4301,7 @@ namespace charutils
             // clang-format off
             PChar->ForAlliance([PMob, &members](CBattleEntity* PPartyMember)
             {
-                if (PPartyMember->getZone() == PMob->getZone() && isWithinDistance(PPartyMember->loc.p, PMob->loc.p, 100.f)) // TODO: verify range
+                if (PPartyMember->getZone() == PMob->getZone() && isWithinDistance(PPartyMember->loc.p, PMob->loc.p, 100.0f)) // TODO: verify range
                 {
                     members.emplace_back((CCharEntity*)PPartyMember);
                 }
@@ -4321,7 +4321,7 @@ namespace charutils
                 }
             }
         }
-        else if (isWithinDistance(PChar->loc.p, PMob->loc.p, 100.f))
+        else if (isWithinDistance(PChar->loc.p, PMob->loc.p, 100.0f))
         {
             UpdateItem(PChar, LOC_INVENTORY, 0, static_cast<int32>(gil));
             PChar->pushPacket<CMessageBasicPacket>(PChar, PChar, static_cast<int32>(gil), 0, 565);
@@ -4521,22 +4521,22 @@ namespace charutils
 
                     if (PMob->getMobMod(MOBMOD_EXP_BONUS))
                     {
-                        const float monsterbonus = 1.f + PMob->getMobMod(MOBMOD_EXP_BONUS) / 100.f;
+                        const float monsterbonus = 1.0f + PMob->getMobMod(MOBMOD_EXP_BONUS) / 100.0f;
                         exp *= monsterbonus;
                     }
 
                     // Per monster caps pulled from: https://ffxiclopedia.fandom.com/wiki/Experience_Points
                     if (PMember->GetMLevel() <= 50)
                     {
-                        exp = std::fmin(exp, 400.f);
+                        exp = std::fmin(exp, 400.0f);
                     }
                     else if (PMember->GetMLevel() <= 60)
                     {
-                        exp = std::fmin(exp, 500.f);
+                        exp = std::fmin(exp, 500.0f);
                     }
                     else
                     {
-                        exp = std::fmin(exp, 600.f);
+                        exp = std::fmin(exp, 600.0f);
                     }
 
                     if (mobCheck > EMobDifficulty::DecentChallenge)
@@ -4936,7 +4936,7 @@ namespace charutils
             }
         }
 
-        capacityPoints *= 1.f + rawBonus / 100;
+        capacityPoints *= 1.0f + rawBonus / 100;
         return capacityPoints;
     }
 
@@ -7308,7 +7308,7 @@ namespace charutils
 
         if (highestItem > 99)
         {
-            itemLevelDiff += (highestItem - 99) / 2.f;
+            itemLevelDiff += (highestItem - 99) / 2.0f;
         }
 
         for (uint8 slotID = 4; slotID < 9; ++slotID)
@@ -7317,7 +7317,7 @@ namespace charutils
 
             if (PItem && PItem->getILvl() > 99)
             {
-                itemLevelDiff += (PItem->getILvl() - 99) / 10.f;
+                itemLevelDiff += (PItem->getILvl() - 99) / 10.0f;
             }
         }
 

--- a/src/map/utils/puppetutils.cpp
+++ b/src/map/utils/puppetutils.cpp
@@ -531,7 +531,7 @@ namespace puppetutils
                 SkillUpChance = 0.5;
             }
 
-            SkillUpChance *= ((100.f + PAutomaton->getMod(Mod::COMBAT_SKILLUP_RATE)) / 100.f);
+            SkillUpChance *= ((100.0f + PAutomaton->getMod(Mod::COMBAT_SKILLUP_RATE)) / 100.0f);
 
             if (Diff > 0 && random < SkillUpChance)
             {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Makes double and float usage uniform

Regex: [0-9][.][f;] in *.h and *.cpp files
