### PR TITLE
[lua, sql] Grand Palace of Huxoi NM adjustments

### DIFF
--- a/scripts/zones/Grand_Palace_of_HuXzoi/IDs.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/IDs.lua
@@ -32,6 +32,7 @@ zones[xi.zone.GRAND_PALACE_OF_HUXZOI] =
         RECENTLY_ACTIVATED            = 7386, -- The alcove has recently been activated...
         TIME_RESTRICTION              = 7387, -- Time restriction: <number> [minute/minutes] (Earth time)
         QUASILUMIN_MAP_QUEST_OFFSET   = 7388, -- Warning. Chamber of Eventide accessed by unauthorized personnel, 4789209-980 increments previous.
+        IXAERN_MNK_QM                 = 7399, -- You hear something vaguely resembling a voice emanating from the depths of your soul. Bring me...aer...reccceptac...
         HOMEPOINT_SET                 = 7472, -- Home point set!
     },
     mob =

--- a/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Ixaern_MNK.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Ixaern_MNK.lua
@@ -41,6 +41,14 @@ end
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 300)
+    mob:addImmunity(xi.immunity.BIND)
+    mob:addImmunity(xi.immunity.BLIND)
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.GRAVITY)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
+    mob:addImmunity(xi.immunity.PARALYZE)
+    mob:addImmunity(xi.immunity.STUN)
+    mob:addImmunity(xi.immunity.TERROR)
 
     mob:addListener('ITEM_DROPS', 'ITEM_DROPS_IXAERN_MNK', function(mobArg, loot)
         local rate = mob:getLocalVar('[SEA]IxAern_DropRate')
@@ -56,21 +64,13 @@ entity.onMobSpawn = function(mob)
     -- reset the subanim otherwise it will respawn with bracers on
     -- note that Aerns are never actually supposed to be in subanim 0
     mob:setAnimationSub(1)
-    mob:addImmunity(xi.immunity.GRAVITY)
-    mob:addImmunity(xi.immunity.BIND)
-    mob:addImmunity(xi.immunity.STUN)
-    mob:addImmunity(xi.immunity.PARALYZE)
-    mob:addImmunity(xi.immunity.BLIND)
-    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
-    mob:addImmunity(xi.immunity.DARK_SLEEP)
-    mob:addImmunity(xi.immunity.TERROR)
 end
 
 entity.onMobFight = function(mob, target)
     if mob:getLocalVar('BracerMode') == 0 then
-        local IxaernID = mob:getID()
-        local qnAern1 = GetMobByID(IxaernID + 1)
-        local qnAern2 = GetMobByID(IxaernID + 2)
+        local ixaernID = mob:getID()
+        local qnAern1 = GetMobByID(ixaernID + 1)
+        local qnAern2 = GetMobByID(ixaernID + 2)
 
         -- if any of the three mobs gets below 60% then all three go to bracer mode
         if

--- a/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Jailer_of_Temperance.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Jailer_of_Temperance.lua
@@ -8,107 +8,97 @@ mixins = { require('scripts/mixins/job_special') }
 ---@type TMobEntity
 local entity = {}
 
+-- Damage resistance configurations
+local resistConfigs = {
+    [0] = { HTH = 0, SLASH = -10000, PIERCE = -10000, IMPACT = 0 }, -- Pot Idle
+    [1] = { HTH = 0, SLASH = -10000, PIERCE = -10000, IMPACT = 0 }, -- Pot Combat
+    [2] = { HTH = -10000, SLASH = -10000, PIERCE = 0, IMPACT = -10000 }, -- Poles
+    [3] = { HTH = -10000, SLASH = 0, PIERCE = -10000, IMPACT = -10000 }  -- Rings
+}
+
 entity.spawnPoints =
 {
     { x = -426.739, y = -0.500, z =  687.728 }
 }
 
+local function applyResistances(mob, form)
+    local config = resistConfigs[form]
+    mob:setMod(xi.mod.HTH_SDT, config.HTH)
+    mob:setMod(xi.mod.SLASH_SDT, config.SLASH)
+    mob:setMod(xi.mod.PIERCE_SDT, config.PIERCE)
+    mob:setMod(xi.mod.IMPACT_SDT, config.IMPACT)
+end
+
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+    mob:addImmunity(xi.immunity.BIND)
+    mob:addImmunity(xi.immunity.BLIND)
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.ELEGY)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
+    mob:addImmunity(xi.immunity.PARALYZE)
+    mob:addImmunity(xi.immunity.PETRIFY)
+    mob:addImmunity(xi.immunity.PLAGUE)
+    mob:addImmunity(xi.immunity.SLOW)
+    mob:addImmunity(xi.immunity.STUN)
+    mob:addImmunity(xi.immunity.TERROR)
 end
 
 entity.onMobSpawn = function(mob)
