### PR TITLE
[core][lua] sourceType COR Rolls, COR Bugfixes, StealStatusEffect()

### DIFF
--- a/scripts/effects/allies_roll.lua
+++ b/scripts/effects/allies_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.ALLIES_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/aspir_daze.lua
+++ b/scripts/effects/aspir_daze.lua
@@ -2,7 +2,7 @@
 -- xi.effect.ASPIR_DAZE
 -- Notes:
 -- Debuff applied to an entity when hit by an another entity's party that have a corresponding Samba effect active.
--- subType for Daze effects stores the ID of the attacker. See battleutils.cpp "HandleEnspell"
+-- sourceTypeParam for Daze effects stores the ID of the attacker. See battleutils.cpp "HandleEnspell"
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/atma.lua
+++ b/scripts/effects/atma.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- xi.effect.ATMA
--- Notes: Effect subType = Atma slot.  See: scripts/globals/abyssea/atma.lua
+-- Notes: Effect sourceTypeParam = Atma slot.  See: scripts/globals/abyssea/atma.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/aubade.lua
+++ b/scripts/effects/aubade.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.AUBADE
--- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/avengers_roll.lua
+++ b/scripts/effects/avengers_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.AVENGERS_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/ballad.lua
+++ b/scripts/effects/ballad.lua
@@ -3,7 +3,6 @@
 -- getPower returns the TIER (e.g. 1, 2, 3, 4)
 -- DO NOT ALTER ANY OF THE EFFECT VALUES! DO NOT ALTER EFFECT POWER!
 -- TODO: Find a better way of doing this. Need to account for varying modifiers + CASTER's skill (not target)
--- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/battlefield.lua
+++ b/scripts/effects/battlefield.lua
@@ -2,7 +2,7 @@
 -- xi.effect.BATTLEFIELD
 -- Notes: Effect parameters:
 -- power: Stores battlefield ID.
--- subType: stores charIDs
+-- sourceTypeParam: Stores charIDs
 -- subPower: stores battlefield area (Which "arena" within the battlefield if not an instanced zone)
 -----------------------------------
 ---@type TEffect

--- a/scripts/effects/beast_roll.lua
+++ b/scripts/effects/beast_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.BEAST_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/blitzers_roll.lua
+++ b/scripts/effects/blitzers_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.BLITZERS_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/bolters_roll.lua
+++ b/scripts/effects/bolters_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.BOLTERS_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/capriccio.lua
+++ b/scripts/effects/capriccio.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.CAPRICCIO
--- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/carol.lua
+++ b/scripts/effects/carol.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.CAROL
--- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/casters_roll.lua
+++ b/scripts/effects/casters_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.CASTERS_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/chaos_roll.lua
+++ b/scripts/effects/chaos_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.CHAOS_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/choral_roll.lua
+++ b/scripts/effects/choral_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.CHORAL_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/companions_roll.lua
+++ b/scripts/effects/companions_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.COMPANIONS_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/corsairs_roll.lua
+++ b/scripts/effects/corsairs_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.CORSAIRS_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/coursers_roll.lua
+++ b/scripts/effects/coursers_roll.lua
@@ -1,7 +1,6 @@
 -----------------------------------
 -- xi.effect.COURSERS_ROLL
 -- TODO: Enable modifier and define power in job_utils/corsair.lua
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/dancers_roll.lua
+++ b/scripts/effects/dancers_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.DANCERS_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/dirge.lua
+++ b/scripts/effects/dirge.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.DIRGE
--- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/double-up_chance.lua
+++ b/scripts/effects/double-up_chance.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.DOUBLE_UP_CHANCE
--- Notes: Effect's subType stores abilityID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/drachen_roll.lua
+++ b/scripts/effects/drachen_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.DRACHEN_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/drain_daze.lua
+++ b/scripts/effects/drain_daze.lua
@@ -2,7 +2,7 @@
 -- xi.effect.DRAIN_DAZE
 -- Notes:
 -- Debuff applied to an entity when hit by an another entity's party that have a corresponding Samba effect active.
