### PR TITLE
[Core][LUA] Refactor Moon Cycle Handling

### DIFF
--- a/scripts/actions/abilities/pets/ecliptic_growl.lua
+++ b/scripts/actions/abilities/pets/ecliptic_growl.lua
@@ -14,21 +14,25 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
 
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    local moon = VanadielMoonPhase()
-    local buffvalue = 1
-    if moon > 90 then
-        buffvalue = 7
-    elseif moon > 75 then
-        buffvalue = 6
-    elseif moon > 60 then
-        buffvalue = 5
-    elseif moon > 40 then
-        buffvalue = 4
-    elseif moon > 25 then
-        buffvalue = 3
-    elseif moon > 10 then
-        buffvalue = 2
-    end
+    local moonCycle = getVanadielMoonCycle()
+
+    local cycleBuffs =
+    {
+        [xi.moonCycle.NEW_MOON]                = 1,
+        [xi.moonCycle.LESSER_WAXING_CRESCENT]  = 2,
+        [xi.moonCycle.GREATER_WAXING_CRESCENT] = 3,
+        [xi.moonCycle.FIRST_QUARTER]           = 4,
+        [xi.moonCycle.LESSER_WAXING_GIBBOUS]   = 5,
+        [xi.moonCycle.GREATER_WAXING_GIBBOUS]  = 6,
+        [xi.moonCycle.FULL_MOON]               = 7,
+        [xi.moonCycle.GREATER_WANING_GIBBOUS]  = 6,
+        [xi.moonCycle.LESSER_WANING_GIBBOUS]   = 5,
+        [xi.moonCycle.THIRD_QUARTER]           = 4,
+        [xi.moonCycle.GREATER_WANING_CRESCENT] = 3,
+        [xi.moonCycle.LESSER_WANING_CRESCENT]  = 2,
+    }
+
+    local buffValue = cycleBuffs[moonCycle]
 
     target:delStatusEffect(xi.effect.STR_BOOST)
     target:delStatusEffect(xi.effect.DEX_BOOST)
@@ -37,13 +41,13 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     target:delStatusEffect(xi.effect.MND_BOOST)
     target:delStatusEffect(xi.effect.CHR_BOOST)
 
-    target:addStatusEffect(xi.effect.STR_BOOST, buffvalue, 0, duration)
-    target:addStatusEffect(xi.effect.DEX_BOOST, buffvalue, 0, duration)
-    target:addStatusEffect(xi.effect.VIT_BOOST, buffvalue, 0, duration)
-    target:addStatusEffect(xi.effect.AGI_BOOST, 8-buffvalue, 0, duration)
-    target:addStatusEffect(xi.effect.INT_BOOST, 8-buffvalue, 0, duration)
-    target:addStatusEffect(xi.effect.MND_BOOST, 8-buffvalue, 0, duration)
-    target:addStatusEffect(xi.effect.CHR_BOOST, 8-buffvalue, 0, duration)
+    target:addStatusEffect(xi.effect.STR_BOOST, buffValue, 0, duration)
+    target:addStatusEffect(xi.effect.DEX_BOOST, buffValue, 0, duration)
+    target:addStatusEffect(xi.effect.VIT_BOOST, buffValue, 0, duration)
+    target:addStatusEffect(xi.effect.AGI_BOOST, 8-buffValue, 0, duration)
+    target:addStatusEffect(xi.effect.INT_BOOST, 8-buffValue, 0, duration)
+    target:addStatusEffect(xi.effect.MND_BOOST, 8-buffValue, 0, duration)
+    target:addStatusEffect(xi.effect.CHR_BOOST, 8-buffValue, 0, duration)
 
     if target:getID() == action:getPrimaryTargetID() then
         petskill:setMsg(xi.msg.basic.STATUS_BOOST)

--- a/scripts/actions/abilities/pets/ecliptic_howl.lua
+++ b/scripts/actions/abilities/pets/ecliptic_howl.lua
@@ -14,26 +14,30 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
 
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    local moon = VanadielMoonPhase()
-    local buffvalue = 1
-    if moon > 90 then
-        buffvalue = 25
-    elseif moon > 75 then
-        buffvalue = 21
-    elseif moon > 60 then
-        buffvalue = 17
-    elseif moon > 40 then
-        buffvalue = 13
-    elseif moon > 25 then
-        buffvalue = 9
-    elseif moon > 10 then
-        buffvalue = 5
-    end
+    local moonCycle = getVanadielMoonCycle()
+
+    local cycleBuffs =
+    {
+        [xi.moonCycle.NEW_MOON]                = 1,
+        [xi.moonCycle.LESSER_WAXING_CRESCENT]  = 5,
+        [xi.moonCycle.GREATER_WAXING_CRESCENT] = 9,
+        [xi.moonCycle.FIRST_QUARTER]           = 13,
+        [xi.moonCycle.LESSER_WAXING_GIBBOUS]   = 17,
+        [xi.moonCycle.GREATER_WAXING_GIBBOUS]  = 21,
+        [xi.moonCycle.FULL_MOON]               = 25,
+        [xi.moonCycle.GREATER_WANING_GIBBOUS]  = 21,
+        [xi.moonCycle.LESSER_WANING_GIBBOUS]   = 17,
+        [xi.moonCycle.THIRD_QUARTER]           = 13,
+        [xi.moonCycle.GREATER_WANING_CRESCENT] = 9,
+        [xi.moonCycle.LESSER_WANING_CRESCENT]  = 5,
+    }
+
+    local buffValue = cycleBuffs[moonCycle]
 
     target:delStatusEffect(xi.effect.ACCURACY_BOOST)
     target:delStatusEffect(xi.effect.EVASION_BOOST)
