### PR TITLE
[lua] Add Default Actions to Mission Doors

### DIFF
--- a/scripts/zones/Grand_Palace_of_HuXzoi/DefaultActions.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/DefaultActions.lua
@@ -1,7 +1,8 @@
--- local ID = zones[xi.zone.GRAND_PALACE_OF_HUXZOI]
+local ID = zones[xi.zone.GRAND_PALACE_OF_HUXZOI]
 
 return {
     ['_0y0'] = { event = 173 },
     ['_iyb'] = { event = 56 },
     ['_iyc'] = { event = 172 },
+    ['_iyq'] = { messageSpecial = ID.text.NOTHING_LEFT_TO_DO }
 }

--- a/scripts/zones/Grand_Palace_of_HuXzoi/IDs.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/IDs.lua
@@ -18,6 +18,7 @@ zones[xi.zone.GRAND_PALACE_OF_HUXZOI] =
         CONQUEST_BASE                 = 7090, -- Tallying conquest results...
         DOES_NOT_RESPOND              = 7254, -- The gate does not respond...
         PRESENCE_HAS_DRAWN            = 7370, -- Your presence has drawn unwanted attention!
+        NOTHING_LEFT_TO_DO            = 7373, -- You have nothing left to do here.
         REQUEST_CONFIRMED             = 7375, -- Security portal access request confirmed. Commencing patrol routine. Stay on alert for intruder interference.
         PATROL_COMPLETED              = 7376, -- Patrol routine completed. Request transfer of final security portal access duty. Awaiting confirmation.
         DUTY_COMPLETE                 = 7377, -- Transfer of final security portal access duty complete.

--- a/scripts/zones/Lower_Delkfutts_Tower/DefaultActions.lua
+++ b/scripts/zones/Lower_Delkfutts_Tower/DefaultActions.lua
@@ -5,4 +5,5 @@ return {
     ['_541'] = { messageSpecial = ID.text.DOOR_FIRMLY_SHUT },
     ['_542'] = { messageSpecial = ID.text.DOOR_FIRMLY_SHUT },
     ['_543'] = { messageSpecial = ID.text.DOOR_FIRMLY_SHUT },
+    ['_545'] = { messageSpecial = ID.text.DOOR_FIRMLY_SHUT }, -- ZM 5-3 Tenzen's Path Disaster Idol Door
 }

--- a/scripts/zones/Northern_San_dOria/DefaultActions.lua
+++ b/scripts/zones/Northern_San_dOria/DefaultActions.lua
@@ -1,6 +1,7 @@
 local ID = zones[xi.zone.NORTHERN_SAN_DORIA]
 
 return {
+    ['_6fc']              = { messageSpecial = ID.text.ITS_LOCKED }, -- Door Papal Chambers
     ['Abeaule']           = { text = ID.text.ABEAULE_DIALOG_THANKS },
     ['Abioleget']         = { text = ID.text.ABIOLEGET_DIALOG },
     ['Ailbeche']          = { event = 868 },

--- a/scripts/zones/Northern_San_dOria/IDs.lua
+++ b/scripts/zones/Northern_San_dOria/IDs.lua
@@ -82,6 +82,7 @@ zones[xi.zone.NORTHERN_SAN_DORIA] =
         AIVEDOIR_DIALOG               = 11541, -- That's funny. I could have sworn she asked me to meet her here...
         CAPIRIA_DIALOG                = 11542, -- He's late! I do hope he hasn't forgotten.
         BERTENONT_DIALOG              = 11543, -- Stars are more beautiful up close. Don't you agree?
+        ITS_LOCKED                    = 11552, -- It's locked.
         GILIPESE_DIALOG               = 11564, -- Nothing to report!
         DOGGOMEHR_SHOP_DIALOG         = 11577, -- Welcome to the Blacksmiths' Guild shop.
         LUCRETIA_SHOP_DIALOG          = 11578, -- Blacksmiths' Guild shop, at your service!


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds default actions to these three mission doors to prevent them from opening outside of their CS.

## Steps to test these changes

1. `!zone <Northern San d'Oria>`
2. `!gotoname _6fc`
3. Click the door
4. `!zone <Lower Delkfutts Tower>`
5. `!gotoname _545`
6. Click the door.
7. '!zone <Grand Palace of Huxzoi>`
8. `!gotoname _iyq`
9. Click door

## Capture
Packets only
https://drive.google.com/drive/folders/1BqemyASFpJw-yo5QdtZtBULe-CfMJMpI?usp=drive_link

Palace door
https://youtu.be/d7I-uEaIu7M
https://drive.google.com/drive/folders/1MIQQCFOIuXQdkSSg6ZbNszNh2pUabrNt?usp=drive_link