### PR TITLE
[docker] update to clang-format-20

### DIFF
--- a/docker/ubuntu.Dockerfile
+++ b/docker/ubuntu.Dockerfile
@@ -93,11 +93,12 @@ FROM staging AS devtools
 
 # Install misc dev/ci tools on top of build tools.
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends --quiet \
-    clang-format \
+    clang-format-20 \
     cppcheck \
     gdb \
     luarocks \
     && rm -rf /var/lib/apt/lists/*
+RUN ln -s /usr/bin/clang-format-20 /usr/bin/clang-format
 RUN luarocks --tree /xiadmin/.luarocks install luacheck
 ENV PATH="/xiadmin/.luarocks/bin:$PATH"
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Updates the Ubuntu Dockerfile to explicitly use clang-format-20 for the devtools image. Sanity checks will use this after it's merged and built.

## Steps to test these changes

Test current:

```
docker run --rm --mount type=bind,src="$(pwd)",dst=/server -it ghcr.io/landsandboat/devtools:ubuntu /server/tools/ci/sanity_checks/cpp.sh
```

clang-format errors:

```
/server/.clang-format:96:17: error: invalid boolean
ReflowComments: Always
                ^~~~~~
Error reading /server/.clang-format: Invalid argument
```

Test changes:

```
docker build --tag landsandboat:devtools-ubuntu --target devtools -f docker/ubuntu.Dockerfile .
docker run --rm --mount type=bind,src="$(pwd)",dst=/server -it landsandboat:devtools-ubuntu /server/tools/ci/sanity_checks/cpp.sh
```