### PR TITLE
Integrating Coro-Roro, the Scheduler

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "C_Cpp.default.cppStandard": "c++17",
+    "C_Cpp.default.cppStandard": "c++20",
     "C_Cpp.default.browse.limitSymbolsToIncludedHeaders": true,
     "C_Cpp.intelliSenseEngine": "default",
     "C_Cpp.intelliSenseEngineFallback": "enabled",

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -17,16 +17,17 @@ if(TRACY_ENABLE)
         GITHUB_REPOSITORY wolfpld/tracy
         GIT_TAG v${TRACY_VERSION}
         OPTIONS
-            "TRACY_ENABLE ON"
-            "TRACY_ON_DEMAND ON"
-            "TRACY_NO_BROADCAST ON"
-            "TRACY_NO_CONTEXT_SWITCH ON"
-            "TRACY_NO_EXIT ON"
-            "TRACY_NO_VSYNC_CAPTURE ON"
-            "TRACY_NO_FRAME_IMAGE ON"
-            # "TRACY_NO_SYSTEM_TRACING ON" # This is incredibly heavy, add this line back if you need to speed up profiling
-            # "TRACY_TIMER_FALLBACK OFF" # Maybe useful to set ON for Linux VMs?
-            "TRACY_LIBBACKTRACE_ELF_DYNLOAD_SUPPORT ON"
+        "TRACY_ENABLE ON"
+        "TRACY_ON_DEMAND ON"
+        "TRACY_NO_BROADCAST ON"
+        "TRACY_NO_CONTEXT_SWITCH ON"
+        "TRACY_NO_EXIT ON"
+        "TRACY_NO_VSYNC_CAPTURE ON"
+        "TRACY_NO_FRAME_IMAGE ON"
+
+        # "TRACY_NO_SYSTEM_TRACING ON" # This is incredibly heavy, add this line back if you need to speed up profiling
+        # "TRACY_TIMER_FALLBACK OFF" # Maybe useful to set ON for Linux VMs?
+        "TRACY_LIBBACKTRACE_ELF_DYNLOAD_SUPPORT ON"
     )
 
     # Download Win32 server executables
@@ -38,19 +39,19 @@ if(TRACY_ENABLE)
             TIMEOUT 60
         )
         execute_process(COMMAND "${CMAKE_COMMAND}" -E
-                tar xvf "${CMAKE_SOURCE_DIR}/tracy.tar.gz"
-                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/
+            tar xvf "${CMAKE_SOURCE_DIR}/tracy.tar.gz"
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/
         )
     else() # UNIX
         # TODO: Auto-build Tracy and capture executables on Linux
         # sudo apt-get -y install libglfw3-dev libdbus-1-dev libcapstone-dev libtbb-dev libdebuginfod-dev libfreetype-dev
 
         # execute_process(COMMAND "make"
-        #     WORKING_DIRECTORY ${tracy_SOURCE_DIR}/profiler/build/unix
+        # WORKING_DIRECTORY ${tracy_SOURCE_DIR}/profiler/build/unix
         # )
 
         # execute_process(COMMAND "make"
-        #     WORKING_DIRECTORY ${tracy_SOURCE_DIR}/capture/build/unix
+        # WORKING_DIRECTORY ${tracy_SOURCE_DIR}/capture/build/unix
         # )
     endif()
 endif(TRACY_ENABLE)
@@ -66,8 +67,8 @@ CPMAddPackage(
     GITHUB_REPOSITORY gabime/spdlog
     GIT_TAG v1.15.0
     OPTIONS
-        "SPDLOG_ENABLE_PCH ON"
-        "SPDLOG_FMT_EXTERNAL ON"
+    "SPDLOG_ENABLE_PCH ON"
+    "SPDLOG_FMT_EXTERNAL ON"
 ) # defines: spdlog
 
 CPMAddPackage(
@@ -75,14 +76,15 @@ CPMAddPackage(
     GITHUB_REPOSITORY recastnavigation/recastnavigation
     GIT_TAG bd98d84c274ee06842bf51a4088ca82ac71f8c2d
     OPTIONS
-        # TODO: Remove this once recast is updated to use CMake 3.5+, it's currently set to what we use in the root CMakeLists.txt
-        "CMAKE_POLICY_VERSION_MINIMUM 3.20"
-        "RECASTNAVIGATION_DEMO OFF"
-        "RECASTNAVIGATION_TESTS OFF"
-        "RECASTNAVIGATION_EXAMPLES OFF"
-        "RECASTNAVIGATION_DT_POLYREF64 OFF"
-        "RECASTNAVIGATION_DT_VIRTUAL_QUERYFILTER OFF"
-        "RECASTNAVIGATION_ENABLE_ASSERTS OFF"
+
+    # TODO: Remove this once recast is updated to use CMake 3.5+, it's currently set to what we use in the root CMakeLists.txt
+    "CMAKE_POLICY_VERSION_MINIMUM 3.20"
+    "RECASTNAVIGATION_DEMO OFF"
+    "RECASTNAVIGATION_TESTS OFF"
+    "RECASTNAVIGATION_EXAMPLES OFF"
+    "RECASTNAVIGATION_DT_POLYREF64 OFF"
+    "RECASTNAVIGATION_DT_VIRTUAL_QUERYFILTER OFF"
+    "RECASTNAVIGATION_ENABLE_ASSERTS OFF"
 ) # defines: RecastNavigation::Recast, RecastNavigation::Detour
 
 CPMAddPackage(
@@ -102,11 +104,11 @@ CPMAddPackage(
     GITHUB_REPOSITORY SpartanJ/efsw
     GIT_TAG 62f785c56b7a34f035193d4cb831921347b586b8 # 1.4.1
     OPTIONS
-        "VERBOSE OFF"
-        "NO_ATOMICS OFF"
-        "BUILD_SHARED_LIBS OFF"
-        "BUILD_TEST_APP OFF"
-        "EFSW_INSTALL OFF"
+    "VERBOSE OFF"
+    "NO_ATOMICS OFF"
+    "BUILD_SHARED_LIBS OFF"
+    "BUILD_TEST_APP OFF"
+    "EFSW_INSTALL OFF"
 ) # defines: efsw
 
 # TODO: std::jthread lands in C++20. Remove this once all compilers for all platforms implement.
@@ -128,8 +130,8 @@ CPMAddPackage(
     GITHUB_REPOSITORY yhirose/cpp-httplib
     GIT_TAG v0.18.3
     OPTIONS
-        "HTTPLIB_REQUIRE_ZLIB OFF"
-        "HTTPLIB_USE_ZLIB_IF_AVAILABLE OFF"
+    "HTTPLIB_REQUIRE_ZLIB OFF"
+    "HTTPLIB_USE_ZLIB_IF_AVAILABLE OFF"
 ) # defines: httplib::httplib
 
 CPMAddPackage(
@@ -143,6 +145,7 @@ CPMAddPackage(
     GITHUB_REPOSITORY imneme/pcg-cpp
     GIT_TAG 428802d1a5634f96bcd0705fab379ff0113bcf13
 ) # defines: pcg-cpp
+
 if(pcg-cpp_ADDED) # pcg-cpp does not include cmake
     add_library(pcg-cpp INTERFACE)
     target_include_directories(pcg-cpp SYSTEM INTERFACE ${pcg-cpp_SOURCE_DIR}/include/)
@@ -153,7 +156,7 @@ CPMAddPackage(
     VERSION 1.32.0
     GITHUB_REPOSITORY chriskohlhoff/asio
     GIT_TAG asio-1-32-0 # asio uses non-standard version tag, we must specify GIT_TAG
-) #defines asio
+) # defines asio
 
 # ASIO doesn't use CMake, we have to configure it manually. Extra notes for using on Windows:
 #
@@ -208,19 +211,20 @@ CPMAddPackage(
     GIT_TAG fb50b847ae760f16ab84a367452027b246df13e1
     DOWNLOAD_ONLY ON
 ) # defines: bcrypt
+
 if(bcrypt_ADDED) # bcrypt's cmake isn't suitable for us
     add_library(bcrypt
         STATIC
-            ${bcrypt_SOURCE_DIR}/src/bcrypt.c
-            ${bcrypt_SOURCE_DIR}/src/crypt_blowfish.c
-            ${bcrypt_SOURCE_DIR}/src/crypt_gensalt.c
-            ${bcrypt_SOURCE_DIR}/src/wrapper.c
-            ${bcrypt_SOURCE_DIR}/src/x86.S
+        ${bcrypt_SOURCE_DIR}/src/bcrypt.c
+        ${bcrypt_SOURCE_DIR}/src/crypt_blowfish.c
+        ${bcrypt_SOURCE_DIR}/src/crypt_gensalt.c
+        ${bcrypt_SOURCE_DIR}/src/wrapper.c
+        ${bcrypt_SOURCE_DIR}/src/x86.S
     )
     target_include_directories(bcrypt
         SYSTEM INTERFACE
-            ${bcrypt_SOURCE_DIR}/include/
-            $<$<PLATFORM_ID:Linux>:${bcrypt_SOURCE_DIR}/include/bcrypt/>
+        ${bcrypt_SOURCE_DIR}/include/
+        $<$<PLATFORM_ID:Linux>:${bcrypt_SOURCE_DIR}/include/bcrypt/>
     )
 endif()
 
@@ -239,14 +243,15 @@ CPMAddPackage(
 CPMAddPackage(
     NAME Coro-Roro
     GITHUB_REPOSITORY zach2good/Coro-Roro
-    GIT_TAG fc988944dd384a731adb38bc45bf228fa4aefc9f
+    GIT_TAG 581d5b2ae3430d2731664f765f64be5012337c19
     OPTIONS
-        "ENABLE_TESTS OFF"
+    "ENABLE_TESTS OFF"
 ) # defines: Coro-Roro and concurrentqueue
 
 set(SHARED_EXTERNAL_LIBS
     fmt::fmt
     spdlog
+
     # concurrentqueue
     mariadbclient
     mariadbcpp
@@ -309,7 +314,6 @@ set(TEST_ONLY_EXTERNAL_LIBS
 #
 # copy external lib lists to parent scope
 #
-
 set(SHARED_EXTERNAL_LIBS
     ${SHARED_EXTERNAL_LIBS}
     PARENT_SCOPE

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -3,7 +3,7 @@
 # add_subdirectory(mariadbcpp) # Handled globally
 # add_subdirectory(zmq) # Handled globally
 # add_subdirectory(openssl) # Handled globally
-add_subdirectory(concurrentqueue)
+# add_subdirectory(concurrentqueue)
 add_subdirectory(sol)
 
 # CPM Modules
@@ -236,10 +236,18 @@ CPMAddPackage(
     GIT_TAG 1a1824df7ac798177a521eed952720681b0bf482
 ) # defines: magic_enum
 
+CPMAddPackage(
+    NAME Coro-Roro
+    GITHUB_REPOSITORY zach2good/Coro-Roro
+    GIT_TAG fc988944dd384a731adb38bc45bf228fa4aefc9f
+    OPTIONS
+        "ENABLE_TESTS OFF"
+) # defines: Coro-Roro and concurrentqueue
+
 set(SHARED_EXTERNAL_LIBS
     fmt::fmt
     spdlog
-    concurrentqueue
+    # concurrentqueue
     mariadbclient
     mariadbcpp
     sol2_single
@@ -251,6 +259,7 @@ set(SHARED_EXTERNAL_LIBS
     asio
     alpaca
     magic_enum
+    Coro-Roro
 )
 
 if(WIN32)

--- a/src/common/console_service.cpp
+++ b/src/common/console_service.cpp
@@ -154,12 +154,6 @@ void ConsoleService::registerDefaultCommands()
         fmt::print("> Application branch: {}\n", version::GetVersionString());
     });
 
-    registerCommand("tasks", "Show the current amount of tasks registered to the application task manager",
-    [](std::vector<std::string>& inputs)
-    {
-        fmt::print("> tasks registered to the application task manager: {}\n", CTaskManager::getInstance()->getTaskList().size());
-    });
-
     registerCommand("reload_settings", "Reload settings files",
     [](std::vector<std::string>& inputs)
     {

--- a/src/common/filewatcher.h
+++ b/src/common/filewatcher.h
@@ -28,7 +28,7 @@
 #include <string>
 #include <vector>
 
-#include <concurrentqueue.h>
+#include <concurrentqueue/concurrentqueue.h>
 #include <efsw/efsw.hpp>
 
 class Filewatcher final : public efsw::FileWatchListener

--- a/src/common/task_manager.h
+++ b/src/common/task_manager.h
@@ -30,6 +30,9 @@
 #include <queue>
 #include <string>
 
+#include <corororo/corororo.h>
+using namespace CoroRoro;
+
 class CTaskManager : public Singleton<CTaskManager>
 {
 public:
@@ -97,7 +100,9 @@ public:
     void RemoveTask(std::string const& TaskName);
 
 protected:
-    CTaskManager() = default;
+    CTaskManager()
+    {
+    }
 
 private:
     TaskList_t m_TaskList;

--- a/src/common/zmq_dealer_wrapper.h
+++ b/src/common/zmq_dealer_wrapper.h
@@ -27,7 +27,7 @@
 #include <atomic>
 #include <memory>
 
-#include <concurrentqueue.h>
+#include <concurrentqueue/concurrentqueue.h>
 #include <nonstd/jthread.hpp>
 #include <zmq.hpp>
 #include <zmq_addon.hpp>

--- a/src/common/zmq_router_wrapper.h
+++ b/src/common/zmq_router_wrapper.h
@@ -27,7 +27,7 @@
 #include <atomic>
 #include <memory>
 
-#include <concurrentqueue.h>
+#include <concurrentqueue/concurrentqueue.h>
 #include <nonstd/jthread.hpp>
 #include <zmq.hpp>
 #include <zmq_addon.hpp>

--- a/src/map/ai/ai_container.cpp
+++ b/src/map/ai/ai_container.cpp
@@ -412,7 +412,7 @@ void CAIContainer::Reset()
     }
 }
 
-void CAIContainer::Tick(timer::time_point _tick)
+auto CAIContainer::Tick(timer::time_point _tick) -> Task<void>
 {
     TracyZoneScoped;
     m_PrevTick = m_Tick;
@@ -429,7 +429,7 @@ void CAIContainer::Tick(timer::time_point _tick)
     bool isPathingPaused = PEntity->GetLocalVar("pauseNPCPathing");
     if (!Controller && CanFollowPath() && !isPathingPaused)
     {
-        PathFind->FollowPath(_tick);
+        co_await PathFind->FollowPath(_tick);
         if (PathFind->OnPoint())
         {
             EventHandler.triggerListener("PATH", PEntity);
@@ -439,7 +439,7 @@ void CAIContainer::Tick(timer::time_point _tick)
 
     if (Controller && Controller->canUpdate)
     {
-        Controller->Tick(_tick);
+        co_await Controller->Tick(_tick);
     }
     CState* top = nullptr;
     while (!m_stateStack.empty() && (top = m_stateStack.top().get())->DoUpdate(_tick))
@@ -453,6 +453,8 @@ void CAIContainer::Tick(timer::time_point _tick)
     }
 
     PEntity->PostTick();
+
+    co_return;
 }
 
 bool CAIContainer::IsStateStackEmpty()

--- a/src/map/ai/ai_container.h
+++ b/src/map/ai/ai_container.h
@@ -81,8 +81,10 @@ public:
     bool Internal_Respawn(timer::duration _duration);
     bool Internal_Synth(SKILLTYPE synthSkill);
 
-    void    Reset();
-    void    Tick(timer::time_point _tick);
+    void Reset();
+
+    auto Tick(timer::time_point _tick) -> Task<void>;
+
     CState* GetCurrentState();
     bool    IsStateStackEmpty();
     void    ClearStateStack();

--- a/src/map/ai/controllers/automaton_controller.cpp
+++ b/src/map/ai/controllers/automaton_controller.cpp
@@ -175,12 +175,12 @@ CurrentManeuvers CAutomatonController::GetCurrentManeuvers() const
              statuses->GetEffectsCount(EFFECT_LIGHT_MANEUVER), statuses->GetEffectsCount(EFFECT_DARK_MANEUVER) };
 }
 
-void CAutomatonController::DoCombatTick(timer::time_point tick)
+auto CAutomatonController::DoCombatTick(timer::time_point tick) -> Task<void>
 {
     if ((PAutomaton->PMaster == nullptr || PAutomaton->PMaster->isDead()) && PAutomaton->isAlive())
     {
         PAutomaton->Die();
-        return;
+        co_return;
     }
 
     PTarget = static_cast<CBattleEntity*>(PAutomaton->GetEntity(PAutomaton->GetBattleTargetID()));
@@ -188,7 +188,7 @@ void CAutomatonController::DoCombatTick(timer::time_point tick)
     if (TryDeaggro())
     {
         Disengage();
-        return;
+        co_return;
     }
 
     // Automatons only attempt actions in 3 second intervals (Reduced by the Tactical Processor)
@@ -199,31 +199,31 @@ void CAutomatonController::DoCombatTick(timer::time_point tick)
         if (TryShieldBash())
         {
             m_LastShieldBashTime = m_Tick;
-            return;
+            co_return;
         }
         else if (TrySpellcast(maneuvers))
         {
             m_LastMagicTime = m_Tick;
-            return;
+            co_return;
         }
         else if (TryTPMove())
         {
-            return;
+            co_return;
         }
         else if (TryRangedAttack())
         {
             m_LastRangedTime = m_Tick;
-            return;
+            co_return;
         }
         else if (TryAttachment())
         {
-            return;
+            co_return;
         }
     }
-    Move();
+    co_await Move();
 }
 
-void CAutomatonController::Move()
+auto CAutomatonController::Move() -> Task<void>
 {
     if ((shouldStandBack() && !isWithinDistance(PAutomaton->loc.p, PTarget->loc.p, 15.0f)) ||
         (PAutomaton->health.mp < 8 && PAutomaton->health.maxmp > 8))
@@ -231,7 +231,7 @@ void CAutomatonController::Move()
         PAutomaton->m_Behavior &= ~BEHAVIOR_STANDBACK;
     }
 
-    CPetController::Move();
+    co_await CPetController::Move();
 }
 
 bool CAutomatonController::TryAction()

--- a/src/map/ai/controllers/automaton_controller.h
+++ b/src/map/ai/controllers/automaton_controller.h
@@ -65,8 +65,8 @@ public:
     virtual bool Disengage() override;
 
 protected:
-    virtual void DoCombatTick(timer::time_point tick) override;
-    virtual void Move() override;
+    auto DoCombatTick(timer::time_point tick) -> Task<void> override;
+    auto Move() -> Task<void> override;
 
     void         setCooldowns();
     void         setMagicCooldowns();

--- a/src/map/ai/controllers/controller.h
+++ b/src/map/ai/controllers/controller.h
@@ -24,7 +24,9 @@
 
 #include "common/cbasetypes.h"
 #include "common/mmo.h"
+#include "common/task_manager.h"
 #include "common/timer.h"
+
 #include "spell.h"
 
 class CBattleEntity;
@@ -36,7 +38,9 @@ public:
     virtual ~CController()
     {
     }
-    virtual void Tick(timer::time_point tick) = 0;
+
+    virtual auto Tick(timer::time_point tick) -> Task<void> = 0;
+
     virtual void Despawn();
     virtual void Reset();
     virtual bool Cast(uint16 targid, SpellID spellid);

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -108,12 +108,12 @@ auto CMobController::CanPursueTarget(const CBattleEntity* PTarget) const -> bool
     if (PMob->getMobMod(MOBMOD_DETECTION) & DETECT_SCENT)
     {
         // if mob is in water it will instant deaggro if target cannot be detected
-        // const bool inWater = runCoroutineInline(PMob->PAI->PathFind->InWater());
-        // if (!inWater && PTarget && !PTarget->StatusEffectContainer->HasStatusEffect(EFFECT_DEODORIZE))
-        // {
-        //     // certain weather / deodorize will turn on time deaggro
-        //     return !PMob->m_disableScent;
-        // }
+        const bool inWater = runTaskInline(PMob->PAI->PathFind->InWater());
+        if (!inWater && PTarget && !PTarget->StatusEffectContainer->HasStatusEffect(EFFECT_DEODORIZE))
+        {
+            // certain weather / deodorize will turn on time deaggro
+            return !PMob->m_disableScent;
+        }
     }
     return false;
 }

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -46,7 +46,7 @@ CMobController::CMobController(CMobEntity* PEntity)
 {
 }
 
-void CMobController::Tick(const timer::time_point tick)
+auto CMobController::Tick(const timer::time_point tick) -> Task<void>
 {
     TracyZoneScoped;
     TracyZoneString(PMob->getName());
@@ -57,11 +57,11 @@ void CMobController::Tick(const timer::time_point tick)
     {
         if (PMob->PAI->IsEngaged())
         {
-            DoCombatTick(tick);
+            co_await DoCombatTick(tick);
         }
         else if (!PMob->isDead())
         {
-            DoRoamTick(tick);
+            co_await DoRoamTick(tick);
         }
     }
 }
@@ -108,11 +108,12 @@ auto CMobController::CanPursueTarget(const CBattleEntity* PTarget) const -> bool
     if (PMob->getMobMod(MOBMOD_DETECTION) & DETECT_SCENT)
     {
         // if mob is in water it will instant deaggro if target cannot be detected
-        if (!PMob->PAI->PathFind->InWater() && PTarget && !PTarget->StatusEffectContainer->HasStatusEffect(EFFECT_DEODORIZE))
-        {
-            // certain weather / deodorize will turn on time deaggro
-            return !PMob->m_disableScent;
-        }
+        // const bool inWater = runCoroutineInline(PMob->PAI->PathFind->InWater());
+        // if (!inWater && PTarget && !PTarget->StatusEffectContainer->HasStatusEffect(EFFECT_DEODORIZE))
+        // {
+        //     // certain weather / deodorize will turn on time deaggro
+        //     return !PMob->m_disableScent;
+        // }
     }
     return false;
 }
@@ -583,7 +584,7 @@ void CMobController::CastSpell(SpellID spellid)
     }
 }
 
