### PR TITLE
[lua] Stat Down decay effects auto clean up

### DIFF
--- a/scripts/effects/agi_down.lua
+++ b/scripts/effects/agi_down.lua
@@ -13,11 +13,13 @@ effectObject.onEffectGain = function(target, effect)
 end
 
 effectObject.onEffectTick = function(target, effect)
-    -- the effect restore agility of 1 every 3 ticks.
+    -- The effect restores 1 AGI every 3 ticks. (1 Tick = 3 seconds).
     local downAGIEffectSize = effect:getPower()
     if downAGIEffectSize > 0 then
         effect:setPower(downAGIEffectSize - 1)
         target:delMod(xi.mod.AGI, -1)
+    else
+        target:delStatusEffect(xi.effect.AGI_DOWN)
     end
 end
 

--- a/scripts/effects/chr_down.lua
+++ b/scripts/effects/chr_down.lua
@@ -13,11 +13,13 @@ effectObject.onEffectGain = function(target, effect)
 end
 
 effectObject.onEffectTick = function(target, effect)
-    -- the effect restore charism of 1 every 3 ticks.
+    -- The effect restores 1 CHR every 3 ticks. (1 Tick = 3 seconds).
     local downCHREffectSize = effect:getPower()
     if downCHREffectSize > 0 then
         effect:setPower(downCHREffectSize - 1)
         target:delMod(xi.mod.CHR, -1)
+    else
+        target:delStatusEffect(xi.effect.CHR_DOWN)
     end
 end
 

--- a/scripts/effects/dex_down.lua
+++ b/scripts/effects/dex_down.lua
@@ -13,11 +13,13 @@ effectObject.onEffectGain = function(target, effect)
 end
 
 effectObject.onEffectTick = function(target, effect)
-    -- the effect restore dexterity of 1 every 3 ticks.
+    -- The effect restores 1 DEX every 3 ticks. (1 Tick = 3 seconds).
     local downDEXEffectSize = effect:getPower()
     if downDEXEffectSize > 0 then
         effect:setPower(downDEXEffectSize - 1)
         target:delMod(xi.mod.DEX, -1)
+    else
+        target:delStatusEffect(xi.effect.DEX_DOWN)
     end
 end
 

--- a/scripts/effects/int_down.lua
+++ b/scripts/effects/int_down.lua
@@ -13,11 +13,13 @@ effectObject.onEffectGain = function(target, effect)
 end
 
 effectObject.onEffectTick = function(target, effect)
-    -- the effect restore intelligence of 1 every 3 ticks.
+    -- The effect restores 1 INT every 3 ticks. (1 Tick = 3 seconds).
     local downINTEffectSize = effect:getPower()
     if downINTEffectSize > 0 then
         effect:setPower(downINTEffectSize - 1)
         target:delMod(xi.mod.INT, -1)
+    else
+        target:delStatusEffect(xi.effect.INT_DOWN)
     end
 end
 

--- a/scripts/effects/mnd_down.lua
+++ b/scripts/effects/mnd_down.lua
@@ -13,11 +13,13 @@ effectObject.onEffectGain = function(target, effect)
 end
 
 effectObject.onEffectTick = function(target, effect)
-    -- the effect restore mind of 1 every 3 ticks.
+    -- The effect restores 1 MND every 3 ticks. (1 Tick = 3 seconds).
     local downMNDEffectSize = effect:getPower()
     if downMNDEffectSize > 0 then
         effect:setPower(downMNDEffectSize - 1)
         target:delMod(xi.mod.MND, -1)
+    else
+        target:delStatusEffect(xi.effect.MND_DOWN)
     end
 end
 

--- a/scripts/effects/str_down.lua
+++ b/scripts/effects/str_down.lua
@@ -13,11 +13,13 @@ effectObject.onEffectGain = function(target, effect)
 end
 
 effectObject.onEffectTick = function(target, effect)
-    -- the effect restore strengh of 1 every 3 ticks.
+    -- The effect restores 1 STR every 3 ticks. (1 Tick = 3 seconds).
     local downSTREffectSize = effect:getPower()
     if downSTREffectSize > 0 then
         effect:setPower(downSTREffectSize - 1)
         target:delMod(xi.mod.STR, -1)
+    else
+        target:delStatusEffect(xi.effect.STR_DOWN)
     end
 end
 

--- a/scripts/effects/vit_down.lua
+++ b/scripts/effects/vit_down.lua
@@ -13,11 +13,13 @@ effectObject.onEffectGain = function(target, effect)
 end
 
 effectObject.onEffectTick = function(target, effect)
-    -- the effect restore vitality of 1 every 3 ticks.
+    -- The effect restores 1 VIT every 3 ticks. (1 Tick = 3 seconds).
     local downVITEffectSize = effect:getPower()
     if downVITEffectSize > 0 then
         effect:setPower(downVITEffectSize - 1)
         target:delMod(xi.mod.VIT, -1)
+    else
+        target:delStatusEffect(xi.effect.VIT_DOWN)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Based on captures of mobskills, effects like STR_DOWN that decay over time will auto delete themselves if the power reaches 0 before the duration ends.

## Steps to test these changes

Have a mob use Bubble Shower on you.
`!exec target:useMobAbility(442, player)` 

See that the effect cleanly deletes once the stat penalty hits ticks to 0 instead of being at 0 power until the effect duration expires.
