### PR TITLE
Change order of emitted packets upon login

### DIFF
--- a/src/map/enums/msg_std.h
+++ b/src/map/enums/msg_std.h
@@ -119,6 +119,7 @@ enum class MsgStd : uint16_t
     StyleLockOff                 = 268, // Style lock mode disabled.
     StyleLockIsOn                = 269, // Style lock mode is enabled.
     StyleLockIsOff               = 270, // Style lock mode is disabled.
+    UnityNotParticipating        = 286, // You are not participating in Unity chat.
     UnityChatFull                = 287, // The maximum number of people are already participating in Unity chat. Please try again later.
     PollProposalLinkshell2       = 289, // Player Name's proposal to the linkshell group (cast vote with command: "/vote ?"):
     CurrentPollResultsLinkshell2 = 290, // Player Name's proposal - Current poll results:

--- a/src/map/packets/c2s/0x00a_login.cpp
+++ b/src/map/packets/c2s/0x00a_login.cpp
@@ -24,7 +24,9 @@
 
 #include "entities/charentity.h"
 #include "packets/s2c/0x008_enterzone.h"
+#include "packets/s2c/0x01c_item_max.h"
 #include "packets/s2c/0x04f_equip_clear.h"
+#include "packets/s2c/0x051_grap_list.h"
 #include "utils/charutils.h"
 #include "utils/gardenutils.h"
 #include "utils/zoneutils.h"
@@ -123,7 +125,8 @@ void GP_CLI_COMMAND_LOGIN::process(MapSession* PSession, CCharEntity* PChar) con
     if (PChar->loc.zone != nullptr)
     {
         PChar->pushPacket<GP_SERV_COMMAND_EQUIP_CLEAR>();
+        PChar->pushPacket<GP_SERV_COMMAND_GRAP_LIST>(PChar);
+        PChar->pushPacket<GP_SERV_COMMAND_ITEM_MAX>(PChar);
         PChar->pushPacket<GP_SERV_COMMAND_LOGIN>(PChar, PChar->currentEvent);
-        PChar->pushPacket<GP_SERV_COMMAND_ENTERZONE>(PChar);
     }
 }

--- a/src/map/packets/c2s/0x00a_login.cpp
+++ b/src/map/packets/c2s/0x00a_login.cpp
@@ -22,10 +22,13 @@
 #include "0x00a_login.h"
 #include "packets/s2c/0x00a_login.h"
 
+#include "ai/ai_container.h"
+#include "ai/helpers/action_queue.h"
 #include "entities/charentity.h"
 #include "packets/s2c/0x008_enterzone.h"
 #include "packets/s2c/0x01c_item_max.h"
 #include "packets/s2c/0x04f_equip_clear.h"
+#include "packets/s2c/0x050_equip_list.h"
 #include "packets/s2c/0x051_grap_list.h"
 #include "utils/charutils.h"
 #include "utils/gardenutils.h"
@@ -128,5 +131,14 @@ void GP_CLI_COMMAND_LOGIN::process(MapSession* PSession, CCharEntity* PChar) con
         PChar->pushPacket<GP_SERV_COMMAND_GRAP_LIST>(PChar);
         PChar->pushPacket<GP_SERV_COMMAND_ITEM_MAX>(PChar);
         PChar->pushPacket<GP_SERV_COMMAND_LOGIN>(PChar, PChar->currentEvent);
+        for (uint8 i = 0; i < 16; ++i)
+        {
+            if (PChar->equip[i] != 0)
+            {
+                PChar->pushPacket<GP_SERV_COMMAND_EQUIP_LIST>(PChar->equip[i], static_cast<SLOTTYPE>(i), static_cast<CONTAINER_ID>(PChar->equipLoc[i]));
+            }
+        }
+        PChar->status = STATUS_TYPE::NORMAL;
+        PChar->PAI->QueueAction(queueAction_t(4000ms, false, zoneutils::AfterZoneIn));
     }
 }

--- a/src/map/packets/c2s/0x00c_gameok.cpp
+++ b/src/map/packets/c2s/0x00c_gameok.cpp
@@ -23,6 +23,7 @@
 
 #include "entities/charentity.h"
 #include "packets/char_status.h"
+#include "packets/char_sync.h"
 #include "packets/s2c/0x008_enterzone.h"
 #include "packets/s2c/0x01b_job_info.h"
 #include "packets/s2c/0x01c_item_max.h"
