### PR TITLE
change HQ rates of normal synthesis

### DIFF
--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -589,11 +589,11 @@ namespace synthutils
                 case 3: // 1 in 4
                     chanceHQ = 25.0f;
                     break;
-                case 2: // 1 in 20
-                    chanceHQ = 5.0f;
+                case 2: // 1 in 16
+                    chanceHQ = 6.25f;
                     break;
-                case 1: // 1 in 100
-                    chanceHQ = 1.0f;
+                case 1: // 1 in 64
+                    chanceHQ = 1.5625f;
                     break;
                 default: // No chance
                     chanceHQ = 0.0f;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
This wasn't as exciting as I was hoping, but this is at least keeping PRs simple and separate from each other.

[t1.csv](https://github.com/user-attachments/files/22921065/t1.csv)
1. The initial 110 or so data points (timestamp 0) are from my previous janky methodology of capturing data points
2. Some filtering will have to be done because of duplicate packets sent, but just searching for strings (Break, Normal Quality, High-Quality) get you the raw numbers you want, and will not include duplicate packets
3. (fun fact) After material loss, the lost material will be continuously sent in subsequent success packets

Dupe packets look like the following:
```
1758846598,0,Success,0,4,16992,Slice of Bluetail,4098,Wind Crystal,8905,Cook. Kit 15,0,,0,,0,,0,,0,,0,,0,,8905,Cook. Kit 15,0,,0,,0,,0,,0,,0,,0,,56,0,0,0,0,0,0,0,17,0,Normal Quality,44,0
1758846598,0,Success,0,4,16992,Slice of Bluetail,4098,Wind Crystal,8905,Cook. Kit 15,0,,0,,0,,0,,0,,0,,0,,8905,Cook. Kit 15,0,,0,,0,,0,,0,,0,,0,,56,0,0,0,0,0,0,0,0,0,,0,0
```

Gloin's raw #s: 
`Stats: Failures 659 Items Lost 1336 NQ 12110 HQ1 191 HQ2 0 HQ3 0 HQs 191`
Source:
https://canary.discord.com/channels/933423693848260678/1294029373690875925/1303512424476840038 (Horizon Discord)
<img width="392" height="530" alt="image" src="https://github.com/user-attachments/assets/ecd33fc6-0136-4827-9f87-bef9fa2d3019" />
wald analysis

Based off of ~10k T1 synths gathered by myself and ~12k T0 synths gathered by Gloin, HQ rates more closely resemble 1/16 for T1 and 1/64 for T0.

T0 data:
659 Break
12110 NQ
191 HQ

This is 0.01552 with a 95% CI of 0.01349 to 0.01786

T1 data:
510 Break
8970 NQ
615 HQ

This is 0.0687 with a CI of .0620 to .0758, which 1/16 fits into.
I do have the honest belief that I got a bit lucky during this testing (and removing the 110 data points _prior_ to capturing with captain I actually have a rate of 0.0638, but data is data!), leading to being on the higher end of the rates, and a 1/2 1/4 1/16 1/64 HQ tiering paradigm makes sense and does agree with era data.

Feel free to ask me to provide the .csv from capturing T1 data, happy to provide it.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
