### PR TITLE
fix: Tweak account creation queries to handle empty database

### DIFF
--- a/src/login/auth_session.cpp
+++ b/src/login/auth_session.cpp
@@ -297,10 +297,10 @@ void auth_session::read_func()
                 // creating new account_id
                 uint32 accid = 0;
 
-                const auto rset1 = db::preparedStmt("SELECT max(accounts.id) FROM accounts");
+                const auto rset1 = db::preparedStmt("SELECT COALESCE(MAX(accounts.id), 0) AS max_id FROM accounts");
                 if (rset1 && rset1->rowsCount() != 0 && rset1->next())
                 {
-                    accid = rset1->get<uint32>("max(accounts.id)") + 1;
+                    accid = rset1->get<uint32>("max_id") + 1;
                 }
                 else
                 {

--- a/src/login/login_helpers.cpp
+++ b/src/login/login_helpers.cpp
@@ -279,7 +279,7 @@ namespace loginHelpers
             }
         }
 
-        const auto rset = db::preparedStmt("SELECT max(charid) FROM chars");
+        const auto rset = db::preparedStmt("SELECT COALESCE(MAX(charid), 0) AS max_id FROM chars");
         if (!rset)
         {
             return -1;
@@ -288,7 +288,7 @@ namespace loginHelpers
         uint32 charID = 0;
         if (rset->rowsCount() != 0 && rset->next())
         {
-            charID = rset->get<uint32>("max(charid)") + 1;
+            charID = rset->get<uint32>("max_id") + 1;
         }
 
         if (saveCharacter(session.accountID, charID, &createchar) == -1)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
The account and char creation queries print an error (**but do not fail**) when executed against an empty database.
This bakes a default 0 into the query so there's always something to ->get

Closes #7981

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
With an empty DB, create account / create char
<!-- Clear and detailed steps to test your changes here -->
