### PR TITLE
S2C XiPackets rework

### DIFF
--- a/src/map/CMakeLists.txt
+++ b/src/map/CMakeLists.txt
@@ -5,7 +5,6 @@ add_subdirectory(items)
 add_subdirectory(los)
 add_subdirectory(lua)
 add_subdirectory(packets)
-add_subdirectory(packets/c2s)
 add_subdirectory(utils)
 
 set(APP_SOURCES
@@ -21,7 +20,6 @@ set(SOURCES
     ${LOS_SOURCES}
     ${LUA_SOURCES}
     ${PACKET_SOURCES}
-    ${PACKET_C2S_SOURCES}
     ${UTIL_SOURCES}
     ${CMAKE_CURRENT_SOURCE_DIR}/ability.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ability.h

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -40,6 +40,7 @@
 
 #include "automatonentity.h"
 #include "battleentity.h"
+#include "packets/s2c/base.h"
 #include "petentity.h"
 
 #include "utils/fishingutils.h"
@@ -436,6 +437,20 @@ public:
     auto getPacketList() const -> const std::deque<std::unique_ptr<CBasicPacket>>&;
     auto getPacketListCopy() -> std::deque<std::unique_ptr<CBasicPacket>>; // Return a COPY of packet list
     void clearPacketList();
+
+    template <typename T>
+    void queuePacket(T pkt)
+    {
+        auto basicPacket = std::make_unique<CBasicPacket>();
+
+        basicPacket->setType(pkt.getId());
+        basicPacket->setSize(pkt.getSize());
+
+        // Add the packet data after the header
+        basicPacket->ref<uint8_t*>(sizeof(GP_SERV_HEADER)) = reinterpret_cast<uint8_t*>(&pkt);
+
+        pushPacket(std::move(basicPacket));
+    }
 
     template <typename T, typename... Args>
     void pushPacket(Args&&... args)

--- a/src/map/ipc_client.cpp
+++ b/src/map/ipc_client.cpp
@@ -48,6 +48,7 @@
 
 #include "items/item_linkshell.h"
 #include "packets/c2s/0x0b7_assist_channel.h"
+#include "packets/s2c/0x0dc_group_solicit_req.h"
 
 #include "utils/charutils.h"
 #include "utils/jailutils.h"
@@ -474,7 +475,11 @@ void IPCClient::handleMessage_PartyInvite(const IPP& ipp, const ipc::PartyInvite
         PInvitee->InvitePending.id     = message.inviterId;
         PInvitee->InvitePending.targid = message.inviterTargId;
 
-        PInvitee->pushPacket(std::make_unique<CPartyInvitePacket>(message.inviterId, message.inviterTargId, message.inviterName, message.inviteType));
+        PInvitee->queuePacket(GP_SERV_COMMAND_GROUP_SOLICIT_REQ{
+            .UniqueNo = message.inviterId,
+            .ActIndex = message.inviterTargId,
+            .Kind     = static_cast<uint8>(message.inviteType),
+        });
     }
 }
 

--- a/src/map/packets/CMakeLists.txt
+++ b/src/map/packets/CMakeLists.txt
@@ -1,4 +1,9 @@
+add_subdirectory(c2s)
+add_subdirectory(s2c)
+
 set(PACKET_SOURCES
+    ${PACKET_C2S_SOURCES}
+    ${PACKET_S2C_SOURCES}
     ${CMAKE_CURRENT_SOURCE_DIR}/action.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/action.h
     ${CMAKE_CURRENT_SOURCE_DIR}/auction_house.cpp
@@ -180,8 +185,6 @@ set(PACKET_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/party_define.h
     ${CMAKE_CURRENT_SOURCE_DIR}/party_effects.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/party_effects.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/party_invite.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/party_invite.h
     ${CMAKE_CURRENT_SOURCE_DIR}/party_map.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/party_map.h
     ${CMAKE_CURRENT_SOURCE_DIR}/party_member_update.cpp

--- a/src/map/packets/c2s/0x06e_group_solicit_req.cpp
+++ b/src/map/packets/c2s/0x06e_group_solicit_req.cpp
@@ -28,6 +28,7 @@
 #include "packets/message_standard.h"
 #include "packets/message_system.h"
 #include "packets/party_invite.h"
+#include "packets/s2c/0x0dc_group_solicit_req.h"
 #include "status_effect_container.h"
 #include "utils/blacklistutils.h"
 #include "utils/jailutils.h"
@@ -119,7 +120,13 @@ void GP_CLI_COMMAND_GROUP_SOLICIT_REQ::process(MapSession* PSession, CCharEntity
                     PInvitee->InvitePending.id     = PInviter->id;
                     PInvitee->InvitePending.targid = PInviter->targid;
 
-                    PInvitee->pushPacket<CPartyInvitePacket>(inviteeCharId, inviteeTargId, PInviter->getName(), INVITE_PARTY);
+                    PInvitee->queuePacket(GP_SERV_COMMAND_GROUP_SOLICIT_REQ{
+                        .UniqueNo = inviteeCharId,
+                        .ActIndex = inviteeTargId,
+                        .AnonFlag = PInviter->isAnon() ? static_cast<uint8_t>(1) : static_cast<uint8_t>(0),
+                        .Kind     = INVITE_PARTY,
+                        .sName    = {},
+                    });
 
                     ShowDebug("Sent party invite packet to %s", PInvitee->getName());
 
@@ -205,8 +212,13 @@ void GP_CLI_COMMAND_GROUP_SOLICIT_REQ::process(MapSession* PSession, CCharEntity
                     PInvitee->InvitePending.id     = PInviter->id;
                     PInvitee->InvitePending.targid = PInviter->targid;
 
-                    PInvitee->pushPacket<CPartyInvitePacket>(inviteeCharId, inviteeTargId, PInviter->getName(), INVITE_ALLIANCE);
-
+                    PInvitee->queuePacket(GP_SERV_COMMAND_GROUP_SOLICIT_REQ{
+                        .UniqueNo = inviteeCharId,
+                        .ActIndex = inviteeTargId,
+                        .AnonFlag = PInviter->isAnon() ? static_cast<uint8_t>(1) : static_cast<uint8_t>(0),
+                        .Kind     = INVITE_ALLIANCE,
+                        .sName    = {},
+                    });
                     ShowDebug("Sent party invite packet to %s", PInvitee->getName());
                 }
                 else

--- a/src/map/packets/s2c/0x0dc_group_solicit_req.cpp
+++ b/src/map/packets/s2c/0x0dc_group_solicit_req.cpp
@@ -1,7 +1,7 @@
 ﻿/*
 ===========================================================================
 
-  Copyright (c) 2010-2015 Darkstar Dev Teams
+  Copyright (c) 2025 LandSandBoat Dev Teams
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -19,21 +19,11 @@
 ===========================================================================
 */
 
-#include <cstring>
+#include "0x0dc_group_solicit_req.h"
 
-#include "party_invite.h"
-
-#include "entities/charentity.h"
-
-CPartyInvitePacket::CPartyInvitePacket(uint32 id, uint16 targid, const std::string& inviterName, INVITETYPE InviteType)
+auto GP_SERV_COMMAND_GROUP_SOLICIT_REQ::getSize() const -> uint16_t
 {
-    this->setType(0xDC);
-    this->setSize(0x20);
-
-    ref<uint32>(0x04) = id;
-    ref<uint16>(0x08) = targid;
-
-    ref<uint8>(0x0B) = InviteType;
-
-    std::memcpy(buffer_.data() + 0x0C, inviterName.c_str(), inviterName.size());
+    // Note: XiPackets claim 32 bytes, but the struct is only 30 bytes.
+    // Might be missing 2 bytes of padding at the end or just relying on FFXI usual 4 bytes alignment?
+    return sizeof(*this);
 }

--- a/src/map/packets/s2c/0x0dc_group_solicit_req.h
+++ b/src/map/packets/s2c/0x0dc_group_solicit_req.h
@@ -1,7 +1,7 @@
 ﻿/*
 ===========================================================================
 
-  Copyright (c) 2010-2015 Darkstar Dev Teams
+  Copyright (c) 2025 LandSandBoat Dev Teams
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -19,17 +19,16 @@
 ===========================================================================
 */
 
-#ifndef _CPARTYINVITEPACKET_H
-#define _CPARTYINVITEPACKET_H
+#pragma once
+#include "base.h"
 
-#include "common/cbasetypes.h"
-
-#include "basic.h"
-
-enum INVITETYPE
-{
-    INVITE_PARTY    = 0,
-    INVITE_ALLIANCE = 5,
-};
-
-#endif
+// https://github.com/atom0s/XiPackets/tree/main/world/server/0x00DC
+// This packet is sent by the server when the client is being invited to a party or alliance.
+GP_SERV_PACKET(GP_SERV_COMMAND_GROUP_SOLICIT_REQ, 0x0DC,
+               uint32_t UniqueNo;
+               uint16_t ActIndex;
+               uint8_t  AnonFlag;  // Flag set if the inviter is anon. (/anon)
+               uint8_t  Kind;      // The type of invite.
+               uint8_t  sName[16]; // The name of the player who invited the client
+               uint16_t RaceNo;    // The race id of the player who invited the client.
+);

--- a/src/map/packets/s2c/CMakeLists.txt
+++ b/src/map/packets/s2c/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(PACKET_S2C_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x0dc_group_solicit_req.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x0dc_group_solicit_req.h
+    PARENT_SCOPE
+)

--- a/src/map/packets/s2c/base.h
+++ b/src/map/packets/s2c/base.h
@@ -1,0 +1,49 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+// https://github.com/atom0s/XiPackets/blob/main/world/Header.md
+struct GP_SERV_HEADER
+{
+    uint16_t id : 9;
+    uint16_t size : 7;
+    uint16_t sync;
+};
+
+#define GP_SERV_PACKET(PacketName, PacketId, ...)       \
+    struct PacketName final                             \
+    {                                                   \
+        GP_SERV_HEADER header;                          \
+        __VA_ARGS__                                     \
+                                                        \
+        inline auto getName() const -> std::string_view \
+        {                                               \
+            return #PacketName;                         \
+        }                                               \
+                                                        \
+        inline auto getId() const -> uint16_t           \
+        {                                               \
+            return PacketId;                            \
+        }                                               \
+                                                        \
+        auto getSize() const -> uint16_t;               \
+    }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [ ] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

**Collecting feedback, NOT for merging.**

Proposing to rework S2C packets in a similar fashion to C2S.

Goals:
- Align definitions on XiPackets
- Get rid of ref notation when composing packets
- Reorganize files with proper XiPackets names and IDs
- (If possible) Embrace brace initialization as much as possible and get rid of the litany of constructors
  - Some packets are much too complex and will very likely still go through dedicated constructors/factory, i.e. Action

Out of scope:
- Ensuring LSB is composing packets in a retail accurate fashion
  - I'd fix the really obvious glaring issues but wouldn't spend too much time on it just yet
- Entity packets will probably be left to a separate focused effort
  - See past conversations in the many different rendering related issues

In details:
- Files laid out in src/map/packets/s2c
- Filename 0xXXX_xipackets_name.{cpp|h}
- Similar macro-based approach. The key difference is the size will need to be implemented as a method since some packets have multiple forms depending on their content. Kind of like unions but they're not exactly handled as such in the client.
  - Most packets will resolve to a simple sizeof though, +/- alignment
- New templated function on charentity to handle these new definitions and build CBasePacket around them
  - I am convinced there is a better syntax to be done here, looking for ideas and feedback.

Misc:
- Unsure why packets are created as unique_ptr and being copied several times today. Would appreciate some background.
- Wouldn't mind replacing the macro approach by straight templating but unsure how to approach it
- Unsure how to cleanly allow constructors while meeting all the requirements for enabling brace initialization
  - I don't mind going all in on constructors either but I'd like to emulate the way we send IPC messages.
- Might replace basic type declarations with their equivalent enum classes where there is one. 
  - This is a change I'm planning to make for C2S packets.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
