### PR TITLE
[lua] Confrontation: distanceLimit implementation for amk6

### DIFF
--- a/scripts/missions/amk/06_An_Errand_The_Professors_Price.lua
+++ b/scripts/missions/amk/06_An_Errand_The_Professors_Price.lua
@@ -62,11 +62,21 @@ local beginCardianFight = function(player, npc)
         table.insert(cardianIds, cardianId)
     end
 
-    local params = {}
-    params.onWin = function(wPlayer)
-        npcUtil.giveKeyItem(wPlayer, xi.keyItem.RIPE_STARFRUIT)
-        npcUtil.giveKeyItem(wPlayer, xi.keyItem.PEACH_CORAL_KEY)
-    end
+    local params = {
+        onWin = function(wPlayer)
+            local messageMob = GetMobByID(cardianIds[1])
+            if messageMob then
+                -- send individually to each confrontation member
+                wPlayer:messageText(messageMob, horutotoID.text.INITIATING_TRANSMISSION)
+            end
+
+            npcUtil.giveKeyItem(wPlayer, xi.keyItem.RIPE_STARFRUIT)
+            npcUtil.giveKeyItem(wPlayer, xi.keyItem.PEACH_CORAL_KEY)
+        end,
+
+        -- confrontation gives warning down the stairs, 35 yalms away from starting npc
+        distanceLimit = 35,
+    }
 
     -- Spawn mobs and start battle
     xi.confrontation.start(player, npc, cardianIds, params)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

`distanceLimit` works by allowing X ticks (default of 5, but configurable) of being too far from the starting NPC, then failing the confrontation.

When you go past the range, your warning message is an offset for the `CONFRONTATION_END` message, same for when you go back into range. If you stay out of range, then the confrontation is failed.

This PR adds the code with many protections since a lua error in `xi.confrontation.check` puts the whole confrontation in limbo (the check function is recursive and calls itself at the end)

It's probably worth noting that there are no current confrontation effects with `distanceLimit` defined

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- go to outer horutoto
- give yourself the starting mission: `!addmission amk AN_ERRAND_THE_PROFESSORS_PRICE`
- give yourself the starting key item: `!addkeyitem ORB_OF_BATONS`
  - can give yourself all 4 for less cardians to spawn
- run to the first pillar on the stairs to the west, and see the message that you are venturing too far
- go back in and see you get the message that you've returned
  - <img width="676" height="197" alt="image" src="https://github.com/user-attachments/assets/50aa4efa-df96-4dfb-a5ae-869fe15ff9dc" />
- go back and stay there, see you get 2 messages then the failure message with the mobs despawning (confrontation is fully failed)
  - <img width="600" height="421" alt="image" src="https://github.com/user-attachments/assets/988fd15f-cba6-4fb1-9abd-9ca8c912760a" />

Edit: bonus, see that the confrontation still completes on killing all cardians
<img width="525" height="160" alt="image" src="https://github.com/user-attachments/assets/91efc934-865f-4658-b230-57b8607a5cbe" />
