### PR TITLE
[lua] Adds/corrects quest fame requirements from quests missing them

### DIFF
--- a/scripts/quests/jeuno/A_Clock_Most_Delicate.lua
+++ b/scripts/quests/jeuno/A_Clock_Most_Delicate.lua
@@ -21,7 +21,8 @@ quest.sections =
 {
     {
         check = function(player, status, vars)
-            return status == xi.questStatus.QUEST_AVAILABLE
+            return status == xi.questStatus.QUEST_AVAILABLE and
+                player:getFameLevel(xi.fameArea.JEUNO) >= 2
         end,
 
         [xi.zone.UPPER_JEUNO] =

--- a/scripts/quests/otherAreas/The_Sand_Charm.lua
+++ b/scripts/quests/otherAreas/The_Sand_Charm.lua
@@ -23,6 +23,7 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_AVAILABLE and
+                player:getFameLevel(xi.fameArea.WINDURST) >= 2 and
                 xi.settings.map.FISHING_ENABLE == true
         end,
 

--- a/scripts/quests/otherAreas/Under_the_Sea.lua
+++ b/scripts/quests/otherAreas/Under_the_Sea.lua
@@ -24,6 +24,7 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_AVAILABLE and
+                player:getFameLevel(xi.fameArea.SELBINA_RABAO) >= 2 and
                 xi.settings.map.FISHING_ENABLE == true
         end,
 

--- a/scripts/quests/sandoria/The_Sweetest_Things.lua
+++ b/scripts/quests/sandoria/The_Sweetest_Things.lua
@@ -26,7 +26,8 @@ quest.sections =
 {
     {
         check = function(player, status, vars)
-            return status == xi.questStatus.QUEST_AVAILABLE
+            return status == xi.questStatus.QUEST_AVAILABLE and
+                player:getFameLevel(xi.fameArea.SANDORIA) >= 2
         end,
 
         [xi.zone.SOUTHERN_SAN_DORIA] =

--- a/scripts/quests/windurst/SOB2_Know_Ones_Onions.lua
+++ b/scripts/quests/windurst/SOB2_Know_Ones_Onions.lua
@@ -31,6 +31,7 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_AVAILABLE and
+                player:getMainLvl() >= 5 and
                 player:hasCompletedQuest(xi.questLog.WINDURST, xi.quest.id.windurst.TRUTH_JUSTICE_AND_THE_ONION_WAY)
         end,
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

It was found that on retail all new characters now start with fame 2. Re-adds the fame requirements I had removed from these quests.
Adds level requirement to SOB2.

## Steps to test these changes

1. `!setfamelevel <x>`
2. Start the quests.
3. `!completequest 2 36`
4. `!changejob 5 WAR`
5. `!zone <Port Windurst>`
6. Talk to Kohlo-Lakolo to start SOB2 `!pos -26.8 -6 190 240`

## Capture
Capture of a fresh char checking their fame and seeing it is set to level 2 despite just being made.
https://drive.google.com/drive/folders/1RYy1dWx1ZS9Btn-d6g_Y90bDdpT2eWae?usp=sharing
