### PR TITLE
core: Paralyze puts abilities on cooldown

### DIFF
--- a/scripts/enum/recast.lua
+++ b/scripts/enum/recast.lua
@@ -14,7 +14,9 @@ xi.recast =
 ---@enum xi.recastID
 xi.recastID =
 {
+    SPECIAL        =   0, -- 1HR abilities
     SIC            = 102,
+    MEDITATE       = 134,
     BLOODPACT_RAGE = 173,
     BLOODPACT_WARD = 174,
     QUICKDRAW      = 195,

--- a/scripts/tests/systems/effects/paralyze.lua
+++ b/scripts/tests/systems/effects/paralyze.lua
@@ -1,0 +1,21 @@
+describe('Paralyze', function()
+    ---@type CClientEntityPair
+    local player
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer({ job = xi.job.SAM, level = 99 })
+        player:setMod(xi.mod.PARALYZE, 100)
+    end)
+
+    it('puts abilities on cooldown', function()
+        player.actions:useAbility(player, xi.jobAbility.MEDITATE)
+        xi.test.world:tickEntity(player)
+        assert(player:hasRecast(xi.recast.ABILITY, xi.recastID.MEDITATE), 'Player did not have ability on recast')
+    end)
+
+    it('does not put 1HR abilities on cooldown', function()
+        player.actions:useAbility(player, xi.jobAbility.MEIKYO_SHISUI)
+        xi.test.world:tickEntity(player)
+        assert(not player:hasRecast(xi.recast.ABILITY, xi.recastID.SPECIAL), 'Player had 1HR ability on recast')
+    end)
+end)

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -8069,4 +8069,24 @@ bool raceChange(CCharEntity* PChar, CharRace newRace, CharFace newFace, CharSize
     return true;
 }
 
+void ApplyAbilityRecast(CCharEntity* PChar, const CAbility* PAbility, const Charge_t* charge, const timer::duration baseChargeTime, const timer::duration recastTime)
+{
+    if (charge)
+    {
+        PChar->PRecastContainer->Add(RECAST_ABILITY, PAbility->getRecastId(), recastTime, baseChargeTime, charge->maxCharges);
+    }
+    else
+    {
+        PChar->PRecastContainer->Add(RECAST_ABILITY, PAbility->getRecastId(), recastTime);
+    }
+
+    const uint16 recastId = PAbility->getRecastId();
+    if (settings::get<bool>("map.BLOOD_PACT_SHARED_TIMER") && (recastId == 173 || recastId == 174))
+    {
+        PChar->PRecastContainer->Add(RECAST_ABILITY, (recastId == 173 ? 174 : 173), recastTime);
+    }
+
+    PChar->pushPacket<GP_SERV_COMMAND_ABIL_RECAST>(PChar);
+}
+
 }; // namespace charutils

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -27,6 +27,7 @@
 #include "items/item_equipment.h"
 #include "zone.h"
 
+struct Charge_t;
 enum class MissionLog : uint8_t;
 enum class QuestLog : uint8_t;
 enum class KeyItem : uint16_t;
@@ -308,5 +309,7 @@ bool isOrchestrionPlaced(CCharEntity* PChar);
 void updateMannequins(CCharEntity* PChar);
 
 bool raceChange(CCharEntity* PChar, CharRace newRace, CharFace newFace, CharSize newSize);
+
+void ApplyAbilityRecast(CCharEntity* PChar, const CAbility* PAbility, const Charge_t* charge, timer::duration baseChargeTime, timer::duration recastTime);
 
 }; // namespace charutils


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- When paralyzed on ability use, puts the ability on cooldown (EXCEPT for 1 Hour abilities)
- Extracted the recast setting logic into a charutils func

https://github.com/HorizonFFXI/HorizonXI-Issues/issues/2513

Retail proof

<img width="2242" height="1184" alt="Screenshot 2025-11-11 153928" src="https://github.com/user-attachments/assets/df597242-a887-40ce-9ee1-e6dc0f203aad" />

## Steps to test these changes
```
[ RUN      ] systems::effects::Paralyze::puts abilities on cooldown
[       OK ] systems::effects::Paralyze::puts abilities on cooldown (296 ms)
[ RUN      ] systems::effects::Paralyze::does not put 1HR abilities on cooldown
[       OK ] systems::effects::Paralyze::does not put 1HR abilities on cooldown (260 ms)
[==========] 2 tests ran. (2.124 s total)
[  PASSED  ] 2 tests.
```
<!-- Clear and detailed steps to test your changes here -->
