### PR TITLE
[lua] Add proper g_mixins.families initializations

### DIFF
--- a/scripts/mixins/families/atori_tutori_qm.lua
+++ b/scripts/mixins/families/atori_tutori_qm.lua
@@ -1,8 +1,9 @@
 require('scripts/globals/mixins')
 
 g_mixins = g_mixins or {}
+g_mixins.families = g_mixins.families or {}
 
-g_mixins.atori_tutori_qm = function(atoriMob)
+g_mixins.families.atori_tutori_qm = function(atoriMob)
     atoriMob:addListener('SPAWN', 'JOB_SPECIAL_SPAWN', function(mob)
         mob:setLocalVar('specialThreshold', 35)
     end)
@@ -44,4 +45,4 @@ g_mixins.atori_tutori_qm = function(atoriMob)
     end)
 end
 
-return g_mixins.atori_tutori_qm
+return g_mixins.families.atori_tutori_qm

--- a/scripts/mixins/families/ghrah.lua
+++ b/scripts/mixins/families/ghrah.lua
@@ -10,6 +10,7 @@ local palaceID = zones[xi.zone.GRAND_PALACE_OF_HUXZOI]
 local gardenID = zones[xi.zone.THE_GARDEN_OF_RUHMET]
 -----------------------------------
 g_mixins = g_mixins or {}
+g_mixins.families = g_mixins.families or {}
 
 local mobFormLookup = {}
 

--- a/scripts/mixins/families/maat.lua
+++ b/scripts/mixins/families/maat.lua
@@ -1,8 +1,9 @@
 require('scripts/globals/mixins')
 
 g_mixins = g_mixins or {}
+g_mixins.families = g_mixins.families or {}
 
-g_mixins.maat = function(maatMob)
+g_mixins.families.maat = function(maatMob)
     maatMob:addListener('SPAWN', 'JOB_SPECIAL_SPAWN', function(mob)
         if mob:getMainJob() == xi.job.NIN then
             mob:setLocalVar('specialThreshold', 40)
@@ -112,4 +113,4 @@ g_mixins.maat = function(maatMob)
     end)
 end
 
-return g_mixins.maat
+return g_mixins.families.maat

--- a/scripts/mixins/families/mimic.lua
+++ b/scripts/mixins/families/mimic.lua
@@ -1,8 +1,9 @@
 require('scripts/globals/mixins')
 
 g_mixins = g_mixins or {}
+g_mixins.families = g_mixins.families or {}
 
-g_mixins.mimic = function(mimicMob)
+g_mixins.families.mimic = function(mimicMob)
     mimicMob:addListener('COMBAT_TICK', 'DRAW_IN_CHECK', function(mob)
         local target = mob:getTarget()
         if target then
@@ -20,4 +21,4 @@ g_mixins.mimic = function(mimicMob)
     end)
 end
 
-return g_mixins.mimic
+return g_mixins.families.mimic

--- a/scripts/mixins/families/ruszor.lua
+++ b/scripts/mixins/families/ruszor.lua
@@ -1,8 +1,9 @@
 require('scripts/globals/mixins')
 
 g_mixins = g_mixins or {}
+g_mixins.families = g_mixins.families or {}
 
-g_mixins.ruszor = function(ruszorMob)
+g_mixins.families.ruszor = function(ruszorMob)
     ruszorMob:addListener('COMBAT_TICK', 'RUSZOR_AURA', function(mob)
         local animationSub = mob:getAnimationSub()
         local hasEffect    = mob:hasStatusEffect(xi.effect.STONESKIN)
@@ -26,4 +27,4 @@ g_mixins.ruszor = function(ruszorMob)
     end)
 end
 
-return g_mixins.ruszor
+return g_mixins.families.ruszor


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
loading current LSB with only sea palace zone had an error due to not initializing the families key properly, this PR fixes it
<img width="1109" height="205" alt="image" src="https://github.com/user-attachments/assets/93901191-6ce9-4e8e-b7aa-77fd86ba0eb6" />

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
load only zone 34 via `xi_map --ip X --port Y` and see no errors