### PR TITLE
[lua] Bugfix for Zdei rotation logic

### DIFF
--- a/scripts/enum/mob_pools.lua
+++ b/scripts/enum/mob_pools.lua
@@ -32,8 +32,8 @@ xi.mobPools =
     AMNAF_PSYCHEFLAYER     = 5310, -- Reset enmity on sleepga
     FAHRAFAHR_THE_BLOODIED = 6750, -- Reset Enmity on Drop Hammer
     HPEMDE_NO_DIVING       = 7033, -- Hpemde that don't dive, such as those in the north end of Al'Taieu
-    EOZDEI_LEFT            = 7092, -- Eo'zdei left rotation
-    AWZDEI_LEFT            = 7093, -- Aw'zdei left rotation
-    AWZDEI_FAST_R          = 7094, -- Aw'zdei fast right rotation
-    AWZDEI_FAST_L          = 7095, -- Aw'zdei fast left rotation
+    EOZDEI_LEFT            = 7095, -- Eo'zdei left rotation
+    AWZDEI_LEFT            = 7096, -- Aw'zdei left rotation
+    AWZDEI_FAST_R          = 7097, -- Aw'zdei fast right rotation
+    AWZDEI_FAST_L          = 7098, -- Aw'zdei fast left rotation
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Closes https://github.com/LandSandBoat/server/issues/8139
- I forgot to update the mob_pools.lua file when fixing merge conflicts in a previous PR, this caused a majority of the zdei to stop spinning.

## Steps to test these changes

- !gotoname Awzdei 10,11,12
- See they spin properly now
