### PR TITLE
Update astral flow mixin to allow more avatar flexibility

### DIFF
--- a/scripts/actions/mobskills/astral_flow.lua
+++ b/scripts/actions/mobskills/astral_flow.lua
@@ -13,15 +13,9 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     local mobID        = mob:getID()
     local avatarOffset = mob:getMobMod(xi.mobMod.ASTRAL_PET_OFFSET)
-    local avatar       = mobID + (avatarOffset > 0 and avatarOffset or 2)
+    local avatarId     = mobID + (avatarOffset > 0 and avatarOffset or 2)
 
-    if not GetMobByID(avatar):isSpawned() then
-        GetMobByID(avatar):setSpawn(mob:getXPos() + 1, mob:getYPos(), mob:getZPos() + 1, mob:getRotPos())
-        local mobTarget = mob:getTarget()
-        if mobTarget then
-            SpawnMob(avatar):updateEnmity(mobTarget)
-        end
-    end
+    xi.mob.callPets(mob, avatarId, { noAnimation = true })
 
     return xi.effect.ASTRAL_FLOW
 end

--- a/scripts/actions/mobskills/ruinous_omen.lua
+++ b/scripts/actions/mobskills/ruinous_omen.lua
@@ -1,0 +1,23 @@
+-----------------------------------
+-- Ruinous Omen
+-- Deals dark elemental damage to enemies within area of effect.
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    local damage = mob:getWeaponDmg() * 9
+
+    damage = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.DARK, 3, xi.mobskills.magicalTpBonus.NO_EFFECT, 1)
+    damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
+
+    target:takeDamage(damage, mob, xi.attackType.MAGICAL, xi.damageType.DARK)
+
+    return damage
+end
+
+return mobskillObject

--- a/scripts/enum/mob_mod.lua
+++ b/scripts/enum/mob_mod.lua
@@ -97,4 +97,6 @@ xi.mobMod =
     BASE_DAMAGE_MULTIPLIER = 86, -- Multiplies the mob's base damage. Example: 150 = x1.5
     DAMAGE_OFFSET          = 87, -- Adds or subtracts the mob's base damage offset.
     RANGED_DAMAGE_OFFSET   = 88, -- Adds or subtracts the mob's ranged base damage offset.
+    AVATAR_PETID           = 89, -- A value from xi.petId to select model/ability from when owner uses astral flow
+    AVATAR_ASTRAL_DELAY    = 90, -- Number of milliseconds to delay AF after avatar spawn
 }

--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -939,6 +939,11 @@ xi.mob.callPets = function(mob, petIds, params)
                             petArg:follow(owner, xi.followType.ROAM)
                         end
                     end)
+
+                    -- so we don't wait for the next roam tick (pet assists as soon as :stun is complete)
+                    petToSummon:queue(0, function(petArg)
+                        petArg:triggerListener('ROAM_TICK', petArg)
+                    end)
                 end
 
                 -- cleanup any listeners related to this pet when it dies

--- a/scripts/mixins/families/avatar.lua
+++ b/scripts/mixins/families/avatar.lua
@@ -1,16 +1,33 @@
+-- Note: override random model selection and delay until astral flow via mobmods
+--  xi.mobMod.AVATAR_PETID: avatar pet from xi.petId to select model/ability from
+--  xi.mobMod.AVATAR_ASTRAL_DELAY: number of milliseconds to delay AF after avatar spawn (defaults to immediately... i.e. value of zero)
+
 require('scripts/globals/mixins')
 
