### PR TITLE
[lua] Fix available check for quest Empty Memories + Flow fix

### DIFF
--- a/scripts/quests/jeuno/Empty_Memories.lua
+++ b/scripts/quests/jeuno/Empty_Memories.lua
@@ -47,8 +47,8 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_AVAILABLE and
-            (player:getCurrentMission(xi.mission.log_id.COP) > xi.mission.id.cop.THE_MOTHERCRYSTALS or
-            xi.mission.getVar(player, xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS, 'Option') > 0)
+            (player:getCurrentMission(xi.mission.log_id.COP) >= xi.mission.id.cop.THE_MOTHERCRYSTALS or
+            xi.mission.getVar(player, xi.mission.log_id.COP, xi.mission.id.cop.BELOW_THE_ARKS, 'Option') > 0)
         end,
 
         [xi.zone.RULUDE_GARDENS] =
@@ -58,7 +58,9 @@ quest.sections =
             onEventFinish =
             {
                 [113] = function(player, csid, option, npc)
-                    quest:begin(player)
+                    if option == 1 then
+                        quest:begin(player)
+                    end
                 end,
             },
         },


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes an issue where you can't flag the quest "Empty Memories" unless you have already completed all 3 Promys.
Updates the logic to where the player must accept the quest.

## Steps to test these changes

Flag CoP.
Complete up to where you enter your first Promy.
Enter your first Promy.
`!zone <RULUDE_GARDENS>`
Talk to Harith to flag "Empty Memories"

## Capture
Quest - Jeuno - Empty Memories (testing behavior if you decline to listen to him)
https://drive.google.com/drive/folders/1iRwyi5adxj5f_enjaMA7rduf401xOvIR?usp=drive_link
https://youtu.be/LbhesENpRDo