### PR TITLE
[core,lua] Introduce new enums for Action packet. Use message enums everywhere in core.

### DIFF
--- a/scripts/actions/mobskills/boreas_mantle.lua
+++ b/scripts/actions/mobskills/boreas_mantle.lua
@@ -34,7 +34,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
             local clone = GetMobByID(cloneID)
             if clone then
                 local action = clone:getCurrentAction()
-                if action ~= xi.action.NONE and action ~= xi.action.DEATH then
+                if action ~= xi.action.category.NONE and action ~= xi.action.category.DEATH then
                     DespawnMob(cloneID)
                 end
             end

--- a/scripts/actions/mobskills/luminous_lance.lua
+++ b/scripts/actions/mobskills/luminous_lance.lua
@@ -13,7 +13,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     if
         not (target:hasStatusEffect(xi.effect.PHYSICAL_SHIELD) and target:hasStatusEffect(xi.effect.MAGIC_SHIELD)) and
         lanceTime + 60 < mob:getBattleTime() and
-        target:getCurrentAction() ~= xi.action.MOBABILITY_USING and
+        target:getCurrentAction() ~= xi.action.category.MOBABILITY_USING and
         lanceOut == 1
     then
         return 0

--- a/scripts/actions/spells/trust/monberaux.lua
+++ b/scripts/actions/spells/trust/monberaux.lua
@@ -129,7 +129,7 @@ spellObject.onMobSpawn = function(mob)
 
     -- This listener is needed for Monberaux to display the correct skill name in the combat log.
     mob:addListener('WEAPONSKILL_USE', 'MONBERAUX_WS', function(mobArg, targetArg, skillid, spentTP, action)
-        action:setCategory(xi.action.MOBABILITY_FINISH)
+        action:setCategory(xi.action.category.MOBABILITY_FINISH)
     end)
 
     mob:setMobMod(xi.mobMod.TRUST_DISTANCE, xi.trust.movementType.NO_MOVE)

--- a/scripts/enum/action.lua
+++ b/scripts/enum/action.lua
@@ -1,13 +1,17 @@
 -----------------------------------
--- ACTION IDs
+-- Action packet
 -----------------------------------
 xi = xi or {}
+xi.action = xi.action or {}
 
----@enum xi.action
-xi.action =
+-- action.cmd_no (4 bits)
+-- Type of the action packet.
+-- Client processes each type in a different fashion.
+---@enum xi.action.category
+xi.action.category =
 {
     NONE                  = 0,
-    ATTACK                = 1,
+    BASIC_ATTACK          = 1,
     RANGED_FINISH         = 2,
     WEAPONSKILL_FINISH    = 3,
     MAGIC_FINISH          = 4,
@@ -20,8 +24,11 @@ xi.action =
     MOBABILITY_FINISH     = 11,
     RANGED_START          = 12,
     PET_MOBABILITY_FINISH = 13,
-    DANCE                 = 14,
-    RUN_WARD_EFFUSION     = 15,
+    DANCER                = 14, -- Used by various Steps and Flourishes
+    RUNEFENCER            = 15, -- Used by various RUN abilities
+
+    -- Everything below this line is 100% made-up
+    -- and has nothing to do with actual action packets
     ROAMING               = 16,
     ENGAGE                = 17,
     DISENGAGE             = 18,
@@ -45,4 +52,173 @@ xi.action =
     LEAVE                 = 36,
     RAISE_MENU_SELECTION  = 37,
     JOBABILITY_INTERRUPT  = 38,
+}
+
+-- action.result.miss (3 bits)
+-- Denotes final resolution of the attack.
+-- Only one may be set.
+---@enum xi.action.resolution
+xi.action.resolution =
+{
+    HIT   = 0,
+    MISS  = 1,
+    GUARD = 2,
+    PARRY = 3,
+    BLOCK = 4,
+}
+
+-- action.result.info (5 bits)
+-- Multiple flags can be set.
+-- For DNC and RUN abilities, they represent animations.
+---@enum xi.action.info
+xi.action.info =
+{
+    NONE               = 0,
+    DEFEATED           = 1,
+    CRITICAL_HIT       = 2,
+    UNKNOWN_AOE        = 4,
+
+    -- Dancer animations
+    -- Only for action packets cmd_no 14
+    -- Substract 4 for equivalent miss animation.
+    WILD_FLOURISH      = 5,
+    QUICK_STEP         = 5,
+    BOX_STEP           = 6,
+    DESPERATE_FLOURISH = 6,
+    STUTTER_STEP       = 7,
+    VIOLENT_FLOURISH   = 7,
+    FEATHER_STEP       = 8,
+
+    -- Rune Fencer rune elements
+    -- Only for action packets cmd_no 15
+    ELEMENTAL_MIX      = 0, -- Used when ability mixes several runes
+    IGNIS              = 1,
+    GELUS              = 2,
+    FLABRA             = 3,
+    TELLUS             = 4,
+    SUPLOR             = 5,
+    UNDO               = 6,
+    LUX                = 7,
+    TENEBRAE           = 8,
+}
+
+-- action.result.scale (5 bits, upper 3 bits shared with distortion)
+-- Notify the client of any knockback effect that must occur.
+---@enum xi.action.knockback
+xi.action.knockback =
+{
+    NONE   = 0,
+    LEVEL1 = 1, -- Vec: 0.083, Dumper: 0.075, Timer: 5.0
+    LEVEL2 = 2, -- Vec: 0.167, Dumper: 0.15, Timer: 5.0
+    LEVEL3 = 3, -- Vec: 0.167, Dumper: 0.15, Timer: 10.0
+    LEVEL4 = 4, -- Vec: 0.167, Dumper: 0.15, Timer: 18.0
+    LEVEL5 = 5, -- Vec: 0.167, Dumper: 0.125, Timer: 30.0
+    LEVEL6 = 6, -- Vec: 0.167, Dumper: 0.1, Timer: 35.0
+    LEVEL7 = 7, -- Vec: 0.167, Dumper: 0.05, Timer: 45.0
+}
+
+-- action.result.scale (5 bits, lower 2 bits, shared with knockback)
+-- Represents how much the defender recoils after being hit.
+---@enum xi.action.hitDistortion
+xi.action.hitDistortion =
+{
+    NONE   = 0,
+    LIGHT  = 1, -- 0.25 distortion
+    MEDIUM = 2, -- 0.5 distortion
+    HEAVY  = 3, -- 1.0 distortion
+}
+
+-- action.result.bit (31 bits)
+-- Modifiers applied to the ability message/result/animation
+---@enum xi.action.modifier
+xi.action.modifier =
+{
+    NONE         = 0,
+    COVER        = 1,
+    RESIST       = 2,
+    MAGIC_BURST  = 4,
+    IMMUNOBREAK  = 8,
+    CRITICAL_HIT = 16,
+}
+
+-- action.result.proc_kind (6 bits)
+-- Represents additional effects or skillchains
+---@enum xi.action.addEffect
+xi.action.addEffect =
+{
+    NONE             = 0,
+    FIRE_DAMAGE      = 1,
+    ICE_DAMAGE       = 2,
+    WIND_DAMAGE      = 3,
+    EARTH_DAMAGE     = 4,
+    LIGHTNING_DAMAGE = 5,
+    WATER_DAMAGE     = 6,
+    LIGHT_DAMAGE     = 7,
+    DARK_DAMAGE      = 8,
+    SLEEP            = 9,
+    POISON           = 10,
+    PARALYZE         = 11,
+    ADDLE            = 11,
+    AMNESIA          = 11,
+    BLIND            = 12,
+    SILENCE          = 13,
+    PETRIFY          = 14,
+    PLAGUE           = 15,
+    STUN             = 16,
+    CURSE            = 17,
+    WEAKEN           = 18,
+    DEFENSE_DOWN     = 18,
+    EVASION_DOWN     = 18,
+    ATTACK_DOWN      = 18,
+    SLOW             = 18,
+    DEATH            = 19,
+    SHIELD           = 20,
+    HP_DRAIN         = 21,
+    MP_DRAIN         = 22,
+    TP_DRAIN         = 22,
+    STATUS_DRAIN     = 22,
+    HASTE            = 23,
+}
+
+-- action.result.proc_kind (6 bits)
+-- Represents additional effects or skillchains
+---@enum xi.action.skillchain
+xi.action.skillchain =
+{
+    NONE          = 0,
+    LIGHT         = 1,
+    DARKNESS      = 2,
+    GRAVITATION   = 3,
+    FRAGMENTATION = 4,
+    DISTORTION    = 5,
+    FUSION        = 6,
+    COMPRESSION   = 7,
+    LIQUEFACTION  = 8,
+    INDURATION    = 9,
+    REVERBERATION = 10,
+    TRANSFIXION   = 11,
+    SCISSION      = 12,
+    DETONATION    = 13,
+    IMPACTION     = 14,
+    RADIANCE      = 15,
+    UMBRA         = 16,
+}
+
+-- action.result.react_kind (6 bits)
+-- Represents spikes and counters
+---@enum xi.action.react
+xi.action.react =
+{
+    NONE            = 0,
+    BLAZE_SPIKES    = 1,
+    ICE_SPIKES      = 2,
+    DREAD_SPIKES    = 3,
+    CURSE_SPIKES    = 4,
+    SHOCK_SPIKES    = 5,
+    REPRISAL_SPIKES = 6,
+    WIND_SPIKES     = 7,
+    EARTH_SPIKES    = 8,
+    WATER_SPIKES    = 9,
+    DEATH_SPIKES    = 10,
+    COUNTER         = 63, -- Also used by Retaliation
 }

