### PR TITLE
Ranged Attack should miss past 25

### DIFF
--- a/src/map/ai/states/range_state.cpp
+++ b/src/map/ai/states/range_state.cpp
@@ -168,6 +168,11 @@ bool CRangeState::Update(timer::time_point tick)
         {
             m_errorMsg.reset();
 
+            if (distance(m_PEntity->loc.p, PTarget->loc.p) > 25)
+            {
+                m_isOutOfRange = true;
+            }
+
             m_PEntity->OnRangedAttack(*this, action);
             m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<CActionPacket>(action));
             m_PEntity->PAI->EventHandler.triggerListener("RANGE_STATE_EXIT", m_PEntity, PTarget, &action);

--- a/src/map/ai/states/range_state.h
+++ b/src/map/ai/states/range_state.h
@@ -35,6 +35,10 @@ public:
     {
         return m_rapidShot;
     }
+    bool IsOutOfRange()
+    {
+        return m_isOutOfRange;
+    }
 
 protected:
     virtual bool CanChangeState() override;
@@ -58,6 +62,7 @@ private:
     const timer::duration m_freePhaseTime     = 1100ms; // Phase 3: The cooldown after a ranged attack is executed. (time after being able to move befer you stop getting "you must wait longer" when attempting to Range Attack again)
     bool                  m_rapidShot{ false };
     position_t            m_startPos;
+    bool                  m_isOutOfRange{ false }; // True if target moved out of range during aim time
 };
 
 #endif

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1130,7 +1130,7 @@ void CCharEntity::PostTick()
         }
 
         sendServerStatus_ = false;
-        updatemask = 0;
+        updatemask        = 0;
     }
 }
 
@@ -2101,7 +2101,7 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
     for (uint8 i = 1; i <= hitCount; ++i)
     {
         // TODO: add Barrage mod racc bonus
-        if (xirand::GetRandomNumber(100) < battleutils::GetRangedHitRate(this, PTarget, isBarrage, 0)) // hit!
+        if (xirand::GetRandomNumber(100) < battleutils::GetRangedHitRate(this, PTarget, isBarrage, 0) && !state.IsOutOfRange()) // hit!
         {
             // absorbed by shadow
             if (battleutils::IsAbsorbByShadow(PTarget, this))
@@ -2145,7 +2145,7 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
             damage                  = 0;
             actionTarget.reaction   = REACTION::EVADE;
             actionTarget.speceffect = SPECEFFECT::NONE;
-            actionTarget.messageID  = 354;
+            actionTarget.messageID  = MSGBASIC_RANGED_ATTACK_MISS;
             hitCount                = i; // end barrage, shot missed
         }
 
@@ -3253,8 +3253,8 @@ void CCharEntity::tryStartNextEvent()
 
     if (eventQueue.empty())
     {
-        updatemask |= UPDATE_POS; // TODO: decouple from this. We want the 250ms post-tick processing.
-        animation = ANIMATION_NONE; // sendServerStatus_ is somewhat like an update mask on its own
+        updatemask |= UPDATE_POS;           // TODO: decouple from this. We want the 250ms post-tick processing.
+        animation         = ANIMATION_NONE; // sendServerStatus_ is somewhat like an update mask on its own
         sendServerStatus_ = true;
         return;
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR will force player ranged attacks to miss if the target has moved past 25 yalms, which matches retail behavior.

## Steps to test these changes

- Start a ranged attack at `24.9` distance
- `!exec target:setMobMod(xi.mobMod.ROAM_COOL, 1)` and hope that it moves away from you past `25.0`
- Verify that if the target moves past `25.0` the ranged attack misses

## Testing Video (Post code review remediation)

https://github.com/user-attachments/assets/d056b58b-c08c-4222-8322-22950affbfa5


