### PR TITLE
[sql] Correct Viator Cape latents

### DIFF
--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -1814,11 +1814,8 @@ INSERT INTO `item_latents` VALUES (16220,10,10,13,114);  -- VIT+10
 INSERT INTO `item_latents` VALUES (16238,369,1,13,3);
 
 -- Viator Cape
--- This item seems to break the pattern of the "Campaign:" latent text which normally overrides,
--- not adds, to the total. Otherwise, why would it say HP +15 both in and out of Campaign?
-INSERT INTO `item_latents` VALUES (16246,2,15,13,267); -- Allied Tags: HP +15
+-- These are confirmed retail-accurate as of Nov 2025.
 INSERT INTO `item_latents` VALUES (16246,3,5,13,267);  -- Allied Tags: HPP +5%
-INSERT INTO `item_latents` VALUES (16246,5,15,13,267); -- Allied Tags: MP +15
 INSERT INTO `item_latents` VALUES (16246,6,5,13,267);  -- Allied Tags: MPP +5%
 INSERT INTO `item_latents` VALUES (16246,71,2,13,267); -- Allied Tags: hMP +2
 INSERT INTO `item_latents` VALUES (16246,72,2,13,267); -- Allied Tags: hHP +2


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Wintersolstice8 just confirmed in retail that despite what you might think based on the description, Viator Cape does not add an additional HP/MP +15 while in a campaign battle.

## Steps to test these changes

Simple SQL change.
