### PR TITLE
Retire `calculateMagicDamage()`, `doEnspell()` and `applyResistanceAbility()` functions

### DIFF
--- a/scripts/actions/abilities/dark_shot.lua
+++ b/scripts/actions/abilities/dark_shot.lua
@@ -30,7 +30,7 @@ abilityObject.onUseAbility = function(player, target, ability, action)
     action:setRecast(math.max(0, action:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
     local duration = 60
     local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
-    local resist   = applyResistanceAbility(player, target, xi.element.DARK, xi.skill.NONE, bonusAcc)
+    local resist   = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.DARK, 0, 0, bonusAcc)
 
     if resist < 0.25 then
         ability:setMsg(xi.msg.basic.JA_MISS_2) -- resist message

--- a/scripts/actions/abilities/earth_shot.lua
+++ b/scripts/actions/abilities/earth_shot.lua
@@ -36,8 +36,8 @@ abilityObject.onUseAbility = function(player, target, ability, action)
     dmg       = addBonusesAbility(player, xi.element.EARTH, target, dmg, params)
 
     local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
-    dmg            = dmg * applyResistanceAbility(player, target, xi.element.EARTH, xi.skill.NONE, bonusAcc)
-    dmg            = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.EARTH)
+    dmg            = math.floor(dmg * xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.EARTH, 0, 0, bonusAcc))
+    dmg            = math.floor(dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.EARTH))
 
     params.targetTPMult = 0 -- Quick Draw does not feed TP
     dmg = xi.ability.takeDamage(target, player, params, true, dmg, xi.attackType.MAGICAL, xi.damageType.EARTH, xi.slot.RANGED, 1, 0, 0, 0, action, nil)

--- a/scripts/actions/abilities/fire_shot.lua
+++ b/scripts/actions/abilities/fire_shot.lua
@@ -36,8 +36,8 @@ abilityObject.onUseAbility = function(player, target, ability, action)
     dmg       = addBonusesAbility(player, xi.element.FIRE, target, dmg, params)
 
     local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
-    dmg            = dmg * applyResistanceAbility(player, target, xi.element.FIRE, xi.skill.NONE, bonusAcc)
-    dmg            = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.FIRE)
+    dmg            = math.floor(dmg * xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.FIRE, 0, 0, bonusAcc))
+    dmg            = math.floor(dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.FIRE))
 
     params.targetTPMult = 0 -- Quick Draw does not feed TP
     dmg                 = xi.ability.takeDamage(target, player, params, true, dmg, xi.attackType.MAGICAL, xi.damageType.FIRE, xi.slot.RANGED, 1, 0, 0, 0, action, nil)

--- a/scripts/actions/abilities/ice_shot.lua
+++ b/scripts/actions/abilities/ice_shot.lua
@@ -36,8 +36,8 @@ abilityObject.onUseAbility = function(player, target, ability, action)
     dmg       = addBonusesAbility(player, xi.element.ICE, target, dmg, params)
 
     local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
-    dmg            = dmg * applyResistanceAbility(player, target, xi.element.ICE, xi.skill.NONE, bonusAcc)
-    dmg            = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.ICE)
+    dmg            = math.floor(dmg * xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.ICE, 0, 0, bonusAcc))
+    dmg            = math.floor(dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.ICE))
 
     params.targetTPMult = 0 -- Quick Draw does not feed TP
     dmg                 = xi.ability.takeDamage(target, player, params, true, dmg, xi.attackType.MAGICAL, xi.damageType.ICE, xi.slot.RANGED, 1, 0, 0, 0, action, nil)

