### PR TITLE
[ci] Only run sanity checks on relevant files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,14 +69,11 @@ jobs:
           mapfile -t changed_files < changed-files.txt
           source_changes=false
           for changed_file in "${changed_files[@]}"; do
-          if [[ $changed_file == *.cpp || \
-                $changed_file == *.cc  || \
-                $changed_file == *.cxx || \
-                $changed_file == *.h   || \
-                $changed_file == *.hpp || \
-                $changed_file == *.hxx || \
+          if [[ $changed_file == src/**/*.cpp || $changed_file == modules/**/*.cpp || \
+                $changed_file == src/**/*.h   || $changed_file == modules/**/*.h   || \
+                $changed_file == src/**/CMakeLists.txt || $changed_file == modules/**/CMakeLists.txt || \
                 $changed_file == CMakeLists.txt || \
-                $changed_file == *.cmake ]]; then
+                $changed_file == cmake/*.cmake ]]; then
               source_changes=true
               break
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: changed-files
-        # Skipping lua language server hinges on checking the changed files list, so we should require downloading the artifact
-        # continue-on-error: true
 
       - name: Check For Changed Lua Files
         id: check-changes
@@ -75,7 +73,7 @@ jobs:
           mapfile -t changed_files < changed-files.txt
           lua_changes=false
           for changed_file in ${changed_files[@]}; do
-              if [[ $changed_file == *.lua ]]; then
+              if [[ $changed_file == scripts/**/*.lua || $changed_file == modules/**/*.lua ]]; then
                 lua_changes=true
                 break
               fi

--- a/tools/ci/sanity_checks/cpp.sh
+++ b/tools/ci/sanity_checks/cpp.sh
@@ -8,11 +8,11 @@ any_issues=false
 if [[ $# -gt 0 ]]; then
     targets=("$@")
 else
-    mapfile -t targets < <(find src -name '*.cpp' -o -name '*.h')
+    mapfile -t targets < <(find src modules -name '*.cpp' -o -name '*.h')
 fi
 
 for file in "${targets[@]}"; do
-    [[ -f $file && $file == *.cpp || $file == *.h ]] || continue
+    [[ -f $file && ($file == *.cpp || $file == *.h) && ($file == src/**/* || $file == modules/**/*) ]] || continue
 
     # Run tools and capture output
     if [[ $file == *.cpp ]]; then

--- a/tools/ci/sanity_checks/general.sh
+++ b/tools/ci/sanity_checks/general.sh
@@ -35,25 +35,18 @@ if [[ $# -gt 0 ]]; then
         [[ -f $file && $file != *.py ]] || continue
 
         general_output=$(python tools/ci/sanity_checks/general.py "$file" 2>&1 || true)
-        if [[ -n "$general_output" ]]; then
-            if ! $any_issues; then
-                echo "## :x: General Checks Failed"
-                any_issues=true
-            fi
-            echo "$general_output"
-            echo
-        fi
     done
 else
     general_output=$(python tools/ci/sanity_checks/general.py . 2>&1 || true)
-    if [[ -n "$general_output" ]]; then
-        if ! $any_issues; then
-            echo "## :x: General Checks Failed"
-            any_issues=true
-        fi
-        echo "$general_output"
-        echo
+fi
+
+if [[ -n "$general_output" ]]; then
+    if ! $any_issues; then
+        echo "## :x: General Checks Failed"
+        any_issues=true
     fi
+    echo "$general_output"
+    echo
 fi
 
 # If no section was written, emit a success summary

--- a/tools/ci/sanity_checks/lua.sh
+++ b/tools/ci/sanity_checks/lua.sh
@@ -10,7 +10,7 @@ any_issues=false
 if [[ $# -gt 0 ]]; then
     targets=("$@")
 else
-    mapfile -t targets < <(find scripts -name '*.lua')
+    mapfile -t targets < <(find scripts modules -name '*.lua')
 fi
 
 global_funcs=`python << EOF
@@ -133,7 +133,7 @@ if [[ -n "$binding_usage_output" ]]; then
 fi
 
 for file in "${targets[@]}"; do
-    [[ -f $file && $file == *.lua && $file != 'tools/ci/sanity_checks/lua_stylecheck.lua' ]] || continue
+    [[ -f $file && ($file == scripts/**/*.lua || $file == modules/**/*.lua) ]] || continue
 
     # Run tools and capture output
     luacheck_output=$(luacheck "$file" \

--- a/tools/ci/sanity_checks/python.sh
+++ b/tools/ci/sanity_checks/python.sh
@@ -9,7 +9,7 @@ else
 fi
 
 for file in "${targets[@]}"; do
-    [[ -f $file && $file == *.py ]] || continue
+    [[ -f $file && $file == tools/**/*.py ]] || continue
 
     # Run tools and capture output
     pylint_output=$(pylint --errors-only "$file" 2>&1 || true)

--- a/tools/ci/sanity_checks/sql.sh
+++ b/tools/ci/sanity_checks/sql.sh
@@ -5,11 +5,11 @@ any_issues=false
 if [[ $# -gt 0 ]]; then
     targets=("$@")
 else
-    mapfile -t targets < <(find sql -name '*.sql')
+    mapfile -t targets < <(find sql modules -name '*.sql')
 fi
 
 for file in "${targets[@]}"; do
-    [[ -f $file && $file == *.sql ]] || continue
+    [[ -f $file && ($file == sql/**/*.sql || $file == modules/**/*.sql) ]] || continue
 
     # Run tools and capture output
     bogus_comments=$(grep -En '(--\w)|^(---\s)' "$file" 2>&1 || true)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Restricts sanity checks to running on relevant files in `src`, `scripts`, `sql`, `tools`, and `modules`.

This is basically the [same behavior as before](https://github.com/LandSandBoat/server/blob/cf774b5838925cebf868cd4f3f97019f43fe05aa/.github/workflows/build.yml#L37-L46) the recent changes.

## Steps to test these changes

Changes to `settings`, `ext` etc don't get checked by sanity checks.
