### PR TITLE
[lua] Remove Neptune Spire Door Default Action

### DIFF
--- a/scripts/zones/Lower_Jeuno/DefaultActions.lua
+++ b/scripts/zones/Lower_Jeuno/DefaultActions.lua
@@ -2,7 +2,6 @@ local ID = zones[xi.zone.LOWER_JEUNO]
 
 return {
     ['_6t2']            = { event = 64 }, -- Door:Merchant's House
-    ['_6tc']            = { messageSpecial = ID.text.ITS_LOCKED }, -- Door:"Neptune's Spire"
     ['_6td']            = { messageSpecial = ID.text.DO_NOT_DISTURB }, -- Door:"Neptune's Spire"
     ['Amhu_Sabaroleka'] = { event = 14 },
     ['Biora']           = { event = 205 },


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Since the events in the base lua file don't use returns this was causing the players to need to click on the door multiple times to get through it.

## Steps to test these changes

!addkeyitem TENSHODO_MEMBERS_CARD
Click door.
