### PR TITLE
[lua] Create helper for mobs to call one or more pets

### DIFF
--- a/scripts/enum/mob_skills.lua
+++ b/scripts/enum/mob_skills.lua
@@ -76,6 +76,8 @@ xi.mobSkill =
     MEIKYO_SHISUI_1          =  730, -- Tenzen, etc...
     MIJIN_GAKURE_1           =  731, -- Season's Greetings KSNM 30 (Ulagohvsdi Tlugvi)
 
+    CALL_WYVERN              =  732,
+
     FAMILIAR_1               =  740, -- "Tango with a Tracker" Shikaree X
 
     DISPELLING_WIND          =  813,

--- a/scripts/zones/Carpenters_Landing/mobs/Cryptonberry_Executor.lua
+++ b/scripts/zones/Carpenters_Landing/mobs/Cryptonberry_Executor.lua
@@ -37,15 +37,8 @@ entity.onMobFight = function(mob, target)
         mob:getLocalVar('spawnedAssassins') == 0 and
         mob:getCE(target) > 0
     then
-        mob:setLocalVar('spawnedAssassins', 1)
-
-        -- inject packet for 2hr animation when spawning
-        mob:injectActionPacket(mob:getID(), 11, 439, 0, 0x18, 0, 0, 307)
-        for _, assassinID in ipairs(assassins) do
-            local assassin = SpawnMob(assassinID)
-            if assassin then
-                assassin:updateEnmity(target)
-            end
+        if xi.mob.callPets(mob, assassins, { inactiveTime = 0 }) then
+            mob:setLocalVar('spawnedAssassins', 1)
         end
     end
 
@@ -55,7 +48,7 @@ entity.onMobFight = function(mob, target)
         mob:getLocalVar('assassinsKilled') > 0 and
         mob:getLocalVar('usedTwoHour') == 0
     then
-    -- have executor use 2hr and unlock the 2hrs of other assassins
+        -- have executor use 2hr and unlock the 2hrs of other assassins
         mob:setLocalVar('usedTwoHour', 1)
         mob:messageText(mob, ID.text.CRYPTONBERRY_EXECUTOR_2HR)
         -- Use Mijin Gakure


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Creates a new function in `xi.mob` to call one or more pets with the option to have a summon animation.
- the pets that get summoned get a permanent listener that makes them assist the owner that summoned them on roam ticks
- the function will return true if pets get summoned
- note that `mob:stun(x)` is NOT a stun, but a forced inactive state (i.e. it works even if mobs have stun immunity)
  - also note that this `callPets` function will early-return false if the mob is busy
- Ark Angel MR is a bst that can have multiple types of bst pets, but uses the same `SUMMONER_START/STOP` animation packets
  - This is reflected by ignoring `callPetJob` if `inactiveTime > 0`
  - I might be wrong, but i think any mob that has this behavior doesn't take any actions during the animation and cannot be stunned
- if inactiveTime is 0, then the animation can be an injected mobskill action packet.
  - I've scanned the repo and found a few examples that seems to fit the paradigm in the function.
    - if you need a particular animation packet, the mob's lua can still inject any action packet based on if `xi.mob.callPets(..., { noAnimation = true })` is true
    - also i've added optional params to adjust partcular action packet parameters away from the defaults determined by the function
- This new function got a little out of hand, but I believe it will fit _most_ use cases and net much more readable/retail-accurate code within mob lua files (not to mention less chance for error)

I've cleaned up two mobs, but if we like this function I can do more either in this PR or a separate one

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- Bomb Queen
  - go to ifrit's cauldron
  - `!gotoname Bomb_Queen`
  - spawn via the mob id shown: `!spawnmob X`
  - speed the process along by resetting her spawn timer: `!setlocalvar spawn_time 0`
  - note that her pets use self destruct immediately. I'm not sure what that's about but it doesn't appear to be due to the way they're being spawned. 
  - `!hp 0` bomb queen and see that her pets die immediately
- Cryptonberry Executor
  - go to carpenter's landing
  - spawn the mob the same way
  - note that the pets don't spawn until you have non-zero enmity, so take an action then watch the same behavior as before

https://imgur.com/a/UFFgLLo