### PR TITLE
[lua] Fix wRatioCap PDIF functions

### DIFF
--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -471,7 +471,7 @@ xi.combat.physical.wRatioCapPC = function(wRatio, pDifFinalCap)
         pDifLowerCap = wRatio - 0.375
     end
 
-    return pDifUpperCap, pDifLowerCap
+    return pDifLowerCap, pDifUpperCap
 end
 
 -- wRatio cap for non-PCs
@@ -506,7 +506,7 @@ xi.combat.physical.wRatioCapOthers = function(wRatio, pDifFinalCap)
         pDifLowerCap = 1 + (1120 / 1024) * (wRatio - 1.59)
     end
 
-    return pDifUpperCap, pDifLowerCap
+    return pDifLowerCap, pDifUpperCap
 end
 
 -- WARNING: This function is used in src/utils/battleutils.cpp "GetDamageRatio" function.
@@ -620,7 +620,7 @@ xi.combat.physical.calculateMeleePDIF = function(actor, target, weaponType, wsAt
         -- This is also known as "pDIF spike"
         local sRatio = 0
 
-        if wRatio > 0.0 and wRatio < 1.75 then
+        if wRatio > 0.0 and wRatio < 0.75 then
             sRatio = -5 / 9 + (10 / 9) * wRatio
         elseif wRatio <= 1.3 then
             sRatio = 0.3


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The recent PDIF calculation change separated the cap calculations to separate functions. Those functions returned pDifUpperCap, pDifLowerCap, in that order, but were then cast to pDifLowerCap, pDifUpperCap. As a result, all PDIF calculations were always returning pDifUpperCap (before other adjustments).

In addition, there was a 1.75 where there should be a 0.75 in the spike PDIF chance calculation.

## Steps to test these changes

Smack and be smacked, see an appropriate variation in damage dealt and received
