### PR TITLE
[lua] Fix Portaure trade - Flyers for Regine

### DIFF
--- a/scripts/zones/Port_San_dOria/npcs/Portaure.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Portaure.lua
@@ -1,0 +1,14 @@
+-----------------------------------
+-- Area: Port San d'Oria
+--  NPC: Portaure
+-----------------------------------
+require('scripts/quests/flyers_for_regine')
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+    quests.ffr.onTrade(player, npc, trade, 3) -- FLYERS FOR REGINE
+end
+
+return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR re-adds the onTrade for the NPC Portaure, which was inadvertently removed in PR #6774 . This PR closes #7984, thank you to @eyes-and-brain for the report and suggested fix!

## Steps to test these changes

Confirm that Portaure accepts the trade and players can advance and complete the quest Flyers for Regine.
