### PR TITLE
[cpp] Fix SMN Mob Pet Mods

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1477,6 +1477,59 @@ void CBattleEntity::restoreModifiers()
     m_modStat = m_modStatSave;
 }
 
+void CBattleEntity::savePetModifiers()
+{
+    // these mods are set dynamically based on pet type
+    const std::vector<Mod> petModsToUpdate = {
+        // Physical SDT
+        Mod::SLASH_SDT,
+        Mod::PIERCE_SDT,
+        Mod::HTH_SDT,
+        Mod::IMPACT_SDT,
+        // Uncapped Magic
+        Mod::UDMGMAGIC,
+        // Element SDT
+        Mod::FIRE_SDT,
+        Mod::ICE_SDT,
+        Mod::WIND_SDT,
+        Mod::EARTH_SDT,
+        Mod::THUNDER_SDT,
+        Mod::WATER_SDT,
+        Mod::LIGHT_SDT,
+        Mod::DARK_SDT,
+        // Element RES_RANK
+        Mod::FIRE_RES_RANK,
+        Mod::ICE_RES_RANK,
+        Mod::WIND_RES_RANK,
+        Mod::EARTH_RES_RANK,
+        Mod::THUNDER_RES_RANK,
+        Mod::WATER_RES_RANK,
+        Mod::LIGHT_RES_RANK,
+        Mod::DARK_RES_RANK,
+        // Status RES_RANK
+        Mod::PARALYZE_RES_RANK,
+        Mod::BIND_RES_RANK,
+        Mod::SILENCE_RES_RANK,
+        Mod::SLOW_RES_RANK,
+        Mod::POISON_RES_RANK,
+        Mod::LIGHT_SLEEP_RES_RANK,
+        Mod::DARK_SLEEP_RES_RANK,
+        Mod::BLIND_RES_RANK,
+    };
+
+    // update the template mods so the dynamic mods are not overwritten
+    for (auto mod : petModsToUpdate)
+    {
+        // Only update the saved map if it exists and is different
+        int16 currentVal = m_modStat[mod];
+        auto  it         = m_modStatSave.find(mod);
+        if (it == m_modStatSave.end() || it->second != currentVal)
+        {
+            m_modStatSave[mod] = currentVal;
+        }
+    }
+}
+
 void CBattleEntity::delModifiers(std::vector<CModifier>* modList)
 {
     TracyZoneScoped;

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -591,6 +591,7 @@ public:
     void delEquipModifiers(std::vector<CModifier>* modList, uint8 itemLevel, uint8 slotid);
     void saveModifiers();    // save current state of modifiers
     void restoreModifiers(); // restore to saved state
+    void savePetModifiers(); // saves dynamic pet modifiers
 
     void addPetModifier(Mod type, PetModType, int16 amount);
     void setPetModifier(Mod type, PetModType, int16 amount);

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1303,6 +1303,8 @@ namespace petutils
             PPet->setModifier(Mod::LIGHT_SLEEP_RES_RANK, petData->light_sleep_res_rank);
             PPet->setModifier(Mod::DARK_SLEEP_RES_RANK, petData->dark_sleep_res_rank);
             PPet->setModifier(Mod::BLIND_RES_RANK, petData->blind_res_rank);
+
+            PPet->savePetModifiers();
         }
     }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
- Fixes SMN Mob Pet Mods during summoning such that the default values from the DB are not overwritting the dynamic mods that are set when deciding on pet type or element.

### Detailed Breakdown
Mobs with dynamic pet types (Elemental Fire vs Elemental Wind)
If the values for the base mob ID/group/pool/family in the DB are set to that of Wind, then even if the mob summoned a fire elemental, it would have the resistance modifiers of a Wind Elemental (meaning it would have Res Rank of 11 for Wind/Earth and -3 for Ice).

The problem exists in the function call stack and how the mods/stats are initialized during a new pet summon.
```
[lua] xi.pet.spawnPet(caster, xi.petId.FIRE_SPIRT, spell)
      ▼▼▼
[cpp] CBaseEntity::spawnPet()
      ▼▼▼
[cpp] petutils::SpawnMobPet()
SpawnMobPet properly sets the mods on the pet/mob entity at this point
      ▼▼▼
[cpp] CMobEntity::Spawn()
      ▼▼▼
[cpp] mobutils::CalculateMobStats()
      ▼▼▼
[cpp] PMob->restoreModifiers()   <--- ISSUE ARISES HERE
unique/custom mods set in SpawnMobPet get overwritten
```
`restoreModifiers()` is called during `CalculateMobStats()` which takes all the data from the `PMob->m_mobStatsSave` that is generated at the server load time with whatever is linked up from the ID/Group/Pool/Family values pulled from the DB and drops them on top of `PMob->m_mobStats` which is the current working set of stats for the mob - Effectively undoing what happened in `SpawnMobPet()`

This fix adds a new function - `CBattleEntity::savePetModifiers()` that is called during the `SpawnMobPet()` stage of the calls.  It modifies the template for that instance of the pet entity with the proper values that are applied in `SpawnMobPet` so that when `restoreModifiers()` is called, those updated values are applied and not the default DB values.  This is called to update that template when a new mob pet is summoned such that if there are dynamic types (such as Elemental Pets, Avatar Pets, etc), the proper new mods are applied to the pet.

Only the values that differ from the DB values stored in `m_mobStatsSave` are updated so that we don't erase values that were not updated during `SpawnMobPet()`.  This avoids modifying the `Spawn()` function logic since this is used by every mob entity in the game, and when a mob respawns, that `restoreModifiers()` call ensures that no previous modifiers are carried over.

Yagudo Mob with Earth Elemental - Has Proper `<ELEMENT>_RES_MOD`
<img width="327" height="265" alt="{456CE8BC-B5A4-48F4-9EEC-EEC3BD76C71E}" src="https://github.com/user-attachments/assets/bc73d84e-c69e-4312-aca6-27f5fd8dc836" /><img width="320" height="476" alt="{7619585F-F1B1-4F02-A5CC-71C469BAA538}" src="https://github.com/user-attachments/assets/fe4a5896-7d28-42d6-9fcc-a315be629795" />

Same mob with Fire Elemental pet from resummon - Has Proper Mods:
<img width="349" height="283" alt="{205EB6DF-031C-4743-BE97-B99E5CF5A0CD}" src="https://github.com/user-attachments/assets/36a7c7bd-21d2-4f21-9ca9-1c87db023cf6" /><img width="325" height="442" alt="{8FB093A9-5182-4F07-A583-3B87A1C0B266}" src="https://github.com/user-attachments/assets/93e55394-9dc0-49b5-9bab-41ba8f0e90a0" />

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - Find any SMN Mob in the game such as Yagudo in Giddeus
2 - `!getmod <ELEMENT>_RES_RANK` for the element that avatar is strong/weak to
Earth would be Earth/Thunder RES_RANK +11 / Wind RES_RANK -3
Fire would be Fire/Ice RES_RANK + 11 / Water RES_RANK -3
etc..
3 - Use `!hp 0` on the pet and wait for a new pet to be summoned
4 - Repeat step 2 for that new elements strength and weaknesses

Result: SMN Mob Pets now properly persist their unique mods that are applied during `SpawnMobPet()`
