### PR TITLE
[lua] Fix Larceny stolen effect duration

### DIFF
--- a/scripts/globals/job_utils/thief.lua
+++ b/scripts/globals/job_utils/thief.lua
@@ -292,7 +292,7 @@ xi.job_utils.thief.useLarceny = function(player, target, ability, action)
         local newStatus = player:getStatusEffect(effectID)
 
         if newStatus then
-            newStatus:setDuration((newStatus:getDuration() + jpValue) * 1000)
+            newStatus:setDuration(newStatus:getDuration() + jpValue * 1000)
         end
     -- Copy an SP Ability if found
     else


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The job point duration extension of the THF ability Larceny introduced a math error; this PR corrects it.

## Steps to test these changes

Use Larceny to steal a status effect with 0 or 1 larceny job points, see a reasonable time remaining for the status effect
