### PR TITLE
fix: CItem, CBattlefield, mariadb-connect memory leaks

### DIFF
--- a/src/common/database.cpp
+++ b/src/common/database.cpp
@@ -393,7 +393,7 @@ auto db::getDatabaseVersion() -> std::string
     // clang-format off
     return detail::getState().write([&](detail::State& state) -> std::string
     {
-        const auto metadata = state.connection->getMetaData();
+        const std::unique_ptr<sql::DatabaseMetaData> metadata(state.connection->getMetaData());
         return fmt::format("{} {}", metadata->getDatabaseProductName().c_str(), metadata->getDatabaseProductVersion().c_str());
     });
     // clang-format on
@@ -406,7 +406,7 @@ auto db::getDriverVersion() -> std::string
     // clang-format off
     return detail::getState().write([&](detail::State& state) -> std::string
     {
-        const auto metadata = state.connection->getMetaData();
+        const std::unique_ptr<sql::DatabaseMetaData> metadata(state.connection->getMetaData());
         return fmt::format("{} {}", metadata->getDriverName().c_str(), metadata->getDriverVersion().c_str());
     });
     // clang-format on

--- a/src/common/database.h
+++ b/src/common/database.h
@@ -429,7 +429,8 @@ namespace db
                     return T{};
                 }
 
-                const auto columnName = resultSet_->getMetaData()->getColumnLabel(index + 1);
+                const std::unique_ptr<sql::ResultSetMetaData> metadata(resultSet_->getMetaData());
+                const auto                                    columnName = metadata->getColumnLabel(index + 1);
                 return get<T>(columnName.c_str());
             }
 
@@ -463,7 +464,8 @@ namespace db
                     return defaultValue;
                 }
 
-                const auto columnName = resultSet_->getMetaData()->getColumnLabel(index + 1);
+                const std::unique_ptr<sql::ResultSetMetaData> metadata(resultSet_->getMetaData());
+                const auto                                    columnName = metadata->getColumnLabel(index + 1);
                 return getOrDefault<T>(columnName.c_str(), defaultValue);
             }
 

--- a/src/common/lua.cpp
+++ b/src/common/lua.cpp
@@ -82,6 +82,11 @@ void lua_init()
     }
 }
 
+void lua_cleanup()
+{
+    lua = sol::state();
+}
+
 /**
  * @brief
  */

--- a/src/common/lua.h
+++ b/src/common/lua.h
@@ -27,6 +27,7 @@
 extern sol::state lua;
 
 void lua_init();
+void lua_cleanup();
 auto lua_to_string_depth(const sol::object& obj, std::size_t depth) -> std::string;
 auto lua_to_string(sol::variadic_args va) -> std::string;
 void lua_print(sol::variadic_args va);

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -76,6 +76,7 @@ CBattlefield::CBattlefield(uint16 id, CZone* PZone, uint8 area, CCharEntity* PIn
 
 CBattlefield::~CBattlefield()
 {
+    m_groups.clear();
     luautils::OnBattlefieldDestroy(this);
 }
 

--- a/src/map/battlefield_handler.cpp
+++ b/src/map/battlefield_handler.cpp
@@ -54,6 +54,15 @@ CBattlefieldHandler::CBattlefieldHandler(CZone* PZone)
 {
 }
 
+CBattlefieldHandler::~CBattlefieldHandler()
+{
+    for (auto& [area, PBattlefield] : m_Battlefields)
+    {
+        destroy(PBattlefield);
+    }
+    m_Battlefields.clear();
+}
+
 void CBattlefieldHandler::HandleBattlefields(timer::time_point tick)
 {
     TracyZoneScoped;

--- a/src/map/battlefield_handler.h
+++ b/src/map/battlefield_handler.h
@@ -53,6 +53,7 @@ class CBattlefieldHandler
 {
 public:
     CBattlefieldHandler(CZone* PZone);
+    ~CBattlefieldHandler();
     void          HandleBattlefields(timer::time_point tick);                                       // called every tick to handle win/lose conditions, locking the bcnm, etc
     uint8         LoadBattlefield(CCharEntity* PChar, const BattlefieldRegistration& registration); // attempts to load battlefield, returns BATTLEFIELD_RETURN_CODE
     CBattlefield* GetBattlefield(CBaseEntity* PEntity, bool checkRegistered = false);               // return pointer to battlefield if exists

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -4378,6 +4378,7 @@ bool CLuaBaseEntity::addUsedItem(uint16 itemID)
             else
             {
                 ShowWarning("addUsedItem: tried to setLastUseTime but itemID <%i> is not type ITEM_CHARGED", itemID);
+                destroy(PItem);
             }
         }
         else
@@ -4802,6 +4803,11 @@ bool CLuaBaseEntity::addLinkpearl(std::string const& lsname, bool equip)
                 return true;
             }
         }
+        else
+        {
+            // Linkshell not found, clean up
+            destroy(PItemLinkPearl);
+        }
     }
     return false;
 }
