### PR TITLE
[sql] Changes Hocho/Debahocho to main hand latent instead of an item mod

### DIFF
--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -1894,6 +1894,9 @@ INSERT INTO `item_latents` VALUES (16911,287,1,0,92);    -- DMG 29~40, increases
 -- Kitsutsuki
 INSERT INTO `item_latents` VALUES (16912,165,5,59,17);   -- Vs. plantoids: Critical hit rate +5%
 
+-- Hocho
+INSERT INTO `item_latents` VALUES (16924,135,3,40,0);    -- Cooking +3 in Main hand
+
 -- Royal Swordsman's Blade +1/+2
 INSERT INTO `item_latents` VALUES (16948,10,2,53,1);     -- VIT +2 in areas outside own nation's control
 INSERT INTO `item_latents` VALUES (16949,10,3,53,1);     -- VIT +3 in areas outside own nation's control
@@ -3145,6 +3148,12 @@ INSERT INTO `item_latents` VALUES (21817,369,-3,56,0);   -- Drains 3 MP/tic from
 
 -- Gokotai
 -- INSERT INTO `item_latents` VALUES (21922,368,1,??,??); -- Regain based on Dual Wield,1 TP/tic for every 1 Dual Wield
+
+-- Debahocho
+INSERT INTO `item_latents` VALUES (21923,135,2,40,0); -- Cooking +2 in Main hand
+
+-- Debahocho +1
+INSERT INTO `item_latents` VALUES (21924,135,3,40,0); -- Cooking +3 in Main hand
 
 -- Saotome-no-Tachi
 -- INSERT INTO `item_latents` VALUES (21968,25,10,??,0); -- Dynamis (D): Accuracy+10

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -33291,9 +33291,6 @@ INSERT INTO `item_mods` VALUES (16911,25,-1); -- ACC: -1
 -- Shinogi
 INSERT INTO `item_mods` VALUES (16913,9,3); -- DEX: 3
 
--- Hocho
-INSERT INTO `item_mods` VALUES (16924,135,3); -- COOK: 3
-
 -- Mokuto +1
 INSERT INTO `item_mods` VALUES (16925,431,2);  -- ITEM_ADDEFFECT_TYPE: DEBUFF
 INSERT INTO `item_mods` VALUES (16925,499,13); -- ITEM_SUBEFFECT: 13
@@ -46010,12 +46007,6 @@ INSERT INTO `item_mods` VALUES (21922,30,40);   -- MACC: 40
 INSERT INTO `item_mods` VALUES (21922,311,217); -- MAGIC_DAMAGE: 217
 INSERT INTO `item_mods` VALUES (21922,355,136); -- ADDS_WEAPONSKILL: 136
 INSERT INTO `item_mods` VALUES (21922,706,60);  -- WSD+% (Blade Ku): 60
-
--- Debahocho
-INSERT INTO `item_mods` VALUES (21923,135,2); -- COOK: 2
-
--- Debahocho +1
-INSERT INTO `item_mods` VALUES (21924,135,3); -- COOK: 3
 
 -- Tsuru
 INSERT INTO `item_mods` VALUES (21926,2,114);    -- HP: 114


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Changes Hocho/Debahocho to main hand latent instead of an item mod.

## Steps to test these changes

Equip main hand and !getmod, equip off hand and !getmod, compare.
**Hocho**: `16924`
**Debahocho**: `21923`
**Debahocho +1**: `21924`