### PR TITLE
[c++] Add distance and mp validation before mob spell cast

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -504,6 +504,38 @@ auto CMobController::TryCastSpell() -> bool
 
     if (chosenSpellId.has_value())
     {
+        // Check if we can actually cast this spell before committing to it
+        CSpell* PSpell = spell::GetSpell(chosenSpellId.value());
+        if (!PSpell)
+        {
+            ShowWarning("CMobController::TryCastSpell: SpellId <%i> is not found", static_cast<uint16>(chosenSpellId.value()));
+            return false;
+        }
+        else
+        {
+            CBattleEntity* PCastTarget = nullptr;
+            if (PSpell->getValidTarget() & TARGET_SELF)
+            {
+                PCastTarget = PMob;
+            }
+            else
+            {
+                PCastTarget = PTarget;
+            }
+
+            // Check if target is in range before attempting to cast
+            if (PCastTarget && distance(PMob->loc.p, PCastTarget->loc.p) > PSpell->getRange())
+            {
+                return false;
+            }
+
+            // Check if mob can afford to cast this spell
+            if (!battleutils::CanAffordSpell(PMob, PSpell, PSpell->getFlag()))
+            {
+                return false;
+            }
+        }
+
         CastSpell(chosenSpellId.value());
         return true;
     }

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -435,8 +435,7 @@ bool CMagicState::HasCost()
         }
     }
     // check has mp available
-    else if (!m_PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_MANAFONT) && !(m_flags & MAGICFLAGS_IGNORE_MP) &&
-             battleutils::CalculateSpellCost(m_PEntity, GetSpell()) > m_PEntity->health.mp)
+    else if (!battleutils::CanAffordSpell(m_PEntity, GetSpell(), m_flags))
     {
         if (m_PEntity->objtype == TYPE_MOB && m_PEntity->health.maxmp == 0)
         {

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -6370,6 +6370,39 @@ namespace battleutils
         return std::clamp<int16>(cost, 0, 9999);
     }
 
+    bool CanAffordSpell(CBattleEntity* PEntity, CSpell* PSpell, uint8 flags)
+    {
+        if (PEntity == nullptr)
+        {
+            return false;
+        }
+
+        // Check if entity bypasses MP costs
+        if (PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_MANAFONT) ||
+            (flags & MAGICFLAGS_IGNORE_MP))
+        {
+            return true;
+        }
+
+        // Special handling for mobs with NO_SPELL_COST modifier
+        if (auto PMob = dynamic_cast<CMobEntity*>(PEntity))
+        {
+            if (PMob->getMobMod(MOBMOD_NO_SPELL_COST) > 0)
+            {
+                return true;
+            }
+        }
+
+        // Check if spell has MP cost and if entity has enough MP
+        if (PSpell->hasMPCost())
+        {
+            uint16 spellCost = CalculateSpellCost(PEntity, PSpell);
+            return PEntity->health.mp >= spellCost;
+        }
+
+        return true; // No MP cost required
+    }
+
     timer::duration CalculateSpellRecastTime(CBattleEntity* PEntity, CSpell* PSpell)
     {
         if (PSpell == nullptr)

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -258,6 +258,7 @@ namespace battleutils
     timer::duration CalculateSpellCastTime(CBattleEntity*, CMagicState*);
     uint16          CalculateSpellCost(CBattleEntity*, CSpell*);
     timer::duration CalculateSpellRecastTime(CBattleEntity*, CSpell*);
+    bool            CanAffordSpell(CBattleEntity* PEntity, CSpell* PSpell, uint8 flags = 0);
     int16           CalculateSpellTP(CBattleEntity* PEntity, CSpell* PSpell);
     int16           CalculateWeaponSkillTP(CBattleEntity*, CWeaponSkill*, int16);
     bool            RemoveAmmo(CCharEntity*, int quantity = 1);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Mobs had an issue where they would get stuck in attempting to cast a spell. This was immediately obvious with Chainspell, where the mob can be bound essentially if all targets run out of range. This also occurs when mobs run out of MP, they will bind themselves attempting to cast a spell they don't have enough MP to.
- I added a new check in TryCastSpell for mobs to validate they are in range and have MP before committing to a spell
- Created a new battleutil `CanAffordSpell` for checking if the entity has MP for the spell

Closes https://github.com/LandSandBoat/server/issues/306

## Steps to test these changes

- Ensure MP checks are properly blocking spell casts for mobs
- Fight a mob with chainspell active, see that it closes the distance if target is out of range