### PR TITLE
[core] GP_SERV_COMMAND_GROUP_LIST: Add undocumented padding after name

### DIFF
--- a/src/map/packets/s2c/0x0dd_group_list.cpp
+++ b/src/map/packets/s2c/0x0dd_group_list.cpp
@@ -69,7 +69,13 @@ GP_SERV_COMMAND_GROUP_LIST::GP_SERV_COMMAND_GROUP_LIST(const CCharEntity* PChar,
         }
     }
 
-    std::memcpy(packet.Name, PChar->getName().c_str(), std::min<size_t>(PChar->getName().size(), sizeof(packet.Name)));
+    const auto nameSize       = std::min<size_t>(PChar->getName().size(), sizeof(packet.Name));
+    const auto packetNameSize = roundUpToNearestFour(static_cast<uint32_t>(nameSize)) + 4; // Always 4 bytes of padding after name
+    std::memcpy(packet.Name, PChar->getName().c_str(), nameSize);
+
+    // Resize packets to match name length + the 4 bytes of padding the client expects.
+    // Header + struct - max name size + effective packet name size
+    this->setSize(sizeof(GP_SERV_HEADER) + sizeof(PacketData) - 16 + packetNameSize);
 }
 
 GP_SERV_COMMAND_GROUP_LIST::GP_SERV_COMMAND_GROUP_LIST(const CTrustEntity* PTrust, const uint8_t MemberNumber)
@@ -95,7 +101,13 @@ GP_SERV_COMMAND_GROUP_LIST::GP_SERV_COMMAND_GROUP_LIST(const CTrustEntity* PTrus
     packet.sjob_no      = PTrust->GetSJob();
     packet.sjob_lv      = PTrust->GetSLevel();
 
-    std::memcpy(packet.Name, PTrust->packetName.c_str(), std::min<size_t>(PTrust->packetName.size(), sizeof(packet.Name)));
+    const auto nameSize       = std::min<size_t>(PTrust->getName().size(), sizeof(packet.Name));
+    const auto packetNameSize = roundUpToNearestFour(static_cast<uint32_t>(nameSize)) + 4; // Always 4 bytes of padding after name
+    std::memcpy(packet.Name, PTrust->packetName.c_str(), nameSize);
+
+    // Resize packets to match name length + the 4 bytes of padding the client expects.
+    // Header + struct - max name size + effective packet name size
+    this->setSize(sizeof(GP_SERV_HEADER) + sizeof(PacketData) - 16 + packetNameSize);
 }
 
 GP_SERV_COMMAND_GROUP_LIST::GP_SERV_COMMAND_GROUP_LIST(const uint32_t id, const std::string& name, const uint16_t memberFlags, const uint8_t MemberNumber, const uint16_t ZoneID)
@@ -113,5 +125,11 @@ GP_SERV_COMMAND_GROUP_LIST::GP_SERV_COMMAND_GROUP_LIST(const uint32_t id, const 
     packet.GAttr.LevelSyncFlg      = (memberFlags >> 8) & 0x01; // Bit 8: LevelSyncFlg
     packet.ZoneNo                  = ZoneID;
 
-    std::memcpy(packet.Name, name.c_str(), std::min<size_t>(name.size(), sizeof(packet.Name)));
+    const auto nameSize       = std::min<size_t>(name.size(), sizeof(packet.Name));
+    const auto packetNameSize = roundUpToNearestFour(static_cast<uint32_t>(nameSize)) + 4; // Always 4 bytes of padding after name
+    std::memcpy(packet.Name, name.c_str(), nameSize);
+
+    // Resize packets to match name length + the 4 bytes of padding the client expects.
+    // Header + struct - max name size + effective packet name size
+    this->setSize(sizeof(GP_SERV_HEADER) + sizeof(PacketData) - 16 + packetNameSize);
 }

--- a/src/map/packets/s2c/0x0dd_group_list.h
+++ b/src/map/packets/s2c/0x0dd_group_list.h
@@ -66,6 +66,7 @@ public:
         uint8_t       masterjob_lv;    // PS2: (New; did not exist.)
         uint8_t       masterjob_flags; // PS2: (New; did not exist.)
         uint8_t       Name[16];        // PS2: Name
+        // 4 bytes padding after the name (itself rounded to nearest 4 bytes)
     };
 
     GP_SERV_COMMAND_GROUP_LIST(const CCharEntity* PChar, uint8_t MemberNumber, uint16_t memberflags, uint16_t ZoneID);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Not only did I forget to make this a proper variable length packet but it turns out there's 4 bytes of padding expected after the name which break `<t>` and `<p#>` if they're missing.

https://github.com/HorizonFFXI/HorizonXI-Issues/issues/2451
https://github.com/atom0s/XiPackets/issues/8

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
<img width="642" height="92" alt="image" src="https://github.com/user-attachments/assets/97bb5b7c-6ff5-449d-9c71-5a65aefded2f" />

<!-- Clear and detailed steps to test your changes here -->