-    target:addStatusEffect(xi.effect.ACCURACY_BOOST, buffvalue, 0, duration)
-    target:addStatusEffect(xi.effect.EVASION_BOOST, 25-buffvalue, 0, duration)
+    target:addStatusEffect(xi.effect.ACCURACY_BOOST, buffValue, 0, duration)
+    target:addStatusEffect(xi.effect.EVASION_BOOST, 25-buffValue, 0, duration)
 
     if target:getID() == action:getPrimaryTargetID() then
         petskill:setMsg(xi.msg.basic.ACC_EVA_BOOST)

--- a/scripts/actions/abilities/pets/lunar_cry.lua
+++ b/scripts/actions/abilities/pets/lunar_cry.lua
@@ -11,26 +11,30 @@ end
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    local moon = VanadielMoonPhase()
-    local buffvalue = 1
-    if moon > 90 then
-        buffvalue = 31
-    elseif moon > 75 then
-        buffvalue = 26
-    elseif moon > 60 then
-        buffvalue = 21
-    elseif moon > 40 then
-        buffvalue = 16
-    elseif moon > 25 then
-        buffvalue = 11
-    elseif moon > 10 then
-        buffvalue = 6
-    end
+    local moonCycle = getVanadielMoonCycle()
+
+    local cycleBuffs =
+    {
+        [xi.moonCycle.NEW_MOON]                = 1,
+        [xi.moonCycle.LESSER_WAXING_CRESCENT]  = 6,
+        [xi.moonCycle.GREATER_WAXING_CRESCENT] = 11,
+        [xi.moonCycle.FIRST_QUARTER]           = 16,
+        [xi.moonCycle.LESSER_WAXING_GIBBOUS]   = 21,
+        [xi.moonCycle.GREATER_WAXING_GIBBOUS]  = 26,
+        [xi.moonCycle.FULL_MOON]               = 31,
+        [xi.moonCycle.GREATER_WANING_GIBBOUS]  = 26,
+        [xi.moonCycle.LESSER_WANING_GIBBOUS]   = 21,
+        [xi.moonCycle.THIRD_QUARTER]           = 16,
+        [xi.moonCycle.GREATER_WANING_CRESCENT] = 11,
+        [xi.moonCycle.LESSER_WANING_CRESCENT]  = 6,
+    }
+
+    local buffValue = cycleBuffs[moonCycle]
 
     target:delStatusEffect(xi.effect.ACCURACY_DOWN)
     target:delStatusEffect(xi.effect.EVASION_DOWN)
-    target:addStatusEffect(xi.effect.ACCURACY_DOWN, buffvalue, 0, 180)
-    target:addStatusEffect(xi.effect.EVASION_DOWN, 32-buffvalue, 0, 180)
+    target:addStatusEffect(xi.effect.ACCURACY_DOWN, buffValue, 0, 180)
+    target:addStatusEffect(xi.effect.EVASION_DOWN, 32-buffValue, 0, 180)
 
     if target:getID() == action:getPrimaryTargetID() then
         petskill:setMsg(xi.msg.basic.ACC_EVA_DOWN)

--- a/scripts/actions/mobskills/lunar_cry.lua
+++ b/scripts/actions/mobskills/lunar_cry.lua
@@ -10,25 +10,28 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local moon = VanadielMoonPhase()
-    local buffvalue = 1
+    local moonCycle = getVanadielMoonCycle()
 
-    if moon > 90 then
-        buffvalue = 31
-    elseif moon > 75 then
-        buffvalue = 26
-    elseif moon > 60 then
-        buffvalue = 21
-    elseif moon > 40 then
-        buffvalue = 16
-    elseif moon > 25 then
-        buffvalue = 11
-    elseif moon > 10 then
-        buffvalue = 6
-    end
+    local cycleBuffs =
+    {
+        [xi.moonCycle.NEW_MOON]                = 1,
+        [xi.moonCycle.LESSER_WAXING_CRESCENT]  = 6,
+        [xi.moonCycle.GREATER_WAXING_CRESCENT] = 11,
+        [xi.moonCycle.FIRST_QUARTER]           = 16,
+        [xi.moonCycle.LESSER_WAXING_GIBBOUS]   = 21,
+        [xi.moonCycle.GREATER_WAXING_GIBBOUS]  = 26,
+        [xi.moonCycle.FULL_MOON]               = 31,
+        [xi.moonCycle.GREATER_WANING_GIBBOUS]  = 26,
+        [xi.moonCycle.LESSER_WANING_GIBBOUS]   = 21,
+        [xi.moonCycle.THIRD_QUARTER]           = 16,
+        [xi.moonCycle.GREATER_WANING_CRESCENT] = 11,
+        [xi.moonCycle.LESSER_WANING_CRESCENT]  = 6,
+    }
 
-    target:addStatusEffect(xi.effect.ACCURACY_DOWN, buffvalue, 0, 180)
-    target:addStatusEffect(xi.effect.EVASION_DOWN, 32-buffvalue, 0, 180)
+    local buffValue = cycleBuffs[moonCycle]
+
+    target:addStatusEffect(xi.effect.ACCURACY_DOWN, buffValue, 0, 180)
+    target:addStatusEffect(xi.effect.EVASION_DOWN, 32-buffValue, 0, 180)
     skill:setMsg(xi.msg.basic.SKILL_ENFEEB_2)
     return 0
 end

