### PR TITLE
[core][lua] Fix NPC Pathing Issues

### DIFF
--- a/scripts/zones/Lower_Jeuno/DefaultActions.lua
+++ b/scripts/zones/Lower_Jeuno/DefaultActions.lua
@@ -46,7 +46,7 @@ return {
     ['Taza']            = { text = ID.text.WAAG_DEEG_SHOP_DIALOG },
     ['Teigero-Bangero'] = { event = 34 },
     ['Tuh_Almodankha']  = { event = 10013 },
-    ['Vhana_Ekgaklywha'] = { text = ID.text.VHANA_DEFAULT },
+    ['Vhana_Ehgaklywha'] = { text = ID.text.VHANA_DEFAULT },
     ['Venika']          = { event = 110 },
     ['Yamilla']         = { event = 109 },
     ['Yatniel']         = { event = 10028 },

--- a/scripts/zones/Lower_Jeuno/Zone.lua
+++ b/scripts/zones/Lower_Jeuno/Zone.lua
@@ -83,7 +83,6 @@ zoneObject.onGameHour = function(zone)
             npc:setStatus(0)
             npc:initNpcAi()
             npc:setLocalVar('path', 1)
-            npc:setLocalVar('keepPathingOnTrigger', 1)
             npc:setPos(xi.path.first(lowerJeunoGlobal.lampPath[1]))
             npc:pathThrough(lowerJeunoGlobal.lampPath[1], bit.bor(xi.path.flag.COORDS, xi.path.flag.WALLHACK))
         end

--- a/scripts/zones/West_Ronfaure/npcs/Palcomondau.lua
+++ b/scripts/zones/West_Ronfaure/npcs/Palcomondau.lua
@@ -45,7 +45,6 @@ local pathNodes =
 
 entity.onSpawn = function(npc)
     npc:initNpcAi()
-    npc:setLocalVar('keepPathingOnTrigger', 1)
     npc:setPos(xi.path.first(pathNodes))
     npc:pathThrough(pathNodes, xi.path.flag.COORDS)
 end

--- a/scripts/zones/West_Ronfaure/npcs/Zovriace.lua
+++ b/scripts/zones/West_Ronfaure/npcs/Zovriace.lua
@@ -62,7 +62,6 @@ local pathNodes =
 
 entity.onSpawn = function(npc)
     npc:initNpcAi()
-    npc:setLocalVar('keepPathingOnTrigger', 1)
     npc:setLocalVar('path', 1)
     npc:setPos(xi.path.first(pathNodes))
     npc:pathThrough(pathNodes, xi.path.flag.COORDS)

--- a/src/map/ai/ai_container.cpp
+++ b/src/map/ai/ai_container.cpp
@@ -155,7 +155,7 @@ bool CAIContainer::Trigger(CCharEntity* player)
     if (CanChangeState())
     {
         auto ret = ChangeState<CTriggerState>(PEntity, player->targid, isDoor);
-        if (PathFind && PEntity->GetLocalVar("keepPathingOnTrigger") != 1)
+        if (PathFind && PEntity->GetLocalVar("stopPathingOnTrigger") == 1)
         {
             PEntity->SetLocalVar("pauseNPCPathing", 1);
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
- Changes the condition to pause NPC Pathing on trigger to be explicitly disabled unless a var is set `stopPathingOnTrigger`
  - Previously, it was configured to always pause a pathing NPC unless a var was set on that NPC.
    - This meant that all pathing NPCs had to have flags/localvars set in their lua scripts to continue pathing if a player triggered them - causing them to stop moving for everyone.
  - The default response for almost all pathing NPCs is that they do continue pathing after their dialog is complete.
  - This change updates the ai_container to mirror that logic
  - NPCs with pathing will continue their pathing unless explicitly flagged to stop all pathing when triggered.
- Also fixes a typo in the NPC Name for `defaultActions.lua` for Lower Jeuno that was causing interactions with that NPC to not fire.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - Go to Lower Jeuno during Night Time
2 - Talk with the `Vhana Ehgaklywha` NPC while she is pathing through town
Result: You are given the proper dialog and she continues pathing.

3 - Go to West Ronfaure
4 - Talk with the NPC `Zovriace` or NPC `Palcomondau`
Result: You are given the proper dialog and they continue pathing.

5 - Go to South San d'Oria
6 - Talk with `Raminel`
Result: You are given the proper dialog and they continue pathing.

Side Note: If testing from a single character, you will notice some NPCs (like Raminel) will stop and face your character when speaking, then after the dialog is complete, will 'teleport' to where it should be.  This is both accurate to retail and also limited to your character only.  Other players in the area will not see Raminel stop and teleport like this.
