### PR TITLE
[lua] Bug Fix - The Rumor - Wrong Global status > questStatus

### DIFF
--- a/scripts/quests/sandoria/The_Rumor.lua
+++ b/scripts/quests/sandoria/The_Rumor.lua
@@ -41,6 +41,7 @@ quest.sections =
             },
         }
     },
+
     {
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_ACCEPTED
@@ -69,9 +70,10 @@ quest.sections =
             },
         },
     },
+
     {
-        check = function(player, status)
-            return status == xi.quest.status.COMPLETED
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_COMPLETED
         end,
 
         [xi.zone.BOSTAUNIEUX_OUBLIETTE] =


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes an error that occurs when interacting with Novalmauge.

## Steps to test these changes

1. `!zone <BOSTAUNIEUX_OUBLIETTE>
2. Talk to Novalmauge
3. `!additem VIAL_OF_BEASTMAN_BLOOD`
4. Trade to Novalmauge
5. Quest Complete
6. Talk to Novalmauge again.
