### PR TITLE
[core] Fix GP_SERV_COMMAND_ABIL_RECAST

### DIFF
--- a/src/map/packets/s2c/0x119_abil_recast.cpp
+++ b/src/map/packets/s2c/0x119_abil_recast.cpp
@@ -33,7 +33,7 @@ GP_SERV_COMMAND_ABIL_RECAST::GP_SERV_COMMAND_ABIL_RECAST(CCharEntity* PChar)
 {
     auto& packet = this->data();
 
-    uint8               count      = 0;
+    uint8               count      = 1;
     const RecastList_t* RecastList = PChar->PRecastContainer->GetRecastList(RECAST_ABILITY);
     for (auto&& recast : *RecastList)
     {
@@ -67,8 +67,8 @@ GP_SERV_COMMAND_ABIL_RECAST::GP_SERV_COMMAND_ABIL_RECAST(CCharEntity* PChar)
         }
         else // 2hr edge case // TODO: retail uses Calc2 on 2hr for some reason...
         {
-            packet.Timers[count].Timer   = recastSeconds;
-            packet.Timers[count].TimerId = 0;
+            packet.Timers[0].Timer   = recastSeconds;
+            packet.Timers[0].TimerId = 0;
         }
 
         // Retail currently only allows 31 distinct recasts to be sent in the packet


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Fixes an issue that arose at some point during the rewrite of this packet that caused 2-hours to display incorrect timers in the client.

`packet.Timers[0]` is reserved for 2-Hour Abilities.  However, the way it was re-written the two-hour ability was set at `packet.Timers[count]` which was possibly not 0, but also not incremented during the else clause which meant that during the following loop iteration, that information was overwritten with another JA cooldown information.

This is fixed by setting setting hard-coded data for 2hours at `packet.timers[0]` (reserved for 2hours) and setting the `[count]` index at `1` so the offset in the packet for normal JAs starts at `0xC` which is the end of the 2-Hour section.

Related Information: https://github.com/atom0s/XiPackets/tree/main/world/server/0x0119

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - Login with any character
2 - Use a normal Job Ability
3 - Proceed to then use the Job SP
4 - Check your Job Abilities and the Recast Time displayed for your SP Ability
Result: The proper timer is now displayed.

<img width="1920" height="523" alt="image" src="https://github.com/user-attachments/assets/0127fe3c-1501-4b76-a8a0-08b9c4f684cd" />
