### PR TITLE
Prepared Statements: itemutils (+ missing item SQL entries)

### DIFF
--- a/scripts/items/scroll_of_dark_carol_ii.lua
+++ b/scripts/items/scroll_of_dark_carol_ii.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- ID: 5061
+-- Scroll of Dark Carol II
+-- Teaches the song Dark Carol II
+-----------------------------------
+---@type TItem
+local itemObject = {}
+
+itemObject.onItemCheck = function(target, item, param, caster)
+    return target:canLearnSpell(xi.magic.spell.DARK_CAROL_II)
+end
+
+itemObject.onItemUse = function(target)
+    target:addSpell(xi.magic.spell.DARK_CAROL_II)
+end
+
+return itemObject

--- a/scripts/items/scroll_of_horde_lullaby_ii.lua
+++ b/scripts/items/scroll_of_horde_lullaby_ii.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- ID: 4985
+-- Scroll of Horde Lullaby II
+-- Teaches the song Horde Lullaby II
+-----------------------------------
+---@type TItem
+local itemObject = {}
+
+itemObject.onItemCheck = function(target, item, param, caster)
+    return target:canLearnSpell(xi.magic.spell.HORDE_LULLABY_II)
+end
+
+itemObject.onItemUse = function(target)
+    target:addSpell(xi.magic.spell.HORDE_LULLABY_II)
+end
+
+return itemObject

--- a/scripts/items/scroll_of_ice_carol_ii.lua
+++ b/scripts/items/scroll_of_ice_carol_ii.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- ID: 5055
+-- Scroll of Ice Carol II
+-- Teaches the song Ice Carol II
+-----------------------------------
+---@type TItem
+local itemObject = {}
+
+itemObject.onItemCheck = function(target, item, param, caster)
+    return target:canLearnSpell(xi.magic.spell.ICE_CAROL_II)
+end
+
+itemObject.onItemUse = function(target)
+    target:addSpell(xi.magic.spell.ICE_CAROL_II)
+end
+
+return itemObject

--- a/scripts/items/scroll_of_light_carol_ii.lua
+++ b/scripts/items/scroll_of_light_carol_ii.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- ID: 5060
+-- Scroll of Light Carol II
+-- Teaches the song Light Carol II
+-----------------------------------
+---@type TItem
+local itemObject = {}
+
+itemObject.onItemCheck = function(target, item, param, caster)
+    return target:canLearnSpell(xi.magic.spell.LIGHT_CAROL_II)
+end
+
+itemObject.onItemUse = function(target)
+    target:addSpell(xi.magic.spell.LIGHT_CAROL_II)
+end
+
+return itemObject

--- a/scripts/items/scroll_of_lightning_carol_ii.lua
+++ b/scripts/items/scroll_of_lightning_carol_ii.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- ID: 5058
+-- Scroll of Lightning Carol II
+-- Teaches the song Lightning Carol II
+-----------------------------------
+---@type TItem
+local itemObject = {}
+
+itemObject.onItemCheck = function(target, item, param, caster)
+    return target:canLearnSpell(xi.magic.spell.LIGHTNING_CAROL_II)
+end
+
+itemObject.onItemUse = function(target)
+    target:addSpell(xi.magic.spell.LIGHTNING_CAROL_II)
+end
+
+return itemObject

--- a/scripts/items/scroll_of_pining_nocturne.lua
+++ b/scripts/items/scroll_of_pining_nocturne.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- ID: 5080
+-- Scroll of Pining Nocturne
+-- Teaches the song Pining Nocturne
+-----------------------------------
+---@type TItem
+local itemObject = {}
+
+itemObject.onItemCheck = function(target, item, param, caster)
+    return target:canLearnSpell(xi.magic.spell.PINING_NOCTURNE)
+end
+
+itemObject.onItemUse = function(target)
+    target:addSpell(xi.magic.spell.PINING_NOCTURNE)
+end
+
+return itemObject

