### PR TITLE
[lua] Some xi.transports-related adjustments to human-readable formats

### DIFF
--- a/scripts/globals/transport.lua
+++ b/scripts/globals/transport.lua
@@ -1,8 +1,6 @@
 -----------------------------------
 -- Transport
 -----------------------------------
-require('scripts/globals/pathfind')
------------------------------------
 xi = xi or {}
 xi.transport = xi.transport or {}
 
@@ -12,18 +10,18 @@ xi.transport = xi.transport or {}
 xi.transport.message =
 {
     NEARING = 0,
-    DOCKING = 1
+    DOCKING = 1,
 }
 
 xi.transport.epochOffset =
 {
     NEARING = 265,
-    DOCKING = 290
+    DOCKING = 290,
 }
 
 xi.transport.messageTime =
 {
-    SILVER_SEA = 480
+    SILVER_SEA = 480,
 }
 
 xi.transport.trigger =
@@ -33,13 +31,13 @@ xi.transport.trigger =
         FERRY_ARRIVING_FROM_ALZAHBI = 0,
         FERRY_DEPARTING_TO_ALZAHBI  = 1,
         FERRY_ARRIVING_FROM_SELBINA = 2,
-        FERRY_DEPARTING_TO_SELBINA  = 3
+        FERRY_DEPARTING_TO_SELBINA  = 3,
     },
     selbina =
     {
         FERRY_ARRIVING_FROM_MHAURA = 0,
-        FERRY_DEPARTING_TO_MHAURA  = 1
-    }
+        FERRY_DEPARTING_TO_MHAURA  = 1,
+    },
 }
 
 xi.transport.interval =
@@ -47,12 +45,12 @@ xi.transport.interval =
     mhaura =
     {
         FROM_TO_ALZAHBI = 480,
-        FROM_TO_SELBINA = 480
+        FROM_TO_SELBINA = 480,
     },
     selbina =
     {
-        FROM_TO_MHAURA = 480
-    }
+        FROM_TO_MHAURA = 480,
+    },
 }
 
 xi.transport.offset =
@@ -62,39 +60,13 @@ xi.transport.offset =
         FERRY_ARRIVING_FROM_ALZAHBI = 159,
         FERRY_DEPARTING_TO_ALZAHBI  = 239,
         FERRY_ARRIVING_FROM_SELBINA = 399,
-        FERRY_DEPARTING_TO_SELBINA  = 479
+        FERRY_DEPARTING_TO_SELBINA  = 479,
     },
     selbina =
     {
         FERRY_ARRIVING_FROM_MHAURA = 399,
-        FERRY_DEPARTING_TO_MHAURA  = 479
-    }
-}
-
-xi.transport.pos =
-{
-    mhaura =
-    {
-        ARRIVING  =
-        {
-            { x = 7.06, y = -1.36, z = 2.20, rotation = 211 }
-        },
-        DEPARTING =
-        {
-            { x = 8.26, y = -1.36, z = 2.20, rotation = 193 }
-        },
+        FERRY_DEPARTING_TO_MHAURA  = 479,
     },
-    selbina =
-    {
-        ARRIVING  =
-        {
-            { x = 16.768, y = -1.38, z = -58.843, rotation = 209 }
-        },
-        DEPARTING =
-        {
-            { x = 17.979, y = -1.389, z = -58.800, rotation = 191 }
-        },
-    }
 }
 
 local direction =
