### PR TITLE
[sql] Add gilfinder 2 trait to lvl 90 thf

### DIFF
--- a/sql/traits.sql
+++ b/sql/traits.sql
@@ -229,7 +229,8 @@ INSERT INTO `traits` VALUES (18,'dual wield',19,40,2,259,15,'ABYSSEA',0);
 INSERT INTO `traits` VALUES (18,'dual wield',19,60,3,259,25,'ABYSSEA',0);
 INSERT INTO `traits` VALUES (18,'dual wield',19,80,4,259,30,'ABYSSEA',0);
 INSERT INTO `traits` VALUES (19,'treasure hunter',6,15,1,303,1,NULL,0);
-INSERT INTO `traits` VALUES (20,'gilfinder',6,5,1,897,50,NULL,0);
+INSERT INTO `traits` VALUES (20,'gilfinder',6,5,1,897,1,NULL,0);
+INSERT INTO `traits` VALUES (20,'gilfinder',6,90,2,897,2,NULL,0); -- https://wiki.ffo.jp/html/1677.html
 INSERT INTO `traits` VALUES (21,'alertness',11,5,1,0,0,NULL,0);
 INSERT INTO `traits` VALUES (22,'stealth',13,5,1,358,3,NULL,0);
 INSERT INTO `traits` VALUES (23,'martial arts',2,1,1,173,80,NULL,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds gilfinder 2 trait

see  https://wiki.ffo.jp/html/1677.html

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

`!getmod gilfinder` at level 90 THF and see GF2 trait is active