### PR TITLE
[Lua, SQL, fishing] Setup skeleton structure of Pirate's Chart quest

### DIFF
--- a/scripts/globals/confrontation.lua
+++ b/scripts/globals/confrontation.lua
@@ -123,6 +123,11 @@ xi.confrontation.check = function(lookupKey, setupTimer)
             xi.confrontation.despawnMobs(mobs)
         end
 
+        -- Reset mobs/npcs/variables that may not be handled by win/lose
+        if lookup.cleanUp then
+            lookup.cleanUp()
+        end
+
         xi.confrontation.lookup[lookupKey] = nil
     else -- Check again soon
         if setupTimer then
@@ -184,11 +189,13 @@ xi.confrontation.start = function(player, npc, mobIds, params)
     -- Cache the lists into the global lookup
     local lookup = {}
 
-    lookup.npc = npc
+    lookup.npc                 = npc
     lookup.registeredPlayerIds = registeredPlayerIds
-    lookup.mobIds = mobIds
-    lookup.onWin = params.winFunc
-    lookup.onLose = params.loseFunc
+    lookup.mobIds              = mobIds
+    lookup.onWin               = params.onWin
+    lookup.onLose              = params.onLose
+    lookup.cleanUp             = params.cleanUp
+    lookup.distanceLimit       = params.distanceLimit
 
     if params.timeLimit then
         lookup.timeLimit = GetSystemTime() + params.timeLimit

--- a/scripts/globals/pirates_chart.lua
+++ b/scripts/globals/pirates_chart.lua
@@ -1,0 +1,111 @@
+-----------------------------------
+-- Pirates Chart Quest (hidden)
+-----------------------------------
+-- !additem 1874 -- Pirates Chart
+-- qm4 : !pos -168.6 4 -131.4 103
+-----------------------------------
+local valkID = zones[xi.zone.VALKURM_DUNES]
+-----------------------------------
+
+xi = xi or {}
+xi.piratesChart = xi.piratesChart or {}
+
+xi.piratesChart.onTrade = function(player, npc, trade)
+    if player:getPartySize() > 3 then
+        player:messageSpecial(valkID.text.TOO_MANY_IN_PARTY, 3)
+    elseif player:checkSoloPartyAlliance() == 2 then
+        player:messageSpecial(valkID.text.ALLIANCE_NOT_ALLOWED)
+    elseif
+        npc:getStatus() == xi.status.NORMAL and
+        npcUtil.tradeHasExactly(trade, xi.item.PIRATES_CHART)
+    then
+        player:messageSpecial(valkID.text.RETURN_TO_SEA, xi.item.PIRATES_CHART)
+        player:startEvent(14, 0, 0, 0, 3)
+    end
+end
+
+xi.piratesChart.onEventUpdate = function(player, csid, option, npc)
+    if csid == 14 and option == 0 then
+        player:confirmTrade()
+
+        -- Change music for party and remove buffs
+        local party = player:getParty()
+        for _, member in pairs(party) do
+            member:changeMusic(0, 136)
+            member:changeMusic(1, 136)
+            member:changeMusic(2, 136)
+            member:changeMusic(3, 136)
+            member:delStatusEffectsByFlag(xi.effectFlag.DISPELABLE)
+            member:addStatusEffect(xi.effect.LEVEL_RESTRICTION, 20, 0, 0, 0, 0)
+        end
+    end
+end
+
+xi.piratesChart.onEventFinish = function(player, csid, option, npc)
+    if csid == 14 and option == 0 then
+        local panicTaru  = GetNPCByID(valkID.npc.PIRATE_CHART_TARU)
+        local shimmering = GetNPCByID(valkID.npc.SHIMMERING_POINT)
+        local barnacle   = GetNPCByID(valkID.npc.BARNACLED_BOX)
+
+        local mobs =
+        {
+            valkID.mob.HOUU_THE_SHOALWADER,
+            valkID.mob.BEACH_MONK,
+            valkID.mob.HEIKE_CRAB,
+        }
+
+        if
+            not panicTaru or
+            not shimmering or
+            not barnacle
+        then
+            return
+        end
+
+        -- Start range checking for out-of-range messages
+
+        -- Setup starting conditions
+        panicTaru:setStatus(xi.status.NORMAL)
+        panicTaru:setAnimation(xi.animation.NONE)
+        shimmering:setStatus(xi.status.NORMAL)
+
+        -- Handle taru messages and emotes
+
+        npc:timer(50000, function(npcArg)
+            local params = {}
+
+            params.timeLimit = 600 -- 10 minutes
+
+            params.onLose = function(member)
+                member:delStatusEffect(xi.effect.LEVEL_RESTRICTION)
+                member:changeMusic(0, 0)
+                member:changeMusic(1, 0)
+                member:changeMusic(2, 101)
+                member:changeMusic(3, 102)
+            end
+
+            params.cleanUp = function()
+                shimmering:setStatus(xi.status.DISAPPEAR)
+                panicTaru:setStatus(xi.status.DISAPPEAR)
+                panicTaru:setAnimation(xi.animation.NONE)
+            end
+
+            -- Start confrontation
+            xi.confrontation.start(player, npc, mobs, params)
+        end)
+    end
+end
+
+xi.piratesChart.barnacledBoxOnTrigger = function(player, npc)
+    -- Remove music
+    -- Crate animations
+    -- Distribute rewards
+end
+
+xi.piratesChart.onMobFight = function(mob, target)
+    -- 2hr and temp item logic
+end
+
+xi.piratesChart.onMobDeath = function(mob, player, optParams)
+    -- check if last mob to die, move box, trigger win conditions
+end

