### PR TITLE
[lua] Fix door in Grauberg (S)

### DIFF
--- a/scripts/zones/Grauberg_[S]/DefaultActions.lua
+++ b/scripts/zones/Grauberg_[S]/DefaultActions.lua
@@ -4,6 +4,9 @@ return {
     ['qm2']               = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
     ['qm3']               = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
     ['qm_reset']          = { messageSpecial = ID.text.AIR_WARPED_AND_DISTORTED },
+    ['Emmerich']          = { event =  8 },
+    ['Vanja']             = { event =  9 },
     ['Childerich']        = { event = 10 },
+    ['_2h3']              = { messageSpecial = 7214 },
     ['Veridical_Conflux'] = { messageSpecial = ID.text.MYSTERIOUS_COLUMN_ROTATES },
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds default dialogue to the NPCs located at E-12 in Grauberg (S).
Mainly so that the door which shouldn't be accessible no longer opens and you fall through the house.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
<img width="1425" height="745" alt="image" src="https://github.com/user-attachments/assets/d8b85ff5-2118-43d0-b9c9-22b02dbc9a68" />
<img width="630" height="56" alt="image" src="https://github.com/user-attachments/assets/77e0483c-d65c-41a1-afe4-fdf717b731eb" />
<img width="642" height="24" alt="image" src="https://github.com/user-attachments/assets/b069b798-d202-4798-8a60-240a0b8cd36c" />
<img width="258" height="25" alt="image" src="https://github.com/user-attachments/assets/0944a2fa-42a9-4b04-b983-a401ec50f970" />

Used this capture (old and had ID shift, so I had to test a bit)
https://drive.google.com/file/d/1SkryTjVYE1IA8PvdQxytd3_EG6Gmtb1h/view


## Steps to test these changes
`!gotoid 17142513`

<!-- Clear and detailed steps to test your changes here -->
