### PR TITLE
[cpp/lua] Transport updates for out of service ships

### DIFF
--- a/scripts/globals/manaclipper.lua
+++ b/scripts/globals/manaclipper.lua
@@ -141,7 +141,7 @@ xi.manaclipper.onZoneIn = function(player)
     end
 end
 
-xi.manaclipper.onTransportEvent = function(player, transport)
+xi.manaclipper.onTransportEvent = function(player, prevZoneId, transportId)
     local ID = zones[player:getZoneID()]
     local aboard = player:getCharVar('[manaclipper]aboard')
 

--- a/scripts/specs/types/Zone.lua
+++ b/scripts/specs/types/Zone.lua
@@ -9,7 +9,7 @@
 ---@field onInitialize? fun(zone: CZone)
 ---@field onEventUpdate? fun(player: CBaseEntity, csid: integer, option: integer, npc: CBaseEntity)
 ---@field onEventFinish? fun(player: CBaseEntity, csid: integer, option: integer, npc: CBaseEntity)
----@field onTransportEvent? fun(player: CBaseEntity, transportId: integer)
+---@field onTransportEvent? fun(player: CBaseEntity, prevZoneId: integer, transportId: integer)
 ---@field onConquestUpdate? fun(zone: CZone, type: integer, influence: integer, owner: integer, ranking: integer, isConquestAlliance: boolean)
 ---@field onGameDay? fun()
 ---@field onGameHour? fun(zone: CZone)

--- a/scripts/zones/Aht_Urhgan_Whitegate/Zone.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/Zone.lua
@@ -80,9 +80,12 @@ end
 zoneObject.onTriggerAreaLeave = function(player, triggerArea)
 end
 
-zoneObject.onTransportEvent = function(player, transport)
+zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
     -- Boat to Mhaura.
-    if transport == 46 or transport == 47 then
+    if
+        prevZoneId == xi.zone.OPEN_SEA_ROUTE_TO_AL_ZAHBI or
+        prevZoneId == xi.zone.OPEN_SEA_ROUTE_TO_MHAURA
+    then
         if player:hasKeyItem(xi.ki.FERRY_TICKET) then
             player:startEvent(200)
         else
@@ -90,7 +93,10 @@ zoneObject.onTransportEvent = function(player, transport)
         end
 
     -- Boat to Nashmau.
-    elseif transport == 58 or transport == 59 then
+    elseif
+        prevZoneId == xi.zone.SILVER_SEA_ROUTE_TO_NASHMAU or
+        prevZoneId == xi.zone.SILVER_SEA_ROUTE_TO_AL_ZAHBI
+    then
         if player:hasKeyItem(xi.ki.SILVER_SEA_FERRY_TICKET) then
             player:startEvent(203)
         else

--- a/scripts/zones/Bastok-Jeuno_Airship/Zone.lua
+++ b/scripts/zones/Bastok-Jeuno_Airship/Zone.lua
@@ -17,7 +17,7 @@ zoneObject.onZoneIn = function(player, prevZone)
     return cs
 end
 
-zoneObject.onTransportEvent = function(player, transport)
+zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
     player:startEvent(100)
 end
 

--- a/scripts/zones/Bibiki_Bay/Zone.lua
+++ b/scripts/zones/Bibiki_Bay/Zone.lua
@@ -39,8 +39,8 @@ zoneObject.onTriggerAreaLeave = function(player, triggerArea)
     xi.manaclipper.aboard(player, triggerArea:getTriggerAreaID(), false)
 end
 
-zoneObject.onTransportEvent = function(player, transport)
-    xi.manaclipper.onTransportEvent(player, transport)
+zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
+    xi.manaclipper.onTransportEvent(player, prevZoneId, transportId)
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Kazham-Jeuno_Airship/Zone.lua
+++ b/scripts/zones/Kazham-Jeuno_Airship/Zone.lua
@@ -17,7 +17,7 @@ zoneObject.onZoneIn = function(player, prevZone)
     return cs
 end
 
-zoneObject.onTransportEvent = function(player, transport)
+zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
     player:startEvent(10)
 end
 

--- a/scripts/zones/Kazham/Zone.lua
+++ b/scripts/zones/Kazham/Zone.lua
@@ -31,7 +31,7 @@ zoneObject.onZoneIn = function(player, prevZone)
     return cs
 end
 