--- a/scripts/enum/animation_string.lua
+++ b/scripts/enum/animation_string.lua
@@ -30,12 +30,14 @@ For most things you can get away with using the wrong one, and they still just w
 xi.animationString =
 {
     -- Physical
+    BASIC_ATTACK              = 'atk0',
     ATTACK_1                  = 'ati0',
     ATTACK_2                  = 'ati1',
     ATTACK_3                  = 'ati2',
     CRITICAL_HIT              = 'chit',
 
     -- Ranged start
+    RANGED_START              = 'calg', -- Generic non-weapon specific
     RANGED_SINGING_START      = 'lc00',
     RANGED_WIND_INSTR_START   = 'lc01',
     RANGED_STRING_INSTR_START = 'lc02',
@@ -44,6 +46,8 @@ xi.animationString =
     RANGED_BOW_START          = 'lc06',
 
     -- Ranged stop
+    RANGED_STOP               = 'shlg', -- Generic non-weapon specific
+    RANGED_INTERRUPT          = 'splg', -- Generic non-weapon specific
     RANGED_SINGING_STOP       = 'ls00',
     RANGED_WIND_INSTR_STOP    = 'ls01',
     RANGED_STRING_INSTR_STOP  = 'ls02',
@@ -54,20 +58,35 @@ xi.animationString =
     -- Casting start
     CAST_BLACK_MAGIC_START    = 'cabk',
     CAST_BLUE_MAGIC_START     = 'cabl',
+    CAST_GEOMANCY_MAGIC_START = 'cage',
     CAST_ITEM_START           = 'cait',
     CAST_NINJA_START          = 'canj',
     CAST_SUMMONER_START       = 'casm',
     CAST_SONG_START           = 'caso',
+    CAST_TRUST_START          = 'cafa',
     CAST_WHITE_MAGIC_START    = 'cawh',
 
     -- Casting finish
     CAST_BLACK_MAGIC_STOP     = 'shbk',
     CAST_BLUE_MAGIC_STOP      = 'shbl',
+    CAST_GEOMANCY_MAGIC_STOP  = 'shge',
     CAST_ITEM_STOP            = 'shit',
     CAST_NINJA_STOP           = 'shnj',
     CAST_SUMMONER_STOP        = 'shsm',
     CAST_SONG_STOP            = 'shso',
+    CAST_TRUST_STOP           = 'shfa',
     CAST_WHITE_MAGIC_STOP     = 'shwh',
+
+    -- Casting interrupt
+    CAST_BLACK_MAGIC_INTERRUPT    = 'spbk',
+    CAST_BLUE_MAGIC_INTERRUPT     = 'spbl',
+    CAST_GEOMANCY_MAGIC_INTERRUPT = 'spge',
+    CAST_ITEM_INTERRUPT           = 'spit',
+    CAST_NINJA_INTERRUPT          = 'spnj',
+    CAST_SUMMONER_INTERRUPT       = 'spsm',
+    CAST_SONG_INTERRUPT           = 'spso',
+    CAST_TRUST_INTERRUPT          = 'spfa',
+    CAST_WHITE_MAGIC_INTERRUPT    = 'spwh',
 
     -- Actions
     JUMP_0                    = 'jmp0',
@@ -76,6 +95,8 @@ xi.animationString =
     RESTING_STOP              = 'res2',
     SITTING_START             = 'sit0',
     SITTING_STOP              = 'sit2',
+    SKILL_START               = 'cate',
+    SKILL_INTERRUPT           = 'spte',
 
     -- Effects
     EFFECT_DEATH              = 'dead',

--- a/scripts/globals/combat/entity_behavior.lua
+++ b/scripts/globals/combat/entity_behavior.lua
@@ -9,9 +9,9 @@ xi.combat.behavior.isEntityBusy = function(actor)
     -- Check poses (actions).
     local currAction = actor:getCurrentAction()
     if
-        currAction ~= xi.action.NONE and
-        currAction ~= xi.action.ATTACK and-- TODO: What does "ATTACK" entail? Just swinging or engaged in general?
-        currAction ~= xi.action.ROAMING
+        currAction ~= xi.action.category.NONE and
+        currAction ~= xi.action.category.BASIC_ATTACK and-- TODO: What does "ATTACK" entail? Just swinging or engaged in general?
+        currAction ~= xi.action.category.ROAMING
     then
         return true
     end

--- a/scripts/globals/job_utils/summoner.lua
+++ b/scripts/globals/job_utils/summoner.lua
@@ -198,12 +198,12 @@ xi.job_utils.summoner.canUseBloodPact = function(player, pet, target, petAbility
         local petAction = pet:getCurrentAction()
 
         -- check if avatar is under status effect
-        if petAction == xi.action.SLEEP or petAction == xi.action.STUN then
+        if petAction == xi.action.category.SLEEP or petAction == xi.action.category.STUN then
             return xi.msg.basic.PET_CANNOT_DO_ACTION, 0 -- TODO: verify exact message in packet.
         end
 
         -- check if avatar is using a move already
-        if petAction == xi.action.PET_MOBABILITY_FINISH then
+        if petAction == xi.action.category.PET_MOBABILITY_FINISH then
             return 0, 0
         end
 

--- a/scripts/globals/job_utils/summoner.lua
+++ b/scripts/globals/job_utils/summoner.lua
@@ -198,7 +198,10 @@ xi.job_utils.summoner.canUseBloodPact = function(player, pet, target, petAbility
         local petAction = pet:getCurrentAction()
 
         -- check if avatar is under status effect
-        if petAction == xi.action.category.SLEEP or petAction == xi.action.category.STUN then
+        if
+            petAction == xi.action.category.SLEEP or
+            petAction == xi.action.category.STUN
+        then
             return xi.msg.basic.PET_CANNOT_DO_ACTION, 0 -- TODO: verify exact message in packet.
         end
 

--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -830,7 +830,7 @@ xi.mob.callPets = function(mob, petIds, params)
                 -- inject "<mob> uses Call Beast"
                 actionParams =
                 {
-                    finishCategory = xi.action.MOBABILITY_FINISH,
+                    finishCategory = xi.action.category.MOBABILITY_FINISH,
                     animationID = 718,
                     actionID = xi.mobSkill.CALL_BEAST,
                     messageID = xi.msg.basic.USES,
@@ -842,7 +842,7 @@ xi.mob.callPets = function(mob, petIds, params)
                 -- inject "<mob> uses Call Wyvern"
                 actionParams =
                 {
-                    finishCategory = xi.action.MOBABILITY_FINISH,
+                    finishCategory = xi.action.category.MOBABILITY_FINISH,
                     animationID = 438,
                     actionID = xi.mobSkill.CALL_WYVERN,
                     messageID = xi.msg.basic.USES,
@@ -855,7 +855,7 @@ xi.mob.callPets = function(mob, petIds, params)
                 -- The mobskill has no action message, so we use the job ability
                 actionParams =
                 {
-                    finishCategory = xi.action.JOBABILITY_FINISH,
+                    finishCategory = xi.action.category.JOBABILITY_FINISH,
                     animationID = 83,
                     actionID = xi.jobAbility.ACTIVATE,
                     messageID = xi.msg.basic.USES_JA,

--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -191,7 +191,10 @@ xi.mob.phOnDespawn = function(ph, phNmId, chance, cooldown, params)
         DisallowRespawn(nmId, true)
         if not params.doNotEnablePhSpawn then
             DisallowRespawn(phId, false)
-            GetMobByID(phId):setRespawnTime(GetMobRespawnTime(phId))
+            local phMob = GetMobByID(phId)
+            if phMob then
+                phMob:setRespawnTime(GetMobRespawnTime(phId))
+            end
         end
 
         if m:getLocalVar('doNotInvokeCooldown') == 0 then

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -458,7 +458,7 @@ xi.mobskills.mobFinalAdjustments = function(damage, mob, skill, target, attackTy
 
     -- Set message to damage
     -- This is for AoE because its only set once
-    if mob:getCurrentAction() == xi.action.PET_MOBABILITY_FINISH then
+    if mob:getCurrentAction() == xi.action.category.PET_MOBABILITY_FINISH then
         if skill:getMsg() ~= xi.msg.basic.JA_MAGIC_BURST then
             skill:setMsg(xi.msg.basic.USES_JA_TAKE_DAMAGE)
         end

--- a/scripts/globals/pets/avatar.lua
+++ b/scripts/globals/pets/avatar.lua
@@ -73,7 +73,7 @@ local setMagicCastCooldown = function(pet)
     end
 
     -- cast delay is ~1s past the finish of last spell, so we add casting time (or time since spell interrupt) to the castingCooldown
-    -- this is done by simply tracking the elapsed time since action is no longer xi.action.MAGIC_CASTING
+    -- this is done by simply tracking the elapsed time since action is no longer xi.action.category.MAGIC_CASTING
     local lastCastTime = pet:getLocalVar(lastCastTimeVar)
     local lastCastTimeStamp = pet:getLocalVar(lastCastTimeStampVar)
     if
@@ -85,7 +85,7 @@ local setMagicCastCooldown = function(pet)
 
     if
         lastCastTime > 0 and
-        pet:getCurrentAction() ~= xi.action.MAGIC_CASTING
+        pet:getCurrentAction() ~= xi.action.category.MAGIC_CASTING
     then
         pet:setLocalVar(lastCastTimeStampVar, 0)
         pet:setLocalVar(lastCastTimeVar, lastCastTime)

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -271,7 +271,7 @@ local attackTypeShields =
 
 xi.summon.avatarFinalAdjustments = function(dmg, mob, skill, target, skilltype, damagetype, shadowbehav)
     local missMessage = xi.msg.basic.SKILL_MISS
-    if mob:getCurrentAction() == xi.action.PET_MOBABILITY_FINISH then
+    if mob:getCurrentAction() == xi.action.category.PET_MOBABILITY_FINISH then
         missMessage = xi.msg.basic.JA_MISS_2
     end
 
@@ -287,7 +287,7 @@ xi.summon.avatarFinalAdjustments = function(dmg, mob, skill, target, skilltype, 
 
     -- set message to damage
     -- this is for AoE because its only set once
-    if mob:getCurrentAction() == xi.action.PET_MOBABILITY_FINISH then
+    if mob:getCurrentAction() == xi.action.category.PET_MOBABILITY_FINISH then
         if skill:getMsg() ~= xi.msg.basic.JA_MAGIC_BURST then
             skill:setMsg(xi.msg.basic.USES_JA_TAKE_DAMAGE)
         end

--- a/scripts/mixins/families/apkallu.lua
+++ b/scripts/mixins/families/apkallu.lua
@@ -26,7 +26,7 @@ g_mixins.families.apkallu = function(apkalluMob)
             if member:getID() ~= 0 and mob:getID() ~= member:getID() then
                 local memberDistance = mob:checkDistance(member)
                 if
-                    member:getCurrentAction() == xi.action.ROAMING and
+                    member:getCurrentAction() == xi.action.category.ROAMING and
                     memberDistance <= distance
                 then
                     closest = member

--- a/scripts/mixins/families/zdei.lua
+++ b/scripts/mixins/families/zdei.lua
@@ -57,7 +57,7 @@ g_mixins.families.zdei = function(zdeiMob)
         -- Change to a new mode if time has expired and not currently charging optic induration
         if
             now >= changeTime and
-            mob:getCurrentAction() == xi.action.ATTACK and
+            mob:getCurrentAction() == xi.action.category.BASIC_ATTACK and
             mob:getLocalVar('chargeCount') == 0
         then
             local newSub = math.random(1, 3)

--- a/scripts/zones/Apollyon/mobs/Proto-Omega.lua
+++ b/scripts/zones/Apollyon/mobs/Proto-Omega.lua
@@ -69,7 +69,7 @@ entity.onMobFight = function(mob, target)
     if mob:getLocalVar('final') == 1 then
         if
             now >= mob:getLocalVar('gunpodTime') and
-            mob:getCurrentAction() == xi.action.ATTACK and
+            mob:getCurrentAction() == xi.action.category.BASIC_ATTACK and
             GetMobByID(mob:getID() + 1):getStatus() == xi.status.DISAPPEAR
         then
             mob:setLocalVar('gunpodTime', now + utils.minutes(5))
@@ -87,7 +87,7 @@ entity.onMobFight = function(mob, target)
 
     -- Swap between forms every 2 minutes
     local form = mob:getLocalVar('formTime')
-    if now >= form and mob:getCurrentAction() == xi.action.ATTACK then
+    if now >= form and mob:getCurrentAction() == xi.action.category.BASIC_ATTACK then
         mob:setLocalVar('formTime', now + utils.minutes(2))
         if mob:getAnimationSub() == 1 then
             bipedForm(mob)

--- a/scripts/zones/Apollyon/mobs/Proto-Omega.lua
+++ b/scripts/zones/Apollyon/mobs/Proto-Omega.lua
@@ -87,7 +87,10 @@ entity.onMobFight = function(mob, target)
 
     -- Swap between forms every 2 minutes
     local form = mob:getLocalVar('formTime')
-    if now >= form and mob:getCurrentAction() == xi.action.category.BASIC_ATTACK then
+    if
+        now >= form and
+        mob:getCurrentAction() == xi.action.category.BASIC_ATTACK
+    then
         mob:setLocalVar('formTime', now + utils.minutes(2))
         if mob:getAnimationSub() == 1 then
             bipedForm(mob)

--- a/scripts/zones/Arrapago_Reef/mobs/Medusa.lua
+++ b/scripts/zones/Arrapago_Reef/mobs/Medusa.lua
@@ -48,7 +48,7 @@ entity.onMobFight = function(mob, target)
         local pet = GetMobByID(i)
         if
             pet and
-            pet:getCurrentAction() == xi.action.ROAMING
+            pet:getCurrentAction() == xi.action.category.ROAMING
         then
             pet:updateEnmity(target)
         end

--- a/scripts/zones/Arrapago_Reef/mobs/Medusa.lua
+++ b/scripts/zones/Arrapago_Reef/mobs/Medusa.lua
@@ -29,18 +29,28 @@ end
 
 entity.onMobFight = function(mob, target)
     if mob:getBattleTime() % 60 < 2 and mob:getBattleTime() > 10 then
-        if not GetMobByID(ID.mob.MEDUSA + 1):isSpawned() then
-            GetMobByID(ID.mob.MEDUSA + 1):setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
+        local mob1 = GetMobByID(ID.mob.MEDUSA + 1)
+        if mob1 and not mob1:isSpawned() then
+            mob1:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
             SpawnMob(ID.mob.MEDUSA + 1):updateEnmity(target)
-        elseif not GetMobByID(ID.mob.MEDUSA + 2):isSpawned() then
-            GetMobByID(ID.mob.MEDUSA + 2):setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
-            SpawnMob(ID.mob.MEDUSA + 2):updateEnmity(target)
-        elseif not GetMobByID(ID.mob.MEDUSA + 3):isSpawned() then
-            GetMobByID(ID.mob.MEDUSA + 3):setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
-            SpawnMob(ID.mob.MEDUSA + 3):updateEnmity(target)
-        elseif not GetMobByID(ID.mob.MEDUSA + 4):isSpawned() then
-            GetMobByID(ID.mob.MEDUSA + 4):setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
-            SpawnMob(ID.mob.MEDUSA + 4):updateEnmity(target)
+        else
+            local mob2 = GetMobByID(ID.mob.MEDUSA + 2)
+            if mob2 and not mob2:isSpawned() then
+                mob2:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
+                SpawnMob(ID.mob.MEDUSA + 2):updateEnmity(target)
+            else
+                local mob3 = GetMobByID(ID.mob.MEDUSA + 3)
+                if mob3 and not mob3:isSpawned() then
+                    mob3:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
+                    SpawnMob(ID.mob.MEDUSA + 3):updateEnmity(target)
+                else
+                    local mob4 = GetMobByID(ID.mob.MEDUSA + 4)
+                    if mob4 and not mob4:isSpawned() then
+                        mob4:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
+                        SpawnMob(ID.mob.MEDUSA + 4):updateEnmity(target)
+                    end
+                end
+            end
         end
     end
 

--- a/scripts/zones/Arrapago_Reef/mobs/Velionis.lua
+++ b/scripts/zones/Arrapago_Reef/mobs/Velionis.lua
@@ -34,7 +34,7 @@ end
 
 entity.onSpikesDamage = function(mob, target, damage)
     -- we don't have an "isCasting()" so use getCurrentAction() instead
-    if mob:getCurrentAction() == xi.action.MAGIC_CASTING then
+    if mob:getCurrentAction() == xi.action.category.MAGIC_CASTING then
         -- No spikes when mid-cast.
         return 0, 0, 0
     else

--- a/scripts/zones/Aydeewa_Subterrane/mobs/Pandemonium_Warden.lua
+++ b/scripts/zones/Aydeewa_Subterrane/mobs/Pandemonium_Warden.lua
@@ -353,9 +353,9 @@ entity.onMobFight = function(mob, target)
             local actionTimer = callPetParams.inactiveTime + 11000
             mob:timer(actionTimer, function(mobArg)
                 -- injects a fake action of "PW readies astral flow" before avatars use their respective abilities
-                mobArg:injectActionPacket(mob:getID(), xi.action.MOBABILITY_START, 438, 0, 0x18, xi.msg.basic.READIES_WS, 0, xi.mobSkill.ASTRAL_FLOW_1)
+                mobArg:injectActionPacket(mob:getID(), xi.action.category.MOBABILITY_START, 438, 0, 0x18, xi.msg.basic.READIES_WS, 0, xi.mobSkill.ASTRAL_FLOW_1)
                 -- injects the packet to end the animation
-                mobArg:injectActionPacket(mob:getID(), xi.action.MOBABILITY_FINISH, 438, 0, 0x18, xi.msg.basic.NONE, 0, xi.mobSkill.ASTRAL_FLOW_1)
+                mobArg:injectActionPacket(mob:getID(), xi.action.category.MOBABILITY_FINISH, 438, 0, 0x18, xi.msg.basic.NONE, 0, xi.mobSkill.ASTRAL_FLOW_1)
             end)
 
             -- Increment astral

--- a/scripts/zones/Balgas_Dais/mobs/Wyrm.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Wyrm.lua
@@ -24,9 +24,9 @@ end
 local function notBusy(mob)
     local action = mob:getCurrentAction()
     if
-        action == xi.action.MOBABILITY_START or
-        action == xi.action.MOBABILITY_USING or
-        action == xi.action.MOBABILITY_FINISH
+        action == xi.action.category.MOBABILITY_START or
+        action == xi.action.category.MOBABILITY_USING or
+        action == xi.action.category.MOBABILITY_FINISH
     then
         return false -- when the Wyrm is in any stage of using a mobskill
     else

--- a/scripts/zones/Caedarva_Mire/mobs/Experimental_Lamia.lua
+++ b/scripts/zones/Caedarva_Mire/mobs/Experimental_Lamia.lua
@@ -40,7 +40,7 @@ entity.onMobFight = function(mob, target)
         local minion = GetMobByID(i)
         if
             minion and
-            minion:getCurrentAction() == xi.action.ROAMING
+            minion:getCurrentAction() == xi.action.category.ROAMING
         then
             minion:updateEnmity(target)
         end

--- a/scripts/zones/Carpenters_Landing/mobs/Overgrown_Ivy.lua
+++ b/scripts/zones/Carpenters_Landing/mobs/Overgrown_Ivy.lua
@@ -15,7 +15,7 @@ entity.onMobFight = function(mob, target)
     local badBreaths = mob:getLocalVar('badBreaths')
     -- also check to make sure that mob is not currently using a bad breath
     if
-        mob:getCurrentAction() == xi.action.ATTACK and
+        mob:getCurrentAction() == xi.action.category.BASIC_ATTACK and
         badBreaths < 5 and
         mob:getHPP() <= 25
     then

--- a/scripts/zones/Dynamis-Beaucedine/mobs/Angra_Mainyu.lua
+++ b/scripts/zones/Dynamis-Beaucedine/mobs/Angra_Mainyu.lua
@@ -11,7 +11,8 @@ local entity = {}
 entity.onMobEngage = function(mob, target)
     local mobId = mob:getID()
     for i = mobId + 1, mobId + 4 do
-        if not GetMobByID(i):isSpawned() then
+        local m = GetMobByID(i)
+        if m and not m:isSpawned() then
             SpawnMob(i)
         end
     end

--- a/scripts/zones/Dynamis-Beaucedine/mobs/Angra_Mainyu.lua
+++ b/scripts/zones/Dynamis-Beaucedine/mobs/Angra_Mainyu.lua
@@ -24,7 +24,7 @@ entity.onMobFight = function(mob, target)
         if
             pet and
             pet:isSpawned() and
-            pet:getCurrentAction() == xi.action.ROAMING
+            pet:getCurrentAction() == xi.action.category.ROAMING
         then
             pet:updateEnmity(target)
         end

--- a/scripts/zones/Dynamis-Xarcabard/mobs/Dynamis_Lord.lua
+++ b/scripts/zones/Dynamis-Xarcabard/mobs/Dynamis_Lord.lua
@@ -41,7 +41,7 @@ entity.onMobFight = function(mob, target)
                 pet:updateEnmity(target)
             end
 
-            if pet:getCurrentAction() == xi.action.ROAMING then
+            if pet:getCurrentAction() == xi.action.category.ROAMING then
                 pet:updateEnmity(target)
             end
         end

--- a/scripts/zones/Dynamis-Xarcabard/mobs/Yang.lua
+++ b/scripts/zones/Dynamis-Xarcabard/mobs/Yang.lua
@@ -34,7 +34,7 @@ entity.onMobFight = function(mob, target)
 
     if
         ying and
-        ying:getCurrentAction() == xi.action.NONE and
+        ying:getCurrentAction() == xi.action.category.NONE and
         GetSystemTime() > yingToD + 30
     then
         ying:setSpawn(mob:getXPos(), mob:getYPos(), mob:getZPos())

--- a/scripts/zones/Dynamis-Xarcabard/mobs/Ying.lua
+++ b/scripts/zones/Dynamis-Xarcabard/mobs/Ying.lua
@@ -34,7 +34,7 @@ entity.onMobFight = function(mob, target)
 
     if
         yang and
-        yang:getCurrentAction() == xi.action.NONE and
+        yang:getCurrentAction() == xi.action.category.NONE and
         GetSystemTime() > yangToD + 30
     then
         yang:setSpawn(mob:getXPos(), mob:getYPos(), mob:getZPos())

--- a/scripts/zones/Empyreal_Paradox/mobs/Prishe.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Prishe.lua
@@ -18,7 +18,7 @@ entity.onMobRoam = function(mob)
     local ready = mob:getLocalVar('ready')
 
     if ready == 0 and wait > 240 then
-        if GetMobByID(promathia):getCurrentAction() ~= xi.action.NONE then
+        if GetMobByID(promathia):getCurrentAction() ~= xi.action.category.NONE then
             mob:entityAnimationPacket('prov')
             mob:messageText(mob, ID.text.PRISHE_TEXT)
         else

--- a/scripts/zones/Empyreal_Paradox/mobs/Prishe.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Prishe.lua
@@ -18,7 +18,11 @@ entity.onMobRoam = function(mob)
     local ready = mob:getLocalVar('ready')
 
     if ready == 0 and wait > 240 then
-        if GetMobByID(promathia):getCurrentAction() ~= xi.action.category.NONE then
+        local promathiaMob = GetMobByID(promathia)
+        if
+            promathiaMob and
+            promathiaMob:getCurrentAction() ~= xi.action.category.NONE
+        then
             mob:entityAnimationPacket('prov')
             mob:messageText(mob, ID.text.PRISHE_TEXT)
         else

--- a/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Ixaern_MNK.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Ixaern_MNK.lua
@@ -100,7 +100,7 @@ entity.onMobEngage = function(mob, target)
         if
             qnAern and
             qnAern:isAlive() and
-            qnAern:getCurrentAction() == xi.action.ROAMING
+            qnAern:getCurrentAction() == xi.action.category.ROAMING
         then
             qnAern:updateEnmity(target)
         end

--- a/scripts/zones/Halvung/mobs/Gurfurlur_the_Menacing.lua
+++ b/scripts/zones/Halvung/mobs/Gurfurlur_the_Menacing.lua
@@ -35,7 +35,7 @@ entity.onMobFight = function(mob, target)
     for i = ID.mob.GURFURLUR_THE_MENACING + 1, ID.mob.GURFURLUR_THE_MENACING + 4 do
         local pet = GetMobByID(i)
 
-        if pet and pet:getCurrentAction() == xi.action.ROAMING then
+        if pet and pet:getCurrentAction() == xi.action.category.ROAMING then
             pet:updateEnmity(target)
         end
     end

--- a/scripts/zones/Halvung/mobs/Gurfurlur_the_Menacing.lua
+++ b/scripts/zones/Halvung/mobs/Gurfurlur_the_Menacing.lua
@@ -17,18 +17,28 @@ end
 
 entity.onMobFight = function(mob, target)
     if mob:getBattleTime() % 60 < 2 and mob:getBattleTime() > 10 then
-        if not GetMobByID(ID.mob.GURFURLUR_THE_MENACING + 1):isSpawned() then
-            GetMobByID(ID.mob.GURFURLUR_THE_MENACING + 1):setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
+        local mob1 = GetMobByID(ID.mob.GURFURLUR_THE_MENACING + 1)
+        if mob1 and not mob1:isSpawned() then
+            mob1:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
             SpawnMob(ID.mob.GURFURLUR_THE_MENACING + 1):updateEnmity(target)
-        elseif not GetMobByID(ID.mob.GURFURLUR_THE_MENACING + 2):isSpawned() then
-            GetMobByID(ID.mob.GURFURLUR_THE_MENACING + 2):setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
-            SpawnMob(ID.mob.GURFURLUR_THE_MENACING + 2):updateEnmity(target)
-        elseif not GetMobByID(ID.mob.GURFURLUR_THE_MENACING + 3):isSpawned() then
-            GetMobByID(ID.mob.GURFURLUR_THE_MENACING + 3):setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
-            SpawnMob(ID.mob.GURFURLUR_THE_MENACING + 3):updateEnmity(target)
-        elseif not GetMobByID(ID.mob.GURFURLUR_THE_MENACING + 4):isSpawned() then
-            GetMobByID(ID.mob.GURFURLUR_THE_MENACING + 4):setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
-            SpawnMob(ID.mob.GURFURLUR_THE_MENACING + 4):updateEnmity(target)
+        else
+            local mob2 = GetMobByID(ID.mob.GURFURLUR_THE_MENACING + 2)
+            if mob2 and not mob2:isSpawned() then
+                mob2:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
+                SpawnMob(ID.mob.GURFURLUR_THE_MENACING + 2):updateEnmity(target)
+            else
+                local mob3 = GetMobByID(ID.mob.GURFURLUR_THE_MENACING + 3)
+                if mob3 and not mob3:isSpawned() then
+                    mob3:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
+                    SpawnMob(ID.mob.GURFURLUR_THE_MENACING + 3):updateEnmity(target)
+                else
+                    local mob4 = GetMobByID(ID.mob.GURFURLUR_THE_MENACING + 4)
+                    if mob4 and not mob4:isSpawned() then
+                        mob4:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
+                        SpawnMob(ID.mob.GURFURLUR_THE_MENACING + 4):updateEnmity(target)
+                    end
+                end
+            end
         end
     end
 

--- a/scripts/zones/Hazhalm_Testing_Grounds/mobs/Andhrimnir.lua
+++ b/scripts/zones/Hazhalm_Testing_Grounds/mobs/Andhrimnir.lua
@@ -52,7 +52,7 @@ end
 
 entity.onMobFight = function(mob, target)
     -- Don't process if the mob is busy
-    if mob:getCurrentAction() ~= xi.action.ATTACK then
+    if mob:getCurrentAction() ~= xi.action.category.BASIC_ATTACK then
         return
     end
 

--- a/scripts/zones/Hazhalm_Testing_Grounds/mobs/Dendainsonne.lua
+++ b/scripts/zones/Hazhalm_Testing_Grounds/mobs/Dendainsonne.lua
@@ -23,12 +23,12 @@ local entity = {}
 local function notBusy(mob)
     local action = mob:getCurrentAction()
     if
-        action == xi.action.MOBABILITY_START or
-        action == xi.action.MOBABILITY_USING or
-        action == xi.action.MOBABILITY_FINISH or
-        action == xi.action.MAGIC_CASTING or
-        action == xi.action.MAGIC_START or
-        action == xi.action.MAGIC_FINISH
+        action == xi.action.category.MOBABILITY_START or
+        action == xi.action.category.MOBABILITY_USING or
+        action == xi.action.category.MOBABILITY_FINISH or
+        action == xi.action.category.MAGIC_CASTING or
+        action == xi.action.category.MAGIC_START or
+        action == xi.action.category.MAGIC_FINISH
     then
         return false
     end

--- a/scripts/zones/Hazhalm_Testing_Grounds/mobs/Freke.lua
+++ b/scripts/zones/Hazhalm_Testing_Grounds/mobs/Freke.lua
@@ -15,9 +15,9 @@ local entity = {}
 local function notBusy(mob)
     local action = mob:getCurrentAction()
     if
-        action == xi.action.MOBABILITY_START or
-        action == xi.action.MOBABILITY_USING or
-        action == xi.action.MOBABILITY_FINISH
+        action == xi.action.category.MOBABILITY_START or
+        action == xi.action.category.MOBABILITY_USING or
+        action == xi.action.category.MOBABILITY_FINISH
     then
         return false
     end

--- a/scripts/zones/Hazhalm_Testing_Grounds/mobs/Hakenmann.lua
+++ b/scripts/zones/Hazhalm_Testing_Grounds/mobs/Hakenmann.lua
@@ -14,9 +14,9 @@ local entity = {}
 local function notBusy(mob)
     local action = mob:getCurrentAction()
     if
-        action == xi.action.MOBABILITY_START or
-        action == xi.action.MOBABILITY_USING or
-        action == xi.action.MOBABILITY_FINISH
+        action == xi.action.category.MOBABILITY_START or
+        action == xi.action.category.MOBABILITY_USING or
+        action == xi.action.category.MOBABILITY_FINISH
     then
         return false
     end

--- a/scripts/zones/Hazhalm_Testing_Grounds/mobs/Tanngrisnir.lua
+++ b/scripts/zones/Hazhalm_Testing_Grounds/mobs/Tanngrisnir.lua
@@ -17,9 +17,9 @@ local entity = {}
 local function notBusy(mob)
     local action = mob:getCurrentAction()
     if
-        action == xi.action.MOBABILITY_START or
-        action == xi.action.MOBABILITY_USING or
-        action == xi.action.MOBABILITY_FINISH
+        action == xi.action.category.MOBABILITY_START or
+        action == xi.action.category.MOBABILITY_USING or
+        action == xi.action.category.MOBABILITY_FINISH
     then
         return false
     end

--- a/scripts/zones/Horlais_Peak/mobs/Aries.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Aries.lua
@@ -28,12 +28,12 @@ local abilityBlocked = function(mob)
     local action = mob:getCurrentAction()
 
     return
-        action == xi.action.MOBABILITY_START or
-        action == xi.action.MOBABILITY_USING or
-        action == xi.action.MOBABILITY_FINISH or
-        action == xi.action.MAGIC_START or
-        action == xi.action.MAGIC_CASTING or
-        action == xi.action.MAGIC_FINISH
+        action == xi.action.category.MOBABILITY_START or
+        action == xi.action.category.MOBABILITY_USING or
+        action == xi.action.category.MOBABILITY_FINISH or
+        action == xi.action.category.MAGIC_START or
+        action == xi.action.category.MAGIC_CASTING or
+        action == xi.action.category.MAGIC_FINISH
 end
 
 -----------------------------------

--- a/scripts/zones/Jade_Sepulcher/mobs/Phantom_Puk.lua
+++ b/scripts/zones/Jade_Sepulcher/mobs/Phantom_Puk.lua
@@ -37,7 +37,7 @@ entity.onMobDeath = function(mob, player, optParams)
         local clone = GetMobByID(cloneID)
         if clone then
             local action = clone:getCurrentAction()
-            if action ~= xi.action.NONE and action ~= xi.action.DEATH then
+            if action ~= xi.action.category.NONE and action ~= xi.action.category.DEATH then
                 DespawnMob(cloneID)
             end
         end

--- a/scripts/zones/LaLoff_Amphitheater/mobs/Ark_Angel_EV.lua
+++ b/scripts/zones/LaLoff_Amphitheater/mobs/Ark_Angel_EV.lua
@@ -35,7 +35,7 @@ entity.onMobEngage = function(mob, target)
 
     for member = mobid-4, mobid + 3 do
         local m = GetMobByID(member)
-        if m and m:getCurrentAction() == xi.action.ROAMING then
+        if m and m:getCurrentAction() == xi.action.category.ROAMING then
             m:updateEnmity(target)
         end
     end

--- a/scripts/zones/LaLoff_Amphitheater/mobs/Ark_Angel_HM.lua
+++ b/scripts/zones/LaLoff_Amphitheater/mobs/Ark_Angel_HM.lua
@@ -36,7 +36,7 @@ entity.onMobEngage = function(mob, target)
 
     for member = mobid, mobid + 7 do
         local m = GetMobByID(member)
-        if m and m:getCurrentAction() == xi.action.ROAMING then
+        if m and m:getCurrentAction() == xi.action.category.ROAMING then
             m:updateEnmity(target)
         end
     end

--- a/scripts/zones/LaLoff_Amphitheater/mobs/Ark_Angel_TT.lua
+++ b/scripts/zones/LaLoff_Amphitheater/mobs/Ark_Angel_TT.lua
@@ -111,7 +111,7 @@ entity.onMobEngage = function(mob, target)
 
     for member = mobid-5, mobid + 2 do
         local m = GetMobByID(member)
-        if m and m:getCurrentAction() == xi.action.ROAMING then
+        if m and m:getCurrentAction() == xi.action.category.ROAMING then
             m:updateEnmity(target)
         end
     end

--- a/scripts/zones/LaLoff_Amphitheater/mobs/Ark_Angels_Mandragora.lua
+++ b/scripts/zones/LaLoff_Amphitheater/mobs/Ark_Angels_Mandragora.lua
@@ -12,7 +12,7 @@ entity.onMobEngage = function(mob, target)
 
     for member = mobid-3, mobid + 4 do
         local m = GetMobByID(member)
-        if m and m:getCurrentAction() == xi.action.ROAMING then
+        if m and m:getCurrentAction() == xi.action.category.ROAMING then
             m:updateEnmity(target)
         end
     end

--- a/scripts/zones/LaLoff_Amphitheater/mobs/Ark_Angels_Tiger.lua
+++ b/scripts/zones/LaLoff_Amphitheater/mobs/Ark_Angels_Tiger.lua
@@ -10,7 +10,7 @@ entity.onMobEngage = function(mob, target)
 
     for member = mobid-2, mobid + 5 do
         local m = GetMobByID(member)
-        if m and m:getCurrentAction() == xi.action.ROAMING then
+        if m and m:getCurrentAction() == xi.action.category.ROAMING then
             m:updateEnmity(target)
         end
     end

--- a/scripts/zones/LaLoff_Amphitheater/mobs/Ark_Angels_Wyvern.lua
+++ b/scripts/zones/LaLoff_Amphitheater/mobs/Ark_Angels_Wyvern.lua
@@ -10,7 +10,7 @@ entity.onMobEngage = function(mob, target)
 
     for member = mobid-7, mobid do
         local m = GetMobByID(member)
-        if m and m:getCurrentAction() == xi.action.ROAMING then
+        if m and m:getCurrentAction() == xi.action.category.ROAMING then
             m:updateEnmity(target)
         end
     end

--- a/scripts/zones/Mamook/mobs/Gulool_Ja_Ja.lua
+++ b/scripts/zones/Mamook/mobs/Gulool_Ja_Ja.lua
@@ -24,18 +24,28 @@ end
 
 entity.onMobFight = function(mob, target)
     if mob:getBattleTime() % 60 < 2 and mob:getBattleTime() > 10 then
-        if not GetMobByID(ID.mob.GULOOL_JA_JA + 1):isSpawned() then
-            GetMobByID(ID.mob.GULOOL_JA_JA + 1):setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
+        local mob1 = GetMobByID(ID.mob.GULOOL_JA_JA + 1)
+        if mob1 and not mob1:isSpawned() then
+            mob1:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
             SpawnMob(ID.mob.GULOOL_JA_JA + 1):updateEnmity(target)
-        elseif not GetMobByID(ID.mob.GULOOL_JA_JA + 2):isSpawned() then
-            GetMobByID(ID.mob.GULOOL_JA_JA + 2):setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
-            SpawnMob(ID.mob.GULOOL_JA_JA + 2):updateEnmity(target)
-        elseif not GetMobByID(ID.mob.GULOOL_JA_JA + 3):isSpawned() then
-            GetMobByID(ID.mob.GULOOL_JA_JA + 3):setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
-            SpawnMob(ID.mob.GULOOL_JA_JA + 3):updateEnmity(target)
-        elseif not GetMobByID(ID.mob.GULOOL_JA_JA + 4):isSpawned() then
-            GetMobByID(ID.mob.GULOOL_JA_JA + 4):setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
-            SpawnMob(ID.mob.GULOOL_JA_JA + 4):updateEnmity(target)
+        else
+            local mob2 = GetMobByID(ID.mob.GULOOL_JA_JA + 2)
+            if mob2 and not mob2:isSpawned() then
+                mob2:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
+                SpawnMob(ID.mob.GULOOL_JA_JA + 2):updateEnmity(target)
+            else
+                local mob3 = GetMobByID(ID.mob.GULOOL_JA_JA + 3)
+                if mob3 and not mob3:isSpawned() then
+                    mob3:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
+                    SpawnMob(ID.mob.GULOOL_JA_JA + 3):updateEnmity(target)
+                else
+                    local mob4 = GetMobByID(ID.mob.GULOOL_JA_JA + 4)
+                    if mob4 and not mob4:isSpawned() then
+                        mob4:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
+                        SpawnMob(ID.mob.GULOOL_JA_JA + 4):updateEnmity(target)
+                    end
+                end
+            end
         end
     end
 

--- a/scripts/zones/Mamook/mobs/Gulool_Ja_Ja.lua
+++ b/scripts/zones/Mamook/mobs/Gulool_Ja_Ja.lua
@@ -41,7 +41,7 @@ entity.onMobFight = function(mob, target)
 
     for i = ID.mob.GULOOL_JA_JA + 1, ID.mob.GULOOL_JA_JA + 4 do
         local pet = GetMobByID(i)
-        if pet and pet:getCurrentAction() == xi.action.ROAMING then
+        if pet and pet:getCurrentAction() == xi.action.category.ROAMING then
             pet:updateEnmity(target)
         end
     end

--- a/scripts/zones/Mamook/mobs/Hundredfaced_Hapool_Ja.lua
+++ b/scripts/zones/Mamook/mobs/Hundredfaced_Hapool_Ja.lua
@@ -11,14 +11,16 @@ entity.onMobSpawn = function(mob)
     local hundredfacedHapoolJa = mob:getID()
     mob:addListener('MAGIC_USE', 'SPAWN_CLONES', function(mobArg, target, spell, action)
         local spellId = spell:getID()
-        local hateTarget = GetMobByID(hundredfacedHapoolJa):getTarget()
+        local mainMob = GetMobByID(hundredfacedHapoolJa)
+        local hateTarget = mainMob and mainMob:getTarget()
 
         -- Utsusemi: Ichi (3 clones)
         if hateTarget then
             if spellId == xi.magic.spell.UTSUSEMI_ICHI then
                 for clone = hundredfacedHapoolJa + 1, hundredfacedHapoolJa + 3 do
-                    if not GetMobByID(clone):isSpawned() then
-                        GetMobByID(clone):setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
+                    local cloneMob = GetMobByID(clone)
+                    if cloneMob and not cloneMob:isSpawned() then
+                        cloneMob:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
                         SpawnMob(clone):updateEnmity(hateTarget)
                     end
                 end
@@ -29,8 +31,9 @@ entity.onMobSpawn = function(mob)
                 spellId == xi.magic.spell.UTSUSEMI_SAN
             then
                 for clone = hundredfacedHapoolJa + 1, hundredfacedHapoolJa + 4 do
-                    if not GetMobByID(clone):isSpawned() then
-                        GetMobByID(clone):setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
+                    local cloneMob = GetMobByID(clone)
+                    if cloneMob and not cloneMob:isSpawned() then
+                        cloneMob:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
                         SpawnMob(clone):updateEnmity(hateTarget)
                     end
                 end

--- a/scripts/zones/Mamook/mobs/Hundredfaced_Hapool_Ja.lua
+++ b/scripts/zones/Mamook/mobs/Hundredfaced_Hapool_Ja.lua
@@ -40,7 +40,7 @@ entity.onMobSpawn = function(mob)
         for i = hundredfacedHapoolJa + 1, hundredfacedHapoolJa + 4 do
             local pet = GetMobByID(i)
 
-            if pet and pet:getCurrentAction() == xi.action.ROAMING then
+            if pet and pet:getCurrentAction() == xi.action.category.ROAMING then
                 pet:updateEnmity(target)
             end
         end

--- a/scripts/zones/Misareaux_Coast/mobs/Bloody_Coffin.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Bloody_Coffin.lua
@@ -9,10 +9,10 @@ local entity = {}
 local function usingAbility(mob)
     local action = mob:getCurrentAction()
     if
-        action == xi.action.MAGIC_CASTING or
-        action == xi.action.MAGIC_FINISH or
-        action == xi.action.MOBABILITY_START or
-        action == xi.action.MOBABILITY_USING
+        action == xi.action.category.MAGIC_CASTING or
+        action == xi.action.category.MAGIC_FINISH or
+        action == xi.action.category.MOBABILITY_START or
+        action == xi.action.category.MOBABILITY_USING
     then
         return true
     end

--- a/scripts/zones/QuBia_Arena/mobs/Death_Clan_Destroyer.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Death_Clan_Destroyer.lua
@@ -20,10 +20,11 @@ entity.onMobFight = function(mob, target)
 
     -- queue curaga II on any sleeping ally
     for i = instOffset + 3, instOffset + 12 do
-        if GetMobByID(i):getCurrentAction() == xi.action.category.SLEEP then
+        local allyMob = GetMobByID(i)
+        if allyMob and allyMob:getCurrentAction() == xi.action.category.SLEEP then
             if not xi.combat.behavior.isEntityBusy(mob) then
                 if mob:getLocalVar('cooldown') == 0 then
-                    mob:castSpell(8, GetMobByID(i))
+                    mob:castSpell(8, allyMob)
                     mob:setLocalVar('cooldown', 20)
                 end
             else

--- a/scripts/zones/QuBia_Arena/mobs/Death_Clan_Destroyer.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Death_Clan_Destroyer.lua
@@ -20,7 +20,7 @@ entity.onMobFight = function(mob, target)
 
     -- queue curaga II on any sleeping ally
     for i = instOffset + 3, instOffset + 12 do
-        if GetMobByID(i):getCurrentAction() == xi.action.SLEEP then
+        if GetMobByID(i):getCurrentAction() == xi.action.category.SLEEP then
             if not xi.combat.behavior.isEntityBusy(mob) then
                 if mob:getLocalVar('cooldown') == 0 then
                     mob:castSpell(8, GetMobByID(i))

--- a/scripts/zones/Sacrarium/mobs/Keremet.lua
+++ b/scripts/zones/Sacrarium/mobs/Keremet.lua
@@ -12,7 +12,7 @@ entity.onMobFight = function(mob, target)
     for i = keremet + 1, keremet + 12 do
         local m = GetMobByID(i)
 
-        if m and m:getCurrentAction() == xi.action.ROAMING then
+        if m and m:getCurrentAction() == xi.action.category.ROAMING then
             m:updateEnmity(target)
         end
     end

--- a/scripts/zones/Sacrificial_Chamber/mobs/Pevv_the_Riverleaper.lua
+++ b/scripts/zones/Sacrificial_Chamber/mobs/Pevv_the_Riverleaper.lua
@@ -28,7 +28,7 @@ entity.onMobFight = function(mob, target)
     if
         pet and
         pet:isSpawned() and
-        pet:getCurrentAction() == xi.action.ROAMING
+        pet:getCurrentAction() == xi.action.category.ROAMING
     then
         pet:updateEnmity(target)
     end

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Ixaern_DRG.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Ixaern_DRG.lua
@@ -71,7 +71,7 @@ entity.onMobEngage = function(mob, target)
         if wynav then
             if not wynav:isSpawned() then
                 wynav:setLocalVar('repop', GetSystemTime() + 20)
-            elseif wynav:getCurrentAction() == xi.action.ROAMING then
+            elseif wynav:getCurrentAction() == xi.action.category.ROAMING then
                 wynav:updateEnmity(target)
             end
         end

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Mother_Globe.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Mother_Globe.lua
@@ -154,7 +154,7 @@ local setupTrainFollowing = function(mob)
         local currentSlave = GetMobByID(slaveGlobeID)
         if currentSlave and currentSlave:isAlive() then
             local action = currentSlave:getCurrentAction()
-            if action ~= xi.action.NONE and action ~= xi.action.DEATH then
+            if action ~= xi.action.category.NONE and action ~= xi.action.category.DEATH then
                 currentSlave:follow(followTarget, xi.followType.ROAM)
                 followTarget = currentSlave
             end
@@ -243,7 +243,7 @@ entity.onMobFight = function(mob, target)
     -- Keep pets linked
     for _, slaveGlobeID in ipairs(slaveGlobes) do
         local pet = GetMobByID(slaveGlobeID)
-        if pet and pet:getCurrentAction() == xi.action.ROAMING then
+        if pet and pet:getCurrentAction() == xi.action.category.ROAMING then
             pet:updateEnmity(target)
         end
     end

--- a/src/map/ability.cpp
+++ b/src/map/ability.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -247,9 +247,9 @@ int32 CAbility::getVE() const
  *                                                                       *
  ************************************************************************/
 
-uint16 CAbility::getMessage() const
+auto CAbility::getMessage() const -> MSGBASIC_ID
 {
-    return m_message;
+    return static_cast<MSGBASIC_ID>(m_message);
 }
 
 void CAbility::setMessage(uint16 message)
@@ -257,63 +257,65 @@ void CAbility::setMessage(uint16 message)
     m_message = message;
 }
 
-uint16 CAbility::getAoEMsg() const
+auto CAbility::getAoEMsg() const -> MSGBASIC_ID
 {
     switch (m_message)
     {
-        case 150: // Ancient Circle
-            return m_message + 1;
-        case 185:
-            return 264;
-        case 186:
-            return 266;
-        case 187:
-            return 281;
-        case 188:
-            return 282;
-        case 189:
-            return 283;
-        case 225:
-            return 366;
-        case 226:
-            return 226; // no message for this... I guess there is no aoe TP drain move
-        case 103:       // recover hp
-        case 102:       // recover hp
-        case 238:       // recover hp
-        case 306:       // recover hp
-        case 318:       // recover hp
-            return 24;
-        case 242:
-            return 277;
-        case 243:
-            return 278;
-        case 284:
-            return 284; // already the aoe message
-        case 370:
-            return 404;
-        case 362:
-            return 363;
-        case 378:
-            return 343;
-        case 224: // recovers mp
-            return 276;
-        case 420:
-        case 424:
-            return 421;
-        case 422:
-        case 425:
-            return 423;
-        case 426:
-            return 427;
-        case 435:
-        case 437:
-        case 439:
-            return m_message + 1;
-        case 668: // Valiance has a seperate message for party member who gain the effect.
-            return m_message + 1;
-
+        case MSGBASIC_USES_ABILITY_FORTIFIED_DRAGONS:
+            return MSGBASIC_TARGET_FORTIFIED_DRAGONS;
+        case MSGBASIC_USES_SKILL_TAKES_DAMAGE:
+            return MSGBASIC_TARGET_TAKES_DAMAGE;
+        case MSGBASIC_USES_SKILL_GAINS_EFFECT:
+            return MSGBASIC_TARGET_GAINS_EFFECT;
+        case MSGBASIC_USES_SKILL_HP_DRAINED:
+            return MSGBASIC_TARGET_HP_DRAINED;
+        case MSGBASIC_USES_SKILL_MISSES:
+            return MSGBASIC_TARGET_EVADES;
+        case MSGBASIC_USES_SKILL_NO_EFFECT:
+            return MSGBASIC_TARGET_NO_EFFECT;
+        case MSGBASIC_USES_SKILL_MP_DRAINED:
+            return MSGBASIC_TARGET_MP_DRAINED;
+        case MSGBASIC_USES_SKILL_TP_DRAINED:
+            return MSGBASIC_USES_SKILL_TP_DRAINED; // no message for this... I guess there is no aoe TP drain move
+        case MSGBASIC_USES_RECOVERS_HP:
+            return MSGBASIC_TARGET_RECOVERS_HP2;
+        case MSGBASIC_SKILL_RECOVERS_HP:
+        case MSGBASIC_USES_SKILL_RECOVERS_HP_AOE:
+        case MSGBASIC_USES_ITEM_RECOVERS_HP_AOE:
+        case MSGBASIC_USES_ITEM_RECOVERS_HP_AOE2:
+            return MSGBASIC_TARGET_RECOVERS_HP_SIMPLE;
+        case MSGBASIC_USES_SKILL_STATUS:
+            return MSGBASIC_TARGET_STATUS;
+        case MSGBASIC_USES_SKILL_RECEIVES_EFFECT:
+            return MSGBASIC_TARGET_RECEIVES_EFFECT;
+        case MSGBASIC_MAGIC_RESISTED_TARGET:
+            return MSGBASIC_MAGIC_RESISTED_TARGET; // already the aoe message
+        case MSGBASIC_USES_SKILL_EFFECT_DRAINED:
+            return MSGBASIC_TARGET_EFFECT_DRAINED;
+        case MSGBASIC_USES_SKILL_TP_REDUCED:
+            return MSGBASIC_TARGET_TP_REDUCED;
+        case MSGBASIC_USES_ABILITY_DISPEL:
+            return MSGBASIC_TARGET_EFFECT_DISAPPEARS;
+        case MSGBASIC_USES_SKILL_RECOVERS_MP:
+            return MSGBASIC_TARGET_RECOVERS_MP;
+        case MSGBASIC_ROLL_MAIN:
+        case MSGBASIC_DOUBLEUP:
+            return MSGBASIC_ROLL_SUB;
+        case MSGBASIC_ROLL_MAIN_FAIL:
+        case MSGBASIC_DOUBLEUP_FAIL:
+            return MSGBASIC_ROLL_SUB_FAIL;
+        case MSGBASIC_DOUBLEUP_BUST:
+            return MSGBASIC_DOUBLEUP_BUST_SUB;
+        case MSGBASIC_USES_ABILITY_RECHARGE:
+            return MSGBASIC_TARGET_ABILITIES_RECHARGED;
+        case MSGBASIC_USES_ABILITY_RECHARGE_TP:
+            return MSGBASIC_TARGET_RECHARGED_TP;
+        case MSGBASIC_USES_ABILITY_RECHARGE_MP:
+            return MSGBASIC_TARGET_RECHARGED_MP;
+        case MSGBASIC_VALLATION_GAIN:
+            return MSGBASIC_VALIANCE_GAIN_PARTY_MEMBER;
         default:
-            return m_message;
+            return static_cast<MSGBASIC_ID>(m_message);
     }
 }
 
@@ -590,17 +592,17 @@ Charge_t* GetCharge(CBattleEntity* PUser, uint16 chargeID)
     return charge;
 }
 
-uint32 GetAbsorbMessage(uint32 msg)
+auto GetAbsorbMessage(const MSGBASIC_ID msg) -> MSGBASIC_ID
 {
-    if (msg == 110)
+    switch (msg)
     {
-        return 102;
+        case MSGBASIC_USES_ABILITY_TAKES_DAMAGE:
+            return MSGBASIC_USES_RECOVERS_HP;
+        case MSGBASIC_TARGET_TAKES_DAMAGE:
+            return MSGBASIC_TARGET_RECOVERS_HP2;
+        default:
+            return msg;
     }
-    else if (msg == 264)
-    {
-        return 263;
-    }
-    return msg;
 }
 
 }; // namespace ability

--- a/src/map/ability.h
+++ b/src/map/ability.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -711,8 +711,8 @@ public:
     uint8           getAOE() const;
     uint16          getValidTarget() const;
     uint16          getAddType() const;
-    uint16          getMessage() const;
-    uint16          getAoEMsg() const;
+    auto            getMessage() const -> MSGBASIC_ID;
+    auto            getAoEMsg() const -> MSGBASIC_ID;
     timer::duration getRecastTime() const;
     uint16          getRecastId() const;
     int32           getCE() const;
@@ -781,7 +781,7 @@ CAbility* GetAbility(uint16 AbilityID);
 CAbility* GetTwoHourAbility(JOBTYPE JobID);
 bool      CanLearnAbility(CBattleEntity* PUser, uint16 AbilityID);
 Charge_t* GetCharge(CBattleEntity* PUser, uint16 chargeID);
-uint32    GetAbsorbMessage(uint32 message);
+auto      GetAbsorbMessage(MSGBASIC_ID msg) -> MSGBASIC_ID;
 
 std::vector<CAbility*> GetAbilities(JOBTYPE JobID);
 

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1936,7 +1936,7 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
 
                 if (value < 0)
                 {
-                    actionTarget.messageID = ability::GetAbsorbMessage(actionTarget.messageID);
+                    actionTarget.messageID = ability::GetAbsorbMessage(static_cast<MSGBASIC_ID>(actionTarget.messageID));
                     actionTarget.param     = -actionTarget.param;
                 }
 
@@ -1979,7 +1979,7 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
 
             if (value < 0)
             {
-                actionTarget.messageID = ability::GetAbsorbMessage(actionTarget.messageID);
+                actionTarget.messageID = ability::GetAbsorbMessage(static_cast<MSGBASIC_ID>(actionTarget.messageID));
                 actionTarget.param     = -value;
             }
 

--- a/src/map/entities/petentity.cpp
+++ b/src/map/entities/petentity.cpp
@@ -340,7 +340,7 @@ void CPetEntity::OnAbility(CAbilityState& state, action_t& action)
 
         if (value < 0)
         {
-            actionTarget.messageID = ability::GetAbsorbMessage(actionTarget.messageID);
+            actionTarget.messageID = ability::GetAbsorbMessage(static_cast<MSGBASIC_ID>(actionTarget.messageID));
             actionTarget.param     = -value;
         }
     }

--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -183,7 +183,7 @@ void CTrustEntity::OnAbility(CAbilityState& state, action_t& action)
 
                 if (value < 0)
                 {
-                    actionTarget.messageID = ability::GetAbsorbMessage(actionTarget.messageID);
+                    actionTarget.messageID = ability::GetAbsorbMessage(static_cast<MSGBASIC_ID>(actionTarget.messageID));
                     actionTarget.param     = -actionTarget.param;
                 }
 
@@ -216,7 +216,7 @@ void CTrustEntity::OnAbility(CAbilityState& state, action_t& action)
 
             if (value < 0)
             {
-                actionTarget.messageID = ability::GetAbsorbMessage(actionTarget.messageID);
+                actionTarget.messageID = ability::GetAbsorbMessage(static_cast<MSGBASIC_ID>(actionTarget.messageID));
                 actionTarget.param     = -value;
             }
         }

--- a/src/map/enums/CMakeLists.txt
+++ b/src/map/enums/CMakeLists.txt
@@ -1,4 +1,13 @@
 set(ENUMS_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/action/category.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/action/hit_distortion.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/action/info.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/action/knockback.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/action/modifier.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/action/proc_add_effect.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/action/proc_skillchain.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/action/react_kind.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/action/resolution.h
     ${CMAKE_CURRENT_SOURCE_DIR}/chat_message_area.h
     ${CMAKE_CURRENT_SOURCE_DIR}/chat_message_type.h
     ${CMAKE_CURRENT_SOURCE_DIR}/emote.h

--- a/src/map/enums/action/animation.h
+++ b/src/map/enums/action/animation.h
@@ -1,0 +1,43 @@
+﻿/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <cstdint>
+
+enum class ActionAnimation : uint16_t
+{
+    None           = 0,
+    PetSkillStart  = 94,
+    SkillStart     = 121,
+    Teleport       = 122,
+    Raise3         = 496,
+    SkillInterrupt = 508,
+    Raise          = 511,
+    Raise2         = 512,
+    RegainHP       = 772,
+    RegainMP       = 773,
+    Arise          = 847,
+    RedTrigger     = 1806,
+    YellowTrigger  = 1807,
+    BlueTrigger    = 1808,
+    WhiteTrigger   = 1946,
+};

--- a/src/map/enums/action/category.h
+++ b/src/map/enums/action/category.h
@@ -1,0 +1,46 @@
+﻿/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <cstdint>
+
+// action.cmd_no
+// 4 bits
+enum class ActionCategory : uint8_t
+{
+    None           = 0,  // 0000
+    BasicAttack    = 1,  // 0001
+    RangedFinish   = 2,  // 0010
+    SkillFinish    = 3,  // 0011
+    MagicFinish    = 4,  // 0100
+    ItemFinish     = 5,  // 0101
+    AbilityFinish  = 6,  // 0110
+    SkillStart     = 7,  // 0111
+    MagicStart     = 8,  // 1000
+    ItemStart      = 9,  // 1001
+    AbilityStart   = 10, // 1010
+    MobSkillFinish = 11, // 1011
+    RangedStart    = 12, // 1100
+    PetSkillFinish = 13, // 1101
+    Dancer         = 14, // 1110
+    RuneFencer     = 15, // 1111
+};

--- a/src/map/enums/action/hit_distortion.h
+++ b/src/map/enums/action/hit_distortion.h
@@ -1,0 +1,36 @@
+﻿/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <cstdint>
+
+// result.distortion
+// For general attacks, this value is used to determine the model hit distortion animation that will play from the attack.
+// Normal hits will generally use 0, 1, or 2 while critical hits will generally use 2 or 3.
+// 2 bits (lower bits of former scale field)
+enum class HitDistortion : uint8_t
+{
+    None   = 0, // 00 - 0.0 distortion
+    Light  = 1, // 01 - 0.25 distortion
+    Medium = 2, // 10 - 0.5 distortion
+    Heavy  = 3, // 11 - 1.0 distortion (critical hits)
+};

--- a/src/map/enums/action/hit_distortion.h
+++ b/src/map/enums/action/hit_distortion.h
@@ -23,10 +23,9 @@
 
 #include <cstdint>
 
-// result.distortion
-// For general attacks, this value is used to determine the model hit distortion animation that will play from the attack.
-// Normal hits will generally use 0, 1, or 2 while critical hits will generally use 2 or 3.
-// 2 bits (lower bits of former scale field)
+// result.scale
+// Defender recoil after physical attacks
+// 2 bits (lower bits)
 enum class HitDistortion : uint8_t
 {
     None   = 0, // 00 - 0.0 distortion

--- a/src/map/enums/action/info.h
+++ b/src/map/enums/action/info.h
@@ -1,0 +1,69 @@
+﻿/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <magic_enum/magic_enum.hpp>
+
+// result.info
+// 5 bits (bitflags)
+// This is used for ranged attacks, weaponskills and melee attacks
+enum class ActionInfo : uint8_t
+{
+    None          = 0,
+    Defeated      = 1, // 00001 - Set when the action defeats the target
+    CriticalHit   = 2, // 00010 - Set when the action is a critical hit
+    UnknownAoE    = 4, // 00100 - Exact purpose unknown, set by self-targeting mobs when no valid target is in range. See Ruszors.
+};
+
+// Dancer Steps and Flourish use result.info for animations
+enum class DancerInfo : uint8_t
+{
+    WildFlourish      = 5,
+    QuickStep         = 5,
+    BoxStep           = 6,
+    DesperateFlourish = 6,
+    StutterStep       = 7,
+    ViolentFlourish   = 7,
+    FeatherStep       = 8,
+};
+
+// Some Rune Fencer abilities use result.info to convey Rune Element
+enum class RuneElement : uint8_t
+{
+    ElementalMix = 0, // 00000 - If the runes are different elemental types, then mixing will occur and animation id 0 is used.
+    Ignis        = 1, // 00001
+    Gelus        = 2, // 00010
+    Flabra       = 3, // 00011
+    Tellus       = 4, // 00100
+    Suplor       = 5, // 00101
+    Unda         = 6, // 00110
+    Lux          = 7, // 00111
+    Tenebrae     = 8, // 01000
+};
+
+template <>
+struct magic_enum::customize::enum_range<ActionInfo>
+{
+    static constexpr bool is_flags = true;
+};
+using namespace magic_enum::bitwise_operators;

--- a/src/map/enums/action/info.h
+++ b/src/map/enums/action/info.h
@@ -29,10 +29,10 @@
 // This is used for ranged attacks, weaponskills and melee attacks
 enum class ActionInfo : uint8_t
 {
-    None          = 0,
-    Defeated      = 1, // 00001 - Set when the action defeats the target
-    CriticalHit   = 2, // 00010 - Set when the action is a critical hit
-    UnknownAoE    = 4, // 00100 - Exact purpose unknown, set by self-targeting mobs when no valid target is in range. See Ruszors.
+    None        = 0,
+    Defeated    = 1, // 00001 - Set when the action defeats the target
+    CriticalHit = 2, // 00010 - Set when the action is a critical hit
+    UnknownAoE  = 4, // 00100 - Exact purpose unknown, set by self-targeting mobs when no valid target is in range. See Ruszors.
 };
 
 // Dancer Steps and Flourish use result.info for animations

--- a/src/map/enums/action/knockback.h
+++ b/src/map/enums/action/knockback.h
@@ -1,0 +1,39 @@
+﻿/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <cstdint>
+
+// result.scale (shared with HitDistortion)
+// Upper 3 bits
+// This does not really need an enum class, but it serves to document possible values.
+enum class Knockback : uint8_t
+{
+    None   = 0, // 000 - No knockback
+    Level1 = 1, // 001 - Vec: 0.083, Dumper: 0.075, Timer: 5.0
+    Level2 = 2, // 010 - Vec: 0.167, Dumper: 0.15, Timer: 5.0
+    Level3 = 3, // 011 - Vec: 0.167, Dumper: 0.15, Timer: 10.0
+    Level4 = 4, // 100 - Vec: 0.167, Dumper: 0.15, Timer: 18.0
+    Level5 = 5, // 101 - Vec: 0.167, Dumper: 0.125, Timer: 30.0
+    Level6 = 6, // 110 - Vec: 0.167, Dumper: 0.1, Timer: 35.0
+    Level7 = 7, // 111 - Vec: 0.167, Dumper: 0.05, Timer: 45.0
+};

--- a/src/map/enums/action/modifier.h
+++ b/src/map/enums/action/modifier.h
@@ -1,0 +1,38 @@
+﻿/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include "common/logging.h"
+
+#include <cstdint>
+
+// result.bit (31 bits)
+enum class ActionModifier : uint32_t
+{
+    None        = 0x00,
+    Cover       = 0x01,
+    Resist      = 0x02,
+    MagicBurst  = 0x04, // Currently known to be used for Swipe/Lunge only
+    Immunobreak = 0x08,
+    CriticalHit = 0x10,
+};
+DECLARE_FORMAT_AS_UNDERLYING(ActionModifier);

--- a/src/map/enums/action/modifier.h
+++ b/src/map/enums/action/modifier.h
@@ -35,4 +35,3 @@ enum class ActionModifier : uint32_t
     Immunobreak = 0x08,
     CriticalHit = 0x10,
 };
-DECLARE_FORMAT_AS_UNDERLYING(ActionModifier);

--- a/src/map/enums/action/proc_add_effect.h
+++ b/src/map/enums/action/proc_add_effect.h
@@ -1,0 +1,69 @@
+﻿/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include "common/logging.h"
+#include <cstdint>
+
+// result.proc_kind (6 bits)
+enum class ActionProcAddEffect : uint8_t
+{
+    None            = 0,  // 000000
+    FireDamage      = 1,  // 000001
+    IceDamage       = 2,  // 000010
+    WindDamage      = 3,  // 000011
+    EarthDamage     = 4,  // 000100
+    LightningDamage = 5,  // 000101
+    WaterDamage     = 6,  // 000110
+    LightDamage     = 7,  // 000111
+    DarkDamage      = 8,  // 001000
+    Sleep           = 9,  // 001001
+    Poison          = 10, // 001010
+    Paralyze        = 11, // 001011
+    Addle           = 11, // 001011
+    Amnesia         = 11, // 001011
+    Blind           = 12, // 001100
+    Silence         = 13, // 001101
+    Petrify         = 14, // 001110
+    Plague          = 15, // 001111
+    Stun            = 16, // 010000
+    Curse           = 17, // 010001
+    Weaken          = 18, // 010010
+    DefenseDown     = 18, // 010010
+    EvasionDown     = 18, // 010010
+    AttackDown      = 18, // 010010
+    Slow            = 18, // 010010
+    Death           = 19, // 010011
+    Shield          = 20, // 010100
+    HPDrain         = 21, // 010101
+    MPDrain         = 22, // 010110
+    TPDrain         = 22, // 010110
+    StatusDrain     = 22, // 010110
+    Haste           = 23, // 010111
+
+    // UNKNOWN
+    ImpairsEvasion = 0,
+    Bind           = 0,
+    Weight         = 0,
+    Auspice        = 0,
+};
+DECLARE_FORMAT_AS_UNDERLYING(ActionProcAddEffect);

--- a/src/map/enums/action/proc_add_effect.h
+++ b/src/map/enums/action/proc_add_effect.h
@@ -66,4 +66,3 @@ enum class ActionProcAddEffect : uint8_t
     Weight         = 0,
     Auspice        = 0,
 };
-DECLARE_FORMAT_AS_UNDERLYING(ActionProcAddEffect);

--- a/src/map/enums/action/proc_skillchain.h
+++ b/src/map/enums/action/proc_skillchain.h
@@ -46,4 +46,3 @@ enum class ActionProcSkillChain : uint8_t
     Radiance      = 15, // 001111
     Umbra         = 16, // 010000
 };
-DECLARE_FORMAT_AS_UNDERLYING(ActionProcSkillChain);

--- a/src/map/enums/action/proc_skillchain.h
+++ b/src/map/enums/action/proc_skillchain.h
@@ -1,0 +1,49 @@
+﻿/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include "common/logging.h"
+
+#include <cstdint>
+
+// result.proc_kind (6 bits)
+enum class ActionProcSkillChain : uint8_t
+{
+    None          = 0,  // 000000
+    Light         = 1,  // 000001
+    Darkness      = 2,  // 000010
+    Gravitation   = 3,  // 000011
+    Fragmentation = 4,  // 000100
+    Distortion    = 5,  // 000101
+    Fusion        = 6,  // 000110
+    Compression   = 7,  // 000111
+    Liquefaction  = 8,  // 001000
+    Induration    = 9,  // 001001
+    Reverberation = 10, // 001010
+    Transfixion   = 11, // 001011
+    Scission      = 12, // 001100
+    Detonation    = 13, // 001101
+    Impaction     = 14, // 001110
+    Radiance      = 15, // 001111
+    Umbra         = 16, // 010000
+};
+DECLARE_FORMAT_AS_UNDERLYING(ActionProcSkillChain);

--- a/src/map/enums/action/react_kind.h
+++ b/src/map/enums/action/react_kind.h
@@ -1,0 +1,41 @@
+﻿/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <cstdint>
+
+// result.react_kind in BATTLE2 packet (6 bits)
+enum class ActionReactKind : uint8_t
+{
+    None           = 0,
+    BlazeSpikes    = 1,  // 000001
+    IceSpikes      = 2,  // 000010
+    DreadSpikes    = 3,  // 000011
+    CurseSpikes    = 4,  // 000100
+    ShockSpikes    = 5,  // 000101
+    ReprisalSpikes = 6,  // 000110
+    WindSpikes     = 7,  // 000111
+    EarthSpikes    = 8,  // 001000
+    WaterSpikes    = 9,  // 001001
+    DeathSpikes    = 10, // 001010
+    Counter        = 63, // 111111 - Also used by Retaliation
+};

--- a/src/map/enums/action/resolution.h
+++ b/src/map/enums/action/resolution.h
@@ -1,0 +1,35 @@
+﻿/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <cstdint>
+
+// result.miss
+// 3 bits
+enum class ActionResolution : uint8_t
+{
+    Hit   = 0, // 000
+    Miss  = 1, // 001
+    Guard = 2, // 010
+    Parry = 3, // 011
+    Block = 4, // 100
+};

--- a/src/map/mobskill.cpp
+++ b/src/map/mobskill.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -48,7 +48,12 @@ CMobSkill::CMobSkill(uint16 id)
 
 bool CMobSkill::hasMissMsg() const
 {
-    return m_Message == 158 || m_Message == 188 || m_Message == 31 || m_Message == 30 || m_Message == 354;
+    return m_Message == MSGBASIC_ABILITY_MISSES ||
+           m_Message == MSGBASIC_USES_SKILL_MISSES ||
+           m_Message == MSGBASIC_USES_SKILL_NO_EFFECT ||
+           m_Message == MSGBASIC_SHADOW_ABSORB ||
+           m_Message == MSGBASIC_TARGET_ANTICIPATES ||
+           m_Message == MSGBASIC_RANGED_ATTACK_MISS;
 }
 
 bool CMobSkill::isAoE() const
@@ -238,9 +243,9 @@ std::optional<uint8> CMobSkill::getFinalAnimationSub()
     return m_FinalAnimationSub;
 }
 
-uint16 CMobSkill::getMsg() const
+auto CMobSkill::getMsg() const -> MSGBASIC_ID
 {
-    return m_Message;
+    return static_cast<MSGBASIC_ID>(m_Message);
 }
 
 uint16 CMobSkill::getMsgForAction() const
@@ -248,46 +253,47 @@ uint16 CMobSkill::getMsgForAction() const
     return getID();
 }
 
-uint16 CMobSkill::getAoEMsg() const
+auto CMobSkill::getAoEMsg() const -> MSGBASIC_ID
 {
     switch (m_Message)
     {
-        case 185:
-            return 264;
-        case 186:
-            return 266;
-        case 187:
-            return 281;
-        case 188:
-            return 282;
-        case 189:
-            return 283;
-        case 225:
-            return 366;
-        case 226:
-            return 226; // no message for this... I guess there is no aoe TP drain move
-        case 103:       // recover hp
-        case 102:       // recover hp
-        case 238:       // recover hp
-        case 306:       // recover hp
-        case 318:       // recover hp
-            return 24;
-        case 242:
-            return 277;
-        case 243:
-            return 278;
-        case 284:
-            return 284; // already the aoe message
-        case 370:
-            return 404;
-        case 362:
-            return 363;
-        case 378:
-            return 343;
-        case 224: // recovers mp
-            return 276;
+        case MSGBASIC_USES_SKILL_TAKES_DAMAGE:
+            return MSGBASIC_TARGET_TAKES_DAMAGE;
+        case MSGBASIC_USES_SKILL_GAINS_EFFECT:
+            return MSGBASIC_TARGET_GAINS_EFFECT;
+        case MSGBASIC_USES_SKILL_HP_DRAINED:
+            return MSGBASIC_TARGET_HP_DRAINED;
+        case MSGBASIC_USES_SKILL_MISSES:
+            return MSGBASIC_TARGET_EVADES;
+        case MSGBASIC_USES_SKILL_NO_EFFECT:
+            return MSGBASIC_TARGET_NO_EFFECT;
+        case MSGBASIC_USES_SKILL_MP_DRAINED:
+            return MSGBASIC_TARGET_MP_DRAINED;
+        case MSGBASIC_USES_SKILL_TP_DRAINED:
+            return MSGBASIC_USES_SKILL_TP_DRAINED; // no message for this... I guess there is no aoe TP drain move
+        case MSGBASIC_USES_RECOVERS_HP:
+            return MSGBASIC_TARGET_RECOVERS_HP2;
+        case MSGBASIC_SKILL_RECOVERS_HP:
+        case MSGBASIC_USES_SKILL_RECOVERS_HP_AOE:
+        case MSGBASIC_USES_ITEM_RECOVERS_HP_AOE:
+        case MSGBASIC_USES_ITEM_RECOVERS_HP_AOE2:
+            return MSGBASIC_TARGET_RECOVERS_HP_SIMPLE;
+        case MSGBASIC_USES_SKILL_STATUS:
+            return MSGBASIC_TARGET_STATUS;
+        case MSGBASIC_USES_SKILL_RECEIVES_EFFECT:
+            return MSGBASIC_TARGET_RECEIVES_EFFECT;
+        case MSGBASIC_MAGIC_RESISTED_TARGET:
+            return MSGBASIC_MAGIC_RESISTED_TARGET; // already the aoe message
+        case MSGBASIC_USES_SKILL_EFFECT_DRAINED:
+            return MSGBASIC_TARGET_EFFECT_DRAINED;
+        case MSGBASIC_USES_SKILL_TP_REDUCED:
+            return MSGBASIC_TARGET_TP_REDUCED;
+        case MSGBASIC_USES_ABILITY_DISPEL:
+            return MSGBASIC_TARGET_EFFECT_DISAPPEARS;
+        case MSGBASIC_USES_SKILL_RECOVERS_MP:
+            return MSGBASIC_TARGET_RECOVERS_MP;
         default:
-            return m_Message;
+            return static_cast<MSGBASIC_ID>(m_Message);
     }
 }
 
@@ -336,7 +342,13 @@ uint8 CMobSkill::getKnockback() const
 
 bool CMobSkill::isDamageMsg() const
 {
-    return m_Message == 110 || m_Message == 185 || m_Message == 197 || m_Message == 264 || m_Message == 187 || m_Message == 225 || m_Message == 226;
+    return m_Message == MSGBASIC_USES_ABILITY_TAKES_DAMAGE ||
+           m_Message == MSGBASIC_USES_SKILL_TAKES_DAMAGE ||
+           m_Message == MSGBASIC_USES_SKILL_HP_DRAINED ||
+           m_Message == MSGBASIC_USES_ABILITY_RESISTS_DAMAGE ||
+           m_Message == MSGBASIC_USES_SKILL_MP_DRAINED ||
+           m_Message == MSGBASIC_USES_SKILL_TP_DRAINED ||
+           m_Message == MSGBASIC_TARGET_TAKES_DAMAGE;
 }
 
 void CMobSkill::setParam(int16 value)

--- a/src/map/mobskill.h
+++ b/src/map/mobskill.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -24,6 +24,7 @@
 
 #include "common/cbasetypes.h"
 #include "common/mmo.h"
+#include "entities/mobentity.h"
 
 #include <vector>
 
@@ -72,8 +73,8 @@ public:
     uint8           getFlag() const;
     timer::duration getAnimationTime() const;
     timer::duration getActivationTime() const;
-    uint16          getMsg() const;
-    uint16          getAoEMsg() const;
+    auto            getMsg() const -> MSGBASIC_ID;
+    auto            getAoEMsg() const -> MSGBASIC_ID;
     uint16          getValidTargets() const;
     int16           getTP() const;
     auto            getHP() const -> int32;

--- a/src/map/petskill.cpp
+++ b/src/map/petskill.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2022 LandSandBoat Dev Team
@@ -49,7 +49,12 @@ CPetSkill::CPetSkill(uint16 id)
 
 bool CPetSkill::hasMissMsg() const
 {
-    return m_Message == 324 || m_Message == 158 || m_Message == 188 || m_Message == 31 || m_Message == 30;
+    return m_Message == MSGBASIC_USES_BUT_MISSES ||
+           m_Message == MSGBASIC_ABILITY_MISSES ||
+           m_Message == MSGBASIC_USES_SKILL_MISSES ||
+           m_Message == MSGBASIC_USES_SKILL_NO_EFFECT ||
+           m_Message == MSGBASIC_SHADOW_ABSORB ||
+           m_Message == MSGBASIC_TARGET_ANTICIPATES;
 }
 
 bool CPetSkill::isAoE() const
@@ -231,9 +236,10 @@ std::optional<uint8> CPetSkill::getFinalAnimationSub()
 {
     return m_FinalAnimationSub;
 }
-uint16 CPetSkill::getMsg() const
+
+auto CPetSkill::getMsg() const -> MSGBASIC_ID
 {
-    return m_Message;
+    return static_cast<MSGBASIC_ID>(m_Message);
 }
 
 uint8 CPetSkill::getSkillFinishCategory() const
@@ -246,49 +252,48 @@ uint16 CPetSkill::getMsgForAction() const
     return getID();
 }
 
