### PR TITLE
[lua] [sql] Quest - "The Fanged One" cleanup, NM and Quest Logic

### DIFF
--- a/scripts/quests/windurst/The_Fanged_One.lua
+++ b/scripts/quests/windurst/The_Fanged_One.lua
@@ -53,11 +53,6 @@ quest.sections =
                 onTrigger = function(player, npc)
                     if quest:getVar(player, 'Prog') == 0 then
                         return quest:event(352)
-                    elseif
-                        quest:getVar(player, 'Prog') == 1 and
-                        not player:hasKeyItem(xi.ki.OLD_TIGERS_FANG)
-                    then
-                        return quest:event(356)
                     elseif player:hasKeyItem(xi.ki.OLD_TIGERS_FANG) then
                         return quest:progressEvent(357)
                     end
@@ -96,6 +91,7 @@ quest.sections =
                         player:unlockJob(xi.job.RNG)
                         npcUtil.giveKeyItem(player, xi.ki.JOB_GESTURE_RANGER)
                         player:messageSpecial(windurstWoodsID.text.PERIH_VASHAI_DIALOG)
+                        quest:setMustZone(player)
                     end
                 end,
             },
@@ -110,19 +106,26 @@ quest.sections =
             ['Tiger_Bones'] =
             {
                 onTrigger = function(player, npc)
+                    local oldTiger = GetMobByID(sauromugueID.mob.OLD_SABERTOOTH)
+
+                    if not oldTiger then
+                        return quest:noAction()
+                    end
+
                     if
-                        quest:getVar(player, 'Prog') == 0 and
-                        quest:getVar(player, 'Timer') <= GetSystemTime() and
-                        not GetMobByID(sauromugueID.mob.OLD_SABERTOOTH):isSpawned()
-                    then
-                        SpawnMob(sauromugueID.mob.OLD_SABERTOOTH):addStatusEffect(xi.effect.POISON, 10, 10, 240)
-                        return quest:messageSpecial(sauromugueID.text.OLD_SABERTOOTH_DIALOG_I)
-                    elseif
-                        quest:getVar(player, 'Prog') == 1 and -- listeners for damage and onMobDeath actions are in Old_Sabtertooth.lua
+                        quest:getVar(player, 'Timer') > GetSystemTime() and
                         not player:hasKeyItem(xi.ki.OLD_TIGERS_FANG)
                     then
                         npcUtil.giveKeyItem(player, xi.ki.OLD_TIGERS_FANG)
+                        quest:setVar(player, 'Prog', 1)
                         return quest:noAction()
+                    elseif
+                        quest:getVar(player, 'Prog') == 0 and
+                        quest:getVar(player, 'Wait') <= GetSystemTime() and
+                        not oldTiger:isSpawned()
+                    then
+                        SpawnMob(sauromugueID.mob.OLD_SABERTOOTH)
+                        return quest:messageSpecial(sauromugueID.text.OLD_SABERTOOTH_DIALOG_I)
                     end
                 end,
             },
@@ -136,7 +139,14 @@ quest.sections =
 
         [xi.zone.WINDURST_WOODS] =
         {
-            ['Perih_Vashai'] = quest:event(348):replaceDefault(),
+            ['Perih_Vashai'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getMustZone(player) then
+                        return quest:event(358)
+                    end
+                end,
+            },
         },
     },
 }

--- a/scripts/zones/Sauromugue_Champaign/mobs/Old_Sabertooth.lua
+++ b/scripts/zones/Sauromugue_Champaign/mobs/Old_Sabertooth.lua
@@ -9,17 +9,18 @@ local entity = {}
 
 local pathNodes =
 {
-    { x = 675, y = -10, z = -362 },
-    { x = 674, y = -10, z = -368 },
-    { x = 672, y = -9.1, z = -372 },
-    { x = 668, y = -8.3, z = -376 },
-    { x = 674, y = -10, z = -366 },
-    { x = 675, y = -9.9, z = -361 },
-    { x = 674, y = -9.5, z = -357 },
-    { x = 673, y = -9.0, z = -352 },
-    { x = 671, y = -8.9, z = -347 },
-    { x = 668, y = -9.5, z = -341 },
-
+    { x = 666.868, y = -9.506, z = -338.416, rotation = 162, wait = 10000 },
+    { x = 671.028, y = -9.169, z = -345.759, rotation = 043 }, -- Turns around and runs to the next spot
+    { x = 667.912, y = -9.512, z = -339.858, rotation = 172, wait = 10000 },
+    { x = 661.358, y = -9.812, z = -332.499, rotation = 162, wait = 10000 },
+    { x = 666.870, y = -9.506, z = -338.418, rotation = 033, wait = 10000 },
+    { x = 671.745, y = -8.992, z = -347.048, rotation = 043, wait = 10000 },
+    { x = 667.945, y = -9.513, z = -339.920, rotation = 172, wait = 10000 },
+    { x = 662.475, y = -9.715, z = -333.734, rotation = 162 }, -- Turns around and runs to the next spot
+    { x = 666.871, y = -9.506, z = -338.418, rotation = 033, wait = 10000 },
+    { x = 671.712, y = -9.001, z = -346.989, rotation = 043, wait = 10000 },
+    { x = 677.547, y = -10.064, z = -361.535, rotation = 075 }, -- Gateway waypoint so it doesn't path through the wall
+    { x = 667.128, y = -8.359, z = -378.015, rotation = 086, wait = 100000 }, -- Final resting place
 }
 
 entity.onMobSpawn = function(mob)
