### PR TITLE
[ci] Check GetMob/NPCByID for Chained Methods

### DIFF
--- a/tools/ci/lua_stylecheck.py
+++ b/tools/ci/lua_stylecheck.py
@@ -362,6 +362,13 @@ class LuaStyleCheck:
         if match:
             self.error(":getPool() compared to integer literal (magic number) using a conditional operator is not allowed.")
 
+    def check_getentity_nilsafety(self, line):
+        """Detect direct GetMobByID() or GetNPCByID() calls with method chaining (unsafe)."""
+        # TODO: Add multi-line context aware checks to ensure nil checks
+        match = re.search(r"Get(?:Mob|NPC)ByID\s*\([^)]*\)\s*:", line)
+        if match:
+            self.error("Get(NPC|Mob)ByID():<method>() call without nil check")
+
     def run_style_check(self):
         if self.filename is None:
             print("ERROR: No filename provided to LuaStyleCheck class.")
@@ -465,6 +472,7 @@ class LuaStyleCheck:
                 self.check_no_newline_before_end(code_line)
                 self.check_no_function_decl_padding(code_line)
                 self.check_invalid_enum(code_line)
+                self.check_getentity_nilsafety(code_line)
 
                 # TODO: Disabled until a solution for float parameters to math.random() is found
                 # self.check_random_bounds(code_line)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
- Update lua_stylecheck to check for chained methods on GetMobByID or GetNPCByID calls without checking for nil first.
  - This stops `GetMobByID():method()` calls from passing sanity.  These are generally unsafe because these entity retrieving calls *should* be nil-checked before attempting to call a method on the object.  If the call returned a nil, calling a method on nil will cause things to break/error out.

Since the stylechecks are only line-aware, it's not a simple implementation to add multiline-context aware nil checks in this file.  Though, at some point, we should find a way to store things so more advanced checks like this can happen:
```lua
local mob = GetMobByID(12345678)
local name = mob:getName() -- <-- This should fail since it wasn't nil checked first

if not mob then return end
local name = mob:getName() -- <-- This should pass since it has now been nil-checked
```

Sample Output on a Test File:
```
Get(NPC|Mob)ByID():<method>() call without nil check: .\scripts\zones\Qufim_Island\mobs\test.lua:21
GetMobByID(ID.mob.TEST_MOB):getName()                              <-- HERE

Lua styling errors: 1
```

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - Add the following code to any lua file in the scripts folder:
```
GetMobByID(12345678):getName()
```
2 - Run lua_stylechecks.py against that file
3 - Receive failing results for chained method without nil check