-// Converts skill's message id to the non-primary target version
-uint16 CPetSkill::getAoEMsg() const // TODO: put this in parent class?
+auto CPetSkill::getAoEMsg() const -> MSGBASIC_ID // TODO: put this in parent class?
 {
     switch (m_Message)
     {
-        case 185:
-            return 264;
-        case 186:
-            return 266;
-        case 187:
-            return 281;
-        case 324: // any miss message
-        case 158:
-        case 188:
-            return 282; // <target> evades.
-        case 189:
-            return 283;
-        case 225:
-            return 366;
-        case 226:
-            return 226; // no message for this... I guess there is no aoe TP drain move
-        case 103:       // recover hp
-        case 102:       // recover hp
-        case 238:       // recover hp
-        case 306:       // recover hp
-        case 318:       // recover hp
-            return 367;
-        case 242:
-            return 277;
-        case 243:
-            return 278;
-        case 284:
-            return 284; // already the aoe message
-        case 370:
-            return 404;
-        case 362:
-            return 363;
-        case 378:
-            return 343;
-        case 224: // recovers mp
-            return 276;
+        case MSGBASIC_USES_SKILL_TAKES_DAMAGE:
+            return MSGBASIC_TARGET_TAKES_DAMAGE;
+        case MSGBASIC_USES_SKILL_GAINS_EFFECT:
+            return MSGBASIC_TARGET_GAINS_EFFECT;
+        case MSGBASIC_USES_SKILL_HP_DRAINED:
+            return MSGBASIC_TARGET_HP_DRAINED;
+        case MSGBASIC_USES_BUT_MISSES:
+        case MSGBASIC_ABILITY_MISSES:
+        case MSGBASIC_USES_SKILL_MISSES:
+            return MSGBASIC_TARGET_EVADES;
+        case MSGBASIC_USES_SKILL_NO_EFFECT:
+            return MSGBASIC_TARGET_NO_EFFECT;
+        case MSGBASIC_USES_SKILL_MP_DRAINED:
+            return MSGBASIC_TARGET_MP_DRAINED;
+        case MSGBASIC_USES_SKILL_TP_DRAINED:
+            return MSGBASIC_USES_SKILL_TP_DRAINED; // no message for this... I guess there is no aoe TP drain move
+        case MSGBASIC_SKILL_RECOVERS_HP:
+        case MSGBASIC_USES_RECOVERS_HP:
+        case MSGBASIC_USES_SKILL_RECOVERS_HP_AOE:
+        case MSGBASIC_USES_ITEM_RECOVERS_HP_AOE:
+        case MSGBASIC_USES_ITEM_RECOVERS_HP_AOE2:
+            return MSGBASIC_TARGET_RECOVERS_HP;
+        case MSGBASIC_USES_SKILL_STATUS:
+            return MSGBASIC_TARGET_STATUS;
+        case MSGBASIC_USES_SKILL_RECEIVES_EFFECT:
+            return MSGBASIC_TARGET_RECEIVES_EFFECT;
+        case MSGBASIC_MAGIC_RESISTED_TARGET:
+            return MSGBASIC_MAGIC_RESISTED_TARGET; // already the aoe message
+        case MSGBASIC_USES_SKILL_EFFECT_DRAINED:
+            return MSGBASIC_TARGET_EFFECT_DRAINED;
+        case MSGBASIC_USES_SKILL_TP_REDUCED:
+            return MSGBASIC_TARGET_TP_REDUCED;
+        case MSGBASIC_USES_ABILITY_DISPEL:
+            return MSGBASIC_TARGET_EFFECT_DISAPPEARS;
+        case MSGBASIC_USES_SKILL_RECOVERS_MP:
+            return MSGBASIC_TARGET_RECOVERS_MP;
         default:
-            return m_Message;
+            return static_cast<MSGBASIC_ID>(m_Message);
     }
 }
 
