### PR TITLE
[sql] Add "original character name" column, populate it and free character name on character deletion

### DIFF
--- a/sql/chars.sql
+++ b/sql/chars.sql
@@ -8,6 +8,7 @@ CREATE TABLE `chars` (
   `accid` int(10) unsigned NOT NULL,
   `original_accid` int(10) unsigned NOT NULL DEFAULT '0',
   `charname` varchar(15) NOT NULL,
+  `original_charname` varchar(15) NOT NULL,
   `nation` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `pos_zone` smallint(3) unsigned NOT NULL,
   `pos_prevzone` smallint(3) unsigned NOT NULL DEFAULT '0',

--- a/src/login/login_helpers.cpp
+++ b/src/login/login_helpers.cpp
@@ -134,7 +134,7 @@ int32 saveCharacter(uint32 accid, uint32 charid, char_mini* createchar)
 {
     const auto charName = asStringFromUntrustedSource(createchar->m_name);
 
-    if (!db::preparedStmt("INSERT INTO chars(charid,accid,charname,pos_zone,nation) VALUES(?, ?, ?, ?, ?)", charid, accid, charName, createchar->m_zone, createchar->m_nation))
+    if (!db::preparedStmt("INSERT INTO chars(charid,accid,original_accid,charname,original_charname,pos_zone,nation) VALUES(?, ?, ?, ?, ?, ?, ?)", charid, accid, accid, charName, charName, createchar->m_zone, createchar->m_nation))
     {
         ShowDebug(fmt::format("lobby_ccsave: char<{}>, accid: {}, charid: {}", charName, accid, charid));
         return -1;

--- a/src/login/view_session.cpp
+++ b/src/login/view_session.cpp
@@ -135,13 +135,10 @@ void view_session::read_func()
             }
 
             // Perform character deletion.
-            // Instead of performing an actual character deletion, we simply set accid to 0, and original_accid to old accid.
+            // Instead of performing an actual character deletion, we simply set accid to 0 and name to "deleted".
             // This allows character recovery.
 
-            db::preparedStmt("UPDATE chars SET accid = 0, original_accid = ? WHERE charid = ? AND accid = ?",
-                             session.accountID,
-                             charID,
-                             session.accountID);
+            db::preparedStmt("UPDATE chars SET accid = 0, charname = '' WHERE charid = ? AND accid = ?", charID, session.accountID);
         }
         break;
         case 0x21: // 33: Registering character name onto the lobby server

--- a/tools/migrations/050_original_name_tracking.py
+++ b/tools/migrations/050_original_name_tracking.py
@@ -1,0 +1,29 @@
+import mariadb
+
+
+def migration_name():
+    return "Adding original_charname column to chars table"
+
+
+def check_preconditions(cur):
+    return
+
+
+def needs_to_run(cur):
+    # Ensure column doesn't already exist.
+    cur.execute("SHOW COLUMNS FROM chars LIKE 'original_charname';")
+
+    row = cur.fetchone()
+    if row:
+        return False
+
+    return True
+
+
+def migrate(cur, db):
+    try:
+        cur.execute("ALTER TABLE `chars` ADD COLUMN `original_charname` varchar(15) GENERATED ALWAYS AS (`charname`) STORED AFTER `charname`;")
+        db.commit()
+
+    except mariadb.Error as err:
+        print("Something went wrong: {}".format(err))


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Exactly what title sais. Notes:
- Migration automatically populates the new column with the current character name.
- Character creation now populates original account id column.
- Character deletion now renames character to "deleted" and stops setting original account id with current id. Thats handled in character creation directly.

## Steps to test these changes

Create character. Delete it. Have name free to use again.
