### PR TITLE
[lua] Add undead check to HP, MP, TP drain additional effects

### DIFF
--- a/scripts/globals/additional_effects.lua
+++ b/scripts/globals/additional_effects.lua
@@ -235,6 +235,11 @@ xi.additionalEffect.procFunctions[xi.additionalEffect.procType.HP_DRAIN] =  func
     params.element = xi.element.DARK
     local damage = xi.additionalEffect.calcDamage(attacker, params.element, defender, params.damage)
 
+    -- Undead cannot be drained
+    if defender:isUndead() then
+        return 0, 0, 0
+    end
+
     if damage > defender:getHP() then
         damage = defender:getHP()
     end
@@ -256,6 +261,11 @@ xi.additionalEffect.procFunctions[xi.additionalEffect.procType.MP_DRAIN] =  func
     params.element = xi.element.DARK
     local damage = xi.additionalEffect.calcDamage(attacker, params.element, defender, params.damage)
 
+    -- Undead cannot be drained
+    if defender:isUndead() then
+        return 0, 0, 0
+    end
+
     if damage > defender:getMP() then
         damage = defender:getMP()
     end
@@ -276,6 +286,11 @@ xi.additionalEffect.procFunctions[xi.additionalEffect.procType.TP_DRAIN] =  func
 
     -- Hardcoded for now
     params.element = xi.element.DARK
+
+    -- Undead cannot be drained
+    if defender:isUndead() then
+        return 0, 0, 0
+    end
 
     local damage = xi.additionalEffect.calcDamage(attacker, params.element, defender, params.damage)
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds conditioning to xi.additional_effects.lua to check whether a defending target is undead and returns 0, 0, 0 if true for any of the three drain additional effects. Undead are unable to be drained.

## Steps to test these changes
Find an undead mob and attempt to HP, MP or TP drain. Drains will no longer proc.
