### PR TITLE
[lua] Clean up Interactions and Events for quest "A Minstrel in Despair"

### DIFF
--- a/scripts/quests/jeuno/A_Minstrel_In_Despair.lua
+++ b/scripts/quests/jeuno/A_Minstrel_In_Despair.lua
@@ -4,6 +4,9 @@
 -- Log ID: 3, Quest ID: 12
 -- Mertaire : !pos -17 0 -61 245
 -----------------------------------
+local buburimuID   = zones[xi.zone.BUBURIMU_PENINSULA]
+local lowerJeunoID = zones[xi.zone.LOWER_JEUNO]
+-----------------------------------
 
 local quest = Quest:new(xi.questLog.JEUNO, xi.quest.id.jeuno.A_MINSTREL_IN_DESPAIR)
 
@@ -22,14 +25,47 @@ quest.sections =
             player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.THE_OLD_MONUMENT) == xi.questStatus.QUEST_COMPLETED
         end,
 
+        -- Failsafe incase the player loses their Poetic Parchment
+        [xi.zone.BUBURIMU_PENINSULA] =
+        {
+            ['Song_Runes'] =
+            {
+                onTrade = function(player, npc, trade)
+                    if npcUtil.tradeHasExactly(trade, xi.item.SHEET_OF_PARCHMENT) then
+                        return quest:progressCutscene(2)
+                    end
+                end,
+
+                onTrigger = quest:messageSpecial(buburimuID.text.SONG_RUNES_REQUIRE, xi.item.SHEET_OF_PARCHMENT),
+            },
+
+            onEventFinish =
+            {
+                [2] = function(player, csid, option, npc)
+                    player:confirmTrade()
+                    npcUtil.giveItem(player, xi.item.POETIC_PARCHMENT)
+                    player:messageSpecial(buburimuID.text.SONG_RUNES_WRITING, xi.item.SHEET_OF_PARCHMENT)
+                end,
+            },
+        },
+
         [xi.zone.LOWER_JEUNO] =
         {
+
+            ['Bki_Tbujhja'] = quest:event(182),
+
+            ['Mataligeat'] = quest:event(144),
+
             ['Mertaire'] =
             {
                 onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, { xi.item.POETIC_PARCHMENT }) then
+                    if npcUtil.tradeHas(trade, { xi.item.POETIC_PARCHMENT }) then
                         return quest:progressEvent(101)
                     end
+                end,
+
+                onTrigger = function(player, npc)
+                    return quest:messageName(lowerJeunoID.text.MERTAIRE_MALLIEBELL_LEFT, 0, 0, 0, 0, true, false)
                 end,
             },
 

--- a/scripts/quests/jeuno/The_Old_Monument.lua
+++ b/scripts/quests/jeuno/The_Old_Monument.lua
@@ -59,7 +59,7 @@ quest.sections =
                         quest:getVar(player, 'Prog') == 2 and
                         npcUtil.tradeHasExactly(trade, xi.item.SHEET_OF_PARCHMENT)
                     then
-                        return quest:progressEvent(2)
+                        return quest:progressCutscene(2)
                     end
                 end,
 

--- a/scripts/zones/Lower_Jeuno/npcs/Mataligeat.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Mataligeat.lua
@@ -7,12 +7,8 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    -- THE OLD MONUMENT
-    if player:getCharVar('TheOldMonument_Event') == 1 then
-        player:startEvent(141) -- looks like his girlfriend dumped him
-
     -- PAINFUL MEMORY
-    elseif player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.PAINFUL_MEMORY) == xi.questStatus.QUEST_ACCEPTED then
+    if player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.PAINFUL_MEMORY) == xi.questStatus.QUEST_ACCEPTED then
         player:startEvent(140) -- he's forgotten why he took up the lute in the first place
 
     -- THE REQUIEM


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds missing interactions.
Adds a failsafe in case the player somehow loses their poetic parchment.

## Steps to test these changes

1. `!completequest 3 11`
2. `!zone <Lower Jeuno>`
3. Trade Poetic Parchment to Mertaire
4. Quest Complete

## Captures
https://youtu.be/fax8emxUUog
https://drive.google.com/drive/folders/1q4wBWR4LqzkVM05VOZU9TGUdn934kTlx?usp=sharing