### PR TITLE
[lua] 99% Retail-accurate chocobo prices

### DIFF
--- a/scripts/globals/chocobo.lua
+++ b/scripts/globals/chocobo.lua
@@ -12,78 +12,102 @@ xi.chocobo = xi.chocobo or {}
 --[[
 Description:
 [1] Level required to rent a chocobo
-[2] Base price
-[3] Amount added to base price
-[4] Amount discounted per time interval
-[5] Amount of seconds before price decay
-[6] Quest 'A Chocobo Riding Game' chance
-[7] Shadowreign zone flag
-[8] Position player is sent to after event, if applicable
+[2] Current sales count
+[3] is Premium priced, out of town and Jeuno have higher costs, everything else is lower
+[4] Shadowreign zone flag
+[5] Position player is sent to after event, if applicable
 --]]
 
-local chocoboInfo =
+xi.chocobo.chocoboInfo =
 {
-    [xi.zone.AL_ZAHBI]                = { levelReq = 20, basePrice = 250, addedPrice = 25, decayPrice = 5, decayTime = 90, questChance = 0.00, past = false, pos = { 610, -24, 356, 128, 51 } },
-    [xi.zone.WAJAOM_WOODLANDS]        = { levelReq = 20, basePrice = 200, addedPrice = 20, decayPrice = 5, decayTime = 90, questChance = 0.00, past = false, pos = nil },
-    [xi.zone.SOUTHERN_SAN_DORIA_S]    = { levelReq = 15, basePrice = 150, addedPrice = 20, decayPrice = 5, decayTime = 90, questChance = 0.00, past = true , pos = { 94, -62, 266, 40, 81 } },
-    [xi.zone.JUGNER_FOREST_S]         = { levelReq = 20, basePrice = 200, addedPrice = 25, decayPrice = 5, decayTime = 90, questChance = 0.00, past = true , pos = nil },
-    [xi.zone.BASTOK_MARKETS_S]        = { levelReq = 15, basePrice = 150, addedPrice = 20, decayPrice = 5, decayTime = 90, questChance = 0.00, past = true , pos = { 380, 0, 147, 192, 88 } },
-    [xi.zone.PASHHOW_MARSHLANDS_S]    = { levelReq = 20, basePrice = 200, addedPrice = 25, decayPrice = 5, decayTime = 90, questChance = 0.00, past = true , pos = nil },
-    [xi.zone.WINDURST_WATERS_S]       = { levelReq = 15, basePrice = 150, addedPrice = 20, decayPrice = 5, decayTime = 90, questChance = 0.00, past = true , pos = { 320, -4, -46, 192, 95 } },
-    [xi.zone.MERIPHATAUD_MOUNTAINS_S] = { levelReq = 20, basePrice = 200, addedPrice = 25, decayPrice = 5, decayTime = 90, questChance = 0.00, past = true , pos = nil },
-    [xi.zone.LA_THEINE_PLATEAU]       = { levelReq = 20, basePrice = 200, addedPrice = 25, decayPrice = 5, decayTime = 90, questChance = 0.00, past = false, pos = nil },
-    [xi.zone.KONSCHTAT_HIGHLANDS]     = { levelReq = 20, basePrice = 200, addedPrice = 25, decayPrice = 5, decayTime = 90, questChance = 0.00, past = false, pos = nil },
-    [xi.zone.EASTERN_ALTEPA_DESERT]   = { levelReq = 20, basePrice = 200, addedPrice = 25, decayPrice = 5, decayTime = 90, questChance = 0.00, past = false, pos = nil },
-    [xi.zone.TAHRONGI_CANYON]         = { levelReq = 20, basePrice = 200, addedPrice = 25, decayPrice = 5, decayTime = 90, questChance = 0.00, past = false, pos = nil },
-    [xi.zone.YHOATOR_JUNGLE]          = { levelReq = 20, basePrice = 200, addedPrice = 25, decayPrice = 5, decayTime = 90, questChance = 0.00, past = false, pos = nil },
-    [xi.zone.SOUTHERN_SAN_DORIA]      = { levelReq = 15, basePrice = 100, addedPrice = 20, decayPrice = 5, decayTime = 60, questChance = 0.10, past = false, pos = { -126, -62, 274, 101, 100 } },
-    [xi.zone.BASTOK_MINES]            = { levelReq = 15, basePrice = 100, addedPrice = 20, decayPrice = 5, decayTime = 60, questChance = 0.10, past = false, pos = { 580, 0, -305, 64, 107 } },
-    [xi.zone.WINDURST_WOODS]          = { levelReq = 15, basePrice = 100, addedPrice = 20, decayPrice = 5, decayTime = 60, questChance = 0.10, past = false, pos = { -122, -4, -520, 0, 116 } },
-    [xi.zone.UPPER_JEUNO]             = { levelReq = 20, basePrice = 200, addedPrice = 25, decayPrice = 5, decayTime = 90, questChance = 0.00, past = false, pos = { 486, 8, -160, 128, 105 } },
-    [xi.zone.LOWER_JEUNO]             = { levelReq = 20, basePrice = 200, addedPrice = 25, decayPrice = 5, decayTime = 90, questChance = 0.00, past = false, pos = { 340, 24, 608, 112, 110 } },
-    [xi.zone.PORT_JEUNO]              = { levelReq = 20, basePrice = 200, addedPrice = 25, decayPrice = 5, decayTime = 90, questChance = 0.00, past = false, pos = { -574, 2, 400, 0, 120 } },
-    [xi.zone.RABAO]                   = { levelReq = 20, basePrice =  90, addedPrice = 10, decayPrice = 5, decayTime = 60, questChance = 0.00, past = false, pos = { 420, 8, 360, 64, 125 } },
-    [xi.zone.KAZHAM]                  = { levelReq = 20, basePrice =  90, addedPrice = 10, decayPrice = 5, decayTime = 60, questChance = 0.10, past = false, pos = { -240, 0, 528, 64, 123 } },
-    [xi.zone.NORG]                    = { levelReq = 20, basePrice =  90, addedPrice = 10, decayPrice = 5, decayTime = 60, questChance = 0.00, past = false, pos = { -456, 17, -348, 0, 123 } },
+    [xi.zone.AL_ZAHBI]                = { levelReq = 20, sales = 0, premiumCost = false, past = false, pos = { 610, -24, 356, 128, 51 } },
+    [xi.zone.WAJAOM_WOODLANDS]        = { levelReq = 20, sales = 0, premiumCost = true, past = false, pos = nil },
+    [xi.zone.SOUTHERN_SAN_DORIA_S]    = { levelReq = 15, sales = 0, premiumCost = false, past = true , pos = { 94, -62, 266, 40, 81 } },
+    [xi.zone.JUGNER_FOREST_S]         = { levelReq = 20, sales = 0, premiumCost = true, past = true , pos = nil },
+    [xi.zone.BASTOK_MARKETS_S]        = { levelReq = 15, sales = 0, premiumCost = false, past = true , pos = { 380, 0, 147, 192, 88 } },
+    [xi.zone.PASHHOW_MARSHLANDS_S]    = { levelReq = 20, sales = 0, premiumCost = true, past = true , pos = nil },
+    [xi.zone.WINDURST_WATERS_S]       = { levelReq = 15, sales = 0, premiumCost = false, past = true , pos = { 320, -4, -46, 192, 95 } },
+    [xi.zone.MERIPHATAUD_MOUNTAINS_S] = { levelReq = 20, sales = 0, premiumCost = true, past = true , pos = nil },
+    [xi.zone.LA_THEINE_PLATEAU]       = { levelReq = 20, sales = 0, premiumCost = true, past = false, pos = nil },
+    [xi.zone.KONSCHTAT_HIGHLANDS]     = { levelReq = 20, sales = 0, premiumCost = true, past = false, pos = nil },
+    [xi.zone.EASTERN_ALTEPA_DESERT]   = { levelReq = 20, sales = 0, premiumCost = true, past = false, pos = nil },
+    [xi.zone.TAHRONGI_CANYON]         = { levelReq = 20, sales = 0, premiumCost = true, past = false, pos = nil },
+    [xi.zone.YHOATOR_JUNGLE]          = { levelReq = 20, sales = 0, premiumCost = true, past = false, pos = nil },
+    [xi.zone.SOUTHERN_SAN_DORIA]      = { levelReq = 15, sales = 0, premiumCost = false, past = false, pos = { -126, -62, 274, 101, 100 } },
+    [xi.zone.BASTOK_MINES]            = { levelReq = 15, sales = 0, premiumCost = false, past = false, pos = { 580, 0, -305, 64, 107 } },
+    [xi.zone.WINDURST_WOODS]          = { levelReq = 15, sales = 0, premiumCost = false, past = false, pos = { -122, -4, -520, 0, 116 } },
+    [xi.zone.UPPER_JEUNO]             = { levelReq = 20, sales = 0, premiumCost = true, past = false, pos = { 486, 8, -160, 128, 105 } },
+    [xi.zone.LOWER_JEUNO]             = { levelReq = 20, sales = 0, premiumCost = true, past = false, pos = { 340, 24, 608, 112, 110 } },
+    [xi.zone.PORT_JEUNO]              = { levelReq = 20, sales = 0, premiumCost = true, past = false, pos = { -574, 2, 400, 0, 120 } },
+    [xi.zone.RABAO]                   = { levelReq = 20, sales = 0, premiumCost = false, past = false, pos = { 420, 8, 360, 64, 125 } },
+    [xi.zone.KAZHAM]                  = { levelReq = 20, sales = 0, premiumCost = false, past = false, pos = { -240, 0, 528, 64, 123 } },
+    [xi.zone.NORG]                    = { levelReq = 20, sales = 0, premiumCost = false, past = false, pos = { -456, 17, -348, 0, 123 } },
 }
 
