### PR TITLE
[fix] Run MapApplication on main thread

### DIFF
--- a/src/common/application.cpp
+++ b/src/common/application.cpp
@@ -255,7 +255,6 @@ auto Application::isRunning() const -> bool
 void Application::requestExit()
 {
     gIsRunning = false;
-    io_context_.stop();
 }
 
 auto Application::isRunningInCI() const -> bool

--- a/src/common/application.h
+++ b/src/common/application.h
@@ -85,7 +85,7 @@ public:
     virtual void requestExit();
 
     // Is expected to block until requestExit() is called and/or isRunning() returns false
-    void run();
+    virtual void run();
 
     auto isRunningInCI() const -> bool;
 

--- a/src/common/arguments.cpp
+++ b/src/common/arguments.cpp
@@ -52,7 +52,7 @@ Arguments::Arguments(const ApplicationConfig& config, const int argc, char** arg
         .flag();
 
     // Specialized arguments
-    for (auto argument : config.arguments)
+    for (const auto& argument : config.arguments)
     {
         args_->add_argument(argument.name)
             .help(argument.description);

--- a/src/login/connect_application.cpp
+++ b/src/login/connect_application.cpp
@@ -67,3 +67,9 @@ void ConnectApplication::registerCommands(ConsoleService& console)
     });
     // clang-format on
 }
+
+void ConnectApplication::requestExit()
+{
+    Application::requestExit();
+    io_context_.stop();
+}

--- a/src/login/connect_application.h
+++ b/src/login/connect_application.h
@@ -35,4 +35,5 @@ public:
 
     auto createEngine() -> std::unique_ptr<Engine> override;
     void registerCommands(ConsoleService& console) override;
+    void requestExit() override;
 };

--- a/src/map/map_application.h
+++ b/src/map/map_application.h
@@ -47,9 +47,8 @@ public:
 
     auto createEngine() -> std::unique_ptr<Engine> override;
     void registerCommands(ConsoleService& console) override;
+    void run() override;
 
 private:
     MapConfig engineConfig_{};
-
-    void requestExit() override;
 };

--- a/src/map/map_engine.cpp
+++ b/src/map/map_engine.cpp
@@ -102,14 +102,6 @@ MapEngine::MapEngine(asio::io_context& io_context, MapConfig& config)
 , engineConfig_(config)
 {
     do_init();
-
-    // Queue the first game loop iteration
-    // clang-format off
-    asio::post([&]()
-    {
-        gameLoop();
-    });
-    // clang-format on
 }
 
 MapEngine::~MapEngine()
@@ -205,17 +197,6 @@ void MapEngine::gameLoop()
     else if (tickDiffTime < -kMainLoopBacklogThreshold)
     {
         RATE_LIMIT(15s, ShowWarningFmt("Main loop is running {}ms behind, performance is degraded!", -timer::count_milliseconds(tickDiffTime)));
-    }
-
-    if (!ioContext_.stopped())
-    {
-        // Requeue loop
-        // clang-format off
-        asio::post([&]()
-        {
-            gameLoop();
-        });
-        // clang-format on
     }
 }
 
@@ -475,9 +456,4 @@ auto MapEngine::statistics() const -> MapStatistics&
 auto MapEngine::zones() const -> std::map<uint16, CZone*>&
 {
     return g_PZoneList;
-}
-
-void MapEngine::requestExit()
-{
-    ioContext_.stop();
 }

--- a/src/search/search_application.cpp
+++ b/src/search/search_application.cpp
@@ -60,3 +60,9 @@ void SearchApplication::registerCommands(ConsoleService& console)
                             "Force-expire all items on the AH, returning to sender",
                             std::bind(&SearchEngine::onExpireAll, searchEngine, std::placeholders::_1));
 }
+
+void SearchApplication::requestExit()
+{
+    Application::requestExit();
+    io_context_.stop();
+}

--- a/src/search/search_application.h
+++ b/src/search/search_application.h
@@ -35,4 +35,5 @@ public:
 
     auto createEngine() -> std::unique_ptr<Engine> override;
     void registerCommands(ConsoleService& console) override;
+    void requestExit() override;
 };

--- a/src/world/world_application.cpp
+++ b/src/world/world_application.cpp
@@ -49,3 +49,9 @@ auto WorldApplication::createEngine() -> std::unique_ptr<Engine>
 {
     return std::make_unique<WorldEngine>(ioContext());
 }
+
+void WorldApplication::requestExit()
+{
+    Application::requestExit();
+    io_context_.stop();
+}

--- a/src/world/world_application.h
+++ b/src/world/world_application.h
@@ -34,4 +34,5 @@ public:
     ~WorldApplication() override;
 
     auto createEngine() -> std::unique_ptr<Engine> override;
+    void requestExit() override;
 };


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Reintroduces the former pattern used by MapServer, i.e. running everything in an infinite loop on the main thread.

I still believe standardizing on the ASIO worker was the right thing to do but:
- _sql is initialized on the main thread and then used on the ASIO worker thread which it really _does not_ like
- The introduction of Coro-Roro will likely change how we think about running the various tasks that make up the game loop

I'll revisit when those 2 points are said and done.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Build, play?

I still need to test a little more thoroughly.
<!-- Clear and detailed steps to test your changes here -->
