### PR TITLE
[core/lua] Streamline removal of Invisible status. Handle Hide/Invisible interaction.

### DIFF
--- a/scripts/globals/spells/enhancing_spell.lua
+++ b/scripts/globals/spells/enhancing_spell.lua
@@ -560,6 +560,14 @@ xi.spells.enhancing.useEnhancingSpell = function(caster, target, spell)
                 target:delStatusEffect(effectValue)
             end
         end
+
+    -- Invisible
+    elseif spellEffect == xi.effect.INVISIBLE then
+        -- Invisible does not overwrite Hide/Camouflage
+        if target:hasStatusEffectByFlag(xi.effectFlag.INVISIBLE) then
+            spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+            return 0
+        end
     end
 
     --------------------------------------------------

--- a/scripts/tests/systems/invisible.lua
+++ b/scripts/tests/systems/invisible.lua
@@ -1,0 +1,48 @@
+describe('Invisible', function()
+    ---@type CClientEntityPair
+    local player
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer()
+    end)
+
+    local invisibleStatus =
+    {
+        ['INVISIBLE']  = xi.effect.INVISIBLE,
+        ['HIDE']       = xi.effect.HIDE,
+        ['CAMOUFLAGE'] = xi.effect.CAMOUFLAGE,
+    }
+
+    for sName, sId in pairs(invisibleStatus) do
+        it(string.format('breaks on itemuse (%s)', sName), function()
+            player:addStatusEffect(sId, 0, 10, 60)
+            player:addItem(xi.item.MEAT_MITHKABOB)
+            local kabob = player:findItem(xi.item.MEAT_MITHKABOB)
+            assert(kabob)
+            player.actions:useItem(player, kabob:getSlotID(), xi.inventoryLocation.INVENTORY)
+            xi.test.world:skipTime(5)
+            player.assert.no:hasEffect(sId)
+            player.assert:hasEffect(xi.effect.FOOD)
+        end)
+    end
+
+    it('cannot be cast on someone with Camouflage/Hide', function()
+        local p2 = xi.test.world:spawnPlayer({ job = xi.job.WHM, level = 99 })
+        p2:addSpell(xi.magic.spell.INVISIBLE)
+        player.actions:inviteToParty(p2)
+        p2.actions:acceptPartyInvite()
+
+        player:changeJob(xi.job.THF)
+        player:setLevel(99)
+        player.actions:useAbility(player, xi.jobAbility.HIDE)
+        xi.test.world:tickEntity(player) -- Wait for Hide to apply
+        player.assert:hasEffect(xi.effect.HIDE)
+
+        p2.actions:useSpell(player, xi.magic.spell.INVISIBLE)
+        xi.test.world:tickEntity(p2) -- Start casting
+        xi.test.world:skipTime(10)   -- Wait for completion
+
+        player.assert:hasEffect(xi.effect.HIDE)
+            .no:hasEffect(xi.effect.INVISIBLE)
+    end)
+end)

--- a/scripts/tests/systems/invisible.lua
+++ b/scripts/tests/systems/invisible.lua
@@ -14,7 +14,7 @@ describe('Invisible', function()
     }
 
     for sName, sId in pairs(invisibleStatus) do
-        it(string.format('breaks on itemuse (%s)', sName), function()
+        it(string.format('breaks on item use (%s)', sName), function()
             player:addStatusEffect(sId, 0, 10, 60)
             player:addItem(xi.item.MEAT_MITHKABOB)
             local kabob = player:findItem(xi.item.MEAT_MITHKABOB)
@@ -22,7 +22,7 @@ describe('Invisible', function()
             player.actions:useItem(player, kabob:getSlotID(), xi.inventoryLocation.INVENTORY)
             xi.test.world:skipTime(5)
             player.assert.no:hasEffect(sId)
-            player.assert:hasEffect(xi.effect.FOOD)
+                :hasEffect(xi.effect.FOOD)
         end)
     end
 

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1779,7 +1779,7 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
             {
                 if (PAbility->getID() == ABILITY_ASSAULT)
                 {
-                    StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_INVISIBLE);
+                    charutils::RemoveInvisible(this);
                 }
                 // generic aggressive action
                 else
@@ -1791,7 +1791,7 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
             else if (PAbility->getID() != ABILITY_TRICK_ATTACK)
             {
                 // remove invisible only
-                StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_INVISIBLE);
+                charutils::RemoveInvisible(this);
                 StatusEffectContainer->DelStatusEffect(EFFECT_ILLUSION);
             }
         }
@@ -2357,7 +2357,6 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
         {
             // Camouflage up, and retained, but all other effects must be dropped
             StatusEffectContainer->DelStatusEffect(EFFECT_SNEAK);
-            StatusEffectContainer->DelStatusEffect(EFFECT_INVISIBLE);
             StatusEffectContainer->DelStatusEffect(EFFECT_DEODORIZE);
             StatusEffectContainer->DelStatusEffect(EFFECT_ILLUSION);
         }

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2727,12 +2727,10 @@ int32 OnItemUse(CBaseEntity* PUser, CBaseEntity* PTarget, CItem* PItem, action_t
     }
 
     // using an item removes invisible status effect
