### PR TITLE
[cpp/lua] On mob pre spawn

### DIFF
--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -177,6 +177,8 @@ xi.mob.phOnDespawn = function(ph, phNmId, chance, cooldown, params)
     -- on PH death, replace PH repop with NM repop
     DisallowRespawn(phId, true)
     DisallowRespawn(nmId, false)
+    -- tell the NM which PH spawned you. Only accessible before spawn, in onMobSpawnCheck or onMobPreSpawn
+    nm:setLocalVar('spawnedFromPhId', phId)
 
     -- Update mob's spawn position, if available
     if not params.noPosUpdate then

--- a/scripts/specs/types/MobEntity.lua
+++ b/scripts/specs/types/MobEntity.lua
@@ -20,6 +20,7 @@
 ---@field onMobFight? fun(mob: CBaseEntity, target: CBaseEntity)
 ---@field onCriticalHit? fun(mob: CBaseEntity, attacker: CBaseEntity?)
 ---@field onMobDeath? fun(mob: CBaseEntity, killer: CBaseEntity?, optParams: { isKiller: boolean, noKiller: boolean, isWeaponSkillKill: boolean, weaponskillUsed: xi.weaponskill, weaponskillDamage: integer })
+---@field onMobPreSpawn? fun(mob: CBaseEntity)
 ---@field onMobSpawnCheck? fun(mob: CBaseEntity): integer
 ---@field onMobSpawn? fun(mob: CBaseEntity)
 ---@field onMobRoamAction? fun(mob: CBaseEntity)

--- a/scripts/zones/RuAun_Gardens/mobs/Despot.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Despot.lua
@@ -1,6 +1,7 @@
 -----------------------------------
--- Area: RuAun Gardens
---   NM: Despot
+--  Area: RuAun Gardens
+--    NM: Despot
+-- Notes: Spawns exactly where the correct placeholder was defeated and claimed to the person who defeated it.
 -----------------------------------
 local ID = zones[xi.zone.RUAUN_GARDENS]
 -----------------------------------
@@ -44,25 +45,30 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.PETRIFY)
 end
 
