### PR TITLE
[lua] Fix Transport Event in Selbina

### DIFF
--- a/scripts/zones/Selbina/Zone.lua
+++ b/scripts/zones/Selbina/Zone.lua
@@ -58,7 +58,7 @@ end
 
 zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
     -- TODO don't double fire transport events (a ship "arrives" from normal and pirates zones at the same time and triggers a transport event)
-    if not player:isInEvent() then
+    if player:isInEvent() then
         return
     end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Fixes a logical error in the transport event for Selbina -> Mhaura boat.  Previously was returning early if the player was NOT in an event, but this is backwards - We only want to return early if the player already is in an event since the pirate boat and the main boat triggers fire at the same time.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - `!zone Selbina`
2 - Buy a boat ticket
3 - Wait for the boat
4 - Board boat and wait some more
5 - Get the cutscene when the boat leaves
Result: Players are now able to leave Mhaura for Selbina via the boat.