### PR TITLE
Aftermath pets

### DIFF
--- a/scripts/effects/aftermath.lua
+++ b/scripts/effects/aftermath.lua
@@ -12,7 +12,6 @@ effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    xi.aftermath.onEffectLose(target, effect)
 end
 
 return effectObject

--- a/scripts/globals/aftermath.lua
+++ b/scripts/globals/aftermath.lua
@@ -644,7 +644,7 @@ xi.aftermath.onEffectGain = function(target, effect)
             end
 
             for i = 1, #aftermath.mods, 2 do
-                target:addMod(aftermath.mods[i], aftermath.mods[i + 1])
+                effect:addMod(aftermath.mods[i], aftermath.mods[i + 1])
             end
         end,
 
@@ -661,45 +661,13 @@ xi.aftermath.onEffectGain = function(target, effect)
             end
 
             for i = 1, #mods, 2 do
-                target:addMod(mods[i], mods[i + 1](tp))
+                effect:addMod(mods[i], mods[i + 1](tp))
             end
         end,
 
         -- Empyrean
         [3] = function(x)
-            target:addMod(aftermath.mod, aftermath.power[math.floor(effect:getSubPower() / 1000)])
-        end
-    }
-end
-
-xi.aftermath.onEffectLose = function(target, effect)
-    local aftermath = xi.aftermath.effects[effect:getPower()]
-    switch (effect:getTier()) : caseof
-    {
-        -- Relic
-        [1] = function(x)
-            local pet = nil
-            if aftermath.includePets then
-                pet = target:getPet()
-            end
-
-            for i = 1, #aftermath.mods, 2 do
-                target:delMod(aftermath.mods[i], aftermath.mods[i + 1])
-            end
-        end,
-
-        -- Mythic
-        [2] = function(x)
-            local tp = effect:getSubPower()
-            local mods = aftermath.mods[math.floor(tp / 1000)]
-            for i = 1, #mods, 2 do
-                target:delMod(mods[i], mods[i + 1](tp))
-            end
-        end,
-
-        -- Empyrean
-        [3] = function(x)
-            target:delMod(aftermath.mod, aftermath.power[math.floor(effect:getSubPower() / 1000)])
+            effect:addMod(aftermath.mod, aftermath.power[math.floor(effect:getSubPower() / 1000)])
         end
     }
 end

--- a/scripts/globals/aftermath.lua
+++ b/scripts/globals/aftermath.lua
@@ -632,16 +632,19 @@ xi.aftermath.onEffectGain = function(target, effect)
     {
         -- Relic
         [1] = function(x)
-            local pet = nil
-            if aftermath.includePets then
-                pet = target:getPet()
+            local pet = target:getPet()
+            if
+                pet and
+                aftermath.includePets
+            then
+                -- pets gain same mods as the player, so give them the effect without a loss message
+                pet:delStatusEffectSilent(xi.effect.AFTERMATH)
+                pet:addStatusEffect(xi.effect.AFTERMATH, effect:getPower(), 0, effect:getDuration() / 1000, 0, effect:getSubPower(), effect:getTier())
+                pet:getStatusEffect(xi.effect.AFTERMATH):addEffectFlag(xi.effectFlag.NO_LOSS_MESSAGE)
             end
 
             for i = 1, #aftermath.mods, 2 do
                 target:addMod(aftermath.mods[i], aftermath.mods[i + 1])
-                if pet then
-                    pet:addMod(aftermath.mods[i], aftermath.mods[i + 1])
-                end
             end
         end,
 
@@ -650,11 +653,15 @@ xi.aftermath.onEffectGain = function(target, effect)
             local tp = effect:getSubPower()
             local mods = aftermath.mods[math.floor(tp / 1000)]
             local pet = target:getPet()
+            if pet then
+                -- pets gain same mods as the player, so give them the effect without a loss message
+                pet:delStatusEffectSilent(xi.effect.AFTERMATH)
+                pet:addStatusEffect(xi.effect.AFTERMATH, effect:getPower(), 0, effect:getDuration() / 1000, 0, effect:getSubPower(), effect:getTier())
+                pet:getStatusEffect(xi.effect.AFTERMATH):addEffectFlag(xi.effectFlag.NO_LOSS_MESSAGE)
+            end
+
             for i = 1, #mods, 2 do
                 target:addMod(mods[i], mods[i + 1](tp))
-                if pet then
-                    pet:addMod(mods[i], mods[i + 1](tp))
-                end
             end
         end,
 
@@ -678,9 +685,6 @@ xi.aftermath.onEffectLose = function(target, effect)
 
             for i = 1, #aftermath.mods, 2 do
                 target:delMod(aftermath.mods[i], aftermath.mods[i + 1])
-                if pet then
-                    pet:delMod(aftermath.mods[i], aftermath.mods[i + 1])
-                end
             end
         end,
 
@@ -688,12 +692,8 @@ xi.aftermath.onEffectLose = function(target, effect)
         [2] = function(x)
             local tp = effect:getSubPower()
             local mods = aftermath.mods[math.floor(tp / 1000)]
-            local pet = target:getPet()
             for i = 1, #mods, 2 do
                 target:delMod(mods[i], mods[i + 1](tp))
-                if pet then
-                    pet:delMod(mods[i], mods[i + 1](tp))
-                end
             end
         end,
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Cleans up the effect application for pets in aftermath. Instead of duplicated logic, apply mods to the effect. And since you can't do `effect:addPetMod`, give the pet the aftermath effect with no loss message. This also resolves the issue of getting aftermath, then pulling out a new pet, losing aftermath, and the pet losing mods permanently

- all aftermath effects are changed to apply mods to the effect, removing the need to `:delMod` on effect lose
- all aftermath effects that give mods to pets do so by applying the same aftermath effect to the pet

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

- give yourself a mythic or relic that applies to pets: `!additem 18999`
- give yourself tp for a tier: `!tp 1000 mowford`
- do primal rend, check stats/effects
  - <img width="652" height="410" alt="image" src="https://github.com/user-attachments/assets/3ed92f2f-264d-4c95-b75b-638ec3adae04" />
  - and of course overwriting an effect swaps out the mods (tier 1 mythic gives acc, tier 2 gives att)
  - <img width="621" height="431" alt="image" src="https://github.com/user-attachments/assets/f393f5e1-b4ab-4708-b64d-1e45abe9ecc8" />
  - <img width="642" height="530" alt="image" src="https://github.com/user-attachments/assets/d6a6fa3e-8f8d-4124-9c8d-ffa25b5c764a" />
 - wait for effects to fall off, see pet gives no message
   - <img width="513" height="90" alt="image" src="https://github.com/user-attachments/assets/4806ad2c-5695-4ce6-984c-f3101520a1b2" />
