### PR TITLE
[lua] Fix issue where players couldn't enter Windurst from Toraimarai Canal Priming Gate

### DIFF
--- a/scripts/zones/Windurst_Walls/npcs/_6n8.lua
+++ b/scripts/zones/Windurst_Walls/npcs/_6n8.lua
@@ -2,22 +2,25 @@
 -- Area: Windurst Walls
 --  Door: Priming Gate
 --  Involved in quest: Toraimarai Turmoil
+-- TODO: There is an edge case where if the player is on the lip of the door on the inside they will get the CS to enter the canal.
+--       Due to the placement of the door, could not map an exception for the lip, without causing issues with the entry CS.
+-----------------------------------
+local ID = zones[xi.zone.WINDURST_WALLS]
 -----------------------------------
 ---@type TNpcEntity
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    local x = player:getXPos()
-    local z = player:getZPos()
+    local y = player:getYPos()
 
-    if x >= 1.51 and x <= 9.49 and z >= 273.1 and z <= 281 then
-        if player:hasKeyItem(xi.ki.RHINOSTERY_CERTIFICATE) then
-            player:startEvent(401)
-        else
-            player:startEvent(264)
-        end
-    else
+    if y == -2.25 then
         player:startEvent(395)
+    else
+        if player:hasKeyItem(xi.ki.RHINOSTERY_CERTIFICATE) then
+                player:startEvent(401)
+        else
+            player:messageSpecial(ID.text.DOORS_SEALED_SHUT)
+        end
     end
 end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a bug where the coordinate mapping of the Priming Gate was preventing players from exiting into Windurst.
Corrects the event if the player does not have a Rhino Certificate. Was playing event 264 should be doing message 7769.

## Notes
There is an edge case where if the player is on the lip of the door on the inside of the gate they will get the CS/text for trying to enter the gate.
I spent about an hour trying to map this just right, but couldn't get it to work right, where it wasn't causing issues for players entering the canal.

## Steps to test these changes

`!zone <Windurst Walls>`
`!gotoname _6n8`
Click Door on inside. `!wallhack` Walk outside. Click door on outside.

## Capture
https://drive.google.com/drive/folders/1xwssHtvrMOvj7TNQ8jBHqyTeD0wqyNu1?usp=sharing

