### PR TITLE
[lua] Fix xi.combat.tp dAGI

### DIFF
--- a/scripts/globals/combat/tp.lua
+++ b/scripts/globals/combat/tp.lua
@@ -139,7 +139,7 @@ xi.combat.tp.calculateTPGainOnPhysicalDamage = function(totalDamage, delay, acto
     if totalDamage > 0 and target and actor then
         local attackOutput       = xi.combat.tp.getModifiedDelayAndCanZanshin(actor, delay)
         local baseTPGain         = xi.combat.tp.calculateTPReturn(target, attackOutput.modifiedDelay)
-        local dAGI               = actor:getMod(xi.mod.AGI) - target:getMod(xi.mod.AGI)
+        local dAGI               = actor:getStat(xi.mod.AGI) - target:getStat(xi.mod.AGI)
         local inhibitTPModifier  = (100 - target:getMod(xi.mod.INHIBIT_TP)) / 100                    -- no known cap: https://www.bg-wiki.com/ffxi/Monster_TP_gain#Inhibit_TP
         local dAGIModifier       = utils.clamp(200 - (dAGI + 30) / 200, 1.0, 0.5)                    -- 50% reduction at +70 dAGI: https://www.bg-wiki.com/ffxi/Monster_TP_gain
         local subtleBlowMerits   = actor:getMerit(xi.merit.SUBTLE_BLOW_EFFECT)
@@ -172,7 +172,7 @@ end
 xi.combat.tp.calculateTPGainOnMagicalDamage = function(totalDamage, actor, target)
     -- TODO: does dAGI penalty work against/for Trusts/Pets? Nothing is documented for this. Currently assuming mob only.
     if totalDamage > 0 and target and actor then
-        local dAGI               = actor:getMod(xi.mod.AGI) - target:getMod(xi.mod.AGI)
+        local dAGI               = actor:getStat(xi.mod.AGI) - target:getStat(xi.mod.AGI)
         local inhibitTPModifier  = (100 - target:getMod(xi.mod.INHIBIT_TP)) / 100                    -- no known cap: https://www.bg-wiki.com/ffxi/Monster_TP_gain#Inhibit_TP
         local dAGIModifier       = utils.clamp(200 - (dAGI + 30) / 200, 1.0, 0.5)                    -- 50% reduction at +70 dAGI: https://www.bg-wiki.com/ffxi/Monster_TP_gain
         local subtleBlowMerits   = actor:getMerit(xi.merit.SUBTLE_BLOW_EFFECT)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

When comparing dAGI, the calculation was using getMod() which would only return the AGI difference from mod/buffs instead of total AGI difference from any source.

Changing it to getStat() will now include buffs/gear mods as well as base stats.

## Steps to test these changes

Go damage stuff using methods that call this function. See that AGI now makes a more significant impact to TP returns.
