### PR TITLE
[lua] Major Rewrite of quest "A Pose By Any Other Name"

### DIFF
--- a/scripts/quests/windurst/A_Pose_by_Any_Other_Name.lua
+++ b/scripts/quests/windurst/A_Pose_by_Any_Other_Name.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 -- A Pose By Any Other Name
+-- Log ID: 2, Quest ID: 7
 -- Angelica !pos -64 -9.25 -9 238
 -----------------------------------
 
@@ -31,6 +32,15 @@ local poseItems =
     [xi.job.RUN] = xi.item.BRONZE_HARNESS,
 }
 
+local poseGear =
+{
+    [xi.item.BRONZE_HARNESS] = 1,
+    [xi.item.ROBE]           = 2,
+    [xi.item.TUNIC]          = 3,
+    [xi.item.LEATHER_VEST]   = 4,
+    [xi.item.KENPOGI]        = 6,
+}
+
 quest.reward =
 {
     fame = 75,
@@ -55,36 +65,33 @@ quest.sections =
                 onTrigger = function(player, npc)
                     local desiredBody = poseItems[player:getMainJob()]
                     local currentBody = player:getEquipID(xi.slot.BODY)
+
                     if currentBody ~= desiredBody then
-                        if quest:getVar(player, 'Prog') == 1 then
+                        if quest:getVar(player, 'Option') == 0 then
                             return quest:progressEvent(90)
                         else
-                            return quest:progressEvent(87)
+                            return quest:progressEvent(91)
                         end
                     else
-                        -- default dialogs
-                        local rand = math.random(1, 3)
-                        if rand == 1 then
-                            player:startEvent(86)
-                        elseif rand == 2 then
-                            player:startEvent(88)
-                        else
-                            player:startEvent(89)
-                        end
+                        return quest:event(86):setPriority(101) -- If the player is wearing the requested body for their job Angelica will only return event 86 intead of cycling between 86 and 87.
                     end
                 end
             },
 
             onEventFinish =
             {
-                [87] = function(player, csid, option, npc)
-                    quest:setVar(player, 'Prog', 1)
-                end,
-
                 [90] = function(player, csid, option, npc)
                     if option == 1 then
                         quest:begin(player)
-                        quest:setVar(player, 'Prog', 0)
+                        quest:setVar(player, 'Option', 0)
+                    elseif option == 2 then
+                        quest:setVar(player, 'Option', 1)
+                    end
+                end,
+
+                [91] = function(player, csid, option, npc)
+                    if option == 1 then
+                        quest:begin(player)
                     end
                 end,
             },
@@ -104,10 +111,9 @@ quest.sections =
                 onTrigger = function(player, npc)
                     local requestedBody = poseItems[player:getMainJob()]
 
-                    quest:setVar(player, 'Stage', GetSystemTime() + 300)
+                    quest:setVar(player, 'Wait', GetSystemTime() + 3600) -- 1 Hour
                     quest:setVar(player, 'Prog', requestedBody)
-
-                    return quest:progressEvent(92, 0, 0, 0, requestedBody)
+                    return quest:progressEvent(92, 0, xi.item.BRONZE_HARNESS, xi.item.ROBE, xi.item.TUNIC, xi.item.LEATHER_VEST, xi.item.ROBE, xi.item.KENPOGI) -- Job check seems to be baked into the DAT.
                 end,
             },
         },
