### PR TITLE
[lua] [sql] Add Quest "A Question of Taste"

### DIFF
--- a/scripts/quests/outlands/A_Question_of_Taste.lua
+++ b/scripts/quests/outlands/A_Question_of_Taste.lua
@@ -1,0 +1,299 @@
+-----------------------------------
+-- A Question of Taste
+-- Log ID: 5, Quest ID: 3
+-- Etteh_Sulaej        !pos 98.153 -15.000 -113.251
+-- Angelica            !pos -64 -9.25 -9
+-- Stone Picture Frame !pos 79.876 0.500 -36.964
+-----------------------------------
+local templeID = zones[xi.zone.TEMPLE_OF_UGGALEPIH]
+-----------------------------------
+
+local quest = Quest:new(xi.questLog.OUTLANDS, xi.quest.id.outlands.A_QUESTION_OF_TASTE)
+
+quest.reward =
+{
+    gil = 3000,
+}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_AVAILABLE and
+                player:getFameLevel(xi.fameArea.WINDURST) >= 6
+        end,
+
+        [xi.zone.KAZHAM] =
+        {
+            ['Etteh_Sulaej'] = quest:progressCutscene(44),
+
+            onEventFinish =
+            {
+                [44] = function(player, csid, option, npc)
+                    quest:begin(player)
+                    npcUtil.giveKeyItem(player, xi.ki.LETTER_TO_ANGELICA)
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_ACCEPTED
+        end,
+
+        [xi.zone.KAZHAM] =
+        {
+            ['Etteh_Sulaej'] =
+            {
+                onTrigger = function(player, npc)
+                    local progress = quest:getVar(player, 'Prog')
+
+                    if progress == 1 then
+                        return quest:progressEvent(47)
+                    elseif progress == 4 then
+                        return quest:progressEvent(50)
+                    elseif progress >= 2 then
+                        return quest:event(49)
+                    else
+                        return quest:event(45)
+                    end
+                end,
+            },
+
+            ['Jakoh_Wahcondalo'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') >= 2 then
+                        return quest:event(48)
+                    else
+                        return quest:event(46)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [47] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 2)
+                    player:delKeyItem(xi.ki.ANGELICAS_LETTER)
+                end,
+
+                [50] = function(player, csid, option, npc)
+                    if quest:complete(player) then
+                        player:delKeyItem(xi.ki.RIPPED_FINAL_FANTASY_PAINTING)
+                        quest:setMustZone(player)
+                    end
+                end,
+            },
+        },
+
+        [xi.zone.TEMPLE_OF_UGGALEPIH] =
+        {
+            ['Stone_Picture_Frame_QoT'] =
+            {
+                onTrigger = function(player, npc)
+                    local progress = quest:getVar(player, 'Prog')
+                    local questNM  = GetMobByID(templeID.mob.TROMPE_LOEIL)
+
+                    if progress == 2 then
+                        if quest:getVar(player, 'Wait') > GetSystemTime() then
+                            player:messageSpecial(templeID.text.FRAME_FOR_A_PAINTING + 1)
+                            return quest:messageSpecial(templeID.text.STILL_HANGS_ON_THE_WALL, xi.ki.RIPPED_FINAL_FANTASY_PAINTING)
+                        elseif not questNM then
+                            return
+                        elseif not GetMobByID(templeID.mob.TROMPE_LOEIL):isSpawned() then
+                            return quest:progressEvent(50, xi.ki.FINAL_FANTASY)
+                        end
+                    elseif progress == 3 then
+                        npcUtil.giveKeyItem(player, xi.ki.RIPPED_FINAL_FANTASY_PAINTING)
+                        quest:setVar(player, 'Prog', 4)
+                        return quest:noAction()
+                    end
+                end,
+            },
+
+            ['Trompe_LOeil'] =
+            {
+                onMobDeath = function(mob, player, optParams)
+                    if quest:getVar(player, 'Prog') == 2 then
+                        quest:setVar(player, 'Prog', 3)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [50] = function(player, csid, option, npc)
+                    if option == 1 then
+                        player:delKeyItem(xi.ki.FINAL_FANTASY)
+                        SpawnMob(templeID.mob.TROMPE_LOEIL):updateClaim(player)
+                        quest:setVar(player, 'Wait', GetSystemTime() + 900) -- Sets a 15min cooldown before the player can repop the NM.
+                    end
+                end,
+            },
+        },
+
+        [xi.zone.WINDURST_WATERS] =
+        {
+            ['Angelica'] =
+            {
+                onTrigger = function(player, npc)
+                    local progress = quest:getVar(player, 'Prog')
+
+                    if
+                        player:hasCompletedQuest(xi.questLog.WINDURST, xi.quest.id.windurst.A_POSE_BY_ANY_OTHER_NAME) and
+                        not xi.quest.getMustZone(player, xi.questLog.WINDURST, xi.quest.id.windurst.A_POSE_BY_ANY_OTHER_NAME)
+                    then
+                        if progress == 0 then
+                            return quest:progressEvent(771)
+                        else
+                            return quest:event(772)
+                        end
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [771] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 1)
+                    npcUtil.giveKeyItem(player, xi.ki.FINAL_FANTASY)
+                    npcUtil.giveKeyItem(player, xi.ki.ANGELICAS_LETTER)
+                    player:delKeyItem(xi.ki.LETTER_TO_ANGELICA)
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_COMPLETED
+        end,
+
+        [xi.zone.KAZHAM] =
+        {
+            ['Etteh_Sulaej'] =
+            {
+                onTrigger = function(player, npc)
+                    local progress = quest:getVar(player, 'Prog')
+
+                    if quest:getMustZone(player) then
+                        return quest:event(51)
+                    elseif progress == 3 then
+                        return quest:progressEvent(57)
+                    elseif progress >= 1 then
+                        return quest:event(55)
+                    else
+                        if quest:getVar(player, 'Option') == 0 then
+                            return quest:progressEvent(53)
+                        else
+                            return quest:progressEvent(54)
+                        end
+                    end
+                end,
+            },
+
+            ['Jakoh_Wahcondalo'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getMustZone(player) then
+                        return quest:event(52)
+                    elseif quest:getVar(player, 'Prog') >= 0 then
+                        return quest:event(56)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [53] = function(player, csid, option, npc)
+                    if option == 2 then
+                        quest:setVar(player, 'Option', 1)
+                    else
+                        quest:setVar(player, 'Prog', 1)
+                        quest:begin(player)
+                        npcUtil.giveKeyItem(player, xi.ki.FINAL_FANTASY_PART_II)
+                    end
+                end,
+
+                [54] = function(player, csid, option, npc)
+                    if option == 1 then
+                        quest:setVar(player, 'Prog', 1)
+                        quest:begin(player)
+                        npcUtil.giveKeyItem(player, xi.ki.FINAL_FANTASY_PART_II)
+                    end
+                end,
+
+                [57] = function(player, csid, option, npc)
+                    if quest:complete(player) then
+                        player:delKeyItem(xi.ki.RIPPED_FINAL_FANTASY_PAINTING)
+                        quest:setMustZone(player)
+                    end
+                end,
+            },
+        },
+
+        [xi.zone.TEMPLE_OF_UGGALEPIH] =
+        {
+            ['Stone_Picture_Frame_QoT'] =
+            {
+                onTrigger = function(player, npc)
+                    local progress = quest:getVar(player, 'Prog')
+                    local questNM  = GetMobByID(templeID.mob.TROMPE_LOEIL)
+
+                    if progress == 1 then
+                        if quest:getVar(player, 'Wait') > GetSystemTime() then
+                            player:messageSpecial(templeID.text.FRAME_FOR_A_PAINTING + 1)
+                            return quest:messageSpecial(templeID.text.STILL_HANGS_ON_THE_WALL, xi.ki.RIPPED_FINAL_FANTASY_PAINTING)
+                        elseif not questNM then
+                            return
+                        elseif not questNM:isSpawned() then
+                            return quest:progressEvent(51, xi.ki.FINAL_FANTASY_PART_II)
+                        end
+                    elseif progress == 2 then
+                        npcUtil.giveKeyItem(player, xi.ki.RIPPED_FINAL_FANTASY_PAINTING)
+                        quest:setVar(player, 'Prog', 3)
+                        return quest:noAction()
+                    end
+                end,
+            },
+
+            ['Trompe_LOeil'] =
+            {
+                onMobDeath = function(mob, player, optParams)
+                    if quest:getVar(player, 'Prog') == 1 then
+                        quest:setVar(player, 'Prog', 2)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [51] = function(player, csid, option, npc)
+                    if option == 1 then
+                        player:delKeyItem(xi.ki.FINAL_FANTASY_PART_II)
+                        SpawnMob(templeID.mob.TROMPE_LOEIL):updateClaim(player)
+                        quest:setVar(player, 'Wait', GetSystemTime() + 900) -- Sets a 15min cooldown before the player can repop the NM.
+                    end
+                end,
+            },
+        },
+
+        [xi.zone.WINDURST_WATERS] =
+        {
+            ['Angelica'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 1 then
+                        return quest:event(772)
+                    else
+                        return quest:event(773):replaceDefault()
+                    end
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/zones/Temple_of_Uggalepih/DefaultActions.lua
+++ b/scripts/zones/Temple_of_Uggalepih/DefaultActions.lua
@@ -13,4 +13,5 @@ return {
     ['qm_key1']       = { messageSpecial = ID.text.OFFERING },
     ['qm_key2']       = { messageSpecial = ID.text.OFFERING },
     ['qm_key3']       = { messageSpecial = ID.text.OFFERING },
+    ['Stone_Picture_Frame_QoT'] = { messageSpecial = ID.text.FRAME_FOR_A_PAINTING },
 }

--- a/scripts/zones/Temple_of_Uggalepih/IDs.lua
+++ b/scripts/zones/Temple_of_Uggalepih/IDs.lua
@@ -29,6 +29,8 @@ zones[xi.zone.TEMPLE_OF_UGGALEPIH] =
         THE_DOOR_IS_LOCKED            = 7371,  -- The door is locked. You might be able to open it with <item>.
         PROTECTED_BY_UNKNOWN_FORCE    = 7372,  -- The door is protected by some unknown force.
         YOUR_KEY_BREAKS               = 7374,  -- Your <item> breaks!
+        FRAME_FOR_A_PAINTING          = 7378,  -- This is a frame for a painting.
+        STILL_HANGS_ON_THE_WALL       = 7390,  -- The <keyitem> still hangs on the wall.
         DOOR_LOCKED                   = 7392,  -- The door is locked.
         HATE_RESET                    = 7445,  -- The built-up hate has been cleansed...!
         DOOR_SHUT                     = 7447,  -- The door is firmly shut.
@@ -55,33 +57,34 @@ zones[xi.zone.TEMPLE_OF_UGGALEPIH] =
     },
     mob =
     {
-        SOZU_SARBERRY            = GetFirstID('Sozu_Sarberry'),
-        SOZU_TERBERRY            = GetFirstID('Sozu_Terberry'),
-        TONBERRY_KINQ            = GetFirstID('Tonberry_Kinq'),
+        BERYL_FOOTED_MOLBERRY    = GetFirstID('Beryl-footed_Molberry'),
+        CLEUVARION_M_RESOAIX     = GetFirstID('Cleuvarion_M_Resoaix'),
+        COOK_OFFSET              = GetFirstID('Cook_Solberry'),
+        CRIMSON_TOOTHED_PAWBERRY = GetFirstID('Crimson-toothed_Pawberry'),
+        DEATH_FROM_ABOVE         = GetFirstID('Death_from_Above'),
         FLAUROS                  = GetFirstID('Flauros'),
-        TEMPLE_GUARDIAN          = GetFirstID('Temple_Guardian'),
+        HABETROT                 = GetFirstID('Habetrot'),
+        MIMIC                    = GetFirstID('Mimic'),
         NIO_A                    = GetFirstID('Nio-A'),
         NIO_HUM                  = GetFirstID('Nio-Hum'),
-        MIMIC                    = GetFirstID('Mimic'),
-        SOZU_ROGBERRY            = GetFirstID('Sozu_Rogberry'),
-        CLEUVARION_M_RESOAIX     = GetFirstID('Cleuvarion_M_Resoaix'),
         ROMPAULION_S_CITALLE     = GetFirstID('Rompaulion_S_Citalle'),
-        BERYL_FOOTED_MOLBERRY    = GetFirstID('Beryl-footed_Molberry'),
-        DEATH_FROM_ABOVE         = GetFirstID('Death_from_Above'),
-        HABETROT                 = GetFirstID('Habetrot'),
-        CRIMSON_TOOTHED_PAWBERRY = GetFirstID('Crimson-toothed_Pawberry'),
         SACRIFICIAL_GOBLET       = GetFirstID('Sacrificial_Goblet'),
-        YALLERY_BROWN            = GetFirstID('Yallery_Brown'),
-        COOK_OFFSET              = GetFirstID('Cook_Solberry')
+        SOZU_ROGBERRY            = GetFirstID('Sozu_Rogberry'),
+        SOZU_SARBERRY            = GetFirstID('Sozu_Sarberry'),
+        SOZU_TERBERRY            = GetFirstID('Sozu_Terberry'),
+        TROMPE_LOEIL             = GetFirstID('Trompe_LOeil'),
+        TEMPLE_GUARDIAN          = GetFirstID('Temple_Guardian'),
+        TONBERRY_KINQ            = GetFirstID('Tonberry_Kinq'),
+        YALLERY_BROWN            = GetFirstID('Yallery_Brown')
     },
     npc =
     {
-        PLONGEUR_MONBERRY    = GetFirstID('Plongeur_Monberry'),
         BOOK_OFFSET          = GetFirstID('Worn_Book'),
-        TEMPLE_GUARDIAN_DOOR = GetFirstID('_mf1'),
+        CHEF_NONBERRY        = GetFirstID('Chef_Nonberry'),
         DOOR_TO_RANCOR       = GetFirstID('_mfb'),
-        TREASURE_COFFER      = GetFirstID('Treasure_Coffer'),
-        CHEF_NONBERRY        = GetFirstID('Chef_Nonberry')
+        PLONGEUR_MONBERRY    = GetFirstID('Plongeur_Monberry'),
+        TEMPLE_GUARDIAN_DOOR = GetFirstID('_mf1'),
+        TREASURE_COFFER      = GetFirstID('Treasure_Coffer')
     },
 }
 

--- a/scripts/zones/Temple_of_Uggalepih/mobs/Trompe_LOeil.lua
+++ b/scripts/zones/Temple_of_Uggalepih/mobs/Trompe_LOeil.lua
@@ -1,0 +1,23 @@
+-----------------------------------
+-- Area: Temple of Uggalepih
+-- Mob: Trompe L'Oeil
+-- Note: Quest NM for "A Question of Taste"
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180) -- 3 minutes
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
+    mob:addImmunity(xi.immunity.PETRIFY)
+    mob:addImmunity(xi.immunity.SILENCE)
+    mob:addImmunity(xi.immunity.TERROR)
+end
+
+entity.onMobSpawn = function(mob)
+    mob:setMobMod(xi.mobMod.GIL_BONUS, -100) -- No gil
+    mob:setMobMod(xi.mobMod.NO_DROPS, 1) -- No drops
+end
+
+return entity

--- a/scripts/zones/Temple_of_Uggalepih/npcs/Stone_Picture_Frame.lua
+++ b/scripts/zones/Temple_of_Uggalepih/npcs/Stone_Picture_Frame.lua
@@ -2,7 +2,7 @@
 -- Area: Temple of Uggalepih
 --  NPC: Stone Picture Frame
 -- Notes: Opens door to Den of Rancor using Painbrush of Souls
--- !pos -52.239 -2.089 10.000 159
+-- !pos -54.657 -0.106 -0.161 159
 -----------------------------------
 local ID = zones[xi.zone.TEMPLE_OF_UGGALEPIH]
 -----------------------------------
@@ -10,17 +10,12 @@ local ID = zones[xi.zone.TEMPLE_OF_UGGALEPIH]
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    local xPos = player:getXPos()
-    local zPos = player:getZPos()
+    local xPos       = player:getXPos()
+    local zPos       = player:getZPos()
+    local rancorDoor = GetNPCByID(ID.npc.DOOR_TO_RANCOR)
 
     if xPos < -60 then
-        if zPos < -6 then -- SW frame
-            if player:hasKeyItem(xi.ki.FINAL_FANTASY) then
-                player:startEvent(50, xi.ki.FINAL_FANTASY)
-            else
-                player:messageSpecial(ID.text.PAINTBRUSH_OFFSET + 31) -- This is a frame for a painting.
-            end
-        elseif zPos < 5 then
+        if zPos < 5 then
             player:messageSpecial(ID.text.PAINTBRUSH_OFFSET + 14) -- It is a picture of an old mage carrying a staff.
         else
             player:messageSpecial(ID.text.PAINTBRUSH_OFFSET + 13) -- It is a picture of a small group of three men and women.
@@ -28,8 +23,13 @@ entity.onTrigger = function(player, npc)
     else
         if zPos < -5 then -- SE picture
             player:messageSpecial(ID.text.PAINTBRUSH_OFFSET + 12) -- It is a painting of a beautiful landscape.
-        elseif zPos > -5 and zPos < 5 then
-            if GetNPCByID(ID.npc.DOOR_TO_RANCOR):getAnimation() == xi.anim.OPEN_DOOR then
+        elseif
+            zPos > -5 and
+            zPos < 5
+        then
+            if not rancorDoor then
+                return
+            elseif rancorDoor:getAnimation() == xi.anim.OPEN_DOOR then
                 player:messageSpecial(ID.text.PAINTBRUSH_OFFSET + 23, xi.ki.PAINTBRUSH_OF_SOULS) -- The <KEY_ITEM> begins to twitch. The canvas is graced with the image from your soul.
             elseif
                 player:hasKeyItem(xi.ki.PAINTBRUSH_OF_SOULS) and
@@ -53,13 +53,17 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    if csid == 50 then
+    local rancorDoor = GetNPCByID(ID.npc.DOOR_TO_RANCOR)
+
+    if not rancorDoor then
+        return
+    elseif csid == 50 then
         -- Soon !
     elseif csid == 60 then
         local timeElapsed = GetSystemTime() - player:getCharVar('started_painting')
         if timeElapsed >= 30 then
             player:messageSpecial(ID.text.PAINTBRUSH_OFFSET + 22) -- You succeeded in projecting the image in your soul to the blank canvas. The door to the Rancor Den has opened!<Prompt>
-            GetNPCByID(ID.npc.DOOR_TO_RANCOR):openDoor(45) -- Open the door to Den of Rancor for 45 sec
+            rancorDoor:openDoor(45) -- Open the door to Den of Rancor for 45 sec
         else
             player:messageSpecial(ID.text.PAINTBRUSH_OFFSET + 21) -- You were unable to fill the canvas with an image from your soul.
         end

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -11017,7 +11017,7 @@ INSERT INTO `mob_groups` VALUES (2,6770,159,'Bloodsucker_fished',0,128,174,0,0,5
 INSERT INTO `mob_groups` VALUES (3,6782,159,'Bouncing_Ball_fished',0,128,343,0,0,65,67,0);
 
 INSERT INTO `mob_groups` VALUES (4,501,159,'Bonze_Marberry',900,0,338,7000,0,66,66,0);
-INSERT INTO `mob_groups` VALUES (5,4039,159,'Trompe_LOeil',0,128,0,0,0,60,60,0);
+INSERT INTO `mob_groups` VALUES (5,4039,159,'Trompe_LOeil',0,128,0,17000,0,60,60,0);
 INSERT INTO `mob_groups` VALUES (6,787,159,'Cook_Solberry',0,128,0,0,0,75,75,0);
 INSERT INTO `mob_groups` VALUES (7,786,159,'Cook_Nalberry',0,128,0,0,0,75,75,0);
 INSERT INTO `mob_groups` VALUES (8,785,159,'Cook_Minberry',0,128,0,0,0,75,75,0);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds the quest "A Question of Taste"
Reorders the IDS in `Temple_of_Uggalepih/IDs.lua` alphabetically.
Adds a nil check to `scripts/zones/Temple_of_Uggalepih/npcs/Stone_Picture_Frame.lua`

## Steps to test these changes

1. Have Windurst Fame 6 or higher.
2. Complete quest "A Pose By Any Other Name"
3. `!zone <Kazham>`
4. Talk to Etteh_Sulaej `!pos 98.153 -15.000 -113.251`
5. `!zone <Windurst Waters>`
6. Talk to Angelica `!pos -64 -9.25 -9`
7. `!zone <Kazham>`
8. Talk to Etteh_Sulaej `!pos 98.153 -15.000 -113.251`
9. `!zone <Temple of UGGALEPIH>`
10. Check Stone Picture Frame `!pos 79.876 0.500 -36.964`
11. Kill Golem
12. Check Stone Picture Frame
13. `!zone <Kazham>`
14. Talk to Etteh_Sulaej `!pos 98.153 -15.000 -113.251`
15. Quest Complete

## Notes
You can flag this quest, but cannot progress unless you have completed "A Pose By Any Other Name".
The NM is a normal Golem with extra immunities.
Can be repeated indefinitely. Just need to zone between repeats.

## Captures
A Question of Taste + Repeat
https://drive.google.com/drive/folders/1tlMpW5poRne4GaBpIvEetu37_WKBS17F?usp=sharing
https://youtu.be/biaC9MAfm9c 

https://youtu.be/T9R5ZGSMb5E
https://1drv.ms/u/s!AlLEVQXhZeaHgXBA49a9-Zp7LIwq?e=ytA75w