### PR TITLE
Inconditional SPAWN listener

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -3457,17 +3457,15 @@ namespace luautils
             return;
         }
 
-        sol::function onMobSpawn = getEntityCachedFunction(PMob, "onMobSpawn");
-        if (!onMobSpawn.valid())
+        const sol::function onMobSpawn = getEntityCachedFunction(PMob, "onMobSpawn");
+        if (onMobSpawn.valid())
         {
-            return;
-        }
-
-        auto result = onMobSpawn(PMob);
-        if (!result.valid())
-        {
-            sol::error err = result;
-            ShowError("luautils::onMobSpawn: %s", err.what());
+            const auto result = onMobSpawn(PMob);
+            if (!result.valid())
+            {
+                sol::error err = result;
+                ShowError("luautils::onMobSpawn: %s", err.what());
+            }
         }
 
         PMob->PAI->EventHandler.triggerListener("SPAWN", PMob);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Execute SPAWN listener even if onMobSpawn is not implemented.

Closes #7922

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Modified Lesser Colibri script, watched them spawn with 1 HP.
```lua
-----------------------------------
-- Area: Wajaom Woodlands
--  Mob: Lesser Colibri
-- Note: Place holder Zoraal Ja's Pkuucha
-----------------------------------
local ID = zones[xi.zone.WAJAOM_WOODLANDS]
-----------------------------------
---@type TMobEntity
local entity = {}

entity.onMobInitialize = function(mob)
    mob:addListener('SPAWN', 'LESSER_COLIBRI_SPAWN', function(mobArg)
        mobArg:setHP(1)
    end)
end

entity.onMobDeath = function(mob, player, optParams)
end

entity.onMobDespawn = function(mob)
    local params = { }
    xi.mob.phOnDespawn(mob, ID.mob.ZORAAL_JAS_PKUUCHA, 5, 1800, params) -- 30 minutes
end

return entity
```

<!-- Clear and detailed steps to test your changes here -->
