### PR TITLE
Xolotl callPets separate timers cleanup

### DIFF
--- a/scripts/zones/Attohwa_Chasm/mobs/Xolotl.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Xolotl.lua
@@ -1,8 +1,10 @@
 -----------------------------------
 -- Area: Attohwa Chasm
 --  Mob: Xolotl
--- Note: The 2 pets do NOT despawn if engaged when Xolotl dies, nor do they despawn if Xolotl disengages
---       Xolotl spawns one pet a time, with a 60s delay between (and after engaging)
+-- Note: The 2 pets do NOT despawn if engaged when Xolotl dies, nor do they
+--       despawn if Xolotl disengages. Xolotl spawns one pet a time, with a
+--       separate timer for each pet, 60 seconds after engaging and 60
+--       seconds after the pet dies.
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
@@ -11,8 +13,8 @@ local ID = zones[xi.zone.ATTOHWA_CHASM]
 
 local pets =
 {
-    ID.mob.XOLOTL + 1,
-    ID.mob.XOLOTL + 2,
+    ID.mob.XOLOTL + 1, -- Xolotl's Hound Warrior
+    ID.mob.XOLOTL + 2, -- Xolotl's Sacrifice
 }
 
 local callPetParams =
@@ -30,15 +32,17 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobEngage = function(mob)
-    mob:setLocalVar('pet_spawn_time', GetSystemTime() + 60)
+    mob:setLocalVar('hound_spawn_time', GetSystemTime() + 60)
+    mob:setLocalVar('sacrifice_spawn_time', GetSystemTime() + 60)
 end
 
 entity.onMobFight = function(mob)
-    if
-        mob:getLocalVar('pet_spawn_time') < GetSystemTime() and
-        xi.mob.callPets(mob, pets, callPetParams)
-    then
-        mob:setLocalVar('pet_spawn_time', GetSystemTime() + 60)
+    if mob:getLocalVar('hound_spawn_time') < GetSystemTime() then
+        xi.mob.callPets(mob, pets[1], callPetParams)
+    end
+
+    if mob:getLocalVar('sacrifice_spawn_time') < GetSystemTime() then
+        xi.mob.callPets(mob, pets[2], callPetParams)
     end
 end
 

--- a/scripts/zones/Attohwa_Chasm/mobs/Xolotls_Hound_Warrior.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Xolotls_Hound_Warrior.lua
@@ -9,7 +9,7 @@ local entity = {}
 entity.onMobDeath = function(mob)
     local xolotl = GetMobByID(zones[xi.zone.ATTOHWA_CHASM].mob.XOLOTL)
     if xolotl then
-        xolotl:setLocalVar('pet_spawn_time', GetSystemTime() + 60)
+        xolotl:setLocalVar('hound_spawn_time', GetSystemTime() + 60)
     end
 end
 

--- a/scripts/zones/Attohwa_Chasm/mobs/Xolotls_Sacrifice.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Xolotls_Sacrifice.lua
@@ -9,7 +9,7 @@ local entity = {}
 entity.onMobDeath = function(mob)
     local xolotl = GetMobByID(zones[xi.zone.ATTOHWA_CHASM].mob.XOLOTL)
     if xolotl then
-        xolotl:setLocalVar('pet_spawn_time', GetSystemTime() + 60)
+        xolotl:setLocalVar('sacrifice_spawn_time', GetSystemTime() + 60)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Post callPets rework cleanup for Xolotl pets.
https://github.com/LandSandBoat/server/pull/8039

Based on captures, Xolotl has a separate timer for summoning Hound Warrior and Sacrifice.

Siknoz: NM - Xolotl - Lullaby Resistance Testing
https://youtu.be/W2H6AX-1Pks
https://www.dropbox.com/scl/fi/1a2ihdjkf11386chzasd0/NM-Xolotl-Lullaby-Resistance-Testing.zip?rlkey=6942fu6aizmmigeakhcmgnt9j&dl=0

Siknoz: HNM - Xolotl - Attohwa Chasm - Immunities testing
https://youtu.be/q2avBzJ93Mc
https://1drv.ms/u/c/87e665e10555c452/EVLEVQXhZeYggIfKAAAAAAABKIw1q91QND6xemN6H-i3RQ?e=CqEPYW 

Snippet:
```
22:15:39 IN 0x038 - Entity Animation - Type: casm (CAST_SUMMONER_START)
22:15:42 IN 0x038 - Entity Animation - Type: shsm (CAST_SUMMONER_STOP)
22:15:42 IN 0x00E - Spawn - ID: 0x05B - {SPAWN} <= 16806216 - 0x01007148 (Xolotl'sHound)

22:15:45 IN 0x038 - Entity Animation - Type: casm (CAST_SUMMONER_START)
22:15:48 IN 0x038 - Entity Animation - Type: shsm (CAST_SUMMONER_STOP)
22:15:48 IN 0x05B - Spawn - ID: 0x05B - Xolotl'sSacrif <= 16806217 - 0x01007149 (Xolotl'sSacrif)
```

- Xolotl will summon both Hound Warrior and Sacrifice after 60s, but they are summoned one at a time, with a 3s summon time.
- After one of Xolotl's pets has been killed, that particular pet will have a 60s cooldown before being resummoned.

## Steps to test these changes

!zone {Attohwah Chasm}
!gotoname Xolotl
If not up: !spawnmob 16806215

- Engage Xolotl
- Wait 60s
- One pet will be summoned on 3s timer
- Second pet will be summoned on 3s timer
- Kill one pet, note the timestamp
- Kill second pet, note the timestamp
- Wait 60s after first pet kill. That pet should be resummoned.
- Wait 60s after second pet kill. That pet should be resummoned.