### PR TITLE
[sql] Fix model ID for Straw Hat/Overalls (females)

### DIFF
--- a/sql/item_equipment.sql
+++ b/sql/item_equipment.sql
@@ -13964,7 +13964,7 @@ INSERT INTO `item_equipment` VALUES (27730,'iuitl_headgear_+1',99,119,2458912,25
 INSERT INTO `item_equipment` VALUES (27731,'gende._caubeen_+1',99,119,524820,265,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (27732,'hagondes_hat_+1',99,119,1622040,262,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (27733,'straw_hat',1,0,4194303,366,0,0,16,0,0,0);
-INSERT INTO `item_equipment` VALUES (27734,'straw_hat',1,0,4194303,366,0,0,16,0,0,0);
+INSERT INTO `item_equipment` VALUES (27734,'straw_hat',1,0,4194303,367,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (27735,'enedron_glasses',99,107,4194303,125,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (27736,'quiahuiz_helm',99,115,8641,333,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (27737,'kaabnax_hat',99,115,1589788,346,0,0,16,0,0,0);
@@ -14109,7 +14109,7 @@ INSERT INTO `item_equipment` VALUES (27876,'iuitl_vest_+1',99,119,2458912,256,0,
 INSERT INTO `item_equipment` VALUES (27877,'gende._bilaut_+1',99,119,524820,265,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (27878,'hagondes_coat_+1',99,119,1622040,262,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (27879,'overalls',1,0,4194303,366,0,0,32,128,0,0);
-INSERT INTO `item_equipment` VALUES (27880,'overalls',1,0,4194303,366,0,0,32,128,0,0);
+INSERT INTO `item_equipment` VALUES (27880,'overalls',1,0,4194303,367,0,0,32,128,0,0);
 INSERT INTO `item_equipment` VALUES (27881,'outrider_mail',99,117,6593,5,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (27882,'espial_gambison',99,117,3662710,23,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (27883,'wayfarer_robe',99,117,4179646,20,0,0,32,0,0,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Correct model ID for female Straw Hat and Overalls, uses +1 offset for female models.

<img width="256" height="582" alt="image" src="https://github.com/user-attachments/assets/c2342ba7-7941-4853-84e4-59f6bb1b1079" />

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Play female character
`!additem 27734`
`!additem 27880`

<!-- Clear and detailed steps to test your changes here -->
