### PR TITLE
Stop teleport/warps on job change

### DIFF
--- a/sql/status_effects.sql
+++ b/sql/status_effects.sql
@@ -665,7 +665,7 @@ INSERT INTO `status_effects` VALUES (793,'ninjutsu_ele_debuff',544,0,0,0,0,0,0,0
 INSERT INTO `status_effects` VALUES (794,'healing',1048948,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (795,'leavegame',1048948,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (796,'haste_samba_haste',320,0,0,0,0,0,0,0,0);
-INSERT INTO `status_effects` VALUES (797,'teleport',32,0,0,0,0,0,0,0,0);
+INSERT INTO `status_effects` VALUES (797,'teleport',0x00400020,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (798,'chainbound',32,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (799,'skillchain',32,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (800,'dynamis',33554432,0,0,0,0,0,0,0,0);

--- a/src/map/packets/c2s/0x100_myroom_job.cpp
+++ b/src/map/packets/c2s/0x100_myroom_job.cpp
@@ -143,6 +143,13 @@ void GP_CLI_COMMAND_MYROOM_JOB::process(MapSession* PSession, CCharEntity* PChar
     charutils::LoadJobChangeGear(PChar);
     PChar->RequestPersist(CHAR_PERSIST::EQUIP);
 
+    // If the player has a teleport effect and they change jobs, cancel the teleport/warps you
+    // Retail does cancel your teleport/warp if you change subs if someone else ports/warps
+    if (auto PTeleportEffect = PChar->StatusEffectContainer->GetStatusEffect(EFFECT::EFFECT_TELEPORT))
+    {
+        PTeleportEffect->SetPower(0);
+    }
+
     PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DISPELABLE | EFFECTFLAG_ROLL | EFFECTFLAG_ON_JOBCHANGE);
 
     // clang-format off


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Set EFFECT_TELEPORT power on job change so you have no teleport destination
Remove EFFECT_TELEPORT on job change

Because the power is 0, you will no longer teleport anywhere

## Steps to test these changes

Go to selbina
Change sub to /BLM, cast warp, finish casting warp, change sub/job and warp is cancelled