### PR TITLE
Fix rewards for Windurst Quest "Paying Lip Service"

### DIFF
--- a/scripts/zones/Windurst_Woods/npcs/Tapoh_Lihzeh.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Tapoh_Lihzeh.lua
@@ -68,10 +68,10 @@ entity.onEventFinish = function(player, csid, option, npc)
             player:addFame(xi.fameArea.WINDURST, 8)
         end
 
-        if option == 1 then
-            npcUtil.giveCurrency(player, 'gil', 150)
-        else
+        if option == 1 then -- remi_shell
             npcUtil.giveCurrency(player, 'gil', 200)
+        else -- beehive_chip
+            npcUtil.giveCurrency(player, 'gil', 150)
         end
 
         player:confirmTrade()


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes #8389

Fixes rewards for quest "Paying Lip Service". I also added comments for each option case.

## Steps to test these changes

Talk to Tapoh Lihzeh in Windurst Woods to start the quest if it hasn't been activated. You should receive a message saying she will pay 150 gil for 3 beehive chips and 200 gil for 2 remi shells.

Trade 3 beehive chips. You should receive 150 gil

<img width="1582" height="111" alt="FFXI - Paying Lip Service - Beehive Chips - Fixed" src="https://github.com/user-attachments/assets/a714a9ca-aba3-4455-b138-29750cdb6d78" />

Trade 2 remi shells. You should receive 200 gil

<img width="1583" height="102" alt="FFXI - Paying Lip Service - Remi Shells - Fixed" src="https://github.com/user-attachments/assets/0b26c85f-9b81-4bfd-80f7-2139e36731ee" />
