### PR TITLE
[lua] Correct edge case despawn logic for Haty/Vran

### DIFF
--- a/scripts/zones/Konschtat_Highlands/mobs/Bendigeit_Vran.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Bendigeit_Vran.lua
@@ -13,7 +13,11 @@ end
 
 entity.onMobRoam = function(mob)
     local hour = VanadielHour()
-    if hour >= 5 and hour < 17 then
+    local phase = VanadielMoonPhase()
+    if
+        (hour >= 5 and hour < 17) or
+        phase > 10
+    then
         DespawnMob(mob:getID())
     end
 end

--- a/scripts/zones/Konschtat_Highlands/mobs/Haty.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Haty.lua
@@ -9,7 +9,11 @@ local entity = {}
 
 entity.onMobRoam = function(mob)
     local hour = VanadielHour()
-    if hour >= 5 and hour < 17 then
+    local phase = VanadielMoonPhase()
+    if
+        (hour >= 5 and hour < 17) or
+        phase < 90
+    then
         DespawnMob(mob:getID())
     end
 end


### PR DESCRIPTION
Haty/Vran can be up on server launch outside of the correct moon phase. They should forcibly despawn if the phase is incorrect.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Haty / Bendigeit Vran can pop on the first night after server spinup but will not depop. This creates an edge case where both can be up on a night that does not meet the requirements to spawn either on server launch. 

## Steps to test these changes

!gotoid 17220000 and/or !gotoid 17220001. 
They should no longer both be valid on the first night after server spin up. At most the relevant one to the current moon phase will remain spawned. 