### PR TITLE
[lua/cpp] Update utils.stoneskin to handle attackTypes

### DIFF
--- a/scripts/globals/utils.lua
+++ b/scripts/globals/utils.lua
@@ -465,28 +465,110 @@ function utils.counter(predicate)
     end
 end
 
+local compareStoneskinToDmg = function(target, skinPower, dmg)
+    if skinPower > 0 then
+        if skinPower > dmg then
+            return 0
+        else
+            target:setMod(xi.mod.STONESKIN, 0)
+            target:delStatusEffect(xi.effect.STONESKIN)
+            return dmg - skinPower
+        end
+    else
+        -- effect should not exist if it has no absorb left
+        target:setMod(xi.mod.STONESKIN, 0)
+        target:delStatusEffect(xi.effect.STONESKIN)
+
+        return dmg
+    end
+end
+
 -- returns unabsorbed damage
 ---@nodiscard
 ---@param target CBaseEntity
 ---@param dmg integer
+---@param attackType xi.attackType
 ---@return integer
-function utils.stoneskin(target, dmg)
-    --handling stoneskin
-    if dmg > 0 then
-        local skin = target:getMod(xi.mod.STONESKIN)
-        if skin > 0 then
-            if skin > dmg then --absorb all damage
-                target:delMod(xi.mod.STONESKIN, dmg)
-                return 0
-            else --absorbs some damage then wear
-                target:delStatusEffect(xi.effect.STONESKIN)
-                target:setMod(xi.mod.STONESKIN, 0)
-                return dmg - skin
-            end
-        end
+function utils.stoneskin(target, dmg, attackType)
+    -- For performance reasons, set mod > 0 even for special subType stoneskin effects
+    if
+        dmg <= 0 or
+        not target or
+        target:getMod(xi.mod.STONESKIN) <= 0
+    then
+        return dmg
     end
 
-    return dmg
+    local effect = target:getStatusEffect(xi.effect.STONESKIN)
+    if not effect then
+        return dmg
+    end
+
+    local subType = effect and effect:getSubType() or 0
+    local subPower = effect and effect:getSubPower() or 0
+
+    --handling stoneskin
+    local switchResult = switch(subType): caseof
+    {
+        -- Normal Stoneskin effect
+        [0] = function()
+            local skinPower = target:getMod(xi.mod.STONESKIN)
+            local adjustedDmg = compareStoneskinToDmg(target, skinPower, dmg)
+
+            effect = target:getStatusEffect(xi.effect.STONESKIN)
+            if effect then
+                -- effect wasn't removed, lower power
+                target:delMod(xi.mod.STONESKIN, dmg)
+            end
+
+            return adjustedDmg
+        end,
+
+        -- Stoneskin effect that absorbs only physical dmg
+        [1] = function()
+            if attackType ~= xi.attackType.PHYSICAL then
+                return dmg
+            end
+
+            local adjustedDmg = compareStoneskinToDmg(target, subPower, dmg)
+
+            effect = target:getStatusEffect(xi.effect.STONESKIN)
+            if effect then
+                -- effect wasn't removed, lower power
+                effect:setSubPower(subPower - dmg)
+            end
+
+            return adjustedDmg
+        end,
+
+        -- Stoneskin effect that absorbs only magical/breath/non-elemental dmg
+        [2] = function()
+            if
+                attackType ~= xi.attackType.MAGICAL and
+                attackType ~= xi.attackType.BREATH and
+                attackType ~= xi.attackType.SPECIAL
+            then
+                return dmg
+            end
+
+            local adjustedDmg = compareStoneskinToDmg(target, subPower, dmg)
+
+            effect = target:getStatusEffect(xi.effect.STONESKIN)
+            if effect then
+                -- effect wasn't removed, lower power
+                effect:setSubPower(subPower - dmg)
+            end
+
+            return adjustedDmg
+        end,
+    }
+
+    if switchResult then
+        return switchResult
+    end
+
+    -- no matches above means the stoneskin effect has improper subtype, delete it
+    return compareStoneskinToDmg(target, 0, dmg)
 end
 
 -- returns reduced magic damage from RUN buff, 'One for All'

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -5268,22 +5268,26 @@ namespace battleutils
         return damage;
     }
 
-    int32 HandleStoneskin(CBattleEntity* PDefender, int32 damage)
+    int32 HandleStoneskin(CBattleEntity* PDefender, int32 damage, ATTACK_TYPE attackType)
     {
-        int16 skin = PDefender->getMod(Mod::STONESKIN);
-        if (damage > 0 && skin > 0)
+        if (damage <= 0 || PDefender->getMod(Mod::STONESKIN) <= 0)
         {
-            if (skin > damage)
-            {
-                PDefender->delModifier(Mod::STONESKIN, damage);
-                return 0;
-            }
-
-            PDefender->StatusEffectContainer->DelStatusEffect(EFFECT_STONESKIN);
-            return damage - skin;
+            return damage;
         }
 
-        return damage;
+        auto adjustedDamage = damage;
+        auto stoneskinFunc  = lua["utils"]["stoneskin"];
+        if (stoneskinFunc.valid())
+        {
+            auto result = stoneskinFunc(PDefender, damage, attackType);
+
+            if (result.valid())
+            {
+                adjustedDamage = result.get<int32>();
+            }
+        }
+
+        return adjustedDamage;
     }
 
     auto HandleSevereDamage(CBattleEntity* PDefender, int32 damage, bool isPhysical) -> int32

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -226,7 +226,7 @@ namespace battleutils
     void BindBreakCheck(CBattleEntity* PAttacker, CBattleEntity* PDefender);
 
     // returns damage taken
-    int32 HandleStoneskin(CBattleEntity* PDefender, int32 damage);
+    int32 HandleStoneskin(CBattleEntity* PDefender, int32 damage, ATTACK_TYPE attackType = ATTACK_TYPE::NONE);
     int32 HandleOneForAll(CBattleEntity* PDefender, int32 damage);
     int32 HandleFanDance(CBattleEntity* PDefender, int32 damage);
     void  HandleScarletDelirium(CBattleEntity* PDefender, int32 damage);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Implements https://github.com/LandSandBoat/server/pull/5734, which enables the special Ruszor Stoneskin to function properly.

It seems like the `STONESKIN` mod has existed for a long time, and functions as a bit of shortcircuit on stoneskin logic to improve performance, so i've kept that and will update the Ruszor mobskills to set power 1 when they set subpower to continue having that.

This PR is in draft to ensure the paradigm is sound before I go and update every call to `HandleStoneskin` and `utils.stoneskin` and test things. It does function in its current form, though:

<img width="587" height="98" alt="image" src="https://github.com/user-attachments/assets/4aa2f7fe-34a5-4473-8d9b-2f97ac991f37" />

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
