### PR TITLE
[cpp] Fix Mighty Strikes affecting Ranged Attacks

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2999,8 +2999,10 @@ namespace battleutils
             critHitRate -= PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_YONIN)->GetPower();
         }
 
+        // Check for Mighty Strikes since Ranged Attacks do not get the crit bonus
+        critHitRate += PAttacker->getMod(Mod::CRITHITRATE) - (PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_MIGHTY_STRIKES) ? 100 : 0);
+
         critHitRate += GetAGICritBonus(PAttacker, PDefender);
-        critHitRate += PAttacker->getMod(Mod::CRITHITRATE);
         critHitRate -= PDefender->getMod(Mod::CRITICAL_HIT_EVASION); // Similar to merits. However, it can be possitive or negative. When mod is negative, it raises crit-hit-rate.
         critHitRate = std::clamp(critHitRate, 0, 100);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
- Fixes GetRangedCritHitRate() to adjust the crit rate based on if the player has Mighty Strikes since it does not affect ranged attacks.  Since the effect grants +100 CRITRATE, we check for the effect and deduct that amount from the mod before its rolled against.

The mod value can go over 100 on the player, but are then clamped between 0, 100 after calculations making -100 safe.

Mighty Strikes only affects Melee Attacks / Weaponskills / Jumps
https://www.bg-wiki.com/ffxi/Mighty_Strikes
<img width="461" height="134" alt="{C4787C04-A042-46AE-AF1B-E4970F396780}" src="https://github.com/user-attachments/assets/b053f54f-f5b5-4273-a076-319f9e2fb01e" />


## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - `!changejob war 75`
2 - `!additem jupiters_staff`
3 - `!additem crossbow`
4 - `!additem crossbow_bolt 99`
5 - `!setmod racc 1000`
6 - `!fafnir` to give yourself a good test target
7 - `!getmod crithitrate` to check your mod value before (+15)
8 - Use Mighty Strikes
9 - `!getmod crithitrate` to check your mod value after (+115)
10 - Shoot the dragon/mob

Result: Don't get guaranteed crits with Mighty Strikes