### PR TITLE
[cpp] Updated checks on CParty::AddMember method

### DIFF
--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -597,9 +597,15 @@ void CParty::AddMember(CBattleEntity* PEntity)
         return;
     }
 
-    if (PEntity->objtype == TYPE_PC && m_PartyType == PARTY_PCS && members.size() > 5)
+    if (PEntity->objtype == TYPE_PC && m_PartyType == PARTY_PCS && IsFull())
     {
         ShowWarning("CParty::AddMember() - Party was full when trying to add a member.");
+        return;
+    }
+
+    if (PEntity->objtype == TYPE_PC && m_PartyType == PARTY_PCS && HasTrusts())
+    {
+        ShowWarning("CParty::AddMember() - Party had summoned trusts when trying to add a member.");
         return;
     }
 
@@ -688,9 +694,15 @@ void CParty::AddMember(uint32 id)
 {
     if (m_PartyType == PARTY_PCS)
     {
-        if (members.size() > 5)
+        if (IsFull())
         {
             ShowWarning("CParty::AddMember() - Party was full when trying to add a member from out of zone.");
+            return;
+        }
+
+        if (HasTrusts())
+        {
+            ShowWarning("CParty::AddMember() - Party had summoned trusts when trying to add a member.");
             return;
         }
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Before this change it was possible to do the following:
- Send an invite to another player outside the player's current zone
- Have the other player leave the invite pending
- Summon trusts in the player current zone
- Have the other player accept (/join) the player's invite and join the party

Leading to the following consequences:
- Another player being able to join a party with trusts summoned, contradicting the behavior where a player is unable to invite another while trusts are summoned
- Making possible to exceed the 6 member party limit by having the player summon 5 trusts while an invite to a player in another zone was still pending and having them accepting it afterwards

The change implemented take advantage of the CParty functions IsFull() and HasTrusts() to perform the necessary checks to prevent this bug.
Note: the same functions are already used to perform checks to prevent the bug described above in other instances so this also results in a more uniform way to perform the same checks.

## Steps to test these changes
Repeat the steps described above and confirm that the bug no longer works and check the logs for confirmation

![srvr_msg_partywithtrusts](https://i.gyazo.com/954b3a4d1006265231490fcca64600b6.jpg)
(I updated the warning message after the screenshot)