@@ -30,8 +31,14 @@
 #include "packets/s2c/0x063_miscdata_homepoints.h"
 #include "packets/s2c/0x063_miscdata_monstrosity.h"
 #include "packets/s2c/0x063_miscdata_status_icons.h"
+#include "packets/s2c/0x08c_merit.h"
+#include "packets/s2c/0x0aa_magic_data.h"
+#include "packets/s2c/0x0ac_command_data.h"
+#include "packets/s2c/0x0ae_mount_data.h"
 #include "packets/s2c/0x0b4_config.h"
+#include "packets/s2c/0x0ca_inspect_message.h"
 #include "treasure_pool.h"
+#include "utils/blacklistutils.h"
 #include "utils/charutils.h"
 #include "utils/petutils.h"
 
@@ -44,6 +51,14 @@ auto GP_CLI_COMMAND_GAMEOK::validate(MapSession* PSession, const CCharEntity* PC
 
 void GP_CLI_COMMAND_GAMEOK::process(MapSession* PSession, CCharEntity* PChar) const
 {
+    // This is one of the first packets sent when zoning in and causes the server
+    // to start rapidly sending a lot of information to initialize the client.
+    //
+    // Note that while the packets are sent synchronously below, retail has a different behavior:
+    // Some of the packets are queued in some sort of prioritization system and will hitch a ride
+    // in the next outgoing batch in an opportunistic fashion.
+    //
+    // This is why the order below will NOT match 1:1 a retail capture!
     PChar->pushPacket<GP_SERV_COMMAND_ENTERZONE>(PChar);
     PChar->pushPacket<GP_SERV_COMMAND_ITEM_MAX>(PChar); // Already sent during LOGIN but retail sends it again
     PChar->pushPacket<GP_SERV_COMMAND_CONFIG>(PChar);
@@ -55,6 +70,17 @@ void GP_CLI_COMMAND_GAMEOK::process(MapSession* PSession, CCharEntity* PChar) co
     charutils::SendExtendedJobPackets(PChar);
     charutils::SendUnityPackets(PChar);
     PChar->pushPacket<GP_SERV_COMMAND_MISCDATA::STATUS_ICONS>(PChar);
+    charutils::SendKeyItems(PChar);
+    charutils::SendQuestMissionLog(PChar);
+    charutils::SendRecordsOfEminenceLog(PChar);
+    PChar->pushPacket<GP_SERV_COMMAND_MAGIC_DATA>(PChar);
+    PChar->pushPacket<GP_SERV_COMMAND_MOUNT_DATA>(PChar);
+    PChar->pushPacket<GP_SERV_COMMAND_COMMAND_DATA>(PChar);
+    PChar->pushPacket<CCharSyncPacket>(PChar);
+    PChar->pushPacket<GP_SERV_COMMAND_INSPECT_MESSAGE>(PChar);
+    PChar->pushPacket<GP_SERV_COMMAND_MERIT>(PChar);
+    charutils::SendInventory(PChar);
+    blacklistutils::SendBlacklist(PChar);
 
     // TODO: While in mog house; treasure pool is not created.
     if (PChar->PTreasurePool != nullptr)

--- a/src/map/packets/c2s/0x00f_clstat.cpp
+++ b/src/map/packets/c2s/0x00f_clstat.cpp
@@ -22,13 +22,6 @@
 #include "0x00f_clstat.h"
 
 #include "entities/charentity.h"
-#include "packets/char_sync.h"
-#include "packets/s2c/0x08c_merit.h"
-#include "packets/s2c/0x0aa_magic_data.h"
-#include "packets/s2c/0x0ac_command_data.h"
-#include "packets/s2c/0x0ae_mount_data.h"
-#include "packets/s2c/0x0ca_inspect_message.h"
-#include "utils/blacklistutils.h"
 #include "utils/charutils.h"
 
 auto GP_CLI_COMMAND_CLSTAT::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
@@ -39,19 +32,8 @@ auto GP_CLI_COMMAND_CLSTAT::validate(MapSession* PSession, const CCharEntity* PC
 
 void GP_CLI_COMMAND_CLSTAT::process(MapSession* PSession, CCharEntity* PChar) const
 {
-    charutils::SendKeyItems(PChar);
-    charutils::SendQuestMissionLog(PChar);
-    charutils::SendRecordsOfEminenceLog(PChar);
-
-    PChar->pushPacket<GP_SERV_COMMAND_MAGIC_DATA>(PChar);
-    PChar->pushPacket<GP_SERV_COMMAND_MOUNT_DATA>(PChar);
-    PChar->pushPacket<GP_SERV_COMMAND_COMMAND_DATA>(PChar);
-    PChar->pushPacket<CCharSyncPacket>(PChar);
-    PChar->pushPacket<GP_SERV_COMMAND_INSPECT_MESSAGE>(PChar);
-    PChar->pushPacket<GP_SERV_COMMAND_MERIT>(PChar);
-
-    charutils::SendInventory(PChar);
-
-    // Note: This sends the stop downloading packet!
-    blacklistutils::SendBlacklist(PChar);
+    // No direct response to this packet in regular conditions.
+    // It is theorized it may be used by the client to report its current state
+    // and may notify the server it is currently severely lagging (stat[0] == 1)
+    // which may have some effect on the packet prioritization.
 }

--- a/src/map/packets/c2s/0x011_zone_transition.cpp
+++ b/src/map/packets/c2s/0x011_zone_transition.cpp
@@ -36,17 +36,7 @@ auto GP_CLI_COMMAND_ZONE_TRANSITION::validate(MapSession* PSession, const CCharE
 
 void GP_CLI_COMMAND_ZONE_TRANSITION::process(MapSession* PSession, CCharEntity* PChar) const
 {
-    PSession->blowfish.status = BLOWFISH_ACCEPTED;
-    PChar->status             = STATUS_TYPE::NORMAL;
-    PChar->health.tp          = 0;
-
-    for (uint8 i = 0; i < 16; ++i)
-    {
-        if (PChar->equip[i] != 0)
-        {
-            PChar->pushPacket<GP_SERV_COMMAND_EQUIP_LIST>(PChar->equip[i], static_cast<SLOTTYPE>(i), static_cast<CONTAINER_ID>(PChar->equipLoc[i]));
-        }
-    }
-
-    PChar->PAI->QueueAction(queueAction_t(4000ms, false, zoneutils::AfterZoneIn));
+    // All this packet does on retail is respond with Kupowers messages.
+    // Retail will respond exactly once to it.
+    // TODO: Kupowers messages
 }

--- a/src/map/packets/c2s/0x050_equip_set.cpp
+++ b/src/map/packets/c2s/0x050_equip_set.cpp
@@ -88,4 +88,9 @@ void GP_CLI_COMMAND_EQUIP_SET::process(MapSession* PSession, CCharEntity* PChar)
     luautils::CheckForGearSet(PChar); // check for gear set on gear change
     PChar->UpdateHealth();
     PChar->retriggerLatents = true; // retrigger all latents later because our gear has changed
+    // TODO: Sort out above logic and ensure the following packets are emitted synchronously as a response
+    // EQUIP_LIST
+    // GRAP_LIST
+    // MAGIC_DATA
+    // COMMAND_DATA
 }

--- a/src/map/packets/c2s/0x061_clistatus.cpp
+++ b/src/map/packets/c2s/0x061_clistatus.cpp
@@ -22,18 +22,13 @@
 #include "0x061_clistatus.h"
 
 #include "entities/charentity.h"
-#include "packets/char_status.h"
 #include "packets/s2c/0x061_clistatus.h"
 #include "packets/s2c/0x062_clistatus2.h"
-#include "packets/s2c/0x063_miscdata_homepoints.h"
 #include "packets/s2c/0x063_miscdata_job_points.h"
 #include "packets/s2c/0x063_miscdata_merits.h"
 #include "packets/s2c/0x063_miscdata_monstrosity.h"
-#include "packets/s2c/0x063_miscdata_status_icons.h"
-#include "packets/s2c/0x08d_job_points.h"
 #include "packets/s2c/0x0df_group_attr.h"
 #include "packets/s2c/0x119_abil_recast.h"
-#include "utils/charutils.h"
 
 auto GP_CLI_COMMAND_CLISTATUS::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
@@ -43,24 +38,11 @@ auto GP_CLI_COMMAND_CLISTATUS::validate(MapSession* PSession, const CCharEntity*
 
 void GP_CLI_COMMAND_CLISTATUS::process(MapSession* PSession, CCharEntity* PChar) const
 {
-    PChar->pushPacket<CCharStatusPacket>(PChar);
     PChar->pushPacket<GP_SERV_COMMAND_GROUP_ATTR>(PChar);
     PChar->pushPacket<GP_SERV_COMMAND_CLISTATUS>(PChar);
     PChar->pushPacket<GP_SERV_COMMAND_CLISTATUS2>(PChar);
     PChar->pushPacket<GP_SERV_COMMAND_ABIL_RECAST>(PChar);
     PChar->pushPacket<GP_SERV_COMMAND_MISCDATA::MERITS>(PChar);
     PChar->pushPacket<GP_SERV_COMMAND_MISCDATA::MONSTROSITY1>(PChar);
-    PChar->pushPacket<GP_SERV_COMMAND_MISCDATA::MONSTROSITY2>(PChar);
     PChar->pushPacket<GP_SERV_COMMAND_MISCDATA::JOB_POINTS>(PChar);
-
-    if (charutils::hasKeyItem(PChar, KeyItem::JOB_BREAKER))
-    {
-        // Only send Job Points Packet if the player has unlocked them
-        PChar->pushPacket<GP_SERV_COMMAND_JOB_POINTS>(PChar);
-    }
-
-    PChar->pushPacket<GP_SERV_COMMAND_MISCDATA::HOMEPOINTS>(PChar);
-    charutils::SendExtendedJobPackets(PChar);
-    charutils::SendUnityPackets(PChar);
-    PChar->pushPacket<GP_SERV_COMMAND_MISCDATA::STATUS_ICONS>(PChar);
 }

--- a/src/map/packets/c2s/0x061_clistatus.cpp
+++ b/src/map/packets/c2s/0x061_clistatus.cpp
@@ -23,12 +23,7 @@
 
 #include "entities/charentity.h"
 #include "packets/s2c/0x061_clistatus.h"
-#include "packets/s2c/0x062_clistatus2.h"
-#include "packets/s2c/0x063_miscdata_job_points.h"
-#include "packets/s2c/0x063_miscdata_merits.h"
-#include "packets/s2c/0x063_miscdata_monstrosity.h"
-#include "packets/s2c/0x0df_group_attr.h"
-#include "packets/s2c/0x119_abil_recast.h"
+#include "utils/charutils.h"
 
 auto GP_CLI_COMMAND_CLISTATUS::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
@@ -38,11 +33,5 @@ auto GP_CLI_COMMAND_CLISTATUS::validate(MapSession* PSession, const CCharEntity*
 
 void GP_CLI_COMMAND_CLISTATUS::process(MapSession* PSession, CCharEntity* PChar) const
 {
-    PChar->pushPacket<GP_SERV_COMMAND_GROUP_ATTR>(PChar);
-    PChar->pushPacket<GP_SERV_COMMAND_CLISTATUS>(PChar);
-    PChar->pushPacket<GP_SERV_COMMAND_CLISTATUS2>(PChar);
-    PChar->pushPacket<GP_SERV_COMMAND_ABIL_RECAST>(PChar);
-    PChar->pushPacket<GP_SERV_COMMAND_MISCDATA::MERITS>(PChar);
-    PChar->pushPacket<GP_SERV_COMMAND_MISCDATA::MONSTROSITY1>(PChar);
-    PChar->pushPacket<GP_SERV_COMMAND_MISCDATA::JOB_POINTS>(PChar);
+    charutils::SendLocalPlayerPackets(PChar);
 }

--- a/src/map/packets/c2s/0x0b5_chat_std.cpp
+++ b/src/map/packets/c2s/0x0b5_chat_std.cpp
@@ -285,21 +285,24 @@ void GP_CLI_COMMAND_CHAT_STD::process(MapSession* PSession, CCharEntity* PChar) 
         break;
         case GP_CLI_COMMAND_CHAT_STD_KIND::Unity:
         {
-            if (PChar->PUnityChat != nullptr)
+            if (!PChar->PUnityChat)
             {
-                message::send(ipc::ChatMessageUnity{
-                    .unityLeaderId = PChar->PUnityChat->getLeader(),
-                    .senderId      = PChar->id,
-                    .senderName    = PChar->getName(),
-                    .message       = rawMessage,
-                    .zoneId        = PChar->getZone(),
-                    .gmLevel       = PChar->m_GMlevel,
-                });
-
-                roeutils::event(ROE_EVENT::ROE_UNITY_CHAT, PChar, RoeDatagram("unityMessage", rawMessage));
-
-                auditUnity(PChar, rawMessage);
+                PChar->pushPacket<GP_SERV_COMMAND_MESSAGE>(MsgStd::UnityNotParticipating);
+                return;
             }
+
+            message::send(ipc::ChatMessageUnity{
+                .unityLeaderId = PChar->PUnityChat->getLeader(),
+                .senderId      = PChar->id,
+                .senderName    = PChar->getName(),
+                .message       = rawMessage,
+                .zoneId        = PChar->getZone(),
+                .gmLevel       = PChar->m_GMlevel,
+            });
+
+            roeutils::event(ROE_EVENT::ROE_UNITY_CHAT, PChar, RoeDatagram("unityMessage", rawMessage));
+
+            auditUnity(PChar, rawMessage);
         }
         break;
         case GP_CLI_COMMAND_CHAT_STD_KIND::LinkshellPvp:

--- a/src/map/packets/c2s/0x0db_config_language.cpp
+++ b/src/map/packets/c2s/0x0db_config_language.cpp
@@ -22,6 +22,7 @@
 #include "0x0db_config_language.h"
 
 #include "entities/charentity.h"
+#include "packets/char_status.h"
 #include "packets/s2c/0x0b4_config.h"
 #include "utils/charutils.h"
 
@@ -76,4 +77,5 @@ void GP_CLI_COMMAND_CONFIG_LANGUAGE::process(MapSession* PSession, CCharEntity* 
     }
 
     PChar->pushPacket<GP_SERV_COMMAND_CONFIG>(PChar);
+    PChar->pushPacket<CCharStatusPacket>(PChar);
 }

--- a/src/map/packets/c2s/0x0e0_set_usermsg.cpp
+++ b/src/map/packets/c2s/0x0e0_set_usermsg.cpp
@@ -22,6 +22,7 @@
 #include "0x0e0_set_usermsg.h"
 
 #include "entities/charentity.h"
+#include "packets/char_status.h"
 
 auto GP_CLI_COMMAND_SET_USERMSG::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
@@ -49,4 +50,6 @@ void GP_CLI_COMMAND_SET_USERMSG::process(MapSession* PSession, CCharEntity* PCha
         PChar->search.message     = message;
         PChar->search.messagetype = static_cast<uint8_t>(type);
     }
+
+    PChar->pushPacket<CCharStatusPacket>(PChar);
 }

--- a/src/map/packets/c2s/0x118_unity_toggle.cpp
+++ b/src/map/packets/c2s/0x118_unity_toggle.cpp
@@ -23,6 +23,7 @@
 
 #include "entities/charentity.h"
 #include "unitychat.h"
+#include "utils/charutils.h"
 
 auto GP_CLI_COMMAND_UNITY_TOGGLE::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
@@ -41,4 +42,6 @@ void GP_CLI_COMMAND_UNITY_TOGGLE::process(MapSession* PSession, CCharEntity* PCh
     {
         unitychat::AddOnlineMember(PChar, PChar->profile.unity_leader);
     }
+
+    charutils::SendLocalPlayerPackets(PChar);
 }

--- a/src/map/packets/c2s/0x11b_mastery_display.cpp
+++ b/src/map/packets/c2s/0x11b_mastery_display.cpp
@@ -23,6 +23,7 @@
 
 #include "entities/charentity.h"
 #include "packets/char_status.h"
+#include "packets/char_sync.h"
 #include "utils/charutils.h"
 
 auto GP_CLI_COMMAND_MASTERY_DISPLAY::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
@@ -33,8 +34,13 @@ auto GP_CLI_COMMAND_MASTERY_DISPLAY::validate(MapSession* PSession, const CCharE
 
 void GP_CLI_COMMAND_MASTERY_DISPLAY::process(MapSession* PSession, CCharEntity* PChar) const
 {
-    PChar->m_jobMasterDisplay = Mode;
+    if (PChar->m_jobMasterDisplay != static_cast<bool>(Mode))
+    {
+        PChar->m_jobMasterDisplay = Mode;
 
-    charutils::SaveJobMasterDisplay(PChar);
-    PChar->pushPacket<CCharStatusPacket>(PChar);
+        charutils::SaveJobMasterDisplay(PChar);
+        PChar->pushPacket<CCharStatusPacket>(PChar);
+        // TODO: This might be broadcast to other players as well
+        PChar->pushPacket<CCharSyncPacket>(PChar);
+    }
 }

--- a/src/map/packets/s2c/0x061_clistatus.cpp
+++ b/src/map/packets/s2c/0x061_clistatus.cpp
@@ -84,10 +84,11 @@ GP_SERV_COMMAND_CLISTATUS::GP_SERV_COMMAND_CLISTATUS(CCharEntity* PChar)
     packet.statusdata.ilvl_mhand   = charutils::getMainhandItemLevel(PChar);
     packet.statusdata.ilvl_ranged  = charutils::getRangedItemLevel(PChar);
 
-    const uint8 unityRank                = PChar->profile.unity_leader > 0 ? roeutils::RoeSystem.unityLeaderRank[PChar->profile.unity_leader - 1] : 0;
-    packet.statusdata.unity_info.Faction = PChar->profile.unity_leader;
-    packet.statusdata.unity_info.Unknown = unityRank;
-    packet.statusdata.unity_info.Points  = charutils::GetPoints(PChar, "unity_accolades");
-    packet.statusdata.unity_points1      = charutils::GetPoints(PChar, "current_accolades") / 1000;
-    packet.statusdata.unity_points2      = charutils::GetPoints(PChar, "prev_accolades") / 1000;
+    const uint8 unityRank                   = PChar->profile.unity_leader > 0 ? roeutils::RoeSystem.unityLeaderRank[PChar->profile.unity_leader - 1] : 0;
+    packet.statusdata.unity_info.Faction    = PChar->profile.unity_leader;
+    packet.statusdata.unity_info.Unknown    = unityRank;
+    packet.statusdata.unity_info.Points     = charutils::GetPoints(PChar, "unity_accolades");
+    packet.statusdata.unity_points1         = charutils::GetPoints(PChar, "current_accolades") / 1000;
+    packet.statusdata.unity_points2         = charutils::GetPoints(PChar, "prev_accolades") / 1000;
+    packet.statusdata.unity_chat_color_flag = PChar->PUnityChat ? 1 : 0;
 }

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -112,6 +112,7 @@
 #include "packets/s2c/0x063_miscdata_monstrosity.h"
 #include "packets/s2c/0x063_miscdata_unity.h"
 #include "packets/s2c/0x075_battlefield.h"
+#include "packets/s2c/0x0df_group_attr.h"
 #include "packets/s2c/0x110_unity.h"
 #include "packets/s2c/0x111_roe_activelog.h"
 #include "packets/s2c/0x112_roe_log.h"
@@ -1590,6 +1591,18 @@ namespace charutils
                     break;
             }
         }
+    }
+
+    // Server sends a specific set of packets when certain player information change.
+    void SendLocalPlayerPackets(CCharEntity* PChar)
+    {
+        PChar->pushPacket<GP_SERV_COMMAND_GROUP_ATTR>(PChar);
+        PChar->pushPacket<GP_SERV_COMMAND_CLISTATUS>(PChar);
+        PChar->pushPacket<GP_SERV_COMMAND_CLISTATUS2>(PChar);
+        PChar->pushPacket<GP_SERV_COMMAND_ABIL_RECAST>(PChar);
+        PChar->pushPacket<GP_SERV_COMMAND_MISCDATA::MERITS>(PChar);
+        PChar->pushPacket<GP_SERV_COMMAND_MISCDATA::MONSTROSITY1>(PChar);
+        PChar->pushPacket<GP_SERV_COMMAND_MISCDATA::JOB_POINTS>(PChar);
     }
 
     /************************************************************************

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -81,6 +81,7 @@ namespace charutils
     void SendInventory(CCharEntity* PChar);
     void SendUnityPackets(CCharEntity* PChar);
     void SendExtendedJobPackets(CCharEntity* PChar);
+    void SendLocalPlayerPackets(CCharEntity* PChar);
 
     void CalculateStats(CCharEntity* PChar);
     void UpdateSubJob(CCharEntity* PChar);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

In one of my past PRs I loaded C2S CLISTATUS response with a full set of packets that I believe were emitted as a response but after careful consideration and reviewing retail flow I believe CLISTATUS only responds with a limited subset of them. 

This is especially relevant since the client sends it when you open the equipment window and swap gear which is causing UI-based equipment changes to be slower than necessary.

It's difficult to figure out exactly where the other packets come from but I assume they are a response to either GAMEOK or CLSTAT. 
- Retail does not respond to either packet beyond the initial zone-in. 
- I'll try and block a few packets and figure out the exact distribution. 
- Settled on GAMEOK for now.

## Steps to test these changes
It works but I'll leave it in draft while I gather more info.

<!-- Clear and detailed steps to test your changes here -->
