### PR TITLE
[lua] Extend ENABLE_COP_ZONE_CAP to all CoP relevant zones

### DIFF
--- a/scripts/zones/Phomiuna_Aqueducts/Zone.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/Zone.lua
@@ -26,6 +26,10 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.afterZoneIn = function(player)
+    -- ZONE WIDE LEVEL RESTRICTION
+    if xi.settings.main.ENABLE_COP_ZONE_CAP == 1 then
+        player:addStatusEffect(xi.effect.LEVEL_RESTRICTION, 40, 0, 0)
+    end
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)

--- a/scripts/zones/Promyvion-Dem/Zone.lua
+++ b/scripts/zones/Promyvion-Dem/Zone.lua
@@ -44,6 +44,10 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.afterZoneIn = function(player)
+    -- ZONE WIDE LEVEL RESTRICTION
+    if xi.settings.main.ENABLE_COP_ZONE_CAP == 1 then
+        player:addStatusEffect(xi.effect.LEVEL_RESTRICTION, 30, 0, 0)
+    end
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)

--- a/scripts/zones/Promyvion-Holla/Zone.lua
+++ b/scripts/zones/Promyvion-Holla/Zone.lua
@@ -44,6 +44,10 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.afterZoneIn = function(player)
+    -- ZONE WIDE LEVEL RESTRICTION
+    if xi.settings.main.ENABLE_COP_ZONE_CAP == 1 then
+        player:addStatusEffect(xi.effect.LEVEL_RESTRICTION, 30, 0, 0)
+    end
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)

--- a/scripts/zones/Promyvion-Mea/Zone.lua
+++ b/scripts/zones/Promyvion-Mea/Zone.lua
@@ -44,6 +44,10 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.afterZoneIn = function(player)
+    -- ZONE WIDE LEVEL RESTRICTION
+    if xi.settings.main.ENABLE_COP_ZONE_CAP == 1 then
+        player:addStatusEffect(xi.effect.LEVEL_RESTRICTION, 30, 0, 0)
+    end
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)

--- a/scripts/zones/Promyvion-Vahzl/Zone.lua
+++ b/scripts/zones/Promyvion-Vahzl/Zone.lua
@@ -44,6 +44,10 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.afterZoneIn = function(player)
+    -- ZONE WIDE LEVEL RESTRICTION
+    if xi.settings.main.ENABLE_COP_ZONE_CAP == 1 then
+        player:addStatusEffect(xi.effect.LEVEL_RESTRICTION, 50, 0, 0)
+    end
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)

--- a/scripts/zones/Riverne-Site_A01/Zone.lua
+++ b/scripts/zones/Riverne-Site_A01/Zone.lua
@@ -26,6 +26,10 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.afterZoneIn = function(player)
+    -- ZONE WIDE LEVEL RESTRICTION
+    if xi.settings.main.ENABLE_COP_ZONE_CAP == 1 then
+        player:addStatusEffect(xi.effect.LEVEL_RESTRICTION, 40, 0, 0)
+    end
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)

--- a/scripts/zones/Riverne-Site_B01/Zone.lua
+++ b/scripts/zones/Riverne-Site_B01/Zone.lua
@@ -26,6 +26,10 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.afterZoneIn = function(player)
+    -- ZONE WIDE LEVEL RESTRICTION
+    if xi.settings.main.ENABLE_COP_ZONE_CAP == 1 then
+        player:addStatusEffect(xi.effect.LEVEL_RESTRICTION, 50, 0, 0)
+    end
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)

--- a/scripts/zones/Sacrarium/Zone.lua
+++ b/scripts/zones/Sacrarium/Zone.lua
@@ -28,6 +28,10 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.afterZoneIn = function(player)
+    -- ZONE WIDE LEVEL RESTRICTION
+    if xi.settings.main.ENABLE_COP_ZONE_CAP == 1 then
+        player:addStatusEffect(xi.effect.LEVEL_RESTRICTION, 50, 0, 0)
+    end
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- ENABLE_COP_ZONE_CAP only set caps for Pso'xja. This adds the level caps to all other relevant zones related to this setting.

## Steps to test these changes

- Enter one of the changed zones, see you get level capped.
