### PR TITLE
[lua] Cleanup duplicate/unreachable code block from the xi.mob.onAddEffect() function

### DIFF
--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -719,16 +719,6 @@ xi.mob.onAddEffect = function(mob, target, damage, effect, params)
             elseif effect == xi.mob.ae.DISPEL and target then
                 return addEffectDispel(target, ae)
 
-            -- DISPEL
-            elseif effect == xi.mob.ae.DISPEL and target then
-                local dispelledEffect = target:dispelStatusEffect(xi.effectFlag.DISPELABLE)
-
-                if dispelledEffect == xi.effect.NONE then
-                    return 0, 0, 0
-                end
-
-                return ae.sub, ae.msg, dispelledEffect
-
             -- IMMEDIATE EFFECT
             else
                 return addEffectImmediate(mob, target, damage, ae, params)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Removes an elseif block that's just a duplicate of the one above.

## Steps to test these changes

Does not apply.
