### PR TITLE
[ci] summary readability

### DIFF
--- a/scripts/globals/dark_ixion.lua
+++ b/scripts/globals/dark_ixion.lua
@@ -666,7 +666,6 @@ xi.darkixion.onMobFight = function(mob, target)
         mob:setTP(0)
         xi.darkixion.beginTramplePath(mob)
     end
-
     if animationSub == animationSubs.TRAMPLE then
         -- cleanly exit trample when reaching the point (TODO check explicitly for a scripted path?)
         -- runPathTime timestamp hard exit in case of navmesh abuse

--- a/sql/fishing_area.sql
+++ b/sql/fishing_area.sql
@@ -46,6 +46,7 @@ LOCK TABLES `fishing_area` WRITE;
 -- Phanauet Channel
 INSERT INTO `fishing_area` VALUES (1,1,'Whole Zone',0,0,0,NULL,0.000,0.000,0.000);
 -- Carpenters' Landing
+--- bad comment
 INSERT INTO `fishing_area` VALUES (2,1,'South Landing',1,20,150,'',172.250,-2.000,-475.286);
 INSERT INTO `fishing_area` VALUES (2,2,'Other Waterside South',1,20,60,'',-101.576,0.000,-484.401);
 INSERT INTO `fishing_area` VALUES (2,3,'Other Waterside Center',1,20,60,'',-221.249,0.000,-283.157);

--- a/tools/ci/sanity_checks.sh
+++ b/tools/ci/sanity_checks.sh
@@ -4,12 +4,26 @@ set -uo pipefail
 checks_failed=false
 
 OUTPUT="sanity_checks_summary.md"
-echo "# Sanity Check Results" > "$OUTPUT"
+echo "## Sanity Check Results" > "$OUTPUT"
+OUTPUT_TEMP="sanity_checks_temp.md"
+OUTPUT_FAILED="sanity_checks_failed.md"
+echo "### Failed Sanity Checks" > "$OUTPUT_FAILED"
+# https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections
+# create collapsed success section
+echo "<details><summary>Passed tests (click to expand)</summary>" >> "$OUTPUT"
+# blank line is necessary for first line to have markdown
+echo >> "$OUTPUT"
 
 run_check() {
     echo "Running $1..."
-    bash "$1" "${@:2}" | tee -a "$OUTPUT"
-    [[ $? -ne 0 ]] && checks_failed=true
+    echo > "$OUTPUT_TEMP"
+    bash "$1" "${@:2}" | tee -a "$OUTPUT_TEMP"
+    if [[ $? -ne 0 ]]; then
+        checks_failed=true
+        cat "$OUTPUT_TEMP" >> "$OUTPUT_FAILED"
+    else
+        cat "$OUTPUT_TEMP" >> "$OUTPUT"
+    fi
 }
 
 if [[ $# -gt 0 ]]; then
@@ -29,7 +43,7 @@ if [[ $# -gt 0 ]]; then
             echo "## :x: Git Checks Failed"
             echo "$gitcheck_output"
             echo
-        } | tee -a "$OUTPUT"
+        } | tee -a "$OUTPUT_FAILED"
     else
         {
             echo "## :heavy_check_mark: Git Checks Passed"
@@ -54,10 +68,17 @@ run_check tools/ci/sanity_checks/lua.sh "${CHANGED_FILES[@]}"
 # C++
 run_check tools/ci/sanity_checks/cpp.sh "${CHANGED_FILES[@]}"
 
+# end collapsed "passed tests" section
+echo "</details>" >> "$OUTPUT"
+# blank line is necessary for collapsing to work properly
+echo >> "$OUTPUT"
+
 if [[ "$checks_failed" == "true" ]]; then
     echo "One or more checks failed."
+
+    cat "$OUTPUT_FAILED" >> "$OUTPUT"
     exit 1
 else
-    echo "All checks passed."
+    echo "## :heavy_check_mark: All checks passed." | tee -a "$OUTPUT"
     exit 0
 fi


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [ ] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Trims down the Sanity Checks summary to take up less space on successes to focus attention on failures. I don't think the other jobs need this treatment, as I think they all report a single checkmark if it's successful.

Draft while I test permutations. Wasn't going to make the PR at LSB until i had it tested on my fork but [something is causing all non-git checks to report successful](https://github.com/MowFord/ZenithXI/actions/runs/18980677085/job/54212128799) and I don't know why. I'm guessing something with not being a PR targetting LSB specifically

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- Fail certain sanity checks (easy ones to trigger are: sql, lua, cpp, git)
  - <img width="923" height="687" alt="image" src="https://github.com/user-attachments/assets/5e8d624f-268f-472a-a006-08ee748fd34b" />
- have no failing sanity checks:
  - <img width="324" height="302" alt="image" src="https://github.com/user-attachments/assets/aa46cca5-9a9f-434b-b169-2b5e9c554bfc" />
  - <img width="396" height="666" alt="image" src="https://github.com/user-attachments/assets/bb741f9c-a1b6-46ba-a04f-a58bd4001445" />



