### PR TITLE
[lua] Dark Ixion Trample mechanic

### DIFF
--- a/scripts/enum/target_type.lua
+++ b/scripts/enum/target_type.lua
@@ -7,16 +7,17 @@ xi = xi or {}
 ---@enum xi.targetType
 xi.targetType =
 {
-    NONE                    = 0x00,
-    SELF                    = 0x01,
-    PLAYER_PARTY            = 0x02,
-    ENEMY                   = 0x04,
-    PLAYER_ALLIANCE         = 0x08,
-    PLAYER                  = 0x10,
-    PLAYER_DEAD             = 0x20,
-    NPC                     = 0x40, -- an npc is a mob that looks like an npc and fights on the side of the character
-    PLAYER_PARTY_PIANISSIMO = 0x80,
-    PET                     = 0x100,
-    PLAYER_PARTY_ENTRUST    = 0x200,
-    IGNORE_BATTLEID         = 0x400, -- Can hit targets that do not have the same battle ID
+    NONE                    = 0x0000,
+    SELF                    = 0x0001,
+    PLAYER_PARTY            = 0x0002,
+    ENEMY                   = 0x0004,
+    PLAYER_ALLIANCE         = 0x0008,
+    PLAYER                  = 0x0010,
+    PLAYER_DEAD             = 0x0020,
+    NPC                     = 0x0040, -- an npc is a mob that looks like an npc and fights on the side of the character
+    PLAYER_PARTY_PIANISSIMO = 0x0080,
+    PET                     = 0x0100,
+    PLAYER_PARTY_ENTRUST    = 0x0200,
+    IGNORE_BATTLEID         = 0x0400, -- Can hit targets that do not have the same battle ID
+    ANY_ALLEGIANCE          = 0x0800, -- Can hit targets from any allegiance simultaneously. To be used with other flags above and only makes sense for non-single-target skills
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

First, it was obvious to me from being immersed in it but thinking more it was pretty silly to not enum the animationSubs with how much they're used/set
- changed all references to Ixion's animationSubs to an enum with hopefully useful keys

expanded the stub functions to handle the trample event/mechanic:
- when trample starts, he chooses a random entity within 30 yalms
  - if none is found, a random point within 10 (it's highly unlikely no entities are found, but if not we can't be sure a random point within 30 is a valid navmesh point)
  - if an enemy is found, calculate the point past them, on their plane, so the trample overshoots
- the `trampleEntitiesInFront` function is both called as soon as Ixion looks at the tramplePos, and every combat tick
  - if the trample target is in range, hit them
  - if any other enemies are in range, hit them only if they're in front
  - in either case, consider every entity only once per trample path. This is done by inserting into a global table that is reset when trample starts (and ends, for cleanliness)
    - I adjusted from storing the entity in an auto-incremented table to using a `set{}` style table keyed on the entity targID

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- [same as before to get to Ixion](https://github.com/LandSandBoat/server/pull/8273)
- watch him fight
- set localvars to speed up phase/event timing
- https://imgur.com/niQkgs7
- can add this to top of `endTramplePath` function to see it's the entity tracking in action:
```
for k,v in pairs(xi.darkixion.hitList) do
    print(k,v)
end
```
<img width="301" height="66" alt="image" src="https://github.com/user-attachments/assets/0ce51087-4498-4b9e-b8d6-de231dac807e" />
