### PR TITLE
CLuaBaseEntity rework proof-of-concept

### DIFF
--- a/scripts/commands/inherit.lua
+++ b/scripts/commands/inherit.lua
@@ -1,0 +1,41 @@
+-----------------------------------
+-- func: inherit
+-- desc:
+-----------------------------------
+---@type TCommand
+local commandObj = {}
+
+commandObj.cmdprops =
+{
+    permission = 1,
+    parameters = '',
+}
+
+commandObj.onTrigger = function(player)
+    -- Just to prove we can take a CCharEntity directly
+    local p = GetPlayerByName(player:getName())
+    if p then
+        -- We can still use CLuaBaseEntity bindings
+        p:setLocalVar('hi', 42)
+        -- But we can also use CLuaCharEntity bindings!
+        p:addExp(500)
+    end
+
+    -- Miladi-Nildi in Lower Jeuno
+    -- This is going to be a CLuaBaseEntity
+    local n = GetNPCByID(17780856)
+    if n then
+        -- CLuaBaseEntity bindings are obviously supported
+        n:setLocalVar('hi', 24)
+
+        -- But CLuaCharEntity bindings are not supported
+        -- n:addExp(500) -- 'attempt to call method 'addExp' (a nil value)'
+
+        -- We can also rely on the strong typing for parameters
+        -- This binding only accepts a CLuaCharEntity parameter
+        n:doesSomething(p) -- This works!
+        -- n:doesSomething(n) -- 'error: stack index 2, expected userdata, received sol.CLuaBaseEntity: value at this index does not properly reflect the desired type (bad argument into 'void(CLuaCharEntity*)')'
+    end
+end
+
+return commandObj