@@ -330,7 +335,14 @@ uint8 CPetSkill::getKnockback() const
 
 bool CPetSkill::isDamageMsg() const
 {
-    return m_Message == 110 || m_Message == 185 || m_Message == 197 || m_Message == 264 || m_Message == 187 || m_Message == 225 || m_Message == 226 || m_Message == 317;
+    return m_Message == MSGBASIC_USES_ABILITY_TAKES_DAMAGE ||
+           m_Message == MSGBASIC_USES_SKILL_TAKES_DAMAGE ||
+           m_Message == MSGBASIC_USES_SKILL_HP_DRAINED ||
+           m_Message == MSGBASIC_USES_ABILITY_RESISTS_DAMAGE ||
+           m_Message == MSGBASIC_USES_SKILL_MP_DRAINED ||
+           m_Message == MSGBASIC_USES_SKILL_TP_DRAINED ||
+           m_Message == MSGBASIC_TARGET_TAKES_DAMAGE ||
+           m_Message == MSGBASIC_USES_JA_TAKE_DAMAGE;
 }
 
 void CPetSkill::setParam(int16 value)

--- a/src/map/petskill.h
+++ b/src/map/petskill.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2022 LandSandBoat Dev Team
@@ -24,6 +24,7 @@
 
 #include "common/cbasetypes.h"
 #include "common/mmo.h"
