### PR TITLE
[core][sql][lua] Implement Garrison latent effects

### DIFF
--- a/scripts/enum/latent.lua
+++ b/scripts/enum/latent.lua
@@ -66,4 +66,5 @@ xi.latent =
     VS_SUPERFAMILY           = 61, -- Vs. Specific Family ID (e.g. Vs. Mandragora: Accuracy+3)
     MAINJOB                  = 62, -- mainjob - PARAM: JOBTYPE
     IN_ADOULIN               = 63, -- in adoulin city zone
+    IN_GARRISON              = 64, -- while in an active Garrison
 }

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -1133,6 +1133,44 @@ INSERT INTO `item_latents` VALUES (14509,11,8,10,0);
 -- Shadow Ring
 INSERT INTO `item_latents` VALUES (14646,29,10,32,0);    -- Darksday: MDB+10
 
+-- Protean Ring
+INSERT INTO `item_latents` VALUES (14652,23,3,64,0); -- Attack +3 during Garrison
+INSERT INTO `item_latents` VALUES (14652,24,3,64,0); -- R.Attack +3 during Garrison
+-- TODO: Verify the points below.
+-- This is bare minimum to see a difference in different garrison tiers.
+-- stops at lv75 as Variable Ring likely does.
+INSERT INTO `item_latents` VALUES (14652,23,1,64,30); -- Atk +4, lv30+
+INSERT INTO `item_latents` VALUES (14652,24,1,64,30);
+INSERT INTO `item_latents` VALUES (14652,23,1,64,40); -- Atk +5, lv40+
+INSERT INTO `item_latents` VALUES (14652,24,1,64,40);
+INSERT INTO `item_latents` VALUES (14652,23,1,64,50); -- Atk +6, lv50+
+INSERT INTO `item_latents` VALUES (14652,24,1,64,50);
+INSERT INTO `item_latents` VALUES (14652,23,1,64,60); -- Atk +7, lv60+
+INSERT INTO `item_latents` VALUES (14652,24,1,64,60);
+INSERT INTO `item_latents` VALUES (14652,23,1,64,70); -- Atk +8, lv70+
+INSERT INTO `item_latents` VALUES (14652,24,1,64,70);
+INSERT INTO `item_latents` VALUES (14652,23,1,64,75); -- Atk +9, lv75+
+INSERT INTO `item_latents` VALUES (14652,24,1,64,75);
+
+-- Variable Ring
+-- [known data points]
+-- lv20: 28 MP, 1 MPHEAL
+-- lv30: 30 MP, 1 MPHEAL
+-- lv50: 40 MP, 2 MPHEAL
+-- lv99: 55 MP, 4 MPHEAL
+-- Assumption: Scaling stops at level 75. TODO: verify
+INSERT INTO `item_latents` VALUES (14653,5,28,64,0);  -- MP +28 during Garrison
+INSERT INTO `item_latents` VALUES (14653,71,1,64,0);  -- MPHEAL +1 during Garrison
+INSERT INTO `item_latents` VALUES (14653,5,2,64,30);  -- MP +2 during Garrison lv30+ (30 MP)
+INSERT INTO `item_latents` VALUES (14653,5,5,64,40);  -- (verify) MP +5 during Garrison lv40+ (35 MP)
+INSERT INTO `item_latents` VALUES (14653,71,1,64,40); -- (verify) MPHEAL +1 during Garrison lv40+
+INSERT INTO `item_latents` VALUES (14653,5,5,64,50);  -- MP +5 during Garrison lv50+ (40 MP) (2 MPHEAL)
+INSERT INTO `item_latents` VALUES (14653,5,6,64,60);  -- (verify) MP +6 during Garrison lv60+ (46 MP)
+INSERT INTO `item_latents` VALUES (14653,71,1,64,60); -- (verify) MPHEAL +1 during Garrison lv60+ (3 MPHEAL)
+INSERT INTO `item_latents` VALUES (14653,5,6,64,70);  -- (verify) MP +6 during Garrison lv70+ (52 MP)
+INSERT INTO `item_latents` VALUES (14653,5,3,64,75);  -- (verify) MP +3 during Garrison lv75+ (55 MP)
+INSERT INTO `item_latents` VALUES (14653,71,1,64,75); -- (verify) MPHEAL +1 during Garrison lv75+ (4 MPHEAL)
+
 -- Atlaua's Ring
 INSERT INTO `item_latents` VALUES (14658,304,4,59,1); -- VS_ECOSYSTEM: AMORPH - TAME: 4
 INSERT INTO `item_latents` VALUES (14658,304,4,59,2); -- VS_ECOSYSTEM: AQUAN  - TAME: 4