@@ -134,50 +106,56 @@ local dockTable =
 
 local scheduleTable =
 {
+    -- used by ship and selbina dock timekeepers
     [xi.transport.routes.SELBINA_MHAURA] = -- Ship bound for [Mhaura/Selbina]
     {
-        [1] = { startTime =    0, endTime =  400, action = direction.ARRIVE, target = 0 },
-        [2] = { startTime =  400, endTime =  480, action = direction.DEPART, target = 0 },
-        [3] = { startTime =  480, endTime =  880, action = direction.ARRIVE, target = 0 },
-        [4] = { startTime =  880, endTime =  960, action = direction.DEPART, target = 0 },
-        [5] = { startTime =  960, endTime = 1360, action = direction.ARRIVE, target = 0 },
-        [6] = { startTime = 1360, endTime = 1440, action = direction.DEPART, target = 0 },
+        { startTime =    0, endTime = utils.timeStringToMinutes('06:40'),    action = direction.ARRIVE, target = 0 }, -- (from dock) arrives at SELBINA
+        { startTime =  400, endTime = utils.timeStringToMinutes('08:00'),    action = direction.DEPART, target = 0 }, -- (from dock) headed to MHAURA
+        { startTime =  480, endTime = utils.timeStringToMinutes('14:40'),    action = direction.ARRIVE, target = 0 }, -- (from dock) arrives at SELBINA
+        { startTime =  880, endTime = utils.timeStringToMinutes('16:00'),    action = direction.DEPART, target = 0 }, -- (from dock) headed to MHAURA
+        { startTime =  960, endTime = utils.timeStringToMinutes('22:40'),    action = direction.ARRIVE, target = 0 }, -- (from dock) arrives at SELBINA
+        { startTime = 1360, endTime = utils.timeStringToMinutes('00:00', 1), action = direction.DEPART, target = 0 }, -- (from dock) headed to MHAURA
     },
 
+    -- used by ship and southern whitegate dock timekeepers
     [xi.transport.routes.OPEN_SEA] = -- Open sea route to [Al Zahbi/Mhaura]
     {
-        [1] = { startTime =    0, endTime =  160, action = direction.ARRIVE, target = 0 },
-        [2] = { startTime =  160, endTime =  240, action = direction.DEPART, target = 0 },
-        [3] = { startTime =  240, endTime =  640, action = direction.ARRIVE, target = 0 },
-        [4] = { startTime =  640, endTime =  720, action = direction.DEPART, target = 0 },
-        [5] = { startTime =  720, endTime = 1120, action = direction.ARRIVE, target = 0 },
-        [6] = { startTime = 1120, endTime = 1200, action = direction.DEPART, target = 0 },
-        [7] = { startTime = 1200, endTime = 1600, action = direction.ARRIVE, target = 0 },
+        { startTime =    0, endTime = utils.timeStringToMinutes('02:40'),    action = direction.ARRIVE, target = 0 }, -- (from dock) arrives at AL_ZAHBI
+        { startTime =  160, endTime = utils.timeStringToMinutes('04:00'),    action = direction.DEPART, target = 0 }, -- (from dock) headed to MHAURA
+        { startTime =  240, endTime = utils.timeStringToMinutes('10:40'),    action = direction.ARRIVE, target = 0 }, -- (from dock) arrives at AL_ZAHBI
+        { startTime =  640, endTime = utils.timeStringToMinutes('12:00'),    action = direction.DEPART, target = 0 }, -- (from dock) headed to MHAURA
+        { startTime =  720, endTime = utils.timeStringToMinutes('18:40'),    action = direction.ARRIVE, target = 0 }, -- (from dock) arrives at AL_ZAHBI
+        { startTime = 1120, endTime = utils.timeStringToMinutes('20:00'),    action = direction.DEPART, target = 0 }, -- (from dock) headed to MHAURA
+        { startTime = 1200, endTime = utils.timeStringToMinutes('02:40', 1), action = direction.ARRIVE, target = 0 },
     },
+
+    -- used by ship and nashmau/whitegate dock timekeepers
     [xi.transport.routes.SILVER_SEA] = -- Silver Sea route to [Al Zahbi/Nashmau]
     {
-        [1] = { startTime =    0, endTime =  300, action = direction.ARRIVE, target = 0 },
-        [2] = { startTime =  300, endTime =  480, action = direction.DEPART, target = 0 },
-        [3] = { startTime =  480, endTime =  780, action = direction.ARRIVE, target = 0 },
-        [4] = { startTime =  780, endTime =  960, action = direction.DEPART, target = 0 },
-        [5] = { startTime =  960, endTime = 1260, action = direction.ARRIVE, target = 0 },
-        [6] = { startTime = 1260, endTime = 1440, action = direction.DEPART, target = 0 },
+        { startTime =    0, endTime = utils.timeStringToMinutes('05:00'),    action = direction.ARRIVE, target = 0 },
+        { startTime =  300, endTime = utils.timeStringToMinutes('08:00'),    action = direction.DEPART, target = 0 },
+        { startTime =  480, endTime = utils.timeStringToMinutes('13:00'),    action = direction.ARRIVE, target = 0 },
+        { startTime =  780, endTime = utils.timeStringToMinutes('16:00'),    action = direction.DEPART, target = 0 },
+        { startTime =  960, endTime = utils.timeStringToMinutes('21:00'),    action = direction.ARRIVE, target = 0 },
+        { startTime = 1260, endTime = utils.timeStringToMinutes('00:00', 1), action = direction.DEPART, target = 0 },
     },
-    [xi.transport.routes.SELBINA_MHAURA_OPEN_SEA] = -- Combination of Ship bound for [Mhaura/Selbina] and Open sea route to [Al Zahbi/Mhaura] used by Dieh Yamilsiah
+
+    -- used by Dieh Yamilsiah and Laughin Bison (Mhaura dock only)
+    [xi.transport.routes.SELBINA_MHAURA_OPEN_SEA] = -- Combination of Ship bound for [Mhaura/Selbina] and Open sea route to [Al Zahbi/Mhaura]
     {
-        [ 1] = { startTime =    0, endTime =  160, action = direction.ARRIVE, target = destination.AL_ZAHBI },
-        [ 2] = { startTime =  160, endTime =  240, action = direction.DEPART, target = destination.AL_ZAHBI },
-        [ 3] = { startTime =  240, endTime =  400, action = direction.ARRIVE, target = destination.SELBINA  },
-        [ 4] = { startTime =  400, endTime =  480, action = direction.DEPART, target = destination.SELBINA  },
-        [ 5] = { startTime =  480, endTime =  640, action = direction.ARRIVE, target = destination.AL_ZAHBI },
-        [ 6] = { startTime =  640, endTime =  720, action = direction.DEPART, target = destination.AL_ZAHBI },
-        [ 7] = { startTime =  720, endTime =  880, action = direction.ARRIVE, target = destination.SELBINA  },
-        [ 8] = { startTime =  880, endTime =  960, action = direction.DEPART, target = destination.SELBINA  },
-        [ 9] = { startTime =  960, endTime = 1120, action = direction.ARRIVE, target = destination.AL_ZAHBI },
-        [10] = { startTime = 1120, endTime = 1200, action = direction.DEPART, target = destination.AL_ZAHBI },
-        [11] = { startTime = 1200, endTime = 1360, action = direction.ARRIVE, target = destination.SELBINA  },
-        [12] = { startTime = 1360, endTime = 1440, action = direction.DEPART, target = destination.SELBINA  },
-    }
+        { startTime =    0, endTime = utils.timeStringToMinutes('02:40'),    action = direction.ARRIVE, target = destination.AL_ZAHBI },
+        { startTime =  160, endTime = utils.timeStringToMinutes('04:00'),    action = direction.DEPART, target = destination.AL_ZAHBI },
+        { startTime =  240, endTime = utils.timeStringToMinutes('06:40'),    action = direction.ARRIVE, target = destination.SELBINA  },
+        { startTime =  400, endTime = utils.timeStringToMinutes('08:00'),    action = direction.DEPART, target = destination.SELBINA  },
+        { startTime =  480, endTime = utils.timeStringToMinutes('10:40'),    action = direction.ARRIVE, target = destination.AL_ZAHBI },
+        { startTime =  640, endTime = utils.timeStringToMinutes('12:00'),    action = direction.DEPART, target = destination.AL_ZAHBI },
+        { startTime =  720, endTime = utils.timeStringToMinutes('14:40'),    action = direction.ARRIVE, target = destination.SELBINA  },
+        { startTime =  880, endTime = utils.timeStringToMinutes('16:00'),    action = direction.DEPART, target = destination.SELBINA  },
+        { startTime =  960, endTime = utils.timeStringToMinutes('18:40'),    action = direction.ARRIVE, target = destination.AL_ZAHBI },
+        { startTime = 1120, endTime = utils.timeStringToMinutes('20:00'),    action = direction.DEPART, target = destination.AL_ZAHBI },
+        { startTime = 1200, endTime = utils.timeStringToMinutes('22:40'),    action = direction.ARRIVE, target = destination.SELBINA  },
+        { startTime = 1360, endTime = utils.timeStringToMinutes('00:00', 1), action = direction.DEPART, target = destination.SELBINA  },
+    },
 }
 
 -----------------------------------
