### PR TITLE
[lua] Protect formMagicBurst from crashes

### DIFF
--- a/scripts/globals/magicburst.lua
+++ b/scripts/globals/magicburst.lua
@@ -23,6 +23,10 @@ local matches = -- [element id][resonance id]
 
 -- Returns a boolean if the spell's element matches the resonance given
 local function doesSpellElementMatchResonance(ele, resonance)
+    if ele == nil or utils.clamp(ele, 0, 12) ~= ele then
+        return false
+    end
+
     local isMatch = matches[ele + 1][resonance:getPower() + 1]
     return (isMatch ~= nil and isMatch > 0)
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adds an element sanity check to the "doesSpellElementMatchResonance" function in magicburst.lua. Whenever a player casts, say, the blue mage spell Head Butt, that spell's damage type param (xi.damageType.BLUNT == 3) is passed into xi.spells.blue.applyBlueAdditionalEffect, and converted to an element: `local element = params.damageType and params.damageType - 5 or 0`. You can see that element is negative 2. Then that is passed into the magic burst function if we're in the MB window, which errors out early when we try to index a nil value. This PR simply returns early if the element is less than 0 or greater than 12.

The "real" issue is `local element = params.damageType and params.damageType - 5 or 0`, since I'm not sure what the intention of that -5 is; if it were +5, then the element would be dark, which isn't right either. If it were +6, then it would correspond with "BLU - Physical Blunt" in the "matches" table in magicburst.lua... but all the numbers are 0 anyway, so the input sanitation step in this PR has the same effect.

## Steps to test these changes
* Cast Head Butt or Disseverment during a skillchain magic burst window, see that no errors appear in the log.
