### PR TITLE
[lua] Abilities return granted status effect

### DIFF
--- a/scripts/actions/abilities/afflatus_misery.lua
+++ b/scripts/actions/abilities/afflatus_misery.lua
@@ -14,7 +14,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.white_mage.useAfflatusMisery(player, target, ability)
+    return xi.job_utils.white_mage.useAfflatusMisery(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/afflatus_solace.lua
+++ b/scripts/actions/abilities/afflatus_solace.lua
@@ -14,7 +14,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.white_mage.useAfflatusSolace(player, target, ability)
+    return xi.job_utils.white_mage.useAfflatusSolace(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/aggressor.lua
+++ b/scripts/actions/abilities/aggressor.lua
@@ -10,7 +10,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.warrior.useAggressor(player, target, ability)
+    return xi.job_utils.warrior.useAggressor(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/ancient_circle.lua
+++ b/scripts/actions/abilities/ancient_circle.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.dragoon.useAncientCircle(player, target, ability)
+    return xi.job_utils.dragoon.useAncientCircle(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/arcane_circle.lua
+++ b/scripts/actions/abilities/arcane_circle.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.dark_knight.useArcaneCircle(player, target, ability)
+    return xi.job_utils.dark_knight.useArcaneCircle(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/assassins_charge.lua
+++ b/scripts/actions/abilities/assassins_charge.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.thief.useAssassinsCharge(player, target, ability)
+    return xi.job_utils.thief.useAssassinsCharge(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/asylum.lua
+++ b/scripts/actions/abilities/asylum.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.white_mage.useAsylum(player, target, ability)
+    return xi.job_utils.white_mage.useAsylum(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/azure_lore.lua
+++ b/scripts/actions/abilities/azure_lore.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    xi.job_utils.blue_mage.useAzureLore(player, target, ability, action)
+    return xi.job_utils.blue_mage.useAzureLore(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/berserk.lua
+++ b/scripts/actions/abilities/berserk.lua
@@ -10,7 +10,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.warrior.useBerserk(player, target, ability)
+    return xi.job_utils.warrior.useBerserk(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/blood_weapon.lua
+++ b/scripts/actions/abilities/blood_weapon.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.dark_knight.useBloodWeapon(player, target, ability)
+    return xi.job_utils.dark_knight.useBloodWeapon(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/boost.lua
+++ b/scripts/actions/abilities/boost.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.monk.useBoost(player, target, ability)
+    return xi.job_utils.monk.useBoost(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/brazen_rush.lua
+++ b/scripts/actions/abilities/brazen_rush.lua
@@ -10,7 +10,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.warrior.useBrazenRush(player, target, ability)
+    return xi.job_utils.warrior.useBrazenRush(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/burst_affinity.lua
+++ b/scripts/actions/abilities/burst_affinity.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    xi.job_utils.blue_mage.useBurstAffinity(player, target, ability, action)
+    return xi.job_utils.blue_mage.useBurstAffinity(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/cascade.lua
+++ b/scripts/actions/abilities/cascade.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.black_mage.useCascade(player, target, ability)
+    return xi.job_utils.black_mage.useCascade(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/chain_affinity.lua
+++ b/scripts/actions/abilities/chain_affinity.lua
@@ -14,7 +14,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    xi.job_utils.blue_mage.useChainAffinity(player, target, ability, action)
+    return xi.job_utils.blue_mage.useChainAffinity(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/chainspell.lua
+++ b/scripts/actions/abilities/chainspell.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.red_mage.useChainspell(player, target, ability)
+    return xi.job_utils.red_mage.useChainspell(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/clarion_call.lua
+++ b/scripts/actions/abilities/clarion_call.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.bard.useClarionCall(player, target, ability)
+    return xi.job_utils.bard.useClarionCall(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/composure.lua
+++ b/scripts/actions/abilities/composure.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.red_mage.useComposure(player, target, ability)
+    return xi.job_utils.red_mage.useComposure(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/conspirator.lua
+++ b/scripts/actions/abilities/conspirator.lua
@@ -14,7 +14,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.thief.useConspirator(player, target, ability)
+    return xi.job_utils.thief.useConspirator(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/consume_mana.lua
+++ b/scripts/actions/abilities/consume_mana.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.dark_knight.useConsumeMana(player, target, ability)
+    return xi.job_utils.dark_knight.useConsumeMana(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/counterstance.lua
+++ b/scripts/actions/abilities/counterstance.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.monk.useCounterstance(player, target, ability)
+    return xi.job_utils.monk.useCounterstance(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/cover.lua
+++ b/scripts/actions/abilities/cover.lua
@@ -14,7 +14,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.paladin.useCover(player, target, ability)
+    return xi.job_utils.paladin.useCover(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/dark_seal.lua
+++ b/scripts/actions/abilities/dark_seal.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.dark_knight.useDarkSeal(player, target, ability)
+    return xi.job_utils.dark_knight.useDarkSeal(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/deep_breathing.lua
+++ b/scripts/actions/abilities/deep_breathing.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.dragoon.useDeepBreathing(player, target, ability)
+    return xi.job_utils.dragoon.useDeepBreathing(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/defender.lua
+++ b/scripts/actions/abilities/defender.lua
@@ -10,7 +10,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.warrior.useDefender(player, target, ability)
+    return xi.job_utils.warrior.useDefender(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/diabolic_eye.lua
+++ b/scripts/actions/abilities/diabolic_eye.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.dark_knight.useDiabolicEye(player, target, ability)
+    return xi.job_utils.dark_knight.useDiabolicEye(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/diffusion.lua
+++ b/scripts/actions/abilities/diffusion.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    xi.job_utils.blue_mage.useDiffusion(player, target, ability, action)
+    return xi.job_utils.blue_mage.useDiffusion(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/divine_caress.lua
+++ b/scripts/actions/abilities/divine_caress.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.white_mage.useDivineCaress(player, target, ability)
+    return xi.job_utils.white_mage.useDivineCaress(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/divine_emblem.lua
+++ b/scripts/actions/abilities/divine_emblem.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.paladin.useDivineEmblem(player, target, ability)
+    return xi.job_utils.paladin.useDivineEmblem(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/divine_seal.lua
+++ b/scripts/actions/abilities/divine_seal.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.white_mage.useDivineSeal(player, target, ability)
+    return xi.job_utils.white_mage.useDivineSeal(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/dodge.lua
+++ b/scripts/actions/abilities/dodge.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.monk.useDodge(player, target, ability)
+    return xi.job_utils.monk.useDodge(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/efflux.lua
+++ b/scripts/actions/abilities/efflux.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    xi.job_utils.blue_mage.useEfflux(player, target, ability, action)
+    return xi.job_utils.blue_mage.useEfflux(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/elemental_seal.lua
+++ b/scripts/actions/abilities/elemental_seal.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.black_mage.useElementalSeal(player, target, ability)
+    return xi.job_utils.black_mage.useElementalSeal(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/fealty.lua
+++ b/scripts/actions/abilities/fealty.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.paladin.useFealty(player, target, ability)
+    return xi.job_utils.paladin.useFealty(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/feint.lua
+++ b/scripts/actions/abilities/feint.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.thief.useFeint(player, target, ability)
+    return xi.job_utils.thief.useFeint(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/flabra.lua
+++ b/scripts/actions/abilities/flabra.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    xi.job_utils.rune_fencer.useRuneEnchantment(player, target, ability, xi.effect.FLABRA)
+    return xi.job_utils.rune_fencer.useRuneEnchantment(player, target, ability, xi.effect.FLABRA)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/flee.lua
+++ b/scripts/actions/abilities/flee.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.thief.useFlee(player, target, ability)
+    return xi.job_utils.thief.useFlee(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/fly_high.lua
+++ b/scripts/actions/abilities/fly_high.lua
@@ -14,7 +14,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.dragoon.useFlyHigh(player, target, ability)
+    return xi.job_utils.dragoon.useFlyHigh(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/focus.lua
+++ b/scripts/actions/abilities/focus.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.monk.useFocus(player, target, ability)
+    return xi.job_utils.monk.useFocus(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/footwork.lua
+++ b/scripts/actions/abilities/footwork.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.monk.useFootwork(player, target, ability)
+    return xi.job_utils.monk.useFootwork(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/formless_strikes.lua
+++ b/scripts/actions/abilities/formless_strikes.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.monk.useFormlessStrikes(player, target, ability)
+    return xi.job_utils.monk.useFormlessStrikes(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/futae.lua
+++ b/scripts/actions/abilities/futae.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    xi.job_utils.ninja.useFutae(player, target, ability, action)
+    return xi.job_utils.ninja.useFutae(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/gelus.lua
+++ b/scripts/actions/abilities/gelus.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    xi.job_utils.rune_fencer.useRuneEnchantment(player, target, ability, xi.effect.GELUS)
+    return xi.job_utils.rune_fencer.useRuneEnchantment(player, target, ability, xi.effect.GELUS)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/hide.lua
+++ b/scripts/actions/abilities/hide.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.thief.useHide(player, target, ability)
+    return xi.job_utils.thief.useHide(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/holy_circle.lua
+++ b/scripts/actions/abilities/holy_circle.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.paladin.useHolyCircle(player, target, ability)
+    return xi.job_utils.paladin.useHolyCircle(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/hundred_fists.lua
+++ b/scripts/actions/abilities/hundred_fists.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.monk.useHundredFists(player, target, ability)
+    return xi.job_utils.monk.useHundredFists(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/ignis.lua
+++ b/scripts/actions/abilities/ignis.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    xi.job_utils.rune_fencer.useRuneEnchantment(player, target, ability, xi.effect.IGNIS)
+    return xi.job_utils.rune_fencer.useRuneEnchantment(player, target, ability, xi.effect.IGNIS)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/impetus.lua
+++ b/scripts/actions/abilities/impetus.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.monk.useImpetus(player, target, ability)
+    return xi.job_utils.monk.useImpetus(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/inner_strength.lua
+++ b/scripts/actions/abilities/inner_strength.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.monk.useInnerStrength(player, target, ability)
+    return xi.job_utils.monk.useInnerStrength(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/innin.lua
+++ b/scripts/actions/abilities/innin.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    xi.job_utils.ninja.useInnin(player, target, ability, action)
+    return xi.job_utils.ninja.useInnin(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/invincible.lua
+++ b/scripts/actions/abilities/invincible.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.paladin.useInvincible(player, target, ability)
+    return xi.job_utils.paladin.useInvincible(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/issekigan.lua
+++ b/scripts/actions/abilities/issekigan.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    xi.job_utils.ninja.useIssekigan(player, target, ability, action)
+    return xi.job_utils.ninja.useIssekigan(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/last_resort.lua
+++ b/scripts/actions/abilities/last_resort.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.dark_knight.useLastResort(player, target, ability)
+    return xi.job_utils.dark_knight.useLastResort(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/lux.lua
+++ b/scripts/actions/abilities/lux.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    xi.job_utils.rune_fencer.useRuneEnchantment(player, target, ability, xi.effect.LUX)
+    return xi.job_utils.rune_fencer.useRuneEnchantment(player, target, ability, xi.effect.LUX)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/majesty.lua
+++ b/scripts/actions/abilities/majesty.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.paladin.useMajesty(player, target, ability)
+    return xi.job_utils.paladin.useMajesty(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/mana_wall.lua
+++ b/scripts/actions/abilities/mana_wall.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.black_mage.useManaWall(player, target, ability)
+    return xi.job_utils.black_mage.useManaWall(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/manafont.lua
+++ b/scripts/actions/abilities/manafont.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.black_mage.useManafont(player, target, ability)
+    return xi.job_utils.black_mage.useManafont(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/manawell.lua
+++ b/scripts/actions/abilities/manawell.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.black_mage.useManawell(player, target, ability)
+    return xi.job_utils.black_mage.useManawell(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/mantra.lua
+++ b/scripts/actions/abilities/mantra.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.monk.useMantra(player, target, ability)
+    return xi.job_utils.monk.useMantra(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/marcato.lua
+++ b/scripts/actions/abilities/marcato.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.bard.useMarcato(player, target, ability)
+    return xi.job_utils.bard.useMarcato(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/mighty_strikes.lua
+++ b/scripts/actions/abilities/mighty_strikes.lua
@@ -10,7 +10,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.warrior.useMightyStrikes(player, target, ability)
+    return xi.job_utils.warrior.useMightyStrikes(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/mikage.lua
+++ b/scripts/actions/abilities/mikage.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    xi.job_utils.ninja.useMikage(player, target, ability, action)
+    return xi.job_utils.ninja.useMikage(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/nether_void.lua
+++ b/scripts/actions/abilities/nether_void.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.dark_knight.useNetherVoid(player, target, ability)
+    return xi.job_utils.dark_knight.useNetherVoid(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/nightingale.lua
+++ b/scripts/actions/abilities/nightingale.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.bard.useNightingale(player, target, ability)
+    return xi.job_utils.bard.useNightingale(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/palisade.lua
+++ b/scripts/actions/abilities/palisade.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.paladin.usePalisade(player, target, ability)
+    return xi.job_utils.paladin.usePalisade(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/perfect_counter.lua
+++ b/scripts/actions/abilities/perfect_counter.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.monk.usePerfectCounter(player, target, ability)
+    return xi.job_utils.monk.usePerfectCounter(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/perfect_dodge.lua
+++ b/scripts/actions/abilities/perfect_dodge.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.thief.usePerfectDodge(player, target, ability)
+    return xi.job_utils.thief.usePerfectDodge(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/pianissimo.lua
+++ b/scripts/actions/abilities/pianissimo.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.bard.usePianissimo(player, target, ability)
+    return xi.job_utils.bard.usePianissimo(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/presto.lua
+++ b/scripts/actions/abilities/presto.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.dancer.usePrestoAbility(player, target, ability)
+    return xi.job_utils.dancer.usePrestoAbility(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/rampart.lua
+++ b/scripts/actions/abilities/rampart.lua
@@ -15,7 +15,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.paladin.useRampart(player, target, ability)
+    return xi.job_utils.paladin.useRampart(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/restraint.lua
+++ b/scripts/actions/abilities/restraint.lua
@@ -10,7 +10,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.warrior.useRestraint(player, target, ability)
+    return xi.job_utils.warrior.useRestraint(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/retaliation.lua
+++ b/scripts/actions/abilities/retaliation.lua
@@ -10,7 +10,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.warrior.useRetaliation(player, target, ability)
+    return xi.job_utils.warrior.useRetaliation(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/saboteur.lua
+++ b/scripts/actions/abilities/saboteur.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.red_mage.useSaboteur(player, target, ability)
+    return xi.job_utils.red_mage.useSaboteur(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/sacrosanctity.lua
+++ b/scripts/actions/abilities/sacrosanctity.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.white_mage.useSacrosanctity(player, target, ability)
+    return xi.job_utils.white_mage.useSacrosanctity(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/sange.lua
+++ b/scripts/actions/abilities/sange.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    xi.job_utils.ninja.useSange(player, target, ability, action)
+    return xi.job_utils.ninja.useSange(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/scarlet_delirium.lua
+++ b/scripts/actions/abilities/scarlet_delirium.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.dark_knight.useScarletDelirium(player, target, ability)
+    return xi.job_utils.dark_knight.useScarletDelirium(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/sentinel.lua
+++ b/scripts/actions/abilities/sentinel.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.paladin.useSentinel(player, target, ability)
+    return xi.job_utils.paladin.useSentinel(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/sneak_attack.lua
+++ b/scripts/actions/abilities/sneak_attack.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.thief.useSneakAttack(player, target, ability)
+    return xi.job_utils.thief.useSneakAttack(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/soul_enslavement.lua
+++ b/scripts/actions/abilities/soul_enslavement.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.dark_knight.useSoulEnslavement(player, target, ability)
+    return xi.job_utils.dark_knight.useSoulEnslavement(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/soul_voice.lua
+++ b/scripts/actions/abilities/soul_voice.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.bard.useSoulVoice(player, target, ability)
+    return xi.job_utils.bard.useSoulVoice(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/souleater.lua
+++ b/scripts/actions/abilities/souleater.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.dark_knight.useSouleater(player, target, ability)
+    return xi.job_utils.dark_knight.useSouleater(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/spirit_bond.lua
+++ b/scripts/actions/abilities/spirit_bond.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.dragoon.useSpiritBond(player, target, ability)
+    return xi.job_utils.dragoon.useSpiritBond(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/spirit_surge.lua
+++ b/scripts/actions/abilities/spirit_surge.lua
@@ -14,7 +14,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.dragoon.useSpiritSurge(player, target, ability)
+    return xi.job_utils.dragoon.useSpiritSurge(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/spontaneity.lua
+++ b/scripts/actions/abilities/spontaneity.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.red_mage.useSpontaneity(player, target, ability)
+    return xi.job_utils.red_mage.useSpontaneity(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/steady_wing.lua
+++ b/scripts/actions/abilities/steady_wing.lua
@@ -15,7 +15,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    xi.job_utils.dragoon.useSteadyWing(player, target, ability, action)
+    return xi.job_utils.dragoon.useSteadyWing(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/stymie.lua
+++ b/scripts/actions/abilities/stymie.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.red_mage.useStymie(player, target, ability)
+    return xi.job_utils.red_mage.useStymie(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/subtle_sorcery.lua
+++ b/scripts/actions/abilities/subtle_sorcery.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.black_mage.useSubtleSorcery(player, target, ability)
+    return xi.job_utils.black_mage.useSubtleSorcery(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/sulpor.lua
+++ b/scripts/actions/abilities/sulpor.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    xi.job_utils.rune_fencer.useRuneEnchantment(player, target, ability, xi.effect.SULPOR)
+    return xi.job_utils.rune_fencer.useRuneEnchantment(player, target, ability, xi.effect.SULPOR)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/swordplay.lua
+++ b/scripts/actions/abilities/swordplay.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.rune_fencer.useSwordplay(player, target, ability)
+    return xi.job_utils.rune_fencer.useSwordplay(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/tellus.lua
+++ b/scripts/actions/abilities/tellus.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    xi.job_utils.rune_fencer.useRuneEnchantment(player, target, ability, xi.effect.TELLUS)
+    return xi.job_utils.rune_fencer.useRuneEnchantment(player, target, ability, xi.effect.TELLUS)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/tenebrae.lua
+++ b/scripts/actions/abilities/tenebrae.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    xi.job_utils.rune_fencer.useRuneEnchantment(player, target, ability, xi.effect.TENEBRAE)
+    return xi.job_utils.rune_fencer.useRuneEnchantment(player, target, ability, xi.effect.TENEBRAE)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/tenuto.lua
+++ b/scripts/actions/abilities/tenuto.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.bard.useTenuto(player, target, ability)
+    return xi.job_utils.bard.useTenuto(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/third_eye.lua
+++ b/scripts/actions/abilities/third_eye.lua
@@ -28,6 +28,8 @@ abilityObject.onUseAbility = function(player, target, ability)
         ability:setMsg(xi.msg.basic.JA_NO_EFFECT)
     else
         player:addStatusEffect(xi.effect.THIRD_EYE, 0, 0, 30) -- Power keeps track of procs
+
+        return xi.effect.THIRD_EYE
     end
 end
 

--- a/scripts/actions/abilities/trick_attack.lua
+++ b/scripts/actions/abilities/trick_attack.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.thief.useTrickAttack(player, target, ability)
+    return xi.job_utils.thief.useTrickAttack(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/triple_shot.lua
+++ b/scripts/actions/abilities/triple_shot.lua
@@ -14,6 +14,8 @@ end
 
 abilityObject.onUseAbility = function(player, target, ability)
     player:addStatusEffect(xi.effect.TRIPLE_SHOT, 40, 0, 90)
+
+    return xi.effect.TRIPLE_SHOT
 end
 
 return abilityObject

--- a/scripts/actions/abilities/troubadour.lua
+++ b/scripts/actions/abilities/troubadour.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.bard.useTroubadour(player, target, ability)
+    return xi.job_utils.bard.useTroubadour(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/unbridled_learning.lua
+++ b/scripts/actions/abilities/unbridled_learning.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    xi.job_utils.blue_mage.useUnbridledLearning(player, target, ability, action)
+    return xi.job_utils.blue_mage.useUnbridledLearning(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/unbridled_wisdom.lua
+++ b/scripts/actions/abilities/unbridled_wisdom.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    xi.job_utils.blue_mage.useUnbridledWisdom(player, target, ability, action)
+    return xi.job_utils.blue_mage.useUnbridledWisdom(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/unda.lua
+++ b/scripts/actions/abilities/unda.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    xi.job_utils.rune_fencer.useRuneEnchantment(player, target, ability, xi.effect.UNDA)
+    return xi.job_utils.rune_fencer.useRuneEnchantment(player, target, ability, xi.effect.UNDA)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/warriors_charge.lua
+++ b/scripts/actions/abilities/warriors_charge.lua
@@ -10,7 +10,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    xi.job_utils.warrior.useWarriorsCharge(player, target, ability)
+    return xi.job_utils.warrior.useWarriorsCharge(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/yonin.lua
+++ b/scripts/actions/abilities/yonin.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    xi.job_utils.ninja.useYonin(player, target, ability, action)
+    return xi.job_utils.ninja.useYonin(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/globals/job_utils/bard.lua
+++ b/scripts/globals/job_utils/bard.lua
@@ -25,29 +25,43 @@ end
 -----------------------------------
 xi.job_utils.bard.useSoulVoice = function(player, target, ability)
     player:addStatusEffect(xi.effect.SOUL_VOICE, 1, 0, 180)
+
+    return xi.effect.SOUL_VOICE
 end
 
 xi.job_utils.bard.usePianissimo = function(player, target, ability)
     player:addStatusEffect(xi.effect.PIANISSIMO, 0, 0, 60)
+
+    return xi.effect.PIANISSIMO
 end
 
 xi.job_utils.bard.useNightingale = function(player, target, ability)
     player:addStatusEffect(xi.effect.NIGHTINGALE, 0, 0, 60)
+
+    return xi.effect.NIGHTINGALE
 end
 
 xi.job_utils.bard.useTroubadour = function(player, target, ability)
     player:addStatusEffect(xi.effect.TROUBADOUR, 0, 0, 60)
+
+    return xi.effect.TROUBADOUR
 end
 
 xi.job_utils.bard.useTenuto = function(player, target, ability)
     -- TODO: Implement this ability
     player:addStatusEffect(xi.effect.TENUTO, 0, 0, 60)
+
+    return xi.effect.TENUTO
 end
 
 xi.job_utils.bard.useMarcato = function(player, target, ability)
     player:addStatusEffect(xi.effect.MARCATO, 50, 0, 60)
+
+    return xi.effect.MARCATO
 end
 
 xi.job_utils.bard.useClarionCall = function(player, target, ability)
     player:addStatusEffect(xi.effect.CLARION_CALL, 10, 0, 180)
+
+    return xi.effect.CLARION_CALL
 end

--- a/scripts/globals/job_utils/beastmaster.lua
+++ b/scripts/globals/job_utils/beastmaster.lua
@@ -394,6 +394,8 @@ end
 -- On Ability Use Unleash
 xi.job_utils.beastmaster.onUseAbilityUnleash = function(player, target, ability)
     player:addStatusEffect(xi.effect.UNLEASH, 9, 0, 60)
+
+    return xi.effect.UNLEASH
 end
 
 -- On Ability Check For Leave, Heel and Stay.
@@ -522,6 +524,8 @@ xi.job_utils.beastmaster.onUseAbilityKillerInstinct = function(player, target, a
     -- TODO: Is there gear/mods that enhance power/duration?
 
     target:addStatusEffect(xi.effect.KILLER_INSTINCT, power, 0, duration, 0, petEcosystem)
+
+    return xi.effect.KILLER_INSTINCT
 end
 
 local function getCharmDuration(charmer, target)

--- a/scripts/globals/job_utils/black_mage.lua
+++ b/scripts/globals/job_utils/black_mage.lua
@@ -23,10 +23,14 @@ end
 -----------------------------------
 xi.job_utils.black_mage.useCascade = function(player, target, ability)
     player:addStatusEffect(xi.effect.CASCADE, 1, 0, 60)
+
+    return xi.effect.CASCADE
 end
 
 xi.job_utils.black_mage.useElementalSeal = function(player, target, ability)
     player:addStatusEffect(xi.effect.ELEMENTAL_SEAL, 1, 0, 60)
+
+    return xi.effect.ELEMENTAL_SEAL
 end
 
 xi.job_utils.black_mage.useEnmityDouse = function(player, target, ability)
@@ -38,16 +42,24 @@ end
 
 xi.job_utils.black_mage.useManafont = function(player, target, ability)
     player:addStatusEffect(xi.effect.MANAFONT, 1, 0, 60)
+
+    return xi.effect.MANAFONT
 end
 
 xi.job_utils.black_mage.useManaWall = function(player, target, ability)
     player:addStatusEffect(xi.effect.MANA_WALL, 1, 0, 300)
+
+    return xi.effect.MANA_WALL
 end
 
 xi.job_utils.black_mage.useManawell = function(player, target, ability)
     target:addStatusEffect(xi.effect.MANAWELL, 1, 0, 60)
+
+    return xi.effect.MANAWELL
 end
 
 xi.job_utils.black_mage.useSubtleSorcery = function(player, target, ability)
     player:addStatusEffect(xi.effect.SUBTLE_SORCERY, 1, 0, 60)
+
+    return xi.effect.SUBTLE_SORCERY
 end

--- a/scripts/globals/job_utils/blue_mage.lua
+++ b/scripts/globals/job_utils/blue_mage.lua
@@ -51,6 +51,8 @@ end
 
 xi.job_utils.blue_mage.useAzureLore = function(player, target, ability, action)
     player:addStatusEffect(xi.effect.AZURE_LORE, 1, 0, 30)
+
+    return xi.effect.AZURE_LORE
 end
 
 xi.job_utils.blue_mage.useBurstAffinity = function(player, target, ability, action)
@@ -70,12 +72,18 @@ end
 
 xi.job_utils.blue_mage.useEfflux = function(player, target, ability, action)
     player:addStatusEffect(xi.effect.EFFLUX, 16, 1, 60)
+
+    return xi.effect.EFFLUX
 end
 
 xi.job_utils.blue_mage.useUnbridledWisdom = function(player, target, ability, action)
     target:addStatusEffect(xi.effect.UNBRIDLED_WISDOM, 16, 1, 30)
+
+    return xi.effect.UNBRIDLED_WISDOM
 end
 
 xi.job_utils.blue_mage.useUnbridledLearning = function(player, target, ability, action)
     target:addStatusEffect(xi.effect.UNBRIDLED_LEARNING, 16, 1, 60)
+
+    return xi.effect.UNBRIDLED_LEARNING
 end

--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -318,6 +318,8 @@ end
 
 xi.job_utils.dancer.usePrestoAbility = function(player, target, ability, action)
     target:addStatusEffect(xi.effect.PRESTO, 19, 3, 30)
+
+    return xi.effect.PRESTO
 end
 
 xi.job_utils.dancer.useNoFootRiseAbility = function(player, target, ability, action)
@@ -478,6 +480,8 @@ end
 
 xi.job_utils.dancer.useContradanceAbility = function(player, target, ability)
     player:addStatusEffect(xi.effect.CONTRADANCE, 0, 0, 60)
+
+    return xi.effect.CONTRADANCE
 end
 
 xi.job_utils.dancer.useWaltzAbility = function(player, target, ability, action)

--- a/scripts/globals/job_utils/dark_knight.lua
+++ b/scripts/globals/job_utils/dark_knight.lua
@@ -66,6 +66,8 @@ xi.job_utils.dark_knight.useArcaneCircle = function(player, target, ability)
     end
 
     target:addStatusEffect(xi.effect.ARCANE_CIRCLE, power, 0, duration)
+
+    return xi.effect.ARCANE_CIRCLE
 end
 
 xi.job_utils.dark_knight.useArcaneCrest = function(player, target, ability)
@@ -80,10 +82,14 @@ xi.job_utils.dark_knight.useBloodWeapon = function(player, target, ability)
     local duration = 30 + player:getMod(xi.mod.ENHANCES_BLOOD_WEAPON)
 
     target:addStatusEffect(xi.effect.BLOOD_WEAPON, power, 0, duration)
+
+    return xi.effect.BLOOD_WEAPON
 end
 
 xi.job_utils.dark_knight.useConsumeMana = function(player, target, ability)
     player:addStatusEffect(xi.effect.CONSUME_MANA, 1, 0, 60)
+
+    return xi.effect.CONSUME_MANA
 end
 
 xi.job_utils.dark_knight.useDarkSeal = function(player, target, ability)
@@ -93,6 +99,8 @@ xi.job_utils.dark_knight.useDarkSeal = function(player, target, ability)
     local subPower = player:getMerit(xi.merit.DARK_SEAL) * player:getMod(xi.mod.ENHANCES_DARK_SEAL) / 10
 
     player:addStatusEffect(xi.effect.DARK_SEAL, power, 0, 60, 0, subPower)
+
+    return xi.effect.DARK_SEAL
 end
 
 xi.job_utils.dark_knight.useDiabolicEye = function(player, target, ability)
@@ -100,10 +108,14 @@ xi.job_utils.dark_knight.useDiabolicEye = function(player, target, ability)
     local duration = 180 + player:getMerit(xi.merit.DIABOLIC_EYE) * player:getMod(xi.mod.ENHANCES_DIABOLIC_EYE)
 
     player:addStatusEffect(xi.effect.DIABOLIC_EYE, power, 0, duration)
+
+    return xi.effect.DIABOLIC_EYE
 end
 
 xi.job_utils.dark_knight.useLastResort = function(player, target, ability)
     player:addStatusEffect(xi.effect.LAST_RESORT, 0, 0, 180)
+
+    return xi.effect.LAST_RESORT
 end
 
 xi.job_utils.dark_knight.useNetherVoid = function(player, target, ability)
@@ -111,16 +123,22 @@ xi.job_utils.dark_knight.useNetherVoid = function(player, target, ability)
     local duration = 60
 
     player:addStatusEffect(xi.effect.NETHER_VOID, power, 0, duration)
+
+    return xi.effect.NETHER_VOID
 end
 
 xi.job_utils.dark_knight.useScarletDelirium = function(player, target, ability)
     local duration = 90 + player:getJobPointLevel(xi.jp.SCARLET_DELIRIUM_DURATION)
 
     player:addStatusEffect(xi.effect.SCARLET_DELIRIUM, 0, 0, duration)
+
+    return xi.effect.SCARLET_DELIRIUM
 end
 
 xi.job_utils.dark_knight.useSoulEnslavement = function(player, target, ability)
     player:addStatusEffect(xi.effect.SOUL_ENSLAVEMENT, 0, 0, 30)
+
+    return xi.effect.SOUL_ENSLAVEMENT
 end
 
 xi.job_utils.dark_knight.useSouleater = function(player, target, ability)
@@ -128,6 +146,8 @@ xi.job_utils.dark_knight.useSouleater = function(player, target, ability)
     local subPower = target:getMod(xi.mod.ENHANCES_MUTED_SOUL) * target:getMerit(xi.merit.MUTED_SOUL) / 10 -- Origin: Abyss Flanchard +2
 
     player:addStatusEffect(xi.effect.SOULEATER, 1, 0, duration, 0, subPower)
+
+    return xi.effect.SOULEATER
 end
 
 xi.job_utils.dark_knight.useWeaponBash = function(player, target, ability)

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -234,6 +234,8 @@ xi.job_utils.dragoon.useAncientCircle = function(player, target, ability)
     power = power + player:getMod(xi.mod.ANCIENT_CIRCLE_POTENCY)
 
     target:addStatusEffect(xi.effect.ANCIENT_CIRCLE, power, 0, duration)
+
+    return xi.effect.ANCIENT_CIRCLE
 end
 
 xi.job_utils.dragoon.useJump = function(player, target, ability, action)
@@ -523,6 +525,8 @@ end
 
 xi.job_utils.dragoon.useSpiritBond = function(player, target, ability)
     player:addStatusEffect(xi.effect.SPIRIT_BOND, 0, 0, 180)
+
+    return xi.effect.SPIRIT_BOND
 end
 
 xi.job_utils.dragoon.useSpiritJump = function(player, target, ability, action)
@@ -565,7 +569,7 @@ xi.job_utils.dragoon.useSoulJump = function(player, target, ability, action)
 end
 
 xi.job_utils.dragoon.useDragonBreaker = function(player, target, ability)
-    player:addStatusEffect(xi.effect.DRAGON_BREAKER, 20, 0, 180)
+    target:addStatusEffect(xi.effect.DRAGON_BREAKER, 20, 0, 180)
 end
 
 xi.job_utils.dragoon.useFlyHigh = function(player, target, ability)
@@ -577,6 +581,8 @@ xi.job_utils.dragoon.useFlyHigh = function(player, target, ability)
     target:resetRecast(xi.recast.ABILITY, 167) -- Soul Jump
 
     player:addStatusEffect(xi.effect.FLY_HIGH, 0, 0, 30)
+
+    return xi.effect.FLY_HIGH
 end
 
 xi.job_utils.dragoon.useSteadyWing = function(player, target, ability, action)

--- a/scripts/globals/job_utils/geomancer.lua
+++ b/scripts/globals/job_utils/geomancer.lua
@@ -283,6 +283,8 @@ end
 xi.job_utils.geomancer.bolster = function(player, target, ability)
     local bonusTime = player:getMod(xi.mod.BOLSTER_EFFECT)
     player:addStatusEffect(xi.effect.BOLSTER, 0, 3, 240 + bonusTime)
+
+    return xi.effect.BOLSTER
 end
 
 xi.job_utils.geomancer.fullCircle = function(player, target, ability)
@@ -344,6 +346,8 @@ end
 
 xi.job_utils.geomancer.collimatedFervor = function(player, target, ability)
     target:addStatusEffect(xi.effect.COLLIMATED_FERVOR, 0, 0, 60)
+
+    return xi.effect.COLLIMATED_FERVOR
 end
 
 xi.job_utils.geomancer.lifeCycle = function(player, target, ability)
@@ -361,6 +365,8 @@ end
 
 xi.job_utils.geomancer.blazeOfGlory = function(player, target, ability)
     player:addStatusEffect(xi.effect.BLAZE_OF_GLORY, 0, 3, 60)
+
+    return xi.effect.BLAZE_OF_GLORY
 end
 
 xi.job_utils.geomancer.dematerialize = function(player, target, ability)
@@ -377,6 +383,8 @@ end
 
 xi.job_utils.geomancer.widenedCompass = function(player, target, ability)
     player:addStatusEffect(xi.effect.WIDENED_COMPASS, 0, 3, 60)
+
+    return xi.effect.WIDENED_COMPASS
 end
 
 -----------------------------------

--- a/scripts/globals/job_utils/monk.lua
+++ b/scripts/globals/job_utils/monk.lua
@@ -96,18 +96,24 @@ xi.job_utils.monk.useCounterstance = function(player, target, ability)
 
     target:delStatusEffect(xi.effect.COUNTERSTANCE) --if not found this will do nothing
     target:addStatusEffect(xi.effect.COUNTERSTANCE, power, 0, 300)
+
+    return xi.effect.COUNTERSTANCE
 end
 
 xi.job_utils.monk.useDodge = function(player, target, ability)
     local jpLevel  = target:getJobPointLevel(xi.jp.DODGE_EFFECT)
     local dodgeMod = target:getMod(xi.mod.DODGE_EFFECT)
     player:addStatusEffect(xi.effect.DODGE, jpLevel + dodgeMod, 0, 30)
+
+    return xi.effect.DODGE
 end
 
 xi.job_utils.monk.useFocus = function(player, target, ability)
     local jpLevel  = target:getJobPointLevel(xi.jp.FOCUS_EFFECT)
     local focusMod = target:getMod(xi.mod.FOCUS_EFFECT)
     player:addStatusEffect(xi.effect.FOCUS, jpLevel + focusMod, 0, 30)
+
+    return xi.effect.FOCUS
 end
 
 xi.job_utils.monk.useFootwork = function(player, target, ability)
@@ -115,14 +121,20 @@ xi.job_utils.monk.useFootwork = function(player, target, ability)
     local kickAttPercent = 25 + player:getMod(xi.mod.FOOTWORK_ATT_BONUS)
 
     player:addStatusEffect(xi.effect.FOOTWORK, kickDmg, 0, 60, 0, kickAttPercent)
+
+    return xi.effect.FOOTWORK
 end
 
 xi.job_utils.monk.useFormlessStrikes = function(player, target, ability)
     player:addStatusEffect(xi.effect.FORMLESS_STRIKES, 1, 0, 180)
+
+    return xi.effect.FORMLESS_STRIKES
 end
 
 xi.job_utils.monk.useHundredFists = function(player, target, ability)
     player:addStatusEffect(xi.effect.HUNDRED_FISTS, 1, 0, 45)
+
+    return xi.effect.HUNDRED_FISTS
 end
 
 -- TODO: Support Tantra Cyclas + 1 (does not give critical hit damage)
@@ -177,10 +189,14 @@ end
 
 xi.job_utils.monk.useImpetus = function(player, target, ability)
     player:addStatusEffect(xi.effect.IMPETUS, 0, 0, 180)
+
+    return xi.effect.IMPETUS
 end
 
 xi.job_utils.monk.useInnerStrength = function(player, target, ability)
     player:addStatusEffect(xi.effect.INNER_STRENGTH, 2, 0, 30)
+
+    return xi.effect.INNER_STRENGTH
 end
 
 xi.job_utils.monk.useMantra = function(player, target, ability)
@@ -194,4 +210,6 @@ end
 
 xi.job_utils.monk.usePerfectCounter = function(player, target, ability)
     player:addStatusEffect(xi.effect.PERFECT_COUNTER, 2, 0, 30)
+
+    return xi.effect.PERFECT_COUNTER
 end

--- a/scripts/globals/job_utils/ninja.lua
+++ b/scripts/globals/job_utils/ninja.lua
@@ -65,27 +65,39 @@ xi.job_utils.ninja.useYonin = function(player, target, ability, action)
     target:delStatusEffect(xi.effect.INNIN)
     target:delStatusEffect(xi.effect.YONIN)
     target:addStatusEffect(xi.effect.YONIN, 30, 15, 300, 0, 0)
+
+    return xi.effect.YONIN
 end
 
 xi.job_utils.ninja.useInnin = function(player, target, ability, action)
     target:delStatusEffect(xi.effect.INNIN)
     target:delStatusEffect(xi.effect.YONIN)
     target:addStatusEffect(xi.effect.INNIN, 30, 15, 300, 0, 20)
+
+    return xi.effect.INNIN
 end
 
 xi.job_utils.ninja.useSange = function(player, target, ability, action)
     local potency = player:getMerit(xi.merit.SANGE)-1
     player:addStatusEffect(xi.effect.SANGE, potency * 25, 0, 60)
+
+    return xi.effect.SANGE
 end
 
 xi.job_utils.ninja.useFutae = function(player, target, ability, action)
     target:addStatusEffect(xi.effect.FUTAE, 0, 0, 60)
+
+    return xi.effect.FUTAE
 end
 
 xi.job_utils.ninja.useIssekigan = function(player, target, ability, action)
     target:addStatusEffect(xi.effect.ISSEKIGAN, 25, 0, 60)
+
+    return xi.effect.ISSEKIGAN
 end
 
 xi.job_utils.ninja.useMikage = function(player, target, ability, action)
     target:addStatusEffect(xi.effect.MIKAGE, 0, 0, 45)
+
+    return xi.effect.MIKAGE
 end

--- a/scripts/globals/job_utils/paladin.lua
+++ b/scripts/globals/job_utils/paladin.lua
@@ -86,6 +86,8 @@ xi.job_utils.paladin.useDivineEmblem = function(player, target, ability)
     local power = 50 + player:getMod(xi.mod.ENHANCES_DIVINE_EMBLEM) -- 50% increase to enmity
 
     player:addStatusEffect(xi.effect.DIVINE_EMBLEM, power, 0, 60)
+
+    return xi.effect.DIVINE_EMBLEM
 end
 
 xi.job_utils.paladin.useFealty = function(player, target, ability)
@@ -94,6 +96,8 @@ xi.job_utils.paladin.useFealty = function(player, target, ability)
     local duration  = 60 + merits + enhFealty
 
     player:addStatusEffect(xi.effect.FEALTY, 1, 0, duration)
+
+    return xi.effect.FEALTY
 end
 
 xi.job_utils.paladin.useHolyCircle = function(player, target, ability)
@@ -112,6 +116,8 @@ xi.job_utils.paladin.useHolyCircle = function(player, target, ability)
     power = power + player:getMod(xi.mod.HOLY_CIRCLE_POTENCY)
 
     target:addStatusEffect(xi.effect.HOLY_CIRCLE, power, 0, duration)
+
+    return xi.effect.HOLY_CIRCLE
 end
 
 xi.job_utils.paladin.useIntervene = function(player, target, ability)
@@ -137,10 +143,14 @@ end
 
 xi.job_utils.paladin.useInvincible = function(player, target, ability)
     player:addStatusEffect(xi.effect.INVINCIBLE, 1, 0, 30)
+
+    return xi.effect.INVINCIBLE
 end
 
 xi.job_utils.paladin.useMajesty = function(player, target, ability)
     player:addStatusEffect(xi.effect.MAJESTY, 25, 0, 180)
+
+    return xi.effect.MAJESTY
 end
 
 xi.job_utils.paladin.usePalisade = function(player, target, ability)
@@ -148,12 +158,16 @@ xi.job_utils.paladin.usePalisade = function(player, target, ability)
     local power   = 30 + jpValue
 
     player:addStatusEffect(xi.effect.PALISADE, power, 0, 60)
+
+    return xi.effect.PALISADE
 end
 
 xi.job_utils.paladin.useRampart = function(player, target, ability)
     local duration = 30 + player:getMod(xi.mod.RAMPART_DURATION)
 
     target:addStatusEffect(xi.effect.RAMPART, 2500, 0, duration)
+
+    return xi.effect.RAMPART
 end
 
 xi.job_utils.paladin.useSentinel = function(player, target, ability)
@@ -167,6 +181,8 @@ xi.job_utils.paladin.useSentinel = function(player, target, ability)
 
     -- Sent as positive power because UINTs, man.
     player:addStatusEffect(xi.effect.SENTINEL, power, 3, duration, 0, guardian + jpValue)
+
+    return xi.effect.SENTINEL
 end
 
 xi.job_utils.paladin.useSepulcher = function(player, target, ability)

--- a/scripts/globals/job_utils/ranger.lua
+++ b/scripts/globals/job_utils/ranger.lua
@@ -165,11 +165,15 @@ end
 
 xi.job_utils.ranger.useVelocityShot = function(player, target, ability, action)
     player:addStatusEffect(xi.effect.VELOCITY_SHOT, 1, 0, 7200)
+
+    return xi.effect.VELOCITY_SHOT
 end
 
 xi.job_utils.ranger.useSharpshot = function(player, target, ability, action)
     local power = 40 + player:getMod(xi.mod.SHARPSHOT)
     player:addStatusEffect(xi.effect.SHARPSHOT, power, 0, 60)
+
+    return xi.effect.SHARPSHOT
 end
 
 xi.job_utils.ranger.useScavenge = function(player, target, ability, action)
@@ -218,10 +222,14 @@ end
 xi.job_utils.ranger.useCamouflage = function(player, target, ability, action)
     local duration = math.random(30, 300) * (1 + 0.01 * player:getMod(xi.mod.CAMOUFLAGE_DURATION))
     player:addStatusEffect(xi.effect.CAMOUFLAGE, 1 , 0, math.floor(duration * xi.settings.main.SNEAK_INVIS_DURATION_MULTIPLIER))
+
+    return xi.effect.CAMOUFLAGE
 end
 
 xi.job_utils.ranger.useBarrage = function(player, target, ability, action)
     player:addStatusEffect(xi.effect.BARRAGE, 0, 0, 60)
+
+    return xi.effect.BARRAGE
 end
 
 xi.job_utils.ranger.useShadowbind = function(player, target, ability, action)
@@ -251,6 +259,8 @@ end
 
 xi.job_utils.ranger.useUnlimitedShot = function(player, target, ability, action)
     player:addStatusEffect(xi.effect.UNLIMITED_SHOT, 1, 0, 60)
+
+    return xi.effect.UNLIMITED_SHOT
 end
 
 xi.job_utils.ranger.useFlashyShot = function(player, target, ability, action)
@@ -263,6 +273,8 @@ end
 
 xi.job_utils.ranger.useDoubleShot = function(player, target, ability, action)
     player:addStatusEffect(xi.effect.DOUBLE_SHOT, 40, 0, 90)
+
+    return xi.effect.DOUBLE_SHOT
 end
 
 xi.job_utils.ranger.useBountyShot = function(player, target, ability, action)
@@ -337,6 +349,8 @@ end
 
 xi.job_utils.ranger.useDecoyShot = function(player, target, ability, action)
     target:addStatusEffect(xi.effect.DECOY_SHOT, 11, 1, 30)
+
+    return xi.effect.DECOY_SHOT
 end
 
 xi.job_utils.ranger.useHoverShot = function(player, target, ability, action)
@@ -345,4 +359,6 @@ end
 
 xi.job_utils.ranger.useOverkill = function(player, target, ability, action)
     player:addStatusEffect(xi.effect.OVERKILL, 11, 1, 60)
+
+    return xi.effect.OVERKILL
 end

--- a/scripts/globals/job_utils/red_mage.lua
+++ b/scripts/globals/job_utils/red_mage.lua
@@ -23,11 +23,15 @@ end
 -----------------------------------
 xi.job_utils.red_mage.useChainspell = function(player, target, ability)
     player:addStatusEffect(xi.effect.CHAINSPELL, 1, 0, 60)
+
+    return xi.effect.CHAINSPELL
 end
 
 xi.job_utils.red_mage.useComposure = function(player, target, ability)
     player:delStatusEffect(xi.effect.COMPOSURE)
     player:addStatusEffect(xi.effect.COMPOSURE, 1, 0, 7200)
+
+    return xi.effect.COMPOSURE
 end
 
 xi.job_utils.red_mage.useConvert = function(player, target, ability)
@@ -51,12 +55,18 @@ end
 
 xi.job_utils.red_mage.useSaboteur = function(player, target, ability)
     player:addStatusEffect(xi.effect.SABOTEUR, 1, 0, 60)
+
+    return xi.effect.SABOTEUR
 end
 
 xi.job_utils.red_mage.useSpontaneity = function(player, target, ability)
     target:addStatusEffect(xi.effect.SPONTANEITY, 1, 0, 60)
+
+    return xi.effect.SPONTANEITY
 end
 
 xi.job_utils.red_mage.useStymie = function(player, target, ability)
     target:addStatusEffect(xi.effect.STYMIE, 1, 0, 60)
+
+    return xi.effect.STYMIE
 end

--- a/scripts/globals/job_utils/rune_fencer.lua
+++ b/scripts/globals/job_utils/rune_fencer.lua
@@ -328,6 +328,8 @@ xi.job_utils.rune_fencer.useSwordplay = function(player, target, ability)
     subPower       = subPower + (subPower / 5) * player:getMod(xi.mod.AUGMENTS_SLEIGHT_OF_SWORD) -- Add augment effect IF player has augment.
 
     player:addStatusEffect(xi.effect.SWORDPLAY, power, 3, 120, 0, subPower, 0)
+
+    return xi.effect.SWORDPLAY
 end
 
 xi.job_utils.rune_fencer.onSwordplayEffectGain = function(target, effect)
@@ -489,6 +491,8 @@ xi.job_utils.rune_fencer.useBattuta = function(player, target, ability, action)
     action:speceffect(target:getID(), getSpecEffectElementWard(highestRune)) -- set element color for animation.
 
     target:addStatusEffect(xi.effect.BATTUTA, inquartataPower, 0, 90, 0, math.floor(spikesPower * modBonus), 0)
+
+    return xi.effect.BATTUTA
 end
 
 xi.job_utils.rune_fencer.onBattutaEffectGain = function(target, effect)
@@ -721,6 +725,8 @@ xi.job_utils.rune_fencer.usePflug = function(player, target, ability, action)
     action:speceffect(target:getID(), getSpecEffectElementWard(highestRune))
 
     player:addStatusEffect(xi.effect.PFLUG, baseStrength, 0, 120, 0, meritBonus)
+
+    return xi.effect.PFLUG
 end
 
 -- see https://www.bg-wiki.com/ffxi/Gambit
@@ -831,6 +837,8 @@ local function applyLiementEffect(target, absorbTypes, absorbPower, duration)
     target:delStatusEffectSilent(xi.effect.LIEMENT)   -- Remove Liement if it's already up. The new one will overwrite regardless of strength.
 
     target:addStatusEffect(xi.effect.LIEMENT, absorbPower, 0, duration, 0, absorbBits)
+
+    return xi.effect.LIEMENT
 end
 
 -- see https://www.bg-wiki.com/ffxi/Liement

--- a/scripts/globals/job_utils/thief.lua
+++ b/scripts/globals/job_utils/thief.lua
@@ -147,6 +147,8 @@ xi.job_utils.thief.useAssassinsCharge = function(player, target, ability)
     end
 
     player:addStatusEffect(xi.effect.ASSASSINS_CHARGE, merits - 5, 0, 60, 0, crit)
+
+    return xi.effect.ASSASSINS_CHARGE
 end
 
 xi.job_utils.thief.useBully = function(player, target, ability)
@@ -190,6 +192,8 @@ xi.job_utils.thief.useConspirator = function(player, target, ability)
     end
 
     target:addStatusEffect(xi.effect.CONSPIRATOR, subtleBlow * scale, 0, 60, 0, accuracy * scale)
+
+    return xi.effect.CONSPIRATOR
 end
 
 xi.job_utils.thief.useDespoil = function(player, target, ability, action)
@@ -262,6 +266,8 @@ xi.job_utils.thief.useFlee = function(player, target, ability)
     end
 
     player:addStatusEffect(xi.effect.FLEE, 10000, 0, duration)
+
+    return xi.effect.FLEE
 end
 
 xi.job_utils.thief.useHide = function(player, target, ability)
@@ -270,6 +276,8 @@ xi.job_utils.thief.useHide = function(player, target, ability)
     duration = duration * (1 + player:getMod(xi.mod.HIDE_DURATION) / 100)
 
     player:addStatusEffect(xi.effect.HIDE, 1, 0, math.floor(duration * xi.settings.main.SNEAK_INVIS_DURATION_MULTIPLIER))
+
+    return xi.effect.HIDE
 end
 
 xi.job_utils.thief.useLarceny = function(player, target, ability, action)
@@ -385,10 +393,14 @@ xi.job_utils.thief.usePerfectDodge = function(player, target, ability)
     local duration = 30 + player:getMod(xi.mod.PERFECT_DODGE)
 
     player:addStatusEffect(xi.effect.PERFECT_DODGE, 1, 0, duration)
+
+    return xi.effect.PERFECT_DODGE
 end
 
 xi.job_utils.thief.useSneakAttack = function(player, target, ability)
     player:addStatusEffect(xi.effect.SNEAK_ATTACK, 1, 0, 60)
+
+    return xi.effect.SNEAK_ATTACK
 end
 
 xi.job_utils.thief.useSteal = function(player, target, ability, action)
@@ -461,4 +473,6 @@ end
 
 xi.job_utils.thief.useTrickAttack = function(player, target, ability)
     player:addStatusEffect(xi.effect.TRICK_ATTACK, 1, 0, 60)
+
+    return xi.effect.TRICK_ATTACK
 end

--- a/scripts/globals/job_utils/warrior.lua
+++ b/scripts/globals/job_utils/warrior.lua
@@ -35,6 +35,8 @@ xi.job_utils.warrior.useAggressor = function(player, target, ability)
     local merits = player:getMerit(xi.merit.AGGRESSIVE_AIM)
 
     player:addStatusEffect(xi.effect.AGGRESSOR, merits, 0, 180 + player:getMod(xi.mod.AGGRESSOR_DURATION))
+
+    return xi.effect.AGGRESSOR
 end
 
 xi.job_utils.warrior.useBerserk = function(player, target, ability)
@@ -47,6 +49,8 @@ xi.job_utils.warrior.useBerserk = function(player, target, ability)
     local duration = 180 + player:getMod(xi.mod.BERSERK_DURATION)
 
     player:addStatusEffect(xi.effect.BERSERK, power, 0, duration)
+
+    return xi.effect.BERSERK
 end
 
 xi.job_utils.warrior.useBloodRage = function(player, target, ability)
@@ -64,6 +68,8 @@ end
 
 xi.job_utils.warrior.useBrazenRush = function(player, target, ability)
     player:addStatusEffect(xi.effect.BRAZEN_RUSH, 100, 3, 30)
+
+    return xi.effect.BRAZEN_RUSH
 end
 
 xi.job_utils.warrior.useDefender = function(player, target, ability)
@@ -76,18 +82,26 @@ xi.job_utils.warrior.useDefender = function(player, target, ability)
     local duration = 180 + player:getMod(xi.mod.DEFENDER_DURATION)
 
     player:addStatusEffect(xi.effect.DEFENDER, power, 0, duration)
+
+    return xi.effect.DEFENDER
 end
 
 xi.job_utils.warrior.useMightyStrikes = function(player, target, ability)
     player:addStatusEffect(xi.effect.MIGHTY_STRIKES, 1, 0, 45)
+
+    return xi.effect.MIGHTY_STRIKES
 end
 
 xi.job_utils.warrior.useRestraint = function(player, target, ability)
     player:addStatusEffect(xi.effect.RESTRAINT, 0, 0, 300)
+
+    return xi.effect.RESTRAINT
 end
 
 xi.job_utils.warrior.useRetaliation = function(player, target, ability)
     player:addStatusEffect(xi.effect.RETALIATION, 1, 0, 180)
+
+    return xi.effect.RETALIATION
 end
 
 xi.job_utils.warrior.useTomahawk = function(player, target, ability)
@@ -119,4 +133,6 @@ xi.job_utils.warrior.useWarriorsCharge = function(player, target, ability)
     local merits = player:getMerit(xi.merit.WARRIORS_CHARGE)
 
     player:addStatusEffect(xi.effect.WARRIORS_CHARGE, merits - 5, 0, 60)
+
+    return xi.effect.WARRIORS_CHARGE
 end

--- a/scripts/globals/job_utils/white_mage.lua
+++ b/scripts/globals/job_utils/white_mage.lua
@@ -60,16 +60,22 @@ xi.job_utils.white_mage.useAfflatusMisery = function(player, target, ability)
     target:delStatusEffect(xi.effect.AFFLATUS_SOLACE)
     target:delStatusEffect(xi.effect.AFFLATUS_MISERY)
     target:addStatusEffect(xi.effect.AFFLATUS_MISERY, 8, 0, 7200)
+
+    return xi.effect.AFFLATUS_MISERY
 end
 
 xi.job_utils.white_mage.useAfflatusSolace = function(player, target, ability)
     target:delStatusEffect(xi.effect.AFFLATUS_SOLACE)
     target:delStatusEffect(xi.effect.AFFLATUS_MISERY)
     target:addStatusEffect(xi.effect.AFFLATUS_SOLACE, 8, 0, 7200)
+
+    return xi.effect.AFFLATUS_SOLACE
 end
 
 xi.job_utils.white_mage.useAsylum = function(player, target, ability)
     target:addStatusEffect(xi.effect.ASYLUM, 3, 0, 30)
+
+    return xi.effect.ASYLUM
 end
 
 xi.job_utils.white_mage.useBenediction = function(player, target, ability)
@@ -122,10 +128,14 @@ end
 
 xi.job_utils.white_mage.useDivineCaress = function(player, target, ability)
     player:addStatusEffect(xi.effect.DIVINE_CARESS_I, 3, 0, 60)
+
+    return xi.effect.DIVINE_CARESS_I
 end
 
 xi.job_utils.white_mage.useDivineSeal = function(player, target, ability)
     player:addStatusEffect(xi.effect.DIVINE_SEAL, 1, 0, 60)
+
+    return xi.effect.DIVINE_SEAL
 end
 
 xi.job_utils.white_mage.useMartyr = function(player, target, ability)
@@ -150,4 +160,6 @@ end
 
 xi.job_utils.white_mage.useSacrosanctity = function(player, target, ability)
     target:addStatusEffect(xi.effect.SACROSANCTITY, 3, 0, 60)
+
+    return xi.effect.SACROSANCTITY
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Noticed while testing the action packet. 
Abilities granting a status effect are supposed to return the status ID in the action packet which is done through the return value of onAbilityUse in LSB.

- Updates all abilities lua to return the status effect
- Fix Dragon Breaker that was applying the debuff to the player

Note that this has almost no bearing on the client as the buffs come in through another packet but it's important for this to be consistent.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
