### PR TITLE
[core] Attempt to fix worm roaming edge case after popping back up

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -1103,14 +1103,26 @@ void CMobController::DoRoamTick(timer::time_point tick)
                         // don't reset m_LastActionTime until the roaming commences
                         if (!PMob->PAI->IsCurrentState<CMagicState>())
                         {
-                            // move down
-                            PMob->animationsub = 1;
-                            PMob->HideName(true);
-                            PMob->SetUntargetable(true);
-
                             // don't move around until i'm fully in the ground
                             // Transition underground takes 2s, allow extra time for any magic effect to finish
-                            Wait(3s);
+                            Wait(4s);
+
+                            // clang-format off
+                            PMob->PAI->QueueAction(queueAction_t(2s, false, [](CBaseEntity* MobEntity)
+                            {
+                                if (auto PMob = dynamic_cast<CMobEntity*>(MobEntity))
+                                {
+                                    // move down
+                                    PMob->animationsub = 1;
+                                    PMob->HideName(true);
+                                    PMob->SetUntargetable(true);
+                                }
+
+                                MobEntity->loc.zone->UpdateEntityPacket(MobEntity, ENTITY_UPDATE, UPDATE_POS | UPDATE_HP);
+                            }));
+                            // clang-format on
+
+                            PMob->loc.zone->UpdateEntityPacket(PMob, ENTITY_UPDATE, UPDATE_POS | UPDATE_HP);
                         }
                     }
                     else if (PMob->PAI->PathFind->RoamAround(PMob->m_SpawnPoint, PMob->GetRoamDistance(), static_cast<uint8>(PMob->getMobMod(MOBMOD_ROAM_TURNS)), PMob->m_roamFlags))
@@ -1191,10 +1203,15 @@ void CMobController::FollowRoamPath()
                 // don't re-enter this block, but don't roam until emerging
                 PMob->SetUntargetable(false);
                 Wait(2s);
+
+                // clang-format off
                 PMob->PAI->QueueAction(queueAction_t(2s, false, [](CBaseEntity* MobEntity)
-                                                     {
+                {
                     MobEntity->animationsub = 0;
-                    MobEntity->HideName(false); }));
+                    MobEntity->HideName(false);
+                    MobEntity->loc.zone->UpdateEntityPacket(MobEntity, ENTITY_UPDATE, UPDATE_POS | UPDATE_HP);
+                }));
+                // clang-format on
             }
 
             // face spawn rotation if I just moved back to spawn


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
There have been reports of Worms in Einherjar not surfacing/being untargetable until they walk 50' and  come back in. I assume there is some conflict with hideName(false) etc being sent out with the update flags possibly being changed along the way. So, forcefully send POS & HP update to surrounding players.

## Steps to test these changes

watch Worms pop in/out with no issue