### PR TITLE
[lua] City Missions 2-3 Add Immunities to Dragons + Add missing KI text

### DIFF
--- a/scripts/missions/windurst/2_3_0_The_Three_Kingdoms.lua
+++ b/scripts/missions/windurst/2_3_0_The_Three_Kingdoms.lua
@@ -111,7 +111,7 @@ mission.sections =
 
                             return mission:progressEvent(95, 0, 0, 0, xi.ki.LETTER_TO_THE_CONSULS_WINDURST, 0, 0, 0, needsSemihTrust)
                         else
-                            return mission:progressEvent(95)
+                            return mission:progressEvent(95, 0, 0, 0, xi.ki.LETTER_TO_THE_CONSULS_WINDURST)
                         end
                     elseif missionStatus == 11 then
                         return mission:progressEvent(101, 0, 0, xi.ki.ADVENTURERS_CERTIFICATE)

--- a/scripts/zones/Balgas_Dais/mobs/Black_Dragon.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Black_Dragon.lua
@@ -8,6 +8,12 @@ mixins = { require('scripts/mixins/draw_in') }
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    mob:addImmunity(xi.immunity.PARALYZE)
+    mob:addImmunity(xi.immunity.POISON)
+    mob:addImmunity(xi.immunity.SLOW)
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     player:addTitle(xi.title.BLACK_DRAGON_SLAYER)
 end

--- a/scripts/zones/Horlais_Peak/mobs/Dread_Dragon.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Dread_Dragon.lua
@@ -8,6 +8,10 @@ mixins = { require('scripts/mixins/draw_in') }
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    mob:addImmunity(xi.immunity.PARALYZE)
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     player:addTitle(xi.title.DREAD_DRAGON_SLAYER)
 end

--- a/scripts/zones/Waughroon_Shrine/mobs/Dark_Dragon.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Dark_Dragon.lua
@@ -8,6 +8,12 @@ mixins = { require('scripts/mixins/draw_in') }
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    mob:addImmunity(xi.immunity.GRAVITY)
+    mob:addImmunity(xi.immunity.PARALYZE)
+    mob:addImmunity(xi.immunity.SILENCE)
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     player:addTitle(xi.title.DARK_DRAGON_SLAYER)
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Split by commit:

- Adds missing KI text if the player is NOT receiving the Semih Trust Spell
- Adds immunities found on the three dragons.

## Steps to test these changes

1. `!addmission 2 5`
2. `!zone <Heavens Tower>`
3. Know the Trust Spell "Trust: Semih Lafihna" or set `xi.settings.main.ENABLE_TRUST_QUESTS` to 0
4. Talk to Kupipi
1. `!togglegm`
2. Enter the BC's at `Holaris Peak` `Balga's Dais` `Waughroon Shrine`
3. Cast spells on the dragons

## Captures
Holaris Peak - Video Only
https://youtu.be/LWTanHwKtNs

`Holaris Peak` and `Waughroon Shrine` - Packets only
https://drive.google.com/drive/folders/1OOC6X_IEx67BH6LDU7YAXls-EmADZYGe?usp=drive_link