### PR TITLE
[lua] Remove unnecessary pw mobskill modelId checks

### DIFF
--- a/scripts/actions/mobskills/bilgestorm.lua
+++ b/scripts/actions/mobskills/bilgestorm.lua
@@ -11,16 +11,6 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getFamily() == 316 then
-        local mobSkin = mob:getModelId()
-
-        if mobSkin == 1840 then
-            return 0
-        else
-            return 1
-        end
-    end
-
     return 0
 end
 

--- a/scripts/actions/mobskills/dreadstorm.lua
+++ b/scripts/actions/mobskills/dreadstorm.lua
@@ -10,17 +10,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getFamily() == 316 then
-        local mobSkin = mob:getModelId()
-
-        if mobSkin == 1805 then
-            return 0
-        else
-            return 1
-        end
-    end
-
-    return 1
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/actions/mobskills/enervation.lua
+++ b/scripts/actions/mobskills/enervation.lua
@@ -7,16 +7,6 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getFamily() == 91 then
-        local mobSkin = mob:getModelId()
-
-        if mobSkin == 1680 then
-            return 0
-        else
-            return 1
-        end
-    end
-
     return 0
 end
 

--- a/scripts/actions/mobskills/firespit.lua
+++ b/scripts/actions/mobskills/firespit.lua
@@ -7,16 +7,6 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getFamily() == 91 then
-        local mobSkin = mob:getModelId()
-
-        if mobSkin == 1639 then
-            return 0
-        else
-            return 1
-        end
-    end
-
     return 0
 end
 

--- a/scripts/actions/mobskills/fossilizing_breath.lua
+++ b/scripts/actions/mobskills/fossilizing_breath.lua
@@ -9,16 +9,6 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getFamily() == 316 then
-        local mobSkin = mob:getModelId()
-
-        if mobSkin == 1805 then
-            return 0
-        else
-            return 1
-        end
-    end
-
     return 0
 end
 

--- a/scripts/actions/mobskills/fulmination.lua
+++ b/scripts/actions/mobskills/fulmination.lua
@@ -10,22 +10,14 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getFamily() == 316 then
-        local mobSkin = mob:getModelId()
-
-        if mobSkin == 1805 then
-            return 0
-        else
-            return 1
-        end
-    end
-
     local family = mob:getFamily()
     local mobHPP = mob:getHPP()
 
     if family == 168 and mobHPP < 35 then -- Khimaira < 35%
         return 0
     elseif family == 315 and mobHPP < 50 then -- Tyger < 50%
+        return 0
+    elseif family == 316 and mobHPP < 50 then -- Pandemonium Warden
         return 0
     end
 

--- a/scripts/actions/mobskills/gates_of_hades.lua
+++ b/scripts/actions/mobskills/gates_of_hades.lua
@@ -10,16 +10,6 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getFamily() == 316 then
-        local mobSkin = mob:getModelId()
-
-        if mobSkin == 1793 then
-            return 0
-        else
-            return 1
-        end
-    end
-
     if mob:getHPP() < 25 then
         return 0
     end

--- a/scripts/actions/mobskills/hellclap.lua
+++ b/scripts/actions/mobskills/hellclap.lua
@@ -6,26 +6,6 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getFamily() == 91 then
-        local mobSkin = mob:getModelId()
-
-        if mobSkin == 1839 then
-            return 0
-        else
-            return 1
-        end
-    end
-
-    if mob:getFamily() == 316 then
-        local mobSkin = mob:getModelId()
-
-        if mobSkin == 1840 then
-            return 0
-        else
-            return 1
-        end
-    end
-
     return 0
 end
 

--- a/scripts/actions/mobskills/lava_spit.lua
+++ b/scripts/actions/mobskills/lava_spit.lua
@@ -6,16 +6,6 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getFamily() == 316 then
-        local mobSkin = mob:getModelId()
-
-        if mobSkin == 1793 then
-            return 0
-        else
-            return 1
-        end
-    end
-
     if target:isBehind(mob, 48) then
         return 1
     else