@@ -191,12 +169,38 @@ xi.transport.captainMessage = function(npc, triggerID, messages)
     end
 end
 
+local dockNpcPos =
+{
+    mhaura =
+    {
+        ARRIVING  =
+        {
+            { x = 7.06, y = -1.36, z = 2.20, rotation = 211 },
+        },
+        DEPARTING =
+        {
+            { x = 8.26, y = -1.36, z = 2.20, rotation = 193 },
+        },
+    },
+    selbina =
+    {
+        ARRIVING  =
+        {
+            { x = 16.768, y = -1.38, z = -58.843, rotation = 209 },
+        },
+        DEPARTING =
+        {
+            { x = 17.979, y = -1.389, z = -58.800, rotation = 191 },
+        },
+    },
+}
+
 xi.transport.dockMessage = function(npc, triggerID, messages, dock)
     npc:showText(npc, messages[triggerID])
     if (triggerID % 2) == 0 then
-        npc:pathThrough(xi.transport.pos[dock].ARRIVING, bit.bor(xi.path.flag.PATROL, xi.path.flag.WALLHACK))
+        npc:pathThrough(dockNpcPos[dock].ARRIVING, bit.bor(xi.path.flag.PATROL, xi.path.flag.WALLHACK))
     else
-        npc:pathThrough(xi.transport.pos[dock].DEPARTING, bit.bor(xi.path.flag.PATROL, xi.path.flag.WALLHACK))
+        npc:pathThrough(dockNpcPos[dock].DEPARTING, bit.bor(xi.path.flag.PATROL, xi.path.flag.WALLHACK))
     end
 end
 

