### PR TITLE
[login] Fix char flags/status regression, allow removal of hung session in edge case

### DIFF
--- a/src/login/data_session.cpp
+++ b/src/login/data_session.cpp
@@ -435,6 +435,9 @@ void data_session::read_func()
                     .destinationZoneId = ZoneID,
                 });
 
+                db::preparedStmt("UPDATE char_flags SET disconnecting = 0 WHERE charid = ?", charid);
+                db::preparedStmt("UPDATE char_stats SET zoning = 2 WHERE charid = ?", charid);
+
                 zmqDealerWrapper_.outgoingQueue_.enqueue(zmq::message_t(payload.data(), payload.size()));
             }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Looks like I accidentally removed these two lines:
```c++
                db::preparedStmt("UPDATE char_flags SET disconnecting = 0 WHERE charid = ?", charid);
                db::preparedStmt("UPDATE char_stats SET zoning = 2 WHERE charid = ?", charid);
```
So they are back in their appropriate spot. This will help with the d/c icon in /sea and some other edge cases wherever "zoning" is used

Also add a check to delete a session if it's stale and the remote has never seen the client.

## Steps to test these changes

Log in, force d/c, log back in and see yourself on search without d/c icon
intentionally don't run any xi_map servers, login (which will time out), force-close client, re-start xi_map, reconnect, you will see the "character already logged in" message, wait about 2 minutes, relog, you will connect
