### PR TITLE
[lua] Era module: CoP battlefield level caps

### DIFF
--- a/modules/era/lua/missions/cop_level_caps.lua
+++ b/modules/era/lua/missions/cop_level_caps.lua
@@ -1,0 +1,54 @@
+-----------------------------------
+-- CoP Mission Battlefield Level Caps Module
+-- Implements era-appropriate level caps for all CoP mission battlefields
+-- Level caps were removed May 2010
+-----------------------------------
+local m = Module:new('cop_level_caps')
+
+-- Apply level caps after server initialization when all battlefields are loaded
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    local battlefields =
+    {
+        -- Level 30 Battlefields
+        { xi.battlefield.id.ANCIENT_FLAMES_BECKON_SPIRE_OF_HOLLA, 30 },
+        { xi.battlefield.id.ANCIENT_FLAMES_BECKON_SPIRE_OF_DEM,   30 },
+        { xi.battlefield.id.ANCIENT_FLAMES_BECKON_SPIRE_OF_MEA,   30 },
+
+        -- Level 40 Battlefields
+        { xi.battlefield.id.DARKNESS_NAMED,                       40 },
+        { xi.battlefield.id.ANCIENT_VOWS,                         40 },
+
+        -- Level 50 Battlefields
+        { xi.battlefield.id.SAVAGE,                               50 },
+        { xi.battlefield.id.DESIRES_OF_EMPTINESS,                 50 },
+        { xi.battlefield.id.HEAD_WIND,                            50 },
+
+        -- Level 60 Battlefields
+        { xi.battlefield.id.ONE_TO_BE_FEARED,                     60 },
+        { xi.battlefield.id.FLAMES_FOR_THE_DEAD,                  60 },
+        { xi.battlefield.id.CENTURY_OF_HARDSHIP,                  60 },
+
+        -- Level 65 Battlefields
+        { xi.battlefield.id.CELESTIAL_NEXUS,                      65 },
+
+        -- Level 75 Battlefields
+        { xi.battlefield.id.WARRIORS_PATH,                        75 },
+        { xi.battlefield.id.WHEN_ANGELS_FALL,                     75 },
+        { xi.battlefield.id.DAWN,                                 75 },
+    }
+
+    -- Apply level caps to each battlefield
+    for _, battlefieldData in pairs(battlefields) do
+        local battlefieldId = battlefieldData[1]
+        local levelCap = battlefieldData[2]
+
+        local battlefield = xi.battlefield.contents[battlefieldId]
+        if battlefield then
+            battlefield.levelCap = levelCap
+        end
+    end
+end)
+
+return m


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds module to apply level caps to CoP related battlefields.
- Added all battlefields even if not currently needed to future proof in case they are updated.

## Steps to test these changes

- Enter "One To Be Feared" (currently 75 cap), see that your level is set to 60.
