### PR TITLE
[lua/cpp] On mob init improvements

### DIFF
--- a/scripts/zones/Bostaunieux_Oubliette/Zone.lua
+++ b/scripts/zones/Bostaunieux_Oubliette/Zone.lua
@@ -7,14 +7,6 @@ local ID = zones[xi.zone.BOSTAUNIEUX_OUBLIETTE]
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
-    UpdateNMSpawnPoint(ID.mob.DREXERION_THE_CONDEMNED)
-    GetMobByID(ID.mob.DREXERION_THE_CONDEMNED):setRespawnTime(math.random(900, 10800))
-
-    UpdateNMSpawnPoint(ID.mob.PHANDURON_THE_CONDEMNED)
-    GetMobByID(ID.mob.PHANDURON_THE_CONDEMNED):setRespawnTime(math.random(900, 10800))
-
-    UpdateNMSpawnPoint(ID.mob.BLOODSUCKER)
-    GetMobByID(ID.mob.BLOODSUCKER):setRespawnTime(3600)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Bostaunieux_Oubliette/mobs/Bloodsucker_NM.lua
+++ b/scripts/zones/Bostaunieux_Oubliette/mobs/Bloodsucker_NM.lua
@@ -3,8 +3,6 @@
 --  Mob: Bloodsucker NM
 -- !pos -96.875 16.999 -277.037 167
 -----------------------------------
-local ID = zones[xi.zone.BOSTAUNIEUX_OUBLIETTE]
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
@@ -12,6 +10,9 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1) -- "Has an Additional Effect of Drain on normal attacks"
     mob:setMobMod(xi.mobMod.GIL_MIN, 3000)
     mob:setMobMod(xi.mobMod.GIL_MAX, 9900)
+
+    xi.mob.updateNMSpawnPoint(mob)
+    mob:setRespawnTime(3600)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
@@ -23,7 +24,7 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    UpdateNMSpawnPoint(ID.mob.BLOODSUCKER)
+    xi.mob.updateNMSpawnPoint(mob)
 end
 
 return entity

--- a/scripts/zones/Bostaunieux_Oubliette/mobs/Drexerion_the_Condemned.lua
+++ b/scripts/zones/Bostaunieux_Oubliette/mobs/Drexerion_the_Condemned.lua
@@ -7,11 +7,16 @@ mixins = { require('scripts/mixins/job_special') }
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    xi.mob.updateNMSpawnPoint(mob)
+    mob:setRespawnTime(math.random(900, 10800))
+end
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    UpdateNMSpawnPoint(mob:getID())
+    xi.mob.updateNMSpawnPoint(mob)
     mob:setRespawnTime(math.random(216000, 259200)) -- 60 to 72 hours
 end
 

--- a/scripts/zones/Bostaunieux_Oubliette/mobs/Phanduron_the_Condemned.lua
+++ b/scripts/zones/Bostaunieux_Oubliette/mobs/Phanduron_the_Condemned.lua
@@ -9,6 +9,9 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
+
+    xi.mob.updateNMSpawnPoint(mob)
+    mob:setRespawnTime(math.random(900, 10800))
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
@@ -19,7 +22,7 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    UpdateNMSpawnPoint(mob:getID())
+    xi.mob.updateNMSpawnPoint(mob)
     mob:setRespawnTime(math.random(216000, 259200)) -- 60 to 72 hours
 end
 

--- a/scripts/zones/Castle_Oztroja/Zone.lua
+++ b/scripts/zones/Castle_Oztroja/Zone.lua
@@ -2,15 +2,11 @@
 -- Zone: Castle_Oztroja (151)
 -----------------------------------
 local oztrojaGlobal = require('scripts/zones/Castle_Oztroja/globals')
-local ID = zones[xi.zone.CASTLE_OZTROJA]
 -----------------------------------
 ---@type TZone
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
-    UpdateNMSpawnPoint(ID.mob.YAGUDO_AVATAR)
-    GetMobByID(ID.mob.YAGUDO_AVATAR):setRespawnTime(math.random(900, 10800))
-
     oztrojaGlobal.pickNewCombo() -- update combination for brass door on floor 2
     oztrojaGlobal.pickNewPassword() -- update password for trap door on floor 4
 

--- a/scripts/zones/Castle_Oztroja/mobs/Yagudo_Avatar.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Yagudo_Avatar.lua
@@ -10,6 +10,11 @@ local ID = zones[xi.zone.CASTLE_OZTROJA]
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    xi.mob.updateNMSpawnPoint(mob)
+    mob:setRespawnTime(math.random(900, 10800))
+end
+
 entity.onMobEngage = function(mob, target)
     mob:showText(mob, ID.text.YAGUDO_AVATAR_ENGAGE)
 end
@@ -38,10 +43,10 @@ entity.onMobDespawn = function(mob)
     if GetSystemTime() > timeOfDeath and popNow then
         DisallowRespawn(mobId, true)
         DisallowRespawn(hqId, false)
-        UpdateNMSpawnPoint(hqId)
+        xi.mob.updateNMSpawnPoint(hqId)
         GetMobByID(hqId):setRespawnTime(respawnTime)
     else
-        UpdateNMSpawnPoint(mobId)
+        xi.mob.updateNMSpawnPoint(mobId)
         mob:setRespawnTime(respawnTime)
         SetServerVariable('[PH]Tzee_Xicu_the_Manifest', kills)
     end

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -667,9 +667,11 @@ namespace zoneutils
             // Spawn mobs after they've all been initialized. Spawning some mobs will spawn other mobs that may not yet be initialized.
             PZone->ForEachMob([](CMobEntity* PMob)
             {
-                PMob->m_AllowRespawn = PMob->m_SpawnType == SPAWNTYPE_NORMAL;
-                if (PMob->m_AllowRespawn)
+                // PMob->m_AllowRespawn initializes as false, so if it's true then mob:setRespawnTime was executed in OnMobInitialize
+                // This makes mob:setRespawnTime(X) behave consistently, making the mob spawn X seconds in the future
+                if (!PMob->m_AllowRespawn && PMob->m_SpawnType == SPAWNTYPE_NORMAL)
                 {
+                    PMob->m_AllowRespawn = true;
                     PMob->Spawn();
                 }
                 else


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

In an effort to allow more definitions directly in mob lua files (and doing the initial portion of https://github.com/LandSandBoat/server/issues/7888), this PR makes a slight tweak to zone init to not explicitly set `m_AllowRespawn` based on spawn type, but entering the spawn-on-init code block based on that. The goal here is just making the data more up front and the lua binding behavior consistent.

Did 2 zones, as an example. I don't know about the retail accuracy of these initial spawn times, but at least the information is in one place to be more obvious with how a mob is behaving

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- Launch the server
- see that normal-spawn mobs are spawned immediately
- See that any mobs that are "script type" with nonzero respawn are still flagged to spawn after that respawn time as before the change.
  - <img width="596" height="85" alt="image" src="https://github.com/user-attachments/assets/97a9efad-0ad8-4885-91aa-5fc4e45b2cfd" />
  - `:getRespawnTime()` shows 600, which means spawning is enabled
- See that the mobs getting their respawn time set in `onMobInitialize` behave the same way as the previous bullet