--- If you subtract 790 from the modelId, you're left with a key into to this table :)
-local abilityIds =
+-- keyed on avatar modelId
+local abilityData =
 {
-    919, -- [modelId: 791] Carbuncle
-    839, -- [modelId: 792] Fenrir
-    913, -- [modelId: 793] Ifrit
-    914, -- [modelId: 794] Titan
-    915, -- [modelId: 795] Leviathan
-    916, -- [modelId: 796] Garuda
-    917, -- [modelId: 797] Shiva
-    918, -- [modelId: 798] Ramuh
+    [791]  = { petId = xi.petId.CARBUNCLE, abilityId = 919 },
+    [792]  = { petId = xi.petId.FENRIR,    abilityId = 839 },
+    [793]  = { petId = xi.petId.IFRIT,     abilityId = 913 },
+    [794]  = { petId = xi.petId.TITAN,     abilityId = 914 },
+    [795]  = { petId = xi.petId.LEVIATHAN, abilityId = 915 },
+    [796]  = { petId = xi.petId.GARUDA,    abilityId = 916 },
+    [797]  = { petId = xi.petId.SHIVA,     abilityId = 917 },
+    [798]  = { petId = xi.petId.RAMUH,     abilityId = 918 },
+    [1145] = { petId = xi.petId.DIABOLOS,  abilityId = 1911 },
+}
+
+local randomAvatarOptions =
+{
+    xi.petId.CARBUNCLE,
+    xi.petId.FENRIR,
+    xi.petId.IFRIT,
+    xi.petId.TITAN,
+    xi.petId.LEVIATHAN,
+    xi.petId.GARUDA,
+    xi.petId.SHIVA,
+    xi.petId.RAMUH,
 }
 
 g_mixins = g_mixins or {}
