### PR TITLE
[lua] Fix Taurus Script

### DIFF
--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Taurus.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Taurus.lua
@@ -10,15 +10,15 @@ local entity = {}
 entity.onMobWeaponSkillPrepare = function(mob, target)
     local tpMoves =
     {
-        xi.mobSkills.TRICLIP_1,
-        xi.mobSkills.BACK_SWISH_1,
-        xi.mobSkills.MOW_1,
-        xi.mobSkills.FRIGHTFUL_ROAR_1,
-        xi.mobSkills.UNBLESSED_ARMOR
+        xi.mobSkill.TRICLIP_1,
+        xi.mobSkill.BACK_SWISH_1,
+        xi.mobSkill.MOW_1,
+        xi.mobSkill.FRIGHTFUL_ROAR_1,
+        xi.mobSkill.UNBLESSED_ARMOR,
     }
 
     if xi.mix.tauri.canUseRay(mob) then
-        table.insert(tpMoves, xi.mobSkills.MORTAL_RAY_1)
+        table.insert(tpMoves, xi.mobSkill.MORTAL_RAY_1)
     end
 
     return tpMoves[math.random(1, #tpMoves)]


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
- Fixes typos in Taurus mob script that was causing lua errors to fire.  `xi.mobSkills.SKILL` needs to be `xi.mobSkill.SKILL`

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - Go engage Taurus in Phomiuna Aqueducts
2 - Give them TP and watch them use TP Moves
Result: See no lua errors in console