### PR TITLE
xi_map: --lazy / Lazy loaded zones

### DIFF
--- a/scripts/globals/interaction/interaction_global.lua
+++ b/scripts/globals/interaction/interaction_global.lua
@@ -8,33 +8,12 @@ InteractionGlobal.lookup = InteractionGlobal.lookup or InteractionLookup:new()
 InteractionGlobal.zones = InteractionGlobal.zones or {}
 
 -----------------------------------
--- Called during server init:
+-- Called during server and test init:
 -- [C++] do_init()
--- [C++] zoneutils::LoadZones()
 -- [C++] luautils::InitInteractionGlobal()
--- [Lua] InteractionGlobal.initZones(zoneIds)
+-- [Lua] InteractionGlobal.initZones(zoneMapping)
 -----------------------------------
-function InteractionGlobal.initZones(zoneIds)
-    -- Add the given zones to the zones table
-    for i = 1, #zoneIds do
-        local zone = GetZone(zoneIds[i])
-        if zone then
-            InteractionGlobal.zones[zoneIds[i]] = zone:getName()
-        end
-    end
-
-    InteractionGlobal.loadDefaultActions(false)
-    InteractionGlobal.loadContainers(false)
-end
-
------------------------------------
--- Alternative entrypoint not relying on loaded zones.
--- Called during xi_test init:
--- [C++] TestLuaEnvironment()
--- [C++] TestLuaEnvironment::initInteractionGlobal()
--- [Lua] InteractionGlobal.initZonesTest(zoneMapping)
------------------------------------
-function InteractionGlobal.initZonesTest(zoneMapping)
+function InteractionGlobal.initZones(zoneMapping)
     -- Add the given zones to the zones table
     for zoneId, zoneName in pairs(zoneMapping) do
         InteractionGlobal.zones[zoneId] = zoneName

--- a/scripts/specs/test/CSimulation.lua
+++ b/scripts/specs/test/CSimulation.lua
@@ -18,11 +18,6 @@ local CSimulation = {}
 function CSimulation:spawnPlayer(params)
 end
 
----@param zoneIds ...integer?
----@return nil
-function CSimulation:loadZone(zoneIds)
-end
-
 ---@param ... xi.tick? Task boundary types to advance to. Defaults to xi.tick.ZONE if none provided.
 ---@return nil
 function CSimulation:tick(...)

