### PR TITLE
[lua] Stop Solby-Maholby (shop) and Ruillont from facing the player when talked to

### DIFF
--- a/scripts/zones/Norg/npcs/Solby-Maholby.lua
+++ b/scripts/zones/Norg/npcs/Solby-Maholby.lua
@@ -25,7 +25,7 @@ entity.onTrigger = function(player, npc)
         { xi.item.SCROLL_OF_SUITON_SAN,    125212 },
     }
 
-    player:showText(npc, zones[xi.zone.NORG].text.SOLBYMAHOLBY_SHOP_DIALOG)
+    player:showText(npc, zones[xi.zone.NORG].text.SOLBYMAHOLBY_SHOP_DIALOG, 0, 0, 0, 0, true, false)
     xi.shop.general(player, stock)
 end
 

--- a/scripts/zones/Ordelles_Caves/npcs/Ruillont.lua
+++ b/scripts/zones/Ordelles_Caves/npcs/Ruillont.lua
@@ -12,9 +12,9 @@ local entity = {}
 entity.onTrigger = function(player, npc)
     -- Ruillont Default Actions vary based on Nation
     if player:getNation() == xi.nation.SANDORIA then
-        player:showText(npc, ID.text.RUILLONT_INITIAL_DIALOG + 2)
+        player:showText(npc, ID.text.RUILLONT_INITIAL_DIALOG + 2, 0, 0, 0, 0, true, false)
     else
-        player:showText(npc, ID.text.RUILLONT_INITIAL_DIALOG + 1)
+        player:showText(npc, ID.text.RUILLONT_INITIAL_DIALOG + 1, 0, 0, 0, 0, true, false)
     end
 end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Makes it to where the NPCs won't face away from their default facing direction when interacted with,

## Steps to test these changes

1. `!zone <Norg>`
2. Talk to Solby-Maholby
3. `!zone <Ordelles Caves>`
4. Talk to Ruillont 

Current LSB
<img width="781" height="364" alt="image" src="https://github.com/user-attachments/assets/d7454790-d81b-492a-80af-bf821a6e17c1" />

Retail
<img width="692" height="477" alt="image" src="https://github.com/user-attachments/assets/41208d24-d3ac-4500-901e-55a49e00ee61" />

