### PR TITLE
[core] Set ecosystem-killer for Jugs and Wyvern pet

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -6937,4 +6937,53 @@ namespace battleutils
         }
         return 1.0;
     }
+
+    void addEcosystemKillerEffects(CBattleEntity* PBattleEntity)
+    {
+        // Killer Effect
+        switch (PBattleEntity->m_EcoSystem)
+        {
+            case ECOSYSTEM::AMORPH:
+                PBattleEntity->addModifier(Mod::BIRD_KILLER, 5);
+                break;
+            case ECOSYSTEM::AQUAN:
+                PBattleEntity->addModifier(Mod::AMORPH_KILLER, 5);
+                break;
+            case ECOSYSTEM::ARCANA:
+                PBattleEntity->addModifier(Mod::UNDEAD_KILLER, 5);
+                break;
+            case ECOSYSTEM::BEAST:
+                PBattleEntity->addModifier(Mod::LIZARD_KILLER, 5);
+                break;
+            case ECOSYSTEM::BIRD:
+                PBattleEntity->addModifier(Mod::AQUAN_KILLER, 5);
+                break;
+            case ECOSYSTEM::DEMON:
+                PBattleEntity->addModifier(Mod::DRAGON_KILLER, 5);
+                break;
+            case ECOSYSTEM::DRAGON:
+                PBattleEntity->addModifier(Mod::DEMON_KILLER, 5);
+                break;
+            case ECOSYSTEM::LIZARD:
+                PBattleEntity->addModifier(Mod::VERMIN_KILLER, 5);
+                break;
+            case ECOSYSTEM::LUMINION:
+                PBattleEntity->addModifier(Mod::LUMINIAN_KILLER, 5);
+                break;
+            case ECOSYSTEM::LUMINIAN:
+                PBattleEntity->addModifier(Mod::LUMINION_KILLER, 5);
+                break;
+            case ECOSYSTEM::PLANTOID:
+                PBattleEntity->addModifier(Mod::BEAST_KILLER, 5);
+                break;
+            case ECOSYSTEM::UNDEAD:
+                PBattleEntity->addModifier(Mod::ARCANA_KILLER, 5);
+                break;
+            case ECOSYSTEM::VERMIN:
+                PBattleEntity->addModifier(Mod::PLANTOID_KILLER, 5);
+                break;
+            default:
+                break;
+        }
+    }
 }; // namespace battleutils

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -273,5 +273,6 @@ namespace battleutils
     CBattleEntity* GetCoverAbilityUser(CBattleEntity* PCoverAbilityTarget, CBattleEntity* PMob);
     bool           IsMagicCovered(CCharEntity* PCoverAbilityUser);
     void           ConvertDmgToMP(CBattleEntity* PDefender, int32 damage, bool IsCovered);
+    void           addEcosystemKillerEffects(CBattleEntity* PBattleEntity);
     float          CheckLiementAbsorb(CBattleEntity* PBattleEntity, DAMAGE_TYPE DamageType);
 }; // namespace battleutils

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -1376,51 +1376,7 @@ namespace mobutils
         PMob->defaultMobMod(MOBMOD_SOUND_RANGE, (int16)CMobEntity::sound_range);
         PMob->defaultMobMod(MOBMOD_MAGIC_RANGE, (int16)CMobEntity::magic_range);
 
-        // Killer Effect
-        switch (PMob->m_EcoSystem)
-        {
-            case ECOSYSTEM::AMORPH:
-                PMob->addModifier(Mod::BIRD_KILLER, 5);
-                break;
-            case ECOSYSTEM::AQUAN:
-                PMob->addModifier(Mod::AMORPH_KILLER, 5);
-                break;
-            case ECOSYSTEM::ARCANA:
-                PMob->addModifier(Mod::UNDEAD_KILLER, 5);
-                break;
-            case ECOSYSTEM::BEAST:
-                PMob->addModifier(Mod::LIZARD_KILLER, 5);
-                break;
-            case ECOSYSTEM::BIRD:
-                PMob->addModifier(Mod::AQUAN_KILLER, 5);
-                break;
-            case ECOSYSTEM::DEMON:
-                PMob->addModifier(Mod::DRAGON_KILLER, 5);
-                break;
-            case ECOSYSTEM::DRAGON:
-                PMob->addModifier(Mod::DEMON_KILLER, 5);
-                break;
-            case ECOSYSTEM::LIZARD:
-                PMob->addModifier(Mod::VERMIN_KILLER, 5);
-                break;
-            case ECOSYSTEM::LUMINION:
-                PMob->addModifier(Mod::LUMINIAN_KILLER, 5);
-                break;
-            case ECOSYSTEM::LUMINIAN:
-                PMob->addModifier(Mod::LUMINION_KILLER, 5);
-                break;
-            case ECOSYSTEM::PLANTOID:
-                PMob->addModifier(Mod::BEAST_KILLER, 5);
-                break;
-            case ECOSYSTEM::UNDEAD:
-                PMob->addModifier(Mod::ARCANA_KILLER, 5);
-                break;
-            case ECOSYSTEM::VERMIN:
-                PMob->addModifier(Mod::PLANTOID_KILLER, 5);
-                break;
-            default:
-                break;
-        }
+        battleutils::addEcosystemKillerEffects(PMob);
 
         if (PMob->m_maxLevel == 0 && PMob->m_minLevel == 0)
         {

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1861,6 +1861,12 @@ namespace petutils
         PPet->status        = STATUS_TYPE::NORMAL;
         PPet->m_ModelRadius = PPetData->radius;
         PPet->m_EcoSystem   = PPetData->EcoSystem;
+
+        if (PPet->getPetType() == PET_TYPE::WYVERN || PPet->getPetType() == PET_TYPE::JUG_PET)
+        {
+            battleutils::addEcosystemKillerEffects(PPet);
+        }
+
         // set the damage type of the pet
         static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setDmgType(PPetData->m_dmgType);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds the Ecosystem-killer effects to jugs and wyverns

Retail proof (for wyverns at least):
vs a demon, no /SAM (so no wyrm mail giving Demon Killer)
<img width="409" height="33" alt="image" src="https://github.com/user-attachments/assets/be056f06-5885-491e-ad1c-449cf14c9cb8" />

Jug pets are simply assumed, and could be removed due to lack of proof.

## Steps to test these changes

<img width="414" height="341" alt="image" src="https://github.com/user-attachments/assets/822eeef9-83f3-479f-879e-54db8127c1fe" />