--- a/scripts/actions/abilities/light_shot.lua
+++ b/scripts/actions/abilities/light_shot.lua
@@ -30,7 +30,7 @@ abilityObject.onUseAbility = function(player, target, ability, action)
     action:setRecast(math.max(0, action:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
     local duration = 60
     local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
-    local resist   = applyResistanceAbility(player, target, xi.element.LIGHT, xi.skill.NONE, bonusAcc)
+    local resist   = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.LIGHT, 0, 0, bonusAcc)
 
     if resist < 0.5 then
         ability:setMsg(xi.msg.basic.JA_MISS_2) -- resist message

--- a/scripts/actions/abilities/modus_veritas.lua
+++ b/scripts/actions/abilities/modus_veritas.lua
@@ -17,7 +17,7 @@ abilityObject.onUseAbility = function(player, target, ability)
 
     if helix ~= nil then
         local mvPower = helix:getSubPower()
-        local resist  = applyResistanceAbility(player, target, xi.element.NONE, xi.skill.ELEMENTAL_MAGIC, 0)
+        local resist  = xi.combat.magicHitRate.calculateResistRate(player, target, 0, xi.skill.ELEMENTAL_MAGIC, 0, xi.element.NONE, 0, 0, 0)
         -- Doesn't work against NMs apparently
         if mvPower > 0 or resist < 0.25 or target:isNM() then -- Don't let Modus Veritas stack to prevent abuse
             ability:setMsg(xi.msg.basic.JA_MISS) --Miss

--- a/scripts/actions/abilities/pets/automaton/flashbulb.lua
+++ b/scripts/actions/abilities/pets/automaton/flashbulb.lua
@@ -10,18 +10,19 @@ end
 
 abilityObject.onAutomatonAbility = function(target, automaton, skill, master, action)
     automaton:addRecast(xi.recast.ABILITY, skill:getID(), 45)
-    local highest = automaton:getSkillLevel(xi.skill.AUTOMATON_MELEE)
-    local highestskill = 22
+    local highest        = automaton:getSkillLevel(xi.skill.AUTOMATON_MELEE)
+    local highestSkillId = xi.skill.AUTOMATON_MELEE
+
     if automaton:getSkillLevel(xi.skill.AUTOMATON_RANGED) > highest then
-        highestskill = 23
-        highest = automaton:getSkillLevel(xi.skill.AUTOMATON_RANGED)
+        highest        = automaton:getSkillLevel(xi.skill.AUTOMATON_RANGED)
+        highestSkillId = xi.skill.AUTOMATON_RANGED
     end
 
     if automaton:getSkillLevel(xi.skill.AUTOMATON_MAGIC) > highest then
-        highestskill = 24
+        highestSkillId = xi.skill.AUTOMATON_MAGIC
     end
 
-    local resist = applyResistanceAbility(automaton, target, 7, highestskill, 150)
+    local resist   = xi.combat.magicHitRate.calculateResistRate(automaton, target, 0, highestSkillId, 0, xi.element.LIGHT, 0, 0, 150)
     local duration = 12 * resist
 
     if resist > 0.0625 then

--- a/scripts/actions/abilities/pets/eerie_eye.lua
+++ b/scripts/actions/abilities/pets/eerie_eye.lua
@@ -19,14 +19,13 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
         bonus = bonus + xi.summon.getSummoningSkillOverCap(pet)
     end
 
-    local resist = applyResistanceAbility(pet, target, ele, xi.skill.ENFEEBLING_MAGIC, bonus)
-
+    local resist = xi.combat.magicHitRate.calculateResistRate(pet, target, 0, xi.skill.ENFEEBLING_MAGIC, 0, ele, 0, 0, bonus)
     -- https://wikiwiki.jp/ffxi/%E5%8F%AC%E5%96%9A%E9%AD%94%E6%B3%95
     -- TL;DR base 30s silence and 10s amnesia (also amnesia is fire element)
     if resist >= 0.5 then --Do it!
         if target:addStatusEffect(xi.effect.SILENCE, 1, 0, duration * resist) then
             petskill:setMsg(xi.msg.basic.JA_GAIN_EFFECT)
-            local resist2 = applyResistanceAbility(pet, target, xi.element.FIRE, xi.skill.ENFEEBLING_MAGIC, bonus)
+            local resist2 = xi.combat.magicHitRate.calculateResistRate(pet, target, 0, xi.skill.ENFEEBLING_MAGIC, 0, xi.element.FIRE, 0, 0, bonus)
             if
                 resist2 >= 0.5 and
                 target:addStatusEffect(xi.effect.AMNESIA, 1, 0, duration * resist2 / 3)

--- a/scripts/actions/abilities/pets/sonic_buffet.lua
+++ b/scripts/actions/abilities/pets/sonic_buffet.lua
@@ -23,7 +23,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.WIND)
     target:updateEnmityFromDamage(pet, damage)
 
-    local resist = applyResistanceAbility(pet, target, xi.element.WIND, xi.skill.NONE, 0) -- Does this get bonus macc from SMN skill?
+    local resist = xi.combat.magicHitRate.calculateResistRate(pet, target, 0, 0, 0, xi.element.WIND, 0, 0, 0)
     if resist > 0.0625 then -- Is there _any_ circumstance wherein a dispel adds a message? Based on testing it seems the ability is magic damage only visibly.
         target:dispelStatusEffect()
     end

--- a/scripts/actions/abilities/thunder_shot.lua
+++ b/scripts/actions/abilities/thunder_shot.lua
@@ -36,7 +36,7 @@ abilityObject.onUseAbility = function(player, target, ability, action)
     dmg       = addBonusesAbility(player, xi.element.THUNDER, target, dmg, params)
 
     local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
-    dmg            = dmg * applyResistanceAbility(player, target, xi.element.THUNDER, xi.skill.NONE, bonusAcc)
+    dmg            = dmg * xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.THUNDER, 0, 0, bonusAcc)
     dmg            = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.THUNDER)
 
     params.targetTPMult = 0 -- Quick Draw does not feed TP

--- a/scripts/actions/abilities/water_shot.lua
+++ b/scripts/actions/abilities/water_shot.lua
@@ -36,7 +36,7 @@ abilityObject.onUseAbility = function(player, target, ability, action)
     dmg       = addBonusesAbility(player, xi.element.WATER, target, dmg, params)
 
     local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
