### PR TITLE
Update KS99 Horns of War to correct loot pool/gil

### DIFF
--- a/scripts/battlefields/Horlais_Peak/horns_of_war.lua
+++ b/scripts/battlefields/Horlais_Peak/horns_of_war.lua
@@ -24,6 +24,10 @@ content:addEssentialMobs({ 'Chlevnik' })
 content.loot =
 {
     {
+        { item = xi.item.GIL, weight = 1000, amount = 32000 }, -- Gil
+    },
+
+    {
         { item = xi.item.LIBATION_ABJURATION, weight = 169 }, -- Libation Abjuration
         { item = xi.item.KRIEGSBEIL,          weight = 268 }, -- Kriegsbeil
         { item = xi.item.SHINSOKU,            weight =  99 }, -- Shinsoku
@@ -108,26 +112,6 @@ content.loot =
         { item = xi.item.HI_POTION_P3,   weight = 225 }, -- Hi-potion +3
         { item = xi.item.HI_RERAISER,    weight = 197 }, -- Hi-reraiser
         { item = xi.item.VILE_ELIXIR_P1, weight = 282 }, -- Vile Elixir +1
-    },
-
-    {
-        { item = xi.item.CORAL_FRAGMENT,           weight = 141 }, -- Coral Fragment
-        { item = xi.item.SQUARE_OF_RAXA,           weight =  14 }, -- Square Of Raxa
-        { item = xi.item.DEMON_HORN,               weight = 113 }, -- Demon Horn
-        { item = xi.item.CHUNK_OF_GOLD_ORE,        weight =  28 }, -- Chunk Of Gold Ore
-        { item = xi.item.CHUNK_OF_MYTHRIL_ORE,     weight =  85 }, -- Chunk Of Mythril Ore
-        { item = xi.item.VILE_ELIXIR,              weight =  56 }, -- Vile Elixir
-        { item = xi.item.RAM_HORN,                 weight =  28 }, -- Ram Horn
-        { item = xi.item.PETRIFIED_LOG,            weight = 296 }, -- Petrified Log
-        { item = xi.item.CHUNK_OF_PLATINUM_ORE,    weight =  14 }, -- Chunk Of Platinum Ore
-        { item = xi.item.MAHOGANY_LOG,             weight =  56 }, -- Mahogany Log
-        { item = xi.item.HANDFUL_OF_WYVERN_SCALES, weight =  70 }, -- Handful Of Wyvern Scales
-        { item = xi.item.SLAB_OF_GRANITE,          weight =  42 }, -- Slab Of Granite
-        { item = xi.item.CHUNK_OF_DARKSTEEL_ORE,   weight =  42 }, -- Chunk Of Darksteel Ore
-        { item = xi.item.EBONY_LOG,                weight =  42 }, -- Ebony Log
-        { item = xi.item.HI_RERAISER,              weight =  42 }, -- Hi-reraiser
-        { item = xi.item.SPOOL_OF_GOLD_THREAD,     weight = 113 }, -- Spool Of Gold Thread
-        { item = xi.item.SQUARE_OF_RAINBOW_CLOTH,  weight =  28 }, -- Square Of Rainbow Cloth
     },
 
     {


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

It updates the loot table for the KS99 Horns of War by removing a loot pool that no longer exists(due to the addition of the pop item) and also adds the correct amount of gil.

Proof 

https://youtu.be/rag-t7NB7UQ?si=mmB_UyypFSIoS62g&t=231

https://youtu.be/fmvfOdPBvbc?si=etamnsk9o3dewIro

https://youtu.be/j3nMr2gkiLI?si=-1jS1AYP-5CZgeb9&t=453
