### PR TITLE
[lua] Fix Dynamis time extension bug

### DIFF
--- a/scripts/globals/dynamis.lua
+++ b/scripts/globals/dynamis.lua
@@ -579,7 +579,7 @@ xi.dynamis.timeExtensionOnDeath = function(mob, player, optParams)
             if effect and not player:hasKeyItem(te.ki) then
                 npcUtil.giveKeyItem(player, te.ki)
                 local oldDuration = effect:getDuration()
-                effect:setDuration((oldDuration + (te.minutes * 60)) * 1000)
+                effect:setDuration(oldDuration + te.minutes * 60 * 1000)
                 player:setLocalVar('dynamis_lasttimeupdate', effect:getTimeRemaining() / 1000)
                 player:messageSpecial(ID.text.DYNAMIS_TIME_EXTEND, te.minutes)
             end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR resolves a math error in the timeExtensionOnDeath function for dynamis TEs.

## Steps to test these changes

Enter Dynamis
`!geteffects`
Kill a time extension mob
`!geteffects` note that your time remaining went up as expected
