### PR TITLE
fix: heap-overflow, use-after-free

### DIFF
--- a/src/map/enums/packet_c2s.h
+++ b/src/map/enums/packet_c2s.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include <magic_enum/magic_enum.hpp>
+
 // Client-to-Server packet IDs
 // https://github.com/atom0s/XiPackets/tree/main/world/client
 // Note: Some packets are not explicitly named in XiPackets and have been given tentative names.
@@ -155,4 +157,11 @@ enum class PacketC2S : uint16_t
     GP_CLI_COMMAND_MASTERY_DISPLAY      = 0x11B,
     GP_CLI_COMMAND_PARTY_REQUEST        = 0x11C,
     GP_CLI_COMMAND_JUMP                 = 0x11D,
+};
+
+template <>
+struct magic_enum::customize::enum_range<PacketC2S>
+{
+    static constexpr int min = 0;
+    static constexpr int max = 300;
 };

--- a/src/map/enums/packet_s2c.h
+++ b/src/map/enums/packet_s2c.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include <magic_enum/magic_enum.hpp>
+
 // Server-to-Client packet IDs
 // https://github.com/atom0s/XiPackets/tree/main/world/server
 // Note: Some packets are not explicitly named in XiPackets and have been given tentative names.
@@ -174,4 +176,11 @@ enum class PacketS2C : uint16_t
     GP_SERV_COMMAND_EMOTELIST         = 0x11A,
     GP_SERV_COMMAND_PARTYREQ          = 0x11D,
     GP_SERV_COMMAND_JUMP              = 0x11E,
+};
+
+template <>
+struct magic_enum::customize::enum_range<PacketS2C>
+{
+    static constexpr int min = 0;
+    static constexpr int max = 300;
 };

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -4916,7 +4916,7 @@ uint8 CLuaBaseEntity::getFreeSlotsCount(sol::object const& locID)
  *  Notes   : Must use trade:confirmItem(slotID) first
  ************************************************************************/
 
-void CLuaBaseEntity::confirmTrade()
+void CLuaBaseEntity::confirmTrade() const
 {
     if (m_PBaseEntity->objtype != TYPE_PC)
     {
@@ -4940,6 +4940,12 @@ void CLuaBaseEntity::confirmTrade()
                 if (confirmedItems > 0)
                 {
                     uint8 invSlotID = PChar->TradeContainer->getInvSlotID(slotID);
+                    if (static_cast<uint32>(quantity) >= PChar->TradeContainer->getItem(slotID)->getQuantity())
+                    {
+                        // Set the trade slot to nullptr as the underlying item is about to be destroyed by UpdateItem
+                        PChar->TradeContainer->setItem(slotID, nullptr);
+                    }
+
                     charutils::UpdateItem(PChar, LOC_INVENTORY, invSlotID, -quantity);
                 }
             }
@@ -4955,7 +4961,7 @@ void CLuaBaseEntity::confirmTrade()
  *  Example : player:tradeComplete()
  ************************************************************************/
 
-void CLuaBaseEntity::tradeComplete()
+void CLuaBaseEntity::tradeComplete() const
 {
     if (m_PBaseEntity->objtype != TYPE_PC)
     {
@@ -4975,6 +4981,12 @@ void CLuaBaseEntity::tradeComplete()
             if (PItem)
             {
                 PItem->setReserve(0);
+                if (static_cast<uint32>(quantity) >= PItem->getQuantity())
+                {
+                    // Set the trade slot to nullptr as the underlying item is about to be destroyed by UpdateItem
+                    PChar->TradeContainer->setItem(slotID, nullptr);
+                }
+
                 charutils::UpdateItem(PChar, LOC_INVENTORY, invSlotID, -quantity);
             }
         }

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -264,8 +264,8 @@ public:
     uint8 getContainerSize(uint8 locationID);
     void  changeContainerSize(uint8 locationID, int8 newSize); // Increase/Decreases container size
     uint8 getFreeSlotsCount(sol::object const& locID);         // Gets value of free slots in Entity inventory
-    void  confirmTrade();                                      // Complete trade with an npc, only removing confirmed items
-    void  tradeComplete();                                     // Complete trade with an npc
+    void  confirmTrade() const;                                // Complete trade with an npc, only removing confirmed items
+    void  tradeComplete() const;                               // Complete trade with an npc
     auto  getTrade() -> CTradeContainer*;
 
     // Equipping

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -2193,9 +2193,12 @@ void CStatusEffectContainer::TickRegen(timer::time_point tick)
             m_POwner->addTP(regain);
         }
 
-        if (m_POwner->PPet && ((CPetEntity*)(m_POwner->PPet))->getPetType() == PET_TYPE::AUTOMATON)
+        if (m_POwner->PPet)
         {
-            ((CAutomatonEntity*)(m_POwner->PPet))->burdenTick();
+            if (auto* PAutomaton = dynamic_cast<CAutomatonEntity*>(m_POwner->PPet))
+            {
+                PAutomaton->burdenTick();
+            }
         }
     }
 }

