### PR TITLE
[lua] Adds Hidden Dialogue CS 106 to Tenshodo Quest

### DIFF
--- a/scripts/quests/jeuno/Tenshodo_Membership.lua
+++ b/scripts/quests/jeuno/Tenshodo_Membership.lua
@@ -36,6 +36,8 @@ quest.sections =
                 onTrigger = function(player, npc)
                     if player:hasKeyItem(xi.keyItem.TENSHODO_APPLICATION_FORM) then
                         return quest:progressEvent(107)
+                    else
+                        return quest:event(106)
                     end
                 end,
             },


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a bug introduced when the default action was updated for Ghebi Damomohe in which the tenshodo membership quest dialogue was no longer possible.
https://github.com/LandSandBoat/server/pull/8550

## Steps to test these changes

Set Jeuno fame to 3 or more.
Talk to Ghebi Damomohe.
