### PR TITLE
[Treasure] Message and animation corrections and TODOs

### DIFF
--- a/scripts/quests/jeuno/helpers.lua
+++ b/scripts/quests/jeuno/helpers.lua
@@ -487,8 +487,11 @@ function xi.jeuno.helpers.BorghertzQuests:new(params)
                 ['Yin_Pocanakhu'] =
                 {
                     onTrigger = function(player, npc)
-                        if quest:getVar(player, 'Prog') == 2 then
+                        local questProgress = quest:getVar(player, 'Prog')
+                        if questProgress == 2 then
                             return quest:progressEvent(220)
+                        elseif questProgress == 3 or questProgress == 4 then
+                            return quest:event(221)
                         end
                     end,
                 },
@@ -499,7 +502,10 @@ function xi.jeuno.helpers.BorghertzQuests:new(params)
                         if player:getGil() >= 1000 then
                             player:delGil(1000)
                             quest:setVar(player, 'Prog', 3) -- Spoken with Yin Pocanakhu.
-                            player:updateEvent(1)
+                            player:updateEvent(1, 1, 0, 0)
+                        else
+                            player:messageText(npc, zones[xi.zone.LOWER_JEUNO].text.YIN_POCANAKHU_GET_LOST)
+                            player:updateEvent(0, 1, 0, 0)
                         end
                     end,
                 },
@@ -570,7 +576,7 @@ function xi.jeuno.helpers.BorghertzQuests:new(params)
                     [26] = function(player, csid, option, npc)
                         if quest:getVar(player, 'Prog') == 0 then
                             if isFirstBorghertzQuest(player) then
-                                quest:setVar(player, 'Prog', 1) -- Speak with Deadly Minnow and Yin Pocanakhu.
+                                quest:setVar(player, 'Prog', 1) -- Need to speak with Deadly Minnow and Yin Pocanakhu.
                             else
                                 quest:setVar(player, 'Prog', 3) -- Skip intermediaries.
                             end

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -1405,6 +1405,11 @@ end
 function CBaseEntity:setWallhack(enable)
 end
 
+---@param isFrozen boolean
+---@return nil
+function CBaseEntity:setFreezeFlag(isFrozen)
+end
+
 ---@nodiscard
 ---@return boolean
 function CBaseEntity:isJailed()

--- a/scripts/zones/Lower_Jeuno/IDs.lua
+++ b/scripts/zones/Lower_Jeuno/IDs.lua
@@ -49,6 +49,7 @@ zones[xi.zone.LOWER_JEUNO] =
         DO_NOT_DISTURB                = 7761,  -- "Do Not Disturb"
         INVENTORY_INCREASED           = 7803,  -- Your inventory capacity has increased.
         ITEM_DELIVERY_DIALOG          = 7804,  -- Now offering quick and easy delivery of packages to residences everywhere!
+        YIN_POCANAKHU_GET_LOST        = 8017,  -- Hey, what are you tryin' to pull? Get lost!
         MERTAIRE_RING                 = 8065,  -- So, what did you do with that ring? Maybe it's valuable. I'd ask a collector if I were you. Of course, he might just say it's worthless...
         CONQUEST                      = 8077,  -- You've earned conquest points!
         PARIKE_PORANKE_DIALOG         = 8975,  -- All these people running back and forth... There have to be a few that have munched down more mithkabobs than they can manage. (And if I don't hand in this report to the Orastery soon... Ulp!)

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -265,6 +265,7 @@ CCharEntity::CCharEntity()
 
     visibleGmLevel        = 0;
     wallhackEnabled       = false;
+    isFrozenFlagged       = false;
     isSettingBazaarPrices = false;
     isLinkDead            = false;
     pendingPositionUpdate = false;

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -293,6 +293,7 @@ public:
 
     uint8 visibleGmLevel;        // See GmLevel of flags0_t
     bool  wallhackEnabled;       // GM walk through walls
+    bool  isFrozenFlagged;       // Player Freeze flag.
     bool  isSettingBazaarPrices; // Is setting bazaar prices (temporarily hide bazaar)
     bool  isLinkDead;            // Player is d/cing
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -6345,6 +6345,25 @@ void CLuaBaseEntity::setWallhack(bool enabled)
 }
 
 /************************************************************************
+ *  Function: setFreezeFlag()
+ *  Purpose : Locks (or releases) a player, disallowing them from moving.
+ *  Example : player:setFreezeFlag(true)
+ ************************************************************************/
+
+void CLuaBaseEntity::setFreezeFlag(bool isFrozen)
+{
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->getName());
+        return;
+    }
+
+    auto* PChar            = static_cast<CCharEntity*>(m_PBaseEntity);
+    PChar->isFrozenFlagged = isFrozen;
+    PChar->updatemask |= UPDATE_HP;
+}
+
+/************************************************************************
  *  Function: isJailed()
  *  Purpose : Returns true if a player is a violent felon
  *  Example : if player:isJailed() then
@@ -19621,6 +19640,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("setGMHidden", CLuaBaseEntity::setGMHidden);
     SOL_REGISTER("getWallhack", CLuaBaseEntity::getWallhack);
     SOL_REGISTER("setWallhack", CLuaBaseEntity::setWallhack);
+    SOL_REGISTER("setFreezeFlag", CLuaBaseEntity::setFreezeFlag);
 
     SOL_REGISTER("isJailed", CLuaBaseEntity::isJailed);
     SOL_REGISTER("jail", CLuaBaseEntity::jail);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -341,6 +341,7 @@ public:
     void  setGMHidden(bool isHidden);
     bool  getWallhack();
     void  setWallhack(bool enable);
+    void  setFreezeFlag(bool isFrozen);
 
     bool isJailed();
     void jail();

--- a/src/map/packets/char_status.cpp
+++ b/src/map/packets/char_status.cpp
@@ -280,7 +280,7 @@ CCharStatusPacket::CCharStatusPacket(CCharEntity* PChar)
 
     flags1.Speed        = PChar->UpdateSpeed();
     flags1.Hackmove     = PChar->wallhackEnabled; // GM wallhack, walk through walls
-    flags1.FreezeFlag   = 0;                      // Freeze client in place. Is this used?
+    flags1.FreezeFlag   = PChar->isFrozenFlagged; // Freezes player in place, making them unable to move. Used when opening treasure chests, for instance.
     flags1.unknown_1_14 = 0;                      // Unknown.
     flags1.InvisFlag    = PChar->m_isGMHidden || PChar->StatusEffectContainer->HasStatusEffectByFlag(EFFECTFLAG_INVISIBLE);
     flags1.unknown_2_16 = 0; // Unknown.


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Fixes treasure respawn timers.
- Fixes player name not being shown when failing to open a treasure.
- Fixes message shown when triggering a chest.
- Adds method to set the "freeze" flag on/off
  - With this, properly locks players in place when kneeling before their chest overlords.
- Adds Key Item specific treasure message.
- Adds TODO for the existing Key Item message thaat looks to be meant for other party members.

Also:
- Fixes Borghertz quests flow based on captures from @slashtangent 

## Steps to test these changes

Open chests/coffers. Preferably with tools.
