### PR TITLE
[lua/cpp/sql] Update player JA that target pets to respect onAbilityCheck messages

### DIFF
--- a/scripts/actions/abilities/spirit_bond.lua
+++ b/scripts/actions/abilities/spirit_bond.lua
@@ -9,7 +9,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    return 0, 0
+    return xi.job_utils.dragoon.abilityCheckRequiresPet(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)

--- a/scripts/globals/job_utils/geomancer.lua
+++ b/scripts/globals/job_utils/geomancer.lua
@@ -204,7 +204,6 @@ end
 xi.job_utils.geomancer.geoOnEclipticAttritionCheck = function(player, target, ability)
     local luopan = getLuopan(player)
 
-    -- TODO: this never fires if you dont have a bubble up and says "Unable to attack that target." Core issue?
     if not luopan then
         return xi.msg.basic.REQUIRE_LUOPAN, 0
     end
@@ -312,8 +311,11 @@ xi.job_utils.geomancer.fullCircle = function(player, target, ability)
 end
 
 xi.job_utils.geomancer.lastingEmanation = function(player, target, ability)
-    local hpDrain = target:getMod(xi.mod.REGEN_DOWN)
-    target:setMod(xi.mod.REGEN_DOWN, hpDrain - math.floor(target:getMainLvl() / 14))
+    local luopan = getLuopan(player)
+    if luopan then
+        local hpDrain = luopan:getMod(xi.mod.REGEN_DOWN)
+        luopan:setMod(xi.mod.REGEN_DOWN, hpDrain - math.floor(luopan:getMainLvl() / 14))
+    end
 end
 
 -- TODO: allegedly Blaze of Glory is additive to this, but we aren't keeping track of that potency, so BoG + Ecliptic Attrition is stronger than it should be.
@@ -362,7 +364,11 @@ xi.job_utils.geomancer.blazeOfGlory = function(player, target, ability)
 end
 
 xi.job_utils.geomancer.dematerialize = function(player, target, ability)
-    target:addStatusEffect(xi.effect.DEMATERIALIZE, 0, 3, 60)
+    local luopan = getLuopan(player)
+    if luopan then
+        luopan:addStatusEffect(xi.effect.DEMATERIALIZE, 0, 3, 60)
+    end
+
     return xi.effect.DEMATERIALIZE
 end
 

