### PR TITLE
fix Jeuno quest “Full Speed Ahead!”

### DIFF
--- a/scripts/zones/Batallia_Downs/Zone.lua
+++ b/scripts/zones/Batallia_Downs/Zone.lua
@@ -25,7 +25,7 @@ end
 
 zoneObject.onInitialize = function(zone)
     -- A Chocobo Riding Game finish line
-    zone:registerCylindricalTriggerArea(1, 467.16, -156.82, 20)
+    zone:registerCylindricalTriggerArea(10, 467.16, -156.82, 20)
 
     for i = 0, 7 do
         registerRegionAroundNPC(zone, ID.npc.RAPTOR_FOOD_BASE + i, i + 1)
@@ -69,9 +69,15 @@ end
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)
     local triggerAreaID = triggerArea:getTriggerAreaID()
 
-    if player:hasStatusEffect(xi.effect.FULL_SPEED_AHEAD) then
+    if
+        triggerAreaID ~= 10 and
+        player:hasStatusEffect(xi.effect.FULL_SPEED_AHEAD)
+    then
         xi.fsa.onTriggerAreaEnter(player, triggerAreaID)
-    elseif triggerAreaID == 1 and player:hasStatusEffect(xi.effect.MOUNTED) then
+    elseif
+        triggerAreaID == 10 and
+        player:hasStatusEffect(xi.effect.MOUNTED)
+    then
         xi.chocoboGame.onTriggerAreaEnter(player)
     end
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes #7976

It seems the trigger area ID's for the first piece of Raptor Food overlaps with the ID for the Chocobo Riding Game finish line.  Because of this, when you zone into Batallia Downs with the quest active, the trigger area fires for the Riding Game since it's area is right on the zoneline for Upper Jeuno, where you enter the zone.  The value is valid, so it counts as interacting with the first piece of raptor food, which is why we get the message on zoning, and it dissapears from the zone.

Changing the triggerAreaID for the Chocobo Riding Game to 10 (so we can keep all the FSA related triggers numbered 1-9) fixes this.

## Steps to test these changes

- Start the quest
- You shouldn't get the  “Ate the food (1/5)” message immediately, and travelling to the first location, the food (and accompanying blue light) is actually there.
- All the raptor food should be available to collect and complete the quest