--- a/scripts/actions/spells/blue/plenilune_embrace.lua
+++ b/scripts/actions/spells/blue/plenilune_embrace.lua
@@ -14,34 +14,30 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local duration = 90
-    local attBoost = 1
-    local magAttBoost = 1
-    local moonPhase = VanadielMoonPhase()
-    if moonPhase <= 5 then
-        magAttBoost = 15
-        attBoost = 1
-    elseif moonPhase <= 25 then
-        magAttBoost = 12
-        attBoost = 3
-    elseif moonPhase <= 40 then
-        magAttBoost = 10
-        attBoost = 5
-    elseif moonPhase <= 60 then
-        magAttBoost = 7
-        attBoost = 7
-    elseif moonPhase <= 75 then
-        magAttBoost = 5
-        attBoost = 10
-    elseif moonPhase <= 90 then
-        magAttBoost = 3
-        attBoost = 12
-    elseif moonPhase <= 100 then
-        magAttBoost = 1
-        attBoost = 15
-    end
+    local moonCycle = getVanadielMoonCycle()
 
-    caster:addStatusEffect(xi.effect.ATTACK_BOOST, attBoost, 0, duration)
-    caster:addStatusEffect(xi.effect.MAGIC_ATK_BOOST, magAttBoost, 0, duration)
+    local cycleBuffs =
+    {
+        [xi.moonCycle.NEW_MOON]                = { atk = 1,  mab = 15 },
+        [xi.moonCycle.LESSER_WAXING_CRESCENT]  = { atk = 3,  mab = 12 },
+        [xi.moonCycle.GREATER_WAXING_CRESCENT] = { atk = 5,  mab = 10 },
+        [xi.moonCycle.FIRST_QUARTER]           = { atk = 7,  mab = 7  },
+        [xi.moonCycle.LESSER_WAXING_GIBBOUS]   = { atk = 10, mab = 5  },
+        [xi.moonCycle.GREATER_WAXING_GIBBOUS]  = { atk = 12, mab = 3  },
+        [xi.moonCycle.FULL_MOON]               = { atk = 15, mab = 1  },
+        [xi.moonCycle.GREATER_WANING_GIBBOUS]  = { atk = 12, mab = 3  },
+        [xi.moonCycle.LESSER_WANING_GIBBOUS]   = { atk = 10, mab = 5  },
+        [xi.moonCycle.THIRD_QUARTER]           = { atk = 7,  mab = 7  },
+        [xi.moonCycle.GREATER_WANING_CRESCENT] = { atk = 5,  mab = 10 },
+        [xi.moonCycle.LESSER_WANING_CRESCENT]  = { atk = 3,  mab = 12 },
+    }
+
+    local moonBuff = cycleBuffs[moonCycle]
+    local atkBoost = moonBuff.atk
+    local mabBoost = moonBuff.mab
+
+    caster:addStatusEffect(xi.effect.ATTACK_BOOST, atkBoost, 0, duration)
+    caster:addStatusEffect(xi.effect.MAGIC_ATK_BOOST, mabBoost, 0, duration)
 
     local minCure = 350
 

--- a/scripts/commands/time.lua
+++ b/scripts/commands/time.lua
@@ -74,28 +74,25 @@ commandObj.onTrigger = function(player)
     player:printToPlayer(fmt('Vana\'diel: {}/{}/{}, {}, {}:{:02} ({}, {} days into the year)', year, month, day, dayElement, hour, minute, totd, VanadielDayOfTheYear()), channel)
 
     -- Moon
-    local moonDirection = VanadielMoonDirection()
     local moonPhase = VanadielMoonPhase()
-    local moonType = IsMoonFull() and 'Full Moon' or IsMoonNew() and 'New Moon'
-    if not moonType then
-        if moonDirection == 1 then
-            if moonPhase <= 93 and moonPhase >= 62 then
-                moonType = 'Waning Gibbous'
-            elseif moonPhase <= 60 and moonPhase >= 43 then
-                moonType = 'Last Quarter'
-            elseif moonPhase <= 40 and moonPhase >= 12 then
-                moonType = 'Waning Crescent'
-            end
-        elseif moonDirection == 2 then
-            if moonPhase >= 7 and moonPhase <= 38 then
-                moonType = 'Waxing Crescent'
-            elseif moonPhase >= 40 and moonPhase <= 55 then
-                moonType = 'First Quarter'
-            elseif moonPhase >= 57 and moonPhase <= 88 then
-                moonType = 'Waxing Gibbous'
-            end
-        end
-    end
+    local moonCycle = getVanadielMoonCycle()
+
+    local moonNames = {
+        [xi.moonCycle.NEW_MOON]                = 'New Moon',
+        [xi.moonCycle.LESSER_WAXING_CRESCENT]  = 'Waxing Crescent',
+        [xi.moonCycle.GREATER_WAXING_CRESCENT] = 'Waxing Crescent',
+        [xi.moonCycle.FIRST_QUARTER]           = 'First Quarter',
+        [xi.moonCycle.LESSER_WAXING_GIBBOUS]   = 'Waxing Gibbous',
+        [xi.moonCycle.GREATER_WAXING_GIBBOUS]  = 'Waxing Gibbous',
+        [xi.moonCycle.FULL_MOON]               = 'Full Moon',
+        [xi.moonCycle.GREATER_WANING_GIBBOUS]  = 'Waning Gibbous',
+        [xi.moonCycle.LESSER_WANING_GIBBOUS]   = 'Waning Gibbous',
+        [xi.moonCycle.THIRD_QUARTER]           = 'Last Quarter',
+        [xi.moonCycle.GREATER_WANING_CRESCENT] = 'Waning Crescent',
+        [xi.moonCycle.LESSER_WANING_CRESCENT]  = 'Waning Crescent',
+    }
+
+    local moonType = moonNames[moonCycle]
 
     player:printToPlayer(fmt('              {} ({}%)', moonType, moonPhase), channel)
 

