### PR TITLE
[Magic] Apply new effect resistance ranks to immunobreak

### DIFF
--- a/scripts/globals/combat/magic_hit_rate.lua
+++ b/scripts/globals/combat/magic_hit_rate.lua
@@ -569,8 +569,9 @@ xi.combat.magicHitRate.calculateResistRate = function(actor, target, spellGroup,
     effectId      = utils.defaultIfNil(effectId, 0)
     bonusMacc     = utils.defaultIfNil(bonusMacc, 0)
 
-    -- Calculate resistance rank.
-    -- Some status effects have their own resistance ranks, because they are special. The rest, use regular elemental resistance ranks.
+    -- Decide which resistance rank modifier to use:
+    -- 1: If an effect exists, check if said effect has a specialized resistance rank.
+    -- 2: If an effect doesn't exist, or does but doesn't have a specialized resistance rank, default to action element.
     local resistanceRank    = 0 -- Specific Resistance rank value.
     local resistanceRankMod = 0 -- Modifier ID of the resistance rank to use.
 
@@ -583,14 +584,14 @@ xi.combat.magicHitRate.calculateResistRate = function(actor, target, spellGroup,
             resistanceRankMod = xi.combat.element.getElementalResistanceRankModifier(actionElement)
         end
 
-        resistanceRank = utils.clamp(target:getMod(resistanceRankMod), -3, 11)
+        -- Fetch resistance rank and apply possible modifiers to it.
+        resistanceRank = target:getMod(resistanceRankMod)
 
-        if
-            effectId > 0 and
-            resistanceRank > 4
-        then
-            resistanceRank = utils.clamp(resistanceRank - target:getMod(xi.combat.statusEffect.getAssociatedImmunobreakModifier(effectId)), 4, 11) -- Apply immunobreak modification.
+        if effectId > 0 then
+            resistanceRank = resistanceRank - target:getMod(xi.combat.statusEffect.getAssociatedImmunobreakModifier(effectId)) -- Apply immunobreak modification.
         end
+
+        resistanceRank = utils.clamp(resistanceRank, -3, 11)
     end
 
     -- Get Actor Magic Accuracy and target Magic Evasion


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Makes immunobreakable actions fetch the proper resistance rank instead of defaulting to the elemental one.

## Steps to test these changes

Go RDM. Go enfeeble-bum against mobs with high resistance ranks.
