### PR TITLE
[lua] Correct interaction with quest "Flyers for Regine"

### DIFF
--- a/scripts/zones/Port_San_dOria/npcs/Regine.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Regine.lua
@@ -47,7 +47,7 @@ end
 entity.onEventFinish = function(player, csid, option, npc)
     -- FLYERS FOR REGINE
     if csid == 510 and option == 2 then
-        if npcUtil.giveItem(player, { { xi.item.MAGICMART_FLYER, 12 }, { xi.item.MAGICMART_FLYER, 3 } }) then
+        if npcUtil.giveItem(player, { { xi.item.MAGICMART_FLYER, 1 }, { xi.item.MAGICMART_FLYER, 14 } })  then
             player:addQuest(xi.questLog.SANDORIA, xi.quest.id.sandoria.FLYERS_FOR_REGINE)
         end
     elseif csid == 603 then


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Corrects the interaction in which the player receives the flyers from Regine to be retail accurate.
From retail capture, you get a message you receive a flyer. But 15 are in your inv.

## Steps to test these changes

1. `!zone <Port San d'Oria>`
2. Talk to Regine and start quest.
3. Check inventory.

## Capture
Logs - https://www.dropbox.com/scl/fi/q7kg686rpgmwqc5eh7zl8/Flyers-for-Regine.rar?rlkey=hkjaznadhvvrnozl7pv1j7qzh&dl=0
Video - https://youtu.be/VZA4ZXGg1tM
<img width="230" height="38" alt="firefox_RP18UVEuXN" src="https://github.com/user-attachments/assets/4c5d8aed-a3c9-4224-8b4b-60aeee49d60a" />
