### PR TITLE
[lua] Fix Boghertz Helper File

### DIFF
--- a/scripts/quests/jeuno/helpers.lua
+++ b/scripts/quests/jeuno/helpers.lua
@@ -435,6 +435,7 @@ function xi.jeuno.helpers.BorghertzQuests:new(params)
                 {
                     onTrigger = function(player, npc)
                         if canStartQuest(player) then
+                            quest:setVar(player, 'Option', player:getMainJob())
                             return quest:progressEvent(155)
                         end
                     end,
@@ -443,7 +444,9 @@ function xi.jeuno.helpers.BorghertzQuests:new(params)
                 onEventFinish =
                 {
                     [155] = function(player, csid, option, npc)
-                        quest:begin(player)
+                        if quest:getVar(player, 'Option') == player:getMainJob() then
+                            quest:begin(player)
+                        end
                     end,
                 },
             },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
- Fixes an issue with Boghertz Quest where checks were not properly applied before flagging the quest causing all AF Hands Quests to be flagged at once.
- Setting the Option var to the job the player is flagging the quest on and checking that before calling `begin()` prevents this issue.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - `!changejob NIN 60`
2 - `!addquest 5 144`
3 - `!completequest <me> 5 144`
4 - `!zone upper jeuno`
5 - Talk with Guslam to trigger the CS
6 - `!getquestvar <me> 3 56 Option`
7 - Check your "Current Quests" for Jeuno
Result: Only the job for the quest you are currently on is flagged instead of all jobs.


Before:
<img width="419" height="277" alt="512679461-df967d19-4e0b-4298-9c3a-280fba8f0173" src="https://github.com/user-attachments/assets/2cca917a-54c7-4461-b874-750efd1e4267" />


After:
<img width="363" height="242" alt="{482517C8-B722-47A0-A95E-903865506B12}" src="https://github.com/user-attachments/assets/5dd0b441-eb29-4e26-af17-d0a048619795" />