--- a/sql/item_basic.sql
+++ b/sql/item_basic.sql
@@ -4874,7 +4874,7 @@ INSERT INTO `item_basic` VALUES (5102,840,'scroll_of_foil','foil',1,1676,@WHITE_
 INSERT INTO `item_basic` VALUES (5103,476,'scroll_of_crusade','crusade',1,1676,@WHITE_MAGIC,0,0);
 INSERT INTO `item_basic` VALUES (5104,845,'scroll_of_flurry','flurry',1,1676,@WHITE_MAGIC,0,3300); -- DAT missing SCROLL flag
 INSERT INTO `item_basic` VALUES (5105,846,'scroll_of_flurry_ii','flurry_ii',1,34444,@WHITE_MAGIC,0,43); -- DAT missing SCROLL flag
-INSERT INTO `item_basic` VALUES (5106,0,'scroll_of_inundation','inundation',1,34444,@WHITE_MAGIC,0,0);
+INSERT INTO `item_basic` VALUES (5106,879,'scroll_of_inundation','inundation',1,34444,@WHITE_MAGIC,0,0);
 INSERT INTO `item_basic` VALUES (5109,0,'frayed_sack_of_abundance_+1','frayed_sack_(a1)',99,30296,@NONE,0,0);
 INSERT INTO `item_basic` VALUES (5110,0,'frayed_sack_of_abundance_+2','frayed_sack_(a2)',99,30296,@NONE,0,0);
 INSERT INTO `item_basic` VALUES (5111,0,'frayed_sack_of_mortality_+1','frayed_sack_(m1)',99,30296,@NONE,1,0);

--- a/sql/item_equipment.sql
+++ b/sql/item_equipment.sql
@@ -11085,8 +11085,21 @@ INSERT INTO `item_equipment` VALUES (22145,'artemiss_bow_+2',99,119,1024,138,0,0
 INSERT INTO `item_equipment` VALUES (22147,'scouts_crossbow',99,119,1024,52,0,0,4,0,0,4);
 INSERT INTO `item_equipment` VALUES (22148,'arke_crossbow',99,119,1024,52,0,0,4,0,0,4);
 INSERT INTO `item_equipment` VALUES (22149,'sharanga',99,119,1024,142,0,0,4,0,0,5);
+INSERT INTO `item_equipment` VALUES (22150,'gletis_crossbow',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22151,'mpacas_bow',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22152,'exeter',99,0,0,0,0,0,32,0,0,0);          -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (22153,'silver_gun',1,0,4194303,139,0,0,4,0,0,0);
 INSERT INTO `item_equipment` VALUES (22154,'silver_gun+1',1,0,4194303,139,0,0,4,0,0,0);
+INSERT INTO `item_equipment` VALUES (22155,'prime_bow',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22156,'pinaka',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22157,'pinaka',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22158,'pinaka',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22159,'prime_gun',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22160,'earp',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22161,'earp',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22162,'earp',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22163,'pinaka',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22164,'earp',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (22195,'flanged_grip',99,0,4194303,0,0,0,2,0,0,0);
 INSERT INTO `item_equipment` VALUES (22196,'alber_strap',99,0,4194303,0,0,0,2,0,0,0);
 INSERT INTO `item_equipment` VALUES (22197,'niobid_strap',99,0,4194303,0,0,0,2,0,0,0);
@@ -11162,6 +11175,14 @@ INSERT INTO `item_equipment` VALUES (22298,'aurgelmir_orb_+1',99,0,2473971,0,0,0
 INSERT INTO `item_equipment` VALUES (22299,'per._lucky_egg',99,0,4194303,0,0,0,8,0,0,0);
 INSERT INTO `item_equipment` VALUES (22300,'crepuscular_pebble',99,0,4194303,0,0,0,8,4,0,0);
 INSERT INTO `item_equipment` VALUES (22301,'sroda_tathlum',99,0,4194303,0,0,0,8,4,0,0);
+INSERT INTO `item_equipment` VALUES (22302,'oshashas_treatise',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22303,'prime_horn',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22304,'loughnashade',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22305,'loughnashade',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22306,'loughnashade',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22307,'loughnashade',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22308,'bayeux_bullet',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22309,'bayeux_arrow',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23040,'pummelers_mask_+2',99,119,1,64,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23041,'anch._crown_+2',99,119,2,66,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23042,'theophany_cap_+2',99,119,4,68,0,0,16,0,0,0);
@@ -11207,7 +11228,28 @@ INSERT INTO `item_equipment` VALUES (23081,'horos_tiara_+2',99,119,262144,304,0,
 INSERT INTO `item_equipment` VALUES (23082,'peda._m.board_+2',99,119,524288,215,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23083,'bagua_galero_+2',99,119,1048576,310,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23084,'fu._bandeau_+2',99,119,2097152,339,0,0,16,0,0,0);
+INSERT INTO `item_equipment` VALUES (23085,'boii_mask_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23086,'bhikku_crown_+2',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23087,'ebers_cap_+2',99,119,4,284,0,0,16,0,0,0);
+INSERT INTO `item_equipment` VALUES (23088,'wicce_petasos_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23089,'lethargy_chappel_+2',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23090,'Skulkers_Bonnet_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23091,'chevaliers_armet_+2',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23092,'heathens_burgeonet_+2',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23093,'nukumi_cabasset_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23094,'fili_calot_+2',99,0,0,0,0,0,32,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23095,'amini_gapette_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23096,'kasuga_kabuto_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23097,'hattori_zukin_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23098,'peltasts_mezail_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23099,'beckoners_horn_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23100,'hashishin_kavuk_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23101,'chasseurs_tricorne_+2',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23102,'karagoz_cappello_+2',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23103,'maculele_tiara_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23104,'arbatel_bonnet_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23105,'azimuth_hood_+2',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23106,'erilaz_galea_+2',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23107,'pumm._lorica_+2',99,119,1,64,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (23108,'anch._cyclas_+2',99,119,2,66,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (23109,'theo._bliaut_+2',99,119,4,68,0,0,32,0,0,0);
@@ -11253,6 +11295,28 @@ INSERT INTO `item_equipment` VALUES (23148,'horos_casaque_+2',99,119,262144,304,
 INSERT INTO `item_equipment` VALUES (23149,'peda._gown_+2',99,119,524288,217,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (23150,'bagua_tunic_+2',99,119,1048576,310,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (23151,'futhark_coat_+2',99,119,2097152,339,0,0,32,0,0,0);
+INSERT INTO `item_equipment` VALUES (23152,'boii_lorica_+2',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23153,'bhikku_cyclas_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23154,'ebers_bliaut_+2',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23155,'wicce_coat_+2',99,0,0,0,0,0,32,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23156,'lethargy_sayon_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23157,'Skulkers_Vest_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23158,'chevaliers_cuirass_+2',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23159,'heathens_cuirass_+2',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23160,'nukumi_gausape_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23161,'fili_hongreline_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23162,'amini_caban_+2',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23163,'kasuga_domaru_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23164,'hattori_ningi_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23165,'peltasts_plackart_+2',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23166,'beckoners_doublet_+2',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23167,'hashishin_mintan_+2',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23168,'chasseurs_frac_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23169,'karagoz_farsetto_+2',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23170,'maculele_casaque_+2',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23171,'arbatel_gown_+2',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23172,'azimuth_coat_+2',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23173,'erilaz_surcoat_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23174,'pumm._mufflers_+2',99,119,1,64,0,0,64,0,0,0);
 INSERT INTO `item_equipment` VALUES (23175,'anchor._gloves_+2',99,119,2,66,0,0,64,0,0,0);
 INSERT INTO `item_equipment` VALUES (23176,'theophany_mitts_+2',99,119,4,68,0,0,64,0,0,0);
@@ -11298,6 +11362,28 @@ INSERT INTO `item_equipment` VALUES (23215,'horos_bangles_+2',99,119,262144,304,
 INSERT INTO `item_equipment` VALUES (23216,'peda._bracers_+2',99,119,524288,215,0,0,64,0,0,0);
 INSERT INTO `item_equipment` VALUES (23217,'bagua_mitaines_+2',99,119,1048576,310,0,0,64,0,0,0);
 INSERT INTO `item_equipment` VALUES (23218,'futhark_mitons_+2',99,119,2097152,339,0,0,64,0,0,0);
+INSERT INTO `item_equipment` VALUES (23219,'boii_mufflers_+2',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23220,'bhikku_gloves_+2',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23221,'ebers_mitts_+2',99,0,0,0,0,0,32,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23222,'wicce_gloves_+2',99,0,0,0,0,0,32,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23223,'lethargy_gantherots_+2',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23224,'skulkers_armlets_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23225,'chevaliers_gauntlets_+2',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23226,'heathens_gauntlets_+2',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23227,'nukumi_manoplas_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23228,'fili_manchettes_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23229,'amini_glovelettes_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23230,'kasuga_kote_+2',99,0,0,0,0,0,32,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23231,'hattori_tekko_+2',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23232,'peltasts_vambraces_+2',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23233,'beckoners_bracers_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23234,'hashishin_bazubands_+2',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23235,'chasseurs_gants_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23236,'karagoz_guanti_+2',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23237,'maculele_bangles_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23238,'arbatel_bracers_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23239,'azimuth_gloves_+2',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23240,'erilaz_gauntlets_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23241,'pumm._cuisses_+2',99,119,1,64,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23242,'anch._hose_+2',99,119,2,66,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23243,'th._pantaloons_+2',99,119,4,68,0,0,128,0,0,0);
@@ -11343,7 +11429,28 @@ INSERT INTO `item_equipment` VALUES (23282,'horos_tights_+2',99,119,262144,304,0
 INSERT INTO `item_equipment` VALUES (23283,'peda._pants_+2',99,119,524288,215,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23284,'bagua_pants_+2',99,119,1048576,310,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23285,'futhark_trousers_+2',99,119,2097152,339,0,0,128,0,0,0);
+INSERT INTO `item_equipment` VALUES (23286,'boii_cuisses_+2',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23287,'bhikku_hose_+2',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23288,'ebers_pantaloons_+2',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23289,'wicce_chausses_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23290,'lethargy_fuseau_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23291,'skulkers_culottes_+2',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23292,'chevaliers_cuisses_+2',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23293,'heathens_flanchard_+2',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23294,'nukumi_quijotes_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23295,'fili_rhingrave_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23296,'amini_bragues_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23297,'kasuga_haidate_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23298,'hattori_hakama_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23299,'peltasts_cuissots_+2',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23300,'beckoners_spats_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23301,'hashishin_tayt_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23302,'chasseurs_culottes_+2',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23303,'kara._pantaloni_+2',99,119,131072,299,0,0,128,0,0,0);
+INSERT INTO `item_equipment` VALUES (23304,'maculele_tights_+2',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23305,'arbatel_pants_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23306,'azimuth_tights_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23307,'erilaz_leg_guards_+2',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23308,'pumm._calligae_+2',99,119,1,64,0,0,256,0,0,0);
 INSERT INTO `item_equipment` VALUES (23309,'anch._gaiters_+2',99,119,2,66,0,0,256,0,0,0);
 INSERT INTO `item_equipment` VALUES (23310,'theo._duckbills_+2',99,119,4,68,0,0,256,0,0,0);
@@ -11389,7 +11496,28 @@ INSERT INTO `item_equipment` VALUES (23349,'horos_t._shoes_+2',99,119,262144,304
 INSERT INTO `item_equipment` VALUES (23350,'peda._loafers_+2',99,119,524288,215,0,0,256,0,0,0);
 INSERT INTO `item_equipment` VALUES (23351,'bagua_sandals_+2',99,119,1048576,310,0,0,256,0,0,0);
 INSERT INTO `item_equipment` VALUES (23352,'futhark_boots_+2',99,119,2097152,339,0,0,256,0,0,0);
+INSERT INTO `item_equipment` VALUES (23353,'boii_calligae_+2',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23354,'bhikku_gaiters_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23355,'ebers_duckbills_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23356,'wicce_sabots_+2',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23357,'lethargy_houseaux_+2',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23358,'skulkers_poulaines +2',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23359,'chevaliers_sabatons_+2',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23360,'heathens_sollerets_+2',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23361,'nukumi_ocreae_+2',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23362,'fili_cothurnes_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23363,'amini_bottillons_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23364,'kas._sune-ate_+2',99,119,2048,293,0,0,256,0,0,0);
+INSERT INTO `item_equipment` VALUES (23365,'hattori_yahan_+2',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23366,'peltasts_schynbalds_+2',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23367,'beckoners_pigaches +2',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23368,'hashishin_basmak_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23369,'chasseurs_bottes_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23370,'karagoz_scarpe_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23371,'maculele_toe_shoes_+2',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23372,'arbatel_loafers_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23373,'azimuth_gaiters_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23374,'erilaz_greaves_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23375,'pummelers_mask_+3',99,119,1,64,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23376,'anch._crown_+3',99,119,2,66,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23377,'theophany_cap_+3',99,119,4,68,0,0,16,0,0,0);
@@ -11435,6 +11563,28 @@ INSERT INTO `item_equipment` VALUES (23416,'horos_tiara_+3',99,119,262144,304,0,
 INSERT INTO `item_equipment` VALUES (23417,'peda._m.board_+3',99,119,524288,215,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23418,'bagua_galero_+3',99,119,1048576,310,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23419,'fu._bandeau_+3',99,119,2097152,339,0,0,16,0,0,0);
+INSERT INTO `item_equipment` VALUES (23420,'boii_mask_+3',99,0,0,0,0,0,32,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23421,'bhikku_crown_+3',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23422,'ebers_cap_+3',99,0,0,0,0,0,32,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23423,'wicce_petasos_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23424,'lethargy_chappel_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23425,'skulkers_bonnet_+3',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23426,'chevaliers_armet_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23427,'heathens_burgeonet_+3',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23428,'nukumi_cabasset_+3',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23429,'fili_calot_+3',99,0,0,0,0,0,32,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23430,'amini_gapette_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23431,'kasuga_kabuto_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23432,'hattori_zukin_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23433,'peltasts_mezail_+3',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23434,'beckoners_horn_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23435,'hashishin_kavuk_+3',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23436,'chasseurs_tricorne_+3',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23437,'karagoz_cappello_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23438,'maculele_tiara_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23439,'arbatel_bonnet_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23440,'azimuth_hood_+3',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23441,'erilaz_galea_+3',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23442,'pumm._lorica_+3',99,119,1,64,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (23443,'anch._cyclas_+3',99,119,2,66,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (23444,'theo._bliaut_+3',99,119,4,68,0,0,32,0,0,0);
@@ -11480,6 +11630,28 @@ INSERT INTO `item_equipment` VALUES (23483,'horos_casaque_+3',99,119,262144,304,
 INSERT INTO `item_equipment` VALUES (23484,'peda._gown_+3',99,119,524288,217,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (23485,'bagua_tunic_+3',99,119,1048576,310,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (23486,'futhark_coat_+3',99,119,2097152,339,0,0,32,0,0,0);
+INSERT INTO `item_equipment` VALUES (23487,'boii_lorica_+3',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23488,'bhikku_cyclas_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23489,'ebers_bliaut_+3',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23490,'wicce_coat_+3',99,0,0,0,0,0,32,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23491,'lethargy_sayon_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23492,'skulkers_vest_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23493,'chevaliers_cuirass_+3',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23494,'heathens_cuirass_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23495,'nukumi_gausape_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23496,'fili_hongreline_+3',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23497,'amini_caban_+3',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23498,'kasuga_domaru_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23499,'hattori_ningi_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23500,'peltasts_plackart_+3',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23501,'beckoners_doublet_+3',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23502,'hashishin_mintan_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23503,'chasseurs_frac_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23504,'karagoz_farsetto_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23505,'maculele_casaque_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23506,'arbatel_gown_+3',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23507,'azimuth_coat_+3',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23508,'erilaz_surcoat_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23509,'pumm._mufflers_+3',99,119,1,64,0,0,64,0,0,0);
 INSERT INTO `item_equipment` VALUES (23510,'anchor._gloves_+3',99,119,2,66,0,0,64,0,0,0);
 INSERT INTO `item_equipment` VALUES (23511,'theophany_mitts_+3',99,119,4,68,0,0,64,0,0,0);
@@ -11525,6 +11697,28 @@ INSERT INTO `item_equipment` VALUES (23550,'horos_bangles_+3',99,119,262144,304,
 INSERT INTO `item_equipment` VALUES (23551,'peda._bracers_+3',99,119,524288,215,0,0,64,0,0,0);
 INSERT INTO `item_equipment` VALUES (23552,'bagua_mitaines_+3',99,119,1048576,310,0,0,64,0,0,0);
 INSERT INTO `item_equipment` VALUES (23553,'futhark_mitons_+3',99,119,2097152,339,0,0,64,0,0,0);
+INSERT INTO `item_equipment` VALUES (23554,'boii_mufflers_+3',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23555,'bhikku_gloves_+3',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23556,'ebers_mitts_+3',99,0,0,0,0,0,32,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23557,'wicce_gloves_+3',99,0,0,0,0,0,32,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23558,'lethargy_gantherots_+3',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23559,'skulkers_armlets_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23560,'chevaliers_gauntlets_+3',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23561,'heathens_gauntlets_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23562,'nukumi_manoplas_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23563,'fili_manchettes_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23564,'amini_glovelettes_+3',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23565,'kasuga_kote_+3',99,0,0,0,0,0,32,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23566,'hattori_tekko_+3',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23567,'peltasts_vambraces_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23568,'beckoners_bracers_+3',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23569,'hashishin_bazubands_+3',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23570,'chasseurs_gants_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23571,'karagoz_guanti_+3',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23572,'maculele_bangles_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23573,'arbatel_bracers_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23574,'azimuth_gloves_+3',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23575,'erilaz_gauntlets_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23576,'pumm._cuisses_+3',99,119,1,64,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23577,'anch._hose_+3',99,119,2,66,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23578,'th._pant._+3',99,119,4,68,0,0,128,0,0,0);
@@ -11570,6 +11764,28 @@ INSERT INTO `item_equipment` VALUES (23617,'horos_tights_+3',99,119,262144,304,0
 INSERT INTO `item_equipment` VALUES (23618,'peda._pants_+3',99,119,524288,215,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23619,'bagua_pants_+3',99,119,1048576,310,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23620,'futhark_trousers_+3',99,119,2097152,339,0,0,128,0,0,0);
+INSERT INTO `item_equipment` VALUES (23621,'boii_cuisses_+3',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23622,'bhikku_hose_+3',99,0,0,0,0,0,32,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23623,'ebers_pantaloons_+3',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23624,'wicce_chausses_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23625,'lethargy_fuseau_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23626,'skulkers_culottes_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23627,'chevaliers_cuisses_+3',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23628,'heathens_flanchards_+3',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23629,'nukumi_quijotes_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23630,'fili_rhingrave_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23631,'amini_bragues_+3',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23632,'kasuga_haidate_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23633,'hattori_hakama_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23634,'peltasts_cuissots_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23635,'beckoners_spats_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23636,'hashishin_tayt_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23637,'chasseurs_culottes_+3',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23638,'karagoz_pantaloni_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23639,'maculele_tights_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23640,'arbatel_pants_+3',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23641,'azimuth_tights_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23642,'erilaz_leg_guards_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23643,'pumm._calligae_+3',99,119,1,64,0,0,256,0,0,0);
 INSERT INTO `item_equipment` VALUES (23644,'anch._gaiters_+3',99,119,2,66,0,0,256,0,0,0);
 INSERT INTO `item_equipment` VALUES (23645,'theo._duckbills_+3',99,119,4,68,0,0,256,0,0,0);
@@ -11615,6 +11831,28 @@ INSERT INTO `item_equipment` VALUES (23684,'horos_t._shoes_+3',99,119,262144,304
 INSERT INTO `item_equipment` VALUES (23685,'peda._loafers_+3',99,119,524288,215,0,0,256,0,0,0);
 INSERT INTO `item_equipment` VALUES (23686,'bagua_sandals_+3',99,119,1048576,310,0,0,256,0,0,0);
 INSERT INTO `item_equipment` VALUES (23687,'futhark_boots_+3',99,119,2097152,339,0,0,256,0,0,0);
+INSERT INTO `item_equipment` VALUES (23688,'boii_calligae_+3',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23689,'bhikku_gaiters_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23690,'ebers_duckbills_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23691,'wicce_sabots_+3',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23692,'lethargy_houseaux_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23693,'skulkers_poulaines_+3',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23694,'chevaliers_sabatons_+3',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23695,'heathens_sollerets_+3',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23696,'nukumi_ocreae_+3',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23697,'fili_cothurnes_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23698,'amini_bottillons_+3',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23699,'kasuga_sune-ate_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23700,'hattori_kyahan_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23701,'peltasts_schynbalds_+3',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23702,'beckoners_pigaches_+3',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23703,'hashishin_basmak_+3',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23704,'chasseurs_bottes_+3',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23705,'karagoz_scarpe_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23706,'maculele_toe_shoes_+3',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23707,'arbatel_loafers_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23708,'azimuth_gaiters_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23709,'erilaz_greaves_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23710,'volte_beret',99,119,1589788,132,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23711,'volte_tiara',99,119,2605043,128,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23712,'volte_salade',99,119,193,164,0,0,16,0,0,0);
@@ -11642,6 +11880,7 @@ INSERT INTO `item_equipment` VALUES (23733,'malignance_tabard',99,119,496946,458
 INSERT INTO `item_equipment` VALUES (23734,'malignance_gloves',99,119,496946,458,0,0,64,0,0,0);
 INSERT INTO `item_equipment` VALUES (23735,'malignance_tights',99,119,496946,458,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23736,'malignance_boots',99,119,496946,458,0,0,256,0,0,0);
+INSERT INTO `item_equipment` VALUES (23737,'byakko_masque',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23738,'hervor_galea',99,119,10689,276,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23739,'heidrek_mask',99,119,2462754,252,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23740,'angantyr_beret',99,119,1720860,267,0,0,16,0,0,0);
@@ -11678,8 +11917,10 @@ INSERT INTO `item_equipment` VALUES (23770,'gletis_gauntlets',99,119,303392,465,
 INSERT INTO `item_equipment` VALUES (23771,'sakpatas_gauntlets',99,119,193,466,0,0,64,0,0,0);
 INSERT INTO `item_equipment` VALUES (23772,'mpacas_gloves',99,119,137218,467,0,0,64,0,0,0);
 INSERT INTO `item_equipment` VALUES (23773,'agwus_gages',99,119,3670024,468,0,0,64,0,0,0);
+INSERT INTO `item_equipment` VALUES (23774,'bunzis_gloves',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23775,'nyame_gauntlets',99,119,4194303,470,0,0,64,0,0,0);
 INSERT INTO `item_equipment` VALUES (23776,'ikengas_trousers',99,119,66560,464,0,0,128,0,0,0);
+INSERT INTO `item_equipment` VALUES (23777,'gletis_breeches',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23778,'sakpatas_cuisses',99,119,193,466,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23779,'mpacas_hose',99,119,137218,467,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23780,'agwus_slops',99,119,3670024,468,0,0,128,0,0,0);
@@ -11699,13 +11940,36 @@ INSERT INTO `item_equipment` VALUES (23793,'ziamet_peti',1,0,4194303,172,0,0,32,
 INSERT INTO `item_equipment` VALUES (23794,'ziamet_bazubands',1,0,4194303,172,0,0,64,0,0,0);
 INSERT INTO `item_equipment` VALUES (23795,'ziamet_salvars',1,0,4194303,172,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23796,'ziamet_nails',1,0,4194303,172,0,0,256,0,0,0);
+INSERT INTO `item_equipment` VALUES (23797,'crepuscular_helm',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23798,'crepuscular_mail',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23799,'crepuscular_cloak',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23800,'cancrine_apron',1,0,4194303,475,0,0,32,0,0,0);
+INSERT INTO `item_equipment` VALUES (23801,'cancrine_apron_+1',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23802,'aucuba_crown',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23803,'poroggo_cassock',1,0,4194303,477,0,0,32,16,0,0);
 INSERT INTO `item_equipment` VALUES (23804,'poroggo_cass._+1',1,0,4194303,477,0,0,32,16,0,0);
 INSERT INTO `item_equipment` VALUES (23805,'morbol_apron',1,0,4194303,478,0,0,32,0,0,0);
+INSERT INTO `item_equipment` VALUES (23806,'vaquero_hat',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23807,'esthetes_masque',1,0,4194303,480,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23808,'esthetes_coat',1,0,4194303,480,0,0,32,64,0,0);
 INSERT INTO `item_equipment` VALUES (23809,'esthetes_hose',1,0,4194303,480,0,0,128,256,0,0);
+INSERT INTO `item_equipment` VALUES (23810,'knit_cap',99,0,0,0,0,0,32,0,0,0);           -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23811,'knit_cap_+1',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23812,'sapphire_mask',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23813,'sapphire_platemail',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23814,'sapphire_gauntlets',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23815,'sapphire_trousers',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23816,'sapphire_leggings',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23817,'jadeite_visor',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23818,'jadeite_cuirie',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23819,'jadeite_gloves',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23820,'jadeite_chausses',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23821,'jadeite_jambeaux',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23832,'ruby_coronal',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23833,'ruby_robe',99,0,0,0,0,0,32,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23834,'ruby_cuffs',99,0,0,0,0,0,32,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23835,'ruby_slops',99,0,0,0,0,0,32,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23836,'ruby_pigaches',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (25414,'elite_royal_collar',99,0,4194303,0,0,0,512,0,0,0);
 INSERT INTO `item_equipment` VALUES (25415,'rep._plat._medal',99,0,4194303,0,0,0,512,0,0,0);
 INSERT INTO `item_equipment` VALUES (25416,'Sibyl_scarf',99,0,4194303,0,0,0,512,0,0,0);
@@ -11884,6 +12148,7 @@ INSERT INTO `item_equipment` VALUES (25588,'aya._zucchetto',99,119,2130452,159,0
 INSERT INTO `item_equipment` VALUES (25589,'aya._zucchetto_+1',99,119,2130452,159,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (25590,'taliah_turban',99,119,147712,160,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (25591,'taliah_turban_+1',99,119,147712,160,0,0,16,0,0,0);
+INSERT INTO `item_equipment` VALUES (25592,'hjarrandi_helm',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (25593,'cath_palug_crown',99,0,1589276,53,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (25600,'maiitsoh_haube',99,119,14785,218,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (25601,'blistering_sallet',99,119,4194303,29,0,0,16,0,0,0);
@@ -12173,6 +12438,7 @@ INSERT INTO `item_equipment` VALUES (25908,'turms_subligar_+1',99,119,2359328,14
 INSERT INTO `item_equipment` VALUES (25909,'morbol_subligar',1,0,4194303,461,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (25910,'cait_sith_subligar',1,0,4194303,463,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (25911,'denim_pants',1,0,4194303,479,0,0,128,0,0,0);
+INSERT INTO `item_equipment` VALUES (25912,'denim_pants_+1',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (25920,'ahosi_leggings',99,119,2593826,110,0,0,256,0,0,0);
 INSERT INTO `item_equipment` VALUES (25921,'skaoi_boots',99,119,3850780,168,0,0,256,0,0,0);
 INSERT INTO `item_equipment` VALUES (25922,'navon_crackows',99,119,1589788,186,0,0,256,0,0,0);
@@ -12491,6 +12757,7 @@ INSERT INTO `item_equipment` VALUES (26403,'srivatsa',99,119,64,658,5,0,2,0,0,0)
 INSERT INTO `item_equipment` VALUES (26406,'kupo_shield',1,0,4194303,56,3,0,2,0,0,0);
 INSERT INTO `item_equipment` VALUES (26409,'dullahan_shield',1,0,4194303,669,3,0,2,0,0,0);
 INSERT INTO `item_equipment` VALUES (26410,'diamond_buckler',1,0,4194303,659,1,0,2,0,0,0);
+INSERT INTO `item_equipment` VALUES (26411,'diamond_buckler_+1',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (26412,'kamalanauts_shield',1,0,4194303,668,1,0,2,0,0,0);
 INSERT INTO `item_equipment` VALUES (26413,'voluspa_shield',99,119,193,30,3,0,2,0,0,0);
 INSERT INTO `item_equipment` VALUES (26414,'twinned_shield',1,0,4194303,672,2,0,2,0,0,0);
@@ -12561,10 +12828,23 @@ INSERT INTO `item_equipment` VALUES (26483,'brewers_shield_-1',1,0,4194303,25,3,
 INSERT INTO `item_equipment` VALUES (26484,'chefs_ecu_-1',1,0,4194303,46,2,0,2,0,0,0);
 INSERT INTO `item_equipment` VALUES (26485,'chefs_scutum_-1',1,0,4194303,33,4,0,2,0,0,0);
 INSERT INTO `item_equipment` VALUES (26486,'chefs_shield_-1',1,0,4194303,25,3,0,2,0,0,0);
+INSERT INTO `item_equipment` VALUES (26487,'sacro_bulwark',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (26488,'diamond_aspis',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (26489,'troth',99,0,0,0,0,0,32,0,0,0);         -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (26490,'ark_shield',1,0,4194303,674,4,0,2,0,0,0);
+INSERT INTO `item_equipment` VALUES (26491,'prime_shield',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (26492,'duban',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (26493,'duban',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (26494,'duban',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (26495,'duban',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (26496,'ageist',1,0,4194303,677,3,0,2,0,0,0);
+INSERT INTO `item_equipment` VALUES (26497,'regis',99,0,0,0,0,0,32,0,0,0);             -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (26514,'poroggo_fleece',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (26515,'poroggo_fleece_+1',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (26516,'citrullus_shirt',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (26517,'shadow_lord_shirt',1,0,4194303,588,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (26518,'jody_shirt',1,0,4194303,587,0,0,32,0,0,0);
+INSERT INTO `item_equipment` VALUES (26519,'mandragora_shirt',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (26520,'akitu_shirt',1,0,4194303,582,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (26523,'delegates_garb',1,0,4194303,441,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (26524,'gil_nabber_shirt',1,0,4194303,585,0,0,32,0,0,0);
@@ -12589,6 +12869,7 @@ INSERT INTO `item_equipment` VALUES (26542,'baayami_robe_+1',99,119,16384,115,0,
 INSERT INTO `item_equipment` VALUES (26543,'turms_harness',99,119,2359328,148,0,0,32,0,0,3);
 INSERT INTO `item_equipment` VALUES (26544,'tu._harness_+1',99,119,2359328,148,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (26545,'mithkabob_shirt',1,0,4194303,8782,0,0,32,0,0,0);
+INSERT INTO `item_equipment` VALUES (26546,'moogle_shirt',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (26624,'agoge_mask',99,109,1,65,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (26625,'agoge_mask_+1',99,119,1,65,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (26626,'hes._crown',99,109,2,67,0,0,16,0,0,0);

--- a/sql/item_furnishing.sql
+++ b/sql/item_furnishing.sql
@@ -496,13 +496,14 @@ INSERT INTO `item_furnishing` VALUES (3728,'ullegore_statue',4,519,8,3);
 INSERT INTO `item_furnishing` VALUES (3729,'light_chest',1,517,6,1);
 INSERT INTO `item_furnishing` VALUES (3730,'bulky_coffer',1,517,6,1);
 INSERT INTO `item_furnishing` VALUES (3731,'azure_chest',1,517,6,1);
+INSERT INTO `item_furnishing` VALUES (3732,'crimson_chest',1,517,6,1);
 INSERT INTO `item_furnishing` VALUES (3735,'aurum_coffer',5,540,7,7);
 INSERT INTO `item_furnishing` VALUES (3736,'well',80,517,6,8);
 INSERT INTO `item_furnishing` VALUES (3737,'doll_stand',2,2855,7,15);
 INSERT INTO `item_furnishing` VALUES (3738,'eastern_umbrella',1,521,6,2); -- Moghancement: Gardening - From https://ffxiclopedia.fandom.com/wiki/Eastern_Umbrella (BG doesn't show Moghancement)
 INSERT INTO `item_furnishing` VALUES (3739,'autumn_tree',1,515,4,5);
--- INSERT INTO `item_furnishing` VALUES (3740, 'model_synergy_furnace', 8, 0, 8, 11); -- Moghancement: Synergy Skill Gains does not yet exist, so commenting this row out for now
--- INSERT INTO `item_furnishing` VALUES (3742, 'painting_of_a_mercenary', 1, 515, 4, 1); -- Moghancement: Mandragora Mania does not yet exist
+INSERT INTO `item_furnishing` VALUES (3740,'model_synergy_furnace',8,0,8,11);  -- TODO: Moghancement: Synergy Skill Gains does not yet exist
+INSERT INTO `item_furnishing` VALUES (3742,'painting_of_a_mercenary',1,0,4,1); -- TODO: Moghancement: Mandragora Mania does not yet exist
 INSERT INTO `item_furnishing` VALUES (3743,'moogle_bed',1,520,7,8);
 INSERT INTO `item_furnishing` VALUES (3744,'mandragora_pot',1,515,4,1);
 INSERT INTO `item_furnishing` VALUES (3745,'korrigan_pot',1,515,4,1);

--- a/sql/item_usable.sql
+++ b/sql/item_usable.sql
@@ -290,6 +290,7 @@ INSERT INTO `item_usable` VALUES (4347,'serving_of_salmon_meuniere_+1',1,1,25,0,
 INSERT INTO `item_usable` VALUES (4348,'mutton_enchilada',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4349,'bunny_ball',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4350,'dragon_steak',1,1,28,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (4351,'giddeus_water',1,1,0,0,0,0,0,0); -- TODO: Review animation, charges, delay
 INSERT INTO `item_usable` VALUES (4352,'derfland_pear',1,1,0,26,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4353,'sea_bass_croute',1,1,25,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4354,'shining_trout',1,1,25,0,0,0,0,0);
@@ -865,6 +866,7 @@ INSERT INTO `item_usable` VALUES (4980,'scroll_of_foe_requiem_v',1,1,15,5,0,0,0,
 INSERT INTO `item_usable` VALUES (4981,'scroll_of_foe_requiem_vi',1,1,15,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4982,'scroll_of_foe_requiem_vii',1,1,15,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4984,'scroll_of_horde_lullaby',1,1,15,5,0,0,0,0);
+INSERT INTO `item_usable` VALUES (4985,'scroll_of_horde_lullaby_ii',1,1,15,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4986,'scroll_of_armys_paeon',1,1,15,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4987,'scroll_of_armys_paeon_ii',1,1,15,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4988,'scroll_of_armys_paeon_iii',1,1,15,5,0,0,0,0);
@@ -925,9 +927,13 @@ INSERT INTO `item_usable` VALUES (5051,'scroll_of_water_carol',1,1,15,5,0,0,0,0)
 INSERT INTO `item_usable` VALUES (5052,'scroll_of_light_carol',1,1,15,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5053,'scroll_of_dark_carol',1,1,15,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5054,'scroll_of_fire_carol_ii',1,1,15,5,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5055,'scroll_of_ice_carol_ii',1,1,15,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5056,'scroll_of_wind_carol_ii',1,1,15,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5057,'scroll_of_earth_carol_ii',1,1,15,5,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5058,'scroll_of_lightning_carol_ii',1,1,15,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5059,'scroll_of_water_carol_ii',1,1,15,5,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5060,'scroll_of_light_carol_ii',1,1,15,5,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5061,'scroll_of_dark_carol_ii',1,1,15,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5062,'scroll_of_fire_threnody',1,1,15,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5063,'scroll_of_ice_threnody',1,1,15,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5064,'scroll_of_wind_threnody',1,1,15,5,0,0,0,0);
@@ -946,6 +952,7 @@ INSERT INTO `item_usable` VALUES (5076,'scroll_of_foe_sirvente',1,1,15,5,0,0,0,0
 INSERT INTO `item_usable` VALUES (5077,'scroll_of_adventurers_dirge',1,1,15,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5078,'scroll_of_sentinels_scherzo',1,1,15,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5079,'scroll_of_foe_lullaby_ii',1,1,15,5,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5080,'scroll_of_pining_nocturne',1,1,15,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5082,'scroll_of_cura_ii',1,1,11,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5083,'scroll_of_cura_iii',1,1,11,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5085,'scroll_of_regen_iv',1,1,11,5,0,0,0,0);
@@ -964,10 +971,23 @@ INSERT INTO `item_usable` VALUES (5097,'scroll_of_boost-agi',1,1,11,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5098,'scroll_of_boost-int',1,1,11,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5099,'scroll_of_boost-mnd',1,1,11,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5100,'scroll_of_boost-chr',1,1,11,5,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5101,'scroll_of_arise',1,1,11,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5102,'scroll_of_foil',1,1,11,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5103,'scroll_of_crusade',1,1,11,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5104,'scroll_of_flurry',1,1,11,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5105,'scroll_of_flurry_ii',1,1,11,5,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5106,'scroll_of_inundation',1,1,11,5,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5109,'frayed_sack_of_abundance_+1',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5110,'frayed_sack_of_abundance_+2',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5111,'frayed_sack_of_mortality_+1',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5112,'frayed_sack_of_mortality_+2',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5113,'cracked_nut',1,1,0,0,0,0,0,0);                 -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5114,'moist_rolanberry',1,1,0,0,0,0,0,0);            -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5115,'clump_of_ravaged_moko_grass',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5116,'cavorting_worm',1,1,0,0,0,0,0,0);              -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5117,'pinch_of_levigated_rock',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5118,'little_lugworm',1,1,0,0,0,0,0,0);              -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5119,'training_manual',1,1,0,0,0,0,0,0);             -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (5120,'titanic_sawfish',1,1,25,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5121,'moorish_idol',1,1,25,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5122,'bibiki_slug',1,1,25,0,0,0,0,0);
@@ -1354,7 +1374,36 @@ INSERT INTO `item_usable` VALUES (5502,'allies_die',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5503,'misers_die',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5504,'companions_die',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5505,'avengers_die',1,1,55,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5506,'immutable_boulder_tincture',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5507,'luminous_isle_tincture',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5508,'flourishing_island_tincture',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5509,'bud_of_the_swarm_tincture',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5510,'immaculate_sands_tincture',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5511,'dragon_driftwood_tincture',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5512,'fruit_of_fecundity_tincture',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5513,'torchbloom_tincture',1,1,0,0,0,0,0,0);           -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5514,'lake_of_light_tincture',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5515,'gales_prominence_tincture',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5516,'sweltering_spring_tincture',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5517,'flames_prominence_tincture',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5518,'sanctum_of_life_tincture',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5519,'soils_prominence_tincture',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5520,'snowdrift_arbor_tincture',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5521,'frostbloom_tincture',1,1,0,0,0,0,0,0);           -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5522,'spring_of_prosperity_tincture',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5523,'pool_of_clarity_tincture',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5524,'bryophitic_boulder_tincture',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5525,'overgrown_grove_tincture',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5526,'fragrant_breeze_budtincture',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5527,'whitewater_arbor_tincture',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5528,'triumvirate_crag_tincture',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5529,'saliferous_spring_tincture',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5530,'ripple_prominence_tincture',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5531,'slice_of_lucerewe_meat',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (5532,'ichinintousen_koma',1,1,116,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5534,'apkallufa',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5535,'deademoiselle',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5536,'yorchete',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (5537,'soryu',1,1,25,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5538,'sekiryu',1,1,25,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5539,'hakuryu',1,1,25,0,0,0,0,0);
@@ -1541,6 +1590,7 @@ INSERT INTO `item_usable` VALUES (5719,'dish_of_spaghetti_marinara',1,1,24,0,0,0
 INSERT INTO `item_usable` VALUES (5720,'dish_of_spaghetti_marinara_+1',1,1,24,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5721,'plate_of_crab_sushi',1,1,25,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5722,'plate_of_crab_sushi_+1',1,1,25,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5724,'pinch_of_pungent_powder',1,1,0,0,0,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (5725,'goshikitenge',1,1,105,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5726,'zucchini',1,1,24,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5727,'serving_of_zaru_soba',1,1,24,0,0,0,0,0);
@@ -1633,6 +1683,8 @@ INSERT INTO `item_usable` VALUES (5813,'dorado_gar',1,4,25,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5814,'crocodilos',1,4,25,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5815,'pelazoea',1,4,25,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5816,'king_perch',1,4,25,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5817,'tiger_shark',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5818,'aurora_bass',1,1,0,0,0,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (5819,'antlion_quiver',1,4,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5820,'darkling_bolt_quiver',1,4,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5821,'fusion_bolt_quiver',1,4,55,0,0,0,0,0);
@@ -1706,8 +1758,23 @@ INSERT INTO `item_usable` VALUES (5889,'stuffed_pitaru',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5890,'poultry_pitaru',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5891,'seafood_pitaru',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5892,'b.e.w._pitaru',1,1,28,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5893,'marine_stewpot',1,1,0,0,0,0,0,0);            -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5894,'prime_marine_stewpot',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5895,'odorless_fungus',1,1,0,0,0,0,0,0);           -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5896,'clump_of_absorbent_moss',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5897,'redolent_root',1,1,0,0,0,0,0,0);             -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5898,'shadescale_skull',1,1,0,0,0,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5899,'shadescale_femur',1,1,0,0,0,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5900,'shadescale_talon',1,1,0,0,0,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5901,'shadescale_heart',1,1,0,0,0,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5902,'vial_of_cagebeast_blood',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5903,'vial_of_sea_monk_venom',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5904,'perforated_wing',1,1,0,0,0,0,0,0);           -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5905,'undying_moiety',1,1,0,0,0,0,0,0);            -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5906,'page_from_abdhaljs_on_war',1,1,0,0,0,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (5907,'winterflower',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5908,'butterpear',1,1,28,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5909,'pickled_rarab_tail',1,1,0,0,0,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (5910,'heavy_metal_pouch',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5911,'olde_rarab_tail',4,1,55,0,0,0,0,0); -- Need to verify animation
 INSERT INTO `item_usable` VALUES (5912,'gargouille_quiver',1,1,55,0,0,0,0,0);
@@ -1736,13 +1803,30 @@ INSERT INTO `item_usable` VALUES (5934,'chocobiscuit',1,1,29,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5935,'bowl_of_moogurt',1,1,26,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5936,'mog_missile',1,1,112,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5937,'bubble_breeze',1,1,113,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5938,'hiatus_whistle',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5939,'terminus_whistle',1,1,0,0,0,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (5940,'trail_cookie',1,1,29,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5941,'bar_of_campfire_chocolate',1,1,29,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5942,'piece_of_cascade_candy',1,1,29,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5943,'strip_of_smoked_mackerel',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5944,'bottle_of_frontier_soda',1,1,26,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5945,'pinch_of_prize_powder',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5946,'frayed_sack_of_deviousness',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5947,'frayed_sack_of_liminality',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (5948,'black_prawn',1,1,25,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5949,'mussel',1,1,0,0,0,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5950,'mackerel',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5951,'bloodblotch',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5952,'ruddy_seema',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5953,'dragonfly_trout',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5954,'barnacle',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5955,'yawning_catfish',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5957,'shockfish',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5959,'dragonfish',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (5960,'ulbukan_lobster',1,1,28,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5961,'contortopus',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5962,'contortacle',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5963,'senroh_sardine',1,1,0,0,0,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (5964,'felicifruit',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5965,'head_of_isleracea',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5966,'ulbuconut',1,1,28,0,0,0,0,0);
@@ -1765,14 +1849,58 @@ INSERT INTO `item_usable` VALUES (5982,'senroh_skewer',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5983,'piscators_skewer',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5984,'branch_of_gnatbane',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5985,'sprig_of_hemlock',1,1,28,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5986,'coalition_potion',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5987,'coalition_ether',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (5988,'scroll_of_instant_protect',1,7,30,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5989,'scroll_of_instant_shell',1,7,32,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5990,'scroll_of_instant_stoneskin',1,7,8,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5991,'farewell_fly',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5992,'fenestral_key',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5993,'senroh_frog',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5995,'malicious_perch',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5997,'shen',1,1,0,0,0,0,0,0);            -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (5998,'bowl_of_adoulinian_soup',1,1,26,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5999,'bowl_of_adoulinian_soup_+1',1,1,26,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6001,'clotflagration',1,1,0,0,0,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6002,'trailblazing_pickaxe',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6003,'trailblazing_pickaxe_+1',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6004,'trailblazing_hatchet',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6005,'trailblazing_hatchet_+1',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6006,'trailblazing_sickle',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6007,'trailblazing_sickle_+1',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6008,'piece_of_copse_candy',1,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6009,'bowl_of_mog_pudding',1,1,26,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6010,'sakura_biscuit',1,1,28,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6011,'celadon_yggrete_shard_i',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6012,'celadon_yggrete_shard_ii',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6013,'celadon_yggrete_shard_iii',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6014,'celadon_yggrete_shard_iv',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6015,'celadon_yggrete_shard_v',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6016,'zaffre_yggrete_shard_i',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6017,'zaffre_yggrete_shard_ii',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6018,'zaffre_yggrete_shard_iii',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6019,'zaffre_yggrete_shard_iv',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6020,'zaffre_yggrete_shard_v',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6021,'alizarin_yggrete_shard_i',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6022,'alizarin_yggrete_shard_ii',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6023,'alizarin_yggrete_shard_iii',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6024,'alizarin_yggrete_shard_iv',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6025,'alizarin_yggrete_shard_v',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6026,'celadon_yggzi_bead_i',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6027,'celadon_yggzi_bead_ii',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6028,'celadon_yggzi_bead_iii',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6029,'celadon_yggzi_bead_iv',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6030,'celadon_yggzi_bead_v',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6031,'zaffre_yggzi_bead_i',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6032,'zaffre_yggzi_bead_ii',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6033,'zaffre_yggzi_bead_iii',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6034,'zaffre_yggzi_bead_iv',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6035,'zaffre_yggzi_bead_v',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6036,'alizarin_yggzi_bead_i',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6037,'alizarin_yggzi_bead_ii',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6038,'alizarin_yggzi_bead_iii',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6039,'alizarin_yggzi_bead_iv',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6040,'alizarin_yggzi_bead_v',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6041,'pyrohelix_schema',1,1,12,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6042,'hydrohelix_schema',1,1,12,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6043,'ionohelix_schema',1,1,12,5,0,0,0,0);
@@ -1795,6 +1923,10 @@ INSERT INTO `item_usable` VALUES (6060,'animus_minuo_schema',1,1,11,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6061,'adloquium_schema',1,1,11,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6063,'fruit_parfait',1,1,26,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6064,'queens_crown',1,1,26,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6065,'tiny_macaroon',1,1,0,0,0,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6066,'tiny_rusk',1,1,0,0,0,0,0,0);              -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6067,'ontic_extremity',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6068,'slice_of_gabbrath_meat',1,1,0,0,0,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6069,'bowl_of_riverfin_soup',1,1,26,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6070,'bowl_of_oceanfin_soup',1,1,26,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6071,'magma_steak',1,1,28,0,0,0,0,0);
@@ -1828,7 +1960,47 @@ INSERT INTO `item_usable` VALUES (6098,'plate_of_indi-languor',1,1,13,5,0,0,0,0)
 INSERT INTO `item_usable` VALUES (6099,'plate_of_indi-slow',1,1,13,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6100,'plate_of_indi-paralysis',1,1,13,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6101,'plate_of_indi-gravity',1,1,13,5,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6102,'geo-regen',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6103,'geo-poison',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6104,'geo-refresh',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6105,'geo-str',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6106,'geo-dex',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6107,'geo-vit',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6108,'geo-agi',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6109,'geo-int',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6110,'geo-mnd',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6111,'geo-chr',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6112,'geo-fury',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6113,'geo-barrier',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6114,'geo-acumen',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6115,'geo-fend',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6116,'geo-precision',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6117,'geo-voidance',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6118,'geo-focus',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6119,'geo-attunement',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6120,'geo-wilt',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6121,'geo-frailty',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6122,'geo-fade',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6123,'geo-malaise',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6124,'geo-slip',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6125,'geo-torpor',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6126,'geo-vex',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6127,'geo-languor',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6128,'geo-slow',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6129,'geo-paralysis',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6130,'geo-gravity',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6131,'plate_of_indi-haste',1,1,13,5,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6132,'geo-haste',1,1,0,0,0,0,0,0);             -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6137,'chapuli_quiver',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6138,'mantid_quiver',1,1,0,0,0,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6139,'midrium_bolt_quiver',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6140,'damascus_bolt_quiver',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6141,'oxidant_bolt_quiver',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6142,'midrium_bullet_pouch',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6143,'damascus_bullet_pouch',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6144,'frigorifish',1,1,0,0,0,0,0,0);           -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6145,'dwarf_remora',1,1,0,0,0,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6146,'remora',1,1,0,0,0,0,0,0);                -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6147,'copy_of_mikhes_memo',1,1,117,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6148,'dagger_enchiridion',1,1,117,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6149,'copy_of_swing_and_stab',1,1,117,0,0,0,0,0);
@@ -1873,6 +2045,26 @@ INSERT INTO `item_usable` VALUES (6187,'piece_of_slimeulation_candy',1,1,55,0,0,
 INSERT INTO `item_usable` VALUES (6188,'piece_of_she-slime_candy',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6189,'piece_of_metal_slime_candy',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6190,'spriggan_spark',1,1,114,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6191,'green_spriggan_lolli',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6192,'red_spriggan_lolli',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6193,'purple_spriggan_lolli',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6194,'loch_of_flux_tincture',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6195,'lambent_pillar_tincture',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6196,'halcyon_icefall_tincture',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6197,'rime_prominence_tincture',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6198,'crystalline_claw_tincture',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6199,'achiyalabopa_quiver',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6200,'adlivun_quiver',1,1,0,0,0,0,0,0);            -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6201,'tulfaire_quiver',1,1,0,0,0,0,0,0);           -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6202,'raaz_quiver',1,1,0,0,0,0,0,0);               -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6203,'achiyalabopa_bolt_quiver',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6204,'adlivun_bolt_quiver',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6205,'titanium_bolt_quiver',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6206,'bismuth_bolt_quiver',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6207,'achiyalabopa_bullet_pouch',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6208,'adlivun_bullet_pouch',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6209,'titanium_bullet_pouch',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6210,'bismuth_bullet_pouch',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6211,'slice_of_marinara_pizza',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6212,'slice_of_marinara_pizza_+1',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6213,'slice_of_margherita_pizza',1,1,28,0,0,0,0,0);
@@ -1881,47 +2073,193 @@ INSERT INTO `item_usable` VALUES (6215,'slice_of_pepperoni_pizza',1,1,28,0,0,0,0
 INSERT INTO `item_usable` VALUES (6216,'slice_of_pepperoni_pizza_+1',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6217,'slice_of_anchovy_pizza',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6218,'slice_of_anchovy_pizza_+1',1,1,28,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6219,'warthog_stewpot',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6220,'prime_warthog_stewpot',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6221,'prized_warthog_stewpot',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6222,'slice_of_warthog_meat',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6223,'cehuetzi_snow_cone',1,1,26,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6224,'apingaut_snow_cone',1,1,26,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6225,'cyclical_coalescence',1,1,26,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6226,'loaf_of_pixioche',1,1,0,0,0,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6227,'phlox_yggrete_shard_i',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6228,'phlox_yggrete_shard_ii',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6229,'phlox_yggrete_shard_iii',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6230,'phlox_yggrete_shard_iv',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6231,'phlox_yggrete_shard_v',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6232,'russet_yggrete_shard_i',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6233,'russet_yggrete_shard_ii',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6234,'russet_yggrete_shard_iii',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6235,'russet_yggrete_shard_iv',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6236,'russet_yggrete_shard_v',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6237,'aster_yggrete_shard_i',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6238,'aster_yggrete_shard_ii',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6239,'aster_yggrete_shard_iii',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6240,'aster_yggrete_shard_iv',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6241,'aster_yggrete_shard_v',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6242,'phlox_yggzi_bead_i',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6243,'phlox_yggzi_bead_ii',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6244,'phlox_yggzi_bead_iii',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6245,'phlox_yggzi_bead_iv',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6246,'phlox_yggzi_bead_v',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6247,'russet_yggzi_bead_i',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6248,'russet_yggzi_bead_ii',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6249,'russet_yggzi_bead_iii',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6250,'russet_yggzi_bead_iv',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6251,'russet_yggzi_bead_v',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6252,'aster_yggzi_bead_i',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6253,'aster_yggzi_bead_ii',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6254,'aster_yggzi_bead_iii',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6255,'aster_yggzi_bead_iv',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6256,'aster_yggzi_bead_v',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6257,'jar_of_jungle_nectar',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6258,'piece_of_shiromochi',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6259,'piece_of_shiromochi_+1',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6260,'piece_of_akamochi',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6261,'piece_of_akamochi_+1',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6262,'piece_of_kusamochi',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6263,'piece_of_kusamochi_+1',1,1,28,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6264,'frayed_sack_of_horror_+1',1,1,0,0,0,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6265,'toolbag_ranka',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6266,'toolbag_furu',1,1,55,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6267,'aged_box_bayld',1,1,0,0,0,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6268,'komanezumi',1,1,118,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6269,'eminent_quiver',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6270,'eminent_bolt_quiver',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6271,'eminent_bullet_pouch',1,1,0,0,0,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6272,'fried_popoto',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6273,'fried_popoto_+1',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6274,'pukatrice_egg',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6275,'pukatrice_egg_+1',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6276,'deep-fried_shrimp',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6277,'deep-fried_shrimp_+1',1,1,28,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6278,'abrasion_bolt_quiver',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6279,'righteous_bolt_quiver',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6280,'rakaznar_quiver',1,1,0,0,0,0,0,0);           -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6281,'rakaznar_bolt_quiver',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6282,'rakaznar_bullet_pouch',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6283,'velkk_coffer',1,1,0,0,0,0,0,0);              -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6284,'grand_velkk_coffer',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6285,'ymmr-ulvids_coffer',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6286,'ymmr-ulvids_grand_coffer',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6287,'ignor-mnts_coffer',1,1,0,0,0,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6288,'ignor-mnts_grand_coffer',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6289,'durs-vikes_coffer',1,1,0,0,0,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6290,'durs-vikes_grand_coffer',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6291,'tryl-wujs_coffer',1,1,0,0,0,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6292,'tryl-wujs_grand_coffer',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6293,'liij-voks_coffer',1,1,0,0,0,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6294,'liij-voks_grand_coffer',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6295,'gramk-droogs_coffer',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6296,'gramk-droogs_grand_coffer',1,1,0,0,0,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6297,'juji_shuriken_pouch',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6298,'manji_shuriken_pouch',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6299,'shuriken_pouch',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6300,'koga_shuriken_pouch',1,1,55,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6301,'togakushi_shuriken_pouch',1,1,0,0,0,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6302,'fuma_shuriken_pouch',1,1,55,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6303,'iga_shuriken_pouch',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6304,'roppo_shuriken_pouch',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6305,'roppo_shuriken_+1_pouch',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6306,'happo_shuriken_pouch',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6307,'happo_shuriken_+1_pouch',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6308,'hachiya_shuriken_pouch',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6309,'suppa_shuriken_pouch',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6310,'gashing_bolt_quiver',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6311,'decimating_bullet_pouch',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6312,'hugemaw_harolds_coffer',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6313,'bounding_belindas_coffer',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6314,'prickly_pitrivs_coffer',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6315,'ironhorn_baldurnos_coffer',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6316,'sleepy_mabels_coffer',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6317,'valkurm_imperators_coffer',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6318,'serpopard_ninlils_coffer',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6319,'abyssdivers_coffer',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6320,'intuilas_coffer',1,1,0,0,0,0,0,0);           -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6321,'emperor_arthros_coffer',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6322,'orcfeltraps_coffer',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6323,'lumber_jills_coffer',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6324,'joyous_greens_coffer',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6325,'strixs_coffer',1,1,0,0,0,0,0,0);             -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6326,'warblade_beaks_coffer',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6327,'arkes_coffer',1,1,0,0,0,0,0,0);              -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6328,'largantuas_coffer',1,1,0,0,0,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6329,'beists_coffer',1,1,0,0,0,0,0,0);             -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6330,'jester_malatrixs_coffer',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6331,'catrot_velozs_coffer',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6332,'woodland_menders_coffer',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6333,'translucent_salpa',1,1,0,0,0,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6334,'rakaznar_shellfish',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6335,'white_lobster',1,1,0,0,0,0,0,0);             -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6336,'bonefish',1,1,0,0,0,0,0,0);                  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6337,'thysanopeltis',1,1,0,0,0,0,0,0);             -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6338,'cameroceras',1,1,0,0,0,0,0,0);               -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6339,'rolanberry_daifuku',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6340,'rolanberry_daifuku_+1',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6341,'bean_daifuku',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6342,'bean_daifuku_+1',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6343,'grape_daifuku',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6344,'grape_daifuku_+1',1,1,28,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6345,'frayed_sack_of_horror_+2',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6346,'frayed_sack_of_beauty',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6347,'sheet_of_promathian_tunes',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6348,'sheet_of_adoulinian_tunes',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6349,'makel-pakels_grab_bag',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6350,'sybaritic_samanthas_coffer',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6351,'keeper_of_heiligtums_coffer',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6352,'douma_weapons_coffer',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6353,'king_uropygids_coffer',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6354,'vedrfolnirs_coffer',1,1,0,0,0,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6355,'stinger_bullet_pouch',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6356,'tiyanaks_coffer',1,1,0,0,0,0,0,0);             -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6357,'immanibugards_coffer',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6358,'muuts_coffer',1,1,0,0,0,0,0,0);                -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6359,'camahuetos_coffer',1,1,0,0,0,0,0,0);           -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6360,'vosos_coffer',1,1,0,0,0,0,0,0);                -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6361,'mephitass_coffer',1,1,0,0,0,0,0,0);            -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6362,'cocas_coffer',1,1,0,0,0,0,0,0);                -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6363,'ayapecs_coffer',1,1,0,0,0,0,0,0);              -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6364,'specter_worms_coffer',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6365,'azraels_coffer',1,1,0,0,0,0,0,0);              -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6366,'borealis_shadows_coffer',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6367,'codex_of_etchings',1,1,0,0,0,0,0,0);           -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6368,'geomancer_die',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6369,'rune_fencer_die',1,1,55,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6370,'frayed_sack_of_splendor',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6371,'quicksilver_blade',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6372,'lord_of_ulbuka',1,1,0,0,0,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6373,'ancient_carp',1,1,0,0,0,0,0,0);            -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6374,'dragons_tabernacle',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6375,'phantom_serpent',1,1,0,0,0,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6376,'tusoteuthis_longa',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6377,'imperial_chair_set',1,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6378,'decorative_chair_set',1,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6379,'ornate_stool_set',1,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6380,'refined_chair_set',1,1,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6381,'fishermans_feast',1,1,0,0,0,0,0,0);                -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6382,'garbage_gels_coffer',1,1,0,0,0,0,0,0);             -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6383,'bakunawas_coffer',1,1,0,0,0,0,0,0);                -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6384,'azure-toothed_clawberrys_coffer',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6385,'vermillion_fishflys_coffer',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6386,'volatile_clusters_coffer',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6387,'mhuufyas_coffer',1,1,0,0,0,0,0,0);                 -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6388,'grand_grenades_coffer',1,1,0,0,0,0,0,0);           -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6389,'vidmapires_coffer',1,1,0,0,0,0,0,0);               -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6390,'centurio_xx-is_coffer',1,1,0,0,0,0,0,0);           -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6391,'silt_pouch',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6392,'bead_pouch',1,1,55,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6393,'cut_of_porxie_pork',1,1,0,0,0,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6394,'pork_cutlet',1,1,24,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6395,'pork_cutlet_+1',1,1,24,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6396,'cutlet_sandwich',1,1,24,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6397,'cutlet_sandwich_+1',1,1,24,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6398,'cage_of_arena_fireflies',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6399,'bottle_of_saviors_tonic',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6400,'bottle_of_mirrors_tonic',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6401,'bottle_of_monetas_tonic',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6402,'bottle_of_steadfast_tonic',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6403,'tolbas_coffer',1,1,0,0,0,0,0,0);              -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6404,'hidhaeggs_coffer',1,1,0,0,0,0,0,0);           -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6405,'sovereign_behemoths_coffer',1,1,0,0,0,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6406,'pork_cutlet_rice_bowl',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6407,'pork_cutlet_rice_bowl_+1',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6408,'portable_container',1,1,0,0,0,0,0,0);
@@ -1932,6 +2270,7 @@ INSERT INTO `item_usable` VALUES (6412,'leaf_bench',1,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6413,'astral_cube',1,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6414,'porxie_quiver',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6415,'seki_shuriken_pouch',1,1,55,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6416,'hunk_of_behemoth_meat',1,1,0,0,0,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6417,'divine_quiver',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6418,'beryllium_quiver',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6419,'raetic_quiver',1,1,55,0,0,0,0,0);
@@ -1944,6 +2283,8 @@ INSERT INTO `item_usable` VALUES (6438,'voluspa_bullet_pouch',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6447,'sasuke_shuriken_pouch',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6448,'sasuke_shuriken_pouch_+1',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6449,'date_shuriken_pouch',1,1,55,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6456,'sheet_of_shadow_lord_tunes',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6457,'flarelet',1,1,0,0,0,0,0,0);                   -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6458,'bowl_of_soy_ramen',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6459,'bowl_of_soy_ramen_+1',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6460,'bowl_of_miso_ramen',1,1,28,0,0,0,0,0);
@@ -1958,12 +2299,89 @@ INSERT INTO `item_usable` VALUES (6468,'plate_of_sublime_sushi',1,1,28,0,0,0,0,0
 INSERT INTO `item_usable` VALUES (6469,'plate_of_sublime_sushi_+1',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6470,'bowl_of_oden',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6471,'bowl_of_oden_+1',1,1,28,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6473,'super_revitalizer',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6474,'phial_of_poison_buffer',1,1,0,0,0,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6475,'pair_of_lucid_wings_ii',1,1,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6476,'phial_of_virus_buffer',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6477,'phial_of_charm_buffer',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6478,'phial_of_curse_buffer',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6479,'tumult_curators_coffer',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6480,'thubans_coffer',1,1,0,0,0,0,0,0);               -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6481,'saramas_coffer',1,1,0,0,0,0,0,0);               -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6482,'shedus_coffer',1,1,0,0,0,0,0,0);                -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6483,'glazemanes_coffer',1,1,0,0,0,0,0,0);            -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6484,'carousing_celines_coffer',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6485,'wyvernhunter_bambroxs_coffer',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6486,'frayed_sack_of_fecundity',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6487,'frayed_sack_of_plenty',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6488,'frayed_sack_of_opulence',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6489,'far_east_puffer',1,1,0,0,0,0,0,0);              -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6498,'bunch_of_fortune_fruits',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6499,'patio_design_plan_document',1,1,117,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6500,'abdhaljs_seal',1,1,0,0,0,0,0,0);                 -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6501,'konjak_tuber',1,1,0,0,0,0,0,0);                  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6502,'konjak',1,1,0,0,0,0,0,0);                        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6503,'daikon',1,1,0,0,0,0,0,0);                        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6505,'chikuwa',1,1,0,0,0,0,0,0);                       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6506,'pyre_crystal',1,1,0,0,0,0,0,0);                  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6507,'frost_crystal',1,1,0,0,0,0,0,0);                 -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6508,'vortex_crystal',1,1,0,0,0,0,0,0);                -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6509,'geo_crystal',1,1,0,0,0,0,0,0);                   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6510,'bolt_crystal',1,1,0,0,0,0,0,0);                  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6511,'fluid_crystal',1,1,0,0,0,0,0,0);                 -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6512,'glimmer_crystal',1,1,0,0,0,0,0,0);               -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6513,'shadow_crystal',1,1,0,0,0,0,0,0);                -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6514,'reisenjima_cage',1,1,0,0,0,0,0,0);               -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6515,'large_tail',1,1,0,0,0,0,0,0);                    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6516,'large_stone',1,1,0,0,0,0,0,0);                   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6517,'large_leaf',1,1,0,0,0,0,0,0);                    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6518,'morbol_latte',1,1,0,0,0,0,0,0);                  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6519,'serving_of_fetid_curry',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6520,'cup_of_rancid_coffee',1,1,0,0,0,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6521,'decanter_ingrid',1,1,0,0,0,0,0,0);               -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6522,'decanter_darrcuiln',1,1,0,0,0,0,0,0);            -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6523,'decanter_arciela',1,1,0,0,0,0,0,0);              -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6524,'decanter_morimar',1,1,0,0,0,0,0,0);              -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6525,'decanter_rosulatia',1,1,0,0,0,0,0,0);            -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6526,'decanter_teodor',1,1,0,0,0,0,0,0);               -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6527,'decanter_august',1,1,0,0,0,0,0,0);               -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6528,'decanter_sajjaka',1,1,0,0,0,0,0,0);              -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6529,'decanter_arciela_ii',1,1,0,0,0,0,0,0);           -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6530,'rolanberry_pickled_rarab_tail',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6531,'black_hourglass',1,1,0,0,0,0,0,0);               -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6532,'pluton_coffer',1,1,0,0,0,0,0,0);                 -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6533,'beitetsu_coffer',1,1,0,0,0,0,0,0);               -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6534,'rift_boulder_coffer',1,1,0,0,0,0,0,0);           -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6535,'pinch_of_pungent_powder_ii',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6536,'new_years_pouch',1,1,0,0,0,0,0,0);               -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6537,'pinch_of_pungent_powder_iii',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6538,'altanas_repast',1,1,28,0,0,0,0,1);
 INSERT INTO `item_usable` VALUES (6539,'altanas_repast_+1',1,1,28,0,0,0,0,1);
 INSERT INTO `item_usable` VALUES (6540,'altanas_repast_+2',1,1,28,0,0,0,0,1);
