### PR TITLE
add typename notations in s2c/base.h for older compilers

### DIFF
--- a/src/map/packets/s2c/base.h
+++ b/src/map/packets/s2c/base.h
@@ -50,14 +50,14 @@ protected:
 
     // Access shifted by header size so individual packets do not need to declare it
     template <typename T = Derived>
-    auto data() -> T::PacketData&
+    auto data() -> typename T::PacketData&
     {
-        return *reinterpret_cast<T::PacketData*>(buffer_.data() + sizeof(GP_SERV_HEADER));
+        return *reinterpret_cast<typename T::PacketData*>(buffer_.data() + sizeof(GP_SERV_HEADER));
     }
 
     template <typename T = Derived>
-    auto data() const -> const T::PacketData&
+    auto data() const -> const typename T::PacketData&
     {
-        return *reinterpret_cast<const T::PacketData*>(buffer_.data() + sizeof(GP_SERV_HEADER));
+        return *reinterpret_cast<const typename T::PacketData*>(buffer_.data() + sizeof(GP_SERV_HEADER));
     }
 };


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Fixes the following compilation error (on VS 2022 17.4.2 at least), thanks @sruon :)
```
C:\Users\=\Documents\repos\LandSandBoat\src\map\packets\s2c\base.h(59): error C3613: missing return type after '->' ('int' assumed)
  C:\Users\=\Documents\repos\LandSandBoat\src\map\packets/s2c/base.h(63): note: see reference to class template instantiation 'GP_SERV_PACKET<PacketId,Derived>' being compiled
C:\Users\=\Documents\repos\LandSandBoat\src\map\packets\s2c\base.h(59): error C2143: syntax error: missing ';' before 'T::PacketData'
C:\Users\=\Documents\repos\LandSandBoat\src\map\packets\s2c\base.h(59): error C2238: unexpected token(s) preceding ';'
C:\Users\=\Documents\repos\LandSandBoat\src\map\packets\s2c\base.h(59): warning C4346: 'PacketData': dependent name is not a type
  C:\Users\=\Documents\repos\LandSandBoat\src\map\packets/s2c/base.h(59): note: prefix with 'typename' to indicate a type
C:\Users\=\Documents\repos\LandSandBoat\src\map\packets\s2c\base.h(59): error C2061: syntax error: identifier 'PacketData'
C:\Users\=\Documents\repos\LandSandBoat\src\map\packets\s2c\base.h(60): error C2334: unexpected token(s) preceding '{'; skipping apparent function body
```

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Build all + be able to log in/run around/interact with npcs.