### PR TITLE
[Fix] Corrects a few typos and bad ENUMs in physical_utilities

### DIFF
--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -115,14 +115,14 @@ xi.combat.physical.calculateAttackDamage = function(actor, target, slot, physica
         local naturalH2hDamage = math.floor(actor:getSkillLevel(xi.skill.HAND_TO_HAND) * 0.11) + 3
 
         if actor:isMob() then
-            local mobH2HPenalty = 1.0
+            local mobH2HPenalty = 1
             local regionID      = actor:getCurrentRegion()
             local fSTR          = xi.combat.physical.calculateMeleeStatFactor(actor, target)
 
             if regionID <= xi.region.LIMBUS then
                 mobH2HPenalty = 0.425 -- Vanilla - COP
             else
-                mobH2HPenalty = 0.650
+                mobH2HPenalty = 0.65
             end
 
             baseDamage = actor:getWeaponDmg() + bonusBasePhysicalDamage
@@ -207,7 +207,7 @@ xi.combat.physical.calculateAttackDamage = function(actor, target, slot, physica
             effect and
             power < 30
         then
-            local jpBonus = actor:getJobPointLevel(xi.jp.RESTRAINT) * 2
+            local jpBonus = actor:getJobPointLevel(xi.jp.RESTRAINT_EFFECT) * 2
 
             -- Convert weapon delay and divide
             -- Pull remainder of previous hit's value from Effect Sub Power
@@ -215,10 +215,10 @@ xi.combat.physical.calculateAttackDamage = function(actor, target, slot, physica
             local remainder     = effect:getSubPower() / 100
 
             -- Calculate bonuses from Enhances Restraint, Job Point upgrades, and remainder from previous hit
-            boostPerRound = remainder + boostPerRound * (1 + actor:getMod(xi.Mod.ENHANCES_RESTRAINT) / 100) * (1 + jpBonus / 100)
+            boostPerRound = remainder + boostPerRound * (1 + actor:getMod(xi.mod.ENHANCES_RESTRAINT) / 100) * (1 + jpBonus / 100)
 
             -- Calculate new remainder and multiply by 100 so significant digits aren't lost
-            remainder     = math.floor((1 - (math.ceil(boostPerRound) - boostPerRound)) * 100)
+            remainder     = math.floor((1 - math.ceil(boostPerRound) - boostPerRound) * 100)
             boostPerRound = math.floor(boostPerRound)
 
             -- Cap total power to +30% WSD


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

As title sais.
- RESTRAINT jp doesnt exist. RESTRAINT_EFFECT does.
- xi.Mod doesnt exist. xi.mod does.

## Steps to test these changes

Enable lua attack round. attack
