### PR TITLE
[core] Yet another blackscreen fix

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -2409,7 +2409,7 @@ void CCharEntity::OnDeathTimer()
     TracyZoneScoped;
 
     charutils::SetCharVar(this, "expLost", 0);
-    charutils::HomePoint(this, true);
+    requestedWarp = true; // zone entities will warp us on the next tick
 }
 
 void CCharEntity::OnRaise()

--- a/src/map/ipc_client.cpp
+++ b/src/map/ipc_client.cpp
@@ -897,7 +897,7 @@ void IPCClient::handleMessage_EntityInformationResponse(const IPP& ipp, const ip
 
             PChar->clearPacketList();
 
-            charutils::SendToZone(PChar, PChar->loc.destination);
+            PChar->requestedZoneChange = true;
         }
     }
 }
@@ -924,7 +924,7 @@ void IPCClient::handleMessage_SendPlayerToLocation(const IPP& ipp, const ipc::Se
 
         PChar->clearPacketList();
 
-        charutils::SendToZone(PChar, PChar->loc.destination);
+        PChar->requestedWarp = true;
     }
 }
 

--- a/src/map/map_networking.cpp
+++ b/src/map/map_networking.cpp
@@ -639,7 +639,7 @@ int32 MapNetworking::send_parse(uint8* buff, size_t* buffsize, MapSession* map_s
                 }
 
                 // Store zoneout packet in case we need to re-send this
-                if (type == 0x00B && map_session_data->blowfish.status == BLOWFISH_PENDING_ZONE && map_session_data->zone_ipp.getRawIPP() == 0)
+                if (type == 0x00B)
                 {
                     const auto IPPacket = static_cast<GP_SERV_COMMAND_LOGOUT*>(PSmallPacket.get());
 
@@ -774,6 +774,7 @@ int32 MapNetworking::send_parse(uint8* buff, size_t* buffsize, MapSession* map_s
             });
         }
 
+        map_session_data->blowfish.status = BLOWFISH_PENDING_ZONE;
         PChar->PSession->PChar.reset(); // destroy PChar
     }
 

--- a/src/map/monstrosity.cpp
+++ b/src/map/monstrosity.cpp
@@ -599,7 +599,8 @@ void monstrosity::HandleDeathMenu(CCharEntity* PChar, const GP_CLI_COMMAND_ACTIO
 
         // Restart this zone with Gestation effect
         PChar->loc.destination = PChar->loc.zone->GetID();
-        charutils::SendToZone(PChar, PChar->loc.destination);
+
+        PChar->requestedZoneChange = true;
     }
 }
 

--- a/src/map/packets/c2s/0x00a_login.cpp
+++ b/src/map/packets/c2s/0x00a_login.cpp
@@ -81,7 +81,7 @@ void GP_CLI_COMMAND_LOGIN::process(MapSession* PSession, CCharEntity* PChar) con
             // TODO: work out how to drop player in moghouse that exits them to the zone they were in before this happened, like we used to.
             ShowWarning("GP_CLI_COMMAND_LOGIN: player tried to enter zone that was invalid or out of range");
             ShowWarning("GP_CLI_COMMAND_LOGIN: dumping player `%s` to homepoint!", PChar->getName());
-            charutils::HomePoint(PChar, true);
+            PChar->requestedWarp = true; // Not a "request" but a demand
             return;
         }
 

--- a/src/map/packets/c2s/0x01a_action.cpp
+++ b/src/map/packets/c2s/0x01a_action.cpp
@@ -251,7 +251,7 @@ void GP_CLI_COMMAND_ACTION::process(MapSession* PSession, CCharEntity* PChar) co
             }
 
             PChar->setCharVar("expLost", 0);
-            charutils::HomePoint(PChar, true);
+            PChar->requestedWarp = true;
         }
         break;
         case GP_CLI_COMMAND_ACTION_ACTIONID::Assist:

--- a/src/map/packets/c2s/0x01a_action.cpp
+++ b/src/map/packets/c2s/0x01a_action.cpp
@@ -355,7 +355,8 @@ void GP_CLI_COMMAND_ACTION::process(MapSession* PSession, CCharEntity* PChar) co
                 PChar->status          = STATUS_TYPE::DISAPPEAR;
                 PChar->loc.boundary    = 0;
                 PChar->clearPacketList();
-                charutils::SendToZone(PChar, PChar->loc.destination);
+
+                PChar->requestedZoneChange = true;
             }
 
             PChar->m_hasTractor = 0;

--- a/src/map/packets/c2s/0x0cb_myroom_is.cpp
+++ b/src/map/packets/c2s/0x0cb_myroom_is.cpp
@@ -124,7 +124,7 @@ void GP_CLI_COMMAND_MYROOM_IS::process(MapSession* PSession, CCharEntity* PChar)
                 PChar->status          = STATUS_TYPE::DISAPPEAR;
 
                 PChar->clearPacketList();
-                charutils::SendToZone(PChar, zoneid);
+                PChar->requestedZoneChange = true;
             }
         }
         break;

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -6795,7 +6795,7 @@ namespace charutils
 
         PChar->clearPacketList();
 
-        SendToZone(PChar, PChar->loc.destination);
+        PChar->requestedZoneChange = true;
     }
 
     void HomePoint(CCharEntity* PChar, bool resetHPMP)

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -1981,7 +1981,7 @@ void CZoneEntities::ZoneServer(timer::time_point tick)
             }
 
             PChar->clearPacketList();
-            charutils::HomePoint(PChar, false);
+            charutils::HomePoint(PChar, PChar->isDead());
         }
         else if (PChar->loc.destination != 0xFFFF)
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

It seems there is/was some race condition for zoning out where BLOWFISH_PENDING_ZONE was not set in our blowfish struct.

Additionally, homepointing was not using the correct codepath to zone.

## Steps to test these changes

`/load packetflow`
`/fps 1`

`!hp 0 <me>` and homepoint a lot
don't blackscreen

test the following:
`!goto <me>`
`!bring <me>`
MH 2nd floor
!monstrosity toggle/feterory
tractor