### PR TITLE
[cpp] Fix BST Stay Command on Charmed Pets

### DIFF
--- a/scripts/globals/job_utils/beastmaster.lua
+++ b/scripts/globals/job_utils/beastmaster.lua
@@ -416,6 +416,15 @@ end
 
 -- On Ability Use Leave
 xi.job_utils.beastmaster.onUseAbilityLeave = function(player, target, ability)
+    local pet = target:getPet()
+
+    if
+        pet and
+        pet:hasStatusEffect(xi.effect.HEALING)
+    then
+        pet:delStatusEffect(xi.effect.HEALING)
+    end
+
     target:despawnPet()
 end
 

--- a/src/map/ai/controllers/pet_controller.cpp
+++ b/src/map/ai/controllers/pet_controller.cpp
@@ -89,7 +89,7 @@ void CPetController::DoRoamTick(timer::time_point tick)
         return;
     }
 
-    if (PPet->objtype == TYPE_PET)
+    if (PPet->objtype == TYPE_PET || (PPet->objtype == TYPE_MOB && PPet->PMaster && PPet->PMaster->objtype == TYPE_PC))
     {
         CPetEntity* PetEntity = static_cast<CPetEntity*>(PPet);
         // automaton, wyvern


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
- Adjusts the checks in `pet_controller.cpp` during `DoRoamTick()` to properly check for BST Pets.
- Adds checks when the Leave Ability is used to remove the healing effect, if present.

Previously the logic was only checking for `TYPE_PET` before moving into the pathfinding logic.  Charmed pets are not `TYPE_PET` though, and and as a result, if a charmed pet was told to Stay, it would ignore it and continue to follow the player.  This PR adds an additional check to account for charmed pets by checking for `TYPE_MOB` + `PMaster` + `PMaster->objtype` being a Player.  This allows the controller to drop into the logic where it would return early if the pet has Healing effect on and stop the mob from pathing to the player despite being in a "healing state".

Also, adds a check for `xi.effect.HEALING` when using the pet Command `Leave` as previously if the pet had the effect, and Leave was used, the mob retained the effect.  This ensures that a pet that is dismissed does not retain the `HEALING` status effect.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - `!changejob bst 75`
2 - Charm any mob
3 - Use `Stay` and move away from your pet
Result: The pet no longer continues to ignore your stay command and actually stays in place.

4 - `!exec player:printToPlayer(tostring(target:hasStatusEffect(xi.effect.HEALING)))` while targeting your pet
5 - Use `Leave` to dismiss the pet
6 - Repeat the command from Step 4
Result: The pet no longer has the `HEALING` status effect once dismissed
