### PR TITLE
Format settings and enforce via sanity checks

### DIFF
--- a/settings/default/logging.lua
+++ b/settings/default/logging.lua
@@ -20,13 +20,13 @@ xi.settings.logging =
         %* : a fixed-length (32) and right-truncated function name + file line number
         %q : a fixed-length (32) and right-truncated file name + file line number
 
-        "Classic" pattern : "[%D %T:%e][%&]%^[%n]%$ %v (%!:%#)"
+        'Classic' pattern : '[%D %T:%e][%&]%^[%n]%$ %v (%!:%#)'
         [12/03/22 19:25:12:812][map][info] do_init: connecting to database (do_init:221)
         [12/03/22 19:25:12:815][map][info] database client version: 3.2.8 (do_init:224)
         [12/03/22 19:25:12:815][map][info] database server version: 10.6.10-MariaDB (do_init:225)
         [12/03/22 19:25:12:815][map][info] luautils: Lua initializing (luautils::init:113)
 
-        "New" pattern : "%Y/%m/%d %T:%e | %_ | %^%-4!l%$ | %* | %v"
+        'New' pattern : '%Y/%m/%d %T:%e | %_ | %^%-4!l%$ | %* | %v'
         2022/12/03 19:24:08:984 | M | info |                      do_init:221 | do_init: connecting to database
         2022/12/03 19:24:08:987 | M | info |                      do_init:224 | database client version: 3.2.8
         2022/12/03 19:24:08:987 | M | info |                      do_init:225 | database server version: 10.6.10-MariaDB
@@ -35,7 +35,7 @@ xi.settings.logging =
         ## Docs:
         https://spdlog.docsforge.com/v1.x/3.custom-formatting/
     --]]
-    PATTERN = "[%D %T:%e][%&]%^[%n]%$ %v (%!:%#)",
+    PATTERN = '[%D %T:%e][%&]%^[%n]%$ %v (%!:%#)',
 
     -- Enable/Disable these logging types globally
     LOG_DEBUG   = true,

--- a/settings/default/login.lua
+++ b/settings/default/login.lua
@@ -12,7 +12,7 @@ xi.settings = xi.settings or {}
 xi.settings.login =
 {
     -- Expected Client version (wrong version cannot log in)
-    CLIENT_VER = "30251003_2",
+    CLIENT_VER = '30251003_2',
 
     -- 0 - disabled (every version allowed)
     -- 1 - enabled - strict (only exact CLIENT_VER allowed)
@@ -36,7 +36,7 @@ xi.settings.login =
 
     -- Allow character creation through the lobby (true/false)
     CHARACTER_CREATION = true,
-    
+
     -- Number of simultaneous game sessions per IP (0 for no limit)
     LOGIN_LIMIT = 0,
 
@@ -68,19 +68,19 @@ xi.settings.login =
 
     -- Character names with any of these words in, in any position, will be rejected
     --
-    -- Examples that will be rejected (using "badword"):
-    -- "badword"
-    -- "imbadword"
-    -- "badwordisme"
-    -- "lolbadwordlol"
+    -- Examples that will be rejected (using 'badword'):
+    -- 'badword'
+    -- 'imbadword'
+    -- 'badwordisme'
+    -- 'lolbadwordlol'
     --
     -- WARNING:
-    -- Be aware of the "Scunthorpe problem"!
+    -- Be aware of the 'Scunthorpe problem'!
     --
     -- NOTE:
-    -- You can Google for "bad word list txt" to find lists of words to populate this table, if you'd like
+    -- You can Google for 'bad word list txt' to find lists of words to populate this table, if you'd like
     BANNED_WORDS_LIST =
     {
-        "badword",
+        'badword',
     }
 }