--- a/src/map/lua/CMakeLists.txt
+++ b/src/map/lua/CMakeLists.txt
@@ -1,4 +1,6 @@
 set(LUA_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/entities/lua_char_entity.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/entities/lua_char_entity.h
     ${CMAKE_CURRENT_SOURCE_DIR}/lua_ability.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/lua_ability.h
     ${CMAKE_CURRENT_SOURCE_DIR}/lua_action.cpp

--- a/src/map/lua/entities/lua_char_entity.cpp
+++ b/src/map/lua/entities/lua_char_entity.cpp
@@ -1,0 +1,90 @@
+﻿/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "lua_char_entity.h"
+
+#include "entities/charentity.h"
+
+CLuaCharEntity::CLuaCharEntity(CCharEntity* PChar)
+: CLuaBaseEntity(PChar)
+, char_(PChar)
+{
+}
+
+/**
+ * @brief Adds a set amount of XP to the player.
+ * @details
+ * Used in Dynamis Pages, etc.
+ * @param [in] exp Amount of XP to grant the player.
+ * @code{.lua}
+ * player:addExp(math.random(500, 1000))
+ * @endcode
+ */
+void CLuaCharEntity::addExp(const uint32 exp) const
+{
+    charutils::AddExperiencePoints(false, char_, char_, exp);
+}
+
+/************************************************************************
+ *  Function: delExp()
+ *  Purpose : Takes XP from a player
+ *  Example : player:delExp(amount)
+ *  Notes   : Used only in GM command takexp.lua
+ ************************************************************************/
+
+void CLuaCharEntity::delExp(const uint32 exp) const
+{
+    charutils::DelExperiencePoints(char_, 0, std::clamp<uint16>(exp, 0, 65535));
+}
+
+/************************************************************************
+ *  Function: getMerit()
+ *  Purpose : Checks for the existence of a merit and returns the value
+ *  Example : caster:getMerit(xi.merit.DOTON_EFFECT)
+ *  Notes   :
+ ************************************************************************/
+
+auto CLuaCharEntity::getMerit(uint16 merit) const -> int32
+{
+    return char_->PMeritPoints->GetMeritValue(static_cast<MERIT_TYPE>(merit), char_);
+}
+
+/************************************************************************
+ *  Function: getMeritCount()
+ *  Purpose : Returns the current value of merits a player has
+ *  Example : player:getMeritCount()
+ *  Notes   :
+ ************************************************************************/
+
+auto CLuaCharEntity::getMeritCount() const -> uint8
+{
+    return char_->PMeritPoints->GetMeritPoints();
+}
+
+void CLuaCharEntity::Register()
+{
+    SOL_USERTYPE_INHERIT("CCharEntity", CLuaCharEntity, CLuaBaseEntity);
+
+    SOL_REGISTER("addExp", CLuaCharEntity::addExp);
+    SOL_REGISTER("delExp", CLuaCharEntity::delExp);
+    SOL_REGISTER("getMerit", CLuaCharEntity::getMerit);
+    SOL_REGISTER("getMeritCount", CLuaCharEntity::getMeritCount);
+}

--- a/src/map/lua/entities/lua_char_entity.h
+++ b/src/map/lua/entities/lua_char_entity.h
@@ -1,0 +1,41 @@
+﻿/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include "lua/lua_baseentity.h"
+
+class CCharEntity;
+class CLuaCharEntity : public CLuaBaseEntity
+{
+public:
+    CLuaCharEntity(CCharEntity*);
+
+    void addExp(uint32 exp) const;
+    void delExp(uint32 exp) const;
+    auto getMerit(uint16 merit) const -> int32;
+    auto getMeritCount() const -> uint8;
+
+    static void Register();
+
+private:
+    CCharEntity* char_;
+};

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -8906,26 +8906,6 @@ void CLuaBaseEntity::unseenKeyItem(const KeyItem keyItemID) const
 }
 
 /************************************************************************
- *  Function: addExp()
- *  Purpose : Adds a set amount of XP to the player
- *  Example : player:addExp(math.random(500,1000))
- *  Notes   : Used in Dynamis Pages, etc
- ************************************************************************/
-
-void CLuaBaseEntity::addExp(uint32 exp)
-{
-    if (m_PBaseEntity->objtype != TYPE_PC)
-    {
-        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->getName());
-        return;
-    }
-
-    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
-
-    charutils::AddExperiencePoints(false, PChar, m_PBaseEntity, exp);
-}
-
-/************************************************************************
  *  Function: addCapacityPoints()
  *  Purpose : Adds a set amount of Capacity Points to the player
  *  Example : player:addCapacity(1000)
@@ -8942,64 +8922,6 @@ void CLuaBaseEntity::addCapacityPoints(uint32 capacity)
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
     charutils::AddCapacityPoints(PChar, m_PBaseEntity, capacity);
-}
-
-/************************************************************************
- *  Function: delExp()
- *  Purpose : Takes XP from a player
- *  Example : player:delExp(amount)
- *  Notes   : Used only in GM command takexp.lua
- ************************************************************************/
-
-void CLuaBaseEntity::delExp(uint32 exp)
-{
-    if (m_PBaseEntity->objtype != TYPE_PC)
-    {
-        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->getName());
-        return;
-    }
-
-    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
-
-    charutils::DelExperiencePoints(PChar, 0, std::clamp<uint16>(exp, 0, 65535));
-}
-
-/************************************************************************
- *  Function: getMerit()
- *  Purpose : Checks for the existence of a merit and returns the value
- *  Example : caster:getMerit(xi.merit.DOTON_EFFECT)
- *  Notes   :
- ************************************************************************/
-
-int32 CLuaBaseEntity::getMerit(uint16 merit)
-{
-    if (m_PBaseEntity->objtype == TYPE_PC)
-    {
-        auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
-
-        return PChar->PMeritPoints->GetMeritValue(static_cast<MERIT_TYPE>(merit), PChar);
-    }
-
-    return 0;
-}
-
-/************************************************************************
- *  Function: getMeritCount()
- *  Purpose : Returns the current value of merits a player has
- *  Example : player:getMeritCount()
- *  Notes   :
- ************************************************************************/
-
-uint8 CLuaBaseEntity::getMeritCount()
-{
-    if (m_PBaseEntity->objtype == TYPE_PC)
-    {
-        auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
-
-        return PChar->PMeritPoints->GetMeritPoints();
-    }
-
-    return 0;
 }
 
 /************************************************************************
@@ -19330,12 +19252,19 @@ void CLuaBaseEntity::clearPacketMods()
     }
 }
 
+// This only works when being passed a player!
+void CLuaBaseEntity::doesSomething(CLuaCharEntity* PChar) const
+{
+    ShowInfo("Hello world.");
+}
+
 //==========================================================//
 
 void CLuaBaseEntity::Register()
 {
     SOL_USERTYPE("CBaseEntity", CLuaBaseEntity);
 
+    SOL_REGISTER("doesSomething", CLuaBaseEntity::doesSomething);
     // Messaging System
     SOL_REGISTER("showText", CLuaBaseEntity::showText);
     SOL_REGISTER("messageText", CLuaBaseEntity::messageText);
@@ -19703,10 +19632,6 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("unseenKeyItem", CLuaBaseEntity::unseenKeyItem);
 
     // Player Points
-    SOL_REGISTER("addExp", CLuaBaseEntity::addExp);
-    SOL_REGISTER("delExp", CLuaBaseEntity::delExp);
-    SOL_REGISTER("getMerit", CLuaBaseEntity::getMerit);
-    SOL_REGISTER("getMeritCount", CLuaBaseEntity::getMeritCount);
     SOL_REGISTER("setMerits", CLuaBaseEntity::setMerits);
 
     SOL_REGISTER("getSpentJobPoints", CLuaBaseEntity::getSpentJobPoints);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -446,11 +446,7 @@ public:
     void unseenKeyItem(KeyItem keyItemID) const; // Attempt to remove the keyitem from the seen key item collection, only works on logout
 
     // Player Points
-    void  addExp(uint32 exp);
     void  addCapacityPoints(uint32 capacity);
-    void  delExp(uint32 exp);
-    int32 getMerit(uint16 merit);
-    uint8 getMeritCount();
     void  setMerits(uint8 numPoints);
 
     uint16 getSpentJobPoints();
@@ -958,6 +954,7 @@ public:
 
     void addPacketMod(uint16 packetId, uint16 offset, uint8 value);
     void clearPacketMods();
+    void doesSomething(CLuaCharEntity* PChar) const;
 
     bool operator==(const CLuaBaseEntity& other) const
     {

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -74,6 +74,7 @@
 #include "battlefield.h"
 #include "conquest_system.h"
 #include "daily_system.h"
+#include "entities/lua_char_entity.h"
 #include "fishingcontest.h"
 #include "instance.h"
 #include "ipc_client.h"
@@ -356,6 +357,7 @@ namespace luautils
         CLuaTreasurePool::Register();
         CLuaZone::Register();
         CLuaItem::Register();
+        CLuaCharEntity::Register();
 
         // Load globals
         // Truly global files first
@@ -1805,7 +1807,7 @@ namespace luautils
      *                                                                       *
      ************************************************************************/
 
