### PR TITLE
[core] Update GP_SERV_GROUP_LIST for Level Sync

### DIFF
--- a/src/map/packets/s2c/0x0dd_group_list.cpp
+++ b/src/map/packets/s2c/0x0dd_group_list.cpp
@@ -44,6 +44,7 @@ GP_SERV_COMMAND_GROUP_LIST::GP_SERV_COMMAND_GROUP_LIST(const CCharEntity* PChar,
     packet.GAttr.AllianceRFlg      = (memberflags >> 5) & 0x01; // Bit 5: Alliance recruiter flag
     packet.GAttr.unknown06         = (memberflags >> 6) & 0x01; // Bit 6: MasterComFlg
     packet.GAttr.unknown07         = (memberflags >> 7) & 0x01; // Bit 7: SubMasterComFlg
+    packet.GAttr.LevelSyncFlg      = (memberflags >> 8) & 0x01; // Bit 8: LevelSyncFlg
 
     if (PChar->getZone() != ZoneID)
     {
@@ -109,6 +110,7 @@ GP_SERV_COMMAND_GROUP_LIST::GP_SERV_COMMAND_GROUP_LIST(const uint32_t id, const 
     packet.GAttr.AllianceRFlg      = (memberFlags >> 5) & 0x01; // Bit 5: Alliance recruiter flag
     packet.GAttr.unknown06         = (memberFlags >> 6) & 0x01; // Bit 6: MasterComFlg
     packet.GAttr.unknown07         = (memberFlags >> 7) & 0x01; // Bit 7: SubMasterComFlg
+    packet.GAttr.LevelSyncFlg      = (memberFlags >> 8) & 0x01; // Bit 8: LevelSyncFlg
     packet.ZoneNo                  = ZoneID;
 
     std::memcpy(packet.Name, name.c_str(), std::min<size_t>(name.size(), sizeof(packet.Name)));

--- a/src/map/packets/s2c/0x0dd_group_list.h
+++ b/src/map/packets/s2c/0x0dd_group_list.h
@@ -35,7 +35,8 @@ struct GP_GROUP_ATTR
     uint32_t AllianceRFlg : 1;      // PS2: AllianceRFlg
     uint32_t unknown06 : 1;         // PS2: MasterComFlg
     uint32_t unknown07 : 1;         // PS2: SubMasterComFlg
-    uint32_t unused : 24;           // PS2: dammy
+    uint32_t LevelSyncFlg : 1;      // PS2: LevelSyncFlg
+    uint32_t unused : 23;           // PS2: dammy
 };
 
 // https://github.com/atom0s/XiPackets/tree/main/world/server/0x00DD


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Adds in support for the Level Sync bit flag in GP_SERV_COMMAND_GROUP_LIST packet that was missing.  This bit tells the client about the level sync so that the red notification dot appears next to the player in the party list, and allows for the level sync to be removed from the Menus.  Without this bit being set, level sync could not be removed unless you were dropping from the party.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - Login with two characters
2 - Create a party with said characters
3 - Enable Level Sync from the menus
NOTE: A red indicator icon now appears next to the party member who has the levelsync memberflag

4 - Go back into the Party Menu and see that the Level Sync icon has updated to "Lvl. Sync Off" and click it
Result: Level sync indicator and removal now work as expected.


Before Sync: 
<img width="126" height="72" alt="image" src="https://github.com/user-attachments/assets/409f255c-8dbc-4633-bdde-ac2b94ae08f1" />

Sync Active with Red Indicator icon in Party List:
<img width="1209" height="689" alt="image" src="https://github.com/user-attachments/assets/85879963-5567-4d18-9a0a-3a4dcd2c39ff" />

Updated Menu Option:
<img width="120" height="240" alt="image" src="https://github.com/user-attachments/assets/3dfb05aa-77c2-4f3a-a83e-80101879f8fd" />

Removal working properly from the menu:
<img width="756" height="38" alt="image" src="https://github.com/user-attachments/assets/2cae599c-86de-4a55-b640-a01566b12309" />