-    dmg            = dmg * applyResistanceAbility(player, target, xi.element.WATER, xi.skill.NONE, bonusAcc)
+    dmg            = dmg * xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.WATER, 0, 0, bonusAcc)
     dmg            = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.WATER)
 
     params.targetTPMult = 0 -- Quick Draw does not feed TP

--- a/scripts/actions/abilities/wind_shot.lua
+++ b/scripts/actions/abilities/wind_shot.lua
@@ -36,7 +36,7 @@ abilityObject.onUseAbility = function(player, target, ability, action)
     dmg       = addBonusesAbility(player, xi.element.WIND, target, dmg, params)
 
     local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
-    dmg            = dmg * applyResistanceAbility(player, target, xi.element.WIND, xi.skill.NONE, bonusAcc)
+    dmg            = dmg * xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.WIND, 0, 0, bonusAcc)
     dmg            = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.WIND)
 
     params.targetTPMult = 0 -- Quick Draw does not feed TP

--- a/scripts/actions/spells/black/bio.lua
+++ b/scripts/actions/spells/black/bio.lua
@@ -10,59 +10,25 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local skillLvl = caster:getSkillLevel(xi.skill.DARK_MAGIC)
-    local basedmg = skillLvl / 4
-    local params = {}
-    params.dmg = basedmg
-    params.multiplier = 1
-    params.skillType = xi.skill.DARK_MAGIC
-    params.attribute = xi.mod.INT
-    params.hasMultipleTargetReduction = false
-    params.diff = caster:getStat(xi.mod.INT)-target:getStat(xi.mod.INT)
-    params.bonus = 10
-
-    -- Calculate raw damage
-    local dmg = calculateMagicDamage(caster, target, spell, params)
-    -- Softcaps at 15, should always do at least 1
-    dmg = utils.clamp(dmg, 1, 15)
-    -- Get resist multiplier (1x if no resist)
-    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, spell:getSpellGroup(), xi.skill.DARK_MAGIC, 0, xi.element.DARK, xi.mod.INT, 0, 0)
-    -- Get the resisted damage
-    dmg = dmg * resist
-    -- Add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
-    dmg = addBonuses(caster, spell, target, dmg)
-    -- Add in target adjustment
-    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, spell:getElement())
-    -- Add in final adjustments including the actual damage dealt
-    local final = finalMagicAdjustments(caster, target, spell, dmg)
-
-    -- Calculate duration
-    local duration = 60
+    local damage = xi.spells.damage.useDamageSpell(caster, target, spell)
 
     -- Check for Dia
     local dia = target:getStatusEffect(xi.effect.DIA)
+    if dia and dia:getPower() > 1 then
+        return damage
+    else
+        target:delStatusEffect(xi.effect.DIA)
+    end
 
     -- Calculate DoT effect
     -- http://wiki.ffo.jp/html/1954.html
-    local dotdmg = 1
-    if skillLvl > 80 then
-        dotdmg = 3
-    elseif skillLvl > 40 then
-        dotdmg = 2
-    end
+    local power = caster:getSkillLevel(xi.skill.DARK_MAGIC)
+    power       = math.ceil(power / 40)
+    power       = utils.clamp(power, 1, 3)
 
-    -- Do it!
-    target:addStatusEffect(xi.effect.BIO, dotdmg, 3, duration, 0, 10, 1)
-    spell:setMsg(xi.msg.basic.MAGIC_DMG)
+    target:addStatusEffect(xi.effect.BIO, power, 3, 60, 0, 10, 1)
 
-    -- Try to kill same tier Dia (default behavior)
-    if xi.settings.main.DIA_OVERWRITE == 1 and dia ~= nil then
-        if dia:getPower() == 1 then
-            target:delStatusEffect(xi.effect.DIA)
-        end
-    end
-
-    return final
+    return damage
 end
 
 return spellObject

--- a/scripts/actions/spells/black/bio_ii.lua
+++ b/scripts/actions/spells/black/bio_ii.lua
@@ -10,56 +10,25 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local skillLvl = caster:getSkillLevel(xi.skill.DARK_MAGIC)
-    local basedmg = skillLvl / 4
-    local params = {}
-    params.dmg = basedmg
-    params.multiplier = 2
-    params.skillType = xi.skill.DARK_MAGIC
-    params.attribute = xi.mod.INT
-    params.hasMultipleTargetReduction = false
-    params.diff = caster:getStat(xi.mod.INT)-target:getStat(xi.mod.INT)
-    params.bonus = 10
-
-    -- Calculate raw damage
-    local dmg = calculateMagicDamage(caster, target, spell, params)
-    -- Softcaps at 30, should always do at least 1
-    dmg = utils.clamp(dmg, 1, 30)
-    -- Get resist multiplier (1x if no resist)
-    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, spell:getSpellGroup(), xi.skill.DARK_MAGIC, 0, xi.element.DARK, xi.mod.INT, 0, 0)
-    -- Get the resisted damage
-    dmg = dmg * resist
-    -- Add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
-    dmg = addBonuses(caster, spell, target, dmg)
-    -- Add in target adjustment
-    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, spell:getElement())
-    -- Add in final adjustments including the actual damage dealt
-    local final = finalMagicAdjustments(caster, target, spell, dmg)
-
-    -- Calculate duration
-    local duration = 120
+    local damage = xi.spells.damage.useDamageSpell(caster, target, spell)
 
     -- Check for Dia
     local dia = target:getStatusEffect(xi.effect.DIA)
