### PR TITLE
[lua, sql] Windurst and San d'Oria Mission Mob Skill Audit

### DIFF
--- a/scripts/actions/mobskills/antiphase.lua
+++ b/scripts/actions/mobskills/antiphase.lua
@@ -13,7 +13,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, 60))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, 90))
 
     return xi.effect.SILENCE
 end

--- a/scripts/actions/mobskills/beatdown.lua
+++ b/scripts/actions/mobskills/beatdown.lua
@@ -12,12 +12,12 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 1
     local accmod = 1
-    local ftp    = 2
+    local ftp    = 1
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.ATK_VARIES, 2, 2, 2)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BIND, 1, 0, 20)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BIND, 1, 0, 60)
 
     return dmg
 end

--- a/scripts/actions/mobskills/blank_gaze.lua
+++ b/scripts/actions/mobskills/blank_gaze.lua
@@ -12,7 +12,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.PARALYSIS, 35, 0, 60))
+    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.PARALYSIS, 35, 0, 180))
 
     return xi.effect.PARALYSIS
 end

--- a/scripts/actions/mobskills/cross_attack.lua
+++ b/scripts/actions/mobskills/cross_attack.lua
@@ -12,8 +12,8 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 2
     local accmod = 1
-    local ftp    = 1.5
-    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
+    local ftp    = 1
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.ATK_VARIES, 1.5, 1.5, 1.5)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.HTH, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.HTH)
     return dmg

--- a/scripts/actions/mobskills/everyones_grudge.lua
+++ b/scripts/actions/mobskills/everyones_grudge.lua
@@ -19,10 +19,26 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local power   = 5
     local realDmg = power * target:getCharVar('EVERYONES_GRUDGE_KILLS') -- Damage is 5 times the amount you have killed
 
-    if target:getID() > 100000 then
+    -- TODO: Verify if this is accurate
+    if target:isPet() then
         realDmg = power * math.random(30, 100)
-    elseif mob:isNM() then
+    end
+
+    if mob:isNM() then
         realDmg = realDmg * 10 -- sets the multiplier to 50 for NM's
+    end
+
+    -- Uggalepih Necklace mitigation
+    -- While worn, consumes all TP to mitigate damage at flat breakpoints
+    -- 1500 TP = 50% reduction, 3000 TP = 100% reduction
+    if
+        target:isPC() and
+        target:getEquipID(xi.slot.NECK) == xi.item.UGGALEPIH_NECKLACE
+    then
+        local tpFactor = 1 - 0.5 * math.floor(target:getTP() / 1500)
+        realDmg        = math.floor(realDmg * tpFactor)
+
+        target:setTP(0)
     end
 
     target:takeDamage(realDmg, mob, xi.attackType.MAGICAL, xi.damageType.ELEMENTAL)

--- a/scripts/actions/mobskills/everyones_rancor.lua
+++ b/scripts/actions/mobskills/everyones_rancor.lua
@@ -26,8 +26,22 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local realDmg = 50 * target:getCharVar('EVERYONES_GRUDGE_KILLS')
 
-    if target:getID() > 100000 then
+    -- TODO: Verify if this is accurate
+    if target:isPet() then
         realDmg = 50 * math.random(50, 100)
+    end
+
+    -- Uggalepih Necklace mitigation
+    -- While worn, consumes all TP to mitigate damage at flat breakpoints
+    -- 1500 TP = 50% reduction, 3000 TP = 100% reduction
+    if
+        target:isPC() and
+        target:getEquipID(xi.slot.NECK) == xi.item.UGGALEPIH_NECKLACE
+    then
+        local tpFactor = 1 - 0.5 * math.floor(target:getTP() / 1500)
+        realDmg        = math.floor(realDmg * tpFactor)
+
+        target:setTP(0)
     end
 
     target:takeDamage(realDmg, mob, xi.attackType.MAGICAL, xi.damageType.ELEMENTAL)

--- a/scripts/actions/mobskills/hard_membrane.lua
+++ b/scripts/actions/mobskills/hard_membrane.lua
@@ -11,11 +11,16 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    if mob:hasStatusEffect(xi.effect.EVASION_BOOST) then
+        return 1
+    end
+
     return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.EVASION_BOOST, 25, 0, 60))
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 180, 300)
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.EVASION_BOOST, 25, 0, duration))
 
     return xi.effect.EVASION_BOOST
 end

--- a/scripts/actions/mobskills/ink_jet.lua
+++ b/scripts/actions/mobskills/ink_jet.lua
@@ -11,13 +11,12 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local damage = math.floor(mob:getWeaponDmg() * 2.5)
-
-    damage = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.DARK, 1, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    local ftp = math.random(1.5, 2.5)
+    local damage = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getMainLvl() + 2, xi.element.DARK, ftp, xi.mobskills.magicalTpBonus.NO_EFFECT)
     damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 
     target:takeDamage(damage, mob, xi.attackType.MAGICAL, xi.damageType.DARK)
-    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 20, 0, 180)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 80, 0, 120)
 
     return damage
 end

