### PR TITLE
add check for existing healing status in leavegame.lua

### DIFF
--- a/scripts/effects/leavegame.lua
+++ b/scripts/effects/leavegame.lua
@@ -27,7 +27,9 @@ effectObject.onEffectGain = function(target, effect)
     end
 
     -- addStatusEffect (non-Ex) forces the icon to the effect ID...
-    target:addStatusEffectEx(xi.effect.HEALING, 0, 0, xi.settings.map.HEALING_TICK_DELAY, 0, true)
+    if not target:hasStatusEffect(xi.effect.HEALING) then
+        target:addStatusEffectEx(xi.effect.HEALING, 0, 0, xi.settings.map.HEALING_TICK_DELAY, 0, true)
+    end
 
     -- Note: Power stores the kind.
     target:messageSystem(messages[effect:getPower()], 30)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Fixes https://github.com/LandSandBoat/server/issues/7991

Adding the status effect that already exists seems to silently fail gaining the leavegame status. Adding this check to only conditionally gain healing fixes the issue.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
/heal
/shutdown or /logout