### PR TITLE
[lua] WAR's Berserk and Defender abilities now scale with level

### DIFF
--- a/scripts/effects/berserk.lua
+++ b/scripts/effects/berserk.lua
@@ -13,7 +13,7 @@ effectObject.onEffectGain = function(target, effect)
 
     target:addMod(xi.mod.ATTP, power)
     target:addMod(xi.mod.RATTP, power)
-    target:addMod(xi.mod.DEFP, -power)
+    target:addMod(xi.mod.DEFP, -25)
 
     -- Job Point Bonuses
     target:addMod(xi.mod.ATT, jpEffect)
@@ -30,7 +30,7 @@ effectObject.onEffectLose = function(target, effect)
 
     target:delMod(xi.mod.ATTP, power)
     target:delMod(xi.mod.RATTP, power)
-    target:delMod(xi.mod.DEFP, -power)
+    target:delMod(xi.mod.DEFP, -25)
 
     -- Job Point Bonuses
     target:delMod(xi.mod.ATT, jpEffect)

--- a/scripts/effects/defender.lua
+++ b/scripts/effects/defender.lua
@@ -5,26 +5,32 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
+    local power = effect:getPower()
     local jpLevel = target:getJobPointLevel(xi.jp.DEFENDER_EFFECT)
+    local jpEffect = jpLevel * 3
 
-    target:addMod(xi.mod.DEFP, 25)
+    target:addMod(xi.mod.DEFP, power)
     target:addMod(xi.mod.RATTP, -25)
     target:addMod(xi.mod.ATTP, -25)
 
-    -- JP Bonus
-    target:addMod(xi.mod.DEF, jpLevel * 3)
+    -- Job Point Bonuses
+    target:addMod(xi.mod.DEF, jpEffect)
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
+    local power = effect:getPower()
     local jpLevel = target:getJobPointLevel(xi.jp.DEFENDER_EFFECT)
+    local jpEffect = jpLevel * 3
 
-    target:delMod(xi.mod.DEF, jpLevel * 3)
-    target:delMod(xi.mod.DEFP, 25)
+    target:delMod(xi.mod.DEFP, power)
     target:delMod(xi.mod.ATTP, -25)
     target:delMod(xi.mod.RATTP, -25)
+
+    -- Job Point Bonuses
+    target:delMod(xi.mod.DEF, jpEffect)
 end
 
 return effectObject

--- a/scripts/globals/job_utils/warrior.lua
+++ b/scripts/globals/job_utils/warrior.lua
@@ -38,7 +38,15 @@ xi.job_utils.warrior.useAggressor = function(player, target, ability)
 end
 
 xi.job_utils.warrior.useBerserk = function(player, target, ability)
-    player:addStatusEffect(xi.effect.BERSERK, 25 + player:getMod(xi.mod.BERSERK_POTENCY), 0, 180 + player:getMod(xi.mod.BERSERK_DURATION))
+    -- Get bonus from WAR lvl as main Job
+    local warriorLevel = player:getMainJob() == xi.job.WAR and player:getMainLvl() or 0
+    local levelScale   = math.floor((warriorLevel - 40) / 10) * 2
+
+    -- Get Power and duration.
+    local power    = 25 + player:getMod(xi.mod.BERSERK_POTENCY) + utils.clamp(levelScale, 0, 10)
+    local duration = 180 + player:getMod(xi.mod.BERSERK_DURATION)
+
+    player:addStatusEffect(xi.effect.BERSERK, power, 0, duration)
 end
 
 xi.job_utils.warrior.useBloodRage = function(player, target, ability)
@@ -59,7 +67,15 @@ xi.job_utils.warrior.useBrazenRush = function(player, target, ability)
 end
 
 xi.job_utils.warrior.useDefender = function(player, target, ability)
-    player:addStatusEffect(xi.effect.DEFENDER, 1, 0, 180 + player:getMod(xi.mod.DEFENDER_DURATION))
+    -- Get bonus from WAR lvl as main Job
+    local warriorLevel = player:getMainJob() == xi.job.WAR and player:getMainLvl() or 0
+    local levelScale   = math.floor((warriorLevel - 40) / 10) * 2
+
+    -- Get Power and duration.
+    local power    = 25 + utils.clamp(levelScale, 0, 10)
+    local duration = 180 + player:getMod(xi.mod.DEFENDER_DURATION)
+
+    player:addStatusEffect(xi.effect.DEFENDER, power, 0, duration)
 end
 
 xi.job_utils.warrior.useMightyStrikes = function(player, target, ability)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes #7963 
Berserk and Defender now gain additional power based on the players level.  It's a 2% boost gained every 10 levels from 50 onwards, capping at 35%.  The negative effect of these abilities (def for berserk, atp for defender) is always only 25%.  If a player has WAR as a subjob, then the power boost is only ever at 25%.

Info source:
[bg-wiki Berserk](https://www.bg-wiki.com/ffxi/Berserk)
[ffo-jp Berserk](https://wiki.ffo.jp/html/3254.html)
[bg-wiki Defender](https://www.bg-wiki.com/ffxi/Defender)
[ffo-jp Defender](https://wiki.ffo.jp/html/3257.html)
[FFXI update October 2014](https://forum.square-enix.com/ffxi/threads/44592?p=527238#post527239) where they introduce the increased effect of Berserk and Defender
[FFXI update May 2015](https://forum.square-enix.com/ffxi/threads/46976-May-14-2015-%28JST%29-Version-Update?p=548833&viewfull=1#post548833) where the power is increased to 2%

## Steps to test these changes

- Change your job to Warrior, level 15
- Use "!getstats 3" to make a note of your total offence.  Use "!getstats 2" to see your total defence.
- Use Berserk
- Use the getstats commands again and see how the total offence has increased by 25% / Defence decreased by 25%
  - You can also use "!geteffects" and see that berserk has a power of 25
- Remove the berserk effect, and use Defender to see the same values but defence increased and offence decreased.
- The negative effect applied to defence with berserk, and offence with defender, is always 25% regardless of level.
- Change Warrior to a higher level and repeat these steps
  - The level boundries and expected effects are taken from the sources listed above and are as follows.

| Level | % Boost |
|-------|---------|
| 15    | 25      |
| 50    | 27      |
| 60    | 29      |
| 70    | 31      |
| 80    | 33      |
| 90    | 35      |

- You can also change your subjob to war and mainjob to anything else, then regardless of level, the power of berserk/defender is always 25%.