### PR TITLE
[lua] Reworking PW fight prelim: intermediate phases

### DIFF
--- a/scripts/zones/Aydeewa_Subterrane/IDs.lua
+++ b/scripts/zones/Aydeewa_Subterrane/IDs.lua
@@ -21,6 +21,7 @@ zones[xi.zone.AYDEEWA_SUBTERRANE] =
         FISHING_MESSAGE_OFFSET        = 7064, -- You can't fish here.
         MINING_IS_POSSIBLE_HERE       = 7335, -- Mining is possible here if you have <item>.
         NO_MORE_SPROUTS               = 7721, -- However, you cannot carry any more sprouts.
+        PW_WHO_DARES                  = 7979, -- Who dares disturb these gates? Pathetic mortal, what foolishness has brought you here? No matter, your fate is now irrevocably sealed. Come now, do not fear. Embrace your death!
         SENSE_OMINOUS_PRESENCE        = 8022, -- You sense an ominous presence...
         BLOOD_STAINS                  = 8028, -- The ground is smeared with bloodstains...
         DRAWS_NEAR                    = 8053, -- Something draws near!
@@ -32,7 +33,9 @@ zones[xi.zone.AYDEEWA_SUBTERRANE] =
         BLUESTREAK_GYUGYUROON = GetFirstID('Bluestreak_Gyugyuroon'),
         CHIGRE                = GetFirstID('Chigre'),
         NOSFERATU             = GetFirstID('Nosferatu'),
