### PR TITLE
Modules OnIncomingPacket

### DIFF
--- a/modules/custom/cpp/ah_pagination.cpp
+++ b/modules/custom/cpp/ah_pagination.cpp
@@ -21,9 +21,6 @@
 #include <functional>
 #include <numeric>
 
-extern uint8                                                                     PacketSize[512];
-extern std::function<void(MapSession* const, CCharEntity* const, CBasicPacket&)> PacketParser[512];
-
 class AHPaginationModule : public CPPModule
 {
     void OnInit() override
@@ -37,113 +34,127 @@ class AHPaginationModule : public CPPModule
             return;
         }
 
-        // If this is set to 7, the client won't let you put up more than 7 items. So, 6.
-        const auto ITEMS_PER_PAGE = 6U;
-        const auto TOTAL_PAGES    = originalAHListLimit == 0 ? 99 : (originalAHListLimit / 6U) + 1;
-
-        ShowInfo("[AH PAGES] AH_LIST_LIMIT is set to %i. Enabling pagination of %i pages with %i items per page.", originalAHListLimit, TOTAL_PAGES, ITEMS_PER_PAGE);
-
-        const auto originalHandler = PacketParser[0x04E];
-
-        const auto newHandler = [ITEMS_PER_PAGE, TOTAL_PAGES, originalHandler](MapSession* const PSession, CCharEntity* const PChar, CBasicPacket& data) -> void
-        {
-            TracyZoneScoped;
-
-            if (PChar->m_GMlevel == 0 && !PChar->loc.zone->CanUseMisc(MISC_AH))
-            {
-                ShowWarning("[AH PAGES] %s is trying to use the auction house in a disallowed zone [%s]", PChar->getName(), PChar->loc.zone->getName());
-                return;
-            }
-
-            // Only intercept for action 0x05: Open List Of Sales / Wait
-            const auto action = data.ref<uint8>(0x04);
-            if (action == 0x05)
-            {
-                const timer::time_point curTick = timer::now();
-                if (curTick > PChar->m_AHHistoryTimestamp + 1500ms)
-                {
-                    // Not const, because we're going to increment it below
-                    // This will get wiped on zoning
-                    auto currentAHPage = PChar->GetLocalVar("AH_PAGE");
-
-                    // Will only show the first time you access the AH until you zone again.
-                    // Since we do rollover of pages inline below.
-                    // This is also good for performance to not hammer the db completely.
-                    if (currentAHPage == 0) // Page "1"
-                    {
-                        // Get the current number of items the player has for sale
-                        const auto ahListings = [&]() -> uint32
-                        {
-                            const auto rset = db::preparedStmt("SELECT COUNT(*) FROM auction_house WHERE seller = ? AND sale = 0", PChar->id);
-                            FOR_DB_SINGLE_RESULT(rset)
-                            {
-                                return rset->get<uint32>(0);
-                            }
-
-                            return 0;
-                        }();
-                        PChar->pushPacket<CChatMessagePacket>(PChar, MESSAGE_SYSTEM_3, fmt::format("You have {} items listed for sale.", ahListings).c_str(), "");
-                    }
-
-                    PChar->SetLocalVar("AH_PAGE", (currentAHPage + 1) % TOTAL_PAGES);
-
-                    PChar->m_ah_history.clear();
-                    PChar->m_AHHistoryTimestamp = curTick;
-                    PChar->pushPacket<CAuctionHousePacket>(action);
-
-                    // Not const, because we're possibly going to overwrite it later
-                    auto rset = db::preparedStmt("SELECT itemid, price, stack FROM auction_house WHERE seller = ? and sale = 0 ORDER BY id ASC LIMIT ? OFFSET ?", PChar->id, ITEMS_PER_PAGE, currentAHPage * ITEMS_PER_PAGE);
-
-                    // If we get back 0 results, we're at the end of the list. We should redo the query and reset to page 1 (OFFSET 0)
-                    if (rset && rset->rowsCount() == 0)
-                    {
-                        PChar->pushPacket<CChatMessagePacket>(PChar, MESSAGE_SYSTEM_3, fmt::format("No results for page: {} of {}.", currentAHPage + 1, TOTAL_PAGES).c_str(), "");
-
-                        // Reset to Page 1
-                        // Overwrite the original rset here
-                        rset = db::preparedStmt("SELECT itemid, price, stack FROM auction_house WHERE seller = ? and sale = 0 ORDER BY id ASC LIMIT ? OFFSET 0", PChar->id, ITEMS_PER_PAGE);
-
-                        // Show Page 1 this time
-                        currentAHPage = 0;
-
-                        // Prepare Page 2 for next load
-                        PChar->SetLocalVar("AH_PAGE", currentAHPage + 1);
-                    }
-
-                    // TODO: Don't use TOTAL_PAGES here, use the actual number of pages of results.
-                    // Current (10 items): Current page: 2 of 99. Showing 4 items.
-                    // Desired (10 items): Current page: 2 of 2. Showing 4 items.
-                    PChar->pushPacket<CChatMessagePacket>(PChar, MESSAGE_SYSTEM_3, fmt::format("Current page: {} of {}. Showing {} items.", currentAHPage + 1, TOTAL_PAGES, rset->rowsCount()).c_str(), "");
-
-                    FOR_DB_MULTIPLE_RESULTS(rset)
-                    {
-                        PChar->m_ah_history.emplace_back(AuctionHistory_t{
-                            .itemid = rset->get<uint16>("itemid"),
-                            .stack  = rset->get<uint8>("stack"),
-                            .price  = rset->get<uint32>("price"),
-                            .status = 0,
-                        });
-                    }
-
-                    const auto totalItemsOnAh = PChar->m_ah_history.size();
-                    for (size_t slot = 0; slot < totalItemsOnAh; slot++)
-                    {
-                        PChar->pushPacket<CAuctionHousePacket>(static_cast<GP_CLI_COMMAND_AUC_COMMAND>(0x0C), static_cast<uint8>(slot), PChar);
-                    }
-                }
-                else
-                {
-                    PChar->pushPacket<CAuctionHousePacket>(static_cast<GP_CLI_COMMAND_AUC_COMMAND>(action), 246, 0, 0, 0, 0); // try again in a little while msg
-                }
-            }
-            else // Otherwise, call original handler
-            {
-                originalHandler(PSession, PChar, data);
-            }
-        };
-
-        PacketParser[0x04E] = newHandler;
+        totalPages_ = originalAHListLimit == 0 ? 99 : (originalAHListLimit / 6U) + 1;
+        ShowInfo("[AH PAGES] AH_LIST_LIMIT is set to %i. Enabling pagination of %i pages with %i items per page.", originalAHListLimit, totalPages_, itemsPerPage_);
     }
