### PR TITLE
[lua/chore] Updated phList/spawnPoints to nm lua: A* zones

### DIFF
--- a/scripts/zones/Alzadaal_Undersea_Ruins/mobs/Cookieduster_Lipiroon.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/mobs/Cookieduster_Lipiroon.lua
@@ -2,8 +2,16 @@
 -- Area: Alzadaal Undersea Ruins (72)
 --   NM: Cookieduster Lipiroon
 -----------------------------------
+local ID = zones[xi.zone.ALZADAAL_UNDERSEA_RUINS]
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
+
+entity.phList =
+{
+    [ID.mob.COOKIEDUSTER_LIPIROON - 8] = ID.mob.COOKIEDUSTER_LIPIROON,
+    [ID.mob.COOKIEDUSTER_LIPIROON - 6] = ID.mob.COOKIEDUSTER_LIPIROON,
+}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)

--- a/scripts/zones/Alzadaal_Undersea_Ruins/mobs/Qiqirn_Goldsmith.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/mobs/Qiqirn_Goldsmith.lua
@@ -8,17 +8,11 @@ local ID = zones[xi.zone.ALZADAAL_UNDERSEA_RUINS]
 ---@type TMobEntity
 local entity = {}
 
-local cookiedusterPHTable =
-{
-    [ID.mob.COOKIEDUSTER_LIPIROON - 8] = ID.mob.COOKIEDUSTER_LIPIROON,
-    [ID.mob.COOKIEDUSTER_LIPIROON - 6] = ID.mob.COOKIEDUSTER_LIPIROON,
-}
-
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, cookiedusterPHTable, 5, 3600) -- 1 hour
+    xi.mob.phOnDespawn(mob, ID.mob.COOKIEDUSTER_LIPIROON, 5, 3600) -- 1 hour
 end
 
 return entity

--- a/scripts/zones/Arrapago_Reef/mobs/Bloody_Bones.lua
+++ b/scripts/zones/Arrapago_Reef/mobs/Bloody_Bones.lua
@@ -2,8 +2,15 @@
 -- Area: Arrapago Reef
 --   NM: Bloody Bones
 -----------------------------------
+local ID = zones[xi.zone.ARRAPAGO_REEF]
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
+
+entity.phList =
+{
+    [ID.mob.BLOODY_BONES - 2] = ID.mob.BLOODY_BONES, -- 136.234 -6.831 468.779
+}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 472)

--- a/scripts/zones/Arrapago_Reef/mobs/Draugar_Servant.lua
+++ b/scripts/zones/Arrapago_Reef/mobs/Draugar_Servant.lua
@@ -8,16 +8,11 @@ local ID = zones[xi.zone.ARRAPAGO_REEF]
 ---@type TMobEntity
 local entity = {}
 
-local bloodyBonesPHTable =
-{
-    [ID.mob.BLOODY_BONES - 2] = ID.mob.BLOODY_BONES, -- 136.234 -6.831 468.779
-}
-
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, bloodyBonesPHTable, 5, 75600) -- 21 hours
+    xi.mob.phOnDespawn(mob, ID.mob.BLOODY_BONES, 5, 75600) -- 21 hours
 end
 
 return entity

--- a/scripts/zones/Attohwa_Chasm/mobs/Ambusher_Antlion.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Ambusher_Antlion.lua
@@ -4,8 +4,15 @@
 -----------------------------------
 mixins = { require('scripts/mixins/families/antlion_ambush') }
 -----------------------------------
+local ID = zones[xi.zone.ATTOHWA_CHASM]
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
+
+entity.phList =
+{
+    [ID.mob.AMBUSHER_ANTLION - 78] = ID.mob.AMBUSHER_ANTLION, -- -433.309 -4.3 113.841
+}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 277)

--- a/scripts/zones/Attohwa_Chasm/mobs/Citipati.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Citipati.lua
@@ -2,8 +2,25 @@
 -- Area: Attohwa Chasm
 --  Mob: Citipati
 -----------------------------------
+local ID = zones[xi.zone.ATTOHWA_CHASM]
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
+
+entity.phList =
+{
+    [ID.mob.CITIPATI - 7] = ID.mob.CITIPATI, -- -328.973 -12.876 67.481
+    [ID.mob.CITIPATI - 4] = ID.mob.CITIPATI, -- -398.931 -4.536 79.640
+    [ID.mob.CITIPATI - 1] = ID.mob.CITIPATI, -- -381.284 -9.233 40.054
+}
+
+entity.spawnPoints =
+{
+    { x = -364.014, y = -4.634,  z = -2.627 },
+    { x = -328.973, y = -12.876, z = 67.481 },
+    { x = -398.931, y = -4.536,  z = 79.640 },
+    { x = -381.284, y = -9.233,  z = 40.054 },
+}
 
 entity.onMobRoam = function(mob)
     -- Since DisallowRespawn() doesn't care about SPAWNTYPE_NIGHT we have to get creative

--- a/scripts/zones/Attohwa_Chasm/mobs/Corse.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Corse.lua
@@ -8,29 +8,13 @@ local ID = zones[xi.zone.ATTOHWA_CHASM]
 ---@type TMobEntity
 local entity = {}
 
