### PR TITLE
[lua] Adjust morbol skills and behavior in ToAU to match retail

### DIFF
--- a/scripts/actions/mobskills/vampiric_lash.lua
+++ b/scripts/actions/mobskills/vampiric_lash.lua
@@ -4,7 +4,8 @@
 -- Type: Magical
 -- Utsusemi/Blink absorb: 1 shadow
 -- Range: Melee
--- Notes: (Unverified) In ToAU zones, this has an additional effect of absorbing all status effects, including food.
+-- Notes: (Unverified) In ToAU zones, this has an additional effect of absorbing all status effects.
+--        (Verified) Will not absorb food in ToAU zones.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}

--- a/scripts/actions/mobskills/vampiric_root.lua
+++ b/scripts/actions/mobskills/vampiric_root.lua
@@ -10,7 +10,8 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    return 0
+    -- will only use vampiric root if there are buffs to steal
+    return target:countEffectWithFlag(xi.effectFlag.DISPELABLE) > 0 and 0 or 1
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/enum/mob_skills.lua
+++ b/scripts/enum/mob_skills.lua
@@ -233,6 +233,8 @@ xi.mobSkill =
     LAVA_SPIT                = 1785,
     GATES_OF_HADES           = 1790,
 
+    VAMPIRIC_ROOT            = 1793,
+
     XENOGLOSSIA              = 1823, -- Unique entry.
 
     SANDBLAST_2              = 1841,

--- a/scripts/zones/Aydeewa_Subterrane/mobs/Great_Ameretat.lua
+++ b/scripts/zones/Aydeewa_Subterrane/mobs/Great_Ameretat.lua
@@ -7,6 +7,10 @@ mixins = { require('scripts.mixins.families.morbol_toau') }
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobWeaponSkillPrepare = function(mob, target)
+    return target:countEffectWithFlag(xi.effectFlag.DISPELABLE) > 0 and xi.mobSkill.VAMPIRIC_ROOT or 0
+end
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 

--- a/scripts/zones/Bhaflau_Thickets/mobs/Ameretat.lua
+++ b/scripts/zones/Bhaflau_Thickets/mobs/Ameretat.lua
@@ -7,6 +7,10 @@ mixins = { require('scripts.mixins.families.morbol_toau') }
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobWeaponSkillPrepare = function(mob, target)
+    return target:countEffectWithFlag(xi.effectFlag.DISPELABLE) > 0 and xi.mobSkill.VAMPIRIC_ROOT or 0
+end
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 

--- a/scripts/zones/Wajaom_Woodlands/mobs/Ameretat.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Ameretat.lua
@@ -7,6 +7,10 @@ mixins = { require('scripts.mixins.families.morbol_toau') }
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobWeaponSkillPrepare = function(mob, target)
+    return target:countEffectWithFlag(xi.effectFlag.DISPELABLE) > 0 and xi.mobSkill.VAMPIRIC_ROOT or 0
+end
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 

--- a/scripts/zones/Wajaom_Woodlands/mobs/Great_Ameretat.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Great_Ameretat.lua
@@ -9,6 +9,10 @@ local ID = zones[xi.zone.WAJAOM_WOODLANDS]
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobWeaponSkillPrepare = function(mob, target)
+    return target:countEffectWithFlag(xi.effectFlag.DISPELABLE) > 0 and xi.mobSkill.VAMPIRIC_ROOT or 0
+end
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 

--- a/scripts/zones/Wajaom_Woodlands/mobs/Jaded_Jody.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Jaded_Jody.lua
@@ -24,6 +24,14 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
 end
 
+entity.onMobSpawn = function(mob)
+    xi.mix.toau_morbol.config(mob, { nightRoaming = 1, })
+end
+
+entity.onMobWeaponSkillPrepare = function(mob, target)
+    return target:countEffectWithFlag(xi.effectFlag.DISPELABLE) > 0 and xi.mobSkill.VAMPIRIC_ROOT or 0
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 448)
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Added skill usage restriction to Ameretats and Jaded Jody NM so they always use Vampiric Root whenever their target has a dispellable buff, this logic does not extend to Morbol Emperor as mentioned in #7405.
Added configuration parameters to the family mixin and configured Jaded Jody so it roams at night, unlike the regular Ameretats,
Fixed a filename typo (there is no such thing as a Greater Ameretat).

## Steps to test these changes

!pos 79.275 -20 17 51, engage an Ameretat, !tp 3000 with and without buffs on.
