### PR TITLE
[core] Always put player in correct state after mount event

### DIFF
--- a/scripts/specs/test/CTestEntityAssertions.lua
+++ b/scripts/specs/test/CTestEntityAssertions.lua
@@ -27,6 +27,12 @@ end
 function CTestEntityAssertions:hasEffect(effectId)
 end
 
+---Assert entity has specified status animation
+---@param animation xi.animation
+---@return CTestEntityAssertions self for chaining
+function CTestEntityAssertions:hasAnimation(animation)
+end
+
 ---Assert player has expected nation rank
 ---@param expectedRank integer
 ---@return CTestEntityAssertions self for chaining

--- a/scripts/tests/systems/chocobo.lua
+++ b/scripts/tests/systems/chocobo.lua
@@ -33,12 +33,14 @@ describe('Chocobo Rental', function()
         -- This returns the correct event but it should NOT mount the PC
         player.entities:gotoAndTrigger('Coumaine', { eventId = 120 })
         player.assert.no:hasEffect(xi.effect.MOUNTED)
+        player.assert.no:hasAnimation(xi.animation.CHOCOBO)
     end)
 
     it('players meeting all qualifications can ride', function()
         player:setGil(140) -- First sale is always 140g for a level 20 PC
         player.entities:gotoAndTrigger('Coumaine', { eventId = 120 })
         player.assert:hasEffect(xi.effect.MOUNTED)
+        player.assert:hasAnimation(xi.animation.CHOCOBO)
     end)
 
     it('price increases after each sale', function()

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -3253,8 +3253,27 @@ void CCharEntity::tryStartNextEvent()
 
     if (eventQueue.empty())
     {
-        updatemask |= UPDATE_POS;           // TODO: decouple from this. We want the 250ms post-tick processing.
-        animation         = ANIMATION_NONE; // sendServerStatus_ is somewhat like an update mask on its own
+        updatemask |= UPDATE_POS; // TODO: decouple from this. We want the 250ms post-tick processing
+
+        // Chocobo NPC (outside, gives you a mount) edge case
+        if (StatusEffectContainer->HasStatusEffect(EFFECT_MOUNTED))
+        {
+            switch (m_mountId)
+            {
+                case MOUNT_CHOCOBO:
+                case MOUNT_NOBLE_CHOCOBO:
+                    animation = ANIMATION_CHOCOBO;
+                    break;
+                default:
+                    animation = ANIMATION_MOUNT;
+                    break;
+            }
+        }
+        else
+        {
+            animation = ANIMATION_NONE;
+        }
+
         sendServerStatus_ = true;
         return;
     }

--- a/src/test/lua/lua_test_entity_assertions.cpp
+++ b/src/test/lua/lua_test_entity_assertions.cpp
@@ -216,6 +216,21 @@ auto CLuaTestEntityAssertions::hasEffect(const EFFECT effectId) -> CLuaTestEntit
 }
 
 /************************************************************************
+ *  Function: hasAnimation()
+ *  Purpose : Assert entity has specified animation
+ *  Example : player.assert:hasAnimation(xi.animation.CHOCOBO)
+ *  Notes   :
+ ************************************************************************/
+
+auto CLuaTestEntityAssertions::hasAnimation(const uint8 animation) -> CLuaTestEntityAssertions&
+{
+    assertCondition(entity_->getAnimation() == animation,
+                    std::format("Does not have animation {} set", getEnumKey("xi.animation", animation)),
+                    std::format("Does have animation {} set", getEnumKey("xi.animation", animation)));
+    return *this;
+}
+
+/************************************************************************
  *  Function: hasNationRank()
  *  Purpose : Assert player has expected nation rank
  *  Example : player.assert:hasNationRank(5)
@@ -476,6 +491,7 @@ void CLuaTestEntityAssertions::Register()
     SOL_REGISTER("inZone", CLuaTestEntityAssertions::inZone);
     SOL_REGISTER("hasLocalVar", CLuaTestEntityAssertions::hasLocalVar);
     SOL_REGISTER("hasEffect", CLuaTestEntityAssertions::hasEffect);
+    SOL_REGISTER("hasAnimation", CLuaTestEntityAssertions::hasAnimation);
     SOL_REGISTER("hasNationRank", CLuaTestEntityAssertions::hasNationRank);
     SOL_REGISTER("hasKI", CLuaTestEntityAssertions::hasKI);
     SOL_REGISTER("hasMission", CLuaTestEntityAssertions::hasMission);

--- a/src/test/lua/lua_test_entity_assertions.h
+++ b/src/test/lua/lua_test_entity_assertions.h
@@ -42,6 +42,7 @@ public:
     auto inZone(ZONEID expectedZone) -> CLuaTestEntityAssertions&;
     auto hasLocalVar(const std::string& varName, uint32 expectedValue) -> CLuaTestEntityAssertions&;
     auto hasEffect(EFFECT effectId) -> CLuaTestEntityAssertions&;
+    auto hasAnimation(uint8 animation) -> CLuaTestEntityAssertions&;
     auto hasNationRank(uint8 expectedRank) -> CLuaTestEntityAssertions&;
     auto hasKI(KeyItem keyItemId) -> CLuaTestEntityAssertions&;
     auto hasMission(MissionLog logId, uint16 expectedMission) -> CLuaTestEntityAssertions&;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Ensures correct animation when getting mounted during a cutscene

## Steps to test these changes

check server status is still 4 during a CS, 0 after if you're not mounting a chocobo, and 5 if you are
mount a chocobo in the field using a chocobo npc