-entity.onMobSpawn = function(mob)
-    local ph = GetMobByID(mob:getLocalVar('ph'))
-    if ph then
-        local pos = ph:getPos()
-        mob:setPos(pos.x, pos.y, pos.z, pos.r)
-        local killerId = ph:getLocalVar('killer')
-        if killerId ~= 0 then
+entity.onMobPreSpawn = function(mob)
+    -- localvar is set in xi.mob.phOnDespawn when PH primes Despot
+    local phId = mob:getLocalVar('spawnedFromPhId')
+    local ph = phId > 0 and GetMobByID(phId) or nil
+    -- localvar is set in a Groundskeeper "TAKE_DAMAGE" listener to store the real final attacker of the PH (if it's a PC)
+    local killerId = ph and ph:getLocalVar('killer') or 0
+    -- Ignores non-PC killers, also the killer must meet some additional conditions on spawn
+    if killerId ~= 0 then
+        mob:addListener('SPAWN', 'SPAWN_PH_KILLER', function(mobArg)
             local killer = GetPlayerByID(killerId)
+            -- "If that person is fighting something else at the time of spawn, it will spawn unclaimed."
             if
                 killer and
                 not killer:isEngaged() and
-                killer:checkDistance(mob) <= 50
+                killer:checkDistance(mobArg) <= 50
             then
-                mob:updateClaim(killer)
+                mobArg:updateClaim(killer)
             end
-        end
+
+            mobArg:removeListener('SPAWN_PH_KILLER')
+        end)
     end
 
-    mob:addListener('WEAPONSKILL_STATE_EXIT', 'PH_VAR', function(mobArg, skillID)
+    mob:addListener('WEAPONSKILL_STATE_EXIT', 'DESPOT_MOBSKILL', function(mobArg, skillID)
         -- Despot rapidly uses several Panzerfaust in a row
         local counter = mob:getLocalVar('panzerfaustCounter')
         local maxCount = mob:getLocalVar('panzerfaustMax')
@@ -105,7 +111,6 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    mob:removeListener('PH_VAR')
 end
 
 return entity

--- a/scripts/zones/RuAun_Gardens/mobs/Groundskeeper.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Groundskeeper.lua
@@ -8,23 +8,38 @@ local ID = zones[xi.zone.RUAUN_GARDENS]
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobSpawn = function(mob)
+    mob:addListener('TAKE_DAMAGE', 'GET_TRUE_KILLER', function(mobArg, amount, attacker)
+        -- update the localvar for 'killer' only if the killer is a PC, otherwise clear it
+        -- this is for Despot to only automatically aggro players on spawn (onMobDeath passes the killer as the PC, NOT the pet)
+        if
+            attacker and
+            attacker:getObjType() == xi.objType.PC and
+            amount >= mobArg:getHP()
+        then
+            mobArg:setLocalVar('killer', attacker:getID())
+        else
+            mobArg:setLocalVar('killer', 0)
+        end
+    end)
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 143, 2, xi.regime.type.FIELDS)
     xi.regime.checkRegime(player, mob, 144, 1, xi.regime.type.FIELDS)
-    if optParams.isKiller then
-        mob:setLocalVar('killer', player:getID())
-    end
 end
 
 entity.onMobDespawn = function(mob)
-    local params = {}
-    params.immediate = true
-    if xi.mob.phOnDespawn(mob, ID.mob.DESPOT, 5, 7200, params) then -- 2 hours
-        local phId = mob:getID()
-        GetMobByID(ID.mob.DESPOT):addListener('SPAWN', 'PH_VAR', function(m)
-            m:setLocalVar('ph', phId)
-        end)
-    end
+    local pos = mob:getPos()
+    local params =
+    {
+        immediate = true,
+        spawnPoints = {
+            { x = pos.x, y = pos.y, z = pos.z },
+        },
+    }
+
+    xi.mob.phOnDespawn(mob, ID.mob.DESPOT, 5, 7200, params)-- 2 hours
 end
 
 return entity

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -629,6 +629,15 @@ bool CMobEntity::CanSpawnFromGroup()
 void CMobEntity::Spawn()
 {
     TracyZoneScoped;
+
+    // The underlying function in GetRandomNumber doesn't accept uint8 as <T> so use uint32
+    // https://stackoverflow.com/questions/31460733/why-arent-stduniform-int-distributionuint8-t-and-stduniform-int-distri
+    uint8 level = static_cast<uint8>(xirand::GetRandomNumber<uint32>(m_minLevel, m_maxLevel + 1));
+    SetMLevel(level);
+
+    // Pre-spawn hook to allow changing spawn position/level/etc, with access to localvars before they are wiped
+    luautils::OnMobPreSpawn(this);
+
     CBattleEntity::Spawn();
     m_giveExp        = true;
     m_HiPCLvl        = 0;
@@ -643,14 +652,9 @@ void CMobEntity::Spawn()
 
     PEnmityContainer->Clear();
 
-    // The underlying function in GetRandomNumber doesn't accept uint8 as <T> so use uint32
-    // https://stackoverflow.com/questions/31460733/why-arent-stduniform-int-distributionuint8-t-and-stduniform-int-distri
-    uint8 level = static_cast<uint8>(xirand::GetRandomNumber<uint32>(m_minLevel, m_maxLevel + 1));
-
-    TraitList.clear(); // Clear traits just in case from random levels. Traits are recalculated in mobutils::CalculateMobStat().
-                       // Note: Traits are NOT stored on DB load as of writing, so mobs won't gradually get stronger on respawn from restoreModifiers()
-    SetMLevel(level);
-    SetSLevel(level); // subjob calculated in function as appropriate
+    TraitList.clear();            // Clear traits just in case from random levels. Traits are recalculated in mobutils::CalculateMobStat().
+                                  // Note: Traits are NOT stored on DB load as of writing, so mobs won't gradually get stronger on respawn from restoreModifiers()
+    SetSLevel(this->GetMLevel()); // subjob calculated in function as appropriate
 
     mobutils::CalculateMobStats(this);
     mobutils::GetAvailableSpells(this);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -16833,13 +16833,18 @@ void CLuaBaseEntity::setMobLevel(uint8 level)
     if (auto* PMob = dynamic_cast<CMobEntity*>(m_PBaseEntity))
     {
         PMob->SetMLevel(level);
-        PMob->SetSLevel(level);
 
-        // Remove traits, because they were calculated in the previous CalculateMobStats and are NOT saved, so they must be recalculated.
-        PMob->TraitList.clear();
+        // all of this is recalculated once the mob spawns
+        if (PMob->PAI->IsSpawned())
+        {
+            PMob->SetSLevel(level);
 
-        mobutils::CalculateMobStats(PMob);
-        mobutils::GetAvailableSpells(PMob);
+            // Remove traits, because they were calculated in the previous CalculateMobStats and are NOT saved, so they must be recalculated.
+            PMob->TraitList.clear();
+
+            mobutils::CalculateMobStats(PMob);
+            mobutils::GetAvailableSpells(PMob);
+        }
     }
 }
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -3498,6 +3498,24 @@ namespace luautils
         }
     }
 
