### PR TITLE
[core] [lua] Handle CS + mount case in 0x00A via server_status

### DIFF
--- a/scripts/effects/mounted.lua
+++ b/scripts/effects/mounted.lua
@@ -8,15 +8,21 @@ effectObject.onEffectGain = function(target, effect)
     local mountId = effect:getPower()
     -- Retail sends a music change packet (packet ID 0x5F) in both cases.
 
+    local animation = xi.animation.NONE
+
     if
         mountId == xi.mount.CHOCOBO or
         mountId == xi.mount.NOBLE_CHOCOBO
     then
         target:changeMusic(4, 212)
-        target:setAnimation(xi.anim.CHOCOBO)
+        animation = xi.anim.CHOCOBO
     else
         target:changeMusic(4, 84)
-        target:setAnimation(xi.anim.MOUNT)
+        animation = xi.anim.MOUNT
+    end
+
+    if not target:isInEvent() then
+        target:setAnimation(animation)
     end
 end
 
@@ -24,7 +30,9 @@ effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:setAnimation(xi.anim.NONE)
+    if not target:isInEvent() then -- Paranoia safety check
+        target:setAnimation(xi.anim.NONE)
+    end
 
     -- Remove CharVars from player participating in chocobo riding game
     if target:isPC() then

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -3256,9 +3256,9 @@ void CCharEntity::tryStartNextEvent()
         updatemask |= UPDATE_POS; // TODO: decouple from this. We want the 250ms post-tick processing
 
         // Chocobo NPC (outside, gives you a mount) edge case
-        if (StatusEffectContainer->HasStatusEffect(EFFECT_MOUNTED))
+        if (auto PStatusEffect = StatusEffectContainer->GetStatusEffect(EFFECT_MOUNTED))
         {
-            switch (m_mountId)
+            switch (PStatusEffect->GetPower())
             {
                 case MOUNT_CHOCOBO:
                 case MOUNT_NOBLE_CHOCOBO:

--- a/src/map/packets/s2c/0x00a_login.cpp
+++ b/src/map/packets/s2c/0x00a_login.cpp
@@ -185,6 +185,9 @@ GP_SERV_COMMAND_LOGIN::GP_SERV_COMMAND_LOGIN(CCharEntity* PChar, const EventInfo
         packet.EventNum  = PChar->getZone();
         packet.EventPara = currentEvent->eventId;
         packet.EventMode = currentEvent->eventFlags & 0xFFFF;
+
+        PChar->animation             = ANIMATION_EVENT;
+        packet.PosHead.server_status = ANIMATION_EVENT;
     }
 
     if (PChar->m_moghouseID != 0)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The client isn't very happy about being in server_status 5 when zoning in with a cutscene, so this is meant to fix that

<img width="601" height="364" alt="image" src="https://github.com/user-attachments/assets/3dd5014e-6756-4d78-a37f-8ab5bebe6643" />

Retail does not send your buffs (or maybe just mounted status?) when zoning in, and server_status is 4. We were setting it to 5, which is wrong.

## Steps to test these changes

Do SMN quest on a mounted chocobo, zone and get a cutscene and not get black screened/stuck
Also try with /mount crab or something other than raptor

Note: your player looks unmounted in some zone ins with a cutscene (this is controlled BY server_status) and that should probably be fixed by KingFlag and delaying entry into the zone like retail, but that's a problem for another day. You will still eventually get the mounted status, though.