### PR TITLE
fix peallaidh chigoe behavior + chigoe ids in caedarva mire

### DIFF
--- a/scripts/enum/mob_pools.lua
+++ b/scripts/enum/mob_pools.lua
@@ -18,6 +18,7 @@ xi.mobPools =
     GULOOL_JA_JA           = 1846, -- Gulool Ja Ja skill check
     KING_VINEGARROON       = 2262, -- KV poison on Wild Rage
     NIDHOGG                = 2840, -- Nidhogg's stronger hurricane wing
+    PEALLAIDH              = 3109, -- Peallaidh's chigoe pets
     PEPPER                 = 3116, -- BCNM20 Charming Trio, Absorbing Kiss
     PHOEDME                = 3132, -- BCNM20 Charming Trio, Deep Kiss
     PLATOON_SCORPION       = 3157, -- KS30 Platoon Scorpion Wild Rage behavior

--- a/scripts/mixins/families/chigoe_pet.lua
+++ b/scripts/mixins/families/chigoe_pet.lua
@@ -16,6 +16,11 @@ g_mixins.families.chigoe_pet = function(hostMob)
             return
         end
 
+        local numChigoesToSpawn = 1
+        if mob:getPool() == xi.mobPools.PEALLAIDH then
+            numChigoesToSpawn = 2
+        end
+
         for _, mobID in pairs(ID.mob.CHIGOES[mobName]) do
             local chigoe = GetMobByID(mobID)
 
@@ -31,7 +36,10 @@ g_mixins.families.chigoe_pet = function(hostMob)
                     mobArg:removeListener('CHIGOE_DISENGAGE')
                 end)
 
-                return
+                numChigoesToSpawn = numChigoesToSpawn - 1
+                if numChigoesToSpawn == 0 then
+                    return
+                end
             end
         end
     end)

--- a/scripts/zones/Caedarva_Mire/IDs.lua
+++ b/scripts/zones/Caedarva_Mire/IDs.lua
@@ -52,7 +52,8 @@ zones[xi.zone.CAEDARVA_MIRE] =
         CHIGOES =
         {
             ['Wild_Karakul'] = utils.slice(GetTableOfIDs('Chigoe'), 1, 5), -- Entries 1-5 of the table (1-indexed, inclusive)
-            ['Mosshorn']     = utils.slice(GetTableOfIDs('Chigoe'), 6, 10), -- Entries 6-10 of the table (1-indexed, inclusive)
+            ['Mosshorn']     = utils.slice(GetTableOfIDs('Chigoe'), 1, 5), -- Shared Chigoes with Karakul
+            ['Peallaidh']    = utils.slice(GetTableOfIDs('Chigoe'), 6, 10), -- Peallaidh's own pool, ids xxx11-15
         },
         EXPERIMENTAL_LAMIA    = GetFirstID('Experimental_Lamia'),
         JAZARAAT              = GetFirstID('Jazaraat'),

--- a/scripts/zones/Caedarva_Mire/mobs/Peallaidh.lua
+++ b/scripts/zones/Caedarva_Mire/mobs/Peallaidh.lua
@@ -2,6 +2,7 @@
 -- Area: Caedarva Mire
 --  Mob: Peallaidh
 -----------------------------------
+mixins = { require('scripts/mixins/families/chigoe_pet') }
 local ID = zones[xi.zone.CAEDARVA_MIRE]
 -----------------------------------
 ---@type TMobEntity

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -4267,7 +4267,7 @@ INSERT INTO `mob_groups` VALUES (47,2330,79,'Lamia_Deathdancer',0,128,0,0,0,73,7
 INSERT INTO `mob_groups` VALUES (48,916,79,'Dark_Rider',0,128,0,0,0,95,95,0);
 INSERT INTO `mob_groups` VALUES (49,910,79,'Dark_Bugler',0,128,0,0,0,76,76,0);
 INSERT INTO `mob_groups` VALUES (50,914,79,'Dark_Esquire',0,128,0,0,0,76,76,0);
-INSERT INTO `mob_groups` VALUES (51,3109,79,'Peallaidh',0,32,2656,0,0,73,75,0);
+INSERT INTO `mob_groups` VALUES (51,3109,79,'Peallaidh',0,32,2656,14400,0,73,75,0);
 INSERT INTO `mob_groups` VALUES (52,4503,79,'Zikko',7200,0,2799,10000,0,80,80,0);
 INSERT INTO `mob_groups` VALUES (53,606,79,'Caedarva_Toad',0,128,0,0,0,63,65,0);
 INSERT INTO `mob_groups` VALUES (54,2144,79,'Jazaraat',0,128,0,0,0,67,70,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Implement Peallaidh's spawning behavior as well as HP values from a capture
- Peallaidh spawns 2 chigoes at a time up to 5 chigoes
- Double-check the IDs that the Wild Karakul, Mosshorns, _and_ Peallaidh spawn (Karakul + Mosshorn share Chigoe ranges, Peallaidh is actually the one taking up the second batch of 5)
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
HP
<img width="531" height="80" alt="image" src="https://github.com/user-attachments/assets/f89016db-eacc-4323-91c3-692a1e7101aa" />

Peallaidh Chigoe ID range
<img width="1062" height="911" alt="image" src="https://github.com/user-attachments/assets/974a088b-2f3b-498a-95bd-5db890ad9a1a" />
<img width="995" height="1012" alt="image" src="https://github.com/user-attachments/assets/e65c27c2-caa0-4a3b-a125-747912402a30" />

Only spawns 5 max, aligns with the available range

Mosshorn Chigoe IDs start here
<img width="1543" height="1161" alt="image" src="https://github.com/user-attachments/assets/e074e8e5-4909-4c67-b078-27cc03c5c1bd" />
