### PR TITLE
[ci] Use tee with clang-tidy so output can be seen in real time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -309,7 +309,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y software-properties-common cmake libmariadb-dev-compat libluajit-5.1-dev libzmq3-dev zlib1g-dev libssl-dev binutils-dev
+          sudo apt-get install -y software-properties-common cmake libmariadb-dev-compat libluajit-5.1-dev libzmq3-dev zlib1g-dev libssl-dev binutils-dev coreutils
       - name: Cache 'build' folder
         uses: actions/cache@v4
         with:
@@ -324,7 +324,8 @@ jobs:
       - name: Build
         run: |
           touch clang-tidy.txt
-          cmake --build build -j4 >> clang-tidy.txt || true
+          # Redirect stderr (2) to stdout (1) so that `tee` picks it up and writes to disk
+          cmake --build build -j4 2>&1 | tee clang-tidy.txt || true
           cat clang-tidy.txt
           if grep -q warning\|error clang-tidy.txt; then
               exit 1


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

clang-tidy was running without any output to the user during a CI run
Instead of writing to disk only, use [coreutils tee](https://www.man7.org/linux/man-pages/man1/tee.1.html) to also write to stdout.
Additionally, due to the fact that tee only logs stderr, redirect stderr to stdout on the cmake call.

## Steps to test these changes

CI runs correctly