### PR TITLE
[sql/lua] Update various 0,0,0 spawnpoints

### DIFF
--- a/scripts/zones/Ship_bound_for_Mhaura/IDs.lua
+++ b/scripts/zones/Ship_bound_for_Mhaura/IDs.lua
@@ -23,6 +23,7 @@ zones[xi.zone.SHIP_BOUND_FOR_MHAURA] =
     },
     mob =
     {
+        SEA_HORROR = GetFirstID('Sea_Horror'),
     },
     npc =
     {

--- a/scripts/zones/Ship_bound_for_Mhaura/mobs/Sea_Horror.lua
+++ b/scripts/zones/Ship_bound_for_Mhaura/mobs/Sea_Horror.lua
@@ -1,0 +1,32 @@
+-----------------------------------
+-- Area: Ship Bound for Mhaura
+--   NM: Sea Horror
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+local ID = zones[xi.zone.SHIP_BOUND_FOR_MHAURA]
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.spawnPoints =
+{
+    { x = -0.329, y = -7.268, z = 5.820 }
+}
+
+entity.phList =
+{
+    [ID.mob.SEA_HORROR - 4] = ID.mob.SEA_HORROR, -- Sea Monk
+}
+
+entity.onMobInitialize = function(mob)
+    -- "May despawn if left alone"
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+    -- TODO any other immunities?
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+end
+
+return entity

--- a/scripts/zones/Ship_bound_for_Mhaura/mobs/Sea_Monk.lua
+++ b/scripts/zones/Ship_bound_for_Mhaura/mobs/Sea_Monk.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- Area: Ship Bound for Mhaura
+--   NM: Sea Horror
+-----------------------------------
+local ID = zones[xi.zone.SHIP_BOUND_FOR_MHAURA]
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobDespawn = function(mob)
+    -- "Can spawn up to three times on the same ferry ride."
+    -- TODO verify if this mob can spawn back-to-back. If so it might be in a spawn group with the sea monk
+    -- a spawn group + IDLE_DESPAWN on the NM would look very much like a ph-style NM
+    xi.mob.phOnDespawn(mob, ID.mob.SEA_HORROR, 50, 1)
+end
+
+return entity

--- a/scripts/zones/Ship_bound_for_Selbina/IDs.lua
+++ b/scripts/zones/Ship_bound_for_Selbina/IDs.lua
@@ -23,7 +23,8 @@ zones[xi.zone.SHIP_BOUND_FOR_SELBINA] =
     },
     mob =
     {
-        ENAGAKURE = GetFirstID('Enagakure'),
+        ENAGAKURE  = GetFirstID('Enagakure'),
+        SEA_HORROR = GetFirstID('Sea_Horror'),
     },
     npc =
     {

--- a/scripts/zones/Ship_bound_for_Selbina/mobs/Sea_Horror.lua
+++ b/scripts/zones/Ship_bound_for_Selbina/mobs/Sea_Horror.lua
@@ -1,0 +1,32 @@
+-----------------------------------
+-- Area: Ship Bound for Mhaura
+--   NM: Sea Horror
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+local ID = zones[xi.zone.SHIP_BOUND_FOR_SELBINA]
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.spawnPoints =
+{
+    { x = -0.230, y = -7.660, z = 2.860 }
+}
+
+entity.phList =
+{
+    [ID.mob.SEA_HORROR - 4] = ID.mob.SEA_HORROR, -- Sea Monk
+}
+
+entity.onMobInitialize = function(mob)
+    -- "May despawn if left alone"
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+    -- TODO any other immunities?
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+end
+
+return entity

--- a/scripts/zones/Ship_bound_for_Selbina/mobs/Sea_Monk.lua
+++ b/scripts/zones/Ship_bound_for_Selbina/mobs/Sea_Monk.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- Area: Ship Bound for Mhaura
+--   NM: Sea Horror
+-----------------------------------
+local ID = zones[xi.zone.SHIP_BOUND_FOR_SELBINA]
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobDespawn = function(mob)
+    -- "Can spawn up to three times on the same ferry ride."
+    -- TODO verify if this mob can spawn back-to-back. If so it might be in a spawn group with the sea monk
+    -- a spawn group + IDLE_DESPAWN on the NM would look very much like a ph-style NM
+    xi.mob.phOnDespawn(mob, ID.mob.SEA_HORROR, 50, 1)
+end
+
+return entity

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -13836,7 +13836,7 @@ INSERT INTO `mob_groups` VALUES (8,3523,220,'Sea_Monk',300,0,2188,0,0,21,29,0);
 INSERT INTO `mob_groups` VALUES (9,3127,220,'Phantom',300,1,1993,0,0,22,25,0);
 INSERT INTO `mob_groups` VALUES (10,3912,220,'Thunder_Elemental',300,4,2410,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (11,4309,220,'Water_Elemental',300,4,2629,0,0,27,29,0);
-INSERT INTO `mob_groups` VALUES (12,3522,220,'Sea_Horror',900,0,2186,0,0,60,62,0);
+INSERT INTO `mob_groups` VALUES (12,3522,220,'Sea_Horror',0,128,2186,0,0,60,62,0);
 INSERT INTO `mob_groups` VALUES (13,1213,220,'Enagakure',0,128,0,0,0,55,55,0);
 
 -- ------------------------------------------------------------
@@ -13857,7 +13857,7 @@ INSERT INTO `mob_groups` VALUES (8,3523,221,'Sea_Monk',300,0,2188,0,0,21,29,0);
 INSERT INTO `mob_groups` VALUES (9,3127,221,'Phantom',300,1,1993,0,0,22,25,0);
 INSERT INTO `mob_groups` VALUES (10,3912,221,'Thunder_Elemental',300,4,2410,0,0,27,29,0);
 INSERT INTO `mob_groups` VALUES (11,4309,221,'Water_Elemental',300,4,2629,0,0,27,29,0);
-INSERT INTO `mob_groups` VALUES (12,3522,221,'Sea_Horror',900,0,2186,0,0,60,62,0);
+INSERT INTO `mob_groups` VALUES (12,3522,221,'Sea_Horror',0,128,2186,0,0,60,62,0);
 
 -- ------------------------------------------------------------
 -- Provenance (Zone 222)


### PR DESCRIPTION
- elementals that had another element sequentially
- ship zones that I had captures of

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Found a 0,0,0 elemental while doing #8353 

<img width="568" height="55" alt="image" src="https://github.com/user-attachments/assets/a0deb290-7036-463d-9a44-28cc7cff9801" />

This led me to searching for elementals with 0,0,0 positions to see what i can figure out.

This PR is the results of that search:
- If you look around in `mob_spawn_points`, sequential elementals of different types generally have similar spawn points
  - Various elementals found in that situation were updated
- Found elementals on various ships
  - since i just spent the last month going over transport captures, they are still fresh in my mind and readily available
  - Ive updated the ship zones with positions from various captures 
- Confirmed the ghosts work properly based on time
- The pirate nms etc all have spawntype 128 so they do not spawn.
- updated [Sea Horror](https://www.bg-wiki.com/ffxi/Sea_Horror) to be ph-style on both ships
  - added basic properties to make him use HF as well as sleep immunity
  - reports indicate it can spawn multiple times on a ride, so gave 50% chance and no cooldown
    - It's possible that it isn't a ph-nm, and simply in a spawn group with the sea monk (though it doesn't appear to ever be up at the start of a boat ride). Added a TODO

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- go to zones in question, see mobs at positions
- ship zones: 47, 59, 220, 227, 228
- if testing elementals, `!setweather X` makes them spawn/despawn immediately to easily see positions relative to other elementals
  - <img width="536" height="447" alt="image" src="https://github.com/user-attachments/assets/4671d2f6-973d-465e-898f-a0fcd84c00be" />
  - <img width="536" height="461" alt="image" src="https://github.com/user-attachments/assets/7eef0c26-e362-4c5e-a799-8d969553768d" />
  - <img width="634" height="507" alt="image" src="https://github.com/user-attachments/assets/5a6e7069-7844-424b-88d0-49149051db4f" />
  - etc
- go into zone 220 and 221, kill sea monks until horror spawns
  - set chance to 100 and params `{ immediate = true }` to speed this up
  - watch it sit for 3m and despawn

