### PR TITLE
Fix shadowing definition of variable

### DIFF
--- a/scripts/battlefields/Bearclaw_Pinnacle/when_hell_freezes_over.lua
+++ b/scripts/battlefields/Bearclaw_Pinnacle/when_hell_freezes_over.lua
@@ -34,7 +34,7 @@ local function spawnSnowDevils(battlefield)
             mob:spawn()
 
             -- Update emnity.
-            local wave  = battlefield:getLocalVar('wave')
+            wave  = battlefield:getLocalVar('wave')
             if wave >= 1 then
                 local players = battlefield:getPlayers()
                 for _, player in pairs(players) do


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a stylecheck issue:
```
scripts/battlefields/Bearclaw_Pinnacle/when_hell_freezes_over.lua:37:19: (W421) shadowing definition of variable 'wave' on line 27
```

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
