### PR TITLE
RoE objectives tweaks

### DIFF
--- a/src/map/packets/c2s/0x0e8_camp.cpp
+++ b/src/map/packets/c2s/0x0e8_camp.cpp
@@ -31,6 +31,7 @@ auto GP_CLI_COMMAND_CAMP::validate(MapSession* PSession, const CCharEntity* PCha
     return PacketValidator()
         .isNormalStatus(PChar)
         .isNotPreventedAction(PChar)
+        .isNotCrafting(PChar)
         .mustNotEqual(PChar->PAI->IsEngaged(), true, "Cannot heal while engaged in combat")
         .oneOf<GP_CLI_COMMAND_REQLOGOUT_MODE>(Mode)
         .mustNotEqual(

--- a/src/map/treasure_pool.cpp
+++ b/src/map/treasure_pool.cpp
@@ -264,6 +264,8 @@ uint8 CTreasurePool::addItem(uint16 ItemID, CBaseEntity* PEntity)
 
     for (const auto& member : m_Members)
     {
+        // Issue RoE event for loot item and issue treasure pool packet
+        roeutils::event(ROE_EVENT::ROE_LOOTITEM, member, RoeDatagram("itemid", m_PoolItems[FreeSlotID].ID));
         member->pushPacket<GP_SERV_COMMAND_TROPHY_LIST>(&m_PoolItems[FreeSlotID], PEntity, false);
     }
 
@@ -577,8 +579,6 @@ void CTreasurePool::treasureWon(CCharEntity* winner, uint8 SlotID)
     }
 
     m_PoolItems[SlotID].TimeStamp = timer::start_time;
-
-    roeutils::event(ROE_EVENT::ROE_LOOTITEM, winner, RoeDatagram("itemid", m_PoolItems[SlotID].ID));
 
     for (const auto& member : m_Members)
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Handful of things I noticed while leveling this week-end. Did not think to take screenshots but I can probably get them this week if needed.

- Award "Spoils" RoE objective credit to all members of a treasure pool when the item is added to it, rather than to the winner only.
- Award "Buff ally" objective credit to the master of the trust buffing
  - The way I changed it will also do it for Heal objectives, which I believe is also correct but have not confirmed it.
- One unrelated fix to the /heal packet

Noticed a bug when testing this... Koru-Moru is casting Haste 2 and then Haste on each target. Not sure where the disconnect is.

## Steps to test these changes
In party with at least another PC:
- Summon Koru
- Enable "Spoils (Fire Crystal)" and "Buff Ally" RoEs
- !addtreasure 4096, see credit
- Engage some mob, see credit as Koru buffs other PCs

<!-- Clear and detailed steps to test your changes here -->