--- a/scripts/actions/mobskills/jet_stream.lua
+++ b/scripts/actions/mobskills/jet_stream.lua
@@ -12,7 +12,7 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 3
     local accmod = 1
-    local ftp    = 0.9 + (mob:getMainLvl() / 100)
+    local ftp    = 1
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.ACC_VARIES, 1, 1.5, 2)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)

--- a/scripts/actions/mobskills/lateral_slash.lua
+++ b/scripts/actions/mobskills/lateral_slash.lua
@@ -17,11 +17,11 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 1
     local accmod = 2
-    local ftp    = 2.7
+    local ftp    = 1
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.DEFENSE_DOWN, 75, 0, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.DEFENSE_DOWN, 83, 0, 30)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/light_of_penance.lua
+++ b/scripts/actions/mobskills/light_of_penance.lua
@@ -12,11 +12,12 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local tpReduced = 0
+    local duration  = 60
     target:setTP(tpReduced)
 
-    xi.mobskills.mobGazeMove(mob, target, xi.effect.BLINDNESS, 20, 0, 120)
+    xi.mobskills.mobGazeMove(mob, target, xi.effect.BLINDNESS, 100, 0, duration)
 
-    xi.mobskills.mobGazeMove(mob, target, xi.effect.BIND, 1, 0, 30)
+    xi.mobskills.mobGazeMove(mob, target, xi.effect.BIND, 1, 0, duration)
 
     skill:setMsg(xi.msg.basic.TP_REDUCED)
 

--- a/scripts/actions/mobskills/maelstrom.lua
+++ b/scripts/actions/mobskills/maelstrom.lua
@@ -11,9 +11,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local damage = math.floor(mob:getWeaponDmg() * 3.5)
+    local ftp = math.random(2, 3)
 
-    damage = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.WATER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    local damage = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getMainLvl() + 2, xi.element.WATER, ftp, xi.mobskills.magicalTpBonus.NO_EFFECT)
     damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
 
     target:takeDamage(damage, mob, xi.attackType.MAGICAL, xi.damageType.WATER)

--- a/scripts/actions/mobskills/needleshot.lua
+++ b/scripts/actions/mobskills/needleshot.lua
@@ -15,7 +15,7 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 1
     local accmod = 0.8
-    local dmgmod = 2.2
+    local dmgmod = 2
     local info = xi.mobskills.mobRangedMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.RANGED, xi.damageType.PIERCING, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.RANGED, xi.damageType.PIERCING)

--- a/scripts/actions/mobskills/photosynthesis.lua
+++ b/scripts/actions/mobskills/photosynthesis.lua
@@ -13,7 +13,10 @@ local mobskillObject = {}
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
     -- only used during daytime
     local currentTime = VanadielHour()
-    if currentTime >= 6 and currentTime <= 18 then
+    if
+        not mob:hasStatusEffect(xi.effect.REGEN) and
+        currentTime >= 6 and currentTime <= 18
+    then
         return 0
     end
 
@@ -21,9 +24,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local power = mob:getMainLvl() / 10 * 4 + 5
+    local power = math.floor(mob:getMainLvl() / 10)
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.REGEN, power, 0, 30))
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.REGEN, power, 0, 180))
 
     return xi.effect.REGEN
 end

--- a/scripts/actions/mobskills/regeneration.lua
+++ b/scripts/actions/mobskills/regeneration.lua
@@ -10,13 +10,18 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    if mob:hasStatusEffect(xi.effect.REGEN) then
+        return 1
+    end
+
     return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local power = mob:getMainLvl() / 10 * 4 + 5
+    local tpFactor = utils.clamp(3 * (skill:getTP() - 1000) / 1000, 0, 6)
+    local power    = 5 + tpFactor
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.REGEN, power, 3, 60))
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.REGEN, power, 3, 300))
 
     return xi.effect.REGEN
 end

--- a/scripts/actions/mobskills/sigh.lua
+++ b/scripts/actions/mobskills/sigh.lua
@@ -15,7 +15,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.EVASION_BOOST, 50, 0, 30))
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.EVASION_BOOST, 200, 0, 15))
 
     return xi.effect.EVASION_BOOST
 end

--- a/scripts/actions/mobskills/slipstream.lua
+++ b/scripts/actions/mobskills/slipstream.lua
@@ -10,7 +10,8 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ACCURACY_DOWN, 25, 0, math.random(120, 180)))
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 120, 180)
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ACCURACY_DOWN, 25, 0, duration))
 
     return xi.effect.ACCURACY_DOWN
 end

--- a/scripts/actions/mobskills/sonic_boom.lua
+++ b/scripts/actions/mobskills/sonic_boom.lua
@@ -10,7 +10,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ATTACK_DOWN, 50, 0, 120))
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 120, 180)
+
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ATTACK_DOWN, 25, 0, duration))
 
     return xi.effect.ATTACK_DOWN
 end

--- a/scripts/actions/mobskills/tentacle.lua
+++ b/scripts/actions/mobskills/tentacle.lua
@@ -12,8 +12,9 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 1
     local accmod = 1
