### PR TITLE
[ci] Summary readability

### DIFF
--- a/tools/ci/sanity_checks.sh
+++ b/tools/ci/sanity_checks.sh
@@ -1,15 +1,26 @@
 #!/bin/bash
 set -uo pipefail
 
-checks_failed=false
-
 OUTPUT="sanity_checks_summary.md"
-echo "# Sanity Check Results" > "$OUTPUT"
+rm -f "$OUTPUT"
+OUTPUT_TEMP="sanity_checks_temp.md"
+OUTPUT_FAILED="sanity_checks_failed.md"
+echo > "$OUTPUT_FAILED"
+# https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections
+# create collapsed success section
+echo "<details><summary>Passed tests (click to expand)</summary>" >> "$OUTPUT"
+# blank line is necessary for first line to have markdown
+echo >> "$OUTPUT"
 
 run_check() {
     echo "Running $1..."
-    bash "$1" "${@:2}" | tee -a "$OUTPUT"
-    [[ $? -ne 0 ]] && checks_failed=true
+    echo > "$OUTPUT_TEMP"
+    bash "$1" "${@:2}" | tee -a "$OUTPUT_TEMP"
+    if [[ $? -ne 0 ]]; then
+        cat "$OUTPUT_TEMP" >> "$OUTPUT_FAILED"
+    else
+        cat "$OUTPUT_TEMP" >> "$OUTPUT"
+    fi
 }
 
 if [[ $# -gt 0 ]]; then
@@ -24,12 +35,11 @@ if [[ $# -gt 0 ]]; then
     echo "Checking commit formatting..."
     gitcheck_output=$(python tools/ci/sanity_checks/git.py $GIT_REF 2>&1 || true)
     if [[ -n "$gitcheck_output" ]]; then
-        checks_failed=true
         {
             echo "## :x: Git Checks Failed"
             echo "$gitcheck_output"
             echo
-        } | tee -a "$OUTPUT"
+        } | tee -a "$OUTPUT_FAILED"
     else
         {
             echo "## :heavy_check_mark: Git Checks Passed"
@@ -48,16 +58,26 @@ run_check tools/ci/sanity_checks/python.sh "${CHANGED_FILES[@]}"
 run_check tools/ci/sanity_checks/sql.sh "${CHANGED_FILES[@]}"
 
 # Lua
-python tools/ci/sanity_checks/lua_stylecheck.py test | tee -a "$OUTPUT"
+# lua_stylecheck.py only outputs errors
+echo "Running tools/ci/sanity_checks/lua_stylecheck.py unit tests..."
+python tools/ci/sanity_checks/lua_stylecheck.py test | tee -a "$OUTPUT_FAILED"
 run_check tools/ci/sanity_checks/lua.sh "${CHANGED_FILES[@]}"
 
 # C++
 run_check tools/ci/sanity_checks/cpp.sh "${CHANGED_FILES[@]}"
 
-if [[ "$checks_failed" == "true" ]]; then
+# end collapsed "passed tests" section
+echo "</details>" >> "$OUTPUT"
+# blank line is necessary for collapsing to work properly
+echo >> "$OUTPUT"
+
+# Failure is determined by any non-trivial lines in the $OUTPUT_FAILED file
+if [[ $(grep -v "^$" "$OUTPUT_FAILED" | wc -l) -gt 0 ]]; then
     echo "One or more checks failed."
+
+    cat "$OUTPUT_FAILED" >> "$OUTPUT"
     exit 1
 else
-    echo "All checks passed."
+    echo "## :heavy_check_mark: All sanity checks passed" | tee -a "$OUTPUT"
     exit 0
 fi


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Well that was a [wild](https://github.com/MowFord/ZenithXI/pull/2) [ride](https://github.com/LandSandBoat/server/pull/8556)

~~I have changes from [a pending PR](https://github.com/LandSandBoat/server/pull/8557) in this PR that fixes the path matching for sql files. But that secondary commit will be removed before this is marked as ready~~

There's actually a bigger issue that will either be fixed there ~~or here~~: 
- `readarray -t CHANGED_FILES` is being called in `lua.sh`, then it was being set to the array expansion. Found it by putting `echo $@` at the top of `lua.sh`. it would report all files twice... except the first file. This likely means that the existing CI in LSB right now will properly style check every file except the first file listed in `changed_files.txt`, but I didn't play around with it too much to see _which_ files get removed when converting via `targets=("$@")` in each stylecheck `.sh` script.
- It's included in the other PR and doesn't affect the goal of this PR now that we have examples of failures, so i've removed it

Onto what this PR is intended change (and I think succeeds nicely): changing the Sanity Checks summary to be less verbose about successes. It offloads errors to a separate file to display them last, and puts all existing success messages in a collapsing section. Finally, if there's no errors it emits a single entry that says all checks passed. Otherwise it puts the errors found.

This should make the summary more direct when viewing

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- Fail certain sanity checks (easy ones to trigger are: sql, lua, cpp, git)
  - <img width="502" height="814" alt="image" src="https://github.com/user-attachments/assets/218c74e2-0349-4f0e-842a-a0b7afafb757" />
  - ci failures on this PR by force pushing bad second commits:
    - https://github.com/LandSandBoat/server/actions/runs/18983863399?pr=8558
    - https://github.com/LandSandBoat/server/actions/runs/18983933044?pr=8558
    - https://github.com/LandSandBoat/server/actions/runs/18983994387?pr=8558
- no failures:
  - https://github.com/LandSandBoat/server/actions/runs/18984064143?pr=8558
  - <img width="402" height="242" alt="image" src="https://github.com/user-attachments/assets/9ed4db33-26ff-4b2a-9b40-1407fc48c914" />
  - and expanded: 
  - <img width="410" height="612" alt="image" src="https://github.com/user-attachments/assets/0dead79d-7261-4c87-8d7b-8ba466374e10" />


