### PR TITLE
[lua] Remove hard-coded mobids in astral_flow

### DIFF
--- a/scripts/actions/mobskills/astral_flow.lua
+++ b/scripts/actions/mobskills/astral_flow.lua
@@ -4,17 +4,6 @@
 ---@type TMobSkill
 local mobskillObject = {}
 
-local avatarOffsets =
-{
-    [17444883] = 3, -- Vermilion-eared Noberry
-    [17444890] = 3, -- Vermilion-eared Noberry
-    [17444897] = 3, -- Vermilion-eared Noberry
-    [17453078] = 3, -- Duke Dantalian
-    [17453085] = 3, -- Duke Dantalian
-    [17453092] = 3, -- Duke Dantalian
-    [17506670] = 5, -- Kirin
-}
-
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
@@ -22,12 +11,9 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     skill:setMsg(xi.msg.basic.USES)
 
-    local mobID  = mob:getID()
-    local avatar = mobID + 2 -- default offset
-
-    if avatarOffsets[mobID] then
-        avatar = mobID + avatarOffsets[mobID]
-    end
+    local mobID        = mob:getID()
+    local avatarOffset = mob:getMobMod(xi.mobMod.ASTRAL_PET_OFFSET)
+    local avatar       = mobID + (avatarOffset > 0 and avatarOffset or 2)
 
     if not GetMobByID(avatar):isSpawned() then
         GetMobByID(avatar):setSpawn(mob:getXPos() + 1, mob:getYPos(), mob:getZPos() + 1, mob:getRotPos())

--- a/scripts/enum/mob_mod.lua
+++ b/scripts/enum/mob_mod.lua
@@ -93,4 +93,5 @@ xi.mobMod =
     RUN_SPEED_MULT         = 82, -- Multiplier for the speed of a mob while running (generally when the target is out of range) 100 = 1.00x
     CLAIM_TYPE             = 83, -- Changes the claim behavior of the mob. See xi.claimType enum.
     NO_SPELL_COST          = 84, -- Mob does not use MP when casting spells
+    ASTRAL_PET_OFFSET      = 85, -- If non-zero, defines the offset from main mob's ID for astral flow (if zero, will assume offset of 2)
 }

--- a/scripts/zones/Sacrificial_Chamber/mobs/Vermilion-eared_Noberry.lua
+++ b/scripts/zones/Sacrificial_Chamber/mobs/Vermilion-eared_Noberry.lua
@@ -6,11 +6,15 @@
 mixins =
 {
     require('scripts/mixins/families/tonberry'),
-    require('scripts/mixins/job_special')
+    require('scripts/mixins/job_special'),
 }
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.ASTRAL_PET_OFFSET, 3)
+end
 
 entity.onMobDeath = function(mob, player, optParams)
     local elementalId = mob:getID() + 2

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Kirin.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Kirin.lua
@@ -9,6 +9,7 @@ mixins = { require('scripts/mixins/job_special') }
 local entity = {}
 
 entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.ASTRAL_PET_OFFSET, 5)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
 end
@@ -29,7 +30,7 @@ entity.onMobFight = function(mob, target)
     if mob:getBattleTime() / 180 == numAdds then
         local godsRemaining = {}
         for i = 1, 4 do
-            if mob:getLocalVar('add'..i) == 0 then
+            if mob:getLocalVar('add' .. i) == 0 then
                 table.insert(godsRemaining, i)
             end
         end
@@ -41,7 +42,7 @@ entity.onMobFight = function(mob, target)
             if god then
                 god:updateEnmity(target)
                 god:setPos(mob:getXPos(), mob:getYPos(), mob:getZPos())
-                mob:setLocalVar('add'..g, 1)
+                mob:setLocalVar('add' .. g, 1)
                 mob:setLocalVar('numAdds', numAdds + 1)
             end
         end

--- a/scripts/zones/Throne_Room/mobs/Duke_Dantalian.lua
+++ b/scripts/zones/Throne_Room/mobs/Duke_Dantalian.lua
@@ -8,9 +8,13 @@ mixins = { require('scripts/mixins/job_special') }
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.ASTRAL_PET_OFFSET, 3)
+end
+
 entity.onMobSpawn = function(mob)
     local mobID = mob:getID()
-    local avatarID = mobID + 3
+    local avatarID = mobID + mob:getMobMod(xi.mobMod.ASTRAL_PET_OFFSET)
     local avatarMob = GetMobByID(avatarID)
     if avatarMob then
         -- Remove the original listener set from mixins/families/avatar

--- a/src/map/mob_modifier.h
+++ b/src/map/mob_modifier.h
@@ -113,6 +113,7 @@ enum MOBMODIFIER : int
     MOBMOD_RUN_SPEED_MULT         = 82, // Multiplier for the speed of a mob while running (generally when the target is out of range) 100 = 1.00x
     MOBMOD_CLAIM_TYPE             = 83, // Changes the claim behavior of the mob. See ClaimType enum.
     MOBMOD_NO_SPELL_COST          = 84, // Mob does not use MP when casting spells
+    MOBMOD_ASTRAL_PET_OFFSET      = 85, // If non-zero, defines the offset from main mob's ID for astral flow (if zero, will assume offset of 2)
 };
 
 #endif


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Adds mob mod in lieu of the hard-coded table to define avatar offsets for astral flow, ~~Puts the default offset of 2 in calculate mob stats, which is called everytime a mob spawns, but doesn't change the mobmod if it's already set, so this allows the mobmod to be optional, but still keep the logic simple in `astral_flow.lua`~~

`astral_flow.lua` is adjusted to use the mobmod if it's non-zero, and use `2` otherwise for the offset

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- for each, `!hp 1` is typically all that's needed to get mob to trigger AF
- go to a normal summoner mob without the mobmod set:
  - <img width="577" height="397" alt="image" src="https://github.com/user-attachments/assets/73d4805e-edcc-4b84-ac39-93103a82ff90" />
- go to each defined in this PR, see they target the proper mob for astral flow
  - <img width="470" height="207" alt="image" src="https://github.com/user-attachments/assets/817cbf48-76a7-4f12-b4e1-bb2d4498823b" />
  - <img width="504" height="163" alt="image" src="https://github.com/user-attachments/assets/b09d9723-d955-4bcf-834c-5fe83aa3b4c6" />
  - <img width="478" height="140" alt="image" src="https://github.com/user-attachments/assets/f3aea074-8d28-44cf-9769-7cf25042de25" />
  - <img width="514" height="315" alt="image" src="https://github.com/user-attachments/assets/941e741b-e726-42c1-a2e6-905ca95f4e18" />




