### PR TITLE
[lua] Correct SMN unlock quest weather counter

### DIFF
--- a/scripts/quests/windurst/SMN_I_Can_Hear_a_Rainbow.lua
+++ b/scripts/quests/windurst/SMN_I_Can_Hear_a_Rainbow.lua
@@ -77,7 +77,7 @@ end
 local function handleEventUpdate(player, csid, option, npc)
     local weather      = player:getZone():getWeather()
     local lightBitMask = quest:getVar(player, 'Light')
-    local lightCounter = 0
+    local lightCounter = -1
 
     for bit = 0, 6 do
         if utils.mask.getBit(lightBitMask, bit) then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR fixes an issue with the quest I Can Hear A Rainbow where the quest would advance after obtaining only six out of the seven necessary weathers.

## Steps to test these changes

Begin the quest I Can Hear A Rainbow, check your Light quest var, confirm that you don't trigger the prog = 1 step until you get all seven weathers.