@@ -1176,6 +1214,20 @@ INSERT INTO `item_latents` VALUES (14737,384,500,8,14);
 
 -- Magician's Earring
 INSERT INTO `item_latents` VALUES (14738,5,30,8,15);
+
+-- Refresh Earring
+INSERT INTO `item_latents` VALUES (14755,369,1,64,0); -- Refresh +1 during Garrison
+
+-- Mecurial Earring
+-- TODO: verify (somehow...) how much evasion increases per level.
+-- Stopping at lv75 as Variable Ring likely does.
+INSERT INTO `item_latents` VALUES (14757,68,1,64,0);  -- Evasion +1 during Garrison
+INSERT INTO `item_latents` VALUES (14757,68,1,64,30); -- Evasion +1 during Garrison, level 30+ (2 Eva)
+INSERT INTO `item_latents` VALUES (14757,68,1,64,40); -- Evasion +1 during Garrison, level 40+ (3 Eva)
+INSERT INTO `item_latents` VALUES (14757,68,1,64,50); -- Evasion +1 during Garrison, level 50+ (4 Eva)
+INSERT INTO `item_latents` VALUES (14757,68,1,64,60); -- Evasion +1 during Garrison, level 60+ (5 Eva)
+INSERT INTO `item_latents` VALUES (14757,68,1,64,70); -- Evasion +1 during Garrison, level 70+ (6 Eva)
+INSERT INTO `item_latents` VALUES (14757,68,1,64,75); -- Evasion +1 during Garrison, level 75+ (7 Eva)
 
 -- Vampire Earring
 INSERT INTO `item_latents` VALUES (14783,8,4,26,1);      -- STR+4 during Nighttime

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -166,6 +166,11 @@ bool CBattleEntity::isInAdoulin()
     return false;
 }
 
+bool CBattleEntity::isInGarrison()
+{
+    return luautils::callGlobal<bool>("xi.garrison.isInGarrison", this);
+}
+
 bool CBattleEntity::isInMogHouse()
 {
     if (this->objtype == TYPE_PC)

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -528,6 +528,7 @@ public:
     bool isInAdoulin();
     bool isInAssault();
     bool isInDynamis();
+    bool isInGarrison();
     bool isInMogHouse();
     bool hasImmunity(uint32 imID);
     bool isAsleep();

--- a/src/map/latent_effect.cpp
+++ b/src/map/latent_effect.cpp
@@ -24,7 +24,9 @@
 #include "entities/charentity.h"
 #include "items/item_weapon.h"
 #include "latent_effect.h"
+#include "packets/s2c/0x0ac_command_data.h"
 #include "status_effect_container.h"
+#include "utils/charutils.h"
 
 CLatentEffect::CLatentEffect(CBattleEntity* owner, LATENT conditionsId, uint16 conditionsValue, uint8 slot, Mod modValue, int16 modPower)
 : m_POwner(owner)
@@ -136,6 +138,8 @@ bool CLatentEffect::Activate()
             if (item)
             {
                 item->addModifier(GetModValue(), GetModPower());
+                charutils::BuildingCharWeaponSkills(PChar);
+                PChar->pushPacket<GP_SERV_COMMAND_COMMAND_DATA>(PChar);
                 m_PItem = item;
             }
         }
@@ -161,6 +165,9 @@ bool CLatentEffect::Deactivate()
             if (m_PItem != nullptr)
             {
                 m_PItem->delModifier(GetModValue(), GetModPower());
+                CCharEntity* PChar = static_cast<CCharEntity*>(m_POwner);
+                charutils::BuildingCharWeaponSkills(PChar);
+                PChar->pushPacket<GP_SERV_COMMAND_COMMAND_DATA>(PChar);
             }
         }
         // Remove other modifiers from player

