### PR TITLE
[lua] Bug Fix - "A Purchase of Arms" Quest Auto Completion

### DIFF
--- a/scripts/quests/sandoria/A_Purchase_of_Arms.lua
+++ b/scripts/quests/sandoria/A_Purchase_of_Arms.lua
@@ -41,9 +41,10 @@ quest.sections =
             },
         },
     },
+
     {
         check = function(player, status, vars)
-            return status ~= xi.questStatus.QUEST_AVAILABLE and
+            return status == xi.questStatus.QUEST_ACCEPTED and
                 player:hasKeyItem(xi.ki.WEAPONS_ORDER)
         end,
 
@@ -66,15 +67,16 @@ quest.sections =
             },
         },
     },
+
     {
         check = function(player, status, vars)
-            return status == xi.questStatus.QUEST_AVAILABLE and
+            return status == xi.questStatus.QUEST_ACCEPTED and
                 not player:hasKeyItem(xi.ki.WEAPONS_ORDER)
         end,
 
         [xi.zone.JUGNER_FOREST] =
         {
-            ['Alexius'] = quest:message(forestID.text.ALEXIUS_ORDERS, xi.ki.WEAPONS_RECEIPT),
+            ['Alexius'] = quest:messageName(forestID.text.ALEXIUS_ORDERS, xi.ki.WEAPONS_RECEIPT, 0, 0, 0, true, false),
         },
 
         [xi.zone.SOUTHERN_SAN_DORIA] =
@@ -91,6 +93,7 @@ quest.sections =
             },
         },
     },
+
     {
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_COMPLETED


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes an issue where the quest auto-completes.
Fixes dialogue interaction with Alexius.

## Steps to test these changes

1. `!completequest 0 4`
2. `!zone <Southern San d'Oria>`
3. Talk to Helbort `!pos 71 -1 65 230`
4. Start quest
5. `!zone <Jugner Forest>`
6. Talk to Alexius `!pos 105 1 382 104`
7. `!zone <Southern San d'Oria>`
8. Talk to Helbort `!pos 71 -1 65 230`
9. Quest Complete

## Captures
https://youtu.be/KYsIm6yEtCc
https://www.dropbox.com/scl/fi/elf9bpevto7l28m2qguct/Quest-Sandoria-A-Purchase-of-Arms.zip?rlkey=cw8mhp59w65igyezkkx0yfdz0&dl=0