### PR TITLE
[cpp/lua] Split player and mob pet spawn bindings

### DIFF
--- a/scripts/globals/pets.lua
+++ b/scripts/globals/pets.lua
@@ -24,15 +24,6 @@ local avatarPetIDs = set
     xi.petId.SIREN,
 }
 
-local onMasterDeath = function(mob)
-    local pet = mob:getPet()
-    if pet ~= nil and pet:isAlive() then
-        if not pet:isEngaged() then
-            DespawnMob(pet:getID(), 2)
-        end
-    end
-end
-
 local astralOnlySpellIDs = set
 {
     xi.magic.spell.ODIN,
@@ -45,6 +36,8 @@ local astralOnlySpellIDs = set
 ---@return number
 xi.pet.onMobSkillCheck = function(target, mob, skill)
     -- block mobskill if mob doesn't have an assigned pet or pet is currently spawned
+    -- TODO implement mobmods to determine if mob can call pet outside of combat
+    --      or how many total pets the mob can call after respawning
     if mob:getPet() == nil or mob:hasPet() then
         return 1
     end
@@ -72,6 +65,8 @@ xi.pet.onCastingCheck = function(caster, target, spell)
         result = xi.summon.avatarMiniFightCheck(caster, spell:getID())
     else
         -- non-pc without an attached pet
+        -- TODO implement mobmods to determine if mob can call pet outside of combat
+        --      or how many total pets the mob can call after respawning
         if caster:getPet() == nil then
             result = 1
         end
@@ -86,39 +81,51 @@ end
 ---@param target CBaseEntity?
 ---@return nil
 xi.pet.spawnPet = function(caster, petID, state, target)
-    caster:spawnPet(petID)
+    local casterType = caster:getObjType()
+    if casterType == xi.objType.PC then
+        caster:spawnPlayerPet(petID)
 
-    -- mobs don't emit message when using call beast/wyvern, activate, or summoner spells
-    if caster:getObjType() ~= xi.objType.PC and state then
-        state:setMsg(xi.msg.basic.NONE)
-
-        if state:getID() == xi.mobSkill.CALL_BEAST then
-            -- bst mob pets despawn if not engaged when owner leaves
-            caster:addListener('DEATH', 'BEASTMASTER_DEATH', onMasterDeath)
-            caster:addListener('DESPAWN', 'BEASTMASTER_DESPAWN', onMasterDeath)
-        end
-    end
-
-    if avatarPetIDs[petID] then
-        local effect = caster:getStatusEffect(xi.effect.AVATARS_FAVOR)
-        if effect then
-            effect:setPower(1) -- resummon resets effect
-            xi.avatarsFavor.applyAvatarsFavorAuraToPet(caster, effect)
-            xi.avatarsFavor.applyAvatarsFavorDebuffsToPet(caster)
-        end
-
-        if petID == xi.petId.ALEXANDER then
-            -- Use Perfect Defense 5 seconds after spawning.
-            local pet = caster:getPet()
-            if pet then
-                pet:timer(5000, function()
-                    pet:usePetAbility(xi.jobAbility.PERFECT_DEFENSE, pet)
-                end)
+        -- These should only be relevant for players
+        if avatarPetIDs[petID] then
+            local effect = caster:getStatusEffect(xi.effect.AVATARS_FAVOR)
+            if effect then
+                effect:setPower(1) -- resummon resets effect
+                xi.avatarsFavor.applyAvatarsFavorAuraToPet(caster, effect)
+                xi.avatarsFavor.applyAvatarsFavorDebuffsToPet(caster)
             end
-        elseif petID == xi.petId.ODIN then
-            if target then
-                caster:petAttack(target)
+
+            if petID == xi.petId.ALEXANDER then
+                -- Use Perfect Defense 5 seconds after spawning.
+                local pet = caster:getPet()
+                if pet then
+                    pet:timer(5000, function()
+                        pet:usePetAbility(xi.jobAbility.PERFECT_DEFENSE, pet)
+                    end)
+                end
+            elseif petID == xi.petId.ODIN then
+                if target then
+                    caster:petAttack(target)
+                end
             end
+        end
+    elseif casterType == xi.objType.MOB then
+        -- copy confrontation effect and potentially morph mob's pet based on avatar/elementals petID given
+        caster:assignMobPetProperties(petID)
+
+        -- TODO implement mobmods to decide what type of pet summon animation we do here. For the time being continue doing the default instant call
+        -- mobs don't emit message when using call beast/wyvern, activate, or summoner spells
+        if state then
+            state:setMsg(xi.msg.basic.NONE)
+        end
+
+        -- TODO utilize xi.mob.callPets(caster, nil, params) where params are determined based on the mob mods mentioned above
+        local pet = caster:getPet()
+        if pet then
+            local ownerPos = caster:getPos()
+            ownerPos.rot = caster:getRotPos()
+            local pos = NearLocation(ownerPos, 2.2, math.pi)
+            pet:setSpawn(pos.x, pos.y, pos.z, ownerPos.rot)
+            pet:spawn()
         end
     end
 

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -3374,9 +3374,14 @@ end
 function CBaseEntity:handleSevereDamage(damage, isPhysical)
 end
 
----@param arg0 integer? Optional Pet ID
+---@param arg0 integer? Pet ID to spawn for player
 ---@return nil
-function CBaseEntity:spawnPet(arg0)
+function CBaseEntity:spawnPlayerPet(arg0)
+end
+
+---@param arg0 integer? Optional Pet ID to clone into mob pet
+---@return nil
+function CBaseEntity:assignMobPetProperties(arg0)
 end
 
 ---@return nil

--- a/scripts/tests/jobs/smn/perpetuation.lua
+++ b/scripts/tests/jobs/smn/perpetuation.lua
@@ -36,10 +36,10 @@ describe('Avatar perpetuation', function()
         verifyPerpetuationCost(player, 0)
         -- Verify losing MP according to avatar perpetuation
         xi.test.world:setVanaDay(xi.day.DARKSDAY)
-        player:spawnPet(xi.petId.GARUDA)
+        player:spawnPlayerPet(xi.petId.GARUDA)
         verifyPerpetuationCost(player, 13)
         player:despawnPet()
-        player:spawnPet(xi.petId.CARBUNCLE)
+        player:spawnPlayerPet(xi.petId.CARBUNCLE)
         verifyPerpetuationCost(player, 9)
     end)
 
@@ -93,11 +93,11 @@ describe('Avatar perpetuation', function()
             player:equipItem(staff.itemId)
             -- Verify the staff increases cost for same element
             player:despawnPet()
-            player:spawnPet(staff.reduction)
+            player:spawnPlayerPet(staff.reduction)
             verifyPerpetuationCost(player, (specialBaseCost[staff.reduction] or 13) - 2)
             -- Verify the staff increases cost for opposite element
             player:despawnPet()
-            player:spawnPet(staff.increase)
+            player:spawnPlayerPet(staff.increase)
             verifyPerpetuationCost(player, (specialBaseCost[staff.increase] or 13) + 2)
         end
     end)
@@ -153,12 +153,12 @@ describe('Avatar perpetuation', function()
             xi.test.world:setVanaDay(case.day)
             player:despawnPet()
             -- Reduced cost with avatar matching day
-            player:spawnPet(case.matching)
+            player:spawnPlayerPet(case.matching)
             local cost = (specialBaseCost[case.matching] or 13) - 3
             verifyPerpetuationCost(player, cost)
             player:despawnPet()
             -- Regular cost with avatar not matching day
-            player:spawnPet(case.notMatching)
+            player:spawnPlayerPet(case.notMatching)
             cost = specialBaseCost[case.notMatching] or 13
             verifyPerpetuationCost(player, cost)
         end
@@ -216,12 +216,12 @@ describe('Avatar perpetuation', function()
             player:setWeather(case.weather)
             player:despawnPet()
             -- Reduced cost with avatar matching day
-            player:spawnPet(case.matching)
+            player:spawnPlayerPet(case.matching)
             local cost = (specialBaseCost[case.matching] or 13) - 3
             verifyPerpetuationCost(player, cost)
             player:despawnPet()
             -- Regular cost with avatar not matching day
-            player:spawnPet(case.notMatching)
+            player:spawnPlayerPet(case.notMatching)
             cost = specialBaseCost[case.notMatching] or 13
             verifyPerpetuationCost(player, cost)
         end

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -15469,62 +15469,59 @@ auto CLuaBaseEntity::handleSevereDamage(int32 damage, bool isPhysical) -> int32
 }
 
 /************************************************************************
- *  Function: spawnPet()
- *  Purpose : Spawns a pet if a few correct conditions are met
- *  Example : caster:spawnPet(xi.petId.CARBUNCLE)
+ *  Function: spawnPlayerPet()
+ *  Purpose : Spawns a player pet if a few correct conditions are met
+ *  Example : player:spawnPlayerPet(xi.petId.CARBUNCLE)
  *  Notes   :
  ************************************************************************/
 
-void CLuaBaseEntity::spawnPet(sol::object const& arg0)
+void CLuaBaseEntity::spawnPlayerPet(sol::object const& arg0)
 {
-    if (m_PBaseEntity->objtype == TYPE_NPC)
+    auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity);
+    if (!PChar)
     {
-        ShowWarning("CLuaBaseEntity::spawnPet() - NPC calling function.");
+        ShowWarning("Non-PC (%d) calling function.", m_PBaseEntity->id);
         return;
     }
 
-    if (m_PBaseEntity->objtype == TYPE_PC)
+    if ((arg0 != sol::lua_nil) && arg0.is<int>())
     {
-        auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
-        if ((arg0 != sol::lua_nil) && arg0.is<int>())
+        uint32 petId = arg0.as<uint32>();
+        if (petId == PETID_HARLEQUINFRAME)
         {
-            uint32 petId = arg0.as<uint32>();
-            if (petId == PETID_HARLEQUINFRAME)
-            {
-                petId = static_cast<uint32>(PETID_HARLEQUINFRAME) + static_cast<uint32>(PChar->getAutomatonFrame()) - 0x20;
-            }
+            petId = static_cast<uint32>(PETID_HARLEQUINFRAME) + static_cast<uint32>(PChar->getAutomatonFrame()) - 0x20;
+        }
 
-            // Note: arg1 of SpawnPet below was arg0 and not petId
-            petutils::SpawnPet(static_cast<CBattleEntity*>(m_PBaseEntity), petId, false);
-        }
-        else
-        {
-            ShowError("CLuaBaseEntity::spawnPet : PetID is nullptr");
-        }
+        // Note: arg1 of SpawnPet below was arg0 and not petId
+        petutils::SpawnPet(static_cast<CBattleEntity*>(m_PBaseEntity), petId, false);
     }
-    else if (m_PBaseEntity->objtype == TYPE_MOB)
+    else
     {
-        auto* PMob = static_cast<CMobEntity*>(m_PBaseEntity);
+        ShowError("Player ID (%d) attempted to spawn pet with no PetID", PChar->id);
+    }
+}
 
