### PR TITLE
Fix Test Your Mite loot table

### DIFF
--- a/scripts/battlefields/The_Shrouded_Maw/test_your_mite.lua
+++ b/scripts/battlefields/The_Shrouded_Maw/test_your_mite.lua
@@ -24,21 +24,21 @@ content:addEssentialMobs({ 'Pasuk' })
 content.loot =
 {
     {
-        { item = xi.item.NONE,              weight = 950 }, -- Nothing
-        { item = xi.item.CLOUD_EVOKER,      weight =  50 }, -- Cloud Evoker
+        { itemId = xi.item.NONE,              weight = 950 }, -- Nothing
+        { itemId = xi.item.CLOUD_EVOKER,      weight =  50 }, -- Cloud Evoker
     },
 
     {
-        { item = xi.item.NONE,              weight = 500 }, -- Nothing
-        { item = xi.item.GEIST_EARRING,     weight = 250 }, -- Geist Earring
-        { item = xi.item.QUICK_BELT,        weight = 250 }, -- Quick Belt
+        { itemId = xi.item.NONE,              weight = 500 }, -- Nothing
+        { itemId = xi.item.GEIST_EARRING,     weight = 250 }, -- Geist Earring
+        { itemId = xi.item.QUICK_BELT,        weight = 250 }, -- Quick Belt
     },
 
     {
-        { item = xi.item.NONE,              weight = 350 }, -- Nothing
-        { item = xi.item.CROSSBOWMANS_RING, weight = 200 }, -- Crossbowman's Ring
-        { item = xi.item.WOODSMAN_RING,     weight = 150 }, -- Woodsman Ring
-        { item = xi.item.ETHER_RING,        weight = 300 }, -- Ether Ring
+        { itemId = xi.item.NONE,              weight = 350 }, -- Nothing
+        { itemId = xi.item.CROSSBOWMANS_RING, weight = 200 }, -- Crossbowman's Ring
+        { itemId = xi.item.WOODSMAN_RING,     weight = 150 }, -- Woodsman Ring
+        { itemId = xi.item.ETHER_RING,        weight = 300 }, -- Ether Ring
     },
 }
 


### PR DESCRIPTION
This PR adds the correct context to the loot table, updating item = to itemId = 

**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes the loot table for test your mite to work properly.

## Steps to test these changes

Go to The Shrouded Maw
!addkeyitem Astral_Covenant
Test the ENM