-    CBaseEntity* GetPlayerByName(std::string const& name)
+    CCharEntity* GetPlayerByName(std::string const& name)
     {
         TracyZoneScoped;
 

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -237,7 +237,7 @@ namespace luautils
 
     auto SpawnMob(uint32 mobid, sol::object const& arg2, sol::object const& arg3) -> CBaseEntity*; // Spawn Mob By Mob Id - NMs, BCNM...
     void DespawnMob(uint32 mobid, sol::object const& arg2);                                        // Despawn (Fade Out) Mob By Id
-    auto GetPlayerByName(std::string const& name) -> CBaseEntity*;
+    auto GetPlayerByName(std::string const& name) -> CCharEntity*;
     auto GetPlayerByID(uint32 pid) -> CBaseEntity*;
     bool PlayerHasValidSession(uint32 playerId);
     void SendToJailOffline(uint32 playerId, int8 cellId, float posX, float posY, float posZ, uint8 rot);

--- a/src/map/lua/sol_bindings.cpp
+++ b/src/map/lua/sol_bindings.cpp
@@ -24,6 +24,7 @@
 // clang-format off
 #include "ability.h"
 #include "lua_ability.h"
+#include "entities/lua_char_entity.h"
 SOL_BIND_DEF(CLuaAbility, CAbility);
 
 #include "packets/action.h"
@@ -48,7 +49,7 @@ SOL_BIND_DEF(CLuaBaseEntity, CBaseEntity);
 #include "entities/trustentity.h"
 SOL_BIND_DEF_SUB(CLuaBaseEntity, CBaseEntity, CBattleEntity);
 SOL_BIND_DEF_SUB(CLuaBaseEntity, CBaseEntity, CNpcEntity);
-SOL_BIND_DEF_SUB(CLuaBaseEntity, CBaseEntity, CCharEntity);
+SOL_BIND_DEF(CLuaCharEntity, CCharEntity);
 SOL_BIND_DEF_SUB(CLuaBaseEntity, CBaseEntity, CMobEntity);
 SOL_BIND_DEF_SUB(CLuaBaseEntity, CBaseEntity, CAutomatonEntity);
 SOL_BIND_DEF_SUB(CLuaBaseEntity, CBaseEntity, CFellowEntity);

--- a/src/map/lua/sol_bindings.h
+++ b/src/map/lua/sol_bindings.h
@@ -72,6 +72,10 @@ class CLuaAction;
 struct action_t;
 SOL_BIND_DEC(CLuaAction, action_t);
 
+class CLuaCharEntity;
+class CCharEntity;
+SOL_BIND_DEC(CLuaCharEntity, CCharEntity);
+
 class CLuaAttack;
 class CAttack;
 SOL_BIND_DEC(CLuaAttack, CAttack);
@@ -82,7 +86,6 @@ SOL_BIND_DEC(CLuaBaseEntity, CBaseEntity);
 
 class CBattleEntity;
 class CNpcEntity;
-class CCharEntity;
 class CMobEntity;
 class CAutomatonEntity;
 class CFellowEntity;
@@ -90,7 +93,6 @@ class CPetEntity;
 class CTrustEntity;
 SOL_BIND_DEC_SUB(CLuaBaseEntity, CBaseEntity, CBattleEntity);
 SOL_BIND_DEC_SUB(CLuaBaseEntity, CBaseEntity, CNpcEntity);
-SOL_BIND_DEC_SUB(CLuaBaseEntity, CBaseEntity, CCharEntity);
 SOL_BIND_DEC_SUB(CLuaBaseEntity, CBaseEntity, CMobEntity);
 SOL_BIND_DEC_SUB(CLuaBaseEntity, CBaseEntity, CAutomatonEntity);
 SOL_BIND_DEC_SUB(CLuaBaseEntity, CBaseEntity, CFellowEntity);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [ ] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

**This is just a POC, not meant to be merged.**

This came up in a discussion recently. CLuaBaseEntity does (in my opinion) a little too much and is plagued by explicit type checks and casts. 

I have had the opportunity to toy with sol2 inheritance for xi_test and believe it _could_ work nicely for `CLuaBaseEntity`.

In this PR, I have created a new `CLuaCharEntity `class, and moved certain EXP related bindings to it. I have also attached a small command script that quickly goes over the main concepts.

```lua
commandObj.onTrigger = function(player)
    -- Just to prove we can take a CCharEntity directly
    local p = GetPlayerByName(player:getName())
    if p then
        -- We can still use CLuaBaseEntity bindings
        p:setLocalVar('hi', 42)
        -- But we can also use CLuaCharEntity bindings!
        p:addExp(500)
    end

    -- Miladi-Nildi in Lower Jeuno
    -- This is going to be a CLuaBaseEntity
    local n = GetNPCByID(17780856)
    if n then
        -- CLuaBaseEntity bindings are obviously supported
        n:setLocalVar('hi', 24)

        -- But CLuaCharEntity bindings are not supported
        -- n:addExp(500) -- 'attempt to call method 'addExp' (a nil value)'

        -- We can also rely on the strong typing for parameters
        -- This binding only accepts a CLuaCharEntity parameter
        n:doesSomething(p) -- This works!
        -- n:doesSomething(n) -- 'error: stack index 2, expected userdata, received sol.CLuaBaseEntity: value at this index does not properly reflect the desired type (bad argument into 'void(CLuaCharEntity*)')'
    end
end
```

For:
- Focused classes
- Can get rid of all the explicit type checks and rely on sol2
  - This is probably half of LuaBaseEntity gone right there.
- (Future) Documentation can clearly state which entity type can do what and which type of entities are accepted as parameters
- Improves maintainability (a tiny bit) on the current 20,000 LOC beast

Against:
- CLuaBaseEntity works fine and is not _too hard_ to maintain
- Newly-found freedom may lead to a large increase of new bindings
- Not exactly the most urgent to fix in the codebase
- Likely to surface undocumented usage of bindings in ways not intended by their author, where the explicit type checks had holes.

## Bonus: Doxygen documentation

I am also proposing to standardize on Doxygen for documenting Lua bindings. 

I haven't worked out the specifics just yet but I'd like to do two things in the near-future:
- Automatically generate the LLS specs from the classes
- Publish somewhere public the specs

I don't specifically care about it being Doxygen but it needs to be somewhat structured so that it can all be programmatically extracted. I also have 0 experience with it so there may be a better preferred style out there.

```cpp
/**
 * @brief Adds a set amount of XP to the player.
 * @details
 * Used in Dynamis Pages, etc.
 * @param [in] exp Amount of XP to grant the player.
 * @code{.lua}
 * player:addExp(math.random(500, 1000))
 * @endcode
 */
```

I am going to be going through all the bindings shortly to write tests and I could get some of it done at the same time, hence why I am bringing it up now.