### PR TITLE
fix: Atonement reports as a hit on 0 CE/VE

### DIFF
--- a/scripts/actions/weaponskills/atonement.lua
+++ b/scripts/actions/weaponskills/atonement.lua
@@ -92,6 +92,15 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     damage = xi.weaponskills.takeWeaponskillDamage(target, player, params, primary, attack, calcParams, action)
 
+    if damage == 0 then
+        -- The logic above sets the action as a miss if CE/VE are 0 on the target
+        -- because the landed hits are (correctly) set to 0
+        -- Atonement is not known to miss and should always report as a hit.
+        -- It is fairly unique in that regard, which is why it is handled as a special case here.
+        action:resolution(target:getID(), xi.action.resolution.HIT)
+        action:messageID(target:getID(), xi.msg.basic.DAMAGE)
+    end
+
     return calcParams.tpHitsLanded, calcParams.extraHitsLanded, calcParams.criticalHit, damage
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Atonement correctly returns 0 TP on 0 CE/VE hit, which is throwing off the global weaponskills logic (since landed hits are set to 0)

This is causing Atonement to report a miss in such cases which is incorrect.

Closes #8706

## Steps to test these changes
Use Atonement on a mob with which you have 0 CE/VE

<!-- Clear and detailed steps to test your changes here -->