+INSERT INTO `item_usable` VALUES (6541,'worn_sack_of_snowslit_stones_+1',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6542,'worn_sack_of_snowslit_stones_+2',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6543,'worn_sack_of_leafslit_stones_+1',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6544,'worn_sack_of_leafslit_stones_+2',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6545,'worn_sack_of_duskslit_stones_+1',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6546,'worn_sack_of_duskslit_stones_+2',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6547,'worn_sack_of_snowtip_stones_+1',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6548,'worn_sack_of_snowtip_stones_+2',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6549,'worn_sack_of_leaftip_stones_+1',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6550,'worn_sack_of_leaftip_stones_+2',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6551,'worn_sack_of_dusktip_stones_+1',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6552,'worn_sack_of_dusktip_stones_+2',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6553,'worn_sack_of_snowdim_stones_+1',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6554,'worn_sack_of_snowdim_stones_+2',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6555,'worn_sack_of_leafdim_stones_+1',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6556,'worn_sack_of_leafdim_stones_+2',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6557,'worn_sack_of_duskdim_stones_+1',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6558,'worn_sack_of_duskdim_stones_+2',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6559,'worn_sack_of_snoworb_stones_+1',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6560,'worn_sack_of_snoworb_stones_+2',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6561,'worn_sack_of_leaforb_stones_+1',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6562,'worn_sack_of_leaforb_stones_+2',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6563,'worn_sack_of_duskorb_stones_+1',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6564,'worn_sack_of_duskorb_stones_+2',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6565,'per._snow_cone',1,1,28,1,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6566,'bonanza_biscuit',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6567,'tropical_crepe',1,1,28,1,0,0,0,0);
@@ -1971,11 +2389,43 @@ INSERT INTO `item_usable` VALUES (6568,'crepe_des_rois',1,1,28,1,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6569,'scroll_of_slow_ii',1,1,11,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6570,'scroll_of_paralyze_ii',1,1,11,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6571,'scroll_of_phalanx_ii',1,1,11,5,0,0,0,0);
-INSERT INTO `item_usable` VALUES (6576,'turkey_with_rolanberry_sauce',1,1,28,0,0,0,0,0); -- TODO: verify animation from retail
+INSERT INTO `item_usable` VALUES (6572,'coffer_of_swart_astral_detritus',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6573,'coffer_of_murky_astral_detritus',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6574,'coffer_of_beit_astral_detritus',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6575,'cheesesteak_sandwich',1,1,0,0,0,0,0,0);             -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6576,'turkey_with_rolanberry_sauce',1,1,28,0,0,0,0,0);    -- TODO: verify animation from retail
+INSERT INTO `item_usable` VALUES (6577,'bowl_of_clam_chowder',1,1,0,0,0,0,0,0);             -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6578,'plate_of_biscuits_&_gravy',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6579,'soy_ramen_(survival)',1,1,0,0,0,0,0,0);             -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6580,'miso_ramen_(survival)',1,1,0,0,0,0,0,0);            -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6581,'shoyu_ramen_(survival)',1,1,0,0,0,0,0,0);           -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6582,'shio_ramen_(survival)',1,1,0,0,0,0,0,0);            -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6583,'bowl_of_sutlac_(survival)',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6584,'bowl_of_seafood_stew_(survival)',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6585,'salmon_sub_sandwich',1,1,0,0,0,0,0,0);             -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6586,'prime_beef_stewpot',1,1,0,0,0,0,0,0);              -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6587,'buffalo_stewpot',1,1,0,0,0,0,0,0);                 -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6588,'rabbit_stewpot',1,1,0,0,0,0,0,0);                  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6589,'sheep_stewpot',1,1,0,0,0,0,0,0);                   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6590,'cockatrice_stewpot',1,1,0,0,0,0,0,0);              -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6591,'behemoth_stewpot',1,1,0,0,0,0,0,0);                -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6592,'dragon_stewpot',1,1,0,0,0,0,0,0);                  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6593,'deep_yellow_curry',1,1,0,0,0,0,0,0);               -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6594,'seafood_curry',1,1,0,0,0,0,0,0);                   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6595,'chicken_curry',1,1,0,0,0,0,0,0);                   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6596,'duck_curry',1,1,0,0,0,0,0,0);                      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6597,'mutton_curry',1,1,0,0,0,0,0,0);                    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6598,'maats_mix',1,1,0,0,0,0,0,0);                       -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6599,'egg_sandwich',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6600,'egg_sandwich_+1',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6601,'omelette_sandwich',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6602,'omelette_sandwich_+1',1,1,28,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6603,'bottle_of_rolanberry_854',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6604,'bottle_of_rolanberry_874',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6605,'bottle_of_rolanberry_894',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6606,'plate_of_mapo_tofu',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6607,'hydra_kofte_(survival)',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6608,'moogle_amplifier',1,1,0,0,0,0,0,0);         -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6609,'serving_of_popotoes_con_queso',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6610,'serving_of_popotoes_con_queso_+1',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6611,'serving_of_seafood_gratin',1,1,28,0,0,0,0,0);

