### PR TITLE
[lua] Slight readability to npcUtil.giveItem

### DIFF
--- a/scripts/tests/systems/utils/giveItem.lua
+++ b/scripts/tests/systems/utils/giveItem.lua
@@ -1,0 +1,123 @@
+describe('npcUtil.giveItem()', function()
+    ---@type CClientEntityPair
+    local player
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer(
+        {
+            job = xi.job.SMN,
+            level = 75,
+        })
+
+        -- Add filler to the inventory
+        player:addItem(xi.item.PILE_OF_CHOCOBO_BEDDING, 80)
+    end)
+
+    it('item table with single item', function()
+        assert(
+            npcUtil.giveItem(player, { xi.item.SHURIKEN }) == false,
+            'Should fail to give a single item'
+        )
+
+        player:delItem(xi.item.PILE_OF_CHOCOBO_BEDDING, 1)
+
+        assert(
+            npcUtil.giveItem(player, { xi.item.SHURIKEN }) == true,
+            'Should give a single item'
+        )
+
+        player.assert:hasItem(xi.item.SHURIKEN)
+    end)
+
+    it('item table with sub table', function()
+        assert(
+            npcUtil.giveItem(player, { { xi.item.SHURIKEN, 2 } }) == false,
+            'Should fail to give a stack'
+        )
+
+        player:delItem(xi.item.PILE_OF_CHOCOBO_BEDDING, 1)
+
+        assert(
+            npcUtil.giveItem(player, { { xi.item.SHURIKEN, 2 } }) == true,
+            'Should give a stack'
+        )
+
+        player.assert:hasItem(xi.item.SHURIKEN)
+
+        -- check that player has the right quantities
+        player:delItem(xi.item.SHURIKEN, 1)
+        player.assert:hasItem(xi.item.SHURIKEN)
+        player:delItem(xi.item.SHURIKEN, 1)
+        player.assert.no:hasItem(xi.item.SHURIKEN)
+    end)
+
+    it('item table with multiple items', function()
+        for _ = 1, 2 do
+            assert(
+                npcUtil.giveItem(player, { xi.item.SHURIKEN, xi.item.JUJI_SHURIKEN }) == false,
+                'Should fail to give items'
+            )
+
+            player:delItem(xi.item.PILE_OF_CHOCOBO_BEDDING, 1)
+        end
+
+        player.assert.no:hasItem(xi.item.SHURIKEN)
+        player.assert.no:hasItem(xi.item.JUJI_SHURIKEN)
+        assert(
+            player:getFreeSlotsCount() == 2,
+            'player should have 2 open inventory slots'
+        )
+
+        assert(
+            npcUtil.giveItem(player, { xi.item.SHURIKEN, xi.item.JUJI_SHURIKEN }) == true,
+            'Should give both items'
+        )
+
+        player.assert
+            :hasItem(xi.item.SHURIKEN)
+            :hasItem(xi.item.JUJI_SHURIKEN)
+
+        -- check that player has the right quantities
+        player:delItem(xi.item.SHURIKEN, 1)
+        player.assert.no:hasItem(xi.item.SHURIKEN)
+
+        player:delItem(xi.item.JUJI_SHURIKEN, 1)
+        player.assert.no:hasItem(xi.item.JUJI_SHURIKEN)
+    end)
+
+    it('item table with multiple sub tables/quantities', function()
+        for _ = 1, 2 do
+            assert(
+                npcUtil.giveItem(player, { { xi.item.SHURIKEN, 1 }, { xi.item.JUJI_SHURIKEN, 2 } }) == false,
+                'Should fail to give items'
+            )
+
+            player:delItem(xi.item.PILE_OF_CHOCOBO_BEDDING, 1)
+        end
+
+        player.assert.no:hasItem(xi.item.SHURIKEN)
+        player.assert.no:hasItem(xi.item.JUJI_SHURIKEN)
+        assert(
+            player:getFreeSlotsCount() == 2,
+            'player should have 2 open inventory slots'
+        )
+
+        assert(
+            npcUtil.giveItem(player, { { xi.item.SHURIKEN, 1 }, { xi.item.JUJI_SHURIKEN, 2 } }) == true,
+            'Should give both items'
+        )
+
+        player.assert
+            :hasItem(xi.item.SHURIKEN)
+            :hasItem(xi.item.JUJI_SHURIKEN)
+
+        -- check that player has the right quantities
+        player:delItem(xi.item.SHURIKEN, 1)
+        player.assert.no:hasItem(xi.item.SHURIKEN)
+
+        player:delItem(xi.item.JUJI_SHURIKEN, 1)
+        player.assert:hasItem(xi.item.JUJI_SHURIKEN)
+        player:delItem(xi.item.JUJI_SHURIKEN, 1)
+        player.assert.no:hasItem(xi.item.JUJI_SHURIKEN)
+    end)
+end)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Sparked by https://github.com/LandSandBoat/server/issues/8535

It's a readability change with a slight functionality "fix" that can be removed if we choose to leave the oversight.
- updated params to be more explicit for readability
  - `:addItem` has two flows, i changed it to use the `sol::table` flow to hopefully eventually do away with the other altogether
  - note that the call to `:addItem` explicitly sets `silent = true` so it can provide messaging in the lua function
- `givenItems[1][1]` is the same as `v[1]`, adjusted to not be as abstract in reading the code
- the one functionality change is that if you provide an item table with multiple items, and one of the `:addItem` calls fails
  - previously, it would still return `true`
  - now it returns `false` if any `:addItem` call fails, regardless of how many items are passed
  - Note that because there's a free space check, this change only affects calls to `npcUtil.giveItem` that would fail `:addItem` for something other than a basic space requirement. Two reason I know of (there might be more)
    - the call to `.giveItem` was bad and set a quantity greater than 1 on an item that isn't stackable and includes other items in the `givenItems` list
    - the call specified multiple items and one of them is rare and fails `:addItem` due to being either in the player's possession or in their recycle bin

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- `!exec print(X)` to see the boolean return of the following commands with and without enough space for the full set of items
  - `npcUtil.giveItem(player, 17301)` - one shuriken
  - `npcUtil.giveItem(player, {17301,17302})` - one shuriken and one juji shuriken
  - `npcUtil.giveItem(player, {{17301,2}})` - two shuriken
- duplicate the above with a third param: `{silent = true}` to see no message either receiving or not having enough space