------------------------------------
--- Local functions
------------------------------------
+local timeServerCounter = 0
 
-local function getPrice(zoneId, info)
-    local lastPrice = GetServerVariable('[CHOCOBO][' .. zoneId .. ']price')
-    local lastTime  = GetServerVariable('[CHOCOBO][' .. zoneId .. ']time')
-    local decay     = math.floor((GetSystemTime() - lastTime) / info.decayTime) * info.decayPrice
-    local price     = math.max(lastPrice - decay, info.basePrice)
+-- This runs on every zone in the xi.chocobo.chocoboInfo global.
+-- This will also run for every unloaded zone (on another process), but the computation is so cheap it may not matter.
+---@return nil
+xi.chocobo.onTimeServerTick = function()
+    -- Run every (2,400 * 25) ms (1 minute)
+    if timeServerCounter % 25 == 0 then
+        for idx, _ in pairs(xi.chocobo.chocoboInfo) do
+            local sales = xi.chocobo.chocoboInfo[idx].sales
 
-    return price
+            -- Reduce sales by 1, but don't go below zero
+            xi.chocobo.chocoboInfo[idx].sales = math.max(0, sales - 1)
+        end
+    end
+
+    timeServerCounter = timeServerCounter + 1
 end
 
-local function updatePrice(zoneId, info, price)
-    SetServerVariable('[CHOCOBO][' .. zoneId .. ']price', price + info.addedPrice)
-    SetServerVariable('[CHOCOBO][' .. zoneId .. ']time', GetSystemTime())
+---@param zoneId integer
+---@return nil
+xi.chocobo.increaseSales = function(zoneId)
+    -- Increase sales to boost price
+    xi.chocobo.chocoboInfo[zoneId].sales = xi.chocobo.chocoboInfo[zoneId].sales + 1
 end
 
