### PR TITLE
[lua] Enables Jailer of Justice

### DIFF
--- a/scripts/enum/mob_skills.lua
+++ b/scripts/enum/mob_skills.lua
@@ -77,6 +77,8 @@ xi.mobSkill =
 
     BLOOD_WEAPON_1           =  695,
 
+    CHARM                    =  710,
+
     MEIKYO_SHISUI_1          =  730, -- Tenzen, etc...
     MIJIN_GAKURE_1           =  731, -- Season's Greetings KSNM 30 (Ulagohvsdi Tlugvi)
 

--- a/scripts/zones/AlTaieu/mobs/Jailer_of_Justice.lua
+++ b/scripts/zones/AlTaieu/mobs/Jailer_of_Justice.lua
@@ -2,34 +2,98 @@
 -- Area: Al'Taieu
 --   NM: Jailer of Justice
 -----------------------------------
+local ID = zones[xi.zone.ALTAIEU]
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
 
+local pets =
+{
+    ID.mob.JAILER_OF_JUSTICE + 1,
+    ID.mob.JAILER_OF_JUSTICE + 2,
+    ID.mob.JAILER_OF_JUSTICE + 3,
+    ID.mob.JAILER_OF_JUSTICE + 4,
+    ID.mob.JAILER_OF_JUSTICE + 5,
+    ID.mob.JAILER_OF_JUSTICE + 6,
+}
+
+local callPetParams =
+{
+    maxSpawns = 1,
+    inactiveTime = 3000,
+    dieWithOwner = true
+}
+
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+    mob:addImmunity(xi.immunity.BIND)
+    mob:addImmunity(xi.immunity.BLIND)
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.GRAVITY)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
+    mob:addImmunity(xi.immunity.PETRIFY)
+    mob:addImmunity(xi.immunity.PLAGUE)
+    mob:addImmunity(xi.immunity.STUN)
+    mob:addImmunity(xi.immunity.TERROR)
+end
+
+entity.onMobSpawn = function(mob)
+    mob:setMobMod(xi.mobMod.SPECIAL_SKILL, 0)
+    xi.mix.jobSpecial.config(mob, { specials = { { id = xi.jsa.FAMILIAR, hpp = 50, cooldown = 210 }, }, })
+end
+
+entity.onMobEngage = function(mob, target)
+    mob:setLocalVar('petTimer', GetSystemTime() + 30)
+    mob:setLocalVar('charmTimer', GetSystemTime() + 150)
 end
 
 entity.onMobFight = function(mob, target)
-    local popTime = mob:getLocalVar('lastPetPop')
-    -- ffxiclopedia says 30 sec, bgwiki says 1-2 min..
-    -- Going with 60 seconds until I see proof of retails timing.
-    if GetSystemTime() - popTime > 60 then
-        local alreadyPopped = false
-        for Xzomit = mob:getID() + 1, mob:getID() + 6 do
-            if alreadyPopped then
-                break
-            else
-                if not GetMobByID(Xzomit):isSpawned() then
-                    SpawnMob(Xzomit, 300):updateEnmity(target)
-                    mob:setLocalVar('lastPetPop', GetSystemTime())
-                    alreadyPopped = true
+    -- Summons a pet every 30 seconds until 6 are out.
+    local petTimer = mob:getLocalVar('petTimer')
+    if
+        GetSystemTime() > petTimer and
+        xi.mob.callPets(mob, pets, callPetParams)
+    then
+        mob:setLocalVar('petTimer', GetSystemTime() + 30)
+    end
+
+    -- Uses Charm every 2 1/2 minutes.
+    local charmTimer = mob:getLocalVar('charmTimer')
+    if GetSystemTime() > charmTimer then
+        mob:setLocalVar('charmTimer', GetSystemTime() + 150)
+        mob:useMobAbility(xi.mobSkill.CHARM)
+    end
+end
+
+entity.onMobWeaponSkill = function(target, mob, skill)
+    -- Don't lose TP from charm 2hr
+    if skill:getID() == xi.mobSkill.FAMILIAR_1 then -- Manually apply Familiar to all pets except first one
+        local mobId = mob:getID()
+        for i = 2, 6 do
+            local pet = GetMobByID(mobId + i)
+            if pet then
+                local hasFamiliar = pet:getLocalVar('hasFamiliar')
+                if
+                    pet:isSpawned() and
+                    hasFamiliar == 0
+                then
+                    -- Boost pet HP and stats by 10%
+                    local boost = math.floor(pet:getMaxHP() * 0.10)
+                    pet:setLocalVar('hasFamiliar', 1)
+                    pet:setMaxHP(pet:getMaxHP() + boost)
+                    pet:setHP(pet:getHP() + boost)
+                    pet:updateHealth()
+
+                    -- Boost stats by 10%
+                    pet:addMod(xi.mod.ATTP, 10)
+                    pet:addMod(xi.mod.ACC, mob:getMod(xi.mod.ACC) * 0.10)
+                    pet:addMod(xi.mod.EVA, mob:getMod(xi.mod.EVA) * 0.10)
+                    pet:addMod(xi.mod.DEFP, 10)
                 end
             end
         end
     end
