### PR TITLE
xi_test: Tracy support

### DIFF
--- a/src/common/synchronized.h
+++ b/src/common/synchronized.h
@@ -60,9 +60,9 @@ struct Synchronized
     }
 
 private:
-    mutable TracyLockable(M, mutex);
-
     T target;
+
+    mutable TracyLockable(M, mutex);
 
     auto lock() const
     {

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -77,3 +77,11 @@ target_link_libraries(xi_test
         xi_test_lib)
 
 set_target_output_directory(xi_test)
+
+if(TRACY_ENABLE)
+    target_link_libraries(xi_test_lib PUBLIC TracyClient)
+    set_target_properties(xi_test PROPERTIES OUTPUT_NAME xi_test_tracy)
+    target_compile_definitions(xi_test_lib PUBLIC TRACY_ENABLE)
+    target_compile_definitions(xi_test_lib PUBLIC TRACY_NO_EXIT=1)
+    message(STATUS "TRACY_ENABLE: xi_test will be output as xi_test_tracy")
+endif(TRACY_ENABLE)

--- a/src/test/lua/lua_client_entity_pair.cpp
+++ b/src/test/lua/lua_client_entity_pair.cpp
@@ -74,6 +74,8 @@ CLuaClientEntityPair::~CLuaClientEntityPair()
 
 void CLuaClientEntityPair::tick()
 {
+    TracyZoneScoped;
+
     testChar_->session()->last_update = timer::now();
     packets().parseIncoming();
 }

--- a/src/test/lua/lua_simulation.cpp
+++ b/src/test/lua/lua_simulation.cpp
@@ -118,6 +118,8 @@ void CLuaSimulation::cleanClients(std::optional<ClientScope> scope)
 
 void CLuaSimulation::tickEntity(CLuaBaseEntity& entity) const
 {
+    TracyZoneScoped;
+
     DebugTestFmt("Ticking entity: {} (ID: {})", entity.getName(), entity.GetBaseEntity()->id);
     entity.GetBaseEntity()->PAI->Tick(timer::now());
 }
@@ -132,6 +134,8 @@ void CLuaSimulation::tickEntity(CLuaBaseEntity& entity) const
 
 void CLuaSimulation::skipTime(uint32 seconds) const
 {
+    TracyZoneScoped;
+
     ShowInfoFmt("Skipping {} seconds", seconds);
 
     // Advance time by the requested amount
@@ -261,6 +265,8 @@ void CLuaSimulation::seed() const
 // Moves all clients session clock and process pending packets
 void CLuaSimulation::processClientUpdates() const
 {
+    TracyZoneScoped;
+
     for (auto&& info : clients_)
     {
         info.client->tick();
@@ -278,6 +284,43 @@ void CLuaSimulation::processClientUpdates() const
 
 void CLuaSimulation::tick(const std::optional<TickType> boundary) const
 {
+    TracyZoneScoped;
+
+    if (boundary)
+    {
+        switch (*boundary)
+        {
+            case TickType::ZoneTick:
+                TracyZoneCString("Zone Tick");
+                break;
+            case TickType::TimeServer:
+                TracyZoneCString("Time Server Tick");
+                break;
+            case TickType::EffectTick:
+                TracyZoneCString("Effect Tick");
+                break;
+            case TickType::TriggerAreas:
+                TracyZoneCString("Trigger Areas Tick");
+                break;
+            case TickType::JSTHourly:
+                TracyZoneCString("JST Hourly Tick");
+                break;
+            case TickType::JSTDaily:
+                TracyZoneCString("JST Daily Tick");
+                break;
+            case TickType::VanadielHourly:
+                TracyZoneCString("Vanadiel Hourly Tick");
+                break;
+            case TickType::VanadielDaily:
+                TracyZoneCString("Vanadiel Daily Tick");
+                break;
+        }
+    }
+    else
+    {
+        TracyZoneCString("Zone Tick");
+    }
+
     // Timer clock may be offset, so calculate Earth/Vana time instead of directly using those clocks.
     const auto timerAdjustedUtcTime = timer::to_utc();
     const auto adjustedVanaTime     = vanadiel_time::from_earth_time(timerAdjustedUtcTime);
@@ -401,6 +444,8 @@ void CLuaSimulation::tick(const std::optional<TickType> boundary) const
 
 auto CLuaSimulation::spawnPlayer(sol::optional<sol::table> params) -> CLuaClientEntityPair*
 {
+    TracyZoneScoped;
+
     uint16               zoneId = ZONE_GM_HOME;
     sol::optional<uint8> job;
     sol::optional<uint8> level;

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -20,12 +20,16 @@
 */
 
 #include "common/lua.h"
+#include "common/tracy.h"
 #include "test_application.h"
 
+#include <iostream>
 #include <memory>
 
 int main(int argc, char** argv)
 {
+    TracySetThreadName("Test Thread");
+
     auto testApp = std::make_unique<TestApplication>(argc, argv);
 
     testApp->run();
@@ -36,6 +40,13 @@ int main(int argc, char** argv)
     // TODO: This should be in ~Application but it needs more testing for xi_map
     // TODO: This wouldn't be needed if lua wasn't global
     lua_cleanup();
+
+#ifdef TRACY_ENABLE
+    // TODO: Tracy profiler exits when program is done
+    // Is there an option to keep it running despite the program exiting?
+    std::cout << "Press Enter to exit..." << std::endl;
+    std::cin.get();
+#endif
 
     return 0;
 }

--- a/src/test/test_application.cpp
+++ b/src/test/test_application.cpp
@@ -116,6 +116,8 @@ auto TestApplication::createEngine() -> std::unique_ptr<Engine>
 
 void TestApplication::run()
 {
+    TracyZoneScoped;
+
     engine_ = createEngine();
     markLoaded();
     //  From this point, every logging statements end up in the in-memory sink

--- a/src/test/test_collector.cpp
+++ b/src/test/test_collector.cpp
@@ -22,6 +22,7 @@
 #include "test_collector.h"
 #include "common/logging.h"
 #include "common/lua.h"
+#include "common/tracy.h"
 #include "reporters/reporter_container.h"
 #include <algorithm>
 #include <chrono>
@@ -40,6 +41,8 @@ TestCollector::TestCollector(const FilterConfig& filters, ReporterContainer& rep
 , matcher_(filters)
 , reporters_(reporters)
 {
+    TracyZoneScoped;
+
     registerTestFramework();
 
     auto testFiles = collectTestFiles();
@@ -96,6 +99,9 @@ auto TestCollector::collectTestFiles() const -> std::vector<std::filesystem::pat
 
 void TestCollector::loadTestFile(const std::filesystem::path& filePath)
 {
+    TracyZoneScoped;
+    TracyZoneString(filePath.generic_string());
+
     // Normalize path to forward slashes and build hierarchical suite name from path
     currentFile_                             = filePath.generic_string();
     const std::filesystem::path relativePath = std::filesystem::relative(filePath, SUITES_PATH);

--- a/src/test/test_engine.cpp
+++ b/src/test/test_engine.cpp
@@ -23,6 +23,7 @@
 #include "common/logging.h"
 #include "common/lua.h"
 #include "common/settings.h"
+#include "common/tracy.h"
 #include "enums/test_status.h"
 #include "in_memory_sink.h"
 #include "lua/lua_simulation.h"
@@ -83,6 +84,8 @@ TestEngine::~TestEngine() = default;
 
 auto TestEngine::executeTests() -> bool
 {
+    TracyZoneScoped;
+
     TestResults results;
     const auto  runStartTime = std::chrono::steady_clock::now();
 
@@ -123,6 +126,9 @@ auto TestEngine::executeTests() -> bool
 
 auto TestEngine::executeSuite(const TestSuite& suite, HookContext context) -> TestResults
 {
+    TracyZoneScoped;
+    TracyZoneString(suite.fullName());
+
     TestResults results;
     auto        suiteStartTime = std::chrono::steady_clock::now();
 
@@ -264,6 +270,9 @@ void TestEngine::reportSetupTeardownFailure(const TestSuite& suite, const std::s
 
 auto TestEngine::executeTestCase(const TestCase& testCase, const HookContext& context, const TestSuite& suite) const -> bool
 {
+    TracyZoneScoped;
+    TracyZoneString(fmt::format("{} :: {}", suite.fullName(), testCase.name()));
+
     // Notify reporters of test start
     reporters_.onTestStart(suite, testCase);
 
@@ -336,6 +345,8 @@ auto TestEngine::executeTestCase(const TestCase& testCase, const HookContext& co
 
 auto TestEngine::runBeforeHooks(const HookContext& context, const std::string& testName) const -> std::optional<std::string>
 {
+    TracyZoneScoped;
+
     if (context.beforeEachHooks.empty())
     {
         return std::nullopt;
@@ -369,6 +380,8 @@ auto TestEngine::runBeforeHooks(const HookContext& context, const std::string& t
 
 void TestEngine::runAfterHooks(const HookContext& context, const std::string& testName) const
 {
+    TracyZoneScoped;
+
     if (context.afterEachHooks.empty())
     {
         return;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Links Tracy to xi_test, sets the variables, adds a handful of zone scopes
- Sets TRACY_NO_EXIT so it will wait until a client connects and downloads the session before exiting
- Adds a keyboard input wait because I have no idea how to make it so the profiler does not close on program exiting.
- Resolves an initialization order issue in Synchronized that was randomly corrupting prepared statements state when executing with Tracy enabled.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<img width="1715" height="1102" alt="Screenshot 2025-09-29 194448" src="https://github.com/user-attachments/assets/1cb7147d-5d83-4458-b271-cab4cf6e9708" />