--- a/src/test/lua/helpers/lua_client_entity_pair_packets.cpp
+++ b/src/test/lua/helpers/lua_client_entity_pair_packets.cpp
@@ -23,6 +23,7 @@
 
 #include "common/logging.h"
 #include "common/lua.h"
+#include "enums/packet_c2s.h"
 #include "lua/lua_client_entity_pair.h"
 #include "lua/lua_simulation.h"
 #include "lua/sol_bindings.h"
@@ -56,7 +57,7 @@ auto CLuaClientEntityPairPackets::createPacket(uint16 packetType) -> std::unique
 void CLuaClientEntityPairPackets::sendBasicPacket(CBasicPacket& packet) const
 {
     const auto testChar = parent_->testChar();
-    DebugTestFmt("Sending C2S Packet 0x{:03X}", packet.ref<uint8>(0x00));
+    DebugTestFmt("C2S 0x{:03X} {}", packet.getType(), magic_enum::enum_name(static_cast<PacketC2S>(packet.getType())));
     PacketParser[packet.ref<uint8>(0x00)](testChar->session(), testChar->entity(), packet);
 }
 

--- a/src/test/lua/lua_client_entity_pair.cpp
+++ b/src/test/lua/lua_client_entity_pair.cpp
@@ -105,6 +105,7 @@ void CLuaClientEntityPair::gotoZone(ZONEID zoneId, sol::optional<sol::table> pos
 
     // SendToZone _only_ prepares the character for zoning.
     testChar_->entity()->loc.destination = zoneId;
+    testChar_->entity()->status          = STATUS_TYPE::DISAPPEAR;
     charutils::SendToZone(testChar_->entity(), zoneId);
     packets().sendZonePackets(); // Send zone in packets, reload PChar
 

--- a/src/test/test_collector.cpp
+++ b/src/test/test_collector.cpp
@@ -23,6 +23,7 @@
 #include "common/logging.h"
 #include "common/lua.h"
 #include "reporters/reporter_container.h"
+#include <algorithm>
 #include <chrono>
 #include <format>
 
@@ -87,6 +88,8 @@ auto TestCollector::collectTestFiles() const -> std::vector<std::filesystem::pat
             }
         }
     }
+
+    std::ranges::sort(luaFiles);
 
     return luaFiles;
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This should fix xi_test crashing in the CI.

- Fix one bad cast in status_container that was leading to heap-overflow
  - Looks like this was corrupting mobs over and over again
- Null items in trade containers when they're going to be destroyed by the subsequent UpdateItem
  - This led to a use-after-free when the TradeContainer was being cleaned up

Made a few enhancements to xi_test:
- Track when in the test lifecycle players are created to ensure they are cleaned up at the correct time
  - The default setting of cleaning up clients only after each file wasnt aggressive enough and led to zones being ticked for no reason
- Sort the list of loaded lua files so the order is consistent across platforms

## Steps to test these changes
I'll retest trade and PUP mobs shortly.

<!-- Clear and detailed steps to test your changes here -->