--- a/sql/item_weapon.sql
+++ b/sql/item_weapon.sql
@@ -2190,6 +2190,7 @@ INSERT INTO `item_weapon` VALUES (18562,'yhatdhara_+1',7,0,0,0,0,2,1,466,120,0);
 INSERT INTO `item_weapon` VALUES (18563,'ark_scythe',7,0,0,0,0,2,1,999,1,0);
 INSERT INTO `item_weapon` VALUES (18564,'devilish_scythe',7,0,0,0,0,2,1,528,130,0);
 INSERT INTO `item_weapon` VALUES (18565,'adflictio',7,0,0,0,0,2,1,513,134,0);
+INSERT INTO `item_weapon` VALUES (18566,'crepuscular_scythe',1,0,0,0,0,1,1,999,1,0); -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (18571,'daurdabla',41,0,0,0,0,0,1,240,0,0);
 INSERT INTO `item_weapon` VALUES (18572,'gjallarhorn',42,0,0,0,0,0,1,240,0,0);
 INSERT INTO `item_weapon` VALUES (18573,'pyf_harp',41,0,0,0,0,0,1,240,0,0);
@@ -4352,6 +4353,9 @@ INSERT INTO `item_weapon` VALUES (21407,'terpander',41,0,0,0,0,0,1,999,0,0);
 INSERT INTO `item_weapon` VALUES (21408,'cama._harp',41,0,0,0,0,0,1,240,0,0);
 INSERT INTO `item_weapon` VALUES (21409,'forefront_flute',42,0,0,0,0,0,1,999,0,0);
 INSERT INTO `item_weapon` VALUES (21422,'kupayopl',0,0,0,0,0,0,1,0,0,0);
