### PR TITLE
[login] Support json-based xiloader

### DIFF
--- a/cmake/FindOpenSSL.cmake
+++ b/cmake/FindOpenSSL.cmake
@@ -3,7 +3,7 @@
 # We only want to match the include directories at this time. We do not use this to link, so that is probably ok.
 
 set(OpenSSL_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/ext/openssl/include/) # Only look internally
-set(OPENSSL_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/ext/openssl/include/) # Only look internally, COTP wants this named "OPENSSL" in all caps. U
+set(OPENSSL_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/ext/openssl/include/) # Only look internally, COTP wants this named "OPENSSL" in all caps.
 
 find_package_handle_standard_args(OpenSSL DEFAULT_MSG OPENSSL_INCLUDE_DIR)
 

--- a/cmake/FindOpenSSL.cmake
+++ b/cmake/FindOpenSSL.cmake
@@ -1,0 +1,12 @@
+# this file exists to redirect Module Mode (basic) to OUR libs
+# see https://cmake.org/cmake/help/latest/command/find_package.html#search-modes
+# We only want to match the include directories at this time. We do not use this to link, so that is probably ok.
+
+set(OpenSSL_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/ext/openssl/include/) # Only look internally
+set(OPENSSL_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/ext/openssl/include/) # Only look internally, COTP wants this named "OPENSSL" in all caps. U
+
+find_package_handle_standard_args(OpenSSL DEFAULT_MSG OPENSSL_INCLUDE_DIR)
+
+message(STATUS "Using LSB FindOpenSSL.cmake over the globally provided version")
+message(STATUS "OpenSSL_FOUND: ${OpenSSL_FOUND}")
+message(STATUS "OpenSSL_INCLUDE_DIR: ${OpenSSL_INCLUDE_DIR}")

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -242,6 +242,15 @@ CPMAddPackage(
     GIT_TAG 89f20096bef51de347ec6f99345f65147359bd7c
 ) # defines: termcolor::termcolor
 