+    mob:addMobMod(xi.mobMod.WEAPON_BONUS, 13) -- 100 total weapon damage
+    mob:addMod(xi.mod.EVA, 10)
+    mob:addMod(xi.mod.MDEF, 20)
+    mob:addMod(xi.mod.ATT, mob:getMod(xi.mod.ATT) * 0.65) -- Increase attack by 65%
+    mob:delMod(xi.mod.DEF, 50)
+
     -- Change animation to pot
     mob:setAnimationSub(0)
-    -- Set the damage resists
-    mob:setMod(xi.mod.HTH_SDT, 0)
-    mob:setMod(xi.mod.SLASH_SDT, -10000)
-    mob:setMod(xi.mod.PIERCE_SDT, -10000)
-    mob:setMod(xi.mod.IMPACT_SDT, 0)
+    applyResistances(mob, 0)
+
+    -- Two usages of Meikyo at specific HP thresholds
+    xi.mix.jobSpecial.config(mob, {
+        specials =
+        {
+            { id = xi.jsa.MEIKYO_SHISUI, hpp = math.random(65, 70) },
+            { id = xi.jsa.MEIKYO_SHISUI, hpp = math.random(35, 40) },
+        },
+    })
 
     -- Set the magic resists. It always takes no damage from direct magic
     for element = xi.element.FIRE, xi.element.DARK do
         mob:setMod(xi.combat.element.getElementalMEVAModifier(element), 0)
         mob:setMod(xi.combat.element.getElementalSDTModifier(element), -10000)
     end
+
+    mob:setLocalVar('changeTime', GetSystemTime() + math.random(30, 180))
 end
 
 entity.onMobFight = function(mob)
-    -- Forms: 0 = Pot  1 = Pot  2 = Poles  3 = Rings
-    local randomTime = math.random(30, 180)
+    local currentTime = GetSystemTime()
     local changeTime = mob:getLocalVar('changeTime')
+    local currentForm = mob:getAnimationSub()
 
-    -- If we're in a pot form, but going to change to either Rings/Poles
-    if
-        (mob:getAnimationSub() == 0 or mob:getAnimationSub() == 1) and
-        mob:getBattleTime() - changeTime > randomTime
-    then
-        local aniChange = math.random(2, 3)
-        mob:setAnimationSub(aniChange)
+    -- Apply the form change
+    if currentTime >= changeTime then
+        local newForm = math.random(1, 3)
 
-        -- We changed to Poles. Make it only take piercing.
-        if aniChange == 2 then
-            mob:setMod(xi.mod.HTH_SDT, -10000)
-            mob:setMod(xi.mod.SLASH_SDT, -10000)
-            mob:setMod(xi.mod.PIERCE_SDT, 0)
-            mob:setMod(xi.mod.IMPACT_SDT, -10000)
-            mob:setLocalVar('changeTime', mob:getBattleTime())
-        else -- We changed to Rings. Make it only take slashing.
-            mob:setMod(xi.mod.HTH_SDT, -10000)
-            mob:setMod(xi.mod.SLASH_SDT, 0)
-            mob:setMod(xi.mod.PIERCE_SDT, -10000)
-            mob:setMod(xi.mod.IMPACT_SDT, -10000)
-            mob:setLocalVar('changeTime', mob:getBattleTime())
+        while newForm == currentForm do
+            newForm = math.random(1, 3)
         end
-    -- We're in poles, but changing
-    elseif
-        mob:getAnimationSub() == 2 and
-        mob:getBattleTime() - changeTime > randomTime
-    then
-        local aniChange = math.random(0, 1)
 