+INSERT INTO `item_weapon` VALUES (21430,'hesperiidae',1,0,0,0,0,1,1,999,1,0);   -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21431,'coiste_bodhar',1,0,0,0,0,1,1,999,1,0); -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21432,'epitaph',1,0,0,0,0,1,1,999,1,0);       -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21433,'neo_animator',0,10,0,0,0,0,1,999,0,0);
 INSERT INTO `item_weapon` VALUES (21438,'poisonous_broth',0,0,0,0,0,0,1,0,8776,0);
 INSERT INTO `item_weapon` VALUES (21439,'venomous_broth',0,0,0,0,0,0,1,0,8777,0);
@@ -4399,6 +4403,8 @@ INSERT INTO `item_weapon` VALUES (21482,'compensator',26,1,242,0,0,1,1,480,89,0)
 INSERT INTO `item_weapon` VALUES (21483,'malison',26,1,242,0,0,1,1,480,92,0);
 INSERT INTO `item_weapon` VALUES (21484,'malison_+1',26,1,242,0,0,1,1,466,93,0);
 INSERT INTO `item_weapon` VALUES (21485,'fomalhaut',26,1,269,0,0,1,1,600,167,0);
+INSERT INTO `item_weapon` VALUES (21488,'jug_of_pristine_sap',1,0,0,0,0,1,1,999,1,0);       -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21489,'jug_of_truly_pristine_sap',1,0,0,0,0,1,1,999,1,0); -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21490,'aged_humus',0,77,0,0,0,1,1,2295,257,0);
 INSERT INTO `item_weapon` VALUES (21492,'insipid_broth',0,0,0,0,0,0,1,2211,6734,0);
 INSERT INTO `item_weapon` VALUES (21493,'deepwater_broth',0,0,0,0,0,0,1,2212,6735,0);
@@ -4451,7 +4457,8 @@ INSERT INTO `item_weapon` VALUES (21563,'eletta_knife',2,0,231,231,231,1,1,180,1
 INSERT INTO `item_weapon` VALUES (21564,'kaja_knife',2,0,242,242,242,1,1,180,117,0);      -- DMG:117 Delay:180
 INSERT INTO `item_weapon` VALUES (21565,'tauret',2,0,250,250,250,1,1,180,125,0);          -- DMG:125 Delay:180
 INSERT INTO `item_weapon` VALUES (21566,'voluspa_knife',2,0,215,215,215,1,1,195,104,0);
-INSERT INTO `item_weapon` VALUES (21567,'gletis_knife',2,0,255,255,242,1,1,200,133,0); -- DMG:133 Delay:200
+INSERT INTO `item_weapon` VALUES (21567,'gletis_knife',2,0,255,255,242,1,1,200,133,0);  -- DMG:133 Delay:200
+INSERT INTO `item_weapon` VALUES (21568,'acrontica',1,0,0,0,0,1,1,999,1,0);             -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21569,'chocobo_knife',2,0,269,269,269,1,1,176,121,0); -- DMG:121 Delay:176
 INSERT INTO `item_weapon` VALUES (21570,'air_knife',2,0,269,269,269,1,1,150,103,0);
 INSERT INTO `item_weapon` VALUES (21573,'assassins_knife',2,0,242,242,228,1,1,196,130,0); -- DMG:130 Delay:196
@@ -4505,6 +4512,17 @@ INSERT INTO `item_weapon` VALUES (21636,'nihility',3,0,0,0,0,2,1,240,1,0);      
 INSERT INTO `item_weapon` VALUES (21637,'sakpatas_sword',3,0,248,248,248,2,1,240,160,0); -- DMG:160 Delay:240
 INSERT INTO `item_weapon` VALUES (21638,'extinction',3,0,0,0,0,2,1,240,1,0); -- DMG:1 Delay:240
 INSERT INTO `item_weapon` VALUES (21640,'onion_sword_iii',3,0,269,269,269,2,1,240,165,0);
+INSERT INTO `item_weapon` VALUES (21641,'save_the_queen_iii',1,0,0,0,0,1,1,999,1,0); -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21642,'prime_sword',1,0,0,0,0,1,1,999,1,0);        -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21643,'caliburnus',1,0,0,0,0,1,1,999,1,0);         -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21644,'caliburnus',1,0,0,0,0,1,1,999,1,0);         -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21645,'caliburnus',1,0,0,0,0,1,1,999,1,0);         -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21646,'caliburnus',1,0,0,0,0,1,1,999,1,0);         -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21649,'helheim',1,0,0,0,0,1,1,999,1,0);            -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21650,'prime_blade',1,0,0,0,0,1,1,999,1,0);        -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21651,'helheim',1,0,0,0,0,1,1,999,1,0);            -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21652,'helheim',1,0,0,0,0,1,1,999,1,0);            -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21653,'helheim',1,0,0,0,0,1,1,999,1,0);            -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21654,'arasy_claymore',4,0,242,242,188,2,1,489,251,0);
 INSERT INTO `item_weapon` VALUES (21655,'arasy_claymore_+1',4,0,242,242,188,2,1,475,252,0);
 INSERT INTO `item_weapon` VALUES (21656,'dyrnwyn',4,0,228,228,228,2,1,480,313,0);
@@ -4515,17 +4533,21 @@ INSERT INTO `item_weapon` VALUES (21660,'bery._sword_+1',4,0,242,242,118,2,1,431
 INSERT INTO `item_weapon` VALUES (21661,'rune_algol',4,0,0,0,0,2,1,489,80,0);             -- DMG:80 Delay:489
 INSERT INTO `item_weapon` VALUES (21662,'raetic_algol',4,0,242,242,215,2,1,489,326,0);    -- DMG:326 Delay:489
 INSERT INTO `item_weapon` VALUES (21663,'raetic_algol_+1',4,0,242,242,215,2,1,474,327,0); -- DMG:327 Delay:474
+INSERT INTO `item_weapon` VALUES (21664,'zantetsuken_x',1,0,0,0,0,1,1,999,1,0);           -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21665,'voluspa_blade',4,0,215,215,215,2,1,480,260,0);
 INSERT INTO `item_weapon` VALUES (21667,'futhark_claymore',4,0,242,242,228,2,1,494,330,0); -- DMG:330 Delay:494
-INSERT INTO `item_weapon` VALUES (21668,'peord_claymore',4,0,255,255,242,2,1,480,331,0);  -- DMG:331 Delay:480
-INSERT INTO `item_weapon` VALUES (21669,'morgelai',4,0,269,269,255,2,1,480,332,0);        -- DMG:332 Delay:480
-INSERT INTO `item_weapon` VALUES (21670,'tokko_claymore',4,0,215,215,215,2,1,480,260,0);  -- DMG:260 Delay:480
-INSERT INTO `item_weapon` VALUES (21671,'ajja_claymore',4,0,223,223,223,2,1,480,280,0);   -- DMG:280 Delay:480
-INSERT INTO `item_weapon` VALUES (21672,'eletta_claymore',4,0,231,231,231,2,1,480,293,0); -- DMG:293 Delay:480
-INSERT INTO `item_weapon` VALUES (21673,'kaja_claymore',4,0,242,242,242,2,1,480,313,0);   -- DMG:313 Delay:480
-INSERT INTO `item_weapon` VALUES (21674,'nandaka',4,0,250,250,250,2,1,480,333,0);         -- DMG:333 Delay:480
-INSERT INTO `item_weapon` VALUES (21681,'ophidian_sword',4,0,0,0,0,2,1,480,1,0);          -- DMG:1 Delay:480
-INSERT INTO `item_weapon` VALUES (21682,'lament',4,0,0,0,0,2,1,430,1,0);                  -- DMG:1 Delay:430
+INSERT INTO `item_weapon` VALUES (21668,'peord_claymore',4,0,255,255,242,2,1,480,331,0);   -- DMG:331 Delay:480
+INSERT INTO `item_weapon` VALUES (21669,'morgelai',4,0,269,269,255,2,1,480,332,0);         -- DMG:332 Delay:480
+INSERT INTO `item_weapon` VALUES (21670,'tokko_claymore',4,0,215,215,215,2,1,480,260,0);   -- DMG:260 Delay:480
+INSERT INTO `item_weapon` VALUES (21671,'ajja_claymore',4,0,223,223,223,2,1,480,280,0);    -- DMG:280 Delay:480
+INSERT INTO `item_weapon` VALUES (21672,'eletta_claymore',4,0,231,231,231,2,1,480,293,0);  -- DMG:293 Delay:480
+INSERT INTO `item_weapon` VALUES (21673,'kaja_claymore',4,0,242,242,242,2,1,480,313,0);    -- DMG:313 Delay:480
+INSERT INTO `item_weapon` VALUES (21674,'nandaka',4,0,250,250,250,2,1,480,333,0);          -- DMG:333 Delay:480
+INSERT INTO `item_weapon` VALUES (21675,'agwus_claymore',1,0,0,0,0,1,1,999,1,0);           -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21676,'brave_blade_iii',1,0,0,0,0,1,1,999,1,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21680,'goujian',1,0,0,0,0,1,1,999,1,0);                  -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21681,'ophidian_sword',4,0,0,0,0,2,1,480,1,0);           -- DMG:1 Delay:480
+INSERT INTO `item_weapon` VALUES (21682,'lament',4,0,0,0,0,2,1,430,1,0);                   -- DMG:1 Delay:430
 INSERT INTO `item_weapon` VALUES (21683,'ragnarok',4,0,269,269,242,2,1,431,304,0);
 INSERT INTO `item_weapon` VALUES (21684,'caladbolg',4,0,269,269,242,2,1,430,303,0);
 INSERT INTO `item_weapon` VALUES (21685,'epeolatry',4,0,269,269,242,2,1,489,305,0);
