### PR TITLE
[lua] Despawn pets when renting chocobos

### DIFF
--- a/scripts/effects/mounted.lua
+++ b/scripts/effects/mounted.lua
@@ -24,6 +24,12 @@ effectObject.onEffectGain = function(target, effect)
     if not target:isInEvent() then
         target:setAnimation(animation)
     end
+
+    -- Chocobo and mounts uncharm current pet
+    local pet = target:getPet()
+    if pet ~= nil and pet:isCharmed() then
+        target:despawnPet()
+    end
 end
 
 effectObject.onEffectTick = function(target, effect)

--- a/scripts/globals/chocobo.lua
+++ b/scripts/globals/chocobo.lua
@@ -246,10 +246,16 @@ xi.chocobo.renterOnEventFinish = function(player, csid, option, eventSucceed)
 
         player:addStatusEffectEx(xi.effect.MOUNTED, xi.effect.MOUNTED, 0, 0, duration, true)
 
+        -- Renting a chocobo force despawns every type of pets
+        -- Note: This does not honor cooldown reductions offered otherwise when dismissing pets with full life.
+        -- TODO: Supposed to despawn without animation
+        player:despawnPet()
+
         if info.pos then
             player:setPos(unpack(info.pos))
         end
     elseif chocoGame ~= 0 and csid == eventSucceed then
+        player:despawnPet()
         xi.chocoboGame.beginRace(player, option)
     end
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Despawns/uncharm all pets when renting a chocobo
- Uncharms current mob when mounting (/mount _and_ rented Chocobo)

Note that this currently plays the full despawn animation. Retail simply vanishes the pet.

https://www.youtube.com/watch?v=RwS9lg1YRKs
https://www.youtube.com/watch?v=4aUlaeAoXjc

I retested pet persistence, I'll leave it here for future reference

<img width="1327" height="319" alt="image" src="https://github.com/user-attachments/assets/538da7bd-a3e7-48d0-b13b-74d9770a06d5" />

https://github.com/HorizonFFXI/HorizonXI-Issues/issues/2372

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Rent a chocobo from a crag with a pet out. See pet is gone once mounted.

<!-- Clear and detailed steps to test your changes here -->
