### PR TITLE
[lua] Use centralized helpers for all spawn pet actions

### DIFF
--- a/scripts/actions/mobskills/activate.lua
+++ b/scripts/actions/mobskills/activate.lua
@@ -6,16 +6,11 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:hasPet() or mob:getPet() == nil then
-        return 1
-    end
-
-    return 0
+    return xi.pet.onMobSkillCheck(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    mob:spawnPet()
-    skill:setMsg(xi.msg.basic.NONE)
+    xi.pet.spawnPet(mob, nil, skill)
 
     return 0
 end

--- a/scripts/actions/mobskills/call_beast.lua
+++ b/scripts/actions/mobskills/call_beast.lua
@@ -6,30 +6,11 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:hasPet() or mob:getPet() == nil then
-        return 1
-    end
-
-    return 0
-end
-
-local onMasterDeath = function(mob)
-    if mob:hasPet() then
-        local pet = mob:getPet()
-        if pet ~= nil then
-            if not pet:isEngaged() then
-                DespawnMob(pet:getID(), 2)
-            end
-        end
-    end
+    return xi.pet.onMobSkillCheck(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    mob:spawnPet()
-
-    skill:setMsg(xi.msg.basic.NONE)
-    mob:addListener('DEATH', 'BEASTMASTER_DEATH', onMasterDeath)
-    mob:addListener('DESPAWN', 'BEASTMASTER_DESPAWN', onMasterDeath)
+    xi.pet.spawnPet(mob, nil, skill)
 
     return 0
 end

--- a/scripts/actions/mobskills/call_wyvern.lua
+++ b/scripts/actions/mobskills/call_wyvern.lua
@@ -6,17 +6,11 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:hasPet() or mob:getPet() == nil then
-        return 1
-    end
-
-    return 0
+    return xi.pet.onMobSkillCheck(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    mob:spawnPet()
-
-    skill:setMsg(xi.msg.basic.NONE)
+    xi.pet.spawnPet(mob, nil, skill)
 
     return 0
 end

--- a/scripts/actions/spells/summoning/air_spirit.lua
+++ b/scripts/actions/spells/summoning/air_spirit.lua
@@ -6,20 +6,12 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    local result = 0
-    if caster:hasPet() then
-        result = xi.msg.basic.ALREADY_HAS_A_PET
-    elseif not caster:canUseMisc(xi.zoneMisc.PET) then
-        result = xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif caster:getObjType() == xi.objType.PC then
-        result = xi.summon.avatarMiniFightCheck(caster)
-    end
-
-    return result
+    return xi.pet.onCastingCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    xi.pet.spawnPet(caster, xi.petId.AIR_SPIRIT)
+    xi.pet.spawnPet(caster, xi.petId.AIR_SPIRIT, spell)
+
     return 0
 end
 

--- a/scripts/actions/spells/summoning/alexander.lua
+++ b/scripts/actions/spells/summoning/alexander.lua
@@ -6,29 +6,11 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    if not caster:canUseMisc(xi.zoneMisc.PET) then
-        return xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif not caster:hasStatusEffect(xi.effect.ASTRAL_FLOW) then
-        return xi.msg.basic.MAGIC_MUST_ASTRAL_FLOW
-    elseif caster:hasPet() then
-        return xi.msg.basic.ALREADY_HAS_A_PET
-    elseif caster:getObjType() == xi.objType.PC then
-        return xi.summon.avatarMiniFightCheck(caster)
-    end
-
-    return 0
+    return xi.pet.onCastingCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    caster:spawnPet(xi.petId.ALEXANDER)
-    local pet = caster:getPet()
-
-    -- Use Perfect Defense 5 seconds after spawning.
-    if pet then
-        pet:timer(5000, function()
-            pet:usePetAbility(xi.jobAbility.PERFECT_DEFENSE, pet)
-        end)
-    end
+    xi.pet.spawnPet(caster, xi.petId.ALEXANDER, spell)
 
     return 0
 end

--- a/scripts/actions/spells/summoning/cait_sith.lua
+++ b/scripts/actions/spells/summoning/cait_sith.lua
@@ -6,26 +6,11 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    if not caster:canUseMisc(xi.zoneMisc.PET) then
-        return xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif caster:hasPet() then
-        return xi.msg.basic.ALREADY_HAS_A_PET
-    elseif caster:getObjType() == xi.objType.PC then
-        return xi.summon.avatarMiniFightCheck(caster)
-    end
-
-    return 0
+    return xi.pet.onCastingCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    xi.pet.spawnPet(caster, xi.petId.CAIT_SITH)
-
-    local effect = caster:getStatusEffect(xi.effect.AVATARS_FAVOR)
-    if effect then
-        effect:setPower(1) -- resummon resets effect
-        xi.avatarsFavor.applyAvatarsFavorAuraToPet(caster, effect)
-        xi.avatarsFavor.applyAvatarsFavorDebuffsToPet(caster)
-    end
+    xi.pet.spawnPet(caster, xi.petId.CAIT_SITH, spell)
 
     return 0
 end

--- a/scripts/actions/spells/summoning/carbuncle.lua
+++ b/scripts/actions/spells/summoning/carbuncle.lua
@@ -6,24 +6,11 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    if not caster:canUseMisc(xi.zoneMisc.PET) then
-        return xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif caster:hasPet() then
-        return xi.msg.basic.ALREADY_HAS_A_PET
-    else
-        return 0
-    end
+    return xi.pet.onCastingCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    xi.pet.spawnPet(caster, xi.petId.CARBUNCLE)
-
-    local effect = caster:getStatusEffect(xi.effect.AVATARS_FAVOR)
-    if effect then
-        effect:setPower(1) -- resummon resets effect
-        xi.avatarsFavor.applyAvatarsFavorAuraToPet(caster, effect)
-        xi.avatarsFavor.applyAvatarsFavorDebuffsToPet(caster)
-    end
+    xi.pet.spawnPet(caster, xi.petId.CARBUNCLE, spell)
 
     return 0
 end

--- a/scripts/actions/spells/summoning/dark_spirit.lua
+++ b/scripts/actions/spells/summoning/dark_spirit.lua
@@ -6,20 +6,12 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    local result = 0
-    if caster:hasPet() then
-        result = xi.msg.basic.ALREADY_HAS_A_PET
-    elseif not caster:canUseMisc(xi.zoneMisc.PET) then
-        result = xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif caster:getObjType() == xi.objType.PC then
-        result = xi.summon.avatarMiniFightCheck(caster)
-    end
-
-    return result
+    return xi.pet.onCastingCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    xi.pet.spawnPet(caster, xi.petId.DARK_SPIRIT)
+    xi.pet.spawnPet(caster, xi.petId.DARK_SPIRIT, spell)
+
     return 0
 end
 

--- a/scripts/actions/spells/summoning/diabolos.lua
+++ b/scripts/actions/spells/summoning/diabolos.lua
@@ -6,26 +6,11 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    if not caster:canUseMisc(xi.zoneMisc.PET) then
-        return xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif caster:hasPet() then
-        return xi.msg.basic.ALREADY_HAS_A_PET
-    elseif caster:getObjType() == xi.objType.PC then
-        return xi.summon.avatarMiniFightCheck(caster)
-    end
-
-    return 0
+    return xi.pet.onCastingCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    xi.pet.spawnPet(caster, xi.petId.DIABOLOS)
-
-    local effect = caster:getStatusEffect(xi.effect.AVATARS_FAVOR)
-    if effect then
-        effect:setPower(1) -- resummon resets effect
-        xi.avatarsFavor.applyAvatarsFavorAuraToPet(caster, effect)
-        xi.avatarsFavor.applyAvatarsFavorDebuffsToPet(caster)
-    end
+    xi.pet.spawnPet(caster, xi.petId.DIABOLOS, spell)
 
     return 0
 end

--- a/scripts/actions/spells/summoning/earth_spirit.lua
+++ b/scripts/actions/spells/summoning/earth_spirit.lua
@@ -6,20 +6,12 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    local result = 0
-    if caster:hasPet() then
-        result = xi.msg.basic.ALREADY_HAS_A_PET
-    elseif not caster:canUseMisc(xi.zoneMisc.PET) then
-        result = xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif caster:getObjType() == xi.objType.PC then
-        result = xi.summon.avatarMiniFightCheck(caster)
-    end
-
-    return result
+    return xi.pet.onCastingCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    xi.pet.spawnPet(caster, xi.petId.EARTH_SPIRIT)
+    xi.pet.spawnPet(caster, xi.petId.EARTH_SPIRIT, spell)
+
     return 0
 end
 

--- a/scripts/actions/spells/summoning/fenrir.lua
+++ b/scripts/actions/spells/summoning/fenrir.lua
@@ -6,26 +6,11 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    if not caster:canUseMisc(xi.zoneMisc.PET) then
-        return xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif caster:hasPet() then
-        return xi.msg.basic.ALREADY_HAS_A_PET
-    elseif caster:getObjType() == xi.objType.PC then
-        return xi.summon.avatarMiniFightCheck(caster)
-    end
-
-    return 0
+    return xi.pet.onCastingCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    caster:spawnPet(xi.petId.FENRIR)
-
-    local effect = caster:getStatusEffect(xi.effect.AVATARS_FAVOR)
-    if effect then
-        effect:setPower(1) -- resummon resets effect
-        xi.avatarsFavor.applyAvatarsFavorAuraToPet(caster, effect)
-        xi.avatarsFavor.applyAvatarsFavorDebuffsToPet(caster)
-    end
+    xi.pet.spawnPet(caster, xi.petId.FENRIR, spell)
 
     return 0
 end

--- a/scripts/actions/spells/summoning/fire_spirit.lua
+++ b/scripts/actions/spells/summoning/fire_spirit.lua
@@ -6,20 +6,12 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    local result = 0
-    if caster:hasPet() then
-        result = xi.msg.basic.ALREADY_HAS_A_PET
-    elseif not caster:canUseMisc(xi.zoneMisc.PET) then
-        result = xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif caster:getObjType() == xi.objType.PC then
-        result = xi.summon.avatarMiniFightCheck(caster)
-    end
-
-    return result
+    return xi.pet.onCastingCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    xi.pet.spawnPet(caster, xi.petId.FIRE_SPIRIT)
+    xi.pet.spawnPet(caster, xi.petId.FIRE_SPIRIT, spell)
+
     return 0
 end
 

--- a/scripts/actions/spells/summoning/garuda.lua
+++ b/scripts/actions/spells/summoning/garuda.lua
@@ -6,26 +6,11 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    if not caster:canUseMisc(xi.zoneMisc.PET) then
-        return xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif caster:hasPet() then
-        return xi.msg.basic.ALREADY_HAS_A_PET
-    elseif caster:getObjType() == xi.objType.PC then
-        return xi.summon.avatarMiniFightCheck(caster)
-    end
-
-    return 0
+    return xi.pet.onCastingCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    xi.pet.spawnPet(caster, xi.petId.GARUDA)
-
-    local effect = caster:getStatusEffect(xi.effect.AVATARS_FAVOR)
-    if effect then
-        effect:setPower(1) -- resummon resets effect
-        xi.avatarsFavor.applyAvatarsFavorAuraToPet(caster, effect)
-        xi.avatarsFavor.applyAvatarsFavorDebuffsToPet(caster)
-    end
+    xi.pet.spawnPet(caster, xi.petId.GARUDA, spell)
 
     return 0
 end

--- a/scripts/actions/spells/summoning/ice_spirit.lua
+++ b/scripts/actions/spells/summoning/ice_spirit.lua
@@ -6,20 +6,12 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    local result = 0
-    if caster:hasPet() then
-        result = xi.msg.basic.ALREADY_HAS_A_PET
-    elseif not caster:canUseMisc(xi.zoneMisc.PET) then
-        result = xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif caster:getObjType() == xi.objType.PC then
-        result = xi.summon.avatarMiniFightCheck(caster)
-    end
-
-    return result
+    return xi.pet.onCastingCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    xi.pet.spawnPet(caster, xi.petId.ICE_SPIRIT)
+    xi.pet.spawnPet(caster, xi.petId.ICE_SPIRIT, spell)
+
     return 0
 end
 

--- a/scripts/actions/spells/summoning/ifrit.lua
+++ b/scripts/actions/spells/summoning/ifrit.lua
@@ -6,26 +6,11 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    if not caster:canUseMisc(xi.zoneMisc.PET) then
-        return xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif caster:hasPet() then
-        return xi.msg.basic.ALREADY_HAS_A_PET
-    elseif caster:getObjType() == xi.objType.PC then
-        return xi.summon.avatarMiniFightCheck(caster)
-    end
-
-    return 0
+    return xi.pet.onCastingCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    xi.pet.spawnPet(caster, xi.petId.IFRIT)
-
-    local effect = caster:getStatusEffect(xi.effect.AVATARS_FAVOR)
-    if effect then
-        effect:setPower(1) -- resummon resets effect
-        xi.avatarsFavor.applyAvatarsFavorAuraToPet(caster, effect)
-        xi.avatarsFavor.applyAvatarsFavorDebuffsToPet(caster)
-    end
+    xi.pet.spawnPet(caster, xi.petId.IFRIT, spell)
 
     return 0
 end

--- a/scripts/actions/spells/summoning/leviathan.lua
+++ b/scripts/actions/spells/summoning/leviathan.lua
@@ -6,26 +6,11 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    if not caster:canUseMisc(xi.zoneMisc.PET) then
-        return xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif caster:hasPet() then
-        return xi.msg.basic.ALREADY_HAS_A_PET
-    elseif caster:getObjType() == xi.objType.PC then
-        return xi.summon.avatarMiniFightCheck(caster)
-    end
-
-    return 0
+    return xi.pet.onCastingCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    xi.pet.spawnPet(caster, xi.petId.LEVIATHAN)
-
-    local effect = caster:getStatusEffect(xi.effect.AVATARS_FAVOR)
-    if effect then
-        effect:setPower(1) -- resummon resets effect
-        xi.avatarsFavor.applyAvatarsFavorAuraToPet(caster, effect)
-        xi.avatarsFavor.applyAvatarsFavorDebuffsToPet(caster)
-    end
+    xi.pet.spawnPet(caster, xi.petId.LEVIATHAN, spell)
 
     return 0
 end

--- a/scripts/actions/spells/summoning/light_spirit.lua
+++ b/scripts/actions/spells/summoning/light_spirit.lua
@@ -6,20 +6,12 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    local result = 0
-    if caster:hasPet() then
-        result = xi.msg.basic.ALREADY_HAS_A_PET
-    elseif not caster:canUseMisc(xi.zoneMisc.PET) then
-        result = xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif caster:getObjType() == xi.objType.PC then
-        result = xi.summon.avatarMiniFightCheck(caster)
-    end
-
-    return result
+    return xi.pet.onCastingCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    xi.pet.spawnPet(caster, xi.petId.LIGHT_SPIRIT)
+    xi.pet.spawnPet(caster, xi.petId.LIGHT_SPIRIT, spell)
+
     return 0
 end
 

--- a/scripts/actions/spells/summoning/odin.lua
+++ b/scripts/actions/spells/summoning/odin.lua
@@ -1,27 +1,16 @@
 -----------------------------------
--- Spell: Alexander
--- Summons Alexander to fight by your side
+-- Spell: Odin
+-- Summons Odin to fight by your side
 -----------------------------------
 ---@type TSpell
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    if not caster:canUseMisc(xi.zoneMisc.PET) then
-        return xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif not caster:hasStatusEffect(xi.effect.ASTRAL_FLOW) then
-        return 581
-    elseif caster:hasPet() then
-        return xi.msg.basic.ALREADY_HAS_A_PET
-    elseif caster:getObjType() == xi.objType.PC then
-        return xi.summon.avatarMiniFightCheck(caster)
-    end
-
-    return 0
+    return xi.pet.onCastingCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    caster:spawnPet(xi.petId.ODIN)
-    caster:petAttack(target)
+    xi.pet.spawnPet(caster, xi.petId.ODIN, spell, target)
 
     return 0
 end

--- a/scripts/actions/spells/summoning/ramuh.lua
+++ b/scripts/actions/spells/summoning/ramuh.lua
@@ -6,26 +6,11 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    if not caster:canUseMisc(xi.zoneMisc.PET) then
-        return xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif caster:hasPet() then
-        return xi.msg.basic.ALREADY_HAS_A_PET
-    elseif caster:getObjType() == xi.objType.PC then
-        return xi.summon.avatarMiniFightCheck(caster)
-    end
-
-    return 0
+    return xi.pet.onCastingCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    xi.pet.spawnPet(caster, xi.petId.RAMUH)
-
-    local effect = caster:getStatusEffect(xi.effect.AVATARS_FAVOR)
-    if effect then
-        effect:setPower(1) -- resummon resets effect
-        xi.avatarsFavor.applyAvatarsFavorAuraToPet(caster, effect)
-        xi.avatarsFavor.applyAvatarsFavorDebuffsToPet(caster)
-    end
+    xi.pet.spawnPet(caster, xi.petId.RAMUH, spell)
 
     return 0
 end

--- a/scripts/actions/spells/summoning/shiva.lua
+++ b/scripts/actions/spells/summoning/shiva.lua
@@ -6,26 +6,11 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    if not caster:canUseMisc(xi.zoneMisc.PET) then
-        return xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif caster:hasPet() then
-        return xi.msg.basic.ALREADY_HAS_A_PET
-    elseif caster:getObjType() == xi.objType.PC then
-        return xi.summon.avatarMiniFightCheck(caster)
-    end
-
-    return 0
+    return xi.pet.onCastingCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    xi.pet.spawnPet(caster, xi.petId.SHIVA)
-
-    local effect = caster:getStatusEffect(xi.effect.AVATARS_FAVOR)
-    if effect then
-        effect:setPower(1) -- resummon resets effect
-        xi.avatarsFavor.applyAvatarsFavorAuraToPet(caster, effect)
-        xi.avatarsFavor.applyAvatarsFavorDebuffsToPet(caster)
-    end
+    xi.pet.spawnPet(caster, xi.petId.SHIVA, spell)
 
     return 0
 end

--- a/scripts/actions/spells/summoning/siren.lua
+++ b/scripts/actions/spells/summoning/siren.lua
@@ -6,26 +6,11 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    if not caster:canUseMisc(xi.zoneMisc.PET) then
-        return xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif caster:hasPet() then
-        return xi.msg.basic.ALREADY_HAS_A_PET
-    elseif caster:getObjType() == xi.objType.PC then
-        return xi.summon.avatarMiniFightCheck(caster)
-    end
-
-    return 0
+    return xi.pet.onCastingCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    xi.pet.spawnPet(caster, xi.petId.SIREN)
-
-    local effect = caster:getStatusEffect(xi.effect.AVATARS_FAVOR)
-    if effect then
-        effect:setPower(1) -- resummon resets effect
-        xi.avatarsFavor.applyAvatarsFavorAuraToPet(caster, effect)
-        xi.avatarsFavor.applyAvatarsFavorDebuffsToPet(caster)
-    end
+    xi.pet.spawnPet(caster, xi.petId.SIREN, spell)
 
     return 0
 end

--- a/scripts/actions/spells/summoning/thunder_spirit.lua
+++ b/scripts/actions/spells/summoning/thunder_spirit.lua
@@ -6,20 +6,12 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    local result = 0
-    if caster:hasPet() then
-        result = xi.msg.basic.ALREADY_HAS_A_PET
-    elseif not caster:canUseMisc(xi.zoneMisc.PET) then
-        result = xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif caster:getObjType() == xi.objType.PC then
-        result = xi.summon.avatarMiniFightCheck(caster)
-    end
-
-    return result
+    return xi.pet.onCastingCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    xi.pet.spawnPet(caster, xi.petId.THUNDER_SPIRIT)
+    xi.pet.spawnPet(caster, xi.petId.THUNDER_SPIRIT, spell)
+
     return 0
 end
 

--- a/scripts/actions/spells/summoning/titan.lua
+++ b/scripts/actions/spells/summoning/titan.lua
@@ -6,26 +6,11 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    if not caster:canUseMisc(xi.zoneMisc.PET) then
-        return xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif caster:hasPet() then
-        return xi.msg.basic.ALREADY_HAS_A_PET
-    elseif caster:getObjType() == xi.objType.PC then
-        return xi.summon.avatarMiniFightCheck(caster)
-    end
-
-    return 0
+    return xi.pet.onCastingCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    xi.pet.spawnPet(caster, xi.petId.TITAN)
-
-    local effect = caster:getStatusEffect(xi.effect.AVATARS_FAVOR)
-    if effect then
-        effect:setPower(1) -- resummon resets effect
-        xi.avatarsFavor.applyAvatarsFavorAuraToPet(caster, effect)
-        xi.avatarsFavor.applyAvatarsFavorDebuffsToPet(caster)
-    end
+    xi.pet.spawnPet(caster, xi.petId.TITAN, spell)
 
     return 0
 end

--- a/scripts/actions/spells/summoning/water_spirit.lua
+++ b/scripts/actions/spells/summoning/water_spirit.lua
@@ -6,20 +6,12 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    local result = 0
-    if caster:hasPet() then
-        result = xi.msg.basic.ALREADY_HAS_A_PET
-    elseif not caster:canUseMisc(xi.zoneMisc.PET) then
-        result = xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif caster:getObjType() == xi.objType.PC then
-        result = xi.summon.avatarMiniFightCheck(caster)
-    end
-
-    return result
+    return xi.pet.onCastingCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    xi.pet.spawnPet(caster, xi.petId.WATER_SPIRIT)
+    xi.pet.spawnPet(caster, xi.petId.WATER_SPIRIT, spell)
+
     return 0
 end
 

--- a/scripts/globals/pets.lua
+++ b/scripts/globals/pets.lua
@@ -6,11 +6,122 @@ require('scripts/globals/nyzul/pathos')
 xi = xi or {}
 xi.pet = xi.pet or {}
 
-xi.pet.spawnPet = function(player, petID)
-    player:spawnPet(petID)
+local avatarPetIDs = set{
+    xi.petId.CARBUNCLE,
+    xi.petId.FENRIR,
+    xi.petId.IFRIT,
+    xi.petId.TITAN,
+    xi.petId.LEVIATHAN,
+    xi.petId.GARUDA,
+    xi.petId.SHIVA,
+    xi.petId.RAMUH,
+    xi.petId.DIABOLOS,
+    xi.petId.ALEXANDER,
+    xi.petId.ODIN,
+    xi.petId.ATOMOS,
+    xi.petId.CAIT_SITH,
+    xi.petId.SIREN,
+}
+
+local onMasterDeath = function(mob)
+    local pet = mob:getPet()
+    if pet ~= nil and pet:isAlive() then
+        if not pet:isEngaged() then
+            DespawnMob(pet:getID(), 2)
+        end
+    end
+end
+
+local astralOnlySpellIDs = set{
+    xi.magic.spell.ODIN,
+    xi.magic.spell.ALEXANDER,
+}
+
+---@param target CBaseEntity
+---@param mob CBaseEntity
+---@param skill CMobSkill
+---@return number
+xi.pet.onMobSkillCheck = function(target, mob, skill)
+    -- block mobskill if mob doesn't have an assigned pet or pet is currently spawned
+    if mob:getPet() == nil or mob:hasPet() then
+        return 1
+    end
+
+    return 0
+end
+
+---@param caster CBaseEntity
+---@param target CBaseEntity
+---@param spell CSpell
+---@return number
+xi.pet.onCastingCheck = function(caster, target, spell)
+    local result = 0
+
+    if caster:hasPet() then
+        result = xi.msg.basic.ALREADY_HAS_A_PET
+    elseif
+        astralOnlySpellIDs[spell:getID()] and
+        not caster:hasStatusEffect(xi.effect.ASTRAL_FLOW)
+    then
+        result = xi.msg.basic.MAGIC_MUST_ASTRAL_FLOW
+    elseif not caster:canUseMisc(xi.zoneMisc.PET) then
+        result = xi.msg.basic.CANT_BE_USED_IN_AREA
+    elseif caster:getObjType() == xi.objType.PC then
+        result = xi.summon.avatarMiniFightCheck(caster, spell:getID())
+    else
+        -- non-pc without an attached pet
+        if caster:getPet() == nil then
+            result = 1
+        end
+    end
+
+    return result
+end
+
+---@param caster CBaseEntity
+---@param petID number?
+---@param state CSpell|CMobSkill?
+---@param target CBaseEntity?
+---@return nil
+xi.pet.spawnPet = function(caster, petID, state, target)
+    caster:spawnPet(petID)
+
+    -- mobs don't emit message when using call beast/wyvern, activate, or summoner spells
+    if caster:getObjType() ~= xi.objType.PC and state then
+        state:setMsg(xi.msg.basic.NONE)
+
+        if state:getID() == xi.mobSkill.CALL_BEAST then
+            -- bst mob pets despawn if not engaged when owner leaves
+            caster:addListener('DEATH', 'BEASTMASTER_DEATH', onMasterDeath)
+            caster:addListener('DESPAWN', 'BEASTMASTER_DESPAWN', onMasterDeath)
+        end
+    end
+
+    if avatarPetIDs[petID] then
+        local effect = caster:getStatusEffect(xi.effect.AVATARS_FAVOR)
+        if effect then
+            effect:setPower(1) -- resummon resets effect
+            xi.avatarsFavor.applyAvatarsFavorAuraToPet(caster, effect)
+            xi.avatarsFavor.applyAvatarsFavorDebuffsToPet(caster)
+        end
+
+        if petID == xi.petId.ALEXANDER then
+            -- Use Perfect Defense 5 seconds after spawning.
+            local pet = caster:getPet()
+            if pet then
+                pet:timer(5000, function()
+                    pet:usePetAbility(xi.jobAbility.PERFECT_DEFENSE, pet)
+                end)
+            end
+        elseif petID == xi.petId.ODIN then
+            if target then
+                caster:petAttack(target)
+            end
+        end
+    end
 
     -- Nyzul Isle has Pathos set randomly on floors and is recorded as bits in a localvar of the instance
-    if player:getZoneID() == xi.zone.NYZUL_ISLE then
-        xi.nyzul.addPetSpawnPathos(player)
+    if caster:getZoneID() == xi.zone.NYZUL_ISLE then
+        xi.nyzul.addPetSpawnPathos(caster)
     end
 end

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -390,20 +390,22 @@ xi.summon.avatarPhysicalHit = function(skill, dmg)
     return skill:getMsg() == xi.msg.basic.DAMAGE
 end
 
--- Checks if the summoner is in a Trial Size Avatar Mini Fight (used to restrict summoning while in bcnm)
-xi.summon.avatarMiniFightCheck = function(caster)
+local trialSizeBattles = set{
+    xi.battlefield.id.TRIAL_SIZE_TRIAL_BY_WIND,
+    xi.battlefield.id.TRIAL_SIZE_TRIAL_BY_LIGHTNING,
+    xi.battlefield.id.TRIAL_SIZE_TRIAL_BY_ICE,
+    xi.battlefield.id.TRIAL_SIZE_TRIAL_BY_FIRE,
+    xi.battlefield.id.TRIAL_SIZE_TRIAL_BY_EARTH,
+    xi.battlefield.id.TRIAL_SIZE_TRIAL_BY_WATER,
+}
+
+-- Checks if the summoner is in a Trial Size Avatar Mini Fight (only carbuncle is allowed)
+xi.summon.avatarMiniFightCheck = function(caster, spellID)
     local result = 0
-    local bcnmid
-    if caster:hasStatusEffect(xi.effect.BATTLEFIELD) then
-        bcnmid = caster:getStatusEffect(xi.effect.BATTLEFIELD):getPower()
-        if
-            bcnmid == 418 or
-            bcnmid == 609 or
-            bcnmid == 450 or
-            bcnmid == 482 or
-            bcnmid == 545 or
-            bcnmid == 578
-        then -- Mini Avatar Fights
+    local effect = caster:getStatusEffect(xi.effect.BATTLEFIELD)
+    if spellID ~= xi.magic.spell.CARBUNCLE and effect then
+        local bcnmid = effect:getPower()
+        if trialSizeBattles[bcnmid] then -- Mini Avatar Fights
             result = 40 -- Cannot use <spell> in this area.
         end
     end

--- a/scripts/mixins/families/aern.lua
+++ b/scripts/mixins/families/aern.lua
@@ -55,7 +55,7 @@ g_mixins.families.aern = function(aernMob)
                 mobArg:setAutoAttackEnabled(true)
                 mobArg:setMobAbilityEnabled(true)
                 mobArg:setMobMod(xi.mobMod.NO_MOVE, 0)
-                mobArg:spawnPet()
+                xi.pet.spawnPet(mobArg)
 
                 -- Add death listener to pet when it spawns
                 mobArg:timer(1000, function(masterMob)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

This is centralizing logic while also laying some ground work to move towards making mobs call pets as they do in retail (see this comment https://github.com/LandSandBoat/server/issues/903#issuecomment-3262814419)

~~in draft while i test all the changes and making sure CI passes~~

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Hopefully i've tested every case touched by these changes, but here's what i did
- for mobs testing in and out of combat was done
- ensure player can still summon all pets (odin and alexander only when AF is up)
  - alex and odin have strange behavior once summoned, but they still seem to behave as they did before
- ensure mobs can still summon all pets (avatars and elementals)
  - lamia in arr reef summoning dark spirit then water spirit
  - <img width="638" height="443" alt="image" src="https://github.com/user-attachments/assets/b77fb3fa-fda6-41b7-a639-a00b196439b7" />
  - vanguard oracle summoning leviathan then ifrti
  - <img width="569" height="477" alt="image" src="https://github.com/user-attachments/assets/3c7958c2-d83d-4806-bd71-35c5fd720e9a" />
  - Note that casting message is still given because there is more work to make the magic casting state not be used for mobs calling pets (that will come in a later PR)
- ensure bst/drg/pup mobs can still call their respective pets via `SPECIAL_SKILL` mobmod
  - I wasn't able to find a pup mob, but the behavior is now identical to bst/drg since they're using the same helper...
  - cape T goblin shepherd calling a new rabbit
  - <img width="552" height="450" alt="image" src="https://github.com/user-attachments/assets/a90ec801-9179-4514-95c7-a4b3ad248612" />
- ensure summoner pet restrictions still work in trial size bcnm (tested in cloister of fire)
  - Note that my pet came with me into the battlefield, not sure that's supposed to be possible, but once i released the restrictions worked as before
  - <img width="523" height="315" alt="image" src="https://github.com/user-attachments/assets/d9505e04-4532-420a-905f-f861a7236df3" />
- Edit: oops also aern mixin:
  - no pets until i engaged, then it summoned an elemental
  - <img width="550" height="89" alt="image" src="https://github.com/user-attachments/assets/fca2f78e-d506-4d45-a195-dea262ed793b" />