@@ -125,11 +131,12 @@ quest.sections =
             {
                 onTrigger = function(player, npc)
                     local requestedBody = quest:getVar(player, 'Prog')
-                    if quest:getVar(player, 'Stage') >= GetSystemTime() then -- Under time. Quest completed.
+
+                    if quest:getVar(player, 'Wait') >= GetSystemTime() then -- Under time. Quest completed.
                         if player:getEquipID(xi.slot.BODY) == requestedBody then
                             return quest:progressEvent(96)
                         else
-                            return quest:progressEvent(93, 0, 0, 0, requestedBody)
+                            return quest:progressEvent(94, poseGear[quest:getVar(player, 'Prog')], xi.item.BRONZE_HARNESS, xi.item.ROBE, xi.item.TUNIC, xi.item.LEATHER_VEST, xi.item.ROBE, xi.item.KENPOGI)
                         end
                     else -- Over time. Quest failed.
                         return quest:progressEvent(102)
@@ -140,13 +147,16 @@ quest.sections =
             onEventFinish =
             {
                 [96] = function(player, csid, option, npc) -- Quest completed
-                    quest:complete(player)
+                    if quest:complete(player) then
+                        quest:setMustZone(player)
+                    end
                 end,
 
                 [102] = function(player, csid, option, npc) -- Quest failed.
                     player:delQuest(xi.questLog.WINDURST, xi.quest.id.windurst.A_POSE_BY_ANY_OTHER_NAME)
-                    quest:setVar(player, 'Prog', 0) -- TODO: Confirm that initial CS has to be repeated aswell upon quest failure. If not, set var to 1 here.
-                    quest:setVar(player, 'Stage', 0)
+                    quest:setVar(player, 'Prog', 0)
+                    quest:setVar(player, 'Wait', 0)
+                    quest:setVar(player, 'Option', 0)
                     player:addTitle(xi.title.LOWER_THAN_THE_LOWEST_TUNNEL_WORM)
                     player:needToZone(true)
                 end,
@@ -165,7 +175,9 @@ quest.sections =
             ['Angelica'] =
             {
                 onTrigger = function(player, npc)
-                    return quest:event(101):replaceDefault()
+                    if quest:getMustZone(player) then
+                        return quest:event(101):setPriority(101)
+                    end
                 end,
             },
         },

--- a/scripts/zones/Windurst_Waters/DefaultActions.lua
+++ b/scripts/zones/Windurst_Waters/DefaultActions.lua
@@ -7,7 +7,6 @@ return {
     ['Anja-Enja']        = { event = 278 },
     ['Aora-Uora']        = { event = 378 },
     ['Arukoko']          = { event = 509 },
-    ['Buchi_Kohmrijah']  = { event = 591 },
     ['Bulolo']           = { event = 566 },
     ['Caliburn']         = { event = 599 },
     ['Chomoro-Kyotoro']  = { event = 432 },

--- a/scripts/zones/Windurst_Waters/npcs/Angelica.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Angelica.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Windurst Waters North
+--  NPC: Angelica
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    -- Dialgoue cycles
+    if player:getLocalVar('spokenAngelica') == 0 then
+        player:startEvent(86)
+    else
+        player:startEvent(87)
+    end
+end
+
+entity.onEventFinish = function(player, csid, option, npc)
+    if csid == 86 then
+        player:setLocalVar('spokenAngelica', 1)
+    elseif csid == 87 then
+        player:setLocalVar('spokenAngelica', 0)
+    end
+end
+
+return entity

--- a/scripts/zones/Windurst_Waters/npcs/Buchi_Kohmrijah.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Buchi_Kohmrijah.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Windurst Waters North
+--  NPC: Buchi Kohmrijah
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    -- Dialgoue cycles
+    if player:getLocalVar('spokenBuchi') == 0 then
+        player:startEvent(591)
+    else
+        player:startEvent(592)
+    end
+end
+
+entity.onEventFinish = function(player, csid, option, npc)
+    if csid == 591 then
+        player:setLocalVar('spokenBuchi', 1)
+    else
+        player:setLocalVar('spokenBuchi', 0)
+    end
+end
+
+return entity


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Corrects the flow of the quest to be retail accurate.
Corrects incorrect interactions.

## Steps to test these changes

1. `!zone <Windurst Waters>`
2. Talk to Angelica `!pos -64 -9.25 -9 238`
3. Talk to her again.
4. Equip the requested armor.
5. Talk to her again.
6. Quest complete.

## Notes

- Trying to start the quest while wearing your job's requested armor will return ONLY event 86.
- Angelica's default action was found to cycle between 86 and 87. If the player fails the quest, this dialogue will cycle until the player zones.
- Failure condition was found to be 1 irl hour. -- NOTE for ERA enjoyers, evidence and player testimonies point towards this being 5 minutes in the level <= 75 ERA, could not find patch notes.
- When the player completes the quest, event 101 will only display until the player zones. After which the cycle of 86 <-> 87 continues.
- Buchi Kohmrijah was found to have cycling default dialogue.
- None of the captures ever got event 93 to play.
- The job check is built into the DAT for event 94 and is displayed depending on the variable for var1.
- Updated var Stage to Wait to line up with IF variable standards.

## Captures
Quest Complete (Capture also includes quest "A Question of Taste"
https://drive.google.com/drive/folders/1tlMpW5poRne4GaBpIvEetu37_WKBS17F?usp=sharing
https://youtu.be/biaC9MAfm9c

Quest Failure Testing
Packets Only
https://drive.google.com/drive/folders/1gNb_0XC8YWMxhQNpzF0xIdh-9EQH7QyX?usp=sharing 

Capture without "A Question of Taste" active
https://youtu.be/PM-QRqImpGI
https://1drv.ms/u/c/87e665e10555c452/EW3nE9EbKr5Po53KrGDaJNsBL2Y_gGliBp0xbTN72odOOQ?e=cC6Hep 