### PR TITLE
[core] Fix Session Cleanup / 3101 Errors on Logout

### DIFF
--- a/src/login/data_session.cpp
+++ b/src/login/data_session.cpp
@@ -491,9 +491,9 @@ void data_session::handle_error(std::error_code ec, std::shared_ptr<handler_sess
 
                 // Remove IP from map if no entries remain
                 auto& sessions = loginHelpers::getAuthenticatedSessions();
-                if (sessions[self->ipAddress].size() == 0)
+                if (auto outerIt = sessions.find(self->ipAddress); outerIt != sessions.end() && outerIt->second.empty())
                 {
-                    sessions.erase(sessions.begin());
+                    sessions.erase(outerIt);
                 }
             }
         }

--- a/src/login/view_session.cpp
+++ b/src/login/view_session.cpp
@@ -466,9 +466,9 @@ void view_session::handle_error(std::error_code ec, std::shared_ptr<handler_sess
 
                 // Remove IP from map if no entries remain
                 auto& sessions = loginHelpers::getAuthenticatedSessions();
-                if (sessions[self->ipAddress].size() == 0)
+                if (auto outerIt = sessions.find(self->ipAddress); outerIt != sessions.end() && outerIt->second.empty())
                 {
-                    sessions.erase(sessions.begin());
+                    sessions.erase(outerIt);
                 }
             }
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Fixes a bug in session cleanup logic where one player logging out could inadvertently remove another player’s session. This resulted in sometimes leaving the affected player with a dangling or “stuck” session, preventing proper `/logout` and reaching the character select screen or being unable to log back in if they `/exit` -> and log back in.

Previously, when a player logged out:
- Their session entry was cleared, leaving an empty session list.
- The code checked the entry with `sessions[self->ipAddress]` which can implicitly create an empty entry if the IP was not already present.
- If the list was empty, the code removed a session entry using sessions.erase(sessions.begin()).
- However, std::map is ordered by key, so this erased the first entry in the map rather than the entry for the logging-out player’s IP.
- This could cause another player’s active session to be deleted leading to them being unable to logout/relog.

```
Player A Logs in with IP 2.3.4.5
Player B Logs in with IP 1.2.3.4
Player C Logs in with IP 5.6.7.8

So lets say Player A logs out --> 2.3.4.5
Their session hash is cleared, leaving an empty session entry.
So instead of deleting 2.3.4.5, `sessions.erase(sessions.begin())` removes 1.2.3.4 (Player B)
Now player B has a broken session and gets the 3101 error when they attempt to `/logout` since the their session is no longer recognized.

Now lets say Player C logs out --> 5.6.7.8
Their cleanup call instead removes Player B's entry 2.3.4.5 and Player C now has the dangling socket/session.

This cascades in severity the longer the server stays online and the more players that trip the condition where their /logout cleared another players session.  Especially if the IP was not in the session table and an empty entry was created with `sessions[self->ipAddress]` which would trigger the `sessions.erase(sessions.begin())` immediately afterwards.

This fix looks up the correct session entry with `sessions.find(self->ipAddress)`, and then verifies that the entry exists and is empty
Only then does it erase that specific session from the outer session data instead of always doing `sessions.begin()`
This would then cascade if phantom entries were created with the `[self->ipAddress]`
```
## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
So, this is quite difficult to test on a local environment because the connecting IP's needs to all be from unique IP's and the more unique IP's you have more likely that you are to see this in action.  I instead tested this on Horizon's live box through a maintenance a few weeks ago.  For most players, this cleared their issues on logout:

```
 [1:30 PM]Synergy: seems like it's definitely much better but not 100% gone. i've only had it happen once or twice the last day or two
 [11:18 AM]Demonthief: Since last week's patch this issue has never happened to me since and my alt is logged into dunes all night. Before last weeks patch every time I'd log out in the morning I'd get the error, not had it apart from last night during server issues.
 [10:14 PM]Fazira: My logout woes seem to have gone away
 [11:33 AM]Fallons: Also echoing that my issue has been resolved. Usually it was intermittent for me, got really really bad the patch before the 19th, 19th patch seems to have fixed the intermittent problem as well 🙏🏼
 [11:14 AM]Muppet: Whatever you did seems to be working for me, Beasty. Haven't had the issue once in 2-3 days now 👍
 [6:36 AM]Daveman: Don't have much to add other than I'm in the "yay it's fixed now!" camp. ♥️ 
 [11:27 PM]Hiruga: at n=2 personally on not having 3101 error, given the frequency I had before, so far I'd say this was a success
 [5:58 PM]Kandi: Haven’t had any issues since the patch 🔥
 [3:35 AM]Masuru: Just putting my experience in.  Before this patch I was getting 3101 after only like maybe 15-30 min, however since this patch I have not gotten a 3101.
...etc...
```
We still have a small handful of players that seem to experience the issue, but its been limited to that specific group of players, so I am guessing there is a common thread with them and not directly tied to this since they were having issues before I pushed this to our live environment.  That said, the widespread cascading logout failures appears to have been resolved by this change.