+CPMAddPackage(
+    NAME cotp
+    GITHUB_REPOSITORY paolostivanin/libcotp
+    GIT_TAG v3.1.0
+    OPTIONS
+        "HMAC_WRAPPER openssl"
+        "BUILD_SHARED_LIBS OFF"
+) # defines: cotp
+
 set(SHARED_EXTERNAL_LIBS
     fmt::fmt
     spdlog
@@ -284,6 +293,7 @@ endif()
 set(CONNECT_ONLY_EXTERNAL_LIBS
     bcrypt
     nlohmann_json::nlohmann_json
+    cotp
 )
 
 set(MAP_ONLY_EXTERNAL_LIBS

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -283,6 +283,7 @@ endif()
 
 set(CONNECT_ONLY_EXTERNAL_LIBS
     bcrypt
+    nlohmann_json::nlohmann_json
 )
 
 set(MAP_ONLY_EXTERNAL_LIBS

--- a/sql/accounts_totp.sql
+++ b/sql/accounts_totp.sql
@@ -1,0 +1,15 @@
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+
+SET FOREIGN_KEY_CHECKS=0;
+
+DROP TABLE IF EXISTS `accounts_totp`;
+CREATE TABLE `accounts_totp` (
+  `accid` int unsigned NOT NULL,
+  `secret` varchar(32) NOT NULL,
+  `recovery_code` varchar(32) NOT NULL,
+  `validated` boolean NOT NULL,
+  PRIMARY KEY (`accid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/src/login/CMakeLists.txt
+++ b/src/login/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SOURCES
     login_helpers.h
     login_helpers.cpp
     login_packets.h
+    otp_helpers.h
     session.h
     view_session.h
     view_session.cpp

--- a/src/login/auth_session.cpp
+++ b/src/login/auth_session.cpp
@@ -139,6 +139,10 @@ void auth_session::read_func()
 
             do_write(1);
         }
+
+        // close socket
+        socket_.lowest_layer().shutdown(asio::socket_base::shutdown_both);
+        socket_.lowest_layer().close();
         return;
     }
 

--- a/src/login/auth_session.h
+++ b/src/login/auth_session.h
@@ -64,13 +64,7 @@ enum class login_result : uint8_t
     LOGIN_SUCCESS_REMOVE_TOTP       = 0x12,
 };
 
-// Only the first 3 characters of the version string are matched
-// ie. 1.1.1 -> 1.1.x
-// Major.Minor.Patch
-// Major and minor version changes should be breaking, patch should not.
-#define SUPPORTED_XILOADER_VERSION "1.1.x"
-
-constexpr std::array<uint8, 3> SupportedJsonXiloaderVersion = { 2, 0, 0 };
+constexpr std::array<uint8, 3> SupportedXiloaderVersion = { 2, 0, 0 };
 
 // NOTE: This collection of flags is 64-bits wide!
 enum AUTH_COMPONENTS

--- a/src/login/auth_session.h
+++ b/src/login/auth_session.h
@@ -30,32 +30,47 @@
 
 #include "common/zmq_dealer_wrapper.h"
 
-// TODO: Move to enum
-#define LOGIN_ATTEMPT         0x10
-#define LOGIN_CREATE          0x20
-#define LOGIN_CHANGE_PASSWORD 0x30
+enum class login_cmd : uint8_t
+{
+    LOGIN_NOOP            = 0x00,
+    LOGIN_ATTEMPT         = 0x10,
+    LOGIN_CREATE          = 0x20,
+    LOGIN_CHANGE_PASSWORD = 0x30,
+
+    // json xiloader
+    LOGIN_CREATE_TOTP         = 0x31,
+    LOGIN_REMOVE_TOTP         = 0x32,
+    LOGIN_REGENERATE_RECOVERY = 0x33,
+    LOGIN_VERIFY_TOTP         = 0x34,
+};
 
 /*return result*/
-#define LOGIN_FAIL                    0x00
-#define LOGIN_SUCCESS                 0x01
-#define LOGIN_SUCCESS_CREATE          0x03
-#define LOGIN_SUCCESS_CHANGE_PASSWORD 0x06
-
-#define LOGIN_REQUEST_NEW_PASSWORD 0x05
-
-#define LOGIN_ERROR                     0x02
-#define LOGIN_ERROR_CREATE              0x09
-#define LOGIN_ERROR_CREATE_TAKEN        0x04
-#define LOGIN_ERROR_CREATE_DISABLED     0x08
-#define LOGIN_ERROR_CHANGE_PASSWORD     0x07
-#define LOGIN_ERROR_ALREADY_LOGGED_IN   0x0A
-#define LOGIN_ERROR_VERSION_UNSUPPORTED 0x0B
+enum class login_result : uint8_t
+{
+    LOGIN_FAIL                      = 0x00,
+    LOGIN_SUCCESS                   = 0x01,
+    LOGIN_ERROR                     = 0x02,
+    LOGIN_SUCCESS_CREATE            = 0x03,
+    LOGIN_ERROR_CREATE_TAKEN        = 0x04,
+    LOGIN_REQUEST_NEW_PASSWORD      = 0x05, // is this used?
+    LOGIN_SUCCESS_CHANGE_PASSWORD   = 0x06,
+    LOGIN_ERROR_CHANGE_PASSWORD     = 0x07,
+    LOGIN_ERROR_CREATE_DISABLED     = 0x08,
+    LOGIN_ERROR_CREATE              = 0x09,
+    LOGIN_ERROR_ALREADY_LOGGED_IN   = 0x0A,
+    LOGIN_ERROR_VERSION_UNSUPPORTED = 0x0B,
+    LOGIN_SUCCESS_CREATE_TOTP       = 0x10,
+    LOGIN_SUCCESS_VERIFY_TOTP       = 0x11,
+    LOGIN_SUCCESS_REMOVE_TOTP       = 0x12,
+};
 
 // Only the first 3 characters of the version string are matched
 // ie. 1.1.1 -> 1.1.x
 // Major.Minor.Patch
 // Major and minor version changes should be breaking, patch should not.
 #define SUPPORTED_XILOADER_VERSION "1.1.x"
+
+constexpr std::array<uint8, 3> SupportedJsonXiloaderVersion = { 2, 0, 0 };
 
 // NOTE: This collection of flags is 64-bits wide!
 enum AUTH_COMPONENTS
@@ -126,4 +141,6 @@ protected:
 
 private:
     ZMQDealerWrapper& zmqDealerWrapper_;
+
+    bool validatePassword(std::string username, std::string password);
 };

--- a/src/login/handler_session.cpp
+++ b/src/login/handler_session.cpp
@@ -57,6 +57,8 @@ void handler_session::start()
 
 void handler_session::do_read()
 {
+    std::memset(buffer_.data(), 0, buffer_.size());
+
     // clang-format off
     socket_.next_layer().async_read_some(asio::buffer(buffer_.data(), buffer_.size()),
     [this, self = shared_from_this()](std::error_code ec, std::size_t length)

--- a/src/login/login_helpers.cpp
+++ b/src/login/login_helpers.cpp
@@ -296,7 +296,7 @@ namespace loginHelpers
             return -1;
         }
 
-        ShowDebug(fmt::format("char<{}> successfully saved", charName));
+        ShowDebug(fmt::format("char <{}> successfully saved", charName));
         return 0;
     }
 
@@ -308,5 +308,16 @@ namespace loginHelpers
             return "";
         }
         return hash;
+    }
+
+    uint32 getAccountId(std::string accountName)
+    {
+        const auto rset = db::preparedStmt("SELECT id FROM accounts WHERE accounts.login = ? LIMIT 1", accountName);
+        if (rset && rset->next())
+        {
+            return rset->get<uint32>("id");
+        }
+
+        return 0;
     }
 } // namespace loginHelpers

--- a/src/login/login_helpers.h
+++ b/src/login/login_helpers.h
@@ -117,7 +117,22 @@ namespace loginHelpers
             return std::nullopt;
         }
 
-        if constexpr (std::is_floating_point<T>::value)
+        // Check types first, boolean can match a number
+        if constexpr (std::is_same_v<T, std::string>)
+        {
+            if (!jsonInput[key].is_string())
+            {
+                return std::nullopt;
+            }
+        }
+        else if constexpr (std::is_same_v<T, bool>)
+        {
+            if (!jsonInput[key].is_boolean())
+            {
+                return std::nullopt;
+            }
+        }
+        else if constexpr (std::is_floating_point<T>::value)
         {
             if (!jsonInput[key].is_number_float())
             {
@@ -134,20 +149,6 @@ namespace loginHelpers
         else if constexpr (std::is_unsigned<T>::value)
         {
             if (!jsonInput[key].is_number_unsigned())
-            {
-                return std::nullopt;
-            }
-        }
-        else if constexpr (std::is_same_v<T, std::string>)
-        {
-            if (!jsonInput[key].is_string())
-            {
-                return std::nullopt;
-            }
-        }
-        else if constexpr (std::is_same_v<T, bool>)
-        {
-            if (!jsonInput[key].is_boolean())
             {
                 return std::nullopt;
             }

--- a/src/login/otp_helpers.h
+++ b/src/login/otp_helpers.h
@@ -1,0 +1,206 @@
+﻿/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+#pragma once
+
+#include "common/xirand.h"
+#include "login_helpers.h"
+
+// This ugly nonsense is because winerror.h defines NO_ERROR and an enum definition inside cotp uses NO_ERROR,
+// if NO_ERROR is defined as 0 (from winerror.h) then the compiler thinks you're trying to define `0` as an enum, which you can't.
+#ifdef NO_ERROR
+
+#define TEMP_DEFINITION_HACK NO_ERROR
+#undef NO_ERROR
+#include "cotp.h"
+#define NO_ERROR TEMP_DEFINITION_HACK
+#undef TEMP_DEFINITION_HACK
+
+#else
+
+#include "cotp.h"
+
+#endif
+
+namespace otpHelpers
+{
+    // Base32 used for OTP standard. Doesn't use repeat alike characters such as both O and 0, and opts to use letters over similar numbers.
+    static const char BASE32_CHARS[32] = {
+        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',
+        'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
+        'U', 'V', 'W', 'X', 'Y', 'Z', '2', '3', '4', '5',
+        '6', '7'
+    };
+
+    inline uint64_t getCurrentTime()
+    {
+        auto now = std::chrono::system_clock::now();
+        auto dur = now.time_since_epoch();
+
+        return std::chrono::duration_cast<std::chrono::seconds>(dur).count();
+    }
+
+    inline bool validateTOTP(const std::string& totpCode, const std::string& secret)
+    {
+        bool         valid   = false;
+        cotp_error_t cotpErr = {};
+
+        auto res = get_totp_at(secret.c_str(), getCurrentTime(), 6, 30, SHA1, &cotpErr);
+
+        // TODO: do we care about errors?
+        if (res)
+        {
+            if (strcmpi(totpCode.c_str(), res) == 0) // Need to use c_str for null terminator
+            {
+                valid = true;
+            }
+            destroy(res); // per docs, this string needs to be freed upon non-null return
+        }
+
+        return valid;
+    }
+
+    inline std::string getNewBase32Secret()
+    {
+        constexpr size_t base32Len = 32; // must be % 8 == 0
+
+        char newSecret[base32Len + 1] = {};
+
+        for (size_t i = 0; i < base32Len; i++)
+        {
+            newSecret[i] = BASE32_CHARS[xirand::GetRandomNumber<uint64_t>(0, std::numeric_limits<uint64_t>::max()) % 32];
+        }
+
+        return newSecret;
+    }
+
+    inline bool doesAccountNeedOTP(const std::string& account, const std::string& secretType)
+    {
+        if (secretType == "TOTP")
+        {
+            const auto accid = loginHelpers::getAccountId(account);
+            if (accid != 0)
+            {
+                const auto rset = db::preparedStmt("SELECT validated FROM accounts_totp where accid = ?", accid);
+                if (!rset)
+                {
+                    return false;
+                }
+
+                bool hasExistingOTP = false;
+
+                if (rset->rowsCount() != 0 && rset->next())
+                {
+                    hasExistingOTP = rset->get<bool>("validated");
+                }
+
+                return hasExistingOTP;
+            }
+        }
+        return false;
+    }
+
+    inline std::string createAccountSecret(const std::string& account, const std::string& secretType)
+    {
+        if (secretType == "TOTP")
+        {
+            const auto hasExistingOTP = otpHelpers::doesAccountNeedOTP(account, "TOTP");
+
+            if (!hasExistingOTP)
+            {
+                uint32 accid = loginHelpers::getAccountId(account);
+                if (accid == 0)
+                {
+                    return "";
+                }
+
+                const auto newSecret       = getNewBase32Secret();
+                const auto newRecoveryCode = getNewBase32Secret();
+
+                const auto rset = db::preparedStmt("INSERT INTO accounts_totp(accid, secret, recovery_code, validated) VALUES(?, ?, ?, 0) ON DUPLICATE KEY UPDATE secret = values(secret), recovery_code = values(recovery_code)", accid, newSecret, newRecoveryCode);
+                if (rset)
+                {
+                    return newSecret;
+                }
+            }
+        }
+        return "";
+    }
+
+    inline std::string regenerateAccountRecoveryCode(const std::string& account, const std::string& secretType)
+    {
+        if (secretType == "TOTP")
+        {
+            const auto hasExistingOTP = otpHelpers::doesAccountNeedOTP(account, "TOTP");
+
+            if (hasExistingOTP)
+            {
+                uint32 accid = loginHelpers::getAccountId(account);
+                if (accid == 0)
+                {
+                    return "";
+                }
+
+                std::string newRecoveryCode = getNewBase32Secret();
+                const auto  rset            = db::preparedStmt("UPDATE accounts_totp SET accounts_totp.recovery_code = ? WHERE accounts_totp.accid = ?", newRecoveryCode, accid);
+                if (rset)
+                {
+                    return newRecoveryCode;
+                }
+            }
+        }
+        return "";
+    }
+
+    inline std::string getAccountSecret(const std::string& account, const std::string& secretType)
+    {
+        if (secretType == "TOTP")
+        {
+            const auto accid = loginHelpers::getAccountId(account);
+            if (accid != 0)
+            {
+                const auto rset = db::preparedStmt("SELECT secret FROM accounts_totp where accid = ? LIMIT 1", accid);
+                if (rset && rset->next())
+                {
+                    return rset->get<std::string>("secret");
+                }
+            }
+        }
+        return "";
+    }
+
+    inline std::string getAccountRecoveryCode(const std::string& account, const std::string& secretType)
+    {
+        if (secretType == "TOTP")
+        {
+            const auto accid = loginHelpers::getAccountId(account);
+            if (accid != 0)
+            {
+                const auto rset = db::preparedStmt("SELECT recovery_code FROM accounts_totp where accid = ? LIMIT 1", accid);
+                if (rset && rset->next())
+                {
+                    return rset->get<std::string>("recovery_code");
+                }
+            }
+        }
+        return "";
+    }
+
+} // namespace otpHelpers

--- a/src/search/search_handler.cpp
+++ b/src/search/search_handler.cpp
@@ -87,6 +87,8 @@ void search_handler::start()
 
 void search_handler::do_read()
 {
+    std::memset(buffer_.data(), 0, buffer_.size());
+
     // clang-format off
     socket_.async_read_some(asio::buffer(buffer_.data(), buffer_.size()),
     [this, self = shared_from_this()](std::error_code ec, std::size_t length)
@@ -114,6 +116,7 @@ void search_handler::do_write()
     auto packet = searchPackets.front();
     auto length = packet.getSize();
 
+    std::memset(buffer_.data(), 0, buffer_.size());
     std::memcpy(buffer_.data(), packet.getData(), packet.getSize());
 
     searchPackets.pop_front();

--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -188,6 +188,7 @@ settings, default_settings = populate_settings()
 player_data = [
     "accounts.sql",
     "accounts_banned.sql",
+    "accounts_totp.sql",
     "auction_house_items.sql",
     "auction_house.sql",
     "audit_bazaar.sql",


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Support json-based xiloader
add TOTP for json-based xiloader
This is a breaking change

Requires https://github.com/LandSandBoat/xiloader/pull/39

## Steps to test these changes

use all features of new json xiloader