### PR TITLE
xi_search: Filter by linkshell ID

### DIFF
--- a/src/search/search.h
+++ b/src/search/search.h
@@ -26,18 +26,19 @@
 
 struct search_req
 {
-    uint16      zoneid[15];
-    uint8       jobid;
-    uint8       minlvl;
-    uint8       maxlvl;
-    uint8       race;
-    uint8       nation;
-    uint8       minRank;
-    uint8       maxRank;
-    uint32      flags;
-    std::string name;
-    uint8       nameLen;
-    uint8       commentType;
+    uint16                zoneid[15];
+    uint8                 jobid;
+    uint8                 minlvl;
+    uint8                 maxlvl;
+    uint8                 race;
+    uint8                 nation;
+    uint8                 minRank;
+    uint8                 maxRank;
+    std::optional<uint32> lsId;
+    uint32                flags;
+    std::string           name;
+    uint8                 nameLen;
+    uint8                 commentType;
 };
 
 class searchPacket


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Hooks the unfinished linkshell filters to xi_search

https://github.com/HorizonFFXI/HorizonXI-Issues/issues/2033

## Steps to test these changes
/sea all linkshell
/sea linkshell2
/sea all linkshell2 war

etc
<!-- Clear and detailed steps to test your changes here -->
