### PR TITLE
fix: Clear entity timer queue when exiting battlefield

### DIFF
--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -523,6 +523,20 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
         return false;
     }
 
+    // Clear timer queue for entity before removal
+    if (PEntity->PAI)
+    {
+        PEntity->PAI->ClearTimerQueue();
+    }
+
+    if (auto* PChar = dynamic_cast<CCharEntity*>(PEntity))
+    {
+        if (PChar->PPet && PChar->PPet->PAI)
+        {
+            PChar->PPet->PAI->ClearTimerQueue();
+        }
+    }
+
     auto found = false;
     if (PEntity->objtype == TYPE_PC)
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Map server crashes if any entity tries to reference the current battlefield in a timer after the battlefield has been destroyed.
This PR force clears the timer queue when any entity is removed from the BCNM (this includes mobs, PCs, allies, NPCs etc)

While the use of a timer is probably not the right way to implement such mechanics, we cannot afford to let timers potentially outlive the battlefield regardless.

## Steps to test these changes
I used [Skold branch](https://github.com/Skold177/SkoldLSB/tree/let-sleeping-dogs-die) with 'Let Sleeping Dogs Lie' BCNM that made use of such mechanism to reproduce the issue and retested with the fix.

<!-- Clear and detailed steps to test your changes here -->
