### PR TITLE
[lua] Delivery crate fixes.

### DIFF
--- a/scripts/zones/RuLude_Gardens/IDs.lua
+++ b/scripts/zones/RuLude_Gardens/IDs.lua
@@ -18,6 +18,7 @@ zones[xi.zone.RULUDE_GARDENS] =
         KEYITEM_LOST                     = 6535,  -- Lost key item: <keyitem>.
         ITEMS_OBTAINED                   = 6540,  -- You obtain <number> <item>!
         RETURN_ITEM                      = 6543,  -- The <item> is returned to you.
+        RETURN_ITEMS                     = 6544,  -- The <number> <item> are returned to you.
         NOTHING_OUT_OF_ORDINARY          = 6545,  -- There is nothing out of the ordinary here.
         CARRIED_OVER_POINTS              = 6570,  -- You have carried over <number> login point[/s].
         LOGIN_CAMPAIGN_UNDERWAY          = 6571,  -- The [/January/February/March/April/May/June/July/August/September/October/November/December] <number> Login Campaign is currently underway!


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes crate stealing items before trade cancel window.
Fixes crate to account for all required trial items in any populated trade slots and sum total.
Adds eventID for RETURN_ITEMS to Ru'lude IDs.lua 

## Steps to test these changes
Start a magian trial that requires items to trade.
Trade multiple items of various amounts to box in any open trade slot.
Confirm trade totals required items and ignores non‑required items. 
Confirm cancel trade now returns items correctly.
Confirm eventIDs play out according to amount of items traded.

<img width="383" height="224" alt="Capture023" src="https://github.com/user-attachments/assets/603c85fb-dcd3-48c4-8c6c-a4a632531558" />
<img width="545" height="141" alt="Capture024" src="https://github.com/user-attachments/assets/cb0d1867-6502-40ca-a7ca-41fdfa0bbe79" />