### PR TITLE
[lua] Remove fame requirement from the quest "The Sand Charm"

### DIFF
--- a/scripts/quests/otherAreas/The_Sand_Charm.lua
+++ b/scripts/quests/otherAreas/The_Sand_Charm.lua
@@ -23,7 +23,6 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_AVAILABLE and
-                player:getFameLevel(xi.fameArea.WINDURST) >= 4 and
                 xi.settings.map.FISHING_ENABLE == true
         end,
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Removes the fame requirement from the quest "The Sand Charm"

## Steps to test these changes

1. Create a new character
2. `!zone <Mhaura>`
3. Talk to Blandine to start "The Sand Charm"

## Capture
Pckets Only
https://drive.google.com/drive/folders/17KWnAmpBTS5Jo-faGmtXEtO32aPytKQ9?usp=sharing