### PR TITLE
[cpp] Add flags to spells/mobskills to not emit start/stop packets

### DIFF
--- a/scripts/enum/magic.lua
+++ b/scripts/enum/magic.lua
@@ -11,7 +11,9 @@ xi.magic.spellFlag =
     NONE           = 0x00,
     HIT_ALL        = 0x01, -- Hit all targets in range regardless of party
     WIPE_SHADOWS   = 0x02, -- Wipe shadows even if single target and miss/resist (example: "Maiden's Virelai")
-    IGNORE_SHADOWS = 0x04  -- Ignore shadows and hit player anyways (example: Mobs "Death" spell)
+    IGNORE_SHADOWS = 0x04, -- Ignore shadows and hit player anyways (example: Mobs "Death" spell)
+    NO_START_MSG   = 0x08, -- Doesn't emit "<caster> starts casting <spell>"
+    NO_FINISH_MSG  = 0x10, -- Doesn't emit finish message when magic state completes
 }
 
 -----------------------------------

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -70,7 +70,7 @@ CMobSkillState::CMobSkillState(CBattleEntity* PEntity, uint16 targid, uint16 wsi
         m_castTime = m_PSkill->getActivationTime();
     }
 
-    if (m_castTime > 0s)
+    if (m_castTime > 0s && !(m_PSkill->getFlag() & SKILLFLAG_NO_START_MSG))
     {
         action_t action;
         action.id         = m_PEntity->id;
@@ -147,7 +147,10 @@ bool CMobSkillState::Update(timer::time_point tick)
     {
         action_t action;
         m_PEntity->OnMobSkillFinished(*this, action);
-        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
+        if (!(m_PSkill->getFlag() & SKILLFLAG_NO_FINISH_MSG))
+        {
+            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
+        }
         m_finishTime = tick + m_PSkill->getAnimationTime();
         Complete();
     }

--- a/src/map/mobskill.h
+++ b/src/map/mobskill.h
@@ -31,12 +31,12 @@ class CBattleEntity;
 
 enum SKILLFLAG
 {
-    SKILLFLAG_NONE        = 0x000,
-    SKILLFLAG_ASTRAL_FLOW = 0x002, // Player's Avatar Astral Flow blood pacts. TODO: give player pet skills their own separate enum, move avatar stuff there.
-    SKILLFLAG_NO_TP_COST  = 0x004, // Don't auto deduct TP
-    SKILLFLAG_HIT_ALL     = 0x008, // Strike players even if not in party/alliance
-    // unused                = 0x010,
-    // unused                = 0x020,
+    SKILLFLAG_NONE           = 0x000,
+    SKILLFLAG_ASTRAL_FLOW    = 0x002, // Player's Avatar Astral Flow blood pacts. TODO: give player pet skills their own separate enum, move avatar stuff there.
+    SKILLFLAG_NO_TP_COST     = 0x004, // Don't auto deduct TP
+    SKILLFLAG_HIT_ALL        = 0x008, // Strike players even if not in party/alliance
+    SKILLFLAG_NO_START_MSG   = 0x010, // Doesn't emit "<mob> readies <skill>"
+    SKILLFLAG_NO_FINISH_MSG  = 0x020, // Doesn't emit finish message when mobskill state completes
     SKILLFLAG_BLOODPACT_RAGE = 0x040,
     SKILLFLAG_BLOODPACT_WARD = 0x080,
 };

--- a/src/map/spell.h
+++ b/src/map/spell.h
@@ -227,7 +227,9 @@ enum SPELLFLAG
     SPELLFLAG_NONE           = 0x00,
     SPELLFLAG_HIT_ALL        = 0x01, // Hit all targets in range regardless of party
     SPELLFLAG_WIPE_SHADOWS   = 0x02, // Wipe shadows even if single target and miss/resist (example: "Maiden's Virelai")
-    SPELLFLAG_IGNORE_SHADOWS = 0x04  // Ignore shadows and hit player anyways (example: Mobs "Death" spell)
+    SPELLFLAG_IGNORE_SHADOWS = 0x04, // Ignore shadows and hit player anyways (example: Mobs "Death" spell)
+    SPELLFLAG_NO_START_MSG   = 0x08, // Doesn't emit "<caster> starts casting <spell>"
+    SPELLFLAG_NO_FINISH_MSG  = 0x10, // Doesn't emit finish message when magic state completes
 };
 
 // clang-format off


### PR DESCRIPTION
- still give messages if paralyzed, etc

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Preliminary changes to mobskill and spell states to emulate retail mob pet behavior.

Rather than create a separate internal system to track mob pet calling. The plan is to keep the existing framework (special_skill cooldowns and spell recast timers), but don't emit a message on start/completion of state. 

This PR puts in the framework to allow that.

Also a small cleanup on the new mobmod that sets magic_state flags, since `m_flags` is attached to the state, it only needs to be set once in the constructor

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- `NO_SPELL_COST` mobmod
  - engage a mob that casts spells
  - `!setmobmod magic_cool 1`
  - see it spam spells
  - set mp to 0 and refresh mod negative so it has no mp: `!setmod refresh -500`
  - see it stop casting spells
  - `!setmobmod NO_SPELL_COST 1`
  - see it cast spells again
- spells
  - put `spell:setFlag(xi.magic.spellFlag.NO_START_MSG + xi.magic.spellFlag.NO_FINISH_MSG)` and `spell:setCastTime(0)` in the casting check function of any spell, see that when you cast it the spell completes immediately with no action packets sent from the server
- mobskills
  - Since mobskills don't get `m_PSkill = std::make_unique<CMobSkill>(*skill);` until after calling onMobskillCheck, we can't create bindings to do the same as spells. We have to set animation/prepare time equal to 0 and mob_skill_flag `& 16` and `& 32` in the db (note they all have flag `& 4` as well to not consume TP:
  - <img width="1133" height="201" alt="image" src="https://github.com/user-attachments/assets/ea11e697-6ab9-41d9-87e9-93fd624dbe5f" />
  - then you see mobskills happen immediately with no action packets emitted