--- a/scripts/enum/moon_cycle.lua
+++ b/scripts/enum/moon_cycle.lua
@@ -1,0 +1,21 @@
+-----------------------------------
+-- Moon Cycle
+-----------------------------------
+xi = xi or {}
+
+---@enum xi.moonCycle
+xi.moonCycle =
+{
+    NEW_MOON                = 0,
+    LESSER_WAXING_CRESCENT  = 1,
+    GREATER_WAXING_CRESCENT = 2,
+    FIRST_QUARTER           = 3,
+    LESSER_WAXING_GIBBOUS   = 4,
+    GREATER_WAXING_GIBBOUS  = 5,
+    FULL_MOON               = 6,
+    GREATER_WANING_GIBBOUS  = 7,
+    LESSER_WANING_GIBBOUS   = 8,
+    THIRD_QUARTER           = 9,
+    GREATER_WANING_CRESCENT = 10,
+    LESSER_WANING_CRESCENT  = 11,
+}

--- a/scripts/quests/outlands/Divine_Might.lua
+++ b/scripts/quests/outlands/Divine_Might.lua
@@ -119,7 +119,7 @@ quest.sections =
                     local vanaHour = VanadielHour()
 
                     if
-                        IsMoonFull() and
+                        (getVanadielMoonCycle() == xi.moonCycle.FULL_MOON) and
                         (vanaHour >= 18 or vanaHour < 6) and
                         npcUtil.tradeHasExactly(trade, { xi.item.BOTTLE_OF_ILLUMININK, xi.item.SHEET_OF_PARCHMENT })
                     then

--- a/scripts/quests/outlands/Divine_Might_Repeat.lua
+++ b/scripts/quests/outlands/Divine_Might_Repeat.lua
@@ -117,7 +117,7 @@ quest.sections =
                     local vanaHour = VanadielHour()
 
                     if
-                        IsMoonFull() and
+                        (getVanadielMoonCycle() == xi.moonCycle.FULL_MOON) and
                         (vanaHour >= 18 or vanaHour < 6)
                     then
                         if npcUtil.tradeHasExactly(trade, { xi.item.BOTTLE_OF_ILLUMININK, xi.item.SHEET_OF_PARCHMENT }) then

--- a/scripts/specs/core/Globals.lua
+++ b/scripts/specs/core/Globals.lua
@@ -289,16 +289,6 @@ end
 function VanadielRSELocation()
 end
 
----@nodiscard
----@return boolean
-function IsMoonNew()
-end
-
----@nodiscard
----@return boolean
-function IsMoonFull()
-end
-
 ---@param ElevatorID integer
 ---@return nil
 function RunElevator(ElevatorID)

--- a/scripts/utils/common.lua
+++ b/scripts/utils/common.lua
@@ -62,3 +62,59 @@ function getVanaMidnight(day)
 
     return curtime + secondsToMidnight
 end