+#include "entities/mobentity.h"
 
 class CPetSkill
 {
@@ -47,9 +48,9 @@ public:
     uint8           getFlag() const;
     timer::duration getAnimationTime() const;
     timer::duration getActivationTime() const;
-    uint16          getMsg() const;
+    auto            getMsg() const -> MSGBASIC_ID;
     uint8           getSkillFinishCategory() const;
-    uint16          getAoEMsg() const;
+    auto            getAoEMsg() const -> MSGBASIC_ID;
     uint16          getValidTargets() const;
     int16           getTP() const;
     auto            getHP() const -> int32;

--- a/src/map/spell.cpp
+++ b/src/map/spell.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -29,6 +29,7 @@
 #include "mob_spell_list.h"
 #include "spell.h"
 
+#include "enums/four_cc.h"
 #include "map_engine.h"
 #include "status_effect_container.h"
 #include "utils/blueutils.h"
@@ -104,7 +105,7 @@ void CSpell::setName(const std::string& name)
     m_name = name;
 }
 
-SPELLGROUP CSpell::getSpellGroup()
+auto CSpell::getSpellGroup() const -> SPELLGROUP
 {
     return m_spellGroup;
 }
@@ -283,33 +284,31 @@ void CSpell::setMultiplier(float multiplier)
     m_multiplier = multiplier;
 }
 
