### PR TITLE
[lua] Minor Correct to Riddle Mobskill

### DIFF
--- a/scripts/actions/mobskills/riddle.lua
+++ b/scripts/actions/mobskills/riddle.lua
@@ -14,7 +14,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local power = utils.clamp(math.floor(4.7 + target:getStat(xi.stat.INT) / 2), 0, 90)
+    local power = utils.clamp(math.floor(4.7 + target:getStat(xi.mod.INT) / 2), 0, 90)
     skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.MAX_MP_DOWN, power, 0, 60))
 
     return xi.effect.MAX_MP_DOWN


### PR DESCRIPTION
- Replace xi.stat with xi.mod

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Corrects the Riddle mobskill to not throw lua errors on firing.. 

## Steps to test these changes

!gotoid 17289303
Pull the manticore.
!exec target:useMobAbility(801)
See Riddle lower max MP.
