### PR TITLE
[lua, sql] Adjust and simplify Guivre behavior

### DIFF
--- a/scripts/zones/Kuftal_Tunnel/mobs/Guivre.lua
+++ b/scripts/zones/Kuftal_Tunnel/mobs/Guivre.lua
@@ -200,13 +200,6 @@ local pathFind =
 }
 
 entity.onMobInitialize = function(mob)
-    -- Guivre has increased movespeed, sight range with
-    -- Natural double/triple attack.
-    mob:setMod(xi.mobMod.RUN_SPEED_MULT, 300)
-    mob:setMobMod(xi.mobMod.SIGHT_RANGE, 30)
-    mob:setMod(xi.mod.DOUBLE_ATTACK, 25)
-    mob:setMod(xi.mod.TRIPLE_ATTACK, 15)
-
     xi.mob.updateNMSpawnPoint(mob)
     mob:setRespawnTime(math.random(900, 10800))
 end

--- a/scripts/zones/Kuftal_Tunnel/mobs/Guivre.lua
+++ b/scripts/zones/Kuftal_Tunnel/mobs/Guivre.lua
@@ -200,6 +200,14 @@ local pathFind =
 }
 
 entity.onMobInitialize = function(mob)
+    -- Guivre has increased movespeed, sight range with
+    -- Natural double/triple attack.
+    mob:setMod(xi.mobMod.RUN_SPEED_MULT, 300)
+    mob:setMod(xi.mod.DOUBLE_ATTACK, 25)
+    mob:setMod(xi.mod.TRIPLE_ATTACK, 15)
+    mob:setMobMod(xi.mobMod.SIGHT_RANGE, 30)
+    mob:setMobMod(xi.mobMod.ALWAYS_AGGRO, 1)
+
     xi.mob.updateNMSpawnPoint(mob)
     mob:setRespawnTime(math.random(900, 10800))
 end

--- a/sql/mob_family_mods.sql
+++ b/sql/mob_family_mods.sql
@@ -680,14 +680,6 @@ INSERT INTO `mob_family_mods` VALUES (265,36,55,1);  -- ROAM_COOL: 55
 -- Wyvern
 INSERT INTO `mob_family_mods` VALUES (266,36,55,1);  -- ROAM_COOL: 55
 
--- Wyvern-Guivre
-INSERT INTO `mob_family_mods` VALUES (267,4,30,1);   -- SIGHT_RANGE: 30
-INSERT INTO `mob_family_mods` VALUES (267,36,55,1);  -- ROAM_COOL: 55
-INSERT INTO `mob_family_mods` VALUES (267,37,1,1);   -- ALWAYS_AGGRO: 1
-INSERT INTO `mob_family_mods` VALUES (267,82,300,1); -- RUN_SPEED_MULT: 300
-INSERT INTO `mob_family_mods` VALUES (267,288,25,0);  -- DOUBLE_ATTACK: 25
-INSERT INTO `mob_family_mods` VALUES (267,302,15,0);  -- TRIPLE_ATTACK: 15
-
 -- Wyvern-Undead
 INSERT INTO `mob_family_mods` VALUES (268,36,55,1);  -- ROAM_COOL: 55
 

--- a/sql/mob_family_mods.sql
+++ b/sql/mob_family_mods.sql
@@ -681,8 +681,12 @@ INSERT INTO `mob_family_mods` VALUES (265,36,55,1);  -- ROAM_COOL: 55
 INSERT INTO `mob_family_mods` VALUES (266,36,55,1);  -- ROAM_COOL: 55
 
 -- Wyvern-Guivre
-INSERT INTO `mob_family_mods` VALUES (267,4,20,1);   -- SIGHT_RANGE: 20
+INSERT INTO `mob_family_mods` VALUES (267,4,30,1);   -- SIGHT_RANGE: 30
 INSERT INTO `mob_family_mods` VALUES (267,36,55,1);  -- ROAM_COOL: 55
+INSERT INTO `mob_family_mods` VALUES (267,37,1,1);   -- ALWAYS_AGGRO: 1
+INSERT INTO `mob_family_mods` VALUES (267,82,300,1); -- RUN_SPEED_MULT: 300
+INSERT INTO `mob_family_mods` VALUES (267,288,25,0);  -- DOUBLE_ATTACK: 25
+INSERT INTO `mob_family_mods` VALUES (267,302,15,0);  -- TRIPLE_ATTACK: 15
 
 -- Wyvern-Undead
 INSERT INTO `mob_family_mods` VALUES (268,36,55,1);  -- ROAM_COOL: 55

