### PR TITLE
[lua] Correct Castle Oztroja Password Statues displaying wrong text

### DIFF
--- a/scripts/zones/Castle_Oztroja/IDs.lua
+++ b/scripts/zones/Castle_Oztroja/IDs.lua
@@ -57,8 +57,8 @@ zones[xi.zone.CASTLE_OZTROJA] =
     {
         HANDLE_DOOR_FLOOR_2    = GetFirstID('_471'),
         FIRST_PASSWORD_STATUE  = GetTableOfIDs('Brass_Statue')[1],
-        SECOND_PASSWORD_STATUE = GetTableOfIDs('Brass_Statue')[2],
-        THIRD_PASSWORD_STATUE  = GetTableOfIDs('Brass_Statue')[3],
+        SECOND_PASSWORD_STATUE = GetTableOfIDs('Brass_Statue')[3], -- This is intentional.
+        THIRD_PASSWORD_STATUE  = GetTableOfIDs('Brass_Statue')[2], -- This is intentional.
         FINAL_PASSWORD_STATUE  = GetTableOfIDs('Brass_Statue')[4],
         BRASS_DOOR_FLOOR_4_H7  = GetFirstID('_477'),
         TRAP_DOOR_FLOOR_4      = GetFirstID('_478'),


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Corrects the wording on the password statues in Castle Oztroja.

The statue that displays the third word is saying "The second word." and the one that displays the second word says "The third word."

Example:
Current LSB
![xiloader_CuQK4FeCW3](https://github.com/user-attachments/assets/b1a17f31-6d91-4f6d-b033-584afc8929dd)

Retail
![pol_qMPsljVQEG](https://github.com/user-attachments/assets/314cb824-7643-499a-871a-d7d10acb15a0)


## Steps to test these changes

Check the statues.
