### PR TITLE
[lua] Remove Fame Requirement from "An Explorers Footsteps"

### DIFF
--- a/scripts/quests/otherAreas/An_Explorers_Footsteps.lua
+++ b/scripts/quests/otherAreas/An_Explorers_Footsteps.lua
@@ -89,8 +89,7 @@ quest.sections =
 {
     {
         check = function(player, status, vars)
-            return status == xi.questStatus.QUEST_AVAILABLE and
-                player:getFameLevel(xi.fameArea.SELBINA_RABAO) >= 1
+            return status == xi.questStatus.QUEST_AVAILABLE
         end,
 
         [xi.zone.SELBINA] =


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Removed the fame requirement from the quest "An Explorer's Footsteps"

## Steps to test these changes

1. Start a fresh character
2. !zone <Selbina>
3. Talk to Abelard to start the quest

## Capture
https://drive.google.com/drive/folders/1Mp3MtEtyVQwxl6jh7y-5X84JTy6kVn86?usp=sharing
