### PR TITLE
[lua] Change Crimson Orb Pools and Final CS to progressCutscene

### DIFF
--- a/scripts/quests/hiddenQuests/Crimson_Orb.lua
+++ b/scripts/quests/hiddenQuests/Crimson_Orb.lua
@@ -48,7 +48,7 @@ local pondOnTrigger = function(player, npc)
     then
         quest:setLocalVar(player, 'npcOffset', npcOffset)
         player:messageSpecial(davoiID.text.ORB_QUEST_OFFSET)
-        return quest:progressEvent(50 + npcOffset, 0, numPonds, player:getRace())
+        return quest:progressCutscene(50 + npcOffset, 0, numPonds, player:getRace())
     else
         return quest:messageSpecial(davoiID.text.COLOR_OF_BLOOD)
     end
@@ -126,7 +126,7 @@ quest.sections =
                     elseif questProgress == 2 then
                         return quest:progressEvent(21)
                     elseif questProgress == 3 then
-                        return quest:progressEvent(25, 0, 0, 0, 136)
+                        return quest:progressCutscene(25, 0, 0, 0, 136)
                     end
                 end,
             },


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

It was found that the pool cutscenes and the final cutscene for the Crimson Orb hidden quest drop agro.
Converts those progressEvents to progressCutscenes

## Steps to test these changes

`!zone <Davoi>`
`!gotoname _45d` Check the gate
`!gotoname Sedal-Godjal` Talk to Sedal
Agro something Check the pools
Agro something `!gotoname Sedal-Godjal` Talk to Sedal

## Capture
Packets Only
https://drive.google.com/drive/folders/1S1e1aQkn_kYfzuCM370CLXWH78wfXMxp?usp=sharing