### PR TITLE
[lua] Support melee hitrate for offhand/kick

### DIFF
--- a/scripts/enum/attack_animation.lua
+++ b/scripts/enum/attack_animation.lua
@@ -1,0 +1,14 @@
+-----------------------------------
+-- Attack Animation
+-----------------------------------
+xi = xi or {}
+
+---@enum xi.attackAnimation
+xi.attackAnimation =
+{
+    RIGHT_ATTACK = 0,
+    LEFT_ATTACK  = 1,
+    RIGHT_KICK   = 2,
+    LEFT_KICK    = 3,
+    THROW        = 4
+}

--- a/scripts/globals/automatonweaponskills.lua
+++ b/scripts/globals/automatonweaponskills.lua
@@ -48,8 +48,8 @@ xi.autows.doAutoPhysicalWeaponskill = function(attacker, target, wsID, tp, prima
     calcParams.bonusTP = wsParams.bonusTP or 0
     calcParams.bonusfTP = flameHolderFTP or 0
     calcParams.bonusAcc = 0 + attacker:getMod(xi.mod.WSACC)
-    calcParams.firstHitRate = xi.weaponskills.getHitRate(attacker, target, calcParams.bonusAcc + 100) -- TODO: do automatons get first hit acc bonus?
-    calcParams.hitRate      = xi.weaponskills.getHitRate(attacker, target, calcParams.bonusAcc)
+    calcParams.firstHitRate = xi.combat.physicalHitRate.getPhysicalHitRate(attacker, target, calcParams.bonusAcc + 100, xi.attackAnimation.RIGHT_ATTACK, true) -- TODO: do automatons get first hit acc bonus?
+    calcParams.hitRate      = xi.combat.physicalHitRate.getPhysicalHitRate(attacker, target, calcParams.bonusAcc, xi.attackAnimation.RIGHT_ATTACK, true)
     calcParams.skillType = attack.weaponType
     calcParams.tpUsed = tp
 

--- a/scripts/globals/combat/counter.lua
+++ b/scripts/globals/combat/counter.lua
@@ -32,7 +32,7 @@ xi.combat.counter.checkSeiganCounter = function(attacker, defender)
 
     -- Calculate counter chance.
     local baseCounterRate = 25 + defender:getMod(xi.mod.THIRD_EYE_COUNTER_RATE)
-    local hitRateFactor   = xi.combat.physicalHitRate.getPhysicalHitRate(defender, attacker, 0, 0, false)
+    local hitRateFactor   = xi.combat.physicalHitRate.getPhysicalHitRate(defender, attacker, 0, xi.attackAnimation.RIGHT_ATTACK, false)
 
     if math.random(1, 100) > baseCounterRate * hitRateFactor then
         return false

--- a/scripts/globals/combat/physical_hit_rate.lua
+++ b/scripts/globals/combat/physical_hit_rate.lua
@@ -43,6 +43,12 @@ xi.combat.physicalHitRate.checkAnticipated = function(attacker, defender)
     return true
 end
 
+---@param attacker CBaseEntity
+---@param target CBaseEntity
+---@param bonus number
+---@param slot xi.attackAnimation
+---@param isWeaponskill boolean
+---@return number
 xi.combat.physicalHitRate.getPhysicalHitRate = function(attacker, target, bonus, slot, isWeaponskill)
     local flourishEffect = attacker:getStatusEffect(xi.effect.BUILDING_FLOURISH)
 
@@ -54,9 +60,8 @@ xi.combat.physicalHitRate.getPhysicalHitRate = function(attacker, target, bonus,
         attacker:addMod(xi.mod.ACC, 40 + flourishEffect:getSubPower() * 2)
     end
 
-    -- TODO: check mainhand vs offhand
     -- TODO: realtime flash penalty
-    local acc = attacker:getACC()
+    local acc = attacker:getACC(slot) -- TODO: clamp slot for 0, 1, 2 (mainhand, offhand, kick)
     local eva = target:getEVA()
 
     if

--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -246,13 +246,13 @@ xi.job_utils.dancer.useStepAbility = function(player, target, ability, action, s
     local stepDurationGift = player:getJobPointLevel(xi.jp.STEP_DURATION)
     local debuffStacks     = 1
     local debuffDuration   = 60 + stepDurationGift
-
+    local hitRate          = xi.combat.physicalHitRate.getPhysicalHitRate(player, target, 10 + player:getMod(xi.mod.STEP_ACCURACY), xi.attackAnimation.RIGHT_ATTACK, false)
     -- Only remove TP if the player doesn't have Trance.
     if not player:hasStatusEffect(xi.effect.TRANCE) then
         player:delTP(100 + player:getMod(xi.mod.STEP_TP_CONSUMED))
     end
 
-    if math.random() <= xi.weaponskills.getHitRate(player, target, 10 + player:getMod(xi.mod.STEP_ACCURACY)) then
+    if math.random() <= hitRate then
         local maxSteps         = player:getMainJob() == xi.job.DNC and 10 or 5
         local debuffEffect     = target:getStatusEffect(stepEffect)
         local origDebuffStacks = 0
@@ -399,11 +399,11 @@ end
 -- TODO: This ability needs verification
 xi.job_utils.dancer.useViolentFlourishAbility = function(player, target, ability, action)
     local numMoves = player:getStatusEffect(xi.effect.FINISHING_MOVE_1):getPower()
-
+    local hitRate  = xi.combat.physicalHitRate.getPhysicalHitRate(player, target, 100, xi.attackAnimation.RIGHT_ATTACK, false)
     setFinishingMoves(player, numMoves - 1)
 
     if
-        math.random() <= xi.weaponskills.getHitRate(player, target, 100) or
+        math.random() <= hitRate or
         (player:hasStatusEffect(xi.effect.SNEAK_ATTACK) and player:isBehind(target))
     then
         local hitType      = 3

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -576,6 +576,10 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
         calcParams.attackInfo.weaponType = offhandSkill
     end
 
+    -- Recalculate hitRate with offhand acc
+    -- No more damage is being processed with mainhand acc, so this is ok
+    calcParams.hitRate = xi.weaponskills.getHitRate(attacker, target, calcParams.bonusAcc, xi.attackAnimation.LEFT_ATTACK)
+
     -- Do the extra hit for our offhand if applicable
     if calcParams.extraOffhandHit and hitsDone < 8 and finaldmg < targetHp then
         calcParams.hitsLanded = 0
@@ -719,8 +723,8 @@ xi.weaponskills.doPhysicalWeaponskill = function(attacker, target, wsID, wsParam
         calcParams.bonusAcc = calcParams.bonusAcc - accLost
     end
 
-    calcParams.firstHitRate = xi.weaponskills.getHitRate(attacker, target, calcParams.bonusAcc + 100)
-    calcParams.hitRate      = xi.weaponskills.getHitRate(attacker, target, calcParams.bonusAcc)
+    calcParams.firstHitRate = xi.weaponskills.getHitRate(attacker, target, calcParams.bonusAcc + 100, xi.attackAnimation.RIGHT_ATTACK)
+    calcParams.hitRate      = xi.weaponskills.getHitRate(attacker, target, calcParams.bonusAcc, xi.attackAnimation.RIGHT_ATTACK)
     calcParams.skillType    = attack.weaponType
 
     -- Send our wsParams off to calculate our raw WS damage, hits landed, and shadows absorbed
@@ -1046,9 +1050,13 @@ xi.weaponskills.getMeleeDmg = function(attacker, weaponType, kick)
     return { mainhandDamage, offhandDamage }
 end
 
-xi.weaponskills.getHitRate = function(attacker, target, bonus)
-    -- TODO: need input for slot
-    return xi.combat.physicalHitRate.getPhysicalHitRate(attacker, target, bonus, 0, false)
+---@param attacker CBaseEntity
+---@param target CBaseEntity
+---@param bonus number
+---@param slot xi.attackAnimation
+---@return number
+xi.weaponskills.getHitRate = function(attacker, target, bonus, slot)
+    return xi.combat.physicalHitRate.getPhysicalHitRate(attacker, target, bonus, slot, true)
 end
 
 -- TODO: Use a common function with optional multiplier on return, or multiply outside of this.

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -3188,8 +3188,9 @@ function CBaseEntity:getStat(statId, optSlot)
 end
 
 ---@nodiscard
+---@param maybeAttackNumber integer?
 ---@return integer
-function CBaseEntity:getACC()
+function CBaseEntity:getACC(maybeAttackNumber)
 end
 
 ---@nodiscard

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -14772,7 +14772,7 @@ uint16 CLuaBaseEntity::getStat(uint16 statId, sol::variadic_args va)
  *  Notes   : Uses the ACC member of CBattleEntity for calculation
  ************************************************************************/
 
-uint16 CLuaBaseEntity::getACC()
+uint16 CLuaBaseEntity::getACC(sol::object const& maybeAttackNumber)
 {
     if (m_PBaseEntity->objtype == TYPE_NPC)
     {
@@ -14780,8 +14780,10 @@ uint16 CLuaBaseEntity::getACC()
         return 0;
     }
 
+    uint8_t attackNumber = maybeAttackNumber.is<uint8_t>() ? maybeAttackNumber.as<uint8_t>() : 0;
+
     auto* PEntity = static_cast<CBattleEntity*>(m_PBaseEntity);
-    return PEntity->ACC(0, 0); // (attackNumber = 0, offsetAcc = 0)
+    return PEntity->ACC(attackNumber, 0); // (attackNumber = 0, offsetAcc = 0)
 }
 
 /************************************************************************

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -731,7 +731,7 @@ public:
 
     // Damage Calculation
     uint16 getStat(uint16 statId, sol::variadic_args va); // STR,DEX,VIT,AGI,INT,MND,CHR,ATT,DEF
-    uint16 getACC();
+    uint16 getACC(sol::object const& maybeAttackNumber);
     uint16 getEVA();
     int    getRACC();
     uint16 getRATT();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Hooks up the appropriate functionality to get hitrate for offhand correctly

## Steps to test these changes

Has to be a bit surgical,
add a print into `local function getSingleHitDamage(attacker, target, dmg, ftp, wsParams, calcParams)` to print `calcParams.hitRate`

otherwise you can just use
```!exec print(xi.weaponskills.getHitRate(player, target, 0, 0, false))```
 and 
 ```!exec print(xi.weaponskills.getHitRate(player, target, 0, 1, false))```
 when dual wielding weapons with different skills and you are uncapped vs the target
such as:

<img width="390" height="64" alt="image" src="https://github.com/user-attachments/assets/214cae10-1002-42ec-96ae-5f93525fa487" />

abs(-18)/2 = 9% lower hit rate
[11/01/25 19:55:27:065][map][lua] 0.71 (lua_print:222)
[11/01/25 19:55:30:339][map][lua] 0.8 (lua_print:222)

spot check dancer/pup stuff just by manually reducing/adding eva (or adding prints, whatever works)

I'll end up writing some more tests for combat after I write some more ports out to lua and improve things such as accuracy caps
