### PR TITLE
[Mobskill] Make pollen use a modifier instead of checking for nm status

### DIFF
--- a/scripts/actions/mobskills/pollen.lua
+++ b/scripts/actions/mobskills/pollen.lua
@@ -10,13 +10,18 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local potencyBonus = mob:isNM() and math.random(0, 294) or 0
-    local potency      = (147 + potencyBonus) / 1024
-    local finalPotency = math.floor(mob:getMaxHP() * potency)
+    local potency           = mob:getMaxHP()
+    local powerMultiplier   = 147 / 1024
+    local healingMultiplier = 1 + target:getMod(xi.mod.CURE_POTENCY_RCVD) / 100
+    local randomMultiplier  = math.random(75, 100) / 100
+
+    potency = math.floor(potency * powerMultiplier)
+    potency = math.floor(potency * healingMultiplier)
+    potency = math.floor(potency * randomMultiplier)
 
     skill:setMsg(xi.msg.basic.SELF_HEAL)
 
-    return xi.mobskills.mobHealMove(mob, finalPotency)
+    return xi.mobskills.mobHealMove(mob, potency)
 end
 
 return mobskillObject

--- a/scripts/zones/QuBia_Arena/mobs/Beelzebub.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Beelzebub.lua
@@ -13,6 +13,8 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
     mob:addImmunity(xi.immunity.SILENCE)
     mob:addImmunity(xi.immunity.PETRIFY)
+
+    mob:setMod(xi.mobMod.CURE_POTENCY_RCVD, 100) -- Double healing recieved.
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/QuBia_Arena/mobs/Hell_Fly.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Hell_Fly.lua
@@ -8,6 +8,8 @@
 local entity = {}
 
 entity.onMobInitialize = function(mob)
+    mob:setMod(xi.mobMod.CURE_POTENCY_RCVD, 100) -- Double healing recieved.
+
     mob:setMobMod(xi.mobMod.CHARMABLE, 1)
 end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
As title sais.
TODO: One day, healing spells will get their conversion to the new magic system. And maybe said day we can give a similar treatment to healing mobskills.

## Steps to test these changes

Run "Infernal Swarm" BCNM