### PR TITLE
[core] Bug fix for ally NPC AOE target find change

### DIFF
--- a/scripts/tests/systems/targetfind.lua
+++ b/scripts/tests/systems/targetfind.lua
@@ -1,0 +1,112 @@
+describe('TargetFind', function()
+    ---@type CClientEntityPair
+    local p1, p2, p3
+    local wyv1, wyv2, wyv3
+
+    before_each(function()
+        -- Spawn everyone in Dragon's Aery as DRG
+        local pConfig =
+        {
+            zone  = xi.zone.DRAGONS_AERY,
+            job   = xi.job.DRG,
+            level = 1,
+        }
+
+        p1 = xi.test.world:spawnPlayer(pConfig)
+        p1:setUnkillable(true)
+        p1.actions:useAbility(p1, xi.jobAbility.CALL_WYVERN)
+        xi.test.world:tickEntity(p1)
+        wyv1 = p1:getPet()
+
+        p2 = xi.test.world:spawnPlayer(pConfig)
+        p2:setUnkillable(true)
+        p2.actions:useAbility(p2, xi.jobAbility.CALL_WYVERN)
+        xi.test.world:tickEntity(p2)
+        wyv2 = p2:getPet()
+
+        p3 = xi.test.world:spawnPlayer(pConfig)
+        p3:setUnkillable(true)
+        p3.actions:useAbility(p3, xi.jobAbility.CALL_WYVERN)
+        xi.test.world:tickEntity(p3)
+        wyv3 = p3:getPet()
+
+        assert(wyv1, 'P1 did not get a Wyvern')
+        assert(wyv2, 'P2 did not get a Wyvern')
+        assert(wyv3, 'P3 did not get a Wyvern')
+
+        -- P1 and P2 are partied, P3 is solo
+        p1.actions:inviteToParty(p2)
+        p2.actions:acceptPartyInvite()
+    end)
+
+    it('Fafnir Spike Flail only hit claiming party', function()
+        -- Force Flail to always hit
+        local m = stub('xi.mobskills.mobPhysicalMove',
+            {
+                dmg        = 100,
+                hitslanded = 3,
+                isCritical = false,
+            })
+        -- All of them should go to Fafnir
+        p1.entities:moveTo('Fafnir')
+        p2.entities:moveTo('Fafnir')
+        local fafnir = p3.entities:moveTo('Fafnir')
+
+        -- Spawn Fafnir and claim it to the party
+        fafnir:spawn()
+        fafnir.assert:isAlive()
+        fafnir:updateClaim(p1)
+
+        -- Use Spike Flail
+        fafnir:setTP(3000)
+        fafnir:useMobAbility(952, p1)
+        -- Give some time for the AI to progress through Prepare and Complete
+        xi.test.world:skipTime(5)
+        xi.test.world:skipTime(5)
+
+        -- P1 and P2 should get hit. P3 should not.
+        assert(p1:getHPP() ~= 100, 'P1 was not hit by Spike Flail')
+        assert(p2:getHPP() ~= 100, 'P2 was not hit by Spike Flail')
+        assert(p3:getHPP() == 100, 'P3 was hit by Spike Flail')
+
+        -- Same for their wyverns!
+        assert(wyv1:getHPP() ~= 100, 'P1 Wyvern was not hit by Spike Flail')
+        assert(wyv2:getHPP() ~= 100, 'P1 Wyvern was not hit by Spike Flail')
+        assert(wyv3:getHPP() == 100, 'P3 Wyvern was hit by Spike Flail')
+    end)
+
+    it('Nidhogg Spike Flail hits everyone', function()
+        -- Force Flail to always hit
+        local m = stub('xi.mobskills.mobPhysicalMove',
+            {
+                dmg        = 100,
+                hitslanded = 3,
+                isCritical = false,
+            })
+
+        -- All players should go to Nidhogg
+        p1.entities:moveTo('Nidhogg')
+        p2.entities:moveTo('Nidhogg')
+        local nidhogg = p3.entities:moveTo('Nidhogg')
+
+        -- Spawn Nidhogg and claim it to the party
+        nidhogg:spawn()
+        nidhogg.assert:isAlive()
+        nidhogg:updateClaim(p1)
+        nidhogg:setTP(3000)
+        nidhogg:useMobAbility(1040, p1)
+        -- Give some time for the AI to progress through Prepare and Complete
+        xi.test.world:skipTime(5)
+        xi.test.world:skipTime(5)
+
+        -- P1, P2 and P3 should get hit.
+        assert(p1:getHPP() ~= 100, 'P1 was not hit by Spike Flail')
+        assert(p2:getHPP() ~= 100, 'P2 was not hit by Spike Flail')
+        assert(p3:getHPP() ~= 100, 'P3 was not hit by Spike Flail')
+
+        -- Same for their wyverns!
+        assert(wyv1:getHPP() ~= 100, 'P1 Wyvern was not hit by Spike Flail')
+        assert(wyv2:getHPP() ~= 100, 'P1 Wyvern was not hit by Spike Flail')
+        assert(wyv3:getHPP() ~= 100, 'P3 Wyvern was not hit by Spike Flail')
+    end)
+end)

--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -184,7 +184,7 @@ void CTargetFind::findWithinArea(CBattleEntity* PTarget, AOE_RADIUS radiusType, 
             // Is the monster casting on a player..
             if (m_findType == FIND_TYPE::MONSTER_PLAYER)
             {
-                if (m_PBattleEntity->allegiance == ALLEGIANCE_TYPE::PLAYER || m_PMasterTarget->allegiance == ALLEGIANCE_TYPE::PLAYER)
+                if (m_PBattleEntity->allegiance == ALLEGIANCE_TYPE::PLAYER || (m_PMasterTarget->objtype == TYPE_MOB && m_PMasterTarget->allegiance == ALLEGIANCE_TYPE::PLAYER))
                 {
                     addAllInZone(m_PMasterTarget, withPet);
                 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Introduced a bug in my recent target find AOE adjustments to include players when targeted on an ally mob, that allowed mob AOEs targeted on players to choose all targets in range regardless of party status.
- Narrowed the scope of the new allegiance check to also only check if the initial target is a mob.

Thanks to Beasty for alerting about this and helping with the fix.

## Steps to test these changes

- Pull a mob with an AOE targeted TP move or spell. See that when cast it does not target players outside of the party/alliance.