@@ -4555,20 +4577,27 @@ INSERT INTO `item_weapon` VALUES (21709,'beryllium_pick_+1',5,0,242,242,188,2,1,
 INSERT INTO `item_weapon` VALUES (21710,'raetic_axe',5,0,242,242,215,2,1,276,184,0);      -- DMG:184 Delay:276
 INSERT INTO `item_weapon` VALUES (21711,'raetic_axe_+1',5,0,242,242,215,2,1,268,185,0);   -- DMG:185 Delay:268
 INSERT INTO `item_weapon` VALUES (21712,'voluspa_axe',5,0,215,215,215,2,1,312,169,0);
-INSERT INTO `item_weapon` VALUES (21715,'monster_axe',5,0,242,242,228,2,1,340,229,0);     -- DMG:229 Delay:340
-INSERT INTO `item_weapon` VALUES (21716,'ankusa_axe',5,0,255,255,242,2,1,333,230,0);      -- DMG:230 Delay:333
-INSERT INTO `item_weapon` VALUES (21717,'pangu',5,0,269,269,255,2,1,333,231,0);           -- DMG:231 Delay:333
-INSERT INTO `item_weapon` VALUES (21718,'tokko_axe',5,0,215,215,215,2,1,288,156,0);       -- DMG:156 Delay:288
-INSERT INTO `item_weapon` VALUES (21719,'ajja_axe',5,0,223,223,223,2,1,288,168,0);        -- DMG:168 Delay:288
-INSERT INTO `item_weapon` VALUES (21720,'eletta_axe',5,0,231,231,231,2,1,288,176,0);      -- DMG:176 Delay:288
-INSERT INTO `item_weapon` VALUES (21721,'kaja_axe',5,0,242,242,242,2,1,288,188,0);        -- DMG:188 Delay:288
-INSERT INTO `item_weapon` VALUES (21722,'dolichenus',5,0,250,250,250,2,1,288,200,0);      -- DMG:200 Delay:288
+INSERT INTO `item_weapon` VALUES (21715,'monster_axe',5,0,242,242,228,2,1,340,229,0); -- DMG:229 Delay:340
+INSERT INTO `item_weapon` VALUES (21716,'ankusa_axe',5,0,255,255,242,2,1,333,230,0);  -- DMG:230 Delay:333
+INSERT INTO `item_weapon` VALUES (21717,'pangu',5,0,269,269,255,2,1,333,231,0);       -- DMG:231 Delay:333
+INSERT INTO `item_weapon` VALUES (21718,'tokko_axe',5,0,215,215,215,2,1,288,156,0);   -- DMG:156 Delay:288
+INSERT INTO `item_weapon` VALUES (21719,'ajja_axe',5,0,223,223,223,2,1,288,168,0);    -- DMG:168 Delay:288
+INSERT INTO `item_weapon` VALUES (21720,'eletta_axe',5,0,231,231,231,2,1,288,176,0);  -- DMG:176 Delay:288
+INSERT INTO `item_weapon` VALUES (21721,'kaja_axe',5,0,242,242,242,2,1,288,188,0);    -- DMG:188 Delay:288
+INSERT INTO `item_weapon` VALUES (21722,'dolichenus',5,0,250,250,250,2,1,288,200,0);  -- DMG:200 Delay:288
+INSERT INTO `item_weapon` VALUES (21723,'ikengas_axe',1,0,0,0,0,1,1,999,1,0);         -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21724,'agwus_axe',1,0,0,0,0,1,1,999,1,0);           -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21725,'malefic_axe',5,0,269,269,269,2,1,340,234,0);
-INSERT INTO `item_weapon` VALUES (21741,'demonic_axe',5,0,0,0,0,2,1,288,1,0);             -- DMG:1 Delay:288
-INSERT INTO `item_weapon` VALUES (21742,'aern_axe',5,0,0,0,0,2,1,288,1,0);                -- DMG:1 Delay:288
-INSERT INTO `item_weapon` VALUES (21743,'aern_axe_ii',5,0,0,0,0,2,1,288,1,0);             -- DMG:1 Delay:288
-INSERT INTO `item_weapon` VALUES (21744,'gramks_axe',5,0,0,0,0,2,1,288,1,0);              -- DMG:1 Delay:288
-INSERT INTO `item_weapon` VALUES (21745,'dullahan_axe',5,0,0,0,0,2,1,288,1,0);            -- DMG:1 Delay:288
+INSERT INTO `item_weapon` VALUES (21726,'prime_pickaxe',1,0,0,0,0,1,1,999,1,0); -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21727,'spalirisos',1,0,0,0,0,1,1,999,1,0);    -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21728,'spalirisos',1,0,0,0,0,1,1,999,1,0);    -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21729,'spalirisos',1,0,0,0,0,1,1,999,1,0);    -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21730,'spalirisos',1,0,0,0,0,1,1,999,1,0);    -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21741,'demonic_axe',5,0,0,0,0,2,1,288,1,0);   -- DMG:1 Delay:288
+INSERT INTO `item_weapon` VALUES (21742,'aern_axe',5,0,0,0,0,2,1,288,1,0);      -- DMG:1 Delay:288
+INSERT INTO `item_weapon` VALUES (21743,'aern_axe_ii',5,0,0,0,0,2,1,288,1,0);   -- DMG:1 Delay:288
+INSERT INTO `item_weapon` VALUES (21744,'gramks_axe',5,0,0,0,0,2,1,288,1,0);    -- DMG:1 Delay:288
+INSERT INTO `item_weapon` VALUES (21745,'dullahan_axe',5,0,0,0,0,2,1,288,1,0);  -- DMG:1 Delay:288
 INSERT INTO `item_weapon` VALUES (21746,'digirbalag',5,0,242,242,188,2,1,276,159,0);
 INSERT INTO `item_weapon` VALUES (21747,'freydis',5,0,242,242,188,2,1,276,178,0);
 INSERT INTO `item_weapon` VALUES (21748,'habilitator',5,0,242,242,188,2,1,288,166,0);
@@ -4592,15 +4621,23 @@ INSERT INTO `item_weapon` VALUES (21766,'hepatizon_axe_+1',6,0,242,242,188,2,1,4
 INSERT INTO `item_weapon` VALUES (21767,'raetic_chopper',6,0,242,242,215,2,1,504,336,0);  -- DMG:336 Delay:504
 INSERT INTO `item_weapon` VALUES (21768,'raetic_chopper_+1',6,0,242,242,215,2,1,489,337,0); -- DMG:337 Delay:489
 INSERT INTO `item_weapon` VALUES (21769,'voluspa_chopper',6,0,215,215,215,2,1,504,273,0);
-INSERT INTO `item_weapon` VALUES (21770,'helgoland',6,0,0,0,0,2,1,504,1,0); -- DMG:1, Delay 504
-INSERT INTO `item_weapon` VALUES (21772,'war._chopper',6,0,242,242,228,2,1,504,336,0);    -- DMG:336 Delay:504
-INSERT INTO `item_weapon` VALUES (21773,'agoge_chopper',6,0,255,255,242,2,1,489,337,0);   -- DMG:337 Delay:489
-INSERT INTO `item_weapon` VALUES (21774,'labraunda',6,0,269,269,255,2,1,489,338,0);       -- DMG:338 Delay:489
-INSERT INTO `item_weapon` VALUES (21775,'tokko_chopper',6,0,215,215,215,2,1,508,275,0);   -- DMG:275 Delay:508
-INSERT INTO `item_weapon` VALUES (21776,'ajja_chopper',6,0,223,223,223,2,1,508,296,0);    -- DMG:296 Delay:508
-INSERT INTO `item_weapon` VALUES (21777,'eletta_chopper',6,0,231,231,231,2,1,508,317,0);  -- DMG:317 Delay:508
-INSERT INTO `item_weapon` VALUES (21778,'kaja_chopper',6,0,242,242,242,2,1,508,338,0);    -- DMG:338 Delay:508
-INSERT INTO `item_weapon` VALUES (21779,'lycurgos',6,0,250,250,250,2,1,508,359,0);        -- DMG:359 Delay:508
+INSERT INTO `item_weapon` VALUES (21770,'helgoland',6,0,0,0,0,2,1,504,1,0);              -- DMG:1, Delay 504
+INSERT INTO `item_weapon` VALUES (21772,'war._chopper',6,0,242,242,228,2,1,504,336,0);   -- DMG:336 Delay:504
+INSERT INTO `item_weapon` VALUES (21773,'agoge_chopper',6,0,255,255,242,2,1,489,337,0);  -- DMG:337 Delay:489
+INSERT INTO `item_weapon` VALUES (21774,'labraunda',6,0,269,269,255,2,1,489,338,0);      -- DMG:338 Delay:489
+INSERT INTO `item_weapon` VALUES (21775,'tokko_chopper',6,0,215,215,215,2,1,508,275,0);  -- DMG:275 Delay:508
+INSERT INTO `item_weapon` VALUES (21776,'ajja_chopper',6,0,223,223,223,2,1,508,296,0);   -- DMG:296 Delay:508
+INSERT INTO `item_weapon` VALUES (21777,'eletta_chopper',6,0,231,231,231,2,1,508,317,0); -- DMG:317 Delay:508
+INSERT INTO `item_weapon` VALUES (21778,'kaja_chopper',6,0,242,242,242,2,1,508,338,0);   -- DMG:338 Delay:508
+INSERT INTO `item_weapon` VALUES (21779,'lycurgos',6,0,250,250,250,2,1,508,359,0);       -- DMG:359 Delay:508
+INSERT INTO `item_weapon` VALUES (21780,'bunzis_chopper',1,0,0,0,0,1,1,999,1,0);         -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21781,'prime_great_axe',1,0,0,0,0,1,1,999,1,0);        -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21782,'laphria',1,0,0,0,0,1,1,999,1,0);                -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21783,'laphria',1,0,0,0,0,1,1,999,1,0);                -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21784,'laphria',1,0,0,0,0,1,1,999,1,0);                -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21785,'laphria',1,0,0,0,0,1,1,999,1,0);                -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21786,'poison_axe',1,0,0,0,0,1,1,999,1,0);             -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21787,'poison_axe_+1',1,0,0,0,0,1,1,999,1,0);          -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21804,'obschine',7,0,242,242,188,2,1,501,295,0);
 INSERT INTO `item_weapon` VALUES (21805,'pixquizpan',7,0,242,242,215,2,1,501,290,0);
 INSERT INTO `item_weapon` VALUES (21806,'pixquizpan_+1',7,0,242,242,215,2,1,490,291,0);
@@ -4618,42 +4655,56 @@ INSERT INTO `item_weapon` VALUES (21819,'raetic_scythe_+1',7,0,242,242,215,2,1,5
 INSERT INTO `item_weapon` VALUES (21820,'lost_sickle',7,0,0,0,0,2,1,528,1,0);             -- DMG:1 Delay:528
 INSERT INTO `item_weapon` VALUES (21821,'lost_sickle_+1',7,0,0,0,0,2,1,513,2,0);          -- DMG:2 Delay:513
 INSERT INTO `item_weapon` VALUES (21822,'voluspa_scythe',7,0,215,215,215,2,1,528,286,0);
-INSERT INTO `item_weapon` VALUES (21823,'abyss_scythe',7,0,242,242,228,2,1,528,352,0);    -- DMG:352 Delay:528
-INSERT INTO `item_weapon` VALUES (21824,'fallens_scythe',7,0,255,255,242,2,1,513,353,0);  -- DMG:353 Delay:513
-INSERT INTO `item_weapon` VALUES (21825,'father_time',7,0,269,269,255,2,1,513,354,0);     -- DMG:354 Delay:513
-INSERT INTO `item_weapon` VALUES (21826,'tokko_scythe',7,0,215,215,215,2,1,528,286,0);    -- DMG:286 Delay:528
-INSERT INTO `item_weapon` VALUES (21827,'ajja_scythe',7,0,223,223,223,2,1,528,308,0);     -- DMG:308 Delay:528
-INSERT INTO `item_weapon` VALUES (21828,'eletta_scythe',7,0,231,231,231,2,1,528,322,0);   -- DMG:322 Delay:528
-INSERT INTO `item_weapon` VALUES (21829,'kaja_scythe',7,0,242,242,242,2,1,528,344,0);     -- DMG:344 Delay:528
-INSERT INTO `item_weapon` VALUES (21830,'drepanum',7,0,250,250,250,2,1,528,366,0);        -- DMG:366 Delay:528
-INSERT INTO `item_weapon` VALUES (21832,'agwus_scythe',7,0,248,248,248,2,1,528,352,0);    -- DMG:352 Delay:528
-INSERT INTO `item_weapon` VALUES (21854,'reienkyo',8,0,242,242,188,2,1,480,282,0);        -- DMG:282 Delay:480
-INSERT INTO `item_weapon` VALUES (21855,'lembing',8,0,242,242,188,2,1,492,313,0);         -- DMG:313 Delay:492
-INSERT INTO `item_weapon` VALUES (21857,'gungnir',8,0,269,269,228,2,1,492,347,0);         -- DMG:347 Delay:492
-INSERT INTO `item_weapon` VALUES (21858,'ryunohige',8,0,269,269,228,2,1,492,307,0);       -- DMG:307 Delay:492
-INSERT INTO `item_weapon` VALUES (21859,'rhongomiant',8,0,269,269,228,2,1,492,347,0);     -- DMG:347 Delay:492
-INSERT INTO `item_weapon` VALUES (21860,'aern_spear',8,0,0,0,0,2,1,396,1,0);              -- DMG:1 Delay:396
-INSERT INTO `item_weapon` VALUES (21861,'aern_spear_ii',8,0,0,0,0,2,1,396,1,0);           -- DMG:1 Delay:396
-INSERT INTO `item_weapon` VALUES (21862,'mizukage_naginata',8,0,0,0,0,2,1,480,1,0);       -- DMG:1 Delay:480
-INSERT INTO `item_weapon` VALUES (21863,'tzee_xicus_blade',8,0,0,0,0,2,1,480,1,0);        -- DMG:1 Delay:480
+INSERT INTO `item_weapon` VALUES (21823,'abyss_scythe',7,0,242,242,228,2,1,528,352,0);   -- DMG:352 Delay:528
+INSERT INTO `item_weapon` VALUES (21824,'fallens_scythe',7,0,255,255,242,2,1,513,353,0); -- DMG:353 Delay:513
+INSERT INTO `item_weapon` VALUES (21825,'father_time',7,0,269,269,255,2,1,513,354,0);    -- DMG:354 Delay:513
+INSERT INTO `item_weapon` VALUES (21826,'tokko_scythe',7,0,215,215,215,2,1,528,286,0);   -- DMG:286 Delay:528
+INSERT INTO `item_weapon` VALUES (21827,'ajja_scythe',7,0,223,223,223,2,1,528,308,0);    -- DMG:308 Delay:528
+INSERT INTO `item_weapon` VALUES (21828,'eletta_scythe',7,0,231,231,231,2,1,528,322,0);  -- DMG:322 Delay:528
+INSERT INTO `item_weapon` VALUES (21829,'kaja_scythe',7,0,242,242,242,2,1,528,344,0);    -- DMG:344 Delay:528
+INSERT INTO `item_weapon` VALUES (21830,'drepanum',7,0,250,250,250,2,1,528,366,0);       -- DMG:366 Delay:528
+INSERT INTO `item_weapon` VALUES (21831,'ligeia_scythe',1,0,0,0,0,1,1,999,1,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21832,'agwus_scythe',7,0,248,248,248,2,1,528,352,0);   -- DMG:352 Delay:528
+INSERT INTO `item_weapon` VALUES (21833,'prime_scythe',1,0,0,0,0,1,1,999,1,0);           -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21834,'foenaria',1,0,0,0,0,1,1,999,1,0);               -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21835,'foenaria',1,0,0,0,0,1,1,999,1,0);               -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21836,'foenaria',1,0,0,0,0,1,1,999,1,0);               -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21837,'foenaria',1,0,0,0,0,1,1,999,1,0);               -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21854,'reienkyo',8,0,242,242,188,2,1,480,282,0);       -- DMG:282 Delay:480
+INSERT INTO `item_weapon` VALUES (21855,'lembing',8,0,242,242,188,2,1,492,313,0);        -- DMG:313 Delay:492
+INSERT INTO `item_weapon` VALUES (21856,'geirrothr',1,0,0,0,0,1,1,999,1,0);              -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21857,'gungnir',8,0,269,269,228,2,1,492,347,0);        -- DMG:347 Delay:492
+INSERT INTO `item_weapon` VALUES (21858,'ryunohige',8,0,269,269,228,2,1,492,307,0);      -- DMG:307 Delay:492
+INSERT INTO `item_weapon` VALUES (21859,'rhongomiant',8,0,269,269,228,2,1,492,347,0);    -- DMG:347 Delay:492
+INSERT INTO `item_weapon` VALUES (21860,'aern_spear',8,0,0,0,0,2,1,396,1,0);             -- DMG:1 Delay:396
+INSERT INTO `item_weapon` VALUES (21861,'aern_spear_ii',8,0,0,0,0,2,1,396,1,0);          -- DMG:1 Delay:396
+INSERT INTO `item_weapon` VALUES (21862,'mizukage_naginata',8,0,0,0,0,2,1,480,1,0);      -- DMG:1 Delay:480
+INSERT INTO `item_weapon` VALUES (21863,'tzee_xicus_blade',8,0,0,0,0,2,1,480,1,0);       -- DMG:1 Delay:480
 INSERT INTO `item_weapon` VALUES (21864,'voluspa_lance',8,0,215,215,215,1,1,492,266,0);
-INSERT INTO `item_weapon` VALUES (21865,'arasy_lance',8,0,242,242,188,1,1,492,252,0);     -- DMG:252 Delay:492
-INSERT INTO `item_weapon` VALUES (21866,'arasy_lance_+1',8,0,242,242,188,1,1,478,253,0);  -- MG:253 Delay:478
-INSERT INTO `item_weapon` VALUES (21867,'sha_wujings_lance',8,0,0,0,0,1,1,396,1,0);       -- DMG:1 Delay:396
-INSERT INTO `item_weapon` VALUES (21868,'sha_wujings_la._+1',8,0,0,0,0,1,1,385,2,0);      -- DMG:2 Delay:385
-INSERT INTO `item_weapon` VALUES (21869,'exalted_spear',8,0,228,228,188,1,1,396,258,0);   -- DMG:258 Delay:396
-INSERT INTO `item_weapon` VALUES (21870,'exalted_spear_+1',8,0,228,228,188,1,1,385,259,0); -- DMG:259 Delay:385
-INSERT INTO `item_weapon` VALUES (21871,'raetic_halberd',8,0,242,242,215,1,1,396,264,0);  -- DMG:264 Delay:396
+INSERT INTO `item_weapon` VALUES (21865,'arasy_lance',8,0,242,242,188,1,1,492,252,0);       -- DMG:252 Delay:492
+INSERT INTO `item_weapon` VALUES (21866,'arasy_lance_+1',8,0,242,242,188,1,1,478,253,0);    -- MG:253 Delay:478
+INSERT INTO `item_weapon` VALUES (21867,'sha_wujings_lance',8,0,0,0,0,1,1,396,1,0);         -- DMG:1 Delay:396
+INSERT INTO `item_weapon` VALUES (21868,'sha_wujings_la._+1',8,0,0,0,0,1,1,385,2,0);        -- DMG:2 Delay:385
+INSERT INTO `item_weapon` VALUES (21869,'exalted_spear',8,0,228,228,188,1,1,396,258,0);     -- DMG:258 Delay:396
+INSERT INTO `item_weapon` VALUES (21870,'exalted_spear_+1',8,0,228,228,188,1,1,385,259,0);  -- DMG:259 Delay:385
+INSERT INTO `item_weapon` VALUES (21871,'raetic_halberd',8,0,242,242,215,1,1,396,264,0);    -- DMG:264 Delay:396
 INSERT INTO `item_weapon` VALUES (21872,'raetic_halberd_+1',8,0,242,242,215,1,1,385,265,0); -- DMG:265 Delay:385
