### PR TITLE
[lua] Add params to mobskills to allow for critical hits

### DIFF
--- a/scripts/actions/mobskills/cannonball.lua
+++ b/scripts/actions/mobskills/cannonball.lua
@@ -22,8 +22,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits      = 1
     local accmod       = 1
     local ftp          = 1.5
-    local isCannonball = true
-    local info         = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT, 0, 0, 0, isCannonball)
+    local params       = { isCannonball = true }
+    local info         = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT, 0, 0, 0, params)
     local dmg          = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)

--- a/scripts/actions/mobskills/panzerschreck.lua
+++ b/scripts/actions/mobskills/panzerschreck.lua
@@ -10,10 +10,11 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 1
-    local accmod = 1
-    local ftp    = 2
-    local info = xi.mobskills.mobRangedMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.CRIT_VARIES)
-    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, info.hitslanded)
+    local accmod  = 1
+    local ftp     = 2
+    local params  = { canCrit = true }
+    local info    = xi.mobskills.mobRangedMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT, 0, 0, 0, params)
+    local dmg     = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
 
     return dmg

--- a/scripts/actions/mobskills/sinuate_rush.lua
+++ b/scripts/actions/mobskills/sinuate_rush.lua
@@ -15,10 +15,11 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 1
-    local accmod = 1
-    local ftp    = 2.0
-    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.CRIT_VARIES, 1, 1, 1)
-    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, xi.mobskills.shadowBehavior.NUMSHADOWS_3)
+    local accmod  = 1
+    local ftp     = 2.0
+    local params  = { canCrit = true }
+    local info    = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT, 0, 0, 0, params)
+    local dmg     = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, xi.mobskills.shadowBehavior.NUMSHADOWS_3)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -686,7 +686,11 @@ xi.combat.physical.calculateRangedPDIF = function(actor, target, weaponType, wsA
     local targetDefense   = math.max(1, target:getStat(xi.mod.DEF))
     local flourishBonus   = 1
     local firstCap        = xi.combat.physical.pDifWeaponCapTable[weaponType][1]
-    local distancePenalty = xi.combat.ranged.attackDistancePenalty(actor, target)
+    local distancePenalty = 0
+
+    if not actor:isMob() then
+        distancePenalty = xi.combat.ranged.attackDistancePenalty(actor, target)
+    end
 
     -- Actor Weaponskill Specific Attack modifiers.
     -- TODO: verify this actually works on ranged WS


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Reworked mobPhysicalMove to utilize a param to include the ability to crit on mob skills. I've lumped in the existing isCannonball check into this param.
- Added the canCrit as a toggle to be turned on as needed per mob skill. I've added this to Sinuate Rush as an example.
- Adjusted mobRangedMove to utilize the new params which now allows for mobRangedMove to utilize tpEffect as needed.

## Steps to test these changes

- Fight a Hpemde and see that Sinuate Rush crits as expected
