### PR TITLE
[cpp] Remove player ability->mobskillid plumbing

### DIFF
--- a/src/map/ability.cpp
+++ b/src/map/ability.cpp
@@ -42,7 +42,6 @@ CAbility::CAbility(uint16 id)
 , m_CE(0)
 , m_VE(0)
 , m_meritModID(0)
-, m_mobskillId(0)
 {
 }
 
@@ -67,19 +66,9 @@ void CAbility::setID(uint16 id)
     m_ID = id;
 }
 
-void CAbility::setMobSkillID(uint16 id)
-{
-    m_mobskillId = id;
-}
-
 uint16 CAbility::getID() const
 {
     return m_ID;
-}
-
-uint16 CAbility::getMobSkillID() const
-{
-    return m_mobskillId;
 }
 
 void CAbility::setJob(JOBTYPE Job)
@@ -352,7 +341,6 @@ namespace ability
 
         const auto rset = db::preparedStmt("SELECT "
                                            "abilityId, "
-                                           "IFNULL(min_id, 0) AS mobskillId, "
                                            "name, "
                                            "job, "
                                            "level, "
@@ -372,9 +360,7 @@ namespace ability
                                            "meritModID, "
                                            "addType, "
                                            "content_tag "
-                                           "FROM abilities LEFT JOIN (SELECT mob_skill_name, MIN(mob_skill_id) AS min_id "
-                                           "FROM mob_skills GROUP BY mob_skill_name) mob_skills_1 ON "
-                                           "abilities.name = mob_skills_1.mob_skill_name "
+                                           "FROM abilities "
                                            "WHERE job < ? AND abilityId < ? "
                                            "ORDER BY job, level ASC",
                                            MAX_JOBTYPE, MAX_ABILITY_ID);
@@ -393,7 +379,6 @@ namespace ability
                 PAbilityList[abilityId] = std::make_unique<CAbility>(abilityId);
                 const auto& PAbility    = PAbilityList[abilityId];
 
-                PAbility->setMobSkillID(rset->get<uint16>("mobskillId"));
                 PAbility->setName(rset->get<std::string>("name"));
                 PAbility->setJob(static_cast<JOBTYPE>(rset->get<uint8>("job")));
                 PAbility->setLevel(rset->get<uint8>("level"));

--- a/src/map/ability.h
+++ b/src/map/ability.h
@@ -723,7 +723,6 @@ public:
     EFFECT          getPostActionEffectCleanup();
 
     void setID(uint16 id);
-    void setMobSkillID(uint16 id);
     void setJob(JOBTYPE Job);
     void setLevel(uint8 level);
     void setAnimationID(uint16 animationID);
@@ -763,7 +762,6 @@ private:
     int32           m_VE;
     uint16          m_meritModID;
     std::string     m_name;
-    uint16          m_mobskillId;
     ACTIONTYPE      m_actionType{};
     EFFECT          m_cleanupEffect{};
 };


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Draft mostly because it needs to wait until #8088 merges, but it's tested and appears to work as expected
- player abilities were assigning a mobskill id based on the results of left joining with mobskills on name matching
  - this would just grab the first ability that was in the db so that it could tell the pet to execute that mobskill ID in `charentity::OnAbility`
- The section that would grab a mobskill now has a generic catchall that shouldn't be able to be hit under any normal circumstances, but felt weird to not interrupt the action with a message, so it gives relevant messages and returns early to not consume cooldowns
- I've inspected the flow and tested with all types of player pets and believe this code isn't used at all once those final jug pets are converted
  - all pet abilities that would be affected by this are abilityid >= 512 (other than: concentric_pulse, mending_halation, and radial_arcana)
    - those early 3 are confirmed to be proper pet abilities and function with these changes
      - <img width="506" height="140" alt="image" src="https://github.com/user-attachments/assets/e15f7229-cc22-4c25-8f23-5e50238e4029" />
    - of the rest, all ready skills (recastid 102) are confirmed converted, once the mentioned PR is merged
      - can confirm which pets have invalid mappings to petskills with this query:
      - `SELECT pet_list.name,abilities.name,pet_skills.* FROM pet_list LEFT JOIN mob_pools USING (poolid) LEFT JOIN mob_skill_lists USING (skill_list_id) left JOIN abilities on mob_skill_id = abilityid LEFT JOIN pet_skills ON abilityid = pet_skill_id WHERE skill_list_id > 0 and petid > 20 AND pet_list.name NOT IN ('Luopan','Wyvern','HarlequinFrame','ValoredgeFrame','SharpshotFrame','StormwakerFrame') AND pet_skill_id IS null `
    - after that, any with recastid 173 or 174 are smn bp, confirmed to be converted a long while ago
    - final list is achieved by this query, and it's a short one: `SELECT * FROM `xidb`.`abilities` WHERE `abilityId` >= 512 AND recastid NOT IN (102,173,174) ORDER BY `abilityId` `
      - dragoon skills are executed as job abilities by the wyvern from the listeners installed in `scripts\globals\pets\wyvern.lua` (and confirmed to still work after this code)
        - healing/removal breaths after casts, dmg breaths after ws, etc (assuming proper subjob is set before calling wyvern)
      -  perfect defense has a weird recastid, but it's never explicitly used by a player so not sure why it has that, regardless this still works as expected (`avatar:usePetAbility` is explicitly called when you summon alexander)

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- use pet jobs: drg, pup, bst, smn, geo
- call various pets and see that all skills still execute as expected

<img width="364" height="91" alt="image" src="https://github.com/user-attachments/assets/ee756334-ee09-46e5-98ba-a01ce2242159" />
<img width="454" height="119" alt="image" src="https://github.com/user-attachments/assets/094908fe-45af-4932-a7c7-d2b695067883" />
<img width="492" height="125" alt="image" src="https://github.com/user-attachments/assets/f673b273-04b6-4c92-8827-6c24e4e98109" />
<img width="392" height="167" alt="image" src="https://github.com/user-attachments/assets/b7b48c2f-0cba-46ec-95c8-72bc4dc292ce" />

- (without the mentioned PR merged) see lucky lulush cannot use snow cloud but can use whirl claws:
  - <img width="545" height="227" alt="image" src="https://github.com/user-attachments/assets/a0e9476b-56f5-4b57-b90f-c1793a4d7b4e" />
  - a breakpoint here also confirms the logic is being hit properly
  - <img width="855" height="139" alt="image" src="https://github.com/user-attachments/assets/0b51cacc-eacc-40f3-b524-6212f9a8f9a4" />