-        -- Changing to Pot, only take Blunt damage
-        if aniChange == 0 then
-            mob:setAnimationSub(0)
-            mob:setMod(xi.mod.HTH_SDT, 0)
-            mob:setMod(xi.mod.SLASH_SDT, -10000)
-            mob:setMod(xi.mod.PIERCE_SDT, -10000)
-            mob:setMod(xi.mod.IMPACT_SDT, 0)
-            mob:setLocalVar('changeTime', mob:getBattleTime())
-        else -- Going to Rings, only take slashing
-            mob:setAnimationSub(3)
-            mob:setMod(xi.mod.HTH_SDT, -10000)
-            mob:setMod(xi.mod.SLASH_SDT, 0)
-            mob:setMod(xi.mod.PIERCE_SDT, -10000)
-            mob:setMod(xi.mod.IMPACT_SDT, -10000)
-            mob:setLocalVar('changeTime', mob:getBattleTime())
-        end
-    -- We're in rings, but going to change to pot or poles
-    elseif
-        mob:getAnimationSub() == 3 and
-        mob:getBattleTime() - changeTime > randomTime
-    then
-        local aniChange = math.random(0, 2)
-        mob:setAnimationSub(aniChange)
+        -- Briefly transition to animationSub 1, then change to new form
+        mob:setAnimationSub(1)
 
-        -- We're changing to pot form, only take blunt damage.
-        if aniChange == 0 or aniChange == 1 then
-            mob:setMod(xi.mod.HTH_SDT, 0)
-            mob:setMod(xi.mod.SLASH_SDT, -10000)
-            mob:setMod(xi.mod.PIERCE_SDT, -10000)
-            mob:setMod(xi.mod.IMPACT_SDT, 0)
-            mob:setLocalVar('changeTime', mob:getBattleTime())
-        else -- Changing to poles, only take piercing
-            mob:setMod(xi.mod.HTH_SDT, -10000)
-            mob:setMod(xi.mod.SLASH_SDT, -10000)
-            mob:setMod(xi.mod.PIERCE_SDT, 0)
-            mob:setMod(xi.mod.IMPACT_SDT, -10000)
-            mob:setLocalVar('changeTime', mob:getBattleTime())
-        end
+        -- Schedule the actual form change after a brief delay
+        mob:timer(2000, function(mobArg)
+            if mobArg then
+                mobArg:setAnimationSub(newForm)
+                applyResistances(mobArg, newForm)
+            end
+        end)
+
+        mob:setLocalVar('changeTime', currentTime + math.random(30, 390))
     end
-end
-
-entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Qnaern.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Qnaern.lua
@@ -11,16 +11,15 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
-end
-
-entity.onMobSpawn = function(mob)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
     mob:addImmunity(xi.immunity.SILENCE)
     mob:addImmunity(xi.immunity.BIND)
     mob:addImmunity(xi.immunity.STUN)
     mob:addImmunity(xi.immunity.TERROR)
+end
 
+entity.onMobSpawn = function(mob)
     local mJob = mob:getMainJob()
 
     if mJob == xi.job.RDM then

--- a/scripts/zones/Grand_Palace_of_HuXzoi/npcs/qm_ixaern_mnk.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/npcs/qm_ixaern_mnk.lua
@@ -50,4 +50,8 @@ entity.onTrade = function(player, npc, trade)
     end
 end
 
+entity.onTrigger = function(player, npc)
+    player:messageSpecial(ID.text.IXAERN_MNK_QM)
+end
+
 return entity

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -1301,7 +1301,7 @@ INSERT INTO `mob_groups` VALUES (19,55,34,'Aerns_Euvhi',0,128,0,0,0,63,65,0);
 INSERT INTO `mob_groups` VALUES (20,6180,34,'Eoaern_drk',960,0,775,0,9999,79,82,0);
 INSERT INTO `mob_groups` VALUES (21,6177,34,'Eoaern_rdm',960,0,775,0,9999,79,82,0);
 INSERT INTO `mob_groups` VALUES (22,2113,34,'Ixghrah',0,128,0,9000,100,76,76,0);
-INSERT INTO `mob_groups` VALUES (23,2136,34,'Jailer_of_Temperance',0,32,1402,22000,0,85,85,0);
+INSERT INTO `mob_groups` VALUES (23,2136,34,'Jailer_of_Temperance',0,32,1402,25000,0,85,85,0);
 INSERT INTO `mob_groups` VALUES (24,4661,34,'Ixaern_mnk',0,128,0,13000,0,83,83,0);
 INSERT INTO `mob_groups` VALUES (25,3269,34,'Qnaern_rdm',0,128,0,7500,0,80,80,0);
 INSERT INTO `mob_groups` VALUES (26,4651,34,'Qnaern_whm',0,128,0,7500,0,80,80,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adjusts immunities for Ix'Aern MNK and Jailer of Temperance
- JoT can go into any form, but defaults to pot form for a brief moment while changing. [Example](https://youtu.be/T2OPAQOv9gg?t=212)

## Steps to test these changes

- Pop either NM and see they reflect changes properly.
