### PR TITLE
[Fix] SMN "I Can Hear a Rainbow" orange light adquisition

### DIFF
--- a/scripts/quests/windurst/SMN_I_Can_Hear_a_Rainbow.lua
+++ b/scripts/quests/windurst/SMN_I_Can_Hear_a_Rainbow.lua
@@ -58,6 +58,12 @@ local function handleZoneIn(player, prevZone)
         local zone    = player:getZone(true)
         local weather = zone:getWeather()
 
+        -- Exception: Handle Sunshine weather as weather ID 0 (NONE) for the time being.
+        if weather == xi.weather.SUNSHINE then
+            weather = xi.weather.NONE
+        end
+
+        -- Fetch weather element if it's a valid element.
         if validWeatherTable[weather] then
             local lightBitMask = quest:getVar(player, 'Light')
             local element      = xi.combat.element.getWeatherElement(weather)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Event expects weather ID 0, but said weather is unused. Or it may be the black skybox. In any case, added some exception logic to handle weather ID 1 (sunshine) to act as weather ID 0

## Steps to test these changes

Run the quest
