### PR TITLE
[lua] Reduce Ul/Om Yovra evasion after testing

### DIFF
--- a/scripts/zones/AlTaieu/mobs/Omyovra.lua
+++ b/scripts/zones/AlTaieu/mobs/Omyovra.lua
@@ -14,8 +14,7 @@ entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.REGEN, 50)
     mob:setMobMod(xi.mobMod.WEAPON_BONUS, mob:getMainLvl() - 2) -- Base damage is level * 2
     mob:setMod(xi.mod.AGI, 76 - mob:getStat(xi.mod.AGI))        -- Jimmy indicates AGI for Omyovra should be 76 or so
-    -- Yovra have a +40% bonus to evasion and a 50% bonus to defense
-    mob:addMod(xi.mod.EVA, mob:getStat(xi.mod.EVA) * 0.4) -- TODO: need better evasion mod
+    -- Yovra have a +50% bonus to defense
     mob:addMod(xi.mod.DEF, mob:getStat(xi.mod.DEF) * 0.5)
     mob:hideName(true)
     mob:setUntargetable(true)

--- a/scripts/zones/AlTaieu/mobs/Ulyovra.lua
+++ b/scripts/zones/AlTaieu/mobs/Ulyovra.lua
@@ -13,8 +13,7 @@ end
 entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.REGEN, 50)
     mob:setMobMod(xi.mobMod.WEAPON_BONUS, mob:getMainLvl() - 2) -- Base damage is level * 2
-    -- Yovra have a +40% bonus to evasion and 50% to defense.
-    mob:addMod(xi.mod.EVA, mob:getStat(xi.mod.EVA) * 0.4) -- TODO: need better evasion mod
+    -- Yovra have a +50% bonus to defense.
     mob:addMod(xi.mod.DEF, mob:getStat(xi.mod.DEF) * 0.5)
     mob:hideName(true)
     mob:setUntargetable(true)


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Removes Ul/Om Yovra evasion bonus

The previous data was for Escha mobs, but I did some testing 

Predicted evasion for a level 84 Yovra with C rank evasion from jobs:
<img width="289" height="107" alt="image" src="https://github.com/user-attachments/assets/654a9738-715e-4cf1-82df-0ed07b8e73e2" />

<img width="535" height="39" alt="image" src="https://github.com/user-attachments/assets/7cd57726-d235-43e2-ab89-ced3185f82ba" />

= ballpark near predicted evasion so no family boost
<img width="406" height="88" alt="image" src="https://github.com/user-attachments/assets/09cf205c-0fd3-4711-b158-357a300d5893" />


## Steps to test these changes
Within predicted stats +/- margin

<img width="451" height="372" alt="image" src="https://github.com/user-attachments/assets/3adba4fb-c0b8-4098-b4db-9894438c0eaa" />
