### PR TITLE
[lua] Small cleanup of ix_drg

### DIFF
--- a/scripts/zones/The_Garden_of_RuHmet/Zone.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/Zone.lua
@@ -68,10 +68,6 @@ zoneObject.onInitialize = function(zone)
     if qmFaith then
         qmFaith:setPos(unpack(gardenGlobal.qmPosFaithTable[math.random(1, 5)]))
     end
-
-    -- Give Ix'DRG a random placeholder by picking one of the four groups at random, then adding a random number of 0-2 for the specific mob.
-    local groups = ID.mob.AWAERN_DRG_GROUPS
-    SetServerVariable('[SEA]IxAernDRG_PH', groups[math.random(1, #groups)] + math.random(0, 2))
 end
 
 zoneObject.afterZoneIn = function(player)

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Awaern.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Awaern.lua
@@ -15,10 +15,9 @@ entity.onMobSpawn = function(mob)
         not GetMobByID(ID.mob.IXAERN_DRG):isSpawned() and
         GetServerVariable('[SEA]IxAernDRG_PH') == 0
     then
-        -- This should be cleared when the mob is killed.
-        local groups      = ID.mob.AWAERN_DRG_GROUPS
-        local IxAernDRGPH = groups[math.random(1, #groups)] + math.random(0, 2) -- The 4th mobid in each group is a pet. F that son
-        SetServerVariable('[SEA]IxAernDRG_PH', IxAernDRGPH)
+        -- Give Ix'DRG a random placeholder by picking one of the four groups' first PH, then adding a random number of 0-2 for the specific mob.
+        local basePhId = utils.randomEntry(ID.mob.AWAERN_DRG_GROUPS)
+        SetServerVariable('[SEA]IxAernDRG_PH', basePhId + math.random(0, 2))
     end
 end
 
@@ -72,7 +71,7 @@ entity.onMobDespawn = function(mob)
             GetMobByID(ID.mob.IXAERN_DRG):setSpawn(-520, 5, -359, 30) -- Top Left
         elseif offset >= 8 and offset <= 11 then
             GetMobByID(ID.mob.IXAERN_DRG):setSpawn(-319, 5, -359, 95) -- Top Right
-        elseif offset >= 12 and offset <= 15 then
+        else
             GetMobByID(ID.mob.IXAERN_DRG):setSpawn(-319, 5, -520, 156) -- Bottom Right
         end
 

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Ixaern_DRGs_Wynav.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Ixaern_DRGs_Wynav.lua
@@ -22,21 +22,21 @@ end
 entity.onMobMagicPrepare = function(mob, target, spellId)
     local spellList =
     {
-        [1] = 382,
-        [2] = 376,
-        [3] = 372,
-        [4] = 392,
-        [5] = 397,
-        [6] = 400,
-        [7] = 422,
-        [8] = 462,
-        [9] = 466 -- Virelai (charm)
+        xi.magic.spell.ARMYS_PAEON_V,
+        xi.magic.spell.HORDE_LULLABY,
+        xi.magic.spell.FOE_REQUIEM_V,
+        xi.magic.spell.KNIGHTS_MINNE_IV,
+        xi.magic.spell.VALOR_MINUET_IV,
+        xi.magic.spell.BLADE_MADRIGAL,
+        xi.magic.spell.CARNAGE_ELEGY,
+        xi.magic.spell.MAGIC_FINALE,
     }
     if mob:hasStatusEffect(xi.effect.SOUL_VOICE) then
-        return spellList[math.random(1, 9)] -- Virelai possible.
-    else
-        return spellList[math.random(1, 8)] -- No Virelai!
+        -- Virelai possible.
+        table.insert(spellList, xi.magic.spell.MAIDENS_VIRELAI)
     end
+
+    return utils.randomEntry(spellList)
 end
 
 entity.onMobDeath = function(mob, player, optParams)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

I had a pending review to mention some changes to the pet behavior that could reduce complexity in ix'drg's lua, but it got merged before i hit save. 

This PR does some small cleanup
- to magic numbers and pet behavior for ix'drg
- to not iterating over his pets quite as much, and letting `xi.mob.callPets` do more of the work
- removed extra server variable setting in zone.lua, since onMobSpawn already has it
- Noticed that retail videos show the wynavs using breath skills as ix'drg _readies_ mobskills, not when it finishes, so moved that logic up the chain

Note: the wynavs are not in a party with ix'drg (confirmed at this timestamp: https://youtu.be/V_UeSQLDfcI?t=50 ), so score one for `xi.mob.callPets` being used instead of an explicit pet/owner relationship

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- go to garden
- find the ix'drg PH: `GetServerVariable('[SEA]IxAernDRG_PH')`
- `!gotoid` on that id
- despawn it, see ix'drg spawns
- shut down server, delete that server variable from the db (it won't exist if you shut down while ix'drg was alive)
- start back up and do the above steps to see server variable was re-randomized
- 20s after spawn, see he uses 2hr animation and spawns pets (as this part of the video: https://youtu.be/V_UeSQLDfcI?t=41)
- `!hp 1` the pets, see they use soul voice and can charm you with maiden's vir
- see his pets die with him by doing `!hp 0` on ix'drg
- see server variable is updated to a new PH id