### PR TITLE
[lua, sql] ZM4 and ZM5 mob audit

### DIFF
--- a/scripts/actions/mobskills/abyss_blast.lua
+++ b/scripts/actions/mobskills/abyss_blast.lua
@@ -15,11 +15,11 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local damage   = mob:getWeaponDmg() * 5
+    local ftp      = 2.5
     local power    = 15
     local duration = 120
 
-    damage = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.DARK, 1, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    local damage = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getMainLvl() + 2, xi.element.DARK, ftp, xi.mobskills.magicalTpBonus.NO_EFFECT)
     damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 
     target:takeDamage(damage, mob, xi.attackType.MAGICAL, xi.damageType.DARK)

--- a/scripts/actions/mobskills/barbed_crescent.lua
+++ b/scripts/actions/mobskills/barbed_crescent.lua
@@ -19,7 +19,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT, 0, 0, 0)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.ACCURACY_DOWN, 100, 0, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.ACCURACY_DOWN, 100, 0, 180)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/call_of_the_grave.lua
+++ b/scripts/actions/mobskills/call_of_the_grave.lua
@@ -14,7 +14,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.INT_DOWN, 10, 3, 120))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.INT_DOWN, 10, 5, 120))
 
     return xi.effect.INT_DOWN
 end

--- a/scripts/actions/mobskills/carnal_nightmare.lua
+++ b/scripts/actions/mobskills/carnal_nightmare.lua
@@ -15,6 +15,10 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     if target:getTP() == 0 then
         skill:setMsg(xi.msg.basic.SKILL_NO_EFFECT) -- no effect
     else
+        if target:isPet() then
+            reset = target:getTP() / 2
+        end
+
         target:setTP(reset)
         skill:setMsg(xi.msg.basic.TP_REDUCED)
     end

--- a/scripts/actions/mobskills/claw_storm.lua
+++ b/scripts/actions/mobskills/claw_storm.lua
@@ -16,12 +16,12 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 3
     local accmod = 1
-    local ftp    = 1.1
+    local ftp    = 1
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.POISON, mob:getMainLvl() / 2.5, 3, 30)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.POISON, 7, 3, 60)
 
     return dmg
 end

--- a/scripts/actions/mobskills/dancing_chains.lua
+++ b/scripts/actions/mobskills/dancing_chains.lua
@@ -11,7 +11,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.DROWN, 15, 0, 120))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.DROWN, 15, 0, 60))
 
     return xi.effect.DROWN
 end

--- a/scripts/actions/mobskills/eye_scratch.lua
+++ b/scripts/actions/mobskills/eye_scratch.lua
@@ -17,13 +17,14 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 1
     local accmod = 1
-    local ftp    = 2.2
+    local ftp    = 3
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BLINDNESS, 15, 0, 120)
-
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
+
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BLINDNESS, 30, 0, 60)
+
     return dmg
 end
 

--- a/scripts/actions/mobskills/grim_halo.lua
+++ b/scripts/actions/mobskills/grim_halo.lua
@@ -26,7 +26,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 1
     local accmod = 1
     local ftp    = 2.5
-    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
+    local params = { canCrit = true }
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT, 0, 0, 0, params)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg

--- a/scripts/actions/mobskills/magic_fruit.lua
+++ b/scripts/actions/mobskills/magic_fruit.lua
@@ -11,17 +11,11 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local potency = skill:getParam()
-
-    if potency == 0 then
-        potency = 9
-    end
-
-    potency = potency - math.random(0, potency / 4)
+    local potency = 18
 
     skill:setMsg(xi.msg.basic.SELF_HEAL)
 
-    return xi.mobskills.mobHealMove(mob, mob:getMaxHP() * potency / 100)
+    return xi.mobskills.mobHealMove(target, mob:getMaxHP() * potency)
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/netherspikes.lua
+++ b/scripts/actions/mobskills/netherspikes.lua
@@ -15,7 +15,7 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 1
     local accmod = 1
-    local ftp    = 2.7
+    local ftp    = 1
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded * 3)
 

--- a/scripts/actions/mobskills/shackled_fists.lua
+++ b/scripts/actions/mobskills/shackled_fists.lua
@@ -15,7 +15,7 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 5
     local accmod = 1
-    local ftp    = 1.4
+    local ftp    = 0.5
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.HTH, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.HTH)