+    if dia and dia:getPower() > 2 then
+        return damage
+    else
+        target:delStatusEffect(xi.effect.DIA)
+    end
 
     -- Calculate DoT effect
     -- http://wiki.ffo.jp/html/1954.html
-    -- This formula gives correct values for every breakpoint listed on that site
-    local dotdmg = math.floor((skillLvl + 29) / 40)
-    dotdmg = utils.clamp(dotdmg, 3, 8)
+    local power = caster:getSkillLevel(xi.skill.DARK_MAGIC)
+    power       = math.floor((power + 29) / 40)
+    power       = utils.clamp(power, 3, 8)
 
-    -- Do it!
-    target:addStatusEffect(xi.effect.BIO, dotdmg, 3, duration, 0, 15, 2)
-    spell:setMsg(xi.msg.basic.MAGIC_DMG)
+    target:addStatusEffect(xi.effect.BIO, power, 3, 120, 0, 15, 2)
 
-    -- Try to kill same tier Dia (default behavior)
-    if xi.settings.main.DIA_OVERWRITE == 1 and dia ~= nil then
-        if dia:getPower() <= 2 then
-            target:delStatusEffect(xi.effect.DIA)
-        end
-    end
-
-    return final
+    return damage
 end
 
 return spellObject

--- a/scripts/actions/spells/black/bio_iii.lua
+++ b/scripts/actions/spells/black/bio_iii.lua
@@ -10,81 +10,34 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local skillLvl = caster:getSkillLevel(xi.skill.DARK_MAGIC)
-    local basedmg = skillLvl / 4
-    local params = {}
-    params.dmg = basedmg
-    params.multiplier = 3
-    params.skillType = xi.skill.DARK_MAGIC
-    params.attribute = xi.mod.INT
-    params.hasMultipleTargetReduction = false
-    params.diff = caster:getStat(xi.mod.INT)-target:getStat(xi.mod.INT)
-    params.bonus = 1.0
-
-    -- Calculate raw damage
-    local dmg = calculateMagicDamage(caster, target, spell, params)
-    -- Softcaps at 62, should always do at least 1
-    dmg = utils.clamp(dmg, 1, 62)
-    -- Get resist multiplier (1x if no resist)
-    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, spell:getSpellGroup(), xi.skill.DARK_MAGIC, 0, xi.element.DARK, xi.mod.INT, 0, 0)
-    -- Get the resisted damage
-    dmg = dmg * resist
-    -- Add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
-    dmg = addBonuses(caster, spell, target, dmg)
-    -- Add in target adjustment
-    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, spell:getElement())
-    -- Add in final adjustments including the actual damage dealt
-    local final = finalMagicAdjustments(caster, target, spell, dmg)
-
-    -- Calculate duration
-    local duration = calculateDuration(180, spell:getSkillType(), spell:getSpellGroup(), caster, target)
+    local damage = xi.spells.damage.useDamageSpell(caster, target, spell)
 
     -- Check for Dia
     local dia = target:getStatusEffect(xi.effect.DIA)
+    if dia and dia:getPower() > 3 then
+        return damage
+    else
+        target:delStatusEffect(xi.effect.DIA)
+    end
 
     -- Calculate DoT effect
     -- http://wiki.ffo.jp/html/1954.html
-    -- this is a tiered calculation that has at least three tiers,
-    -- so I'll use breakpoints for human readability
-    local dotdmg = 5
-    if skillLvl > 400 then
-        dotdmg = 17
-    elseif skillLvl > 373 then
-        dotdmg = 16
-    elseif skillLvl > 346 then
-        dotdmg = 15
-    elseif skillLvl > 319 then
-        dotdmg = 14
-    elseif skillLvl > 291 then
-        dotdmg = 13
-    elseif skillLvl > 280 then
-        dotdmg = 12
-    elseif skillLvl > 269 then
-        dotdmg = 11
-    elseif skillLvl > 258 then
-        dotdmg = 10
-    elseif skillLvl > 246 then
-        dotdmg = 9
-    elseif skillLvl > 211 then
-        dotdmg = 8
-    elseif skillLvl > 171 then
-        dotdmg = 7
-    elseif skillLvl > 131 then
-        dotdmg = 6
+    local skillLevel = caster:getSkillLevel(xi.skill.DARK_MAGIC)
+    local power      = 0
+
+    if skillLevel > 291 then
+        power = 13 + math.floor((skillLevel - 291) / 27) -- 13 + 1 every 27 skill levels.
+    elseif skillLevel > 246 then
+        power = 9 + math.floor((skillLevel - 246) / 11) -- 9 + 1 every 11 skill levels.
+    else
+        power = 5 + math.floor((skillLevel - 106) / 35) -- 5 + 1 every 35 skill levels.
     end
 
