### PR TITLE
[Magic] Implement Magic Critical Hit II and add upper bound for Magic Critical Damage I

### DIFF
--- a/scripts/enum/mod.lua
+++ b/scripts/enum/mod.lua
@@ -271,6 +271,7 @@ xi.mod =
     CRITICAL_HIT_EVASION            = 166,
     CRIT_DEF_BONUS                  = 908, -- Reduces crit hit damage
     MAGIC_CRITHITRATE               = 562,
+    MAGIC_CRITHITRATE_II            = 1168, -- Raises chance to add a critical 1.25 magic damage multiplier.
     MAGIC_CRIT_DMG_INCREASE         = 563,
     HASTE_MAGIC                     = 167,
     SPELLINTERRUPT                  = 168,

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -674,6 +674,20 @@ xi.spells.damage.calculateMagicBonusDiff = function(caster, target, spellId, ski
     return magicBonusDiff
 end
 
+xi.spells.damage.calculateMagicCriticalMultiplier = function(caster)
+    -- Also known as "Magic Critical Hit II"
+    -- https://www.bg-wiki.com/ffxi/Magic_Critical_Hit
+    -- https://www.bg-wiki.com/ffxi/Sroda_Tathlum
+    local criticalMultiplier = 1
+    local criticalChance     = caster:getMod(xi.mod.MAGIC_CRITHITRATE_II)
+
+    if math.random(1, 100) <= criticalChance then
+        criticalMultiplier = 1.25
+    end
+
+    return criticalMultiplier
+end
+
 -- Calculate: Target Magic Damage Adjustment (TMDA)
 -- SDT follow-up. This time for specific modifiers.
 -- Referred to on item as "Magic Damage Taken -%", "Damage Taken -%" (Ex. Defending Ring) and "Magic Damage Taken II -%" (Aegis)
@@ -1102,6 +1116,7 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
     local sdt                       = xi.spells.damage.calculateSDT(target, spellElement)
     local dayAndWeather             = xi.spells.damage.calculateDayAndWeather(caster, spellElement, forceDayWeatherBonus)
     local magicBonusDiff            = xi.spells.damage.calculateMagicBonusDiff(caster, target, spellId, skillType, spellElement)
+    local criticalDamageMultiplier  = xi.spells.damage.calculateMagicCriticalMultiplier(caster)
     local divineSealMultiplier      = xi.spells.damage.calculateDivineSealMultiplier(caster, skillType)
     local divineEmblemMultiplier    = xi.spells.damage.calculateDivineEmblemMultiplier(caster, skillType)
     local eleSealMultiplier         = xi.spells.damage.calculateEnhancedElementalSealMultiplier(caster, skillType, spellElement)
@@ -1124,6 +1139,7 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
     finalDamage = math.floor(finalDamage * additionalResistTier)
     finalDamage = math.floor(finalDamage * dayAndWeather)
     finalDamage = math.floor(finalDamage * magicBonusDiff)
+    finalDamage = math.floor(finalDamage * criticalDamageMultiplier)
     finalDamage = math.floor(finalDamage * targetMagicDamageAdjustment)
     finalDamage = math.floor(finalDamage * divineSealMultiplier)
     finalDamage = math.floor(finalDamage * divineEmblemMultiplier)

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -589,7 +589,7 @@ xi.spells.damage.calculateMagicBonusDiff = function(caster, target, spellId, ski
     local magicBonusDiff = 1 -- The variable we want to calculate
     local casterJob      = caster:getMainJob()
     local mab            = caster:getMod(xi.mod.MATT) + cardinalChantBonus(caster, target, xi.direction.EAST, spellId, skillType)
-    local mabCrit        = caster:getMod(xi.mod.MAGIC_CRITHITRATE) + cardinalChantBonus(caster, target, xi.direction.NORTH, spellId, skillType)
+    local mabCritChance  = caster:getMod(xi.mod.MAGIC_CRITHITRATE) + cardinalChantBonus(caster, target, xi.direction.NORTH, spellId, skillType)
     local mDefBarBonus   = 0
 
     -- Ninja spell bonuses
@@ -634,8 +634,8 @@ xi.spells.damage.calculateMagicBonusDiff = function(caster, target, spellId, ski
         mab = mab + caster:getMod(xi.mod.NIN_NUKE_BONUS_GEAR)
     end
 
-    if math.random(1, 100) <= mabCrit then
-        mab = mab + 10 + caster:getMod(xi.mod.MAGIC_CRIT_DMG_INCREASE)
+    if math.random(1, 100) <= mabCritChance then
+        mab = mab + utils.clamp(10 + caster:getMod(xi.mod.MAGIC_CRIT_DMG_INCREASE), 10, 40)
     end
 
     -- Bar Spells bonuses and BLM merits.

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -47018,9 +47018,9 @@ INSERT INTO `item_mods` VALUES (22300,160,-300); -- DMG: -300
 -- TODO: Physical damage limit +3%
 
 -- Sroda Tathlum
-INSERT INTO `item_mods` VALUES (22301,30,-10); -- MACC: -10
-INSERT INTO `item_mods` VALUES (22301,31,-10); -- MEVA: -10
--- INSERT INTO `item_mods` VALUES (22301,??,10); -- TODO: MAGIC_CRITHITRATE_II: 10
+INSERT INTO `item_mods` VALUES (22301,30,-10);  -- MACC: -10
+INSERT INTO `item_mods` VALUES (22301,31,-10);  -- MEVA: -10
+INSERT INTO `item_mods` VALUES (22301,1168,10); -- MAGIC_CRITHITRATE_II: 10
 
 -- Pummelers Mask +2
 INSERT INTO `item_mods` VALUES (23040,1,123);    -- DEF: 123

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -264,14 +264,15 @@ enum class Mod
     DARK_ABSORB       = 466, // Occasionally absorbs dark elemental damage.
 
     // Crit Damage / Delay
-    CRITHITRATE              = 165, // Raises chance to crit
-    CRITHITRATE_ONLY_WEP     = 141, // Raises chance to crit (but only for attacks with the specific weapon that has the mod)
-    CRIT_DMG_INCREASE        = 421, // Raises the damage of critical hit by percent %
-    RANGED_CRIT_DMG_INCREASE = 964, // Increases ranged critical damage by a percent
-    CRITICAL_HIT_EVASION     = 166, // Modifies chance enemy will crit
-    CRIT_DEF_BONUS           = 908, // Reduces crit hit damage
-    MAGIC_CRITHITRATE        = 562, // Raises chance to magic crit
-    MAGIC_CRIT_DMG_INCREASE  = 563, // Raises damage done when criting with magic
+    CRITHITRATE              = 165,  // Raises chance to crit
+    CRITHITRATE_ONLY_WEP     = 141,  // Raises chance to crit (but only for attacks with the specific weapon that has the mod)
+    CRIT_DMG_INCREASE        = 421,  // Raises the damage of critical hit by percent %
+    RANGED_CRIT_DMG_INCREASE = 964,  // Increases ranged critical damage by a percent
+    CRITICAL_HIT_EVASION     = 166,  // Modifies chance enemy will crit
+    CRIT_DEF_BONUS           = 908,  // Reduces crit hit damage
+    MAGIC_CRITHITRATE        = 562,  // Raises chance to magic crit
+    MAGIC_CRITHITRATE_II     = 1168, // Raises chance to add a critical 1.25 magic damage multiplier.
+    MAGIC_CRIT_DMG_INCREASE  = 563,  // Raises damage done when criting with magic
 
     FENCER_TP_BONUS    = 903, // TP Bonus to weapon skills from Fencer Trait
     FENCER_CRITHITRATE = 904, // Increased Crit chance from Fencer Trait
@@ -1115,7 +1116,7 @@ enum class Mod
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     // 570 through 825 used by WS DMG mods these are not spares.
     //
-    // SPARE IDs: 1168 and onward
+    // SPARE IDs: 1169 and onward
 };
 
 // temporary workaround for using enum class as unordered_map key until compilers support it


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Minor change to account for magical critical damage limit, based on this [BG Wiki Page](https://www.bg-wiki.com/ffxi/Magic_Critical_Hit)

## Steps to test these changes

None, really. It's just a clamp.