------------------------------------
--- Public functions
------------------------------------
+---@param player CBaseEntity
+---@return integer
+xi.chocobo.getPrice = function(player)
+    local zoneId      = player:getZoneID()
+    local sales       = xi.chocobo.chocoboInfo[zoneId].sales
+    local premiumCost = xi.chocobo.chocoboInfo[zoneId].premiumCost
+    local basePrice   = premiumCost and 100 or 50
+    local levelMult   = premiumCost and 2 or 1
+    local level       = player and player:getMainLvl() or 100 -- If we don't have a player, assume lvl 100
 
+    -- Calculate base price, such as 100 + 99 * 2
+    basePrice = math.floor(basePrice + level * levelMult) -- Floor just in case...
+
+    -- Add in the 5% per sale cost
+    return basePrice + math.floor(basePrice * 0.05 * sales)
+end
+
+---@param zone CZone
+---@return nil
 xi.chocobo.initZone = function(zone)
     local zoneId = zone:getID()
-    local info = chocoboInfo[zoneId]
 
-    if info then
-        SetServerVariable('[CHOCOBO][' .. zoneId .. ']price', info.basePrice)
-        SetServerVariable('[CHOCOBO][' .. zoneId .. ']time', GetSystemTime())
+    if xi.chocobo.chocoboInfo[zoneId] then
+        xi.chocobo.chocoboInfo[zoneId].sales = 0
     else
         printf('[warning] bad zoneId %i in xi.chocobo.initZone (%s)', zoneId, zone:getName())
     end
 end
 
