### PR TITLE
Add DefaultActions for Battlefield QMs

### DIFF
--- a/scripts/zones/Beadeaux_[S]/DefaultActions.lua
+++ b/scripts/zones/Beadeaux_[S]/DefaultActions.lua
@@ -1,0 +1,5 @@
+-- local ID = zones[xi.zone.BEADEAUX_S]
+
+return {
+    ['_2k5'] = { messageSpecial = -1 }, -- Battlefield entrance.
+}

--- a/scripts/zones/Jade_Sepulcher/DefaultActions.lua
+++ b/scripts/zones/Jade_Sepulcher/DefaultActions.lua
@@ -1,0 +1,5 @@
+-- local ID = zones[xi.zone.JADE_SEPULCHER]
+
+return {
+    ['_1v0'] = { messageSpecial = -1 }, -- Battlefield entrance.
+}

--- a/scripts/zones/Navukgo_Execution_Chamber/DefaultActions.lua
+++ b/scripts/zones/Navukgo_Execution_Chamber/DefaultActions.lua
@@ -1,0 +1,5 @@
+-- local ID = zones[xi.zone.NAVUKGO_EXECUTION_CHAMBER]
+
+return {
+    ['_1s0'] = { messageSpecial = -1 }, -- Battlefield entrance.
+}

--- a/scripts/zones/Stellar_Fulcrum/DefaultActions.lua
+++ b/scripts/zones/Stellar_Fulcrum/DefaultActions.lua
@@ -1,0 +1,5 @@
+-- local ID = zones[xi.zone.STELLAR_FULCRUM]
+
+return {
+    ['_4z0'] = { messageSpecial = -1 }, -- Battlefield entrance.
+}

--- a/scripts/zones/Talacca_Cove/DefaultActions.lua
+++ b/scripts/zones/Talacca_Cove/DefaultActions.lua
@@ -1,0 +1,5 @@
+-- local ID = zones[xi.zone.TALACCA_COVE]
+
+return {
+    ['_1l0'] = { messageSpecial = -1 }, -- Battlefield entrance.
+}

--- a/scripts/zones/The_Celestial_Nexus/DefaultActions.lua
+++ b/scripts/zones/The_Celestial_Nexus/DefaultActions.lua
@@ -1,0 +1,5 @@
+-- local ID = zones[xi.zone.THE_CELESTIAL_NEXUS]
+
+return {
+    ['_513'] = { messageSpecial = -1 }, -- Battlefield entrance.
+}


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adds a DefaultAction for the battlefield entrances in the following zones:
* Beadeaux [S]
* Jade Sepulcher
* Navukgo Execution Chamber
* Stellar Fulcrum
* Talacca Cove
* The Celestial Nexus

Without a default action defined, each of these battlefield entrances would just act as an ordinary door when a player interacts with them without a battlefield KI or mission status. If a player walked through, they'd typically be stuck in a dead-end room that isn't intended to be accessible.

## Steps to test these changes

`!zone Jade Sepulcher`
`!gotoname _1v0`

Click the Rock Slab without any ToAU mission active, and the door should stay shut. Repeat for the other four zones.