### PR TITLE
CL Barge cutscenes parameters, flags

### DIFF
--- a/scripts/enum/cutscene_flag.lua
+++ b/scripts/enum/cutscene_flag.lua
@@ -7,8 +7,20 @@ xi = xi or {}
 ---@enum xi.cutsceneFlag
 xi.cutsceneFlag =
 {
-    UNKNOWN_1       = 0x01, -- Commonly set, effect unknown
-    NO_PCS          = 0x02, -- Do not display other Player Characters
-    NO_NPCS         = 0x10, -- Do not display NPCs and Mobs
-    UNKNOWN_2       = 0x80, -- Commonly set, effect unknown
+    UNKNOWN_1       = 0x0001, -- Commonly set, effect unknown
+    NO_PCS          = 0x0002, -- Do not display other Player Characters
+    UNKNOWN_3       = 0x0004, -- Unknown
+    UNKNOWN_4       = 0x0008, -- Unknown
+    NO_NPCS         = 0x0010, -- Do not display NPCs and Mobs
+    UNKNOWN_5       = 0x0020, -- Unknown
+    UNKNOWN_6       = 0x0040, -- Unknown
+    UNKNOWN_2       = 0x0080, -- Commonly set, effect unknown
+    UNKNOWN_7       = 0x0100, -- Unknown (possibly camera related)
+    UNKNOWN_8       = 0x0200, -- Unknown
+    UNKNOWN_9       = 0x0400, -- Unknown
+    UNKNOWN_10      = 0x0800, -- Unknown
+    UNKNOWN_11      = 0x1000, -- Unknown
+    UNKNOWN_12      = 0x2000, -- Unknown
+    UNKNOWN_13      = 0x4000, -- Unknown
+    UNKNOWN_14      = 0x8000, -- Unknown
 }

--- a/scripts/globals/barge.lua
+++ b/scripts/globals/barge.lua
@@ -267,7 +267,7 @@ xi.barge.onZoneIn = function(player, prevZone)
         zoneId == xi.zone.CARPENTERS_LANDING and
         prevZone == xi.zone.PHANAUET_CHANNEL
     then
-        -- Zoning into Carptener's Landing. Play the cs saved when we started the ride.
+        -- Zoning into Carpenter's Landing. Play the cs saved when we started the ride.
         local bargeDestinationId = player:getCharVar('[barge]destinationDockId')
         player:setCharVar('[barge]destinationDockId', 0)
 
@@ -275,15 +275,14 @@ xi.barge.onZoneIn = function(player, prevZone)
         local bargeDestinationData = dockEventData[bargeDestinationId] or dockEventData[destinations.CENTRAL_LANDING]
         player:setPos(bargeDestinationData.arrivalPos)
 
-        return bargeDestinationData.arrivalCsId
+        return { bargeDestinationData.arrivalCsId, -1, bit.bor(xi.cutsceneFlag.UNKNOWN_1, xi.cutsceneFlag.NO_PCS) }
     end
 
     return -1
 end
 
 xi.barge.onTransportEvent = function(player, zoneId, transportId)
-    local ID = zones[player:getZoneID()]
-    local aboard = player:getLocalVar('[barge]aboard')
+    local aboard   = player:getLocalVar('[barge]aboard')
     local destData = nil
 
     for _, bargeDestinationData in pairs(dockEventData) do
@@ -304,24 +303,43 @@ xi.barge.onTransportEvent = function(player, zoneId, transportId)
         -- was in trigger area but no in-service boat was departing from this dock
         player:startEvent(destData.kickEvent)
     elseif player:hasKeyItem(xi.ki.BARGE_TICKET) then
-        player:messageSpecial(ID.text.BARGE_TICKET_USED, 0, xi.ki.BARGE_TICKET)
+        -- This is technically done on event end but does not matter
         player:delKeyItem(xi.ki.BARGE_TICKET)
-        -- was in trigger area and had a ticket
-        player:startEvent(destData.departEvent)
+
+        player:startEvent(destData.departEvent,
+            {
+                [0] = 0,
+                [1] = xi.ki.BARGE_TICKET,
+                [2] = 0, -- Important to be set to 0
+                flags = bit.bor(
+                    xi.cutsceneFlag.UNKNOWN_1,
+                    xi.cutsceneFlag.NO_PCS,
+                    xi.cutsceneFlag.UNKNOWN_4,
+                    xi.cutsceneFlag.UNKNOWN_7
+                ),
+            })
     elseif player:hasKeyItem(xi.ki.BARGE_MULTI_TICKET) then
         local usesLeft = player:getCharVar('[barge]multiTicket') - 1
 
         if usesLeft <= 0 then
             usesLeft = 0
