### PR TITLE
[core] Fix offhand equipment resetting TP -- Pending Caps --

### DIFF
--- a/scripts/tests/equipment/equipment_weapons.lua
+++ b/scripts/tests/equipment/equipment_weapons.lua
@@ -1,0 +1,49 @@
+-----------------------------------
+-- Equipment Weapon TP Reset Tests
+-- Tests that TP is reset when equipping/unequipping weapons from various slots
+-----------------------------------
+
+describe('Equipment Weapons - Verify TP reset on weapon slot changes', function()
+    ---@type CClientEntityPair
+    local player
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer({
+            level = 50,
+            job = xi.job.WAR,
+            zone = xi.zone.WEST_RONFAURE
+        })
+    end)
+
+    it('should reset TP when unequipping main hand weapon', function()
+        player:addItem(xi.item.BRONZE_DAGGER)
+        player:equipItem(xi.item.BRONZE_DAGGER, nil, xi.slot.MAIN)
+        player:setTP(2500)
+
+        player:unequipItem(xi.slot.MAIN)
+
+        assert(player:getTP() == 0, 'TP should reset to 0 when unequipping main hand weapon')
+    end)
+
+    it('should reset TP when swapping main hand weapon', function()
+        player:addItem(xi.item.BRONZE_DAGGER)
+        player:addItem(xi.item.BRASS_DAGGER)
+        player:equipItem(xi.item.BRONZE_DAGGER, nil, xi.slot.MAIN)
+        player:setTP(1800)
+
+        -- Swap main hand weapon (triggers unequip + equip)
+        player:equipItem(xi.item.BRASS_DAGGER, nil, xi.slot.MAIN)
+
+        assert(player:getTP() == 0, 'TP should reset to 0 when swapping main hand weapon')
+    end)
+
+    it('should reset TP when unequipping ranged weapon', function()
+        player:addItem(xi.item.LONGBOW)
+        player:equipItem(xi.item.LONGBOW, nil, xi.slot.RANGED)
+        player:setTP(2200)
+
+        player:unequipItem(xi.slot.RANGED)
+
+        assert(player:getTP() == 0, 'TP should reset to 0 when unequipping ranged weapon')
+    end)
+end)

