### PR TITLE
[lua/sql] Fixed Hills Are Alive KSNM99

### DIFF
--- a/scripts/battlefields/Waughroon_Shrine/hills_are_alive.lua
+++ b/scripts/battlefields/Waughroon_Shrine/hills_are_alive.lua
@@ -14,15 +14,17 @@ local content = Battlefield:new({
     index            = 12,
     entryNpc         = 'BC_Entrance',
     exitNpc          = 'Burning_Circle',
-    requiredItems    = { xi.item.THEMIS_ORB, wearMessage = waughroonID.text.A_CRACK_HAS_FORMED, wornMessage = waughroonID.text.ORB_IS_CRACKED },
-
-    experimental = true,
+    requiredItems    = { xi.item.THEMIS_ORB, wearMessage = waughroonID.text.A_CRACK_HAS_FORMED, wornMessage = waughroonID.text.ORB_IS_CRACKED }
 })
 
 content:addEssentialMobs({ 'Tartaruga_Gigante' })
 
 content.loot =
 {
+    {
+        { item = xi.item.GIL, weight = 1000, amount = 32000 }, -- Gil
+    },
+
     {
         { item = xi.item.CLUMP_OF_BLUE_PONDWEED, weight = 1000 }, -- Blue Pondweed
     },
@@ -101,27 +103,6 @@ content.loot =
         { item = xi.item.HI_POTION_P3,   weight = 250 },  -- Hi-potion +3
         { item = xi.item.HI_RERAISER,    weight = 196 },  -- Hi-reraiser
         { item = xi.item.VILE_ELIXIR_P1, weight = 214 },  -- Vile Elixir +1
-    },
-
-    {
-        { item = xi.item.CORAL_FRAGMENT,           weight = 139 }, -- Coral Fragment
-        { item = xi.item.CHUNK_OF_DARKSTEEL_ORE,   weight =  59 }, -- Chunk Of Darksteel Ore
-        { item = xi.item.DEMON_HORN,               weight =  50 }, -- Demon Horn
-        { item = xi.item.EBONY_LOG,                weight = 109 }, -- Ebony Log
-        { item = xi.item.CHUNK_OF_GOLD_ORE,        weight =  69 }, -- Chunk Of Gold Ore
-        { item = xi.item.SLAB_OF_GRANITE,          weight =  99 }, -- Slab Of Granite
-        { item = xi.item.HI_RERAISER,              weight =  79 }, -- Hi-reraiser
-        { item = xi.item.MAHOGANY_LOG,             weight = 129 }, -- Mahogany Log
-        { item = xi.item.CHUNK_OF_MYTHRIL_ORE,     weight = 119 }, -- Chunk Of Mythril Ore
-        { item = xi.item.PHOENIX_FEATHER,          weight =  69 }, -- Phoenix Feather
-        { item = xi.item.PETRIFIED_LOG,            weight = 168 }, -- Petrified Log
-        { item = xi.item.CHUNK_OF_PLATINUM_ORE,    weight = 129 }, -- Chunk Of Platinum Ore
-        { item = xi.item.RAM_HORN,                 weight = 109 }, -- Ram Horn
-        { item = xi.item.SQUARE_OF_RAXA,           weight =  79 }, -- Square Of Raxa
-        { item = xi.item.VILE_ELIXIR,              weight =  69 }, -- Vile Elixir
-        { item = xi.item.HANDFUL_OF_WYVERN_SCALES, weight =  79 }, -- Handful Of Wyvern Scales
-        { item = xi.item.RERAISER,                 weight =  50 }, -- Reraiser
-        { item = xi.item.SPOOL_OF_GOLD_THREAD,     weight =  89 }, -- Spool Of Gold Thread
     },
 
     {

--- a/scripts/zones/Waughroon_Shrine/mobs/Tartaruga_Gigante.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Tartaruga_Gigante.lua
@@ -5,7 +5,107 @@
 ---@type TMobEntity
 local entity = {}
 
+-- Removes any possible debuff when it goes into shell and we have no function that exists for this
+local removables =
+{
+    xi.effect.FLASH,              xi.effect.BLINDNESS,      xi.effect.MAX_HP_DOWN,    xi.effect.MAX_MP_DOWN,
+    xi.effect.PARALYSIS,          xi.effect.POISON,         xi.effect.CURSE_I,        xi.effect.CURSE_II,
+    xi.effect.DISEASE,            xi.effect.PLAGUE,         xi.effect.WEIGHT,         xi.effect.BIND,
+    xi.effect.BIO,                xi.effect.DIA,            xi.effect.BURN,           xi.effect.FROST,
+    xi.effect.CHOKE,              xi.effect.RASP,           xi.effect.SHOCK,          xi.effect.DROWN,
+    xi.effect.STR_DOWN,           xi.effect.DEX_DOWN,       xi.effect.VIT_DOWN,       xi.effect.AGI_DOWN,
+    xi.effect.INT_DOWN,           xi.effect.MND_DOWN,       xi.effect.CHR_DOWN,       xi.effect.ADDLE,
+    xi.effect.SLOW,               xi.effect.HELIX,          xi.effect.ACCURACY_DOWN,  xi.effect.ATTACK_DOWN,
+    xi.effect.EVASION_DOWN,       xi.effect.DEFENSE_DOWN,   xi.effect.MAGIC_ACC_DOWN, xi.effect.MAGIC_ATK_DOWN,
+    xi.effect.MAGIC_EVASION_DOWN, xi.effect.MAGIC_DEF_DOWN, xi.effect.MAX_TP_DOWN,    xi.effect.SILENCE,
+    xi.effect.PETRIFICATION
+}
+
+local setDmgToChange = function(mob)
+    if mob:getHP() > 2000 then
+        mob:setLocalVar('dmgToChange', mob:getHP() - 2000)
+    else
+        mob:setLocalVar('dmgToChange', 0)
+    end
+end
+
+local intoShell = function(mob)
+    for _, effect in ipairs(removables) do
+        if mob:hasStatusEffect(effect) then
+            mob:delStatusEffect(effect)
+        end
+    end
+
+    mob:setAnimationSub(1)
+    mob:setMobAbilityEnabled(false)
+    mob:setAutoAttackEnabled(false)
+    mob:setMagicCastingEnabled(true)
+    mob:setMod(xi.mod.REGEN, 400)
+    mob:setMod(xi.mod.UDMGRANGE, -9500)
+    mob:setMod(xi.mod.UDMGPHYS, -9500)
+    mob:setMobMod(xi.mobMod.NO_MOVE, 1)
+    mob:setMobMod(xi.mobMod.NO_STANDBACK, 0)
+    mob:setBehavior(bit.bor(mob:getBehavior(), xi.behavior.NO_TURN))
+    mob:setLocalVar('changeTime', GetSystemTime() + 90)
+end
+
+local outOfShell = function(mob)
+    mob:setTP(3000)
+    mob:setAnimationSub(2)
+    mob:setMobAbilityEnabled(true)
+    mob:setAutoAttackEnabled(true)
+    mob:setMagicCastingEnabled(false)
+    mob:setMod(xi.mod.REGEN, 0)
+    mob:setMod(xi.mod.UDMGRANGE, 0)
+    mob:setMod(xi.mod.UDMGPHYS, 0)
+    mob:setMobMod(xi.mobMod.NO_MOVE, 0)
+    mob:setMobMod(xi.mobMod.NO_STANDBACK, 1)
+    mob:setBehavior(bit.band(mob:getBehavior(), bit.bnot(xi.behavior.NO_TURN)))
+end
+
+entity.onMobSpawn = function(mob)
+    mob:setMobAbilityEnabled(true)
+    mob:setAutoAttackEnabled(true)
+    mob:setMagicCastingEnabled(false) -- will not cast until it goes into shell
+    mob:setMobMod(xi.mobMod.NO_STANDBACK, 1)
+    mob:setBehavior(bit.bor(mob:getBehavior(), xi.behavior.NO_TURN))
+    mob:setMobMod(xi.mobMod.SIGHT_RANGE, 13)
+    mob:setMod(xi.mod.REGEN, 0)
+    mob:setMod(xi.mod.DOUBLE_ATTACK, 20)
+    mob:setMod(xi.mod.DMGMAGIC, -3000)
+    mob:setMod(xi.mod.CURSERES, 100)
+
+    setDmgToChange(mob)
+    mob:setAnimationSub(2)
+end
+
+entity.onMobFight = function(mob, target)
+    local changeHP = mob:getLocalVar('dmgToChange')
+
+    if -- In shell
+        mob:getAnimationSub() == 1 and
+        (GetSystemTime() > mob:getLocalVar('changeTime') or mob:getHPP() == 100)
+    then
+        setDmgToChange(mob)
+        outOfShell(mob)
+    end
+
+    if mob:getHP() <= changeHP then
+        if mob:getAnimationSub() == 1 then -- In shell
+            setDmgToChange(mob)
+            outOfShell(mob)
+        elseif mob:getAnimationSub() == 2 then -- Out of shell
+            setDmgToChange(mob)
+            intoShell(mob)
+        end
+    end
+end
+
 entity.onMobDeath = function(mob, player, optParams)
+end
+
+entity.onMobDespawn = function(mob)
+    mob:resetLocalVars()
 end
 
 return entity

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -10317,7 +10317,7 @@ INSERT INTO `mob_groups` VALUES (29,2200,144,'KaNha_Jabbertongue',0,128,0,0,0,62
 INSERT INTO `mob_groups` VALUES (30,426,144,'BiFho_Jestergrin',0,128,0,0,0,62,64,0);
 INSERT INTO `mob_groups` VALUES (31,2305,144,'KuTya_Hotblood',0,128,0,0,0,62,64,0);
 INSERT INTO `mob_groups` VALUES (32,1167,144,'EaTho_Cruelheart',0,128,0,0,0,62,64,0);
-INSERT INTO `mob_groups` VALUES (33,3847,144,'Tartaruga_Gigante',0,128,0,40000,0,85,85,0);
+INSERT INTO `mob_groups` VALUES (33,3847,144,'Tartaruga_Gigante',0,128,0,35000,0,85,85,0);
 INSERT INTO `mob_groups` VALUES (34,3894,144,'The_Waughroon_Kid',0,128,0,0,0,50,50,0);
 INSERT INTO `mob_groups` VALUES (35,1330,144,'Fee',0,128,0,7500,0,62,62,0);
 INSERT INTO `mob_groups` VALUES (36,3064,144,'Osschaart',0,128,0,0,0,75,75,0);


### PR DESCRIPTION
Fixed mob's HP, and added all logic for Tartaruga Gigante (CriticalXI wrote the main logic)

**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR fixes The Hills are Alive KSNM99, specifically changing the loot pool to be accurate, and adding over logic for Tartaruga Gigante.

## Sources used

https://youtu.be/JI2l-7roemg
https://youtu.be/qXFeafuO3W0
https://1drv.ms/u/c/87e665e10555c452/EbWe9UEP6r1AlzK4583NhXEB3eqsfhwx37KaFiKMWqx2Iw?e=t1YfGk
https://1drv.ms/u/c/87e665e10555c452/EXZf4z-MmtxJuMP5JjND5xUBndAGMrisDtc9uqzho5V-pQ?e=w3GhIR

## Steps to test these changes

Run the KSNM99 The Hills are Alive using a Themis Orb.