--- subType for Daze effects stores the ID of the attacker. See battleutils.cpp "HandleEnspell"
+-- sourceTypeParam for Daze effects stores the ID of the attacker. See battleutils.cpp "HandleEnspell"
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/enchantment.lua
+++ b/scripts/effects/enchantment.lua
@@ -1,6 +1,8 @@
 -----------------------------------
 -- xi.effect.ENCHANTMENT
 -- Notes: Effect subType is used to store itemID of source item. See: CStatusEffectContainer::SetEffectParams
+-- TODO: Most if not all enchantments are attached to an usable item.
+-- Will need to audit any outliers not using sourceType/sourceTypeParam. subType is currently used as a fallback.
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/etude.lua
+++ b/scripts/effects/etude.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.ETUDE
--- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/evokers_roll.lua
+++ b/scripts/effects/evokers_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.EVOKERS_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/fantasia.lua
+++ b/scripts/effects/fantasia.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.FANTASIA
--- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/fighters_roll.lua
+++ b/scripts/effects/fighters_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.FIGHTERS_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/gallants_roll.lua
+++ b/scripts/effects/gallants_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.GALLANTS_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/gavotte.lua
+++ b/scripts/effects/gavotte.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.GAVOTTE
--- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/haste_daze.lua
+++ b/scripts/effects/haste_daze.lua
@@ -2,7 +2,7 @@
 -- xi.effect.HASTE_DAZE
 -- Notes:
 -- Debuff applied to an entity when hit by an another entity's party that have a corresponding Samba effect active.
--- subType for Daze effects stores the ID of the attacker. See battleutils.cpp "HandleEnspell"
+-- sourceTypeParam for Daze effects stores the ID of the attacker. See battleutils.cpp "HandleEnspell"
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/healers_roll.lua
+++ b/scripts/effects/healers_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.HEALERS_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/hunters_roll.lua
+++ b/scripts/effects/hunters_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.HUNTERS_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/hymnus.lua
+++ b/scripts/effects/hymnus.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.HYMNUS
--- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/madrigal.lua
+++ b/scripts/effects/madrigal.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.MADRIGAL
--- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -- getPower returns the TIER (e.g. 1, 2, 3, 4)
 -----------------------------------
 ---@type TEffect

--- a/scripts/effects/maguss_roll.lua
+++ b/scripts/effects/maguss_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.MAGUSS_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/mambo.lua
+++ b/scripts/effects/mambo.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.MAMBO
--- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/march.lua
+++ b/scripts/effects/march.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.MARCH
--- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -- getPower returns the TIER (e.g. 1, 2, 3, 4)
 -- DO NOT ALTER ANY OF THE EFFECT VALUES! DO NOT ALTER EFFECT POWER!
 -- TODO: Find a better way of doing this. Need to account for varying modifiers + CASTER's skill (not target)

--- a/scripts/effects/mazurka.lua
+++ b/scripts/effects/mazurka.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.MAZURKA
--- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/minne.lua
+++ b/scripts/effects/minne.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.MINNE
--- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/minuet.lua
+++ b/scripts/effects/minuet.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.MINUET
--- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/misers_roll.lua
+++ b/scripts/effects/misers_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.MISERS_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/monks_roll.lua
+++ b/scripts/effects/monks_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.MONKS_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/naturalists_roll.lua
+++ b/scripts/effects/naturalists_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.NATURALISTS_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/ninja_roll.lua
+++ b/scripts/effects/ninja_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.NINJA_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/operetta.lua
+++ b/scripts/effects/operetta.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.OPERETTA
--- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/paeon.lua
+++ b/scripts/effects/paeon.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.PAEON
--- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/pastoral.lua
+++ b/scripts/effects/pastoral.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.PASTORAL
--- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/prelude.lua
+++ b/scripts/effects/prelude.lua
@@ -1,8 +1,6 @@
 -----------------------------------
 -- xi.effect.PRELUDE
--- Notes:
--- Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
--- getPower returns the TIER (e.g. 1, 2, 3, 4)
+-- Notes: getPower returns the TIER (e.g. 1, 2, 3, 4)
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/puppet_roll.lua
+++ b/scripts/effects/puppet_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.PUPPET_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/rogues_roll.lua
+++ b/scripts/effects/rogues_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.ROGUES_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/round.lua
+++ b/scripts/effects/round.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.ROUND
--- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/samurai_roll.lua
+++ b/scripts/effects/samurai_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.SAMURAI_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/scherzo.lua
+++ b/scripts/effects/scherzo.lua
@@ -1,7 +1,9 @@
 -----------------------------------
 -- xi.effect.SCHERZO
