### PR TITLE
[lua] Corrects Variable on CS 8 and CS 9 for quest "The Missing Piece"

### DIFF
--- a/scripts/quests/outlands/The_Missing_Piece.lua
+++ b/scripts/quests/outlands/The_Missing_Piece.lua
@@ -68,9 +68,9 @@ quest.sections =
                     if progress == 0 then
                         return quest:event(7, xi.ki.ANCIENT_TABLET_FRAGMENT) -- Reminder to get KI
                     elseif progress == 1 then
-                        return quest:progressEvent(8, xi.ki.ANCIENT_TABLET_FRAGMENT) -- Player has returned with KI
+                        return quest:progressEvent(8, xi.ki.ANCIENT_TABLET_FRAGMENT, xi.ki.TABLET_OF_ANCIENT_MAGIC, xi.ki.LETTER_FROM_ALFESAR) -- Player has returned with KI
                     elseif progress == 2 then
-                        return quest:event(9, 0, xi.ki.ANCIENT_TABLET_FRAGMENT) -- Reminder to go to Sandy
+                        return quest:event(9, 0, xi.ki.TABLET_OF_ANCIENT_MAGIC) -- Reminder to go to Sandy
                     end
                 end,
             },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Corrects incorrect/missing dialogue variable for Cutscenes 8 and 9 for the quest "The Missing Piece"

## Steps to test these changes

`!zone <RABAO>`
Be level 10 or higher. Have SELBINA_RABAO fame 4 or higher.
`!gotoname Alfesar` Talk to Alfesar
`!setquestvar <me> 5 193 Prog 1`
Talk to Alfesar

Current Dialogue:
<img width="1309" height="101" alt="image" src="https://github.com/user-attachments/assets/5458a421-53e7-4442-94ff-af0ad9c0c2f2" />

Fixed Dialogue:
<img width="1306" height="97" alt="image" src="https://github.com/user-attachments/assets/fe1010f3-73d6-4c1f-8591-4673a0977c57" />

Expected Dialogue:
<img width="1184" height="133" alt="image" src="https://github.com/user-attachments/assets/dceb9ece-a698-4eba-b71d-15f95b509673" />

## Capture
https://youtu.be/LkuZrms8V10
https://1drv.ms/u/s!AlLEVQXhZeaHgivaEuHv2ZBW10l_?e=Mc9AJb