-INSERT INTO `item_weapon` VALUES (21876,'wyrm_lance',8,0,242,242,228,1,1,507,338,0);      -- DMG:338 Delay:507
+INSERT INTO `item_weapon` VALUES (21876,'wyrm_lance',8,0,242,242,228,1,1,507,338,0);        -- DMG:338 Delay:507
 INSERT INTO `item_weapon` VALUES (21877,'pteroslaver_lance',8,0,255,255,242,1,1,492,339,0); -- DMG:339 Delay:492
-INSERT INTO `item_weapon` VALUES (21878,'aram',8,0,269,269,255,1,1,492,340,0);            -- DMG:340 Delay:492
-INSERT INTO `item_weapon` VALUES (21879,'tokko_lance',8,0,215,215,215,1,1,480,260,0);     -- DMG:260 Delay:480
-INSERT INTO `item_weapon` VALUES (21880,'ajja_lance',8,0,223,223,223,1,1,480,280,0);      -- DMG:280 Delay:480
-INSERT INTO `item_weapon` VALUES (21881,'eletta_lance',8,0,231,231,231,1,1,480,293,0);    -- DMG:293 Delay:480
-INSERT INTO `item_weapon` VALUES (21882,'kaja_lance',8,0,242,242,242,1,1,480,313,0);      -- DMG:313 Delay:480
-INSERT INTO `item_weapon` VALUES (21883,'shining_one',8,0,250,250,250,1,1,480,333,0);     -- DMG:333 Delay:480
+INSERT INTO `item_weapon` VALUES (21878,'aram',8,0,269,269,255,1,1,492,340,0);              -- DMG:340 Delay:492
+INSERT INTO `item_weapon` VALUES (21879,'tokko_lance',8,0,215,215,215,1,1,480,260,0);       -- DMG:260 Delay:480
+INSERT INTO `item_weapon` VALUES (21880,'ajja_lance',8,0,223,223,223,1,1,480,280,0);        -- DMG:280 Delay:480
+INSERT INTO `item_weapon` VALUES (21881,'eletta_lance',8,0,231,231,231,1,1,480,293,0);      -- DMG:293 Delay:480
+INSERT INTO `item_weapon` VALUES (21882,'kaja_lance',8,0,242,242,242,1,1,480,313,0);        -- DMG:313 Delay:480
+INSERT INTO `item_weapon` VALUES (21883,'shining_one',8,0,250,250,250,1,1,480,333,0);       -- DMG:333 Delay:480
+INSERT INTO `item_weapon` VALUES (21884,'ikengas_lance',1,0,0,0,0,1,1,999,1,0);             -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21885,'hebos_spear',1,0,0,0,0,1,1,999,1,0);               -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21886,'iapetus',8,0,0,0,0,1,1,492,1,0);
+INSERT INTO `item_weapon` VALUES (21887,'prime_lance',1,0,0,0,0,1,1,999,1,0); -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21888,'gae_buide',1,0,0,0,0,1,1,999,1,0);   -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21889,'gae_buide',1,0,0,0,0,1,1,999,1,0);   -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21890,'gae_buide',1,0,0,0,0,1,1,999,1,0);   -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21891,'gae_buide',1,0,0,0,0,1,1,999,1,0);   -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21904,'kanaria',9,0,242,242,188,2,1,227,127,0);
 INSERT INTO `item_weapon` VALUES (21905,'taka',9,0,228,228,215,2,1,190,123,0);
 INSERT INTO `item_weapon` VALUES (21906,'kikoku',9,0,269,269,242,2,1,210,148,0);
@@ -4662,16 +4713,24 @@ INSERT INTO `item_weapon` VALUES (21908,'kannagi',9,0,269,269,242,2,1,210,148,0)
 INSERT INTO `item_weapon` VALUES (21909,'yoshikiri',9,0,242,242,188,0,1,227,116,0);
 INSERT INTO `item_weapon` VALUES (21910,'yoshikiri_+1',9,0,242,242,188,0,1,222,117,0);
 INSERT INTO `item_weapon` VALUES (21912,'voluspa_katana',9,0,215,215,215,0,1,227,122,0);
-INSERT INTO `item_weapon` VALUES (21915,'koga_shin',9,0,242,242,228,0,1,227,152,0);       -- DMG:152 Delay:227
-INSERT INTO `item_weapon` VALUES (21916,'mochi._shin.',9,0,255,255,242,0,1,222,153,0);    -- DMG:153 Delay:222
-INSERT INTO `item_weapon` VALUES (21917,'fudo_masamune',9,0,269,269,255,0,1,222,154,0);   -- DMG:154 Delay:222
-INSERT INTO `item_weapon` VALUES (21918,'tokko_katana',9,0,215,215,215,0,1,227,122,0);    -- DMG:122 Delay:227
-INSERT INTO `item_weapon` VALUES (21919,'ajja_katana',9,0,223,223,223,0,1,227,132,0);     -- DMG:132 Delay:227
-INSERT INTO `item_weapon` VALUES (21920,'eletta_katana',9,0,231,231,231,0,1,227,138,0);   -- DMG:138 Delay:227
-INSERT INTO `item_weapon` VALUES (21921,'kaja_katana',9,0,242,242,242,0,1,227,148,0);     -- DMG:148 Delay:227
-INSERT INTO `item_weapon` VALUES (21922,'gokotai',9,0,250,250,250,0,1,227,157,0);         -- DMG:157 Delay:227
-INSERT INTO `item_weapon` VALUES (21923,'debahocho',9,0,0,0,0,0,1,227,1,0);               -- DMG:1 Delay:227
-INSERT INTO `item_weapon` VALUES (21924,'debahocho_+1',9,0,0,0,0,0,1,222,2,0);            -- DMG:2 Delay:222
+INSERT INTO `item_weapon` VALUES (21915,'koga_shin',9,0,242,242,228,0,1,227,152,0);     -- DMG:152 Delay:227
+INSERT INTO `item_weapon` VALUES (21916,'mochi._shin.',9,0,255,255,242,0,1,222,153,0);  -- DMG:153 Delay:222
+INSERT INTO `item_weapon` VALUES (21917,'fudo_masamune',9,0,269,269,255,0,1,222,154,0); -- DMG:154 Delay:222
+INSERT INTO `item_weapon` VALUES (21918,'tokko_katana',9,0,215,215,215,0,1,227,122,0);  -- DMG:122 Delay:227
+INSERT INTO `item_weapon` VALUES (21919,'ajja_katana',9,0,223,223,223,0,1,227,132,0);   -- DMG:132 Delay:227
+INSERT INTO `item_weapon` VALUES (21920,'eletta_katana',9,0,231,231,231,0,1,227,138,0); -- DMG:138 Delay:227
+INSERT INTO `item_weapon` VALUES (21921,'kaja_katana',9,0,242,242,242,0,1,227,148,0);   -- DMG:148 Delay:227
+INSERT INTO `item_weapon` VALUES (21922,'gokotai',9,0,250,250,250,0,1,227,157,0);       -- DMG:157 Delay:227
+INSERT INTO `item_weapon` VALUES (21923,'debahocho',9,0,0,0,0,0,1,227,1,0);             -- DMG:1 Delay:227
+INSERT INTO `item_weapon` VALUES (21924,'debahocho_+1',9,0,0,0,0,0,1,222,2,0);          -- DMG:2 Delay:222
+INSERT INTO `item_weapon` VALUES (21925,'kunimitsu',1,0,0,0,0,1,1,999,1,0);             -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21926,'tsuru',1,0,0,0,0,1,1,999,1,0);                 -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21927,'yagyu_darkblade',1,0,0,0,0,1,1,999,1,0);       -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21928,'genshitanto',1,0,0,0,0,1,1,999,1,0);           -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21929,'dokoku',1,0,0,0,0,1,1,999,1,0);                -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21930,'dokoku',1,0,0,0,0,1,1,999,1,0);                -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21931,'dokoku',1,0,0,0,0,1,1,999,1,0);                -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21932,'dokoku',1,0,0,0,0,1,1,999,1,0);                -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21954,'amanomurakumo',10,0,269,269,228,2,1,437,308,0);
 INSERT INTO `item_weapon` VALUES (21955,'kogarasumaru',10,0,269,269,228,2,1,450,281,0);
 INSERT INTO `item_weapon` VALUES (21956,'masamune',10,0,269,269,228,2,1,437,308,0);
@@ -4692,9 +4751,23 @@ INSERT INTO `item_weapon` VALUES (21974,'kaja_tachi',10,0,242,242,242,0,1,450,30
 INSERT INTO `item_weapon` VALUES (21975,'hachimonji',10,0,250,250,250,0,1,450,318,0);     -- DMG:318 Delay:450
 INSERT INTO `item_weapon` VALUES (21976,'voluspa_tachi',10,0,215,215,215,0,1,450,243,0);
 INSERT INTO `item_weapon` VALUES (21977,'mutsunokami',10,0,0,0,0,0,1,450,1,0);            -- DMG:1 Delay:450
+INSERT INTO `item_weapon` VALUES (21978,'mutsunokami_+1',1,0,0,0,0,1,1,999,1,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21979,'gekkei',1,0,0,0,0,1,1,999,1,0);                  -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21980,'zanmato_+2',1,0,0,0,0,1,1,999,1,0);              -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21981,'mutsu-no-kami_yoshiyuki',1,0,0,0,0,1,1,999,1,0); -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21982,'genshito',1,0,0,0,0,1,1,999,1,0);                -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21983,'kusanagi-no-tsurugi',1,0,0,0,0,1,1,999,1,0);     -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21984,'kusanagi-no-tsurugi',1,0,0,0,0,1,1,999,1,0);     -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21985,'kusanagi-no-tsurugi',1,0,0,0,0,1,1,999,1,0);     -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21986,'kusanagi-no-tsurugi',1,0,0,0,0,1,1,999,1,0);     -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21990,'zanmato_+2',10,0,269,269,269,0,1,464,320,0);
-INSERT INTO `item_weapon` VALUES (22004,'soulflayers_wand',11,0,0,0,0,3,1,264,1,0);       -- DMG:1 Delay:264
-INSERT INTO `item_weapon` VALUES (22005,'burrowers_wand',11,0,0,0,0,3,1,264,1,0);         -- DMG:1 Delay:264
+INSERT INTO `item_weapon` VALUES (21998,'lorg_mor',1,0,0,0,0,1,1,999,1,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21999,'prime_maul',1,0,0,0,0,1,1,999,1,0);        -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22000,'lorg_mor',1,0,0,0,0,1,1,999,1,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22001,'lorg_mor',1,0,0,0,0,1,1,999,1,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22002,'lorg_mor',1,0,0,0,0,1,1,999,1,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22004,'soulflayers_wand',11,0,0,0,0,3,1,264,1,0); -- DMG:1 Delay:264
+INSERT INTO `item_weapon` VALUES (22005,'burrowers_wand',11,0,0,0,0,3,1,264,1,0);   -- DMG:1 Delay:264
 INSERT INTO `item_weapon` VALUES (22006,'voluspa_hammer',11,0,215,215,215,3,1,340,184,0);
 INSERT INTO `item_weapon` VALUES (22015,'arasy_rod',11,0,242,242,215,3,1,288,148,0);
 INSERT INTO `item_weapon` VALUES (22016,'arasy_rod_+1',11,0,242,242,215,3,1,280,149,0);
@@ -4704,23 +4777,36 @@ INSERT INTO `item_weapon` VALUES (22019,'jingly_rod',11,0,0,0,0,0,1,216,1,0);
 INSERT INTO `item_weapon` VALUES (22020,'jingly_rod_+1',11,0,0,0,0,0,1,210,2,0);
 INSERT INTO `item_weapon` VALUES (22021,'ames',11,0,242,242,215,0,1,216,141,0);
 INSERT INTO `item_weapon` VALUES (22022,'ames_+1',11,0,242,242,215,0,1,210,142,0);
-INSERT INTO `item_weapon` VALUES (22023,'beryllium_mace',11,0,242,242,188,0,1,300,195,0); -- DMG:195 Delay:300
+INSERT INTO `item_weapon` VALUES (22023,'beryllium_mace',11,0,242,242,188,0,1,300,195,0);    -- DMG:195 Delay:300
 INSERT INTO `item_weapon` VALUES (22024,'beryllium_mace_+1',11,0,242,242,188,0,1,291,196,0); -- DMG:196 Delay:291
-INSERT INTO `item_weapon` VALUES (22025,'raetic_rod',11,0,215,215,242,0,1,288,192,0);     -- DMG:192 Delay:288
-INSERT INTO `item_weapon` VALUES (22026,'raetic_rod_+1',11,0,215,215,242,0,1,280,193,0);  -- DMG:193 Delay:280
-INSERT INTO `item_weapon` VALUES (22027,'tokko_rod',11,0,215,215,215,0,1,288,156,0);      -- DMG:156 Delay:288
-INSERT INTO `item_weapon` VALUES (22028,'ajja_rod',11,0,223,223,223,0,1,288,168,0);       -- DMG:168 Delay:288
-INSERT INTO `item_weapon` VALUES (22029,'eletta_rod',11,0,231,231,231,0,1,288,176,0);     -- DMG:176 Delay:288
-INSERT INTO `item_weapon` VALUES (22030,'kaja_rod',11,0,242,242,242,0,1,288,188,0);       -- DMG:188 Delay:288
-INSERT INTO `item_weapon` VALUES (22031,'maxentius',11,0,250,250,250,0,1,288,200,0);      -- DMG:200 Delay:288
-INSERT INTO `item_weapon` VALUES (22033,'clerics_wand',11,0,228,228,242,0,1,288,192,0);   -- DMG:192 Delay:288
-INSERT INTO `item_weapon` VALUES (22034,'piety_wand',11,0,242,242,255,0,1,280,193,0);     -- DMG:193 Delay:280
-INSERT INTO `item_weapon` VALUES (22035,'asclepius',11,0,255,255,269,0,1,280,194,0);      -- DMG:194 Delay:280
-INSERT INTO `item_weapon` VALUES (22036,'bagua_wand',11,0,228,228,242,0,1,288,192,0);     -- DMG:192 Delay:288
-INSERT INTO `item_weapon` VALUES (22037,'sifang_wand',11,0,242,242,255,0,1,280,193,0);    -- DMG:193 Delay:280
-INSERT INTO `item_weapon` VALUES (22038,'bhima',11,0,255,255,269,0,1,280,194,0);          -- DMG:194 Delay:280
-INSERT INTO `item_weapon` VALUES (22039,'floral_hagoita',11,0,0,0,0,0,1,264,2,0);         -- DMG:2 Delay:264
+INSERT INTO `item_weapon` VALUES (22025,'raetic_rod',11,0,215,215,242,0,1,288,192,0);        -- DMG:192 Delay:288
+INSERT INTO `item_weapon` VALUES (22026,'raetic_rod_+1',11,0,215,215,242,0,1,280,193,0);     -- DMG:193 Delay:280
+INSERT INTO `item_weapon` VALUES (22027,'tokko_rod',11,0,215,215,215,0,1,288,156,0);         -- DMG:156 Delay:288
+INSERT INTO `item_weapon` VALUES (22028,'ajja_rod',11,0,223,223,223,0,1,288,168,0);          -- DMG:168 Delay:288
+INSERT INTO `item_weapon` VALUES (22029,'eletta_rod',11,0,231,231,231,0,1,288,176,0);        -- DMG:176 Delay:288
+INSERT INTO `item_weapon` VALUES (22030,'kaja_rod',11,0,242,242,242,0,1,288,188,0);          -- DMG:188 Delay:288
+INSERT INTO `item_weapon` VALUES (22031,'maxentius',11,0,250,250,250,0,1,288,200,0);         -- DMG:200 Delay:288
+INSERT INTO `item_weapon` VALUES (22032,'thunder_hammer',1,0,0,0,0,1,1,999,1,0);             -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22033,'clerics_wand',11,0,228,228,242,0,1,288,192,0);      -- DMG:192 Delay:288
+INSERT INTO `item_weapon` VALUES (22034,'piety_wand',11,0,242,242,255,0,1,280,193,0);        -- DMG:193 Delay:280
+INSERT INTO `item_weapon` VALUES (22035,'asclepius',11,0,255,255,269,0,1,280,194,0);         -- DMG:194 Delay:280
+INSERT INTO `item_weapon` VALUES (22036,'bagua_wand',11,0,228,228,242,0,1,288,192,0);        -- DMG:192 Delay:288
+INSERT INTO `item_weapon` VALUES (22037,'sifang_wand',11,0,242,242,255,0,1,280,193,0);       -- DMG:193 Delay:280
+INSERT INTO `item_weapon` VALUES (22038,'bhima',11,0,255,255,269,0,1,280,194,0);             -- DMG:194 Delay:280
+INSERT INTO `item_weapon` VALUES (22039,'floral_hagoita',11,0,0,0,0,0,1,264,2,0);            -- DMG:2 Delay:264
+INSERT INTO `item_weapon` VALUES (22040,'daybreak',1,0,0,0,0,1,1,999,1,0);                   -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22041,'bunzis_rod',1,0,0,0,0,1,1,999,1,0);                 -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22042,'wizards_rod',11,0,250,250,250,0,1,216,200,0);
+INSERT INTO `item_weapon` VALUES (22043,'apkallu_scepter',1,0,0,0,0,1,1,999,1,0);   -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22044,'tengu_war_fan',1,0,0,0,0,1,1,999,1,0);     -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22045,'feline_hagoita',1,0,0,0,0,1,1,999,1,0);    -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22046,'feline_hagoita_+1',1,0,0,0,0,1,1,999,1,0); -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22047,'korrigan_mallet',1,0,0,0,0,1,1,999,1,0);   -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22048,'adenium_mallet',1,0,0,0,0,1,1,999,1,0);    -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22049,'citrullus_mallet',1,0,0,0,0,1,1,999,1,0);  -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22050,'chac-chacs',1,0,0,0,0,1,1,999,1,0);        -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22051,'lycopodium_mallet',1,0,0,0,0,1,1,999,1,0); -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22052,'summer_uchiwa',1,0,0,0,0,1,1,999,1,0);     -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22054,'grioavolr',12,0,242,242,228,3,1,366,202,0);
 INSERT INTO `item_weapon` VALUES (22055,'oranyan',12,0,242,242,228,3,1,366,230,0);
 INSERT INTO `item_weapon` VALUES (22056,'gozuki_mezuki',12,0,242,242,188,3,1,412,266,0);