-void CMobController::DoCombatTick(timer::time_point tick)
+auto CMobController::DoCombatTick(timer::time_point tick) -> Task<void>
 {
     TracyZoneScopedC(0xFF0000);
     if (PMob->m_OwnerID.targid != 0 && static_cast<CCharEntity*>(PMob->GetEntity(PMob->m_OwnerID.targid))->PClaimedMob != static_cast<CBattleEntity*>(PMob))
@@ -601,7 +602,7 @@ void CMobController::DoCombatTick(timer::time_point tick)
     if (TryDeaggro())
     {
         Disengage();
-        return;
+        co_return;
     }
 
     TryLink();
@@ -611,7 +612,7 @@ void CMobController::DoCombatTick(timer::time_point tick)
 
     if (PMob->PAI->IsCurrentState<CInactiveState>() || !PMob->PAI->CanChangeState())
     {
-        return;
+        co_return;
     }
 
     if (PFollowTarget != nullptr && m_followType == FollowType::RunAway)
@@ -619,15 +620,17 @@ void CMobController::DoCombatTick(timer::time_point tick)
         if (distance(PMob->loc.p, PFollowTarget->loc.p) > FollowRunAwayDistance)
         {
             if (!PMob->PAI->PathFind->IsFollowingPath())
-                PMob->PAI->PathFind->PathTo(PFollowTarget->loc.p);
-            PMob->PAI->PathFind->FollowPath(m_Tick);
+            {
+                co_await PMob->PAI->PathFind->PathTo(PFollowTarget->loc.p);
+            }
+            co_await PMob->PAI->PathFind->FollowPath(m_Tick);
         }
         else
         {
             PMob->PAI->EventHandler.triggerListener("RUN_AWAY", PMob, PFollowTarget);
             ClearFollowTarget();
         }
-        return;
+        co_return;
     }
 
     if (PTarget)
@@ -636,21 +639,21 @@ void CMobController::DoCombatTick(timer::time_point tick)
 
         if (IsSpecialSkillReady(currentDistance) && TrySpecialSkill())
         {
-            return;
+            co_return;
         }
 
         if (IsSpellReady(currentDistance) && TryCastSpell()) // Try to spellcast (this is done first so things like Chainspell spam is prioritised over TP moves etc.
         {
-            return;
+            co_return;
         }
 
         if (m_Tick >= m_LastMobSkillTime && (1 + xirand::GetRandomNumber(10000)) <= PMob->TPUseChance() && MobSkill())
         {
-            return;
+            co_return;
         }
     }
 
-    Move();
+    co_await Move();
 }
 
 void CMobController::FaceTarget(const uint16 targid) const
@@ -668,17 +671,18 @@ void CMobController::FaceTarget(const uint16 targid) const
     PMob->UpdateSpeed();
 }
 
-void CMobController::Move()
+auto CMobController::Move() -> Task<void>
 {
     TracyZoneScoped;
     if (!PMob->PAI->CanFollowPath())
     {
-        return;
+        co_return;
     }
+
     if (PMob->PAI->PathFind->IsFollowingScriptedPath() && PMob->PAI->CanFollowPath())
     {
-        PMob->PAI->PathFind->FollowPath(m_Tick);
-        return;
+        co_await PMob->PAI->PathFind->FollowPath(m_Tick);
+        co_return;
     }
 
     // attempt to teleport
@@ -749,7 +753,7 @@ void CMobController::Move()
                     {
                         MobSkill(PMob->targid, teleportBegin->getID());
                         m_LastSpecialTime = m_Tick;
-                        return;
+                        co_return;
                     }
                 }
                 else if (CanMoveForward(currentDistance))
@@ -760,16 +764,16 @@ void CMobController::Move()
                         if (currentDistance > (offsetMod == 0 ? PMob->GetMeleeRange() : closeDistance))
                         {
                             // try to find path towards target
-                            PMob->PAI->PathFind->PathInRange(PTarget->loc.p, closeDistance, PATHFLAG_WALLHACK | PATHFLAG_RUN);
+                            co_await PMob->PAI->PathFind->PathInRange(PTarget->loc.p, closeDistance, PATHFLAG_WALLHACK | PATHFLAG_RUN);
                         }
                     }
                     else if (!isWithinDistance(PMob->PAI->PathFind->GetDestination(), PTarget->loc.p, 2.5f))
                     {
                         // try to find path towards target
-                        PMob->PAI->PathFind->PathInRange(PTarget->loc.p, closeDistance, PATHFLAG_WALLHACK | PATHFLAG_RUN);
+                        co_await PMob->PAI->PathFind->PathInRange(PTarget->loc.p, closeDistance, PATHFLAG_WALLHACK | PATHFLAG_RUN);
                     }
 
-                    PMob->PAI->PathFind->FollowPath(m_Tick);
+                    co_await PMob->PAI->PathFind->FollowPath(m_Tick);
 
                     if (!PMob->PAI->PathFind->IsFollowingPath())
                     {
@@ -798,7 +802,7 @@ void CMobController::Move()
 
                                     if (PMob->PAI->PathFind->ValidPosition(new_pos))
                                     {
-                                        PMob->PAI->PathFind->PathTo(new_pos, PATHFLAG_WALLHACK | PATHFLAG_RUN);
+                                        co_await PMob->PAI->PathFind->PathTo(new_pos, PATHFLAG_WALLHACK | PATHFLAG_RUN);
                                         needToMove = true;
                                     }
                                     break;
@@ -829,6 +833,8 @@ void CMobController::Move()
     {
         FaceTarget();
     }
+
+    co_return;
 }
 
 void CMobController::HandleEnmity()
@@ -904,14 +910,14 @@ void CMobController::HandleEnmity()
     }
 }
 
-void CMobController::DoRoamTick(timer::time_point tick)
+auto CMobController::DoRoamTick(timer::time_point tick) -> Task<void>
 {
     TracyZoneScopedC(0x00FF00);
     // If there's someone on our enmity list, go from roaming -> engaging
     if (PMob->PEnmityContainer->GetHighestEnmity() != nullptr && !(PMob->m_roamFlags & ROAMFLAG_IGNORE))
     {
         Engage(PMob->PEnmityContainer->GetHighestEnmity()->targid);
-        return;
+        co_return;
     }
     else if (PMob->m_OwnerID.id != 0 && !(PMob->m_roamFlags & ROAMFLAG_IGNORE))
     {
@@ -923,13 +929,13 @@ void CMobController::DoRoamTick(timer::time_point tick)
             Engage(PTarget->targid);
         }
 
-        return;
+        co_return;
     }
     // TODO
     else if (PMob->GetDespawnTime() > timer::time_point::min() && PMob->GetDespawnTime() < m_Tick)
     {
         Despawn();
-        return;
+        co_return;
     }
 
     if (PMob->m_roamFlags & ROAMFLAG_IGNORE)
@@ -940,8 +946,8 @@ void CMobController::DoRoamTick(timer::time_point tick)
 
     if (PFollowTarget != nullptr && m_followType == FollowType::Roam && distance(PMob->loc.p, PFollowTarget->loc.p) > FollowRoamDistance)
     {
-        PMob->PAI->PathFind->PathAround(PFollowTarget->loc.p, 2.0f, PATHFLAG_RUN | PATHFLAG_WALLHACK);
-        PMob->PAI->PathFind->FollowPath(m_Tick);
+        co_await PMob->PAI->PathFind->PathAround(PFollowTarget->loc.p, 2.0f, PATHFLAG_RUN | PATHFLAG_WALLHACK);
+        co_await PMob->PAI->PathFind->FollowPath(m_Tick);
     }
 
     if (m_Tick >= m_mobHealTime + 10s && PMob->getMobMod(MOBMOD_NO_REST) == 0 && PMob->CanRest())
@@ -972,12 +978,12 @@ void CMobController::DoRoamTick(timer::time_point tick)
 
         if (PMob->PAI->PathFind->IsFollowingPath())
         {
-            FollowRoamPath();
+            co_await FollowRoamPath();
         }
         else if (PMob->PAI->PathFind->IsPatrolling())
         {
             PMob->PAI->PathFind->ResumePatrol();
-            FollowRoamPath();
+            co_await FollowRoamPath();
         }
         else if (m_Tick >= m_LastActionTime + std::chrono::milliseconds(PMob->getBigMobMod(MOBMOD_ROAM_COOL)))
         {
@@ -995,16 +1001,16 @@ void CMobController::DoRoamTick(timer::time_point tick)
                 {
                     PMob->m_IsPathingHome = true;
                     // walk back to spawn if too far away
-                    if (!PMob->PAI->PathFind->IsFollowingPath() && !PMob->PAI->PathFind->PathTo(PMob->m_SpawnPoint))
+                    if (!PMob->PAI->PathFind->IsFollowingPath() && !(co_await PMob->PAI->PathFind->PathTo(PMob->m_SpawnPoint)))
                     {
-                        PMob->PAI->PathFind->PathInRange(PMob->m_SpawnPoint, PMob->m_maxRoamDistance, PATHFLAG_RUN | PATHFLAG_WALLHACK);
+                        co_await PMob->PAI->PathFind->PathInRange(PMob->m_SpawnPoint, PMob->m_maxRoamDistance, PATHFLAG_RUN | PATHFLAG_WALLHACK);
                     }
 
                     // limit total path to just 10 or
                     // else we'll move straight back to spawn
                     PMob->PAI->PathFind->LimitDistance(10.0f);
 
-                    FollowRoamPath();
+                    co_await FollowRoamPath();
 
                     // move back every 5 seconds
                     m_LastActionTime = m_Tick - (std::chrono::milliseconds(PMob->getBigMobMod(MOBMOD_ROAM_COOL)) + 10s);
@@ -1012,7 +1018,7 @@ void CMobController::DoRoamTick(timer::time_point tick)
                 else if (!(PMob->getMobMod(MOBMOD_NO_DESPAWN) != 0) && !settings::get<bool>("map.MOB_NO_DESPAWN"))
                 {
                     PMob->PAI->Despawn();
-                    return;
+                    co_return;
                 }
             }
             else
@@ -1045,7 +1051,7 @@ void CMobController::DoRoamTick(timer::time_point tick)
                     luautils::OnMobRoamAction(PMob);
                     m_LastActionTime = m_Tick;
                 }
-                else if (PMob->CanRoam() && PMob->PAI->PathFind->RoamAround(PMob->m_SpawnPoint, PMob->GetRoamDistance(), static_cast<uint8>(PMob->getMobMod(MOBMOD_ROAM_TURNS)), PMob->m_roamFlags))
+                else if (PMob->CanRoam() && co_await PMob->PAI->PathFind->RoamAround(PMob->m_SpawnPoint, PMob->GetRoamDistance(), static_cast<uint8>(PMob->getMobMod(MOBMOD_ROAM_TURNS)), PMob->m_roamFlags))
                 {
                     // TODO: #AIToScript (event probably)
                     if (PMob->m_roamFlags & ROAMFLAG_WORM && !PMob->PAI->IsCurrentState<CMagicState>())
@@ -1068,7 +1074,7 @@ void CMobController::DoRoamTick(timer::time_point tick)
                     }
                     else
                     {
-                        FollowRoamPath();
+                        co_await FollowRoamPath();
                     }
                 }
                 else
@@ -1084,6 +1090,8 @@ void CMobController::DoRoamTick(timer::time_point tick)
         luautils::OnMobRoam(PMob);
         m_LastRoamScript = m_Tick;
     }
+
+    co_return;
 }
 
 void CMobController::Wait(timer::duration _duration)
@@ -1098,12 +1106,12 @@ void CMobController::Wait(timer::duration _duration)
     }
 }
 
-void CMobController::FollowRoamPath()
+auto CMobController::FollowRoamPath() -> Task<void>
 {
     TracyZoneScoped;
     if (PMob->PAI->CanFollowPath())
     {
-        PMob->PAI->PathFind->FollowPath(m_Tick);
+        co_await PMob->PAI->PathFind->FollowPath(m_Tick);
 
         CBattleEntity* PPet = PMob->PPet;
         if (PPet != nullptr && PPet->PAI->IsSpawned() && !PPet->PAI->IsEngaged())
@@ -1111,7 +1119,7 @@ void CMobController::FollowRoamPath()
             // pet should follow me if roaming
             position_t targetPoint = nearPosition(PMob->loc.p, 2.1f, (float)M_PI);
 
-            PPet->PAI->PathFind->PathTo(targetPoint);
+            co_await PPet->PAI->PathFind->PathTo(targetPoint);
         }
 
         // if I just finished reset my last action time
@@ -1142,6 +1150,8 @@ void CMobController::FollowRoamPath()
             luautils::OnPath(PMob);
         }
     }
+
+    co_return;
 }
 
 void CMobController::Despawn()

--- a/src/map/ai/controllers/mob_controller.h
+++ b/src/map/ai/controllers/mob_controller.h
@@ -35,7 +35,8 @@ class CMobController : public CController
 public:
     CMobController(CMobEntity* PEntity);
 
-    virtual void Tick(timer::time_point tick) override;
+    auto Tick(timer::time_point tick) -> Task<void> override;
+
     virtual auto Disengage() -> bool override;
     virtual auto Engage(uint16 targid) -> bool override;
     virtual void Despawn() override;
@@ -72,18 +73,21 @@ protected:
     auto         CheckDetection(CBattleEntity* PTarget) -> bool;
     virtual auto CanCastSpells() -> bool;
     void         CastSpell(SpellID spellid);
-    virtual void Move();
 
-    virtual void DoCombatTick(timer::time_point tick);
+    virtual auto Move() -> Task<void>;
+
+    virtual auto DoCombatTick(timer::time_point tick) -> Task<void>;
+
     void         FaceTarget(uint16 targid = 0) const;
     virtual void HandleEnmity();
 
-    virtual void DoRoamTick(timer::time_point tick);
-    void         Wait(timer::duration _duration);
-    void         FollowRoamPath();
-    auto         CanMoveForward(float currentDistance) -> bool;
-    auto         IsSpecialSkillReady(float currentDistance) const -> bool;
-    auto         IsSpellReady(float currentDistance) const -> bool;
+    virtual auto DoRoamTick(timer::time_point tick) -> Task<void>;
+
+    void Wait(timer::duration _duration);
+    auto FollowRoamPath() -> Task<void>;
+    auto CanMoveForward(float currentDistance) -> bool;
+    auto IsSpecialSkillReady(float currentDistance) const -> bool;
+    auto IsSpellReady(float currentDistance) const -> bool;
 
     CBattleEntity* PTarget{ nullptr };
 

