### PR TITLE
[core] [lua] Reduce base damage of mob kicks from retail data

### DIFF
--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -113,11 +113,11 @@ xi.combat.physical.calculateAttackDamage = function(actor, target, slot, physica
 
     if isH2H then
         local naturalH2hDamage = math.floor(actor:getSkillLevel(xi.skill.HAND_TO_HAND) * 0.11) + 3
-        local kickDamage = 0
 
         if actor:isMob() then
             local mobH2HPenalty = 1.0
             local regionID      = actor:getCurrentRegion()
+            local fSTR          = xi.combat.physical.calculateMeleeStatFactor(actor, target)
 
             if regionID <= xi.region.LIMBUS then
                 mobH2HPenalty = 0.425 -- Vanilla - COP
@@ -125,11 +125,18 @@ xi.combat.physical.calculateAttackDamage = function(actor, target, slot, physica
                 mobH2HPenalty = 0.650
             end
 
-            if physicalAttackType == xi.physicalAttackType.KICK then
-                kickDamage = actor:getMod(xi.mod.KICK_DMG)
-            end
+            baseDamage = actor:getWeaponDmg() + bonusBasePhysicalDamage
 
-            baseDamage = (actor:getWeaponDmg() + kickDamage + bonusBasePhysicalDamage + xi.combat.physical.calculateMeleeStatFactor(actor, target)) * mobH2HPenalty
+            if physicalAttackType == xi.physicalAttackType.KICK then
+                local kickPenalty = 2 / 3 -- Per Jimmy, kicks get a second penalty, then fSTR is added
+                local kickDamage  = actor:getMod(xi.mod.KICK_DMG)
+
+                -- Per Jimmy, kick damage penalty for mobs can only be damage * h2h penalty * kickpenalty + fstr
+                -- The math doesn't work in any other way, which is strange given fSTR is before the penalty on non-kicks
+                baseDamage = (baseDamage + kickDamage) * mobH2HPenalty * kickPenalty + fSTR
+            else
+                baseDamage = (baseDamage + fSTR) * mobH2HPenalty
+            end
         elseif physicalAttackType == xi.physicalAttackType.KICK then
             baseDamage = naturalH2hDamage + actor:getMod(xi.mod.KICK_DMG) + bonusBasePhysicalDamage + xi.combat.physical.calculateMeleeStatFactor(actor, target)
         else

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -199,7 +199,7 @@ namespace mobutils
             multiplier = PMob->getMobMod(MOBMOD_BASE_DAMAGE_MULTIPLIER) / 100.0f;
         }
 
-        damage = damage * multiplier + offset;
+        damage = (damage + offset) * multiplier;
 
         damage = std::clamp<int32>(damage, 1, 65535);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

tl;dr: kick attacks are done slightly differently for mobs on base damage than normal hits

Data:
[troll KA level 83.xls](https://github.com/user-attachments/files/23364011/troll.KA.level.83.xls)

<img width="662" height="253" alt="image" src="https://github.com/user-attachments/assets/7eea6b29-0244-4552-a522-b0e1541fa05f" />

Also move the mobmob for base damage mult after the offset (per jimmy's sheet)

## Steps to test these changes

Get kicked, see its lower base damage compared to normal hits (from mobs)
Also check lua version (setting)