### PR TITLE
[Chore] Remove named-based logic from pollen mobskill

### DIFF
--- a/scripts/actions/mobskills/pollen.lua
+++ b/scripts/actions/mobskills/pollen.lua
@@ -10,22 +10,13 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local potency = skill:getParam()
-
-    if potency == 0 then
-        potency = 12
-    end
-
-    -- TODO do this cleaner
-    if mob:getName() == 'Beelzebub' or mob:getName() == 'Hell_Fly' then
-        potency = 24 -- Double Potency for Infernal Swarm Mobs
-    end
-
-    potency = potency - math.random(0, potency / 4)
+    local potencyBonus = mob:isNM() and math.random(0, 294) or 0
+    local potency      = (147 + potencyBonus) / 1024
+    local finalPotency = math.floor(mob:getMaxHP() * potency)
 
     skill:setMsg(xi.msg.basic.SELF_HEAL)
 
-    return xi.mobskills.mobHealMove(mob, mob:getMaxHP() * potency / 100)
+    return xi.mobskills.mobHealMove(mob, finalPotency)
 end
 
 return mobskillObject


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Originally, I WAS going to handle the extra potency by adding/using the "Cure potency" modifier.

EDIT: After even further research, the only conclusion I can reach is that theres a random component. But that does change the fact a potency of 24% max HP isnt the answer.

More testing/information is needed, but for now, this should do better than checking for the mob names, which isnt a good pattern to have ever.

- [Bee](https://www.bg-wiki.com/ffxi/Category:Bee) (Pollen info on the bottom)
- [Infernal Swarm](https://www.bg-wiki.com/ffxi/Infernal_Swarm)

## Steps to test these changes

Have a bee use pollen.