### PR TITLE
[lua] Fixes duplicate gil text and wrong fame area

### DIFF
--- a/scripts/quests/windurst/Teachers_Pet.lua
+++ b/scripts/quests/windurst/Teachers_Pet.lua
@@ -11,7 +11,6 @@ quest.reward =
 {
     fame     = 8,
     fameArea = xi.fameArea.WINDURST,
-    gil      = 250,
 }
 
 quest.sections =
@@ -73,9 +72,12 @@ quest.sections =
             {
                 [440] = function(player, csid, option, npc)
                     player:confirmTrade()
+                    player:addGil(250) -- "Obtained X gil." Text is baked into the CS, so gil needs to be given outside of the quest rewards.
 
+                    -- From previous implementation, award 75 fame (67 + 8) on first completion,
+                    -- and 8 fame for any subsequent trade.
                     if player:getQuestStatus(quest.areaId, quest.questId) == xi.questStatus.QUEST_ACCEPTED then
-                        player:addFame(xi.fameArea.BASTOK, 67)
+                        player:addFame(xi.fameArea.WINDURST, 67)
                     end
 
                     if quest:complete(player) then


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Removed the gil from the quest reward. This is one of the quests that has the gil rewarded text baked into the cs.
Fixes the wrong fame area being awarded.

## Steps to test these changes

Complete the quest.

Current dialogue:
<img width="780" height="363" alt="508005048-ce6115fe-650a-451a-bfc1-c774492002ea" src="https://github.com/user-attachments/assets/da660a8c-83c1-40d2-bc04-3ba9977660f3" />
