### PR TITLE
[Fix] "I Can Hear A Rainbow" quest ID and update npc data

### DIFF
--- a/scripts/quests/windurst/SMN_I_Can_Hear_a_Rainbow.lua
+++ b/scripts/quests/windurst/SMN_I_Can_Hear_a_Rainbow.lua
@@ -5,7 +5,7 @@
 -----------------------------------
 local laTheineID = zones[xi.zone.LA_THEINE_PLATEAU]
 -----------------------------------
-local quest = Quest:new(xi.questLog.WINDURST, xi.quest.id.windurst.THE_PUPPET_MASTER)
+local quest = Quest:new(xi.questLog.WINDURST, xi.quest.id.windurst.I_CAN_HEAR_A_RAINBOW)
 
 local validWeatherTable =
 set{


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Fixes wrong quest ID used in quest script
- Updates npc speed, speedSub and status values according to caps. This also has the side-effect of making the gem actually appear in the cutscene.

<img width="762" height="620" alt="imagen" src="https://github.com/user-attachments/assets/5c48005e-b6b5-4818-b850-8e3f683b5eeb" />


## Steps to test these changes

Run the quest.
