### PR TITLE
[login] Don't close sessions when a lone session is still alive

### DIFF
--- a/src/login/data_session.cpp
+++ b/src/login/data_session.cpp
@@ -494,9 +494,9 @@ void data_session::handle_error(std::error_code ec, std::shared_ptr<handler_sess
                 // Remove entry if needs to be
                 map.erase(it);
 
-                // Remove IP from map if it's the last entry
+                // Remove IP from map if no entries remain
                 auto& sessions = loginHelpers::getAuthenticatedSessions();
-                if (sessions[self->ipAddress].size() == 1)
+                if (sessions[self->ipAddress].size() == 0)
                 {
                     sessions.erase(sessions.begin());
                 }

--- a/src/login/view_session.cpp
+++ b/src/login/view_session.cpp
@@ -455,9 +455,9 @@ void view_session::handle_error(std::error_code ec, std::shared_ptr<handler_sess
                 // Remove entry if needs to be
                 map.erase(it);
 
-                // Remove IP from map if it's the last entry
+                // Remove IP from map if no entries remain
                 auto& sessions = loginHelpers::getAuthenticatedSessions();
-                if (sessions[self->ipAddress].size() == 1)
+                if (sessions[self->ipAddress].size() == 0)
                 {
                     sessions.erase(sessions.begin());
                 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Essentially, we were accidentally closing a valid session for no reason if you went from N sessions = 2 on an IP to N sessions = 1

## Steps to test these changes

Dualbox (specifically dual box) close one session, /logout (NOT /shutdown) and log back in on the second one successfully
