### PR TITLE
[ci] PR stale workflow

### DIFF
--- a/.github/workflows/pr_stale.yaml
+++ b/.github/workflows/pr_stale.yaml
@@ -1,0 +1,28 @@
+name: 'Label and close stale PRs'
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions:
+  actions: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-issue-stale: -1
+          days-before-pr-stale: 14
+          days-before-pr-close: 60
+          stale-pr-message: |
+            This PR has been automatically marked as stale because
+            it has not had recent activity. It will be closed if no
+            further activity occurs.
+          stale-pr-label: 'stale'
+          close-pr-label: 'abandoned'
+          exempt-pr-labels: 'hold'
+          remove-pr-stale-when-updated: true


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a stale workflow for PRs

Once a day:
- Adds a stale label on PRs after 14 days without activity
- Posts a comment when it does, stating the PR is considered stale
  - I was hoping we could repeat that once a week but it doesn't appear the action supports this just yet
- Closes the PR if no activity after 60 days total and adds an 'abandoned' label
- PRs with 'hold' label will be ignored
- Issues are ignored

I believe it will start adding labels and comments 14 days from now, and not the original creation date but I could be wrong.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
