### PR TITLE
[lua] Add WotG content tag to "Too Many Chefs" quest

### DIFF
--- a/scripts/zones/Metalworks/npcs/Ferghus.lua
+++ b/scripts/zones/Metalworks/npcs/Ferghus.lua
@@ -10,7 +10,11 @@ entity.onTrigger = function(player, npc)
     local tooManyChefs = player:getQuestStatus(xi.questLog.BASTOK, xi.quest.id.bastok.TOO_MANY_CHEFS)
     local pFame = player:getFameLevel(xi.fameArea.BASTOK)
 
-    if tooManyChefs == xi.questStatus.QUEST_AVAILABLE and pFame >= 5 then
+    if
+        xi.settings.main.ENABLE_WOTG == 1 and
+        tooManyChefs == xi.questStatus.QUEST_AVAILABLE and
+        pFame >= 5
+    then
         player:startEvent(946) -- Start Quest "Too Many Chefs"
     elseif player:getCharVar('TOO_MANY_CHEFS') == 4 then -- after trade to Leonhardt
         player:startEvent(947)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a content tag to Ferghus the quest giver for "Too Many Chefs" that Wings of the Goddess needs to be enabled.

## Steps to test these changes

1. Set WOTG to 0 in main.
2. Talk to Fergus.
