### PR TITLE
[ci] Add rule to prevent usage of os.time in favor of GetSystemTime

### DIFF
--- a/tools/ci/lua_stylecheck.py
+++ b/tools/ci/lua_stylecheck.py
@@ -25,6 +25,7 @@ import sys
 # [["deprecated func", "suggested replacement"], ...]
 deprecated_functions = [
     ["table.getn", "#t"],
+    ["os.time", "GetSystemTime"],
 ]
 
 deprecated_requires = [
@@ -519,7 +520,7 @@ elif target == 'scripts':
         total_errors += LuaStyleCheck(filename).errcount
 elif target == 'test':
     total_errors = LuaStyleCheck('tools/ci/tests/stylecheck.lua', show_errors = False).errcount
-    expected_errors = 82
+    expected_errors = 83
 else:
     total_errors = LuaStyleCheck(target).errcount
 

--- a/tools/ci/tests/stylecheck.lua
+++ b/tools/ci/tests/stylecheck.lua
@@ -246,3 +246,6 @@ math.random(1, 100) -- PASS
 math.random(1) -- FAIL
 math.random() -- FAIL
 math.random(1, 2, 3) -- FAIL
+
+os.time() -- FAIL
+GetSystemTime() -- PASS


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds os.time to deprecated function check in CI along with tests to run on sanity
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
CI should pass
<!-- Clear and detailed steps to test your changes here -->
