### PR TITLE
[lua, sql] Euvhi family behavior and skill adjustments

### DIFF
--- a/scripts/actions/mobskills/axial_bloom.lua
+++ b/scripts/actions/mobskills/axial_bloom.lua
@@ -14,7 +14,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 30))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, math.random(30, 60)))
 
     return xi.effect.BIND
 end

--- a/scripts/actions/mobskills/efflorescent_foetor.lua
+++ b/scripts/actions/mobskills/efflorescent_foetor.lua
@@ -1,0 +1,22 @@
+-----------------------------------
+-- Efflorescent Foetor
+-- Description: Sprays toxic pollen in a fan-shaped area of effect, inflicting Blind & Silence.
+-- Type: Enfeebling
+-- Utsusemi/Blink absorb: Ignores shadows
+-- Range: Unknown radial
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 100, 0, math.random(10, 30)))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, math.random(10, 30)))
+
+    return xi.effect.BLINDNESS
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/morning_glory.lua
+++ b/scripts/actions/mobskills/morning_glory.lua
@@ -1,0 +1,30 @@
+-----------------------------------
+--  Morning Glory
+--  Family: Euvhi
+--  Description: Hits nearby targets with a petal bloom.
+--  Type: Physical
+--  Utsusemi/Blink absorb: 2-3 shadows
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    if mob:getAnimationSub() ~= 1 then
+        return 1
+    end
+
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    local numhits = 1
+    local accmod = 1
+    local ftp    = 1
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.CRIT_VARIES, 1, 1, 1)
+    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, info.hitslanded)
+
+    target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
+    return dmg
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/nutrient_absorption.lua
+++ b/scripts/actions/mobskills/nutrient_absorption.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Nutrient Absorption
+-- Family: Euvhi
+-- Steals HP from a single target.
+-- Type: Drain
+-- Utsusemi/Blink absorb: 1 shadow
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    -- Damage is 300 + dINT
+    local damage = xi.mobskills.mobMagicalMove(mob, target, skill, 300, xi.element.DARK, 1, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, xi.mobskills.shadowBehavior.NUMSHADOWS_1)
+
+    skill:setMsg(xi.mobskills.mobPhysicalDrainMove(mob, target, skill, xi.mobskills.drainType.HP, damage))
+
+    return damage
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/stupor_spores.lua
+++ b/scripts/actions/mobskills/stupor_spores.lua
@@ -1,0 +1,27 @@
+-----------------------------------
+-- Stupor Spores
+-- Family: Euvhi
+-- Description: Spreads intoxicating spores that damages nearby targets. Additional effect: Sleep
+-- Type: Magical
+-- Utsusemi/Blink absorb: Ignores shadows
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    -- TODO: Damage needs 1 + dINT added
+    local damage = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getMainLvl() + 2, xi.element.NONE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.ELEMENTAL, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
+
+    target:takeDamage(damage, mob, xi.attackType.MAGICAL, xi.damageType.ELEMENTAL)
+
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLEEP_I, 1, 0, math.random(15, 60))
+
+    return damage
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/vertical_cleave.lua
+++ b/scripts/actions/mobskills/vertical_cleave.lua
@@ -14,7 +14,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 1
     local accmod = 1
     local ftp    = 2
-    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.ATK_VARIES, 1.2, 1.2, 1.2)
+    -- TODO: Add ability to crit
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.ATK_VARIES, 1.25, 1.25, 1.25)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/viscid_nectar.lua
+++ b/scripts/actions/mobskills/viscid_nectar.lua
@@ -15,7 +15,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 1250, 0, 120))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 10000, 0, 120))
 
     return xi.effect.SLOW
 end

