### PR TITLE
[lua] Chocobo Riding Game Bug Fix = localvar > charvar

### DIFF
--- a/scripts/globals/chocobo.lua
+++ b/scripts/globals/chocobo.lua
@@ -197,7 +197,7 @@ end
 ---@param eventSucceed integer
 ---@return nil
 xi.chocobo.renterOnEventFinish = function(player, csid, option, eventSucceed)
-    local chocoGame = player:getLocalVar('[ChocoGame]DestCity')
+    local chocoGame = player:getCharVar('[ChocoGame]DestCity')
 
     if csid == eventSucceed and option == 0 then
         local mLvl     = player:getMainLvl()

--- a/scripts/globals/chocobo_riding_game.lua
+++ b/scripts/globals/chocobo_riding_game.lua
@@ -80,7 +80,7 @@ xi.chocoboGame.startRaceEvent = function(player, destination, eventSucceed)
     local eventParam = raceData[zoneId][destination].eventParam
 
     -- Temp destination var until player confirms race
-    player:setLocalVar('[ChocoGame]DestCity', destination)
+    player:setCharVar('[ChocoGame]DestCity', destination)
     player:startEvent(eventSucceed, -3, 0, 0, eventParam)
 end
 
@@ -88,14 +88,14 @@ end
 xi.chocoboGame.beginRace = function(player, option)
     if option == 0 then
         local zoneId     = player:getZone():getID()
-        local destCity   = player:getLocalVar('[ChocoGame]DestCity')
+        local destCity   = player:getCharVar('[ChocoGame]DestCity')
 
         player:setCharVar('[ChocoGame]StartingCity', zoneId)
         player:setCharVar('[ChocoGame]DestCity', destCity)
         player:setCharVar('[ChocoGame]NextEntryTime', 1, NextConquestTally())
         player:setCharVar('[ChocoGame]StartTime', GetSystemTime())
     else -- Player declined race, clearing var
-        player:setLocalVar('[ChocoGame]DestCity', 0)
+        player:setCharVar('[ChocoGame]DestCity', 0)
     end
 end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The Chocobo Riding Game had an issue that was preventing it from starting and if it does start it couldn't be completed.
Updates the local vars to char vars. The inconsistency of timing when zoning was not passing the vars properly sometimes.

In about 20 attempts to start the minigame, I only successfully started it once, and when I did, it did not complete upon reaching the finish line since DestCity was 0.

After updating the variables from local to char I was able to start and complete the minigame 3 times in a row without issue.

## Steps to test these changes

1. Go to a city stable and talk to the chocobo rental NPCs. A different route determines which npc is active.

https://www.mithrapride.org/vana_time/chocoracetable.html

2. Talk to the correct NPC and find your destination, and start the minigame.
3. `!exec player:setMod(xi.mod.MOUNT_MOVE, 255)`
4. Upon zoning you should get an update with your current time.
5. Reach your destination, the ending area is in front of the zoneline to your destination zone.
6. Complete the race.

