### PR TITLE
[lua] Bug fix - Gourmet Quest - Require zoning after completion

### DIFF
--- a/scripts/quests/bastok/Gourmet.lua
+++ b/scripts/quests/bastok/Gourmet.lua
@@ -2,7 +2,7 @@
 -- Gourmet
 -----------------------------------
 -- Log ID: 1, Quest ID: 12
--- Salimah : !pos -173 -5 64 235
+-- Salimah : !pos -31.687 -6.824 -73.282
 -----------------------------------
 
 local quest = Quest:new(xi.questLog.BASTOK, xi.quest.id.bastok.GOURMET)
@@ -64,21 +64,23 @@ quest.sections =
             ['Salimah'] =
             {
                 onTrade = function(player, npc, trade)
-                    for itemId, itemData in pairs(tradeItemData) do
-                        if npcUtil.tradeHasExactly(trade, itemId) then
-                            local timeOffset = VanadielHour() - 6
+                    if not quest:getMustZone(player) then
+                        for itemId, itemData in pairs(tradeItemData) do
+                            if npcUtil.tradeHasExactly(trade, itemId) then
+                                local timeOffset = VanadielHour() - 6
 
-                            if timeOffset < 0 then
-                                timeOffset = 24 + timeOffset
-                            end
+                                if timeOffset < 0 then
+                                    timeOffset = 24 + timeOffset
+                                end
 
-                            if
-                                timeOffset >= itemData[2] and
-                                timeOffset < itemData[3]
-                            then
-                                return quest:progressEvent(itemData[1], itemId)
-                            else
-                                return quest:progressEvent(203, itemId)
+                                if
+                                    timeOffset >= itemData[2] and
+                                    timeOffset < itemData[3]
+                                then
+                                    return quest:progressEvent(itemData[1], itemId)
+                                else
+                                    return quest:progressEvent(203, itemId)
+                                end
                             end
                         end
                     end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a zoning requirement to trade in more quest items for the repeat portion of the quest.
Corrects the coordinates of Salimah

## Steps to test these changes

`!zone <Bastok Markets>`
Talk to Salimah `!pos -31.687 -6.824 -73.282`
Talk to Rothais to know what item to trade Salimah
`!additem <Item indicated by Rothais>`
Trade item to Salimah
Try training another, should fail.
!goto <me>
Trade item to Salimah should succeed.

## Captures
https://youtu.be/28d2ZncyVpA
https://www.dropbox.com/scl/fi/xx4qxgycnqfofdj2h19y7/Quest-Bastok-Gourmet-Repeats.zip?rlkey=za3h95ogbvau41kg43levqniq&dl=0