### PR TITLE
[cpp] Do not emit console warning for valid slots in weapon dmg/subskill

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -15244,6 +15244,10 @@ uint16 CLuaBaseEntity::getWeaponDamageType(uint8 slotID)
         {
             return static_cast<uint16>(PWeapon->getDmgType());
         }
+        else
+        {
+            return 0;
+        }
     }
 
     ShowError("lua::getWeaponDamageType :: Invalid slot specified!");
@@ -15310,6 +15314,10 @@ uint8 CLuaBaseEntity::getWeaponSubSkillType(uint8 slotID)
         if (PWeapon)
         {
             return PWeapon->getSubSkillType();
+        }
+        else
+        {
+            return 0;
         }
     }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

These two bindings were printing a warning that the slot was invalid when in fact there's just nothing in the slot. Specifically, it was printing an error when pups try to use a maneuver while not wearing anything in the ranged slot:

<img width="1107" height="147" alt="image" src="https://github.com/user-attachments/assets/b5be7329-17c2-43bb-8158-ea134bd84883" />

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Functionally, there's no change. In the map console you will see that errors aren't shown when you run these bindings for slot 1, 2, or 3 with nothing equipped