-uint16 CSpell::getMessage() const
+auto CSpell::getMessage() const -> MSGBASIC_ID
 {
-    return m_message;
+    return static_cast<MSGBASIC_ID>(m_message);
 }
 
-uint16 CSpell::getAoEMessage() const
+auto CSpell::getAoEMessage() const -> MSGBASIC_ID
 {
     switch (m_message)
     {
-        case 7: // recovers HP
-            return 367;
-        case 93: // vanishes
-            return 273;
-        case 85: // resists
-            return 284;
-        case 230:       // casts gain the effect of
-            return 266; // gains the effect of
-        case 236:       // is blind
-            // return 203;
-            return 277;
-            // 279
-        case 237: // if its a damage spell msg and is hitting the 2nd+ target
-            return 278;
-        case 2: // if its a damage spell msg and is hitting the 2nd+ target
-            return 264;
+        case MSGBASIC_MAGIC_RECOVERS_HP:
+            return MSGBASIC_TARGET_RECOVERS_HP;
+        case MSGBASIC_MAGIC_TELEPORT:
+            return MSGBASIC_TARGET_TELEPORT;
+        case MSGBASIC_MAGIC_RESISTED:
+            return MSGBASIC_MAGIC_RESISTED_TARGET;
+        case MSGBASIC_MAGIC_GAINS_EFFECT:
+            return MSGBASIC_TARGET_GAINS_EFFECT;
+        case MSGBASIC_MAGIC_STATUS:
+            return MSGBASIC_TARGET_STATUS;
+        case MSGBASIC_MAGIC_RECEIVES_EFFECT:
+            return MSGBASIC_TARGET_RECEIVES_EFFECT;
+        case MSGBASIC_MAGIC_DAMAGE:
+            return MSGBASIC_TARGET_TAKES_DAMAGE;
         default:
-            return m_message;
+            return static_cast<MSGBASIC_ID>(m_message);
     }
 }
 
