### PR TITLE
[cpp] Fix logic for mobs to cast buffs on other mobs

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -562,8 +562,9 @@ void CMobController::CastSpell(SpellID spellid)
                         // randomly select a target
                         PCastTarget = PMob->PAI->TargetFind->m_targets[xirand::GetRandomNumber(PMob->PAI->TargetFind->m_targets.size())];
 
-                        // only target if are on same action
-                        if (PMob->PAI->IsEngaged() == PCastTarget->PAI->IsEngaged())
+                        // revert target to self if not on same action
+                        // TODO can engaged mobs buff idle mobs?
+                        if (PMob->PAI->IsEngaged() != PCastTarget->PAI->IsEngaged())
                         {
                             PCastTarget = PMob;
                         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Was testing some improvements to mob buff casting (to avoid spamming blaze spikes every 30s, etc) and found that I never saw mobs cast buffs on other mobs. Turns out the logic was inverted and mobs would only cast a buff on another mob if one was roaming and one was engaged

TL;DR of this section of code: `CastSpell` is called, and this section is choosing a target of the spell. If the spell can target its party, there's a 50% chance to randomly choose a party member in range, then finally it chooses the mob and this erroneous logic was resetting target back to self if they were either both roaming or both engaged :(

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Literally just stand there and watch mobs buff eachother, good spot is here in davoi: `!pos 42 3 -212 149`
<img width="771" height="458" alt="image" src="https://github.com/user-attachments/assets/d442fb2a-a596-4d08-8d07-6dbc5c3e631e" />
