### PR TITLE
[core] Set server_status to 4 when in cutscene, send 0x037 update when transitioning in/out of cutscenes

### DIFF
--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -456,6 +456,7 @@ public:
     bool   isPacketFiltered(std::unique_ptr<CBasicPacket>& packet);
 
     bool pendingPositionUpdate;
+    bool sendServerStatus_ = false;
 
     virtual void HandleErrorMessage(std::unique_ptr<CBasicPacket>&) override;
 

--- a/src/map/packets/char_status.cpp
+++ b/src/map/packets/char_status.cpp
@@ -216,7 +216,7 @@ CCharStatusPacket::CCharStatusPacket(CCharEntity* PChar)
     std::memcpy(&packet->BufStatusBits, &PChar->StatusEffectContainer->m_Flags, sizeof(status_bits_t));
 
     packet->UniqueNo      = PChar->id;
-    packet->server_status = PChar->isInEvent() ? static_cast<uint8>(ANIMATION_EVENT) : PChar->animation;
+    packet->server_status = PChar->animation;
 
     CItemLinkshell* linkshell = (CItemLinkshell*)PChar->getEquip(SLOT_LINK1);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Set server_status to 4 when entering a cutscene, set it back to 0 when leaving.
SE always sends server_status via S2C 0x037

<img width="866" height="119" alt="image" src="https://github.com/user-attachments/assets/cd986831-7ba9-4b6c-949b-1a7448bc41ec" />

They also sometimes send 0x00D which also contains server_status, meaning this is a very explicit send on SE's part
<img width="463" height="86" alt="image" src="https://github.com/user-attachments/assets/c4f8be13-86d9-48e7-9751-e2e179da8f4c" />

It's also sent when you trigger teleports (such as in hall of transference)
<img width="378" height="249" alt="image" src="https://github.com/user-attachments/assets/1241995e-30cd-48ed-bf39-5641d33ddf3c" />

It seems that any "real" cutscene that makes the player perform input, listen to an npc talk, camera move, etc beyond simply clicking a QM and getting a reply sets server_status to 4
## Steps to test these changes

Cap packets on LSB, see we send appropriate 0x037 with server_status 4 after entering a CS, and 0 after leaving

<img width="876" height="246" alt="image" src="https://github.com/user-attachments/assets/c188477d-adab-473f-9793-8b21cff1712a" />