-    -- Do it!
-    target:addStatusEffect(xi.effect.BIO, dotdmg, 3, duration, 0, 20, 3)
-    spell:setMsg(xi.msg.basic.MAGIC_DMG)
+    power = utils.clamp(power, 5, 17)
 
-    -- Try to kill same tier Dia (default behavior)
-    if xi.settings.main.DIA_OVERWRITE == 1 and dia ~= nil then
-        if dia:getPower() <= 3 then
-            target:delStatusEffect(xi.effect.DIA)
-        end
-    end
+    target:addStatusEffect(xi.effect.BIO, power, 3, 180, 0, 20, 3)
 
-    return final
+    return damage
 end
 
 return spellObject

--- a/scripts/enum/skill.lua
+++ b/scripts/enum/skill.lua
@@ -7,65 +7,69 @@ xi = xi or {}
 xi.skill =
 {
     -- Combat Skills
-    NONE = 0,
-    HAND_TO_HAND = 1,
-    DAGGER = 2,
-    SWORD = 3,
-    GREAT_SWORD = 4,
-    AXE = 5,
-    GREAT_AXE = 6,
-    SCYTHE = 7,
-    POLEARM = 8,
-    KATANA = 9,
-    GREAT_KATANA = 10,
-    CLUB = 11,
-    STAFF = 12,
-    -- 13~21 unused
-    AUTOMATON_MELEE = 22,
-    AUTOMATON_RANGED = 23,
-    AUTOMATON_MAGIC = 24,
-    ARCHERY = 25,
-    MARKSMANSHIP = 26,
-    THROWING = 27,
+    NONE              = 0,
+    HAND_TO_HAND      = 1,
+    DAGGER            = 2,
+    SWORD             = 3,
+    GREAT_SWORD       = 4,
+    AXE               = 5,
+    GREAT_AXE         = 6,
+    SCYTHE            = 7,
+    POLEARM           = 8,
+    KATANA            = 9,
+    GREAT_KATANA      = 10,
+    CLUB              = 11,
+    STAFF             = 12,
+
+    -- 13 to 21 unused
+
+    AUTOMATON_MELEE   = 22,
+    AUTOMATON_RANGED  = 23,
+    AUTOMATON_MAGIC   = 24,
+    ARCHERY           = 25,
+    MARKSMANSHIP      = 26,
+    THROWING          = 27,
 
     -- Defensive Skills
-    GUARD = 28,
-    EVASION = 29,
-    SHIELD = 30,
-    PARRY = 31,
+    GUARD             = 28,
+    EVASION           = 29,
+    SHIELD            = 30,
+    PARRY             = 31,
 
     -- Magic Skills
-    DIVINE_MAGIC = 32,
-    HEALING_MAGIC = 33,
-    ENHANCING_MAGIC = 34,
-    ENFEEBLING_MAGIC = 35,
-    ELEMENTAL_MAGIC = 36,
-    DARK_MAGIC = 37,
-    SUMMONING_MAGIC = 38,
-    NINJUTSU = 39,
-    SINGING = 40,
+    DIVINE_MAGIC      = 32,
+    HEALING_MAGIC     = 33,
+    ENHANCING_MAGIC   = 34,
+    ENFEEBLING_MAGIC  = 35,
+    ELEMENTAL_MAGIC   = 36,
+    DARK_MAGIC        = 37,
+    SUMMONING_MAGIC   = 38,
+    NINJUTSU          = 39,
+    SINGING           = 40,
     STRING_INSTRUMENT = 41,
-    WIND_INSTRUMENT = 42,
-    BLUE_MAGIC = 43,
-    GEOMANCY = 44,
-    HANDBELL = 45,
-    -- 46~47 unused
+    WIND_INSTRUMENT   = 42,
+    BLUE_MAGIC        = 43,
+    GEOMANCY          = 44,
+    HANDBELL          = 45,
+
+    -- 46 and 47 unused
 
     -- Crafting Skills
-    FISHING      = 48,
-    WOODWORKING  = 49,
-    SMITHING     = 50,
-    GOLDSMITHING = 51,
-    CLOTHCRAFT   = 52,
-    LEATHERCRAFT = 53,
-    BONECRAFT    = 54,
-    ALCHEMY      = 55,
-    COOKING      = 56,
-    SYNERGY      = 57,
+    FISHING           = 48,
+    WOODWORKING       = 49,
+    SMITHING          = 50,
+    GOLDSMITHING      = 51,
+    CLOTHCRAFT        = 52,
+    LEATHERCRAFT      = 53,
+    BONECRAFT         = 54,
+    ALCHEMY           = 55,
+    COOKING           = 56,
+    SYNERGY           = 57,
 
     -- Other Skills
-    RID          = 58,
-    DIG          = 59,
-    -- 60~63 unused
+    RID               = 58,
+    DIG               = 59,
+
+    -- 60 to 63 unused
     -- MAX_SKILLTYPE = 64
 }

