### PR TITLE
[lua] Update certain buffs to not cast if target already has effect and caster is mob

### DIFF
--- a/scripts/actions/spells/black/blaze_spikes.lua
+++ b/scripts/actions/spells/black/blaze_spikes.lua
@@ -5,7 +5,7 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    return 0
+    return xi.spells.enhancing.onEnhancingSpellCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)

--- a/scripts/actions/spells/black/dread_spikes.lua
+++ b/scripts/actions/spells/black/dread_spikes.lua
@@ -5,7 +5,7 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    return 0
+    return xi.spells.enhancing.onEnhancingSpellCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)

--- a/scripts/actions/spells/black/ice_spikes.lua
+++ b/scripts/actions/spells/black/ice_spikes.lua
@@ -5,7 +5,7 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    return 0
+    return xi.spells.enhancing.onEnhancingSpellCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)

--- a/scripts/actions/spells/black/shock_spikes.lua
+++ b/scripts/actions/spells/black/shock_spikes.lua
@@ -5,7 +5,7 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    return 0
+    return xi.spells.enhancing.onEnhancingSpellCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)

--- a/scripts/actions/spells/white/aquaveil.lua
+++ b/scripts/actions/spells/white/aquaveil.lua
@@ -5,7 +5,7 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    return 0
+    return xi.spells.enhancing.onEnhancingSpellCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)

--- a/scripts/actions/spells/white/enaero.lua
+++ b/scripts/actions/spells/white/enaero.lua
@@ -5,7 +5,7 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    return 0
+    return xi.spells.enhancing.onEnhancingSpellCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)

--- a/scripts/actions/spells/white/enaero_ii.lua
+++ b/scripts/actions/spells/white/enaero_ii.lua
@@ -5,7 +5,7 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    return 0
+    return xi.spells.enhancing.onEnhancingSpellCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)

--- a/scripts/actions/spells/white/enblizzard.lua
+++ b/scripts/actions/spells/white/enblizzard.lua
@@ -5,7 +5,7 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    return 0
+    return xi.spells.enhancing.onEnhancingSpellCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)

--- a/scripts/actions/spells/white/enblizzard_ii.lua
+++ b/scripts/actions/spells/white/enblizzard_ii.lua
@@ -5,7 +5,7 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    return 0
+    return xi.spells.enhancing.onEnhancingSpellCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)

--- a/scripts/actions/spells/white/enfire.lua
+++ b/scripts/actions/spells/white/enfire.lua
@@ -5,7 +5,7 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    return 0
+    return xi.spells.enhancing.onEnhancingSpellCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)

--- a/scripts/actions/spells/white/enfire_ii.lua
+++ b/scripts/actions/spells/white/enfire_ii.lua
@@ -5,7 +5,7 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    return 0
+    return xi.spells.enhancing.onEnhancingSpellCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)

--- a/scripts/actions/spells/white/enstone.lua
+++ b/scripts/actions/spells/white/enstone.lua
@@ -5,7 +5,7 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    return 0
+    return xi.spells.enhancing.onEnhancingSpellCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)

--- a/scripts/actions/spells/white/enstone_ii.lua
+++ b/scripts/actions/spells/white/enstone_ii.lua
@@ -5,7 +5,7 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    return 0
+    return xi.spells.enhancing.onEnhancingSpellCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)

--- a/scripts/actions/spells/white/enthunder.lua
+++ b/scripts/actions/spells/white/enthunder.lua
@@ -5,7 +5,7 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    return 0
+    return xi.spells.enhancing.onEnhancingSpellCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)

--- a/scripts/actions/spells/white/enthunder_ii.lua
+++ b/scripts/actions/spells/white/enthunder_ii.lua
@@ -5,7 +5,7 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    return 0
+    return xi.spells.enhancing.onEnhancingSpellCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)

--- a/scripts/actions/spells/white/enwater.lua
+++ b/scripts/actions/spells/white/enwater.lua
@@ -5,7 +5,7 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    return 0
+    return xi.spells.enhancing.onEnhancingSpellCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)

--- a/scripts/actions/spells/white/enwater_ii.lua
+++ b/scripts/actions/spells/white/enwater_ii.lua
@@ -5,7 +5,7 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    return 0
+    return xi.spells.enhancing.onEnhancingSpellCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)

--- a/scripts/actions/spells/white/stoneskin.lua
+++ b/scripts/actions/spells/white/stoneskin.lua
@@ -5,7 +5,7 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    return 0
+    return xi.spells.enhancing.onEnhancingSpellCheck(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)

--- a/scripts/globals/spells/enhancing_spell.lua
+++ b/scripts/globals/spells/enhancing_spell.lua
@@ -563,7 +563,7 @@ xi.spells.enhancing.useEnhancingSpell = function(caster, target, spell)
     end
 
     --------------------------------------------------
