### PR TITLE
[Test Framework] Fix CoP 1-2 test

### DIFF
--- a/scripts/tests/missions/cop.lua
+++ b/scripts/tests/missions/cop.lua
@@ -55,17 +55,17 @@ describe('Chains of Promathia', function()
         it('should complete Promyvion Holla and Spire battles to advance to The Mothercrystals', function()
             player:addMission(xi.mission.log_id.COP, xi.mission.id.cop.BELOW_THE_ARKS)
 
-            -- trigger Pherimociel to goto next Prog
             player:gotoZone(xi.zone.UPPER_JEUNO)
             player.entities:gotoAndTrigger('Monberaux', { eventId = 9 })
 
+            -- Ru'Lude Gardens: Trigger Pherimociel to goto next Prog
             player:gotoZone(xi.zone.RULUDE_GARDENS)
-            player.entities:gotoAndTrigger('High_Wind', { eventId = 33 })
-            player.entities:gotoAndTrigger('Rainhard', { eventId = 34 })
             player.entities:gotoAndTrigger('Pherimociel', { eventId = 24 })
 
-            -- optional dialog
+            -- Ru'Lude Gardens: Optional dialog
             player.entities:gotoAndTrigger('Pherimociel', { eventId = 25 })
+            player.entities:gotoAndTrigger('High_Wind', { eventId = 33 })
+            player.entities:gotoAndTrigger('Rainhard', { eventId = 34 })
 
             -- entering hall of transference -> Promy Holla
             player:gotoZone(xi.zone.HALL_OF_TRANSFERENCE)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

As title sais. Explanation:
Pherimoncel interaction is the one setting status to 1, leading to the optional dialog being available.
However, not only were those NPCs being triggered before Phermoncel's interaction, they also werent marked as optional.
Test was passing without issues because the default actions of this NPCs happened to be (wrongly) the same as the events the test expected.

## Steps to test these changes

Merge. Have PR #8186 be rebased with it. Have said PR pass the tests.