--- a/src/map/ai/controllers/pet_controller.cpp
+++ b/src/map/ai/controllers/pet_controller.cpp
@@ -44,7 +44,7 @@ CPetController::CPetController(CMobEntity* _PPet)
     SetWeaponSkillEnabled(false);
 }
 
-void CPetController::Tick(timer::time_point tick)
+auto CPetController::Tick(timer::time_point tick) -> Task<void>
 {
     TracyZoneScoped;
     TracyZoneString(PPet->getName());
@@ -58,7 +58,7 @@ void CPetController::Tick(timer::time_point tick)
         if (PPet->isCharmed && tick > PPet->charmTime)
         {
             petutils::DespawnPet(PPet->PMaster);
-            return;
+            co_return;
         }
 
         // if a jug pet and the current time > jug spawn time + jug duration then despawn
@@ -68,25 +68,26 @@ void CPetController::Tick(timer::time_point tick)
             if (tick > PPetEntity->getJugSpawnTime() + PPetEntity->getJugDuration())
             {
                 petutils::DespawnPet(PPetEntity->PMaster);
-                return;
+                co_return;
             }
         }
     }
-    CMobController::Tick(tick);
+
+    co_await CMobController::Tick(tick);
 }
 
-void CPetController::DoRoamTick(timer::time_point tick)
+auto CPetController::DoRoamTick(timer::time_point tick) -> Task<void>
 {
     if ((PPet->PMaster == nullptr || PPet->PMaster->isDead()) && PPet->isAlive() && PPet->objtype != TYPE_MOB)
     {
         PPet->Die();
-        return;
+        co_return;
     }
 
     // if pet cannot change state (for example because pet is asleep) then just return
     if (!PPet->PAI->CanChangeState())
     {
-        return;
+        co_return;
     }
 
     if (PPet->objtype == TYPE_PET)
@@ -97,24 +98,24 @@ void CPetController::DoRoamTick(timer::time_point tick)
         {
             if (PetIsHealing())
             {
-                return;
+                co_return;
             }
         }
         else if (PetEntity->isBstPet() && PPet->StatusEffectContainer->GetStatusEffect(EFFECT_HEALING))
         {
-            return;
+            co_return;
         }
         else if (PetEntity->m_PetID == PETID_LIGHTSPIRIT) // Only Light Spirit will cast on roam tick
         {
             // this will respect the pet's mob casting cooldown properties via MOBMOD_MAGIC_COOL
             if (CMobController::IsSpellReady(0) && CMobController::TryCastSpell())
             {
-                return;
+                co_return;
             }
         }
         else if (immobilePets.contains(static_cast<PETID>(PetEntity->m_PetID))) // certain pets do not roam
         {
-            return;
+            co_return;
         }
     }
 
@@ -127,12 +128,12 @@ void CPetController::DoRoamTick(timer::time_point tick)
             if (!PPet->PAI->PathFind->IsFollowingPath() ||
                 distance(PPet->PAI->PathFind->GetDestination(), PPet->PMaster->loc.p) > 2.0f) // recalculate path only if owner moves more than X yalms
             {
-                if (!PPet->PAI->PathFind->PathAround(PPet->PMaster->loc.p, 2.0f, PATHFLAG_RUN | PATHFLAG_WALLHACK))
+                if (!(co_await PPet->PAI->PathFind->PathAround(PPet->PMaster->loc.p, 2.0f, PATHFLAG_RUN | PATHFLAG_WALLHACK)))
                 {
-                    PPet->PAI->PathFind->PathInRange(PPet->PMaster->loc.p, 2.0f, PATHFLAG_RUN | PATHFLAG_WALLHACK);
+                    co_await PPet->PAI->PathFind->PathInRange(PPet->PMaster->loc.p, 2.0f, PATHFLAG_RUN | PATHFLAG_WALLHACK);
                 }
             }
-            PPet->PAI->PathFind->FollowPath(m_Tick);
+            co_await PPet->PAI->PathFind->FollowPath(m_Tick);
         }
         else if (PPet->GetSpeed() > 0)
         {

--- a/src/map/ai/controllers/pet_controller.h
+++ b/src/map/ai/controllers/pet_controller.h
@@ -31,13 +31,15 @@ public:
     CPetController(CMobEntity* PPet);
 
     static constexpr float PetRoamDistance{ 2.1f };
-    virtual void           DoRoamTick(timer::time_point tick) override;
-    bool                   PetSkill(uint16 targid, uint16 abilityid);
+
+    virtual auto DoRoamTick(timer::time_point tick) -> Task<void> override;
+
+    bool PetSkill(uint16 targid, uint16 abilityid);
 
 protected:
     bool PetIsHealing();
 
-    virtual void Tick(timer::time_point tick) override;
+    virtual auto Tick(timer::time_point tick) -> Task<void> override;
     virtual void HandleEnmity() override
     {
     }

--- a/src/map/ai/controllers/player_charm_controller.cpp
+++ b/src/map/ai/controllers/player_charm_controller.cpp
@@ -42,26 +42,26 @@ CPlayerCharmController::~CPlayerCharmController()
     POwner->allegiance = ALLEGIANCE_TYPE::PLAYER;
 }
 
-void CPlayerCharmController::Tick(timer::time_point tick)
+auto CPlayerCharmController::Tick(timer::time_point tick) -> Task<void>
 {
     m_Tick = tick;
     if (POwner->PMaster == nullptr || !POwner->PMaster->isAlive())
     {
         POwner->StatusEffectContainer->DelStatusEffect(EFFECT_CHARM);
-        return;
+        co_return;
     }
 
     if (POwner->PAI->IsEngaged())
     {
-        DoCombatTick(tick);
+        co_await DoCombatTick(tick);
     }
     else
     {
-        DoRoamTick(tick);
+        co_await DoRoamTick(tick);
     }
 }
 
-void CPlayerCharmController::DoCombatTick(timer::time_point tick)
+auto CPlayerCharmController::DoCombatTick(timer::time_point tick) -> Task<void>
 {
     if (!POwner->PMaster->PAI->IsEngaged())
     {
@@ -82,15 +82,17 @@ void CPlayerCharmController::DoCombatTick(timer::time_point tick)
             {
                 if (POwner->GetSpeed() > 0)
                 {
-                    POwner->PAI->PathFind->PathAround(PTarget->loc.p, 2.0f, PATHFLAG_WALLHACK | PATHFLAG_RUN);
-                    POwner->PAI->PathFind->FollowPath(m_Tick);
+                    co_await POwner->PAI->PathFind->PathAround(PTarget->loc.p, 2.0f, PATHFLAG_WALLHACK | PATHFLAG_RUN);
+                    co_await POwner->PAI->PathFind->FollowPath(m_Tick);
                 }
             }
         }
     }
+
+    co_return;
 }
 
-void CPlayerCharmController::DoRoamTick(timer::time_point tick)
+auto CPlayerCharmController::DoRoamTick(timer::time_point tick) -> Task<void>
 {
     if (POwner->PMaster->PAI->IsEngaged())
     {
@@ -103,9 +105,9 @@ void CPlayerCharmController::DoRoamTick(timer::time_point tick)
     {
         if (POwner->PAI->PathFind)
         {
-            if (currentDistance < 35.0f && POwner->PAI->PathFind->PathAround(POwner->PMaster->loc.p, 2.0f, PATHFLAG_RUN | PATHFLAG_WALLHACK))
+            if (currentDistance < 35.0f && (co_await POwner->PAI->PathFind->PathAround(POwner->PMaster->loc.p, 2.0f, PATHFLAG_RUN | PATHFLAG_WALLHACK)))
             {
-                POwner->PAI->PathFind->FollowPath(m_Tick);
+                co_await POwner->PAI->PathFind->FollowPath(m_Tick);
             }
             else if (POwner->GetSpeed() > 0)
             {
@@ -113,4 +115,6 @@ void CPlayerCharmController::DoRoamTick(timer::time_point tick)
             }
         }
     }
+
+    co_return;
 }

--- a/src/map/ai/controllers/player_charm_controller.h
+++ b/src/map/ai/controllers/player_charm_controller.h
@@ -32,16 +32,18 @@ public:
     CPlayerCharmController(CCharEntity*);
     virtual ~CPlayerCharmController();
 
-    virtual void Tick(timer::time_point) override;
+    auto Tick(timer::time_point) -> Task<void> override;
 
     virtual bool Cast(uint16 targid, SpellID spellid) override
     {
         return false;
     }
+
     virtual bool ChangeTarget(uint16 targid) override
     {
         return false;
     }
+
     virtual bool WeaponSkill(uint16 targid, uint16 wsid) override
     {
         return false;
@@ -51,6 +53,7 @@ public:
     {
         return false;
     }
+
     virtual bool RangedAttack(uint16 targid) override
     {
         return false;
@@ -58,8 +61,9 @@ public:
 
 private:
     static constexpr float RoamDistance{ 2.1f };
-    void                   DoCombatTick(timer::time_point tick);
-    void                   DoRoamTick(timer::time_point tick);
+
+    auto DoCombatTick(timer::time_point tick) -> Task<void>;
+    auto DoRoamTick(timer::time_point tick) -> Task<void>;
 };
 
 #endif // _PLAYERCONTROLLER

--- a/src/map/ai/controllers/player_controller.cpp
+++ b/src/map/ai/controllers/player_controller.cpp
@@ -41,8 +41,9 @@ CPlayerController::CPlayerController(CCharEntity* _PChar)
 {
 }
 
-void CPlayerController::Tick(timer::time_point /*tick*/)
+auto CPlayerController::Tick(timer::time_point /*tick*/) -> Task<void>
 {
+    co_return;
 }
 
 bool CPlayerController::Cast(uint16 targid, SpellID spellid)

--- a/src/map/ai/controllers/player_controller.h
+++ b/src/map/ai/controllers/player_controller.h
@@ -35,7 +35,7 @@ public:
     {
     }
 
-    virtual void Tick(timer::time_point) override;
+    virtual auto Tick(timer::time_point) -> Task<void> override;
 
     virtual bool Cast(uint16 targid, SpellID spellid) override;
     virtual bool Engage(uint16 targid) override;

--- a/src/map/ai/controllers/trust_controller.cpp
+++ b/src/map/ai/controllers/trust_controller.cpp
@@ -83,7 +83,7 @@ void CTrustController::Despawn()
     CMobController::Despawn();
 }
 
-void CTrustController::Tick(timer::time_point tick)
+auto CTrustController::Tick(timer::time_point tick) -> Task<void>
 {
     TracyZoneScoped;
     TracyZoneString(POwner->getName());
@@ -92,7 +92,7 @@ void CTrustController::Tick(timer::time_point tick)
 
     if (!POwner->PMaster)
     {
-        return;
+        co_return;
     }
 
     if (POwner->PMaster->isCharmed)
@@ -102,15 +102,15 @@ void CTrustController::Tick(timer::time_point tick)
 
     if (POwner->PAI->IsEngaged())
     {
-        DoCombatTick(tick);
+        co_await DoCombatTick(tick);
     }
     else if (!POwner->isDead())
     {
-        DoRoamTick(tick);
+        co_await DoRoamTick(tick);
     }
 }
 
-void CTrustController::DoCombatTick(timer::time_point tick)
+auto CTrustController::DoCombatTick(timer::time_point tick) -> Task<void>
 {
     TracyZoneScoped;
 
@@ -130,7 +130,7 @@ void CTrustController::DoCombatTick(timer::time_point tick)
     // If busy, don't run around!
     if (POwner->PAI->IsCurrentState<CMagicState>() || POwner->PAI->IsCurrentState<CRangeState>())
     {
-        return;
+        co_return;
     }
 
     CTrustEntity* PTrust  = static_cast<CTrustEntity*>(POwner);
@@ -159,11 +159,11 @@ void CTrustController::DoCombatTick(timer::time_point tick)
                 {
                     if (currentDistanceToMaster > CastingDistance)
                     {
-                        PathOutToDistance(PTarget, 9.0f);
+                        co_await PathOutToDistance(PTarget, 9.0f);
                     }
                     else if (currentDistanceToTarget > CastingDistance)
                     {
-                        PathOutToDistance(PTarget, 9.0f);
+                        co_await PathOutToDistance(PTarget, 9.0f);
                     }
                     break;
                 }
@@ -175,9 +175,9 @@ void CTrustController::DoCombatTick(timer::time_point tick)
                         if (currentDistanceToTarget > RoamDistance)
                         {
                             if (currentDistanceToTarget < RoamDistance * 3.0f &&
-                                POwner->PAI->PathFind->PathAround(PTarget->loc.p, RoamDistance, PATHFLAG_RUN | PATHFLAG_WALLHACK))
+                                co_await POwner->PAI->PathFind->PathAround(PTarget->loc.p, RoamDistance, PATHFLAG_RUN | PATHFLAG_WALLHACK))
                             {
-                                POwner->PAI->PathFind->FollowPath(m_Tick);
+                                co_await POwner->PAI->PathFind->FollowPath(m_Tick);
                             }
                             else if (POwner->GetSpeed() > 0)
                             {
@@ -193,29 +193,31 @@ void CTrustController::DoCombatTick(timer::time_point tick)
                     [[fallthrough]];
                 default: // Using the positive-non-zero movementDistance mobMod value
                 {
-                    PathOutToDistance(PTarget, static_cast<float>(movementDistance));
+                    co_await PathOutToDistance(PTarget, static_cast<float>(movementDistance));
                     break;
                 }
             }
 
             if (!POwner->PAI->PathFind->IsFollowingPath())
             {
-                Declump(PMaster, PTarget);
+                co_await Declump(PMaster, PTarget);
             }
         }
 
         if (!m_InTransit)
         {
-            POwner->PAI->PathFind->FollowPath(m_Tick);
+            co_await POwner->PAI->PathFind->FollowPath(m_Tick);
         }
 
         m_GambitsContainer->Tick(tick);
 
         POwner->PAI->EventHandler.triggerListener("COMBAT_TICK", POwner, POwner->PMaster, PTarget);
     }
+
+    co_return;
 }
 
-void CTrustController::DoRoamTick(timer::time_point tick)
+auto CTrustController::DoRoamTick(timer::time_point tick) -> Task<void>
 {
     TracyZoneScoped;
 
@@ -269,9 +271,9 @@ void CTrustController::DoRoamTick(timer::time_point tick)
             };
             // clang-format on
 
-            if (POwner->PAI->PathFind->ValidPosition(new_pos) && POwner->PAI->PathFind->PathAround(new_pos, RoamDistance, PATHFLAG_RUN | PATHFLAG_WALLHACK))
+            if (POwner->PAI->PathFind->ValidPosition(new_pos) && co_await POwner->PAI->PathFind->PathAround(new_pos, RoamDistance, PATHFLAG_RUN | PATHFLAG_WALLHACK))
             {
-                POwner->PAI->PathFind->FollowPath(m_Tick);
+                co_await POwner->PAI->PathFind->FollowPath(m_Tick);
             }
             break;
         }
@@ -283,9 +285,9 @@ void CTrustController::DoRoamTick(timer::time_point tick)
     }
     else if (currentDistance > RoamDistance)
     {
-        if (currentDistance < RoamDistance * 3.0f && POwner->PAI->PathFind->PathAround(PFollowTarget->loc.p, RoamDistance, PATHFLAG_RUN | PATHFLAG_WALLHACK))
+        if (currentDistance < RoamDistance * 3.0f && co_await POwner->PAI->PathFind->PathAround(PFollowTarget->loc.p, RoamDistance, PATHFLAG_RUN | PATHFLAG_WALLHACK))
         {
-            POwner->PAI->PathFind->FollowPath(m_Tick);
+            co_await POwner->PAI->PathFind->FollowPath(m_Tick);
         }
         else if (POwner->GetSpeed() > 0)
         {
@@ -308,9 +310,11 @@ void CTrustController::DoRoamTick(timer::time_point tick)
             m_NumHealingTicks = std::clamp(m_NumHealingTicks + 1, static_cast<std::size_t>(0U), m_tickDelays.size() - 1U);
         }
     }
+
+    co_return;
 }
 
-void CTrustController::Declump(CCharEntity* PMaster, CBattleEntity* PTarget)
+auto CTrustController::Declump(CCharEntity* PMaster, CBattleEntity* PTarget) -> Task<void>
 {
     TracyZoneScoped;
 
@@ -335,14 +339,16 @@ void CTrustController::Declump(CCharEntity* PMaster, CBattleEntity* PTarget)
 
             if (POwner->PAI->PathFind->ValidPosition(newPos))
             {
-                POwner->PAI->PathFind->PathTo(newPos, PATHFLAG_RUN | PATHFLAG_WALLHACK);
+                co_await POwner->PAI->PathFind->PathTo(newPos, PATHFLAG_RUN | PATHFLAG_WALLHACK);
             }
             break;
         }
     }
+
+    co_return;
 }
 
-void CTrustController::PathOutToDistance(CBattleEntity* PTarget, float amount)
+auto CTrustController::PathOutToDistance(CBattleEntity* PTarget, float amount) -> Task<void>
 {
     TracyZoneScoped;
 
@@ -394,13 +400,15 @@ void CTrustController::PathOutToDistance(CBattleEntity* PTarget, float amount)
     // Get somewhat close to the target destination
     if (distance(POwner->loc.p, target_position) > 2.0f && m_failedRepositionAttempts < 3)
     {
-        POwner->PAI->PathFind->PathTo(target_position, PATHFLAG_RUN | PATHFLAG_WALLHACK);
+        co_await POwner->PAI->PathFind->PathTo(target_position, PATHFLAG_RUN | PATHFLAG_WALLHACK);
     }
     else
     {
         FaceTarget(PTarget->targid);
         m_InTransit = false;
     }
+
+    co_return;
 }
 
 bool CTrustController::Ability(uint16 targid, uint16 abilityid)

--- a/src/map/ai/controllers/trust_controller.h
+++ b/src/map/ai/controllers/trust_controller.h
@@ -40,7 +40,7 @@ public:
     CTrustController(CCharEntity*, CTrustEntity*);
     ~CTrustController() override;
 