--- a/scripts/tests/missions/cop.lua
+++ b/scripts/tests/missions/cop.lua
@@ -71,11 +71,10 @@ describe('Chains of Promathia', function()
             player:gotoZone(xi.zone.HALL_OF_TRANSFERENCE)
             -- TODO: Not seeing 108 on the capture
             player.events:expect({ eventId = 108 })
-            xi.test.world:loadZone(xi.zone.PROMYVION_HOLLA)
-            player.entities:gotoAndTrigger('_0e3', { eventId = 160 })
-            -- Is ported to promyvion after event.
 
+            player.entities:gotoAndTrigger('_0e3', { eventId = 160 })
             player.assert:inZone(xi.zone.PROMYVION_HOLLA)
+
             -- 1st time entering gets a CS
             player.events:expect({ eventId = 50 })
 
@@ -93,22 +92,14 @@ describe('Chains of Promathia', function()
         it('should complete all three Promyvion battles and unlock teleports', function()
             player:addMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS)
             player:addKeyItem(xi.ki.LIGHT_OF_HOLLA)
-            --             player:setCharVar()
-            --             player:setVar('M[6][3]Prog', 1) -- set at end of last mission
-
-            -- TODO: Optional event not implemented?
-            -- player:gotoZone(xi.zone.RULUDE_GARDENS)
-            -- player.entities:gotoAndTrigger('Chapi_Galepilai', { eventId = 11 })
 
             -- entering next promy
             player:gotoZone(xi.zone.KONSCHTAT_HIGHLANDS)
+            -- Touching the telepoint will warp us to Hall of Transference and then Promyvion-Dem
             player.entities:gotoAndTrigger('Shattered_Telepoint')
-            player.events:expect({ eventId = 912 })
-
-            -- CS on entering promy
-            player:gotoZone(xi.zone.HALL_OF_TRANSFERENCE)
-            player:gotoZone(xi.zone.PROMYVION_DEM)
-            player.events:expect({ eventId = 51 })
+            player.events:expect({ eventId = 912 }) -- Hall of Transference
+            player.events:expect({ eventId = 51 })  -- Promyvion-Dem
+            player.assert:inZone(xi.zone.PROMYVION_DEM)
 
             -- Fight at BCNM
             player:gotoZone(xi.zone.SPIRE_OF_DEM)
@@ -121,15 +112,12 @@ describe('Chains of Promathia', function()
             player:gotoZone(xi.zone.TAHRONGI_CANYON)
             player.entities:gotoAndTrigger('Shattered_Telepoint', { eventId = 913, finishOption = 0 })
 
-            xi.test.world:loadZone(xi.zone.PROMYVION_MEA)
-
             -- event upon entering hall
+            player.assert:inZone(xi.zone.HALL_OF_TRANSFERENCE)
             player.events:expect({ eventId = 155 })
 
-            -- TODO: This whole Promyvion section is a mess
-            player:gotoZone(xi.zone.PROMYVION_MEA)
-
             -- Event upon entering promy
+            player:gotoZone(xi.zone.PROMYVION_MEA)
             player.events:expect({ eventId = 52 })
 
             -- enter and beat BCNM
@@ -137,13 +125,12 @@ describe('Chains of Promathia', function()
             player.bcnm:enter('_0l0', xi.battlefield.id.ANCIENT_FLAMES_BECKON_SPIRE_OF_MEA)
             player.bcnm:killMobs()
             player.bcnm:expectWin({ finishOption = 2 })
-            player.assert:hasKI(xi.ki.LIGHT_OF_MEA)
 
-            -- check if mission completes
+            -- Should have Light of Mea and be teleported to Lufaise Meadows
             player.assert:hasMission(xi.mission.log_id.COP, xi.mission.id.cop.AN_INVITATION_WEST)
+                :hasKI(xi.ki.LIGHT_OF_MEA)
+                :inZone(xi.zone.LUFAISE_MEADOWS)
 
-            -- Mission complete check if new teleports work
-            player:gotoZone(xi.zone.LUFAISE_MEADOWS)
             -- zone in cs
             player.events:expect({ eventId = 110 })
             player.entities:gotoAndTrigger('Swirling_Vortex', { eventId = 100 })
@@ -207,10 +194,6 @@ describe('Chains of Promathia', function()
             -- Sewer door needs this mission explicitly completed to trigger event
             player:addMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_LOST_CITY)
             player:completeMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_LOST_CITY)
-
-            -- setup mission
-            xi.test.world:loadZone(xi.zone.PHOMIUNA_AQUEDUCTS)
-
             player:addMission(xi.mission.log_id.COP, xi.mission.id.cop.DISTANT_BELIEFS)
 
             player:gotoZone(xi.zone.TAVNAZIAN_SAFEHOLD)
@@ -281,9 +264,6 @@ describe('Chains of Promathia', function()
 
             player:gotoZone(xi.zone.RIVERNE_SITE_A01)
             player.events:expect({ eventId = 100 })
-
-            -- Upcoming CS will dump us in Gustaberg
-            xi.test.world:loadZone(xi.zone.SOUTH_GUSTABERG)
 
             player:gotoZone(xi.zone.MONARCH_LINN)
             player.bcnm:enter('SD_Entrance', xi.battlefield.id.ANCIENT_VOWS)
@@ -516,8 +496,6 @@ describe('Chains of Promathia', function()
     describe('4-3 The Secrets of Worship', function()
         it('should complete the mission successfully', function()
             local ID = zones[xi.zone.SACRARIUM]
-            -- Misareaux CS will teleport us to Sacrarium
-            xi.test.world:loadZone(xi.zone.SACRARIUM)
 
             -- setup mission
             player:addMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_SECRETS_OF_WORSHIP)
@@ -529,6 +507,7 @@ describe('Chains of Promathia', function()
             player.entities:gotoAndTrigger('_0p8', { eventId = 9, finishOption = 1 })
 
             -- Player is now in Sacrarium
+            player.assert:inZone(xi.zone.SACRARIUM)
             player.entities:gotoAndTrigger('_0s8', { eventId = 6 })
 
             local qm3 = player.entities:get('qm_prof_3')
@@ -596,13 +575,11 @@ describe('Chains of Promathia', function()
 
             player:claimAndKillMob(golem)
 
-            xi.test.world:loadZone(xi.zone.PROMYVION_VAHZL)
             player.entities:gotoAndTrigger('_i99', { eventId = 2, finishOption = 1 })
-
             player.assert:inZone(xi.zone.PROMYVION_VAHZL)
             player.events:expect({ eventId = 50 })
             player.assert:hasMission(xi.mission.log_id.COP, xi.mission.id.cop.DESIRES_OF_EMPTINESS)
-            player.assert:hasKI(xi.ki.LIGHT_OF_VAHZL)
+                :hasKI(xi.ki.LIGHT_OF_VAHZL)
         end)
     end)
 
@@ -641,9 +618,9 @@ describe('Chains of Promathia', function()
             xi.test.world:skipTime(15)
             xi.test.world:tick()
             -- Player is sent to Beaucedine Glacier at end of event
-            xi.test.world:loadZone(xi.zone.BEAUCEDINE_GLACIER)
             player.bcnm:expectWin({ finishOption = 2 })
             player.events:expect({ eventId = 206 })
+            player.assert:inZone(xi.zone.BEAUCEDINE_GLACIER)
 
             player:gotoZone(xi.zone.METALWORKS)
             player.entities:gotoAndTrigger('Cid', { eventId = 850 })
@@ -1003,8 +980,6 @@ describe('Chains of Promathia', function()
 
             player:gotoZone(xi.zone.SEALIONS_DEN)
             player.entities:gotoAndTrigger('_0w0', { eventId = 32 })
-            -- Post BCNM will warp to AlTaieu
-            xi.test.world:loadZone(xi.zone.ALTAIEU)
 
             player.bcnm:enter('_0w0', xi.battlefield.id.WARRIORS_PATH)
             -- TODO: Tenzen can't be killed and causes this call to fail
@@ -1012,6 +987,7 @@ describe('Chains of Promathia', function()
             --             player.bcnm:expectWin({ finishOption = 2 })
             --             player.events:expect({ eventId = 1 })
             --
+            --             player.assert:inZone(xi.zone.ALTAIEU)
             --             player.assert:hasMission(xi.mission.log_id.COP, xi.mission.id.cop.GARDEN_OF_ANTIQUITY)
         end)
     end)

--- a/scripts/tests/missions/rotz.lua
+++ b/scripts/tests/missions/rotz.lua
@@ -384,11 +384,6 @@ describe('Rise of the Zilart', function()
             player:addMission(xi.mission.log_id.ZILART, xi.mission.id.zilart.THE_CELESTIAL_NEXUS)
 
             player:gotoZone(xi.zone.THE_CELESTIAL_NEXUS)
-
-            -- Upcoming CS will dump us in Hall of the Gods.
-            -- TODO: Figure out how we can smartly load it on demand.
-            xi.test.world:loadZone(xi.zone.HALL_OF_THE_GODS)
-
             player.bcnm:enter('_513', xi.battlefield.id.CELESTIAL_NEXUS)
 
             -- Phase 1

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1261,17 +1261,16 @@ namespace luautils
 
     void InitInteractionGlobal()
     {
-        auto initZones = lua["InteractionGlobal"]["initZones"];
+        auto       initZones   = lua["InteractionGlobal"]["initZones"];
+        sol::table zoneMapping = lua.create_table();
 
-        std::vector<uint16> zoneIds;
-        // clang-format off
-        zoneutils::ForEachZone([&zoneIds](const CZone* PZone)
+        // Build zoneId -> zoneName map
+        for (const auto& [zoneId, zoneName] : zoneutils::GetManagedZones())
         {
-            zoneIds.emplace_back(PZone->GetID());
-        });
-        // clang-format on
+            zoneMapping[zoneId] = zoneName;
+        }
 
-        const auto result = initZones(zoneIds);
+        const auto result = initZones(zoneMapping);
 
         if (!result.valid())
         {

--- a/src/map/map_application.cpp
+++ b/src/map/map_application.cpp
@@ -45,6 +45,11 @@ namespace
                 .name        = "--port",
                 .description = "Specify the port to bind to",
             },
+            ArgumentDefinition{
+                .name        = "--lazy",
+                .description = "Load zones on demand. For development only.",
+                .type        = ArgumentType::Flag,
+            },
         };
 
         return ApplicationConfig{
@@ -70,8 +75,9 @@ MapApplication::MapApplication(const int argc, char** argv)
         port = std::stoi(*maybePort);
     }
 
-    engineConfig_.inCI = Application::isRunningInCI();
-    engineConfig_.ipp  = IPP(ip, port);
+    engineConfig_.lazyZones = args().get<bool>("--lazy");
+    engineConfig_.inCI      = Application::isRunningInCI();
+    engineConfig_.ipp       = IPP(ip, port);
 }
 
 MapApplication::~MapApplication()

--- a/src/map/map_engine.cpp
+++ b/src/map/map_engine.cpp
@@ -298,10 +298,10 @@ void MapEngine::do_init()
         ShowInfo("./losmeshes/ directory isn't present or is empty");
     }
 
+    zoneutils::Initialize(mapIPP, engineConfig_.lazyZones, !engineConfig_.isTestServer);
+
     if (!engineConfig_.lazyZones)
     {
-        ShowInfo("do_init: loading zones");
-        zoneutils::LoadZoneList(mapIPP);
         instanceutils::LoadInstanceList(mapIPP);
         CTransportHandler::getInstance()->InitializeTransport(mapIPP);
     }

--- a/src/map/time_server.cpp
+++ b/src/map/time_server.cpp
@@ -169,6 +169,7 @@ int32 time_server(timer::time_point tick, CTaskManager::CTask* PTask)
     CTriggerHandler::getInstance()->triggerTimer();
     CTransportHandler::getInstance()->TransportTimer();
     instanceutils::CheckInstance();
+    zoneutils::ProcessLoadQueue();
     luautils::OnTimeServerTick();
     luautils::TryReloadFilewatchList();
     moduleutils::OnTimeServerTick();

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -905,6 +905,12 @@ namespace charutils
         PChar->health.mp = canRestore ? PChar->GetMaxMP() : MP;
         PChar->UpdateHealth();
 
+        // Lazy loading: ensure initial zone is loaded synchronously before OnZoneIn
+        if (zoneutils::IsLazyLoadingEnabled() && !zoneutils::GetZone(PChar->loc.destination))
+        {
+            zoneutils::LoadZones({ PChar->loc.destination });
+        }
+
         luautils::OnZoneIn(PChar);
         luautils::OnGameIn(PChar, zoning == 1);
 

--- a/src/map/utils/zoneutils.h
+++ b/src/map/utils/zoneutils.h
@@ -32,8 +32,24 @@ class CNpcEntity;
 
 namespace zoneutils
 {
+    namespace detail
+    {
+        struct LazyLoadState
+        {
+            bool               enabled{ false };
+            bool               asyncMode{ false };
+            std::set<uint16>   managedZones{};
+            std::queue<uint16> loadQueue{};
+        };
+    } // namespace detail
+
     void LoadZones(const std::vector<uint16>& zoneIds);
     void LoadZoneList(IPP mapIPP);
+    void Initialize(IPP mapIPP, bool lazyLoading, bool asyncMode);
+    void ProcessLoadQueue();
+    auto IsLazyLoadingEnabled() -> bool;
+    auto IsZoneReady(uint16 zoneId) -> bool;
+    auto GetManagedZones() -> std::vector<std::pair<uint16, std::string>>;
     void FreeZoneList();
     void InitializeWeather();
     void TOTDChange(vanadiel_time::TOTD TOTD);

--- a/src/map/zone_entities.h
+++ b/src/map/zone_entities.h
@@ -133,10 +133,10 @@ private:
     // Intermediate collections for use inside ZoneServer
     //
 
-    std::vector<CMobEntity*>   m_mobsToDelete;
-    std::vector<CNpcEntity*>   m_npcsToDelete;
-    std::vector<CPetEntity*>   m_petsToDelete;
-    std::vector<CTrustEntity*> m_trustsToDelete;
-    std::vector<CMobEntity*>   m_aggroableMobs;
-    std::vector<CCharEntity*>  m_charsToChangeZone;
+    std::vector<CMobEntity*>         m_mobsToDelete;
+    std::vector<CNpcEntity*>         m_npcsToDelete;
+    std::vector<CPetEntity*>         m_petsToDelete;
+    std::vector<CTrustEntity*>       m_trustsToDelete;
+    std::vector<CMobEntity*>         m_aggroableMobs;
+    std::unordered_set<CCharEntity*> m_charsToChangeZone;
 };

--- a/src/test/lua/helpers/lua_client_entity_pair_actions.cpp
+++ b/src/test/lua/helpers/lua_client_entity_pair_actions.cpp
@@ -21,6 +21,7 @@
 
 #include "lua/helpers/lua_client_entity_pair_actions.h"
 #include "common/logging.h"
+#include "enums/packet_c2s.h"
 #include "lua/helpers/lua_client_entity_pair_entities.h"
 #include "lua/helpers/lua_client_entity_pair_events.h"
 #include "lua/helpers/lua_client_entity_pair_packets.h"
@@ -57,7 +58,7 @@ void CLuaClientEntityPairActions::useSpell(CLuaBaseEntity* target, const SpellID
         return;
     }
 
-    const auto packet               = parent_->packets().createPacket(0x1A);
+    const auto packet               = parent_->packets().createPacket(PacketC2S::GP_CLI_COMMAND_ACTION);
     auto*      actionPacket         = packet->as<GP_CLI_COMMAND_ACTION>();
     actionPacket->UniqueNo          = target->getID();
     actionPacket->ActIndex          = target->getTargID();
@@ -82,7 +83,7 @@ void CLuaClientEntityPairActions::useWeaponskill(CLuaBaseEntity* target, const u
         return;
     }
 
-    const auto packet                 = parent_->packets().createPacket(0x1A);
+    const auto packet                 = parent_->packets().createPacket(PacketC2S::GP_CLI_COMMAND_ACTION);
     auto*      actionPacket           = packet->as<GP_CLI_COMMAND_ACTION>();
     actionPacket->UniqueNo            = target->getID();
     actionPacket->ActIndex            = target->getTargID();
@@ -107,7 +108,7 @@ void CLuaClientEntityPairActions::useAbility(CLuaBaseEntity* target, const ABILI
         return;
     }
 
-    const auto packet                = parent_->packets().createPacket(0x1A);
+    const auto packet                = parent_->packets().createPacket(PacketC2S::GP_CLI_COMMAND_ACTION);
     auto*      actionPacket          = packet->as<GP_CLI_COMMAND_ACTION>();
     actionPacket->UniqueNo           = target->getID();
     actionPacket->ActIndex           = target->getTargID();
@@ -132,12 +133,11 @@ void CLuaClientEntityPairActions::changeTarget(CLuaBaseEntity* target) const
         return;
     }
 
-    const auto packet = parent_->packets().createPacket(0x1A);
-
-    auto* actionPacket     = packet->as<GP_CLI_COMMAND_ACTION>();
-    actionPacket->UniqueNo = target->getID();
-    actionPacket->ActIndex = target->getTargID();
-    actionPacket->ActionID = static_cast<uint16>(GP_CLI_COMMAND_ACTION_ACTIONID::ChangeTarget);
+    const auto packet       = parent_->packets().createPacket(PacketC2S::GP_CLI_COMMAND_ACTION);
+    auto*      actionPacket = packet->as<GP_CLI_COMMAND_ACTION>();
+    actionPacket->UniqueNo  = target->getID();
+    actionPacket->ActIndex  = target->getTargID();
+    actionPacket->ActionID  = static_cast<uint16>(GP_CLI_COMMAND_ACTION_ACTIONID::ChangeTarget);
 
     parent_->packets().sendBasicPacket(*packet);
 }
@@ -157,7 +157,7 @@ void CLuaClientEntityPairActions::rangedAttack(CLuaBaseEntity* target) const
         return;
     }
 
-    const auto packet       = parent_->packets().createPacket(0x1A);
+    const auto packet       = parent_->packets().createPacket(PacketC2S::GP_CLI_COMMAND_ACTION);
     auto*      actionPacket = packet->as<GP_CLI_COMMAND_ACTION>();
     actionPacket->UniqueNo  = target->getID();
     actionPacket->ActIndex  = target->getTargID();
@@ -181,7 +181,7 @@ void CLuaClientEntityPairActions::useItem(CLuaBaseEntity* target, const uint8 sl
         return;
     }
 
-    const auto packet             = parent_->packets().createPacket(0x37);
+    const auto packet             = parent_->packets().createPacket(PacketC2S::GP_CLI_COMMAND_ITEM_USE);
     auto*      itemPacket         = packet->as<GP_CLI_COMMAND_ITEM_USE>();
     itemPacket->UniqueNo          = target->getID();
     itemPacket->ItemNum           = 0;
@@ -207,7 +207,7 @@ void CLuaClientEntityPairActions::trigger(CLuaBaseEntity* target, sol::optional<
         return;
     }
 
-    const auto packet       = parent_->packets().createPacket(0x1A);
+    const auto packet       = parent_->packets().createPacket(PacketC2S::GP_CLI_COMMAND_ACTION);
     auto*      actionPacket = packet->as<GP_CLI_COMMAND_ACTION>();
     actionPacket->UniqueNo  = target->getID();
     actionPacket->ActIndex  = target->getTargID();
@@ -235,7 +235,7 @@ void CLuaClientEntityPairActions::inviteToParty(CLuaBaseEntity* player) const
         return;
     }
 
-    const auto packet       = parent_->packets().createPacket(0x6E);
+    const auto packet       = parent_->packets().createPacket(PacketC2S::GP_CLI_COMMAND_GROUP_SOLICIT_REQ);
     auto*      invitePacket = packet->as<GP_CLI_COMMAND_GROUP_SOLICIT_REQ>();
     invitePacket->UniqueNo  = player->getID();
     invitePacket->ActIndex  = player->getTargID();
@@ -259,7 +259,7 @@ void CLuaClientEntityPairActions::formAlliance(CLuaBaseEntity* player) const
         return;
     }
 