--- a/src/map/latent_effect.h
+++ b/src/map/latent_effect.h
@@ -93,9 +93,10 @@ enum class LATENT : uint16
     VS_SUPERFAMILY         = 61, // Vs. Specific SuperFamily ID (e.g. Vs. Mandragora: Accuracy+3)
     MAINJOB                = 62, // mainjob - PARAM: JOBTYPE
     IN_ADOULIN             = 63, //
+    IN_GARRISON            = 64, // while in an active Garrison
 };
 
-#define MAX_LATENTEFFECTID 64
+#define MAX_LATENTEFFECTID 65
 
 /************************************************************************
  *                                                                       *

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -307,6 +307,7 @@ void CLatentEffectContainer::CheckLatentsStatusEffect()
             case LATENT::WEATHER_CONDITION:
             case LATENT::WEATHER_ELEMENT:
             case LATENT::NATION_CONTROL:
+            case LATENT::IN_GARRISON:
                 return ProcessLatentEffect(latentEffect);
                 break;
             default:
@@ -553,6 +554,7 @@ void CLatentEffectContainer::CheckLatentsJobLevel()
             case LATENT::JOB_MULTIPLE_AT_NIGHT:
             case LATENT::JOB_LEVEL_BELOW:
             case LATENT::JOB_LEVEL_ABOVE:
+            case LATENT::IN_GARRISON:
                 return ProcessLatentEffect(latentEffect);
                 break;
             default:
@@ -1150,6 +1152,9 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect, bo
             break;
         case LATENT::IN_ADOULIN:
             expression = m_POwner->isInAdoulin();
+            break;
+        case LATENT::IN_GARRISON:
+            expression = m_POwner->isInGarrison() && m_POwner->GetMLevel() >= latentEffect.GetConditionsValue();
             break;
         case LATENT::FOOD_ACTIVE:
             expression = m_POwner->StatusEffectContainer->HasStatusEffect(EFFECT_FOOD) &&


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR implements the "Garrison" latent effect, which affects four items: Variable Ring, Protean Ring, Mecurial Earring, and Refresh Earring. A check is triggered on a) level up/down events and b) status effect add/remove events (since Garrison applies level restriction). I found that the status effect check was necessary or else the latents would persist after the battle. The check itself looks at the player's zone's Garrison info, and returns true if the player's ID is in the players table _and_ their level is above the conditions value. To that end I had to reorder the sequence of events in the Garrison code: We have to edit the player list first, and apply/remove the level restriction status effect second.

The specifics of the item_latents additions include some extrapolations. We have very limited data available as to how the Variable Ring, Protean Ring, and Mecurial Earring scale with level. I honestly have no idea how we'd even quantify small increases in Evasion while in Garrison. So, I have made what I think are conservative assumptions, namely: that players very likely get at least _some_ increased value from each of these items per Garrison tier. I have also assumed that the scaling stops at level 75, because it's a little hard to extrapolate a sensible scaling for lv20-99 for these Variable Ring data points otherwise:

> lv20: 28 MP, 1 MPHEAL
lv30: 30 MP, 1 MPHEAL
lv50: 40 MP, 2 MPHEAL
lv99: 55 MP, 4 MPHEAL (lv75? 80? 95?)

These are very old and unpopular items and it's absolutely plausible that SE didn't add more latent tiers for them when the level cap increased.

Ancillary Change: This PR also makes an improvement to the logic of latent weaponskills introduced in #8630, ensuring the player's weaponskill list is updated at the moment the ADDS_WEAPONSKILL mod is applied to the weapon.

## Steps to test these changes

* Equip each of these items, notice no change in mods
* Begin a Garrison at an outpost, see your relevant mods go up with `!getmod`
* Take note that you shouldn't see any refresh+ when doing a Garrison below lv 60 because the refresh earring is lv51
* When the Garrison ends, ensure your items' mods go away

For the weaponskill latent addition:
* Equip Griffonclaw
* Check your WS list: you should not see Uriel Blade
* Begin Campaign battle (give yourself Allied Tags), see Uriel Blade in WS list
* End battle, see Uriel Blade no longer in WS list