-local citipatiPHTable =
-{
-    [ID.mob.CITIPATI - 7] = ID.mob.CITIPATI, -- -328.973 -12.876 67.481
-    [ID.mob.CITIPATI - 4] = ID.mob.CITIPATI, -- -398.931 -4.536 79.640
-    [ID.mob.CITIPATI - 1] = ID.mob.CITIPATI, -- -381.284 -9.233 40.054
-}
-
-local citiSpawnPoints =
-{
-    { x = -364.014, y = -4.634,  z = -2.627 },
-    { x = -328.973, y = -12.876, z = 67.481 },
-    { x = -398.931, y = -4.536,  z = 79.640 },
-    { x = -381.284, y = -9.233,  z = 40.054 },
-}
-
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
     local params = {}
     params.nightOnly = true
-    params.spawnPoints = citiSpawnPoints
-    xi.mob.phOnDespawn(mob, citipatiPHTable, 20, math.random(10800, 21600), params) -- 3 to 6 hours, night only
+    xi.mob.phOnDespawn(mob, ID.mob.CITIPATI, 20, math.random(10800, 21600), params) -- 3 to 6 hours, night only
 end
 
 return entity

--- a/scripts/zones/Attohwa_Chasm/mobs/Trench_Antlion.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Trench_Antlion.lua
@@ -9,16 +9,11 @@ local ID = zones[xi.zone.ATTOHWA_CHASM]
 ---@type TMobEntity
 local entity = {}
 
-local ambusherAntlionPHTable =
-{
-    [ID.mob.AMBUSHER_ANTLION - 78] = ID.mob.AMBUSHER_ANTLION, -- -433.309 -4.3 113.841
-}
-
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ambusherAntlionPHTable, 10, 3600) -- 1 hour
+    xi.mob.phOnDespawn(mob, ID.mob.AMBUSHER_ANTLION, 10, 3600) -- 1 hour
 end
 
 return entity

--- a/scripts/zones/Aydeewa_Subterrane/mobs/Bluestreak_Gyugyuroon.lua
+++ b/scripts/zones/Aydeewa_Subterrane/mobs/Bluestreak_Gyugyuroon.lua
@@ -2,8 +2,16 @@
 -- Area: Aydeewa Subterrane
 --   NM: Bluestreak Gyugyuroon
 -----------------------------------
+local ID = zones[xi.zone.AYDEEWA_SUBTERRANE]
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
+
+entity.phList =
+{
+    [ID.mob.BLUESTREAK_GYUGYUROON - 215] = ID.mob.BLUESTREAK_GYUGYUROON, -- -221.7 13.762 -346.83
+    [ID.mob.BLUESTREAK_GYUGYUROON - 214] = ID.mob.BLUESTREAK_GYUGYUROON, -- -219 14.003 -364.83
+}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 464)

--- a/scripts/zones/Aydeewa_Subterrane/mobs/Qiqirn_Archaeologist.lua
+++ b/scripts/zones/Aydeewa_Subterrane/mobs/Qiqirn_Archaeologist.lua
@@ -8,17 +8,11 @@ local ID = zones[xi.zone.AYDEEWA_SUBTERRANE]
 ---@type TMobEntity
 local entity = {}
 
-local bluestreakGyugyuroonPHTable =
-{
-    [ID.mob.BLUESTREAK_GYUGYUROON - 215] = ID.mob.BLUESTREAK_GYUGYUROON, -- -221.7 13.762 -346.83
-    [ID.mob.BLUESTREAK_GYUGYUROON - 214] = ID.mob.BLUESTREAK_GYUGYUROON, -- -219 14.003 -364.83
-}
-
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, bluestreakGyugyuroonPHTable, 10, 7200) -- 2 hours
+    xi.mob.phOnDespawn(mob, ID.mob.BLUESTREAK_GYUGYUROON, 10, 7200) -- 2 hours
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Now that https://github.com/LandSandBoat/server/pull/7798 is merged, It's time to pull up my sleeves and work on deprecating the second param of `xi.mob.phOnDespawn` being a `phList` table.

I've written a script that does all the work if the NM has a single ph mob lua. I'll have to take it case by case on the small instances where that isn't the case. Doing zones that start with A to make sure we're good with this before i make a giant PR doing all the automated fixes. Then probably one final separate PR to fix the one-offs like Poisonhand Gnadgad (that one was fixed, but ones like him that have multiple PH mob names for a single NM)

This PR was generated strictly by the script, then verified by eye and manually at each NM. The original PR was tested pretty thoroughly and enacted changes for all types of PH-style NMs i know of, so it'd be surprising if anything other than formatting was broken by moving this data around, but just being extra cautious

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- As usual, testing PH-to-NM spawn is easiest by adjusting: `chance = 100`, `cooldown = 1`, `params = {immediate=true}`
- go to each zone, then `!gotoname <nmName>` to get the NM's ID. Offset as appropriate and despawn the PH
- Citipati is annoying to test, but you can spawn his PH manually (and additionally removing the nightOnly param), then despawn and it and check his respawntime before and after spawn/despawn
  - <img width="622" height="475" alt="image" src="https://github.com/user-attachments/assets/c9fb643e-b6d3-4ba7-99a7-57c7144e83c8" />
  - <img width="255" height="67" alt="image" src="https://github.com/user-attachments/assets/965b1b54-6b0b-4c95-b5a1-85772aac79f8" />


