### PR TITLE
[core][lua] handleSevereDamage Lua binding

### DIFF
--- a/scripts/globals/ability.lua
+++ b/scripts/globals/ability.lua
@@ -68,6 +68,7 @@ xi.ability.adjustDamage = function(dmg, attacker, skill, target, skilltype, skil
         local element = utils.clamp(skillparam - 5, xi.element.NONE, xi.element.DARK) -- Transform damage type to element
         dmg = math.floor(dmg * xi.spells.damage.calculateTMDA(target, element))
         dmg = math.floor(dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, element))
+        dmg = math.floor(target:handleSevereDamage(dmg, false))
     elseif skilltype == xi.attackType.BREATH then
         dmg = target:breathDmgTaken(dmg)
     elseif skilltype == xi.attackType.RANGED then

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -254,6 +254,7 @@ function finalMagicAdjustments(caster, target, spell, dmg)
 
     dmg = math.floor(dmg * xi.spells.damage.calculateTMDA(target, spell:getElement()))
     dmg = math.floor(dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, spell:getElement()))
+    dmg = math.floor(target:handleSevereDamage(dmg, false))
 
     if dmg > 0 then
         dmg = dmg - target:getMod(xi.mod.PHALANX)
@@ -292,6 +293,7 @@ function finalMagicNonSpellAdjustments(caster, target, ele, dmg)
 
     dmg = math.floor(dmg * xi.spells.damage.calculateTMDA(target, ele))
     dmg = math.floor(dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, ele))
+    dmg = math.floor(target:handleSevereDamage(dmg, false))
 
     if dmg > 0 then
         dmg = dmg - target:getMod(xi.mod.PHALANX)

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -496,6 +496,7 @@ xi.mobskills.mobFinalAdjustments = function(dmg, mob, skill, target, attackType,
         local element = utils.clamp(damageType - 5, xi.element.NONE, xi.element.DARK) -- Transform damage type to element
         dmg = math.floor(dmg * xi.spells.damage.calculateTMDA(target, element))
         dmg = math.floor(dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, element))
+        dmg = math.floor(target:handleSevereDamage(dmg, false))
     elseif attackType == xi.attackType.BREATH then
         dmg = target:breathDmgTaken(dmg)
     elseif attackType == xi.attackType.RANGED then

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -319,6 +319,7 @@ local function calculateHybridMagicDamage(tp, physicaldmg, attacker, target, wsP
     magicdmg = math.floor(magicdmg + calcParams.bonusfTP * physicaldmg)
     magicdmg = math.floor(magicdmg * applyResistanceAbility(attacker, target, wsParams.ele, wsParams.skill, calcParams.bonusAcc))
     magicdmg = math.floor(magicdmg * xi.spells.damage.calculateTMDA(target, wsParams.ele))
+    magicdmg = math.floor(target:handleSevereDamage(magicdmg, false))
 
     if magicdmg > 0 then
         magicdmg = math.floor(magicdmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, wsParams.ele))
@@ -871,6 +872,7 @@ xi.weaponskills.doMagicWeaponskill = function(attacker, target, wsID, wsParams, 
         dmg = math.floor(addBonusesAbility(attacker, wsParams.ele, target, dmg, wsParams))
         dmg = math.floor(dmg * applyResistanceAbility(attacker, target, wsParams.ele, wsParams.skill, gearAcc))
         dmg = math.floor(dmg * xi.spells.damage.calculateTMDA(target, wsParams.ele))
+        dmg = math.floor(target:handleSevereDamage(dmg, false))
 
         if dmg < 0 then
             calcParams.finalDmg = dmg

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -3338,6 +3338,13 @@ end
 function CBaseEntity:checkDamageCap(damage)
 end
 
+---@nodiscard
+---@param damage integer
+---@param isPhysical boolean
+---@return integer
+function CBaseEntity:handleSevereDamage(damage, isPhysical)
+end
+
 ---@param arg0 integer? Optional Pet ID
 ---@return nil
 function CBaseEntity:spawnPet(arg0)

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -15337,6 +15337,17 @@ int32 CLuaBaseEntity::checkDamageCap(int32 damage)
     return 0;
 }
 