--- a/scripts/utils/time_utils.lua
+++ b/scripts/utils/time_utils.lua
@@ -81,8 +81,10 @@ end
 -- Returns an integer number of minutes since midnight from a time string like "HH:MM"
 ---@nodiscard
 ---@param timeString string
+---@param addDays integer?
 ---@return integer
-utils.timeStringToMinutes = function(timeString)
+function utils.timeStringToMinutes(timeString, addDays)
+    addDays = addDays or 0
     local hours, minutes = timeString:match('^(%d%d?):(%d%d)$')
     hours   = tonumber(hours)
     minutes = tonumber(minutes)
@@ -97,5 +99,5 @@ utils.timeStringToMinutes = function(timeString)
         return -1
     end
 
-    return hours * 60 + minutes
+    return hours * 60 + minutes + addDays * 1440
 end

--- a/scripts/zones/Aht_Urhgan_Whitegate/Zone.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/Zone.lua
@@ -26,16 +26,12 @@ zoneObject.onZoneIn = function(player, prevZone)
         player:getYPos() == 0 and
         player:getZPos() == 0
     then
-        if
-            player:hasKeyItem(xi.ki.FERRY_TICKET) and
-            prevZone == xi.zone.OPEN_SEA_ROUTE_TO_AL_ZAHBI
-        then
+        if prevZone == xi.zone.OPEN_SEA_ROUTE_TO_AL_ZAHBI then
             player:setPos(-11, 2, -142, 192)
             return 201
         elseif
-            player:hasKeyItem(xi.ki.SILVER_SEA_FERRY_TICKET) and
-            (prevZone == xi.zone.SILVER_SEA_ROUTE_TO_AL_ZAHBI or
-            prevZone == xi.zone.SILVER_SEA_ROUTE_TO_NASHMAU)
+            prevZone == xi.zone.SILVER_SEA_ROUTE_TO_AL_ZAHBI or
+            prevZone == xi.zone.SILVER_SEA_ROUTE_TO_NASHMAU
         then
             player:setPos(11, 2, 142, 64)
             return 204
@@ -114,13 +110,9 @@ zoneObject.onEventFinish = function(player, csid, option, npc)
         player:setCharVar('vanishingactCS', 4)
         player:setPos(-80, -6, 122, 5)
     elseif csid == 200 then
-        player:setPos(0, -2, 0, 0, 47)
-    elseif csid == 201 then
-        player:setPos(-11, 2, -142, 192)
+        player:setPos(0, -2, 0, 0, xi.zone.OPEN_SEA_ROUTE_TO_MHAURA)
     elseif csid == 203 then
-        player:setPos(0, -2, 0, 0, 58)
-    elseif csid == 204 then
-        player:setPos(11, 2, 142, 64)
+        player:setPos(0, -2, 0, 0, xi.zone.SILVER_SEA_ROUTE_TO_NASHMAU)
     elseif csid == 526 then
         player:setCharVar('gotitallCS', 6)
         player:setPos(60, 0, -71, 38)

