### PR TITLE
[cpp] Fix Crash in GP_SERV_COMMAND_ABIL_RECAST

### DIFF
--- a/src/map/packets/s2c/0x119_abil_recast.cpp
+++ b/src/map/packets/s2c/0x119_abil_recast.cpp
@@ -52,15 +52,16 @@ GP_SERV_COMMAND_ABIL_RECAST::GP_SERV_COMMAND_ABIL_RECAST(CCharEntity* PChar)
 
             if (recast.maxCharges != 0)
             {
-                const auto* charge = ability::GetCharge(PChar, recast.ID);
-
-                const uint16_t actualChargeTime = timer::count_seconds(recast.chargeTime);
-                const uint16_t baseChargeTime   = timer::count_seconds(charge->chargeTime);
-
-                if (baseChargeTime > actualChargeTime)
+                if (const auto* charge = ability::GetCharge(PChar, recast.ID))
                 {
-                    packet.Timers[count].Calc1 = 0; // Not used in Ready, QD, Stratagems... Is this never used?
-                    packet.Timers[count].Calc2 = 65536 - (baseChargeTime - actualChargeTime) * recast.maxCharges;
+                    const uint16_t actualChargeTime = timer::count_seconds(recast.chargeTime);
+                    const uint16_t baseChargeTime   = timer::count_seconds(charge->chargeTime);
+
+                    if (baseChargeTime > actualChargeTime)
+                    {
+                        packet.Timers[count].Calc1 = 0; // Not used in Ready, QD, Stratagems... Is this never used?
+                        packet.Timers[count].Calc2 = 65536 - (baseChargeTime - actualChargeTime) * recast.maxCharges;
+                    }
                 }
             }
             count++;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
- Fixes a crash in Packet 0x119 `GP_SERV_COMMAND_ABIL_RECAST` where the logic for checking charges was not checking for `nullptr` before de-referencing the return.

When the check for ability charges is done, the charge data is obtained from `ability::GetCharge()` which can return a `nullptr`.  This condition happens when a player is level sync'd below the level of an ability with charges (such as Ready/Sic).
```cpp
    Charge_t* GetCharge(CBattleEntity* PUser, uint16 chargeID)
    {
        Charge_t* charge = nullptr;   // <--- Initialized to nullptr
        for (auto& PCharge : PChargesList)
        {
            if (PCharge->ID == chargeID)
            {
                if (PUser->GetMJob() == PCharge->job)
                {
                    if (PUser->GetMLevel() >= PCharge->level)   // <--- Level 75 BST Sync'd to Level 10 Fails this check
                    {
                        charge = PCharge.get();
                    }
                    else
                    {
                        break;
                    }
                }
                else if (PUser->GetSJob() == PCharge->job)
                {
                    if (PUser->GetSLevel() >= PCharge->level)
                    {
                        charge = PCharge.get();
                    }
                    else
                    {
                        break;
                    }
                }
            }
        }
        return charge;  // <--- nullptr returned due to failed check
    }
```
This was then de-referenced as a `nullptr`:
```cpp
                const auto* charge = ability::GetCharge(PChar, recast.ID);

                const uint16_t actualChargeTime = timer::count_seconds(recast.chargeTime);
                const uint16_t baseChargeTime   = timer::count_seconds(charge->chargeTime);
```
This PR puts a check around the logic so that we are not de-referencing nullptrs.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - Login with 2 Characters
2 - `!changejob bst 75` on Character 1
3 - `!changejob war 10` on Character 2
4 - Charm a mob on Character 1 so that you have the `Sic` ability available
5 - Create a party with both characters
6 - Level Sync to the Level 10 character
Result: No Map Crash from de-referencing the nullptr

7 - Break Level Sync
8 - Send your pet to attack a mob and burn Sic to trigger the timer
9 - Re-enable Level Sync
10 - Break Level Sync agaain
11 - Wait till the sync effect expires
12 - Open your Pet Abilities and check your Sic/Ready timer
Result: Your ready/sic timers are still functional.