### PR TITLE
[cpp] Lua table type detection

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -335,6 +335,8 @@
         "GetSynergyRecipeByID",
         "GetSynergyRecipeByTrade",
         "ReloadSynthRecipes",
+
+        "IsTableIpairsCompatible",
     ],
     "Lua.diagnostics.disable": [
         "lowercase-global"

--- a/scripts/specs/core/Globals.lua
+++ b/scripts/specs/core/Globals.lua
@@ -433,25 +433,30 @@ end
 function RoeParseTimed(timedSchedule)
 end
 
---@return table
+---@return table
 function GetFishingContest()
 end
 
---@return nil
+---@return nil
 function InitNewFishingContest()
 end
 
---@param fishId integer
---@param measure integer
---@param criteria integer
---@return nil
+---@param fishId integer
+---@param measure integer
+---@param criteria integer
+---@return nil
 function SetContestParameters(fishId, measure, criteria)
 end
 
---@return nil
+---@return nil
 function ProgressFishingContest()
 end
 
---@return nil
+---@return nil
 function InitializeFishingContestSystem()
+end
+
+---@param maybeSequentialTable table
+---@return bool
+function IsTableIpairsCompatible(maybeSequentialTable)
 end

--- a/scripts/utils/utils.lua
+++ b/scripts/utils/utils.lua
@@ -817,6 +817,11 @@ end
 ---@param t table
 ---@return integer|string, any
 function utils.randomEntryIdx(t)
+    if IsTableIpairsCompatible(t) then
+        local index = math.random(1, #t)
+        return index, t[index]
+    end
+
     local keys = {}
 
     for key, _ in pairs(t) do

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -316,6 +316,7 @@ namespace luautils
         lua.set_function("GetSynergyRecipeByID", &luautils::GetSynergyRecipeByID);
         lua.set_function("GetSynergyRecipeByTrade", &luautils::GetSynergyRecipeByTrade);
         lua.set_function("ReloadSynthRecipes", &synthutils::LoadSynthRecipes);
+        lua.set_function("IsTableIpairsCompatible", &luautils::IsTableIpairsCompatible);
 
         // Fishing Contest Functions
         lua.set_function("GetFishingContest", &luautils::GetFishingContest);
@@ -5824,5 +5825,48 @@ namespace luautils
         table["resultName"]            = result.resultName;
 
         return table;
+    }
+
+    // Determines if a table is compatible with ipairs() behavior (loop from 1 to N where N+1 is the first key that returns a nil value from the table)
+    // Also implies #tableName reliably returns the size of the table
+    bool IsTableIpairsCompatible(const sol::table& maybeSequentialTable)
+    {
+        // get "array length" of the table same as "#table" in lua
+        size_t tableLuaLength = maybeSequentialTable.size();
+
+        if (tableLuaLength == 0)
+        {
+            // don't consider an empty table valid
+            return false;
+        }
+
+        // Loop over all key-values and detect any non-numeric keys or holes
+        size_t indicesMatched = 0;
+        for (auto& kvp : maybeSequentialTable)
+        {
+            const auto& key = kvp.first;
+
+            if (!key.is<size_t>())
+            {
+                // Found non-integer key
+                return false;
+            }
+
+            size_t k = key.as<size_t>();
+            if (k < 1 || k > tableLuaLength)
+            {
+                // key is out of range of detected table size
+                return false;
+            }
+
+            // Ensure detected table length has no holes/nil values in the table
+            if (!kvp.second.is<sol::nil_t>())
+            {
+                ++indicesMatched;
+            }
+        }
+
+        // Table has all integer keys, that range from 1 to index, with no missing (or nil-valued) keys
+        return indicesMatched == tableLuaLength;
     }
 }; // namespace luautils

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -330,11 +330,11 @@ namespace luautils
     void OnUpdateAttachment(CBattleEntity* PEntity, CItemPuppet* attachment, uint8 maneuvers);
 
     int32 OnItemUse(CBaseEntity* PUser, CBaseEntity* PTarget, CItem* PItem, action_t& action);
-    auto OnItemCheck(CBaseEntity* PTarget, CItem* PItem, ITEMCHECK param = ITEMCHECK::NONE, CBaseEntity* PCaster = nullptr) -> std::tuple<int32, int32, int32>;
-    void OnItemDrop(CBaseEntity* PUser, CItem* PItem);
-    void OnItemEquip(CBaseEntity* PUser, CItem* PItem);
-    void OnItemUnequip(CBaseEntity* PUser, CItem* PItem);
-    void CheckForGearSet(CBaseEntity* PTarget);
+    auto  OnItemCheck(CBaseEntity* PTarget, CItem* PItem, ITEMCHECK param = ITEMCHECK::NONE, CBaseEntity* PCaster = nullptr) -> std::tuple<int32, int32, int32>;
+    void  OnItemDrop(CBaseEntity* PUser, CItem* PItem);
+    void  OnItemEquip(CBaseEntity* PUser, CItem* PItem);
+    void  OnItemUnequip(CBaseEntity* PUser, CItem* PItem);
+    void  CheckForGearSet(CBaseEntity* PTarget);
 
     int32 OnMagicCastingCheck(CBaseEntity* PChar, CBaseEntity* PTarget, CSpell* PSpell);
     int32 OnSpellCast(CBattleEntity* PCaster, CBattleEntity* PTarget, CSpell* PSpell);
@@ -470,6 +470,8 @@ namespace luautils
 
     auto GetSynergyRecipeByID(uint32 id) -> sol::table;
     auto GetSynergyRecipeByTrade(CLuaTradeContainer luaTradeContainer) -> sol::table;
+
+    bool IsTableIpairsCompatible(const sol::table& maybeSequentialTable);
 }; // namespace luautils
 
 // template impl


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Recently learned that `utils.randomEntry` loops over the whole table even for sequential or otherwise auto-incremented lua tables.

This PR adds a luautil that loops over the table in a much more efficient manner (with little impact if the table isn't ipairs-compatible).

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- See no change in `utils.randomEntry` (adding a print when the table is found to be ipairs-compatible):
  - <img width="543" height="263" alt="image" src="https://github.com/user-attachments/assets/011781b6-34c4-4997-a11b-fe943acf35d2" />
- Under the hood, check that the new luautil binding functions as expected
  - <img width="619" height="378" alt="image" src="https://github.com/user-attachments/assets/9b740aa6-2005-4451-84f6-b0d178901c2c" />

