### PR TITLE
[lua] Update NIN AF2 Mob Enagakure behavior

### DIFF
--- a/scripts/zones/Ship_bound_for_Selbina/mobs/Enagakure.lua
+++ b/scripts/zones/Ship_bound_for_Selbina/mobs/Enagakure.lua
@@ -17,7 +17,6 @@ entity.onMobDeath = function(mob, player, optParams)
     then
         player:setCharVar('Enagakure_Killed', 1)
     end
-
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Ship_bound_for_Selbina/mobs/Enagakure.lua
+++ b/scripts/zones/Ship_bound_for_Selbina/mobs/Enagakure.lua
@@ -17,6 +17,11 @@ entity.onMobDeath = function(mob, player, optParams)
     then
         player:setCharVar('Enagakure_Killed', 1)
     end
+
+end
+
+entity.onMobDespawn = function(mob)
+    mob:setLocalVar('closed', VanadielUniqueDay())
 end
 
 return entity

--- a/scripts/zones/Ship_bound_for_Selbina_Pirates/IDs.lua
+++ b/scripts/zones/Ship_bound_for_Selbina_Pirates/IDs.lua
@@ -24,6 +24,7 @@ zones[xi.zone.SHIP_BOUND_FOR_SELBINA_PIRATES] =
     mob =
     {
         BLACKBEARD = GetFirstID('Blackbeard'),
+        ENAGAKURE  = GetFirstID('Enagakure'),
         SHIP_WIGHT = GetFirstID('Ship_Wight'),
     },
     npc =

--- a/scripts/zones/Ship_bound_for_Selbina_Pirates/Zone.lua
+++ b/scripts/zones/Ship_bound_for_Selbina_Pirates/Zone.lua
@@ -1,6 +1,8 @@
 -----------------------------------
 -- Zone: Ship bound for Selbina Pirates (227)
 -----------------------------------
+local ID = zones[xi.zone.SHIP_BOUND_FOR_SELBINA_PIRATES]
+-----------------------------------
 ---@type TZone
 local zoneObject = {}
 
@@ -9,6 +11,8 @@ end
 
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
+    local ninMob = GetMobByID(ID.mob.ENAGAKURE)
+    local hour = VanadielHour()
 
     if
         player:getXPos() == 0 and
@@ -17,6 +21,25 @@ zoneObject.onZoneIn = function(player, prevZone)
     then
         local position = math.random(-2, 2) + 0.150
         player:setPos(position, -2.100, 3.250, 64)
+    end
+
+    -- Enagakure failsafe in case of player logging mid-boat transport
+    if not ninMob then
+        return cs
+    end
+
+    local mobDespawn = ninMob:getLocalVar('closed')
+
+    if VanadielUniqueDay() > mobDespawn then
+        if
+            player:hasKeyItem(xi.ki.SEANCE_STAFF) and
+            player:getCharVar('Enagakure_Killed') == 0 and
+            hour < 4 and
+            hour >= 20 and
+            not ninMob:isSpawned()
+        then
+            SpawnMob(ID.mob.ENAGAKURE)
+        end
     end
 
     return cs
@@ -35,6 +58,40 @@ end
 zoneObject.onEventFinish = function(player, csid, option, npc)
     if csid == 255 then
         player:setPos(0, 0, 0, 0, xi.zone.SELBINA)
+    end
+end
+
+zoneObject.onGameHour = function(zone)
+    local hour = VanadielHour()
+    local ninMob = GetMobByID(ID.mob.ENAGAKURE)
+
+    if not ninMob then
+        return
+    end
+
+    local mobDespawn = ninMob:getLocalVar('closed')
+
+    -- Check for Enagakure
+    if VanadielUniqueDay() > mobDespawn then
+        if hour >= 20 or hour < 4 then
+            local players = zone:getPlayers()
+            for _, player in pairs(players) do
+                if
+                    player:hasKeyItem(xi.ki.SEANCE_STAFF) and
+                    player:getCharVar('Enagakure_Killed') == 0 and
+                    not ninMob:isSpawned()
+                then
+                    SpawnMob(ID.mob.ENAGAKURE)
+                end
+            end
+        else
+            if
+                ninMob:isSpawned() and
+                not ninMob:isEngaged()
+            then
+                DespawnMob(ID.mob.ENAGAKURE)
+            end
+        end
     end
 end
 

--- a/scripts/zones/Ship_bound_for_Selbina_Pirates/mobs/Enagakure.lua
+++ b/scripts/zones/Ship_bound_for_Selbina_Pirates/mobs/Enagakure.lua
@@ -17,7 +17,6 @@ entity.onMobDeath = function(mob, player, optParams)
     then
         player:setCharVar('Enagakure_Killed', 1)
     end
-
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Ship_bound_for_Selbina_Pirates/mobs/Enagakure.lua
+++ b/scripts/zones/Ship_bound_for_Selbina_Pirates/mobs/Enagakure.lua
@@ -1,0 +1,27 @@
+-----------------------------------
+-- Area: Ship bound for Selbina Pirates
+--  Mob: Enagakure
+-- Involved in Quest: I'll Take the Big Box
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 600)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if
+        player:hasKeyItem(xi.ki.SEANCE_STAFF) and
+        player:getCharVar('Enagakure_Killed') == 0
+    then
+        player:setCharVar('Enagakure_Killed', 1)
+    end
+
+end
+
+entity.onMobDespawn = function(mob)
+    mob:setLocalVar('closed', VanadielUniqueDay())
+end
+
+return entity


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Updates spawn behavior for Enagakure so that it only spawns at night.
Allows for it's spawn during pirates should the player meet requirements.
Assures mob does not despawn if actively engaged past 4:00:00 Vanadiel time.
Implements a check to assure the mob can only be popped once per boat ride.
Implements a failsafe should a player log in on the boat with requirements met to spawn mob (and it has not been spawned already or killed during the current voyage).

## Steps to test these changes

Flag "I'll Take The Bigger Box" quest for NIN AF2.
Take the 16:00:00 or 00:00:00 ferry from Mhaura to Selbina.
Depending on time, wait around until Enagakure spawns at 20:00:00 or upon zone in if you took the later ferry.
Note that mob will despawn if not engaged before 4:00:00 or if idle for 10mins.