--- a/scripts/missions/amk/06_An_Errand_The_Professors_Price.lua
+++ b/scripts/missions/amk/06_An_Errand_The_Professors_Price.lua
@@ -63,7 +63,7 @@ local beginCardianFight = function(player, npc)
     end
 
     local params = {}
-    params.winFunc = function(wPlayer)
+    params.onWin = function(wPlayer)
         npcUtil.giveKeyItem(wPlayer, xi.keyItem.RIPE_STARFRUIT)
         npcUtil.giveKeyItem(wPlayer, xi.keyItem.PEACH_CORAL_KEY)
     end

--- a/scripts/zones/Valkurm_Dunes/IDs.lua
+++ b/scripts/zones/Valkurm_Dunes/IDs.lua
@@ -39,7 +39,9 @@ zones[xi.zone.VALKURM_DUNES] =
         AN_EMPTY_LIGHT_SWIRLS          = 7767,  -- An empty light swirls about the cave, eating away at the surroundings...
         GARRISON_BASE                  = 7769,  -- Hm? What is this? %? How do I know this is not some [San d'Orian/Bastokan/Windurstian] trick?
         TIME_ELAPSED                   = 7816,  -- Time elapsed: <number> [hour/hours] (Vana'diel time) <number> [minute/minutes] and <number> [second/seconds] (Earth time)
-        MONSTERS_KILLED_ADVENTURERS    = 7843,  -- Long ago, monsters killed many adventurers and merchants just off the coast here. If you find any vestige of the victims and return it to the sea, perhaps it would appease the spirits of the dead.
+        TOO_MANY_IN_PARTY              = 7840,  -- Nothing happens. Your party exceeds the maximum number of <number> members.
+        ALLIANCE_NOT_ALLOWED           = 7841,  -- Nothing happens. You must dissolve your alliance.
+        RETURN_TO_SEA                  = 7844,  -- You return the <item> to the sea.
         YOU_CANNOT_ENTER_DYNAMIS       = 7881,  -- You cannot enter Dynamis - [Dummy/San d'Oria/Bastok/Windurst/Jeuno/Beaucedine/Xarcabard/Valkurm/Buburimu/Qufim/Tavnazia] for <number> [day/days] (Vana'diel time).
         PLAYERS_HAVE_NOT_REACHED_LEVEL = 7883,  -- Players who have not reached level <number> are prohibited from entering Dynamis.
         DYNA_NPC_DEFAULT_MESSAGE       = 8005,  -- There is a strange symbol drawn here. A haunting chill sweeps through you as you gaze upon it...
@@ -67,9 +69,13 @@ zones[xi.zone.VALKURM_DUNES] =
 
     npc =
     {
-        SUNSAND_QM    = GetFirstID('qm1'),
-        OVERSEER_BASE = GetFirstID('Quanteilleron_RK'),
-        WHM_AF1_QM    = GetFirstID('qm2')
+        BARNACLED_BOX     = GetFirstID('Barnacled_Box'),
+        OVERSEER_BASE     = GetFirstID('Quanteilleron_RK'),
+        PIRATE_CHART_QM   = GetFirstID('qm4'),
+        PIRATE_CHART_TARU = GetFirstID('Pirate_Chart_Taru'),
+        SHIMMERING_POINT  = GetFirstID('Shimmering_Point'),
+        SUNSAND_QM        = GetFirstID('qm1'),
+        WHM_AF1_QM        = GetFirstID('qm2')
     },
 }
 

--- a/scripts/zones/Valkurm_Dunes/mobs/Beach_Monk.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Beach_Monk.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Beach Monk
+-- Part of Pirate's chart miniquest fight
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobFight = function(mob, target)
+    return xi.piratesChart.onMobFight(mob, target)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    return xi.piratesChart.onMobDeath(mob, player, optParams)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/mobs/Heike_Crab.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Heike_Crab.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Heike Crab
+-- Part of Pirate's chart miniquest fight
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobFight = function(mob, target)
+    return xi.piratesChart.onMobFight(mob, target)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    return xi.piratesChart.onMobDeath(mob, player, optParams)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/mobs/Houu_the_Shoalwader.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Houu_the_Shoalwader.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Houu the Shoalwader
+-- Part of Pirate's chart miniquest fight
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobFight = function(mob, target)
+    return xi.piratesChart.onMobFight(mob, target)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    return xi.piratesChart.onMobDeath(mob, player, optParams)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/npcs/Barnacled_Box.lua
+++ b/scripts/zones/Valkurm_Dunes/npcs/Barnacled_Box.lua
@@ -1,0 +1,13 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  NPC: Barnacled Box
+-- Part of Pirate's chart miniquest fight
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    return xi.piratesChart.barnacledBoxOnTrigger(player, npc)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/npcs/qm4.lua
+++ b/scripts/zones/Valkurm_Dunes/npcs/qm4.lua
@@ -1,0 +1,27 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  NPC: qm4 (???)
+-- Involved In Pirates Chart quest
+-- !pos -168 4 -131 103
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+    if xi.settings.map.FISHING_ENABLE then
+        return xi.piratesChart.onTrade(player, npc, trade)
+    end
+end
+
+entity.onTrigger = function(player, npc)
+end
+
+entity.onEventUpdate = function(player, csid, option, npc)
+    return xi.piratesChart.onEventUpdate(player, csid, option, npc)
+end
+
+entity.onEventFinish = function(player, csid, option, npc)
+    return xi.piratesChart.onEventFinish(player, csid, option, npc)
+end
+
+return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements Pirate's Chart quest.  I want to add this quest in bite size sections to make life easier for the reviewer.  Assuming this structure makes sense, I will add the other sections shortly after.

## Steps to test these changes

!additem pirates_chart
!pos -161 4 129 103 -- qm4 in valkurm dunes
- Trade item to qm, see cutscene with little taru, monsters will spawn after 50 seconds (shorten timer in pirates_chart.lua to speed this up)
- box will appear

Follow-up PRs will include: winning conditions/rewards, range checking, taru flavor motions, mob stats and logic
