### PR TITLE
[core] [login] Improve session handling

### DIFF
--- a/src/common/ipc_structs.h
+++ b/src/common/ipc_structs.h
@@ -38,10 +38,9 @@ namespace ipc
     {
     };
 
-    struct CharLogin
+    struct AccountLogin
     {
         uint32 accountId{};
-        uint32 charId{};
     };
 
     struct CharZone

--- a/src/common/xi.h
+++ b/src/common/xi.h
@@ -497,4 +497,21 @@ namespace xi
         std::optional<T>   instance_;
         std::function<T()> constructFn_;
     };
+
+    template <typename Container, typename Predicate>
+    void eraseIf(Container& container, Predicate&& pred)
+    {
+        auto it = container.begin();
+        while (it != container.end())
+        {
+            if (pred(*it))
+            {
+                it = container.erase(it); // erase returns the next valid iterator
+            }
+            else
+            {
+                ++it;
+            }
+        }
+    }
 } // namespace xi

--- a/src/login/data_session.h
+++ b/src/login/data_session.h
@@ -30,13 +30,15 @@
 #include "login_packets.h"
 
 #include "common/ipp.h"
+#include "common/zmq_dealer_wrapper.h"
 
 // port 54230
 class data_session : public handler_session
 {
 public:
-    data_session(asio::ssl::stream<asio::ip::tcp::socket> socket)
+    data_session(asio::ssl::stream<asio::ip::tcp::socket> socket, ZMQDealerWrapper& zmqDealerWrapper)
     : handler_session(std::move(socket))
+    , zmqDealerWrapper_(zmqDealerWrapper)
     {
         DebugSockets("data_session from IP %s", ipAddress);
     }
@@ -50,4 +52,7 @@ protected:
     }
 
     void handle_error(std::error_code ec, std::shared_ptr<handler_session> self) override;
+
+private:
+    ZMQDealerWrapper& zmqDealerWrapper_;
 };

--- a/src/login/handler.h
+++ b/src/login/handler.h
@@ -71,7 +71,7 @@ private:
                 }
                 else if constexpr (std::is_same_v<T, data_session>)
                 {
-                    const auto data_handler = std::make_shared<T>(asio::ssl::stream<asio::ip::tcp::socket>(std::move(socket), sslContext_));
+                    const auto data_handler = std::make_shared<T>(asio::ssl::stream<asio::ip::tcp::socket>(std::move(socket), sslContext_), zmqDealerWrapper_);
                     data_handler->start();
                 }
             }

--- a/src/login/login_errors.h
+++ b/src/login/login_errors.h
@@ -31,6 +31,7 @@ namespace loginErrors
         // TODO -- This message is displayed in Japanese, needs fixing.
         CHARACTER_NAME_UNAVAILABLE = 313, // "The character name you entered is unavailable.\nPlease choose another name."
 
+        CHARACTER_ALREADY_LOGGED_IN             = 201, // "Same character already logged in.\nPlease wait a few minutes before trying to reconnect."
         FAILED_TO_REGISTER_WITH_THE_NAME_SERVER = 314, // "Failed to register with the name server."
         CHARACTERS_PARAMETERS_ARE_INCORRECT     = 321, // "Character's parameters are incorrect."
         GAMES_DATA_HAS_BEEN_UPDATED             = 331, // "The games data has been updated."

--- a/src/login/session.h
+++ b/src/login/session.h
@@ -40,6 +40,7 @@ struct session_t
     std::string requestedNewCharacterName = "";
     bool        justCreatedNewChar        = false;
     bool        versionMismatch           = false;
+    uint8       incrementKeyValue         = 0; // Used to increment key by N in case of errors
 
     timer::time_point authorizedTime = timer::now();
 };

--- a/src/map/ipc_client.h
+++ b/src/map/ipc_client.h
@@ -53,7 +53,7 @@ public:
     //
 
     void handleMessage_EmptyStruct(const IPP& ipp, const ipc::EmptyStruct& message);
-    void handleMessage_CharLogin(const IPP& ipp, const ipc::CharLogin& message);
+    void handleMessage_AccountLogin(const IPP& ipp, const ipc::AccountLogin& message);
     void handleMessage_CharZone(const IPP& ipp, const ipc::CharZone& message);
     void handleMessage_CharVarUpdate(const IPP& ipp, const ipc::CharVarUpdate& message);
     void handleMessage_ChatMessageTell(const IPP& ipp, const ipc::ChatMessageTell& message);

--- a/src/map/map_networking.h
+++ b/src/map/map_networking.h
@@ -52,7 +52,7 @@ public:
     // TODO: Replace bool with named enum class
     void  handle_incoming_packet(const std::error_code& ec, std::span<uint8> buffer, const IPP& ipp);
     int32 map_decipher_packet(uint8*, size_t, MapSession*, blowfish_t*); // Decipher packet
