### PR TITLE
Allow mob families that do not link natively to link with sublink groups

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -227,6 +227,14 @@ void CMobController::TryLink()
                 continue;
             }
 
+            // Handle the case where a mob doesn't link with its own family but has a sublink
+            // This is needed because the sublink will cause like family members to be in the same
+            // party so that they are linked with sublinked families.
+            if (!PMob->ShouldForceLink() && !PMob->m_Link && PMob->m_Family == PPartyMember->m_Family)
+            {
+                continue;
+            }
+
             if (PPartyMember->PAI->IsRoaming() && PPartyMember->CanLink(&PMob->loc.p, PMob->getMobMod(MOBMOD_SUPERLINK)))
             {
                 PPartyMember->PAI->Engage(PTarget->targid);

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -390,6 +390,29 @@ bool CMobEntity::CanLink(position_t* pos, int16 superLink)
     return true;
 }
 
+bool CMobEntity::ShouldForceLink()
+{
+    // There are certain cases where mobs should always be able
+    // to link with other mobs, even if their families or sublinks
+    // do not align
+    if (loc.zone->GetTypeMask() & ZONE_TYPE::DYNAMIS)
+    {
+        return true;
+    }
+
+    if (m_Type & MOBTYPE_BATTLEFIELD)
+    {
+        return true;
+    }
+
+    if (getMobMod(MOBMOD_SUPERLINK))
+    {
+        return true;
+    }
+
+    return false;
+}
+
 bool CMobEntity::CanDeaggro() const
 {
     return !(m_Type & MOBTYPE_NOTORIOUS || m_Type & MOBTYPE_BATTLEFIELD);

--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -134,6 +134,7 @@ public:
     void              TapDeaggroTime(); // call CMobController->TapDeaggroTime if PAI->GetController() is a CMobController, otherwise do nothing.
 
     bool CanLink(position_t* pos, int16 superLink = 0);
+    bool ShouldForceLink();
 
     bool CanDropGil();    // mob has gil to drop
     bool CanStealGil();   // can steal gil from mob

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -350,23 +350,23 @@ void CZoneEntities::FindPartyForMob(CBaseEntity* PEntity)
 
     CMobEntity* PMob = static_cast<CMobEntity*>(PEntity);
 
-    // force all mobs in a burning circle to link
-    ZONE_TYPE zonetype  = m_zone->GetTypeMask();
-    bool      forceLink = zonetype & ZONE_TYPE::DYNAMIS || PMob->getMobMod(MOBMOD_SUPERLINK);
-
-    if ((forceLink || PMob->m_Link || PMob->m_Type & MOBTYPE_BATTLEFIELD) && PMob->PParty == nullptr)
+    bool forceLink = PMob->ShouldForceLink();
+    // check for sublinks even if a family doesn't link with itself
+    int16 sublink = PMob->getMobMod(MOBMOD_SUBLINK);
+    if ((forceLink || PMob->m_Link || sublink) && PMob->PParty == nullptr)
     {
         FOR_EACH_PAIR_CAST_SECOND(CMobEntity*, PCurrentMob, m_mobList)
         {
-            if (!forceLink && !PCurrentMob->m_Link)
+            if (!forceLink && !sublink && !PCurrentMob->m_Link)
             {
                 continue;
             }
 
-            int16 sublink = PMob->getMobMod(MOBMOD_SUBLINK);
-
-            if (PCurrentMob->PParty && PCurrentMob->allegiance == PMob->allegiance &&
-                (forceLink || PCurrentMob->m_Family == PMob->m_Family || (sublink && sublink == PCurrentMob->getMobMod(MOBMOD_SUBLINK))))
+            if (
+                PCurrentMob->PParty && PCurrentMob->allegiance == PMob->allegiance &&
+                ((forceLink && PCurrentMob->ShouldForceLink()) ||
+                 (PCurrentMob->m_Link && PCurrentMob->m_Family == PMob->m_Family) ||
+                 (sublink && sublink == PCurrentMob->getMobMod(MOBMOD_SUBLINK))))
             {
                 if (PCurrentMob->PMaster == nullptr || PCurrentMob->PMaster->objtype == TYPE_MOB)
                 {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
There are some mob families where the mobs do not link with each other, but they link with mobs of _other_ families. The case where this occurred specifically and my testing was Treants linking with saplings.

The changes in this PR allows Saplings to link with Treants, but not Treants with other Treants.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

1. Run out to any place with treants (Bhaflau Thickets) and aggro a treant. Observe that it links with the nearby sapling.
2. Kill the sapling and drag the treant through another nearby treant (careful not to aggro that treant by hearing) and observe that it does _not_ link the other treant. 
