### PR TITLE
[lua] Fix quest prereqs for: Boy and the Beast, Light in the Darkness

### DIFF
--- a/scripts/quests/crystalWar/Boy_and_the_Beast.lua
+++ b/scripts/quests/crystalWar/Boy_and_the_Beast.lua
@@ -19,7 +19,8 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_AVAILABLE and
-                player:hasCompletedMission(xi.mission.log_id.WOTG, xi.mission.id.wotg.BACK_TO_THE_BEGINNING)
+                player:hasCompletedMission(xi.mission.log_id.WOTG, xi.mission.id.wotg.BACK_TO_THE_BEGINNING) and -- WotG mission requirement.
+                player:hasCompletedQuest(xi.questLog.CRYSTAL_WAR, xi.quest.id.crystalWar.CLAWS_OF_THE_GRIFFON)   -- WotG nation quest requirement.
         end,
 
         [xi.zone.SOUTHERN_SAN_DORIA_S] =

--- a/scripts/quests/crystalWar/Light_in_the_Darkness.lua
+++ b/scripts/quests/crystalWar/Light_in_the_Darkness.lua
@@ -23,7 +23,8 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_AVAILABLE and
-                player:getCurrentMission(xi.mission.log_id.WOTG) == xi.mission.id.wotg.CAIT_SITH
+                player:hasCompletedMission(xi.mission.log_id.WOTG, xi.mission.id.wotg.BACK_TO_THE_BEGINNING) and -- WotG mission requirement.
+                player:hasCompletedQuest(xi.questLog.CRYSTAL_WAR, xi.quest.id.crystalWar.FIRES_OF_DISCONTENT)    -- WotG nation quest requirement.
         end,
 
         [xi.zone.BASTOK_MARKETS_S] =

--- a/scripts/zones/Windurst_Waters_[S]/npcs/Door_Acolyte_Hostel_down.lua
+++ b/scripts/zones/Windurst_Waters_[S]/npcs/Door_Acolyte_Hostel_down.lua
@@ -16,14 +16,10 @@ entity.onTrigger = function(player, npc)
         player:startEvent(129)
     elseif
         player:getQuestStatus(xi.questLog.CRYSTAL_WAR, xi.quest.id.crystalWar.THE_TIGRESS_STRIKES) == xi.questStatus.QUEST_COMPLETED and
-        player:getQuestStatus(xi.questLog.CRYSTAL_WAR, xi.quest.id.crystalWar.KNOT_QUITE_THERE) == xi.questStatus.QUEST_AVAILABLE
+        player:getQuestStatus(xi.questLog.CRYSTAL_WAR, xi.quest.id.crystalWar.KNOT_QUITE_THERE) == xi.questStatus.QUEST_AVAILABLE and
+        player:hasCompletedMission(xi.mission.log_id.WOTG, xi.mission.id.wotg.BACK_TO_THE_BEGINNING)
     then
-        if
-            player:getCurrentMission(xi.mission.log_id.WOTG) == xi.mission.id.wotg.CAIT_SITH or
-            player:hasCompletedMission(xi.mission.log_id.WOTG, xi.mission.id.wotg.CAIT_SITH)
-        then
-            player:startEvent(151)
-        end
+        player:startEvent(151)
     elseif player:getQuestStatus(xi.questLog.CRYSTAL_WAR, xi.quest.id.crystalWar.KNOT_QUITE_THERE) == xi.questStatus.QUEST_ACCEPTED then
         player:startEvent(152)
     else


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR fixes the requirements for two WotG quests: Boy and the Beast, and Light in the Darkness. A prereq for Boy and the Beast is the quest Claws of the Griffon; otherwise you can get cutscenes out of order which is confusing but not a hard block. Light in the Darkness has a similar quest prereq, however it has another issue which is that if you advance the WotG mission line beyond 'Cait Sith' (easy to do), you can get forever locked out of the quest; this PR relaxes the mission check so it still triggers if you have gone past mission 3.

Edit: Another change was made for the Windurst-equivalent quest, 'Knot Quite There'. Functionally it is almost identical to how it was before, but it's a little more legible and consistent with the language for the other two nations' quests.

## Steps to test these changes

`player:delQuest(xi.questLog.CRYSTAL_WAR, xi.quest.id.crystalWar.CLAWS_OF_THE_GRIFFON)`
Confirm that you can't get the cutscene from Raustigne for Boy and the Beast even if you have completed WotG mission 2. Then confirm you can start the quest after `player:completeQuest(xi.questLog.CRYSTAL_WAR, xi.quest.id.crystalWar.CLAWS_OF_THE_GRIFFON)`. Repeat for Fires of Discontent as prereq for Light in the Darkness.
