### PR TITLE
[lua/cpp] Gear temp grant spells without touching char_spells db

### DIFF
--- a/scripts/commands/addallspells.lua
+++ b/scripts/commands/addallspells.lua
@@ -29,23 +29,25 @@ addSpellsInBatches = function(player, targetName, validSpells, batchSize, learne
 
     local startTime = GetSystemTime()
     local remainingSpells = {}
-    local save = true
-    local silent = true
-    local sendUpdate = false
+    local addSpellConfig =
+    {
+        silentLog = true,
+        saveToDB = true,
+        sendUpdate = false,
+    }
 
     for i = 1, #validSpells do
         if i > batchSize then
             remainingSpells[i - batchSize] = validSpells[i]
         else
-            targ:addSpell(validSpells[i], silent, save, sendUpdate)
+            targ:addSpell(validSpells[i], addSpellConfig)
         end
     end
 
     learned = learned + batchSize
     if learned >= total then
-        -- send player update by deleting then re-adding a spell now that all spells are added
-        targ:delSpell(validSpells[1])
-        targ:addSpell(validSpells[1], true, true, true)
+        -- send player update "<player> learns a new spell"
+        player:messageBasic(xi.msg.basic.PLAYER_LEARNS_NEW_SPELL)
         player:printToPlayer(fmt('{} now has all spells.', targ:getName()), xi.msg.channel.SYSTEM_3)
     else
         player:printToPlayer(fmt('{} now has learned {} of {} spells.', targ:getName(), learned, total), xi.msg.channel.SYSTEM_3)

--- a/scripts/commands/addspell.lua
+++ b/scripts/commands/addspell.lua
@@ -8,15 +8,17 @@ local commandObj = {}
 commandObj.cmdprops =
 {
     permission = 1,
-    parameters = 'is'
+    parameters = 'ss'
 }
 
 local function error(player, msg)
     player:printToPlayer(msg)
-    player:printToPlayer('!addspell <spellID> (player)')
+    player:printToPlayer('!addspell <spellID/spellName> (player)')
 end
 
-commandObj.onTrigger = function(player, spellId, target)
+commandObj.onTrigger = function(player, spellParam, target)
+    local spellId = tonumber(spellParam) or xi.magic.spell[string.upper(spellParam)]
+
     -- validate spellId
     if spellId == nil then
         error(player, 'Invalid spellID.')
@@ -36,9 +38,7 @@ commandObj.onTrigger = function(player, spellId, target)
     end
 
     -- add spell
-    local save = true
-    local silent = false
-    targ:addSpell(spellId, silent, save)
+    targ:addSpell(spellId)
     player:printToPlayer(string.format('Added spell %i to %s.', spellId, targ:getName()))
 end
 

--- a/scripts/commands/delspell.lua
+++ b/scripts/commands/delspell.lua
@@ -8,15 +8,17 @@ local commandObj = {}
 commandObj.cmdprops =
 {
     permission = 1,
-    parameters = 'is'
+    parameters = 'ss'
 }
 
 local function error(player, msg)
     player:printToPlayer(msg)
-    player:printToPlayer('!delspell <spellID> (player)')
+    player:printToPlayer('!delspell <spellID/spellName> (player)')
 end
 
-commandObj.onTrigger = function(player, spellId, target)
+commandObj.onTrigger = function(player, spellParam, target)
+    local spellId = tonumber(spellParam) or xi.magic.spell[string.upper(spellParam)]
+
     -- validate spellId
     if spellId == nil then
         error(player, 'Invalid spellID.')

--- a/scripts/enum/msg.lua
+++ b/scripts/enum/msg.lua
@@ -75,6 +75,7 @@ xi.msg.basic =
     MAGIC_RECOVERS_HP               = 7,   -- <caster> casts <spell>. <target> recovers <amount> HP.
     MAGIC_UNABLE_TO_CAST            = 17,  -- Unable to cast spells at this time.
     MAGIC_UNABLE_TO_CAST_2          = 18,  -- Unable to cast spells at this time.
+    PLAYER_LEARNS_NEW_SPELL         = 23,  -- <player> learns a new spell!
     MAGIC_CANNOT_CAST               = 47,  -- <caster> cannot cast <spell>.
     MAGIC_CANNOT_BE_CAST            = 48,  -- <spell> cannot be cast on <target>. (example: tractor)
     MAGIC_NO_EFFECT                 = 75,  -- <caster>'s <spell> has no effect on <target>.

--- a/scripts/globals/geomantic_reservoir.lua
+++ b/scripts/globals/geomantic_reservoir.lua
@@ -101,7 +101,7 @@ end
 
 xi.geomanticReservoir.onEventFinish = function(player, csid, geoSpell)
     if csid == 15000 then
-        player:addSpell(geoSpell, true, true) -- Quiesce the baked in message from addSpell(), we prefer the one below.
+        player:addSpell(geoSpell, { silentLog = true })
         player:messageSpecial(zones[player:getZoneID()].text.LEARNS_SPELL, geoSpellTable[geoSpell][1])
     end
 end

--- a/scripts/items/daybreak.lua
+++ b/scripts/items/daybreak.lua
@@ -12,12 +12,12 @@ end
 itemObject.onItemEquip = function(target, item)
     local mainWeapon = target:getEquippedItem(xi.slot.MAIN)
     if mainWeapon and mainWeapon:getID() == xi.item.DAYBREAK then
-        target:addSpell(xi.magic.spell.DISPELGA, true)
+        target:addSpell(xi.magic.spell.DISPELGA, { silentLog = true, saveToDB = false })
     end
 end
 
 itemObject.onItemUnequip = function(target, item)
-    target:delSpell(xi.magic.spell.DISPELGA)
+    target:delSpell(xi.magic.spell.DISPELGA, { saveToDB = false })
 end
 
 return itemObject

--- a/scripts/items/twilight_cloak.lua
+++ b/scripts/items/twilight_cloak.lua
@@ -10,11 +10,11 @@ itemObject.onItemCheck = function(target, item, param, caster)
 end
 
 itemObject.onItemEquip = function(target, item)
-    target:addSpell(xi.magic.spell.IMPACT)
+    target:addSpell(xi.magic.spell.IMPACT, { silentLog = true, saveToDB = false })
 end
 
 itemObject.onItemUnequip = function(target, item)
-    target:delSpell(xi.magic.spell.IMPACT)
+    target:delSpell(xi.magic.spell.IMPACT, { saveToDB = false })
 end
 
 return itemObject

--- a/scripts/quests/bastok/Trust_Bastok.lua
+++ b/scripts/quests/bastok/Trust_Bastok.lua
@@ -229,7 +229,7 @@ quest.sections =
             onEventFinish =
             {
                 [980] = function(player, csid, option, npc)
-                    player:addSpell(xi.magic.spell.NAJI, true, true)
+                    player:addSpell(xi.magic.spell.NAJI, { silentLog = true })
                     player:messageSpecial(metalworksID.text.YOU_LEARNED_TRUST, 0, xi.magic.spell.NAJI)
                     quest:setVar(player, 'Prog', 1)
                 end,
@@ -245,7 +245,7 @@ quest.sections =
 
                 [984] = function(player, csid, option, npc)
                     if quest:complete(player) then
-                        player:addSpell(xi.magic.spell.NAJI, true, true)
+                        player:addSpell(xi.magic.spell.NAJI, { silentLog = true })
                         player:messageSpecial(metalworksID.text.YOU_LEARNED_TRUST, 0, xi.magic.spell.NAJI)
                         player:delKeyItem(xi.ki.BLUE_INSTITUTE_CARD)
                         player:messageSpecial(metalworksID.text.KEYITEM_LOST, xi.ki.BLUE_INSTITUTE_CARD)
@@ -326,21 +326,21 @@ quest.sections =
             {
                 [985] = function(player, csid, option, npc)
                     if option == 2 then
-                        player:addSpell(xi.magic.spell.AYAME, true, true)
+                        player:addSpell(xi.magic.spell.AYAME, { silentLog = true })
                         player:messageSpecial(metalworksID.text.YOU_LEARNED_TRUST, 0, xi.magic.spell.AYAME)
                     end
                 end,
 
                 [986] = function(player, csid, option, npc)
                     if option == 2 then
-                        player:addSpell(xi.magic.spell.VOLKER, true, true)
+                        player:addSpell(xi.magic.spell.VOLKER, { silentLog = true })
                         player:messageSpecial(metalworksID.text.YOU_LEARNED_TRUST, 0, xi.magic.spell.VOLKER)
                     end
                 end,
 
                 [988] = function(player, csid, option, npc)
                     if option == 2 then
-                        player:addSpell(xi.magic.spell.IRON_EATER, true, true)
+                        player:addSpell(xi.magic.spell.IRON_EATER, { silentLog = true })
                         player:messageSpecial(metalworksID.text.YOU_LEARNED_TRUST, 0, xi.magic.spell.IRON_EATER)
                     end
                 end,

--- a/scripts/quests/crystalWar/A_Little_Knowledge.lua
+++ b/scripts/quests/crystalWar/A_Little_Knowledge.lua
@@ -197,8 +197,8 @@ quest.sections =
             onEventFinish =
             {
                 [47] = function(player, csid, option, npc)
-                    player:addSpell(xi.magic.spell.EMBRAVA, true)
-                    player:addSpell(xi.magic.spell.KAUSTRA, true)
+                    player:addSpell(xi.magic.spell.EMBRAVA, { silentLog = true })
+                    player:addSpell(xi.magic.spell.KAUSTRA, { silentLog = true })
                     player:messageSpecial(eldiemeSID.text.YOU_LEARN_EMBRAVA_AND_KAUSTRA)
                 end,
             }

--- a/scripts/quests/hiddenQuests/Trust_Cherukiki.lua
+++ b/scripts/quests/hiddenQuests/Trust_Cherukiki.lua
@@ -50,7 +50,7 @@ quest.sections =
             {
                 [10235] = function(player, csid, option, npc)
                     if option == 2 and quest:complete(player) then
-                        player:addSpell(xi.magic.spell.CHERUKIKI, true, true)
+                        player:addSpell(xi.magic.spell.CHERUKIKI, { silentLog = true })
                         player:messageSpecial(ruludeID.text.YOU_LEARNED_TRUST, 0, xi.magic.spell.CHERUKIKI)
                     end
                 end,

--- a/scripts/quests/hiddenQuests/Trust_Ingrid.lua
+++ b/scripts/quests/hiddenQuests/Trust_Ingrid.lua
@@ -33,7 +33,7 @@ quest.sections =
             {
                 [5062] = function(player, csid, option, npc)
                     if option == 2 then
-                        player:addSpell(xi.magic.spell.INGRID, true, true)
+                        player:addSpell(xi.magic.spell.INGRID, { silentLog = true })
 
                         player:messageSpecial(easternAdoulinID.text.YOU_LEARNED_TRUST, 0, xi.magic.spell.INGRID)
                     end

--- a/scripts/quests/hiddenQuests/Trust_Maat.lua
+++ b/scripts/quests/hiddenQuests/Trust_Maat.lua
@@ -32,7 +32,7 @@ quest.sections =
             {
                 [10241] = function(player, csid, option, npc)
                     if option == 2 and quest:complete(player) then
-                        player:addSpell(xi.magic.spell.MAAT, true, true)
+                        player:addSpell(xi.magic.spell.MAAT, { silentLog = true })
                         player:messageSpecial(ruludeID.text.YOU_LEARNED_TRUST, 0, xi.magic.spell.MAAT)
                     end
                 end,

--- a/scripts/quests/hiddenQuests/Trust_Nashmeira.lua
+++ b/scripts/quests/hiddenQuests/Trust_Nashmeira.lua
@@ -28,7 +28,7 @@ quest.sections =
             {
                 [5092] = function(player, csid, option, npc)
                     if option == 2 and quest:complete(player) then
-                        player:addSpell(xi.magic.spell.NASHMEIRA, true, true)
+                        player:addSpell(xi.magic.spell.NASHMEIRA, { silentLog = true })
                         player:messageSpecial(whitegateID.text.YOU_LEARNED_TRUST, 0, xi.magic.spell.NASHMEIRA)
                     end
                 end,

--- a/scripts/quests/hiddenQuests/Trust_Prishe.lua
+++ b/scripts/quests/hiddenQuests/Trust_Prishe.lua
@@ -70,7 +70,7 @@ quest.sections =
             {
                 [633] = function(player, csid, option, npc)
                     if option == 2 and quest:complete(player) then
-                        player:addSpell(xi.magic.spell.PRISHE, true, true)
+                        player:addSpell(xi.magic.spell.PRISHE, { silentLog = true })
                         player:messageSpecial(tavnaziaID.text.YOU_LEARNED_TRUST, 0, xi.magic.spell.PRISHE)
                     end
                 end,

--- a/scripts/quests/hiddenQuests/Trust_Shantotto.lua
+++ b/scripts/quests/hiddenQuests/Trust_Shantotto.lua
@@ -104,7 +104,7 @@ quest.sections =
             {
                 [529] = function(player, csid, option, npc)
                     if option == 2 then
-                        player:addSpell(xi.magic.spell.SHANTOTTO, true, true)
+                        player:addSpell(xi.magic.spell.SHANTOTTO, { silentLog = true })
                         player:messageSpecial(wallsID.text.YOU_LEARNED_TRUST, 0, xi.magic.spell.SHANTOTTO)
                     end
                 end,

--- a/scripts/quests/hiddenQuests/Trust_ShikareeZ.lua
+++ b/scripts/quests/hiddenQuests/Trust_ShikareeZ.lua
@@ -40,7 +40,7 @@ quest.sections =
             {
                 [869] = function(player, csid, option, npc)
                     if xi.trust.hasPermit(player) then
-                        player:addSpell(xi.magic.spell.SHIKAREE_Z, true, true)
+                        player:addSpell(xi.magic.spell.SHIKAREE_Z, { silentLog = true })
                         player:messageSpecial(woodsID.text.YOU_LEARNED_TRUST, 0, xi.magic.spell.SHIKAREE_Z)
                     end
                 end,

--- a/scripts/quests/hiddenQuests/Trust_Ulmia.lua
+++ b/scripts/quests/hiddenQuests/Trust_Ulmia.lua
@@ -48,7 +48,7 @@ quest.sections =
             {
                 [560] = function(player, csid, option, npc)
                     if option == 2 and quest:complete(player) then
-                        player:addSpell(xi.magic.spell.ULMIA, true, true)
+                        player:addSpell(xi.magic.spell.ULMIA, { silentLog = true })
                         player:messageSpecial(misareauxID.text.YOU_LEARNED_TRUST, 0, xi.magic.spell.ULMIA)
                     end
                 end,

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -2299,11 +2299,9 @@ function CBaseEntity:delLearnedAbility(abilityID)
 end
 
 ---@param spellID integer
----@param silentLog boolean?
----@param save boolean?
----@param sendUpdate boolean?
+---@param arg0 table?
 ---@return nil
-function CBaseEntity:addSpell(spellID, silentLog, save, sendUpdate)
+function CBaseEntity:addSpell(spellID, arg0)
 end
 
 ---@nodiscard
@@ -2319,8 +2317,9 @@ function CBaseEntity:canLearnSpell(spellID)
 end
 
 ---@param spellID integer
+---@param arg0 table?
 ---@return nil
-function CBaseEntity:delSpell(spellID)
+function CBaseEntity:delSpell(spellID, arg0)
 end
 
 ---@return nil

--- a/scripts/zones/Chateau_dOraguille/npcs/Curilla.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/Curilla.lua
@@ -105,7 +105,7 @@ entity.onEventFinish = function(player, csid, option, npc)
     elseif csid == 562 then
         player:setCharVar('WildcatSandy', utils.mask.setBit(player:getCharVar('WildcatSandy'), 15, true))
     elseif csid == 573 and option == 2 then
-        player:addSpell(xi.magic.spell.CURILLA, true, true)
+        player:addSpell(xi.magic.spell.CURILLA, { silentLog = true })
         player:messageSpecial(ID.text.YOU_LEARNED_TRUST, 0, xi.magic.spell.CURILLA)
     end
 end

--- a/scripts/zones/Chateau_dOraguille/npcs/_6h0.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/_6h0.lua
@@ -105,8 +105,8 @@ entity.onEventFinish = function(player, csid, option, npc)
             player:completeQuest(xi.questLog.SANDORIA, xi.quest.id.sandoria.UNDER_OATH)
         end
     elseif csid == 574 and option == 2 then
-        player:addSpell(xi.magic.spell.TRION, false, true)
-        player:messageSpecial(ID.text.YOU_LEARNED_TRUST, 0, 905)
+        player:addSpell(xi.magic.spell.TRION, { silentLog = true })
+        player:messageSpecial(ID.text.YOU_LEARNED_TRUST, 0, xi.magic.spell.TRION)
     end
 end
 

--- a/scripts/zones/Heavens_Tower/npcs/Kupipi.lua
+++ b/scripts/zones/Heavens_Tower/npcs/Kupipi.lua
@@ -77,7 +77,7 @@ end
 entity.onEventFinish = function(player, csid, option, npc)
     --TRUST
     if csid == 435 then
-        player:addSpell(xi.magic.spell.KUPIPI, true, true)
+        player:addSpell(xi.magic.spell.KUPIPI, { silentLog = true })
         player:messageSpecial(ID.text.YOU_LEARNED_TRUST, 0, xi.magic.spell.KUPIPI)
         player:setCharVar('WindurstFirstTrust', 1)
     elseif csid == 437 then
@@ -89,7 +89,7 @@ entity.onEventFinish = function(player, csid, option, npc)
             var = 'WindurstFirstTrust' })
         player:messageSpecial(ID.text.CALL_MULTIPLE_ALTER_EGO)
     elseif csid == 439 then
-        player:addSpell(xi.magic.spell.KUPIPI, true, true)
+        player:addSpell(xi.magic.spell.KUPIPI, { silentLog = true })
         player:messageSpecial(ID.text.YOU_LEARNED_TRUST, 0, xi.magic.spell.KUPIPI)
         player:delKeyItem(xi.ki.GREEN_INSTITUTE_CARD)
         player:messageSpecial(ID.text.KEYITEM_LOST, xi.ki.GREEN_INSTITUTE_CARD)

--- a/scripts/zones/Northern_San_dOria/npcs/Excenmille.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Excenmille.lua
@@ -73,7 +73,7 @@ end
 entity.onEventFinish = function(player, csid, option, npc)
     -- TRUST
     if csid == 893 then
-        player:addSpell(xi.magic.spell.EXCENMILLE, true, true)
+        player:addSpell(xi.magic.spell.EXCENMILLE, { silentLog = true })
         player:messageSpecial(ID.text.YOU_LEARNED_TRUST, 0, xi.magic.spell.EXCENMILLE)
         player:setCharVar('SandoriaFirstTrust', 1)
     elseif csid == 895 then
@@ -86,7 +86,7 @@ entity.onEventFinish = function(player, csid, option, npc)
         })
         player:messageSpecial(ID.text.CALL_MULTIPLE_ALTER_EGO)
     elseif csid == 897 then
-        player:addSpell(xi.magic.spell.EXCENMILLE, true, true)
+        player:addSpell(xi.magic.spell.EXCENMILLE, { silentLog = true })
         player:messageSpecial(ID.text.YOU_LEARNED_TRUST, 0, xi.magic.spell.EXCENMILLE)
         player:delKeyItem(xi.ki.RED_INSTITUTE_CARD)
         player:messageSpecial(ID.text.KEYITEM_LOST, xi.ki.RED_INSTITUTE_CARD)

--- a/scripts/zones/Port_Bastok/npcs/Clarion_Star.lua
+++ b/scripts/zones/Port_Bastok/npcs/Clarion_Star.lua
@@ -17,7 +17,7 @@ entity.onEventFinish = function(player, csid, option, npc)
     if csid == 437 or csid == 458 then
         local spellID = player:getLocalVar('TradingTrustCipher')
         player:setLocalVar('TradingTrustCipher', 0)
-        player:addSpell(spellID, true, true)
+        player:addSpell(spellID, { silentLog = true })
         player:messageSpecial(ID.text.YOU_LEARNED_TRUST, 0, spellID)
         player:tradeComplete()
     end

--- a/scripts/zones/Southern_San_dOria/npcs/Gondebaud.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Gondebaud.lua
@@ -50,7 +50,7 @@ entity.onEventFinish = function(player, csid, option, npc)
     elseif csid == 3503 or csid == 3553 then
         local spellID = player:getLocalVar('TradingTrustCipher')
         player:setLocalVar('TradingTrustCipher', 0)
-        player:addSpell(spellID, true, true)
+        player:addSpell(spellID, { silentLog = true })
         player:messageSpecial(ID.text.YOU_LEARNED_TRUST, 0, spellID)
         player:tradeComplete()
     end

--- a/scripts/zones/Windurst_Woods/npcs/Apururu.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Apururu.lua
@@ -120,7 +120,7 @@ entity.onEventFinish = function(player, csid, option, npc)
 
         -- TRUST
     elseif csid == 866 and option == 2 then
-        player:addSpell(xi.magic.spell.AJIDO_MARUJIDO, true, true)
+        player:addSpell(xi.magic.spell.AJIDO_MARUJIDO, { silentLog = true })
         player:messageSpecial(ID.text.YOU_LEARNED_TRUST, 0, xi.magic.spell.AJIDO_MARUJIDO)
     end
 end

--- a/scripts/zones/Windurst_Woods/npcs/Nanaa_Mihgo.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Nanaa_Mihgo.lua
@@ -78,7 +78,7 @@ entity.onEventFinish = function(player, csid, option, npc)
         player:setCharVar('WildcatWindurst', utils.mask.setBit(player:getCharVar('WildcatWindurst'), 4, true))
 
     elseif csid == 865 and option == 2 then
-        player:addSpell(xi.magic.spell.NANAA_MIHGO, true, true)
+        player:addSpell(xi.magic.spell.NANAA_MIHGO, { silentLog = true })
         player:messageSpecial(ID.text.YOU_LEARNED_TRUST, 0, xi.magic.spell.NANAA_MIHGO)
     end
 end

--- a/scripts/zones/Windurst_Woods/npcs/Wetata.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Wetata.lua
@@ -50,7 +50,7 @@ entity.onEventFinish = function(player, csid, option, npc)
     elseif csid == 862 or csid == 902 then
         local spellID = player:getLocalVar('TradingTrustCipher')
         player:setLocalVar('TradingTrustCipher', 0)
-        player:addSpell(spellID, true, true)
+        player:addSpell(spellID, { silentLog = true })
         player:messageSpecial(ID.text.YOU_LEARNED_TRUST, 0, spellID)
         player:tradeComplete()
     end

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -547,10 +547,10 @@ public:
     uint32 canLearnAbility(uint16 abilityID);
     void   delLearnedAbility(uint16 abilityID);
 
-    void   addSpell(uint16 spellID, sol::variadic_args va);
+    void   addSpell(uint16 spellID, sol::object const& arg0);
     bool   hasSpell(uint16 spellID);
     uint32 canLearnSpell(uint16 spellID);
-    void   delSpell(uint16 spellID);
+    void   delSpell(uint16 spellID, sol::object const& arg0);
 
     void recalculateSkillsTable();
     void recalculateAbilitiesTable();

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3884,22 +3884,23 @@ namespace charutils
         return PChar->m_SpellList[SpellID];
     }
 
-    int32 addSpell(CCharEntity* PChar, uint16 SpellID)
+    int32 addSpell(CCharEntity* PChar, uint16 spellID)
     {
-        // Todo: come up with a good way to validate that the SpellID exists in the database also.
-        if (SpellID > 0 && SpellID < 1024 && !hasSpell(PChar, SpellID))
+        auto* PSpell = spell::GetSpell(static_cast<SpellID>(spellID));
+        if (PSpell && !hasSpell(PChar, spellID))
         {
-            PChar->m_SpellList[SpellID] = true;
+            PChar->m_SpellList[spellID] = true;
             return 1;
         }
         return 0;
     }
 
-    int32 delSpell(CCharEntity* PChar, uint16 SpellID)
+    int32 delSpell(CCharEntity* PChar, uint16 spellID)
     {
-        if (hasSpell(PChar, SpellID))
+        auto* PSpell = spell::GetSpell(static_cast<SpellID>(spellID));
+        if (PSpell && hasSpell(PChar, spellID))
         {
-            PChar->m_SpellList[SpellID] = false;
+            PChar->m_SpellList[spellID] = false;
             return 1;
         }
         return 0;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

per this video, twilight cloak doesn't give a chat message that you learned the spell: https://youtu.be/deGA1qF_DpI?t=296

This PR does 4 main things:
- adds some consistency to addSpell/delSpell lua bindings
  - in changing this to sol::table, i had to find all calls to `:addSpell` that had a comma in it and update the params to use the table format
- while updating the commands for add/del spell, I updated to do like `!addeffect` and take an int or string for the spell
- adds protections in charutils versions of those functions to check for a valid spellid
- updates the two pieces of gear that add temporary spells to not save the player's spell list to the db

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- give yourself either of the items: `twilight_cloak` and `daybreak`
  - equip/remove and see spell list reflected properly
  - zone and see you still have the spell if the item is equipped
- directly play with calling the lua bindings, and see they work as expected:
  - <img width="895" height="177" alt="image" src="https://github.com/user-attachments/assets/e2d882e4-a61c-4237-b37a-84b9b1af2322" />
  - no message for 1023, which is not a spell in the db (but smaller than `MAX_SPELL_ID`)
  - message from learning shantoto_II
  - <img width="417" height="92" alt="image" src="https://github.com/user-attachments/assets/e1b5661d-cd3e-4e77-bc97-d0ca12e4b5ba" />
  - <img width="660" height="500" alt="image" src="https://github.com/user-attachments/assets/1981ba38-3e7f-490e-83ef-86b0852e3f8e" />
  - etc



