### PR TITLE
[core] Use 0.5 STR multiplier in attack calc for non-PCs

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -926,7 +926,11 @@ uint16 CBattleEntity::ATT(SLOTTYPE slot)
     float strMultiplier = 0.5;
 
     // https://www.bg-wiki.com/ffxi/Strength
-    if (weapon && weapon->isTwoHanded()) // 2-handed weapon
+    if (objtype != TYPE_PC)
+    {
+        strMultiplier = 0.5;
+    }
+    else if (weapon && weapon->isTwoHanded()) // 2-handed weapon
     {
         strMultiplier = 1.0;
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Mobs/pets should use .5 STR multiplier for attack

per retail:
<img width="459" height="650" alt="image" src="https://github.com/user-attachments/assets/421eed52-e5ad-4f3c-a52e-77b67870fc4d" />

8+95*.5+159 = 214.5

## Steps to test these changes

/checkparam <pet> and check attack
