### PR TITLE
[lua] Some cleanup to xi.transports related to event timing (selb<>mhaura<>wg<>nashmau)

### DIFF
--- a/scripts/globals/transport.lua
+++ b/scripts/globals/transport.lua
@@ -104,6 +104,13 @@ local dockTable =
     ['Yohj_Dukonlhy'  ] = { 231, xi.transport.routes.SILVER_SEA              }, -- Nashmau to Aht Urhgan Whitegate
 }
 
+-- times are minutes past midnight, and aligns with the transports.sql entries.
+-- Since the cycle is every 480 minutes, 3 cycles are listed for simpler logic
+-- time for arrivalStart: time_offset
+-- time for arrivalEnd:   time_offset + time_anim_arrive
+-- time for departStart:  time_offset + time_anim_arrive + time_waiting
+-- time for departEnd:    time_offset + time_anim_arrive + time_waiting + time_anim_depart
+-- time for ride on the boat to end: time_offset + time_anim_arrive - 10
 local scheduleTable =
 {
     -- used by ship and selbina dock timekeepers
@@ -172,12 +179,12 @@ end
 xi.transport.dockMessage = function(npc, triggerID, messages, dock)
     local dockNpcPos =
     {
-        mhaura =
+        [xi.zone.MHAURA] =
         {
             ARRIVING  = { { x = 7.06, y = -1.36, z = 2.20, rotation = 211 }, },
             DEPARTING = { { x = 8.26, y = -1.36, z = 2.20, rotation = 193 }, },
         },
-        selbina =
+        [xi.zone.SELBINA] =
         {
             ARRIVING  = { { x = 16.768, y = -1.38,  z = -58.843, rotation = 209 }, },
             DEPARTING = { { x = 17.979, y = -1.389, z = -58.800, rotation = 191 }, },

--- a/scripts/zones/Mhaura/npcs/Dieh_Yamilsiah.lua
+++ b/scripts/zones/Mhaura/npcs/Dieh_Yamilsiah.lua
@@ -35,7 +35,7 @@ entity.onSpawn = function(npc)
 end
 
 entity.onTimeTrigger = function(npc, triggerID)
-    xi.transport.dockMessage(npc, triggerID, messages, 'mhaura')
+    xi.transport.dockMessage(npc, triggerID, messages, xi.zone.MHAURA)
 end
 
 entity.onTrigger = function(player, npc)

--- a/scripts/zones/Selbina/npcs/Humilitie.lua
+++ b/scripts/zones/Selbina/npcs/Humilitie.lua
@@ -26,7 +26,7 @@ entity.onSpawn = function(npc)
 end
 
 entity.onTimeTrigger = function(npc, triggerID)
-    xi.transport.dockMessage(npc, triggerID, messages, 'selbina')
+    xi.transport.dockMessage(npc, triggerID, messages, xi.zone.SELBINA)
 end
 
 entity.onTrigger = function(player, npc)

--- a/sql/transport.sql
+++ b/sql/transport.sql
@@ -52,8 +52,8 @@ INSERT INTO `transport` VALUES (14,'Nashmau-Whitegate_Boat',16994327,16994326,3.
 INSERT INTO `transport` VALUES (15,'Manaclip_Bibiki-Tours',16793984,16793985,491.500,0.000,687.400,128,0,18,19,710,720,20,40,20,3);
 INSERT INTO `transport` VALUES (16,'Manaclip_Bibiki-Purgonorgo',16793984,16793985,491.500,0.000,687.400,128,0,18,19,270,720,20,40,20,3);
 INSERT INTO `transport` VALUES (17,'Manaclip_Purgonorgo-Bibiki',16793984,16793986,-392.000,0.000,-364.000,128,0,20,21,500,720,20,40,20,3);
-INSERT INTO `transport` VALUES (18,'Selbina-Mhaura_Boat_Pirates',17793088,17793087,9.294,0.000,-69.775,0,485,18,19,382,480,18,80,17,227);
-INSERT INTO `transport` VALUES (19,'Mhaura-Selbina_Boat_Pirates',17797182,17797181,-0.516,0.026,-8.409,0,493,18,19,382,480,18,80,17,228);
+INSERT INTO `transport` VALUES (18,'Selbina-Mhaura_Boat_Pirates',17793088,17793087,9.294,0.000,-69.775,0,485,18,19,382,480,18,80,17,227); -- Due to the way transport.cpp evicts from zones, causes duplicate onTransportEvent trigger in town
+INSERT INTO `transport` VALUES (19,'Mhaura-Selbina_Boat_Pirates',17797182,17797181,-0.516,0.026,-8.409,0,493,18,19,382,480,18,80,17,228); -- Due to the way transport.cpp evicts from zones, causes duplicate onTransportEvent trigger in town
 INSERT INTO `transport` VALUES (20,'Barge_South-Central',16785748,16785756,246.377,0.0,-529.793,192,0,18,19,0,1440,15,35,15,0);
 INSERT INTO `transport` VALUES (21,'Barge_Central-South-Day',16785748,16785757,-125.04,0.0,72.79,160,0,20,21,260,1440,15,35,15,1);
 INSERT INTO `transport` VALUES (22,'Barge_South-OOS-Day',16785748,0,246.377,0.0,-529.793,64,0,23,0,520,1440,15,6,15,1);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

~~Draft for now, but wanted to create the PR to get CI and feedback if direction isn't liked.~~

Basically
- trying to simplify the "which boat goes where" logic to using human-readable calls to `utils.timeStringToMinutes`
  - This is by centralizing the `onTransportEvent` to a function that takes the event and handles if the player can leave on the boat or not
- resolving double fire events when a player is on the boat headed to selbina/mhaura (due to 2 `transport.sql` entries existing for that boat, technically)
  - <img width="1114" height="113" alt="image" src="https://github.com/user-attachments/assets/98cb932f-b100-4440-a8f6-e1dc4084236a" />
- Removing `GetServerVariable` for every player headed to selbina/mhaura to check if they're going to normal or pirates zone. zone localvar is all that's needed, and randomized once per voyage (instead of onGameHour)
- Updated the dock message key from a string to zone id enum value


~~Not touching the boat to nashmau, sticking to boats affected by `xi.transport`~~ Turns out that boat is part of this file

~~Note that the schedule table diffs are annoying to read because the last entry was "24:00" (1440 minutes past midnight), which should be "00:00" so they're cycled down by one~~

Note: strikethroughs are from changes that got fixed in previous PRs meant to simplify the changes in this PR

Changes in this PR:
- The logic was updated to match `manaclipper.lua` and `barge.lua`, with the hopes of moving them into this file to just have one `transport.lua` for all boat rides (haven't looked at airships, they're probably simple enough to bring them in as well).
  - The total file size would grow, but not completely additive since there's a fair bit of re-usable `local`s and timekeeper logic
  - Mentioning it here, but I'd like to tackle pirates before I circle back to doing that
- ~~Updated all related `Zone.lua` `:setPos` calls to use zone enum values~~
- ~~Removed ticket key item check for zoning _into_ a dock in WG/Nashmau~~
- Changed WG ontransport logic to utilize the existing schedule table, instead of the (admittedly clever) `DepartureTime % 8 == 0` check
- Converted all the more-complex zones to use a centralize `xi.transport.onTransportEvent` function
  - added LLS hints to ensure the function is understood and utilized properly in the future
  - The logic for having a ticket/being in the right ship is done here, and the function returns false if there's an issue that should reject the player from the ride. `Zone.lua` sets the player's position in that case
  - if the player is put into a cutscene, `player:setLocalVar('destZoneId', ...)` is called, for the `Zone.lua` to pick it up on event finish
    - I considered putting the dock positions in `transport.lua` for kicking off the boat on departure, but opted for less changes this go around, but am open to doing that if it's desired. Felt easier to parse the changes by leaving that core in the `Zone.lua` for now
  - adjusted selection of the pirates zone to a zone localvar that is set once per transport, with a `local` at the top of the file to define the chance
- `transport.lua` changes
  - ~~Random style changes are from LLS `.editorconfig` autoformat~~
  - ~~made `xi.transport.pos` a local table since it's only used in the periodic triggers to make npcs path between boat rides~~
  - ~~as mentioned, the schedule table had the bottom entry moved to the top (since `getNextEvent` assumes the events are listed in order)~~
- Note added to `transport.sql` about the double firing events and issue created: https://github.com/LandSandBoat/server/issues/8243
- also, I've updated the WG/Nashmau/Selb/Mhaura bgwiki pages with ship schedules based on external sources (and confirmed they're the same as the schedule table here)
  - https://www.bg-wiki.com/ffxi/Aht_Urhgan_Whitegate
  - https://www.bg-wiki.com/ffxi/Nashmau
  - https://www.bg-wiki.com/ffxi/Mhaura
  - https://www.bg-wiki.com/ffxi/Selbina
- Bonus, found the speed values for the ship npcs were wrong in selb/mhaura/Nashmau. updated to 50/50 from capture and the boat animations entering/leaving dock are perfect now:
  - https://imgur.com/a/zCbQYDn


## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- ship departure/arrival times unchanged _in sql_ so `onTransportEvent` is fired at the same time for all zones (towns and ships)
- timekeepers are unchanged (except for the key adjustment from string to zoneid), but doesn't hurt to verify
  - putting an override to the `local currentTime = utils.timeStringToMinutes(...` line in the timekeeper functions can help ensure the schedule is being respected properly for the dock/ship timekeeper npcs
- The changes in this PR are related to `onTransportEvent` logic all being centralized into a single function with a switch statement
  - ride the boat from selbina, see it's sometimes pirates
  - ride the boat from mhaura at 0:00, 8:00, 16:00, see it's sometimes pirates
  - ride the boat from mhaura at 02:40, 10:40, 18:40, see it goes to al zhabi port in WG (southern dock)
  - wg docks
    - ride the boat from southern dock in wg, see it goes to mhaura
    - ride the boat from northern dock in wg, see it goes to nashmau
    - see if you are on the invisible platform where the boat should be (because you logged out before the ship left), you don't get swept to the other boat's sea zone (afaik it wasn't doing this before, but good to check)
  - ride boat from nashmau, see it goes to wg northern dock
  - there is no `nextEvent` logic on leaving the ship zones like CL barge had, because every ship is a separate zone. This means it's safe to catch the boat, zone into the ship zone, then zone into the destination zone to see the cutscenes work properly