### PR TITLE
[cpp] Fix Additional Effects Firing on 0HP Mobs

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2799,7 +2799,11 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
         // if we did hit, run enspell/spike routines as long as this isn't a Daken swing
         if ((actionTarget.reaction & REACTION::MISS) == REACTION::NONE && attack.GetAttackType() != PHYSICAL_ATTACK_TYPE::DAKEN)
         {
-            battleutils::HandleEnspell(this, PTarget, &actionTarget, attack.IsFirstSwing(), (CItemWeapon*)this->m_Weapons[attack.GetWeaponSlot()], attack.GetDamage(), attack);
+            // Handle addtl effects/enspells only if the target is not already dead
+            if (PTarget->GetHPP() > 0)
+            {
+                battleutils::HandleEnspell(this, PTarget, &actionTarget, attack.IsFirstSwing(), (CItemWeapon*)this->m_Weapons[attack.GetWeaponSlot()], attack.GetDamage(), attack);
+            }
             battleutils::HandleSpikesDamage(this, PTarget, &actionTarget, attack.GetDamage());
         }
 

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -2252,7 +2252,11 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
         {
             // TODO
         }
-        luautils::additionalEffectAttack(this, PTarget, (PAmmo != nullptr ? PAmmo : PItem), &actionTarget, totalDamage);
+        // Handle additional effects only if target is not already dead
+        if (PTarget->GetHPP() > 0)
+        {
+            luautils::additionalEffectAttack(this, PTarget, (PAmmo != nullptr ? PAmmo : PItem), &actionTarget, totalDamage);
+        }
     }
     else if (shadowsTaken > 0)
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
- Adjusts the logic during ranged/melee attacks to only proc the additional effect is the mob still has more than 0 HP after the base damage from the attack has been removed from its HP.

This mirrors retail and stops effects like HP Drain still going off even when the target is already at 0HP from the direct damage of the ranged attack.

Retail Evidence (<3 Thanks @9001-Sols )

https://github.com/user-attachments/assets/ea1bbee8-8c1d-4bc5-a633-1b4f1da60c31

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - `!godmode` yourself
2 - `!changejob rng 75`
3 - `!additem crossbow` and `!additem bloody_bolt 99`
4 - Find any mob to attack and `!hp 1` it
5 - Shoot the mob with the bolt
Result: The additional effect of the ranged attack does not fire.

6 - Find another mob and `!immortal` + `!hp 1` it
7 - Shoot the mob with the bolt
Result: The drain effect fires (since immortal keeps it at 1HP and is not dead)

8 - `!changejob rdm 75`
9 - Equip a weapon
10 - Cast Enfire or some En-Spell
11 - `!stun` and `!hp 1` a mob
12 - Attack the mob with your Enspell'd weapon
Result: The additional effect of the attack does not fire.

13 - Find another mob and `!immortal` + `!hp 1` it
14 - Attack the mob with your Enspell'd weapon
Result: The additional effect fires (since immortal keeps it at 1HP and is not dead)

Post-Fix Enspell:
<img width="331" height="130" alt="{6C273C5E-65FC-485B-B66D-6F1CCAD8AF63}" src="https://github.com/user-attachments/assets/0e9f636e-05e9-4aaa-bd83-13481824a11c" />

<img width="555" height="132" alt="{BCC327FF-5DBC-4343-BDF7-1AE3B73ABB47}" src="https://github.com/user-attachments/assets/f67c13ab-898f-43db-acf2-3ef4ef2d2e01" />
