### PR TITLE
Add null check to Lua functions with userdata params

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -11574,6 +11574,12 @@ uint8 CLuaBaseEntity::checkSoloPartyAlliance()
 
 bool CLuaBaseEntity::checkKillCredit(CLuaBaseEntity* PLuaBaseEntity, sol::object const& minRange)
 {
+    if (PLuaBaseEntity == nullptr)
+    {
+        ShowWarning("CLuaBaseEntity::checkKillCredit() - PLuaBaseEntity received null value.");
+        return false;
+    }
+
     if (m_PBaseEntity->objtype != TYPE_PC || (PLuaBaseEntity && PLuaBaseEntity->GetBaseEntity()->objtype != TYPE_MOB))
     {
         ShowWarning("CLuaBaseEntity::checkKillCredit() - Non-PC type calling function, or PLuaBaseEntity is not a MOB.");
@@ -11611,6 +11617,12 @@ bool CLuaBaseEntity::checkKillCredit(CLuaBaseEntity* PLuaBaseEntity, sol::object
  ************************************************************************/
 uint8 CLuaBaseEntity::checkDifficulty(CLuaBaseEntity* PLuaBaseEntity)
 {
+    if (PLuaBaseEntity == nullptr)
+    {
+        ShowWarning("CLuaBaseEntity::checkDifficulty() - PLuaBaseEntity received null value.");
+        return 0;
+    }
+
     CMobEntity*  PMob  = dynamic_cast<CMobEntity*>(PLuaBaseEntity->GetBaseEntity());
     CCharEntity* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity);
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -4964,6 +4964,12 @@ namespace luautils
 
     sol::table GetFurthestValidPosition(CLuaBaseEntity* fromTarget, float distance, float theta)
     {
+        if (!fromTarget || !fromTarget->GetBaseEntity())
+        {
+            ShowError("luautils::GetFurthestValidPosition: fromTarget is null or invalid");
+            return sol::lua_nil;
+        }
+
         CBaseEntity* entity = fromTarget->GetBaseEntity();
         position_t   pos    = nearPosition(entity->loc.p, distance, theta);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
If nil was passed into `GetFurthestValidPosition()`, `checkKillCredit()` or `checkDifficulty()` for the first argument, a crash would occur.  Adds additional check to ensure userdata params are not null.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
`!exec GetFurthestValidPosition(nil, 1, 1)`
`!exec player:checkDifficulty(nil)`
`!exec player:checkKillCredit(nil, 1)`
<!-- Clear and detailed steps to test your changes here -->
