### PR TITLE
Set Bastok allegiance - The Fighting Fourth

### DIFF
--- a/scripts/quests/crystalWar/WOTG_BAS_0_The_Fighting_Fourth.lua
+++ b/scripts/quests/crystalWar/WOTG_BAS_0_The_Fighting_Fourth.lua
@@ -162,6 +162,7 @@ quest.sections =
                 end,
 
                 [143] = function(player, csid, option, npc)
+                    player:setCampaignAllegiance(2)
                     quest:complete(player)
                 end,
             },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The Fighting Fourth quest for setting your allegiance to Bastok for Campaign does not actually set allegiance at the end. This PR adds setCampaignAllegiance(2) when the quest is complete.

## Steps to test these changes

Ran through the quest, confirmed that player:getCampaignAllegiance() was 2 and not 0
