### PR TITLE
[lua] Don't emit RoE item reward if you weren't going to get it

### DIFF
--- a/scripts/globals/roe.lua
+++ b/scripts/globals/roe.lua
@@ -213,7 +213,7 @@ local function completeRecord(player, record)
 
     -- NOTE: To preserve retail order, messaging is here, but item is given if able at the beginning of this
     -- function, since if it fails, it will need to bail out.
-    if rewards['item'] then
+    if not player:getEminenceCompleted(record) and rewards['item'] then
         local itemQty   = type(rewards['item'][1]) == 'table' and rewards['item'][1][2] or 1
         local itemId    = type(rewards['item'][1]) == 'table' and rewards['item'][1][1] or rewards['item'][1]
         local messageId = itemQty > 1 and xi.msg.basic.ROE_BONUS_ITEM_PLURAL or xi.msg.basic.ROE_BONUS_ITEM


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Currently we emit messages for items that we didn't actually get. This fixes erroneous messages and is partially accurate.

Also adds the ability to add exceptions for item rewards (Edge case, seems only Silt/Beads actually repeat.)

Closes #5965

from my logs on a repeat:
```[17:22:55] You have completed the following Records of Eminence objective: Conflict: Escha - Zi'Tah VI.
[17:22:55] You receive 300 sparks of eminence, and now possess a total of 5850.
[17:22:55] Lillyanne gains 900 experience points.
[17:22:55] You receive 34 Unity accolades for a total of 12566!
[17:22:56] As a special bonus for your valiant efforts, you have been awarded a bead pouch!
[17:22:56] This objective may be repeated, and can be cancelled from the menu.
```
From my logs as a a first-time bonus (No unity? it was a new char after all..)
```[23:39:36] You have completed the following Records of Eminence objective: Conflict: Escha - Zi'Tah VI.
[23:39:36] As a first-time bonus, you receive 900 sparks of eminence for a total of 1500!
[23:39:36] Dickjones gains 900 experience points.
[23:39:36] As a special bonus for your valiant efforts, you have been awarded a bead pouch!
[23:39:36] This objective may be repeated, and can be cancelled from the menu.
```
Retail just now with a new reward:
<img width="783" height="416" alt="image" src="https://github.com/user-attachments/assets/a27371e9-4ce2-4c40-b3dc-833b000fbb01" />

Selectively, some RoE rewards do repeat. if I had to guess if the item is is Silt Pouch/Bead pouch it rewards again.

For reference, a few lines above my changes:
```lua
    if not player:getEminenceCompleted(record) and rewards['item'] then
        if not npcUtil.giveItem(player, rewards['item'], { silent = true }) then
            player:messageBasic(xi.msg.basic.ROE_UNABLE_BONUS_ITEM)
            return false
        end
    end
```
Unconditionally, the item hasn't been given to the player on the repeat so the message is a lie no matter what

## Steps to test these changes

Do item-dropping RoEs, dont get items on repeat except for beads/silt