--- a/scripts/zones/Mhaura/npcs/Laughing_Bison.lua
+++ b/scripts/zones/Mhaura/npcs/Laughing_Bison.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Area: Mhaura
---  NPC: Laughing_Bison
+--  NPC: Laughing Bison
 -----------------------------------
 ---@type TNpcEntity
 local entity = {}

--- a/scripts/zones/Open_sea_route_to_Al_Zahbi/Zone.lua
+++ b/scripts/zones/Open_sea_route_to_Al_Zahbi/Zone.lua
@@ -37,7 +37,7 @@ end
 
 zoneObject.onEventFinish = function(player, csid, option, npc)
     if csid == 1028 then
-        player:setPos(0, 0, 0, 0, 50)
+        player:setPos(0, 0, 0, 0, xi.zone.AHT_URHGAN_WHITEGATE)
     end
 end
 

--- a/scripts/zones/Open_sea_route_to_Mhaura/Zone.lua
+++ b/scripts/zones/Open_sea_route_to_Mhaura/Zone.lua
@@ -34,7 +34,7 @@ end
 
 zoneObject.onEventFinish = function(player, csid, option, npc)
     if csid == 1028 then
-        player:setPos(0, 0, 0, 0, 249)
+        player:setPos(0, 0, 0, 0, xi.zone.MHAURA)
     end
 end
 

--- a/scripts/zones/Ship_bound_for_Mhaura/Zone.lua
+++ b/scripts/zones/Ship_bound_for_Mhaura/Zone.lua
@@ -31,7 +31,7 @@ end
 
 zoneObject.onEventFinish = function(player, csid, option, npc)
     if csid == 512 then
-        player:setPos(0, 0, 0, 0, 249)
+        player:setPos(0, 0, 0, 0, xi.zone.MHAURA)
     end
 end
 

--- a/scripts/zones/Ship_bound_for_Selbina/Zone.lua
+++ b/scripts/zones/Ship_bound_for_Selbina/Zone.lua
@@ -41,7 +41,7 @@ end
 
 zoneObject.onEventFinish = function(player, csid, option, npc)
     if csid == 255 then
-        player:setPos(0, 0, 0, 0, 248)
+        player:setPos(0, 0, 0, 0, xi.zone.SELBINA)
     end
 end
 

--- a/scripts/zones/Silver_Sea_route_to_Al_Zahbi/Zone.lua
+++ b/scripts/zones/Silver_Sea_route_to_Al_Zahbi/Zone.lua
@@ -25,7 +25,7 @@ end
 
 zoneObject.onEventFinish = function(player, csid, option, npc)
     if csid == 1025 then
-        player:setPos(0, 0, 0, 0, 50)
+        player:setPos(0, 0, 0, 0, xi.zone.AHT_URHGAN_WHITEGATE)
     end
 end
 

--- a/scripts/zones/Silver_Sea_route_to_Nashmau/Zone.lua
+++ b/scripts/zones/Silver_Sea_route_to_Nashmau/Zone.lua
@@ -25,7 +25,7 @@ end
 
 zoneObject.onEventFinish = function(player, csid, option, npc)
     if csid == 1025 then
-        player:setPos(0, 0, 0, 0, 53)
+        player:setPos(0, 0, 0, 0, xi.zone.NASHMAU)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Preliminary changes for https://github.com/LandSandBoat/server/pull/8232 to be less obscure to read diffs.

- small formatting changes
- `Zone.lua` `:setPos` enums for zone changes
- `xi.transport.pos` changed to local and moved closer to the function that uses it
- `scripts/zones/Aht_Urhgan_Whitegate/Zone.lua` 
  - zoning _into_ port from boat doesn't need to check for ticket key item, you're entering the zone either way
  - `:setPos` for zoning in after boat is called immediately, no need to call again on cs end
  - collapsed other 2 boat-related event finishes into a single call
- `scripts/zones/Nashmau/Zone.lua`
  - zoning _into_ port from boat doesn't need to check for ticket key item, you're entering the zone either way
  - transport event doesn't need a conditional on prevZoneId, there's only one transport in the zone

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- see Dieh and Humilitie both move and announce when the boat arrives
- see the resultant scheduleTable is the same after adjusting to use the util function by adding `print(scheduleTable)` in an ontrigger fuction:
  - <img width="365" height="589" alt="image" src="https://github.com/user-attachments/assets/35db5afd-1561-4d0e-83e4-71b5d31c78e7" />
- `!zone X` between dock zones and boat zones and back to destination zones to see cutscenes work properly
