### PR TITLE
[lua] Update treasure.lua to print retail-like gil message from chests

### DIFF
--- a/scripts/enum/msg.lua
+++ b/scripts/enum/msg.lua
@@ -459,6 +459,7 @@ xi.msg.system =
 {
     GLOBAL_TRUST_OFFSET          = 0,
     EXECUTING_LOGOUT             = 7,   -- Executing logout in <seconds> seconds. Cancel healing to remain logged in.
+    OBTAINS_GIL                  = 19,  -- Treasure pool message ala 0x0D2 `Gold` value of non- zero "<Name> obtains <value> gil."
     EXECUTING_SHUTDOWN           = 35,  -- Executing shutdown in <seconds> seconds. Cancel healing to remain logged in.
     TRUST_NO_SEEKING_PARTY       = 296, -- You cannot use Trust magic while seeking a party.
     TRUST_DELAY_NEW_PARTY_MEMBER = 297, -- While inviting a party member, you must wait a while before using Trust magic.

--- a/scripts/globals/npc_util.lua
+++ b/scripts/globals/npc_util.lua
@@ -422,8 +422,9 @@ end
 ---@param player CBaseEntity
 ---@param currency string
 ---@param amount integer
+---@param useTreasurePoolMsg boolean?
 ---@return boolean
-function npcUtil.giveCurrency(player, currency, amount)
+function npcUtil.giveCurrency(player, currency, amount, useTreasurePoolMsg)
     local ID = zones[player:getZoneID()]
 
     if type(currency) ~= 'string' or type(amount) ~= 'number' then
@@ -460,7 +461,11 @@ function npcUtil.giveCurrency(player, currency, amount)
         player:addCurrency(currency, amount)
     end
 
-    player:messageSpecial(messageId, amount)
+    if useTreasurePoolMsg then
+        player:messageSystem(xi.msg.system.OBTAINS_GIL, amount)
+    else
+        player:messageSpecial(messageId, amount)
+    end
 
     return true
 end

--- a/scripts/globals/treasure.lua
+++ b/scripts/globals/treasure.lua
@@ -1654,7 +1654,7 @@ local function handleGilDistribution(player, treasureLevel)
 
     -- Distribute gil.
     for i = 1, #playersInZoneTable do
-        npcUtil.giveCurrency(playersInZoneTable[i], 'gil', gilPerEntity)
+        npcUtil.giveCurrency(playersInZoneTable[i], 'gil', gilPerEntity, true)
     end
 end
 
@@ -1937,8 +1937,8 @@ xi.treasure.onTrade = function(player, npc, trade, bypassType, bypassReward)
         -- Distribute gil.
         player:timer(2000, function(playerEntity)
             playerEntity:tradeComplete()
-            handleGilDistribution(playerEntity, treasureLevel)
             playerEntity:messageSpecial(ID.text.CHEST_UNLOCKED)
+            handleGilDistribution(playerEntity, treasureLevel)
             openAndMoveTreasure(npc, respawnType.REGULAR)
         end)
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Tweaks treasure.lua to print the retail-like gil packet from treasure packet, and changes the order to match what you see from retail.

Why didn't I use the treasure packet? Our treasure pool is not set up correctly to handle this and we dont know the edge cases. There is a very real risk of forcing the client to access out of bounds and crash if we do it that way.

The client has a fixed array of size 10, and if we send an [0x0D2](https://github.com/atom0s/XiPackets/blob/main/world/server/0x00D2/README.md) and do not follow up with a proper [0x0D3](https://github.com/atom0s/XiPackets/blob/main/world/server/0x00D3/README.md) the client CAN access out of bounds.

Per a decomp from atom0s, if `Gold` is set to non-zero on 0x0D2, the client emits message ID 19 to itself with param0 set to `Gold` from the packet.

Also, doing it this way means that we can go above the uint16 limit in the treasure packet, thus being "better than retail"

Additionally, this 
## Steps to test these changes
<img width="515" height="137" alt="image" src="https://github.com/user-attachments/assets/32f7d8c2-d9fe-40c4-8bcf-cf81a963c317" />

And testing the npcutil...
<img width="524" height="76" alt="image" src="https://github.com/user-attachments/assets/cb9a8785-ff61-47e0-84e3-b3cd7b542a99" />
