### PR TITLE
[lua] Bugfix in quest "Painful Memory" not giving KI

### DIFF
--- a/scripts/quests/jeuno/Painful_Memory.lua
+++ b/scripts/quests/jeuno/Painful_Memory.lua
@@ -44,6 +44,7 @@ quest.sections =
                 [137] = function(player, csid, option, npc)
                     if option == 1 then
                         quest:begin(player)
+                        npcUtil.giveKeyItem(player, xi.ki.MERTAIRES_BRACELET)
                     end
                 end,
 
@@ -52,6 +53,7 @@ quest.sections =
                         quest:setVar(player, 'Option', 1) -- Player declined
                     else
                         quest:begin(player)
+                        npcUtil.giveKeyItem(player, xi.ki.MERTAIRES_BRACELET)
                     end
                 end,
             },


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixed a bug in which the player is not receiving the KI at the start of the quest, resulting in it being uncompletable.

## Steps to test these changes

`!changejob BRD 50`
`!completequest 3 20`
`!zone <Lower Jeuno>`
Talk to Mertaire `!pos -17 0 -61` to start quest and get the KI