### PR TITLE
[sql] NM Xolotl HP adjustment

### DIFF
--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -321,7 +321,7 @@ INSERT INTO `mob_groups` VALUES (38,2770,7,'Mummy',330,1,678,0,0,62,64,0);
 INSERT INTO `mob_groups` VALUES (39,2407,7,'Lich',330,1,958,0,0,62,64,0);
 INSERT INTO `mob_groups` VALUES (40,801,7,'Corse',330,1,517,0,0,66,67,0);
 INSERT INTO `mob_groups` VALUES (41,733,7,'Citipati',0,33,475,0,0,67,70,0);
-INSERT INTO `mob_groups` VALUES (42,4396,7,'Xolotl',0,1,2683,0,0,80,81,0);
+INSERT INTO `mob_groups` VALUES (42,4396,7,'Xolotl',0,1,2683,20000,20000,80,81,0);
 INSERT INTO `mob_groups` VALUES (43,4397,7,'Xolotls_Hound_Warrior',0,128,0,0,0,72,72,0);
 INSERT INTO `mob_groups` VALUES (44,4398,7,'Xolotls_Sacrifice',0,128,0,0,0,72,72,0);
 INSERT INTO `mob_groups` VALUES (45,225,7,'Arch_Corse',330,1,162,0,0,75,81,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Increases Xolotl HP from 4.699 HP to 20.000 HP.

Skold from FFXI Captures Discord:
```
Defeated Xolotl's Sacrifice: 4491~4672 HP
Defeated Xolotl's Hound Warrior: 1434~4762 HP
Defeated Xolotl's Sacrifice: 4425~4572 HP
Defeated Xolotl's Hound Warrior: 2803~4575 HP
Defeated Xolotl's Sacrifice: 4557~4671 HP
Defeated Xolotl: 16393~23449 HP
Defeated Xolotl's Hound Warrior: 4404~5169 HP
Defeated Xolotl's Sacrifice: 4181~6135 HP
```

Additionally https://www.youtube.com/watch?v=GFXR1idcdj0 shows the 50% health mark is reached after about 10.000 damage, but a full damage parse is inaccurate due to charms causing de-aggro and Xolotl healing on roam.

As a result, 20.000 HP should be relatively close to the actual Xolotl HP, and at least a vast improvement over 4.699 HP.
Matched MP to 20.000 for consistency.

## Steps to test these changes

!zone Attohwa Chasm
!gotoname Xolotl
!getstats 1
Xolotl should display as having 20.000 HP.