+    void OnMobPreSpawn(CBaseEntity* PMob)
+    {
+        TracyZoneScoped;
+
+        auto onMobPreSpawn = getEntityCachedFunction(PMob, "onMobPreSpawn");
+        if (!onMobPreSpawn.valid())
+        {
+            return;
+        }
+
+        auto result = onMobPreSpawn(PMob);
+        if (!result.valid())
+        {
+            sol::error err = result;
+            ShowError("luautils::onMobPreSpawn: %s", err.what());
+        }
+    }
+
     int32 OnMobSpawnCheck(CBaseEntity* PMob)
     {
         TracyZoneScoped;

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -349,6 +349,7 @@ namespace luautils
     void ApplyMixins(CBaseEntity* PMob);
     void ApplyZoneMixins(CBaseEntity* PMob);
     auto OnMobSpawnCheck(CBaseEntity* PMob) -> int32;
+    void OnMobPreSpawn(CBaseEntity* PMob);
     void OnMobSpawn(CBaseEntity* PMob);
     void OnMobRoamAction(CBaseEntity* PMob); // triggers when event mob is ready for a custom roam action
     void OnMobRoam(CBaseEntity* PMob);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

I quite like the distinction of splitting spawnCheck (checking if a mob should spawn out of respawn state only) and prespawn (always runs right before a mob spawns)

This PR splits the always-running pre-spawn logic out of https://github.com/LandSandBoat/server/pull/7791. ~~I will have to rebase this once the other merges, so leaving as draft for now~~

Creates a Pre-spawn mob function to allow last-minute changes to a mob just before it spawns. This allows
- more efficiently changing level (not sure that's used for anything retail, but it's free functionality)
- any logic that needs to consider values of localvars (since those are wiped on spawn)

Despot is adjusted as an example of the logic
- instead of a spawn listener which sets the localvar on despot, and an `onMobSpawn` function on despot to utilize that variable (which i'm pretty sure doesn't work anymore now that the spawn listener is set to happen inside `luautils::onMobSpawn`...)
- we keep logic related to the groundskeeper in the groundskeeper file
- and, logic related to Despot in despot's file
  - Note that I found a bug that was setting the `killer` localvar in `onMobDeath`, which is always a player based on `mOwnerId`
  - I've moved it to a take_damage listener, which works reliably

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- Admire the organization of Despot's code
- set PH lua to have chance `100` and cooldown of `1`
- kill PH with a pet
  - see despot spawns unclaimed
- do it again but get killing blow with a player
  - see despot spawns claimed to that player