### PR TITLE
[lua] Make JP for automaton hp/mp apply to deus ex automata

### DIFF
--- a/scripts/actions/abilities/deus_ex_automata.lua
+++ b/scripts/actions/abilities/deus_ex_automata.lua
@@ -9,11 +9,11 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    return xi.job_utils.puppetmaster.onAbilityCheckDeuxExAutomata(player, target, ability)
+    return xi.job_utils.puppetmaster.onAbilityCheckDeusExAutomata(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    return xi.job_utils.puppetmaster.onAbilityUseDeuxExAutomata(player, target, ability)
+    return xi.job_utils.puppetmaster.onAbilityUseDeusExAutomata(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/globals/job_utils/puppetmaster.lua
+++ b/scripts/globals/job_utils/puppetmaster.lua
@@ -85,11 +85,16 @@ xi.job_utils.puppetmaster.onAbilityUseActivate = function(player, target, abilit
         local jpValue = player:getJobPointLevel(xi.jp.AUTOMATON_HP_MP_BONUS)
         pet:addMod(xi.mod.HP, jpValue * 10)
         pet:addMod(xi.mod.MP, jpValue * 5)
+        pet:updateHealth()
+
+        -- ensure it spawns at full hp
+        pet:addHP(pet:getMod(xi.mod.HP))
+        pet:addMP(pet:getMod(xi.mod.MP))
     end
 end
 
--- On Ability Check Deux Ex Automata
-xi.job_utils.puppetmaster.onAbilityCheckDeuxExAutomata = function(player, target, ability)
+-- On Ability Check Deus Ex Automata
+xi.job_utils.puppetmaster.onAbilityCheckDeusExAutomata = function(player, target, ability)
     if player:getPet() ~= nil then
         return xi.msg.basic.ALREADY_HAS_A_PET, 0
     elseif not player:canUseMisc(xi.zoneMisc.PET) then
@@ -103,15 +108,21 @@ xi.job_utils.puppetmaster.onAbilityCheckDeuxExAutomata = function(player, target
     end
 end
 
--- On Ability Use Deux Ex Automata
-xi.job_utils.puppetmaster.onAbilityUseDeuxExAutomata = function(player, target, ability)
+-- On Ability Use Deus Ex Automata
+xi.job_utils.puppetmaster.onAbilityUseDeusExAutomata = function(player, target, ability)
     xi.pet.spawnPet(player, xi.petId.AUTOMATON)
     local pet = player:getPet()
 
     if pet then
+        local jpValue = player:getJobPointLevel(xi.jp.AUTOMATON_HP_MP_BONUS)
+        pet:addMod(xi.mod.HP, jpValue * 10)
+        pet:addMod(xi.mod.MP, jpValue * 5)
+        pet:updateHealth()
+
+        -- ensure it spawns at specific HPP/MPP based on level
         local percent = math.floor((player:getMainLvl() / 3)) / 100
-        pet:setHP(math.max(pet:getHP() * percent, 1))
-        pet:setMP(pet:getMP() * percent)
+        pet:setHP(math.max(pet:getMaxHP() * percent, 1))
+        pet:setMP(pet:getMaxMP() * percent)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Closed https://github.com/LandSandBoat/server/issues/8004

Small cleanup to [deus ex automata](https://www.bg-wiki.com/ffxi/Deus_Ex_Automata)
- add JP bonus HP/MP
- make % consider new max hp/mp since adding the mod doesn't give the hp to cap

Also made activate JA run `:updateHealth` so the UI immediately reflects updated values

confirmation from retail that activate and Deus Ex both provide JP bonus:
<img width="330" height="119" alt="image" src="https://github.com/user-attachments/assets/ab4fbfc3-201a-4662-a35f-9b8b37a9536c" />
<img width="314" height="128" alt="image" src="https://github.com/user-attachments/assets/0e0d4874-6371-46a7-950d-debb304c5a27" />


## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- `!changejob pup 99`
- `!addkeyitem JOB_BREAKER`
- `!setjobpoints <playername> 100`
- go to mog house and spend points in automaton hp/mp
- see activate and deus ex have same max hp/mp