### PR TITLE
[core] Standardize weapon damage/wrank getters

### DIFF
--- a/src/map/attackround.cpp
+++ b/src/map/attackround.cpp
@@ -175,7 +175,7 @@ CBattleEntity* CAttackRound::GetCoverAbilityUserEntity()
  ************************************************************************/
 bool CAttackRound::IsH2H()
 {
-    if (auto* weapon = dynamic_cast<CItemWeapon*>(m_attacker->m_Weapons[SLOT_MAIN]))
+    if (auto* weapon = dynamic_cast<CItemWeapon*>(m_attacker->m_Weapons[SLOT_MAIN]); m_attacker->objtype == TYPE_PC)
     {
         return weapon->getSkillType() == SKILL_HAND_TO_HAND;
     }

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -14982,22 +14982,7 @@ uint16 CLuaBaseEntity::getWeaponDmg()
         return 0;
     }
 
-    uint16 weaponDamage = 0;
-
-    // TODO: Determine if trusts and player fellows use mob or player damage formula
-    if (m_PBaseEntity->objtype == TYPE_MOB ||
-        (m_PBaseEntity->objtype == TYPE_PET &&
-         static_cast<CPetEntity*>(m_PBaseEntity)->getPetType() != PET_TYPE::AUTOMATON))
-    {
-        auto* PMob   = static_cast<CMobEntity*>(m_PBaseEntity);
-        weaponDamage = mobutils::GetWeaponDamage(PMob, SLOT_MAIN);
-    }
-    else
-    {
-        weaponDamage = static_cast<CBattleEntity*>(m_PBaseEntity)->GetMainWeaponDmg();
-    }
-
-    return weaponDamage;
+    return static_cast<CBattleEntity*>(m_PBaseEntity)->GetMainWeaponDmg();
 }
 
 /************************************************************************


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

mob weapon damage is fetched correctly on autos (it was fine from lua auto attacks and any damage calculated in lua for the most part...)
wrank modifiers are applied correctly (more correctly?): see https://www.bg-wiki.com/ffxi/Weapon_Rank

player weapon damage is applied consistently (h2h was the edge case there)

reduces spaghetti
<img width="1300" height="956" alt="image" src="https://github.com/user-attachments/assets/aae86f16-feba-4068-a51f-e0df812690c1" />

## Steps to test these changes

get slapped by tiamat and vrtra 
<img width="261" height="90" alt="image" src="https://github.com/user-attachments/assets/9f568c47-d142-4562-a34f-88e47530752c" />
<img width="360" height="415" alt="image" src="https://github.com/user-attachments/assets/dcb6d510-489d-4d3d-838d-50e5366f88d2" />

