### PR TITLE
fix: Trust RoE nullptr check, New Adventurer Flag

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2018,7 +2018,10 @@ void CBattleEntity::OnCastFinished(CMagicState& state, action_t& action)
         auto* PEminenceTarget = this;
         if (const auto* PTrust = dynamic_cast<CTrustEntity*>(this))
         {
-            PEminenceTarget = static_cast<CBattleEntity*>(PTrust->PMaster);
+            if (PTrust->PMaster)
+            {
+                PEminenceTarget = static_cast<CBattleEntity*>(PTrust->PMaster);
+            }
         }
 
         if (PEminenceTarget == PTarget || // Casting on self or ally

--- a/src/map/packets/c2s/0x0dc_config.cpp
+++ b/src/map/packets/c2s/0x0dc_config.cpp
@@ -92,7 +92,7 @@ void GP_CLI_COMMAND_CONFIG::process(MapSession* PSession, CCharEntity* PChar) co
     // Flag set if the client has disabled the 'New Adventurer' status. (Red question mark.)
     if (NewAdventurerOffFlg && PChar->playerConfig.NewAdventurerOffFlg != value)
     {
-        if (PChar->playerConfig.NewAdventurerOffFlg) // Can only turn it off, not on.
+        if (!PChar->playerConfig.NewAdventurerOffFlg) // Can only turn it off, not on.
         {
             updated                                 = true;
             PChar->playerConfig.NewAdventurerOffFlg = value;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Quick bugfix for yesterday's PR... turns out PMaster can be null before a trust completes a cast
  - This happens if you zone while a trust is casting, which tells me there's something wrong with the destruction order but that's a much longer fix than I can afford right now
-  Reverse the conditional on New Adventurer flag in the config packet because confusingly its set to true when you want to disable the status

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Help Desk > Config > Disable New Adventurer Flag -> New Adventurer flag gone

<!-- Clear and detailed steps to test your changes here -->