+auto CLuaBaseEntity::handleSevereDamage(int32 damage, bool isPhysical) -> int32
+{
+    if (auto* PBattle = dynamic_cast<CBattleEntity*>(m_PBaseEntity))
+    {
+        return battleutils::HandleSevereDamage(PBattle, damage, isPhysical);
+    }
+
+    ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->getName());
+    return 0;
+}
+
 /************************************************************************
  *  Function: spawnPet()
  *  Purpose : Spawns a pet if a few correct conditions are met
@@ -19912,6 +19923,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("takeSpellDamage", CLuaBaseEntity::takeSpellDamage);
     SOL_REGISTER("takeSwipeLungeDamage", CLuaBaseEntity::takeSwipeLungeDamage);
     SOL_REGISTER("checkDamageCap", CLuaBaseEntity::checkDamageCap);
+    SOL_REGISTER("handleSevereDamage", CLuaBaseEntity::handleSevereDamage);
 
     // Pets and Automations
     SOL_REGISTER("spawnPet", CLuaBaseEntity::spawnPet);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -762,6 +762,7 @@ public:
     int32 takeSpellDamage(CLuaBaseEntity* caster, CLuaSpell* spell, int32 damage, uint8 atkType, uint8 dmgType);
     int32 takeSwipeLungeDamage(CLuaBaseEntity* caster, int32 damage, uint8 atkType, uint8 dmgType);
     int32 checkDamageCap(int32 damage);
+    auto  handleSevereDamage(int32 damage, bool isPhysical) -> int32;
 
     // Pets and Automations
     void spawnPet(sol::object const& arg0);

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -5298,10 +5298,11 @@ namespace battleutils
         return damage;
     }
 
-    int32 HandleSevereDamage(CBattleEntity* PDefender, int32 damage, bool isPhysical)
+    auto HandleSevereDamage(CBattleEntity* PDefender, int32 damage, bool isPhysical) -> int32
     {
         damage = HandleSevereDamageEffect(PDefender, EFFECT_MIGAWARI, damage, true);
-        // In the future, handle other Severe Damage Effects like Earthen Armor here
+        // TODO: Earthen Armor effect
+        // TODO: Sentinel's Scherzo effect
 
         if (isPhysical && PDefender->objtype == TYPE_PET && PDefender->getMod(Mod::AUTO_SCHURZEN) != 0 && damage >= PDefender->health.hp &&
             ((CPetEntity*)PDefender)->PMaster->StatusEffectContainer->GetEffectsCount(EFFECT_EARTH_MANEUVER) >= 1)
@@ -5349,7 +5350,7 @@ namespace battleutils
         }
     }
 
-    int32 HandleSevereDamageEffect(CBattleEntity* PDefender, EFFECT effect, int32 damage, bool removeEffect)
+    auto HandleSevereDamageEffect(CBattleEntity* PDefender, EFFECT effect, int32 damage, bool removeEffect) -> int32
     {
         if (PDefender->StatusEffectContainer->HasStatusEffect(effect))
         {

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -217,11 +217,11 @@ namespace battleutils
     int32 HandleSteamJacket(CBattleEntity* PDefender, int32 damage, DAMAGE_TYPE damageType);
     int32 CheckAndApplyDamageCap(int32 damage, CBattleEntity* PDefender);
 
-    void  HandleIssekiganEnmityBonus(CBattleEntity* PDefender, CBattleEntity* PAttacker);
-    int32 HandleSevereDamage(CBattleEntity* PDefender, int32 damage, bool isPhysical);
-    int32 HandleSevereDamageEffect(CBattleEntity* PDefender, EFFECT effect, int32 damage, bool removeEffect);
-    void  HandleTacticalParry(CBattleEntity* PEntity);
-    void  HandleTacticalGuard(CBattleEntity* PEntity);
+    void HandleIssekiganEnmityBonus(CBattleEntity* PDefender, CBattleEntity* PAttacker);
+    auto HandleSevereDamage(CBattleEntity* PDefender, int32 damage, bool isPhysical) -> int32;
+    auto HandleSevereDamageEffect(CBattleEntity* PDefender, EFFECT effect, int32 damage, bool removeEffect) -> int32;
+    void HandleTacticalParry(CBattleEntity* PEntity);
+    void HandleTacticalGuard(CBattleEntity* PEntity);
 
     // Handles everything related to breaking Bind
     void BindBreakCheck(CBattleEntity* PAttacker, CBattleEntity* PDefender);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

1. Adds a lua binding for the "HandleSevereDamage" function. This is used for Migawari:Ichi and other effects that mitigate high damage. Currently HandleSevereDamage is only called in broad functions like magicDmgTaken(retired in lua: https://github.com/LandSandBoat/server/pull/7493), breathDmgTaken, etc.

Since we retired magicDmgTaken, this will re-add functionality where magicDmgTaken was removed.

2. Converts related functions to use trailing return type.

## Steps to test these changes
1. Change job to NIN.
2. !additem mokujin ##
3. Edit a mobskill to use a high damage multiplier. (You want a damage to exceed the damage threshold required to trigger HandleSevereDamage.)
4. Cast Migawari on yourself and force the mob to use the mobskill with `!exec target:useMobAbility(####, player)`
5. If the damage reached the threshold, it will deal 0 damage, and the ninjutsu effect will wear off.