--- TODO: MOD_CRITICAL_DAMAGE_REDUCTION
--- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
+-- TODO: MOD_CRITICAL_DAMAGE_REDUCTION - Name pending. Will be used for gear that enhances reduction potency.
+-- TODO: Will also need a mod that enhances Scherzo duration.
+-- TODO: This will be handled in battleutils::HandleSevereDamage
+-- https://www.bg-wiki.com/ffxi/Category:Scherzo
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/scholars_roll.lua
+++ b/scripts/effects/scholars_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.SCHOLARS_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/sirvente.lua
+++ b/scripts/effects/sirvente.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.SIRVENTE
--- Notes: Effect subType for enhancing songs stores IDs of the caster. Set in scripts/globals/spells/enhancing_song.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/tacticians_roll.lua
+++ b/scripts/effects/tacticians_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.TACTICIANS_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/warlocks_roll.lua
+++ b/scripts/effects/warlocks_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.WARLOCKS_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/effects/wizards_roll.lua
+++ b/scripts/effects/wizards_roll.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 -- xi.effect.WIZARDS_ROLL
--- Notes: Effect's subType stores caster's ID. See: scripts/globals/job_utils/corsair.lua
 -----------------------------------
 ---@type TEffect
 local effectObject = {}

--- a/scripts/enum/effect_source_type.lua
+++ b/scripts/enum/effect_source_type.lua
@@ -11,4 +11,5 @@ xi.effectSourceType =
     TEMPORARY_ITEM = 2,
     MOB            = 3,
     FOOD           = 4,
+    CORSAIR_ROLL   = 5,
 }

--- a/scripts/globals/job_utils/corsair.lua
+++ b/scripts/globals/job_utils/corsair.lua
@@ -118,7 +118,7 @@ local function corsairSetup(caster, ability, action, effect, job)
     local roll = math.random(1, 6)
 
     caster:delStatusEffectSilent(xi.effect.DOUBLE_UP_CHANCE)
-    caster:addStatusEffectEx(xi.effect.DOUBLE_UP_CHANCE, xi.effect.DOUBLE_UP_CHANCE, roll, 0, 45, ability:getID(), effect, job, true)
+    caster:addStatusEffectEx(xi.effect.DOUBLE_UP_CHANCE, xi.effect.DOUBLE_UP_CHANCE, roll, 0, 45, 0, effect, job, 0, xi.effectSourceType.CORSAIR_ROLL, ability:getID(), caster:getID(), true)
     caster:setLocalVar('corsairRollTotal', roll)
     caster:setLocalVar('corsairDuEffect', effect)
     action:speceffect(caster:getID(), roll)
