### PR TITLE
[sql] Update audit_trade to handle NPC names

### DIFF
--- a/sql/audit_trade.sql
+++ b/sql/audit_trade.sql
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS `audit_trade` (
   `sender` int(10) unsigned NOT NULL DEFAULT '0',
   `sender_name` varchar(15) DEFAULT NULL,
   `receiver` int(10) unsigned NOT NULL DEFAULT '0',
-  `receiver_name` varchar(15) DEFAULT NULL,
+  `receiver_name` varchar(24) DEFAULT NULL,
   `date` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `itemid` (`itemid`),


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
- Updates the column width on audit_trade to match the column width of the name column in npc_list to prevent the following errors from occurring:
```
[09/26/25 23:56:18:795][map][error] Query Failed: INSERT INTO audit_trade(itemid, quantity, sender, sender_name, receiver, receiver_name, date) VALUES (?, ?, ?, ?, ?, ?, ?) (db::preparedStmt::<lambda_1>::operator ():731)`
[09/26/25 23:56:18:795][map][error] (conn=19567) Data too long for column 'receiver_name' at row 1 (db::preparedStmt::<lambda_1>::operator ():732)
```
- Under the old system, the trade logs column width for the receiver was set to 15 to accommodate player trades and that was safe for player names.  However, when a player trades a NPC, the internal `name` column from the `npc_list.sql` is used and can be longer than the 15 character name limit
- This updates the `receiver_name` column in the `audit_trade.sql` to accommodate that width.

### Considerations
- I thought about truncating the names of the npc's being stored, but in some cases, this means they can no longer have unique or meaningful names.  Examples:
  - `qm_jailer_of_hope` becomes `qm_jailer_of_ho`
  - `qm_jailer_of_justice` becomes `qm_jailer_of_ju`
  - `qm_jailer_of_prudence` becomes `qm_jailer_of_pr`
  - `qm_jailer_of_love` becomes `qm_jailer_of_lo`
  - `qm_jailer_of_fortitude` becomes `qm_jailer_of_fo`
- Also can't really use `polutils_name` due to the fact that they are even more ambiguous
  - Example - All the `qm_jailer_...` above would be logged as `???`
- I then thought about the potential to use the npc id, but due to npc shifts that happen from retail updates, this does not really work well because ID `12345678` could shift to `12345679` and if someone ever looked up that specific ID, they would be shown the wrong NPC data for that trade transaction.
- Then looked into `VARCHAR()` and how it is stored in the DB with size considerations:
  - `VARCHAR` are stored as `N + 1` where `N < 255` (1 Byte reserved for null terminator)
  - When storing the data, the column width is somewhat arbitrary when it comes to storage size aside from enforcing a certain length restriction.
  - If you stored `APPLES` (6 bytes), it doesn't matter if the DB Column is `VARCHAR(15)` or `VARCHAR(200)`, the size on disk would still be `N+1`, so a total of 7 Bytes of data stored.
- `audit_trade` is also an optional setting and not required to be enabled.

So this brings me to the solution in this PR (which is also the simplest adjustment).  Just increase the column width to match the size of the column for `name` in `npc_list.sql`.  It does increase storage requirements from before, but only by nominal amounts when the npc name is actually longer than the previously used 15 width.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - Enable `AUDIT_PLAYER_TRADES` in `map.lua` and start the server
2 - `!gotoid 16912887`
3 - `!additem fourth_virtue`
4 - `!additem fifth_virtue`
5 - `!additem sixth_virtue`
6 - Trade the virtues to the ???
7 - Check the `audit_gm` table for the trade transaction

Result: No errors in the xi_map console log and proper trade logging in the `audit_trade` table.