### PR TITLE
[lua] Add lua util function to detect ipair-compatible tables

### DIFF
--- a/scripts/specs/core/Globals.lua
+++ b/scripts/specs/core/Globals.lua
@@ -433,25 +433,25 @@ end
 function RoeParseTimed(timedSchedule)
 end
 
---@return table
+---@return table
 function GetFishingContest()
 end
 
---@return nil
+---@return nil
 function InitNewFishingContest()
 end
 
---@param fishId integer
---@param measure integer
---@param criteria integer
---@return nil
+---@param fishId integer
+---@param measure integer
+---@param criteria integer
+---@return nil
 function SetContestParameters(fishId, measure, criteria)
 end
 
---@return nil
+---@return nil
 function ProgressFishingContest()
 end
 
---@return nil
+---@return nil
 function InitializeFishingContestSystem()
 end

--- a/scripts/tests/systems/utils/isTableIpairsCompatible.lua
+++ b/scripts/tests/systems/utils/isTableIpairsCompatible.lua
@@ -1,0 +1,55 @@
+describe('isTableIpairsCompatible', function()
+    local tables =
+    {
+        int =
+        {
+            [100]    = {},
+            [1000]   = {},
+        },
+        string =
+        {
+            [100]    = {},
+            [1000]   = {},
+        },
+        mixed =
+        {
+            [100]    = {},
+            [1000]   = {},
+        },
+    }
+
+    it('initializes tables', function()
+        for desiredCount, tab in pairs(tables['int']) do
+            for i = 1, desiredCount do
+                table.insert(tab, math.random(1, 1000))
+            end
+        end
+
+        for desiredCount, tab in pairs(tables['string']) do
+            for i = 1, desiredCount do
+                tab[string.format('key%d', i)] = math.random(1, 1000)
+            end
+        end
+
+        for desiredCount, tab in pairs(tables['mixed']) do
+            for i = 1, desiredCount do
+                if math.random(1, 100) < 50 then
+                    tab[string.format('key%d', i)] = math.random(1, 1000)
+                else
+                    table.insert(tab, math.random(1, 1000))
+                end
+            end
+        end
+    end)
+
+    for keyType, subTables in pairs(tables) do
+        for size, table in pairs(subTables) do
+            it(fmt('check table compatibility of table with {} keys of size {}', keyType, size), function()
+                assert(
+                    utils.isTableIpairsCompatible(table) == (keyType == 'int'),
+                    fmt('Table with {} keys and {} entries has appropriate ipairs compatibility', keyType, size)
+                )
+            end)
+        end
+    end
+end)

--- a/scripts/tests/systems/utils/randomEntry.lua
+++ b/scripts/tests/systems/utils/randomEntry.lua
@@ -1,0 +1,56 @@
+describe('randomEntry', function()
+    local tables =
+    {
+        int =
+        {
+            [100]    = {},
+            [1000]   = {},
+        },
+        string =
+        {
+            [100]    = {},
+            [1000]   = {},
+        },
+        mixed =
+        {
+            [100]    = {},
+            [1000]   = {},
+        },
+    }
+
+    it('initializes tables', function()
+        for desiredCount, tab in pairs(tables['int']) do
+            for i = 1, desiredCount do
+                table.insert(tab, math.random(1, 1000))
+            end
+        end
+
+        for desiredCount, tab in pairs(tables['string']) do
+            for i = 1, desiredCount do
+                tab[string.format('key%d', i)] = math.random(1, 1000)
+            end
+        end
+
+        for desiredCount, tab in pairs(tables['mixed']) do
+            for i = 1, desiredCount do
+                if math.random(1, 100) < 50 then
+                    tab[string.format('key%d', i)] = math.random(1, 1000)
+                else
+                    table.insert(tab, math.random(1, 1000))
+                end
+            end
+        end
+    end)
+
+    for keyType, subTables in pairs(tables) do
+        for size, table in pairs(subTables) do
+            it(fmt('selects a random entry from table with {} keys of size {}', keyType, size), function()
+                local result = utils.randomEntry(table)
+                assert(
+                    result ~= nil,
+                    fmt('Random entry with {} keys of size {} is not nil', keyType, size)
+                )
+            end)
+        end
+    end
+end)