-        PANDEMONIUM_WARDEN    = GetFirstID('Pandemonium_Warden'), -- 2 Copies: +0, +1
+        PANDEMONIUM_WARDEN    = GetFirstID('Pandemonium_Warden'),
+        PANDEMONIUM_LAMPS     = GetTableOfIDs('Pandemonium_Lamp'),
+        -- PANDEMONIUM_AVATARS   = GetTableOfIDs('Pandemonium_Lamp_Avatar'), -- For use when main PW lua gets converted
     },
     npc =
     {

--- a/scripts/zones/Aydeewa_Subterrane/mobs/Pandemonium_Lamp.lua
+++ b/scripts/zones/Aydeewa_Subterrane/mobs/Pandemonium_Lamp.lua
@@ -6,7 +6,12 @@
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 900)
+    mob:setMobMod(xi.mobMod.NO_DROPS, 1)
+    mob:setMobMod(xi.mobMod.EXP_BONUS, -101)
+
+    -- TODO any other immunities?
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Aydeewa_Subterrane/mobs/Pandemonium_Lamp_Avatar.lua
+++ b/scripts/zones/Aydeewa_Subterrane/mobs/Pandemonium_Lamp_Avatar.lua
@@ -1,0 +1,33 @@
+-----------------------------------
+-- Area: Aydeewa Subterrane
+--  ZNM: Pandemonium Lamp (astral flow)
+-- Note: The amount of avatars spawned is based on the number of living Pandemonium Lamps when PW calls avatars at each 25% hp
+-----------------------------------
+mixins = { require('scripts/mixins/families/avatar') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    for i, mobId in ipairs(zones[xi.zone.AYDEEWA_SUBTERRANE].mob.PANDEMONIUM_AVATARS) do
+        if mob:getID() == mobId then
+            mob:setMobMod(xi.mobMod.AVATAR_PETID, xi.petId.CARBUNCLE - 1 + i)
+        end
+    end
+
+    -- 6:34 to 6:46 in this video: https://www.youtube.com/watch?v=T_Us2Tmlm-E
+    -- shows approx 12 seconds between spawn and AF usage
+    mob:setMobMod(xi.mobMod.AVATAR_ASTRAL_DELAY, 12000)
+
+    mob:setMobMod(xi.mobMod.NO_DROPS, 1)
+    mob:setMobMod(xi.mobMod.EXP_BONUS, -101)
+
+    -- TODO any other immunities?
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+end
+
+return entity

--- a/scripts/zones/Aydeewa_Subterrane/mobs/Pandemonium_Warden_HNM.lua
+++ b/scripts/zones/Aydeewa_Subterrane/mobs/Pandemonium_Warden_HNM.lua
@@ -1,0 +1,270 @@
+-----------------------------------
+-- Area: Aydeewa Subterrane
+--  ZNM: Pandemonium Warden for intermediate phases
+-- Note: This mob is respawned every HNM phase and enmity is fresh
+--       Medusa uses eagle eye shot, safe to say each phase has the respective 2hr?
+--
+-- Outline of fight:
+--    Each phase has an increasing amount of HP
+--    In-between phases the real PW shows up (not this mob), and is hard-coded to use cackle, then hellsnap, then change to next phase.
+--      During this sequence, no damage can be inflicted, and pets do not do anything except follow the primary target
+--    Each phase, this mob has the job's respective 2-hour ability at 70% of the starting HP
+--
+--    If a full wipe happens, DoT will keep PW from regen, which will keep him in current form. If he regens to full HP, he resets to phase 1
+--    In each phase, he has access to the respective mobskills and spells of the mob he's mimicing
+--      Pet forms vary depending on what mob the Warden is currently mimicking
+--      No phases seem to use AoE elemental magic
+-----------------------------------
+mixins = { require('scripts/mixins/draw_in') }
+local ID = zones[xi.zone.AYDEEWA_SUBTERRANE]
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+---@class phaseRow
+---@field mobHP integer
+---@field mobModelId integer
+---@field mobSkillList integer
+---@field mobSpecial string
+---@field mobSpellList integer
+---@field petModelId integer
+---@field petSkillList integer
+---@field petSpellLists table<integer>
+local phaseRow = {}
+phaseRow.__index = phaseRow
+
+---@param mobHP integer
+---@param mobModelId integer
+---@param mobSkillList integer
+---@param mobSpecial string
+---@param mobSpellList integer
+---@param petModelId integer
+---@param petSkillList integer
+---@param petSpellLists table<integer>
+---@return phaseRow
+phaseRow.new = function(mobHP, mobModelId, mobSkillList, mobSpecial, mobSpellList, petModelId, petSkillList, petSpellLists)
+    local self = setmetatable({}, phaseRow)
+    self.mobHP = mobHP
+    self.mobModelId = mobModelId
+    self.mobSkillList = mobSkillList
+    self.mobSpecial = mobSpecial
+    self.mobSpellList = mobSpellList
+    self.petModelId = petModelId
+    self.petSkillList = petSkillList
+    self.petSpellLists = petSpellLists
+    return self
+end
+
+-- Table of phase data, with LLS hints above so we can reliably know phaseTable[3].mobSkillList is an int, etc
+local phaseTable = {
+    phaseRow.new(10000, 1825, 1000, 'MIGHTY_STRIKES',   0, 1820,  150, { 0 }),             -- Armed Chariot          pets: Archaic Gears (Melee only)
+    phaseRow.new(10000, 1824, 1001, 'MIGHTY_STRIKES',   0, 1820,  150, { 0 }),             -- Battle Chariot         pets: Archaic Gears (Melee only)
+    phaseRow.new(10000, 1822, 1002, 'MIGHTY_STRIKES',   0, 1820,  150, { 0 }),             -- Armored Chariot        pets: Archaic Gears (Melee only)
+    phaseRow.new(10000, 1823, 1003, 'MIGHTY_STRIKES',   0, 1820,  150, { 0 }),             -- Bowed Chariot          pets: Archaic Gears (Melee only)
+    phaseRow.new(15000, 1863,  285, 'MIJIN_GAKURE',   563, 1639,  176, { 560, 562, 563 }), -- Gulool Ja Ja           pets: Mamool Ja (some cast blm, some cast whm, some cast ninjutsu)
+    phaseRow.new(15000, 1865,  725, 'EES_LAMIA',        0, 1643,  171, { 0, 561 }),        -- Medusa                 pets: Lamiae (some cast rdm spells)
+    phaseRow.new(15000, 1867,  326, 'HUNDRED_FISTS',    0, 1682,  246, { 0, 0, 560 }),     -- Gurfurlur the Menacing pets: Trolls (some cast whm spells, but not half)
+    phaseRow.new(20000, 1805,  168, 'MIGHTY_STRIKES',   0, 1746,  198, { 0 }),             -- Khimaira               pets: Puks (Melee only)
+    phaseRow.new(20000, 1796,  164, 'MIGHTY_STRIKES',   0,  421, 2007, { 0 }),             -- Hydra                  pets: Dahaks (Melee only)
+    phaseRow.new(20000, 1793,   62, 'MIGHTY_STRIKES',   0,  281, 2039, { 0 }),             -- Cerberus               pets: Bombs (Melee only)
+    -- Dvergr - pets: Miniature Dvergr All cast blm spells (not this mob, but listed here for completion's sake)
+}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DROPS, 1)
+    mob:setMod(xi.mod.STATUSRES, 50)
+
+    mob:setMobMod(xi.mobMod.ALLI_HATE, 30)
+    mob:setMobMod(xi.mobMod.HP_STANDBACK, 0)
+
+    -- this mob is always unkillable, simply despawns when "defeated"
+    mob:setUnkillable(true)
+    mob:hideHP(true)
+
+    -- "If all individuals who have developed enmity die, Pandemonium Warden will return to his spawn point, with his train of lamps, and will not be aggressive to any non-combat action"
+    mob:setAggressive(false)
+end
+
+local despawnPW = function(mob)
+    if mob and mob:isSpawned() then
+        DespawnMob(mob:getID())
+    end
+
+    for _, petId in ipairs(ID.mob.PANDEMONIUM_LAMPS) do
+        DespawnMob(petId)
+        local pet = GetMobByID(petId)
+        if pet then
+            pet:setAutoAttackEnabled(false)
+            pet:setMobAbilityEnabled(false)
+            pet:setMagicCastingEnabled(false)
+        end
+    end
+end
+
+entity.onMobRoam = function(mob)
+    if
+        mob:getHPP() == 100 and
+        not xi.combat.behavior.isEntityBusy(mob)
+    then
+        despawnPW(mob)
+        return
+    end
+end
+
+entity.onMobSpawn = function(mob)
+    mob:setMod(xi.mod.DEF, 450)
+    mob:setMod(xi.mod.MEVA, 380)
+    mob:setMod(xi.mod.MDEF, 50)
+
+    -- get phase number from main PW
+    local pw = GetMobByID(ID.mob.PANDEMONIUM_WARDEN)
+    local phase = pw and pw:getLocalVar('phase') or 0
+    local phaseData = phaseTable[phase]
+    if not pw or not phaseData then
+        despawnPW(mob)
+        return
+    end
+
+    -- adjust skill/spell/model of PW and PL mobs
+    mob:setAnimationSub(0)
+    mob:setMaxHP(phaseData.mobHP)
+    mob:setModelId(phaseData.mobModelId)
+    mob:setMobMod(xi.mobMod.SKILL_LIST, phaseData.mobSkillList)
+    mob:setLocalVar('twoHourSkill', xi.jobSpecialAbility[phaseData.mobSpecial] or 0)
+    mob:setMobMod(xi.mobMod.SPELL_LIST, phaseData.mobSpellList)
+    if mob:getMobMod(xi.mobMod.SPELL_LIST) == 0 then
+        mob:setMagicCastingEnabled(false)
+    else
+        mob:setMagicCastingEnabled(true)
+    end
+
+    -- final 3 HNM phases
+    if phase >= 8 then
+        mob:setBehavior(bit.bor(mob:getBehavior(), xi.behavior.NO_TURN))
+
+        -- Hydra phase
+        if phase == 9 then
+            mob:setLocalVar('critsRemaining', math.random(10, 30))
+        end
+    else
+        mob:setBehavior(bit.band(mob:getBehavior(), bit.bnot(xi.behavior.NO_TURN)))
+    end
+
+    for _, petId in ipairs(ID.mob.PANDEMONIUM_LAMPS) do
+        local pet = GetMobByID(petId)
+        if pet then
+            pet:setAggressive(false)
+            pet:setModelId(phaseData.petModelId)
+            local skillList = phaseData.petSkillList
+            -- not all pets each phase use spells. Spell List 0 is included in each pet's SpellLists table to account for this
+            local spellList = utils.randomEntry(phaseData.petSpellLists)
+
+            -- skill/spell list has to be set after spawn
+            pet:addListener('SPAWN', 'SET_ABILITY_LISTS', function(petArg)
+                petArg:setMobMod(xi.mobMod.SKILL_LIST, skillList)
+                petArg:setMobMod(xi.mobMod.HP_STANDBACK, 0)
+                if spellList == 0 then
+                    petArg:setMagicCastingEnabled(false)
+                else
+                    petArg:setSpellList(spellList)
+                    petArg:setMagicCastingEnabled(true)
+                end
+
+                petArg:setAutoAttackEnabled(true)
+                petArg:setMobAbilityEnabled(true)
+            end)
+        end
+    end
+
+    -- TODO can he call more pets during HNM phases?
+    local callPetParams =
+    {
+        noAnimation = true,
+        maxSpawns = 6,
+        ignoreBusy = true,
+    }
+    mob:timer(2000, function(mobArg)
+        xi.mob.callPets(mobArg, ID.mob.PANDEMONIUM_LAMPS, callPetParams)
+    end)
+
+    -- intermediate PW forms spawn claimed but don't attack for up to 4s after phase change
+    local pwTarget = pw:getTarget()
+    if pwTarget then
+        mob:updateClaim(pwTarget)
+    end
+
+    mob:stun(2000)
+end
+
+entity.onMobDisengage = function(mob)
+end
+
+entity.onMobEngage = function(mob, target)
+end
+
+entity.onCriticalHit = function(mob)
+    local critsRemaining = mob:getLocalVar('critsRemaining')
+    local animationSub = mob:getAnimationSub()
+
+    if critsRemaining == 0 then
+        return
+    end
+
+    critsRemaining = critsRemaining - 1
+    if critsRemaining <= 0 then  -- Lose a head
+        -- TODO can he re-grow heads?
+        if animationSub < 2 then
+            mob:setAnimationSub(animationSub + 1)
+        end
+
+        -- Number of crits to lose a head, re-randoming
+        critsRemaining = math.random(10, 30)
+    end
+
+    mob:setLocalVar('critsRemaining', critsRemaining)
+end
+
+entity.onMobFight = function(mob, target)
+    local mobHPP    = mob:getHPP()
+    local twoHour = mob:getLocalVar('twoHourSkill')
+    if not xi.combat.behavior.isEntityBusy(mob) then
+        if mobHPP <= 1 then
+            -- despawn PW phase and interrupt all pets
+            despawnPW(mob)
+
+            return
+        end
+
+        if
+            mobHPP <= 70 and
+            twoHour > 0
+        then
+            mob:setLocalVar('twoHourSkill', 0)
+            mob:useMobAbility(twoHour)
+        end
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    despawnPW(mob)
+
+    -- adjust PW phase and unhide main mob
+    local pw = GetMobByID(ID.mob.PANDEMONIUM_WARDEN)
+    if pw then
+        if mob:getHPP() == 100 then
+            -- mob was despawned from being full hp after a wipe, reset fight
+            pw:setLocalVar('phase', 1)
+        else
+            pw:setLocalVar('phase', pw:getLocalVar('phase') + 1)
+        end
+
+        if pw:isAlive() then
+            -- reappear
+            pw:timer(3000, function(mobArg)
+                mobArg:setStatus(xi.status.UPDATE)
+            end)
+        end
+    end
+end
+
+return entity

--- a/scripts/zones/Aydeewa_Subterrane/npcs/qm2.lua
+++ b/scripts/zones/Aydeewa_Subterrane/npcs/qm2.lua
@@ -11,7 +11,7 @@ local entity = {}
 entity.onTrade = function(player, npc, trade)
     if
         npcUtil.tradeHas(trade, xi.item.PANDEMONIUM_KEY) and
-        npcUtil.popFromQM(player, npc, ID.mob.PANDEMONIUM_WARDEN + 1)
+        npcUtil.popFromQM(player, npc, ID.mob.PANDEMONIUM_WARDEN)
     then
         -- Trade Pandemonium Key
         player:confirmTrade()


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
This PR gets the bulk of PW's logic staged onto the secondary mob id (used on retail for the intermediate phases). The intermediate (hnm) phases of the fight use the second mobid, and it spawns with no enmity, but claimed to the pw target
- see [this timestamp](https://youtu.be/fvgG8zfqr2o): 
  - <img width="671" height="150" alt="image" src="https://github.com/user-attachments/assets/5edc5e53-f734-4cd5-9063-2089fea960e0" />
- and [this timestamp](https://youtu.be/fvgG8zfqr2o?t=108)
  - <img width="674" height="162" alt="image" src="https://github.com/user-attachments/assets/1e5e33db-b0c7-46d0-9911-f1c4b6201dff" />
- finally, see [this timestamp](https://youtu.be/BPbsHhbi4LE?t=205) to see a cure IV going off, and ifrit [stealing aggro from a single autoattack on the next phase](https://youtu.be/BPbsHhbi4LE?t=255) (showing enmity is reset each phase)



The goal is to leave existing PW as-is with old logic and the next PR would adjust primary mob to have the transition sequences and final phase.

I.e. this PR has very little net change in the server behavior from a player perspective
- spawning PW spawns the first mobid, fight respects the existing lua, and drops are defined on that mob
- the tiny changes were in the meta behavior like `:showText` when he spawns, protecting lua errors on adding title, etc
- Note that I did add the future description to the main lua file. it's not _wrong_ in the current PR, but it references the fight as it will be at the end, not so much as it is now
- Extra note: `Pandemonium_Lamp_Avatar.lua` is unused in this PR, as none of the pets have that lua name. Adding it to get as much as I can done before the final PR
  - I've also put a comment in `mob_spawn_points.sql` to remind that they need to get updated
- Edit: [LLS complained about quite a few bindings](https://github.com/LandSandBoat/server/actions/runs/18362633760/job/52309328611?pr=8367) using `phaseData` values without a type check. 
  - The phase table is already wide so I was on the fence about adding the keys to each row, but then LLS complaining about types made me realize that wouldn't help anyway. 
  - Opted to add hints and give proper field names at the same time without expanding the width of the `phaseTable`

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- go to the zone: `!zone 68` trade a pandemonium key, see that fight behaves as it did with some slight fixes to flavor text on start/end of fight
  - <img width="665" height="215" alt="image" src="https://github.com/user-attachments/assets/275d1b24-9f2b-4dce-9ede-511b8846d832" />
  - <img width="656" height="412" alt="image" src="https://github.com/user-attachments/assets/9014df86-9baf-4e1c-998a-2b774e1edbb0" />
- to test the meat of this PR, spawn the next mobid: `!spawnmob 17056168`
  - When it spawns, it updates the warden and lamp mobs to have proper models and skill/spell lists
  - since spell lists are defined on the Warden and Lamps directly (they're used for the final phase), we have to disable casting if the phase doesn't have spells for a given Warden/Lamp
  - also, since mobmods are reset on spawn, we have to update spell/skill lists on Lamps after spawn. When the main PW gets updated, we'll make his phase pet spawning create the same named `SPAWN` listener, to overwrite the one created in `PW_HNM.lua`
    - I could self-destruct the listener, but figured it's better to not in case we find that he can spawn more pets during an intermediate phase
  - Video dump of the phases: https://imgur.com/a/yL67xnV