--- a/scripts/actions/mobskills/necrobane.lua
+++ b/scripts/actions/mobskills/necrobane.lua
@@ -5,26 +5,6 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getFamily() == 316 then
-        local mobSkin = mob:getModelId()
-
-        if mobSkin == 1840 then
-            return 0
-        else
-            return 1
-        end
-    end
-
-    if mob:getFamily() == 91 then
-        local mobSkin = mob:getModelId()
-
-        if mobSkin == 1839 then
-            return 0
-        else
-            return 1
-        end
-    end
-
     return 0
 end
 

--- a/scripts/actions/mobskills/necropurge.lua
+++ b/scripts/actions/mobskills/necropurge.lua
@@ -5,26 +5,6 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getFamily() == 316 then
-        local mobSkin = mob:getModelId()
-
-        if mobSkin == 1840 then
-            return 0
-        else
-            return 1
-        end
-    end
-
-    if mob:getFamily() == 91 then
-        local mobSkin = mob:getModelId()
-
-        if mobSkin == 1839 then
-            return 0
-        else
-            return 1
-        end
-    end
-
     return 0
 end
 

--- a/scripts/actions/mobskills/nerve_gas.lua
+++ b/scripts/actions/mobskills/nerve_gas.lua
@@ -10,14 +10,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getFamily() == 316 then -- PW
-        local mobSkin = mob:getModelId()
-        if mobSkin == 1796 then
-            return 0
-        else
-            return 1
-        end
-    elseif mob:getFamily() == 313 then -- Tinnin can use at will
+    if mob:getFamily() == 313 then -- Tinnin can use at will
         return 0
     else
         if mob:getAnimationSub() == 0 then

--- a/scripts/actions/mobskills/pl_body_slam.lua
+++ b/scripts/actions/mobskills/pl_body_slam.lua
@@ -7,13 +7,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    local mobSkin = mob:getModelId()
-
-    if mobSkin == 421 then
-        return 0
-    else
-        return 1
-    end
+    return 0
 end
 
 -- TODO: can crit

--- a/scripts/actions/mobskills/pl_chaos_blade.lua
+++ b/scripts/actions/mobskills/pl_chaos_blade.lua
@@ -9,13 +9,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    local mobSkin = mob:getModelId()
-
-    if mobSkin == 421 then
-        return 0
-    else
-        return 1
-    end
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/actions/mobskills/pl_heavy_stomp.lua
+++ b/scripts/actions/mobskills/pl_heavy_stomp.lua
@@ -11,13 +11,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    local mobSkin = mob:getModelId()
-
-    if mobSkin == 421 then
-        return 0
-    else
-        return 1
-    end
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/actions/mobskills/pl_hellclap.lua
+++ b/scripts/actions/mobskills/pl_hellclap.lua
@@ -5,13 +5,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    local mobSkin = mob:getModelId()
-
-    if mobSkin == 1839 then
-        return 0
-    else
-        return 1
-    end
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/actions/mobskills/pl_hellsnap.lua
+++ b/scripts/actions/mobskills/pl_hellsnap.lua
@@ -5,13 +5,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    local mobSkin = mob:getModelId()
-
-    if mobSkin == 1839 then
-        return 0
-    else
-        return 1
-    end
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/actions/mobskills/pl_petro_eyes.lua
+++ b/scripts/actions/mobskills/pl_petro_eyes.lua
@@ -9,13 +9,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    local mobSkin = mob:getModelId()
-
-    if mobSkin == 421 then
-        return 0
-    else
-        return 1
-    end
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/actions/mobskills/pl_tidal_slash.lua
+++ b/scripts/actions/mobskills/pl_tidal_slash.lua
@@ -13,13 +13,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    local mobSkin = mob:getModelId()
-
-    if mobSkin == 1643 then
-        return 0
-    else
-        return 1
-    end
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/actions/mobskills/polar_blast.lua
+++ b/scripts/actions/mobskills/polar_blast.lua
@@ -7,16 +7,6 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getFamily() == 316 then -- TODO: Pandemonium Warden, Set skill lists
-        local mobSkin = mob:getModelId()
-
-        if mobSkin == 1796 then
-            return 0
-        else
-            return 1
-        end
-    end
-
     if mob:getAnimationSub() <= 1 then
         -- TODO: Does this need an inFront() check?
         return 0