+
+-----------------------------------
+--  getVanadielMoonCycle()
+--  Returns the current moon cycle index (0–11) based on Vanadiel moon phase and direction
+-----------------------------------
+function getVanadielMoonCycle()
+    local phase = VanadielMoonPhase()
+    local direction = VanadielMoonDirection()
+
+    local moonTable =
+    {
+        -- Peak State
+        [0] =
+        {
+            { 100, xi.moonCycle.FULL_MOON },                -- Full Moon                - 100% Full
+            { 0,   xi.moonCycle.NEW_MOON },                 -- New Moon                 - 0% Full
+        },
+        -- Descending
+        [1] =
+        {
+            { 94, xi.moonCycle.FULL_MOON },                 -- Full Moon                - 100 to 94%
+            { 77, xi.moonCycle.GREATER_WANING_GIBBOUS },    -- Greater Waning Gibbous   - 93 to 77%
+            { 61, xi.moonCycle.LESSER_WANING_GIBBOUS },     -- Lesser Waning Gibbous    - 76 to 61%
+            { 41, xi.moonCycle.THIRD_QUARTER },             -- Third Quarter            - 60 to 41%
+            { 25, xi.moonCycle.GREATER_WANING_CRESCENT },   -- Greater Waning Crescent  - 40 to 25%
+            { 11, xi.moonCycle.LESSER_WANING_CRESCENT },    -- Lesser Waning Crescent   - 24 to 11%
+            { 0,  xi.moonCycle.NEW_MOON },                  -- New Moon                 - 10 to 0%
+        },
+        -- Ascending
+        [2] =
+        {
+            { 90, xi.moonCycle.FULL_MOON },                 -- Full Moon                - 100 to 90%
+            { 72, xi.moonCycle.GREATER_WAXING_GIBBOUS },    -- Greater Waxing Gibbous   - 89 to 72%
+            { 56, xi.moonCycle.LESSER_WAXING_GIBBOUS },     -- Lesser Waxing Gibbous    - 71 to 56%
+            { 39, xi.moonCycle.FIRST_QUARTER },             -- First Quarter            - 55 to 39%
+            { 22, xi.moonCycle.GREATER_WAXING_CRESCENT },   -- Greater Waxing Crescent  - 38 to 22%
+            {  6, xi.moonCycle.LESSER_WAXING_CRESCENT },    -- Lesser Waxing Crescent   - 21 to 6%
+            {  0, xi.moonCycle.NEW_MOON },                  -- New Moon                 - 5 to 0%
+        },
+    }
+
+    local directionTable = moonTable[direction]
+    if not directionTable then
+        return xi.moonCycle.GREATER_WANING_GIBBOUS -- Greater Waxing Gibbous is the least offensive as base case.
+    end
+
+    -- Itterate down and trigger on the first matching phase
+    for _, entry in ipairs(directionTable) do
+        local threshold, moonCycle = entry[1], entry[2]
+        if phase >= threshold then
+            return moonCycle
+        end
+    end
+
+    return xi.moonCycle.GREATER_WANING_GIBBOUS -- Greater Waxing Gibbous is the least offensive as base case. (Shouldn't be able to hit this.)
+end

--- a/scripts/zones/Konschtat_Highlands/Zone.lua
+++ b/scripts/zones/Konschtat_Highlands/Zone.lua
@@ -52,21 +52,21 @@ zoneObject.onGameHour = function(zone)
     local hour = VanadielHour()
 
     if hour < 5 or hour >= 17 then
-        local phase = VanadielMoonPhase()
+        local moonCycle = getVanadielMoonCycle()
         local haty = GetMobByID(ID.mob.HATY)
         local vran = GetMobByID(ID.mob.BENDIGEIT_VRAN)
         local time = GetSystemTime()
 
         if
             haty and
-            phase >= 90 and
+            moonCycle == xi.moonCycle.FULL_MOON and
             not haty:isSpawned() and
             time > haty:getLocalVar('cooldown')
         then
             SpawnMob(ID.mob.HATY)
         elseif
             vran and
-            phase <= 10 and
+            moonCycle == xi.moonCycle.NEW_MOON and
             not vran:isSpawned() and
             time > vran:getLocalVar('cooldown')
         then

--- a/scripts/zones/Konschtat_Highlands/mobs/Bendigeit_Vran.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Bendigeit_Vran.lua
@@ -13,10 +13,10 @@ end
 
 entity.onMobRoam = function(mob)
     local hour = VanadielHour()
-    local phase = VanadielMoonPhase()
+    local moonCycle = getVanadielMoonCycle()
     if
         (hour >= 5 and hour < 17) or
-        phase > 10
+        (moonCycle ~= xi.moonCycle.NEW_MOON)
     then
         DespawnMob(mob:getID())
     end

--- a/scripts/zones/Konschtat_Highlands/mobs/Haty.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Haty.lua
@@ -9,10 +9,10 @@ local entity = {}
 
 entity.onMobRoam = function(mob)
     local hour = VanadielHour()
-    local phase = VanadielMoonPhase()
+    local moonCycle = getVanadielMoonCycle()
     if
         (hour >= 5 and hour < 17) or
-        phase < 90
+        (moonCycle ~= xi.moonCycle.FULL_MOON)
     then
         DespawnMob(mob:getID())
     end

--- a/scripts/zones/Kuftal_Tunnel/Zone.lua
+++ b/scripts/zones/Kuftal_Tunnel/Zone.lua
@@ -37,67 +37,40 @@ end
 zoneObject.onEventFinish = function(player, csid, option, npc)
 end
 
--- NOTE: Data order in these tables matters to determine the range that is being checked.
--- If the first entry is larger, it is a boundary case where and `or` range is used instead
--- (Example, moon phase > 90, or moon phase < 10)
-local boulderOpenPhases =
+local boulderOpenCycles =
 {
-    [1] =
-    {
-        [ 1] = { 29, 43 },
-        [ 3] = { 12, 26 },
-        [ 5] = { 95, 10 },
-        [ 7] = { 79, 93 },
-        [ 9] = { 62, 76 },
-        [11] = { 45, 60 },
-        [13] = { 29, 43 },
-        [15] = { 12, 26 },
-        [17] = { 95, 10 },
-        [19] = { 79, 93 },
-        [21] = { 62, 76 },
-        [23] = { 45, 60 },
-    },
-
-    [2] =
-    {
-        [ 1] = { 57, 71 },
-        [ 3] = { 74, 88 },
-        [ 5] = { 90,  5 },
-        [ 7] = {  7, 21 },
-        [ 9] = { 24, 38 },
-        [11] = { 40, 55 },
-        [13] = { 57, 71 },
-        [15] = { 74, 88 },
-        [17] = { 90,  5 },
-        [19] = {  7, 21 },
-        [21] = { 24, 38 },
-        [23] = { 40, 55 },
-    }
+    [ 1] = { xi.moonCycle.LESSER_WAXING_GIBBOUS, xi.moonCycle.GREATER_WANING_CRESCENT },
+    [ 3] = { xi.moonCycle.GREATER_WAXING_GIBBOUS, xi.moonCycle.LESSER_WANING_CRESCENT },
+    [ 5] = { xi.moonCycle.NEW_MOON, xi.moonCycle.FULL_MOON },
+    [ 7] = { xi.moonCycle.LESSER_WAXING_CRESCENT, xi.moonCycle.GREATER_WANING_GIBBOUS },
+    [ 9] = { xi.moonCycle.GREATER_WAXING_CRESCENT, xi.moonCycle.LESSER_WANING_GIBBOUS },
+    [11] = { xi.moonCycle.FIRST_QUARTER, xi.moonCycle.THIRD_QUARTER },
+    [13] = { xi.moonCycle.LESSER_WAXING_GIBBOUS, xi.moonCycle.GREATER_WANING_CRESCENT },
+    [15] = { xi.moonCycle.GREATER_WAXING_GIBBOUS, xi.moonCycle.LESSER_WANING_CRESCENT },
+    [17] = { xi.moonCycle.NEW_MOON, xi.moonCycle.FULL_MOON },
+    [19] = { xi.moonCycle.LESSER_WAXING_CRESCENT, xi.moonCycle.GREATER_WANING_GIBBOUS },
+    [21] = { xi.moonCycle.GREATER_WAXING_CRESCENT, xi.moonCycle.LESSER_WANING_GIBBOUS },
+    [23] = { xi.moonCycle.FIRST_QUARTER, xi.moonCycle.THIRD_QUARTER },
 }
 
-local function isInRange(inputNum, rangeTable)
-    if not rangeTable then
-        return false
-    end
-
-    if rangeTable[1] < rangeTable[2] then
-        return inputNum >= rangeTable[1] and inputNum <= rangeTable[2]
-    else
-        return inputNum >= rangeTable[1] or inputNum <= rangeTable[2]
-    end
-end
-
 zoneObject.onGameHour = function(zone)
-    local moonDirection = VanadielMoonDirection() -- 0 (neither) 1 (waning) or 2 (waxing)
+    local moonCycle = getVanadielMoonCycle()
+    local hour = VanadielHour()
+    local boulder = GetNPCByID(ID.npc.DOOR_ROCK)
+    local validCycles = nil
 
-    if moonDirection > 0 then
-        local phaseInfo = boulderOpenPhases[moonDirection][VanadielHour()]
-        local boulder = GetNPCByID(ID.npc.DOOR_ROCK)
+    if hour then
+        validCycles = boulderOpenCycles[hour]
+    end
 
+    if
+        boulder and
+        validCycles and
+        boulder:getAnimation() == xi.anim.CLOSE_DOOR
+    then
         if
-            boulder and
-            isInRange(VanadielMoonPhase(), phaseInfo) and
-            boulder:getAnimation() == xi.anim.CLOSE_DOOR
+            moonCycle == validCycles[1] or
+            moonCycle == validCycles[2]
         then
             boulder:openDoor(144 * 6) -- one vanadiel hour is 144 earth seconds. lower boulder for 6 vanadiel hours.
         end

--- a/scripts/zones/RoMaeve/Zone.lua
+++ b/scripts/zones/RoMaeve/Zone.lua
@@ -8,7 +8,10 @@ local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
     local newPosition = npcUtil.pickNewPosition(ID.npc.BASTOK_7_1_QM, ID.npc.BASTOK_7_1_QM_POS, true)
-    GetNPCByID(ID.npc.BASTOK_7_1_QM):setPos(newPosition.x, newPosition.y, newPosition.z)
+    local bastokMissionQM = GetNPCByID(ID.npc.BASTOK_7_1_QM)
+    if bastokMissionQM then
+        bastokMissionQM:setPos(newPosition.x, newPosition.y, newPosition.z)
+    end
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
@@ -39,12 +42,21 @@ zoneObject.onGameHour = function(zone)
     local qm2 = GetNPCByID(ID.npc.BASTOK_7_1_QM)
     local newPosition = npcUtil.pickNewPosition(ID.npc.BASTOK_7_1_QM, ID.npc.BASTOK_7_1_QM_POS, false)
     -- Make Ro'Maeve come to life between 6pm and 6am during a full moon
-    if moongate1 and moongate2 then
-        if IsMoonFull() and (vanadielHour >= 18 or vanadielHour < 6) then
+    if
+        moongate1 and
+        moongate2
+    then
+        if
+            (getVanadielMoonCycle() == xi.moonCycle.FULL_MOON) and
+            (vanadielHour >= 18 or vanadielHour < 6)
+        then
             if moongate1:getLocalVar('romaeveActive') == 0 then
                 -- Loop over the affected NPCs: Moongates, bridges and fountain
                 for i = ID.npc.MOONGATE_OFFSET, ID.npc.MOONGATE_OFFSET + 7 do
-                    GetNPCByID(i):setAnimation(xi.anim.OPEN_DOOR) -- Open them
+                    local npc = GetNPCByID(i)
+                    if npc then
+                        npc:setAnimation(xi.anim.OPEN_DOOR) -- Open them
+                    end
                 end
 
                 moongate2:setUntargetable(true)
@@ -56,7 +68,10 @@ zoneObject.onGameHour = function(zone)
         elseif vanadielHour == 6 then
             if moongate1:getLocalVar('romaeveActive') == 1 then
                 for i = ID.npc.MOONGATE_OFFSET, ID.npc.MOONGATE_OFFSET + 7 do
-                    GetNPCByID(i):setAnimation(xi.anim.CLOSE_DOOR)
+                    local npc = GetNPCByID(i)
+                    if npc then
+                        npc:setAnimation(xi.anim.CLOSE_DOOR) -- Close them
+                    end
                 end
 
                 moongate2:setUntargetable(false)

--- a/scripts/zones/San_dOria-Jeuno_Airship/Zone.lua
+++ b/scripts/zones/San_dOria-Jeuno_Airship/Zone.lua
@@ -26,7 +26,7 @@ zoneObject.onGameHour = function(zone)
     local vanadielHour = VanadielHour()
 
     if
-        IsMoonFull() and
+        (getVanadielMoonCycle() == xi.moonCycle.FULL_MOON) and
         (vanadielHour >= 18 or
         vanadielHour < 6)
     then

--- a/scripts/zones/The_Boyahda_Tree/npcs/qm2.lua
+++ b/scripts/zones/The_Boyahda_Tree/npcs/qm2.lua
@@ -17,25 +17,31 @@ entity.onTrigger = function(player, npc)
     local zoneMinute = VanadielMinute()
     local correctTime = zoneHour >= 19 or zoneHour < 4 or (zoneHour == 4 and zoneMinute == 0)
 
-    if not GetMobByID(ID.mob.AGAS):isSpawned() then
-        if player:hasKeyItem(xi.ki.MOONDROP) then
-            player:messageSpecial(ID.text.CAN_SEE_SKY)
+    local agas = GetMobByID(ID.mob.AGAS)
+    if agas then
+        if not agas:isSpawned() then
+            if player:hasKeyItem(xi.ki.MOONDROP) then
+                player:messageSpecial(ID.text.CAN_SEE_SKY)
 
-        elseif player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SEARCHING_FOR_THE_RIGHT_WORDS) == xi.questStatus.QUEST_ACCEPTED then
+            elseif player:getQuestStatus(xi.questLog.JEUNO, xi.quest.id.jeuno.SEARCHING_FOR_THE_RIGHT_WORDS) == xi.questStatus.QUEST_ACCEPTED then
 
