### PR TITLE
fix: BST with charmed pets tripping avatar check on /heal

### DIFF
--- a/scripts/effects/healing.lua
+++ b/scripts/effects/healing.lua
@@ -58,13 +58,13 @@ effectObject.onEffectTick = function(target, effect)
     local healtime = effect:getTickCount()
 
     if healtime > 1 then
-        -- Avatars cancel healing on first healing tick if summoned
+        -- Summoned avatars and spirits cancel healing on first healing tick if summoned
         local pet = target:getPet()
         if pet ~= nil then
             local petId = pet:getPetID()
             if
                 pet:isAvatar() or
-                petId >= xi.petId.FIRE_SPIRIT and petId <= xi.petId.DARK_SPIRIT
+                (not pet:isCharmed() and petId >= xi.petId.FIRE_SPIRIT and petId <= xi.petId.DARK_SPIRIT)
             then
                 target:messageBasic(xi.msg.basic.CANT_HEAL_WITH_AVATAR)
                 target:delStatusEffect(xi.effect.HEALING)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
BST with charmed pets are tripping up the existing conditional because their petID always returns 0 since they're not technically considered pets in core (and there's no unified binding to detect if pet is avatar/spirit)

Will now check AVATAR_PERPETUATION as it is always set to the base cost of the avatar/spirit (before any sort of reductions) and is always > 0 when a pet is present.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
- Heal as BST with a charmed pet -> no error
- Heal as SMN without a pet -> no error
- Heal as SMN with an avatar/spirit -> error on first tick
<!-- Clear and detailed steps to test your changes here -->
