### PR TITLE
PRESPAWN listener

### DIFF
--- a/scripts/mixins/families/uragnite.lua
+++ b/scripts/mixins/families/uragnite.lua
@@ -84,7 +84,7 @@ g_mixins.families.uragnite = function(uragniteMob)
     -- at spawn, give mob default skill lists for in-shell and out-of-shell states
     -- these defaults can be overwritten by using xi.mix.uragnite.config() in onMobSpawn.
 
-    uragniteMob:addListener('SPAWN', 'URAGNITE_SPAWN', function(mob)
+    uragniteMob:addListener('PRESPAWN', 'URAGNITE_SPAWN', function(mob)
         mob:setLocalVar('[uragnite]noShellSkillList', 251)
         mob:setLocalVar('[uragnite]inShellSkillList', 250)
         mob:setLocalVar('[uragnite]chanceToShell', 20)

--- a/scripts/mixins/job_special.lua
+++ b/scripts/mixins/job_special.lua
@@ -268,7 +268,7 @@ g_mixins.job_special = function(jobSpecialMob)
     -- At spawn, give mob its default main job 2hr, which it'll use at 40-60% HP.
     -- these defaults can be overwritten by using xi.mix.jobSpecial.config() in onMobSpawn.
 
-    jobSpecialMob:addListener('SPAWN', 'JOB_SPECIAL_SPAWN', function(mob)
+    jobSpecialMob:addListener('PRESPAWN', 'JOB_SPECIAL_SPAWN', function(mob)
         local mJob    = mob:getMainJob()
         local ability = job2hr[mJob]
 

--- a/scripts/mixins/rage.lua
+++ b/scripts/mixins/rage.lua
@@ -13,7 +13,7 @@ require('scripts/globals/mixins')
 g_mixins = g_mixins or {}
 
 g_mixins.rage = function(rageMob)
-    rageMob:addListener('SPAWN', 'RAGE_SPAWN', function(mob)
+    rageMob:addListener('PRESPAWN', 'RAGE_SPAWN', function(mob)
         mob:setLocalVar('[rage]timer', 1200) -- 20 minutes
     end)
 

--- a/scripts/mixins/remove_doom.lua
+++ b/scripts/mixins/remove_doom.lua
@@ -17,7 +17,7 @@ xi.mix.clear_doom.config = function(mob, params)
 end
 
 g_mixins.clear_doom = function(doomMob)
-    doomMob:addListener('SPAWN', 'REMOVE_DOOM_SPAWN', function(mob)
+    doomMob:addListener('PRESPAWN', 'REMOVE_DOOM_SPAWN', function(mob)
         mob:setLocalVar('[remove_doom]removalChance', 100)
     end)
 

--- a/scripts/mixins/weapon_break.lua
+++ b/scripts/mixins/weapon_break.lua
@@ -11,7 +11,7 @@ g_mixins.weapon_break = function(weaponBreakMob)
     -- set default 10% chance to break weapon on critical hit taken
     -- this can be overridden in onMobSpawn
 
-    weaponBreakMob:addListener('SPAWN', 'WEAPON_BREAK', function(mob)
+    weaponBreakMob:addListener('PRESPAWN', 'WEAPON_BREAK', function(mob)
         mob:setLocalVar('BreakChance', 10)
     end)
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -3510,6 +3510,8 @@ namespace luautils
             return;
         }
 
+        PMob->PAI->EventHandler.triggerListener("PRESPAWN", PMob);
+
         const sol::function onMobSpawn = getEntityCachedFunction(PMob, "onMobSpawn");
         if (onMobSpawn.valid())
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

I missed that certain mixins make use of the SPAWN listener and were built with the former ordering in mind.

Namely any mixin that have the following characteristics:
- Sets base default values
- Exposes customization through another function or assumptions about local variables

The pattern relies on customization being provided in `onMobSpawn` such that, taking rage mixin as an example:

- Fafnir gets `[rage]timer` set to 1200 from the mixin (default)
- Fafnir `onMobSpawn` overrides `[rage]timer` to 3600

With the new ordering, `onMobSpawn` sets the timer to 3600 and _then_ the SPAWN listener overrides it to 1200

Given that:
- I believe base listeners should always execute after the associated lua function to keep the design consistent
- The setting of defaults at spawn for mixins is a decently useful feature to keep code simple
- onMobInitialize cannot really be used for setting localvars that may change from mob instance to mob instance

I am proposing to simply break the listener into PRESPAWN and SPAWN, so that the order becomes PRESPAWN -> onMobSpawn -> SPAWN

## Steps to test these changes
In Dragon's Aery, spawn Fafnir, verify rage is set to correct timer.
In Arrapago Reef, spawn Medusa and verify job special vars are correctly set.

<img width="633" height="172" alt="image" src="https://github.com/user-attachments/assets/782c2e9a-78d9-4404-a0bc-e2e966ed4324" />

<img width="657" height="294" alt="image" src="https://github.com/user-attachments/assets/f5c28253-dc95-4903-8a12-8d9cc32825dc" />

<!-- Clear and detailed steps to test your changes here -->
