### PR TITLE
Added saving and using zoneline id's

### DIFF
--- a/scripts/commands/getprevzoneline.lua
+++ b/scripts/commands/getprevzoneline.lua
@@ -1,0 +1,30 @@
+-----------------------------------
+-- func: getprevzoneline
+-- desc: gets the ID of the players last zoneline or cursor target.
+-- Only works on players
+-----------------------------------
+
+---@type TCommand
+local commandObj = {}
+
+commandObj.cmdprops =
+{
+    permission = 1,
+    parameters = ''
+}
+
+commandObj.onTrigger = function(player)
+    local target = player:getCursorTarget()
+
+    if target and not target:isPC() then
+            player:printToPlayer('Current target is not a Player, only Players have a previous zoneline IDs saved.')
+            return
+    elseif not target then
+        target = player
+    end
+
+    local zoneline = player:getPreviousZoneLineID() or 0
+    player:printToPlayer(string.format('Previous Zoneline ID: %u', zoneline))
+end
+
+return commandObj

--- a/scripts/globals/moghouse.lua
+++ b/scripts/globals/moghouse.lua
@@ -67,32 +67,71 @@ local offsetAxis =
 {
     X = 1,
     Z = 3,
+    R = 4,
 }
 
---  [zoneId]                       = {      x,      y,      z, rot, offsetAxis  , max }
+--  [zoneId]                       = { [Entrance] ={x,      y,     z,   rot, offsetAxis,   max } }
 xi.moghouse.exits =
 {
-    [xi.zone.AL_ZAHBI]             = {     37,      0,    -62, 192, offsetAxis.X, 5.0 },
-    [xi.zone.AHT_URHGAN_WHITEGATE] = {   -100,      0,    -83,   0, offsetAxis.Z, 5.0 },
-    [xi.zone.SOUTHERN_SAN_DORIA_S] = {    147,     -2,    116,  95, offsetAxis.X, 5.0 },
-    [xi.zone.BASTOK_MARKETS_S]     = {   -177,     -8,    -33, 128, offsetAxis.Z, 5.0 },
-    [xi.zone.WINDURST_WATERS_S]    = {    157,      0,     -8, 191, offsetAxis.X, 5.0 },
-    [xi.zone.SOUTHERN_SAN_DORIA]   = {    161,     -2,  162.1,  95, offsetAxis.Z, 3.0 },
-    [xi.zone.NORTHERN_SAN_DORIA]   = {    130,   -0.2,     -3, 160, offsetAxis.X, 3.0 },
-    [xi.zone.PORT_SAN_DORIA]       = {     78,    -16, -135.9, 165, offsetAxis.X, 2.0 },
-    [xi.zone.BASTOK_MINES]         = {    116,   0.99,    -75, 127, offsetAxis.Z, 5.0 },
-    [xi.zone.BASTOK_MARKETS]       = {   -177,     -8,    -33, 127, offsetAxis.Z, 5.0 },
-    [xi.zone.PORT_BASTOK]          = {     57,    8.5,   -239, 192, offsetAxis.X, 5.0 },
-    [xi.zone.WINDURST_WATERS]      = {    157,     -5,    -62, 192, offsetAxis.X, 5.0 },
-    [xi.zone.WINDURST_WALLS]       = { -257.5,  -5.05,   -123,   0, offsetAxis.Z, 5.0 },
-    [xi.zone.PORT_WINDURST]        = {    195, -15.56,    258,  65, offsetAxis.X, 5.0 },
-    [xi.zone.WINDURST_WOODS]       = {   -138,    -10,     37,   0, offsetAxis.Z, 5.0 },
-    [xi.zone.RULUDE_GARDENS]       = {     45,     10,    -73, 192, offsetAxis.X, 5.0 },
-    [xi.zone.UPPER_JEUNO]          = {     45,     -5,    -78, 172, offsetAxis.X, 2.5 },
-    [xi.zone.LOWER_JEUNO]          = {   41.2,     -5,     84,  85, offsetAxis.X, 2.5 },
-    [xi.zone.PORT_JEUNO]           = { -192.5,     -5,   -1.3,   0, offsetAxis.Z, 2.5 },
-    [xi.zone.WESTERN_ADOULIN]      = {     -0,     -0,   -144, 223, offsetAxis.Z, 5.0 },
-    [xi.zone.EASTERN_ADOULIN]      = {  -59.3,      0, -128.5, 191, offsetAxis.X, 5.0 },
+    -- Single Exit Zones -------------------------------------------------------------------------
+    [xi.zone.BASTOK_MINES]         = { [1] = {    117,   0.99,    -72,  127, offsetAxis.Z, 5.0 } },
+    [xi.zone.PORT_BASTOK]          = { [1] = {     60,    8.5,   -239,  192, offsetAxis.X, 5.0 } },
+    [xi.zone.AL_ZAHBI]             = { [1] = {     40,      0,    -61,  191, offsetAxis.X, 2.0 } },
+    [xi.zone.AHT_URHGAN_WHITEGATE] = { [1] = {   -101,      0,    -80,  255, offsetAxis.Z, 2.0 } },
+    [xi.zone.SOUTHERN_SAN_DORIA_S] = { [1] = {  148.5,     -2,    116,   95, offsetAxis.X, 2.0 } },
+    [xi.zone.WINDURST_WATERS_S]    = { [1] = {    160,   0.99,    -11,  191, offsetAxis.X, 2.0 } },
+    [xi.zone.SOUTHERN_SAN_DORIA]   = { [1] = {  159.5,     -2,    160,   95, offsetAxis.Z, 2.0 } },
+    [xi.zone.NORTHERN_SAN_DORIA]   = { [1] = {    130,   -0.2,     -3,  160, offsetAxis.X, 2.0 } },
+    [xi.zone.PORT_SAN_DORIA]       = { [1] = {   79.4,    -16, -135.5,  165, offsetAxis.R, 1.8 } },
+    [xi.zone.WINDURST_WATERS]      = { [1] = {    160,  -2.65,  -53.7,  192, offsetAxis.X, 2.5 } },
+    [xi.zone.WINDURST_WALLS]       = { [1] = {   -249,  -2.65,   -120,    0, offsetAxis.Z, 2.5 } },
+    [xi.zone.PORT_WINDURST]        = { [1] = {    198, -15.65,    258,   65, offsetAxis.X, 2.5 } },
+    [xi.zone.WINDURST_WOODS]       = { [1] = {   -130,  -7.65,     40,    0, offsetAxis.Z, 2.5 } },
+    [xi.zone.RULUDE_GARDENS]       = { [1] = {   46.5,     10,    -73,  192, offsetAxis.X, 1.8 } },
+    [xi.zone.UPPER_JEUNO]          = { [1] = {     47,     -5,  -79.3,  172, offsetAxis.R, 1.0 } },
+    [xi.zone.LOWER_JEUNO]          = { [1] = {     42,     -5,     85,   85, offsetAxis.R, 1.0 } },
+    [xi.zone.PORT_JEUNO]           = { [1] = {   -193,     -5,     -0,    0, offsetAxis.Z, 1.0 } },
+    [xi.zone.WESTERN_ADOULIN]      = { [1] = {      0,   0.75,   -142,  223, offsetAxis.R, 4.0 } },
+    [xi.zone.EASTERN_ADOULIN]      = { [1] = {    -56,  -0.15,   -127,  191, offsetAxis.X, 4.0 } },
+
+    --- Multiple Exit Zones ----------------------------------------------------------------------
+    [xi.zone.BASTOK_MARKETS_S]     = {
+        [1] = { -177,  -8,  -30, 128, offsetAxis.Z, 2.0 },
+        [2] = { -177,  -8,   30, 128, offsetAxis.Z, 2.0 }
+    },
+
+    [xi.zone.BASTOK_MARKETS]       = {
+        [1] = { -177,  -8,  -30, 128, offsetAxis.Z, 2.0 },
+        [2] = { -177,  -8,   30, 128, offsetAxis.Z, 2.0 }
+    },
+}
+
+local moghouseZoneLines =
+{
+--  [Zoneline ID] = entrance no.
+    [ 812805498] = 1, -- (230) SOUTHERN_SANDORIA
+    [ 812871034] = 1, -- ( 80) SOUTHERN_SANDORIA_S
+    [ 846359930] = 1, -- (231) NORTHERN_SANDORIA
+    [ 879979898] = 1, -- ( 87) BASTOK_MARKETS_S [Entrance 1]
+    [ 846425466] = 2, -- ( 87) BASTOK_MARKETS_S [Entrance 2]
+    [ 879914362] = 1, -- (232) PORT_SANDORIA
+    [ 913468794] = 1, -- (238) WINDURST_WATERS
+    [ 913534330] = 1, -- ( 94) WINDURST_WATERS_S
+    [ 947023226] = 1, -- (238) WINDURST_WALLS
+    [1668443514] = 1, -- (235) BASTOK_MARKETS [Entrance 1]
+    [1634889082] = 2, -- (235) BASTOK_MARKETS [Entrance 2]
+    [1701997946] = 1, -- (240) PORT_WINDURST
+    [1735552378] = 1, -- (234) BASTOK_MINES
+    [1769106810] = 1, -- (236) PORT_BASTOK
+    [1802661242] = 1, -- (241) WINDURST_WOODS
+    [1836215674] = 1, -- (243) RULUDE_GARDENS
+    [1869770106] = 1, -- (244) UPPER_JEUNO
+    [1936878970] = 1, -- (246) PORT_JEUNO
+    [1970433402] = 1, -- (245) LOWER_JEUNO
+    [2003987834] = 1, -- ( 48) AL_ZAHBI
+    [2037542266] = 1, -- ( 50) AHT_URHGAN_WHITEGATE
+    [ 947088762] = 1, -- (256) WESTERN_ADOULIN
+    [1634954618] = 1, -- (257) EASTERN_ADOULIN
 }
 
 xi.moghouse.isInMogHouseInHomeNation = function(player)
