### PR TITLE
[core] Improve "exit" on xi_map 

### DIFF
--- a/src/common/application.h
+++ b/src/common/application.h
@@ -81,8 +81,8 @@ public:
     // Runtime
     //
 
-    auto isRunning() const -> bool;
-    void requestExit();
+    auto         isRunning() const -> bool;
+    virtual void requestExit();
 
     // Is expected to block until requestExit() is called and/or isRunning() returns false
     void run();

--- a/src/map/map_application.cpp
+++ b/src/map/map_application.cpp
@@ -25,6 +25,8 @@
 #include "common/console_service.h"
 #include "common/utils.h"
 #include "map_engine.h"
+#include "map_networking.h"
+#include "map_socket.h"
 
 #ifdef _WIN32
 #include <io.h>
@@ -89,4 +91,21 @@ void MapApplication::registerCommands(ConsoleService& console)
     console.registerCommand("reload_recipes", "Reload crafting recipes", std::bind(&MapEngine::onReloadRecipes, mapEngine, std::placeholders::_1));
     console.registerCommand("stats", "Print runtime stats", std::bind(&MapEngine::onStats, mapEngine, std::placeholders::_1));
     console.registerCommand("backtrace", "Print backtrace", std::bind(&MapEngine::onBacktrace, mapEngine, std::placeholders::_1));
+}
+
+void MapApplication::requestExit()
+{
+    Application::requestExit();
+
+    // Empty task manager
+    auto taskManager = CTaskManager::getInstance();
+    while (!taskManager->getTaskList().empty())
+    {
+        taskManager->getTaskList().pop();
+    }
+
+    if (auto* mapEngine = dynamic_cast<MapEngine*>(engine_.get()))
+    {
+        mapEngine->requestExit();
+    }
 }

--- a/src/map/map_application.h
+++ b/src/map/map_application.h
@@ -50,4 +50,6 @@ public:
 
 private:
     MapConfig engineConfig_{};
+
+    void requestExit() override;
 };

--- a/src/map/map_engine.h
+++ b/src/map/map_engine.h
@@ -62,7 +62,7 @@ public:
     MapEngine(asio::io_context& io_context, MapConfig& config);
     ~MapEngine() override;
 
-    void gameLoop(asio::io_context& io_context);
+    void gameLoop();
 
     //
     // Init
@@ -98,7 +98,10 @@ public:
     auto zones() const -> std::map<uint16, CZone*>&; // g_PZoneList
     // gameState()
 
+    void requestExit();
+
 private:
+    asio::io_context&              ioContext_; // this is also shared with networking_
     std::unique_ptr<MapStatistics> mapStatistics_;
     std::unique_ptr<MapNetworking> networking_;
     std::unique_ptr<Watchdog>      watchdog_;

--- a/src/map/map_socket.h
+++ b/src/map/map_socket.h
@@ -43,6 +43,8 @@ public:
     void recvFor(timer::duration duration);
     void send(const IPP& ipp, std::span<uint8> buffer);
 
+    void requestExit();
+
 private:
     void startReceive();
 
@@ -51,6 +53,7 @@ private:
     asio::ip::udp::socket   socket_;
     NetworkBuffer           buffer_; // TODO: Pass in the global buffer, or only use this one
     asio::ip::udp::endpoint remote_endpoint_;
+    bool                    isRunning;
 
     ReceiveFn onReceiveFn_;
 };


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Close map socket on requestExit, not doing this caused the socket to spin and requestExit to (only sometimes)? hang forever
## Steps to test these changes

Launch xi_map, connect, type `exit` and it exits quickly (as of writing, there is a double free bug which can cause a crash but I am working on it right now)