-        if (PMob->PPet == nullptr)
-        {
-            ShowError("lua_baseentity::spawnPet PMob (%d) trying to spawn pet but its nullptr", PMob->id);
-            return;
-        }
+/************************************************************************
+ *  Function: assignMobPetProperties()
+ *  Purpose : Prepares a mob's pet to be spawned
+ *  Example : mob:assignMobPetProperties(xi.petId.CARBUNCLE)
+ *  Notes   : Clones the properties of a pet from pet_list.sql if a petid is passed
+ ************************************************************************/
 
-        CMobEntity* PPet = static_cast<CMobEntity*>(PMob->PPet);
+void CLuaBaseEntity::assignMobPetProperties(sol::object const& arg0)
+{
+    auto* PMob = dynamic_cast<CMobEntity*>(m_PBaseEntity);
 
-        // if a number is given its an avatar or elemental spawn
-        if ((arg0 != sol::lua_nil) && arg0.is<int>())
-        {
-            petutils::SpawnMobPet(PMob, arg0.as<uint32>());
-        }
+    if (!PMob || PMob->PPet == nullptr)
+    {
+        ShowWarning("Entity (%d) not valid or pet is a nullptr", m_PBaseEntity->id);
+        return;
+    }
 
-        // always spawn on master
-        PPet->m_SpawnPoint = nearPosition(PMob->loc.p, 2.2f, static_cast<float>(M_PI));
-
-        // setup AI
-        PPet->Spawn();
+    // if a number is given its an avatar or elemental spawn
+    if (arg0 != sol::lua_nil && arg0.is<int>())
+    {
+        petutils::AssignMobPetProperties(PMob, arg0.as<uint32>());
     }
 }
 
