### PR TITLE
[core] [lua] Check for ammo usage properly in physical/hybrid ranged WS

### DIFF
--- a/scripts/globals/combat/ranged_utilities.lua
+++ b/scripts/globals/combat/ranged_utilities.lua
@@ -112,3 +112,22 @@ xi.combat.ranged.accuracyDistancePenalty = function(attacker, defender)
 
     return penalty
 end
+
+xi.combat.ranged.shouldUseAmmo = function(attacker)
+    if attacker:isPC() then
+        local recycleChance = attacker:getMod(xi.mod.RECYCLE) + attacker:getMerit(xi.merit.RECYCLE) + attacker:getJobPointLevel(xi.jp.AMMO_CONSUMPTION)
+
+        if attacker:hasStatusEffect(xi.effect.UNLIMITED_SHOT) then
+            attacker:delStatusEffect(xi.effect.UNLIMITED_SHOT) -- TODO: allegedly Unlimited Shot doesn't remove itself unless you hit
+            recycleChance = 100
+        end
+
+        if math.random(1, 100) <= recycleChance then
+            return false
+        end
+
+        return true
+    end
+
+    return false
+end

--- a/scripts/globals/job_utils/beastmaster.lua
+++ b/scripts/globals/job_utils/beastmaster.lua
@@ -88,7 +88,7 @@ xi.job_utils.beastmaster.onUseAbilityJug = function(player, target, ability)
     xi.pet.spawnPet(player, player:getWeaponSubSkillType(xi.slot.AMMO))
 
     if ability:getID() == xi.jobAbility.CALL_BEAST then
-        player:removeAmmo()
+        player:removeAmmo(1)
     end
 
     -- Briefly put the recastId for READY/SIC (102) into a recast state to

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -508,7 +508,7 @@ xi.job_utils.dragoon.useAngon = function(player, target, ability)
     end
 
     target:updateClaim(player)
-    player:removeAmmo()
+    player:removeAmmo(1)
 
     return xi.effect.DEFENSE_DOWN
 end

--- a/scripts/globals/job_utils/puppetmaster.lua
+++ b/scripts/globals/job_utils/puppetmaster.lua
@@ -184,7 +184,7 @@ xi.job_utils.puppetmaster.onAbilityUseRepair = function(player, target, ability)
 
     pet:delStatusEffect(xi.effect.REGEN)
     pet:addStatusEffect(xi.effect.REGEN, regenAmount, 3, regenTime) -- 3 = tick, each 3 seconds.
-    player:removeAmmo()
+    player:removeAmmo(1)
     return totalHealing
 end
 
@@ -221,7 +221,7 @@ xi.job_utils.puppetmaster.onAbilityUseMaintenance = function(player, target, abi
         numRemoved = numRemoved + 1
     until toRemove <= 0
 
-    player:removeAmmo()
+    player:removeAmmo(1)
 
     return numRemoved
 end

--- a/scripts/globals/job_utils/ranger.lua
+++ b/scripts/globals/job_utils/ranger.lua
@@ -232,12 +232,6 @@ xi.job_utils.ranger.useShadowbind = function(player, target, ability, action)
     end
 
     local duration      = 30 + player:getMod(xi.mod.SHADOW_BIND_EXT) + player:getJobPointLevel(xi.jp.SHADOWBIND_DURATION)
-    local recycleChance = player:getMod(xi.mod.RECYCLE) + player:getMerit(xi.merit.RECYCLE)
-
-    if player:hasStatusEffect(xi.effect.UNLIMITED_SHOT) then
-        player:delStatusEffect(xi.effect.UNLIMITED_SHOT)
-        recycleChance = 100
-    end
 
     -- TODO: Acc penalty for /RNG, acc vs. mob level?
     if
@@ -250,8 +244,8 @@ xi.job_utils.ranger.useShadowbind = function(player, target, ability, action)
         ability:setMsg(xi.msg.basic.JA_MISS) -- Player uses Shadowbind, but misses.
     end
 
-    if math.random(0, 99) >= recycleChance then
-        player:removeAmmo() -- Shadowbind depletes one round of ammo.
+    if xi.combat.ranged.shouldUseAmmo(player) then
+        player:removeAmmo(1) -- Shadowbind depletes one round of ammo.
     end
 
     return xi.effect.BIND
@@ -279,7 +273,8 @@ xi.job_utils.ranger.useBountyShot = function(player, target, ability, action)
     local playerTHLevel     = player:getMod(xi.mod.TREASURE_HUNTER)
     local newTHLevel        = 0
 
-    player:removeAmmo()
+    player:removeAmmo(1) -- TODO: does this check recycle?
+
     action:speceffect(target:getID(), 0x01) -- functional, animation not correct without this
     ability:setMsg(xi.msg.basic.JA_NO_EFFECT_2)
 

--- a/scripts/globals/znm.lua
+++ b/scripts/globals/znm.lua
@@ -232,7 +232,7 @@ xi.znm.soultrapper.onItemUse = function(target, player, item)
             playerArg:messageBasic(xi.msg.basic.SOULTRAPPER_FAILED)
         end)
 