--- a/scripts/mixins/families/euvhi.lua
+++ b/scripts/mixins/families/euvhi.lua
@@ -1,0 +1,78 @@
+-----------------------------------
+--- Euvhi Family Mixin
+--  https://ffxiclopedia.fandom.com/wiki/Category:Euvhi
+--  https://www.bg-wiki.com/ffxi/Category:Euvhi
+--  Euvhi open mouth after 80 seconds, and deal 1.5% base damage
+--  Close mouth after taking 350 damage
+-----------------------------------
+require('scripts/globals/mixins')
+-----------------------------------
+
+g_mixins = g_mixins or {}
+g_mixins.families = g_mixins.families or {}
+
+local function openMouth(mob)
+    local damage = 1 + mob:getMainLvl() / 2
+    mob:setMobMod(xi.mobMod.WEAPON_BONUS, damage)
+    mob:setAnimationSub(2)
+    mob:wait(2000)
+end
+
+local function closeMouth(mob)
+    mob:setMobMod(xi.mobMod.WEAPON_BONUS, 0)
+    mob:setLocalVar('[euvhi]changeTime', GetSystemTime() + 80)
+    mob:setLocalVar('closeMouth', 0)
+    mob:setAnimationSub(1)
+    mob:wait(2000)
+end
+
+g_mixins.families.euvhi = function(euvhiMob)
+    euvhiMob:addListener('SPAWN', 'EUVHI_SPAWN', function(mob)
+        mob:setLocalVar('defaultAnimation', mob:getAnimationSub())
+    end)
+
+    euvhiMob:addListener('ENGAGE', 'EUVHI_ENGAGE', function(mob, target)
+        mob:setLocalVar('[euvhi]changeTime', GetSystemTime() + 80)
+    end)
+
+    euvhiMob:addListener('COMBAT_TICK', 'EUVHI_CTICK', function(mob)
+        if
+            mob:getAnimationSub() == 1 and
+            mob:getBattleTime() > mob:getLocalVar('[euvhi]changeTime') and
+            not xi.combat.behavior.isEntityBusy(mob)
+        then
+            openMouth(mob)
+        elseif
+            mob:getAnimationSub() == 2 and
+            mob:getLocalVar('closeMouth') == 1 and
+            not xi.combat.behavior.isEntityBusy(mob)
+        then
+            closeMouth(mob)
+        end
+    end)
+
+    euvhiMob:addListener('TAKE_DAMAGE', 'EUVHI_TAKE_DAMAGE', function(mob, damage, attacker, attackType, damageType)
+        if
+            mob:getAnimationSub() == 2 and
+            damage >= 350
+        then
+            mob:setLocalVar('closeMouth', 1)
+        end
+    end)
+
+    euvhiMob:addListener('ROAM_TICK', 'EUVHI_RTICK', function(mob)
+        local animSub = mob:getAnimationSub()
+        if animSub % 2 == 1 then
+            mob:setAggressive(false)
+        elseif animSub % 2 == 0 then
+            mob:setAggressive(true)
+        end
+    end)
+
+    euvhiMob:addListener('DISENGAGE', 'EUVHI_DISENGAGE', function(mob)
+        mob:setLocalVar('[euvhi]changeTime', 0)
+        mob:setAnimationSub(mob:getLocalVar('defaultAnimation'))
+    end)
+end
+
+return g_mixins.families.euvhi

--- a/scripts/zones/AlTaieu/mobs/Aweuvhi.lua
+++ b/scripts/zones/AlTaieu/mobs/Aweuvhi.lua
@@ -3,6 +3,7 @@
 --  Mob: Aw'euvhi
 -----------------------------------
 local ID = zones[xi.zone.ALTAIEU]
+mixins = { require('scripts/mixins/families/euvhi') }
 -----------------------------------
 ---@type TMobEntity
 local entity = {}