-            if IsMoonNew() or not correctTime then
-                player:messageSpecial(ID.text.CANNOT_SEE_MOON)
+                if
+                    (getVanadielMoonCycle() == xi.moonCycle.NEW_MOON) or
+                    not correctTime
+                then
+                    player:messageSpecial(ID.text.CANNOT_SEE_MOON)
 
-            elseif player:getCharVar('Searching_AgasKilled') == 1 then
-                player:startEvent(14)
+                elseif player:getCharVar('Searching_AgasKilled') == 1 then
+                    player:startEvent(14)
+
+                else
+                    player:messageSpecial(ID.text.SOMETHING_NOT_RIGHT)
+                    SpawnMob(ID.mob.AGAS):updateClaim(player) -- missing repop timer for Agas due to errors with SpawnMob
+                end
 
             else
-                player:messageSpecial(ID.text.SOMETHING_NOT_RIGHT)
-                SpawnMob(ID.mob.AGAS):updateClaim(player) -- missing repop timer for Agas due to errors with SpawnMob
+                player:messageSpecial(ID.text.CAN_SEE_SKY)
             end
-
-        else
-            player:messageSpecial(ID.text.CAN_SEE_SKY)
         end
     end
 end

--- a/scripts/zones/Uleguerand_Range/npcs/Rabbit_Footprint.lua
+++ b/scripts/zones/Uleguerand_Range/npcs/Rabbit_Footprint.lua
@@ -32,9 +32,9 @@ entity.onTrade = function(player, npc, trade)
     local coney
     local currentPoint = npc:getLocalVar('currentPoint')
 