@@ -431,6 +430,33 @@ float CSpell::getRange() const
 uint32 CSpell::getPrimaryTargetID() const
 {
     return m_primaryTargetID;
+}
+
+auto CSpell::getFourCC(const bool interrupt) const -> FourCC
+{
+    switch (this->getSpellGroup())
+    {
+        case SPELLGROUP_WHITE:
+            return interrupt ? FourCC::WhiteMagicInterrupt : FourCC::WhiteMagicCast;
+        case SPELLGROUP_BLACK:
+            return interrupt ? FourCC::BlackMagicInterrupt : FourCC::BlackMagicCast;
+        case SPELLGROUP_BLUE:
+            return interrupt ? FourCC::BlueMagicInterrupt : FourCC::BlueMagicCast;
+        case SPELLGROUP_SONG:
+            return interrupt ? FourCC::SongMagicInterrupt : FourCC::SongMagicCast;
+        case SPELLGROUP_NINJUTSU:
+            return interrupt ? FourCC::NinjutsuMagicInterrupt : FourCC::NinjutsuMagicCast;
+        case SPELLGROUP_SUMMONING:
+            return interrupt ? FourCC::SummonMagicInterrupt : FourCC::SummonMagicCast;
+        case SPELLGROUP_GEOMANCY:
+            return interrupt ? FourCC::GeomancyMagicInterrupt : FourCC::GeomancyMagicCast;
+        case SPELLGROUP_TRUST:
+            return interrupt ? FourCC::TrustMagicInterrupt : FourCC::TrustMagicCast;
+        case SPELLGROUP_NONE:
+        default:
+            // Uh...
+            return FourCC::WhiteMagicInterrupt;
+    }
 }
 
 void CSpell::setContentTag(const std::string& contentTag)