+
+    auto OnIncomingPacket(MapSession* session, CCharEntity* PChar, CBasicPacket& packet) -> bool override
+    {
+        if (packet.getType() != 0x04E)
+        {
+            return false;
+        }
+
+        if (PChar->m_GMlevel == 0 && !PChar->loc.zone->CanUseMisc(MISC_AH))
+        {
+            ShowWarning("[AH PAGES] %s is trying to use the auction house in a disallowed zone [%s]", PChar->getName(), PChar->loc.zone->getName());
+            return true;
+        }
+
+        const auto typedPacket = packet.as<GP_CLI_COMMAND_AUC>();
+
+        // Only intercept for action 0x05: Open List Of Sales / Wait
+        if (typedPacket->Command != GP_CLI_COMMAND_AUC_COMMAND::Info)
+        {
+            return false;
+        }
+
+        // Rate limit opening the AH Sales Info to once every 1.5 seconds
+        const timer::time_point curTick = timer::now();
+        if (curTick < PChar->m_AHHistoryTimestamp + 1500ms)
+        {
+            PChar->pushPacket<CAuctionHousePacket>(typedPacket->Command, 246, 0, 0, 0, 0); // try again in a little while msg
+            return true;
+        }
+
+        // Not const, because we're going to increment it below
+        // This will get wiped on zoning
+        auto currentAHPage = PChar->GetLocalVar("AH_PAGE");
+
+        // Will only show the first time you access the AH until you zone again.
+        // Since we do rollover of pages inline below.
+        // This is also good for performance to not hammer the db completely.
+        if (currentAHPage == 0) // Page "1"
+        {
+            // Get the current number of items the player has for sale
+            const auto ahListings = [&]() -> uint32
+            {
+                const auto rset = db::preparedStmt("SELECT COUNT(*) "
+                                                   "FROM auction_house "
+                                                   "WHERE seller = ? AND sale = 0",
+                                                   PChar->id);
+                FOR_DB_SINGLE_RESULT(rset)
+                {
+                    return rset->get<uint32>(0);
+                }
+
+                return 0;
+            }();
+            PChar->pushPacket<CChatMessagePacket>(PChar, MESSAGE_SYSTEM_3, fmt::format("You have {} items listed for sale.", ahListings).c_str(), "");
+        }
+
+        PChar->SetLocalVar("AH_PAGE", (currentAHPage + 1) % totalPages_);
+
+        PChar->m_ah_history.clear();
+        PChar->m_AHHistoryTimestamp = curTick;
+        PChar->pushPacket<CAuctionHousePacket>(typedPacket->Command);
+
+        // Not const, because we're possibly going to overwrite it later
+        auto rset = db::preparedStmt("SELECT itemid, price, stack "
+                                     "FROM auction_house "
+                                     "WHERE seller = ? and sale = 0 "
+                                     "ORDER BY id ASC "
+                                     "LIMIT ? OFFSET ?",
+                                     PChar->id, static_cast<uint32>(itemsPerPage_), static_cast<uint32>(currentAHPage * itemsPerPage_));
+
+        // If we get back 0 results, we're at the end of the list. We should redo the query and reset to page 1 (OFFSET 0)
+        if (rset && rset->rowsCount() == 0)
+        {
+            PChar->pushPacket<CChatMessagePacket>(PChar, MESSAGE_SYSTEM_3, fmt::format("No results for page: {} of {}.", currentAHPage + 1, totalPages_).c_str(), "");
+
+            // Reset to Page 1
+            // Overwrite the original rset here
+            rset = db::preparedStmt("SELECT itemid, price, stack "
+                                    "FROM auction_house "
+                                    "WHERE seller = ? and sale = 0 "
+                                    "ORDER BY id ASC "
+                                    "LIMIT ? OFFSET 0",
+                                    PChar->id, static_cast<uint32>(itemsPerPage_));
+
+            // Show Page 1 this time
+            currentAHPage = 0;
+
+            // Prepare Page 2 for next load
+            PChar->SetLocalVar("AH_PAGE", currentAHPage + 1);
+        }
+
+        // TODO: Don't use totalPages_ here, use the actual number of pages of results.
+        // Current (10 items): Current page: 2 of 99. Showing 4 items.
+        // Desired (10 items): Current page: 2 of 2. Showing 4 items.
+        PChar->pushPacket<CChatMessagePacket>(PChar, MESSAGE_SYSTEM_3, fmt::format("Current page: {} of {}. Showing {} items.", currentAHPage + 1, totalPages_, rset->rowsCount()).c_str(), "");
+
+        FOR_DB_MULTIPLE_RESULTS(rset)
+        {
+            PChar->m_ah_history.emplace_back(AuctionHistory_t{
+                .itemid = rset->get<uint16>("itemid"),
+                .stack  = rset->get<uint8>("stack"),
+                .price  = rset->get<uint32>("price"),
+                .status = 0,
+            });
+        }
+
+        const auto totalItemsOnAh = PChar->m_ah_history.size();
+        for (size_t slot = 0; slot < totalItemsOnAh; slot++)
+        {
+            PChar->pushPacket<CAuctionHousePacket>(GP_CLI_COMMAND_AUC_COMMAND::LotCancel, static_cast<uint8>(slot), PChar);
+        }
+
+        return true;
+    }
+
+    // If this is set to 7, the client won't let you put up more than 7 items. So, 6.
+    uint8 itemsPerPage_{ 6u };
+    uint8 totalPages_{ 1 };
 };
 
 REGISTER_CPP_MODULE(AHPaginationModule);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -2500,7 +2500,7 @@ void CLuaBaseEntity::sendMenu(uint32 menu)
             PChar->pushPacket<CShopItemsPacket>(PChar);
             break;
         case 3:
