### PR TITLE
[core] Fix /lsmes Write Level Permission Check

### DIFF
--- a/src/map/items/item_linkshell.h
+++ b/src/map/items/item_linkshell.h
@@ -34,6 +34,8 @@ struct lscolor_t
     uint8 A : 4;
 };
 
+// TODO: The LSTYPE definition is wrong here and values are off by 1 compared to what is actually passed
+// by the client. The correct values are listed in 0x0e2_set_lsmsg.h in GP_CLI_COMMAND_SET_LSMSG_WRITELEVEL
 enum LSTYPE : uint8
 {
     LSTYPE_NEW_LINKSHELL,

--- a/src/map/packets/c2s/0x0e2_set_lsmsg.cpp
+++ b/src/map/packets/c2s/0x0e2_set_lsmsg.cpp
@@ -40,7 +40,10 @@ void GP_CLI_COMMAND_SET_LSMSG::process(MapSession* PSession, CCharEntity* PChar)
 {
     auto canEditLsMes = [&](CItemLinkshell* PItemLinkshell) -> bool
     {
-        switch (PChar->PLinkshell1->m_postRights)
+        // TODO: The LSTYPE definition is wrong in item_linkshell.h and values are off by 1 compared to what is actually passed
+        // by the client. We account for this temporarily by doing m_postRights - 1
+        const auto postRights = static_cast<uint8_t>(PChar->PLinkshell1->m_postRights) - 1;
+        switch (static_cast<GP_CLI_COMMAND_SET_LSMSG_WRITELEVEL>(postRights))
         {
             case GP_CLI_COMMAND_SET_LSMSG_WRITELEVEL::Linkshell:
                 // Only the linkshell owner can edit the message


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
- Fixes the write level permission check for /lsmes to use the adjusted values from the `LSTYPE` enum which are offset by 1 compared to the `GP_CLI_COMMAND_SET_LSMSG_WRITELEVEL` values.

Note: The packet implementation and values in the `GP_CLI_COMMAND_SET_LSMSG_WRITE_LEVEL` are correct.  The `LSTYPE` enum in `linkshell.h` is the one in the wrong here.  This should eventually be rewritten to use the proper values that the client is actually sending up and match what is used in the packet.  Included a note about the shift to keep us aware of this.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - Login with two characters
2 - `!additem new_linkshell`
3 - Create a new linkshell and equip it
4 - Create a linkpearl and trade it to the other character
5 - Equip the linkshell on the second character
6 - Attempt to write to the LS Message by using `/lsmes test`
Result: You are given a message saying you don't have permission

7 - Promote the second character to Pearlsack
8 - Use the same command from step 6
Result: You are able to adjust the linkshell message

9 - Adjust the write permissions to only the LS Leader with `/lsmes level ls` from Character 1
10 - Attempt to change the LS message again from character 2 with a pearlsack
Result: You are given a message saying you don't have permission.

<img width="227" height="55" alt="image" src="https://github.com/user-attachments/assets/43e9e13f-781c-4369-8384-d9611c38d9b4" />
<img width="137" height="37" alt="image" src="https://github.com/user-attachments/assets/2517b675-074e-4b1a-a3bc-7c4e2b711f61" />
<img width="437" height="26" alt="image" src="https://github.com/user-attachments/assets/ae5a783b-047d-480a-8785-b85e0d382971" />
