### PR TITLE
[lua] Fix edge case where def down multiplier can zero defense

### DIFF
--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -551,7 +551,7 @@ xi.combat.physical.calculateMeleePDIF = function(actor, target, weaponType, wsAt
     if tpIgnoresDefense then
         local ignoreDefenseFactor = 1 - tpFactor
 
-        targetDefense = math.floor(targetDefense * ignoreDefenseFactor)
+        targetDefense = math.max(1, math.floor(targetDefense * ignoreDefenseFactor))
     end
 
     if isCannonball then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

There is an edge case where super low DEF * the mult can result in 0 DEF, at which point wRatio is 0 when it shouldn't be

## Steps to test these changes

wheeling thrust a mob with 3k tp, see non-zero wRatio