--- a/scripts/globals/job_utils/beastmaster.lua
+++ b/scripts/globals/job_utils/beastmaster.lua
@@ -188,7 +188,7 @@ xi.job_utils.beastmaster.onUseAbilityTame = function(player, target, ability)
         return 0
     end
 
-    local resist = applyResistanceAbility(player, target, xi.element.NONE, xi.skill.NONE, player:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
+    local resist = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.NONE, xi.mod.INT, 0, 0)
 
     if resist <= 0.25 then
         ability:setMsg(xi.msg.basic.JA_MISS_2)

--- a/scripts/globals/job_utils/thief.lua
+++ b/scripts/globals/job_utils/thief.lua
@@ -417,9 +417,9 @@ xi.job_utils.thief.useSteal = function(player, target, ability, action)
     -- Attempt Aura steal
     -- local effect = xi.effect.NONE
     if player:hasTrait(xi.trait.AURA_STEAL) then
-        local resist = applyResistanceAbility(player, target, xi.element.NONE, 0, 0)
+        local resist = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.NONE, xi.mod.INT, 0, 0)
         -- local effectStealSuccess = false
-        if resist > 0.0625 then
+        if resist >= 0.25 then
             local auraStealChance = math.min(player:getMerit(xi.merit.AURA_STEAL), 95)
             if math.random(1, 100) <= auraStealChance then
                 local targetShadows = target:getMod(xi.mod.UTSUSEMI)

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -176,11 +176,6 @@ function isValidHealTarget(caster, target)
             target:getObjType() == xi.objType.FELLOW)
 end
 
--- Applies resistance for things that may not be spells - ie. Quick Draw
-function applyResistanceAbility(actor, target, element, skillType, bonusMacc)
-    return xi.combat.magicHitRate.calculateResistRate(actor, target, 0, skillType, 0, element, 0, 0, bonusMacc)
-end
-
 -- Applies resistance for additional effects
 function applyResistanceAddEffect(actor, target, element, bonusMacc)
     return xi.combat.magicHitRate.calculateResistRate(actor, target, 0, xi.skill.NONE, 0, element, 0, 0, bonusMacc)

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -106,24 +106,6 @@ function calculateMagicDamage(caster, target, spell, params)
     return dmg
 end
 
-function doEnspell(caster, target, spell, effect)
-    local duration = calculateDuration(180, spell:getSkillType(), spell:getSpellGroup(), caster, target)
-
-    --calculate potency
-    local magicskill = caster:getSkillLevel(xi.skill.ENHANCING_MAGIC)
-
-    local potency = 3 + math.floor(6 * magicskill / 100)
-    if magicskill > 200 then
-        potency = 5 + math.floor(5 * magicskill / 100)
-    end
-
-    if target:addStatusEffect(effect, potency, 0, duration) then
-        spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
-    else
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-end
-
 -----------------------------------
 --   getCurePower returns the caster's cure power
 --   getCureFinal returns the final cure amount

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -7,10 +7,6 @@ require('scripts/globals/utils')
 xi = xi or {}
 xi.magic = xi.magic or {}
 
--- USED FOR DAMAGING MAGICAL SPELLS (Stages 1 and 2 in Calculating Magic Damage on wiki)
-local softCap = 60 --guesstimated
-local hardCap = 120 --guesstimated
-
 -----------------------------------
 -- Returns the staff bonus for the caster and spell.
 -----------------------------------
@@ -79,31 +75,6 @@ local function calculateMagicBurst(caster, spell, target, params)
     burst = modburst * skillchainburst
 
     return burst
-end
-
-function calculateMagicDamage(caster, target, spell, params)
-    local dINT = caster:getStat(params.attribute) - target:getStat(params.attribute)
-    local dmg = params.dmg
-
-    if dINT <= 0 then --if dINT penalises, it's always M=1
-        dmg = dmg + dINT
-        if dmg <= 0 then --dINT penalty cannot result in negative damage (target absorption)
-            return 0
-        end
-    elseif dINT > 0 and dINT <= softCap then --The standard calc, most spells hit this
-        dmg = dmg + (dINT * params.multiplier)
-    elseif dINT > 0 and dINT > softCap and dINT < hardCap then --After softCap, INT is only half effective
-        dmg = dmg + softCap * params.multiplier + ((dINT - softCap) * params.multiplier) / 2
-    elseif dINT > 0 and dINT > softCap and dINT >= hardCap then --After hardCap, INT has no xi.effect.
-        dmg = dmg + hardCap * params.multiplier
-    end
-
-    if params.skillType == xi.skill.DIVINE_MAGIC and target:isUndead() then
-        -- 150% bonus damage
-        dmg = dmg * 1.5
-    end
-
-    return dmg
 end
 
 -----------------------------------

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -89,8 +89,15 @@ local pTable =
     [xi.magic.spell.WATER_VI      ] = { xi.mod.INT,    0, 1010,  1.5, 1010, 550,  6.5,  5.9,  4.9,  3.9, 2.95, 1.99,    1 }, -- I value Unknown. Guesstimate used.
     [xi.magic.spell.FLOOD         ] = { xi.mod.INT,    0,  552,    2,  700, 657,    2,    2,    2,    2,    2,    2,    2 },
     [xi.magic.spell.FLOOD_II      ] = { xi.mod.INT,   10,  710,    2,  800, 780,    2,    2,    2,    2,    2,    2,    2 },
