### PR TITLE
[lua] Remove hardcoded power for Marcato and Sengikori

### DIFF
--- a/scripts/actions/abilities/sengikori.lua
+++ b/scripts/actions/abilities/sengikori.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    player:addStatusEffect(xi.effect.SENGIKORI, 12, 0, 60)
+    player:addStatusEffect(xi.effect.SENGIKORI, 25, 0, 60)
 end
 
 return abilityObject

--- a/scripts/globals/job_utils/bard.lua
+++ b/scripts/globals/job_utils/bard.lua
@@ -45,7 +45,7 @@ xi.job_utils.bard.useTenuto = function(player, target, ability)
 end
 
 xi.job_utils.bard.useMarcato = function(player, target, ability)
-    player:addStatusEffect(xi.effect.MARCATO, 0, 0, 60)
+    player:addStatusEffect(xi.effect.MARCATO, 50, 0, 60)
 end
 
 xi.job_utils.bard.useClarionCall = function(player, target, ability)

--- a/scripts/globals/spells/enfeebling_song.lua
+++ b/scripts/globals/spells/enfeebling_song.lua
@@ -92,10 +92,11 @@ xi.spells.enfeebling.calculateSongPower = function(caster, spellEffect, basePowe
     }
 
     if effectTable[spellEffect] then
+        local marcatoEffect = caster:getStatusEffect(xi.effect.MARCATO)
         if caster:hasStatusEffect(xi.effect.SOUL_VOICE) then
             power = power * 2
-        elseif caster:hasStatusEffect(xi.effect.MARCATO) then
-            power = power * 1.5
+        elseif marcatoEffect ~= nil then
+            power = power * (1 + (marcatoEffect:getPower() / 100))
         end
     end
 

--- a/scripts/globals/spells/enhancing_song.lua
+++ b/scripts/globals/spells/enhancing_song.lua
@@ -207,10 +207,11 @@ xi.spells.enhancing.calculateSongPower = function(caster, target, spell, spellId
 
     -- Additional Potency from Status Effects.
     if soulVoicePower then -- Soul Voice/Macarato affects Power.
+        local marcatoEffect = caster:getStatusEffect(xi.effect.MARCATO)
         if caster:hasStatusEffect(xi.effect.SOUL_VOICE) then
             power = math.floor(power * 2)
-        elseif caster:hasStatusEffect(xi.effect.MARCATO) then
-            power = math.floor(power * 1.5)
+        elseif marcatoEffect ~= nil then
+            power = math.floor(power * (1 + (marcatoEffect:getPower() / 100)))
         end
     end
 
@@ -246,10 +247,11 @@ xi.spells.enhancing.calculateSongDuration = function(caster, target, spell, inst
 
     -- Additional duration from Status Effects.
     if not soulVoicePower then -- Soul Voice/Macarato doesn't affect potency, so it affects Duration.
+        local marcatoEffect = caster:getStatusEffect(xi.effect.MARCATO)
         if caster:hasStatusEffect(xi.effect.SOUL_VOICE) then
             duration = math.floor(duration * 2)
-        elseif caster:hasStatusEffect(xi.effect.MARCATO) then
-            duration = math.floor(duration * 1.5)
+        elseif marcatoEffect ~= nil then
+            duration = math.floor(duration * (1 + (marcatoEffect:getPower() / 100)))
         end
     end
 

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -976,15 +976,16 @@ xi.weaponskills.takeWeaponskillDamage = function(defender, attacker, wsParams, p
         defender:updateEnmityFromDamage(enmityEntity, finaldmg * enmityMult)
     end
 
+    local sengikoriEffect = attacker:getStatusEffect(xi.effect.SENGIKORI)
     -- TODO: does this effect not apply if you do 0 damage (or absorb)?
     -- Skillchains will still "proc" if you do 0 damage, so assume it does for now
     if
         (wsResults.tpHitsLanded +
         wsResults.extraHitsLanded > 0) and
-        attacker:hasStatusEffect(xi.effect.SENGIKORI)
+        sengikoriEffect ~= nil
     then
         local sengikoriBonus = attacker:getMod(xi.mod.SENGIKORI_BONUS) -- Additive % bonus: https://www.ffxiah.com/forum/topic/23457/july-11-sam-update/4/#1421344
-        local power = 25 + sengikoriBonus                              -- base 25% bonus for SC or MB
+        local power = sengikoriEffect:getPower() + sengikoriBonus
 
         -- If no SC effect, apply SC damage debuff
         -- If there is one, apply MB damage debuff


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

- Removes the hardcoded power in both Marcato and Sengikori and moves it to effect:getPower()
- This is for module support

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Use the abilities with prints to show the power is unchanged when using effect:getPower()