-            PChar->pushPacket<CAuctionHousePacket>(2);
+            PChar->pushPacket<CAuctionHousePacket>(GP_CLI_COMMAND_AUC_COMMAND::Open);
             break;
         default:
             ShowDebug("Menu %i not implemented, yet.", menu);

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -166,6 +166,7 @@
 #include "packets/c2s/0x11b_mastery_display.h"
 #include "packets/c2s/0x11c_party_request.h"
 #include "packets/c2s/0x11d_jump.h"
+#include "utils/moduleutils.h"
 
 uint8 PacketSize[512];
 
@@ -221,6 +222,12 @@ void ValidatedPacketHandler(MapSession* const PSession, CCharEntity* const PChar
 
     if (const auto result = packet->validate(PSession, PChar); result.valid())
     {
+        // Modules can optionally block processing of packets by returning true from OnIncomingPacket
+        if (moduleutils::OnIncomingPacket(PSession, PChar, data))
+        {
+            return;
+        }
+
         packet->process(PSession, PChar);
     }
     else

--- a/src/map/packets/auction_house.cpp
+++ b/src/map/packets/auction_house.cpp
@@ -30,16 +30,16 @@
 
 bool IsAuctionOpen = true; // Trading is allowed at the auction
 
-CAuctionHousePacket::CAuctionHousePacket(uint8 action)
+CAuctionHousePacket::CAuctionHousePacket(const GP_CLI_COMMAND_AUC_COMMAND action)
 {
     this->setType(0x4C);
     this->setSize(0x3C);
 
-    ref<uint8>(0x04) = action;
-    ref<uint8>(0x05) = 0xFF;
-    ref<uint8>(0x06) = IsAuctionOpen;
+    ref<GP_CLI_COMMAND_AUC_COMMAND>(0x04) = action;
+    ref<uint8>(0x05)                      = 0xFF;
+    ref<uint8>(0x06)                      = IsAuctionOpen;
 
-    if (action == 2)
+    if (action == GP_CLI_COMMAND_AUC_COMMAND::Open)
     {
         ref<uint8>(0x0A) = AUCTION_ID;
     }

--- a/src/map/packets/auction_house.h
+++ b/src/map/packets/auction_house.h
@@ -34,7 +34,7 @@ class CCharEntity;
 class CAuctionHousePacket : public CBasicPacket
 {
 public:
-    CAuctionHousePacket(uint8 action);                                                      // Send the auction menu
+    CAuctionHousePacket(GP_CLI_COMMAND_AUC_COMMAND action);                                 // Send the auction menu
     CAuctionHousePacket(GP_CLI_COMMAND_AUC_COMMAND action, uint8 slot, CCharEntity* PChar); // Send the list of items sold by a character
     CAuctionHousePacket(GP_CLI_COMMAND_AUC_COMMAND action, uint8 message, uint16 itemid, uint32 price, uint8 quantity, uint8 stacksize);
     CAuctionHousePacket(GP_CLI_COMMAND_AUC_COMMAND action, uint8 message, CCharEntity* PChar, uint8 slot, bool keepItem);

--- a/src/map/packets/c2s/0x04e_auc.cpp
+++ b/src/map/packets/c2s/0x04e_auc.cpp
@@ -34,7 +34,7 @@ auto GP_CLI_COMMAND_AUC::validate(MapSession* PSession, const CCharEntity* PChar
                   .mustEqual(Result, 0, "Result not 0")
                   .mustEqual(ResultStatus, 0, "Result status");
 
-    switch (static_cast<GP_CLI_COMMAND_AUC_COMMAND>(Command))
+    switch (Command)
     {
         case GP_CLI_COMMAND_AUC_COMMAND::AskCommit:
         {
@@ -79,6 +79,8 @@ auto GP_CLI_COMMAND_AUC::validate(MapSession* PSession, const CCharEntity* PChar
             pv.range("AucWorkIndex", AucWorkIndex, 0, 6);
         }
         break;
+        default:
+            break;
     }
 
     return pv;
@@ -88,7 +90,7 @@ void GP_CLI_COMMAND_AUC::process(MapSession* PSession, CCharEntity* PChar) const
 {
     const auto playerName = PChar->getName();
 
-    switch (static_cast<GP_CLI_COMMAND_AUC_COMMAND>(Command))
+    switch (Command)
     {
         case GP_CLI_COMMAND_AUC_COMMAND::AskCommit:
         {
@@ -126,5 +128,7 @@ void GP_CLI_COMMAND_AUC::process(MapSession* PSession, CCharEntity* PChar) const
             auctionutils::UpdateSaleListByPlayer(PChar, AucWorkIndex);
         }
         break;
+        default:
+            break;
     }
 }

--- a/src/map/packets/c2s/0x04e_auc.h
+++ b/src/map/packets/c2s/0x04e_auc.h
@@ -100,6 +100,7 @@ struct GP_AUC_PARAM
 
 enum class GP_CLI_COMMAND_AUC_COMMAND : uint8_t
 {
+    Open      = 0x02, // Only in S2C responses
     AskCommit = 0x04, // Used when placing an item up for sale; before confirmation.
     Info      = 0x05, // Used when opening the 'Sales Status' window.
     WorkCheck = 0x0A, // Used when opening the auction house.
@@ -112,10 +113,10 @@ enum class GP_CLI_COMMAND_AUC_COMMAND : uint8_t
 // https://github.com/atom0s/XiPackets/tree/main/world/client/0x004E
 // This packet is sent by the client when interacting with the auction house system.
 GP_CLI_PACKET(GP_CLI_COMMAND_AUC,
-              uint8_t      Command;      // PS2: Command
-              int8_t       AucWorkIndex; // PS2: AucWorkIndex
-              int8_t       Result;       // PS2: Result
-              int8_t       ResultStatus; // PS2: ResultStatus
-              GP_AUC_PARAM Param;        // PS2: Param
-              GP_AUC_BOX   Parcel;       // PS2: Parcel
+              GP_CLI_COMMAND_AUC_COMMAND Command;      // PS2: Command
+              int8_t                     AucWorkIndex; // PS2: AucWorkIndex
+              int8_t                     Result;       // PS2: Result
+              int8_t                     ResultStatus; // PS2: ResultStatus
+              GP_AUC_PARAM               Param;        // PS2: Param
+              GP_AUC_BOX                 Parcel;       // PS2: Parcel
 );

--- a/src/map/packets/c2s/validation.h
+++ b/src/map/packets/c2s/validation.h
@@ -156,6 +156,7 @@ public:
     }
 
     // Value must be contained in the enum class
+    // This handles comparing base types to enum values
     template <typename E>
     auto oneOf(const std::underlying_type_t<E> value) -> PacketValidator&
     {
@@ -165,6 +166,23 @@ public:
         {
             constexpr std::string_view enumTypeName = magic_enum::enum_type_name<E>();
             result_.addError(std::format("{} not a valid {} value.", value, enumTypeName));
+        }
+
+        return *this;
+    }
+
+    // Value must be contained in the enum class
+    // This handles comparing enum values to enum values
+    template <typename E>
+    auto oneOf(const E value) -> PacketValidator&
+    {
+        static_assert(std::is_enum_v<E>, "Template parameter E must be an enum");
+
+        if (!magic_enum::enum_contains<E>(value))
+        {
+            constexpr std::string_view enumTypeName    = magic_enum::enum_type_name<E>();
+            auto                       underlyingValue = static_cast<std::underlying_type_t<E>>(value);
+            result_.addError(std::format("{} not a valid {} value.", underlyingValue, enumTypeName));
         }
 
         return *this;

--- a/src/map/utils/auctionutils.cpp
+++ b/src/map/utils/auctionutils.cpp
@@ -86,7 +86,7 @@ void auctionutils::OpenListOfSales(CCharEntity* PChar)
     {
         PChar->m_ah_history.clear();
         PChar->m_AHHistoryTimestamp = curTick;
-        PChar->pushPacket<CAuctionHousePacket>(static_cast<uint8_t>(GP_CLI_COMMAND_AUC_COMMAND::Info));
+        PChar->pushPacket<CAuctionHousePacket>(GP_CLI_COMMAND_AUC_COMMAND::Info);
 
         // A single SQL query for the player's AH history which is stored in a Char Entity struct + vector.
         const auto rset = db::preparedStmt("SELECT itemid, price, stack FROM auction_house WHERE seller = ? AND sale=0 ORDER BY id ASC LIMIT 7", PChar->id);

--- a/src/map/utils/moduleutils.cpp
+++ b/src/map/utils/moduleutils.cpp
@@ -106,6 +106,21 @@ namespace moduleutils
         }
     }
 
+    auto OnIncomingPacket(MapSession* PSession, CCharEntity* PChar, CBasicPacket& packet) -> bool
+    {
+        TracyZoneScoped;
+
+        for (auto* module : cppModules())
+        {
+            if (module->OnIncomingPacket(PSession, PChar, packet))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     struct Override
     {
         std::string              filename;

--- a/src/map/utils/moduleutils.h
+++ b/src/map/utils/moduleutils.h
@@ -55,6 +55,10 @@ public:
     virtual void OnCharZoneIn(CCharEntity* PChar) {};
     virtual void OnCharZoneOut(CCharEntity* PChar) {};
     virtual void OnPushPacket(CCharEntity* PChar, const std::unique_ptr<CBasicPacket>& packet) {};
+    virtual auto OnIncomingPacket(MapSession* session, CCharEntity* PChar, CBasicPacket& packet) -> bool
+    {
+        return false;
+    };
 
     template <typename T>
     static T* Register()
@@ -80,6 +84,7 @@ namespace moduleutils
     void OnCharZoneIn(CCharEntity* PChar);
     void OnCharZoneOut(CCharEntity* PChar);
     void OnPushPacket(CCharEntity* PChar, const std::unique_ptr<CBasicPacket>& packet);
+    auto OnIncomingPacket(MapSession* PSession, CCharEntity* PChar, CBasicPacket& packet) -> bool;
 
     // The program has two "states":
     // - Load-time: As all data is being loaded and init'd


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

I know updates to the module interface is a touchy subject but this is absolutely required to be able to hide the `PacketParser` map from the global space - something I will be doing in my next C2S iteration.

The pattern used today is to replace the handler entirely in the `PacketParser` map to support one of these use cases:
- Modifying the behavior of specific packet types (either entirely or selectively)
  - `ah_pagination` is a good example
- Blocking certain packet types entirely
  - Not in this codebase but needed _to some degree_ for Era and custom garbage
- Post-processing after the original packet handler has completed
  - `ah_announcement` is a good example
  - This pattern is actually not served very well by my proposal since it is strictly 'Pre' by design to support blocking packets but I am not looking to introduce Pre/Post patterns _right now outside of a deeper module interface rework_.
- Supporting custom packet types
  - I haven't heard anyone doing it, but wouldn't be surprised if that was happening.

In detail:
- Introduce `OnIncomingPacket`, following the model of existing C++ module methods. 
- First module returning true will cancel the processing of the packet right here and then.
  - Conflicting modules dealing with the same packet may step on each other toes but if you get to that point you should reevaluate your life choices
  - Note that the packet validation remains mandatory and not skippable _by design_.
- The packet is passed as the base `CBasePacket`
  - Module implementers are expected to cast it to the right type with `.as<T>()`
  - The packet is non-const and can technically be modified by the handler. 

I have toyed with CRTP to make this work by implementing specialized packet handlers directly but it was several degrees of complexity above the rest of the module stuff.

Another pattern I thought of was letting modules explicitly register handlers in a way similar to Ashita addons but that would be inconsistent with the rest of the module interface.

Misc:
- Replaced one base type with enum class in the Auction House C2S packet. I brought it up in the S2C proposal and figured it was a good time to to test and introduce the pattern.
- I flipped a bunch of conditionals in ah_pagination so it's not as deeply nested as it was.

## Steps to test these changes
Tested with `ah_pagination` module

<!-- Clear and detailed steps to test your changes here -->
