### PR TITLE
[core] Rate Limit Guild/Vendor Shop through PacketGuard

### DIFF
--- a/src/map/packet_guard.cpp
+++ b/src/map/packet_guard.cpp
@@ -82,14 +82,16 @@ namespace PacketGuard
         // NOTE: You should rate limit any packet that a player can
         //     : send at will that results in an immediate database hit
         //     : or generates logs or results in file or network io.
-        ratelimitList[0x017] = 1s; // Invalid NPC Information Response
-        ratelimitList[0x03B] = 1s; // Mannequin Equip
-        ratelimitList[0x05D] = 2s; // Emotes
-        ratelimitList[0x0B7] = 1s; // Assist Channel
-        ratelimitList[0x0F4] = 1s; // Wide Scan
-        ratelimitList[0x0F5] = 1s; // Wide Scan Track
-        ratelimitList[0x11B] = 2s; // Set Job Master Display
-        ratelimitList[0x11D] = 2s; // Jump
+        ratelimitList[0x017] = 1s;    // Invalid NPC Information Response
+        ratelimitList[0x03B] = 1s;    // Mannequin Equip
+        ratelimitList[0x05D] = 2s;    // Emotes
+        ratelimitList[0x083] = 250ms; // Vendor Shop Purchase
+        ratelimitList[0x0AA] = 250ms; // Guild Shop Purchase
+        ratelimitList[0x0B7] = 1s;    // Assist Channel
+        ratelimitList[0x0F4] = 1s;    // Wide Scan
+        ratelimitList[0x0F5] = 1s;    // Wide Scan Track
+        ratelimitList[0x11B] = 2s;    // Set Job Master Display
+        ratelimitList[0x11D] = 2s;    // Jump
     }
 
     bool PacketIsValidForPlayerState(CCharEntity* PChar, uint16 SmallPD_Type)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
- Adds `0x0AA` and `0x083` to Packet Guard, rate-limited to 1s
  - This prevents players from being able to packet-inject vendors and guild shops to rapid purchase items/limited-supply items.

Example Test at 5s: https://youtu.be/6ae4O8YfHV8

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - Login with any character
2 - Go to a guild shop, purchase an item from the Guild Shop
3 - Attempt to purchase again with 1s
Result: The purchase within the time limit is blocked and a message is generated in the map server console.

4 - Wait till the 1s timer has elapsed and make another purchase from the guild shop.
Result: The purchase will now go through since the minimum wait time has been observed.