### PR TITLE
[core] Fix packet data for currently spent job points in categories

### DIFF
--- a/src/map/job_points.h
+++ b/src/map/job_points.h
@@ -338,7 +338,6 @@ enum JOBPOINT_TYPE : uint16
 #define JobPointsCategoryIndexByJpType(jp_type) (jp_type >> 5)
 #define JobPointTypeIndex(id)                   (id & 0x1F)
 #define JobPointCost(value)                     ((value + 1) % 21)
-#define JobPointValueFormat(value)              (value << 2)
 
 /************************************************************************
  *                                                                       *

--- a/src/map/packets/s2c/0x08d_job_points.cpp
+++ b/src/map/packets/s2c/0x08d_job_points.cpp
@@ -52,7 +52,7 @@ GP_SERV_COMMAND_JOB_POINTS::GP_SERV_COMMAND_JOB_POINTS(CCharEntity* PChar)
                     .index  = static_cast<uint16_t>(currentType.id & 0x1F), // Lower 5 bits
                     .job_no = static_cast<uint16_t>(currentType.id >> 5),   // Upper 11 bits
                     .next   = static_cast<uint16_t>(JobPointCost(currentType.value)),
-                    .level  = static_cast<uint16_t>(JobPointValueFormat(currentType.value)),
+                    .level  = static_cast<uint16_t>(currentType.value),
                 };
                 pointIndex++;
             }
@@ -81,7 +81,7 @@ GP_SERV_COMMAND_JOB_POINTS::GP_SERV_COMMAND_JOB_POINTS(const CCharEntity* PChar,
         .index  = static_cast<uint16_t>(PJobPoint->id & 0x1F), // Lower 5 bits
         .job_no = static_cast<uint16_t>(PJobPoint->id >> 5),   // Upper 11 bits
         .next   = static_cast<uint16_t>(JobPointCost(PJobPoint->value)),
-        .level  = static_cast<uint16_t>(JobPointValueFormat(PJobPoint->value)),
+        .level  = static_cast<uint16_t>(PJobPoint->value),
     };
 
     // Retail sends full size packet even for single updates


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes #8597 

## Steps to test these changes
Spend job points
<img width="573" height="706" alt="image" src="https://github.com/user-attachments/assets/8e9e9167-b2e3-4a64-a481-8f524ac3213d" />

Check job points (1+2+3+4+5+6 = 21)
<img width="573" height="706" alt="image" src="https://github.com/user-attachments/assets/7f4835fb-8d2b-4594-a157-d44d42994134" />
