### PR TITLE
Adjust CI build caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,8 @@ jobs:
       run:
         shell: bash
     env:
-      SCCACHE_DIR: ${{ format('{0}/sccache', github.workspace) }}
+      SCCACHE_DIR: ${{ format('{0}/build/sccache', github.workspace) }}
+      SCCACHE_CACHE_SIZE: "1G"
     steps:
       - name: Download changed files artifact
         if: ${{ inputs.optional_build }}
@@ -168,9 +169,7 @@ jobs:
           cmake_hash: ${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
           source_hash: ${{ hashFiles('src/**/*', 'ext/**/*') }}
         with:
-          path: |
-            build
-            ${{ env.SCCACHE_DIR }}
+          path: build
           key: ${{ format('buildcache-{0}-{1}-{2}-{3}-{4}', runner.os, inputs.compiler, inputs.build_type, env.cmake_hash, env.source_hash) }}
           restore-keys: |
             ${{ format('buildcache-{0}-{1}-{2}-{3}-', runner.os, inputs.compiler, inputs.build_type, env.cmake_hash) }}
@@ -210,7 +209,5 @@ jobs:
         if: ${{ inputs.save_cache && !steps.restore_build.outputs.cache-hit && (!inputs.optional_build || steps.check-changes.outputs.source_changes == 'true') }}
         uses: actions/cache/save@v4
         with:
-          path: |
-            build
-            ${{ env.SCCACHE_DIR }}
+          path: build
           key: ${{ steps.restore_build.outputs.cache-primary-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,6 @@ jobs:
         with:
           name: changed-files
           path: changed-files.txt
-          retention-days: 7
         continue-on-error: true
 
   Lua_Language_server:

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -27,19 +27,19 @@ jobs:
             runner: windows-2025
             compiler: msvc19
             tracy: false
-            build_modules: true
+            build_modules: false
             save_cache: true
           - build_type: Debug
             runner: macos-15
             compiler: appleClang16
             tracy: false
-            build_modules: true
+            build_modules: false
             save_cache: true
           - build_type: Debug
             runner: ubuntu-24.04
             compiler: gcc14
             tracy: false
-            build_modules: true
+            build_modules: false
             save_cache: true
           - build_type: Debug
             runner: ubuntu-24.04


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes an issue with the CI caches being built with modules. CI doesn't build with modules so we don't want the caches built with them (clang-tidy still builds with modules). Also simplifies the sccache location so we only have to cache the build dir to the github actions cache. Sets a sccache cache size limit to 1GB. Should be more than enough for our needs.

## Steps to test these changes

CI builds might run slightly faster. Nothing major here.

Note: An issue seems to exist where sccache cache exists and is cached to github actions, but occasionally is invalid(?) when restored, resulting in longer build times. Seems random where the same restored cache will speed up a build for some runs and not others, despite no source changes.

Example:
https://github.com/LandSandBoat/server/actions/runs/18766468219/job/53542413951
https://github.com/LandSandBoat/server/actions/runs/18767926722/job/53546501791
Both of these runs use the same `buildcache-Windows-msvc19-Debug-0e4968eb0af2fc029665347688c65e0b29e2df0c066f77058cf9bfe16f4ab104-53c9bae50df7a45dbb1561c50f7b67e51a485423b5a71b41e2204f2846c31d72` cache, neither commit has any source changes, but one of the windows builds doesn't use the cache for some reason.

https://github.com/LandSandBoat/server/actions/runs/18795521244
Here is a mac build having the same effect, so it's not isolated to windows.

