### PR TITLE
[Core] Add lua binding and listener for spell interruptions

### DIFF
--- a/documentation/AI_Events.txt
+++ b/documentation/AI_Events.txt
@@ -53,7 +53,8 @@ WEAPONSKILL_USE - Entity, Target, Skillid, TP, action
 WEAPONSKILL_TAKE - Target, Entity, Skillid, TP, action
 WEAPONSKILL_STATE_EXIT - Entity, Skillid
 
-MAGIC_START - Entity, Spell, action
-MAGIC_USE - Entity, Target, Spell, action
-MAGIC_TAKE - Target, Entity, Spell, action
-MAGIC_STATE_EXIT - Entity, Spell
+MAGIC_START       - Entity, Spell, action
+MAGIC_USE         - Entity, Target, Spell, action
+MAGIC_INTERRUPTED - Entity, Target, Spell, action
+MAGIC_TAKE        - Target, Entity, Spell, action
+MAGIC_STATE_EXIT  - Entity, Spell

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -280,6 +280,7 @@ bool CMagicState::Update(timer::time_point tick)
         if (m_interrupted)
         {
             m_PEntity->OnCastInterrupted(*this, action, msg, false);
+            m_PEntity->PAI->EventHandler.triggerListener("MAGIC_INTERRUPTED", m_PEntity, PTarget, m_PSpell.get(), &action);
         }
         else
         {

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2049,6 +2049,8 @@ void CBattleEntity::OnCastInterrupted(CMagicState& state, action_t& action, MSGB
             // For some reason, despite the system supporting interrupted message in the action packet (like auto attacks, JA), an 0x029 message is sent for spells.
             loc.zone->PushPacket(this, CHAR_INRANGE_SELF, std::make_unique<CMessageBasicPacket>(this, state.GetTarget() ? state.GetTarget() : this, 0, 0, msg));
         }
+
+        luautils::OnSpellInterrupted(this, PSpell);
     }
 }
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2826,6 +2826,30 @@ namespace luautils
         }
     }
 
+    void OnSpellInterrupted(CBattleEntity* PCaster, CSpell* PSpell)
+    {
+        TracyZoneScoped;
+
+        if (PCaster->objtype != TYPE_MOB)
+        {
+            return;
+        }
+
+        sol::function onSpellInterrupted = getEntityCachedFunction(PCaster, "onSpellInterrupted");
+        if (!onSpellInterrupted.valid())
+        {
+            return;
+        }
+
+        auto result = onSpellInterrupted(PCaster, PSpell);
+        if (!result.valid())
+        {
+            sol::error err = result;
+            ShowError("luautils::onSpellInterrupted: %s", err.what());
+            ReportErrorToPlayer(PCaster, err.what());
+        }
+    }
+
     std::optional<SpellID> OnMobMagicPrepare(CBattleEntity* PCaster, CBattleEntity* PTarget, std::optional<SpellID> startingSpellId)
     {
         TracyZoneScoped;

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -339,6 +339,7 @@ namespace luautils
     int32 OnMagicCastingCheck(CBaseEntity* PChar, CBaseEntity* PTarget, CSpell* PSpell);
     int32 OnSpellCast(CBattleEntity* PCaster, CBattleEntity* PTarget, CSpell* PSpell);
     void  OnSpellPrecast(CBattleEntity* PCaster, CSpell* PSpell);
+    void  OnSpellInterrupted(CBattleEntity* PCaster, CSpell* PSpell);
     auto  OnMobMagicPrepare(CBattleEntity* PCaster, CBattleEntity* PTarget, std::optional<SpellID> startingSpellId) -> std::optional<SpellID>;
     void  OnMagicHit(CBattleEntity* PCaster, CBattleEntity* PTarget, CSpell* PSpell);
     void  OnWeaponskillHit(CBattleEntity* PMob, CBaseEntity* PAttacker, uint16 PWeaponskill);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Allows non-player battle entities to react to spell interruptions.
Example use case would be [Wild Wild Whiskers](https://www.bg-wiki.com/ffxi/Wild_Wild_Whiskers) BCNM mob [Macan Gadangan](https://www.bg-wiki.com/ffxi/Macan_Gadangan) that reacts to spell interruptions by counter-attacking with `Frenzied Rage`

It may be overkill to add both a lua binding and a listener, however, I would assume this (or similar) behavior is used in other content and I want to future-proof it.

## Steps to test these changes

I guess it's time to properly implement this BCNM