-        player:removeAmmo()
+        player:removeAmmo(1)
     else
         -- Determine Zeni starting value
         local zeni = xi.znm.soultrapper.getZeniValue(target, player)

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -3293,7 +3293,8 @@ function CBaseEntity:addDamageFromMultipliers(damage, attackType, weaponSlot, al
 end
 
 ---@return nil
-function CBaseEntity:removeAmmo()
+---@param ammoUsed integer
+function CBaseEntity:removeAmmo(ammoUsed)
 end
 
 ---@nodiscard

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1562,22 +1562,6 @@ void CCharEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& acti
 
             if (primary)
             {
-                if (isRangedWS)
-                {
-                    uint16 recycleChance = getMod(Mod::RECYCLE) + PMeritPoints->GetMeritValue(MERIT_RECYCLE, this) + this->PJobPoints->GetJobPointValue(JP_AMMO_CONSUMPTION);
-
-                    if (StatusEffectContainer->HasStatusEffect(EFFECT_UNLIMITED_SHOT))
-                    {
-                        StatusEffectContainer->DelStatusEffect(EFFECT_UNLIMITED_SHOT);
-                        recycleChance = 100;
-                    }
-
-                    if (xirand::GetRandomNumber(100) > recycleChance)
-                    {
-                        battleutils::RemoveAmmo(this);
-                    }
-                }
-
                 // See battleentity.h for REACTION class
                 // On retail, weaponskills will contain 0x08, 0x10 (HIT, ABILITY) on hit and may include the following:
                 // 0x01, 0x02, 0x04 (MISS, GUARDED, BLOCK)

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -15166,7 +15166,7 @@ uint32 CLuaBaseEntity::addDamageFromMultipliers(uint32 damage, PHYSICAL_ATTACK_T
  *  Notes   : Ammo consumed is calculated in charentity.cpp and passed to battleutils
  ************************************************************************/
 
-void CLuaBaseEntity::removeAmmo()
+void CLuaBaseEntity::removeAmmo(uint8 ammoUsed)
 {
     if (m_PBaseEntity->objtype != TYPE_PC)
     {
@@ -15174,7 +15174,7 @@ void CLuaBaseEntity::removeAmmo()
         return;
     }
 
-    battleutils::RemoveAmmo(static_cast<CCharEntity*>(m_PBaseEntity));
+    battleutils::RemoveAmmo(static_cast<CCharEntity*>(m_PBaseEntity), ammoUsed);
 }
 
 /************************************************************************

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -750,7 +750,7 @@ public:
     uint16 getWeaponHitCount(bool offhand); // Get PC weapon hit count (Occasionally Attacks N times weapons)
     uint32 addDamageFromMultipliers(uint32 damage, PHYSICAL_ATTACK_TYPE attackType, uint8 weaponSlot, bool allowProc);
 
-    void removeAmmo();
+    void removeAmmo(uint8 ammoUsed);
 
     uint16 getWeaponSkillLevel(uint8 slotID);                        // Get Skill for equipped weapon
     uint16 getWeaponDamageType(uint8 slotID);                        // gets the type of weapon equipped


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Use ammo on physical and hybrid ranged WS
Change removeAmmo to take in ammo used uint param
Make a utility func for recycle

## Steps to test these changes

!setmod recycle 0 on yourself (and dont be on COR for the job points...)

Use physical/hybrid ranged WS, use ammo (importantly, ammo >1 on Last Stand if you shoot twice in the WS)