+---@param player CBaseEntity
+---@param npc CBaseEntity
+---@param trade CTradeContainer
+---@param eventSucceed integer
+---@param eventFail integer
+---@return nil
 xi.chocobo.renterOnTrade = function(player, npc, trade, eventSucceed, eventFail)
     local zoneId = player:getZoneID()
-    local info   = chocoboInfo[zoneId]
+    local info   = xi.chocobo.chocoboInfo[zoneId]
 
     if not info then
         printf('[warning] player %s passed bad zoneId %i in xi.chocobo.renterOntrade', player:getName(), zoneId)
@@ -125,10 +149,15 @@ xi.chocobo.renterOnTrade = function(player, npc, trade, eventSucceed, eventFail)
     end
 end
 
+---@param player CBaseEntity
+---@param npc CBaseEntity
+---@param eventSucceed integer
+---@param eventFail integer
+---@return nil
 xi.chocobo.renterOnTrigger = function(player, npc, eventSucceed, eventFail)
     local mLvl      = player:getMainLvl()
     local zoneId    = player:getZoneID()
-    local info      = chocoboInfo[zoneId]
+    local info      = xi.chocobo.chocoboInfo[zoneId]
     local canRace   = xi.chocoboGame.raceCheck(player, npc)
 
     if info then
@@ -140,7 +169,7 @@ xi.chocobo.renterOnTrigger = function(player, npc, eventSucceed, eventFail)
             if canRace then -- Check if NPC can start A Chocobo Riding Game
                 xi.chocoboGame.startRaceEvent(player, canRace, eventSucceed)
             else
-                local price = getPrice(zoneId, info)
+                local price = xi.chocobo.getPrice(player)
                 player:setLocalVar('[CHOCOBO]price', price)
 
                 local currency = 0
@@ -162,13 +191,18 @@ xi.chocobo.renterOnTrigger = function(player, npc, eventSucceed, eventFail)
     end
 end
 
+---@param player CBaseEntity
+---@param csid integer
+---@param option integer
+---@param eventSucceed integer
+---@return nil
 xi.chocobo.renterOnEventFinish = function(player, csid, option, eventSucceed)
     local chocoGame = player:getLocalVar('[ChocoGame]DestCity')
 
     if csid == eventSucceed and option == 0 then
         local mLvl     = player:getMainLvl()
         local zoneId   = player:getZoneID()
