### PR TITLE
[LUA] Mob Ranged Shouldn't Interrupt Spellcasting

### DIFF
--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -139,7 +139,11 @@ local function handleSinglePhysicalHit(mob, target, hitdamage, hitslanded, final
             end
         end
 
-        if hitdamage > 0 and not isBlockedWithShieldMastery then
+        if
+            hitdamage > 0 and
+            not isBlockedWithShieldMastery and
+            not params.isRanged
+        then
             target:tryHitInterrupt(mob)
         end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Retail Proof

<img width="607" height="945" alt="image" src="https://github.com/user-attachments/assets/33266648-cf91-431d-a2c5-a7af7d1fc11a" />
<img width="642" height="888" alt="image" src="https://github.com/user-attachments/assets/397c29e2-73f2-4a48-a02e-ca90f88b9f44" />


## What does this pull request do?

This prevents mob ranged attacks (which are treated as mobskills) from interrupting spellcasting, to match retail behavior (screenshots above).

## Steps to test these changes

Cast a long spell while a ranged mob continuously shoots you. Verify you don't get interrupted.