### PR TITLE
[ZM16] Improve "The celestial Nexus" BCNM combat logic

### DIFF
--- a/scripts/zones/The_Celestial_Nexus/mobs/Ealdnarche.lua
+++ b/scripts/zones/The_Celestial_Nexus/mobs/Ealdnarche.lua
@@ -18,6 +18,7 @@ end
 
 entity.onMobSpawn = function(mob)
     mob:setAutoAttackEnabled(false)
+    mob:setUnkillable(true)
     mob:setMobMod(xi.mobMod.GA_CHANCE, 25)
     mob:addStatusEffectEx(xi.effect.PHYSICAL_SHIELD, 0, 1, 0, 0)
     mob:addStatusEffectEx(xi.effect.ARROW_SHIELD, 0, 1, 0, 0)

--- a/scripts/zones/The_Celestial_Nexus/mobs/Exoplates.lua
+++ b/scripts/zones/The_Celestial_Nexus/mobs/Exoplates.lua
@@ -11,60 +11,72 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.PETRIFY)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
-    mob:addMod(xi.mod.REGAIN, 50)
 end
 
 entity.onMobSpawn = function(mob)
+    mob:setMod(xi.mod.REGAIN, 100)                -- When left alone, still uses TP moves.
+    mob:setMod(xi.mod.DESPAWN_TIME_REDUCTION, 15) -- Fast despawn.
+    mob:setMobMod(xi.mobMod.SKILL_LIST, 2057)     -- Default skill list.
     mob:setAnimationSub(0)
     mob:setAutoAttackEnabled(false)
-    mob:setUnkillable(true)
-    mob:setLocalVar('phase', 0)
+    mob:setUnkillable(true) -- Death is scripted.
 end
 
+-- TODO: HP shield similar to !immortal, but for HP values different than 1.
 entity.onMobFight = function(mob, target)
+    -- Early return: Entity can't act.
+    if
+        xi.combat.behavior.isEntityBusy(mob) or
+        mob:getTP() < 600
+    then
+        return
+    end
+
+    -- Phase change logic.
     local animationSub = mob:getAnimationSub()
     local mobHPP       = mob:getHPP()
-    local phase        = mob:getLocalVar('phase')
 
-    if animationSub == 0 and phase == 0 and mobHPP <= 66 then
+    if animationSub == 0 and mobHPP <= 66 then
         mob:useMobAbility(xi.mobSkill.PHASE_SHIFT_1_EXOPLATES)
-    elseif animationSub == 1 and phase == 1 and mobHPP <= 33 then
+    elseif animationSub == 1 and mobHPP <= 33 then
         mob:useMobAbility(xi.mobSkill.PHASE_SHIFT_2_EXOPLATES)
-    elseif animationSub == 2 and phase == 2 and mobHPP <= 2 then
+    elseif animationSub == 2 and mobHPP <= 1 then
         mob:useMobAbility(xi.mobSkill.PHASE_SHIFT_3_EXOPLATES)
     end
 end
 
+-- Note: This mobskills aren't in any skill list, and shouldn't be. Their use is 100% scripted.
 entity.onMobWeaponSkill = function(target, mob, skill)
     local skillId = skill:getID()
 
     -- First phase end.
     if skillId == xi.mobSkill.PHASE_SHIFT_1_EXOPLATES then