-    if (auto* PBattleEntity = dynamic_cast<CBattleEntity*>(PUser))
+    // TODO: This is not always true! See #8673
+    if (const auto* PChar = dynamic_cast<CCharEntity*>(PUser))
     {
-        if (PBattleEntity->StatusEffectContainer->HasStatusEffect(EFFECT_INVISIBLE))
-        {
-            PBattleEntity->StatusEffectContainer->DelStatusEffect(EFFECT_INVISIBLE);
-        }
+        charutils::RemoveInvisible(PChar);
     }
 
     auto result = onItemUse(PTarget, PUser, PItem, action);

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -6778,6 +6778,14 @@ auto CheckAbilityAddtype(CCharEntity* PChar, const CAbility* PAbility) -> bool
     return true;
 }
 
+void RemoveInvisible(const CCharEntity* PChar)
+{
+    if (PChar && PChar->StatusEffectContainer)
+    {
+        PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_INVISIBLE);
+    }
+}
+
 void RemoveStratagems(CCharEntity* PChar, CSpell* PSpell)
 {
     if (PSpell->getSpellGroup() == SPELLGROUP_WHITE)

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -235,6 +235,7 @@ bool isAnyDeliveryBoxOpen(CCharEntity* PChar);
 
 auto CheckAbilityAddtype(CCharEntity* PChar, const CAbility* PAbility) -> bool;
 
+void RemoveInvisible(const CCharEntity* PChar);
 void RemoveStratagems(CCharEntity* PChar, CSpell* PSpell);
 
 void RemoveAllEquipMods(CCharEntity* PChar);

--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -1947,9 +1947,7 @@ void StartFishing(CCharEntity* PChar)
         return;
     }
 
-    PChar->StatusEffectContainer->DelStatusEffect(EFFECT_INVISIBLE);
-    PChar->StatusEffectContainer->DelStatusEffect(EFFECT_HIDE);
-    PChar->StatusEffectContainer->DelStatusEffect(EFFECT_CAMOUFLAGE);
+    charutils::RemoveInvisible(PChar);
     uint16       MessageOffset = GetMessageOffset(PChar->getZone());
     CItemWeapon* Rod           = nullptr;
     CItemWeapon* Bait          = nullptr;

--- a/src/test/lua/lua_test_entity_assertions.cpp
+++ b/src/test/lua/lua_test_entity_assertions.cpp
@@ -212,8 +212,8 @@ auto CLuaTestEntityAssertions::hasLocalVar(const std::string& varName, uint32 ex
 auto CLuaTestEntityAssertions::hasEffect(const EFFECT effectId) -> CLuaTestEntityAssertions&
 {
     assertCondition(entity_->hasStatusEffect(effectId, sol::lua_nil),
-                    std::format("Does not have effect {}", getEnumKey("xi.effect", effectId)),
-                    std::format("Has effect {}", getEnumKey("xi.effect", effectId)));
+                    std::format("Expected entity to have status effect {}", getEnumKey("xi.effect", effectId)),
+                    std::format("Expected entity to NOT have status effect {}", getEnumKey("xi.effect", effectId)));
     return *this;
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Routes all paths removing Invisible status to a common charutils func (that clears every Invisible-like status)
  - This resolves an issue where using an item while Hidden/Camouflaged did not break it 
- Ensures Invisible spell cannot be applied on someone with Hide/Camouflage
- Added a TODO clarifying not all items are supposed to break invisible
- Slightly tweaked the error messages for status effect assertions
  
I removed the removal of Invisible from the Camouflage block because it did not make sense. Which is what led me to discovering Invisible was able to be applied to Camouflaged chars.

https://github.com/HorizonFFXI/HorizonXI-Issues/issues/2509

Retail proofs

<img width="906" height="109" alt="image" src="https://github.com/user-attachments/assets/27cbb7ad-4688-4e0c-a23c-c56346c0fb7e" />

<img width="709" height="105" alt="image" src="https://github.com/user-attachments/assets/1286eee1-e54f-451c-8324-2468afbc9965" />

## Steps to test these changes

```
[ RUN      ] systems::Invisible::breaks on item use (INVISIBLE)
[       OK ] systems::Invisible::breaks on item use (INVISIBLE) (418 ms)
[ RUN      ] systems::Invisible::breaks on item use (CAMOUFLAGE)
[       OK ] systems::Invisible::breaks on item use (CAMOUFLAGE) (266 ms)
[ RUN      ] systems::Invisible::breaks on item use (HIDE)
[       OK ] systems::Invisible::breaks on item use (HIDE) (267 ms)
[ RUN      ] systems::Invisible::cannot be cast on someone with Camouflage/Hide
[       OK ] systems::Invisible::cannot be cast on someone with Camouflage/Hide (750 ms)
[==========] 4 tests ran. (3.657 s total)
[  PASSED  ] 4 tests.
```

<!-- Clear and detailed steps to test your changes here -->