-            player:messageSpecial(ID.text.BARGE_TICKET_USED, 0, xi.ki.BARGE_MULTI_TICKET)
             player:delKeyItem(xi.ki.BARGE_MULTI_TICKET)
-        else
-            player:messageSpecial(ID.text.BARGE_TICKET_REMAINING, 0, xi.ki.BARGE_MULTI_TICKET, usesLeft)
         end
 
         player:setCharVar('[barge]multiTicket', usesLeft)
         -- was in trigger area and had a ticket
-        player:startEvent(destData.departEvent)
+        player:startEvent(destData.departEvent,
+            {
+                [0] = usesLeft,     -- Not actually used by CS but passed in
+                [1] = xi.ki.BARGE_MULTI_TICKET,
+                [2] = usesLeft + 1, -- This expects the number of uses before it get decremented
+                flags = bit.bor(
+                    xi.cutsceneFlag.UNKNOWN_1,
+                    xi.cutsceneFlag.NO_PCS,
+                    xi.cutsceneFlag.UNKNOWN_4,
+                    xi.cutsceneFlag.UNKNOWN_7
+                ),
+            })
     else
         -- was in trigger area but didn't have a ticket
         player:startEvent(destData.kickEvent)

--- a/scripts/zones/Carpenters_Landing/Zone.lua
+++ b/scripts/zones/Carpenters_Landing/Zone.lua
@@ -19,21 +19,19 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)
-    local cs = -1
-
     if
         player:getXPos() == 0 and
         player:getYPos() == 0 and
         player:getZPos() == 0
     then
-        cs = xi.barge.onZoneIn(player, prevZone)
-
-        if cs == -1 then
-            player:setPos(6.509, -9.163, -819.333, 239)
+        if prevZone == xi.zone.PHANAUET_CHANNEL then
+            return xi.barge.onZoneIn(player, prevZone)
         end
+
+        player:setPos(6.509, -9.163, -819.333, 239)
     end
 
-    return cs
+    return -1
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)

--- a/scripts/zones/Phanauet_Channel/Zone.lua
+++ b/scripts/zones/Phanauet_Channel/Zone.lua
@@ -25,7 +25,9 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
-    player:startEvent(100)
+    -- TODO: Only seen event 0 in captures but used to be 100 here. Both events have the exact same code.
+    -- This might be used by SE to differentiate where to send the player?
+    player:startEvent(0)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
@@ -39,7 +41,7 @@ zoneObject.onEventUpdate = function(player, csid, option, npc)
 end
 
 zoneObject.onEventFinish = function(player, csid, option, npc)
-    if csid == 100 then
+    if csid == 0 then
         player:setPos(0, 0, 0, 0, xi.zone.CARPENTERS_LANDING)
     end
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Looked at some reported issues and made some slight changes:
- The CS were missing the flags - I haven't quite figured out what they all do but these flags line up with captures
- The CS were missing the parameters for tickets, which caused the messages to not be printed by the event itself
  - Conversely the messageSpecial etc are not required - see the [dump here](https://github.com/sruon/FFXI-EventsDump/blob/main/dumps/Carpenters'%20Landing/Zone%20Events.md#event-14)
- The Phanauet fade to black CS is 0 on all my captures. [100 looks like it works too](https://github.com/sruon/FFXI-EventsDump/blob/main/dumps/Phanauet%20Channel/Zone%20Events.md#event-0) so it might be hinting at some special condition SE uses for _something_

There are a couple of other issues but I don't believe they are necessarily related to the barge itself:
- Players showing above water while they're in the boarding CS
  - Did not quite capture this case but I know it happens with airships on LSB so I'll go check there
- Mobs showing in the arrival CS
  - Retail sends packets in a different order so the client doesnt know about the mobs by the time the CS is executing. I'll take another look at it once packets are all sorted.
- Player not showing in the arrival CS
  - This is actually retail accurate. The CS has the HIDE_PCS flag set.
- Other players being invisible after completing the zone-in
  - Likely a packet ordering issue here too or maybe some deeper issues with the way spawnlists are handled when you're in a zone CS - not worth tracking right this minute.
- Ship not at right position possibly?
  - I didnt quite capture all pos on retail but they look way off from where the ship is supposed to be (mid-transport) - right now it looks like the ship is just made invisible next to the last docks.
- Kings NPCs not being sent with higher priority
  - This is a known issue but that concept is still relatively poorly understood.

Might conflict with #8216 

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