-end
-
-entity.onMobDeath = function(mob, player, optParams)
 end
 
 return entity

--- a/scripts/zones/AlTaieu/mobs/Qnxzomit.lua
+++ b/scripts/zones/AlTaieu/mobs/Qnxzomit.lua
@@ -9,10 +9,27 @@ local ID = zones[xi.zone.ALTAIEU]
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+    if mob:getID() < ID.mob.JAILER_OF_LOVE then
+        mob:addImmunity(xi.immunity.BIND)
+        mob:addImmunity(xi.immunity.BLIND)
+        mob:addImmunity(xi.immunity.DARK_SLEEP)
+        mob:addImmunity(xi.immunity.LIGHT_SLEEP)
+        mob:addImmunity(xi.immunity.PETRIFY)
+        mob:addImmunity(xi.immunity.STUN)
+    end
+end
+
 entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.EXP_BONUS, -100)
     mob:setMobMod(xi.mobMod.GIL_BONUS, -100)
     mob:setMobMod(xi.mobMod.NO_DROPS, 1)
+
+    -- only JoJ pops
+    if mob:getID() < ID.mob.JAILER_OF_LOVE then
+        xi.mix.jobSpecial.config(mob, { specials = { { id = xi.jsa.MIJIN_GAKURE, hpp = 20 }, }, })
+    end
 end
 
 entity.onMobDeath = function(mob, player, optParams)
@@ -23,20 +40,6 @@ entity.onMobEngage = function(mob, target)
     mob:setMobMod(xi.mobMod.NO_STANDBACK, 1)
     mob:setMobMod(xi.mobMod.SPECIAL_SKILL, 0)
     mob:setMobMod(xi.mobMod.SPECIAL_COOL, 0)
-
-    -- only JoJ pops
-    if mob:getID() < ID.mob.JAILER_OF_LOVE then
-        mob:timer(30000, function(mobArg)
-            if mobArg:isAlive() then
-                mobArg:useMobAbility(xi.jsa.MIJIN_GAKURE)
-                mobArg:timer(2000, function(mobArg2)
-                    mobArg2:setHP(0)
-                end)
-            end
-        end)
-
-        mob:addStatusEffectEx(xi.effect.FLEE, 0, 100, 0, 60) -- TODO: is this real (aura stealable) or is this supposed to be movement speed?
-    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/AlTaieu/npcs/qm_jailer_of_justice.lua
+++ b/scripts/zones/AlTaieu/npcs/qm_jailer_of_justice.lua
@@ -4,23 +4,22 @@
 -- Allows players to spawn the Jailer of Justice by trading the Second Virtue, Deed of Moderation, and HQ Xzomit Organ to a ???.
 -- !pos , -278 0 -463
 -----------------------------------
+local ID = zones[xi.zone.ALTAIEU]
+-----------------------------------
 ---@type TNpcEntity
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    --[[
-    -- JAILER OF JUSTICE
-    if (
-        not GetMobByID(ID.mob.JAILER_OF_JUSTICE):isSpawned() and
-        trade:hasItemQty(1853, 1) and -- second_virtue
-        trade:hasItemQty(1854, 1) and -- deed_of_moderation
-        trade:hasItemQty(1855, 1) and -- hq_xzomit_organ
-        trade:getItemCount() == 3
-    ) then
-        player:tradeComplete()
-        SpawnMob(ID.mob.JAILER_OF_JUSTICE):updateClaim(player)
+    if
+        npcUtil.tradeHas(trade, { xi.item.SECOND_VIRTUE, xi.item.DEED_OF_MODERATION, xi.item.HIGH_QUALITY_XZOMIT_ORGAN }) and
+        npcUtil.popFromQM(player, npc, ID.mob.JAILER_OF_JUSTICE)
+    then
+        player:confirmTrade()
     end
-    --]]
+end
+
+entity.onTrigger = function(player, npc)
+    player:startEvent(201)
 end
 
 return entity

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -724,7 +724,7 @@ INSERT INTO `mob_skills` VALUES (696,438,'soul_voice',0,0.0,7.0,2000,0,1,2,0,0,0
 INSERT INTO `mob_skills` VALUES (707,451,'sentinel',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (708,452,'last_resort',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (709,439,'souleater',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (710,438,'charm',0,0.0,18.0,2000,0,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (710,438,'charm',0,0.0,18.0,2000,0,4,4,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (711,455,'eagle_eye_shot',0,0.0,7.0,2000,1500,4,2,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (712,456,'eagle_eye_shot',0,0.0,7.0,2000,1500,4,2,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (713,457,'sharpshot',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Enables the ability to pop Jailer of Justice
- JoJ summons a pet every 30 seconds up to 6 pets, uses both charm and familiar. 
- The pets mijin gakure if brought below 20% health and do not die when they use it.

## Steps to test these changes

Pop JoJ and see that it summons pets as described