### PR TITLE
[core] [sql] [lua] Stat adjustments for Yovra, pick evasion rank based off both jobs for a mob

### DIFF
--- a/scripts/zones/AlTaieu/mobs/Omyovra.lua
+++ b/scripts/zones/AlTaieu/mobs/Omyovra.lua
@@ -12,8 +12,9 @@ end
 entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.REGEN, 50)
     mob:setMobMod(xi.mobMod.WEAPON_BONUS, mob:getMainLvl() - 2) -- Base damage is level * 2
-    -- Yovra have a +50% bonus to evasion and defense.
-    mob:addMod(xi.mod.EVA, mob:getStat(xi.mod.EVA) * 0.5)
+    mob:setMod(xi.mod.AGI, 76 - mob:getStat(xi.mod.AGI))        -- Jimmy indicates AGI for Omyovra should be 76 or so
+    -- Yovra have a +40% bonus to evasion and a 50% bonus to defense
+    mob:addMod(xi.mod.EVA, mob:getStat(xi.mod.EVA) * 0.4) -- TODO: need better evasion mod
     mob:addMod(xi.mod.DEF, mob:getStat(xi.mod.DEF) * 0.5)
     mob:hideName(true)
     mob:setUntargetable(true)

--- a/scripts/zones/AlTaieu/mobs/Ulyovra.lua
+++ b/scripts/zones/AlTaieu/mobs/Ulyovra.lua
@@ -12,8 +12,8 @@ end
 entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.REGEN, 50)
     mob:setMobMod(xi.mobMod.WEAPON_BONUS, mob:getMainLvl() - 2) -- Base damage is level * 2
-    -- Yovra have a +50% bonus to evasion and defense.
-    mob:addMod(xi.mod.EVA, mob:getStat(xi.mod.EVA) * 0.5)
+    -- Yovra have a +40% bonus to evasion and 50% to defense.
+    mob:addMod(xi.mod.EVA, mob:getStat(xi.mod.EVA) * 0.4) -- TODO: need better evasion mod
     mob:addMod(xi.mod.DEF, mob:getStat(xi.mod.DEF) * 0.5)
     mob:hideName(true)
     mob:setUntargetable(true)

--- a/sql/mob_family_system.sql
+++ b/sql/mob_family_system.sql
@@ -322,7 +322,7 @@ INSERT INTO `mob_family_system` VALUES (267,'Wyvern-Guivre',109,'Wyvern',10,'Dra
 INSERT INTO `mob_family_system` VALUES (268,'Wyvern-Undead',109,'Wyvern',10,'Dragon',1.00,40,109,90,4,2,3,4,6,3,3,1,3,1,3,8.0,1,0);
 INSERT INTO `mob_family_system` VALUES (269,'Xzomit',150,'Xzomit',15,'Luminian',0.00,50,100,110,3,2,4,6,4,5,1,1,3,1,3,0.0,1,0);
 INSERT INTO `mob_family_system` VALUES (270,'Yagudo',151,'Yagudo',7,'Beastmen',0.00,40,85,120,2,2,3,3,4,5,3,1,3,1,3,3.0,1,0);
-INSERT INTO `mob_family_system` VALUES (271,'Yovra',152,'Yovra',15,'Luminian',3.00,40,80,140,2,3,4,6,1,2,2,1,3,1,3,0.0,2,0);
+INSERT INTO `mob_family_system` VALUES (271,'Yovra',152,'Yovra',15,'Luminian',3.00,40,80,140,2,3,4,5,5,5,5,1,3,1,5,0.0,2,0);
 INSERT INTO `mob_family_system` VALUES (272,'Zdei',97,'Magic_Pot',16,'Luminion',0.00,40,100,140,6,3,4,4,1,3,4,1,3,1,3,0.0,1,0);
 INSERT INTO `mob_family_system` VALUES (273,'Scorpion-Serket',128,'Scorpion',20,'Vermin',3.00,40,90,120,3,5,4,4,4,4,4,1,3,1,3,4.0,258,0);
 INSERT INTO `mob_family_system` VALUES (274,'Scorpion-KingV',128,'Scorpion',20,'Vermin',3.00,40,90,120,3,5,4,4,4,4,4,1,3,1,3,4.0,2,0);

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -726,12 +726,12 @@ namespace mobutils
             }
         }
 
