### PR TITLE
[core, lua] xi_test improvements / Handle weaponskills guarded by mobs

### DIFF
--- a/scripts/specs/test/CClientEntityPairActions.lua
+++ b/scripts/specs/test/CClientEntityPairActions.lua
@@ -8,8 +8,9 @@ local CClientEntityPairActions = {}
 ---@param x number
 ---@param y number
 ---@param z number
+---@param rot number?
 ---@return nil
-function CClientEntityPairActions:move(x, y, z)
+function CClientEntityPairActions:move(x, y, z, rot)
 end
 
 ---Cast a spell on a target
@@ -87,4 +88,15 @@ end
 ---@param expectedEvent? ExpectedEvent Expected event configuration
 ---@return nil
 function CClientEntityPairActions:tradeNpc(npcQuery, items, expectedEvent)
+end
+
+---Accept raise prompt
+---@return nil
+function CClientEntityPairActions:acceptRaise()
+end
+
+---Move to, face and engage entity.
+---@param mob CBaseEntity Monster to engage
+---@return nil
+function CClientEntityPairActions:engage(mob)
 end

--- a/scripts/specs/test/Globals.lua
+++ b/scripts/specs/test/Globals.lua
@@ -74,7 +74,6 @@ end
 ---Create a stub that replaces a global function (alias for mock)
 ---@param path string Dot-separated path to the function (e.g., "xi.globals.interaction.trade")
 ---@param impl? function|any Optional implementation or return value
----@nodiscard
 ---@return CStub
 function stub(path, impl)
 end

--- a/src/test/lua/helpers/lua_client_entity_pair_actions.h
+++ b/src/test/lua/helpers/lua_client_entity_pair_actions.h
@@ -35,7 +35,7 @@ public:
     CLuaClientEntityPairActions(CLuaClientEntityPair* parent);
     ~CLuaClientEntityPairActions() = default;
 
-    void move(float x, float y, float z) const;
+    void move(float x, float y, float z, sol::optional<uint8_t> rot) const;
     void useSpell(CLuaBaseEntity* target, SpellID spellId) const;
     void useWeaponskill(CLuaBaseEntity* target, uint16 wsId) const;
     void useAbility(CLuaBaseEntity* target, ABILITY abilityId) const;
@@ -47,6 +47,8 @@ public:
     void formAlliance(CLuaBaseEntity* player) const;
     void acceptPartyInvite() const;
     void tradeNpc(const sol::object& npcQuery, const sol::table& items, sol::optional<sol::table> expectedEvent) const;
+    void acceptRaise() const;
+    void engage(CLuaBaseEntity* mob) const;
 
     static void Register();
 

--- a/src/test/lua/helpers/lua_client_entity_pair_entities.cpp
+++ b/src/test/lua/helpers/lua_client_entity_pair_entities.cpp
@@ -29,6 +29,7 @@
 #include "map/lua/lua_baseentity.h"
 #include "map/utils/zoneutils.h"
 #include "map/zone.h"
+#include "test_char.h"
 #include "test_common.h"
 
 CLuaClientEntityPairEntities::CLuaClientEntityPairEntities(CLuaClientEntityPair* parent)
@@ -118,7 +119,15 @@ auto CLuaClientEntityPairEntities::moveTo(const sol::object& entityQuery) const 
     {
         if (const CBaseEntity* baseEntity = entity.value().GetBaseEntity())
         {
-            parent_->GetBaseEntity()->loc.p = baseEntity->loc.p;
+            // Move the player to the entity
+            const auto playerEntity = parent_->testChar()->entity();
+            playerEntity->loc.p     = baseEntity->loc.p;
+
+            // Force refresh of spawn lists, as if we had moved there manually.
+            playerEntity->loc.zone->SpawnNPCs(playerEntity);
+            playerEntity->loc.zone->SpawnMOBs(playerEntity);
+            playerEntity->loc.zone->SpawnPETs(playerEntity);
+            playerEntity->loc.zone->SpawnTRUSTs(playerEntity);
         }
     }
 

--- a/src/test/lua/lua_spy.h
+++ b/src/test/lua/lua_spy.h
@@ -41,7 +41,7 @@ public:
     auto original() const -> sol::object;
     auto path() const -> std::string;
 
-    virtual auto operator()(sol::variadic_args args) -> sol::object;
+    virtual auto operator()(sol::variadic_args args) -> sol::as_returns_t<std::vector<sol::object>>;
     static void  Register();
 
 protected:

--- a/src/test/lua/lua_stub.h
+++ b/src/test/lua/lua_stub.h
@@ -32,7 +32,7 @@ public:
     void returnValue(const sol::object& value);
     void sideEffect(const sol::protected_function& func);
 
-    auto        operator()(sol::variadic_args args) -> sol::object override;
+    auto        operator()(sol::variadic_args args) -> sol::as_returns_t<std::vector<sol::object>> override;
     static void Register();
 
 private:


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Make `stub` no longer tagged with `nodiscard`, this allows replacing the implementation of a global lua function without necessarily caring about its usage in the test.
- Couple of tweaks to `stub` and `spy` so they can work with lua functions returning tuples / arbitrary unpacked values
  - i.e. if a function is supposed to `return a, b, c` then the spy/stub funcs are not working today as they assume only a single result will be returned
- Add 2 new helper methods:
  - `acceptRaise` to... accept a raise (used in Mijin Gakure test)
  - `engage` to teleport to a monster, ensure both entities are facing each other and then send the engage packet
- Ensure `moveTo` triggers entity spawnlists recalculations, as if the player had moved there

- Treat guard procs on weaponskills (PC > Mobs) as pdif reduction instead of complete miss

I shouldn't have cropped it so much but this is a screenshot of actionparse showing a retail Mandragora guarding my single hit WS
<img width="595" height="110" alt="Screenshot 2025-11-08 104741" src="https://github.com/user-attachments/assets/14fc9b0d-c7f5-4638-8ec6-2ace8510965d" />

And this is a screenshot of LSB with this PR on the same mandragora
<img width="843" height="555" alt="image" src="https://github.com/user-attachments/assets/fe14b74b-fc2d-4213-988c-ab2e556571d1" />


## Steps to test these changes
Engage a mandragora, observe packets with actionparse.

<!-- Clear and detailed steps to test your changes here -->