--- a/scripts/actions/mobskills/polar_bulwark.lua
+++ b/scripts/actions/mobskills/polar_bulwark.lua
@@ -8,16 +8,6 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getFamily() == 316 then
-        local mobSkin = mob:getModelId()
-
-        if mobSkin == 1796 then
-            return 0
-        else
-            return 1
-        end
-    end
-
     if mob:getAnimationSub() == 0 then
         return 0
     else

--- a/scripts/actions/mobskills/pw_acheron_flame.lua
+++ b/scripts/actions/mobskills/pw_acheron_flame.lua
@@ -10,13 +10,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    local mobSkin = mob:getModelId()
-
-    if mobSkin == 1793 then  -- TODO: Or we could, you know, define the skill list properly.
-        return 0
-    else
-        return 1
-    end
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/actions/mobskills/pw_calcifying_deluge.lua
+++ b/scripts/actions/mobskills/pw_calcifying_deluge.lua
@@ -11,13 +11,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    local mobSkin = mob:getModelId()
-
-    if mobSkin == 1865 then
-        return 0
-    else
-        return 1
-    end
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/actions/mobskills/pw_decussate.lua
+++ b/scripts/actions/mobskills/pw_decussate.lua
@@ -11,13 +11,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    local mobSkin = mob:getModelId()
-
-    if mobSkin == 1863 then
-        return 0
-    else
-        return 1
-    end
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/actions/mobskills/pw_fossilizing_breath.lua
+++ b/scripts/actions/mobskills/pw_fossilizing_breath.lua
@@ -10,13 +10,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    local mobSkin = mob:getModelId()
-
-    if mobSkin == 1805 then
-        return 0
-    else
-        return 1
-    end
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/actions/mobskills/pw_groundburst.lua
+++ b/scripts/actions/mobskills/pw_groundburst.lua
@@ -11,13 +11,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    local mobSkin = mob:getModelId()
-
-    if mobSkin == 1863 then
-        return 0
-    else
-        return 1
-    end
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/actions/mobskills/pw_pinning_shot.lua
+++ b/scripts/actions/mobskills/pw_pinning_shot.lua
@@ -11,13 +11,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    local mobSkin = mob:getModelId()
-
-    if mobSkin == 1865 then
-        return 0
-    else
-        return 1
-    end
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/actions/mobskills/pw_rushing_slash.lua
+++ b/scripts/actions/mobskills/pw_rushing_slash.lua
@@ -11,13 +11,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    local mobSkin = mob:getModelId()
-
-    if mobSkin == 1863 then
-        return 0
-    else
-        return 1
-    end
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/actions/mobskills/pw_shadow_thrust.lua
+++ b/scripts/actions/mobskills/pw_shadow_thrust.lua
@@ -11,13 +11,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    local mobSkin = mob:getModelId()
-
-    if mobSkin == 1865 then
-        return 0
-    else
-        return 1
-    end
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/actions/mobskills/pw_tyrranic_blare.lua
+++ b/scripts/actions/mobskills/pw_tyrranic_blare.lua
@@ -11,13 +11,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    local mobSkin = mob:getModelId()
-
-    if mobSkin == 1863 then
-        return 0
-    else
-        return 1
-    end
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/actions/mobskills/pyric_blast.lua
+++ b/scripts/actions/mobskills/pyric_blast.lua
@@ -7,16 +7,6 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getFamily() == 316 then -- TODO: Pandemonium Warden. Set skill lists/clean up.
-        local mobSkin = mob:getModelId()
-
-        if mobSkin == 1796 then
-            return 0
-        else
-            return 1
-        end
-    end
-
     -- Only used when all 3 heads are alive.
     if mob:getAnimationSub() == 0 then
         -- TODO: Does this need an inFront() check?