--- a/scripts/tests/traits/dual_wield.lua
+++ b/scripts/tests/traits/dual_wield.lua
@@ -1,0 +1,85 @@
+-----------------------------------
+-- Dual Wield Trait tests
+--
+-- These tests verify that TP is reset when appropriate, but
+-- preserved when it should be (i.e. when offhand equip fails due to the lack of the Dual Wield trait)
+-----------------------------------
+
+describe('Dual Wield Trait - TP Reset on equipment change success or failure', function()
+    ---@type CClientEntityPair
+    local player
+
+    before_each(function()
+        -- Spawn NIN5 (before DW unlocks at level 10)
+        player = xi.test.world:spawnPlayer({
+            level = 5,
+            job = xi.job.NIN,
+            zone = xi.zone.WEST_RONFAURE
+        })
+    end)
+
+    it('should preserve TP when offhand equip fails without Dual Wield trait', function()
+        player:addItem(xi.item.BRONZE_DAGGER)
+        player:addItem(xi.item.BRASS_DAGGER)
+        player:equipItem(xi.item.BRONZE_DAGGER, nil, xi.slot.MAIN)
+        player:setTP(1500)
+
+        -- Try to equip offhand weapon without Dual Wield trait
+        -- This should fail validation and NOT change TP
+        player:equipItem(xi.item.BRASS_DAGGER, nil, xi.slot.SUB)
+
+        assert(player:getTP() == 1500, 'TP should be preserved when offhand equip fails without Dual Wield trait')
+    end)
+
+    it('should preserve shield and TP when offhand weapon equip fails without Dual Wield trait', function()
+        player:changeJob(xi.job.WAR)
+        player:setLevel(50)
+
+        player:addItem(xi.item.BRONZE_SWORD)
+        player:addItem(xi.item.BUCKLER)
+        player:addItem(xi.item.LONGSWORD)
+        player:equipItem(xi.item.BRONZE_SWORD, nil, xi.slot.MAIN)
+        player:equipItem(xi.item.BUCKLER, nil, xi.slot.SUB)
+        player:setTP(2000)
+
+        -- Verify shield is equipped before test action
+        local shieldBefore = player:getEquippedItem(xi.slot.SUB)
+        assert(shieldBefore ~= nil, 'Shield should be equipped before weapon equip attempt')
+        assert(shieldBefore:getID() == xi.item.BUCKLER, 'Buckler should be equipped in SUB slot')
+
+        -- Try to equip offhand weapon without Dual Wield trait (WAR can't dual wield)
+        player:equipItem(xi.item.LONGSWORD, nil, xi.slot.SUB)
+
+        local shieldAfter = player:getEquippedItem(xi.slot.SUB)
+        assert(shieldAfter ~= nil, 'Shield should still be equipped after failed weapon equip')
+        assert(shieldAfter:getID() == xi.item.BUCKLER, 'Buckler should remain equipped in SUB slot')
+        assert(player:getTP() == 2000, 'TP should be preserved')
+    end)
+
+    it('should reset TP when dual wield equip succeeds with Dual Wield trait', function()
+        player:setLevel(10)
+        player:addItem(xi.item.BRONZE_DAGGER)
+        player:addItem(xi.item.BRASS_DAGGER)
+        player:equipItem(xi.item.BRONZE_DAGGER, nil, xi.slot.MAIN)
+        player:setTP(1500)
+
+        -- This should succeed and reset TP
+        player:equipItem(xi.item.BRASS_DAGGER, nil, xi.slot.SUB)
+
+        assert(player:getTP() == 0, 'TP should be reset to 0 when offhand weapon equip succeeds with Dual Wield')
+    end)
+
+
+    it('should reset TP when unequipping offhand weapon', function()
+        player:setLevel(10)
+        player:addItem(xi.item.BRONZE_DAGGER)
+        player:addItem(xi.item.BRASS_DAGGER)
+        player:equipItem(xi.item.BRONZE_DAGGER, nil, xi.slot.MAIN)
+        player:equipItem(xi.item.BRASS_DAGGER, nil, xi.slot.SUB)
+        player:setTP(3000)
+
+        player:unequipItem(xi.slot.SUB)
+
+        assert(player:getTP() == 0, 'TP should reset to 0 when unequipping offhand weapon')
+    end)
+end)

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -2276,6 +2276,18 @@ bool EquipArmor(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 conta
         return false;
     }
 
+    // Early validation for SLOT_SUB: prevent unequipping shield if dual wield will fail
+    if (equipSlotID == SLOT_SUB && PItem->isType(ITEM_WEAPON))
+    {
+        const auto* mainWeapon = dynamic_cast<CItemWeapon*>(PChar->getEquip(SLOT_MAIN));
+        const auto* newWeapon  = dynamic_cast<CItemWeapon*>(PItem);
+
+        if (mainWeapon && (!charutils::hasTrait(PChar, TRAIT_DUAL_WIELD) || (newWeapon && newWeapon->getSkillType() == SKILL_NONE)))
+        {
+            return false;
+        }
+    }
+
     if (equipSlotID == SLOT_MAIN)
     {
         if (!(slotID == PItem->getSlotID() && oldItem && (oldItem->isType(ITEM_WEAPON) && PItem->isType(ITEM_WEAPON)) &&
@@ -3113,7 +3125,8 @@ void EquipItem(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 contai
         }
     }
 
-    if (slotID == 0)
+    bool equipSuccess = false;
+    if (slotID == SLOT_MAIN)
     {
         CItemEquipment* PSubItem = PChar->getEquip(SLOT_SUB);
 
@@ -3132,6 +3145,7 @@ void EquipItem(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 contai
         {
             if (!PItem->isSubType(ITEM_LOCKED) && EquipArmor(PChar, slotID, equipSlotID, containerID))
             {
+                equipSuccess = true;
                 if (PItem->getScriptType() & SCRIPT_EQUIP)
                 {
                     luautils::OnItemCheck(PChar, PItem, ITEMCHECK::EQUIP, nullptr);
@@ -3171,7 +3185,12 @@ void EquipItem(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 contai
             }
         }
     }
-    if (equipSlotID == SLOT_MAIN || equipSlotID == SLOT_RANGED || equipSlotID == SLOT_SUB)
+
+    // Reset TP (and remove aftermath etc..) if the equipment change was successful
+    // and any of the relevant slots are changed (main, ranged, sub)
+    // Note that the unequip logic earlier (with slotID == 0) already handled this inside
+    // UnequipItem(), so it's fine to only do this on equipSuccess
+    if (equipSuccess && (equipSlotID == SLOT_MAIN || equipSlotID == SLOT_RANGED || equipSlotID == SLOT_SUB))
     {
         if (!PItem || !PItem->isType(ITEM_EQUIPMENT) ||
             (((CItemWeapon*)PItem)->getSkillType() != SKILL_STRING_INSTRUMENT && ((CItemWeapon*)PItem)->getSkillType() != SKILL_WIND_INSTRUMENT))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* No longer reset tp when attempting to equip an offhand without Dual Wield trait
* No longer unequip a shield if equiped when attempting to equip and offhand without a DW trait
* Add tests to cover the changed cases.

## Steps to test these changes

* Run unit tests
* Launch the game, equip a weapon in the main hand as nin 8.
* Gain TP
* Try to equip a valid weapon in the offhand
* observe tp not resetting.