-        PMob->addModifier(Mod::DEF, GetBaseDefEva(PMob, PMob->defRank));                   // Base Defense for all mobs
-        PMob->addModifier(Mod::EVA, GetBaseDefEva(PMob, JobSkillRankToBaseEvaRank(mJob))); // Evasion is based off main job rank. // TODO: add family bonuses (colibri has static evasion+ porrogos have % boost.)
-        PMob->addModifier(Mod::ATT, GetBaseSkill(PMob, PMob->attRank));                    // Base Attack for all mobs is Rank A+ but pull from DB for specific cases
-        PMob->addModifier(Mod::ACC, GetBaseSkill(PMob, PMob->accRank));                    // Base Accuracy for all mobs is Rank A+ but pull from DB for specific cases
-        PMob->addModifier(Mod::RATT, GetBaseSkill(PMob, PMob->attRank));                   // Base Ranged Attack for all mobs is Rank A+ but pull from DB for specific cases
-        PMob->addModifier(Mod::RACC, GetBaseSkill(PMob, PMob->accRank));                   // Base Ranged Accuracy for all mobs is Rank A+ but pull from DB for specific cases
+        PMob->addModifier(Mod::DEF, GetBaseDefEva(PMob, PMob->defRank));                         // Base Defense for all mobs
+        PMob->addModifier(Mod::EVA, GetBaseDefEva(PMob, JobSkillRankToBaseEvaRank(mJob, sJob))); // Evasion is based off the highest job rank. // TODO: add family bonuses (colibri has static evasion+ porrogos have % boost.)
+        PMob->addModifier(Mod::ATT, GetBaseSkill(PMob, PMob->attRank));                          // Base Attack for all mobs is Rank A+ but pull from DB for specific cases
+        PMob->addModifier(Mod::ACC, GetBaseSkill(PMob, PMob->accRank));                          // Base Accuracy for all mobs is Rank A+ but pull from DB for specific cases
+        PMob->addModifier(Mod::RATT, GetBaseSkill(PMob, PMob->attRank));                         // Base Ranged Attack for all mobs is Rank A+ but pull from DB for specific cases
+        PMob->addModifier(Mod::RACC, GetBaseSkill(PMob, PMob->accRank));                         // Base Ranged Accuracy for all mobs is Rank A+ but pull from DB for specific cases
 
         // Known Base Parry for all mobs is Rank C
         // MOBMOD_CAN_PARRY uses the mod value as the rank, unknown if mobs in current retail or somewhere else have a different parry rank
@@ -1043,11 +1043,14 @@ namespace mobutils
         }
     }
 
-    uint8 JobSkillRankToBaseEvaRank(JOBTYPE job)
+    uint8 JobSkillRankToBaseEvaRank(JOBTYPE mjob, JOBTYPE sjob)
     {
-        uint8 evasionSkillRank = battleutils::GetSkillRank(SKILL_EVASION, job);
+        // Pick the best rank between the two jobs
+        // Lower is better
+        uint8 mainEvasionSkillRank = battleutils::GetSkillRank(SKILL_EVASION, mjob);
+        uint8 subEvasionSkillRank  = battleutils::GetSkillRank(SKILL_EVASION, sjob);
 
-        switch (evasionSkillRank)
+        switch (std::min(mainEvasionSkillRank, subEvasionSkillRank))
         {
             case 1:
             case 2:

--- a/src/map/utils/mobutils.h
+++ b/src/map/utils/mobutils.h
@@ -62,7 +62,7 @@ namespace mobutils
     void SetupDungeonInstanceMob(CMobEntity* PMob);
     void SetupPetSkills(CMobEntity* PMob);
 
-    uint8 JobSkillRankToBaseEvaRank(JOBTYPE job);
+    uint8 JobSkillRankToBaseEvaRank(JOBTYPE mjob, JOBTYPE sjob);
 
     uint16 GetWeaponDamage(CMobEntity* PMob, uint16 slot);
     uint16 GetMagicEvasion(CMobEntity* PMob);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Pick mob evasion rank based on both jobs, selecting the best one
Yovra adjustments based on the above findings and talks with jimmy

## Steps to test these changes

See more accurate stats