--- a/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Eoeuvhi.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Eoeuvhi.lua
@@ -1,0 +1,13 @@
+-----------------------------------
+-- Area: Grand Palace of Hu'Xzoi
+--  Mob: Eo'euvhi
+-----------------------------------
+mixins = { require('scripts/mixins/families/euvhi') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobDeath = function(mob, player, optParams)
+end
+
+return entity

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Aweuvhi.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Aweuvhi.lua
@@ -2,13 +2,10 @@
 -- Area: The Garden of Ru'Hmet
 --  Mob: Aw'euvhi
 -----------------------------------
+mixins = { require('scripts/mixins/families/euvhi') }
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
-
-entity.onMobSpawn = function(mob)
-    -- Set a random animation when it spawns
-    mob:setAnimationSub(math.random(1, 4))
-end
 
 entity.onMobFight = function(mob)
     -- Forms: 0 = Closed  1 = Closed  2 = Open 3 = Closed

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -1305,6 +1305,7 @@ INSERT INTO `mob_groups` VALUES (24,4661,34,'Ixaern_mnk',0,128,0,13000,0,83,83,0
 INSERT INTO `mob_groups` VALUES (25,3269,34,'Qnaern_rdm',0,128,0,7500,0,80,80,0);
 INSERT INTO `mob_groups` VALUES (26,4651,34,'Qnaern_whm',0,128,0,7500,0,80,80,0);
 INSERT INTO `mob_groups` VALUES (27,7057,34,'Quasilumin',0,128,0,1000,0,65,65,0);
+INSERT INTO `mob_groups` VALUES (28,7093,34,'Eoeuvhi_closed',960,0,776,0,0,74,77,0);
 
 -- ------------------------------------------------------------
 -- The_Garden_of_RuHmet (Zone 35)
@@ -1343,6 +1344,7 @@ INSERT INTO `mob_groups` VALUES (30,2130,35,'Jailer_of_Faith',0,128,1396,18000,0
 INSERT INTO `mob_groups` VALUES (31,2112,35,'Ixaern_drg',0,128,2843,21000,0,82,87,0);
 INSERT INTO `mob_groups` VALUES (32,5536,35,'Ixaern_drgs_Wynav',0,128,0,0,0,78,79,0);
 INSERT INTO `mob_groups` VALUES (33,7039,35,'Ixzdei_RDM',0,128,0,6500,0,78,78,0);
+INSERT INTO `mob_groups` VALUES (34,7092,35,'Aweuvhi_closed',960,0,199,0,0,78,82,0);
 
 -- ------------------------------------------------------------
 -- Empyreal_Paradox (Zone 36)

--- a/sql/mob_pools.sql
+++ b/sql/mob_pools.sql
@@ -7176,6 +7176,10 @@ INSERT INTO `mob_pools` VALUES (7090,'Nickel_Quadav_NM','Nickel_Quadav_NM',202,0
 -- Jugner Forest Quest NM
 INSERT INTO `mob_pools` VALUES (7091,'Skeleton_Esquire_NM','Skeleton_Esquire_NM',227,0x0000340200000000000000000000000000000000,8,8,7,240,100,0,1,0,1,2,0,0,0,131,0,0,5,0,0,227,227);
 
+-- Euvhi Default Closed Mouth
+INSERT INTO `mob_pools` VALUES (7092,'Aweuvhi_closed','Aweuvhi',109,0x00000E0200000000000000000000000000000000,1,1,11,240,100,0,0,0,1,0,0,0,0,1155,5,0,0,0,0,109,109);
+INSERT INTO `mob_pools` VALUES (7093,'Eoeuvhi_closed','Eoeuvhi',109,0x00000E0200000000000000000000000000000000,1,1,11,240,100,0,0,0,1,0,0,0,0,1155,5,0,0,0,0,109,109);
+
 -- ------------------------------------------------------------
 -- Start of Ambuscade section
 -- NOTE: The mobs are changed every update in the DATs, so using out-of-date

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1463,11 +1463,11 @@ INSERT INTO `mob_skills` VALUES (1445,1063,'damnation_dive',4,0.0,10.0,2000,1500
 INSERT INTO `mob_skills` VALUES (1446,1064,'sickle_slash',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0); -- Only used in spider form.
 INSERT INTO `mob_skills` VALUES (1447,1070,'vertical_cleave',0,0.0,7.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1448,1071,'efflorescent_foetor',4,0.0,10.0,2000,1000,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1449,1072,'stupor_spores',1,0.0,15.0,2000,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1449,1072,'stupor_spores',1,0.0,10.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1450,1067,'viscid_nectar',4,0.0,10.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1451,1073,'morning_glory',1,0.0,15.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1452,1068,'axial_bloom',1,0.0,15.0,2000,1000,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1453,1069,'nutrient_aborption',0,0.0,7.0,2000,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1453,1069,'nutrient_absorption',0,0.0,7.0,2000,1000,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1454,1198,'palsy_pollen',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1455,1199,'toxic_spit',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1456,1200,'filamented_hold',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds missing Euvhi skills: Morning Glory, Efflorescent Foetor, Nutrient Absorption, and Stupor Spores
- Audited remaining skills based off Monster Stats sheet.
- Adds mixins for Euvhi to control opening and closing their mouths, along with applying a damage boost when in open mouth
- Adjusts Euvhi to spawn with a set animation sub that they return to after leaving combat and controls aggro behavior based on form

## Steps to test these changes

- Fight an euvhi and confirm it opens and closes its mouth based off behavior in comments
