### PR TITLE
[lua] In a Stew Req Lowered and Kuoh Rhel default action move

### DIFF
--- a/scripts/quests/windurst/In_a_Stew.lua
+++ b/scripts/quests/windurst/In_a_Stew.lua
@@ -21,7 +21,7 @@ quest.sections =
             return vars.Prog == 0 and
             vars.Wait < NextConquestTally() and
             player:hasCompletedQuest(xi.questLog.WINDURST, xi.quest.id.windurst.CHOCOBILIOUS) and
-            player:getFameLevel(xi.fameArea.WINDURST) >= 3 and
+            player:getFameLevel(xi.fameArea.WINDURST) >= 2 and
             not xi.quest.getMustZone(player, xi.questLog.WINDURST, xi.quest.id.windurst.CHOCOBILIOUS)
         end,
 
@@ -146,8 +146,6 @@ quest.sections =
                 onTrigger = function(player, npc)
                     if quest:getMustZone(player) then
                         return quest:event(240)
-                    else
-                        return quest:event(222):replaceDefault()
                     end
                 end,
             },

--- a/scripts/zones/Windurst_Woods/DefaultActions.lua
+++ b/scripts/zones/Windurst_Woods/DefaultActions.lua
@@ -33,6 +33,7 @@ return {
     ['Ki_Volep']           = { event = 260 },
     ['Kohpe_Takhabio']     = { event = 423 },
     ['Kototo']             = { event = 410 },
+    ['Kuoh_Rhel']          = { event = 222 },
     ['Kuu_Lohro']          = { event = 430 },
     ['Mahoh_Mahborogho']   = { event = 257 },
     ['Matata']             = { event = 223 },


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Lowers the fame required to start In a Stew from 3 to 2.
Moves Kuoh's defact action out of the quest IF.

## Steps to test these changes

1. Set Windurst fame to 1 talk to Kuoh Rhel.
2. Set Windurst fame to 2. Start quest.

## Capture
(Retail starts new players at Fame 2 now)
Captured on a fresh character
https://drive.google.com/drive/folders/1RYy1dWx1ZS9Btn-d6g_Y90bDdpT2eWae?usp=sharing