### PR TITLE
[lua] Correct blue magic MB and burst affinity behavior

### DIFF
--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -361,16 +361,25 @@ xi.spells.blue.useMagicalSpell = function(caster, target, spell, params)
     finalDamage = math.floor(finalDamage * xi.spells.damage.calculateSDT(target, spellElement))
     finalDamage = math.floor(finalDamage * xi.spells.damage.calculateDayAndWeather(caster, spellElement, false))
     finalDamage = math.floor(finalDamage * xi.spells.damage.calculateMagicBonusDiff(caster, target, spellId, skillType, spellElement))
-    finalDamage = math.floor(finalDamage * xi.spells.damage.calculateIfMagicBurst(target, spellElement, skillchainCount))
-    finalDamage = math.floor(finalDamage * xi.spells.damage.calculateIfMagicBurstBonus(caster, target, spellId, skillType, spellElement))
+
+    if
+        caster:hasStatusEffect(xi.effect.BURST_AFFINITY) or
+        caster:hasStatusEffect(xi.effect.AZURE_LORE)
+    then
+        if skillchainCount > 0 then
+            finalDamage = math.floor(finalDamage * xi.spells.damage.calculateIfMagicBurst(target, spellElement, skillchainCount))
+            finalDamage = math.floor(finalDamage * xi.spells.damage.calculateIfMagicBurstBonus(caster, target, spellId, skillType, spellElement))
+
+            spell:setMsg(spell:getMagicBurstMessage()) -- "Magic Burst!"
+
+            caster:triggerRoeEvent(xi.roeTrigger.MAGIC_BURST)
+        end
+
+        caster:delStatusEffectSilent(xi.effect.BURST_AFFINITY)
+    end
+
     finalDamage = math.floor(finalDamage * xi.spells.damage.calculateEbullienceMultiplier(caster, spellGroup))
     finalDamage = math.floor(finalDamage * xi.settings.main.BLUE_POWER)
-
-    if skillchainCount > 1 then
-        spell:setMsg(spell:getMagicBurstMessage()) -- "Magic Burst!"
-
-        caster:triggerRoeEvent(xi.roeTrigger.MAGIC_BURST)
-    end
 
     return xi.spells.blue.applySpellDamage(caster, target, spell, finalDamage, params, nil)
 end
@@ -409,17 +418,26 @@ xi.spells.blue.useDrainSpell = function(caster, target, spell, params, damageCap
     finalDamage = math.floor(finalDamage * xi.spells.damage.calculateSDT(target, spellElement))
     finalDamage = math.floor(finalDamage * xi.spells.damage.calculateDayAndWeather(caster, spellElement, false))
     finalDamage = math.floor(finalDamage * xi.spells.damage.calculateMagicBonusDiff(caster, target, spellId, skillType, spellElement))
-    finalDamage = math.floor(finalDamage * xi.spells.damage.calculateIfMagicBurst(target, spellElement, skillchainCount))
-    finalDamage = math.floor(finalDamage * xi.spells.damage.calculateIfMagicBurstBonus(caster, target, spellId, skillType, spellElement))
+
+    if
+        caster:hasStatusEffect(xi.effect.BURST_AFFINITY) or
+        caster:hasStatusEffect(xi.effect.AZURE_LORE)
+    then
+        if skillchainCount > 0 then
+            finalDamage = math.floor(finalDamage * xi.spells.damage.calculateIfMagicBurst(target, spellElement, skillchainCount))
+            finalDamage = math.floor(finalDamage * xi.spells.damage.calculateIfMagicBurstBonus(caster, target, spellId, skillType, spellElement))
+
+            spell:setMsg(spell:getMagicBurstMessage()) -- "Magic Burst!"
+
+            caster:triggerRoeEvent(xi.roeTrigger.MAGIC_BURST)
+        end
+
+        caster:delStatusEffectSilent(xi.effect.BURST_AFFINITY)
+    end
+
     finalDamage = math.floor(finalDamage * xi.spells.damage.calculateEbullienceMultiplier(caster, spellGroup))
     finalDamage = math.floor(finalDamage * xi.spells.damage.calculateTMDA(target, spellElement))
     finalDamage = math.floor(finalDamage * xi.settings.main.BLUE_POWER)
-
-    if skillchainCount > 1 then
-        spell:setMsg(spell:getMagicBurstMessage()) -- "Magic Burst!"
-
-        caster:triggerRoeEvent(xi.roeTrigger.MAGIC_BURST)
-    end
 
     -- MP drain
     if mpDrain then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR fixes an issue where all magical-type and drain-type blue magic spells were treated as if they were magic bursting every cast. In addition, this PR correctly removes the Burst Affinity status effect after a spell is cast. Finally, it displays the "magic burst" message when skillchainCount > 0, instead of > 1.

## Steps to test these changes

`!changejob blu 99`, cast regurgitation and MP drainkiss on mobs with and without burst affinity, see that the damage is within acceptable range and does not always count as a magic burst.
