### PR TITLE
[lua] getFameLevel magic numbers to enums, comparison operator >= consistency

### DIFF
--- a/scripts/quests/otherAreas/RQ2_Way_of_the_Cook.lua
+++ b/scripts/quests/otherAreas/RQ2_Way_of_the_Cook.lua
@@ -31,7 +31,7 @@ quest.sections =
                 onTrigger = function(player, npc)
                     if
                         player:getCharVar('Quest[4][0]DayCompleted') + 8 <= VanadielUniqueDay() and
-                        player:getFameLevel(xi.fameArea.WINDURST) > 2
+                        player:getFameLevel(xi.fameArea.WINDURST) >= 3
                     then
                         return quest:progressEvent(76, xi.item.BEEHIVE_CHIP, xi.item.SLICE_OF_DHALMEL_MEAT) -- Way of the Cook starting event.
                     else

--- a/scripts/quests/otherAreas/RQ3_Unending_Chase.lua
+++ b/scripts/quests/otherAreas/RQ3_Unending_Chase.lua
@@ -32,7 +32,7 @@ quest.sections =
                 onTrigger = function(player, npc)
                     if
                         player:getCharVar('Quest[4][1]DayCompleted') + 7 < VanadielUniqueDay() and
-                        player:getFameLevel(xi.fameArea.WINDURST) > 2
+                        player:getFameLevel(xi.fameArea.WINDURST) >= 3
                     then
                         if quest:getVar(player, 'Prog') == 0 then
                             return quest:progressEvent(82, xi.item.PUFFBALL) -- Unending Chase starting event.

--- a/scripts/quests/otherAreas/RQ4_His_Name_is_Valgeir.lua
+++ b/scripts/quests/otherAreas/RQ4_His_Name_is_Valgeir.lua
@@ -33,7 +33,7 @@ quest.sections =
                 onTrigger = function(player, npc)
                     if
                         player:getCharVar('Quest[4][2]DayCompleted') + 2 < VanadielUniqueDay() and
-                        player:getFameLevel(xi.fameArea.WINDURST) > 2
+                        player:getFameLevel(xi.fameArea.WINDURST) >= 3
                     then
                         return quest:progressEvent(86) -- His Name is Valgeir starting event.
                     else

