### PR TITLE
[core] Delete PChar early to attempt to prevent race condition

### DIFF
--- a/src/map/map_networking.h
+++ b/src/map/map_networking.h
@@ -34,6 +34,7 @@
 #include <map>
 #include <span>
 
+class CBasicPacket;
 struct MapConfig;
 class MapEngine;
 class MapNetworking
@@ -56,6 +57,8 @@ public:
     int32 recv_parse(uint8*, size_t*, MapSession*, const IPP& ipp);      // main function to parse recv packets
     int32 parse(uint8*, size_t*, MapSession*);                           // main function parsing the packets
     int32 send_parse(uint8*, size_t*, MapSession*, bool);                // main function is building big packet
+
+    int32 sendSinglePacketNoPchar(uint8*, size_t*, MapSession*, bool, CBasicPacket*); // used to resend 0x00B if client didn't receive it (dropped packet)
 
     //
     // Accessors


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

There was a race condition where one map server hadn't yet deleted PChar and the player arrived on the new map server before the PChar was deleted causing issues with race conditions from DB transactions in CCharEntity Destructor

## Steps to test these changes

Zone, see stuff still works
