### PR TITLE
[lua] Fix BattlefieldQuest Requirement Checks

### DIFF
--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -963,7 +963,10 @@ function Battlefield:onBattlefieldInitialize(battlefield)
     end
 
     for mobId, path in pairs(self.paths) do
-        GetMobByID(mobId):pathThrough(path, xi.path.flag.PATROL)
+        local mEntity = GetMobByID(mobId)
+        if mEntity then
+            mEntity:pathThrough(path, xi.path.flag.PATROL)
+        end
     end
 
     self:setupBattlefield(battlefield)
@@ -1450,9 +1453,11 @@ function BattlefieldQuest:new(data)
     local obj = Battlefield:new(data)
     setmetatable(obj, self)
 
-    obj.questArea  = data.questArea
-    obj.quest      = data.quest
-    obj.canLoseExp = data.canLoseExp or false
+    obj.questArea     = data.questArea
+    obj.quest         = data.quest
+    obj.canLoseExp    = data.canLoseExp or false
+    obj.requiredVar   = data.requiredVar
+    obj.requiredValue = data.requiredValue
 
     return obj
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Adds in the RequiredVar / RequiredValue parameters to BattlefieldQuest.  Since this object inherits from the base Battlefield, it did not have direct access to the RequiredVar/Value params.  This meant that a player could endlessly enter into a Quest Related BCNM even after completion and no longer meeting the requirements specified in the lua for that BCNM.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - `!addquest 3 86` to flag Storms of Fate
2 - `!gotoid 16896218` to go to the Unstable Displacement
3 - `!setquestvar <me> 3 86 Prog 1`
4 - Click the Portal for a CS (Updates Prog to 2)
5 - Click the Portal again for the BCNM Menu
6 - Enter Storms of Fate and Complete the BCNM
7 - After exiting the BCNM, attempt to re-enter again
Result: Unless you have clearance for another battlefield, you are not allowed back into the Quest BCNM
