### PR TITLE
[core] Move MesNum assignment to end of packet constructor

### DIFF
--- a/src/map/packets/message_special.cpp
+++ b/src/map/packets/message_special.cpp
@@ -57,7 +57,6 @@ CMessageSpecialPacket::CMessageSpecialPacket(CBaseEntity* PEntity, uint16 messag
     packet->num[3] = param3;
 
     packet->ActIndex = PEntity->targid;
-    packet->MesNum   = messageID;
 
     packet->Type = 0; // Old behavior is hardcoded to zero
     packet->Flag = 0; // Old behavior is hardcoded to zero
@@ -73,4 +72,6 @@ CMessageSpecialPacket::CMessageSpecialPacket(CBaseEntity* PEntity, uint16 messag
     {
         messageID += 0x8000;
     }
+
+    packet->MesNum = messageID;
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This oversight caused some QMs to print player name when it should not

## Steps to test these changes
in carpenters landing:
<img width="342" height="72" alt="image" src="https://github.com/user-attachments/assets/fd992818-8bf9-4504-af3e-ca78e264fdc8" />