### PR TITLE
[lua] ECO Windurst and Bastok Cleanup - Idle Despawn and NM Spawn pos

### DIFF
--- a/scripts/zones/Gusgen_Mines/mobs/Pudding.lua
+++ b/scripts/zones/Gusgen_Mines/mobs/Pudding.lua
@@ -12,18 +12,30 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
 end
 
+entity.onMobSpawn = function(mob)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180) -- 3 minutes
+end
+
 entity.onAdditionalEffect = function(mob, target, damage)
     return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.SLOW)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
+    local pudding = ID.mob.PUDDING_OFFSET
+
     if
         player:getCharVar('EcoStatus') == 101 and
         player:hasStatusEffect(xi.effect.LEVEL_RESTRICTION)
     then
         local bothDead = true
-        for i = ID.mob.PUDDING_OFFSET, ID.mob.PUDDING_OFFSET + 1 do
-            if i ~= mob:getID() and GetMobByID(i):isAlive() then
+        for i = pudding, pudding + 1 do
+            local nmCheck = GetMobByID(i)
+
+            if
+                i ~= mob:getID() and
+                nmCheck and
+                nmCheck:isAlive()
+            then
                 bothDead = false
             end
         end

--- a/scripts/zones/Ordelles_Caves/mobs/Necroplasm.lua
+++ b/scripts/zones/Ordelles_Caves/mobs/Necroplasm.lua
@@ -10,6 +10,10 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
 end
 
+entity.onMobSpawn = function(mob)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180) -- 3 minutes
+end
+
 entity.onAdditionalEffect = function(mob, target, damage)
     return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.PARALYZE)
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds an idle despawn to these NMs so they despawn in case of a party wipe/accidental pop.

- Windurst NMs already had it coded.

Fixes the spawn point of the Bastok NMs to be closer to retail. (Before they were in the wall).

## Steps to test these changes

1. Spawn the mobs.
2. !goto <me>
3. Wait 3 minutes for them to despawn.