--- a/scripts/actions/mobskills/pyric_bulwark.lua
+++ b/scripts/actions/mobskills/pyric_bulwark.lua
@@ -8,16 +8,6 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getFamily() == 316 then
-        local mobSkin = mob:getModelId()
-
-        if mobSkin == 1796 then
-            return 0
-        else
-            return 1
-        end
-    end
-
     -- TODO: Used only when second/left head is alive (animationsub 0 or 1)
     if mob:getAnimationSub() <= 1 then
         return 0

--- a/scripts/actions/mobskills/quake_stomp.lua
+++ b/scripts/actions/mobskills/quake_stomp.lua
@@ -9,16 +9,6 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getFamily() == 91 then
-        local mobSkin = mob:getModelId()
-
-        if mobSkin == 1680 then
-            return 0
-        else
-            return 1
-        end
-    end
-
     return 0
 end
 

--- a/scripts/actions/mobskills/rock_smash.lua
+++ b/scripts/actions/mobskills/rock_smash.lua
@@ -9,16 +9,6 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getFamily() == 91 then
-        local mobSkin = mob:getModelId()
-
-        if mobSkin == 1680 then
-            return 0
-        else
-            return 1
-        end
-    end
-
     -- Do not use if still holding a weapon
     if mob:getAnimationSub() == 0 then
         return 1

--- a/scripts/actions/mobskills/scorching_lash.lua
+++ b/scripts/actions/mobskills/scorching_lash.lua
@@ -11,16 +11,6 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getFamily() == 316 then
-        local mobSkin = mob:getModelId()
-
-        if mobSkin == 1793 then
-            return 0
-        else
-            return 1
-        end
-    end
-
     if not target:isBehind(mob, 48) then
         return 1
     else

--- a/scripts/actions/mobskills/somersault_kick.lua
+++ b/scripts/actions/mobskills/somersault_kick.lua
@@ -10,16 +10,6 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getFamily() == 91 then
-        local mobSkin = mob:getModelId()
-
-        if mobSkin == 1639 then
-            return 0
-        else
-            return 1
-        end
-    end
-
     return 0
 end
 

--- a/scripts/actions/mobskills/tail_slap.lua
+++ b/scripts/actions/mobskills/tail_slap.lua
@@ -7,16 +7,6 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getFamily() == 91 then
-        local mobSkin = mob:getModelId()
-
-        if mobSkin == 1643 then
-            return 0
-        else
-            return 1
-        end
-    end
-
     return 0
 end
 

--- a/scripts/actions/mobskills/tenebrous_mist.lua
+++ b/scripts/actions/mobskills/tenebrous_mist.lua
@@ -10,15 +10,6 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getFamily() == 316 then
-        local mobSkin = mob:getModelId()
-        if mobSkin == 1805 then
-            return 0
-        else
-            return 1
-        end
-    end
-
     return 0
 end
 

--- a/scripts/actions/mobskills/wind_shear.lua
+++ b/scripts/actions/mobskills/wind_shear.lua
@@ -11,16 +11,6 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getFamily() == 91 then
-        local mobSkin = mob:getModelId()
-
-        if mobSkin == 1746 then
-            return 0
-        else
-            return 1
-        end
-    end
-
     return 0
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Now that PW is fully using the cleaned up phase changes, we don't need `onMobSkillCheck` functions to look for a particular modelId

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
See no change except `dreadstorm` had a default `return 1` so now it's usable by khim