### PR TITLE
[lua] Fix boost cleanup

### DIFF
--- a/scripts/globals/job_utils/monk.lua
+++ b/scripts/globals/job_utils/monk.lua
@@ -35,8 +35,10 @@ xi.job_utils.monk.useBoost = function(player, target, ability)
 
     if player:hasStatusEffect(xi.effect.BOOST) then
         local effect = player:getStatusEffect(xi.effect.BOOST)
-        effect:setPower(effect:getPower() + power)
-        player:addMod(xi.mod.ATTP, power)
+
+        effect:setPower(effect:getPower() + power) -- Store updated power in boost for zoning
+        effect:addMod(xi.mod.ATTP, power) -- Add to effect for later cleanup (this does not add to the player directly after effectObject.onEffectGain)
+        player:addMod(xi.mod.ATTP, power) -- Add to player so they get the immediate boost
     else
         player:addStatusEffect(xi.effect.BOOST, power, 0, 180)
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Cleanup effect better

## Steps to test these changes

Use boost, zone, see stuff is consistent