-    local ftp    = 2.6
-    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
+    local ftp    = 2
+    local params = { canCrit = true }
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT, 0, 0, 0, params)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/turbulence.lua
+++ b/scripts/actions/mobskills/turbulence.lua
@@ -10,9 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local damage = mob:getWeaponDmg() * 3
-
-    damage = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    local damage = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getMainLvl() + 2, xi.element.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT)
     damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
 
     target:takeDamage(damage, mob, xi.attackType.MAGICAL, xi.damageType.WIND)

--- a/scripts/actions/mobskills/vertical_slash.lua
+++ b/scripts/actions/mobskills/vertical_slash.lua
@@ -15,11 +15,11 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 1
     local accmod = 2
-    local ftp    = 2.6
+    local ftp    = 1.5
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.ACCURACY_DOWN, 25, 0, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.ACCURACY_DOWN, 100, 0, 30)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/whirlwind.lua
+++ b/scripts/actions/mobskills/whirlwind.lua
@@ -11,12 +11,13 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local damage = mob:getWeaponDmg() * 4
+    local ftp = math.random(2, 3)
 
-    damage = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    local damage = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getMainLvl() + 2, xi.element.WIND, ftp, xi.mobskills.magicalTpBonus.NO_EFFECT)
     damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
 
     target:takeDamage(damage, mob, xi.attackType.MAGICAL, xi.damageType.WIND)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.VIT_DOWN, 10, 3, 120)
 
     return damage
 end

--- a/scripts/actions/mobskills/words_of_bane.lua
+++ b/scripts/actions/mobskills/words_of_bane.lua
@@ -13,7 +13,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.CURSE_I, 25, 0, 360))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.CURSE_I, 25, 0, 45))
 
     return xi.effect.CURSE_I
 end

--- a/scripts/enum/item.lua
+++ b/scripts/enum/item.lua
@@ -5475,6 +5475,7 @@ xi.item =
     OPO_OPO_NECKLACE                    = 13143,
     WING_GORGET                         = 13144,
     UGGALEPIH_PENDANT                   = 13145,
+    UGGALEPIH_NECKLACE                  = 13147,
     EVASION_TORQUE                      = 13148,
     PARRYING_TORQUE                     = 13149,
     SHIELD_TORQUE                       = 13150,

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -600,7 +600,7 @@ INSERT INTO `mob_skills` VALUES (581,325,'blow',0,0.0,7.0,2000,1500,4,0,0,0,0,0,
 INSERT INTO `mob_skills` VALUES (583,327,'beatdown',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (584,328,'uppercut',0,0.0,7.0,2000,1500,4,0,0,2,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (585,329,'hekaton_punch',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (586,330,'blank_gaze',0,0.0,7.0,2000,2000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (586,330,'blank_gaze',4,0.0,7.0,2000,2000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (587,331,'antiphase',1,0.0,15.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (588,398,'death_trap',1,0.0,30.0,2000,2000,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (589,333,'mortal_ray',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
@@ -934,8 +934,8 @@ INSERT INTO `mob_skills` VALUES (916,573,'aerial_blast',1,0.0,30.0,2000,0,4,64,0
 INSERT INTO `mob_skills` VALUES (917,586,'diamond_dust',1,0.0,30.0,2000,0,4,64,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (918,599,'judgment_bolt',1,0.0,30.0,2000,0,4,64,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (919,611,'searing_light',1,0.0,30.0,2000,0,4,64,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (920,503,'everyones_grudge',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (921,504,'everyones_rancor',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (920,503,'everyones_grudge',1,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (921,504,'everyones_rancor',1,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (922,143,'blind_vortex',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (923,144,'giga_scream',0,0.0,7.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (924,145,'dread_dive',0,0.0,7.0,2000,1500,4,0,0,2,0,0,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Audited mobs relevant to the remaining Windurst and San d'Oria missions. 
- This resulted in adjustments to Sabotenders, Sea Monks, Tonberries, and Goobbues.
- Added functionality to Uggalepih Necklace as part of Tonberry mob skill audit to reduce damage from Everyone's Rancor/Grudge.

## Steps to test these changes

- Fight mobs, see they reflect listed changed

## Sources
[Monster Stats](https://docs.google.com/spreadsheets/d/1YBoveP-weMdidrirY-vPDzHyxbEI2ryECINlfCnFkLI/edit?gid=57955395#gid=57955395)

Sabotenders
<img width="1285" height="157" alt="image" src="https://github.com/user-attachments/assets/e02e6029-de33-4e8c-b084-d33257416515" />

Sea Monks
<img width="1282" height="155" alt="image" src="https://github.com/user-attachments/assets/45090b29-555b-4d0c-917a-e52b41599333" />

Goobbue
<img width="1286" height="170" alt="image" src="https://github.com/user-attachments/assets/626a17a7-e55c-4543-88e0-6bcdf647e10b" />

Tonberry
<img width="1386" height="270" alt="image" src="https://github.com/user-attachments/assets/94a56726-1ddb-4902-9fa8-f85ebecdcd18" />
