### PR TITLE
[lua] Snapshot focus/dodge gear power on ability use

### DIFF
--- a/scripts/effects/dodge.lua
+++ b/scripts/effects/dodge.lua
@@ -1,18 +1,17 @@
 -----------------------------------
 -- xi.effect.DODGE
+-- Note: Glanzfaust bonus is implemented as a latent effect while wearing the equipment and having the effect
 -----------------------------------
 ---@type TEffect
 local effectObject = {}
 
--- TODO: implement Glanzfaust effects
 effectObject.onEffectGain = function(target, effect)
-    local jpLevel   = target:getJobPointLevel(xi.jp.DODGE_EFFECT)
-    local dodgeMod  = target:getMod(xi.mod.DODGE_EFFECT)
-    local monkLevel = utils.getActiveJobLevel(target, xi.job.MNK)
+    local bonusPower = effect:getPower()
+    local monkLevel = utils.getActiveJobLevel(target, xi.job.MNK) + 1
 
     -- https://www.bg-wiki.com/ffxi/Dodge
-    effect:addMod(xi.mod.EVA, monkLevel + 1 + dodgeMod + jpLevel)
-    effect:addMod(xi.mod.ADDITIVE_GUARD, math.floor((monkLevel + 1) * 0.2))
+    effect:addMod(xi.mod.EVA, monkLevel + bonusPower)
+    effect:addMod(xi.mod.ADDITIVE_GUARD, math.floor(monkLevel * 0.2))
 end
 
 effectObject.onEffectTick = function(target, effect)

--- a/scripts/effects/focus.lua
+++ b/scripts/effects/focus.lua
@@ -1,21 +1,20 @@
 -----------------------------------
 -- xi.effect.FOCUS
+-- Note: Glanzfaust bonus is implemented as a latent effect while wearing the equipment and having the effect
 -----------------------------------
 ---@type TEffect
 local effectObject = {}
 
--- TODO: implement Glanzfaust effects
 -- TODO: implement focus ranged accuracy bonus (needs verification)
 effectObject.onEffectGain = function(target, effect)
-    local jpLevel   = target:getJobPointLevel(xi.jp.FOCUS_EFFECT)
-    local focusMod  = target:getMod(xi.mod.FOCUS_EFFECT)
-    local monkLevel = utils.getActiveJobLevel(target, xi.job.MNK)
+    local bonusPower = effect:getPower()
+    local monkLevel = utils.getActiveJobLevel(target, xi.job.MNK) + 1
 
     -- https://wiki.ffo.jp/html/2841.html
-    effect:addMod(xi.mod.ACC, monkLevel + 1 + focusMod + jpLevel)
+    effect:addMod(xi.mod.ACC, monkLevel + bonusPower)
 
     -- https://www.bg-wiki.com/ffxi/Focus
-    effect:addMod(xi.mod.CRITHITRATE, math.floor((monkLevel + 1) * .2))
+    effect:addMod(xi.mod.CRITHITRATE, math.floor(monkLevel * 0.2))
 end
 
 effectObject.onEffectTick = function(target, effect)

--- a/scripts/globals/job_utils/monk.lua
+++ b/scripts/globals/job_utils/monk.lua
@@ -99,11 +99,15 @@ xi.job_utils.monk.useCounterstance = function(player, target, ability)
 end
 
 xi.job_utils.monk.useDodge = function(player, target, ability)
-    player:addStatusEffect(xi.effect.DODGE, 0, 0, 30)
+    local jpLevel  = target:getJobPointLevel(xi.jp.DODGE_EFFECT)
+    local dodgeMod = target:getMod(xi.mod.DODGE_EFFECT)
+    player:addStatusEffect(xi.effect.DODGE, jpLevel + dodgeMod, 0, 30)
 end
 
 xi.job_utils.monk.useFocus = function(player, target, ability)
-    player:addStatusEffect(xi.effect.FOCUS, 0, 0, 30)
+    local jpLevel  = target:getJobPointLevel(xi.jp.FOCUS_EFFECT)
+    local focusMod = target:getMod(xi.mod.FOCUS_EFFECT)
+    player:addStatusEffect(xi.effect.FOCUS, jpLevel + focusMod, 0, 30)
 end
 
 xi.job_utils.monk.useFootwork = function(player, target, ability)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
For current retail, 30s duration isn't affected much, but still good to separate concepts and be consistent (also if an era server made a module to revert duration back to a longer duration, it would matter more)

Basically, focus/dodge are supposed to snapshot the bonus power based on gear worn when the ability is used. This stores that part as the power of the effect, then the level-based logic adds on top of that. If you zoned with the effect active, it was losing the gear bonus.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- use dodge/focus, see no difference from before
- equip one of the AF pieces that affect the respective buff, see it's stored as the effect's power and persists zoning
- <img width="633" height="508" alt="image" src="https://github.com/user-attachments/assets/e3128538-e796-4079-bce5-12dc292f45e9" />
