### PR TITLE
[lua] [sql] Magic Defense Bonus stuff: bad family mod, implement magic defense down status

### DIFF
--- a/scripts/effects/magic_def_down.lua
+++ b/scripts/effects/magic_def_down.lua
@@ -5,6 +5,7 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
+    effect:addMod(xi.mod.MDEF, -effect:getPower()) -- Reduce MDB by N
 end
 
 effectObject.onEffectTick = function(target, effect)

--- a/sql/mob_family_mods.sql
+++ b/sql/mob_family_mods.sql
@@ -559,7 +559,6 @@ INSERT INTO `mob_family_mods` VALUES (174,51,4,1);  -- ROAM_TURNS: 4
 INSERT INTO `mob_family_mods` VALUES (174,52,30,1); -- ROAM_RATE: 30
 
 -- Magic Pot: https://www.bg-wiki.com/ffxi/Category:Magic_Pot
-INSERT INTO `mob_family_mods` VALUES (175,29,50,0);     -- MDEF: 50
 INSERT INTO `mob_family_mods` VALUES (175,31,5,1);      -- ROAM_DISTANCE: 5
 INSERT INTO `mob_family_mods` VALUES (175,36,55,1);     -- ROAM_COOL: 55
 INSERT INTO `mob_family_mods` VALUES (175,52,30,1);     -- ROAM_RATE: 30


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

see title

## Steps to test these changes
Check Magic Defense Down works
Check !getmod mdef of a Sprinkler and see it's 12 and not 50+