-    void Tick(timer::time_point) override;
+    auto Tick(timer::time_point) -> Task<void> override;
     void Despawn() override;
 
     bool Ability(uint16 targid, uint16 abilityid) override;
@@ -60,11 +60,11 @@ public:
     std::unique_ptr<gambits::CGambitsContainer> m_GambitsContainer;
 
 private:
-    void DoCombatTick(timer::time_point tick) override;
-    void DoRoamTick(timer::time_point tick) override;
+    auto DoCombatTick(timer::time_point tick) -> Task<void> override;
+    auto DoRoamTick(timer::time_point tick) -> Task<void> override;
 
-    void Declump(CCharEntity* PMaster, CBattleEntity* PTarget);
-    void PathOutToDistance(CBattleEntity* PTarget, float amount);
+    auto Declump(CCharEntity* PMaster, CBattleEntity* PTarget) -> Task<void>;
+    auto PathOutToDistance(CBattleEntity* PTarget, float amount) -> Task<void>;
 
     CBattleEntity* m_LastTopEnmity;
 

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -71,7 +71,7 @@ CPathFind::~CPathFind()
     Clear();
 }
 
-bool CPathFind::RoamAround(const position_t& point, float maxRadius, uint8 maxTurns, uint16 roamFlags)
+auto CPathFind::RoamAround(const position_t& point, float maxRadius, uint8 maxTurns, uint16 roamFlags) -> Task<bool>
 {
     TracyZoneScoped;
     Clear();
@@ -80,14 +80,14 @@ bool CPathFind::RoamAround(const position_t& point, float maxRadius, uint8 maxTu
 
     if (isNavMeshEnabled())
     {
-        if (FindRandomPath(point, maxRadius, maxTurns, roamFlags))
+        if (co_await FindRandomPath(point, maxRadius, maxTurns, roamFlags))
         {
-            return true;
+            co_return true;
         }
         else
         {
             Clear();
-            return false;
+            co_return false;
         }
     }
     else
@@ -96,22 +96,23 @@ bool CPathFind::RoamAround(const position_t& point, float maxRadius, uint8 maxTu
         if (m_roamFlags & ROAMFLAG_WORM)
         {
             Clear();
-            return false;
+            co_return false;
         }
 
         m_points.emplace_back(pathpoint_t{ { point.x - 1 + rand() % 2, point.y, point.z - 1 + rand() % 2, 0, 0 }, 0s, false });
     }
 
-    return true;
+    co_return true;
 }
 
-bool CPathFind::PathTo(const position_t& point, uint8 pathFlags, bool clear)
+auto CPathFind::PathTo(const position_t& point, uint8 pathFlags, bool clear) -> Task<bool>
 {
     TracyZoneScoped;
+
     // don't follow a new path if the current path has script flag and new path doesn't
     if (IsFollowingPath() && (m_pathFlags & PATHFLAG_SCRIPT) && !(pathFlags & PATHFLAG_SCRIPT))
     {
-        return false;
+        co_return false;
     }
 
     if (clear)
@@ -127,11 +128,11 @@ bool CPathFind::PathTo(const position_t& point, uint8 pathFlags, bool clear)
 
         if (m_pathFlags & PATHFLAG_WALLHACK)
         {
-            result = FindClosestPath(m_POwner->loc.p, point);
+            result = co_await FindClosestPath(m_POwner->loc.p, point);
         }
         else
         {
-            result = FindPath(m_POwner->loc.p, point);
+            result = co_await FindPath(m_POwner->loc.p, point);
         }
 
         if (!result)
@@ -139,7 +140,7 @@ bool CPathFind::PathTo(const position_t& point, uint8 pathFlags, bool clear)
             Clear();
         }
 
-        return result;
+        co_return result;
     }
     else
     {
@@ -151,10 +152,10 @@ bool CPathFind::PathTo(const position_t& point, uint8 pathFlags, bool clear)
         m_points.emplace_back(pathpoint_t{ point, 0s, false });
     }
 
-    return true;
+    co_return true;
 }
 
-bool CPathFind::PathInRange(const position_t& point, float range, uint8 pathFlags /*= 0*/, bool clear /*= true*/)
+auto CPathFind::PathInRange(const position_t& point, float range, uint8 pathFlags /*= 0*/, bool clear /*= true*/) -> Task<bool>
 {
     TracyZoneScoped;
     if (clear)
@@ -164,13 +165,14 @@ bool CPathFind::PathInRange(const position_t& point, float range, uint8 pathFlag
 
     m_distanceFromPoint = range;
 
-    bool result = PathTo(point, pathFlags, false);
+    bool result = co_await PathTo(point, pathFlags, false);
 
     PrunePathWithin(range);
-    return result;
+
+    co_return result;
 }
 
-bool CPathFind::PathAround(const position_t& point, float distanceFromPoint, uint8 pathFlags)
+auto CPathFind::PathAround(const position_t& point, float distanceFromPoint, uint8 pathFlags) -> Task<bool>
 {
     TracyZoneScoped;
     Clear();
@@ -181,7 +183,7 @@ bool CPathFind::PathAround(const position_t& point, float distanceFromPoint, uin
 
     // Don't clear path so
     // original point / distance are kept
-    return PathTo(point, pathFlags, false);
+    co_return co_await PathTo(point, pathFlags, false);
 }
 
 bool CPathFind::PathThrough(std::vector<pathpoint_t>&& points, uint8 pathFlags)
@@ -280,12 +282,12 @@ void CPathFind::PrunePathWithin(float within)
     }
 }
 
-void CPathFind::FollowPath(timer::time_point tick)
+auto CPathFind::FollowPath(timer::time_point tick) -> Task<void>
 {
     TracyZoneScoped;
     if (!IsFollowingPath())
     {
-        return;
+        co_return;
     }
 
     if (m_timeAtPoint != timer::time_point::min())
@@ -299,13 +301,19 @@ void CPathFind::FollowPath(timer::time_point tick)
             if (m_currentPoint >= (int16)m_points.size())
             {
                 luautils::OnPathComplete(m_POwner);
-                FinishedPath();
+                co_await FinishedPath();
             }
         }
-        return;
+        co_return;
     }
 
     m_onPoint = false;
+
+    if (m_currentPoint >= (int16)m_points.size())
+    {
+        ShowErrorFmt("Bad Step!: {}", m_POwner->getName());
+        co_return;
+    }
 
     pathpoint_t targetPoint = m_points[m_currentPoint];
 
@@ -319,7 +327,7 @@ void CPathFind::FollowPath(timer::time_point tick)
         // if I have a max distance, check to stop me
         Clear();
         m_onPoint = true;
-        return;
+        co_return;
     }
 
     // Iterate over points in the current path and find the first point
@@ -339,7 +347,7 @@ void CPathFind::FollowPath(timer::time_point tick)
             if (targetPoint.wait != 0s && m_timeAtPoint == timer::time_point::min())
             {
                 m_timeAtPoint = tick + targetPoint.wait;
-                return;
+                co_return;
             }
 
             luautils::OnPathPoint(m_POwner);
@@ -356,9 +364,11 @@ void CPathFind::FollowPath(timer::time_point tick)
     if (m_currentPoint >= (int16)m_points.size())
     {
         luautils::OnPathComplete(m_POwner);
-        FinishedPath();
+        co_await FinishedPath();
         m_onPoint = true;
     }
+
+    co_return;
 }
 
 void CPathFind::StepTo(const position_t& pos, bool run)
@@ -445,39 +455,39 @@ void CPathFind::StepTo(const position_t& pos, bool run)
     m_POwner->updatemask |= UPDATE_POS;
 }
 
-bool CPathFind::FindPath(const position_t& start, const position_t& end)
+auto CPathFind::FindPath(const position_t& start, const position_t& end) -> Task<bool>
 {
     TracyZoneScoped;
 
     if (arePositionsClose(start, end))
     {
-        return false;
+        co_return false;
     }
 
     if (!isNavMeshEnabled())
     {
-        return false;
+        co_return false;
     }
 
-    m_points       = m_POwner->loc.zone->m_navMesh->findPath(start, end);
+    m_points       = co_await m_POwner->loc.zone->m_navMesh->findPath(start, end);
     m_currentPoint = 0;
 
     if (m_points.empty())
     {
         DebugNavmesh("CPathFind::FindPath Entity (%s - %d) could not find path", m_POwner->getName(), m_POwner->id);
-        return false;
+        co_return false;
     }
 
-    return true;
+    co_return true;
 }
 
-bool CPathFind::FindRandomPath(const position_t& start, float maxRadius, uint8 maxTurns, uint16 roamFlags)
+auto CPathFind::FindRandomPath(const position_t& start, float maxRadius, uint8 maxTurns, uint16 roamFlags) -> Task<bool>
 {
     TracyZoneScoped;
 
     if (!isNavMeshEnabled())
     {
-        return false;
+        co_return false;
     }
 
     auto m_turnLength = static_cast<uint8_t>(xirand::GetRandomNumber<uint32>(maxTurns) + 1);
@@ -490,12 +500,12 @@ bool CPathFind::FindRandomPath(const position_t& start, float maxRadius, uint8 m
     for (int i = 0; i < m_turnLength * 2; i++)
     {
         // look for new turnPoint. findRandomPosition doesn't guarantee the new point is within the radius
-        auto status = m_POwner->loc.zone->m_navMesh->findRandomPosition(startPosition, maxRadiusForPolyQuery);
+        auto status = co_await m_POwner->loc.zone->m_navMesh->findRandomPosition(startPosition, maxRadiusForPolyQuery);
 
         // couldn't find one point so just break out
         if (status.first != 0)
         {
-            return false;
+            co_return false;
         }
 
         // only add the roam point if it's _actually_ within range of the spawn point...
@@ -515,28 +525,28 @@ bool CPathFind::FindRandomPath(const position_t& start, float maxRadius, uint8 m
     }
     if (m_turnPoints.size() > 0)
     {
-        m_points       = m_POwner->loc.zone->m_navMesh->findPath(start, m_turnPoints[0]);
+        m_points       = co_await m_POwner->loc.zone->m_navMesh->findPath(start, m_turnPoints[0]);
         m_currentPoint = 0;
     }
 
-    return !m_points.empty();
+    co_return !m_points.empty();
 }
 
-bool CPathFind::FindClosestPath(const position_t& start, const position_t& end)
+auto CPathFind::FindClosestPath(const position_t& start, const position_t& end) -> Task<bool>
 {
     TracyZoneScoped;
 
     if (arePositionsClose(start, end))
     {
-        return false;
+        co_return false;
     }
 
     if (!isNavMeshEnabled())
     {
-        return false;
+        co_return false;
     }
 
-    m_points       = m_POwner->loc.zone->m_navMesh->findPath(start, end);
+    m_points       = co_await m_POwner->loc.zone->m_navMesh->findPath(start, end);
     m_currentPoint = 0;
     m_points.emplace_back(pathpoint_t{ end, 0s, false }); // this prevents exploits with navmesh / impassible terrain
 
@@ -548,7 +558,7 @@ bool CPathFind::FindClosestPath(const position_t& start, const position_t& end)
     }
 */
 
-    return true;
+    co_return true;
 }
 
 void CPathFind::LookAt(const position_t& point)
@@ -593,14 +603,14 @@ bool CPathFind::AtPoint(const position_t& pos)
     }
 }
 
-bool CPathFind::InWater()
+auto CPathFind::InWater() -> Task<bool>
 {
     if (isNavMeshEnabled())
     {
-        return m_POwner->loc.zone->m_navMesh->inWater(m_POwner->loc.p);
+        co_return co_await m_POwner->loc.zone->m_navMesh->inWater(m_POwner->loc.p);
     }
 
-    return false;
+    co_return false;
 }
 
 const position_t& CPathFind::GetDestination() const
@@ -658,7 +668,7 @@ void CPathFind::AddPoints(std::vector<pathpoint_t>&& points, bool reverse)
     }
 }
 
-void CPathFind::FinishedPath()
+auto CPathFind::FinishedPath() -> Task<void>
 {
     m_currentTurn++;
 
@@ -668,7 +678,7 @@ void CPathFind::FinishedPath()
         // move on to next turn
         position_t& nextTurn = m_turnPoints[m_currentTurn];
 
-        bool result = FindPath(m_POwner->loc.p, nextTurn);
+        bool result = co_await FindPath(m_POwner->loc.p, nextTurn);
 
         if (!result)
         {
@@ -684,4 +694,6 @@ void CPathFind::FinishedPath()
     {
         Clear();
     }
+
+    co_return;
 }

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -71,7 +71,7 @@ CPathFind::~CPathFind()
     Clear();
 }
 
-auto CPathFind::RoamAround(const position_t& point, float maxRadius, uint8 maxTurns, uint16 roamFlags) -> Task<bool>
+auto CPathFind::RoamAround(const position_t& point, float maxRadius, uint8 maxTurns, uint16 roamFlags) -> AsyncTask<bool>
 {
     TracyZoneScoped;
     Clear();
@@ -105,7 +105,7 @@ auto CPathFind::RoamAround(const position_t& point, float maxRadius, uint8 maxTu
     co_return true;
 }
 
-auto CPathFind::PathTo(const position_t& point, uint8 pathFlags, bool clear) -> Task<bool>
+auto CPathFind::PathTo(const position_t& point, uint8 pathFlags, bool clear) -> AsyncTask<bool>
 {
     TracyZoneScoped;
 
@@ -155,7 +155,7 @@ auto CPathFind::PathTo(const position_t& point, uint8 pathFlags, bool clear) -> 
     co_return true;
 }
 
-auto CPathFind::PathInRange(const position_t& point, float range, uint8 pathFlags /*= 0*/, bool clear /*= true*/) -> Task<bool>
+auto CPathFind::PathInRange(const position_t& point, float range, uint8 pathFlags /*= 0*/, bool clear /*= true*/) -> AsyncTask<bool>
 {
     TracyZoneScoped;
     if (clear)
@@ -172,7 +172,7 @@ auto CPathFind::PathInRange(const position_t& point, float range, uint8 pathFlag
     co_return result;
 }
 
-auto CPathFind::PathAround(const position_t& point, float distanceFromPoint, uint8 pathFlags) -> Task<bool>
+auto CPathFind::PathAround(const position_t& point, float distanceFromPoint, uint8 pathFlags) -> AsyncTask<bool>
 {
     TracyZoneScoped;
     Clear();
@@ -282,7 +282,7 @@ void CPathFind::PrunePathWithin(float within)
     }
 }
 
-auto CPathFind::FollowPath(timer::time_point tick) -> Task<void>
+auto CPathFind::FollowPath(timer::time_point tick) -> AsyncTask<void>
 {
     TracyZoneScoped;
     if (!IsFollowingPath())
@@ -455,7 +455,7 @@ void CPathFind::StepTo(const position_t& pos, bool run)
     m_POwner->updatemask |= UPDATE_POS;
 }
 
-auto CPathFind::FindPath(const position_t& start, const position_t& end) -> Task<bool>
+auto CPathFind::FindPath(const position_t& start, const position_t& end) -> AsyncTask<bool>
 {
     TracyZoneScoped;
 
@@ -481,7 +481,7 @@ auto CPathFind::FindPath(const position_t& start, const position_t& end) -> Task
     co_return true;
 }
 
-auto CPathFind::FindRandomPath(const position_t& start, float maxRadius, uint8 maxTurns, uint16 roamFlags) -> Task<bool>
+auto CPathFind::FindRandomPath(const position_t& start, float maxRadius, uint8 maxTurns, uint16 roamFlags) -> AsyncTask<bool>
 {
     TracyZoneScoped;
 
@@ -532,7 +532,7 @@ auto CPathFind::FindRandomPath(const position_t& start, float maxRadius, uint8 m
     co_return !m_points.empty();
 }
 
-auto CPathFind::FindClosestPath(const position_t& start, const position_t& end) -> Task<bool>
+auto CPathFind::FindClosestPath(const position_t& start, const position_t& end) -> AsyncTask<bool>
 {
     TracyZoneScoped;
 
@@ -668,7 +668,7 @@ void CPathFind::AddPoints(std::vector<pathpoint_t>&& points, bool reverse)
     }
 }
 
-auto CPathFind::FinishedPath() -> Task<void>
+auto CPathFind::FinishedPath() -> AsyncTask<void>
 {
     m_currentTurn++;
 

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -282,7 +282,7 @@ void CPathFind::PrunePathWithin(float within)
     }
 }
 
