### PR TITLE
[lua] Raise retail accurate error message

### DIFF
--- a/scripts/actions/spells/white/arise.lua
+++ b/scripts/actions/spells/white/arise.lua
@@ -9,7 +9,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
         target:isAlive() or          -- Can't cast on alive targets.
         target:hasRaiseTractorMenu() -- Raise and tractor menus both block the casting.
     then
-        return xi.msg.basic.CANNOT_ON_THAT_TARG
+        return xi.msg.basic.MAGIC_CANNOT_BE_CAST
     end
 
     return 0

--- a/scripts/actions/spells/white/raise.lua
+++ b/scripts/actions/spells/white/raise.lua
@@ -9,7 +9,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
         target:isAlive() or          -- Can't cast on alive targets.
         target:hasRaiseTractorMenu() -- Raise and tractor menus both block the casting.
     then
-        return xi.msg.basic.CANNOT_ON_THAT_TARG
+        return xi.msg.basic.MAGIC_CANNOT_BE_CAST
     end
 
     return 0

--- a/scripts/actions/spells/white/raise_ii.lua
+++ b/scripts/actions/spells/white/raise_ii.lua
@@ -9,7 +9,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
         target:isAlive() or          -- Can't cast on alive targets.
         target:hasRaiseTractorMenu() -- Raise and tractor menus both block the casting.
     then
-        return xi.msg.basic.CANNOT_ON_THAT_TARG
+        return xi.msg.basic.MAGIC_CANNOT_BE_CAST
     end
 
     return 0

--- a/scripts/actions/spells/white/raise_iii.lua
+++ b/scripts/actions/spells/white/raise_iii.lua
@@ -9,7 +9,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
         target:isAlive() or          -- Can't cast on alive targets.
         target:hasRaiseTractorMenu() -- Raise and tractor menus both block the casting.
     then
-        return xi.msg.basic.CANNOT_ON_THAT_TARG
+        return xi.msg.basic.MAGIC_CANNOT_BE_CAST
     end
 
     return 0


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Correct message when you can't cast on someone because they are alive or have tractor/raise menu showing.

Proof
<img width="964" height="86" alt="image" src="https://github.com/user-attachments/assets/82752894-e225-4d00-8add-745b9ec417fb" />

https://github.com/HorizonFFXI/HorizonXI-Issues/issues/2591

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