-    if IsMoonNew() then
+    if getVanadielMoonCycle() == xi.moonCycle.NEW_MOON then
         coney = ID.mob.BLACK_CONEY
-    elseif IsMoonFull() then
+    elseif getVanadielMoonCycle() == xi.moonCycle.FULL_MOON then
         coney = ID.mob.WHITE_CONEY
     end
 
@@ -42,12 +42,16 @@ entity.onTrade = function(player, npc, trade)
         local x = points[currentPoint][1]
         local y = points[currentPoint][2]
         local z = points[currentPoint][3]
-        GetMobByID(coney):setSpawn(x, y, z, 0)
-        if
-            npcUtil.tradeHas(trade, xi.item.SAN_DORIAN_CARROT) and
-            npcUtil.popFromQM(player, npc, coney)
-        then
-            player:confirmTrade()
+
+        local rabbit = GetMobByID(coney)
+        if rabbit then
+            rabbit:setSpawn(x, y, z, 0)
+            if
+                npcUtil.tradeHas(trade, xi.item.SAN_DORIAN_CARROT) and
+                npcUtil.popFromQM(player, npc, coney)
+            then
+                player:confirmTrade()
+            end
         end
     end
 end
@@ -75,11 +79,22 @@ local function moveFootprint(npc)
 end
 
 entity.onTimeTrigger = function(npc, triggerID)
-    local isSpawned = GetMobByID(ID.mob.WHITE_CONEY):isSpawned() or GetMobByID(ID.mob.BLACK_CONEY):isSpawned()
+    local whiteConey = GetMobByID(ID.mob.WHITE_CONEY)
+    local blackConey = GetMobByID(ID.mob.BLACK_CONEY)
     local activeTime = npc:getLocalVar('activeTime')
+    local isSpawned =  nil
+
+    if whiteConey then
+        isSpawned = whiteConey:isSpawned()
+    elseif blackConey then
+        isSpawned = blackConey:isSpawned()
+    end
 
     if not isSpawned then