--- a/scripts/quests/otherAreas/RQ5_Expertise.lua
+++ b/scripts/quests/otherAreas/RQ5_Expertise.lua
@@ -35,7 +35,7 @@ quest.sections =
             {
                 onTrigger = function(player, npc)
                     if
-                        player:getFameLevel(xi.fameArea.WINDURST) > 2 and
+                        player:getFameLevel(xi.fameArea.WINDURST) >= 3 and
                         player:getCharVar('Quest[4][3]DayCompleted') + 8 < VanadielUniqueDay()
                     then
                         return quest:progressEvent(61) -- Quest starting event.

--- a/scripts/quests/otherAreas/RQ6_The_Clue.lua
+++ b/scripts/quests/otherAreas/RQ6_The_Clue.lua
@@ -21,7 +21,7 @@ quest.sections =
     -- Section: Quest is available and never interacted.
     {
         check = function(player, status, vars)
-            return status == xi.questStatus.QUEST_AVAILABLE and player:getFameLevel(xi.fameArea.WINDURST) > 4 and
+            return status == xi.questStatus.QUEST_AVAILABLE and player:getFameLevel(xi.fameArea.WINDURST) >= 5 and
                 player:getQuestStatus(xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.EXPERTISE) == xi.questStatus.QUEST_COMPLETED
         end,
 

--- a/scripts/quests/otherAreas/RQ7_The_Basics.lua
+++ b/scripts/quests/otherAreas/RQ7_The_Basics.lua
@@ -24,7 +24,7 @@ quest.sections =
     -- Section: Quest is available.
     {
         check = function(player, status, vars)
-            return status == xi.questStatus.QUEST_AVAILABLE and player:getFameLevel(xi.fameArea.WINDURST) > 4 and
+            return status == xi.questStatus.QUEST_AVAILABLE and player:getFameLevel(xi.fameArea.WINDURST) >= 5 and
                 player:getQuestStatus(xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.THE_CLUE) == xi.questStatus.QUEST_COMPLETED
         end,
 

--- a/scripts/quests/sandoria/The_Generals_Secret.lua
+++ b/scripts/quests/sandoria/The_Generals_Secret.lua
@@ -18,7 +18,7 @@ quest.sections =
 {
     {
         check = function(player, status)
-            return status == xi.questStatus.QUEST_AVAILABLE and player:getFameLevel(xi.fameArea.SANDORIA) > 1
+            return status == xi.questStatus.QUEST_AVAILABLE and player:getFameLevel(xi.fameArea.SANDORIA) >= 2
         end,
 
         [xi.zone.CHATEAU_DORAGUILLE] =

--- a/scripts/zones/Mhaura/npcs/Nereus.lua
+++ b/scripts/zones/Mhaura/npcs/Nereus.lua
@@ -20,7 +20,7 @@ end
 entity.onTrigger = function(player, npc)
     if
         player:getQuestStatus(xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.A_POTTERS_PREFERENCE) == xi.questStatus.QUEST_AVAILABLE and
-        player:getFameLevel(xi.fameArea.WINDURST) > 5
+        player:getFameLevel(xi.fameArea.WINDURST) >= 6
     then
         player:startEvent(111, xi.item.DISH_OF_GUSGEN_CLAY) -- start quest A Potter's Preference
     elseif player:getQuestStatus(xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.A_POTTERS_PREFERENCE) == xi.questStatus.QUEST_ACCEPTED then

--- a/scripts/zones/Rabao/npcs/Waylea.lua
+++ b/scripts/zones/Rabao/npcs/Waylea.lua
@@ -8,7 +8,7 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(57 + (player:getFameLevel(4) - 1))
+    player:startEvent(57 + (player:getFameLevel(xi.fameArea.SELBINA_RABAO) - 1))
 end
 
 return entity

--- a/scripts/zones/Windurst_Waters/npcs/Zabirego-Hajigo.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Zabirego-Hajigo.lua
@@ -6,7 +6,7 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    local fame = player:getFameLevel(2)
+    local fame = player:getFameLevel(xi.fameArea.WINDURST)
     if fame == 9 then
         player:startEvent(784)
     else


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Changes getFameLevel magic numbers to xi.fameArea enums
- Changes getFameLevel comparison operators to be consistent with existing getFameLevel checks (e.g. use >=3 instead of >2)

## Steps to test these changes

**Rycharde Chain:**

!pos 17.451 -16.000 88.815 249
**_Prequest RQ1:_** 
Talk to Numi Adaligo, Take and Rycharde
!additem 4359 2 
Trade to 2x Dhalmel Meat Rycharde

**_RQ2:_**
Set CharVar Quest[4][0]DayCompleted to 0
!setfamelevel 2 2
!goto \<me\>
Talk to Rycharde: quest not available
!setfamelevel 2 3
Talk to Rycharde: quest available
!additem 912
!additem 4359
Trade Dhalmel Meat and Beehive Chip to Rycharde

**_RQ3:_**
Set Quest[4][1]DayCompleted to 0
!goto \<me\>
!setfamelevel 2 2
Talk to Rycharde: quest not available
!setfamelevel 2 3
Talk to Rycharde: quest available
!additem 4448
Trade Puffball to Rycharde

**_RQ4:_**
Set Quest[4][2]DayCompleted to 0
!goto \<me\>
!setfamelevel 2 2
Talk to Rycharde: quest not available
!setfamelevel 2 3
Talk to Rycharde: quest available
!zone Selbina
!gotoname Valgeir
Talk to Valgeir
!zone Mhaura
!gotoname Rycharde
Talk to Rycharde

**_RQ5:_**
Set Quest[4][3]DayCompleted to 0
!goto \<me\>
Talk to Rycharde
!gotoname Take
!setfamelevel 2 2
Talk to Take: quest not available
!setfamelevel 2 3
Talk to Take: quest available
!zone Selbina
!gotoname Valgeir
Talk to Valgeir
!additem 4447
!additem 4400
Trade Scream fungus and Land crab meat to Valgeir
Set Quest[4][4]readyTime to 0
!goto \<me\>
!zone Mhaura
!gotoname Take
Talk to Take

**_RQ6:_**
!gotoname Rycharde
Set Quest[4][4]DayCompleted to 0
!goto \<me\>
!setfamelevel 2 4
Talk to Rycharde: quest not available
!setfamelevel 2 5
Talk to Rycharde.
Talk to Rycharde again: quest available
!additem 4357 4
Trade 4x Crawler Egg to Rycharde

**_RQ7:_**
Set Quest[4][5]DayCompleted to 0
!goto \<me\>
!setfamelevel 2 4
Talk to Rycharde: quest not available
!setfamelevel 2 5
Talk to Rycharde: quest available

**The General's Secret:**
!zone Chateau d'Oraguille
!gotoname Curilla 1
!setfamelevel 0 1
Talk to Curilla: quest not available
!setfamelevel 0 2
Talk to Curilla: quest available

**A Potter's Preference**
!zone Mhaura
!gotoname Nereus
!setfamelevel 2 5
Talk to Nereus: quest not available
!setfamelevel 2 6
Talk to Nereus: quest available

**Waylea (Rabao Reputation):**
!zone Rabao
!gotoname Waylea
!setfamelevel 0 1
!setfamelevel 1 1
!setfamelevel 4 1
Talk to Waylea: "Never heard that name before. Is that somebody famous?"
!setfamelevel 4 9
Talk to Waylea: "I've known you since you were just starting out"

**Zabirego-Hajigo (Windurst Reputation):**
!zone Windurst Waters
!gotoname Zabirego-Hajigo
!setfamelevel 2 1
Talk to Zabirego-Hajigo: "Sorry, but I never head that name before."
!setfamelevel 2 9
Talk to Zabirego-Hajigo: "I am honored to have the hero of Windurst in my presence."