### PR TITLE
Fix issue with CMake cache option

### DIFF
--- a/cmake/Cache.cmake
+++ b/cmake/Cache.cmake
@@ -17,7 +17,7 @@ if(${CACHE_OPTION_INDEX} EQUAL -1)
     )
 endif()
 
-find_program(CACHE_BINARY NAMES ${CACHE_OPTION_VALUES})
+find_program(CACHE_BINARY NAMES ${CACHE_OPTION})
 if(CACHE_BINARY)
     message(STATUS "${CACHE_BINARY} found and enabled")
     set(CMAKE_CXX_COMPILER_LAUNCHER


### PR DESCRIPTION
Was not respecting options.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

I think this is right. `CACHE_OPTION_VALUES` is just selecting the first in "`"ccache" "sccache"`" so sccache is never used. Use `CACHE_OPTION`.

## Steps to test these changes

Install sccache and build with `CACHE_OPTION=sccache` and see it uses sccache and not ccache.
