### PR TITLE
CLuaPetSkill::getMobHP, fix BST pets breath skills

### DIFF
--- a/scripts/specs/core/CMobSkill.lua
+++ b/scripts/specs/core/CMobSkill.lua
@@ -11,6 +11,11 @@ end
 
 ---@nodiscard
 ---@return integer
+function CMobSkill:getMobHP()
+end
+
+---@nodiscard
+---@return integer
 function CMobSkill:getMobHPP()
 end
 

--- a/scripts/specs/core/CPetSkill.lua
+++ b/scripts/specs/core/CPetSkill.lua
@@ -11,6 +11,11 @@ end
 
 ---@nodiscard
 ---@return integer
+function CPetSkill:getMobHP()
+end
+
+---@nodiscard
+---@return integer
 function CPetSkill:getMobHPP()
 end
 

--- a/src/map/entities/petentity.cpp
+++ b/src/map/entities/petentity.cpp
@@ -508,6 +508,7 @@ void CPetEntity::OnPetSkillFinished(CPetSkillState& state, action_t& action)
     PSkill->setTotalTargets(targets);
     PSkill->setPrimaryTargetID(PTarget->id);
     PSkill->setTP(state.GetSpentTP());
+    PSkill->setHP(health.hp);
     PSkill->setHPP(GetHPP());
 
     uint16 msg            = 0;

--- a/src/map/lua/lua_petskill.cpp
+++ b/src/map/lua/lua_petskill.cpp
@@ -111,6 +111,11 @@ float CLuaPetSkill::getTP()
     return static_cast<float>(m_PLuaPetSkill->getTP());
 }
 
+auto CLuaPetSkill::getMobHP() const -> uint8
+{
+    return m_PLuaPetSkill->getHP();
+}
+
 // Retrieves the Monsters HP% as it was at the start of mobskill
 uint8 CLuaPetSkill::getMobHPP()
 {
@@ -134,6 +139,7 @@ void CLuaPetSkill::Register()
     SOL_REGISTER("getPrimaryTargetID", CLuaPetSkill::getPrimaryTargetID);
     SOL_REGISTER("setFinalAnimationSub", CLuaPetSkill::setFinalAnimationSub);
     SOL_REGISTER("getTP", CLuaPetSkill::getTP);
+    SOL_REGISTER("getMobHP", CLuaPetSkill::getMobHP);
     SOL_REGISTER("getMobHPP", CLuaPetSkill::getMobHPP);
 }
 

--- a/src/map/lua/lua_petskill.h
+++ b/src/map/lua/lua_petskill.h
@@ -42,6 +42,7 @@ public:
     friend std::ostream& operator<<(std::ostream& out, const CLuaPetSkill& mobskill);
 
     float  getTP();
+    auto   getMobHP() const -> uint8;
     uint8  getMobHPP();
     uint16 getID();
     int16  getParam();

--- a/src/map/petskill.cpp
+++ b/src/map/petskill.cpp
@@ -40,6 +40,7 @@ CPetSkill::CPetSkill(uint16 id)
 , m_secondarySkillchain(0)
 , m_tertiarySkillchain(0)
 , m_TP(0)
+, m_HP(0)
 , m_HPP(0)
 , m_TotalTargets(1)
 , m_PrimaryTargetID(0)
@@ -154,6 +155,11 @@ void CPetSkill::setTP(int16 tp)
     m_TP = tp;
 }
 
+void CPetSkill::setHP(const int32 hp)
+{
+    m_HP = hp;
+}
+
 // Stores the Monsters HP% as it was at the start of mobskill
 void CPetSkill::setHPP(uint8 hpp)
 {
@@ -193,6 +199,11 @@ uint16 CPetSkill::getMobSkillID() const
 int16 CPetSkill::getTP() const
 {
     return m_TP;
+}
+
+auto CPetSkill::getHP() const -> int32
+{
+    return m_HP;
 }
 
 // Retrieves the Pet's HP% as it was at the start of mobskill

--- a/src/map/petskill.h
+++ b/src/map/petskill.h
@@ -52,6 +52,7 @@ public:
     uint16          getAoEMsg() const;
     uint16          getValidTargets() const;
     int16           getTP() const;
+    auto            getHP() const -> int32;
     uint8           getHPP() const;
     uint16          getTotalTargets() const;
     uint32          getPrimaryTargetID() const;
@@ -78,6 +79,7 @@ public:
     void setSkillFinishCategory(uint8 category);
     void setValidTargets(uint16 targ);
     void setTP(int16 tp);
+    void setHP(int32 hp);
     void setHPP(uint8 hpp);
     void setTotalTargets(uint16 targets);
     void setPrimaryTargetID(uint32 targid);
@@ -111,6 +113,7 @@ private:
     uint8           m_tertiarySkillchain;
 
     int16  m_TP;  // the tp at the time of finish readying (for scripts)
+    int32  m_HP;  // HP at the time of using mob skill (for scripts)
     uint8  m_HPP; // HPP at the time of using mob skill (for scripts)
     uint16 m_TotalTargets;
     uint32 m_PrimaryTargetID; // primary target ID


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Noticed pet breath skills (Discreet Louise / Dark Spore) were broken while testing Ready recast.

https://github.com/LandSandBoat/server/pull/8305/files#diff-65ce01b97890c1a998c02cd422974c422326c99da769f247c9757b5f5299dfbcR363

CLuaPetSkill did not expose getMobHP. I just aligned the implementation on how it's done for CMobSkill / CLuaMobSkill.

@UmeboshiXI fyi

## Steps to test these changes

!additem deepbed_soil
Call Beast / Ready etc.
