### PR TITLE
[lua] Fix more NPC interactions

### DIFF
--- a/scripts/quests/windurst/Rock_Racketeer.lua
+++ b/scripts/quests/windurst/Rock_Racketeer.lua
@@ -94,9 +94,7 @@ quest.sections =
                 onTrigger = function(player, npc)
                     local progress = quest:getVar(player, 'Prog')
 
-                    if progress <= 1 then
-                        return quest:event(432)
-                    elseif progress == 3 then
+                    if progress == 3 then
                         if quest:getVar(player, 'Option') < 2 then
                             return quest:progressEvent(100) -- Optional Dialogue that only places once
                         else

--- a/scripts/zones/Kazham/DefaultActions.lua
+++ b/scripts/zones/Kazham/DefaultActions.lua
@@ -39,7 +39,7 @@ return {
     ['Romaa_Mihgo']       = { event = 263 },
     ['Roropp']            = { text = ID.text.OPO_OPO },
     ['Soun_Abralah']      = { event = 101 },
-    ['Swift']             = { event = 10018 },
+    ['Swift']             = { text = ID.text.SUSPICIOUS_CHARACTERS }, -- TODO: Confirm old event was for quest "A Discerning Eye"
     ['Tatapp']            = { text = ID.text.OPO_OPO },
     ['Thali_Mhobrum']     = { event = 190 },
     ['Tio_Moshroca']      = { event = 123 },

--- a/scripts/zones/Kazham/IDs.lua
+++ b/scripts/zones/Kazham/IDs.lua
@@ -38,6 +38,7 @@ zones[xi.zone.KAZHAM] =
         NOMAD_MOOGLE_DIALOG           = 10610, -- I'm a traveling moogle, kupo. I help adventurers in the Outlands access items they have stored in a Mog House elsewhere, kupo.
         MAMERIE_SHOP_DIALOG           = 10634, -- Is there something you require?
         EVISCERATION_LEARNED          = 10671, -- You have learned the weapon skill Evisceration!
+        SUSPICIOUS_CHARACTERS         = 10690, -- It's my job to look out for suspicious characters coming in on the airships.
         RETRIEVE_DIALOG_ID            = 11021, -- You retrieve <item> from the porter moogle's care.
         COMMON_SENSE_SURVIVAL         = 11879, -- It appears that you have arrived at a new survival guide provided by the Adventurers' Mutual Aid Network. Common sense dictates that you should now be able to teleport here from similar tomes throughout the world.
     },