+    [xi.magic.spell.IMPACT        ] = { xi.mod.INT,    0,  932,  2.3,  932, 525,    0,    0,    0,    0,    0,    0,    0 }, -- I value unknown. Guesstimate used.
     [xi.magic.spell.COMET         ] = { xi.mod.INT,    0,  964,  2.3, 1000, 850,    4, 3.75,  3.5,    3,    2,    1,    1 }, -- I value unknown. Guesstimate used.
     [xi.magic.spell.DEATH         ] = {          0,    0,   32,    0,   32,   0,    0,    0,    0,    0,    0,    0,    0 },
+
+    -- Bio as nuke
+    [xi.magic.spell.BIO           ] = { xi.mod.INT,    0,   10,    1,   10,   5,    0,    0,    0,    0,    0,    0,    0 },
+    [xi.magic.spell.BIO_II        ] = { xi.mod.INT,    0,   50,    1,   50,  10,    0,    0,    0,    0,    0,    0,    0 },
+    [xi.magic.spell.BIO_III       ] = { xi.mod.INT,    0,  100,  1.5,  100,  21,    0,    0,    0,    0,    0,    0,    0 },
+    [xi.magic.spell.BIO_IV        ] = { xi.mod.INT,    0,  125,  1.5,  125,  27,    0,    0,    0,    0,    0,    0,    0 },
 
     -- Helixes (Initial damage) https://www.bluegartr.com/threads/108196-Random-Facts-Thread-Magic?p=6817880&viewfull=1#post6817880
     [xi.magic.spell.GEOHELIX      ] = { xi.mod.INT,    0,   35,    1,   31, 100,    1,    1,  0.5,    0,    0,    0,    0 },

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -281,7 +281,7 @@ local function calculateHybridMagicDamage(tp, physicaldmg, attacker, target, wsP
     magicdmg = math.floor(magicdmg * (100 + wsd) / 100)
     magicdmg = math.floor(addBonusesAbility(attacker, wsParams.ele, target, magicdmg, wsParams))
     magicdmg = math.floor(magicdmg + calcParams.bonusfTP * physicaldmg)
-    magicdmg = math.floor(magicdmg * applyResistanceAbility(attacker, target, wsParams.ele, wsParams.skill, calcParams.bonusAcc))
+    magicdmg = math.floor(magicdmg * xi.combat.magicHitRate.calculateResistRate(attacker, target, 0, wsParams.skill, 0, wsParams.ele, 0, 0, wsParams.bonusAcc))
     magicdmg = math.floor(magicdmg * xi.spells.damage.calculateTMDA(target, wsParams.ele))
     magicdmg = math.floor(target:handleSevereDamage(magicdmg, false))
 
@@ -887,7 +887,7 @@ xi.weaponskills.doMagicWeaponskill = function(attacker, target, wsID, wsParams, 
 
         -- Calculate magical bonuses and reductions
         dmg = math.floor(addBonusesAbility(attacker, wsParams.ele, target, dmg, wsParams))
-        dmg = math.floor(dmg * applyResistanceAbility(attacker, target, wsParams.ele, wsParams.skill, gearAcc))
+        dmg = math.floor(dmg * xi.combat.magicHitRate.calculateResistRate(attacker, target, 0, wsParams.skill, 0, wsParams.ele, 0, 0, gearAcc))
         dmg = math.floor(dmg * xi.spells.damage.calculateTMDA(target, wsParams.ele))
         dmg = math.floor(target:handleSevereDamage(dmg, false))
 

--- a/scripts/items/aero_mufflers.lua
+++ b/scripts/items/aero_mufflers.lua
@@ -11,8 +11,8 @@ itemObject.onItemCheck = function(target, item, param, caster)
 end
 
 itemObject.onItemUse = function(target)
-    local effect = xi.effect.ENAERO
-    doEnspell(target, target, nil, effect)
+    local fakeSpell = GetSpell(xi.magic.spell.ENAERO)
+    xi.spells.enhancing.useEnhancingSpell(target, target, fakeSpell)
 end
 
 return itemObject

--- a/scripts/items/blizzard_gloves.lua
+++ b/scripts/items/blizzard_gloves.lua
@@ -11,8 +11,8 @@ itemObject.onItemCheck = function(target, item, param, caster)
 end
 
 itemObject.onItemUse = function(target)
-    local effect = xi.effect.ENBLIZZARD
-    doEnspell(target, target, nil, effect)
+    local fakeSpell = GetSpell(xi.magic.spell.ENBLIZZARD)
+    xi.spells.enhancing.useEnhancingSpell(target, target, fakeSpell)
 end
 
 return itemObject

--- a/scripts/items/fire_bracers.lua
+++ b/scripts/items/fire_bracers.lua
@@ -11,8 +11,8 @@ itemObject.onItemCheck = function(target, item, param, caster)
 end
 
 itemObject.onItemUse = function(target)
-    local effect = xi.effect.ENFIRE
-    doEnspell(target, target, nil, effect)
+    local fakeSpell = GetSpell(xi.magic.spell.ENFIRE)
+    xi.spells.enhancing.useEnhancingSpell(target, target, fakeSpell)
 end
 
 return itemObject

--- a/scripts/items/stone_bangles.lua
+++ b/scripts/items/stone_bangles.lua
@@ -11,8 +11,8 @@ itemObject.onItemCheck = function(target, item, param, caster)
 end
 
 itemObject.onItemUse = function(target)
-    local effect = xi.effect.ENSTONE
-    doEnspell(target, target, nil, effect)
+    local fakeSpell = GetSpell(xi.magic.spell.ENSTONE)
+    xi.spells.enhancing.useEnhancingSpell(target, target, fakeSpell)
 end
 
 return itemObject

--- a/scripts/items/thunder_mittens.lua
+++ b/scripts/items/thunder_mittens.lua
@@ -11,8 +11,8 @@ itemObject.onItemCheck = function(target, item, param, caster)
 end
 
 itemObject.onItemUse = function(target)
-    local effect = xi.effect.ENTHUNDER
-    doEnspell(target, target, nil, effect)
+    local fakeSpell = GetSpell(xi.magic.spell.ENTHUNDER)
+    xi.spells.enhancing.useEnhancingSpell(target, target, fakeSpell)
 end
 
 return itemObject

--- a/scripts/items/water_mitts.lua
+++ b/scripts/items/water_mitts.lua
@@ -11,8 +11,8 @@ itemObject.onItemCheck = function(target, item, param, caster)
 end
 
 itemObject.onItemUse = function(target)
-    local effect = xi.effect.ENWATER
-    doEnspell(target, target, nil, effect)
+    local fakeSpell = GetSpell(xi.magic.spell.ENWATER)
+    xi.spells.enhancing.useEnhancingSpell(target, target, fakeSpell)
 end
 
 return itemObject

--- a/scripts/zones/Nyzul_Isle/mobs/Amnaf_Psycheflayer.lua
+++ b/scripts/zones/Nyzul_Isle/mobs/Amnaf_Psycheflayer.lua
@@ -27,26 +27,6 @@ entity.onMobEngage = function(mob, target)
     mob:showText(mob, ID.text.CANNOT_LET_YOU_PASS)
 end
 
---[[
-entity.onSpikesDamage = function(mob, target, damage)
-    -- Amnaf's Ice Spikes from blm spell will process first on retail.
-    -- In battleutils.cpp the spike effect is checked before trying to process onSpikesDamage()
-    -- thus no status effect = no proc, but 2 spike effects can't coexist..
-    -- local resist = getEffectResistance(target, xi.effect.CURSE_I) -- NO, dont ever uncomment this.
-    local rnd = math.random (1, 100)
-    -- This res check is a little screwy till we get the server's resistance handling closer to retail.
-    -- looks like applyResistanceAddEffect() doesn't even handle status resistance, only elemental.
-    if resist > rnd or rnd <= 20 then
-        return 0, 0, 0
-    else
-        -- Estimated from https://youtu.be/7jsXnwkqMM4?t=5m42s
-        -- And yes it does overwrite itself
-        target:addStatusEffect(xi.effect.CURSE_I, 10, 0, 10)
-        return xi.subEffect.CURSE_SPIKES, xi.msg.basic.STATUS_SPIKES, xi.effect.CURSE_I
-    end
-end
-]]
-
 entity.onSpellPrecast = function(mob, spell)
     mob:showText(mob, ID.text.PHSHOOO)
 end

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -77,12 +77,8 @@ global_objects=(
 
     addBonuses
     addBonusesAbility
-    applyResistanceAbility
     applyResistanceEffect
-    adjustForTarget
     calculateDuration
-    calculateMagicDamage
-    doEnspell
     finalMagicAdjustments
     finalMagicNonSpellAdjustments
     getBaseCure
@@ -90,8 +86,6 @@ global_objects=(
     getCurePowerOld
     getCureFinal
     getBaseCureOld
-    getElementalDamageReduction
-    handleThrenody
     isValidHealTarget
 
     ForceCrash


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Death to magic.lua continues.

## Steps to test these changes
None.
