### PR TITLE
[core] [sql] Fix Sic/Ready recast merits, implement Stratagem jp gift

### DIFF
--- a/scripts/enum/mod.lua
+++ b/scripts/enum/mod.lua
@@ -1042,6 +1042,7 @@ xi.mod =
     BLUE_JOB_TRAIT_BONUS    = 1058, -- TODO: Increases job traits gained from equipped blue magic (percent)
     BLUE_MAGIC_EFFECT       = 1059, -- TODO: Bonus to Attribute Value of spell (percent)
     QUICK_DRAW_RECAST       = 1060, -- Quick Draw Charge Reduction (seconds)
+    STRATAGEM_RECAST        = 1159, -- Recast reduction in seconds
 
     DIG_BYPASS_FATIGUE      = 1074, -- Chocobo digging modifier found in "Blue Race Silks". Modifier works as a direct percent.
     DIG_RARE_ABILITY        = 1133, -- Chocobo digging modifier found in "Black Chocobo Suit" and "Denim Pants +1".

--- a/sql/abilities_charges.sql
+++ b/sql/abilities_charges.sql
@@ -16,7 +16,7 @@ CREATE TABLE `abilities_charges` (
 -- ----------------------------
 -- Records 
 -- ----------------------------
-INSERT INTO `abilities_charges` VALUES (102,9,25,3,30,0);
+INSERT INTO `abilities_charges` VALUES (102,9,25,3,30,902);
 INSERT INTO `abilities_charges` VALUES (195,17,40,2,60,1410);
 INSERT INTO `abilities_charges` VALUES (231,20,10,1,240,0);
 INSERT INTO `abilities_charges` VALUES (231,20,30,2,120,0);

--- a/sql/job_point_gifts.sql
+++ b/sql/job_point_gifts.sql
@@ -1315,7 +1315,7 @@ INSERT INTO `job_point_gifts` VALUES (20,450,112,8,'SCH_Healing Magic Skill Bonu
 INSERT INTO `job_point_gifts` VALUES (20,500,997,1,'SCH_Superior 3');
 INSERT INTO `job_point_gifts` VALUES (20,500,274,3,'SCH_Magic Burst Damage Bonus');
 INSERT INTO `job_point_gifts` VALUES (20,545,915,23,'SCH_Capacity Point Bonus');
-INSERT INTO `job_point_gifts` VALUES (20,550,987,15,'SCH_Stratagem Recast Time');
+INSERT INTO `job_point_gifts` VALUES (20,550,1159,15,'SCH_Stratagem Recast Time');
 INSERT INTO `job_point_gifts` VALUES (20,605,29,6,'SCH_Magic Defense Bonus');
 INSERT INTO `job_point_gifts` VALUES (20,655,915,25,'SCH_Capacity Point Bonus');
 INSERT INTO `job_point_gifts` VALUES (20,660,28,10,'SCH_Magic Attack Bonus');

--- a/src/map/ai/controllers/player_controller.cpp
+++ b/src/map/ai/controllers/player_controller.cpp
@@ -127,7 +127,7 @@ bool CPlayerController::Ability(uint16 targid, uint16 abilityid)
             // Set recast time to the normal recast time minus any charge time.
             // Abilities without a charge will have zero chargeTime
             timer::duration currentRecast = recast->TimeStamp - timer::now() + recast->RecastTime;
-            // Abilities with a single charge (low-level scholoar stratagems) behave like abilities without a charge
+            // Abilities with a single charge (low-level scholar stratagems) behave like abilities without a charge
             if (recast->maxCharges > 1)
             {
                 currentRecast -= recast->chargeTime * (recast->maxCharges - 1);

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -733,24 +733,25 @@ enum class Mod
     STEP_TP_CONSUMED         = 1077, // Modifies the amount of TP consumed when using steps
 
     // Scholar
-    BLACK_MAGIC_COST         = 393, // MP cost for black magic (light/dark arts)
-    WHITE_MAGIC_COST         = 394, // MP cost for white magic (light/dark arts)
-    BLACK_MAGIC_CAST         = 395, // Cast time for black magic (light/dark arts)
-    WHITE_MAGIC_CAST         = 396, // Cast time for black magic (light/dark arts)
-    BLACK_MAGIC_RECAST       = 397, // Recast time for black magic (light/dark arts)
-    WHITE_MAGIC_RECAST       = 398, // Recast time for white magic (light/dark arts)
-    ALACRITY_CELERITY_EFFECT = 399, // Bonus for celerity/alacrity effect
-    LIGHT_ARTS_EFFECT        = 334, //
-    DARK_ARTS_EFFECT         = 335, //
-    LIGHT_ARTS_SKILL         = 336, //
-    DARK_ARTS_SKILL          = 337, //
-    LIGHT_ARTS_REGEN         = 338, // Regen bonus flat HP amount from Light Arts and Tabula Rasa
-    REGEN_DURATION           = 339, //
-    HELIX_EFFECT             = 478, //
-    HELIX_DURATION           = 477, //
-    STORMSURGE_EFFECT        = 400, //
-    SUBLIMATION_BONUS        = 401, //
-    GRIMOIRE_SPELLCASTING    = 489, // "Grimoire: Reduces spellcasting time" bonus
+    BLACK_MAGIC_COST         = 393,  // MP cost for black magic (light/dark arts)
+    WHITE_MAGIC_COST         = 394,  // MP cost for white magic (light/dark arts)
+    BLACK_MAGIC_CAST         = 395,  // Cast time for black magic (light/dark arts)
+    WHITE_MAGIC_CAST         = 396,  // Cast time for black magic (light/dark arts)
+    BLACK_MAGIC_RECAST       = 397,  // Recast time for black magic (light/dark arts)
+    WHITE_MAGIC_RECAST       = 398,  // Recast time for white magic (light/dark arts)
+    ALACRITY_CELERITY_EFFECT = 399,  // Bonus for celerity/alacrity effect
+    LIGHT_ARTS_EFFECT        = 334,  //
+    DARK_ARTS_EFFECT         = 335,  //
+    LIGHT_ARTS_SKILL         = 336,  //
+    DARK_ARTS_SKILL          = 337,  //
+    LIGHT_ARTS_REGEN         = 338,  // Regen bonus flat HP amount from Light Arts and Tabula Rasa
+    REGEN_DURATION           = 339,  //
+    HELIX_EFFECT             = 478,  //
+    HELIX_DURATION           = 477,  //
+    STORMSURGE_EFFECT        = 400,  //
+    SUBLIMATION_BONUS        = 401,  //
+    GRIMOIRE_SPELLCASTING    = 489,  // "Grimoire: Reduces spellcasting time" bonus
+    STRATAGEM_RECAST         = 1159, // Recast reduction in seconds
 
     // Geo
     CARDINAL_CHANT       = 959,
@@ -1104,7 +1105,7 @@ enum class Mod
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     // 570 through 825 used by WS DMG mods these are not spares.
     //
-    // SPARE IDs: 1159 and onward
+    // SPARE IDs: 1160 and onward
 };
 
 // temporary workaround for using enum class as unordered_map key until compilers support it


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements stratagem JP gift recast reduction
Fixes Sic/Ready recast merit not working  properly

## Steps to test these changes

use Sic/Ready with recast fixes while having merits, see it work
get 550+ JP on SCH, get 15s stratagem time reduction