### PR TITLE
[code comments] Improve clarity for message channel descriptions

### DIFF
--- a/scripts/enum/msg.lua
+++ b/scripts/enum/msg.lua
@@ -21,10 +21,10 @@ xi.msg.channel =
     EMOTION       = 8,
     -- 9 / 10 / 11 = Does not work / nothing
     GM_PROMPT     = 12, -- Menu prompt from GM
-    NS_SAY        = 13, -- Same as MESSAGE_SAY but has no speaker object displayed
-    NS_SHOUT      = 14, -- Same as MESSAGE_SHOUT but has no speaker object displayed
-    NS_PARTY      = 15, -- Same as MESSAGE_PARTY but has no speaker object displayed
-    NS_LINKSHELL  = 16, -- Same as MESSAGE_LINKSHELL but has no speaker object displayed
+    NS_SAY        = 13, -- NS = "No speaker object displayed", otherwise same as SAY
+    NS_SHOUT      = 14, -- NS = "No speaker object displayed", otherwise same as SHOUT
+    NS_PARTY      = 15, -- NS = "No speaker object displayed", otherwise same as PARTY
+    NS_LINKSHELL  = 16, -- NS = "No speaker object displayed", otherwise same as LINKSHELL
     UNKNOWN_17    = 17, -- 17 through 25 appear to repeat the effects of other values
     UNKNOWN_18    = 18,
     UNKNOWN_19    = 19,
@@ -36,7 +36,7 @@ xi.msg.channel =
     UNKNOWN_25    = 25,
     YELL          = 26,
     LINKSHELL2    = 27, -- Second LS color. Default is Green
-    NS_LINKSHELL2 = 28, -- Same as LINKSHELL_2 but has but has no speaker object displayed
+    NS_LINKSHELL2 = 28, -- NS = "No speaker object displayed", otherwise same as LINKSHELL2
     SYSTEM_3      = 29, -- "Basic system messages" in config menu. Yellow by default.
     LINKSHELL3    = 30, -- Yes really it looks like a 3rd LS may have been planned at some point.
     NS_LINKSHELL3 = 31, -- (assumed as it follows pattern and color)

--- a/scripts/events/egg_hunt_egg-stravaganza.lua
+++ b/scripts/events/egg_hunt_egg-stravaganza.lua
@@ -884,7 +884,7 @@ xi.events.eggHunt.onTrade = function(player, npc, trade)
                 if type(v.message) == 'number' then
                     player:messageText(npc, zones[zoneID].text.EGG_HUNT_OFFSET + v.message)
                 else
-                    player:printToPlayer(string.format('Moogle : %s', v.message), xi.msg.channel.NS_SAY, 'Moogle')
+                    player:printToPlayer(v.message, xi.msg.channel.SAY, 'Moogle')
                 end
             end
 

--- a/src/map/packets/chat_message.h
+++ b/src/map/packets/chat_message.h
@@ -44,10 +44,10 @@ enum CHAT_MESSAGE_TYPE : uint8
     MESSAGE_EMOTION   = 8,
     // 9 / 10 / 11 = Does not work / nothing
     MESSAGE_GMPROMPT      = 12, // Menu prompt from GM
-    MESSAGE_NS_SAY        = 13, // Same as MESSAGESAY but has no speaker object displayed
-    MESSAGE_NS_SHOUT      = 14, // Same as MESSAGESHOUT but has no speaker object displayed
-    MESSAGE_NS_PARTY      = 15, // Same as MESSAGEPARTY but has no speaker object displayed
-    MESSAGE_NS_LINKSHELL  = 16, // Same as MESSAGELINKSHELL but has no speaker object displayed
+    MESSAGE_NS_SAY        = 13, // NS = "No speaker object displayed", otherwise same as MESSAGE_SAY
+    MESSAGE_NS_SHOUT      = 14, // NS = "No speaker object displayed", otherwise same as MESSAGE_SHOUT
+    MESSAGE_NS_PARTY      = 15, // NS = "No speaker object displayed", otherwise same as MESSAGE_PARTY
+    MESSAGE_NS_LINKSHELL  = 16, // NS = "No speaker object displayed", otherwise same as MESSAGE_LINKSHELL
     MESSAGE_UNKNOWN_17    = 17, // 17 through 25 appear to repeat the effects of other values
     MESSAGE_UNKNOWN_18    = 18,
     MESSAGE_UNKNOWN_19    = 19,
@@ -59,7 +59,7 @@ enum CHAT_MESSAGE_TYPE : uint8
     MESSAGE_UNKNOWN_25    = 25,
     MESSAGE_YELL          = 26,
     MESSAGE_LINKSHELL2    = 27, // Second LS color...Default is Green
-    MESSAGE_NS_LINKSHELL2 = 28, // Same as LINKSHELL2 but has but has no speaker object displayed
+    MESSAGE_NS_LINKSHELL2 = 28, // NS = "No speaker object displayed", otherwise same as MESSAGE_LINKSHELL2
     MESSAGE_SYSTEM_3      = 29, // "Basic system messages" in config menu. Yellow by default.
     MESSAGE_LINKSHELL3    = 30, // Yes really, it looks like a 3rd LS may have been planned at some point.
     MESSAGE_NS_LINKSHELL3 = 31, // (assumed, as it follows pattern and color)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

IDK feel free to reject this if it's silly, but i've been dealing with various print messages for a while and it never occurred to me that `NS_` meant no speaker. I think if the comments said that first I'd probably have picked up on it sooner. Hopefully this change saves someone else the embarrassment 

closes https://github.com/LandSandBoat/server/issues/7993

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
None of the eggstravaganza messages are non-numbers, but i updated the failover print to use the proper chat channel with the simpler message string. Also serves as an example in the codebase of setting the speaker name