### PR TITLE
Fix localVar for Riding Game

### DIFF
--- a/scripts/globals/chocobo.lua
+++ b/scripts/globals/chocobo.lua
@@ -163,7 +163,7 @@ xi.chocobo.renterOnTrigger = function(player, npc, eventSucceed, eventFail)
 end
 
 xi.chocobo.renterOnEventFinish = function(player, csid, option, eventSucceed)
-    local chocoGame = player:getLocalVar('tempDestCity')
+    local chocoGame = player:getLocalVar('[ChocoGame]DestCity')
 
     if csid == eventSucceed and option == 0 then
         local mLvl     = player:getMainLvl()


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes #8281 

Cause of this issue appears to be this line in scripts/globals/chocobo.lua (inside xi.chocobo.renterOnEventFinish) that reads:
```local chocoGame = player:getLocalVar('tempDestCity') ```

And it should instead read
```local chocoGame = player:getLocalVar('[ChocoGame]DestCity') ```

Seems it simply got missed when the quest was originally added.
Without the above change, we don't actually hit the logic that sets up the quest and instead we enter just a normal chocobo ride.

## Steps to test these changes

- Head to one of the starting NPC's in the Chocobo Riding Game quest and accept.
- Ride to the location it asked for, or use the !zone command
- Upon reaching the trigger area (it's always close to the zoneline) you should dismount chocobo automatically and enter cutscene giving player the reward based on their time
