### PR TITLE
[ci] Add rule to prevent deprecated keys in quest/mission reward table

### DIFF
--- a/scripts/quests/otherAreas/The_Sand_Charm.lua
+++ b/scripts/quests/otherAreas/The_Sand_Charm.lua
@@ -14,7 +14,7 @@ quest.reward =
 {
     exp      = 2000,
     gil      = 2000,
-    ki       = xi.ki.MAP_OF_BOSTAUNIEUX_OUBLIETTE,
+    keyItem  = xi.ki.MAP_OF_BOSTAUNIEUX_OUBLIETTE,
     fameArea = xi.fameArea.WINDURST,
 }
 

--- a/scripts/quests/otherAreas/Unforgiven.lua
+++ b/scripts/quests/otherAreas/Unforgiven.lua
@@ -11,8 +11,8 @@ local quest = Quest:new(xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.UNFORGIV
 
 quest.reward =
 {
-    exp = 2000,
-    ki  = xi.ki.MAP_OF_TAVNAZIA,
+    exp     = 2000,
+    keyItem = xi.ki.MAP_OF_TAVNAZIA,
 }
 
 quest.sections =

--- a/tools/ci/tests/stylecheck.lua
+++ b/tools/ci/tests/stylecheck.lua
@@ -249,3 +249,37 @@ math.random(1, 2, 3) -- FAIL
 
 os.time() -- FAIL
 GetSystemTime() -- PASS
+
+-- quest/mission reward table
+quest.reward =
+{
+    xp = 5000, -- FAIL
+    ki = xi.ki.SOME_KEYITEM, -- FAIL
+}
+
+mission.reward =
+{
+    xp = 5000, -- FAIL
+    ki = xi.ki.SOME_KEYITEM, -- FAIL
+}
+
+-- quest/mission reward table
+quest.reward =
+{
+    exp = 5000, -- PASS
+    keyItem = xi.ki.SOME_KEYITEM, -- PASS
+}
+
+mission.reward =
+{
+    exp = 5000, -- PASS
+    keyItem = xi.ki.SOME_KEYITEM, -- PASS
+}
+
+-- getPool magic numbers
+something:getPool() == 1 -- FAIL
+something:getPool() ~= 2 -- FAIL
+something:getPool() < 3 -- FAIL
+something:getPool() > 4 -- FAIL
+something:getPool() <= 5 -- FAIL
+something:getPool() >= 6 -- FAIL


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
* Adds CI rule to prevent `xp` and `ki` keys in quest/mission.reward table, along with tests to verify function
* Adds mobPool magic number tests
* Corrects two quests with invalid keys (third is covered in #8014)
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
CI runs lua_stylecheck tests as a part of sanity, which should pass
<!-- Clear and detailed steps to test your changes here -->