--- a/sql/abilities.sql
+++ b/sql/abilities.sql
@@ -350,12 +350,12 @@ INSERT INTO `abilities` VALUES (342,'caper_emissarius',20,96,2,3600,254,0,0,290,
 INSERT INTO `abilities` VALUES (343,'bolster',21,1,1,3600,0,0,0,303,2000,0,6,0.0,0,1,300,0,4,'SOA'); -- check animation
 INSERT INTO `abilities` VALUES (344,'swipe',22,25,4,90,241,110,0,0,2000,0,15,4.5,0,80,320,0,0,'SOA');
 INSERT INTO `abilities` VALUES (345,'full_circle',21,5,1,10,243,0,0,94,2000,0,6,20.0,0,1,300,0,0,'SOA');
-INSERT INTO `abilities` VALUES (346,'lasting_emanation',21,25,256,300,244,663,0,306,2000,0,6,10.0,0,1,300,1730,0,'SOA');
-INSERT INTO `abilities` VALUES (347,'ecliptic_attrition',21,25,256,300,244,664,0,307,2000,0,6,10.0,0,1,300,1730,0,'SOA');
+INSERT INTO `abilities` VALUES (346,'lasting_emanation',21,25,257,300,244,663,0,306,2000,0,6,10.0,0,1,300,1730,0,'SOA');
+INSERT INTO `abilities` VALUES (347,'ecliptic_attrition',21,25,257,300,244,664,0,307,2000,0,6,10.0,0,1,300,1730,0,'SOA');
 INSERT INTO `abilities` VALUES (348,'collimated_fervor',21,40,1,300,245,100,0,304,2000,0,6,0.0,0,1,300,0,0,'SOA');
-INSERT INTO `abilities` VALUES (349,'life_cycle',21,50,256,600,246,306,0,309,2000,0,6,20.0,0,1,300,1732,0,'SOA');
+INSERT INTO `abilities` VALUES (349,'life_cycle',21,50,257,600,246,306,0,309,2000,0,6,20.0,0,1,300,1732,0,'SOA');
 INSERT INTO `abilities` VALUES (350,'blaze_of_glory',21,60,1,600,247,100,0,308,2000,0,6,20.0,0,1,300,1734,0,'SOA');
-INSERT INTO `abilities` VALUES (351,'dematerialize',21,70,256,600,248,319,0,310,2000,0,6,20.0,0,1,300,1736,0,'SOA');
+INSERT INTO `abilities` VALUES (351,'dematerialize',21,70,257,600,248,319,0,310,2000,0,6,20.0,0,1,300,1736,0,'SOA');
 INSERT INTO `abilities` VALUES (352,'theurgic_focus',21,80,1,300,249,100,0,305,2000,0,6,0.0,0,1,300,0,0,'SOA');
 INSERT INTO `abilities` VALUES (353,'concentric_pulse',21,90,4,300,250,0,0,94,2000,0,6,10.0,0,1,300,0,0,'SOA');
 INSERT INTO `abilities` VALUES (354,'mending_halation',21,75,3,300,251,0,0,94,2000,0,6,10.0,0,1,0,3392,0,'SOA');
@@ -602,9 +602,9 @@ INSERT INTO `abilities` VALUES (748,'corrosive_ooze',9,25,257,3,102,0,0,0,2000,0
 INSERT INTO `abilities` VALUES (749,'back_heel',9,25,257,2,102,0,0,0,2000,0,6,18.0,0,1,60,0,0,NULL);
 INSERT INTO `abilities` VALUES (750,'jettatura',9,25,257,4,102,0,0,0,2000,0,6,18.0,0,1,60,0,0,NULL);
 INSERT INTO `abilities` VALUES (751,'choke_breath',9,25,257,2,102,0,0,0,2000,0,6,18.0,0,1,60,0,0,NULL);
-INSERT INTO `abilities` VALUES (752,'fantod',9,25,257,2,103,0,0,0,2000,0,6,18.0,0,1,60,0,0,NULL);
+INSERT INTO `abilities` VALUES (752,'fantod',9,25,257,2,102,0,0,0,2000,0,6,18.0,0,1,60,0,0,NULL);
 INSERT INTO `abilities` VALUES (753,'tortoise_stomp',9,25,257,3,102,0,0,0,2000,0,6,18.0,0,1,60,0,0,NULL);
-INSERT INTO `abilities` VALUES (754,'harden_shell',9,25,257,2,103,0,0,0,2000,0,6,18.0,0,1,60,0,0,NULL);
+INSERT INTO `abilities` VALUES (754,'harden_shell',9,25,257,2,102,0,0,0,2000,0,6,18.0,0,1,60,0,0,NULL);
 INSERT INTO `abilities` VALUES (755,'aqua_breath',9,25,257,3,102,1,0,0,2000,0,6,18.0,0,1,60,0,0,NULL);
 INSERT INTO `abilities` VALUES (756,'wing_slap',9,25,257,2,102,0,1,0,2000,0,6,18.0,0,1,60,0,0,NULL);
 INSERT INTO `abilities` VALUES (757,'beak_lunge',9,25,257,1,102,0,1,0,2000,0,6,18.0,0,1,60,0,0,NULL);

--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -614,7 +614,7 @@ CBattleEntity* CTargetFind::getValidTarget(uint16 actionTargetID, uint16 validTa
         return nullptr;
     }
 
-    if (validTargetFlags & TARGET_PET)
+    if (validTargetFlags & TARGET_PET && m_PBattleEntity->PPet)
     {
         return m_PBattleEntity->PPet;
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Closes https://github.com/LandSandBoat/server/issues/7915 with the most unexpected detour ever
- `PLAYER_PET` targetfind flag was set to _always_ return the pet pointer regardless if the entity has a pet
  - this made on ability executions fail early if the player didn't have a pet
  - updated to only return the pet if the player has a pet
    - this way if the player doesn't have a pet, they will be returned as the valid target, and the `onAbilityCheck` function can check if the player has a pet and return the proper message.
- Audited all abilities with flag & 256 true and found 
  - a ton of ready abilities (they don't show up in the menu if there's no pet and are fine to report a generic "you can't attack that target" if someone packet injects them somehow)
  - repair, snarl, spirit link, reward, steady wing, mana cede: 
    - all properly hooked up to check for a pet in the `onAbilityCheck` function
  - 2 ready skills were tied to the wrong recast id
    - fixed it, but the implication was that harden shell and fantod had unlimited use every 2s for a bst. Both relatively low-impact, but still...
  - spirit bond, updated to check for a pet in the check function
  - finally, the 4 skills that I originally made this PR about. Updated them all to have 257 find flags so it can target the player, but if they have a pet the target is forced to be the pet 
    - lasting_emanation
    - ecliptic_attrition
    - life_cycle
    - dematerialize
    - <img width="592" height="316" alt="image" src="https://github.com/user-attachments/assets/bdbbdb83-fd09-4bcb-99b2-e6315bc084f3" />
- There are no spells, mobskills, or petskills that have validTargets & 256 set

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- use any ability with a findflag that includes 256
- see that it targets the pet if it exists, otherwise requires self as the target to fire off `onAbilityCheck`. 
- If `onAbilityCheck` succeeds, then the `onAbilityUse` function will fire, so proper logic needs to be in the check function to ensure JAs that shouldn't be possible are blocked