@@ -27,9 +28,7 @@ entity.onMobSpawn = function(mob)
     mob:setBehavior(bit.bor(mob:getBehavior(), xi.behavior.NO_TURN))
     mob:setMobAbilityEnabled(false)
     mob:setAutoAttackEnabled(false)
-    mob:setRoamFlags(bit.bor(xi.roamFlag.IGNORE, xi.roamFlag.SCRIPTED))
-    mob:pathThrough(pathNodes, xi.path.flag.PATROL)
-
+    mob:addStatusEffect(xi.effect.POISON, 7, 10, 240)
     mob:addListener('TAKE_DAMAGE', 'PRIME_TAKE_DAMAGE', function(tiger, amount, attacker)
         if attacker then
             tiger:setLocalVar('tookDamage', 1)
@@ -38,6 +37,13 @@ entity.onMobSpawn = function(mob)
             tiger:setBehavior(0)
         end
     end)
+
+    mob:pathThrough(pathNodes, xi.path.flag.COORDS)
+end
+
+-- Breaks the pathing script if the mob enters the engage state
+entity.onMobEngage = function(mob)
+    mob:clearPath()
 end
 
 entity.onMobFight = function(mob)
@@ -59,9 +65,9 @@ entity.onMobDeath = function(mob, player, optParams)-- TODO: We currently can't 
                 person:checkDistance(mob) < 32
         then
             if mob:getLocalVar('tookDamage') == 0 then
-                person:setCharVar('Quest[2][31]Prog', 1)
+                person:setCharVar('Quest[2][31]Timer', GetSystemTime() + 180) -- Player has about 3 minutes to get the KI before they have to watch the tiger die again.
             else
-                person:setCharVar('Quest[2][31]Timer', GetSystemTime() + 300)
+                person:setCharVar('Quest[2][31]Wait', GetSystemTime() + 300)
             end
         end
     end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

 - Corrects the spawnpoint of the NM
- Adds the condition that the player must click the QM within 3 minutes of the NM dying as observed on retail.
- Corrects post quest cs, which was incorrect
- Updates the NM's path. Currently, it runs around like it has rabies before it dies. Now it follows the same path observed in captures.
- Moves the spawn status effect of poison to the mob lua. Also lowers the tick rate to get the rate closer to what is on retail.
- Updates the quest logic in the NM script for the new 3 minute timer that was added.

## Notes
The old quest logic was coded to where from of the quest logic had to be in the NM lua. I was unable to move this into the quest IF due to how the NM functions.
The NM is supposed to pop claimed, but it causes issues with the scripted movement that it is supposed to run if the NM is spawned claimed.

The distance check is to account for the above since normally you need to be on the mob's hate table to get updates via on mob death. This way plays on the quest in the range of the NM dying get credit.

I am unsure how we want to do null checks in quest IF, logically it made sense to have the check before the mob ID was called so the player could still progress the quest at least up to that point.

## Steps to test these changes

1. `!changejob ANY 30+`
2. Talk to Perih Vashai `!pos 117 -3 92 241`
3. Check Tiger Bones Tiger Bones: `!pos 666 -8 -379 120`
4. Watch tiger die.
5. Click bones again within 3 minutes.
6. Talk to Perih Vashai `!pos 117 -3 92 241`
7. Quest Complete

## Captures/Resources
Video Only
https://youtu.be/aHrEiFvz1dI

https://youtu.be/x8dmgg7TT0M
https://drive.google.com/drive/folders/1_Md28bvkjB0DujTuLibrRs_m8eTyyubO?usp=drive_link

https://www.bg-wiki.com/ffxi/The_Fanged_One "If you do not click the Tiger Bones in a reasonable amount of time after death, you will have to click on the Tiger Bones and watch it die naturally again." Observed below by @WinterSolstice8
<img width="492" height="144" alt="image" src="https://github.com/user-attachments/assets/9e5da267-6e14-4e65-b5ad-a1207ebb3e6e" />
