### PR TITLE
[lua] Update manaclipper with optimizations from barge.lua

### DIFF
--- a/scripts/globals/barge.lua
+++ b/scripts/globals/barge.lua
@@ -81,9 +81,16 @@ local bargeSchedule =
 }
 
 local getNextEvent = function(currentTime, schedule)
-    local nextEvent = schedule[#schedule]
-    local prevEventEndTime = schedule[#schedule].endTime - 1440
+    local nextEvent = schedule[1]
+    if
+        schedule[#schedule].endTime <= currentTime or -- currentTime after the last event
+        schedule[1].endTime > currentTime             -- currentTime before first event
+    then
+        -- next event is first of the day
+        return schedule[1]
+    end
 
+    local prevEventEndTime = 0
     for i, currEvent in ipairs(schedule) do
         if
             prevEventEndTime <= currentTime and
@@ -113,9 +120,10 @@ xi.barge.timekeeperOnTrigger = function(player, location, eventId)
     local nextEvent = getNextEvent(currentTime, schedule)
 
     local gameMins = nextEvent.endTime - currentTime
-    if gameMins < 0 then
+    if nextEvent.endTime < currentTime then
         -- next event is before current time because it's near the end of the day, add a cycle
-        gameMins = gameMins + 1440
+        -- nextEvent.endTime - currentTime underflows so add 1440 first
+        gameMins = 1440 + nextEvent.endTime - currentTime
     end
 
     local earthSecs = gameMins * 60 / 25 -- one earth second is 25 game seconds

--- a/scripts/zones/Bibiki_Bay/Zone.lua
+++ b/scripts/zones/Bibiki_Bay/Zone.lua
@@ -17,9 +17,9 @@ zoneObject.onZoneIn = function(player, prevZone)
         player:getYPos() == 0 and
         player:getZPos() == 0
     then
-        if prevZone == xi.zone.MANACLIPPER then
-            cs = xi.manaclipper.onZoneIn(player)
-        else
+        cs = xi.manaclipper.onZoneIn(player, prevZone)
+
+        if cs == -1 then
             player:setPos(669.917, -23.138, 911.655, 111)
         end
     end
@@ -32,11 +32,14 @@ zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranki
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)
-    xi.manaclipper.aboard(player, triggerArea:getTriggerAreaID(), true)
+    local triggerAreaID = triggerArea:getTriggerAreaID()
+    if triggerAreaID <= 2 then
+        player:setLocalVar('[manaclipper]aboard', triggerAreaID)
+    end
 end
 
 zoneObject.onTriggerAreaLeave = function(player, triggerArea)
-    xi.manaclipper.aboard(player, triggerArea:getTriggerAreaID(), false)
+    player:setLocalVar('[manaclipper]aboard', 0)
 end
 
 zoneObject.onTransportEvent = function(player, prevZoneId, transportId)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

~~Draft for now, but updating to use the `utils` function for readability. Also times are slightly off from wiki. Reviewing a few videos to lock down the exact schedule of each trip.~~

Note that I was correct in https://github.com/LandSandBoat/server/issues/8200 and this PR closes that:
https://youtu.be/Uqi7KwM4okM?t=1371
(ignore the timed message saying the boat is arriving, talking to the npc switches from event 2 to event 1 when less than 1 minute remains on the boat ride
<img width="969" height="196" alt="image" src="https://github.com/user-attachments/assets/79da9813-1937-43c3-82e2-1290e1867307" />

Also found the boat arrives at 20:40 (which makes sense because the cycle is 12 hours). from same video:
<img width="859" height="441" alt="image" src="https://github.com/user-attachments/assets/38751f15-4cf3-41ff-bd6d-1e0596a50e9b" />

I've updated the bgwiki with my findings

Changes in this PR:
- small logic updates to in `barge.lua` to match the identified issue with `getNextEvent`.
  - Notes on how manaclipper is different from barge, which made me find logical holes in barge.lua
    - Best i can tell, I just got lucky that the only boat that was truly affected was south landing's first boat of the day, but it was so close in time that the event just reported "arriving soon"
    - manaclipper has a much less dense schedule, so there's large delays between boats arriving at a dock
  - this function should be re-usable for WG boats as well, which I plan on looking into next and possibly making `getNextEvent` a global function
  - `nextEvent.endTime - currentTime` underflows for whatever reason when it should just go negative, so I adjusted the conditional in the trigger function and added a note
- consuming tickets is adjusted to the way i did it in barge.lua, which makes the charvar cleanup in the event that a gm gives themself a multi-ticket without setting the charvar
- arrivals/departures are updated to use the helper to make them more obvious, and also found a hole in bg-wiki that didn't have them _quite_ in a twelve-hour cycle
- simplified the triggerarea to just use a localvar
- updated `xi.manaclipper.onZoneIn` to consider prevZone to reduce conditional nesting in the `Zone.lua` and added default behavior in the case of a player not having the eventid charvar

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- very simple way to test timekeepers
  - update `local currentTime` line to explicitly set a time: `currentTime = utils.timeStringToMinutes('00:49')` etc
  - update just below next line to `print(nextEvent)` 
  - talk to them and see they say the right thing and map server prints the proper next "minutes after minute" event
  - Note that retail bugs out when the time until the next boat is too large (lol):
    - <img width="1105" height="197" alt="image" src="https://github.com/user-attachments/assets/07b66ed0-8fed-44a0-94bc-516e69b7e72f" />
  - on-boat timekeeper has special event when within 25 game minutes to arrival: 
    - <img width="655" height="121" alt="image" src="https://github.com/user-attachments/assets/62d89862-ad8a-45ea-beeb-3fac76e1b9db" />
- actual boat schedules in the db are untouched, but confirm that they arrive on time based on wiki table
- ensure zoning into carpenter's landing reliably puts you on a dock when you come from manaclipper zone
  - also that you get put to the start of the zone even if you have the eventid charvar: go from manaclipper > some other zone > bibiki bay
  - you will still get placed at the start of the zone