--- a/scripts/actions/mobskills/stinking_gas.lua
+++ b/scripts/actions/mobskills/stinking_gas.lua
@@ -11,7 +11,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.VIT_DOWN, 10, 3, 120))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.VIT_DOWN, 10, 5, 180))
 
     return xi.effect.VIT_DOWN
 end

--- a/scripts/actions/mobskills/stone_throw.lua
+++ b/scripts/actions/mobskills/stone_throw.lua
@@ -14,14 +14,15 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 1
-    local accmod = 0.8
-    local ftp    = 2.5
-    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
+    local accmod = 1
+    local ftp    = 1.5
+    local info = xi.mobskills.mobRangedMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.RANGED, xi.damageType.BLUNT, info.hitslanded)
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PARALYSIS, 20, 0, 60)
-
     target:takeDamage(dmg, mob, xi.attackType.RANGED, xi.damageType.BLUNT)
+
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PARALYSIS, 50, 0, 60)
+
     return dmg
 end
 

--- a/scripts/actions/mobskills/undead_mold.lua
+++ b/scripts/actions/mobskills/undead_mold.lua
@@ -13,13 +13,11 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local damage = math.floor(mob:getWeaponDmg() * 2.5)
-
-    damage = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.DARK, 1, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    local damage = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getMainLvl() + 2, xi.element.DARK, 2, xi.mobskills.magicalTpBonus.NO_EFFECT)
     damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 
     target:takeDamage(damage, mob, xi.attackType.MAGICAL, xi.damageType.DARK)
-    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.DISEASE, 1, 0, 180)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.DISEASE, 1, 0, 660)
 
     return damage
 end

--- a/scripts/actions/mobskills/vicious_claw.lua
+++ b/scripts/actions/mobskills/vicious_claw.lua
@@ -15,7 +15,7 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 1
     local accmod = 1
-    local ftp    = 2.2
+    local ftp    = 3
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)

--- a/scripts/actions/mobskills/whip_tongue.lua
+++ b/scripts/actions/mobskills/whip_tongue.lua
@@ -15,13 +15,15 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 1
     local accmod = 1
-    local ftp    = 2.8
-    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
+    local ftp    = 1.5
+    local params = { canCrit = true }
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT, 0, 0, 0, params)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
+
+    target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
 
     xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
-    target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg
 end
 

--- a/scripts/zones/Cape_Teriggan/mobs/Axesarion_the_Wanderer.lua
+++ b/scripts/zones/Cape_Teriggan/mobs/Axesarion_the_Wanderer.lua
@@ -19,8 +19,11 @@ entity.onMobDisengage = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    if optParams.isKiller then
-        GetNPCByID(ID.npc.CERMET_HEADSTONE):setLocalVar('cooldown', GetSystemTime() + 900)
+    if optParams.isKiller or optParams.noKiller then
+        local headstone = GetNPCByID(ID.npc.CERMET_HEADSTONE)
+        if headstone then
+            headstone:setLocalVar('cooldown', GetSystemTime() + 900)
+        end
     end
 end
 

--- a/scripts/zones/Sacrificial_Chamber/mobs/Graviton.lua
+++ b/scripts/zones/Sacrificial_Chamber/mobs/Graviton.lua
@@ -12,9 +12,14 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
+    mob:addImmunity(xi.immunity.TERROR)
+    mob:addImmunity(xi.immunity.SILENCE)
+end
+
 entity.onMobSpawn = function(mob)
-    mob:addMod(xi.mod.SLEEP_MEVA, 50)
-    mob:addMod(xi.mod.LULLABY_MEVA, 50)
     mob:setLocalVar('everyonesRancorHPP', math.random(20, 30))
 end
 

--- a/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Doomed_Pilgrims.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Doomed_Pilgrims.lua
@@ -11,6 +11,8 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.SILENCE)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.PETRIFY)
+    mob:addImmunity(xi.immunity.TERROR)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 300)
 end
 
@@ -19,8 +21,11 @@ entity.onMobDisengage = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    if optParams.isKiller then
-        GetNPCByID(ID.npc.CERMET_HEADSTONE):setLocalVar('cooldown', GetSystemTime() + 900)
+    if optParams.isKiller or optParams.noKiller then
+        local headstone = GetNPCByID(ID.npc.CERMET_HEADSTONE)
+        if headstone then
+            headstone:setLocalVar('cooldown', GetSystemTime() + 900)
+        end
     end
 end
 

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Carthi.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Carthi.lua
@@ -11,6 +11,8 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.SILENCE)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.TERROR)
+    mob:addImmunity(xi.immunity.PETRIFY)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 300)
 end
 