-zoneObject.onTransportEvent = function(player, transport)
+zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
     player:startEvent(10000)
 end
 

--- a/scripts/zones/Manaclipper/Zone.lua
+++ b/scripts/zones/Manaclipper/Zone.lua
@@ -42,7 +42,7 @@ zoneObject.onZoneIn = function(player, prevZone)
     return cs
 end
 
-zoneObject.onTransportEvent = function(player, transport)
+zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
     player:startEvent(100)
 end
 

--- a/scripts/zones/Mhaura/Zone.lua
+++ b/scripts/zones/Mhaura/Zone.lua
@@ -52,8 +52,11 @@ zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranki
     xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
 end
 
-zoneObject.onTransportEvent = function(player, transport)
-    if transport == 47 or transport == 46 then
+zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
+    if
+        prevZoneId == xi.zone.OPEN_SEA_ROUTE_TO_AL_ZAHBI or
+        prevZoneId == xi.zone.OPEN_SEA_ROUTE_TO_MHAURA
+    then
         if
             xi.settings.main.ENABLE_TOAU == 1 and
             player:hasKeyItem(xi.ki.BOARDING_PERMIT) and

--- a/scripts/zones/Nashmau/Zone.lua
+++ b/scripts/zones/Nashmau/Zone.lua
@@ -36,8 +36,8 @@ end
 zoneObject.onTriggerAreaLeave = function(player, triggerArea)
 end
 
-zoneObject.onTransportEvent = function(player, transport)
-    if transport == 59 then
+zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
+    if prevZoneId == xi.zone.SILVER_SEA_ROUTE_TO_AL_ZAHBI then
         if player:hasKeyItem(xi.ki.SILVER_SEA_FERRY_TICKET) then
             player:startEvent(200)
         else

--- a/scripts/zones/Open_sea_route_to_Al_Zahbi/Zone.lua
+++ b/scripts/zones/Open_sea_route_to_Al_Zahbi/Zone.lua
@@ -24,7 +24,7 @@ zoneObject.onZoneIn = function(player, prevZone)
     return cs
 end
 
-zoneObject.onTransportEvent = function(player, transport)
+zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
     player:startEvent(1028)
     player:messageSpecial(ID.text.DOCKING_IN_AL_ZAHBI)
 end

--- a/scripts/zones/Open_sea_route_to_Mhaura/Zone.lua
+++ b/scripts/zones/Open_sea_route_to_Mhaura/Zone.lua
@@ -24,7 +24,7 @@ zoneObject.onZoneIn = function(player, prevZone)
     return cs
 end
 
-zoneObject.onTransportEvent = function(player, transport)
+zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
     player:startEvent(1028)
     player:messageSpecial(ID.text.DOCKING_IN_MHAURA)
 end

--- a/scripts/zones/Port_Bastok/Zone.lua
+++ b/scripts/zones/Port_Bastok/Zone.lua
@@ -35,7 +35,7 @@ end
 zoneObject.onTriggerAreaLeave = function(player, triggerArea)
 end
 
-zoneObject.onTransportEvent = function(player, transport)
+zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
     player:startEvent(71)
 end
 

--- a/scripts/zones/Port_Jeuno/Zone.lua
+++ b/scripts/zones/Port_Jeuno/Zone.lua
@@ -48,14 +48,14 @@ zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranki
     xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
 end
 
-zoneObject.onTransportEvent = function(player, transport)
-    if transport == 223 then
+zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
+    if prevZoneId == xi.zone.SAN_DORIA_JEUNO_AIRSHIP then
         player:startEvent(10010)
-    elseif transport == 224 then
+    elseif prevZoneId == xi.zone.BASTOK_JEUNO_AIRSHIP then
         player:startEvent(10012)
-    elseif transport == 225 then
+    elseif prevZoneId == xi.zone.WINDURST_JEUNO_AIRSHIP then
         player:startEvent(10011)
-    elseif transport == 226 then
+    elseif prevZoneId == xi.zone.KAZHAM_JEUNO_AIRSHIP then
         player:startEvent(10013)
     end
 end

--- a/scripts/zones/Port_San_dOria/Zone.lua
+++ b/scripts/zones/Port_San_dOria/Zone.lua
@@ -36,7 +36,7 @@ end
 zoneObject.onTriggerAreaLeave = function(player, triggerArea)
 end
 