@@ -169,7 +169,7 @@ local function applyRoll(caster, target, inAbility, action, total, isDoubleup, c
     end
 
     caster:setLocalVar('corsairApplyingRoll', 1)
-    if not target:addCorsairRoll(caster:getMainJob(), caster:getMerit(xi.merit.BUST_DURATION), corsairRollMods[abilityId][4], effectpower, 0, duration, caster:getID(), total, corsairRollMods[abilityId][5]) then
+    if not target:addCorsairRoll(caster:getMainJob(), caster:getMerit(xi.merit.BUST_DURATION), corsairRollMods[abilityId][4], effectpower, 0, duration, corsairRollMods[abilityId][5], total, 0, xi.effectSourceType.CORSAIR_ROLL, caster:getID(), caster:getID()) then
         -- no effect or otherwise prevented
         if caster:getID() == target:getID() then                  -- dead code? you can't roll if the same roll is already active. There is no known buff that would prevent a corsair roll.
             currentAbility:setMsg(xi.msg.basic.ROLL_MAIN_FAIL)    -- no effect for the COR rolling if they had the buff already
@@ -197,6 +197,7 @@ local function applyRoll(caster, target, inAbility, action, total, isDoubleup, c
     end
 
     caster:setLocalVar('corsairApplyingRoll', 0)
+
     return total
 end
 
@@ -228,7 +229,7 @@ xi.job_utils.corsair.useDoubleUp = function(caster, target, ability, action)
         local roll     = prevRoll:getSubPower()
         local job      = duEffect:getTier()
 
-        caster:setLocalVar('corsairActiveRoll', duEffect:getSubType())
+        caster:setLocalVar('corsairActiveRoll', duEffect:getSourceTypeParam())
 
         local snakeEye = caster:getStatusEffect(xi.effect.SNAKE_EYE)
 

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -2852,8 +2852,26 @@ end
 function CBaseEntity:addStatusEffect(effect)
 end
 
--- NOTE: Currently this function allows for an optional last parameter at any position.  This is represented
+-- NOTE: TODO: Currently this function allows for an optional last parameter at any position.  This is represented
 -- in currently-used overloads, but should be standardized in the future and just pass 0-values.
+
+---@param effectID integer
+---@param effectIcon integer
+---@param power number
+---@param tick number
+---@param duration number
+---@param subType integer?
+---@param subPower integer?
+---@param tier integer?
+---@param effectFlag integer?
+---@param sourceType integer?
+---@param sourceTypeParam integer?
+---@param originID integer?
+---@param silent boolean?
+---@return boolean
+function CBaseEntity:addStatusEffectEx(effectID, effectIcon, power, tick, duration, subType, subPower, tier, effectFlag, sourceType, sourceTypeParam, originID, silent)
+end
+
 ---@param effectID integer
 ---@param effectIcon integer
 ---@param power number
@@ -3070,11 +3088,14 @@ end
 ---@param power integer
 ---@param tick integer
 ---@param duration integer
----@param arg6 integer?
----@param arg7 integer?
----@param arg8 integer?
+---@param subType integer
+---@param subPower integer
+---@param tier integer
+---@param sourceType integer
+---@param sourceTypeParam integer
+---@param originID integer
 ---@return boolean
-function CBaseEntity:addCorsairRoll(casterJob, bustDuration, effectID, power, tick, duration, arg6, arg7, arg8)
+function CBaseEntity:addCorsairRoll(casterJob, bustDuration, effectID, power, tick, duration, subType, subPower, tier, sourceType, sourceTypeParam, originID)
 end
 
 ---@nodiscard

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -13374,7 +13374,7 @@ bool CLuaBaseEntity::addStatusEffect(sol::variadic_args va)
  *  Notes   : For instance, Chocobo status, Fireflights, Teleport
  ************************************************************************/
 
-bool CLuaBaseEntity::addStatusEffectEx(sol::variadic_args va)
+auto CLuaBaseEntity::addStatusEffectEx(sol::variadic_args va) -> bool
 {
     auto* PBattleEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
     if (!PBattleEntity)
@@ -13401,10 +13401,13 @@ bool CLuaBaseEntity::addStatusEffectEx(sol::variadic_args va)
     auto duration   = static_cast<uint32>(va[4].as<double>());
 
     // Optional
-    auto subType    = va[5].is<uint32>() ? va[5].as<uint32>() : 0;
-    auto subPower   = va[6].is<double>() ? static_cast<uint16>(va[6].as<double>()) : 0;
-    auto tier       = va[7].is<uint16>() ? va[7].as<uint16>() : 0;
-    auto effectFlag = va[8].is<uint32>() ? va[8].as<uint32>() : 0;
+    auto subType         = va[5].is<uint32>() ? va[5].as<uint32>() : 0;
+    auto subPower        = va[6].is<double>() ? static_cast<uint16>(va[6].as<double>()) : 0;
+    auto tier            = va[7].is<uint16>() ? va[7].as<uint16>() : 0;
+    auto effectFlag      = va[8].is<uint32>() ? va[8].as<uint32>() : 0;
+    auto sourceType      = va[9].is<uint16>() ? va[9].as<uint16>() : 0;
+    auto sourceTypeParam = va[10].is<uint32>() ? va[10].as<uint32>() : 0;
+    auto originID        = va[11].is<uint32>() ? va[11].as<uint32>() : 0;
 
     CStatusEffect* PEffect =
         new CStatusEffect(effectID,
@@ -13418,6 +13421,14 @@ bool CLuaBaseEntity::addStatusEffectEx(sol::variadic_args va)
                           effectFlag); // Effect Flag (i.e in lua xi.effectFlag.AURA will make this an aura effect)
 
     auto addNotice = silent ? EffectNotice::Silent : EffectNotice::ShowMessage;
+
+    if (sourceType != EffectSourceType::SOURCE_NONE && sourceTypeParam > 0)
+    {
+        PEffect->SetSource(sourceType, sourceTypeParam);
+    }
+
+    // Set the originID. This is the original source of the effect(Usually an entity)
+    PEffect->SetOriginID(originID);
 
     return ((CBattleEntity*)m_PBaseEntity)->StatusEffectContainer->AddStatusEffect(PEffect, addNotice);
 }
@@ -14191,11 +14202,11 @@ bool CLuaBaseEntity::doRandomDeal(CLuaBaseEntity* PTarget)
 /************************************************************************
  *  Function: addCorsairRoll()
  *  Purpose : Adds the Corsair Roll to the Target's Status Effect Container
- *  Example : target:addCorsairRoll(caster:getMainJob(), caster:getMerit(xi.merit.BUST_DURATION), xi.effect.CHAOS_ROLL, effectpower, 0, duration, caster:getID(),
- *total, MOD_ATTP) Notes   : Returns true if success (Is range a factor?)
+ *  Example : target:addCorsairRoll(caster:getMainJob(), caster:getMerit(xi.merit.BUST_DURATION), xi.effect.CHAOS_ROLL, effectpower, 0, duration, subType(MOD ID),
+ * rollTotal, 0, sourceType, sourceTypeParam, originID) Notes   : Returns true if success (Is range a factor?)
  ************************************************************************/
 
-bool CLuaBaseEntity::addCorsairRoll(uint8 casterJob, uint8 bustDuration, uint16 effectID, uint16 power, uint32 tick, uint32 duration, sol::object const& arg6, sol::object const& arg7, sol::object const& arg8)
+auto CLuaBaseEntity::addCorsairRoll(sol::variadic_args va) -> bool
 {
     if (m_PBaseEntity->objtype == TYPE_NPC)
     {
@@ -14203,18 +14214,39 @@ bool CLuaBaseEntity::addCorsairRoll(uint8 casterJob, uint8 bustDuration, uint16 
         return false;
     }
 
-    CStatusEffect* PEffect = new CStatusEffect(static_cast<EFFECT>(effectID),                  // Effect ID
-                                               effectID,                                       // Effect Icon (Associated with ID)
-                                               power,                                          // Power
-                                               std::chrono::seconds(tick),                     // Tick
-                                               std::chrono::seconds(duration),                 // Duration
-                                               (arg6 != sol::lua_nil) ? arg6.as<uint32>() : 0, // SubType or 0
-                                               (arg7 != sol::lua_nil) ? arg7.as<uint16>() : 0, // SubPower or 0
-                                               (arg8 != sol::lua_nil) ? arg8.as<uint16>() : 0  // Tier or 0
+    if (va.size() < 12)
+    {
+        return false;
+    }
+
+    // Mandatory parameters
+    auto casterJob       = va[0].as<uint8>();
+    auto bustDuration    = va[1].as<uint8>();
+    auto effectID        = va[2].as<uint16>();
+    auto power           = static_cast<uint16>(va[3].as<double>());
+    auto tick            = static_cast<uint32>(va[4].as<double>());
+    auto duration        = static_cast<uint32>(va[5].as<double>());
+    auto subType         = va[6].is<uint32>() ? va[6].as<uint32>() : 0;
+    auto subPower        = va[7].is<double>() ? static_cast<uint16>(va[7].as<double>()) : 0;
+    auto tier            = va[8].is<uint16>() ? va[8].as<uint16>() : 0;
+    auto sourceType      = va[9].is<uint16>() ? va[9].as<uint16>() : 0;
+    auto sourceTypeParam = va[10].is<uint32>() ? va[10].as<uint32>() : 0;
+    auto originID        = va[11].is<uint32>() ? va[11].as<uint32>() : 0;
+
+    CStatusEffect* PEffect = new CStatusEffect(static_cast<EFFECT>(effectID),  // Effect ID
+                                               effectID,                       // Effect Icon (Associated with ID)
+                                               power,                          // Power (Mod power)
+                                               std::chrono::seconds(tick),     // Tick
+                                               std::chrono::seconds(duration), // Duration
+                                               subType,                        // SubType (Mod ID)
+                                               subPower,                       // SubPower (Roll #)
+                                               tier                            // Tier
     );
 
-    uint8 maxRolls = 2;
+    PEffect->SetSource(sourceType, sourceTypeParam);
+    PEffect->SetOriginID(originID);
 
+    uint8 maxRolls = 2;
     if (casterJob != JOB_COR)
     {
         maxRolls = 1;

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -670,7 +670,7 @@ public:
 
     // Status Effects
     bool  addStatusEffect(sol::variadic_args va);
-    bool  addStatusEffectEx(sol::variadic_args va);
+    auto  addStatusEffectEx(sol::variadic_args va) -> bool;
     auto  getStatusEffect(uint16 StatusID, sol::object const& SubType, sol::object const& SourceType, sol::object const& SourceTypeParam) -> CStatusEffect*;
     auto  getStatusEffectBySource(uint16 StatusID, EffectSourceType SourceType, uint16 SourceTypeParam) -> CStatusEffect*;
     auto  getStatusEffects() -> sol::table;
@@ -704,8 +704,7 @@ public:
     void   fold();
     void   doWildCard(CLuaBaseEntity* PEntity, uint8 total);
     bool   doRandomDeal(CLuaBaseEntity* PTarget);
-    bool   addCorsairRoll(uint8 casterJob, uint8 bustDuration, uint16 effectID, uint16 power, uint32 tick, uint32 duration,
-                          sol::object const& arg6, sol::object const& arg7, sol::object const& arg8);
+    auto   addCorsairRoll(sol::variadic_args va) -> bool;
     bool   hasCorsairEffect();
     bool   hasBustEffect(uint16 id); // Checks to see if a character has a specified busted corsair roll
     uint8  numBustEffects();         // Gets the number of bust effects on the player

--- a/src/map/status_effect.h
+++ b/src/map/status_effect.h
@@ -777,6 +777,7 @@ enum EffectSourceType : uint8_t
     SOURCE_TEMPORARY_ITEM = 2,
     SOURCE_MOB            = 3,
     SOURCE_FOOD           = 4,
+    SOURCE_CORSAIR_ROLL   = 5,
 };
 
 class CStatusEffect

--- a/src/map/status_effect_container.h
+++ b/src/map/status_effect_container.h
@@ -99,7 +99,7 @@ public:
     uint8 GetEffectsCountWithFlag(EFFECTFLAG flag); // We get the number of effects with the specified flag
     uint8 GetLowestFreeSlot();                      // returns the lowest free slot for songs/rolls
 
-    bool ApplyCorsairEffect(CStatusEffect* PStatusEffect, uint8 maxRolls, uint8 bustDuration);
+    auto ApplyCorsairEffect(CStatusEffect* PStatusEffect, uint8 maxRolls, uint8 bustDuration) -> bool;
     bool CheckForElevenRoll();
     bool HasBustEffect(uint16 id);
     bool HasCorsairEffect(uint32 charid);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

1. Hooks up sourceType/sourceTypeParam/originID to StealStatusEffect()

2. Hooks up sourceType/sourceTypeParam/originID to addStatusEffectEx()

3. Adds CORSAIR_ROLL sourceType ENUM.

4. Converts relevant functions to use trailing return type.

5. Converts COR Rolls and Bust effect to use sourceTypeParam to store casterID instead of subType(Called SubID in core)

6. Fixes a bug in COR Roll logic where a player could overwrite their first bust effect with a roll if the bust effect was older than the two COR rolls.
## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

1. StealStatusEffect() will now also copy sourceType/sourceTypeParam/originID. There should be no noticeable change since most effects are not hooked up to these yet.

2. addStatusEffectEx() was hooked up now since COR Rolls use it. COR Rolls work correctly = this function is working as it should. Other places this function is used should see no difference since the new arguments are optional.

3. COR Rolls: Use rolls, see that they work correctly.

I put together some videos testing COR rolls:

Did not catch it in videos but COR sub is still only able to use 1 roll and is unable to cast if they have 1 bust.

[Test 1](https://youtu.be/No4w1dly4-Y)

[Test 2](https://youtu.be/Hi5V1TDyl48)

[Test 3](https://youtu.be/2vjM18tFywY)
