### PR TITLE
[lua] Update event type for NPC Mustafa to display his name

### DIFF
--- a/scripts/zones/Port_Bastok/DefaultActions.lua
+++ b/scripts/zones/Port_Bastok/DefaultActions.lua
@@ -32,7 +32,7 @@ return {
     ['Lone_Horn']        = { event = 39 },
     ['Mathurin']         = { event = 101 },
     ['Mine_Konte']       = { event = 42 },
-    ['Mustafa']          = { messageSpecial = ID.text.ARRIVING_PASSENGER_DIALOG },
+    ['Mustafa']          = { text = ID.text.ARRIVING_PASSENGER_DIALOG },
     ['Nicadio']          = { event = 32 },
     ['Odyssean_Passage'] = { messageSpecial = ID.text.NOTHING_HAPPENS },
     ['Oggbi']            = { event = 230 },


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Updates the event type for the default action for the NPC Mustafa in Port Bastok to properly display his name.

## Steps to test these changes

1. `!zone <Port Bastok>`
2. Talk to Mustafa `!gotoname Mustafa`
