### PR TITLE
[core] Leak extdata on item move like retail

### DIFF
--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -36,6 +36,10 @@ xi.settings.map =
     -- Minimal number of 0x3A packets which uses for detect lightluggage (set 0 for disable)
     LIGHTLUGGAGE_BLOCK = 4,
 
+    -- Enable or disable leaking item extdata to client when moving items out of an inventory container into another one
+    -- Retail leaks extdata on move, which is useful for edge cases such as weapon skill points
+    LEAK_EXT_DATA_ON_ITEM_MOVE = true,
+
     -- Enable or disable Recycle Bin (Set to false for items to be dropped immediately)
     ENABLE_ITEM_RECYCLE_BIN = true,
 

--- a/src/map/packets/c2s/0x029_item_move.cpp
+++ b/src/map/packets/c2s/0x029_item_move.cpp
@@ -227,7 +227,7 @@ void GP_CLI_COMMAND_ITEM_MOVE::process(MapSession* PSession, CCharEntity* PChar)
             {
                 PChar->getStorage(Category1)->InsertItem(nullptr, ItemIndex1);
 
-                PChar->pushPacket<GP_SERV_COMMAND_ITEM_ATTR>(nullptr, static_cast<CONTAINER_ID>(Category1), ItemIndex1);
+                PChar->pushPacket<GP_SERV_COMMAND_ITEM_ATTR>(nullptr, static_cast<CONTAINER_ID>(Category1), ItemIndex1, PItem);
                 PChar->pushPacket<GP_SERV_COMMAND_ITEM_ATTR>(PItem, static_cast<CONTAINER_ID>(Category2), newSlotId);
             }
             else

--- a/src/map/packets/s2c/0x020_item_attr.cpp
+++ b/src/map/packets/s2c/0x020_item_attr.cpp
@@ -113,7 +113,7 @@ GP_SERV_COMMAND_ITEM_ATTR::GP_SERV_COMMAND_ITEM_ATTR(CItem* PItem, const CONTAIN
             packet.Attr[8] = static_cast<CItemLinkshell*>(PItem)->GetLSType();
         }
     }
-    else if (staleItem) // Yes, retail copies the previously moved item's extdata which leaks information about weaponskill points.
+    else if (staleItem && settings::get<bool>("map.LEAK_EXT_DATA_ON_ITEM_MOVE")) // Yes, retail copies the previously moved item's extdata which leaks information about weaponskill points.
     {
         std::memcpy(packet.Attr, staleItem->m_extra, sizeof(staleItem->m_extra));
     }

--- a/src/map/packets/s2c/0x020_item_attr.cpp
+++ b/src/map/packets/s2c/0x020_item_attr.cpp
@@ -28,7 +28,7 @@
 
 #include <cstring>
 
-GP_SERV_COMMAND_ITEM_ATTR::GP_SERV_COMMAND_ITEM_ATTR(CItem* PItem, const CONTAINER_ID locationId, const uint8_t slotId)
+GP_SERV_COMMAND_ITEM_ATTR::GP_SERV_COMMAND_ITEM_ATTR(CItem* PItem, const CONTAINER_ID locationId, const uint8_t slotId, CItem* staleItem)
 {
     auto& packet = this->data();
 
@@ -112,5 +112,9 @@ GP_SERV_COMMAND_ITEM_ATTR::GP_SERV_COMMAND_ITEM_ATTR(CItem* PItem, const CONTAIN
         {
             packet.Attr[8] = static_cast<CItemLinkshell*>(PItem)->GetLSType();
         }
+    }
+    else if (staleItem) // Yes, retail copies the previously moved item's extdata which leaks information about weaponskill points.
+    {
+        std::memcpy(packet.Attr, staleItem->m_extra, sizeof(staleItem->m_extra));
     }
 }

--- a/src/map/packets/s2c/0x020_item_attr.h
+++ b/src/map/packets/s2c/0x020_item_attr.h
@@ -43,5 +43,8 @@ public:
         uint8_t      Attr[24];  // PS2: Attr TODO: Make structs for each possible exdata
     };
 
-    GP_SERV_COMMAND_ITEM_ATTR(CItem* PItem, CONTAINER_ID locationId, uint8_t slotId);
+    // On retail, when you move an item out of the original slot to a different bag, it first sends "move old item to new slot"
+    // It then sends a "set old slot to empty" and when it does so, it leaks the old extdata
+    // We emulate this here with a non-null `staleItem` pointer to the old item
+    GP_SERV_COMMAND_ITEM_ATTR(CItem* PItem, const CONTAINER_ID locationId, const uint8_t slotId, CItem* staleItem = nullptr);
 };

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1800,7 +1800,7 @@ namespace charutils
                 {
                     PItemContainer->InsertItem(nullptr, SlotID);
 
-                    PChar->pushPacket<GP_SERV_COMMAND_ITEM_ATTR>(nullptr, static_cast<CONTAINER_ID>(LocationID), SlotID);
+                    PChar->pushPacket<GP_SERV_COMMAND_ITEM_ATTR>(nullptr, static_cast<CONTAINER_ID>(LocationID), SlotID, PItemContainer->GetItem(NewSlotID));
                     PChar->pushPacket<GP_SERV_COMMAND_ITEM_ATTR>(PItemContainer->GetItem(NewSlotID), static_cast<CONTAINER_ID>(LocationID), NewSlotID);
                     return NewSlotID;
                 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

So apparently retail leaks extdata when you move an item by copying the previous item's extdata

Wand of trials with unknown WS points after moving
<img width="451" height="102" alt="image" src="https://github.com/user-attachments/assets/5106c320-ff0f-4d2c-abbe-89849833fdb9" />
Wand of trials after 1 no-SC WS
<img width="606" height="96" alt="image" src="https://github.com/user-attachments/assets/4d633eff-4e32-4d99-a075-8125d007e082" />

Note: SE changed WS points in a recent patch:
<img width="884" height="191" alt="image" src="https://github.com/user-attachments/assets/d49f15c1-e89d-40e3-8ca9-b622864888b3" />
It seems they increased the amount of WS points you receive

Additionally, here's a move of an Aegis with a trial on it

Empty but occupying the old slot with extdata on it:
<img width="433" height="108" alt="image" src="https://github.com/user-attachments/assets/43ae6eb7-dfa2-4add-a2ae-6d64502d720e" />

Item move:
<img width="432" height="98" alt="image" src="https://github.com/user-attachments/assets/8ed184a7-371a-40e5-ae79-3f4932f4fb3d" />

## Steps to test these changes
capture packets, see leaked extdata

<img width="621" height="174" alt="image" src="https://github.com/user-attachments/assets/abffd2bc-166e-456d-b743-f84fb123d755" />