### PR TITLE
[lua, core] sendEmote for NPC

### DIFF
--- a/scripts/globals/helm.lua
+++ b/scripts/globals/helm.lua
@@ -1532,11 +1532,13 @@ xi.helm.onTrade = function(player, npc, trade, helmType, csid, func)
         local broke  = doesToolBreak(player, info) and 1 or 0
         local full   = (player:getFreeSlotsCount() == 0) and 1 or 0
 
+        -- Cutscene plays the emote in all zones but Adoulin.
+        -- Adoulin uses emote packets.
         if csid then
             player:startEvent(csid, itemID, broke, full)
+        else
+            player:sendEmote(npc, info.animation, xi.emoteMode.MOTION)
         end
-
-        player:sendEmote(npc, info.animation, xi.emoteMode.MOTION)
 
         -- WotG : The Price of Valor; Success does not award an item, but only KI.
         if xi.wotg.helpers.helmTrade(player, helmType, broke) then

--- a/scripts/missions/soa/2_2_2_In_the_Presence_of_Royalty.lua
+++ b/scripts/missions/soa/2_2_2_In_the_Presence_of_Royalty.lua
@@ -30,7 +30,7 @@ mission.sections =
             -- ['Harvesting_Point'] =
             -- {
             --     onTrade = function(player, npc, trade)
-            --         -- TODO: CSID for YORCIA_WEALD
+            --         -- No CS for HELM in Adoulin
             --         xi.helm.onTrade(player, npc, trade, xi.helmType.HARVESTING, nil, nil)
             --         return mission:keyItem(xi.ki.YORCIAS_TEAR)
             --     end,

--- a/scripts/quests/adoulin/Flavors_of_Our_Lives.lua
+++ b/scripts/quests/adoulin/Flavors_of_Our_Lives.lua
@@ -173,8 +173,8 @@ quest.sections =
             ['Harvesting_Point'] =
             {
                 onTrade = function(player, npc, trade)
-                    -- TODO: CSID for YAHSE_HUNTING_GROUNDS
-                    xi.helm.onTrade(player, npc, trade, xi.helmType.HARVESTING, nil, nil)
+                    -- No CS for HELM in Adoulin
+                    xi.helm.onTrade(player, npc, trade, xi.helmType.HARVESTING, nil)
                     return quest:keyItem(xi.ki.BLIGHTBERRY)
                 end,
             },

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -173,7 +173,7 @@ public:
     bool sendGuild(uint16 guildID, uint8 open, uint8 close, uint8 holiday); // Sends guild shop menu
     void openSendBox() const;                                               // Opens send box (to deliver items)
     void leaveGame();
-    void sendEmote(CLuaBaseEntity* target, uint8 emID, uint8 emMode);
+    void sendEmote(const CLuaBaseEntity* target, uint8 emID, uint8 emMode) const;
 
     // Location and Positioning
     int16 getWorldAngle(sol::variadic_args va);                                                // return angle (rot) between two points (vector from a to b), aligned to absolute cardinal degree

--- a/src/map/packets/char_emotion.cpp
+++ b/src/map/packets/char_emotion.cpp
@@ -21,36 +21,37 @@
 
 #include "char_emotion.h"
 #include "entities/charentity.h"
+#include "entities/npcentity.h"
 #include "item_container.h"
 #include "items/item_weapon.h"
 
-CCharEmotionPacket::CCharEmotionPacket(CCharEntity* PChar, uint32 TargetID, uint16 TargetIndex, Emote EmoteID, EmoteMode emoteMode, uint16 extra)
+CCharEmotionPacket::CCharEmotionPacket(const CCharEntity* PChar, const uint32 targetId, const uint16 targetIndex, Emote emoteId, EmoteMode emoteMode, const uint16 extra)
 {
     this->setType(0x5A);
     this->setSize(0x70);
 
     ref<uint32>(0x04) = PChar->id;
-    ref<uint32>(0x08) = TargetID;
+    ref<uint32>(0x08) = targetId;
     ref<uint16>(0x0C) = PChar->targid;
-    ref<uint16>(0x0E) = TargetIndex;
-    ref<uint8>(0x10)  = EmoteID == Emote::JOB ? static_cast<uint8>(EmoteID) + (extra - 0x1F) : static_cast<uint8>(EmoteID);
+    ref<uint16>(0x0E) = targetIndex;
+    ref<uint8>(0x10)  = emoteId == Emote::JOB ? static_cast<uint8>(emoteId) + (extra - 0x1F) : static_cast<uint8>(emoteId);
 
-    if (EmoteID == Emote::SALUTE)
+    if (emoteId == Emote::SALUTE)
     {
         ref<uint16>(0x12) = PChar->profile.nation;
     }
-    else if (EmoteID == Emote::HURRAY)
+    else if (emoteId == Emote::HURRAY)
     {
-        auto* PWeapon = PChar->getStorage(PChar->equipLoc[SLOT_MAIN])->GetItem(PChar->equip[SLOT_MAIN]);
+        const auto* PWeapon = PChar->getStorage(PChar->equipLoc[SLOT_MAIN])->GetItem(PChar->equip[SLOT_MAIN]);
         if (PWeapon && PWeapon->getID() != 65535)
         {
             ref<uint16>(0x12) = PWeapon->getID();
         }
     }
-    else if (EmoteID == Emote::AIM)
+    else if (emoteId == Emote::AIM)
     {
-        ref<uint16>(0x12)    = 65535;
-        CItemWeapon* PWeapon = static_cast<CItemWeapon*>(PChar->getStorage(PChar->equipLoc[SLOT_RANGED])->GetItem(PChar->equip[SLOT_RANGED]));
+        ref<uint16>(0x12)          = 65535;
+        const CItemWeapon* PWeapon = static_cast<CItemWeapon*>(PChar->getStorage(PChar->equipLoc[SLOT_RANGED])->GetItem(PChar->equip[SLOT_RANGED]));
         if (PWeapon && PWeapon->getID() != 65535)
         {
             if (PWeapon->getSkillType() == SKILL_THROWING)
@@ -59,7 +60,7 @@ CCharEmotionPacket::CCharEmotionPacket(CCharEntity* PChar, uint32 TargetID, uint
             }
             else if (PWeapon->getSkillType() == SKILL_MARKSMANSHIP || PWeapon->getSkillType() == SKILL_ARCHERY)
             {
-                CItemWeapon* PAmmo = static_cast<CItemWeapon*>(PChar->getStorage(PChar->equipLoc[SLOT_AMMO])->GetItem(PChar->equip[SLOT_AMMO]));
+                const CItemWeapon* PAmmo = static_cast<CItemWeapon*>(PChar->getStorage(PChar->equipLoc[SLOT_AMMO])->GetItem(PChar->equip[SLOT_AMMO]));
                 if (PAmmo && PAmmo->getID() != 65535)
                 {
                     ref<uint16>(0x12) = PWeapon->getID();
@@ -67,17 +68,30 @@ CCharEmotionPacket::CCharEmotionPacket(CCharEntity* PChar, uint32 TargetID, uint
             }
         }
     }
-    else if (EmoteID == Emote::BELL)
+    else if (emoteId == Emote::BELL)
     {
         // No emote text for /bell
         emoteMode = EmoteMode::MOTION;
 
         ref<uint8>(0x12) = (extra - 0x06);
     }
-    else if (EmoteID == Emote::JOB)
+    else if (emoteId == Emote::JOB)
     {
         ref<uint8>(0x12) = (extra - 0x1F);
     }
 
     ref<uint8>(0x16) = static_cast<uint8>(emoteMode);
+}
+
+CCharEmotionPacket::CCharEmotionPacket(const CNpcEntity* PEntity, const uint32 targetId, const uint16 targetIndex, Emote emoteId, EmoteMode emoteMode)
+{
+    this->setType(0x5A);
+    this->setSize(0x70);
+
+    ref<uint32>(0x04) = PEntity->id;
+    ref<uint32>(0x08) = targetId;
+    ref<uint16>(0x0C) = PEntity->targid;
+    ref<uint16>(0x0E) = targetIndex;
+    ref<uint8>(0x10)  = static_cast<uint8>(emoteId);
+    ref<uint8>(0x16)  = static_cast<uint8>(emoteMode);
 }

--- a/src/map/packets/char_emotion.h
+++ b/src/map/packets/char_emotion.h
@@ -19,8 +19,7 @@
 ===========================================================================
 */
 
-#ifndef _CCHAREMOTIONPACKET_H
-#define _CCHAREMOTIONPACKET_H
+#pragma once
 
 #include "common/cbasetypes.h"
 
@@ -89,11 +88,10 @@ enum class EmoteMode : uint8
 };
 
 class CCharEntity;
-
+class CNpcEntity;
 class CCharEmotionPacket : public CBasicPacket
 {
 public:
-    CCharEmotionPacket(CCharEntity* PChar, uint32 TargetID, uint16 TargetIndex, Emote EmoteID, EmoteMode emoteMode, uint16 extra);
+    CCharEmotionPacket(const CCharEntity* PChar, uint32 targetId, uint16 targetIndex, Emote emoteId, EmoteMode emoteMode, uint16 extra);
+    CCharEmotionPacket(const CNpcEntity* PEntity, uint32 targetId, uint16 targetIndex, Emote emoteId, EmoteMode emoteMode);
 };
-
-#endif


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Extends sendEmote to NPCs
  - Pirate's Chart capture shows the NPC emitting emote packets
- Add a new constructor for the emote packet, accepting a NPC entity
  - This doesn't support the same degree of customization as the other one because I have no proof NPCs can do more than basic emotes
- Clarifies that Adoulin HELM have no event involved. SE sends emote packets. 
- Bugfix: Also send the emote packet to self when used on players

Closes #7868
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
I modified a NPC script and made it send emotes on trigger, both to another NPC and to no one.

npc:sendEmote(npc2, xi.emote.HURRAY, xi.emoteMode.MOTION)
npc:sendEmote(nil, xi.emote.HURRAY, xi.emoteMode.MOTION)

Tested player with:
- !exec player:sendEmote(target, 1, 2)
- !exec player:sendEmote(nil, 1, 2)

<!-- Clear and detailed steps to test your changes here -->