--- a/sql/mob_family_mods.sql
+++ b/sql/mob_family_mods.sql
@@ -683,6 +683,7 @@ INSERT INTO `mob_family_mods` VALUES (266,36,55,1);  -- ROAM_COOL: 55
 -- Wyvern-Guivre
 INSERT INTO `mob_family_mods` VALUES (267,4,20,1);   -- SIGHT_RANGE: 20
 INSERT INTO `mob_family_mods` VALUES (267,36,55,1);  -- ROAM_COOL: 55
+INSERT INTO `mob_family_mods` VALUES (267,37,1,1);   -- ALWAYS_AGGRO: 1
 
 -- Wyvern-Undead
 INSERT INTO `mob_family_mods` VALUES (268,36,55,1);  -- ROAM_COOL: 55

--- a/sql/mob_family_mods.sql
+++ b/sql/mob_family_mods.sql
@@ -681,9 +681,12 @@ INSERT INTO `mob_family_mods` VALUES (265,36,55,1);  -- ROAM_COOL: 55
 INSERT INTO `mob_family_mods` VALUES (266,36,55,1);  -- ROAM_COOL: 55
 
 -- Wyvern-Guivre
-INSERT INTO `mob_family_mods` VALUES (267,4,20,1);   -- SIGHT_RANGE: 20
+INSERT INTO `mob_family_mods` VALUES (267,4,30,1);   -- SIGHT_RANGE: 30
 INSERT INTO `mob_family_mods` VALUES (267,36,55,1);  -- ROAM_COOL: 55
 INSERT INTO `mob_family_mods` VALUES (267,37,1,1);   -- ALWAYS_AGGRO: 1
+INSERT INTO `mob_family_mods` VALUES (267,82,300,1); -- RUN_SPEED_MULT: 300
+INSERT INTO `mob_family_mods` VALUES (267,288,25,0);  -- DOUBLE_ATTACK: 25
+INSERT INTO `mob_family_mods` VALUES (267,302,15,0);  -- TRIPLE_ATTACK: 15
 
 -- Wyvern-Undead
 INSERT INTO `mob_family_mods` VALUES (268,36,55,1);  -- ROAM_COOL: 55

--- a/sql/mob_family_system.sql
+++ b/sql/mob_family_system.sql
@@ -321,7 +321,7 @@ INSERT INTO `mob_family_system` VALUES (263,'Wyrm-Nidhogg',149,'Wyrm',10,'Dragon
 INSERT INTO `mob_family_system` VALUES (264,'Wyrm',149,'Wyrm',10,'Dragon',4.00,40,120,90,4,1,3,2,2,3,1,1,3,1,3,1.0,1,0);
 INSERT INTO `mob_family_system` VALUES (265,'Wyvern-Simorg',109,'Wyvern',10,'Dragon',1.00,50,115,90,4,2,3,4,6,3,3,1,3,1,3,2.0,1,0);
 INSERT INTO `mob_family_system` VALUES (266,'Wyvern',109,'Wyvern',10,'Dragon',1.00,75,115,90,4,2,3,4,6,3,3,1,3,1,3,3.0,1,0);
-INSERT INTO `mob_family_system` VALUES (267,'Wyvern-Guivre',109,'Wyvern',10,'Dragon',1.00,50,115,90,4,2,3,4,6,3,3,1,3,1,3,7.0,3,0);
+INSERT INTO `mob_family_system` VALUES (267,'Wyvern-Guivre',109,'Wyvern',10,'Dragon',1.00,50,115,90,4,2,3,4,6,3,3,1,3,1,3,7.0,257,0);
 INSERT INTO `mob_family_system` VALUES (268,'Wyvern-Undead',109,'Wyvern',10,'Dragon',1.00,40,109,90,4,2,3,4,6,3,3,1,3,1,3,8.0,1,0);
 INSERT INTO `mob_family_system` VALUES (269,'Xzomit',150,'Xzomit',15,'Luminian',0.00,50,100,110,3,2,4,6,4,5,1,1,3,1,3,0.0,1,0);
 INSERT INTO `mob_family_system` VALUES (270,'Yagudo',151,'Yagudo',7,'Beastmen',0.00,40,85,120,2,2,3,3,4,5,3,1,3,1,3,3.0,1,0);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adjusts Guivre's detection so that he no longer aggros via sound and is sight only. He will also always aggro, even if 99.
Moves lua mob mods/mods to mob_family_mods.sql

Capture: [1](https://youtu.be/WjkbHITRm84?t=55)

## Steps to test these changes

!zone Kuftal Tunnel
!spawnmob 17490234

And attempt to aggro Guivre whilst invisible and without sneak.