### PR TITLE
[core] Fix PathThrough argument handling

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -1959,7 +1959,7 @@ bool CLuaBaseEntity::pathThrough(sol::table const& pointsTable, sol::object cons
             }
 
             auto wait  = pointData["wait"];
-            point.wait = wait.valid() ? std::chrono::seconds(wait.get<uint32>()) : 0s;
+            point.wait = wait.valid() ? std::chrono::milliseconds(wait.get<uint32>()) : 0s;
             points.emplace_back(point);
         }
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
- Fixes an issue that arose from the [time tracking refactor](https://github.com/LandSandBoat/server/pull/7500).
  - Mob and NPC Scripts specify waits in pathing tables in milliseconds.
  - After the time tracking rework, the argument for the wait was being handled as `std::chrono::seconds` which is then converted to nanoseconds within the AI Handler.
  - This caused all pathing scripts that had wait values of 1000/4000/etc. to be turned into 16 Mins/66 Mins/etc. instead of 1s/4s
  - The PR changes the conversion of the argument back into milliseconds to align with the scripting logic in use.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - `!zone port jeuno`
2 - Find Red Ghost (the galka that paths back and forth)
3 - Watch him properly path back and forth

4 - `!zone southern sandoria`
5 - Find Raminel (West side of the auction house)
6 - Watch him properly path back and forth

7 - `!gotoid 17502570`
8 - Watch Zipacna properly path and perform waits

Result: Mobs and NPCs are now pathing properly again.