--- a/scripts/utils/utils.lua
+++ b/scripts/utils/utils.lua
@@ -811,12 +811,65 @@ function utils.hasKey(keyVal, collection)
     return false
 end
 
+-- Determines if a table is compatible with ipairs() behavior (loop from 1 to N where N+1 is the first key that returns a nil value from the table)
+-- Also implies #tableName reliably returns the size of the table
+-- yes, there's no built-in way for lua to determine this
+---@param tbl table
+---@return boolean
+function utils.isTableIpairsCompatible(tbl)
+    local tableSize = #tbl
+    -- most basic requirement to be ipairs-compatible: 1st and Nth entry is not nil
+    if
+        tableSize == 0 or
+        tbl[1] == nil or
+        tbl[tableSize] == nil
+    then
+        return false
+    end
+
+    -- assume a table with 1000+ entries with sequential, natural-number keys starting from 1 has no other relevant entries
+    -- technically incorrect but very highly unlikely (and improves performance by a large margin)
+    if tableSize >= 1000 then
+        return true
+    end
+
+    local nonNilEntries = 0
+    -- Loop over all key-values and detect any non-numeric keys or holes
+    for k, v in pairs(tbl) do
+        -- Found non-integer key
+        if type(k) ~= 'number' or k ~= math.floor(k) then
+            return false
+        end
+
+        -- key is out of range of detected table size
+        if
+            k < 1 or
+            k > tableSize
+        then
+            return false
+        end
+
+        -- Ensure detected table length has no holes/nil values in the table
+        if v ~= nil then
+            nonNilEntries = nonNilEntries + 1
+        end
+    end
+
+    -- Table has all integer keys, that range from 1 to index, with no missing (or nil-valued) keys
+    return nonNilEntries == tableSize
+end
+
 -- Selects a random entry from a table, returns the index and the entry
 -- https://gist.github.com/jdev6/1e7ff30671edf88d03d4
 ---@nodiscard
 ---@param t table
 ---@return integer|string, any
 function utils.randomEntryIdx(t)
+    if utils.isTableIpairsCompatible(t) then
+        local index = math.random(1, #t)
+        return index, t[index]
+    end
+
     local keys = {}
 
     for key, _ in pairs(t) do


### PR DESCRIPTION
(and add to utils.randomEntryIdx)

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Continues https://github.com/LandSandBoat/server/pull/8473 in a fresh PR because everything I was doing there was wrong (based on the assumption that _doing things_ in cpp was inherently faster, neglecting that _getting things_ from lua to cpp makes it not worth the time savings)

This PR:
- adds a new util that does what it says on the tin, with many comments to hand hold the reader into the ~~annoyances~~ complexities of lua table assumptions.
- Puts a guard clause on the `util.randomEntryIdx` function to use the much faster method of pulling a random element from an ipairs-compatible table.
  - based on the benchmarks below, it is faster to loop through the table to confirm ipairs compatibility (with the new util) than it is to build a `keys` table
  - most tables that fail to meet ipairs compatibility will fail almost immediately in the new util, so the impact to mixed/string-only keyed tables is next to nothing

As I said in the other PR, imo this is very useful to show _intention_ when someone comes by and reads the util to help understand the differences between how tables are formatted. 
- Also, the new util function may end up being helpful in other contexts to check if a table, `tableName`, is dense between index `1` and `#tableName`

Also also, [here's the nitty gritty on benchmarking the changes](https://github.com/LandSandBoat/server/pull/8482#issuecomment-3433171764). putting in a comment so the wall of screenshots don't push down the rest of this summary.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
same as the previous PR:
- testing the randomEntry util
  - adding a print in the guard clause: 
    - <img width="366" height="120" alt="image" src="https://github.com/user-attachments/assets/5586b2ae-31e4-41ed-b914-c71ff5b8e1e9" />
  - <img width="596" height="345" alt="image" src="https://github.com/user-attachments/assets/a204f773-d1f4-4608-85b8-574e2dcd4f07" />
- testing the new util directly
  - <img width="586" height="212" alt="image" src="https://github.com/user-attachments/assets/f02641f4-b2e3-4f3d-8ff2-3710d681ea19" />