@@ -212,14 +251,24 @@ xi.moghouse.onMoghouseZoneEvent = function(player, prevZone)
         player:getYPos() == 0 and
         player:getZPos() == 0
     then
-        local x, y, z, r, randomizedAxis, randomMax = unpack(xi.moghouse.exits[player:getZoneID()])
-        local randomOffset                          = math.random(randomMax * 1000)
 
-        -- 0.000 - N.N00 variance
-        if randomizedAxis == offsetAxis.X then
-            x = x + (randomOffset / 1000)
+        local zoneId = player:getZoneID()
+        local prevZoneLineID = player:getPreviousZoneLineID()
+        local moghouseEntrance = moghouseZoneLines[prevZoneLineID] or 1
+        local x, y, z, r, randomizedAxis, randomMax = unpack(xi.moghouse.exits[zoneId][moghouseEntrance])
+        local randomOffset                          = math.random(-randomMax * 1000, randomMax * 1000) -- offset -/+ from center point
+        local offsetValue                           = randomOffset / 1000 -- 0.000 - N.N00 variance
+
+        -- A few moghouses are rotated so we handle them first.
+        if randomizedAxis == offsetAxis.R then
+            local lineRot = (r + 64) % 256 -- Calculate the perpendicular angle (90 degrees / 64 units offset) from the rotaion of r.
+            local lineRadians = lineRot * (math.pi * 2 / 256) -- Convert to radians.
+            x = x + (offsetValue * math.cos(lineRadians))
+            z = z - (offsetValue * math.sin(lineRadians))
+        elseif randomizedAxis == offsetAxis.X then
+            x = x + offsetValue
         elseif randomizedAxis == offsetAxis.Z then
