### PR TITLE
Soultrapper test, CItemState cleanup

### DIFF
--- a/scripts/tests/systems/soultrapper.lua
+++ b/scripts/tests/systems/soultrapper.lua
@@ -1,0 +1,81 @@
+describe('Soultrapper', function()
+    ---@type CClientEntityPair
+    local player
+    ---@type CBaseEntity
+    local euvhi
+    local soultrapper
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer(
+        {
+            job = xi.job.SMN,
+            level = 75,
+            zone = xi.zone.ALTAIEU
+        })
+
+        -- Add equipment needed to take pictures
+        player:addItem(xi.item.SOULTRAPPER_2000)
+        player:addItem(xi.item.BLANK_SOUL_PLATE, 12)
+        soultrapper = player:findItem(xi.item.SOULTRAPPER_2000)
+        assert(soultrapper)
+
+        -- Equip soultrapper and plates
+        player:equipItem(xi.item.SOULTRAPPER_2000)
+        player:equipItem(xi.item.BLANK_SOUL_PLATE)
+
+        -- Force ZNM success to 100% for testing
+        xi.znm.SOULTRAPPER_SUCCESS = 100
+
+        -- Find a mob to take picture of
+        euvhi = player.entities:moveTo('Aweuvhi')
+    end)
+
+    it('cant be used before timer reaches 0', function()
+        player.actions:useItem(euvhi, soultrapper:getSlotID())
+        xi.test.world:skipTime(1)
+
+        -- If we have a soul plate before the timer is up, the test fails
+        player.assert.no:hasItem(xi.item.SOUL_PLATE)
+    end)
+
+    it('can be used when timer reaches 0', function()
+        xi.test.world:skipTime(31)
+        player.actions:useItem(euvhi, soultrapper:getSlotID())
+        xi.test.world:skipTime(1)
+        xi.test.world:tickEntity(player)
+        player.assert:hasItem(xi.item.SOUL_PLATE)
+    end)
+
+    it('cant be reused before cooldown reaches 0', function()
+        -- Take first picture
+        xi.test.world:skipTime(31)
+        player.actions:useItem(euvhi, soultrapper:getSlotID())
+        xi.test.world:skipTime(1)
+        xi.test.world:tickEntity(player)
+        player.assert:hasItem(xi.item.SOUL_PLATE)
+        player:delItem(xi.item.SOUL_PLATE, 1, xi.inv.INVENTORY)
+
+        -- Try to use again immediately
+        player.actions:useItem(euvhi, soultrapper:getSlotID())
+        xi.test.world:skipTime(1)
+        xi.test.world:tickEntity(player)
+        player.assert.no:hasItem(xi.item.SOUL_PLATE)
+    end)
+
+    it('can be reused when cooldown reaches 0', function()
+        -- Take first picture
+        xi.test.world:skipTime(31)
+        player.actions:useItem(euvhi, soultrapper:getSlotID())
+        xi.test.world:skipTime(1)
+        xi.test.world:tickEntity(player)
+        player.assert:hasItem(xi.item.SOUL_PLATE)
+        player:delItem(xi.item.SOUL_PLATE, 1, xi.inv.INVENTORY)
+
+        -- Reuse after 30s
+        xi.test.world:skipTime(30)
+        player.actions:useItem(euvhi, soultrapper:getSlotID())
+        xi.test.world:skipTime(1)
+        xi.test.world:tickEntity(player)
+        player.assert:hasItem(xi.item.SOUL_PLATE)
+    end)
+end)

--- a/src/map/ai/states/item_state.h
+++ b/src/map/ai/states/item_state.h
@@ -19,8 +19,7 @@
  ===========================================================================
  */
 
-#ifndef _CITEM_STATE_H
-#define _CITEM_STATE_H
+#pragma once
 
 #include "state.h"
 
@@ -36,28 +35,28 @@ public:
     CItemState(CCharEntity* PEntity, uint16 targid, uint8 loc, uint8 slotid);
     void UpdateTarget(CBaseEntity* target) override;
     void UpdateTarget(uint16 targid) override;
-    bool Update(timer::time_point tick) override;
+    auto Update(timer::time_point tick) -> bool override;
     void Cleanup(timer::time_point tick) override;
-    bool CanChangeState() override;
-    bool CanFollowPath() override
+    auto CanChangeState() -> bool override;
+    auto CanFollowPath() -> bool override
     {
         return false;
     }
 
-    bool CanInterrupt() override
+    auto CanInterrupt() -> bool override
     {
         return m_interruptable;
     }
 
-    void TryInterrupt(CBattleEntity* PAttacker) override;
+    void TryInterrupt(CBattleEntity* PTarget) override;
 
-    CItemUsable* GetItem();
+    CItemUsable* GetItem() const;
 
     void InterruptItem(action_t& action);
     void FinishItem(action_t& action);
 
 protected:
-    bool HasMoved();
+    bool HasMoved() const;
 
     CCharEntity*    m_PEntity;
     CItemUsable*    m_PItem;
@@ -69,5 +68,3 @@ protected:
     bool            m_interrupted{ false };
     bool            m_interruptable{ true };
 };
-
-#endif

--- a/src/map/packets/message_basic.h
+++ b/src/map/packets/message_basic.h
@@ -138,6 +138,7 @@ enum MSGBASIC_ID : uint16
     MSGBASIC_NO_ELIGIBLE_ROLL           = 428, // There are no rolls eligible for Double-Up. Unable to use ability.
     MSGBASIC_ROLL_ALREADY_ACTIVE        = 429, // The same roll is already active on the <player>.
     MSGBASIC_MAGIC_STEAL                = 430, // <caster> casts <spell>. <number> of <target>'s effects is drained.
+    MSGBASIC_CANNOT_USE_ITEMS           = 445, // You cannot use items at this time.
     MSGBASIC_CANNOT_ATTACK_TARGET       = 446, // You cannot attack that target
     MSGBASIC_NO_FINISHINGMOVES          = 524,
     MSGBASIC_PET_CANNOT_DO_ACTION       = 574, // <player>'s pet is currently unable to perform that action.

--- a/src/test/lua/helpers/lua_client_entity_pair_actions.cpp
+++ b/src/test/lua/helpers/lua_client_entity_pair_actions.cpp
@@ -183,7 +183,7 @@ void CLuaClientEntityPairActions::useItem(CLuaBaseEntity* target, const uint8 sl
     const auto packet             = parent_->packets().createPacket(0x37);
     auto*      itemPacket         = packet->as<GP_CLI_COMMAND_ITEM_USE>();
     itemPacket->UniqueNo          = target->getID();
-    itemPacket->ItemNum           = 1;
+    itemPacket->ItemNum           = 0;
     itemPacket->ActIndex          = target->getTargID();
     itemPacket->PropertyItemIndex = slotId;
     itemPacket->Category          = storageId.value_or(0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds a test for Soultrapper usage. Originally from Eden
- Cleans up CItemState to use enums for messages
- Change a field on ITEM_USE packet within xi_test as it's supposed to always be 0 and I'm an idiot

## Steps to test these changes
✨The test is in the PR. ✨

<!-- Clear and detailed steps to test your changes here -->