@@ -19,8 +21,16 @@ entity.onMobDisengage = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    if optParams.isKiller and GetMobByID(ID.mob.TIPHA):isDead() then
-        GetNPCByID(ID.npc.CERMET_HEADSTONE):setLocalVar('cooldown', GetSystemTime() + 900)
+    if optParams.isKiller or optParams.noKiller then
+        local headstone = GetNPCByID(ID.npc.CERMET_HEADSTONE)
+        local tipha     = GetMobByID(ID.mob.TIPHA)
+        if
+            headstone and
+            tipha and
+            tipha:isDead()
+        then
+            headstone:setLocalVar('cooldown', GetSystemTime() + 900)
+        end
     end
 end
 

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Tipha.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Tipha.lua
@@ -11,6 +11,8 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.SILENCE)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.TERROR)
+    mob:addImmunity(xi.immunity.PETRIFY)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 300)
 end
 
@@ -19,8 +21,16 @@ entity.onMobDisengage = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    if optParams.isKiller and GetMobByID(ID.mob.CARTHI):isDead() then
-        GetNPCByID(ID.npc.CERMET_HEADSTONE):setLocalVar('cooldown', GetSystemTime() + 900)
+    if optParams.isKiller or optParams.noKiller then
+        local carthi = GetMobByID(ID.mob.CARTHI)
+        local headstone = GetNPCByID(ID.npc.CERMET_HEADSTONE)
+        if
+            headstone and
+            carthi and
+            carthi:isDead()
+        then
+            headstone:setLocalVar('cooldown', GetSystemTime() + 900)
+        end
     end
 end
 

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -8214,7 +8214,7 @@ INSERT INTO `mob_groups` VALUES (24,6835,113,'Zmey_Gorynych',3600,0,3289,0,0,78,
 INSERT INTO `mob_groups` VALUES (25,1806,113,'Greater_Manticore',330,0,1228,0,0,76,79,0);
 INSERT INTO `mob_groups` VALUES (26,1429,113,'Frostmane',0,32,912,0,0,80,80,0);
 INSERT INTO `mob_groups` VALUES (27,2287,113,'Kreutzet',0,128,1466,11000,0,79,80,0);
-INSERT INTO `mob_groups` VALUES (28,302,113,'Axesarion_the_Wanderer',0,128,0,8200,0,68,70,0);
+INSERT INTO `mob_groups` VALUES (28,302,113,'Axesarion_the_Wanderer',0,128,0,7600,0,68,68,0);
 INSERT INTO `mob_groups` VALUES (29,1983,113,'Hobgoblin_Warrior',0,128,0,0,0,75,80,0);
 INSERT INTO `mob_groups` VALUES (30,1984,113,'Hobgoblin_White_Mage',0,128,0,0,0,75,80,0);
 INSERT INTO `mob_groups` VALUES (31,1972,113,'Hobgoblin_Black_Mage',0,128,0,0,0,75,80,0);
@@ -8767,7 +8767,7 @@ INSERT INTO `mob_groups` VALUES (3,1268,121,'Bigclaw_fished',0,128,273,0,0,42,45
 INSERT INTO `mob_groups` VALUES (4,204,121,'Apsaras',0,128,147,0,0,26,31,0);
 
 INSERT INTO `mob_groups` VALUES (5,1832,121,'Guardian_Treant',0,128,0,0,0,33,33,0);
-INSERT INTO `mob_groups` VALUES (6,1080,121,'Doomed_Pilgrims',0,128,0,17000,0,60,60,0);
+INSERT INTO `mob_groups` VALUES (6,1080,121,'Doomed_Pilgrims',0,128,0,17000,0,68,68,0);
 INSERT INTO `mob_groups` VALUES (7,1690,121,'Goblin_Mugger',330,0,1117,0,0,25,29,0);
 INSERT INTO `mob_groups` VALUES (8,1666,121,'Goblin_Gambler',330,0,1081,0,0,25,29,0);
 INSERT INTO `mob_groups` VALUES (9,120,121,'Ancient_Bat',330,2,386,0,0,26,28,0);
@@ -8866,8 +8866,8 @@ INSERT INTO `mob_groups` VALUES (1,5865,123,'Ironshell_fished',0,128,93,0,0,35,3
 INSERT INTO `mob_groups` VALUES (2,1268,123,'Bigclaw_fished',0,128,2930,0,0,41,42,0);
 INSERT INTO `mob_groups` VALUES (3,6770,123,'Bloodsucker_fished',0,128,174,0,0,53,55,0);
 
-INSERT INTO `mob_groups` VALUES (4,3925,123,'Tipha',0,128,0,6000,0,65,65,0);
-INSERT INTO `mob_groups` VALUES (5,657,123,'Carthi',0,128,0,6000,0,65,65,0);
+INSERT INTO `mob_groups` VALUES (4,3925,123,'Tipha',0,128,0,5500,0,65,65,0);
+INSERT INTO `mob_groups` VALUES (5,657,123,'Carthi',0,128,0,5500,0,65,65,0);
 INSERT INTO `mob_groups` VALUES (6,4482,123,'Yuhtunga_Mandragora',330,0,2793,0,0,29,33,0);
 INSERT INTO `mob_groups` VALUES (7,1715,123,'Goblin_Smithy',330,0,1162,0,0,32,37,0);
 INSERT INTO `mob_groups` VALUES (8,2110,123,'Ivory_Lizard',330,0,1382,0,0,32,35,0);
@@ -11225,8 +11225,8 @@ INSERT INTO `mob_groups` VALUES (45,932,162,'Deadly_Iris',960,0,580,0,0,55,56,0)
 -- Sacrificial_Chamber (Zone 163)
 -- ------------------------------------------------------------
 
-INSERT INTO `mob_groups` VALUES (1,1798,163,'Graviton',0,128,0,4700,0,65,65,0);
-INSERT INTO `mob_groups` VALUES (2,2729,163,'Molybiton',0,128,0,4500,0,63,63,0);
+INSERT INTO `mob_groups` VALUES (1,1798,163,'Graviton',0,128,0,5200,0,65,65,0);
+INSERT INTO `mob_groups` VALUES (2,2729,163,'Molybiton',0,128,0,4700,0,63,63,0);
 INSERT INTO `mob_groups` VALUES (3,4052,163,'Tungsiton',0,128,0,4500,0,63,63,0);
 INSERT INTO `mob_groups` VALUES (4,4674,163,'Tonberrys_Elemental',0,128,0,2400,0,57,58,0);
 INSERT INTO `mob_groups` VALUES (5,3970,163,'Tonberrys_Avatar',0,128,0,2400,0,57,58,0);

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -306,7 +306,7 @@ INSERT INTO `mob_skills` VALUES (288,32,'vicious_claw',0,0.0,7.0,2000,1500,4,0,0
 INSERT INTO `mob_skills` VALUES (289,33,'stone_throw',0,0.0,25.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (290,34,'spinning_claw',1,0.0,15.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (291,35,'claw_storm',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (292,36,'blank_gaze_dispel',0,0.0,16.0,2000,2000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (292,36,'blank_gaze_dispel',4,0.0,16.0,2000,2000,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (293,37,'whistle_call',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (294,38,'eye_scratch',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (295,39,'magic_fruit',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Added missing immunities to Graviton in ZM4 battlefield
- Audited Opo-opo, Fomor, and Doomed related to ZM5 mission
- HP totals adjusted for mobs based off of captures

## Steps to test these changes

Open the respective ZM mission lua and utilize commands to give yourself the mission

## Sources
https://youtu.be/lBH7xdFCNsM
https://1drv.ms/u/c/87e665e10555c452/Ed7L5EmtjdVDnxOpjM-5AB4BlpccHHn4JzZoBsa49_A0Tw?e=ip86Le

Please see capture discord for full ZM5 capture list for HP numbers

Doomed
<img width="1285" height="246" alt="504004070-a0076631-f5a3-47c9-865a-619b896006aa" src="https://github.com/user-attachments/assets/78d8d413-1c30-497b-b939-24204194bab9" />

Fomor
<img width="1279" height="189" alt="image" src="https://github.com/user-attachments/assets/7839082b-0fa8-4bd3-867d-a180d95a937c" />

Opo-opo
<img width="1284" height="180" alt="image" src="https://github.com/user-attachments/assets/aed6b72b-15e6-4516-af21-179b56153eaa" />