-zoneObject.onTransportEvent = function(player, transport)
+zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
     player:startEvent(700)
 end
 

--- a/scripts/zones/Port_Windurst/Zone.lua
+++ b/scripts/zones/Port_Windurst/Zone.lua
@@ -29,7 +29,7 @@ zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranki
     xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
 end
 
-zoneObject.onTransportEvent = function(player, transport)
+zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
     player:startEvent(10002)
 end
 

--- a/scripts/zones/San_dOria-Jeuno_Airship/Zone.lua
+++ b/scripts/zones/San_dOria-Jeuno_Airship/Zone.lua
@@ -17,7 +17,7 @@ zoneObject.onZoneIn = function(player, prevZone)
     return cs
 end
 
-zoneObject.onTransportEvent = function(player, transport)
+zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
     player:startEvent(100)
 end
 

--- a/scripts/zones/Selbina/Zone.lua
+++ b/scripts/zones/Selbina/Zone.lua
@@ -55,7 +55,7 @@ zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranki
     xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
 end
 
-zoneObject.onTransportEvent = function(player, transport)
+zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
     if player:hasKeyItem(xi.ki.FERRY_TICKET) then
         player:startEvent(200)
     else

--- a/scripts/zones/Ship_bound_for_Mhaura/Zone.lua
+++ b/scripts/zones/Ship_bound_for_Mhaura/Zone.lua
@@ -22,7 +22,7 @@ zoneObject.onZoneIn = function(player, prevZone)
     return cs
 end
 
-zoneObject.onTransportEvent = function(player, transport)
+zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
     player:startEvent(512)
 end
 

--- a/scripts/zones/Ship_bound_for_Mhaura_Pirates/Zone.lua
+++ b/scripts/zones/Ship_bound_for_Mhaura_Pirates/Zone.lua
@@ -22,7 +22,7 @@ zoneObject.onZoneIn = function(player, prevZone)
     return cs
 end
 
-zoneObject.onTransportEvent = function(player, transport)
+zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
     player:startEvent(512)
 end
 

--- a/scripts/zones/Ship_bound_for_Selbina/Zone.lua
+++ b/scripts/zones/Ship_bound_for_Selbina/Zone.lua
@@ -32,7 +32,7 @@ zoneObject.onZoneIn = function(player, prevZone)
     return cs
 end
 
-zoneObject.onTransportEvent = function(player, transport)
+zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
     player:startEvent(255)
 end
 

--- a/scripts/zones/Ship_bound_for_Selbina_Pirates/Zone.lua
+++ b/scripts/zones/Ship_bound_for_Selbina_Pirates/Zone.lua
@@ -22,7 +22,7 @@ zoneObject.onZoneIn = function(player, prevZone)
     return cs
 end
 
-zoneObject.onTransportEvent = function(player, transport)
+zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
     player:startEvent(255)
 end
 

--- a/scripts/zones/Silver_Sea_route_to_Al_Zahbi/Zone.lua
+++ b/scripts/zones/Silver_Sea_route_to_Al_Zahbi/Zone.lua
@@ -16,7 +16,7 @@ end
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)
 end
 
-zoneObject.onTransportEvent = function(player, transport)
+zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
     player:startEvent(1025)
 end
 

--- a/scripts/zones/Silver_Sea_route_to_Nashmau/Zone.lua
+++ b/scripts/zones/Silver_Sea_route_to_Nashmau/Zone.lua
@@ -13,7 +13,7 @@ zoneObject.onZoneIn = function(player, prevZone)
     return cs
 end
 
-zoneObject.onTransportEvent = function(player, transport)
+zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
     player:startEvent(1025)
 end
 

--- a/scripts/zones/Windurst-Jeuno_Airship/Zone.lua
+++ b/scripts/zones/Windurst-Jeuno_Airship/Zone.lua
@@ -17,7 +17,7 @@ zoneObject.onZoneIn = function(player, prevZone)
     return cs
 end
 
-zoneObject.onTransportEvent = function(player, transport)
+zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
     player:startEvent(100)
 end
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -4692,7 +4692,7 @@ namespace luautils
         charutils::ClearCharVarFromAll(varName);
     }
 