--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -12,11 +12,11 @@ xi.settings = xi.settings or {}
 xi.settings.main =
 {
     -- Server name (not longer than 15 characters)
-    SERVER_NAME = "Nameless",
+    SERVER_NAME = 'Nameless',
 
     SERVER_MESSAGE =
-        "Please visit https://github.com/LandSandBoat/server for the latest information on the project.\n" ..
-        "Thank you, and we hope you enjoy sailing the sands!",
+        'Please visit https://github.com/LandSandBoat/server for the latest information on the project.\n' ..
+        'Thank you, and we hope you enjoy sailing the sands!',
 
     -- Setting to lock content more accurately to the expansions defined below.
     -- This generally results in a more accurate presentation of your selected expansions,
@@ -158,14 +158,14 @@ xi.settings.main =
     ENABLE_TRUST_ALTER_EGO_EXPO_ANNOUNCE         = 0, -- 0 = disabled, 1 = add announcement to player login
 
     TRUST_ALTER_EGO_EXTRAVAGANZA_MESSAGE =
-        "\n \n" .. -- The space between these newlines is intentional
-        "\129\153\129\154 The Alter Ego Extravaganza Campaign is active! \129\154\129\153\n" ..
-        "This is an excellent time to fill out your roster of Trusts!",
+        '\n \n' .. -- The space between these newlines is intentional
+        '\129\153\129\154 The Alter Ego Extravaganza Campaign is active! \129\154\129\153\n' ..
+        'This is an excellent time to fill out your roster of Trusts!',
 
     TRUST_ALTER_EGO_EXPO_MESSAGE =
-        "\n \n" .. -- The space between these newlines is intentional
-        "\129\153\129\154 The Alter Ego Expo Campaign is active! \129\154\129\153\n" ..
-        "Trusts gain the benefits of Increased HP, MP, and Status Resistances!",
+        '\n \n' .. -- The space between these newlines is intentional
+        '\129\153\129\154 The Alter Ego Expo Campaign is active! \129\154\129\153\n' ..
+        'Trusts gain the benefits of Increased HP, MP, and Status Resistances!',
 
     HARVESTING_BREAK_CHANCE = 33, -- % chance for the sickle to break during harvesting.  Set between 0 and 100.
     EXCAVATION_BREAK_CHANCE = 33, -- % chance for the pickaxe to break during excavation.  Set between 0 and 100.
@@ -220,8 +220,8 @@ xi.settings.main =
     AF2_QUEST_LEVEL = 50,    -- Minimum level to start AF2 quest
     AF3_QUEST_LEVEL = 50,    -- Minimum level to start AF3 quest
     OLDSCHOOL_G1    = false, -- Set to true to require farming Exoray Mold, Bombd Coal, and Ancient Papyrus drops instead of allowing key item method.
-    OLDSCHOOL_G2    = false, -- Set true to require the NMs for "Atop the Highest Mountains" be dead to get KI like before SE changed it.
-    FRIGICITE_TIME  = 30,    -- When OLDSCHOOL_G2 is enabled, this is the time (in seconds) you have from killing Boreal NMs to click the "???" target.
+    OLDSCHOOL_G2    = false, -- Set true to require the NMs for 'Atop the Highest Mountains' be dead to get KI like before SE changed it.
+    FRIGICITE_TIME  = 30,    -- When OLDSCHOOL_G2 is enabled, this is the time (in seconds) you have from killing Boreal NMs to click the '???' target.
     ASSAULT_MINIMUM = 1,     -- Minimum amount of people needed to start an assault mission. TOAU era is 3, Default is 1.
 
     -- SPELL SPECIFIC SETTINGS

--- a/settings/default/network.lua
+++ b/settings/default/network.lua
@@ -11,19 +11,19 @@ xi.settings = xi.settings or {}
 
 xi.settings.network =
 {
-    SQL_HOST     = "127.0.0.1",
+    SQL_HOST     = '127.0.0.1',
     SQL_PORT     = 3306,
-    SQL_LOGIN    = "root",
-    SQL_PASSWORD = "root",
-    SQL_DATABASE = "xidb",
+    SQL_LOGIN    = 'root',
+    SQL_PASSWORD = 'root',
+    SQL_DATABASE = 'xidb',
 
-    LOGIN_DATA_IP   = "0.0.0.0",
+    LOGIN_DATA_IP   = '0.0.0.0',
     LOGIN_DATA_PORT = 54230,
-    LOGIN_VIEW_IP   = "0.0.0.0",
+    LOGIN_VIEW_IP   = '0.0.0.0',
     LOGIN_VIEW_PORT = 54001,
-    LOGIN_AUTH_IP   = "0.0.0.0",
+    LOGIN_AUTH_IP   = '0.0.0.0',
     LOGIN_AUTH_PORT = 54231,
-    LOGIN_CONF_IP   = "0.0.0.0",
+    LOGIN_CONF_IP   = '0.0.0.0',
     LOGIN_CONF_PORT = 51220,
 
     MAP_PORT = 54230,
@@ -34,11 +34,11 @@ xi.settings.network =
     SQL_QUERY_RETRY_COUNT = 1,
 
     ENABLE_HTTP = false,
-    HTTP_HOST   = "localhost",
+    HTTP_HOST   = 'localhost',
     HTTP_PORT   = 8088,
 
     -- Central message server settings (ensure these are the same on both all map servers and the central (lobby) server
-    ZMQ_IP   = "127.0.0.1",
+    ZMQ_IP   = '127.0.0.1',
     ZMQ_PORT = 54003,
 
     -- ===========================
@@ -78,9 +78,9 @@ xi.settings.network =
     --   allow,deny     : Checks allow rules, then deny rules. Allows if no rules match.
     --   mutual-failure : Allows only if an allow rule matches and no deny rules match.
     -- (default is deny,allow)
-    TCP_ORDER = "deny,allow",
-    --TCP_ORDER = "allow,deny",
-    --TCP_ORDER = "mutual-failure",
+    TCP_ORDER = 'deny,allow',
+    --TCP_ORDER = 'allow,deny',
+    --TCP_ORDER = 'mutual-failure',
 
     -- ===========================
     -- IP rules
@@ -90,17 +90,17 @@ xi.settings.network =
     -- The rules are processed in order, the first matching rule of each list
     -- (allow and deny) is used
 
-    TCP_ALLOW = "",
-    --TCP_ALLOW = "127.0.0.1,192.168.0.0/16",
-    --TCP_ALLOW = "127.0.0.1"
-    --TCP_ALLOW = "192.168.0.0/16"
-    --TCP_ALLOW = "10.0.0.0/255.0.0.0"
-    --TCP_ALLOW = "all"
+    TCP_ALLOW = '',
+    --TCP_ALLOW = '127.0.0.1,192.168.0.0/16',
+    --TCP_ALLOW = '127.0.0.1'
+    --TCP_ALLOW = '192.168.0.0/16'
+    --TCP_ALLOW = '10.0.0.0/255.0.0.0'
+    --TCP_ALLOW = 'all'
 
-    TCP_DENY = "",
-    --TCP_DENY = "10.0.0.0/8,192.168.0.0/16",
-    --TCP_DENY = "127.0.0.1",
-    --TCP_DENY = "10.0.0.0/255.0.0.0",
+    TCP_DENY = '',
+    --TCP_DENY = '10.0.0.0/8,192.168.0.0/16',
+    --TCP_DENY = '127.0.0.1',
+    --TCP_DENY = '10.0.0.0/255.0.0.0',
 
     -- ===========================
     -- Connection Limit Settings

--- a/settings/default/search.lua
+++ b/settings/default/search.lua
@@ -26,8 +26,8 @@ xi.settings.search =
     -- IP address strings in this list won't be subject to 'IPAddressesInUse' rate limiting
     ACCESS_WHITELIST =
     {
-        "127.0.0.1",   -- Example, not actually needed
-        "192.168.0.1", -- Example, not actually needed
+        '127.0.0.1',   -- Example, not actually needed
+        '192.168.0.1', -- Example, not actually needed
     },
 
     -- true/false: Enable/disable logging the content of packets being sent to the client (required Debug mode)

--- a/settings/default/test.lua
+++ b/settings/default/test.lua
@@ -12,5 +12,5 @@ xi.settings = xi.settings or {}
 xi.settings.test =
 {
     -- [22:32:06][info][    CClass::func:120] Log message
-    PATTERN = "[%T][%^%-4!l%$][%*] %v",
+    PATTERN = '[%T][%^%-4!l%$][%*] %v',
 }

--- a/tools/ci/sanity_checks/lua.sh
+++ b/tools/ci/sanity_checks/lua.sh
@@ -10,7 +10,7 @@ any_issues=false
 if [[ $# -gt 0 ]]; then
     targets=("$@")
 else
-    mapfile -t targets < <(find scripts modules -name '*.lua')
+    mapfile -t targets < <(find scripts settings/default modules -name '*.lua')
 fi
 
 global_funcs=`python << EOF
@@ -133,7 +133,7 @@ if [[ -n "$binding_usage_output" ]]; then
 fi
 
 for file in "${targets[@]}"; do
-    [[ -f $file && ($file == scripts/**/*.lua || $file == modules/**/*.lua) ]] || continue
+    [[ -f $file && ($file == scripts/**/*.lua || $file == settings/default/*.lua || $file == modules/**/*.lua) ]] || continue
 
     # Run tools and capture output
     luacheck_output=$(luacheck "$file" \

--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -141,6 +141,8 @@ def populate_settings():
                             # pop off leading quote
                             if val.startswith('"'):
                                 val = val[1:]
+                            elif val.startswith("'"):
+                                val = val[1:]
 
                             # pop off trailing comma
                             if val.endswith(","):
@@ -148,6 +150,8 @@ def populate_settings():
 
                             # pop off trailing quote
                             if val.endswith('"'):
+                                val = val[:-1]
+                            elif val.endswith("'"):
                                 val = val[:-1]
 
                             current_settings[key] = val

--- a/tools/give_items.py
+++ b/tools/give_items.py
@@ -34,7 +34,9 @@ def connect():
             line = f.readline()
             if not line:
                 break
-            match = re.findall(r"(SQL_\w+)\s*=\s*(?:\"(.*?)\"|([^\"\s,]+)),", line)
+            match = re.findall(
+                r"(SQL_\w+)\s*=\s*(?:[\'\"](.*?)[\'\"]|([^\'\s,]+)),", line
+            )
             if match:
                 credentials[match[0][0]] = match[0][2] if match[0][2] else match[0][1]
 

--- a/tools/headlessxi/hxiclient.py
+++ b/tools/headlessxi/hxiclient.py
@@ -25,7 +25,7 @@ class HXIClient:
         if client_str == "":
             with open("settings/default/login.lua") as f:
                 settings_file = f.read()
-                client_str = re.search(r'CLIENT_VER = "(.*?)"', settings_file)[1]
+                client_str = re.search(r"CLIENT_VER = '(.*?)'", settings_file)[1]
 
         print("Client version:", client_str)
         self.client_str = client_str


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a Lua styling issue (use single quotes) in default settings files. Add settings files to sanity checks. Updates Python tooling to parse single or double quotes (headless xi only needs default settings so that's fine if it doesn't parse double quotes correctly).

## Steps to test these changes

Lua sanity checks pass, dbtool works (locally using settings files, not env vars), startup checks work.