-auto CPathFind::FollowPath(timer::time_point tick) -> AsyncTask<void>
+auto CPathFind::FollowPath(timer::time_point tick) -> Task<void>
 {
     TracyZoneScoped;
     if (!IsFollowingPath())

--- a/src/map/ai/helpers/pathfind.h
+++ b/src/map/ai/helpers/pathfind.h
@@ -76,7 +76,7 @@ public:
     void ResumePatrol();
 
     // moves mob to next point
-    auto FollowPath(timer::time_point tick) -> AsyncTask<void>;
+    auto FollowPath(timer::time_point tick) -> Task<void>;
 
     // returns true if entity is on a way point
     bool OnPoint() const;

--- a/src/map/ai/helpers/pathfind.h
+++ b/src/map/ai/helpers/pathfind.h
@@ -24,6 +24,7 @@
 
 #include "common/logging.h"
 #include "common/mmo.h"
+#include "common/task_manager.h"
 #include "common/timer.h"
 
 #include <vector>
@@ -54,15 +55,16 @@ public:
     ~CPathFind();
 
     // move to a random point around given point
-    bool RoamAround(const position_t& point, float maxRadius, uint8 maxTurns, uint16 roamFlags = 0);
+    auto RoamAround(const position_t& point, float maxRadius, uint8 maxTurns, uint16 roamFlags = 0) -> Task<bool>;
 
     // find and walk to the given point
-    bool PathTo(const position_t& point, uint8 pathFlags = 0, bool clear = true);
+    auto PathTo(const position_t& point, uint8 pathFlags = 0, bool clear = true) -> Task<bool>;
+
     // walk to the given point until in range
-    bool PathInRange(const position_t& point, float range, uint8 pathFlags = 0, bool clear = true);
+    auto PathInRange(const position_t& point, float range, uint8 pathFlags = 0, bool clear = true) -> Task<bool>;
 
     // move some where around the point
-    bool PathAround(const position_t& point, float distanceFromPoint, uint8 pathFlags = 0);
+    auto PathAround(const position_t& point, float distanceFromPoint, uint8 pathFlags = 0) -> Task<bool>;
 
     // walk through the given points. No new points made.
     bool PathThrough(std::vector<pathpoint_t>&& points, uint8 pathFlags = 0);
@@ -74,7 +76,7 @@ public:
     void ResumePatrol();
 
     // moves mob to next point
-    void FollowPath(timer::time_point tick);
+    auto FollowPath(timer::time_point tick) -> Task<void>;
 
     // returns true if entity is on a way point
     bool OnPoint() const;
@@ -108,7 +110,7 @@ public:
     bool AtPoint(const position_t& pos);
 
     // returns true if i'm in water
-    bool InWater();
+    auto InWater() -> Task<bool>;
 
     // returns the final destination of the current path
     const position_t& GetDestination() const;
@@ -121,18 +123,18 @@ public:
 
 private:
     // find a valid path using polys
-    bool FindPath(const position_t& start, const position_t& end);
+    auto FindPath(const position_t& start, const position_t& end) -> Task<bool>;
 
     // cut some corners and find the fastest path
     // this will make the mob run down cliffs
-    bool FindClosestPath(const position_t& start, const position_t& end);
+    auto FindClosestPath(const position_t& start, const position_t& end) -> Task<bool>;
 
     // finds a random path around the given point
-    bool FindRandomPath(const position_t& start, float maxRadius, uint8 maxTurns, uint16 roamFlags);
+    auto FindRandomPath(const position_t& start, float maxRadius, uint8 maxTurns, uint16 roamFlags) -> Task<bool>;
 
     void AddPoints(std::vector<pathpoint_t>&& points, bool reverse = false);
 
-    void FinishedPath();
+    auto FinishedPath() -> Task<void>;
 
     CBaseEntity*             m_POwner;
     std::vector<pathpoint_t> m_points;

--- a/src/map/ai/helpers/pathfind.h
+++ b/src/map/ai/helpers/pathfind.h
@@ -55,16 +55,16 @@ public:
     ~CPathFind();
 
     // move to a random point around given point
-    auto RoamAround(const position_t& point, float maxRadius, uint8 maxTurns, uint16 roamFlags = 0) -> Task<bool>;
+    auto RoamAround(const position_t& point, float maxRadius, uint8 maxTurns, uint16 roamFlags = 0) -> AsyncTask<bool>;
 
     // find and walk to the given point
-    auto PathTo(const position_t& point, uint8 pathFlags = 0, bool clear = true) -> Task<bool>;
+    auto PathTo(const position_t& point, uint8 pathFlags = 0, bool clear = true) -> AsyncTask<bool>;
 
     // walk to the given point until in range
-    auto PathInRange(const position_t& point, float range, uint8 pathFlags = 0, bool clear = true) -> Task<bool>;
+    auto PathInRange(const position_t& point, float range, uint8 pathFlags = 0, bool clear = true) -> AsyncTask<bool>;
 
     // move some where around the point
-    auto PathAround(const position_t& point, float distanceFromPoint, uint8 pathFlags = 0) -> Task<bool>;
+    auto PathAround(const position_t& point, float distanceFromPoint, uint8 pathFlags = 0) -> AsyncTask<bool>;
 
     // walk through the given points. No new points made.
     bool PathThrough(std::vector<pathpoint_t>&& points, uint8 pathFlags = 0);
@@ -76,7 +76,7 @@ public:
     void ResumePatrol();
 
     // moves mob to next point
-    auto FollowPath(timer::time_point tick) -> Task<void>;
+    auto FollowPath(timer::time_point tick) -> AsyncTask<void>;
 
     // returns true if entity is on a way point
     bool OnPoint() const;
@@ -123,18 +123,18 @@ public:
 
 private:
     // find a valid path using polys
-    auto FindPath(const position_t& start, const position_t& end) -> Task<bool>;
+    auto FindPath(const position_t& start, const position_t& end) -> AsyncTask<bool>;
 
     // cut some corners and find the fastest path
     // this will make the mob run down cliffs
-    auto FindClosestPath(const position_t& start, const position_t& end) -> Task<bool>;
+    auto FindClosestPath(const position_t& start, const position_t& end) -> AsyncTask<bool>;
 
     // finds a random path around the given point
-    auto FindRandomPath(const position_t& start, float maxRadius, uint8 maxTurns, uint16 roamFlags) -> Task<bool>;
+    auto FindRandomPath(const position_t& start, float maxRadius, uint8 maxTurns, uint16 roamFlags) -> AsyncTask<bool>;
 
     void AddPoints(std::vector<pathpoint_t>&& points, bool reverse = false);
 
-    auto FinishedPath() -> Task<void>;
+    auto FinishedPath() -> AsyncTask<void>;
 
     CBaseEntity*             m_POwner;
     std::vector<pathpoint_t> m_points;

--- a/src/map/entities/baseentity.cpp
+++ b/src/map/entities/baseentity.cpp
@@ -182,10 +182,10 @@ bool CBaseEntity::CanSeeTarget(const position_t& targetPointBase, bool fallbackN
     {
         return loc.zone->lineOfSight->CanEntitySee(this, targetPointBase);
     }
-    // else if (fallbackNavMesh && loc.zone->m_navMesh)
-    // {   // TODO: runCoroutineInline needs to support AsyncTask and forcing it inline
-    //     return runCoroutineInline(loc.zone->m_navMesh->raycast(loc.p, targetPointBase));
-    // }
+    else if (fallbackNavMesh && loc.zone->m_navMesh)
+    {
+        return runTaskInline(loc.zone->m_navMesh->raycast(loc.p, targetPointBase));
+    }
 
     return true;
 }

--- a/src/map/entities/baseentity.cpp
+++ b/src/map/entities/baseentity.cpp
@@ -182,10 +182,10 @@ bool CBaseEntity::CanSeeTarget(const position_t& targetPointBase, bool fallbackN
     {
         return loc.zone->lineOfSight->CanEntitySee(this, targetPointBase);
     }
-    else if (fallbackNavMesh && loc.zone->m_navMesh)
-    {
-        return loc.zone->m_navMesh->raycast(loc.p, targetPointBase);
-    }
+    // else if (fallbackNavMesh && loc.zone->m_navMesh)
+    // {   // TODO: runCoroutineInline needs to support AsyncTask and forcing it inline
+    //     return runCoroutineInline(loc.zone->m_navMesh->raycast(loc.p, targetPointBase));
+    // }
 
     return true;
 }

--- a/src/map/ipc_client.cpp
+++ b/src/map/ipc_client.cpp
@@ -23,7 +23,7 @@
 
 #include "common/ipp.h"
 
-#include <concurrentqueue.h>
+#include <concurrentqueue/concurrentqueue.h>
 #include <queue>
 
 #include "alliance.h"

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -1912,8 +1912,8 @@ void CLuaBaseEntity::pathTo(float x, float y, float z, sol::object const& flags)
 
     if (m_PBaseEntity->PAI->PathFind)
     {
-        // uint8 pathFlags = (flags != sol::lua_nil) ? flags.as<uint8>() : (PATHFLAG_RUN | PATHFLAG_WALLHACK | PATHFLAG_SCRIPT);
-        // runCoroutineInline(m_PBaseEntity->PAI->PathFind->PathTo(point, pathFlags));
+        uint8 pathFlags = (flags != sol::lua_nil) ? flags.as<uint8>() : (PATHFLAG_RUN | PATHFLAG_WALLHACK | PATHFLAG_SCRIPT);
+        runTaskInline(m_PBaseEntity->PAI->PathFind->PathTo(point, pathFlags));
     }
 }
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -1912,9 +1912,8 @@ void CLuaBaseEntity::pathTo(float x, float y, float z, sol::object const& flags)
 
     if (m_PBaseEntity->PAI->PathFind)
     {
-        uint8 pathFlags = (flags != sol::lua_nil) ? flags.as<uint8>() : (PATHFLAG_RUN | PATHFLAG_WALLHACK | PATHFLAG_SCRIPT);
-
-        m_PBaseEntity->PAI->PathFind->PathTo(point, pathFlags);
+        // uint8 pathFlags = (flags != sol::lua_nil) ? flags.as<uint8>() : (PATHFLAG_RUN | PATHFLAG_WALLHACK | PATHFLAG_SCRIPT);
+        // runCoroutineInline(m_PBaseEntity->PAI->PathFind->PathTo(point, pathFlags));
     }
 }
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -4973,11 +4973,13 @@ namespace luautils
         position_t   pos    = nearPosition(entity->loc.p, distance, theta);
 
         float validPos[3];
-        bool  success = entity->loc.zone->m_navMesh->findFurthestValidPoint(entity->loc.p, pos, validPos);
-        if (!success)
-        {
-            return sol::lua_nil;
-        }
+
+        // TODO: runCoroutineInline needs to support AsyncTask and forcing it inline
+        // bool success = runCoroutineInline(entity->loc.zone->m_navMesh->findFurthestValidPoint(entity->loc.p, pos, validPos));
+        // if (!success)
+        // {
+        //     return sol::lua_nil;
+        // }
 
         sol::table outPos = lua.create_table();
         outPos["x"]       = validPos[0];

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -4974,12 +4974,11 @@ namespace luautils
 
         float validPos[3];
 
-        // TODO: runCoroutineInline needs to support AsyncTask and forcing it inline
-        // bool success = runCoroutineInline(entity->loc.zone->m_navMesh->findFurthestValidPoint(entity->loc.p, pos, validPos));
-        // if (!success)
-        // {
-        //     return sol::lua_nil;
-        // }
+        bool success = runTaskInline(entity->loc.zone->m_navMesh->findFurthestValidPoint(entity->loc.p, pos, validPos));
+        if (!success)
+        {
+            return sol::lua_nil;
+        }
 
         sol::table outPos = lua.create_table();
         outPos["x"]       = validPos[0];

--- a/src/map/map_engine.cpp
+++ b/src/map/map_engine.cpp
@@ -166,11 +166,17 @@ void MapEngine::gameLoop()
 
     const auto tickStart = timer::now();
     {
-        tasksDuration = gScheduler.runExpiredTasks(tickStart);
+        {
+            TracyZoneScoped;
+            tasksDuration = gScheduler.runExpiredTasks(tickStart);
+        }
 
-        // Use tick remainder for networking with a maximum to ensure that the network phase
-        // doesn't starve and a minimum to prevent bumping up against the time limit.
-        networkDuration = networking_->doSocketsBlocking(kMainLoopInterval - std::clamp<timer::duration>(tasksDuration, 50ms, 150ms));
+        {
+            TracyZoneScoped;
+            // Use tick remainder for networking with a maximum to ensure that the network phase
+            // doesn't starve and a minimum to prevent bumping up against the time limit.
+            networkDuration = networking_->doSocketsBlocking(kMainLoopInterval - std::clamp<timer::duration>(tasksDuration, 50ms, 150ms));
+        }
     }
     tickDuration = timer::now() - tickStart;
 

--- a/src/map/map_engine.cpp
+++ b/src/map/map_engine.cpp
@@ -95,6 +95,8 @@
 std::unique_ptr<SqlConnection>  _sql;
 extern std::map<uint16, CZone*> g_PZoneList; // Global array of pointers for zones
 
+extern Scheduler gScheduler;
+
 MapEngine::MapEngine(asio::io_context& io_context, MapConfig& config)
 : ioContext_(io_context)
 , mapStatistics_(std::make_unique<MapStatistics>())
@@ -164,7 +166,8 @@ void MapEngine::gameLoop()
 
     const auto tickStart = timer::now();
     {
-        tasksDuration = CTaskManager::getInstance()->doExpiredTasks(tickStart);
+        tasksDuration = gScheduler.runExpiredTasks(tickStart);
+
         // Use tick remainder for networking with a maximum to ensure that the network phase
         // doesn't starve and a minimum to prevent bumping up against the time limit.
         networkDuration = networking_->doSocketsBlocking(kMainLoopInterval - std::clamp<timer::duration>(tasksDuration, 50ms, 150ms));
@@ -299,8 +302,8 @@ void MapEngine::do_init()
     {
         ShowInfo("do_init: loading zones");
         zoneutils::LoadZoneList(mapIPP);
-        instanceutils::LoadInstanceList(mapIPP);
-        CTransportHandler::getInstance()->InitializeTransport(mapIPP);
+        // instanceutils::LoadInstanceList(mapIPP);
+        // CTransportHandler::getInstance()->InitializeTransport(mapIPP);
     }
 
     fishingutils::InitializeFishingSystem();
@@ -314,12 +317,13 @@ void MapEngine::do_init()
 
     if (!engineConfig_.isTestServer)
     {
-        CTaskManager::getInstance()->AddTask("map_cleanup", timer::now(), nullptr, CTaskManager::TASK_INTERVAL, 5s, std::bind(&MapEngine::map_cleanup, this, std::placeholders::_1, std::placeholders::_2));
-        CTaskManager::getInstance()->AddTask("garbage_collect", timer::now(), nullptr, CTaskManager::TASK_INTERVAL, 15min, std::bind(&MapEngine::map_garbage_collect, this, std::placeholders::_1, std::placeholders::_2));
+        gScheduler.scheduleInterval(std::chrono::seconds(5), std::bind(&MapEngine::map_cleanup, this));
+        gScheduler.scheduleInterval(std::chrono::minutes(15), std::bind(&MapEngine::map_garbage_collect, this));
     }
 
-    CTaskManager::getInstance()->AddTask("time_server", timer::now(), nullptr, CTaskManager::TASK_INTERVAL, kTimeServerTickInterval, time_server);
-    CTaskManager::getInstance()->AddTask("persist_server_vars", timer::now(), nullptr, CTaskManager::TASK_INTERVAL, 1min, serverutils::PersistVolatileServerVars);
+    // TODO: Fix this hack
+    gScheduler.scheduleInterval(kTimeServerTickInterval, []() -> Task<void> { time_server(timer::now(), nullptr); co_return; });
+    gScheduler.scheduleInterval(1min,  []() -> Task<void> { co_await serverutils::PersistVolatileServerVars(); });
 
     zoneutils::TOTDChange(vanadiel_time::get_totd()); // This tells the zones to spawn stuff based on time of day conditions (such as undead at night)
 
@@ -371,7 +375,7 @@ void MapEngine::do_final() const
     luautils::cleanup();
 }
 
-auto MapEngine::map_cleanup(timer::time_point tick, CTaskManager::CTask* PTask) const -> int32
+auto MapEngine::map_cleanup() const -> Task<void>
 {
     TracyZoneScoped;
 
@@ -384,17 +388,18 @@ auto MapEngine::map_cleanup(timer::time_point tick, CTaskManager::CTask* PTask) 
     });
     // clang-format on
 
-    return 0;
+    co_return;
 }
 
-auto MapEngine::map_garbage_collect(timer::time_point tick, CTaskManager::CTask* PTask) const -> int32
+auto MapEngine::map_garbage_collect() const -> Task<void>
 {
     TracyZoneScoped;
 
     ShowInfo("CTaskManager Active Tasks: %i", CTaskManager::getInstance()->getTaskList().size());
 
     luautils::garbageCollectFull();
-    return 0;
+
+    co_return;
 }
 
 void MapEngine::onStats(std::vector<std::string>& inputs) const

