### PR TITLE
[lua] xi.mob.callPets improvements

### DIFF
--- a/scripts/globals/combat/entity_behavior.lua
+++ b/scripts/globals/combat/entity_behavior.lua
@@ -7,9 +7,11 @@ xi.combat.behavior = xi.combat.behavior or {}
 
 xi.combat.behavior.isEntityBusy = function(actor)
     -- Check poses (actions).
+    local currAction = actor:getCurrentAction()
     if
-        actor:getCurrentAction() ~= xi.action.NONE and
-        actor:getCurrentAction() ~= xi.action.ATTACK -- TODO: What does "ATTACK" entail? Just swinging or engaged in general?
+        currAction ~= xi.action.NONE and
+        currAction ~= xi.action.ATTACK and-- TODO: What does "ATTACK" entail? Just swinging or engaged in general?
+        currAction ~= xi.action.ROAMING
     then
         return true
     end

--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -944,7 +944,7 @@ xi.mob.callPets = function(mob, petIds, params)
                         local newtarget = owner and owner:getTarget() or nil
                         if newtarget then
                             petArg:updateEnmity(newtarget)
-                        elseif owner:isDead() then
+                        elseif owner and owner:isDead() then
                             petArg:setHP(0)
                         elseif not petArg:hasFollowTarget() then
                             petArg:follow(owner, xi.followType.ROAM)

--- a/scripts/mixins/families/aern.lua
+++ b/scripts/mixins/families/aern.lua
@@ -41,27 +41,13 @@ g_mixins.families.aern = function(aernMob)
                 mob:setLocalVar('aernElementalCount', eleCount + 1)
 
                 -- Add death listener to elemental when it spawns
-                mob:timer(1000, function(mobArg)
-                    petDeath(mobArg)
-                end)
+                petDeath(mob)
             end
         elseif mainJob == xi.job.BST or mainJob == xi.job.DRG then
-            mob:entityAnimationPacket(xi.animationString.CAST_SUMMONER_START)
-            mob:setAutoAttackEnabled(false)
-            mob:setMobAbilityEnabled(false)
-            mob:setMobMod(xi.mobMod.NO_MOVE, 1)
-            mob:timer(3000, function(mobArg)
-                mobArg:entityAnimationPacket(xi.animationString.CAST_SUMMONER_STOP)
-                mobArg:setAutoAttackEnabled(true)
-                mobArg:setMobAbilityEnabled(true)
-                mobArg:setMobMod(xi.mobMod.NO_MOVE, 0)
-                xi.pet.spawnPet(mobArg)
+            xi.mob.callPets(mob, nil, { inactiveTime = 3000, ignoreBusy = true })
 
-                -- Add death listener to pet when it spawns
-                mobArg:timer(1000, function(masterMob)
-                    petDeath(masterMob)
-                end)
-            end)
+            -- Add death listener to pet when it spawns
+            petDeath(mob)
         end
     end
 

--- a/scripts/zones/Attohwa_Chasm/IDs.lua
+++ b/scripts/zones/Attohwa_Chasm/IDs.lua
@@ -36,6 +36,7 @@ zones[xi.zone.ATTOHWA_CHASM] =
         AMBUSHER_ANTLION    = GetFirstID('Ambusher_Antlion'),
         ALASTOR_ANTLION     = GetFirstID('Alastor_Antlion'),
         EXECUTIONER_ANTLION = GetTableOfIDs('Executioner_Antlion'),
+        XOLOTL              = GetFirstID('Xolotl'),
     },
     npc =
     {

--- a/scripts/zones/Attohwa_Chasm/mobs/Xolotl.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Xolotl.lua
@@ -1,20 +1,51 @@
 -----------------------------------
 -- Area: Attohwa Chasm
 --  Mob: Xolotl
+-- Note: The 2 pets do NOT despawn if engaged when Xolotl dies, nor do they despawn if Xolotl disengages
+--       Xolotl spawns one pet a time, with a 60s delay between (and after engaging)
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
+local ID = zones[xi.zone.ATTOHWA_CHASM]
+
+local pets =
+{
+    ID.mob.XOLOTL + 1,
+    ID.mob.XOLOTL + 2,
+}
+
+local callPetParams =
+{
+    superLink = true,
+    maxSpawns = 1,
+    inactiveTime = 3000,
+}
+
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 32)
 end
 
 entity.onMobSpawn = function(mob)
     mob:setRespawnTime(0)
 end
 