-    void OnTransportEvent(CCharEntity* PChar, uint32 TransportID)
+    void OnTransportEvent(CCharEntity* PChar, uint16 prevZoneId, uint16 transportId)
     {
         TracyZoneScoped;
 
@@ -4704,7 +4704,7 @@ namespace luautils
             return;
         }
 
-        auto result = onTransportEvent(PChar, TransportID);
+        auto result = onTransportEvent(PChar, prevZoneId, transportId);
         if (!result.valid())
         {
             sol::error err = result;

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -303,7 +303,7 @@ namespace luautils
     void OnTriggerAreaEnter(CCharEntity* PChar, std::unique_ptr<ITriggerArea> const& PTriggerArea); // when player enters a trigger area in a zone
     void OnTriggerAreaLeave(CCharEntity* PChar, std::unique_ptr<ITriggerArea> const& PTriggerArea); // when player leaves a trigger area in a zone
 
-    void OnTransportEvent(CCharEntity* PChar, uint32 TransportID);
+    void OnTransportEvent(CCharEntity* PChar, uint16 prevZoneId, uint16 transportId);
     void OnTimeTrigger(CNpcEntity* PNpc, uint8 triggerID);
     void OnConquestUpdate(CZone* PZone, ConquestUpdate type, uint8 influence, uint8 owner, uint8 ranking, bool isConquestAlliance); // conquest update (hourly or tally)
 

--- a/src/map/transport.h
+++ b/src/map/transport.h
@@ -67,9 +67,10 @@ struct Transport_Time
 
 struct Transport_Ship : Transport_Time
 {
-    uint8 animationArrive;
-    uint8 animationDepart;
-    uint8 state;
+    uint16 transportId;
+    uint8  animationArrive;
+    uint8  animationDepart;
+    uint8  state;
 
     CBaseEntity* npc;
     location_t   dock;

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -484,9 +484,9 @@ void CZone::FindPartyForMob(CBaseEntity* PEntity)
     m_zoneEntities->FindPartyForMob(PEntity);
 }
 
-void CZone::TransportDepart(uint16 boundary, uint16 zone)
+void CZone::TransportDepart(uint16 boundary, uint16 prevZoneId, uint16 transportId)
 {
-    m_zoneEntities->TransportDepart(boundary, zone);
+    m_zoneEntities->TransportDepart(boundary, prevZoneId, transportId);
 }
 
 void CZone::updateCharLevelRestriction(CCharEntity* PChar)

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -612,7 +612,9 @@ public:
     virtual void InsertTRUST(CBaseEntity* PTrust);
 
     virtual void FindPartyForMob(CBaseEntity* PEntity);
-    virtual void TransportDepart(uint16 boundary, uint16 zone);  // Collect passengers if ship/boat is departing
+
+    virtual void TransportDepart(uint16 boundary, uint16 prevZoneId, uint16 transportId); // Collect passengers if ship/boat is departing
+
     virtual void updateCharLevelRestriction(CCharEntity* PChar); // Removes the character's level restriction. If the zone has a level restriction, it is applied after it is removed.
 
     void InsertTriggerArea(std::unique_ptr<ITriggerArea>&& triggerArea); // Add an active area to the zone

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -378,7 +378,7 @@ void CZoneEntities::FindPartyForMob(CBaseEntity* PEntity)
     }
 }
 
-void CZoneEntities::TransportDepart(uint16 boundary, uint16 zone)
+void CZoneEntities::TransportDepart(uint16 boundary, uint16 prevZoneId, uint16 transport)
 {
     TracyZoneScoped;
 
@@ -403,7 +403,7 @@ void CZoneEntities::TransportDepart(uint16 boundary, uint16 zone)
                 }
             }
 
-            luautils::OnTransportEvent(PCurrentChar, zone);
+            luautils::OnTransportEvent(PCurrentChar, prevZoneId, transport);
         }
     }
 }

--- a/src/map/zone_entities.h
+++ b/src/map/zone_entities.h
@@ -72,8 +72,9 @@ public:
     void InsertPET(CBaseEntity* PPet);
     void InsertTRUST(CBaseEntity* PTrust);
 