@@ -20029,7 +20026,8 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("handleSevereDamage", CLuaBaseEntity::handleSevereDamage);
 
     // Pets and Automations
-    SOL_REGISTER("spawnPet", CLuaBaseEntity::spawnPet);
+    SOL_REGISTER("spawnPlayerPet", CLuaBaseEntity::spawnPlayerPet);
+    SOL_REGISTER("assignMobPetProperties", CLuaBaseEntity::assignMobPetProperties);
     SOL_REGISTER("despawnPet", CLuaBaseEntity::despawnPet);
     SOL_REGISTER("setJugRemainingTime", CLuaBaseEntity::setJugRemainingTime);
 

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -768,7 +768,8 @@ public:
     auto  handleSevereDamage(int32 damage, bool isPhysical) -> int32;
 
     // Pets and Automations
-    void spawnPet(sol::object const& arg0);
+    void spawnPlayerPet(sol::object const& arg0);
+    void assignMobPetProperties(sol::object const& arg0);
     void despawnPet();
     void setJugRemainingTime(uint32 remainingSeconds);
 

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1235,20 +1235,28 @@ namespace petutils
         }
     }
 
-    void SpawnMobPet(CBattleEntity* PMaster, uint32 PetID)
+    // this is ONLY used for mob pets
+    void AssignMobPetProperties(CBattleEntity* PMaster, std::optional<uint32> PetID)
     {
-        // this is ONLY used for mob smn elementals / avatars
-        /*
-        This should eventually be merged into one big spawn pet method.
-        At the moment player pets and mob pets are totally different. We need a central place
-        to manage pet families and spawn them.
-        */
+        // Calling this function clones the mob properties from the partciular g_PPetList entry into the pet
+        // Since player pets are dynamic entities, they are handled separately from mob pets
+        // Mob pets are simply another mob whose AI relies on following the master
 
-        // grab pet info
-        Pet_t*      petData = g_PPetList.at(PetID);
-        CMobEntity* PPet    = dynamic_cast<CMobEntity*>(PMaster->PPet);
+        CMobEntity* PPet = dynamic_cast<CMobEntity*>(PMaster->PPet);
         if (PPet)
         {
+            PPet->allegiance = PMaster->allegiance;
+            PMaster->StatusEffectContainer->CopyConfrontationEffect(PPet);
+            // TODO do we need setBattleID, battlefield, instance as in the player spawnPet function?
+
+            if (!PetID.has_value())
+            {
+                return;
+            }
+
+            // grab pet info
+            Pet_t* petData = g_PPetList.at(PetID.value());
+
             PPet->look = petData->look;
             PPet->name = petData->name;
             PPet->SetMJob(petData->mJob);
@@ -1257,9 +1265,6 @@ namespace petutils
             PPet->m_Element   = petData->m_Element;
             PPet->HPscale     = petData->HPscale;
             PPet->MPscale     = petData->MPscale;
-
-            PPet->allegiance = PMaster->allegiance;
-            PMaster->StatusEffectContainer->CopyConfrontationEffect(PPet);
 
             // TODO: Lets not do this here.
             if (PPet->m_EcoSystem == ECOSYSTEM::AVATAR || PPet->m_EcoSystem == ECOSYSTEM::ELEMENTAL)

--- a/src/map/utils/petutils.h
+++ b/src/map/utils/petutils.h
@@ -212,7 +212,7 @@ namespace petutils
     void FreePetList();
 
     void  SpawnPet(CBattleEntity* PMaster, uint32 PetID, bool spawningFromZone);
-    void  SpawnMobPet(CBattleEntity* PMaster, uint32 PetID);
+    void  AssignMobPetProperties(CBattleEntity* PMaster, std::optional<uint32> PetID);
     void  DetachPet(CBattleEntity* PMaster);
     void  DespawnPet(CBattleEntity* PMaster);
     void  AttackTarget(CBattleEntity* PMaster, CBattleEntity* PTarget);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Inching closer towards perfect (and resolving https://github.com/LandSandBoat/server/issues/5495) this PR splits the `:spawnPet()` function to only handle player entities, and moves the mob logic into a different function that only prepares a pet for summoning. Logic to report incorrect usage:

<img width="1105" height="86" alt="image" src="https://github.com/user-attachments/assets/9adf409e-e47c-4ec1-b42c-f83621cc8506" />


This PR should have a net behavior change of zero. Except perhaps that the copyconfrontation is moved out of requiring a petid when preparing a mob's pet. It's possible there's some edge case resolved by this, but I would imagine the only thing affected would have been summoner pets, which already pass a petid.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- Go to smn, pup, bst, drg mobs, see they still summon pets
  - note that bst mobs were getting a death listener to remove their pet if it isn't engaged, this is not necessary as of [this PR](https://github.com/LandSandBoat/server/pull/8016)
- be those jobs yourself, see you can still summon pets