### PR TITLE
[cpp] Fix Physical <Type>_SDT Calculations

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2154,16 +2154,16 @@ namespace battleutils
                 switch (damageType)
                 {
                     case DAMAGE_TYPE::PIERCING:
-                        damage = damage * (1 + PDefender->getMod(Mod::PIERCE_SDT) / 10000);
+                        damage = damage * (1 + PDefender->getMod(Mod::PIERCE_SDT) / 10000.0f);
                         break;
                     case DAMAGE_TYPE::SLASHING:
-                        damage = damage * (1 + PDefender->getMod(Mod::SLASH_SDT) / 10000);
+                        damage = damage * (1 + PDefender->getMod(Mod::SLASH_SDT) / 10000.0f);
                         break;
                     case DAMAGE_TYPE::IMPACT:
-                        damage = damage * (1 + PDefender->getMod(Mod::IMPACT_SDT) / 10000);
+                        damage = damage * (1 + PDefender->getMod(Mod::IMPACT_SDT) / 10000.0f);
                         break;
                     case DAMAGE_TYPE::HTH:
-                        damage = damage * (1 + PDefender->getMod(Mod::HTH_SDT) / 10000);
+                        damage = damage * (1 + PDefender->getMod(Mod::HTH_SDT) / 10000.0f);
                         break;
                     default:
                         break;
@@ -2171,7 +2171,7 @@ namespace battleutils
             }
             else
             {
-                damage = damage * (1 + PDefender->getMod(Mod::HTH_SDT) / 10000);
+                damage = damage * (1 + PDefender->getMod(Mod::HTH_SDT) / 10000.0f);
             }
 
             if (isBlocked)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
- Fixes an error in the logic of Physical SDT Calculations that resulted in none of them working.
- Since getMod() returns an int16 and 10000 is an int literal, the resulting operation is implicit integer division which is forced to round towards 0
- This meant a X_SDT of -5000 (-50%) on a mod resulted in -.5 which was then rounded to 0
  - `-5000 / 10000 = -0.5 > Rounded towards 0 > Result: 0`
- Likewise a X_SDT of 1250 (+12.5%) would result in a .125 which was also rounded to 0.
  - `1250 / 10000 = 0.125 > Rounded towards 0 > Result: 0`
- The net result is that unless something hit a whole value (IE: _SDT = +/- 10000/20000) the mod would have no effect on the actual damage the mob takes.

vs Skeleton (-50%) Pierce - Base Damage before SDT Adjustment
<img width="690" height="81" alt="image" src="https://github.com/user-attachments/assets/0ce4392e-6b7a-46d2-8427-41fee5a20f92" />

After SDT Adjustment
<img width="124" height="32" alt="image" src="https://github.com/user-attachments/assets/aaffdd17-8670-434a-9c53-53d0b0307641" />

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - Spawn or find an Undead Mob (-50% Pierce)
2 - Equip a Piercing Weapon
3 - Shoot the mob and note the damage
4 - Find a normal mob around the same level with (+0 Pierce)
5 - Shoot the mob and note the damage
6 - Find a mob that is weak to pierce [Colibri] (+12.5% Pierce)
7 - Shoot the mob and note the damage

Result: Physical SDT Types now affect incoming player damage.