### PR TITLE
[cpp] Add optional param to lookAt to send update pkt

### DIFF
--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -439,8 +439,9 @@ end
 ---@param arg0 number
 ---@param arg1 number
 ---@param arg2 number
+---@param sendUpdateImmediately boolean?
 ---@return nil
-function CBaseEntity:lookAt(arg0, arg1, arg2)
+function CBaseEntity:lookAt(arg0, arg1, arg2, sendUpdateImmediately)
 end
 
 ---@param posTable table

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -1782,10 +1782,12 @@ bool CLuaBaseEntity::canUseAbilities()
  *  Purpose : Forces an entity to 'look' at something like it's self-aware
  *  Example : npc:lookAt(player:getPos()) -- Make an NPC look at the PC
  *  Notes   : Expects x, y, and z and does not confirm missing!
+ *            If sending a position table, add a key for sendUpdateImmediately instead of a 4th parameter
  ************************************************************************/
 
-void CLuaBaseEntity::lookAt(sol::object const& arg0, sol::object const& arg1, sol::object const& arg2)
+void CLuaBaseEntity::lookAt(sol::object const& arg0, sol::object const& arg1, sol::object const& arg2, sol::object const& sendUpdateImmediately)
 {
+    bool       sendPacket = (sendUpdateImmediately != sol::lua_nil) ? sendUpdateImmediately.as<bool>() : false;
     position_t point;
 
     if ((arg0 != sol::lua_nil) && (arg0.is<double>()))
@@ -1796,11 +1798,32 @@ void CLuaBaseEntity::lookAt(sol::object const& arg0, sol::object const& arg1, so
     }
     else
     {
-        auto position = arg0.as<std::map<std::string, float>>();
+        for (const auto& kv : arg0.as<sol::table>())
+        {
+            std::string key = kv.first.as<std::string>();
 
-        point.x = position["x"];
-        point.y = position["y"];
-        point.z = position["z"];
+            if (key == "sendUpdateImmediately" && kv.second.is<bool>())
+            {
+                sendPacket = kv.second.as<bool>();
+            }
+            else if (kv.second.is<float>())
+            {
+                auto val = kv.second.as<float>();
+
+                if (key == "x")
+                {
+                    point.x = val;
+                }
+                else if (key == "y")
+                {
+                    point.y = val;
+                }
+                else if (key == "z")
+                {
+                    point.z = val;
+                }
+            }
+        }
     }
 
     // Avoid unpredictable results if we're too close.
@@ -1808,6 +1831,11 @@ void CLuaBaseEntity::lookAt(sol::object const& arg0, sol::object const& arg1, so
     {
         m_PBaseEntity->loc.p.rotation = worldAngle(m_PBaseEntity->loc.p, point);
         m_PBaseEntity->updatemask |= UPDATE_POS;
+
+        if (sendPacket)
+        {
+            m_PBaseEntity->loc.zone->UpdateEntityPacket(m_PBaseEntity, ENTITY_UPDATE, UPDATE_COMBAT);
+        }
     }
 }
 

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -137,7 +137,7 @@ public:
     uint8 getCurrentAction();
     bool  canUseAbilities();
 
-    void lookAt(sol::object const& arg0, sol::object const& arg1, sol::object const& arg2);
+    void lookAt(sol::object const& arg0, sol::object const& arg1, sol::object const& arg2, sol::object const& sendUpdateImmediately);
     void facePlayer(CLuaBaseEntity* PLuaBaseEntity, sol::object const& nonGlobal);
     void clearTargID();
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Implementing Dark Ixion, I need to be able to make him look just before a mobskill goes off. `mob:lookAt()` sets the update flag, but the next tick is too late to properly display his position.
- Acheron Kick needs to turn his back to whichever target gets chosen
- Lighting Spear turns in a random direction just before firing

Both have unreliable behavior using the existing `:lookAt()` binding within a `WEAPONSKILL_STATE_ENTER` listener

The changes in this PR make him reliably turn before the skill goes off

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- add a breakpoint at the `isWithinDistance` line
- execute various combinations of `lookAt` to see `point` gets set the same as before, but `sendUpdate` is false unless explicitly setting 4 parameters `(x,y,z,bool)` or sending a table `{x=1,y=2,z=3,sendUpdateImmediately=true}`
- <img width="661" height="157" alt="image" src="https://github.com/user-attachments/assets/3060c4b5-f7e0-40f8-bdfc-3d2147d3126d" />
