### PR TITLE
[lua] Updated KS30 Loot Pools (Gil)

### DIFF
--- a/scripts/battlefields/Chamber_of_Oracles/eye_of_the_storm.lua
+++ b/scripts/battlefields/Chamber_of_Oracles/eye_of_the_storm.lua
@@ -22,6 +22,10 @@ content:addEssentialMobs({ 'Radiant_Wyvern', 'Blizzard_Wyvern', 'Lightning_Wyver
 content.loot =
 {
     {
+        { item = xi.item.GIL, weight = 1000, amount = 24000 }, -- Gil
+    },
+
+    {
         { item = xi.item.WYVERN_WING, weight = 1000 }, -- Wyvern Wing
     },
 

--- a/scripts/battlefields/Horlais_Peak/contaminated_colosseum.lua
+++ b/scripts/battlefields/Horlais_Peak/contaminated_colosseum.lua
@@ -22,6 +22,10 @@ content:addEssentialMobs({ 'Evil_Oscar' })
 content.loot =
 {
     {
+        { item = xi.item.GIL, weight = 1000, amount = 24000 }, -- Gil
+    },
+
+    {
         { item = xi.item.SPOOL_OF_MALBORO_FIBER, weight = 1000 }, -- Spool Of Malboro Fiber
     },
 

--- a/scripts/battlefields/Horlais_Peak/double_dragonian.lua
+++ b/scripts/battlefields/Horlais_Peak/double_dragonian.lua
@@ -22,6 +22,10 @@ content:addEssentialMobs({ 'Dragonian_Berzerker', 'Dragonian_Minstrel' })
 content.loot =
 {
     {
+        { item = xi.item.GIL, weight = 1000, amount = 24000 }, -- Gil
+    },
+
+    {
         { item = xi.item.SUBDUER,        weight = 222 }, -- Subduer
         { item = xi.item.DISSECTOR,      weight = 302 }, -- Dissector
         { item = xi.item.DESTROYERS,     weight = 245 }, -- Destroyers

--- a/scripts/battlefields/QuBia_Arena/infernal_swarm.lua
+++ b/scripts/battlefields/QuBia_Arena/infernal_swarm.lua
@@ -23,7 +23,12 @@ local content = Battlefield:new({
 
 content:addEssentialMobs({ 'Hell_Fly', 'Beelzebub' })
 
-content.loot = {
+content.loot =
+{
+    {
+        { item = xi.item.GIL, weight = 1000, amount = 24000 }, -- Gil
+    },
+
     {
         { item = xi.item.PHOENIX_FEATHER, weight = 1000 }, -- Phoenix Feather
     },


### PR DESCRIPTION
After research, I am updating all of the completed KS30 loot pools with 24,000 gil. The remaining KS30s will be fixed when we update them to work correctly.

**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Updated our completed KSNMs with the correct amount of gil. 

## Steps to test these changes

Run any 4 of the affected KSNM and observe you are now 24,000gil richer (split with party members)

## Proof

https://youtu.be/_HRf9ZK2fuA?si=7HZGcVnpP-6JKwq_&t=152

https://youtu.be/TlvThE0sM14?si=fDoxmTU7NRu0tzZk&t=952

https://youtu.be/egs_MSsNSfI?si=4r7mPijRDu0lft19&t=567

https://www.dropbox.com/scl/fi/zicxrsz6gzzhea7vobvqn/infernal-swarm.rar?rlkey=odhd5sanmbivviwrxftjgknb7&e=3&dl=0