-    -- Calculate Spell Pottency and Duration.
+    -- Calculate Spell Potency and Duration.
     --------------------------------------------------
     local basePower  = xi.spells.enhancing.calculateEnhancingBasePower(caster, target, spell, spellId, spellEffect)
     local finalPower = xi.spells.enhancing.calculateEnhancingFinalPower(caster, target, spell, basePower, spellGroup, tier, spellEffect)
@@ -595,4 +595,36 @@ xi.spells.enhancing.useEnhancingSpell = function(caster, target, spell)
     end
 
     return spellEffect
+end
+
+-- determines if a mob will cast a buff on the target
+-- TODO apply to all enhancing spells check functions
+xi.spells.enhancing.onEnhancingSpellCheck = function(caster, target, spell)
+    local spellId     = spell:getID()
+    local spellGroup  = spell:getSpellGroup()
+    local effectTable = pTable[spellId]
+    if
+        caster:isPC() or
+        not effectTable
+    then
+        return 0
+    end
+
+    local tier            = effectTable[column.EFFECT_TIER]
+    local spellEffect     = effectTable[column.EFFECT_ID]
+    local alwaysOverwrite = effectTable[column.EFFECT_WILL_OVERWRITE]
+    local basePower       = xi.spells.enhancing.calculateEnhancingBasePower(caster, target, spell, spellId, spellEffect)
+    local finalPower      = xi.spells.enhancing.calculateEnhancingFinalPower(caster, target, spell, basePower, spellGroup, tier, spellEffect)
+    local targetEffect    = target:getStatusEffect(spellEffect)
+    if
+        not targetEffect or                       -- doesn't currently have effect
+        targetEffect:getPower() < finalPower or   -- has a weaker version of the effect
+        (targetEffect:getPower() > finalPower and -- has a more powerful version but table says to always overwrite
+        alwaysOverwrite)
+    then
+        return 0
+    end
+
+    -- block cast
+    return 1
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Noticed while implementing [Ereshkigal](https://www.bg-wiki.com/ffxi/Ereshkigal) and going through a ton of logs/videos. Mobs don't seem to overwrite buffs until they wear off. It's hard to tell since retail doesn't give "X loses Y effect" message, but the timing of the spells correlates with the duration of the spells. 

<img width="548" height="174" alt="image" src="https://github.com/user-attachments/assets/53e362d8-7031-4560-a831-e3c50a8830bb" />


This PR seeks to add some intelligence to the casting of mob buffs. Note that the way that the mob controller logic is, a spell failing `onMagicCastingCheck` just quietly fails _that attempt_ at casting a spell, and it doesn't reset the cast cooldown:
- While in combat, this will mean that it'll probably skip a few combat ticks of casting but eventually get a spell off (basically unnoticable)
- while roaming, there's a limiter of of a _chance_ to cast a spell every roam tick, which causes mobs to cast much less frequently than `MAGIC_COOL`. I suspect the 20% limiter is strictly due to the fact that mobs would just spam buffs every `MAGIC_COOL` seconds. 
  - Perhaps adding this PR's logic to all enhancing spells would allow us to consolidate these two roam checks into a single check with a 100% chance to trigger every tick: smn pet and buff spells

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- witness mobs not reapplying buffs touched by this PR when they already have it
  - <img width="600" height="427" alt="image" src="https://github.com/user-attachments/assets/4f692a36-19da-4131-8441-166855a1fbb5" />
  - <img width="653" height="150" alt="image" src="https://github.com/user-attachments/assets/75c8ebc7-7395-4679-a9e2-596bc54f9d5c" />
- specifically, blaze/ice spikes and en-X were the biggest offenders
  - <img width="614" height="528" alt="image" src="https://github.com/user-attachments/assets/dfb72908-5758-41a7-87e4-1ff8bc1ef2c2" />
- worm stoneskin:
  - For this i updated the recast for stoneskin to 0 in the db so i could test more quickly
  - <img width="648" height="288" alt="image" src="https://github.com/user-attachments/assets/8b74ba29-1c4c-44a3-bd76-fe0a8837cf43" />
- other spikes:
  - for this i updated the jobs list and recast times as above. Also I added the spells into the worm spell list (id 9)
  - `INSERT INTO `mob_spell_lists` VALUES ('Worm',9,251,28,255);` etc
  - <img width="688" height="271" alt="image" src="https://github.com/user-attachments/assets/f1b36aca-8aa5-4110-b6df-7d3af7ca399a" />
  - <img width="664" height="456" alt="image" src="https://github.com/user-attachments/assets/6d3f9af6-209e-453e-91df-6f81b961dd29" />
- Note for testing: mobs still respect spell recast timers, so spamming `target:castSpell()` isn't truly testing the logic, but adding `print(xi.spells.enhancing.onEnhancingSpellCheck(caster, target, spell))` to the spell's `onMagicCastingCheck` helps to determine when the recast is gone and the mob is actually being blocked by this new logic instead. Or simply specify the spell and target in `:castSpell`
  - This actually brings up a whole other can of worms as mobs don't consider recasts when choosing a spell in `TryCastSpell`... oh well, that's an issue for another day
