### PR TITLE
[lua][sql] Implement Vulkodlac spawn QM

### DIFF
--- a/scripts/enum/item.lua
+++ b/scripts/enum/item.lua
@@ -1668,6 +1668,7 @@ xi.item =
     ONE_HUNDRED_EIGHT_KNOT_QUIPU        = 2562,
     LUMP_OF_KARUGO_NARUGO_CLAY          = 2563,
     JAR_OF_PEISTE_PELLETS               = 2564,
+    JAR_OF_GNOLE_PELLETS                = 2565,
     JAR_OF_GNAT_PELLETS                 = 2566,
     LETHE_CONSOMME                      = 2568,
     LETHE_POTAGE                        = 2569,

--- a/scripts/zones/Jugner_Forest_[S]/IDs.lua
+++ b/scripts/zones/Jugner_Forest_[S]/IDs.lua
@@ -48,6 +48,7 @@ zones[xi.zone.JUGNER_FOREST_S] =
         DRUMSKULL_ZOGDREGG    = GetFirstID('Drumskull_Zogdregg'),
         FINGERFILCHER_DRADZAD = GetFirstID('Fingerfilcher_Dradzad'),
         COBRACLAW_BUCHZVOTCH  = GetFirstID('Cobraclaw_Buchzvotch'),
+        VULKODLAC             = GetFirstID('Vulkodlac'),
 
         VOIDWALKER =
         {

--- a/scripts/zones/Jugner_Forest_[S]/npcs/qm1.lua
+++ b/scripts/zones/Jugner_Forest_[S]/npcs/qm1.lua
@@ -1,0 +1,24 @@
+-----------------------------------
+-- Area: Jugner Forest [S]
+--  NPC: ???
+-- !pos 8.54 -11.18 -511 82
+-----------------------------------
+local ID = zones[xi.zone.JUGNER_FOREST_S]
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+    if
+        npcUtil.tradeHasOnly(trade, xi.item.JAR_OF_GNOLE_PELLETS) and
+        npcUtil.popFromQM(player, npc, ID.mob.VULKODLAC, { hide = 0 })
+    then
+        player:confirmTrade()
+    end
+end
+
+entity.onTrigger = function(player, npc)
+    player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)
+end
+
+return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR implements the spawn quest marker for the gnole NM "Vulkodlac" in Jugner Forest [S].

## Steps to test these changes

Trade a "jar of gnole pellets" (ID 2565) to the ??? in Jugner Forest [S] (`!pos 8.54 -11.18 -511 82`), see that Vulkodlac appears. 