-        local info     = chocoboInfo[zoneId]
+        local info     = xi.chocobo.chocoboInfo[zoneId]
         local trade    = player:getLocalVar('Chocopass')
         local duration = 900
 
@@ -202,10 +236,11 @@ xi.chocobo.renterOnEventFinish = function(player, csid, option, eventSucceed)
                     player:delCurrency('allied_notes', price)
                 end
 
-                updatePrice(zoneId, info, price)
-
+                xi.chocobo.increaseSales(zoneId)
             else
-                printf('[warning] player %s reached succeed without enough currency in xi.chocobo.renterOnEventFinish', player:getName())
+                printf('[warning] player %s reached succeed without enough currency in xi.chocobo.renterOnEventFinish',
+                    player:getName())
+                return
             end
         end
 

--- a/scripts/globals/server.lua
+++ b/scripts/globals/server.lua
@@ -13,6 +13,7 @@ xi.server.onJSTMidnight = function()
 end
 
 xi.server.onTimeServerTick = function()
+    xi.chocobo.onTimeServerTick()
 end
 
 -- Message for use with SmallPacket0x04B

--- a/scripts/tests/systems/chocobo.lua
+++ b/scripts/tests/systems/chocobo.lua
@@ -1,0 +1,82 @@
+-- TODO:
+--  - Allied notes
+--  - Racing game
+--  - Non-premium pricing
+
+describe('Chocobo Rental', function()
+    ---@type CClientEntityPair
+    local player
+    -- The data we'll be testing
+    local chocoboTable = xi.chocobo.chocoboInfo[xi.zone.LA_THEINE_PLATEAU]
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer({ level = 20, zone = xi.zone.LA_THEINE_PLATEAU })
+        player:addKeyItem(xi.ki.CHOCOBO_LICENSE)
+    end)
+
+    after_each(function()
+        -- Reset sales after each test
+        chocoboTable.sales = 0
+    end)
+
+    it('players under 20 cant ride', function()
+        player:setLevel(19) -- Even with a license!
+        player.entities:gotoAndTrigger('Coumaine', { eventId = 121 })
+    end)
+
+    it('players without a license cant ride', function()
+        player:delKeyItem(xi.ki.CHOCOBO_LICENSE)
+        player.entities:gotoAndTrigger('Coumaine', { eventId = 121 })
+    end)
+
+    it('players without enough gil cant ride', function()
+        -- This returns the correct event but it should NOT mount the PC
+        player.entities:gotoAndTrigger('Coumaine', { eventId = 120 })
+        player.assert.no:hasEffect(xi.effect.MOUNTED)
+    end)
+
+    it('players meeting all qualifications can ride', function()
+        player:setGil(140) -- First sale is always 140g for a level 20 PC
+        player.entities:gotoAndTrigger('Coumaine', { eventId = 120 })
+        player.assert:hasEffect(xi.effect.MOUNTED)
+    end)
+
+    it('price increases after each sale', function()
+        -- Setup stubs to ensure they get called when renting a chocobo
+        local increaseSalesStub = stub('xi.chocobo.increaseSales')
+        local getPriceStub      = stub('xi.chocobo.getPrice')
+
+        player:setGil(140)
+        player.entities:gotoAndTrigger('Coumaine', { eventId = 120, finishOption = 0 })
+        player.assert:hasEffect(xi.effect.MOUNTED)
+        player.assert:hasGil(0)
+        increaseSalesStub:called(1)
+        getPriceStub:called(1)
+
+        -- Next getPrice should be 5% higher
+        local expectedPrice = math.floor(140 + 140 * 0.05)
+        assert(xi.chocobo.getPrice(player) == expectedPrice, 'Chocobo price did not increase')
+    end)
+
+    it('price decreases every minute', function()
+        local onTimeServerTickStub = stub('xi.chocobo.onTimeServerTick')
+
+        -- Simulate that 1000 sales have occured
+        -- Verify that the price reflects the change
+        chocoboTable.sales = 1000
+        local expectedPrice = math.floor(140 + 140 * (0.05 * 1000))
+        assert(xi.chocobo.getPrice(player) == expectedPrice, 'Chocobo price did not increase')
+
+        -- Now pass 1 Vanadiel minute (25 ticks)
+        -- TODO: Figure out a better notation?
+        for _ = 1, 25 do
+            xi.test.world:tick(xi.tick.TIME)
+        end
+
+        -- Verify that the function was called 25 times and the price decreased
+        expectedPrice = math.floor(140 + 140 * (0.05 * 999))
+        onTimeServerTickStub:called(25)
+        assert(chocoboTable.sales == 999, 'Chocobo sales did not decrease after 1 minute')
+        assert(xi.chocobo.getPrice(player) == expectedPrice, 'Chocobo price did not decrease')
+    end)
+end)


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The timer isn't exactly 60 seconds, but seems to drift for unknown reasons

