### PR TITLE
[Lua] Added taru snare mobMod for dmg reduction

### DIFF
--- a/scripts/globals/pirates_chart.lua
+++ b/scripts/globals/pirates_chart.lua
@@ -298,6 +298,7 @@ xi.piratesChart.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.NO_DROPS, 1)
     mob:setMobMod(xi.mobMod.GIL_MAX, -1)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 60)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 100)
 end
 
 xi.piratesChart.onMobFight = function(mob, target)
@@ -307,6 +308,10 @@ xi.piratesChart.onMobFight = function(mob, target)
     then
         mob:useMobAbility(xi.mobSkill.HUNDRED_FISTS_1)
         mob:setLocalVar('usedTwoHour', 1)
+    end
+
+    if GetSystemTime() > mob:getLocalVar('snareTimeLimit') then
+        mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 100)
     end
 end
 

--- a/scripts/items/tarutaru_snare.lua
+++ b/scripts/items/tarutaru_snare.lua
@@ -2,7 +2,7 @@
 -- ID: 5329
 -- Item: Tarutaru snare
 -- Used in Pirates Chart quest
--- When used on one of the quest nms, lowers its damage to 1 for 60 seconds
+-- When used on one of the quest nms, lowers its damage for 60 seconds
 -----------------------------------
 ---@type TItem
 local itemObject = {}
@@ -12,7 +12,8 @@ itemObject.onItemCheck = function(target, item, param, caster)
 end
 
 itemObject.onItemUse = function(target)
-    -- TODO: reduce damage
+    target:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 1)
+    target:setLocalVar('snareTimeLimit', GetSystemTime() + 60)
 end
 
 return itemObject

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -206,7 +206,7 @@ namespace mobutils
         return static_cast<uint16>(damage);
     }
 
-    // Gest base skill rankings for ACC/ATT/EVA/MEVA
+    // Get base skill rankings for ACC/ATT/EVA/MEVA
     uint16 GetBaseSkill(CMobEntity* PMob, uint8 rank)
     {
         int8 mlvl = PMob->GetMLevel();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements damage reduction for tarutaru snare item used in pirates chart fight confrontation

## Steps to test these changes
!additem pirates_chart
!additem tarutaru_snare
Use snare on mobs and see damage dramatically reduced for 60 seconds.  Only works on pirate chart mobs.
