### PR TITLE
[core] Adjust how mobs close in to the player

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -731,7 +731,7 @@ void CMobController::Move()
     float       attack_range  = PMob->GetMeleeRange();
     const int16 offsetMod     = PMob->getMobMod(MOBMOD_TARGET_DISTANCE_OFFSET);
     const float offset        = static_cast<float>(offsetMod) / 10.0f;
-    float       closeDistance = attack_range - (offsetMod == 0 ? 0.2f : offset);
+    float       closeDistance = (attack_range - (offsetMod == 0 ? 0.2f : offset)) / 2;
 
     // No going negative on the final value.
     if (closeDistance < 0.0f)
@@ -803,7 +803,7 @@ void CMobController::Move()
                     if (!PMob->PAI->PathFind->IsFollowingPath())
                     {
                         // out of melee range, try to path towards
-                        if (currentDistance > (offsetMod == 0 ? PMob->GetMeleeRange() : closeDistance))
+                        if (currentDistance > closeDistance)
                         {
                             // try to find path towards target
                             PMob->PAI->PathFind->PathInRange(PTarget->loc.p, closeDistance, PATHFLAG_WALLHACK | PATHFLAG_RUN);


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This should improve mobs hitting the player more often. I adjusted the range at which mobs want to move towards the player at, which is half their normal melee distance. This is sort of a hack, but players shouldn't get to be able to run from mobs for free. I assume it works because when player movement was being processed, just being barely in melee range meant any movement directly away from the player effectively disabled the ability to melee

see

No movement speed
[2025-11-08 19-33-14.webm](https://github.com/user-attachments/assets/69052390-9636-4ecf-a7c4-65623204b4af)


Movement speed (12%)

[2025-11-08 19-34-16.webm](https://github.com/user-attachments/assets/1d002935-e125-463b-b74f-ed03551529d8)


## Steps to test these changes

Run from mobs and stuff