### PR TITLE
Update KS99 Early Bird Catches the Wyrm to correct loot table / gil

### DIFF
--- a/scripts/battlefields/Balgas_Dais/early_bird_catches_the_wyrm.lua
+++ b/scripts/battlefields/Balgas_Dais/early_bird_catches_the_wyrm.lua
@@ -24,6 +24,10 @@ content:addEssentialMobs({ 'Wyrm' })
 content.loot =
 {
     {
+        { item = xi.item.GIL, weight = 1000, amount = 32000 }, -- Gil
+    },
+
+    {
         { item = xi.item.JUG_OF_HONEY_WINE, weight = 1000 }, -- Jug Of Honey Wine
     },
 
@@ -100,28 +104,6 @@ content.loot =
         { item = xi.item.HI_POTION_P3,   weight = 225 }, -- Hi-potion +3
         { item = xi.item.HI_RERAISER,    weight = 210 }, -- Hi-reraiser
         { item = xi.item.VILE_ELIXIR_P1, weight = 217 }, -- Vile Elixir +1
-    },
-
-    {
-        { item = xi.item.CORAL_FRAGMENT,           weight =  87 }, -- Coral Fragment
-        { item = xi.item.CHUNK_OF_DARKSTEEL_ORE,   weight =  80 }, -- Chunk Of Darksteel Ore
-        { item = xi.item.DEMON_HORN,               weight =  58 }, -- Demon Horn
-        { item = xi.item.EBONY_LOG,                weight =  72 }, -- Ebony Log
-        { item = xi.item.CHUNK_OF_GOLD_ORE,        weight =  87 }, -- Chunk Of Gold Ore
-        { item = xi.item.SPOOL_OF_GOLD_THREAD,     weight =  14 }, -- Spool Of Gold Thread
-        { item = xi.item.HI_RERAISER,              weight =  22 }, -- Hi-reraiser
-        { item = xi.item.MAHOGANY_LOG,             weight =  80 }, -- Mahogany Log
-        { item = xi.item.CHUNK_OF_MYTHRIL_ORE,     weight =  36 }, -- Chunk Of Mythril Ore
-        { item = xi.item.PETRIFIED_LOG,            weight = 145 }, -- Petrified Log
-        { item = xi.item.PHOENIX_FEATHER,          weight =   7 }, -- Phoenix Feather
-        { item = xi.item.CHUNK_OF_PLATINUM_ORE,    weight =  51 }, -- Chunk Of Platinum Ore
-        { item = xi.item.SQUARE_OF_RAINBOW_CLOTH,  weight =  29 }, -- Square Of Rainbow Cloth
-        { item = xi.item.RAM_HORN,                 weight =  36 }, -- Ram Horn
-        { item = xi.item.SQUARE_OF_RAXA,           weight =  72 }, -- Square Of Raxa
-        { item = xi.item.RERAISER,                 weight =  29 }, -- Reraiser
-        { item = xi.item.VILE_ELIXIR,              weight =  29 }, -- Vile Elixir
-        { item = xi.item.VILE_ELIXIR_P1,           weight =   7 }, -- Vile Elixir +1
-        { item = xi.item.HANDFUL_OF_WYVERN_SCALES, weight =  22 }, -- Handful Of Wyvern Scales
     },
 
     {


### PR DESCRIPTION
Updated the drop table of this KS99 because there are no longer 11 items in the treasure pool, only 10. Also updated the amount of gil the KS99 drops to correct values.

**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

What does this pull request do?

It updates the loot table for the KS99 Early Bird Catches the Wyrm by removing a loot pool that no longer exists(due to the addition of the pop item) and also adds the correct amount of gil.

Proof

https://youtu.be/NtQKFx5Pb1Q?si=-R0spAPc_U3kxYVv&t=598

https://drive.google.com/file/d/1djXRogMu-_og9PrZFJxSqlXMI0QNd8-D/view @ 15:00


