### PR TITLE
[cpp] Filter /anon Players in Filtered Search

### DIFF
--- a/src/search/data_loader.cpp
+++ b/src/search/data_loader.cpp
@@ -379,6 +379,13 @@ std::list<SearchEntity*> CDataLoader::GetPlayersList(search_req sr, int* count)
                 }
             }
 
+            // filter anon players if job/nation/race/rank/level search
+            if ((PPlayer->flags1 & 0x4000) &&
+                (sr.jobid > 0 || sr.nation != 255 || sr.race != 255 || sr.minRank > 0 || sr.maxRank > 0 || sr.minlvl > 0 || sr.maxlvl > 0))
+            {
+                continue;
+            }
+
             // filter by job
             if (sr.jobid > 0 && sr.jobid != PPlayer->mjob)
             {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
- Adds extra logic to filter anon players when searching by Job, Race, Nation, Level, or Rank to mirror retail functionality.  These specific aspects are "hidden" when /anon is enabled and thus should not be returning results based on those "hidden" attributes.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - Login with two characters
2 - `!changejob war 10` and `/anon` on one of the characters
3 - `/sea all war`
Result: WAR Character does not appear in search results.

4 - `/sea all` to perform a search without filters
Result: See the anon character since a filter was not applied to the "hidden" attributes from someone being `/anon`