### PR TITLE
[core/sql] Fix Duplicate Key Errors on Audit GM

### DIFF
--- a/sql/audit_gm.sql
+++ b/sql/audit_gm.sql
@@ -4,9 +4,9 @@
 
 DROP TABLE IF EXISTS `audit_gm`;
 CREATE TABLE `audit_gm` (
-  `date_time` datetime NOT NULL,
-  `gm_name` varchar(16) NOT NULL,
-  `command` varchar(40) NOT NULL,
-  `full_string` varchar(200) NOT NULL,
+  `date_time` DATETIME(3) NOT NULL,
+  `gm_name` VARCHAR(16) NOT NULL,
+  `command` VARCHAR(40) NOT NULL,
+  `full_string` VARCHAR(200) NOT NULL,
   PRIMARY KEY (`date_time`,`gm_name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/src/map/command_handler.cpp
+++ b/src/map/command_handler.cpp
@@ -217,7 +217,7 @@ int32 CCommandHandler::call(sol::state& lua, CCharEntity* PChar, const std::stri
             // clang-format off
             Async::getInstance()->submit([name, cmdname, cmdlinestr]()
             {
-                const auto query = "INSERT into audit_gm (date_time, gm_name, command, full_string) VALUES(current_timestamp(), ?, ?, ?)";
+                const auto query = "INSERT into audit_gm (date_time, gm_name, command, full_string) VALUES(CURRENT_TIMESTAMP(3), ?, ?, ?)";
                 if (!db::preparedStmt(query, db::escapeString(name), db::escapeString(cmdname), db::escapeString(cmdlinestr)))
                 {
                     ShowError("cmdhandler::call: Failed to log GM command.");


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Adds ms precision to GM Command Logging to prevent duplicate key errors when commands from the same character come at the same second.

Previously, if timed properly, GM Commands coming in too fast (on the same second) would generate duplicate key errors and prevent logging of the second GM command issued - Technically making it possible to issue GM commands without logs, even though the AUDIT_GM setting was enabled.

Before:
```
[09/25/25 08:15:06:716][map][error] Query Failed: INSERT into audit_gm (date_time, gm_name, command, full_string) VALUES(current_timestamp(), ?, ?, ?) (db::preparedStmt::<lambda_1>::operator ():731)
[09/25/25 08:15:06:716][map][error] (conn=10439) Duplicate entry '2025-09-25 08:15:06-Beasty' for key 'PRIMARY' (db::preparedStmt::<lambda_1>::operator ():732)
[09/25/25 08:15:06:716][map][error] cmdhandler::call: Failed to log GM command. (CCommandHandler::call::<lambda_1>::operator ():223)
[09/25/25 08:15:06:717][map][error] Query Failed: INSERT into audit_gm (date_time, gm_name, command, full_string) VALUES(current_timestamp(), ?, ?, ?) (db::preparedStmt::<lambda_1>::operator ():731)
[09/25/25 08:15:06:717][map][error] (conn=10439) Duplicate entry '2025-09-25 08:15:06-Beasty' for key 'PRIMARY' (db::preparedStmt::<lambda_1>::operator ():732)
[09/25/25 08:15:06:717][map][error] cmdhandler::call: Failed to log GM command. (CCommandHandler::call::<lambda_1>::operator ():223)
[09/25/25 08:15:06:717][map][error] Query Failed: INSERT into audit_gm (date_time, gm_name, command, full_string) VALUES(current_timestamp(), ?, ?, ?) (db::preparedStmt::<lambda_1>::operator ():731)
[09/25/25 08:15:06:717][map][error] (conn=10439) Duplicate entry '2025-09-25 08:15:06-Beasty' for key 'PRIMARY' (db::preparedStmt::<lambda_1>::operator ():732)
[09/25/25 08:15:06:717][map][error] cmdhandler::call: Failed to log GM command. (CCommandHandler::call::<lambda_1>::operator ():223)
[09/25/25 08:15:06:718][map][error] Query Failed: INSERT into audit_gm (date_time, gm_name, command, full_string) VALUES(current_timestamp(), ?, ?, ?) (db::preparedStmt::<lambda_1>::operator ():731)
[09/25/25 08:15:06:718][map][error] (conn=10439) Duplicate entry '2025-09-25 08:15:06-Beasty' for key 'PRIMARY' (db::preparedStmt::<lambda_1>::operator ():732)
[09/25/25 08:15:06:718][map][error] cmdhandler::call: Failed to log GM command. (CCommandHandler::call::<lambda_1>::operator ():223)
[09/25/25 08:15:06:719][map][error] Query Failed: INSERT into audit_gm (date_time, gm_name, command, full_string) VALUES(current_timestamp(), ?, ?, ?) (db::preparedStmt::<lambda_1>::operator ():731)
[09/25/25 08:15:06:719][map][error] (conn=10439) Duplicate entry '2025-09-25 08:15:06-Beasty' for key 'PRIMARY' (db::preparedStmt::<lambda_1>::operator ():732)
[09/25/25 08:15:06:719][map][error] cmdhandler::call: Failed to log GM command. (CCommandHandler::call::<lambda_1>::operator ():223)
[09/25/25 08:15:06:720][map][error] Query Failed: INSERT into audit_gm (date_time, gm_name, command, full_string) VALUES(current_timestamp(), ?, ?, ?) (db::preparedStmt::<lambda_1>::operator ():731)
[09/25/25 08:15:06:720][map][error] (conn=10439) Duplicate entry '2025-09-25 08:15:06-Beasty' for key 'PRIMARY' (db::preparedStmt::<lambda_1>::operator ():732)
[09/25/25 08:15:06:720][map][error] cmdhandler::call: Failed to log GM command. (CCommandHandler::call::<lambda_1>::operator ():223)
[09/25/25 08:15:06:721][map][error] Query Failed: INSERT into audit_gm (date_time, gm_name, command, full_string) VALUES(current_timestamp(), ?, ?, ?) (db::preparedStmt::<lambda_1>::operator ():731)
[09/25/25 08:15:06:721][map][error] (conn=10439) Duplicate entry '2025-09-25 08:15:06-Beasty' for key 'PRIMARY' (db::preparedStmt::<lambda_1>::operator ():732)
[09/25/25 08:15:06:721][map][error] cmdhandler::call: Failed to log GM command. (CCommandHandler::call::<lambda_1>::operator ():223)
[09/25/25 08:15:06:721][map][error] Query Failed: INSERT into audit_gm (date_time, gm_name, command, full_string) VALUES(current_timestamp(), ?, ?, ?) (db::preparedStmt::<lambda_1>::operator ():731)
[09/25/25 08:15:06:721][map][error] (conn=10439) Duplicate entry '2025-09-25 08:15:06-Beasty' for key 'PRIMARY' (db::preparedStmt::<lambda_1>::operator ():732)
```

After:
```
[09/25/25 13:35:51:332][map][info] ======================================================================= (Application::markLoaded:240)
[09/25/25 13:35:51:332][map][info] CTaskManager Active Tasks: 192 (MapEngine::map_garbage_collect:396)
[09/25/25 13:35:51:434][map][info] Garbage Collected (Full) (luautils::garbageCollectFull:507)
[09/25/25 13:35:51:434][map][info] Current State Top: 0, Total Memory Used: 59620kb -> 51095kb (luautils::garbageCollectFull:508)
[09/25/25 13:35:51:434][map][debug] Creating pending session for character id 1 (MapSessionContainer::createPendingSession:70)
[09/25/25 13:35:53:590][map][debug] Closing pending session for character id 1 (MapSessionContainer::destroyPendingSession:373)
[09/25/25 13:35:53:590][map][debug] Creating session for 127.0.0.1 (MapSessionContainer::createSession:40)
[09/25/25 13:35:53:995][map][debug] KillSession for charid 1 not needed (IPCClient::handleMessage_KillSession:768)
[09/25/25 13:35:55:647][map][debug] CZone:: East_Ronfaure IncreaseZoneCounter <1> Beasty (CZoneEntities::InsertPC:222)
[09/25/25 13:35:57:322][map][debug] GP_CLI_COMMAND_BATTLEFIELD_REQ: Not implemented. Kind: 0 (GP_CLI_COMMAND_BATTLEFIELD_REQ::process:34)
```

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - Issue GM Commands at a very rapid pace
2 - Check the server console logs and note that there are no errors
3 - Check the DB Logs for `audit_gm` table and see everything is actually logged now