-    int32 recv_parse(uint8*, size_t*, MapSession*);                      // main function to parse recv packets
+    int32 recv_parse(uint8*, size_t*, MapSession*, const IPP& ipp);      // main function to parse recv packets
     int32 parse(uint8*, size_t*, MapSession*);                           // main function parsing the packets
     int32 send_parse(uint8*, size_t*, MapSession*, bool);                // main function is building big packet
 

--- a/src/map/map_session.h
+++ b/src/map/map_session.h
@@ -44,6 +44,7 @@ struct MapSession
     std::unique_ptr<CCharEntity> PChar;                   // game char
     uint8                        shuttingDown = 0;        // prevents double session closing
     uint32                       charID       = 0;
+    uint32                       accountID    = 0;
 
     // Store old blowfish data, when a player recieves 0x00B their key should increment
     // If it doesn't, and we can still successfully decrypt here, that means we need to resend 0x00B.

--- a/src/map/map_session_container.h
+++ b/src/map/map_session_container.h
@@ -30,18 +30,24 @@ class MapSessionContainer
 {
 public:
     auto createSession(IPP ipp) -> MapSession*;
+    auto createPendingSession(uint32 charId) -> MapSession*;
 
     auto getSessionByIPP(IPP ipp) -> MapSession*;
     auto getSessionByIPP(uint64 ipp) -> MapSession*;
     auto getSessionByChar(CCharEntity* PChar) -> MapSession*;
     auto getSessionByCharId(uint32 charId) -> MapSession*;
+    auto getPendingSessionByCharId(uint32 charId) -> MapSession*;
+    auto getSessionByAccountId(uint32 accountId) -> MapSession*;
     auto getSessionByCharName(const std::string& name) -> MapSession*;
 
     void cleanupSessions(IPP mapIPP);
 
     void destroySession(IPP ipp);
     void destroySession(MapSession* map_session_data);
+    void destroyPendingSession(MapSession* map_session_data);
+    void destroyPendingSession(uint32 charId);
 
 private:
-    std::map<IPP, std::unique_ptr<MapSession>> sessions_;
+    std::map<IPP, std::unique_ptr<MapSession>>    sessions_;         // Confirmed sessions mapped by IP
+    std::map<uint32, std::unique_ptr<MapSession>> pending_sessions_; // Pending sessions notified via IPC that a character may be arriving
 };

--- a/src/world/ipc_server.cpp
+++ b/src/world/ipc_server.cpp
@@ -383,13 +383,17 @@ void IPCServer::handleMessage_EmptyStruct(const IPP& ipp, const ipc::EmptyStruct
     ShowWarningFmt("Received EmptyStruct message from {} - this is probably a bug", ipp.toString());
 }
 
-void IPCServer::handleMessage_CharLogin(const IPP& ipp, const ipc::CharLogin& message)
+void IPCServer::handleMessage_AccountLogin(const IPP& ipp, const ipc::AccountLogin& message)
 {
     TracyZoneScoped;
 
-    DebugIPCFmt("Received CharLogin message from {} for account {} char {}", ipp.toString(), message.accountId, message.charId);
+    DebugIPCFmt("Received AccountLogin message from {} for account {}", ipp.toString(), message.accountId);
 
-    // NOTE: Originally a NO-OP
+    for (const auto& zoneIIP : getIPPsForAllZones())
+    {
+        DebugIPCFmt("Message: -> rerouting to all zones on {}", ipp.toString());
+        sendMessage(zoneIIP, message);
+    }
 }
 
 void IPCServer::handleMessage_CharZone(const IPP& ipp, const ipc::CharZone& message)

--- a/src/world/ipc_server.h
+++ b/src/world/ipc_server.h
@@ -82,7 +82,7 @@ public:
     //
 
     void handleMessage_EmptyStruct(const IPP& ipp, const ipc::EmptyStruct& message);
-    void handleMessage_CharLogin(const IPP& ipp, const ipc::CharLogin& message);
+    void handleMessage_AccountLogin(const IPP& ipp, const ipc::AccountLogin& message);
     void handleMessage_CharZone(const IPP& ipp, const ipc::CharZone& message);
     void handleMessage_CharVarUpdate(const IPP& ipp, const ipc::CharVarUpdate& message);
     void handleMessage_ChatMessageTell(const IPP& ipp, const ipc::ChatMessageTell& message);

--- a/tools/generate_ipc_stubs.py
+++ b/tools/generate_ipc_stubs.py
@@ -16,7 +16,7 @@ import sys
 IPC_STRUCT_NAMES = [
     "EmptyStruct",
 
-    "CharLogin",
+    "AccountLogin",
     "CharZone",
     "CharVarUpdate",
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

After much head bashing, and a ridiculous amount of time thinking about sessions...

Add support to kick your account off by logging back in (like retail)

Send IPC to future zone that a new session might be coming (the client may not end up connecting for one reason or another)
The IPC will allow the future map zone to track sessions better

Some cleanup with bad variable names as well

## Steps to test these changes

Log in, block packets when zoning, still zone in. Intentionally create hung session with packet blocking and see it clear anyway
Just really go crazy with zoning and see if it still works