@@ -18,15 +35,37 @@ g_mixins.families = g_mixins.families or {}
 
 g_mixins.families.avatar = function(avatarMob)
     avatarMob:addListener('SPAWN', 'AVATAR_SPAWN', function(mob)
-        mob:setModelId(math.random(791, 798))
+        mob:removeListener('AVATAR_MOBSKILL_FINISHED')
+
+        local modelId = 0
+        local petId   = mob:getMobMod(xi.mobMod.AVATAR_PETID)
+        if petId == 0 then
+            -- choose a random petId since it's not specified by the avatar mob
+            petId = utils.randomEntry(randomAvatarOptions)
+        end
+
+        for mId, ability in pairs(abilityData) do
+            if ability.petId == petId then
+                modelId = mId
+                break
+            end
+        end
+
+        if modelId == 0 then
+            -- if AVATAR_PETID is set and doesn't map to an ability, exit and don't install listeners
+            -- this is used for pets that can either use AF or be regular pets (like Pandemonium Lamps)
+            return
+        end
+
+        mob:setModelId(modelId)
         mob:hideName(false)
         mob:setUntargetable(true)
         mob:setUnkillable(true)
         mob:setAutoAttackEnabled(false)
+        mob:setMobAbilityEnabled(false)
         mob:setMagicCastingEnabled(false)
 
-        -- When GM is enabled, mobs will not automatically engage.  Update Enmity one more
-        -- time to ensure that the listener will actually be triggered.
+        -- most AF avatars are not actually assigned as a mob pet, avatar is set to engage owner's target in astral_flow.lua
         local master = mob:getMaster()
         if master ~= nil then
             local target = master:getTarget()
@@ -35,8 +74,15 @@ g_mixins.families.avatar = function(avatarMob)
             end
         end
 
-        -- If something goes wrong, the avatar will clean itself up in 5s
-        mob:timer(5000, function(mobArg)
+        -- avatar dies as soon as AF ability completes
+        mob:addListener('WEAPONSKILL_STATE_EXIT', 'AVATAR_MOBSKILL_FINISHED', function(mobArg)
+            mobArg:setUnkillable(false)
+            mobArg:setHP(0)
+        end)
+
+        -- If something goes wrong, the avatar will clean itself up 5s after astralDelayMs
+        local astralDelayMs = mob:getMobMod(xi.mobMod.AVATAR_ASTRAL_DELAY) > 0 and mob:getMobMod(xi.mobMod.AVATAR_ASTRAL_DELAY) or 0
+        mob:timer(astralDelayMs + 5000, function(mobArg)
             if mobArg:isAlive() then
                 mobArg:setUnkillable(false)
                 mobArg:setHP(0)
@@ -46,15 +92,16 @@ g_mixins.families.avatar = function(avatarMob)
 
     avatarMob:addListener('ENGAGE', 'AVATAR_ENGAGE', function(mob, target)
         local modelId = mob:getModelId()
-        local abilityId = abilityIds[modelId - 790]
-        if abilityId ~= nil then
-            mob:useMobAbility(abilityId)
+        -- use AF ability AVATAR_ASTRAL_DELAY milliseconds after spawn/engage (engaged immediately in astral_flow.lua)
+        local abilityId = abilityData[modelId] and abilityData[modelId].abilityId or 0
+        local astralDelayMs = mob:getMobMod(xi.mobMod.AVATAR_ASTRAL_DELAY) > 0 and mob:getMobMod(xi.mobMod.AVATAR_ASTRAL_DELAY) or 0
+        if abilityId > 0 then
+            mob:timer(astralDelayMs, function(mobArg)
+                if mobArg:isAlive() then
+                    mobArg:useMobAbility(abilityId)
+                end
+            end)
         end
-    end)
-
-    avatarMob:addListener('WEAPONSKILL_STATE_EXIT', 'AVATAR_MOBSKILL_FINISHED', function(mob)
-        mob:setUnkillable(false)
-        mob:setHP(0)
     end)
 end
 

--- a/scripts/zones/Temple_of_Uggalepih/mobs/Crimson-toothed_Pawberry.lua
+++ b/scripts/zones/Temple_of_Uggalepih/mobs/Crimson-toothed_Pawberry.lua
@@ -16,32 +16,6 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
-    local mobID = mob:getID()
-    local avatarID = mobID + 2
-    local avatarMob = GetMobByID(avatarID)
-    if avatarMob then
-        -- Remove the original listener set from mixins/families/avatar
-        avatarMob:removeListener('AVATAR_SPAWN')
-
-        -- Replace with a similar listener which is hardcoded to use Carbuncle
-        avatarMob:addListener('SPAWN', 'AVATAR_SPAWN', function(mobArg)
-            local modelId = 791 -- Carbuncle
-            mobArg:setModelId(modelId)
-            mobArg:hideName(false)
-            mobArg:setUntargetable(true)
-            mobArg:setUnkillable(true)
-            mobArg:setAutoAttackEnabled(false)
-            mobArg:setMagicCastingEnabled(false)
-
-            -- If something goes wrong, the avatar will clean itself up in 5s
-            mobArg:timer(5000, function(mobTimerArg)
-                if mobTimerArg:isAlive() then
-                    mobTimerArg:setUnkillable(false)
-                    mobTimerArg:setHP(0)
-                end
-            end)
-        end)
-    end
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Temple_of_Uggalepih/mobs/Tonberrys_Avatar.lua
+++ b/scripts/zones/Temple_of_Uggalepih/mobs/Tonberrys_Avatar.lua
@@ -7,6 +7,13 @@ mixins = { require('scripts/mixins/families/avatar') }
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    if mob:getID() - 2 == zones[xi.zone.TEMPLE_OF_UGGALEPIH].mob.CRIMSON_TOOTHED_PAWBERRY then
+        -- Crimson-toothed Pawberry's avatar is always carbuncle
+        mob:setMobMod(xi.mobMod.AVATAR_PETID, xi.petId.CARBUNCLE)
+    end
+end
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 

--- a/scripts/zones/Throne_Room/mobs/Demons_Avatar.lua
+++ b/scripts/zones/Throne_Room/mobs/Demons_Avatar.lua
@@ -1,11 +1,15 @@
 -----------------------------------
 -- Area: Throne Room
---  Mob: Demon's Avatar
+--  Mob: Demon's Avatar (Astral flow pet for Duke Dantalian)
 -----------------------------------
 mixins = { require('scripts/mixins/families/avatar') }
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.AVATAR_PETID, xi.petId.SHIVA)
+end
 
 entity.onMobDeath = function(mob, player, optParams)
 end

--- a/scripts/zones/Throne_Room/mobs/Duke_Dantalian.lua
+++ b/scripts/zones/Throne_Room/mobs/Duke_Dantalian.lua
@@ -13,32 +13,6 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
-    local mobID = mob:getID()
-    local avatarID = mobID + mob:getMobMod(xi.mobMod.ASTRAL_PET_OFFSET)
-    local avatarMob = GetMobByID(avatarID)
-    if avatarMob then
-        -- Remove the original listener set from mixins/families/avatar
-        avatarMob:removeListener('AVATAR_SPAWN')
-
-        -- Replace with a similar listener which is hardcoded to use Shiva
-        avatarMob:addListener('SPAWN', 'AVATAR_SPAWN', function(mobArg)
-            local modelId = 797 -- Shiva
-            mobArg:setModelId(modelId)
-            mobArg:hideName(false)
-            mobArg:setUntargetable(true)
-            mobArg:setUnkillable(true)
-            mobArg:setAutoAttackEnabled(false)
-            mobArg:setMagicCastingEnabled(false)
-
-            -- If something goes wrong, the avatar will clean itself up in 5s
-            mobArg:timer(5000, function(mobTimerArg)
-                if mobTimerArg:isAlive() then
-                    mobTimerArg:setUnkillable(false)
-                    mobTimerArg:setHP(0)
-                end
-            end)
-        end)
-    end
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/src/map/mob_modifier.h
+++ b/src/map/mob_modifier.h
@@ -117,6 +117,8 @@ enum MOBMODIFIER : int
     MOBMOD_BASE_DAMAGE_MULTIPLIER = 86, // Multiplies the mob's base damage. Example: 150 = x1.5
     MOBMOD_DAMAGE_OFFSET          = 87, // Adds or subtracts the mob's base damage offset.
     MOBMOD_RANGED_DAMAGE_OFFSET   = 88, // Adds or subtracts the mob's ranged base damage offset.
+    AVATAR_PETID                  = 89, // A value from xi.petId to select model/ability from when owner uses astral flow
+    AVATAR_ASTRAL_DELAY           = 90, // Number of milliseconds to delay AF after avatar spawn
 };
 
 #endif


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

closes #8085

- Updates the AF avatar mixin to allow setting the petId before the SPAWN listener is executed. This allows the ability to hardcode a certain pet model in `onMobSpawn` for the 2 mentioned NMs in the issue, as well as allowing Pandemonium Warden to specify petId and af delay during final phase

- Also adds Diabolos and updates the RNG system to not select him unless explicitly set
  - for use by PW:
  - <img width="691" height="444" alt="image" src="https://github.com/user-attachments/assets/3ab02a2e-1b48-4518-9afd-780e57a66962" />
- Updated `astral_flow.lua` to use `xi.mob.callPets` and updated that function to be more real-time with pet assisting the "owner"


## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
go to any summoner mob, set the mobmod on the avatar in `onMobSpawn` or `onMobInitialize` to see they work as expected
- example of two NMs working as expected
  - <img width="708" height="604" alt="image" src="https://github.com/user-attachments/assets/519e7de4-4357-430b-957b-05b9437b961c" />
  - <img width="643" height="458" alt="image" src="https://github.com/user-attachments/assets/40e8f4c3-57ea-4975-b99f-530dd54f8714" />
  - setting petId to DIABOLOS:
  - <img width="456" height="46" alt="image" src="https://github.com/user-attachments/assets/7f589507-747b-4017-9fa6-8672b8177d2a" />
- example of setting an af delay: `mob:setMobMod(xi.mobMod.AVATAR_ASTRAL_DELAY, 5000)`
  - Note that the searing light messages are delayed from the action/animation
  - <img width="466" height="186" alt="image" src="https://github.com/user-attachments/assets/74b1e8a2-5840-4523-8155-be84c682020c" />
  - and 12s
  - <img width="496" height="264" alt="image" src="https://github.com/user-attachments/assets/d4f920ae-efaf-4cd9-914f-ce7cb6d9c953" />


