### PR TITLE
Fix clang-tidy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,9 @@ add_definitions(
 # For external libs
 set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "" FORCE)
 
+option(PCH_ENABLE "Enable precompiled headers." ON)
+message(STATUS "PCH_ENABLE: ${PCH_ENABLE}")
+
 # Tracy flags
 option(TRACY_ENABLE "Enable Tracy profiling." OFF)
 if(ENABLE_TRACY OR TRACY_ENABLED OR TRACY) # Also handle close flags

--- a/cmake/ClangTidy.cmake
+++ b/cmake/ClangTidy.cmake
@@ -7,6 +7,7 @@ message(STATUS "ENABLE_CLANG_TIDY: ${ENABLE_CLANG_TIDY}")
 message(STATUS "ENABLE_CLANG_TIDY_AUTO_FIX: ${ENABLE_CLANG_TIDY_AUTO_FIX}")
 
 if(ENABLE_CLANG_TIDY)
+  set(PCH_ENABLE OFF)
   find_program(CLANG_TIDY_COMMAND NAMES clang-tidy)
   if(NOT CLANG_TIDY_COMMAND)
     message(WARNING "CMake_RUN_CLANG_TIDY is ON but clang-tidy is not found!")

--- a/modules/era/sql/pre_rmt_drops.sql
+++ b/modules/era/sql/pre_rmt_drops.sql
@@ -1,10 +1,10 @@
 DROP PROCEDURE IF EXISTS replace_drop;
 DELIMITER $$
 CREATE PROCEDURE replace_drop(
-    IN zoneName TINYTEXT,
-    IN mobName TINYTEXT,
-    IN oldDropName TINYTEXT,
-    IN newDropName TINYTEXT
+    IN zoneName TINYTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
+    IN mobName TINYTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
+    IN oldDropName TINYTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
+    IN newDropName TINYTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci
 )
 BEGIN
     SET @zoneId = (SELECT zoneid FROM zone_settings WHERE `name` = zoneName);

--- a/src/map/CMakeLists.txt
+++ b/src/map/CMakeLists.txt
@@ -242,7 +242,7 @@ target_link_libraries(xi_map
     PUBLIC
         xi_map_lib)
 
-if(NOT ${ENABLE_CLANG_TIDY})
+if(PCH_ENABLE)
     target_precompile_headers(xi_map_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/pch.h)
 endif()
 

--- a/src/map/ai/helpers/gambits_container.cpp
+++ b/src/map/ai/helpers/gambits_container.cpp
@@ -39,6 +39,8 @@
 #include "ai/controllers/trust_controller.h"
 #include "weapon_skill.h"
 
+#include <ranges>
+
 namespace gambits
 {
     // Return a new unique identifier for a gambit

--- a/src/map/map_networking.h
+++ b/src/map/map_networking.h
@@ -31,6 +31,7 @@
 #include "map_socket.h"
 #include "map_statistics.h"
 
+#include <map>
 #include <span>
 
 struct MapConfig;

--- a/src/map/map_session_container.h
+++ b/src/map/map_session_container.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "common/ipp.h"
+#include <map>
 
 class CCharEntity;
 struct MapSession;

--- a/src/map/map_statistics.h
+++ b/src/map/map_statistics.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "common/cbasetypes.h"
+#include <unordered_map>
 
 class MapStatistics
 {

--- a/src/map/navmesh.cpp
+++ b/src/map/navmesh.cpp
@@ -28,7 +28,6 @@
 #include "common/utils.h"
 #include "common/xirand.h"
 
-#include <cfloat>
 #include <cstring>
 #include <fstream>
 #include <iostream>

--- a/src/map/navmesh.h
+++ b/src/map/navmesh.h
@@ -27,6 +27,7 @@
 #include "common/logging.h"
 #include "common/mmo.h"
 
+#include <cfloat>
 #include <memory>
 #include <vector>
 

--- a/src/map/packets/c2s/validation.h
+++ b/src/map/packets/c2s/validation.h
@@ -23,6 +23,8 @@
 
 #include "magic_enum/magic_enum.hpp"
 #include "zone.h"
+#include <format>
+#include <set>
 
 enum LSTYPE : std::uint8_t;
 class CCharEntity;

--- a/src/map/utils/mountutils.h
+++ b/src/map/utils/mountutils.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 class CCharEntity;
 
 struct MountPacketDefinition

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -41,6 +41,7 @@
 #include <algorithm>
 #include <cstring>
 #include <execution>
+#include <ranges>
 
 std::map<uint16, CZone*> g_PZoneList; // Global array of pointers for zones
 CNpcEntity*              g_PTrigger;  // trigger to start events

--- a/src/world/zone_settings.h
+++ b/src/world/zone_settings.h
@@ -26,6 +26,7 @@
 #include "common/ipp.h"
 #include "common/logging.h"
 
+#include <ranges>
 #include <set>
 #include <unordered_map>
 #include <vector>


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This should fix the clang-tidy build by moving the `cfloat` include from navmesh.cpp to navmesh.h. I also added some explicit includes in other places, and added a toggle for using precompiled headers during the build.

## Steps to test these changes

Map builds correctly with clang-tidy enabled/pch disabled.
