### PR TITLE
[lua] ENM Bionic Bug - Additional Polish

### DIFF
--- a/scripts/actions/mobskills/heavy_blow.lua
+++ b/scripts/actions/mobskills/heavy_blow.lua
@@ -14,7 +14,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 1
     local accmod = 1
     local ftp    = 1.5
-    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
+    local params  = { canCrit = true }
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT, params)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.HTH, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.HTH)
     return dmg


### PR DESCRIPTION
Added some extra mechanics and polish after receiving an additional capture from Tao

**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds the ability for Heavy Blow to critically strike and improves the logic of Bugboy to follow up his Mighty Strikes with a Heavy Blow. 

## Steps to test these changes

Head on over to Mine Shaft 2716 and fight the ENM Bionic Bug with !addkeyitem SHAFT_2716_OPERATING_LEVER

## Capture 

https://youtu.be/IktFmukBiUY?t=683

This snippet right here shows the follow up attack, and the critical hit. 