-    void FindPartyForMob(CBaseEntity* PEntity);         // looking for a party for the monster
-    void TransportDepart(uint16 boundary, uint16 zone); // ship/boat is leaving, passengers need to be collected
+    void FindPartyForMob(CBaseEntity* PEntity); // looking for a party for the monster
+
+    void TransportDepart(uint16 boundary, uint16 prevZoneId, uint16 transportId); // ship/boat is leaving, passengers need to be collected
 
     void TOTDChange(vanadiel_time::TOTD TOTD); // process the world's reactions to changing time of day
     void WeatherChange(WEATHER weather);

--- a/src/map/zone_instance.cpp
+++ b/src/map/zone_instance.cpp
@@ -132,12 +132,12 @@ void CZoneInstance::FindPartyForMob(CBaseEntity* PEntity)
     }
 }
 
-void CZoneInstance::TransportDepart(uint16 boundary, uint16 zone)
+void CZoneInstance::TransportDepart(uint16 boundary, uint16 prevZoneId, uint16 transportId)
 {
     TracyZoneScoped;
     for (const auto& PInstance : m_InstanceList)
     {
-        PInstance->TransportDepart(boundary, zone);
+        PInstance->TransportDepart(boundary, prevZoneId, transportId);
     }
 }
 

--- a/src/map/zone_instance.h
+++ b/src/map/zone_instance.h
@@ -52,8 +52,9 @@ public:
     virtual void InsertPET(CBaseEntity* PPet) override;
     virtual void InsertTRUST(CBaseEntity* PTrust) override;
 
-    virtual void FindPartyForMob(CBaseEntity* PEntity) override;         // looking for a party for the monster
-    virtual void TransportDepart(uint16 boundary, uint16 zone) override; // ship/boat is leaving, passengers need to be collected
+    virtual void FindPartyForMob(CBaseEntity* PEntity) override; // looking for a party for the monster
+
+    virtual void TransportDepart(uint16 boundary, uint16 prevZoneId, uint16 transportId) override; // ship/boat is leaving, passengers need to be collected
 
     virtual void TOTDChange(vanadiel_time::TOTD TOTD) override; // process the world's reactions to changing time of day
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Adds some plumbing that is needed to emulate the Carpenter's Landing barge
- OOS transports: a ship that arrives when players ride the previous transport to a dock, but doesn't pick anyone up
  - allows `door` to be 0, and updates the open/close functions to ignore null doornpcs
  - allows `anim_depart` to be zero, and updates the `depart()` function to not update the npc's animation
    - the ship's animation for the 3 OOS transports is set once when the ship shows up in carptenter's landing, and the animation encompasses the full arrival/departure
  - allows `zone` to be zero. This makes no triggers happen to evict players from some other zone (since there's no passengers on the ship)
- this is the set i'm working with in `transport.sql` to achieve this behavior
  - <img width="1491" height="191" alt="image" src="https://github.com/user-attachments/assets/c866ac29-c7d7-4e30-a6e8-0a277e83f26b" />
- Also noticed that `onTransportEvent` was sending the voyageZoneId but labeling it as `transport`...
  - updated the luautil and all the intermediates to pass the actual transport id as a third parameter, and updated the names for sanity
  - this third param will be useful when handling `onTransportEvent` in carpenter's landing

Note: I misspoke in how `zone == 0` will be used for carpenter's landing. It will actually be the next barge that comes after an OOS ship. Since that ship is not coming with passengers, it should not trigger a voyage zone

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- ensure existing transports aren't broken
  - zone to selbina
  - add `print(player, zoneId, transportId)` to the `onTransportEvent` in selbina's `Zone.lua`
  - wait for a ship to arrive
  - see that it opens the door to allow boarding
  - see the print on departure in map server with player, voyage zoneId, and unique transportId from the `transport` table
- I have my transport db from https://github.com/LandSandBoat/server/pull/8172, but for testing any transport entry can be updated to have a door npcid, anim_depart, and zone all set to zero
  - see that door being zero makes the arrival not allow boarding
  - see that anim_depart 0 has the ship just stay at dock (or watch one of the OOS barges from above screenshot animate a full arrival/departure without `anim_depart` explicitly set
  - Not really sure the best way to prove a negative with `zone == 0` not triggering voyage evictions, but a breakpoint during startup will allow stepping through loading each transport and seeing that no voyageZone gets inserted into `voyageZoneList`
    - note that zoneid 0 must be loaded on the particular map server to even see it