@@ -4731,13 +4817,14 @@ INSERT INTO `item_weapon` VALUES (22061,'tupsimati',12,0,269,269,269,3,1,402,251
 INSERT INTO `item_weapon` VALUES (22062,'laevateinn',12,0,269,269,269,3,1,402,251,0);
 INSERT INTO `item_weapon` VALUES (22063,'nirvana',12,0,269,269,269,3,1,402,251,0);
 INSERT INTO `item_weapon` VALUES (22064,'hvergelmir',12,0,269,269,269,3,1,390,275,0);
-INSERT INTO `item_weapon` VALUES (22065,'aern_staff',12,0,0,0,0,3,1,366,1,0);             -- DMG:1 Delay:366
-INSERT INTO `item_weapon` VALUES (22066,'aern_staff_ii',12,0,0,0,0,3,1,366,1,0);          -- DMG:1 Delay:366
-INSERT INTO `item_weapon` VALUES (22067,'levin',12,0,0,0,0,3,1,366,1,0);                  -- DMG:1 Delay:366
-INSERT INTO `item_weapon` VALUES (22068,'savage._pole',12,0,0,0,0,3,1,366,1,0);           -- DMG:1 Delay:366
-INSERT INTO `item_weapon` VALUES (22069,'hapy_staff',12,0,0,0,0,3,1,366,1,0);             -- DMG:1 Delay:366
-INSERT INTO `item_weapon` VALUES (22070,'ranine_staff',12,0,0,0,0,3,1,366,1,0);           -- DMG:1 Delay:366
-INSERT INTO `item_weapon` VALUES (22072,'lamia_staff',12,0,0,0,0,3,1,366,1,0);            -- DMG:1 Delay:366
+INSERT INTO `item_weapon` VALUES (22065,'aern_staff',12,0,0,0,0,3,1,366,1,0);    -- DMG:1 Delay:366
+INSERT INTO `item_weapon` VALUES (22066,'aern_staff_ii',12,0,0,0,0,3,1,366,1,0); -- DMG:1 Delay:366
+INSERT INTO `item_weapon` VALUES (22067,'levin',12,0,0,0,0,3,1,366,1,0);         -- DMG:1 Delay:366
+INSERT INTO `item_weapon` VALUES (22068,'savage._pole',12,0,0,0,0,3,1,366,1,0);  -- DMG:1 Delay:366
+INSERT INTO `item_weapon` VALUES (22069,'hapy_staff',12,0,0,0,0,3,1,366,1,0);    -- DMG:1 Delay:366
+INSERT INTO `item_weapon` VALUES (22070,'ranine_staff',12,0,0,0,0,3,1,366,1,0);  -- DMG:1 Delay:366
+INSERT INTO `item_weapon` VALUES (22071,'profane_staff',1,0,0,0,0,1,1,999,1,0);  -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22072,'lamia_staff',12,0,0,0,0,3,1,366,1,0);   -- DMG:1 Delay:366
 INSERT INTO `item_weapon` VALUES (22074,'arasy_staff',12,0,242,242,228,3,1,366,188,0);
 INSERT INTO `item_weapon` VALUES (22075,'arasy_staff_+1',12,0,242,242,228,3,1,356,189,0);
 INSERT INTO `item_weapon` VALUES (22076,'was',12,0,242,242,188,0,1,366,238,0);
@@ -4765,12 +4852,17 @@ INSERT INTO `item_weapon` VALUES (22098,'pedagogy_staff',12,0,242,242,255,0,1,39
 INSERT INTO `item_weapon` VALUES (22099,'musa',12,0,255,255,269,0,1,399,276,0);           -- DMG:276 Delay:399
 INSERT INTO `item_weapon` VALUES (22100,'mpacas_staff',12,0,242,242,255,0,1,402,268,0); -- DMG:268 Delay:402
 INSERT INTO `item_weapon` VALUES (22101,'pandits_staff',12,0,269,269,269,0,1,412,284,0);
-INSERT INTO `item_weapon` VALUES (22107,'ullr',25,0,250,0,0,1,1,360,178,0);               -- DMG:178 Delay:360
-INSERT INTO `item_weapon` VALUES (22108,'tokko_bow',25,0,215,0,0,1,1,360,136,0);          -- DMG:136 Delay:360
-INSERT INTO `item_weapon` VALUES (22109,'ajja_bow',25,0,223,0,0,1,1,360,147,0);           -- DMG:147 Delay:360
-INSERT INTO `item_weapon` VALUES (22110,'eletta_bow',25,0,231,0,0,1,1,360,157,0);         -- DMG:157 Delay:360
-INSERT INTO `item_weapon` VALUES (22111,'kaja_bow',25,0,242,0,0,1,1,360,164,0);           -- DMG:164 Delay:360
-INSERT INTO `item_weapon` VALUES (22112,'mizukage-no-yumi',25,4,0,0,0,1,1,524,1,0);       -- DMG:1 Delay:524
+INSERT INTO `item_weapon` VALUES (22102,'prime_staff',1,0,0,0,0,1,1,999,1,0);       -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22103,'opashoro',1,0,0,0,0,1,1,999,1,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22104,'opashoro',1,0,0,0,0,1,1,999,1,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22105,'opashoro',1,0,0,0,0,1,1,999,1,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22106,'opashoro',1,0,0,0,0,1,1,999,1,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22107,'ullr',25,0,250,0,0,1,1,360,178,0);         -- DMG:178 Delay:360
+INSERT INTO `item_weapon` VALUES (22108,'tokko_bow',25,0,215,0,0,1,1,360,136,0);    -- DMG:136 Delay:360
+INSERT INTO `item_weapon` VALUES (22109,'ajja_bow',25,0,223,0,0,1,1,360,147,0);     -- DMG:147 Delay:360
+INSERT INTO `item_weapon` VALUES (22110,'eletta_bow',25,0,231,0,0,1,1,360,157,0);   -- DMG:157 Delay:360
+INSERT INTO `item_weapon` VALUES (22111,'kaja_bow',25,0,242,0,0,1,1,360,164,0);     -- DMG:164 Delay:360
+INSERT INTO `item_weapon` VALUES (22112,'mizukage-no-yumi',25,4,0,0,0,1,1,524,1,0); -- DMG:1 Delay:524
 INSERT INTO `item_weapon` VALUES (22113,'teller',25,4,242,0,0,1,1,600,270,0);
 INSERT INTO `item_weapon` VALUES (22114,'steinthor',25,4,242,0,0,1,1,600,290,0);
 INSERT INTO `item_weapon` VALUES (22115,'yoichinoyumi',25,4,269,0,0,1,1,524,303,0);
@@ -4804,11 +4896,25 @@ INSERT INTO `item_weapon` VALUES (22142,'armageddon',26,1,269,0,0,1,1,582,143,0)
 INSERT INTO `item_weapon` VALUES (22143,'fomalhaut',26,1,269,0,0,1,1,600,167,0);          -- DMG:167 Delay:600
 INSERT INTO `item_weapon` VALUES (22144,'voluspa_gun',26,0,215,0,0,1,1,600,113,0);
 INSERT INTO `item_weapon` VALUES (22145,'artemiss_bow_+2',25,4,269,0,0,1,1,540,276,0);
-INSERT INTO `item_weapon` VALUES (22147,'scouts_crossbow',26,0,242,0,0,1,1,288,126,0);    -- DMG:126 Delay:288
-INSERT INTO `item_weapon` VALUES (22148,'arke_crossbow',26,0,255,0,0,1,1,280,127,0);      -- DMG:127 Delay:280
-INSERT INTO `item_weapon` VALUES (22149,'sharanga',26,0,269,0,0,1,1,280,128,0);           -- DMG:128 Delay:280
-INSERT INTO `item_weapon` VALUES (22153,'silver_gun',26,1,0,0,0,1,1,600,1,0);             -- DMG:1 Delay:600
-INSERT INTO `item_weapon` VALUES (22154,'silver_gun_+1',26,1,0,0,0,1,1,582,2,0);          -- DMG:2 Delay:582
+INSERT INTO `item_weapon` VALUES (22147,'scouts_crossbow',26,0,242,0,0,1,1,288,126,0); -- DMG:126 Delay:288
+INSERT INTO `item_weapon` VALUES (22148,'arke_crossbow',26,0,255,0,0,1,1,280,127,0);   -- DMG:127 Delay:280
+INSERT INTO `item_weapon` VALUES (22149,'sharanga',26,0,269,0,0,1,1,280,128,0);        -- DMG:128 Delay:280
+INSERT INTO `item_weapon` VALUES (22150,'gletis_crossbow',1,0,0,0,0,1,1,999,1,0);      -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22151,'mpacas_bow',1,0,0,0,0,1,1,999,1,0);           -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22152,'exeter',1,0,0,0,0,1,1,999,1,0);               -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22153,'silver_gun',26,1,0,0,0,1,1,600,1,0);          -- DMG:1 Delay:600
+INSERT INTO `item_weapon` VALUES (22154,'silver_gun_+1',26,1,0,0,0,1,1,582,2,0);       -- DMG:2 Delay:582
+INSERT INTO `item_weapon` VALUES (22155,'prime_bow',1,0,0,0,0,1,1,999,1,0);            -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22156,'pinaka',1,0,0,0,0,1,1,999,1,0);               -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22157,'pinaka',1,0,0,0,0,1,1,999,1,0);               -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22158,'pinaka',1,0,0,0,0,1,1,999,1,0);               -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22159,'prime_gun',1,0,0,0,0,1,1,999,1,0);            -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22160,'earp',1,0,0,0,0,1,1,999,1,0);                 -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22161,'earp',1,0,0,0,0,1,1,999,1,0);                 -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22162,'earp',1,0,0,0,0,1,1,999,1,0);                 -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22163,'pinaka',1,0,0,0,0,1,1,999,1,0);               -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22164,'earp',1,0,0,0,0,1,1,999,1,0);                 -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22218,'khonsu',1,0,0,0,0,1,1,999,1,0);               -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22249,'miracle_cheer',42,0,0,0,0,0,1,240,0,0);
 INSERT INTO `item_weapon` VALUES (22250,'seraphic_ampulla',0,0,0,0,0,0,1,999,0,0);
 INSERT INTO `item_weapon` VALUES (22251,'grenade_core',0,0,0,0,0,0,1,999,0,0);
@@ -4858,6 +4964,15 @@ INSERT INTO `item_weapon` VALUES (22297,'aurgelmir_orb',0,0,0,0,0,1,1,999,0,0);
 INSERT INTO `item_weapon` VALUES (22298,'aurgelmir_orb_+1',0,0,0,0,0,1,1,999,0,0);
 INSERT INTO `item_weapon` VALUES (22299,'per._lucky_egg',0,0,0,0,0,1,1,999,0,0);
 INSERT INTO `item_weapon` VALUES (22300,'crepuscular_pebble',0,0,0,0,0,0,0,0,0,0);
+INSERT INTO `item_weapon` VALUES (22301,'sroda_tathlum',1,0,0,0,0,1,1,999,1,0);     -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22302,'oshashas_treatise',1,0,0,0,0,1,1,999,1,0); -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22303,'prime_horn',1,0,0,0,0,1,1,999,1,0);        -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22304,'loughnashade',1,0,0,0,0,1,1,999,1,0);      -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22305,'loughnashade',1,0,0,0,0,1,1,999,1,0);      -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22306,'loughnashade',1,0,0,0,0,1,1,999,1,0);      -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22307,'loughnashade',1,0,0,0,0,1,1,999,1,0);      -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22308,'bayeux_bullet',1,0,0,0,0,1,1,999,1,0);     -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22309,'bayeux_arrow',1,0,0,0,0,1,1,999,1,0);      -- TODO: Not implemented
 
 /*!40000 ALTER TABLE `item_weapon` ENABLE KEYS */;
 UNLOCK TABLES;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -92,6 +92,8 @@
 #include "entities/npcentity.h"
 #include "entities/petentity.h"
 #include "entities/trustentity.h"
+#include "items/item_furnishing.h"
+#include "items/item_linkshell.h"
 
 #include "packets/action.h"
 #include "packets/auction_house.h"

--- a/src/map/lua/lua_item.cpp
+++ b/src/map/lua/lua_item.cpp
@@ -24,6 +24,7 @@
 #include "common/logging.h"
 #include "items/item.h"
 #include "items/item_equipment.h"
+#include "items/item_furnishing.h"
 #include "items/item_general.h"
 #include "items/item_weapon.h"
 #include "utils/itemutils.h"

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -77,6 +77,7 @@
 #include "fishingcontest.h"
 #include "instance.h"
 #include "ipc_client.h"
+#include "items/item_furnishing.h"
 #include "map_engine.h"
 #include "mob_modifier.h"
 #include "mobskill.h"

--- a/src/map/packets/char_check.cpp
+++ b/src/map/packets/char_check.cpp
@@ -27,6 +27,7 @@
 #include <cstring>
 
 #include "entities/charentity.h"
+#include "items/item_linkshell.h"
 #include "utils/itemutils.h"
 
 CCheckPacket::CCheckPacket(CCharEntity* PChar, CCharEntity* PTarget)

--- a/src/map/packets/char_status.cpp
+++ b/src/map/packets/char_status.cpp
@@ -32,6 +32,7 @@
 #include "ai/states/death_state.h"
 #include "entities/charentity.h"
 #include "item_container.h"
+#include "items/item_linkshell.h"
 #include "status_effect_container.h"
 #include "utils/itemutils.h"
 #include "utils/mountutils.h"

--- a/src/map/packets/char_update.cpp
+++ b/src/map/packets/char_update.cpp
@@ -24,6 +24,7 @@
 #include "char_update.h"
 
 #include "entities/charentity.h"
+#include "items/item_linkshell.h"
 #include "status_effect_container.h"
 #include "utils/itemutils.h"
 #include "utils/mountutils.h"

--- a/src/map/packets/inventory_item.cpp
+++ b/src/map/packets/inventory_item.cpp
@@ -23,6 +23,7 @@
 
 #include "common/utils.h"
 #include "common/vana_time.h"
+#include "items/item_linkshell.h"
 
 #include <cstring>
 

--- a/src/map/packets/trade_update.cpp
+++ b/src/map/packets/trade_update.cpp
@@ -23,6 +23,7 @@
 
 #include "common/utils.h"
 #include "common/vana_time.h"
+#include "items/item_linkshell.h"
 
 #include <cstring>
 

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -108,6 +108,8 @@
 #include "zoneutils.h"
 
 #include "enums/key_items.h"
+#include "items/item_furnishing.h"
+#include "items/item_linkshell.h"
 
 /************************************************************************
  *                                                                       *

--- a/src/map/utils/itemutils.h
+++ b/src/map/utils/itemutils.h
@@ -19,20 +19,12 @@
 ===========================================================================
 */
 
-#ifndef _ITEMUTILS_H
-#define _ITEMUTILS_H
+#pragma once
 
 #include <vector>
 
 #include "items/item.h"
 #include "items/item_currency.h"
-#include "items/item_equipment.h"
-#include "items/item_fish.h"
-#include "items/item_furnishing.h"
-#include "items/item_general.h"
-#include "items/item_linkshell.h"
-#include "items/item_puppet.h"
-#include "items/item_usable.h"
 #include "items/item_weapon.h"
 
 #define MAX_ITEMID        32768
@@ -116,5 +108,5 @@ namespace itemutils
 
     DropList_t* GetDropList(uint16 DropID);
 
+    auto IsGrip(const uint16 itemId) -> bool;
 }; // namespace itemutils
-#endif


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Ugh...

- Convert queries in itemutils.cpp to prepared statements
  - Note: This will  print an error in the future for any item missing the expected related entries. 
- Reworked the ranges used by CreateItem
  - Pulled them from POLUtils but as you can tell this logic is super brittle
- Adds 3 missing item_furnishing entries (Crimson Chest, Model Synergy Furnace, Painting of a Mercenary)
- Adds 450+ missing item_usable entries
  - I have added the missing lua files for the scrolls.
  - Everything else is unimplemented with a comment clearly stating so.
- Adds 100+ missing item_weapon entries
  - DMG1 / Delay 999 for everything and a comment stating they are not implemented
- Adds 100+ missing item_equipment entries
  - Everything is set to level 99, unequipable with a comment stating they are unimplemented
  - Also adds entries that were in item_weapon but missing in item_equipment 

**Alternatively we could disable the items in item_basics.sql if that's preferred...**

I'll probably do the following in a separate PR:
- Introduce a type column in items_basic
- Use that column to instantiate the correct item type (and get rid of ID based logic)
- Do a DAT dump and compare all entries

## Steps to test these changes
- [x] Items load correctly
- [x] Item mods load correctly
- [x] Item latents load correctly
- [x] Mob droplists load correctly
- [x] Test new furnishing items
- [x] Test new scrolls
- [x] Test unimplemented items, make sure they can't be used
- [x] Test unimplemented weapons/equipment, make sure they can't be equipped

<!-- Clear and detailed steps to test your changes here -->