--- a/scripts/zones/Port_Bastok/DefaultActions.lua
+++ b/scripts/zones/Port_Bastok/DefaultActions.lua
@@ -16,7 +16,7 @@ return {
     ['Ensetsu']          = { event = 27 },
     ['Evi']              = { event = 21 },
     ['Ferrol']           = { event = 254 },
-    ['Grin']             = { event = 295 },
+    ['Grin']             = { text = ID.text.SUSPICIOUS_CHARACTERS }, -- TODO: Confirm old event was for quest "A Discerning Eye"
     ['Gudav']            = { event = 31 },
     ['Gwinar']           = { event = 365 },
     ['Hilda']            = { event = 48 },
@@ -56,7 +56,6 @@ return {
     ['Tiger_Tooth']      = { event = 12 },
     ['Tilian']           = { event = 100 },
     ['Trilok']           = { event = 44 },
-    ['Varden']           = { event = 141 },
     ['Wurteh']           = { event = 95 },
     ['Yazan']            = { event = 190 },
     ['Zeldaff']          = { event = 30 },

--- a/scripts/zones/Port_Bastok/IDs.lua
+++ b/scripts/zones/Port_Bastok/IDs.lua
@@ -68,6 +68,7 @@ zones[xi.zone.PORT_BASTOK] =
         NOKKHI_GOOD_TRADE             = 8835,  -- And here you go! Come back soon, and bring your friends!
         NOKKHI_BAD_ITEM               = 8836,  -- I'm real sorry, but there's nothing I can do with those.
         ASURAN_FISTS_LEARNED          = 8852,  -- You have learned the weapon skill Asuran Fists!
+        SUSPICIOUS_CHARACTERS         = 8881,  -- It's my job to look out for suspicious characters coming in on the airships.
         BAGNOBROK_CLOSED_DIALOG       = 9164,  -- Kbastok sis kweak! Smoblins yonly twant gstrong sfriends! Non sgoods mfrom Smovalpolos ytoday!
         BAGNOBROK_OPEN_DIALOG         = 9165,  -- Kbastok! Crepublic sis gstrong! Smoblins lsell sgoods oto gstrong sfriends!
         CLOUD_BAD_COUNT               = 9260,  -- Well, don't just stand there like an idiot! I can't do any bundlin' until you fork over a set of 99 tools and <item>! And I ain't doin' no more than seven sets at one time, so don't even try it!

--- a/scripts/zones/Port_Bastok/npcs/Varden.lua
+++ b/scripts/zones/Port_Bastok/npcs/Varden.lua
@@ -1,0 +1,33 @@
+-----------------------------------
+-- Area: Port Bastok
+--  NPC: Varden
+-- !pos -57.365 2.392 -4.871
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    local xPos = player:getXPos()
+
+    if
+        xPos <= -58 and
+        player:hasKeyItem(xi.ki.AIRSHIP_PASS) and
+        player:getGil() >= 200
+    then
+        player:startEvent(141)
+    else
+        player:startEvent(142)
+    end
+end
+
+entity.onEventFinish = function(player, csid, option, npc)
+    if csid == 141 and option == 0 then
+        local xPos = player:getXPos()
+
+        if xPos >= -58 and xPos <= -55 then
+            player:delGil(200)
+        end
+    end
+end
+
+return entity

--- a/scripts/zones/Port_San_dOria/DefaultActions.lua
+++ b/scripts/zones/Port_San_dOria/DefaultActions.lua
@@ -20,7 +20,7 @@ return {
     ['Dabbio']       = { event = 722 },
     ['Diraulate']    = { event = 581 },
     ['Eaugouint']    = { event = 579 },
-    ['Eddy']         = { event = 723 },
+    ['Eddy']         = { text = ID.text.SUSPICIOUS_CHARACTERS }, -- TODO: Confirm old event was for quest "A Discerning Eye"
     ['Fontoumant']   = { event = 561 },
     ['Gournaie']     = { event = 715 },
     ['Gulemont']     = { event = 593 },

--- a/scripts/zones/Port_San_dOria/IDs.lua
+++ b/scripts/zones/Port_San_dOria/IDs.lua
@@ -78,6 +78,7 @@ zones[xi.zone.PORT_SAN_DORIA] =
         PATOLLE_OPEN_DIALOG            = 8330,  -- Hey, [mister/miss]! How about some specialty goods from Kuzotz?
         BONMAURIEUT_OPEN_DIALOG        = 8331,  -- My shipment is in! Would you like to see what has just arrived from the Elshimo Uplands?
         FFR_LOOKS_CURIOUSLY_BASE       = 8468,  -- Answald looks over curiously for a moment.
+        SUSPICIOUS_CHARACTERS          = 8544,  -- It's my job to look out for suspicious characters coming in on the airships.
         IMPERIAL_STANDING_INCREASED    = 11175, -- Your Imperial Standing has increased!
         EARNED_ALLIED_NOTES            = 11176, -- You have earned <number> Allied Note[/s]!
         OBTAINED_GUILD_POINTS          = 11177, -- Obtained: <number> guild points.

--- a/scripts/zones/Port_Windurst/DefaultActions.lua
+++ b/scripts/zones/Port_Windurst/DefaultActions.lua
@@ -56,7 +56,7 @@ return {
     ['Pherchabalet']        = { event = 553 },
     ['Pichichi']            = { event = 364 },
     ['Puo_Rhen']            = { event = 72 },
-    ['Pygmalion']           = { event = 10019 },
+    ['Pygmalion']           = { text = ID.text.SUSPICIOUS_CHARACTERS }, -- TODO: Confirm old event was for quest "A Discerning Eye"
     ['Pyo_Nzon']            = { event = 366 },
     ['Rachuchu']            = { event = 234 },
     ['Reiso-Haroiso']       = { event = 334 },

--- a/scripts/zones/Port_Windurst/IDs.lua
+++ b/scripts/zones/Port_Windurst/IDs.lua
@@ -67,6 +67,7 @@ zones[xi.zone.PORT_WINDURST] =
         SATTSUHAHKANPARI_CLOSED_DIALOG  = 12587, -- You've heard of the Elshimo Uplands, haven't you? Well, if you'll hold on a minute, I'll have a shipment of goods coming in any time now.
         BLACK_HALO_LEARNED              = 12683, -- You have learned the weapon skill Black Halo!
         KUCHAMALKOBHI_SHOP_DIALOG       = 12732, -- How about a nice suit of adventurer-issue armorrr? Be careful though. We offer no rrrefunds!
+        SUSPICIOUS_CHARACTERS           = 12814, -- It's my job to look out for suspicious characters coming in on the airships.
         ALIZABE_OPEN_DIALOG             = 12912, -- Don't tell anybody, but I've managed to get my hands on some items from Tavnazia! Take a look!
         ALIZABE_CLOSED_DIALOG           = 12913, -- Pssst! Have you heard of Tavnazia? Boy, do they have some sweet items on those islands...
         ALIZABE_COP_NOT_COMPLETED       = 12914, -- It won't be long before I set up shop right here in this very place. And once I start, there won't be no stoppin' me!

--- a/scripts/zones/Windurst_Woods/DefaultActions.lua
+++ b/scripts/zones/Windurst_Woods/DefaultActions.lua
@@ -67,5 +67,6 @@ return {
     ['Three_of_Spades']    = { event = 270 },
     ['Two_of_Spades']      = { event = 271 },
     ['Uuroro']             = { event = 272 },
+    ['Verun']              = { event = 432 },
     ['Zahsa_Syalmhaia']    = { event = 797 },
 }


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Ordered by Commit:

- Found that event 432 is the default action for Verun.
- Changes the dialogue for the 4 NPCs involved with the quest "A Discerning Eye". The quest start event was set to the default action. Replaced with their final dialogue with a TODO for someone to verify.
- Added a NPC lua for Varden. Was found that players could `/fillmode` and talk to them to get through the door without possessing an airship pass. The lua adds in a check to see which side of the door you're on.

## Steps to test these changes

Talk to the NPCs.