--- a/src/map/map_engine.cpp
+++ b/src/map/map_engine.cpp
@@ -160,6 +160,8 @@ void MapEngine::prepareWatchdog()
 
 void MapEngine::gameLoop()
 {
+    TracyZoneScoped;
+
     timer::duration tasksDuration;
     timer::duration networkDuration;
     timer::duration tickDuration;
@@ -168,7 +170,7 @@ void MapEngine::gameLoop()
     {
         {
             TracyZoneScoped;
-            tasksDuration = gScheduler.runExpiredTasks(tickStart);
+            tasksDuration = gScheduler.runExpiredTasks();
         }
 
         {
@@ -323,13 +325,24 @@ void MapEngine::do_init()
 
     if (!engineConfig_.isTestServer)
     {
-        gScheduler.scheduleInterval(std::chrono::seconds(5), std::bind(&MapEngine::map_cleanup, this));
-        gScheduler.scheduleInterval(std::chrono::minutes(15), std::bind(&MapEngine::map_garbage_collect, this));
+        mapCleanupCancellationToken_        = gScheduler.scheduleInterval(std::chrono::seconds(5), std::bind(&MapEngine::map_cleanup, this));
+        mapGarbageCollectCancellationToken_ = gScheduler.scheduleInterval(std::chrono::minutes(15), std::bind(&MapEngine::map_garbage_collect, this));
     }
 
-    // TODO: Fix this hack
-    gScheduler.scheduleInterval(kTimeServerTickInterval, []() -> Task<void> { time_server(timer::now(), nullptr); co_return; });
-    gScheduler.scheduleInterval(1min,  []() -> Task<void> { co_await serverutils::PersistVolatileServerVars(); });
+    timeServerCancellationToken_ = gScheduler.scheduleInterval(
+        kTimeServerTickInterval,
+        []() -> Task<void>
+        {
+            time_server(timer::now(), nullptr);
+            co_return;
+        });
+
+    persistVolatileServerVarsCancellationToken_ = gScheduler.scheduleInterval(
+        1min,
+        []() -> Task<void>
+        {
+            co_await serverutils::PersistVolatileServerVars();
+        });
 
     zoneutils::TOTDChange(vanadiel_time::get_totd()); // This tells the zones to spawn stuff based on time of day conditions (such as undead at night)
 

--- a/src/map/map_engine.h
+++ b/src/map/map_engine.h
@@ -106,4 +106,9 @@ private:
     std::unique_ptr<MapNetworking> networking_;
     std::unique_ptr<Watchdog>      watchdog_;
     MapConfig&                     engineConfig_;
+
+    CancellationToken mapCleanupCancellationToken_;
+    CancellationToken mapGarbageCollectCancellationToken_;
+    CancellationToken timeServerCancellationToken_;
+    CancellationToken persistVolatileServerVarsCancellationToken_;
 };

--- a/src/map/map_engine.h
+++ b/src/map/map_engine.h
@@ -77,8 +77,8 @@ public:
     // Maintenance
     //
 
-    int32 map_cleanup(timer::time_point tick, CTaskManager::CTask* PTask) const; // Clean up timed out players
-    int32 map_garbage_collect(timer::time_point tick, CTaskManager::CTask* PTask) const;
+    auto map_cleanup() const -> Task<void>; // Clean up timed out players
+    auto map_garbage_collect() const -> Task<void>;
 
     //
     // Commands callbacks

--- a/src/map/map_networking.cpp
+++ b/src/map/map_networking.cpp
@@ -126,8 +126,6 @@ void MapNetworking::tapStatistics()
 
 auto MapNetworking::doSocketsBlocking(timer::duration next) -> timer::duration
 {
-    TracyZoneScoped;
-
     const auto start = timer::now();
 
     message::handle_incoming();

--- a/src/map/map_networking.cpp
+++ b/src/map/map_networking.cpp
@@ -113,7 +113,7 @@ void MapNetworking::tapStatistics()
     mapStatistics_.set(MapStatistics::Key::ActiveZones, activeZoneCount);
     mapStatistics_.set(MapStatistics::Key::ConnectedPlayers, playerCount);
     mapStatistics_.set(MapStatistics::Key::ActiveMobs, mobCount);
-    mapStatistics_.set(MapStatistics::Key::TaskManagerTasks, CTaskManager::getInstance()->getTaskList().size());
+    // mapStatistics_.set(MapStatistics::Key::TaskManagerTasks, CTaskManager::getInstance()->getTaskList().size());
 
     const auto percent = (static_cast<double>(dynamicTargIdCount) / static_cast<double>(dynamicTargIdCapacity)) * 100.0;
     mapStatistics_.set(MapStatistics::Key::DynamicTargIdUsagePercent, static_cast<int64>(percent));

--- a/src/map/navmesh.cpp
+++ b/src/map/navmesh.cpp
@@ -245,14 +245,14 @@ void CNavMesh::unload()
     m_navMesh = nullptr;
 }
 
-auto CNavMesh::findPath(const position_t& start, const position_t& end) const -> std::vector<pathpoint_t>
+auto CNavMesh::findPath(position_t start, position_t end) const -> AsyncTask<std::vector<pathpoint_t>>
 {
     TracyZoneScoped;
 
     if (!m_navMesh)
     {
         DebugNavmesh("CNavMesh::findPath No navmesh loaded (%u)", m_zoneID);
-        return {};
+        co_return {};
     }
 
     DebugNavmesh("CNavMesh::findPath (%f, %f, %f) -> (%f, %f, %f) (zone: %u) (MAX_NAV_POLYS: %u)", start.x, start.y, start.z, end.x, end.y, end.z, m_zoneID, MAX_NAV_POLYS);
@@ -280,7 +280,7 @@ auto CNavMesh::findPath(const position_t& start, const position_t& end) const ->
     {
         DebugNavmesh("CNavMesh::findPath start point invalid (%f, %f, %f) (%u)", spos[0], spos[1], spos[2], m_zoneID);
         ShowError(detourStatusString(status));
-        return {};
+        co_return {};
     }
 
     // Validate epos into endRef and eNearestPoint
@@ -289,7 +289,7 @@ auto CNavMesh::findPath(const position_t& start, const position_t& end) const ->
     {
         ShowError("CNavMesh::findPath end point invalid (%f, %f, %f) (%u)", epos[0], epos[1], epos[2], m_zoneID);
         ShowError(detourStatusString(status));
-        return {};
+        co_return {};
     }
 
     // TODO: Do we need these isValidPolyRef checks? We've just found the nearest polys and checked them with dtStatusFailed.
@@ -298,14 +298,14 @@ auto CNavMesh::findPath(const position_t& start, const position_t& end) const ->
     if (!m_navMesh->isValidPolyRef(startRef))
     {
         DebugNavmesh("CNavMesh::findPath Start poly invalid: (%f, %f, %f) (%u)", start.x, start.y, start.z, m_zoneID);
-        return {};
+        co_return {};
     }
 
     // Make sure the end poly is valid
     if (!m_navMesh->isValidPolyRef(endRef))
     {
         DebugNavmesh("CNavMesh::findPath End poly invalid: (%f, %f, %f) (%u)", end.x, end.y, end.z, m_zoneID);
-        return {};
+        co_return {};
     }
 
     // First, we're going to build up a list of polys that make up the path
@@ -317,7 +317,7 @@ auto CNavMesh::findPath(const position_t& start, const position_t& end) const ->
     {
         ShowError("CNavMesh::findPath findPath error (%u)", m_zoneID);
         ShowError(detourStatusString(status));
-        return {};
+        co_return {};
     }
 
     // At this point, findPath() has generated a list of polys that make up a path, but these polys aren't guaranteed to contain a complete path
@@ -327,7 +327,7 @@ auto CNavMesh::findPath(const position_t& start, const position_t& end) const ->
     if (pathPolyCount <= 0)
     {
         ShowError("CNavMesh::findPath Unable to generate polys for path (%f, %f, %f)->(%f, %f, %f) (%u)", start.x, start.y, start.z, end.x, end.y, end.z, m_zoneID);
-        return {};
+        co_return {};
     }
 
     // Find the best straight path possible between sNearestPoint and eNearestPoint within the bounds of all the polys in pathPolys.
@@ -346,7 +346,7 @@ auto CNavMesh::findPath(const position_t& start, const position_t& end) const ->
     {
         ShowError("CNavMesh::findPath findStraightPath error (%u)", m_zoneID);
         ShowError(detourStatusString(status));
-        return {};
+        co_return {};
     }
 
     // Now that we have list of sequential positions in straightPath, we need to check to see if eNearestPoint is the final point. If it isn't we've been given a partial path.
@@ -380,7 +380,7 @@ auto CNavMesh::findPath(const position_t& start, const position_t& end) const ->
     // We have now exhausted our path, return empty results.
     if (straightPathCount <= 1)
     {
-        return {};
+        co_return {};
     }
 
     // TODO: Detect local minima and re-try pathing with a larger buffer.
@@ -400,19 +400,22 @@ auto CNavMesh::findPath(const position_t& start, const position_t& end) const ->
         outPoints.emplace_back(pathpoint_t{ { pathPos[0], pathPos[1], pathPos[2], 0, 0 }, 0s, false });
     }
 
-    return outPoints;
+    co_return outPoints;
 }
 
-auto CNavMesh::findRandomPosition(const position_t& start, float maxRadius) const -> std::pair<int16, position_t>
+auto CNavMesh::findRandomPosition(position_t start, float maxRadius) const -> AsyncTask<std::pair<int16, position_t>>
 {
     TracyZoneScoped;
 
     if (!m_navMesh)
     {
-        return {};
+        co_return {};
     }
 
     DebugNavmesh("CNavMesh::findRandomPosition (%f, %f, %f) (%u)", start.x, start.y, start.z, m_zoneID);
+
+    dtNavMeshQuery navMeshQuery;
+    navMeshQuery.init(m_navMesh, MAX_NAV_POLYS);
 
     dtStatus status = 0;
 
@@ -429,23 +432,23 @@ auto CNavMesh::findRandomPosition(const position_t& start, float maxRadius) cons
     dtPolyRef startRef  = 0;
     dtPolyRef randomRef = 0;
 
-    status = m_navMeshQuery.findNearestPoly(spos, polyPickExt, &filter, &startRef, snearest);
+    status = navMeshQuery.findNearestPoly(spos, polyPickExt, &filter, &startRef, snearest);
 
     if (dtStatusFailed(status))
     {
         ShowError("CNavMesh::findRandomPosition start point invalid (%f, %f, %f) (%u)", spos[0], spos[1], spos[2], m_zoneID);
         ShowError(detourStatusString(status));
-        return std::make_pair(ERROR_NEARESTPOLY, position_t{});
+        co_return std::make_pair(ERROR_NEARESTPOLY, position_t{});
     }
 
     if (!m_navMesh->isValidPolyRef(startRef))
     {
         DebugNavmesh("CNavMesh::findRandomPosition startRef is invalid (%f, %f, %f) (%u)", start.x, start.y, start.z, m_zoneID);
-        return std::make_pair(ERROR_NEARESTPOLY, position_t{});
+        co_return std::make_pair(ERROR_NEARESTPOLY, position_t{});
     }
 
     // clang-format off
-    status = m_navMeshQuery.findRandomPointAroundCircle(
+    status = navMeshQuery.findRandomPointAroundCircle(
         startRef, spos, maxRadius, &filter,
         []() -> float
         {
@@ -458,23 +461,23 @@ auto CNavMesh::findRandomPosition(const position_t& start, float maxRadius) cons
     {
         ShowError("CNavMesh::findRandomPosition Error (%u)", m_zoneID);
         ShowError(detourStatusString(status));
-        return std::make_pair(ERROR_NEARESTPOLY, position_t{});
+        co_return std::make_pair(ERROR_NEARESTPOLY, position_t{});
     }
 
     CNavMesh::ToFFXIPos(randomPt);
 
-    return std::make_pair(0, position_t{ randomPt[0], randomPt[1], randomPt[2], 0, 0 });
+    co_return std::make_pair(0, position_t{ randomPt[0], randomPt[1], randomPt[2], 0, 0 });
 }
 
-auto CNavMesh::inWater(const position_t& point) const -> bool
+auto CNavMesh::inWater(const position_t& point) const -> Task<bool>
 {
     if (!m_navMesh)
     {
-        return false;
+        co_return false;
     }
 
     // TODO:
-    return false;
+    co_return false;
 }
 
 auto CNavMesh::validPosition(const position_t& position) const -> bool
@@ -509,13 +512,13 @@ auto CNavMesh::validPosition(const position_t& position) const -> bool
     return m_navMesh->isValidPolyRef(startRef);
 }
 
-auto CNavMesh::findClosestValidPoint(const position_t& position, float* validPoint) const -> bool
+auto CNavMesh::findClosestValidPoint(const position_t& position, float* validPoint) const -> AsyncTask<bool>
 {
     TracyZoneScoped;
 
     if (!m_navMesh)
     {
-        return true;
+        co_return true;
     }
 
     DebugNavmesh("CNavMesh::findClosestValidPoint (%f, %f, %f) (%u)", position.x, position.y, position.z, m_zoneID);
@@ -533,20 +536,20 @@ auto CNavMesh::findClosestValidPoint(const position_t& position, float* validPoi
 
     if (dtStatusFailed(status))
     {
-        return false;
+        co_return false;
     }
 
     CNavMesh::ToFFXIPos(validPoint);
-    return true;
+    co_return true;
 }
 
-auto CNavMesh::findFurthestValidPoint(const position_t& startPosition, const position_t& endPosition, float* validEndPoint) const -> bool
+auto CNavMesh::findFurthestValidPoint(const position_t& startPosition, const position_t& endPosition, float* validEndPoint) const -> AsyncTask<bool>
 {
     TracyZoneScoped;
 
     if (!m_navMesh)
     {
-        return true;
+        co_return true;
     }
 
     DebugNavmesh("CNavMesh::findFurthestValidPoint (%f, %f, %f) -> (%f, %f, %f) (%u)", startPosition.x, startPosition.y, startPosition.z, endPosition.x, endPosition.y, endPosition.z, m_zoneID);
@@ -564,7 +567,7 @@ auto CNavMesh::findFurthestValidPoint(const position_t& startPosition, const pos
     dtStatus status = m_navMeshQuery.findNearestPoly(spos, largePolyPickExt, &filter, &startRef, validStartPoint);
     if (dtStatusFailed(status))
     {
-        return false;
+        co_return false;
     }
 
     dtPolyRef visited[MAX_QUERY_POLYS];
@@ -577,11 +580,11 @@ auto CNavMesh::findFurthestValidPoint(const position_t& startPosition, const pos
 
     if (dtStatusFailed(status))
     {
-        return false;
+        co_return false;
     }
 
     CNavMesh::ToFFXIPos(validEndPoint);
-    return true;
+    co_return true;
 }
 
 auto CNavMesh::snapToValidPosition(position_t& position) const -> void
@@ -624,13 +627,13 @@ auto CNavMesh::snapToValidPosition(position_t& position) const -> void
     }
 }
 
-auto CNavMesh::onSameFloor(const position_t& start, float* spos, const position_t& end, float* epos, dtQueryFilter& filter) const -> bool
+auto CNavMesh::onSameFloor(const position_t& start, float* spos, const position_t& end, float* epos, dtQueryFilter& filter) const -> AsyncTask<bool>
 {
     TracyZoneScoped;
 
     if (!m_navMesh)
     {
-        return true;
+        co_return true;
     }
 
     DebugNavmesh("CNavMesh::onSameFloor (%f, %f, %f) -> (%f, %f, %f) (%u)", start.x, start.y, start.z, end.x, end.y, end.z, m_zoneID);
@@ -639,7 +642,7 @@ auto CNavMesh::onSameFloor(const position_t& start, float* spos, const position_
     if (verticalDistance > 2 * verticalLimit)
     {
         // Too far away, abort check
-        return false;
+        co_return false;
     }
     else if (verticalDistance > verticalLimit)
     {
@@ -653,7 +656,7 @@ auto CNavMesh::onSameFloor(const position_t& start, float* spos, const position_
         {
             ShowError("CNavMesh::Bad vertical polygon query (%f, %f, %f) (%u)", epos[0], epos[1], epos[2], m_zoneID);
             ShowError(detourStatusString(status));
-            return false;
+            co_return false;
         }
 
         // Collect the heights of queried polygons
@@ -681,26 +684,26 @@ auto CNavMesh::onSameFloor(const position_t& start, float* spos, const position_
             // if we are within verticalLimitTrunc of a point, that's our closest.
             if (startHeight != endHeight)
             {
-                return false;
+                co_return false;
             }
         }
     }
 
-    return true;
+    co_return true;
 }
 
-auto CNavMesh::raycast(const position_t& start, const position_t& end) const -> bool
+auto CNavMesh::raycast(const position_t& start, const position_t& end) const -> AsyncTask<bool>
 {
     TracyZoneScoped;
 
     if (start.x == end.x && start.y == end.y && start.z == end.z)
     {
-        return true;
+        co_return true;
     }
 
     if (!m_navMesh)
     {
-        return true;
+        co_return true;
     }
 
     DebugNavmesh("CNavMesh::raycast (%f, %f, %f) -> (%f, %f, %f) (%u)", start.x, start.y, start.z, end.x, end.y, end.z, m_zoneID);
@@ -722,9 +725,9 @@ auto CNavMesh::raycast(const position_t& start, const position_t& end) const -> 
     // you from above/below and then wallhack their way to you. To get around this, we're
     // going to query in a small column for polys above and below and then test against
     // the results.
-    if (!onSameFloor(start, spos, end, epos, filter))
+    if (!co_await onSameFloor(start, spos, end, epos, filter))
     {
-        return false;
+        co_return false;
     }
 
     dtPolyRef startRef = 0;
@@ -736,13 +739,13 @@ auto CNavMesh::raycast(const position_t& start, const position_t& end) const -> 
     {
         ShowError("CNavMesh::raycast start point invalid (%f, %f, %f) (%u)", spos[0], spos[1], spos[2], m_zoneID);
         ShowError(detourStatusString(status));
-        return true;
+        co_return true;
     }
 
     if (!m_navMesh->isValidPolyRef(startRef))
     {
         DebugNavmesh("CNavMesh::raycast startRef is invalid (%f, %f, %f) (%u)", start.x, start.y, start.z, m_zoneID);
-        return true;
+        co_return true;
     }
 
     dtPolyRef endRef = 0;
@@ -754,13 +757,13 @@ auto CNavMesh::raycast(const position_t& start, const position_t& end) const -> 
     {
         ShowError("CNavMesh::raycast end point invalid (%f, %f, %f) (%u)", epos[0], epos[1], epos[2], m_zoneID);
         ShowError(detourStatusString(status));
-        return true;
+        co_return true;
     }
 
     if (!m_navMesh->isValidPolyRef(endRef))
     {
         DebugNavmesh("CNavMesh::raycast endRef is invalid (%f, %f, %f) (%u)", end.x, end.y, end.z, m_zoneID);
-        return true;
+        co_return true;
     }
 
     float distanceToWall = 0.0f;
@@ -773,7 +776,7 @@ auto CNavMesh::raycast(const position_t& start, const position_t& end) const -> 
     {
         ShowError("CNavMesh::raycast findDistanceToWall failed (%f, %f, %f) (%u)", epos[0], epos[1], epos[2], m_zoneID);
         ShowError(detourStatusString(status));
-        return true;
+        co_return true;
     }
 
     // There is a tiny strip of walkable map at the very edge of walls that
@@ -790,7 +793,7 @@ auto CNavMesh::raycast(const position_t& start, const position_t& end) const -> 
         {
             ShowError("CNavMesh::raycast closestPointOnPolyBoundary failed (%u)", m_zoneID);
             ShowError(detourStatusString(status));
-            return true;
+            co_return true;
         }
     }
 
@@ -806,9 +809,9 @@ auto CNavMesh::raycast(const position_t& start, const position_t& end) const -> 
     {
         ShowError("CNavMesh::raycast raycast failed (%f, %f, %f)->(%f, %f, %f) (%u)", spos[0], spos[1], spos[2], epos[0], epos[1], epos[2], m_zoneID);
         ShowError(detourStatusString(status));
-        return true;
+        co_return true;
     }
 
     // no wall was hit
-    return raycastHit.t == FLT_MAX;
+    co_return raycastHit.t == FLT_MAX;
 }

--- a/src/map/navmesh.cpp
+++ b/src/map/navmesh.cpp
@@ -152,15 +152,6 @@ CNavMesh::CNavMesh(uint16 zoneID)
 : m_zoneID(zoneID)
 , m_navMesh(nullptr)
 {
-    m_navMeshQueryPolyData.resize(MAX_NAV_POLYS);
-    m_navMeshQueryStraightPathFloatData.resize(MAX_NAV_POLYS * 3);
-    m_navMeshQueryStraightPathFlagData.resize(MAX_NAV_POLYS);
-    m_navMeshQueryStraightPathPolyData.resize(MAX_NAV_POLYS);
-
-    m_navMeshQueryRaycastHitPath.resize(MAX_HIT_PATH_SIZE);
-
-    m_raycastHit.path    = m_navMeshQueryRaycastHitPath.data();
-    m_raycastHit.maxPath = MAX_HIT_PATH_SIZE;
 }
 
 CNavMesh::~CNavMesh()
@@ -254,7 +245,7 @@ void CNavMesh::unload()
     m_navMesh = nullptr;
 }
 
-auto CNavMesh::findPath(const position_t& start, const position_t& end) -> std::vector<pathpoint_t>
+auto CNavMesh::findPath(const position_t& start, const position_t& end) const -> std::vector<pathpoint_t>
 {
     TracyZoneScoped;
 
@@ -318,9 +309,10 @@ auto CNavMesh::findPath(const position_t& start, const position_t& end) -> std::
     }
 
     // First, we're going to build up a list of polys that make up the path
-    int32 pathPolyCount = 0;
+    int32     pathPolyCount = 0;
+    dtPolyRef navMeshQueryPolyData[MAX_NAV_POLYS];
 
-    status = m_navMeshQuery.findPath(startRef, endRef, sNearestPoint, eNearestPoint, &filter, m_navMeshQueryPolyData.data(), &pathPolyCount, MAX_NAV_POLYS);
+    status = m_navMeshQuery.findPath(startRef, endRef, sNearestPoint, eNearestPoint, &filter, navMeshQueryPolyData, &pathPolyCount, MAX_NAV_POLYS);
     if (dtStatusFailed(status))
     {
         ShowError("CNavMesh::findPath findPath error (%u)", m_zoneID);
@@ -341,9 +333,13 @@ auto CNavMesh::findPath(const position_t& start, const position_t& end) -> std::
     // Find the best straight path possible between sNearestPoint and eNearestPoint within the bounds of all the polys in pathPolys.
     int32 straightPathCount = 0;
 
+    float         navMeshQueryStraightPathFloatData[MAX_NAV_POLYS * 3];
+    unsigned char navMeshQueryStraightPathFlagData[MAX_NAV_POLYS];
+    dtPolyRef     navMeshQueryStraightPathPolyData[MAX_NAV_POLYS];
+
     // NOTE: The DT_STRAIGHTPATH_ALL_CROSSINGS flag can exasorbate the issue of getting trapped in local minima.
-    status = m_navMeshQuery.findStraightPath(sNearestPoint, eNearestPoint, m_navMeshQueryPolyData.data(), pathPolyCount,
-                                             m_navMeshQueryStraightPathFloatData.data(), m_navMeshQueryStraightPathFlagData.data(), m_navMeshQueryStraightPathPolyData.data(),
+    status = m_navMeshQuery.findStraightPath(sNearestPoint, eNearestPoint, navMeshQueryPolyData, pathPolyCount,
+                                             navMeshQueryStraightPathFloatData, navMeshQueryStraightPathFlagData, navMeshQueryStraightPathPolyData,
                                              &straightPathCount, MAX_NAV_POLYS /*, DT_STRAIGHTPATH_ALL_CROSSINGS */);
 
     if (dtStatusFailed(status))
@@ -365,9 +361,9 @@ auto CNavMesh::findPath(const position_t& start, const position_t& end) -> std::
     };
 
     const auto pathEndPosition = position_t{
-        m_navMeshQueryStraightPathFloatData[straightPathCount * 3 - 3],
-        m_navMeshQueryStraightPathFloatData[straightPathCount * 3 - 2],
-        m_navMeshQueryStraightPathFloatData[straightPathCount * 3 - 1],
+        navMeshQueryStraightPathFloatData[straightPathCount * 3 - 3],
+        navMeshQueryStraightPathFloatData[straightPathCount * 3 - 2],
+        navMeshQueryStraightPathFloatData[straightPathCount * 3 - 1],
         0,
         0,
     };
@@ -395,9 +391,9 @@ auto CNavMesh::findPath(const position_t& start, const position_t& end) -> std::
     for (int i = 3; i < straightPathCount * 3;)
     {
         float pathPos[3];
-        pathPos[0] = m_navMeshQueryStraightPathFloatData[i++];
-        pathPos[1] = m_navMeshQueryStraightPathFloatData[i++];
-        pathPos[2] = m_navMeshQueryStraightPathFloatData[i++];
+        pathPos[0] = navMeshQueryStraightPathFloatData[i++];
+        pathPos[1] = navMeshQueryStraightPathFloatData[i++];
+        pathPos[2] = navMeshQueryStraightPathFloatData[i++];
 
         CNavMesh::ToFFXIPos(pathPos);
 
@@ -407,7 +403,7 @@ auto CNavMesh::findPath(const position_t& start, const position_t& end) -> std::
     return outPoints;
 }
 
-std::pair<int16, position_t> CNavMesh::findRandomPosition(const position_t& start, float maxRadius)
+auto CNavMesh::findRandomPosition(const position_t& start, float maxRadius) const -> std::pair<int16, position_t>
 {
     TracyZoneScoped;
 
@@ -470,7 +466,7 @@ std::pair<int16, position_t> CNavMesh::findRandomPosition(const position_t& star
     return std::make_pair(0, position_t{ randomPt[0], randomPt[1], randomPt[2], 0, 0 });
 }
 
-bool CNavMesh::inWater(const position_t& point)
+auto CNavMesh::inWater(const position_t& point) const -> bool
 {
     if (!m_navMesh)
     {
@@ -481,7 +477,7 @@ bool CNavMesh::inWater(const position_t& point)
     return false;
 }
 
-bool CNavMesh::validPosition(const position_t& position)
+auto CNavMesh::validPosition(const position_t& position) const -> bool
 {
     TracyZoneScoped;
 
@@ -513,7 +509,7 @@ bool CNavMesh::validPosition(const position_t& position)
     return m_navMesh->isValidPolyRef(startRef);
 }
 
-bool CNavMesh::findClosestValidPoint(const position_t& position, float* validPoint)
+auto CNavMesh::findClosestValidPoint(const position_t& position, float* validPoint) const -> bool
 {
     TracyZoneScoped;
 
@@ -544,7 +540,7 @@ bool CNavMesh::findClosestValidPoint(const position_t& position, float* validPoi
     return true;
 }
 
-bool CNavMesh::findFurthestValidPoint(const position_t& startPosition, const position_t& endPosition, float* validEndPoint)
+auto CNavMesh::findFurthestValidPoint(const position_t& startPosition, const position_t& endPosition, float* validEndPoint) const -> bool
 {
     TracyZoneScoped;
 
@@ -588,7 +584,7 @@ bool CNavMesh::findFurthestValidPoint(const position_t& startPosition, const pos
     return true;
 }
 
-void CNavMesh::snapToValidPosition(position_t& position)
+auto CNavMesh::snapToValidPosition(position_t& position) const -> void
 {
     TracyZoneScoped;
 
@@ -628,7 +624,7 @@ void CNavMesh::snapToValidPosition(position_t& position)
     }
 }
 
-bool CNavMesh::onSameFloor(const position_t& start, float* spos, const position_t& end, float* epos, dtQueryFilter& filter)
+auto CNavMesh::onSameFloor(const position_t& start, float* spos, const position_t& end, float* epos, dtQueryFilter& filter) const -> bool
 {
     TracyZoneScoped;
 
@@ -693,7 +689,7 @@ bool CNavMesh::onSameFloor(const position_t& start, float* spos, const position_
     return true;
 }
 
-bool CNavMesh::raycast(const position_t& start, const position_t& end)
+auto CNavMesh::raycast(const position_t& start, const position_t& end) const -> bool
 {
     TracyZoneScoped;
 
@@ -798,7 +794,13 @@ bool CNavMesh::raycast(const position_t& start, const position_t& end)
         }
     }
 
-    status = m_navMeshQuery.raycast(startRef, spos, epos, &filter, 0, &m_raycastHit);
+    dtPolyRef    navMeshQueryRaycastHitPath[MAX_HIT_PATH_SIZE];
+    dtRaycastHit raycastHit;
+
+    raycastHit.path    = navMeshQueryRaycastHitPath;
+    raycastHit.maxPath = MAX_HIT_PATH_SIZE;
+
+    status = m_navMeshQuery.raycast(startRef, spos, epos, &filter, 0, &raycastHit);
 
     if (dtStatusFailed(status))
     {
@@ -808,5 +810,5 @@ bool CNavMesh::raycast(const position_t& start, const position_t& end)
     }
 
     // no wall was hit
-    return m_raycastHit.t == FLT_MAX;
+    return raycastHit.t == FLT_MAX;
 }

--- a/src/map/navmesh.h
+++ b/src/map/navmesh.h
@@ -26,6 +26,7 @@
 
 #include "common/logging.h"
 #include "common/mmo.h"
+#include "common/task_manager.h"
 
 #include <memory>
 #include <vector>
@@ -48,22 +49,22 @@ public:
     void reload();
     void unload();
 
-    auto findPath(const position_t& start, const position_t& end) const -> std::vector<pathpoint_t>;
-    auto findRandomPosition(const position_t& start, float maxRadius) const -> std::pair<int16, position_t>;
+    auto findPath(position_t start, position_t end) const -> AsyncTask<std::vector<pathpoint_t>>;
+    auto findRandomPosition(position_t start, float maxRadius) const -> AsyncTask<std::pair<int16, position_t>>;
 
     // Returns true if the point is in water (not implemented)
-    auto inWater(const position_t& point) const -> bool;
+    auto inWater(const position_t& point) const -> Task<bool>;
 
     // Returns true if no wall was hit
     //
     // Recast Detour Docs:
     // Casts a 'walkability' ray along the surface of the navigation mesh from the start position toward the end position.
     // Note: This is not a point-to-point in 3D space calculation, it is 2D across the navmesh!
-    auto raycast(const position_t& start, const position_t& end) const -> bool;
+    auto raycast(const position_t& start, const position_t& end) const -> AsyncTask<bool>;
 
     auto validPosition(const position_t& position) const -> bool;
-    auto findClosestValidPoint(const position_t& position, float* validPoint) const -> bool;
-    auto findFurthestValidPoint(const position_t& startPosition, const position_t& endPosition, float* validPoint) const -> bool;
+    auto findClosestValidPoint(const position_t& position, float* validPoint) const -> AsyncTask<bool>;
+    auto findFurthestValidPoint(const position_t& startPosition, const position_t& endPosition, float* validPoint) const -> AsyncTask<bool>;
 
     // Like validPosition(), but will also set the given position to the valid position that it finds.
     auto snapToValidPosition(position_t& position) const -> void;
@@ -124,7 +125,7 @@ public:
     }
 
 private:
-    auto onSameFloor(const position_t& start, float* spos, const position_t& end, float* epos, dtQueryFilter& filter) const -> bool;
+    auto onSameFloor(const position_t& start, float* spos, const position_t& end, float* epos, dtQueryFilter& filter) const -> AsyncTask<bool>;
 
     std::string    m_filename;
     uint16         m_zoneID;

--- a/src/map/navmesh.h
+++ b/src/map/navmesh.h
@@ -48,25 +48,25 @@ public:
     void reload();
     void unload();
 
-    auto findPath(const position_t& start, const position_t& end) -> std::vector<pathpoint_t>;
-    auto findRandomPosition(const position_t& start, float maxRadius) -> std::pair<int16, position_t>;
+    auto findPath(const position_t& start, const position_t& end) const -> std::vector<pathpoint_t>;
+    auto findRandomPosition(const position_t& start, float maxRadius) const -> std::pair<int16, position_t>;
 
     // Returns true if the point is in water (not implemented)
-    bool inWater(const position_t& point);
+    auto inWater(const position_t& point) const -> bool;
 
     // Returns true if no wall was hit
     //
     // Recast Detour Docs:
     // Casts a 'walkability' ray along the surface of the navigation mesh from the start position toward the end position.
     // Note: This is not a point-to-point in 3D space calculation, it is 2D across the navmesh!
-    bool raycast(const position_t& start, const position_t& end);
+    auto raycast(const position_t& start, const position_t& end) const -> bool;
 
-    bool validPosition(const position_t& position);
-    bool findClosestValidPoint(const position_t& position, float* validPoint);
-    bool findFurthestValidPoint(const position_t& startPosition, const position_t& endPosition, float* validPoint);
+    auto validPosition(const position_t& position) const -> bool;
+    auto findClosestValidPoint(const position_t& position, float* validPoint) const -> bool;
+    auto findFurthestValidPoint(const position_t& startPosition, const position_t& endPosition, float* validPoint) const -> bool;
 
     // Like validPosition(), but will also set the given position to the valid position that it finds.
-    void snapToValidPosition(position_t& position);
+    auto snapToValidPosition(position_t& position) const -> void;
 
     [[nodiscard]] static auto detourStatusString(const uint32 status) -> std::string
     {
@@ -124,18 +124,10 @@ public:
     }
 
 private:
-    bool onSameFloor(const position_t& start, float* spos, const position_t& end, float* epos, dtQueryFilter& filter);
+    auto onSameFloor(const position_t& start, float* spos, const position_t& end, float* epos, dtQueryFilter& filter) const -> bool;
 
     std::string    m_filename;
     uint16         m_zoneID;
     dtNavMesh*     m_navMesh;
     dtNavMeshQuery m_navMeshQuery;
-
-    std::vector<dtPolyRef>     m_navMeshQueryPolyData;
-    std::vector<float>         m_navMeshQueryStraightPathFloatData;
-    std::vector<unsigned char> m_navMeshQueryStraightPathFlagData;
-    std::vector<dtPolyRef>     m_navMeshQueryStraightPathPolyData;
-
-    std::vector<dtPolyRef> m_navMeshQueryRaycastHitPath;
-    dtRaycastHit           m_raycastHit;
 };

--- a/src/map/pch.h
+++ b/src/map/pch.h
@@ -84,7 +84,7 @@
 
 #include <argparse/argparse.hpp>
 #include <asio.hpp>
-#include <concurrentqueue.h>
+#include <concurrentqueue/concurrentqueue.h>
 #include <nonstd/jthread.hpp>
 
 #include <fmt/chrono.h>

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -24,6 +24,7 @@
 #include "common/database.h"
 #include "common/logging.h"
 #include "common/sql.h"
+#include "common/task_manager.h"
 #include "common/timer.h"
 #include "common/utils.h"
 

--- a/src/map/utils/serverutils.cpp
+++ b/src/map/utils/serverutils.cpp
@@ -86,11 +86,11 @@ namespace serverutils
         return GetServerVar(name);
     }
 
-    int32 PersistVolatileServerVars(timer::time_point tick, CTaskManager::CTask* PTask)
+    auto PersistVolatileServerVars() -> AsyncTask<void>
     {
         if (serverVarChanges.empty())
         {
-            return 0;
+            co_return;
         }
 
         for (const auto& name : serverVarChanges)
@@ -111,7 +111,7 @@ namespace serverutils
 
         serverVarChanges.clear();
 
-        return 0;
+        co_return;
     }
 
     void PersistServerVar(std::string const& name, int32 value, uint32 expiry /* = 0 */)

--- a/src/map/utils/serverutils.cpp
+++ b/src/map/utils/serverutils.cpp
@@ -38,6 +38,8 @@ namespace serverutils
 
     uint32 GetServerVar(std::string const& name)
     {
+        TracyZoneScoped;
+
         const auto rset = db::preparedStmt("SELECT value, expiry FROM server_variables WHERE name = ? LIMIT 1", name);
 
         int32  value  = 0;
@@ -60,17 +62,23 @@ namespace serverutils
 
     void SetServerVar(std::string const& name, int32 value, uint32 expiry /* = 0 */)
     {
+        TracyZoneScoped;
+
         PersistServerVar(name, value, expiry);
     }
 
     void SetVolatileServerVar(std::string const& name, int32 value, uint32 expiry /* = 0 */)
     {
+        TracyZoneScoped;
+
         serverVarCache[name] = { value, expiry };
         serverVarChanges.insert(name);
     }
 
     int32 GetVolatileServerVar(std::string const& name)
     {
+        TracyZoneScoped;
+
         if (auto var = serverVarCache.find(name); var != serverVarCache.end())
         {
             std::pair cachedVarData = var->second;
@@ -88,6 +96,8 @@ namespace serverutils
 
     auto PersistVolatileServerVars() -> AsyncTask<void>
     {
+        TracyZoneScoped;
+
         if (serverVarChanges.empty())
         {
             co_return;
@@ -116,6 +126,8 @@ namespace serverutils
 
     void PersistServerVar(std::string const& name, int32 value, uint32 expiry /* = 0 */)
     {
+        TracyZoneScoped;
+
         int32 tries  = 0;
         int32 verify = INT_MIN;
 

--- a/src/map/utils/serverutils.h
+++ b/src/map/utils/serverutils.h
@@ -37,7 +37,7 @@ namespace serverutils
     int32 GetVolatileServerVar(std::string const& var);
     void  SetVolatileServerVar(std::string const& var, int32 value, uint32 expiry = 0);
 
-    int32 PersistVolatileServerVars(timer::time_point tick, CTaskManager::CTask* PTask);
+    auto PersistVolatileServerVars() -> AsyncTask<void>;
 } // namespace serverutils
 
 #endif // _SERVERUTILS_H

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -75,7 +75,7 @@ namespace zoneutils
         {
             if (!PZone->IsWeatherStatic())
             {
-                PZone->UpdateWeather();
+                gScheduler.schedule(PZone->UpdateWeather());
             }
             else
             {

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -58,6 +58,9 @@
 #include "utils/battleutils.h"
 #include "utils/charutils.h"
 #include "utils/moduleutils.h"
+#include "utils/zoneutils.h"
+
+Scheduler gScheduler = Scheduler(4);
 
 CZone::CZone(ZONEID ZoneID, REGION_TYPE RegionID, CONTINENT_TYPE ContinentID, uint8 levelRestriction)
 : m_zoneID(ZoneID)
@@ -71,9 +74,6 @@ CZone::CZone(ZONEID ZoneID, REGION_TYPE RegionID, CONTINENT_TYPE ContinentID, ui
 
     m_useNavMesh = false;
     std::ignore  = m_useNavMesh;
-
-    ZoneTimer             = nullptr;
-    ZoneTimerTriggerAreas = nullptr;
 
     m_TreasurePool       = nullptr;
     m_BattlefieldHandler = nullptr;
@@ -623,19 +623,19 @@ void CZone::UpdateWeather()
     SetWeather((WEATHER)Weather);
     luautils::OnZoneWeatherChange(GetID(), Weather);
 
-    // clang-format off
-    timer::time_point nextWeatherTick = timer::now() + std::chrono::duration_cast<earth_time::duration>(WeatherNextUpdate);
-    CTaskManager::getInstance()->AddTask("zone_update_weather", nextWeatherTick, this, CTaskManager::TASK_ONCE, 1s,
-    [](timer::time_point tick, CTaskManager::CTask* PTask)
-    {
-        CZone* PZone = std::any_cast<CZone*>(PTask->m_data);
-        if (!PZone->IsWeatherStatic())
+    timer::duration   timeToNextWeatherTick = std::chrono::duration_cast<earth_time::duration>(WeatherNextUpdate);
+    timer::time_point nextWeatherTick       = timer::now() + timeToNextWeatherTick;
+
+    zoneTimerWeatherCancellationToken_ = gScheduler.scheduleAt(
+        nextWeatherTick,
+        [this]() -> Task<void>
         {
-            PZone->UpdateWeather();
-        }
-        return 0;
-    });
-    // clang-format on
+            if (!IsWeatherStatic())
+            {
+                UpdateWeather();
+            }
+            co_return;
+        });
 }
 
 bool CZone::CheckMobsPathedBack()
@@ -713,7 +713,7 @@ void CZone::IncreaseZoneCounter(CCharEntity* PChar)
 
     m_zoneEntities->InsertPC(PChar);
 
-    if (!ZoneTimer && !m_zoneEntities->CharListEmpty())
+    if (!zoneTimerCancellationToken_.valid() && !m_zoneEntities->CharListEmpty())
     {
         createZoneTimers();
     }
@@ -823,25 +823,24 @@ void CZone::WideScan(CCharEntity* PChar, uint16 radius)
  *                                                                       *
  ************************************************************************/
 
-void CZone::ZoneServer(timer::time_point tick)
+auto CZone::ZoneServer(timer::time_point tick) -> Task<void>
 {
     TracyZoneScoped;
 
-    m_zoneEntities->ZoneServer(tick);
+    co_await m_zoneEntities->ZoneServer(tick);
 
     if (m_BattlefieldHandler != nullptr)
     {
         m_BattlefieldHandler->HandleBattlefields(tick);
     }
 
-    if (ZoneTimer && m_zoneEntities->CharListEmpty() && m_timeZoneEmpty + 5s < timer::now() && CheckMobsPathedBack())
+    if (zoneTimerCancellationToken_.valid() && m_zoneEntities->CharListEmpty() && m_timeZoneEmpty + 5s < timer::now() && CheckMobsPathedBack())
     {
-        ZoneTimer->m_type = CTaskManager::TASK_REMOVE;
-        ZoneTimer         = nullptr;
-
-        ZoneTimerTriggerAreas->m_type = CTaskManager::TASK_REMOVE;
-        ZoneTimerTriggerAreas         = nullptr;
+        zoneTimerCancellationToken_.cancel();
+        zoneTimerTriggerAreasCancellationToken_.cancel();
     }
+
+    co_return;
 }
 
 void CZone::ForEachChar(std::function<void(CCharEntity*)> const& func)
@@ -932,23 +931,28 @@ void CZone::createZoneTimers()
 {
     TracyZoneScoped;
 
-    // clang-format off
-    ZoneTimer = CTaskManager::getInstance()->AddTask(m_zoneName, timer::now(), this, CTaskManager::TASK_INTERVAL, kLogicUpdateInterval,
-    [](timer::time_point tick, CTaskManager::CTask* PTask)
-    {
-        CZone* PZone = std::any_cast<CZone*>(PTask->m_data);
-        PZone->ZoneServer(tick);
-        return 0;
-    });
+    const auto zoneId = static_cast<uint16>(this->GetID());
 
-    ZoneTimerTriggerAreas = CTaskManager::getInstance()->AddTask(m_zoneName + "TriggerAreas", timer::now(), this, CTaskManager::TASK_INTERVAL, kTriggerAreaInterval,
-    [](timer::time_point tick, CTaskManager::CTask* PTask)
+    const auto zoneRunner = [zoneId]() -> Task<void>
     {
-        CZone* PZone = std::any_cast<CZone*>(PTask->m_data);
-        PZone->CheckTriggerAreas();
-        return 0;
-    });
-    // clang-format on
+        if (auto PZone = zoneutils::GetZone(zoneId))
+        {
+            co_await PZone->ZoneServer(timer::now());
+        }
+        co_return;
+    };
+
+    const auto zoneTriggerRunner = [zoneId]() -> Task<void>
+    {
+        if (auto PZone = zoneutils::GetZone(zoneId))
+        {
+            co_await PZone->CheckTriggerAreas();
+        }
+        co_return;
+    };
+
+    zoneTimerCancellationToken_             = gScheduler.scheduleInterval(kLogicUpdateInterval, zoneRunner);
+    zoneTimerTriggerAreasCancellationToken_ = gScheduler.scheduleInterval(kTriggerAreaInterval, zoneTriggerRunner);
 }
 
 void CZone::CharZoneIn(CCharEntity* PChar)
@@ -1135,7 +1139,7 @@ void CZone::CharZoneOut(CCharEntity* PChar)
 
 bool CZone::IsZoneActive() const
 {
-    return ZoneTimer != nullptr;
+    return zoneTimerCancellationToken_.valid();
 }
 
 CZoneEntities* CZone::GetZoneEntities()
@@ -1143,7 +1147,7 @@ CZoneEntities* CZone::GetZoneEntities()
     return m_zoneEntities;
 }
 
-void CZone::CheckTriggerAreas()
+auto CZone::CheckTriggerAreas() -> Task<void>
 {
     TracyZoneScoped;
 
@@ -1180,4 +1184,6 @@ void CZone::CheckTriggerAreas()
         }
     });
     // clang-format on
+
+    co_return;
 }

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -32,6 +32,7 @@
 #include "common/vana_time.h"
 
 #include <cstring>
+#include <thread>
 
 #include "battlefield.h"
 #include "common/vana_time.h"
@@ -60,7 +61,7 @@
 #include "utils/moduleutils.h"
 #include "utils/zoneutils.h"
 
-Scheduler gScheduler = Scheduler(4);
+Scheduler gScheduler = Scheduler(static_cast<size_t>(std::thread::hardware_concurrency()) - 1U);
 
 CZone::CZone(ZONEID ZoneID, REGION_TYPE RegionID, CONTINENT_TYPE ContinentID, uint8 levelRestriction)
 : m_zoneID(ZoneID)
@@ -556,7 +557,7 @@ void CZone::SetWeather(WEATHER weather)
     m_zoneEntities->PushPacket(nullptr, CHAR_INZONE, std::make_unique<CWeatherPacket>(m_WeatherChangeTime, m_Weather, xirand::GetRandomNumber(4, 28)));
 }
 
-void CZone::UpdateWeather()
+auto CZone::UpdateWeather() -> Task<void>
 {
     TracyZoneScoped;
 
@@ -623,19 +624,13 @@ void CZone::UpdateWeather()
     SetWeather((WEATHER)Weather);
     luautils::OnZoneWeatherChange(GetID(), Weather);
 
-    timer::duration   timeToNextWeatherTick = std::chrono::duration_cast<earth_time::duration>(WeatherNextUpdate);
-    timer::time_point nextWeatherTick       = timer::now() + timeToNextWeatherTick;
-
+    // Cue up next weather change
+    const auto timeToNextWeatherTick   = std::chrono::duration_cast<earth_time::duration>(WeatherNextUpdate);
+    const auto nextWeatherTick         = timer::now() + timeToNextWeatherTick;
     zoneTimerWeatherCancellationToken_ = gScheduler.scheduleAt(
-        nextWeatherTick,
-        [this]() -> Task<void>
-        {
-            if (!IsWeatherStatic())
-            {
-                UpdateWeather();
-            }
-            co_return;
-        });
+        nextWeatherTick, std::bind(&CZone::UpdateWeather, this));
+
+    co_return;
 }
 
 bool CZone::CheckMobsPathedBack()

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -591,7 +591,7 @@ public:
     bool IsWeatherStatic() const;
     bool CanUseMisc(uint16 misc) const;
     void SetWeather(WEATHER weatherCondition);
-    void UpdateWeather();
+    auto UpdateWeather() -> Task<void>;
     bool CheckMobsPathedBack();
 
     virtual void SpawnPCs(CCharEntity* PChar);

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -37,6 +37,8 @@
 #include "packets/weather.h"
 #include "trigger_area.h"
 
+extern Scheduler gScheduler;
+
 //
 // Forward Declarations
 //
@@ -627,8 +629,8 @@ public:
 
     weatherVector_t m_WeatherVector; // The probability of each weather type
 
-    virtual void ZoneServer(timer::time_point tick);
-    virtual void CheckTriggerAreas();
+    virtual auto ZoneServer(timer::time_point tick) -> Task<void>;
+    virtual auto CheckTriggerAreas() -> Task<void>;
 
     virtual void ForEachChar(std::function<void(CCharEntity*)> const& func);
     virtual void ForEachCharInstance(CBaseEntity* PEntity, std::function<void(CCharEntity*)> const& func);
@@ -693,8 +695,9 @@ private:
     std::unordered_map<std::string, QueryByNameResult_t> m_queryByNameResults;
 
 protected:
-    CTaskManager::CTask* ZoneTimer; // The pointer to the created timer is Zoneserver.necessary for the possibility of stopping it
-    CTaskManager::CTask* ZoneTimerTriggerAreas;
+    CancellationToken zoneTimerCancellationToken_;
+    CancellationToken zoneTimerTriggerAreasCancellationToken_;
+    CancellationToken zoneTimerWeatherCancellationToken_;
 
     triggerAreaList_t m_triggerAreaList;
 

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -1668,7 +1668,7 @@ void CZoneEntities::WideScan(CCharEntity* PChar, uint16 radius)
     PChar->pushPacket<CWideScanPacket>(WIDESCAN_END);
 }
 
-void CZoneEntities::ZoneServer(timer::time_point tick)
+auto CZoneEntities::ZoneServer(timer::time_point tick) -> Task<void>
 {
     TracyZoneScoped;
     TracyZoneString(m_zone->getName());
@@ -1679,14 +1679,14 @@ void CZoneEntities::ZoneServer(timer::time_point tick)
     // Mob tick logic
     //
 
+    size_t mobTickCount = 0;
+
     FOR_EACH_PAIR_CAST_SECOND(CMobEntity*, PMob, m_mobList)
     {
         if (!PMob)
         {
             continue;
         }
-
-        ShowTrace(fmt::format("CZoneEntities::ZoneServer: Mob: {} ({})", PMob->getName(), PMob->id).c_str());
 
         if (PMob->PBattlefield && PMob->PBattlefield->CanCleanup())
         {
@@ -1701,7 +1701,8 @@ void CZoneEntities::ZoneServer(timer::time_point tick)
             PMob->StatusEffectContainer->TickEffects(tick);
         }
 
-        PMob->PAI->Tick(tick);
+        co_await PMob->PAI->Tick(tick);
+        mobTickCount++;
 
         // This is only valid for dynamic entities
         if (PMob->status == STATUS_TYPE::DISAPPEAR && PMob->m_bReleaseTargIDOnDisappear)
@@ -1781,7 +1782,7 @@ void CZoneEntities::ZoneServer(timer::time_point tick)
     {
         ShowTrace(fmt::format("CZoneEntities::ZoneServer: NPC: {} ({})", PNpc->getName(), PNpc->id).c_str());
 
-        PNpc->PAI->Tick(tick);
+        co_await PNpc->PAI->Tick(tick);
 
         // This is only valid for dynamic entities
         if (PNpc->status == STATUS_TYPE::DISAPPEAR && PNpc->m_bReleaseTargIDOnDisappear)
@@ -1832,7 +1833,7 @@ void CZoneEntities::ZoneServer(timer::time_point tick)
             PPet->StatusEffectContainer->TickEffects(tick);
         }
 
-        PPet->PAI->Tick(tick);
+        co_await PPet->PAI->Tick(tick);
     }
 
     //
@@ -1851,7 +1852,7 @@ void CZoneEntities::ZoneServer(timer::time_point tick)
             PTrust->StatusEffectContainer->TickEffects(tick);
         }
 
-        PTrust->PAI->Tick(tick);
+        co_await PTrust->PAI->Tick(tick);
 
         if (PTrust->status == STATUS_TYPE::DISAPPEAR)
         {
@@ -1891,7 +1892,7 @@ void CZoneEntities::ZoneServer(timer::time_point tick)
                 PChar->StatusEffectContainer->TickEffects(tick);
             }
 
-            PChar->PAI->Tick(tick);
+            co_await PChar->PAI->Tick(tick);
 
             if (PChar->PTreasurePool)
             {
@@ -2069,6 +2070,8 @@ void CZoneEntities::ZoneServer(timer::time_point tick)
     m_charsToLogout.clear();
     m_charsToWarp.clear();
     m_charsToChangeZone.clear();
+
+    co_return;
 }
 
 CZone* CZoneEntities::GetZone()

--- a/src/map/zone_entities.h
+++ b/src/map/zone_entities.h
@@ -81,7 +81,7 @@ public:
 
     void PushPacket(CBaseEntity*, GLOBAL_MESSAGE_TYPE, const std::unique_ptr<CBasicPacket>&); // send a global package within the zone
 
-    void ZoneServer(timer::time_point tick);
+    auto ZoneServer(timer::time_point tick) -> Task<void>;
 
     CZone* GetZone();
 

--- a/src/map/zone_instance.cpp
+++ b/src/map/zone_instance.cpp
@@ -198,7 +198,7 @@ void CZoneInstance::IncreaseZoneCounter(CCharEntity* PChar)
 
     if (PChar->PInstance)
     {
-        if (!ZoneTimer)
+        if (!zoneTimerCancellationToken_.valid())
         {
             createZoneTimers();
         }
@@ -382,14 +382,15 @@ void CZoneInstance::WideScan(CCharEntity* PChar, uint16 radius)
     }
 }
 
-void CZoneInstance::ZoneServer(timer::time_point tick)
+auto CZoneInstance::ZoneServer(timer::time_point tick) -> Task<void>
 {
     TracyZoneScoped;
 
     std::vector<CInstance*> instancesToRemove;
     for (const auto& PInstance : m_InstanceList)
     {
-        PInstance->ZoneServer(tick);
+        co_await PInstance->ZoneServer(tick);
+
         PInstance->CheckTime(tick);
 
         if ((PInstance->Failed() || PInstance->Completed()) && PInstance->CharListEmpty())
@@ -411,7 +412,7 @@ void CZoneInstance::ZoneServer(timer::time_point tick)
     }
 }
 
-void CZoneInstance::CheckTriggerAreas()
+auto CZoneInstance::CheckTriggerAreas() -> Task<void>
 {
     TracyZoneScoped;
 
@@ -451,6 +452,8 @@ void CZoneInstance::CheckTriggerAreas()
         });
         // clang-format on
     }
