### PR TITLE
[lua] Remove level requirement from quest "Truth, Justice, and the Onion Way"

### DIFF
--- a/scripts/quests/windurst/SOB1_Truth_Justice_and_the_Onion_Way.lua
+++ b/scripts/quests/windurst/SOB1_Truth_Justice_and_the_Onion_Way.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Truth, Justice, and the Onion Way
---
+-- Log ID: 2, Quest ID: 36
 -- Kohlo-Lakolo, !pos -26.8 -6 190 240
 -----------------------------------
 
@@ -19,8 +19,7 @@ quest.sections =
     -- Section: Quest is available.
     {
         check = function(player, status, vars)
-            return status == xi.questStatus.QUEST_AVAILABLE and
-                player:getMainLvl() >= 5 -- To be confirmed, but only way to see default interaction.
+            return status == xi.questStatus.QUEST_AVAILABLE
         end,
 
         [xi.zone.PORT_WINDURST] =


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Removes the level requirement for the quest "Truth, Justice, and the Onion Way" - Confirmed on retail

## Steps to test these changes

1. By any job at any level.
2. Talk to Kohlo-Lakolo, `!pos -26.8 -6 190 240`

## Capture
Packets only
https://drive.google.com/drive/folders/1ZznGbM_7a8Qnh7MGeZb6fFtPrfmOyqLB?usp=sharing