-        if IsMoonFull() or IsMoonNew() then
+        if
+            (getVanadielMoonCycle() == xi.moonCycle.FULL_MOON) or
+            (getVanadielMoonCycle() == xi.moonCycle.NEW_MOON)
+        then
             if activeTime == 0 then
                 npc:setLocalVar('activeTime', GetSystemTime() + math.random(60 * 9, 60 * 15)) -- moon phase just changed, i'm active in 9 to 15 mins from now
             elseif GetSystemTime() > activeTime then

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -287,8 +287,6 @@ void init(IPP mapIPP, bool isRunningInCI)
     lua.set_function("VanadielRSERace", &luautils::VanadielRSERace);
     lua.set_function("VanadielRSELocation", &luautils::VanadielRSELocation);
     lua.set_function("SetTimeOffset", &luautils::SetTimeOffset);
-    lua.set_function("IsMoonNew", &luautils::IsMoonNew);
-    lua.set_function("IsMoonFull", &luautils::IsMoonFull);
     lua.set_function("RunElevator", &luautils::StartElevator);
     lua.set_function("GetElevatorState", &luautils::GetElevatorState);
     lua.set_function("GetServerVariable", &luautils::GetServerVariable);
@@ -1667,79 +1665,8 @@ uint8 VanadielRSELocation()
 void SetTimeOffset(const int32 offset)
 {
     TracyZoneScoped;
-
     earth_time::reset_offset();
     earth_time::add_offset(std::chrono::seconds(offset));
-}
-
-bool IsMoonNew()
-{
-    TracyZoneScoped;
-    // New moon occurs when:
-    // Waning (decreasing) from 10% to 0%,
-    // Waxing (increasing) from 0% to 5%.
-
-    vanadiel_time::time_point currentVanaTime = vanadiel_time::now();
-    auto                      phase           = vanadiel_time::moon::get_phase(currentVanaTime);
-
-    switch (vanadiel_time::moon::get_direction(currentVanaTime))
-    {
-        case 0: // None
-            if (phase == 0)
-            {
-                return true;
-            }
-            break;
-        case 1: // Waning (decending)
-            if (phase <= 10)
-            {
-                return true;
-            }
-            break;
-        case 2: // Waxing (increasing)
-            if (phase <= 5)
-            {
-                return true;
-            }
-            break;
-    }
-
-    return false;
-}
-
-bool IsMoonFull()
-{
-    TracyZoneScoped;
-    // Full moon occurs when:
-    // Waxing (increasing) from 90% to 100%,
-    // Waning (decending) from 100% to 95%.
-
-    vanadiel_time::time_point currentVanaTime = vanadiel_time::now();
-    auto                      phase           = vanadiel_time::moon::get_phase(currentVanaTime);
-
-    switch (vanadiel_time::moon::get_direction(currentVanaTime))
-    {
-        case 0: // None
-            if (phase == 100)
-            {
-                return true;
-            }
-            break;
-        case 1: // Waning (decending)
-            if (phase >= 95 && phase <= 100)
-            {
-                return true;
-            }
-            break;
-        case 2: // Waxing (increasing)
-            if (phase >= 90 && phase <= 100)
-            {
-                return true;
-            }
-            break;
-    }
-
-    return false;
 }
 
 /************************************************************************

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -273,8 +273,6 @@ uint8  VanadielMoonDirection();
 uint8  VanadielRSERace();
 uint8  VanadielRSELocation();
 void   SetTimeOffset(int32 offset); // Manipulate earth time forward or backward by offset seconds. Affects Vana'Diel time.
-bool   IsMoonNew();
-bool   IsMoonFull();
 void   StartElevator(uint32 ElevatorID);
 int16  GetElevatorState(uint8 id); // Returns -1 if elevator is not found. Otherwise, returns the uint8 state.
 

--- a/tools/ci/sanity_checks/lua.sh
+++ b/tools/ci/sanity_checks/lua.sh
@@ -55,6 +55,7 @@ global_objects=(
     fmt
     switch
     getVanaMidnight
+    getVanadielMoonCycle
     getMidnight
 
     Mission


### PR DESCRIPTION
 - Better accounting for asymmetrical moon phases.
 - Creates enums and cleans up / replaces existing checks for capstone phase states.
 - Replace all existing uses of phase where cycle should have been checked intead.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Refactors core components of Moon Phase to better properly account for the [asymmetrical nature of moon cycles](https://www.bg-wiki.com/ffxi/Category:Moon_Phase).
- Adds a new getVanadielMoonCycle() method based on[ brief discussions](https://github.com/LandSandBoat/server/issues/8581) with Xaver and Sruon that translates to a new moon cycle out of the 12 possible cycle states. 
- Added a new ENUM for moon_cycles for use within the code base. 
- Combining the above two made IsMoonNew() and IsMoonFull() redundant so I removed them and replaced them in the code with a comparison outside of Core.
- Replaced all relevant calls to VanadielMoonPhase() with VanadielMoonCycle().
  -  Several places continue to use Phase when the actual % mattered and not the cycle state. Such as warhorse footprint and ~~chocobo digging~~. 

## Steps to test these changes

Summon Fenrir and use a BP Ward. Any of the first four wards should now properly account for asymmetrical edge cases. 
Go to Kuftal Tunnel and see the rock properly retreat using the new cycle function. 
Go to Konschat Highlands and see the behavior of Haty/Vran during Full/New Moons.
Go to Uleg Range and spawn White/Black Coney in their respective timeframes. 

### TODO: Impacts untested at this time:
 - Plenilune Embrace (Do BLU spells work? I can't even set it?)
 - ~~Chocobo Digging~~ _No longer relevant. Moved to Hobbies._