+
+    co_return;
 }
 
 void CZoneInstance::ForEachChar(const std::function<void(CCharEntity*)>& func)

--- a/src/map/zone_instance.h
+++ b/src/map/zone_instance.h
@@ -61,8 +61,8 @@ public:
 
     virtual void UpdateEntityPacket(CBaseEntity* PEntity, ENTITYUPDATE type, uint8 updatemask, bool alwaysInclude = false) override;
 
-    virtual void ZoneServer(timer::time_point tick) override;
-    virtual void CheckTriggerAreas() override;
+    virtual auto ZoneServer(timer::time_point tick) -> Task<void> override;
+    virtual auto CheckTriggerAreas() -> Task<void> override;
 
     void ForEachChar(std::function<void(CCharEntity*)> const& func) override;
     void ForEachCharInstance(CBaseEntity* PEntity, std::function<void(CCharEntity*)> const& func) override;

--- a/src/world/ipc_server.cpp
+++ b/src/world/ipc_server.cpp
@@ -27,7 +27,8 @@
 #include "colonization_system.h"
 #include "conquest_system.h"
 
-#include <concurrentqueue.h>
+#include <concurrentqueue/concurrentqueue.h>
+
 #include <memory>
 
 #include "common/database.h"

--- a/tools/ci/cpp.sh
+++ b/tools/ci/cpp.sh
@@ -21,7 +21,7 @@ target=${1:-src}
 # passByConstRef here, so we can silence this warning.
 # https://quick-bench.com/q/13EX97WSfj9-rY_98opaAwgDOQc
 
