### PR TITLE
[Fix] Oversight in moghouse zoneline checking

### DIFF
--- a/scripts/globals/moghouse.lua
+++ b/scripts/globals/moghouse.lua
@@ -252,9 +252,10 @@ xi.moghouse.onMoghouseZoneEvent = function(player, prevZone)
         player:getZPos() == 0
     then
 
-        local zoneId = player:getZoneID()
-        local prevZoneLineID = player:getPreviousZoneLineID()
-        local moghouseEntrance = moghouseZoneLines[prevZoneLineID] or 1
+        local zoneId                                = player:getZoneID()
+        local prevZoneId                            = player:getPreviousZone()
+        local prevZoneLineID                        = player:getPreviousZoneLineID()
+        local moghouseEntrance                      = zoneId == prevZoneId and moghouseZoneLines[prevZoneLineID] or 1
         local x, y, z, r, randomizedAxis, randomMax = unpack(xi.moghouse.exits[zoneId][moghouseEntrance])
         local randomOffset                          = math.random(-randomMax * 1000, randomMax * 1000) -- offset -/+ from center point
         local offsetValue                           = randomOffset / 1000 -- 0.000 - N.N00 variance


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes issue where code didnt account for moghouse exits in different zones.

## Steps to test these changes
Follow the steps in [this](https://github.com/HorizonFFXI/HorizonXI-Issues/issues/2355) issue.
