### PR TITLE
[core] Fix pet zoning persistence

### DIFF
--- a/src/map/ipc_client.cpp
+++ b/src/map/ipc_client.cpp
@@ -898,6 +898,12 @@ void IPCClient::handleMessage_EntityInformationResponse(const IPP& ipp, const ip
             PChar->clearPacketList();
 
             PChar->requestedZoneChange = true;
+
+            // Save pet if any
+            if (PChar->shouldPetPersistThroughZoning())
+            {
+                PChar->setPetZoningInfo();
+            }
         }
     }
 }
@@ -925,6 +931,12 @@ void IPCClient::handleMessage_SendPlayerToLocation(const IPP& ipp, const ipc::Se
         PChar->clearPacketList();
 
         PChar->requestedWarp = true;
+
+        // Save pet if any
+        if (PChar->shouldPetPersistThroughZoning())
+        {
+            PChar->setPetZoningInfo();
+        }
     }
 }
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -3256,8 +3256,8 @@ void CLuaBaseEntity::setPos(sol::variadic_args va)
             PChar->m_moghouseID        = 0;
             PChar->requestedZoneChange = true;
 
-            // Edge case for !zone and cutscenes teleporting you
-            if (PChar->PPet)
+            // Save pet if any
+            if (PChar->shouldPetPersistThroughZoning())
             {
                 PChar->setPetZoningInfo();
             }
@@ -3287,6 +3287,12 @@ void CLuaBaseEntity::warp()
     if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
     {
         PChar->requestedWarp = true;
+
+        // Save pet if any
+        if (PChar->shouldPetPersistThroughZoning())
+        {
+            PChar->setPetZoningInfo();
+        }
     }
 }
 

--- a/src/map/packets/c2s/0x00a_login.cpp
+++ b/src/map/packets/c2s/0x00a_login.cpp
@@ -82,6 +82,12 @@ void GP_CLI_COMMAND_LOGIN::process(MapSession* PSession, CCharEntity* PChar) con
             ShowWarning("GP_CLI_COMMAND_LOGIN: player tried to enter zone that was invalid or out of range");
             ShowWarning("GP_CLI_COMMAND_LOGIN: dumping player `%s` to homepoint!", PChar->getName());
             PChar->requestedWarp = true; // Not a "request" but a demand
+
+            // Save pet if any
+            if (PChar->shouldPetPersistThroughZoning())
+            {
+                PChar->setPetZoningInfo();
+            }
             return;
         }
 

--- a/src/map/packets/c2s/0x05e_maprect.cpp
+++ b/src/map/packets/c2s/0x05e_maprect.cpp
@@ -239,4 +239,10 @@ void GP_CLI_COMMAND_MAPRECT::process(MapSession* PSession, CCharEntity* PChar) c
     }
 
     PChar->requestedZoneChange = true;
+
+    // Save pet if any
+    if (PChar->shouldPetPersistThroughZoning())
+    {
+        PChar->setPetZoningInfo();
+    }
 }

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -6765,6 +6765,12 @@ namespace charutils
         PChar->pushPacket<GP_SERV_COMMAND_LOGOUT>(GP_GAME_LOGOUT_STATE::ZONECHANGE, IPP(ipp));
 
         PChar->status = STATUS_TYPE::DISAPPEAR;
+
+        // Save pet if any
+        if (PChar->shouldPetPersistThroughZoning())
+        {
+            PChar->setPetZoningInfo();
+        }
     }
 
     void SendDisconnect(CCharEntity* PChar)
@@ -6777,6 +6783,12 @@ namespace charutils
         PChar->loc.destination     = 0xFFFF;
         PChar->status              = STATUS_TYPE::SHUTDOWN;
         PChar->requestedZoneChange = true;
+
+        // Save pet if any
+        if (PChar->shouldPetPersistThroughZoning())
+        {
+            PChar->setPetZoningInfo();
+        }
 
         PChar->pushPacket<GP_SERV_COMMAND_LOGOUT>(GP_GAME_LOGOUT_STATE::LOGOUT, IPP());
     }
@@ -6796,6 +6808,12 @@ namespace charutils
         PChar->clearPacketList();
 
         PChar->requestedZoneChange = true;
+
+        // Save pet if any
+        if (PChar->shouldPetPersistThroughZoning())
+        {
+            PChar->setPetZoningInfo();
+        }
     }
 
     void HomePoint(CCharEntity* PChar, bool resetHPMP)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

New zoneout method apparently was skipping setting pet zone info because the pet detached before it could be set
So set it when we are requesting warp or zone change

## Steps to test these changes

warp, teleport, change zoneline, etc with a pet that can zone and see them persist
