### PR TITLE
core: C2S healing/crafting checks

### DIFF
--- a/src/map/packets/c2s/0x01a_action.cpp
+++ b/src/map/packets/c2s/0x01a_action.cpp
@@ -54,7 +54,21 @@ const auto actionToStr = [](const GP_CLI_COMMAND_ACTION_ACTIONID actionIn)
 auto GP_CLI_COMMAND_ACTION::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
     return PacketValidator()
-        .oneOf<GP_CLI_COMMAND_ACTION_ACTIONID>(ActionID);
+        .oneOf<GP_CLI_COMMAND_ACTION_ACTIONID>(ActionID)
+        .custom([&](PacketValidator& pv)
+        {
+            switch (static_cast<GP_CLI_COMMAND_ACTION_ACTIONID>(ActionID))
+            {
+                // /assist and /blockaid can be performed while healing
+                // Everything else is blocked.
+                case GP_CLI_COMMAND_ACTION_ACTIONID::Assist:
+                case GP_CLI_COMMAND_ACTION_ACTIONID::Blockaid:
+                    return;
+                default:
+                    pv.isNotResting(PChar)
+                      .isNotCrafting(PChar);
+            }
+        });
 }
 
 void GP_CLI_COMMAND_ACTION::process(MapSession* PSession, CCharEntity* PChar) const

--- a/src/map/packets/c2s/0x01a_action.cpp
+++ b/src/map/packets/c2s/0x01a_action.cpp
@@ -56,19 +56,19 @@ auto GP_CLI_COMMAND_ACTION::validate(MapSession* PSession, const CCharEntity* PC
     return PacketValidator()
         .oneOf<GP_CLI_COMMAND_ACTION_ACTIONID>(ActionID)
         .custom([&](PacketValidator& pv)
-        {
-            switch (static_cast<GP_CLI_COMMAND_ACTION_ACTIONID>(ActionID))
-            {
-                // /assist and /blockaid can be performed while healing
-                // Everything else is blocked.
-                case GP_CLI_COMMAND_ACTION_ACTIONID::Assist:
-                case GP_CLI_COMMAND_ACTION_ACTIONID::Blockaid:
-                    return;
-                default:
-                    pv.isNotResting(PChar)
-                      .isNotCrafting(PChar);
-            }
-        });
+                {
+                    switch (static_cast<GP_CLI_COMMAND_ACTION_ACTIONID>(ActionID))
+                    {
+                        // /assist and /blockaid can be performed while healing
+                        // Everything else is blocked.
+                        case GP_CLI_COMMAND_ACTION_ACTIONID::Assist:
+                        case GP_CLI_COMMAND_ACTION_ACTIONID::Blockaid:
+                            return;
+                        default:
+                            pv.isNotResting(PChar)
+                                .isNotCrafting(PChar);
+                    }
+                });
 }
 
 void GP_CLI_COMMAND_ACTION::process(MapSession* PSession, CCharEntity* PChar) const

--- a/src/map/packets/c2s/0x036_item_transfer.cpp
+++ b/src/map/packets/c2s/0x036_item_transfer.cpp
@@ -28,6 +28,7 @@
 #include "packets/s2c/0x053_systemmes.h"
 #include "status_effect_container.h"
 #include "trade_container.h"
