### PR TITLE
[cpp] Implement tiered aggro ranges for low HP detection

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -320,9 +320,22 @@ auto CMobController::CanDetectTarget(CBattleEntity* PTarget, const bool forceSig
         return false;
     }
 
-    if ((detects & DETECT_LOWHP) && PTarget->GetHPP() < 75)
+    if (detects & DETECT_LOWHP)
     {
-        return isTargetAndInRange || PMob->CanSeeTarget(PTarget);
+        const uint8 targetHPP = PTarget->GetHPP();
+        float aggroRange = 0.0f;
+
+        if (targetHPP < 25)         // Red HP
+            aggroRange = 20.0f;
+        else if (targetHPP < 50)    // Orange HP
+            aggroRange = 18.0f;
+        else if (targetHPP < 75)    // Yellow HP
+            aggroRange = 8.0f;
+
+        if (aggroRange > 0.0f && currentDistance <= aggroRange)
+        {
+            return isTargetAndInRange || PMob->CanSeeTarget(PTarget);
+        }
     }
 
     if ((detects & DETECT_WEAPONSKILL) && PTarget->PAI->IsCurrentState<CWeaponSkillState>())


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Updates the low HP detection behavior by introducing variable aggression range based on target HP percentage :
- Yellow HP (<75%) triggers aggro within 8 yalms
- Orange HP (<50%) triggers aggro within 18 yalms
- Red HP (<25%) triggers aggro within 20 yalms

Source: https://www.bg-wiki.com/ffxi/Aggressive#Bleeding (verified on retail).

## Steps to test these changes

Find a mob with low HP detection.
Reduce your HP and adjust your distance from the mob to trigger (or not) aggro.