-    const auto packet       = parent_->packets().createPacket(0x6E);
+    const auto packet       = parent_->packets().createPacket(PacketC2S::GP_CLI_COMMAND_GROUP_SOLICIT_REQ);
     auto*      invitePacket = packet->as<GP_CLI_COMMAND_GROUP_SOLICIT_REQ>();
     invitePacket->UniqueNo  = player->getID();
     invitePacket->ActIndex  = player->getTargID();
@@ -277,7 +277,7 @@ void CLuaClientEntityPairActions::formAlliance(CLuaBaseEntity* player) const
 
 void CLuaClientEntityPairActions::acceptPartyInvite() const
 {
-    const auto packet         = parent_->packets().createPacket(0x74);
+    const auto packet         = parent_->packets().createPacket(PacketC2S::GP_CLI_COMMAND_GROUP_SOLICIT_RES);
     auto*      responsePacket = packet->as<GP_CLI_COMMAND_GROUP_SOLICIT_RES>();
     responsePacket->Res       = static_cast<uint8>(GP_CLI_COMMAND_GROUP_SOLICIT_RES_RES::Accept);
 
@@ -315,9 +315,8 @@ void CLuaClientEntityPairActions::tradeNpc(const sol::object& npcQuery, const so
         return;
     }
 
-    const auto packet = parent_->packets().createPacket(0x36);
-
-    auto* tradePacket = packet->as<GP_CLI_COMMAND_ITEM_TRANSFER>();
+    const auto packet      = parent_->packets().createPacket(PacketC2S::GP_CLI_COMMAND_ITEM_TRANSFER);
+    auto*      tradePacket = packet->as<GP_CLI_COMMAND_ITEM_TRANSFER>();
 
     tradePacket->UniqueNo = npc.value().getID();
     tradePacket->ActIndex = npc.value().getTargID();

--- a/src/test/lua/helpers/lua_client_entity_pair_events.cpp
+++ b/src/test/lua/helpers/lua_client_entity_pair_events.cpp
@@ -23,6 +23,7 @@
 
 #include "common/logging.h"
 #include "common/lua.h"
+#include "enums/packet_c2s.h"
 #include "lua/helpers/lua_client_entity_pair_packets.h"
 #include "lua/lua_client_entity_pair.h"
 #include "lua/lua_simulation.h"
@@ -63,7 +64,7 @@ void CLuaClientEntityPairEvents::sendEventPacket(sol::optional<uint16> eventId, 
         return;
     }
 
-    const auto packet      = parent_->packets().createPacket(0x5B);
+    const auto packet      = parent_->packets().createPacket(PacketC2S::GP_CLI_COMMAND_EVENTEND);
     auto*      eventPacket = packet->as<GP_CLI_COMMAND_EVENTEND>();
 
     eventPacket->EndPara   = option.value_or(0);
@@ -150,7 +151,6 @@ void CLuaClientEntityPairEvents::expect(sol::table expectedEvent) const
     {
         if (const CLuaSimulation* simulation = parent_->simulation())
         {
-            simulation->skipTime(1);
             simulation->tick();
         }
 

--- a/src/test/lua/helpers/lua_client_entity_pair_packets.h
+++ b/src/test/lua/helpers/lua_client_entity_pair_packets.h
@@ -25,6 +25,7 @@
 #include <memory>
 #include <sol/sol.hpp>
 
+enum class PacketC2S : uint16_t;
 class CBasicPacket;
 class CLuaClientEntityPair;
 class CLuaClientEntityPairPackets
@@ -33,9 +34,9 @@ public:
     CLuaClientEntityPairPackets(CLuaClientEntityPair* parent);
     ~CLuaClientEntityPairPackets() = default;
 
-    auto createPacket(uint16 packetType) -> std::unique_ptr<CBasicPacket>;
+    auto createPacket(PacketC2S packetType) -> std::unique_ptr<CBasicPacket>;
     void sendBasicPacket(CBasicPacket& packet) const;
-    void send(uint16 packetId, const sol::object& ffiData, size_t ffiSize);
+    void send(PacketC2S packetId, const sol::object& ffiData, size_t ffiSize);
     void sendZonePackets();
 
     void parseIncoming();

--- a/src/test/lua/lua_client_entity_pair.cpp
+++ b/src/test/lua/lua_client_entity_pair.cpp
@@ -100,11 +100,6 @@ void CLuaClientEntityPair::gotoZone(ZONEID zoneId, sol::optional<sol::table> pos
 
     ShowInfoFmt("Player {} zoning to zone ID: {}", testChar_->entity()->getName(), zoneId);
 
-    if (zoneutils::GetZone(zoneId) == nullptr)
-    {
-        zoneutils::LoadZones({ zoneId });
-    }
-
     // SendToZone _only_ prepares the character for zoning.
     testChar_->entity()->loc.destination = zoneId;
     testChar_->entity()->status          = STATUS_TYPE::DISAPPEAR;

--- a/src/test/lua/lua_simulation.h
+++ b/src/test/lua/lua_simulation.h
@@ -57,7 +57,6 @@ public:
     CLuaSimulation(CLuaSimulation&&)                 = default;
     CLuaSimulation& operator=(CLuaSimulation&&)      = default;
 
-    void loadZone(sol::variadic_args va) const;
     void cleanClients(std::optional<ClientScope> scope = std::nullopt);
     void tick(std::optional<TickType> boundary = std::nullopt) const;
     void processClientUpdates() const;

--- a/src/test/test_lua_environment.cpp
+++ b/src/test/test_lua_environment.cpp
@@ -45,28 +45,6 @@ TestLuaEnvironment::TestLuaEnvironment(MockManager* mockManager)
 
     registerCoreLuaBindings();
     registerTestSpecificFunctions();
-    initInteractionGlobal();
-}
-
-// Load IF handlers through the alternative entrypoint
-void TestLuaEnvironment::initInteractionGlobal() const
-{
-    auto       initZones   = lua["InteractionGlobal"]["initZonesTest"];
-    sol::table zoneMapping = lua.create_table();
-
-    const auto rset = db::preparedStmt("SELECT zoneid, name FROM zone_settings");
-    FOR_DB_MULTIPLE_RESULTS(rset)
-    {
-        auto zoneId         = rset->get<uint16>("zoneid");
-        auto zoneName       = rset->get<std::string>("name");
-        zoneMapping[zoneId] = zoneName;
-    }
-
-    if (const auto result = initZones(zoneMapping); !result.valid())
-    {
-        const sol::error err = result;
-        ShowErrorFmt("luautils::InitInteractionGlobal: {}", err.what());
-    }
 }
 
 // Register core Lua bindings needed for tests

--- a/src/test/test_lua_environment.h
+++ b/src/test/test_lua_environment.h
@@ -28,7 +28,6 @@ public:
     explicit TestLuaEnvironment(MockManager* mockManager);
 
 private:
-    void         initInteractionGlobal() const;
     void         registerCoreLuaBindings() const;
     void         registerTestSpecificFunctions() const;
     MockManager* mockManager_;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

**Note: This is for development purposes only.**

- Adds `--lazy` flag to `xi_map`
- When set:
  - Will not load any zone on start but will collect the list of eligible zones in `zoneutils`
  - Will force load the PChar zone on first login (there's no way to delay that unfortunately)
  - Will delay subsequent zone-outs until the zones have been 1) queued 2) processed and loaded on next tick
- Changes the container for `charsToZoneOut` in zone_entities from vector to `unordered_set` - to ensure we're not collecting the same PChar on successive ticks while keeping O(1)
- Changes the way the `charsToZoneOut` container is cleared, from a loop and .clear() to `std::erase_if`

Zone-outs will feel slightly slower but not by a huge amount

Outstanding:
- While the logic is essentially no-op if not lazy loading, I would like to wrap the changes around conditionals but I haven't found a good way to signal to the namespaces they have to operate in different conditions and I don't want to change their signature and/or use globals
- I need to go through xi_test and see if I can probably remove some of the xi_test specific logic
- I'll have to retest IF but this is more or less a 1:1 of xi_test workflow so I'm relatively confident about it
- Watchdog may cause problems if running without a debugger but not sure if that matters too much for development workflows

## Steps to test these changes
xi_map --lazy

<!-- Clear and detailed steps to test your changes here -->