+#include "utils/synthutils.h"
 
 namespace
 {
@@ -118,4 +119,13 @@ void GP_CLI_COMMAND_ITEM_TRANSFER::process(MapSession* PSession, CCharEntity* PC
 
     luautils::OnTrade(PChar, PNpc);
     PChar->TradeContainer->unreserveUnconfirmed();
+    if (PChar->isInEvent())
+    {
+        // Retail accurate: If the trade started an event then any current synth is a crit fail.
+        if (PChar->animation == ANIMATION_SYNTH ||
+            (PChar->CraftContainer && PChar->CraftContainer->getItemsCount() > 0))
+        {
+            charutils::forceSynthCritFail("GP_CLI_COMMAND_ITEM_TRANSFER", PChar);
+        }
+    }
 }

--- a/src/map/packets/c2s/0x0ea_sit.cpp
+++ b/src/map/packets/c2s/0x0ea_sit.cpp
@@ -21,9 +21,9 @@
 
 #include "0x0ea_sit.h"
 
-#include "status_effect_container.h"
 #include "entities/charentity.h"
 #include "entities/petentity.h"
+#include "status_effect_container.h"
 
 auto GP_CLI_COMMAND_SIT::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {

--- a/src/map/packets/c2s/0x0ea_sit.cpp
+++ b/src/map/packets/c2s/0x0ea_sit.cpp
@@ -21,6 +21,7 @@
 
 #include "0x0ea_sit.h"
 
+#include "status_effect_container.h"
 #include "entities/charentity.h"
 #include "entities/petentity.h"
 
@@ -35,6 +36,9 @@ auto GP_CLI_COMMAND_SIT::validate(MapSession* PSession, const CCharEntity* PChar
 
 void GP_CLI_COMMAND_SIT::process(MapSession* PSession, CCharEntity* PChar) const
 {
+    // Retail accurate: Can inject /sit while healing/logging out, but it cancels the effect.
+    PChar->StatusEffectContainer->DelStatusEffectSilent(EFFECT_HEALING);
+
     switch (static_cast<GP_CLI_COMMAND_SIT_MODE>(Mode))
     {
         case GP_CLI_COMMAND_SIT_MODE::Toggle:

--- a/src/map/packets/c2s/0x113_sitchair.cpp
+++ b/src/map/packets/c2s/0x113_sitchair.cpp
@@ -29,6 +29,7 @@
 auto GP_CLI_COMMAND_SITCHAIR::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
     return PacketValidator()
+        .isNotCrafting(PChar)
         .isNormalStatus(PChar)
         .isNotPreventedAction(PChar)
         .oneOf<GP_CLI_COMMAND_SITCHAIR_MODE>(Mode)
@@ -37,6 +38,9 @@ auto GP_CLI_COMMAND_SITCHAIR::validate(MapSession* PSession, const CCharEntity* 
 
 void GP_CLI_COMMAND_SITCHAIR::process(MapSession* PSession, CCharEntity* PChar) const
 {
+    // Retail accurate: Can inject /sitchair while healing/logging out, but it cancels the effect.
+    PChar->StatusEffectContainer->DelStatusEffectSilent(EFFECT_HEALING);
+
     if (Mode == static_cast<uint8>(GP_CLI_COMMAND_SITCHAIR_MODE::Off))
     {
         PChar->animation = ANIMATION_NONE;

--- a/src/map/packets/c2s/validation.cpp
+++ b/src/map/packets/c2s/validation.cpp
@@ -26,7 +26,8 @@
 #include "status_effect_container.h"
 #include "trade_container.h"
 
-auto PacketValidator::isNotResting(const CCharEntity* PChar) -> PacketValidator& {
+auto PacketValidator::isNotResting(const CCharEntity* PChar) -> PacketValidator&
+{
     if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_HEALING) ||
         PChar->animation == ANIMATION_HEALING)
     {

--- a/src/map/packets/c2s/validation.cpp
+++ b/src/map/packets/c2s/validation.cpp
@@ -26,6 +26,16 @@
 #include "status_effect_container.h"
 #include "trade_container.h"
 
+auto PacketValidator::isNotResting(const CCharEntity* PChar) -> PacketValidator& {
+    if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_HEALING) ||
+        PChar->animation == ANIMATION_HEALING)
+    {
+        result_.addError("Character is resting.");
+    }
+
+    return *this;
+}
+
 auto PacketValidator::isNotCrafting(const CCharEntity* PChar) -> PacketValidator&
 {
     if (PChar->animation == ANIMATION_SYNTH ||

--- a/src/map/packets/c2s/validation.h
+++ b/src/map/packets/c2s/validation.h
@@ -191,6 +191,8 @@ public:
         return *this;
     }
 
+    // Character must not be resting
+    auto isNotResting(const CCharEntity* PChar) -> PacketValidator&;
     // Character must not be crafting
     auto isNotCrafting(const CCharEntity* PChar) -> PacketValidator&;
     // Character current status must be NORMAL


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Disable most ACTION requests while healing/crafting
- Crit fails any ongoing synth if the NPC trade starts an event
- Allow /sit and /sitchair while healing (which includes logging out) but cancel the healing effect

Proof for crit fail
<img width="1374" height="240" alt="image" src="https://github.com/user-attachments/assets/f6bbdc2c-c8bf-4bdf-ac74-8f7f83d89fee" />

## Steps to test these changes
- Trade 5g to Varchet while crafting in Southern Sandy

<!-- Clear and detailed steps to test your changes here -->
