### PR TITLE
[cpp] Fix oversight with effect:addMod

### DIFF
--- a/scripts/globals/job_utils/monk.lua
+++ b/scripts/globals/job_utils/monk.lua
@@ -37,8 +37,7 @@ xi.job_utils.monk.useBoost = function(player, target, ability)
         local effect = player:getStatusEffect(xi.effect.BOOST)
 
         effect:setPower(effect:getPower() + power) -- Store updated power in boost for zoning
-        effect:addMod(xi.mod.ATTP, power) -- Add to effect for later cleanup (this does not add to the player directly after effectObject.onEffectGain)
-        player:addMod(xi.mod.ATTP, power) -- Add to player so they get the immediate boost
+        effect:addMod(xi.mod.ATTP, power)
     else
         player:addStatusEffect(xi.effect.BOOST, power, 0, 180)
     end

--- a/scripts/tests/jobs/mnk/abilities/boost.lua
+++ b/scripts/tests/jobs/mnk/abilities/boost.lua
@@ -1,0 +1,36 @@
+describe('Boost', function()
+    local player
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer(
+            {
+                job   = xi.job.MNK,
+                level = 5,
+            })
+    end)
+
+    it('increases attack by 25%', function()
+        assert(
+            player:getMod(xi.mod.ATTP) == 0,
+            'Fresh level 5 monk should have no ATTP bonus'
+        )
+
+        player.actions:useAbility(player, xi.jobAbility.BOOST)
+        xi.test.world:tick()
+        player:resetRecasts()
+        player.actions:useAbility(player, xi.jobAbility.BOOST)
+        xi.test.world:tick()
+
+        player.assert
+            :hasEffect(xi.effect.BOOST)
+            :hasModifier(xi.mod.ATTP, 25)
+
+        player:delStatusEffect(xi.effect.BOOST)
+        xi.test.world:tick()
+
+        assert(
+            player:getMod(xi.mod.ATTP) == 0,
+            'Losing boost should revert ATTP bonus'
+        )
+    end)
+end)

--- a/scripts/tests/jobs/run/abilities/gambit.lua
+++ b/scripts/tests/jobs/run/abilities/gambit.lua
@@ -1,0 +1,50 @@
+describe('Gambit', function()
+    ---@type CClientEntityPair
+    local player
+    ---@type CTestEntity
+    local euvhi
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer(
+        {
+            job = xi.job.RUN,
+            level = 75,
+            zone = xi.zone.ALTAIEU
+        })
+
+        -- Find a mob to reduce res
+        euvhi = player.entities:moveTo('Aweuvhi')
+    end)
+
+    it('reduces wind res', function()
+        local origWind = euvhi:getMod(xi.mod.WIND_SDT)
+        player.actions:useAbility(player, xi.jobAbility.FLABRA)
+        xi.test.world:tick()
+        player:resetRecasts()
+        player.actions:useAbility(player, xi.jobAbility.FLABRA)
+        xi.test.world:tick()
+        player:resetRecasts()
+        player.actions:useAbility(player, xi.jobAbility.FLABRA)
+        xi.test.world:tick()
+
+        assert(
+            player:getActiveRuneCount() == 3,
+            'Using Flabra 3 times should have 3 runes'
+        )
+
+        player.actions:useAbility(euvhi, xi.jobAbility.GAMBIT)
+        xi.test.world:tick()
+
+        euvhi.assert
+            :hasEffect(xi.effect.GAMBIT)
+            :hasModifier(xi.mod.WIND_SDT, origWind + 3000)
+
+        euvhi:delStatusEffect(xi.effect.GAMBIT)
+        xi.test.world:tick()
+
+        assert(
+            euvhi:getMod(xi.mod.WIND_SDT) == origWind,
+            'Losing rayke should revert WIND_SDT'
+        )
+    end)
+end)

--- a/src/map/status_effect.cpp
+++ b/src/map/status_effect.cpp
@@ -244,6 +244,13 @@ void CStatusEffect::SetEffectName(std::string name)
 
 void CStatusEffect::addMod(Mod modType, int16 amount)
 {
+    // Since an effect's mod list is only applied to entity when adding the effect
+    // we need to add the mod to the entity manually if the effect is already applied
+    if (m_POwner)
+    {
+        m_POwner->addModifier(modType, amount);
+    }
+
     for (auto& i : modList)
     {
         if (i.getModID() == modType)
@@ -253,13 +260,6 @@ void CStatusEffect::addMod(Mod modType, int16 amount)
         }
     }
     modList.emplace_back(modType, amount);
-
-    // Since an effect's mod list is only applied to entity when adding the effect
-    // we need to add the mod to the entity manually if the effect is already applied
-    if (m_POwner)
-    {
-        m_POwner->addModifier(modType, amount);
-    }
 }
 
 void CStatusEffect::setMod(Mod modType, int16 value)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
The fix in https://github.com/LandSandBoat/server/pull/8547 shouldn't be necessary since https://github.com/LandSandBoat/server/pull/7799

Turns out I didn't consider adding the _same_ mod to an effect. The core `addMod` function has an early return so it wasn't working as expected. This PR
- fixes that oversight
- re-updates monk boost to properly use `effect:addMod` by itself (as opposed to `player:addMod`, which fails to remove the mod when the effect wears off)
- Was discovered below this also fixes RUN's Rayke when the same runes are up more than once on the player

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
<img width="481" height="234" alt="image" src="https://github.com/user-attachments/assets/eba66468-371c-46b6-8b0c-c315bad328f1" />
