### PR TITLE
[cpp] Process first mobskill tick immediately if castTime=0

### DIFF
--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -107,6 +107,13 @@ CMobSkillState::CMobSkillState(CBattleEntity* PEntity, uint16 targid, uint16 wsi
     }
     m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_STATE_ENTER", m_PEntity, m_PSkill->getID());
     SpendCost();
+
+    // Probably ok to do this for all skills, but there's no need
+    // This allows instant mobskills to actually be instant by processing the first tick immediately
+    if (m_castTime == 0s)
+    {
+        DoUpdate(GetEntryTime());
+    }
 }
 
 CMobSkill* CMobSkillState::GetSkill()
@@ -150,7 +157,7 @@ bool CMobSkillState::Update(timer::time_point tick)
         }
     }
 
-    if (m_PEntity && m_PEntity->isAlive() && (tick > GetEntryTime() + m_castTime && !IsCompleted()))
+    if (m_PEntity && m_PEntity->isAlive() && (tick >= GetEntryTime() + m_castTime && !IsCompleted()))
     {
         action_t action;
         m_PEntity->OnMobSkillFinished(*this, action);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Coding Dark Ixion, I noticed that autoattacks that go through `MOBMOD_ATTACK_SKILL_LIST` were able to be ranged
- walk away from mob
- it closes the gap
- but instead of being hit, you get a message "Mowford is too far away"

Two changes in this PR:
- Tracked it down to the state successfully entering, but exiting before `Update` could consider the prepare time done.
  - the inequality fixes the logical issue there
- This still didn't function properly, because the next call to `Update` wasn't happening immediately
  - Added a call to the base class's `DoUpdate` with the entry tick.
 

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- give a mob an auto-attack mobskill list: `!setmobmod attack_skill_list 39`
- engage it and run away
- see that you get hit 