### PR TITLE
[fix] Compile modules with xi_map

### DIFF
--- a/src/map/CMakeLists.txt
+++ b/src/map/CMakeLists.txt
@@ -8,6 +8,10 @@ add_subdirectory(packets)
 add_subdirectory(packets/c2s)
 add_subdirectory(utils)
 
+set(APP_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
+)
+
 set(SOURCES
     ${COMMON_SOURCES}
     ${AI_SOURCES}
@@ -185,16 +189,16 @@ foreach(entry ${INIT_FILE_ENTRIES})
             "${CMAKE_SOURCE_DIR}/modules/${entry}/*.cpp"
             "${CMAKE_SOURCE_DIR}/modules/${entry}/*.h")
         list(APPEND module_include_dirs "${CMAKE_SOURCE_DIR}/modules/${entry}")
-        list(APPEND SOURCES ${module_files})
+        list(APPEND APP_SOURCES ${module_files})
         message(STATUS "Adding module files to build: ${module_files}")
     elseif (${entry} MATCHES "\.cpp")
-        list(APPEND SOURCES "${CMAKE_SOURCE_DIR}/modules/${entry}")
+        list(APPEND APP_SOURCES "${CMAKE_SOURCE_DIR}/modules/${entry}")
         message(STATUS "Adding module files to build: ${CMAKE_SOURCE_DIR}/modules/${entry}")
     endif()
 endforeach()
 
 add_executable(xi_map
-    ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
+    ${APP_SOURCES}
     ${resource})
 
 set(MAP_LIB_SOURCES ${SOURCES})
@@ -222,12 +226,16 @@ target_link_libraries(xi_map_lib
         project_warnings
 )
 
+target_include_directories(xi_map
+    PUBLIC
+        ${module_include_dirs}
+)
+
 target_include_directories(xi_map_lib
     PUBLIC
         ${CMAKE_SOURCE_DIR}
         ${CMAKE_SOURCE_DIR}/src
         ${CMAKE_CURRENT_SOURCE_DIR}
-        ${module_include_dirs}
 )
 
 target_link_libraries(xi_map


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds module sources and headers to the xi_map target instead of xi_map_lib. 
Pretty sure the fact it's a static library means the REGISTER_CPP_MODULE macro (that's living outside of the class) is being optimized away / not collected.

I may have to rework that when I add support for xi_test for modules but for now it fixes the issue.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Compile with a module, test it in game.

<!-- Clear and detailed steps to test your changes here -->
