### PR TITLE
[core] [lua] Tie initial satchel to OTP

### DIFF
--- a/scripts/quests/jeuno/helpers.lua
+++ b/scripts/quests/jeuno/helpers.lua
@@ -93,7 +93,11 @@ function xi.jeuno.helpers.GobbiebagQuest:new(params)
                     [73] = function(player, csid, option, npc)
                         if quest:complete(player) then
                             player:changeContainerSize(xi.inv.INVENTORY, bagIncrease)
-                            player:changeContainerSize(xi.inv.MOGSATCHEL, bagIncrease)
+
+                            if player:getContainerSize(xi.inv.MOGSATCHEL) > 0 then
+                                player:changeContainerSize(xi.inv.MOGSATCHEL, bagIncrease)
+                            end
+
                             player:messageSpecial(params.message)
                             player:confirmTrade()
                         end

--- a/sql/char_storage.sql
+++ b/sql/char_storage.sql
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS `char_storage` (
   `inventory` tinyint(2) unsigned NOT NULL DEFAULT '30',
   `safe` tinyint(2) unsigned NOT NULL DEFAULT '50',
   `locker` tinyint(2) unsigned NOT NULL DEFAULT '0',
-  `satchel` tinyint(2) unsigned NOT NULL DEFAULT '30',
+  `satchel` tinyint(2) unsigned NOT NULL DEFAULT '0',
   `sack` tinyint(2) unsigned NOT NULL DEFAULT '0',
   `case` tinyint(2) unsigned NOT NULL DEFAULT '80',
   `wardrobe` tinyint(2) unsigned NOT NULL DEFAULT '80',

--- a/tools/migrations/049_char_storage_satchel_default.py
+++ b/tools/migrations/049_char_storage_satchel_default.py
@@ -1,0 +1,30 @@
+import mariadb
+
+
+def migration_name():
+    return "Adjusting char_storage default satchel to size 0"
+
+
+def check_preconditions(cur):
+    return
+
+
+def needs_to_run(cur):
+    # check
+    cur.execute(
+        "show columns from char_storage where field = 'satchel' and `Default` = 30;"
+    )
+    if cur.fetchone():
+        return True
+    return False
+
+
+def migrate(cur, db):
+    pass
+    try:
+        cur.execute(
+            "ALTER TABLE char_storage MODIFY satchel tinyint(2) unsigned NOT NULL DEFAULT '0';"
+        )
+        db.commit()
+    except mariadb.Error as err:
+        print("Something went wrong: {}".format(err))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This is a retail parity upgrade:

With a new char if you do not have an OTP registered will not have a satchel (size 0)
This acts just like an existing char with satchel size of 0

Once registered and you login, all your characters on your account will gain a satchel with the same size satchel as your inventory. 

After your satchel size is non-zero, your satchel will upgrade with your inventory. It does not matter if your satchel is registered or not, you will never lose the ability to have it or to upgrade it

## Steps to test these changes

Make new char with no OTP registered, verify 0 size satchel and it's disabled in the menu:
<img width="153" height="337" alt="image" src="https://github.com/user-attachments/assets/6c29d0a7-bf4f-46eb-862c-256bda5ddf32" />
Register OTP, verify it's there
<img width="124" height="313" alt="image" src="https://github.com/user-attachments/assets/7329dde2-6326-4de0-9707-3ae178143b4a" />

upgrade inventory, see size upgraded:
<img width="423" height="746" alt="image" src="https://github.com/user-attachments/assets/4027376a-7b2b-4007-9915-0bcdbdbfe01a" />

Make a new char without OTP registered (zero sized satchel) and upgrade inventory, but see no satchel:
<img width="896" height="727" alt="image" src="https://github.com/user-attachments/assets/ad74335d-f6d3-444d-b249-165eda880bfe" />