@@ -5029,7 +5035,7 @@ bool CLuaBaseEntity::canEquipItem(uint16 itemID, sol::object const& chkLevel)
 
     bool checkLevel = (chkLevel != sol::lua_nil) ? chkLevel.as<bool>() : false;
 
-    auto* PItem = static_cast<CItemEquipment*>(itemutils::GetItem(itemID));
+    auto* PItem = static_cast<CItemEquipment*>(itemutils::GetItemPointer(itemID));
     auto* PChar = static_cast<CBattleEntity*>(m_PBaseEntity);
 
     if (PItem == nullptr)
@@ -16336,7 +16342,7 @@ bool CLuaBaseEntity::hasAttachment(uint16 itemID)
         return false;
     }
 
-    CItem* PItem = itemutils::GetItem(itemID);
+    CItem* PItem = itemutils::GetItemPointer(itemID);
     return puppetutils::HasAttachment(static_cast<CCharEntity*>(m_PBaseEntity), PItem);
 }
 
@@ -16467,7 +16473,7 @@ bool CLuaBaseEntity::unlockAttachment(uint16 itemID)
         return false;
     }
 
-    CItem* PItem = itemutils::GetItem(itemID);
+    CItem* PItem = itemutils::GetItemPointer(itemID);
     return puppetutils::UnlockAttachment(static_cast<CCharEntity*>(m_PBaseEntity), PItem);
 }
 

--- a/src/map/treasure_pool.cpp
+++ b/src/map/treasure_pool.cpp
@@ -324,7 +324,7 @@ void CTreasurePool::lotItem(CCharEntity* PChar, uint8 SlotID, uint16 Lot)
         return;
     }
 
-    CItem* PItem = itemutils::GetItem(m_PoolItems[SlotID].ID);
+    CItem* PItem = itemutils::GetItemPointer(m_PoolItems[SlotID].ID);
     if (PItem == nullptr)
     {
         ShowWarning(fmt::format("Player {} is trying to lot on an item that doesn't exist (PItem was nullptr) (Packet injection?)!", PChar->getName()).c_str());
@@ -536,7 +536,7 @@ void CTreasurePool::checkTreasureItem(timer::time_point tick, uint8 SlotID)
             std::vector<CCharEntity*> candidates;
             for (auto& member : m_Members)
             {
-                if (charutils::HasItem(member, m_PoolItems[SlotID].ID) && itemutils::GetItem(m_PoolItems[SlotID].ID)->getFlag() & ITEM_FLAG_RARE)
+                if (charutils::HasItem(member, m_PoolItems[SlotID].ID) && itemutils::GetItemPointer(m_PoolItems[SlotID].ID)->getFlag() & ITEM_FLAG_RARE)
                 {
                     continue;
                 }

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -19,15 +19,23 @@
 ===========================================================================
 */
 
+#include "common/lua.h"
 #include "test_application.h"
 
 #include <memory>
 
 int main(int argc, char** argv)
 {
-    const auto testApp = std::make_unique<TestApplication>(argc, argv);
+    auto testApp = std::make_unique<TestApplication>(argc, argv);
 
     testApp->run();
+
+    // Explicitly destroy TestApplication before the lua state get cleaned up
+    testApp.reset();
+
+    // TODO: This should be in ~Application but it needs more testing for xi_map
+    // TODO: This wouldn't be needed if lua wasn't global
+    lua_cleanup();
 
     return 0;
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This addresses (almost?) everything ASan is reporting when executing the full set of tests with xi_test

### mariadb-connector getMetadata()
This leaks on every calls. Documentation for the original mysql connector states they had this cleaned up automatically (... in 2009) but I'm not seeing such mechanisms in the mariadb connector.

https://github.com/mariadb-corporation/mariadb-connector-cpp/blob/748d9bb1cf941ef2ae8a47a344946478f623ddcd/src/MariaDbConnection.cpp#L807-L810

Besides, they explicitly wrap it in unique_ptr in their test code

https://github.com/mariadb-corporation/mariadb-connector-cpp/blob/dc5b6d1e21bf2e75731f8e983e06e517dc9cd0ba/test/unit/classes/connection.cpp#L3452-L3453

### GetItem
Not going to go in the lore of why this is a terrible design but GetItem returns new copies of an item whereas GetItemPointer returns the "base template".

Handful of places are using GetItem when they could be using GetItemPointer, furthermore they weren't cleaning up the objects leading to leaks on every single treasure pool entries and usage of certain bindings.

### CBattlefieldHandler
This wasn't releasing current battlefields instances on destruction. Doesn't exactly matter in the grand scheme of things.

### Lua state
The order of destruction being undefined is leading to various use-after-free when objects referencing the sol state are being destroyed. I've added explicit destruction order to xi_test to test the change before eventually adding it to xi_map.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

All tests are passing but I'll need to re-test thoroughly the GetItem changes. I'm relatively confident about the rest.

<!-- Clear and detailed steps to test your changes here -->
