### PR TITLE
[sql] Monastic Caverns Spawn Groupings

### DIFF
--- a/sql/mob_spawn_sets.sql
+++ b/sql/mob_spawn_sets.sql
@@ -8,19 +8,48 @@ CREATE TABLE IF NOT EXISTS `mob_spawn_sets` (
 )
 ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
--- AlTaieu
--- INSERT INTO `mob_spawn_sets` VALUES (33, 1, 7);
--- INSERT INTO `mob_spawn_sets` VALUES (33, 2, 1);
--- INSERT INTO `mob_spawn_sets` VALUES (33, 3, 3);
--- INSERT INTO `mob_spawn_sets` VALUES (33, 4, 7);
--- INSERT INTO `mob_spawn_sets` VALUES (33, 5, 3);
--- INSERT INTO `mob_spawn_sets` VALUES (33, 6, 4);
--- INSERT INTO `mob_spawn_sets` VALUES (33, 7, 9);
--- INSERT INTO `mob_spawn_sets` VALUES (33, 8, 3);
--- INSERT INTO `mob_spawn_sets` VALUES (33, 9, 2);
--- INSERT INTO `mob_spawn_sets` VALUES (33, 10, 3);
--- INSERT INTO `mob_spawn_sets` VALUES (33, 11, 2);
--- INSERT INTO `mob_spawn_sets` VALUES (33, 12, 1);
--- INSERT INTO `mob_spawn_sets` VALUES (33, 13, 1);
+-- Monastic Cavern
+INSERT INTO `mob_spawn_sets` VALUES (150, 1, 1);
+INSERT INTO `mob_spawn_sets` VALUES (150, 2, 1);
+INSERT INTO `mob_spawn_sets` VALUES (150, 3, 2);
+INSERT INTO `mob_spawn_sets` VALUES (150, 4, 2);
+INSERT INTO `mob_spawn_sets` VALUES (150, 5, 2);
+INSERT INTO `mob_spawn_sets` VALUES (150, 6, 2);
+INSERT INTO `mob_spawn_sets` VALUES (150, 7, 2);
+INSERT INTO `mob_spawn_sets` VALUES (150, 8, 1);
+INSERT INTO `mob_spawn_sets` VALUES (150, 9, 1);
+INSERT INTO `mob_spawn_sets` VALUES (150, 10, 2);
+INSERT INTO `mob_spawn_sets` VALUES (150, 11, 2);
+INSERT INTO `mob_spawn_sets` VALUES (150, 12, 1);
+INSERT INTO `mob_spawn_sets` VALUES (150, 13, 1);
+INSERT INTO `mob_spawn_sets` VALUES (150, 14, 1);
+INSERT INTO `mob_spawn_sets` VALUES (150, 15, 1);
+INSERT INTO `mob_spawn_sets` VALUES (150, 16, 1);
+INSERT INTO `mob_spawn_sets` VALUES (150, 17, 1);
+INSERT INTO `mob_spawn_sets` VALUES (150, 18, 1);
+INSERT INTO `mob_spawn_sets` VALUES (150, 19, 1);
+INSERT INTO `mob_spawn_sets` VALUES (150, 20, 1);
+INSERT INTO `mob_spawn_sets` VALUES (150, 21, 3);
+INSERT INTO `mob_spawn_sets` VALUES (150, 22, 2);
+INSERT INTO `mob_spawn_sets` VALUES (150, 23, 2);
+INSERT INTO `mob_spawn_sets` VALUES (150, 24, 1);
+INSERT INTO `mob_spawn_sets` VALUES (150, 25, 1);
+INSERT INTO `mob_spawn_sets` VALUES (150, 26, 1);
+INSERT INTO `mob_spawn_sets` VALUES (150, 27, 1);
+INSERT INTO `mob_spawn_sets` VALUES (150, 28, 1);
+INSERT INTO `mob_spawn_sets` VALUES (150, 29, 1);
+INSERT INTO `mob_spawn_sets` VALUES (150, 30, 1);
+INSERT INTO `mob_spawn_sets` VALUES (150, 31, 1);
+INSERT INTO `mob_spawn_sets` VALUES (150, 32, 1);
+INSERT INTO `mob_spawn_sets` VALUES (150, 33, 1);
+INSERT INTO `mob_spawn_sets` VALUES (150, 34, 2);
+INSERT INTO `mob_spawn_sets` VALUES (150, 35, 2);
+INSERT INTO `mob_spawn_sets` VALUES (150, 36, 2);
+INSERT INTO `mob_spawn_sets` VALUES (150, 37, 1);
+INSERT INTO `mob_spawn_sets` VALUES (150, 38, 3);
+INSERT INTO `mob_spawn_sets` VALUES (150, 39, 1);
+INSERT INTO `mob_spawn_sets` VALUES (150, 40, 1);
+INSERT INTO `mob_spawn_sets` VALUES (150, 41, 1);
 
+-- Korroloka Tunnel
 INSERT INTO `mob_spawn_sets` VALUES (173, 1, 10);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Implements spawn groupings for Monastic Caverns.

This work was done by myself and Monti (a member of the community) roughly around 2 years ago. I will be implementing the zones that *HAVE NOT CHANGED* since then.

The time spent on this project was roughly 3 months and seeing how big this project was not everything here will be 100% correct. The only way to make this system 100% correct is by killing each mob over and over and over again 1 by 1 in order to determine was every exact spawn grouping is. This was done for all COP zones only.

Process: Monastic as an example
1) Wait until the entire zone is empty of players
2) Run around the zone capturing all *CURRENT* mob positions. Something to note here is that a retail-like spawn system consists of "spawn regions" and mobs do *NOT* spawn in the same static spot.
3) The data was then ported into an excel doc. Notice the 1 and 7s in the green column. This means that the mob with a 7 is currently not spawned. This was extremely helpful determining  which mobs belong to which grouping.
<img width="2274" height="1004" alt="image" src="https://github.com/user-attachments/assets/9997d925-63ad-4aaa-a692-ea6cb7e74bd7" />
4) We then imported the current spawn points in our database into a separate sheet.
<img width="900" height="1014" alt="image" src="https://github.com/user-attachments/assets/c4237871-c412-4bd4-8c52-2f388e45f50f" />
5) Once these were both in the files were then combined into one combining the NEW spawn points with the OLD
<img width="1410" height="975" alt="image" src="https://github.com/user-attachments/assets/546443e5-0f5c-490e-a070-1d1b2833ccfc" />

by doing all of this it was updating the positions of mobs that were freely roaming around the zone with NO players in it except us. Groupings were then killed 1 by 1 to make sure nothing extremely odd was happening. This data was then compared to a monster bible book we purchased on line which looks like this:
<img width="969" height="763" alt="image" src="https://github.com/user-attachments/assets/b89acf0d-f246-4be5-8632-02aca9786288" />

Surprisingly the data matches EXTREMELY well. The fact this was documented so long ago was also extremely helpful to know we were on the right track.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Go to monastic caverns and see that its empty :)
Previous:
<img width="981" height="483" alt="image" src="https://github.com/user-attachments/assets/ea9e7042-a060-4bb2-aa5a-5d4c85fca528" />

New: 
<img width="1054" height="588" alt="image" src="https://github.com/user-attachments/assets/8d82d5f9-9294-4938-964d-ce232ac73994" />

<!-- Clear and detailed steps to test your changes here -->
