### PR TITLE
fix: Tell client subjob is unlocked

### DIFF
--- a/src/map/packets/s2c/0x01b_job_info.cpp
+++ b/src/map/packets/s2c/0x01b_job_info.cpp
@@ -40,8 +40,9 @@ GP_SERV_COMMAND_JOB_INFO::GP_SERV_COMMAND_JOB_INFO(CCharEntity* PChar)
     std::memcpy(packet.dancer.bp_base, &PChar->stats, sizeof(packet.dancer.bp_base));
     std::memcpy(packet.dancer.job_lev2, &PChar->jobs.job, sizeof(packet.dancer.job_lev2));
 
-    packet.dancer.hpmax = PChar->health.maxhp;
-    packet.dancer.mpmax = PChar->health.maxmp;
+    packet.dancer.hpmax   = PChar->health.maxhp;
+    packet.dancer.mpmax   = PChar->health.maxmp;
+    packet.dancer.sjobflg = PChar->jobs.unlocked & 1;
 
     packet.encumbrance          = (PChar->m_EquipBlock) | (PChar->m_StatsDebilitation << 16);
     packet.can_thumbs_up_mentor = PChar->aman().canThumbsUp();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Closes #8426

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!exec player:unlockJob(0)
Talk to Moogle
<!-- Clear and detailed steps to test your changes here -->
