### PR TITLE
[lua] Update Pallas and JoJ with centralized Familiar function

### DIFF
--- a/scripts/zones/AlTaieu/mobs/Jailer_of_Justice.lua
+++ b/scripts/zones/AlTaieu/mobs/Jailer_of_Justice.lua
@@ -67,30 +67,16 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onMobWeaponSkill = function(target, mob, skill)
-    -- Don't lose TP from charm 2hr
-    if skill:getID() == xi.mobSkill.FAMILIAR_1 then -- Manually apply Familiar to all pets except first one
-        local mobId = mob:getID()
-        for i = 2, 6 do
-            local pet = GetMobByID(mobId + i)
-            if pet then
-                local hasFamiliar = pet:getLocalVar('hasFamiliar')
-                if
-                    pet:isSpawned() and
-                    hasFamiliar == 0
-                then
-                    -- Boost pet HP and stats by 10%
-                    local boost = math.floor(pet:getMaxHP() * 0.10)
-                    pet:setLocalVar('hasFamiliar', 1)
-                    pet:setMaxHP(pet:getMaxHP() + boost)
-                    pet:setHP(pet:getHP() + boost)
-                    pet:updateHealth()
-
-                    -- Boost stats by 10%
-                    pet:addMod(xi.mod.ATTP, 10)
-                    pet:addMod(xi.mod.ACC, mob:getMod(xi.mod.ACC) * 0.10)
-                    pet:addMod(xi.mod.EVA, mob:getMod(xi.mod.EVA) * 0.10)
-                    pet:addMod(xi.mod.DEFP, 10)
-                end
+    -- Manually apply Familiar to all pets except first one
+    if skill:getID() == xi.mobSkill.FAMILIAR_1 then
+        for _, petId in ipairs(pets) do
+            local pet = GetMobByID(petId)
+            if
+                pet and
+                pet ~= mob:getPet() and -- base familiar mobskill buffs this one
+                pet:isAlive()
+            then
+                xi.pet.applyFamiliarBuffs(mob, pet)
             end
         end
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Small tidyup on the two recent mobs that use familiar and it applies to their main pet as well as the additional pets

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- Spawn Pallas in vunkerl, `!setlocalvar petTimer 0` twice, `!hp 1`, set petTimer again to get a 3rd pet, see first 2 have same stats, see 3rd has lesser stats from being a weakling without Familiar buffs
- same for JoJ in AlTaieu