-        mob:setLocalVar('phase', 1)
-        mob:timer(3000, function(mobArg)
+        mob:setMobMod(xi.mobMod.SKILL_LIST, 2058)
+        mob:timer(2000, function(mobArg)
             mobArg:setAnimationSub(1)
         end)
 
     -- Second phase end.
     elseif skillId == xi.mobSkill.PHASE_SHIFT_2_EXOPLATES then
-        mob:setLocalVar('phase', 2)
-        mob:timer(3000, function(mobArg)
+        mob:setMobMod(xi.mobMod.SKILL_LIST, 2059)
+        mob:timer(2000, function(mobArg)
             mobArg:setAnimationSub(2)
         end)
 
     -- Third (Last) phase end.
     elseif skillId == xi.mobSkill.PHASE_SHIFT_3_EXOPLATES then
-        mob:setLocalVar('phase', 3)
-        mob:timer(3000, function(mobArg)
+        mob:timer(2000, function(mobArg)
             mobArg:setUnkillable(false)
+            mobArg:setHP(0)
         end)
     end
 end
 
-entity.onMobDeath = function(mob, player, optParams)
+entity.onMobDespawn = function(mob)
     local ealdnarche = GetMobByID(mob:getID() - 1)
 
     if ealdnarche then
+        ealdnarche:setUnkillable(false) -- Fail-safe.
         ealdnarche:delStatusEffect(xi.effect.PHYSICAL_SHIELD)
         ealdnarche:delStatusEffect(xi.effect.ARROW_SHIELD)
         ealdnarche:delStatusEffect(xi.effect.MAGIC_SHIELD)

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -1013,18 +1013,9 @@ INSERT INTO `mob_skill_lists` VALUES ('Spheroid',235,984);
 INSERT INTO `mob_skill_lists` VALUES ('Spider',236,810);
 INSERT INTO `mob_skill_lists` VALUES ('Spider',236,811);
 INSERT INTO `mob_skill_lists` VALUES ('Spider',236,812);
-INSERT INTO `mob_skill_lists` VALUES ('Structure_Exoplate',237,990);
-INSERT INTO `mob_skill_lists` VALUES ('Structure_Exoplate',237,991);
-INSERT INTO `mob_skill_lists` VALUES ('Structure_Exoplate',237,992);
-INSERT INTO `mob_skill_lists` VALUES ('Structure_Exoplate',237,993);
-INSERT INTO `mob_skill_lists` VALUES ('Structure_Exoplate',237,994);
-INSERT INTO `mob_skill_lists` VALUES ('Structure_Exoplate',237,995);
-INSERT INTO `mob_skill_lists` VALUES ('Structure_Exoplate',237,996);
-INSERT INTO `mob_skill_lists` VALUES ('Structure_Exoplate',237,997);
-INSERT INTO `mob_skill_lists` VALUES ('Structure_Exoplate',237,998);
-INSERT INTO `mob_skill_lists` VALUES ('Structure_Exoplate',237,999);
-INSERT INTO `mob_skill_lists` VALUES ('Structure_Exoplate',237,1000);
-INSERT INTO `mob_skill_lists` VALUES ('Structure_Exoplate',237,1001);
+
+-- Spare ID: 237
+
 INSERT INTO `mob_skill_lists` VALUES ('Eldritch_Edge',238,397); -- Flurry of rage
 INSERT INTO `mob_skill_lists` VALUES ('Thunderclaw_Thuban',239,378); -- thunderbolt
 INSERT INTO `mob_skill_lists` VALUES ('Tauri',240,498);
@@ -4155,7 +4146,19 @@ INSERT INTO `mob_skill_lists` VALUES ('Vampyr_Jarl',2054,2112); -- Nocturnal Ser
 INSERT INTO `mob_skill_lists` VALUES ('Tenzen_Ranged_High',2055,1398); -- Tenzen Ranged Attack
 INSERT INTO `mob_skill_lists` VALUES ('Tenzen_Ranged_Low',2056,1400); -- Tenzen Ranged Attack
 
--- Next ID : 2057
+INSERT INTO `mob_skill_lists` VALUES ('Exoplate_Phase_1',2057,990);
+INSERT INTO `mob_skill_lists` VALUES ('Exoplate_Phase_1',2057,991);
+INSERT INTO `mob_skill_lists` VALUES ('Exoplate_Phase_1',2057,992);
+
+INSERT INTO `mob_skill_lists` VALUES ('Exoplate_Phase_2',2058,994);
+INSERT INTO `mob_skill_lists` VALUES ('Exoplate_Phase_2',2058,995);
+INSERT INTO `mob_skill_lists` VALUES ('Exoplate_Phase_2',2058,996);
+
+INSERT INTO `mob_skill_lists` VALUES ('Exoplate_Phase_3',2059,998);
+INSERT INTO `mob_skill_lists` VALUES ('Exoplate_Phase_3',2059,999);
+INSERT INTO `mob_skill_lists` VALUES ('Exoplate_Phase_3',2059,1000);
+
+-- Next ID : 2060
 
 -- ------------------------------------------------------------
 -- Start of Ambuscade section


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Exoplates: Implements phase changes affecting skills used.
- Exoplates: Implements last phase-change mobskill forcing entity death.
- Exoplates: Fixed exoplates being able to use "phase change" skills at will, instead of being scripted use only.
- Exoplates: Cleaned logic to not use local vars unnededly.
- Eald'Narche: Implemented fail-safe method to force Exoplates to be killed before he can.

## Steps to test these changes

Enter and fight in "The celestial Nexus" BCNM.
