### PR TITLE
[core] Remove COTP.h and Implement TOTP Functions from RFC

### DIFF
--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -242,15 +242,6 @@ CPMAddPackage(
     GIT_TAG 89f20096bef51de347ec6f99345f65147359bd7c
 ) # defines: termcolor::termcolor
 
-CPMAddPackage(
-    NAME cotp
-    GITHUB_REPOSITORY paolostivanin/libcotp
-    GIT_TAG v3.1.0
-    OPTIONS
-        "HMAC_WRAPPER openssl"
-        "BUILD_SHARED_LIBS OFF"
-) # defines: cotp
-
 set(SHARED_EXTERNAL_LIBS
     fmt::fmt
     spdlog
@@ -293,7 +284,6 @@ endif()
 set(CONNECT_ONLY_EXTERNAL_LIBS
     bcrypt
     nlohmann_json::nlohmann_json
-    cotp
 )
 
 set(MAP_ONLY_EXTERNAL_LIBS


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Update TOTP Implementation to remove COTP Dependency and use the algorithm directly listed in the RFC: https://datatracker.ietf.org/doc/html/rfc6238

_Base32 RFC: https://datatracker.ietf.org/doc/html/rfc4648_

This also fixes an issue that arises with running the server in windows where the `get_totp_at()` call does not return the proper value:
Showing `secret` + Token Value from Authenticator
<img width="289" height="44" alt="{DF29E13D-5B2B-48B7-AA39-5E1D58F7641E}" src="https://github.com/user-attachments/assets/469ac911-124b-4e0a-b4df-fa5d3eb6585a" />

Generated TOTP Code from `get_totp_at()`
<img width="218" height="18" alt="{3A765D8E-D4A3-4AFC-9CC0-0DD699DE5CF5}" src="https://github.com/user-attachments/assets/f4934043-0238-4771-b188-de935a14a94b" />

Values from the algorithm implemented directly:
Showing `secret` + Token Value from Authenticator
<img width="277" height="44" alt="{A65F8A74-41DF-4C2C-9585-A4CDEA69A922}" src="https://github.com/user-attachments/assets/181034de-2386-4427-a9b3-401f528a649b" />

Generated TOTP Code from `generateTOTP()` implemented directly
<img width="103" height="22" alt="{DB98D136-5A86-4DDC-BD10-299380AFA9D1}" src="https://github.com/user-attachments/assets/688d4809-f0a1-4aed-9d28-c337875cb4e9" />

The `cotp` library is implemented in C directly, so this is likely due to low level handling of how the data is being processed, but by implementing the algorithm directly into `otp_helpers.h` we avoid an extra dependency and is guaranteed to work on both *nix/Win environments.

Had winter test this on Linux and validate that this produces the correct values.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - Create a new account in xiloader
2 - Add 2FA to the account
3 - Set a breakpoint in `generateTOTP()`
4 - Validate your 2FA through xiloader
5 - When the breakpoint is hit, check the following values:
- secret: Should be the same secret stored in the database
- totpCode: Should be the same code being displayed in your Authenticator

6 - Step through till `res` is populated with the generated code
7 - Validate that the value of `res` matches the value of `totpCode`

Result: Proper TOTP codes are generated when validating in both Linux/Windows environments.