### PR TITLE
audit converted quests with onTrade and no confirmTrade

### DIFF
--- a/scripts/quests/adoulin/Flavors_of_Our_Lives.lua
+++ b/scripts/quests/adoulin/Flavors_of_Our_Lives.lua
@@ -174,6 +174,7 @@ quest.sections =
             {
                 onTrade = function(player, npc, trade)
                     -- No CS for HELM in Adoulin
+                    -- Note: do not confirm trade here, as this is regular HELM
                     xi.helm.onTrade(player, npc, trade, xi.helmType.HARVESTING, nil)
                     return quest:keyItem(xi.ki.BLIGHTBERRY)
                 end,

--- a/scripts/quests/ahtUrhgan/An_Empty_Vessel.lua
+++ b/scripts/quests/ahtUrhgan/An_Empty_Vessel.lua
@@ -150,6 +150,7 @@ quest.sections =
             onEventFinish =
             {
                 [67] = function(player, csid, option, npc)
+                    -- Note: do not confirm trade here, as you need to take the item elsewhere.
                     quest:setVar(player, 'Prog', 2)
                 end,
             },

--- a/scripts/quests/ahtUrhgan/Vanishing_Act.lua
+++ b/scripts/quests/ahtUrhgan/Vanishing_Act.lua
@@ -144,6 +144,8 @@ quest.sections =
             ['Harvesting_Point'] =
             {
                 onTrade = function(player, npc, trade)
+                    -- Note: do not confirm trade here, as this is regular HELM
+                    -- TODO: this should be a chance for a berry and not guaranteed
                     if
                         npcUtil.tradeHasExactly(trade, xi.item.SICKLE) and
                         quest:getVar(player, 'Prog') == 2 and

--- a/scripts/quests/bastok/Trial_Size_Trial_by_Earth.lua
+++ b/scripts/quests/bastok/Trial_Size_Trial_by_Earth.lua
@@ -78,6 +78,7 @@ quest.sections =
             {
                 [298] = function(player, csid, option, npc)
                     if option == 1 then
+                        -- Note: do not confirm trade here, as the mini tuning fork isn't used until entry
                         xi.teleport.to(player, xi.teleport.id.CLOISTER_OF_TREMORS)
                     end
                 end,

--- a/scripts/quests/crystalWar/Songbirds_in_a_Snowstorm.lua
+++ b/scripts/quests/crystalWar/Songbirds_in_a_Snowstorm.lua
@@ -198,6 +198,7 @@ quest.sections =
                 end,
 
                 [4] = function(player, csid, option, npc)
+                    player:confirmTrade()
                     quest:setVar(player, 'Prog', 5)
                 end,
 

--- a/scripts/quests/jeuno/A_Chocobos_Tale.lua
+++ b/scripts/quests/jeuno/A_Chocobos_Tale.lua
@@ -155,6 +155,7 @@ quest.sections =
                 end,
 
                 [22] = function(player, csid, option, npc)
+                    player:confirmTrade()
                     quest:setVar(player, 'Prog', 3)
                 end,
             },

--- a/scripts/quests/otherAreas/Monstrosity.lua
+++ b/scripts/quests/otherAreas/Monstrosity.lua
@@ -58,6 +58,7 @@ local suspiciousCityNpc =
 }
 
 local tradeEventFinish = function(player, csid, option, npc)
+    player:confirmTrade()
     npcUtil.giveKeyItem(player, xi.ki.RING_OF_SUPERNAL_DISJUNCTION)
     local species = player:getLocalVar('MONSTROSITY_UNLOCK')
     if species > 0 then

--- a/scripts/quests/windurst/Water_Way_to_Go.lua
+++ b/scripts/quests/windurst/Water_Way_to_Go.lua
@@ -98,6 +98,7 @@ quest.sections =
 
                 [355] = function(player, csid, option, npc)
                     if quest:complete(player) then
+                        player:confirmTrade()
                         -- Note: Message display for gil reward is handled by the event
                         player:addGil(900)
                         player:setLocalVar('Quest[2][17]mustZone', 1)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [ ] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Fixes https://github.com/LandSandBoat/server/issues/7926

Audited the quests in the attached Issue and commented whenever the confirm trade wasn't necessary, or fixed otherwise.

Still need to confirm that the flint stone is taken on retail, and that the monstrosity trade works properly.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