+entity.onMobEngage = function(mob)
+    mob:setLocalVar('pet_spawn_time', GetSystemTime() + 60)
+end
+
+entity.onMobFight = function(mob)
+    if
+        mob:getLocalVar('pet_spawn_time') < GetSystemTime() and
+        xi.mob.callPets(mob, pets, callPetParams)
+    then
+        mob:setLocalVar('pet_spawn_time', GetSystemTime() + 60)
+    end
+end
+
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.XOLOTL_XTRAPOLATOR)
+    if player then
+        player:addTitle(xi.title.XOLOTL_XTRAPOLATOR)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Attohwa_Chasm/mobs/Xolotls_Hound_Warrior.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Xolotls_Hound_Warrior.lua
@@ -6,8 +6,11 @@
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 32)
+entity.onMobDeath = function(mob)
+    local xolotl = GetMobByID(zones[xi.zone.ATTOHWA_CHASM].mob.XOLOTL)
+    if xolotl then
+        xolotl:setLocalVar('pet_spawn_time', GetSystemTime() + 60)
+    end
 end
 
 return entity

--- a/scripts/zones/Attohwa_Chasm/mobs/Xolotls_Sacrifice.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Xolotls_Sacrifice.lua
@@ -6,8 +6,11 @@
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 32)
+entity.onMobDeath = function(mob)
+    local xolotl = GetMobByID(zones[xi.zone.ATTOHWA_CHASM].mob.XOLOTL)
+    if xolotl then
+        xolotl:setLocalVar('pet_spawn_time', GetSystemTime() + 60)
+    end
 end
 
 return entity

--- a/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Queen.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Queen.lua
@@ -8,6 +8,25 @@ mixins = { require('scripts/mixins/draw_in') }
 ---@type TMobEntity
 local entity = {}
 
+local ID = zones[xi.zone.IFRITS_CAULDRON]
+
+local basicPets =
+{
+    ID.mob.BOMB_QUEEN + 1,
+    ID.mob.BOMB_QUEEN + 2,
+    ID.mob.BOMB_QUEEN + 3,
+    ID.mob.BOMB_QUEEN + 4,
+}
+
+local bombBastard = ID.mob.BOMB_QUEEN + 5
+
+local callPetParams =
+{
+    inactiveTime = 5000,
+    dieWithOwner = true,
+    maxSpawns = 1,
+}
+
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 900)
     mob:setMobMod(xi.mobMod.HP_STANDBACK, -1)
@@ -30,22 +49,10 @@ entity.onMobFight = function(mob, target)
         GetSystemTime() >= mob:getLocalVar('spawn_time')
     then
         mob:setLocalVar('spawn_time', GetSystemTime() + 30)
-        local mobId = mob:getID()
-        -- Pick a random Prince or Princess
-        local petId = 0
-        local offsets = utils.shuffle({ 1, 2, 3, 4 })
-        -- and finally if none are available, the Bastard
-        table.insert(offsets, 5)
-        for _, petOffset in ipairs(offsets) do
-            local id = mobId + petOffset
-            if not GetMobByID(id):isSpawned() then
-                petId = id
-                break
-            end
-        end
 
-        if petId > 0 then
-            xi.mob.callPets(mob, petId, { inactiveTime = 5000, dieWithOwner = true })
+        -- will call the first that is not spawned
+        if not xi.mob.callPets(mob, utils.shuffle(basicPets), callPetParams) then
+            xi.mob.callPets(mob, bombBastard, callPetParams)
         end
     end
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

- Fixed an oversight in `xi.combat.behavior.isEntityBusy` to not consider roaming "busy"
- Implements new `params` that i've thought of since i submitted [the original PR](https://github.com/LandSandBoat/server/pull/7994)
  - `superLink`: makes the assist work in the opposite direction to emulate full superlink behavior
  - `maxSpawns`: stops calling pets if the count is met, for mobs with multiple pets but only wanting to spawn some
  - `ignoreBusy`: will attempt to call pets and interrupt the current action to do it
  - Also, updated to not install the `ROAM` listener if the called pet is actually the mob's pet (since roam logic is built in for those)
  - Edit: forgot to mention the updates to `actionParams`. 
    - I had an oversight in adding `params.actions.param` to add an optional parameter to the injectAction call (some mobs send a param when they perform the action, weirdly enough)
    - it was causing the `callPetJob` functionality to break, since the actions were offset
    - tl;dr, they all function properly now:
    - <img width="691" height="444" alt="image" src="https://github.com/user-attachments/assets/e96e1538-f70d-43c0-9a71-0b069eab3b07" />
- updated bomb queen to cleanup the logic using `maxSpawns`
- updated Xolotl to spawn pets based on captures
  - spawns one pet at a time, 60s after engage and 60s after last pet death
- updated aern mixin to use the helper 
- updated Vrtra to use the helper with the same-ish logic as before, except Vrtra was allowed to interrupt their current action, that doesn't seem likely
  - if I'm mistaken, glad to change it, but as it is coded in this PR Vrtra will simply wait until the current action finishes
- Updated Bomb Queen since that logic was still a little convoluted
  - confirmed it still works
  - <img width="459" height="336" alt="image" src="https://github.com/user-attachments/assets/4c21d88a-219a-4b29-aace-8ff950eb47c2" />


## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
