### PR TITLE
[lua] Remove fame requirement from quest "Under the Sea"

### DIFF
--- a/scripts/quests/otherAreas/Under_the_Sea.lua
+++ b/scripts/quests/otherAreas/Under_the_Sea.lua
@@ -7,6 +7,7 @@
 -- Oswald  : !pos 47.119 -15.273 7.989 248
 -- Jimaida : !pos -17.342 -2.597 -18.766 248
 -- Zaldon  : !pos -11.810 -7.287 -6.742 248
+-- TODO: The quest is NOT supposed to appear in your log after talking to Yaya. Verify if/when it does appear.
 -----------------------------------
 
 local quest = Quest:new(xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.UNDER_THE_SEA)
@@ -23,7 +24,6 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_AVAILABLE and
-                player:getFameLevel(xi.fameArea.SELBINA_RABAO) >= 2 and
                 xi.settings.map.FISHING_ENABLE == true
         end,
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Removed the fame requirement from the quest "Under the Sea"
Adds a TODO indicating that the quest does not appear in the quest log upon starting it as observed in captures. Needs verification on if/when it does appear.

## Steps to test these changes

1. Start a fresh character
2. `!zone <Selbina>`
3. Talk to Yaya to start the quest

## Capture
Packets Only
https://drive.google.com/drive/folders/1Mp3MtEtyVQwxl6jh7y-5X84JTy6kVn86?usp=sharing
