### PR TITLE
[lua] Remove Fame Requirement from quest "The Sweestest Things"

### DIFF
--- a/scripts/quests/sandoria/The_Sweetest_Things.lua
+++ b/scripts/quests/sandoria/The_Sweetest_Things.lua
@@ -26,8 +26,7 @@ quest.sections =
 {
     {
         check = function(player, status, vars)
-            return status == xi.questStatus.QUEST_AVAILABLE and
-                player:getFameLevel(xi.fameArea.SANDORIA) >= 2
+            return status == xi.questStatus.QUEST_AVAILABLE
         end,
 
         [xi.zone.SOUTHERN_SAN_DORIA] =


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Removes the fame requirement.

## Steps to test these changes

Set San d'Oria Fame to lvl 1.
`!zone <Southern San d'Oria>`
Talk to Raimbroy to start the quest sequence.

## Captures
Observed with a fresh lvl 1 character just created.
Packets Only:
https://drive.google.com/drive/folders/1Ur7v02t3a--FjP-fEMeVbaN3LXtXHYuT?usp=sharing