### PR TITLE
[lua] Fix Default Action for Ghebi Damomohe

### DIFF
--- a/scripts/zones/Lower_Jeuno/DefaultActions.lua
+++ b/scripts/zones/Lower_Jeuno/DefaultActions.lua
@@ -16,7 +16,7 @@ return {
     ['Faursel']         = { event = 10065 },
     ['Garnev']          = { event = 207 },
     ['Geuhbe']          = { event = 10033 },
-    ['Ghebi_Damomohe']  = { event = 106, 4 },
+    ['Ghebi_Damomohe']  = { event = 106, options = 4 },
     ['Greyson']         = { event = 20082 },
     ['Guide_Stone']     = { messageSpecial = ID.text.GUIDE_STONE },
     ['Gurdern']         = { event = 112 },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Fixes the default action for Ghebi Damomohe in the Lower Jeuno Tenshodo such that she no longer offeres the hidden prompt to start the Tenshodo Membership quest when the player is not eligible.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - Make a fresh character
2 - `!zone lower jeuno`
3 - Talk to Ghebi Damomohe in the tenshodo shop
4 - Get the Menu that does not have the 3rd hidden option
5 - `!setfame 3 3`
6 - Talk with Ghebi Damomohe again

Result: Players only get the special option to start the quest when they have completed the rank requirement for the quest.