### PR TITLE
[core][lua] Mob Base Damage Plumbing

### DIFF
--- a/scripts/enum/mob_mod.lua
+++ b/scripts/enum/mob_mod.lua
@@ -94,4 +94,7 @@ xi.mobMod =
     CLAIM_TYPE             = 83, -- Changes the claim behavior of the mob. See xi.claimType enum.
     NO_SPELL_COST          = 84, -- Mob does not use MP when casting spells
     ASTRAL_PET_OFFSET      = 85, -- If non-zero, defines the offset from main mob's ID for astral flow (if zero, will assume offset of 2)
+    BASE_DAMAGE_MULTIPLIER = 86, -- Multiplies the mob's base damage. Example: 150 = x1.5
+    DAMAGE_OFFSET          = 87, -- Adds or subtracts the mob's base damage offset.
+    RANGED_DAMAGE_OFFSET   = 88, -- Adds or subtracts the mob's ranged base damage offset.
 }

--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -113,7 +113,24 @@ xi.combat.physical.calculateAttackDamage = function(actor, target, slot, physica
 
     if isH2H then
         local naturalH2hDamage = math.floor(actor:getSkillLevel(xi.skill.HAND_TO_HAND) * 0.11) + 3
-        if physicalAttackType == xi.physicalAttackType.KICK then
+        local kickDamage = 0
+
+        if actor:isMob() then
+            local mobH2HPenalty = 1.0
+            local regionID      = actor:getCurrentRegion()
+
+            if regionID <= xi.region.LIMBUS then
+                mobH2HPenalty = 0.425 -- Vanilla - COP
+            else
+                mobH2HPenalty = 0.650
+            end
+
+            if physicalAttackType == xi.physicalAttackType.KICK then
+                kickDamage = actor:getMod(xi.mod.KICK_DMG)
+            end
+
+            baseDamage = (actor:getWeaponDmg() + kickDamage + bonusBasePhysicalDamage + xi.combat.physical.calculateMeleeStatFactor(actor, target)) * mobH2HPenalty
+        elseif physicalAttackType == xi.physicalAttackType.KICK then
             baseDamage = naturalH2hDamage + actor:getMod(xi.mod.KICK_DMG) + bonusBasePhysicalDamage + xi.combat.physical.calculateMeleeStatFactor(actor, target)
         else
             baseDamage = naturalH2hDamage + actor:getWeaponDmg() + bonusBasePhysicalDamage + xi.combat.physical.calculateMeleeStatFactor(actor, target)

--- a/src/map/attackround.cpp
+++ b/src/map/attackround.cpp
@@ -175,7 +175,7 @@ CBattleEntity* CAttackRound::GetCoverAbilityUserEntity()
  ************************************************************************/
 bool CAttackRound::IsH2H()
 {
-    if (auto* weapon = dynamic_cast<CItemWeapon*>(m_attacker->m_Weapons[SLOT_MAIN]); m_attacker->objtype == TYPE_PC)
+    if (auto* weapon = dynamic_cast<CItemWeapon*>(m_attacker->m_Weapons[SLOT_MAIN]))
     {
         return weapon->getSkillType() == SKILL_HAND_TO_HAND;
     }
@@ -488,12 +488,12 @@ bool CAttackRound::AddFollowUpAttack(PHYSICAL_ATTACK_DIRECTION direction)
  ************************************************************************/
 void CAttackRound::CreateKickAttacks()
 {
-    if (m_attacker->objtype == TYPE_PC && IsH2H())
+    if (IsH2H())
     {
         // kick attack mod (All jobs)
         uint16 kickAttack = m_attacker->getMod(Mod::KICK_ATTACK_RATE);
 
-        if (m_attacker->GetMJob() == JOB_MNK) // MNK (Main job)
+        if (m_attacker->GetMJob() == JOB_MNK && m_attacker->objtype == TYPE_PC) // MNK (Main job)
         {
             kickAttack += ((CCharEntity*)m_attacker)->PMeritPoints->GetMeritValue(MERIT_KICK_ATTACK_RATE, (CCharEntity*)m_attacker);
         }

--- a/src/map/mob_modifier.h
+++ b/src/map/mob_modifier.h
@@ -114,6 +114,9 @@ enum MOBMODIFIER : int
     MOBMOD_CLAIM_TYPE             = 83, // Changes the claim behavior of the mob. See ClaimType enum.
     MOBMOD_NO_SPELL_COST          = 84, // Mob does not use MP when casting spells
     MOBMOD_ASTRAL_PET_OFFSET      = 85, // If non-zero, defines the offset from main mob's ID for astral flow (if zero, will assume offset of 2)
+    MOBMOD_BASE_DAMAGE_MULTIPLIER = 86, // Multiplies the mob's base damage. Example: 150 = x1.5
+    MOBMOD_DAMAGE_OFFSET          = 87, // Adds or subtracts the mob's base damage offset.
+    MOBMOD_RANGED_DAMAGE_OFFSET   = 88, // Adds or subtracts the mob's ranged base damage offset.
 };
 
 #endif


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

1. Resolves https://github.com/LandSandBoat/server/issues/8174
 * Moved the `objtype == TYPE_PC` check from `CAttackRound::IsH2H()` to `CAttackRound::CreateKickAttacks()` in the block that checks for MERIT_KICK_ATTACK_RATE to prevent crash when called by non PC.
 
2. Allow mobs to utilize kick attacks(Previously was players only). I observed this happening on normal MNK mobs on retail.

3. First draft of implementing closer to retail mob base damage using [Jimmayus's data](https://docs.google.com/spreadsheets/d/1YBoveP-weMdidrirY-vPDzHyxbEI2ryECINlfCnFkLI/edit?pli=1&gid=1743955268#gid=1743955268).

4. Implements mob H2H auto attack damage penalty using above data in link.

To summarize the data:

* Vanilla - COP Zones: Normal mob damage is Level + 2 offset (Currently what LSB uses)

* TOAU Zones: Level + 10 offset

* WOTG+: Level + 11 offset

* Some mob families have custom offsets.

* Mobs in beginner zones outside the 3 cities have an additional -1 offset compared to normal.

* Some mobs have a multiplier to the base damage value but before the offset.

* Some mobs such as Korrigans/Tauri have their offset included in damage multipliers. (Will be implemented by setting their offset mod to 0 and then adding a WEAPON_BONUS mobmod with the value of what the offset was.)

`BASE_DAMAGE_MULTIPLIER`: Used for things like Morbols which according to the spreadsheet have a 1.5x base damage multiplier before the offset is added.

`DAMAGE_OFFSET`: Allows us to set a custom offset. Potentially useful if edge cases come up (Think HNMs and their base damage).

`RANGED_DAMAGE_OFFSET`: Same as above but for Ranged slot

## Steps to test these changes

Go get hit by stuff in different expansion zones. Take note of MNK mobs especially.

MNK mobs on average should hit less hard per hit compared to current LSB.
Mobs in TOAU and WOTG zones should hit a bit harder.

Note: The mob mods are not currently used, a follow up PR will be done to go through and implement known values based off Jimmayus's data.