-            z = z + (randomOffset / 1000)
+            z = z + offsetValue
         end
 
         player:setPos(x, y, z, r)

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -720,6 +720,11 @@ end
 
 ---@nodiscard
 ---@return integer
+function CBaseEntity:getPreviousZoneLineID()
+end
+
+---@nodiscard
+---@return integer
 function CBaseEntity:getCurrentRegion()
 end
 

--- a/scripts/zones/Western_Adoulin/Zone.lua
+++ b/scripts/zones/Western_Adoulin/Zone.lua
@@ -11,15 +11,6 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local heartwingsAndTheKindhearted = player:getCurrentMission(xi.mission.log_id.SOA) == xi.mission.id.soa.HEARTWINGS_AND_THE_KINDHEARTED
 
-    -- MOG HOUSE EXIT
-    if
-        player:getXPos() == 0 and
-        player:getYPos() == 0 and
-        player:getZPos() == 0
-    then
-        player:setPos(-0, -0, -143, 223)
-    end
-
     if player:getCharVar('Raptor_Rapture_Status') == 2 then
         -- Resuming cutscene for Quest: 'Raptor Rapture', after Pagnelle warps you to Rala Waterways mid-CS, then back here.
         return 5056

--- a/sql/chars.sql
+++ b/sql/chars.sql
@@ -11,6 +11,7 @@ CREATE TABLE `chars` (
   `nation` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `pos_zone` smallint(3) unsigned NOT NULL,
   `pos_prevzone` smallint(3) unsigned NOT NULL DEFAULT '0',
+  `pos_prevzonelineid` int(10) unsigned NOT NULL DEFAULT '0',
   `pos_rot` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `pos_x` float(7,3) NOT NULL DEFAULT '0.000',
   `pos_y` float(7,3) NOT NULL DEFAULT '0.000',

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -258,6 +258,7 @@ CCharEntity::CCharEntity()
     m_StartActionPos   = {};
     m_ActionOffsetPos  = {};
     m_previousLocation = {};
+    m_PrevZonelineID   = 0;
 
     m_jobMasterDisplay = false;
     m_EffectsChanged   = false;

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -517,6 +517,8 @@ public:
 
     location_t m_previousLocation{};
 
+    uint32 m_PrevZonelineID; // The ID of the previous zoneline the player went through.
+
     timer::duration   m_PlayTime;
     timer::time_point m_SaveTime;
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -2857,6 +2857,25 @@ uint16 CLuaBaseEntity::getPreviousZone()
 }
 
 /************************************************************************
+ *  Function: getPreviousZoneLineID()
+ *  Purpose : Returns the integer ID of the last zoneline the PC visited
+ *  Example : local prevZonelineID = player:getPreviousZoneLineID()
+ *  Notes   : Mainly used for moghouse exits
+ ************************************************************************/
+
+uint32 CLuaBaseEntity::getPreviousZoneLineID()
+{
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->getName());
+        return 0;
+    }
+
+    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
+    return PChar->m_PrevZonelineID;
+}
+
+/************************************************************************
  *  Function: getCurrentRegion()
  *  Purpose : Returns the integer value of the PC's region
  *  Example : local region = target:getCurrentRegion()
@@ -19550,6 +19569,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("getZoneName", CLuaBaseEntity::getZoneName);
     SOL_REGISTER("hasVisitedZone", CLuaBaseEntity::hasVisitedZone);
     SOL_REGISTER("getPreviousZone", CLuaBaseEntity::getPreviousZone);
+    SOL_REGISTER("getPreviousZoneLineID", CLuaBaseEntity::getPreviousZoneLineID);
     SOL_REGISTER("getCurrentRegion", CLuaBaseEntity::getCurrentRegion);
     SOL_REGISTER("getContinentID", CLuaBaseEntity::getContinentID);
     SOL_REGISTER("isInMogHouse", CLuaBaseEntity::isInMogHouse);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -194,6 +194,7 @@ public:
     auto   getZoneName() -> std::string;
     bool   hasVisitedZone(uint16 zone);
     uint16 getPreviousZone();
+    uint32 getPreviousZoneLineID();
     uint8  getCurrentRegion();
     uint8  getContinentID();
     bool   isInMogHouse();

--- a/src/map/packets/c2s/0x05e_maprect.cpp
+++ b/src/map/packets/c2s/0x05e_maprect.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
   Copyright (c) 2025 LandSandBoat Dev Teams
@@ -206,11 +206,15 @@ void GP_CLI_COMMAND_MAPRECT::process(MapSession* PSession, CCharEntity* PChar) c
                     PChar->m_moghouseID    = PChar->id;
                     PChar->loc.p           = PZoneLine->m_toPos;
                     PChar->loc.destination = PChar->getZone();
+
+                    charutils::SavePrevZoneLineID(PChar, PZoneLine->m_zoneLineID);
                 }
                 else
                 {
                     PChar->loc.destination = PZoneLine->m_toZone;
                     PChar->loc.p           = PZoneLine->m_toPos;
+
+                    charutils::SavePrevZoneLineID(PChar, PZoneLine->m_zoneLineID);
                 }
             }
         }

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -409,6 +409,7 @@ namespace charutils
                                "nation, "
                                "pos_zone, "
                                "pos_prevzone, "
+                               "pos_prevzonelineid, "
                                "pos_rot, "
                                "pos_x, "
                                "pos_y, "
@@ -451,15 +452,17 @@ namespace charutils
             PChar->targid = 0x400;
             PChar->SetName(rset->get<std::string>("charname").c_str());
 
-            PChar->loc.destination = rset->get<uint16>("pos_zone");
-            PChar->loc.prevzone    = rset->get<uint16>("pos_prevzone");
-            PChar->loc.p.rotation  = rset->get<uint8>("pos_rot");
-            PChar->loc.p.x         = rset->get<float>("pos_x");
-            PChar->loc.p.y         = rset->get<float>("pos_y");
-            PChar->loc.p.z         = rset->get<float>("pos_z");
-            PChar->m_moghouseID    = rset->get<uint32>("moghouse");
-            PChar->loc.boundary    = rset->get<uint16>("boundary");
-            PChar->accid           = rset->get<uint32>("accid");
+            PChar->loc.destination  = rset->get<uint16>("pos_zone");
+            PChar->loc.prevzone     = rset->get<uint16>("pos_prevzone");
+            PChar->m_PrevZonelineID = rset->get<uint32>("pos_prevzonelineid");
+
+            PChar->loc.p.rotation = rset->get<uint8>("pos_rot");
+            PChar->loc.p.x        = rset->get<float>("pos_x");
+            PChar->loc.p.y        = rset->get<float>("pos_y");
+            PChar->loc.p.z        = rset->get<float>("pos_z");
+            PChar->m_moghouseID   = rset->get<uint32>("moghouse");
+            PChar->loc.boundary   = rset->get<uint16>("boundary");
+            PChar->accid          = rset->get<uint32>("accid");
 
             PChar->profile.home_point.destination = rset->get<uint16>("home_zone");
             PChar->profile.home_point.p.rotation  = rset->get<uint8>("home_rot");
@@ -5832,6 +5835,17 @@ namespace charutils
                          "WHERE charid = ? "
                          "LIMIT 1",
                          PChar->m_ZonesVisitedList, PChar->id);
+    }
+
+    void SavePrevZoneLineID(CCharEntity* PChar, uint32 ZoneLineID)
+    {
+        TracyZoneScoped;
+
+        db::preparedStmt("UPDATE chars "
+                         "SET pos_prevzonelineid = ? "
+                         "WHERE charid = ? "
+                         "LIMIT 1",
+                         ZoneLineID, PChar->id);
     }
 
     void SaveCharEquip(CCharEntity* PChar)

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -198,24 +198,25 @@ namespace charutils
     void SaveCharInventoryCapacity(CCharEntity* PChar); // save Character inventory capacity
     void SaveSpell(CCharEntity* PChar, uint16 spellID); // save learned spells
     void DeleteSpell(CCharEntity* PChar, uint16 spellID);
-    void SaveLearnedAbilities(CCharEntity* PChar);                // save learned abilities (e.g., corsair rolls)
-    void SaveTitles(CCharEntity* PChar);                          // save character's titles
-    void SaveCharStats(CCharEntity* PChar);                       // save flags, current values of character stats (jobs/HP/MP/etc.)
-    void SaveCharGMLevel(CCharEntity* PChar);                     // save the character's gm level
-    void SaveMentorFlag(CCharEntity* PChar);                      // save the character's mentor flag
-    void SaveJobMasterDisplay(CCharEntity* PChar);                // Save the character's job master display status
-    void SavePlayerSettings(CCharEntity* PChar);                  // save the character's settings
-    void SaveChatFilterFlags(CCharEntity* PChar);                 // save the character's chat filters
-    void SaveLanguages(CCharEntity* PChar);                       // save the character's language preference
-    void SaveCharNation(CCharEntity* PChar);                      // save the character's nation of allegiance
-    void SaveCampaignAllegiance(const CCharEntity* PChar);        // save the character's campaign allegiance
-    void SaveCharMoghancement(const CCharEntity* PChar);          // save the character's current moghancement
-    void SaveCharSkills(const CCharEntity* PChar, uint8 skillID); // save the character's skills
-    void SaveTeleport(CCharEntity* PChar, TELEPORT_TYPE type);    // save the character's teleports (homepoints, outposts, maws, etc)
-    void SaveDeathTime(CCharEntity* PChar);                       // save when this character last died
-    void SavePlayTime(CCharEntity* PChar);                        // save this character's total play time
-    void SaveLastLogout(const CCharEntity* PChar);                // save the last logout time of this character
-    bool hasMogLockerAccess(const CCharEntity* PChar);            // true if have access, false otherwise
+    void SaveLearnedAbilities(CCharEntity* PChar);                  // save learned abilities (e.g., corsair rolls)
+    void SaveTitles(CCharEntity* PChar);                            // save character's titles
+    void SaveCharStats(CCharEntity* PChar);                         // save flags, current values of character stats (jobs/HP/MP/etc.)
+    void SaveCharGMLevel(CCharEntity* PChar);                       // save the character's gm level
+    void SaveMentorFlag(CCharEntity* PChar);                        // save the character's mentor flag
+    void SaveJobMasterDisplay(CCharEntity* PChar);                  // Save the character's job master display status
+    void SavePlayerSettings(CCharEntity* PChar);                    // save the character's settings
+    void SaveChatFilterFlags(CCharEntity* PChar);                   // save the character's chat filters
+    void SaveLanguages(CCharEntity* PChar);                         // save the character's language preference
+    void SaveCharNation(CCharEntity* PChar);                        // save the character's nation of allegiance
+    void SaveCampaignAllegiance(const CCharEntity* PChar);          // save the character's campaign allegiance
+    void SaveCharMoghancement(const CCharEntity* PChar);            // save the character's current moghancement
+    void SaveCharSkills(const CCharEntity* PChar, uint8 skillID);   // save the character's skills
+    void SaveTeleport(CCharEntity* PChar, TELEPORT_TYPE type);      // save the character's teleports (homepoints, outposts, maws, etc)
+    void SaveDeathTime(CCharEntity* PChar);                         // save when this character last died
+    void SavePlayTime(CCharEntity* PChar);                          // save this character's total play time
+    void SaveLastLogout(const CCharEntity* PChar);                  // save the last logout time of this character
+    void SavePrevZoneLineID(CCharEntity* PChar, uint32 ZoneLineID); // save the last zoneline the player crossed.
+    bool hasMogLockerAccess(const CCharEntity* PChar);              // true if have access, false otherwise
 
     uint8 getQuestStatus(CCharEntity* PChar, uint8 log, uint8 quest); // Get Quest status (used in FishingUtils.cpp, allows to fish quest specific mobs, like PLD AF NM)
 

--- a/tools/migrations/048_char_prevzone_column.py
+++ b/tools/migrations/048_char_prevzone_column.py
@@ -1,0 +1,27 @@
+import mariadb
+
+
+def migration_name():
+    return "Adding pos_prevzonelineid column to chars table"
+
+def check_preconditions(cur):
+    return
+
+def needs_to_run(cur):
+    # Ensure pos_prevzonelineid column exists in chars
+    cur.execute("SHOW COLUMNS FROM chars LIKE 'pos_prevzonelineid'")
+
+    if cur.fetchone():
+        return False
+
+    return True
+
+def migrate(cur, db):
+    try:
+        cur.execute(
+            "ALTER TABLE `chars` \
+            ADD COLUMN `pos_prevzonelineid` int(10) unsigned NOT NULL DEFAULT 0 AFTER `pos_prevzone`;"
+        )
+        db.commit()
+    except mariadb.Error as err:
+        print("Something went wrong: {}".format(err))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The main objective of this pull request is to ensure players exit a Mog House at the correct location when a zone has multiple possible entrances/exits (like the two entrances to the Bastok Markets Mog House), by using the zoneline ID they last crossed as the reference point.

This addresses issue https://github.com/LandSandBoat/server/issues/8402

I have evaluated all the positions for the moghouse exits in retail and updated all the positions in the moghouse.lua to match retail as possisble.

- Database: A new column, pos_prevzonelineid, is added to the chars table in sql/chars.sql to store the ID of the last zoneline a character passed through when a zone request is made.

- Migration file added for the new column added to chars sql

- Zoneline ID Saving: When a player crosses a zoneline (C2S packet 0x05e_maprect.cpp), the zoneline's ID is now saved to the character entity using charutils::SavePrevZoneLineID.

- Introduced m_PrevZonelineID into CCharEntity

- Mog House Exits (scripts/globals/moghouse.lua):

    The xi.moghouse.exits table is restructured to support multiple exit points per zone. For example, Bastok Markets/Bastok Markets[S] now has two distinct exit positions (entrances [1] and [2]).

    A new table, moghouseZoneLines, is introduced to map specific zoneline IDs to their corresponding Mog House exit number (entrance no.). This links the player's entry point to the correct exit coordinate.

    The randomized exit position logic is updated to include a new offset axis R (Rotation) for specific zones (e.g., Jeuno and Adoulin ports) and to allow for perpendicular movement from the r value in the table.
    


## Steps to test these changes

Zone into Bastok Markets/[s] moghouse and you should see you came out the correct side.

Zone into Upper or Lower Jeuno moghouse and notice the placement when zoning out will now follow a perpendicular line,
and can no longer spawn on the walls to the sides.

Use !getprevzoneline to view the last zoneline ID crossed after zoneing.
