### PR TITLE
[lua] Fixed reward for quest Exit The Gambler

### DIFF
--- a/scripts/quests/sandoria/Exit_the_Gambler.lua
+++ b/scripts/quests/sandoria/Exit_the_Gambler.lua
@@ -14,9 +14,9 @@ local quest = Quest:new(xi.questLog.SANDORIA, xi.quest.id.sandoria.EXIT_THE_GAMB
 
 quest.reward =
 {
-    exp   = 2000,
-    ki    = xi.ki.MAP_OF_KING_RANPERRES_TOMB,
-    title = xi.title.DAYBREAK_GAMBLER,
+    exp        = 2000,
+    keyItem    = xi.ki.MAP_OF_KING_RANPERRES_TOMB,
+    title      = xi.title.DAYBREAK_GAMBLER,
 }
 
 quest.sections =


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes #7945 
Simply fix the typo for the keyItem var that was preventing the reward being given

## Steps to test these changes

Go through the steps for the quest [Exit the Gambler](https://ffxiclopedia.fandom.com/wiki/Exit_the_Gambler)
Receive the Key Item of Map of King Ranperres Tomb.
(You wont receive the map if you already have it for any reason, so use "!delkeyitem 391" to remove it beforehand if need be)

