### PR TITLE
Prepared Statements: battleutils

### DIFF
--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -19,8 +19,7 @@
 ===========================================================================
 */
 
-#ifndef _BATTLEUTILS_H
-#define _BATTLEUTILS_H
+#pragma once
 
 #include "blue_spell.h"
 #include "common/cbasetypes.h"
@@ -275,5 +274,3 @@ namespace battleutils
     void           ConvertDmgToMP(CBattleEntity* PDefender, int32 damage, bool IsCovered);
     float          CheckLiementAbsorb(CBattleEntity* PBattleEntity, DAMAGE_TYPE DamageType);
 }; // namespace battleutils
-
-#endif

--- a/src/map/weapon_skill.cpp
+++ b/src/map/weapon_skill.cpp
@@ -22,21 +22,20 @@
 #include "weapon_skill.h"
 #include <cstring>
 
-CWeaponSkill::CWeaponSkill(uint16 id)
+CWeaponSkill::CWeaponSkill(const uint16 id)
 : m_ID(id)
 , m_TypeID(0)
+, m_Skilllevel(0)
+, m_AnimationId(0)
+, m_Element(0)
+, m_PrimarySkillchain(SC_NONE)
+, m_SecondarySkillchain(SC_NONE)
+, m_TertiarySkillchain(SC_NONE)
+, m_Range(0)
+, m_AOE(0)
+, m_mainOnly(0)
+, m_unlockId(0)
 {
-    std::memset(m_Job, 0, sizeof(m_Job));
-    m_Skilllevel          = 0;
-    m_AnimationId         = 0;
-    m_Element             = 0;
-    m_PrimarySkillchain   = SC_NONE;
-    m_SecondarySkillchain = SC_NONE;
-    m_TertiarySkillchain  = SC_NONE;
-    m_Range               = 0;
-    m_AOE                 = 0;
-    m_mainOnly            = 0;
-    m_unlockId            = 0;
 }
 
 void CWeaponSkill::setID(uint16 id)
@@ -69,9 +68,9 @@ void CWeaponSkill::setUnlockId(uint8 id)
     m_unlockId = id;
 }
 
-void CWeaponSkill::setJob(int8* jobs)
+void CWeaponSkill::setJob(const std::array<uint8, MAX_JOBTYPE>& jobs)
 {
-    std::memcpy(&m_Job[1], jobs, 22);
+    m_Job = jobs;
 }
 
 void CWeaponSkill::setSkillLevel(uint16 level)
@@ -109,7 +108,7 @@ void CWeaponSkill::setName(const std::string& name)
     m_name = name;
 }
 
-void CWeaponSkill::setAnimationId(int8 id)
+void CWeaponSkill::setAnimationId(const uint8 id)
 {
     m_AnimationId = id;
 }

--- a/src/map/weapon_skill.h
+++ b/src/map/weapon_skill.h
@@ -50,7 +50,7 @@ public:
     uint8           getUnlockId() const;
 
     void setID(uint16 id);
-    void setJob(int8* jobs);
+    void setJob(const std::array<uint8, MAX_JOBTYPE>& jobs);
     void setSkillLevel(uint16 level);
     void setRange(uint8 range);
     void setElement(uint8 element);
@@ -58,7 +58,7 @@ public:
     void setSecondarySkillchain(uint8 skillchain);
     void setTertiarySkillchain(uint8 skillchain);
     void setAoe(uint8 aoe);
-    void setAnimationId(int8 animation);
+    void setAnimationId(uint8 id);
     void setAnimationTime(timer::duration time);
     void setType(uint8 type);
     void setMainOnly(uint8 main);
@@ -72,20 +72,20 @@ public:
     void               setName(const std::string& name);
 
 private:
-    uint16          m_ID;
-    uint8           m_TypeID;
-    uint8           m_Job[MAX_JOBTYPE]{};
-    uint16          m_Skilllevel;
-    uint8           m_AnimationId;
-    timer::duration m_AnimationTime{};
-    uint8           m_Element;
-    uint8           m_PrimarySkillchain;
-    uint8           m_SecondarySkillchain;
-    uint8           m_TertiarySkillchain;
-    uint8           m_Range;
-    uint8           m_AOE;
-    uint8           m_mainOnly;
-    uint8           m_unlockId;
+    uint16                         m_ID;
+    uint8                          m_TypeID;
+    std::array<uint8, MAX_JOBTYPE> m_Job{};
+    uint16                         m_Skilllevel;
+    uint8                          m_AnimationId;
+    timer::duration                m_AnimationTime{};
+    uint8                          m_Element;
+    uint8                          m_PrimarySkillchain;
+    uint8                          m_SecondarySkillchain;
+    uint8                          m_TertiarySkillchain;
+    uint8                          m_Range;
+    uint8                          m_AOE;
+    uint8                          m_mainOnly;
+    uint8                          m_unlockId;
 
     std::string m_name;
 };


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Convert battleutils queries to prepared statements
- CWeaponSkill::setAnimationId takes uint8 instead of int8

## Steps to test these changes
Tested:
- Verified skill caps lined up correctly
- Player WS
- Mobs skills
- BST / SMN pet skills

<!-- Clear and detailed steps to test your changes here -->
