### PR TITLE
[lua] Converts tradeHasExactly to tradeHas on quests "Beauty and the Galka" and "Shady Business"

### DIFF
--- a/scripts/quests/bastok/Beauty_and_the_Galka.lua
+++ b/scripts/quests/bastok/Beauty_and_the_Galka.lua
@@ -83,7 +83,7 @@ quest.sections =
 
                 onTrade = function(player, npc, trade)
                     if
-                        npcUtil.tradeHasExactly(trade, xi.item.CHUNK_OF_ZINC_ORE) and
+                        npcUtil.tradeHas(trade, xi.item.CHUNK_OF_ZINC_ORE) and
                         not player:hasKeyItem(xi.ki.PALBOROUGH_MINES_LOGS)
                     then
                         return quest:progressEvent(3)

--- a/scripts/quests/bastok/Shady_Business.lua
+++ b/scripts/quests/bastok/Shady_Business.lua
@@ -31,7 +31,7 @@ quest.sections =
                 end,
 
                 onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, { { xi.item.CHUNK_OF_ZINC_ORE, 4 } }) then
+                    if npcUtil.tradeHas(trade, { { xi.item.CHUNK_OF_ZINC_ORE, 4 } }) then
                         return quest:progressEvent(91)
                     end
                 end,


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Converts tradeHasExactly to tradeHas as confirmed in captures.

## Steps to test these changes

1. `!additem Zinc_Ore 12`
2. Start quest "Beauty and the Galka"
3. Trade more than 1 zinc ore to Talib.
4. Observe trade only take 1 zinc ore.
5. `!completequest 1 1 <me>`
6. Talk to Talib to start "Shady Business"
7. Trade more than 4 zinc ore to Talib.
8. Observe only 4 are taken.

## Capture
https://youtu.be/YqaP_tvyjkQ
https://drive.google.com/drive/folders/1KZRf67q0p1FnW9nXzP8GJI1UA8H9Srs8?usp=sharing
