### PR TITLE
[lua] Bomb Prince/Princess/Bastard protect from stacked mobskills

### DIFF
--- a/scripts/enum/mob_skills.lua
+++ b/scripts/enum/mob_skills.lua
@@ -64,6 +64,8 @@ xi.mobSkill =
 
     TRANSMOGRIFICATION       =  487, -- Mammet-800
 
+    SELF_DESTRUCT            =  511,
+
     DANSE_MACABRE            =  533,
 
     TREMOROUS_TREAD          =  540, -- Mammet-800

--- a/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Bastard.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Bastard.lua
@@ -14,8 +14,12 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobFight = function(mob, target)
-    if mob:getBattleTime() > 10 then
-        mob:useMobAbility(511)
+    if
+        mob:getLocalVar('usedDestruct') == 0 and
+        mob:getBattleTime() > 10
+    then
+        mob:setLocalVar('usedDestruct', 1)
+        mob:useMobAbility(xi.mobSkill.SELF_DESTRUCT)
     end
 end
 

--- a/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Prince.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Prince.lua
@@ -14,8 +14,12 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobFight = function(mob, target)
-    if mob:getBattleTime() > 10 then
-        mob:useMobAbility(511)
+    if
+        mob:getLocalVar('usedDestruct') == 0 and
+        mob:getBattleTime() > 10
+    then
+        mob:setLocalVar('usedDestruct', 1)
+        mob:useMobAbility(xi.mobSkill.SELF_DESTRUCT)
     end
 end
 

--- a/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Princess.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Princess.lua
@@ -14,8 +14,12 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobFight = function(mob, target)
-    if mob:getBattleTime() > 10 then
-        mob:useMobAbility(511)
+    if
+        mob:getLocalVar('usedDestruct') == 0 and
+        mob:getBattleTime() > 10
+    then
+        mob:setLocalVar('usedDestruct', 1)
+        mob:useMobAbility(xi.mobSkill.SELF_DESTRUCT)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

After toying around with it a bit, i figured out one part of #8040 was due to `onMobFight` processing while the mobskill prepares, which was stacking mobskills in the mob's queue. Next time the mob spawned, it would immediately firing off one, etc etc

Feel free to close that issue if you think the other concern is not valid. I have no idea how retail is supposed to work so maybe the expectation is to just kite the pets 

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Fight bomb queen, see that her pets properly wait 10s before 'sploding