### PR TITLE
[lua] Add quest not complete check to old ring KI in Castle O

### DIFF
--- a/scripts/zones/Castle_Oztroja/npcs/_47d.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_47d.lua
@@ -7,12 +7,19 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    if not player:hasKeyItem(xi.ki.OLD_RING) then
-        npcUtil.giveKeyItem(player, xi.ki.OLD_RING)
-    end
-
-    if npc:getAnimation() == xi.anim.CLOSE_DOOR then
+    if
+        not player:hasCompletedQuest(xi.questLog.WINDURST, xi.quest.id.windurst.ONION_RINGS) and
+        not player:hasKeyItem(xi.ki.OLD_RING)
+    then
+        player:startCutscene(44, 0, xi.ki.OLD_RING)
+    elseif npc:getAnimation() == xi.anim.CLOSE_DOOR then
         npc:openDoor()
+    end
+end
+
+entity.onEventFinish = function(player, csid, option, npc)
+    if csid == 44 then
+        npcUtil.giveKeyItem(player, xi.ki.OLD_RING)
     end
 end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a check that the player has NOT completed the quest "Onion Rings". Was confirmed on retail you cannot obtain the KI again after the quest is completed.

## Steps to test these changes

1. `!zone <Castle Oztroja>`
2. `!gotoname _47d`
3. Click trapdoor get KI.
4. `!delkeyitem old_ring`
5. `!completequest 2 42`
6. Click trapdoor don't get KI.

## Capture
Trying to get the KI After completing the quest:
https://youtu.be/sngOheiZYAA
https://1drv.ms/u/c/87e665e10555c452/ESAQccop0BpPvI9BZO7vz3ABzf0kt6VSLBg358izVwS-KA?e=J8ThG6

Trying to get the KI before flagging the quest:
https://drive.google.com/drive/folders/1-pCUZcESrK9JLSPQIEZQcdrIeRRAcpDO?usp=sharing