Chocobo price is calculated as follows on retail:

Base Price = 50 or 100 (if premium)
Level Mult = 1 or 2 (if premium)

Level Adjusted price = base price * player level * level mult (a whole number)

Then there's a 5% increase per sale after level adjusted price

so for a level 99 player, their base cost for a "premium" rental is 298, or 149.

## Steps to test these changes

Verify sales count and the following (ALL pics and logs are from retail!) :

premium or not is omitted because I am simply lazy.

level 91:
<img width="607" height="636" alt="image" src="https://github.com/user-attachments/assets/7f40dd32-7a25-4caa-9adc-57d848661ff3" />

Level 75:
<img width="674" height="444" alt="image" src="https://github.com/user-attachments/assets/f95bccc5-78e9-476c-aec1-f69431b80625" />

level 28:
<img width="103" height="395" alt="image" src="https://github.com/user-attachments/assets/efeb1f9e-bc75-45c6-bdff-88ea9bb26133" />

level 27:
<img width="98" height="375" alt="image" src="https://github.com/user-attachments/assets/4c372b4b-267c-4641-92b1-8159f3de13fa" />

level 23:
<img width="487" height="134" alt="image" src="https://github.com/user-attachments/assets/42f0db18-e5d2-4ea2-b0c7-7d2e7625d3ee" />

level 50:
<img width="114" height="1118" alt="image" src="https://github.com/user-attachments/assets/4405ae0f-b024-41b4-aae7-252b5500687e" />

level 51:
<img width="119" height="405" alt="image" src="https://github.com/user-attachments/assets/fdbd302d-4328-47a3-be66-c3463bdc6961" />

level 37:
<img width="100" height="692" alt="image" src="https://github.com/user-attachments/assets/2ba6cb92-09cb-465f-8c48-729cbd7e051d" />

level 25:
<img width="379" height="176" alt="image" src="https://github.com/user-attachments/assets/80ca3b3c-370a-46d2-9df2-116c962cf40f" />

era sales:

level 66 with 18 and 21 sales
```
2007_04_13_fflog.txt:[2007/04/13 11:58:21] 98 Pucotte : You can rent a chocobo for 440 gil. I see you currently have 126150 gil.
2007_04_13_fflog.txt:[2007/04/13 11:58:29] 98 Pucotte : You can rent a chocobo for 475 gil. I see you currently have 126150 gil.
```

level 65 with 0 and 2 sales (non-premium)
```
2008_09_19_fflog.txt:[2008/09/19 10:52:21] 98 Dahaaba : You can rent a chocobo for 114 gil. I see you currently have 983601 gil.
2008_09_19_fflog.txt:[2008/09/19 10:54:24] 98 Dahaaba : You can rent a chocobo for 125 gil. I see you currently have 983601 gil.
```
