### PR TITLE
fix: Treasure pool lot numbers not showing

### DIFF
--- a/src/map/packets/s2c/0x0d3_trophy_solution.cpp
+++ b/src/map/packets/s2c/0x0d3_trophy_solution.cpp
@@ -62,9 +62,7 @@ GP_SERV_COMMAND_TROPHY_SOLUTION::GP_SERV_COMMAND_TROPHY_SOLUTION(const CBaseEnti
     packet.EntryUniqueNo   = PLotter->id;
     packet.EntryActIndex   = PLotter->targid;
     packet.TrophyItemIndex = slotId;
-
-    // Use packBitsBE to handle lot number - this fixes an offset problem with lot numbers
-    packBitsBE(reinterpret_cast<uint8_t*>(&packet), lot, 144, 16);
+    packet.EntryPoint      = lot;
 
     std::memcpy(packet.sLootName2, PLotter->getName().c_str(), std::min(PLotter->getName().size(), sizeof(packet.sLootName2)));
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Puts the lot number at the right location in the packet

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
<img width="605" height="202" alt="image" src="https://github.com/user-attachments/assets/2d9fda77-6235-48a2-9f16-817fdd16ac8a" />

<!-- Clear and detailed steps to test your changes here -->