-cppcheck -v -j 4 --force --quiet --inconclusive --std=c++17 \
+cppcheck -v -j 4 --force --quiet --inconclusive --std=c++20 \
 --suppress=passedByValue:src/map/packet_system.cpp \
 --suppress=unmatchedSuppression \
 --suppress=missingIncludeSystem \


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

https://github.com/zach2good/Coro-Roro

From its own repo:

### Coro-Roro

Coro-Roro provides a tiny coroutine interface with explicit scheduling and a simple, pluggable work-queue scheduler.

The main goal is to have a clean separation of "what to run" (coroutines) and "where to run it" (the scheduler).

It was built for [LandSandBoat](https://github.com/LandSandBoat/server), a Final Fantasy XI server emulator.

#### Why the name?

The Tarutaru naming convention from Final Fantasy XI:
```
Tarutaru males are given two rhyming names put together, such as Ajido-Marujido or Zonpa-Zippa.
Tarutaru females are given a single name that ends in a rhyme, such as Apururu or Shantotto.
```

## TODO

- [x] Packet and tick flow is as it was
- [x] Zone ticks and trigger areas as they were
- [ ] Offloading Navmesh work onto worker threads via `AsyncTask<T>`
- [ ] Replacing current `Async` work offloading with `AsyncTask<T>` & `Scheduler`
- [ ] Create an `AsyncTask<T>` and `Task<T>` version of the `db::` interface
- [ ] Write a fun intro document teaching everyone about coroutines and task graphs
- [ ] See if I can find some artificial benchmarks that look better than the current `13.5x` throughput increase...