--- a/src/map/spell.h
+++ b/src/map/spell.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -26,6 +26,7 @@
 
 #define CANNOT_USE_SPELL 0
 
+enum class FourCC : uint32_t;
 enum SPELLGROUP
 {
     SPELLGROUP_NONE      = 0,
@@ -1059,7 +1060,7 @@ public:
     uint16             getValidTarget() const;
     uint16             getAnimationID() const;
     timer::duration    getAnimationTime() const;
-    SPELLGROUP         getSpellGroup();
+    auto               getSpellGroup() const -> SPELLGROUP;
     SPELLFAMILY        getSpellFamily();
     uint8              getSkillType() const;
     uint16             getZoneMisc() const;
@@ -1067,20 +1068,21 @@ public:
     uint16             getBase() const;
     uint16             getElement() const;
     float              getMultiplier() const;
-    uint16             getMessage() const;
+    auto               getMessage() const -> MSGBASIC_ID;
     uint16             getDefaultMessage();
     uint16             getMagicBurstMessage() const;
     int32              getCE() const;
     int32              getVE() const;
     timer::duration    getModifiedRecast() const;
     float              getRadius() const;
-    uint16             getAoEMessage() const; // returns the single target message for AoE moves
+    auto               getAoEMessage() const -> MSGBASIC_ID; // returns the single target message for AoE moves
     uint8              getRequirements() const;
     uint16             getMeritId() const;
     uint8              getFlag() const;
     const std::string& getContentTag();
     float              getRange() const;
     uint32             getPrimaryTargetID() const;
+    auto               getFourCC(bool interrupt = false) const -> FourCC;
     bool               tookEffect() const; // returns true if the spell landed, not resisted or missed
     bool               hasMPCost();        // checks if spell costs mp to use
     bool               isHeal();           // is a heal spell

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -271,7 +271,7 @@ void LoadPetSkillsList()
         PPetSkill->setMobSkillID(rset->get<uint16>("mob_skill_id"));
         g_PPetSkillList[PPetSkill->getID()] = PPetSkill;
 
-        auto filename = fmt::format("./scripts/actions/abilities/pet/{}.lua", PPetSkill->getName());
+        auto filename = fmt::format("./scripts/actions/abilities/pets/{}.lua", PPetSkill->getName());
         luautils::CacheLuaObjectFromFile(filename);
     }
 }
@@ -1382,11 +1382,11 @@ void HandleEnspell(CBattleEntity* PAttacker, CBattleEntity* PDefender, actionTar
                 if (Action->addEffectParam < 0)
                 {
                     Action->addEffectParam   = -Action->addEffectParam;
-                    Action->addEffectMessage = 384;
+                    Action->addEffectMessage = MSGBASIC_ADD_EFFECT_RECOVERS_HP;
                 }
                 else
                 {
-                    Action->addEffectMessage = 229;
+                    Action->addEffectMessage = MSGBASIC_ADD_EFFECT_ADDITIONAL_DAMAGE;
                 }
 
                 PDefender->takeDamage(Action->addEffectParam, PAttacker, ATTACK_TYPE::MAGICAL, GetEnspellDamageType((ENSPELL)enspell));


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Replaces magic numbers in core with actual MSGBASIC
- Make the various functions that used to return raw uints return MSGBASIC instead
- Introduce various enums for the upcoming action packet rework (both core + lua)
  - Yes, they largely overlap with existing enums (SPECEFFECT, REACT...). The older ones will be nuked in due time.
- Modify the existing `xi.action` enum to be `xi.action.category` so we can slot all the other enums under the same `xi.action` namespace
- Includes a small bugfix for caching pet skills (the path was missing a 's')
- Introduce a method to get FourCC animation string on CSpell (unused presently)

## Steps to test these changes
No actual changes to the executed code... yet

<!-- Clear and detailed steps to test your changes here -->
