### PR TITLE
[Combat] Retire `BreathDmgTaken()` function usage

### DIFF
--- a/scripts/actions/abilities/earth_shot.lua
+++ b/scripts/actions/abilities/earth_shot.lua
@@ -37,7 +37,8 @@ abilityObject.onUseAbility = function(player, target, ability, action)
 
     local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
     dmg            = math.floor(dmg * xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.EARTH, 0, 0, bonusAcc))
-    dmg            = math.floor(dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.EARTH))
+    dmg            = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, xi.element.EARTH, false))
+    dmg            = math.floor(dmg * xi.spells.damage.calculateNullification(target, xi.element.EARTH, false, false))
 
     params.targetTPMult = 0 -- Quick Draw does not feed TP
     dmg = xi.ability.takeDamage(target, player, params, true, dmg, xi.attackType.MAGICAL, xi.damageType.EARTH, xi.slot.RANGED, 1, 0, 0, 0, action, nil)

--- a/scripts/actions/abilities/fire_shot.lua
+++ b/scripts/actions/abilities/fire_shot.lua
@@ -37,7 +37,8 @@ abilityObject.onUseAbility = function(player, target, ability, action)
 
     local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
     dmg            = math.floor(dmg * xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.FIRE, 0, 0, bonusAcc))
-    dmg            = math.floor(dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.FIRE))
+    dmg            = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, xi.element.FIRE, false))
+    dmg            = math.floor(dmg * xi.spells.damage.calculateNullification(target, xi.element.FIRE, false, false))
 
     params.targetTPMult = 0 -- Quick Draw does not feed TP
     dmg                 = xi.ability.takeDamage(target, player, params, true, dmg, xi.attackType.MAGICAL, xi.damageType.FIRE, xi.slot.RANGED, 1, 0, 0, 0, action, nil)

--- a/scripts/actions/abilities/ice_shot.lua
+++ b/scripts/actions/abilities/ice_shot.lua
@@ -37,7 +37,8 @@ abilityObject.onUseAbility = function(player, target, ability, action)
 
     local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
     dmg            = math.floor(dmg * xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.ICE, 0, 0, bonusAcc))
-    dmg            = math.floor(dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.ICE))
+    dmg            = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, xi.element.ICE, false))
+    dmg            = math.floor(dmg * xi.spells.damage.calculateNullification(target, xi.element.ICE, false, false))
 
     params.targetTPMult = 0 -- Quick Draw does not feed TP
     dmg                 = xi.ability.takeDamage(target, player, params, true, dmg, xi.attackType.MAGICAL, xi.damageType.ICE, xi.slot.RANGED, 1, 0, 0, 0, action, nil)

--- a/scripts/actions/abilities/thunder_shot.lua
+++ b/scripts/actions/abilities/thunder_shot.lua
@@ -36,8 +36,9 @@ abilityObject.onUseAbility = function(player, target, ability, action)
     dmg       = addBonusesAbility(player, xi.element.THUNDER, target, dmg, params)
 
     local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
-    dmg            = dmg * xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.THUNDER, 0, 0, bonusAcc)
-    dmg            = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.THUNDER)
+    dmg            = math.floor(dmg * xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.THUNDER, 0, 0, bonusAcc))
+    dmg            = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, xi.element.THUNDER, false))
+    dmg            = math.floor(dmg * xi.spells.damage.calculateNullification(target, xi.element.THUNDER, false, false))
 
     params.targetTPMult = 0 -- Quick Draw does not feed TP
     dmg                 = xi.ability.takeDamage(target, player, params, true, dmg, xi.attackType.MAGICAL, xi.damageType.THUNDER, xi.slot.RANGED, 1, 0, 0, 0, action, nil)

--- a/scripts/actions/abilities/water_shot.lua
+++ b/scripts/actions/abilities/water_shot.lua
@@ -36,8 +36,9 @@ abilityObject.onUseAbility = function(player, target, ability, action)
     dmg       = addBonusesAbility(player, xi.element.WATER, target, dmg, params)
 
     local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
-    dmg            = dmg * xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.WATER, 0, 0, bonusAcc)
-    dmg            = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.WATER)
+    dmg            = math.floor(dmg * xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.WATER, 0, 0, bonusAcc))
+    dmg            = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, xi.element.WATER, false))
+    dmg            = math.floor(dmg * xi.spells.damage.calculateNullification(target, xi.element.WATER, false, false))
 
     params.targetTPMult = 0 -- Quick Draw does not feed TP
     dmg                 = xi.ability.takeDamage(target, player, params, true, dmg, xi.attackType.MAGICAL, xi.damageType.WATER, xi.slot.RANGED, 1, 0, 0, 0, action, nil)

--- a/scripts/actions/abilities/wind_shot.lua
+++ b/scripts/actions/abilities/wind_shot.lua
@@ -36,8 +36,9 @@ abilityObject.onUseAbility = function(player, target, ability, action)
     dmg       = addBonusesAbility(player, xi.element.WIND, target, dmg, params)
 
     local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
-    dmg            = dmg * xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.WIND, 0, 0, bonusAcc)
-    dmg            = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.WIND)
+    dmg            = math.floor(dmg * xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.WIND, 0, 0, bonusAcc))
+    dmg            = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, xi.element.WIND, false))
+    dmg            = math.floor(dmg * xi.spells.damage.calculateNullification(target, xi.element.WIND, false, false))
 
     params.targetTPMult = 0 -- Quick Draw does not feed TP
     dmg                 = xi.ability.takeDamage(target, player, params, true, dmg, xi.attackType.MAGICAL, xi.damageType.WIND, xi.slot.RANGED, 1, 0, 0, 0, action, nil)

--- a/scripts/actions/mobskills/spirits_within.lua
+++ b/scripts/actions/mobskills/spirits_within.lua
@@ -31,10 +31,13 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         dmg = math.floor(hp * (math.floor(0.072 * tp) - 96) / 256)
     end
 
-    dmg = dmg * 2.5
+    dmg = math.floor(dmg * 2.5)
 
     -- Believe it or not, it's been proven to be breath damage.
-    dmg = target:breathDmgTaken(dmg)
+    dmg = math.floor(dmg * xi.spells.damage.calculateDamageAdjustment(target, false, false, false, true))
+    dmg = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, xi.element.NONE, false))
+    dmg = math.floor(dmg * xi.spells.damage.calculateNullification(target, xi.element.NONE, false, true))
+    dmg = math.floor(target:handleSevereDamage(dmg, false))
 
     -- Handling phalanx
     dmg = dmg - target:getMod(xi.mod.PHALANX)

--- a/scripts/actions/spells/black/meteor.lua
+++ b/scripts/actions/spells/black/meteor.lua
@@ -39,7 +39,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     damage = math.floor(damage * xi.spells.damage.calculateAbsorption(target, xi.element.NONE, true))
     damage = math.floor(damage * xi.spells.damage.calculateNullification(target, xi.element.NONE, true, false))
     damage = math.floor(damage * xi.spells.damage.calculateMTDR(spell))
-    damage = math.floor(damage * xi.spells.damage.calculateTMDA(target, xi.element.NONE))
+    damage = math.floor(damage * xi.spells.damage.calculateDamageAdjustment(target, false, true, false, false))
 
     -- Handle Phalanx, One for All, Stoneskin.
     damage = utils.clamp(damage - target:getMod(xi.mod.PHALANX), 0, 99999)

--- a/scripts/actions/spells/black/meteor.lua
+++ b/scripts/actions/spells/black/meteor.lua
@@ -36,7 +36,8 @@ spellObject.onSpellCast = function(caster, target, spell)
         damage = ((100 + caster:getMod(xi.mod.MATT)) / (100 + target:getMod(xi.mod.MDEF))) * (caster:getStat(xi.mod.INT) + (caster:getMaxSkillLevel(caster:getMainLvl(), xi.job.BLM, xi.skill.ELEMENTAL_MAGIC)) / 6) * 9.4
     end
 
-    damage = math.floor(damage * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.NONE))
+    damage = math.floor(damage * xi.spells.damage.calculateAbsorption(target, xi.element.NONE, true))
+    damage = math.floor(damage * xi.spells.damage.calculateNullification(target, xi.element.NONE, true, false))
     damage = math.floor(damage * xi.spells.damage.calculateMTDR(spell))
     damage = math.floor(damage * xi.spells.damage.calculateTMDA(target, xi.element.NONE))
 

--- a/scripts/actions/weaponskills/atonement.lua
+++ b/scripts/actions/weaponskills/atonement.lua
@@ -71,7 +71,12 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.enmityMult = params.enmityMult + (tp + xi.combat.physical.calculateFTPBonus(player) * 1000 - 1000) / 2000
     params.enmityMult = utils.clamp(params.enmityMult, 1, 2) -- necessary because of Gorget/Belt bonus
 
-    damage = target:breathDmgTaken(dmg)
+    damage = dmg
+    damage = math.floor(damage * xi.spells.damage.calculateDamageAdjustment(target, false, false, false, true))
+    damage = math.floor(damage * xi.spells.damage.calculateAbsorption(target, xi.element.NONE, false))
+    damage = math.floor(damage * xi.spells.damage.calculateNullification(target, xi.element.NONE, false, true))
+    damage = math.floor(target:handleSevereDamage(damage, false))
+
     if player:getMod(xi.mod.WEAPONSKILL_DAMAGE_BASE + wsID) > 0 then
         damage = damage * (100 + player:getMod(xi.mod.WEAPONSKILL_DAMAGE_BASE + wsID)) / 100
     end

--- a/scripts/actions/weaponskills/spirits_within.lua
+++ b/scripts/actions/weaponskills/spirits_within.lua
@@ -54,7 +54,12 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
         end
     end
 
-    local damage = target:breathDmgTaken(wsc)
+    local damage = wsc
+    damage = math.floor(damage * xi.spells.damage.calculateDamageAdjustment(target, false, false, false, true))
+    damage = math.floor(damage * xi.spells.damage.calculateAbsorption(target, xi.element.NONE, false))
+    damage = math.floor(damage * xi.spells.damage.calculateNullification(target, xi.element.NONE, false, true))
+    damage = math.floor(target:handleSevereDamage(damage, false))
+
     if damage > 0 then
         if player:getOffhandDmg() > 0 then
             calcParams.tpHitsLanded = 2

--- a/scripts/globals/ability.lua
+++ b/scripts/globals/ability.lua
@@ -62,11 +62,11 @@ xi.ability.adjustDamage = function(dmg, attacker, skill, target, skilltype, skil
         return 0
     end
 
+    local element = utils.clamp(skillparam - 5, xi.element.NONE, xi.element.DARK) -- Transform damage type to element
     if skilltype == xi.attackType.PHYSICAL then
         dmg = target:physicalDmgTaken(dmg, skillparam)
     elseif skilltype == xi.attackType.MAGICAL then
-        local element = utils.clamp(skillparam - 5, xi.element.NONE, xi.element.DARK) -- Transform damage type to element
-        dmg = math.floor(dmg * xi.spells.damage.calculateTMDA(target, element))
+        dmg = math.floor(dmg * xi.spells.damage.calculateDamageAdjustment(target, false, true, false, false))
         dmg = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, element, true))
         dmg = math.floor(dmg * xi.spells.damage.calculateNullification(target, element, true, false))
         dmg = math.floor(target:handleSevereDamage(dmg, false))

--- a/scripts/globals/ability.lua
+++ b/scripts/globals/ability.lua
@@ -67,7 +67,8 @@ xi.ability.adjustDamage = function(dmg, attacker, skill, target, skilltype, skil
     elseif skilltype == xi.attackType.MAGICAL then
         local element = utils.clamp(skillparam - 5, xi.element.NONE, xi.element.DARK) -- Transform damage type to element
         dmg = math.floor(dmg * xi.spells.damage.calculateTMDA(target, element))
-        dmg = math.floor(dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, element))
+        dmg = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, element, true))
+        dmg = math.floor(dmg * xi.spells.damage.calculateNullification(target, element, true, false))
         dmg = math.floor(target:handleSevereDamage(dmg, false))
     elseif skilltype == xi.attackType.BREATH then
         dmg = target:breathDmgTaken(dmg)

--- a/scripts/globals/ability.lua
+++ b/scripts/globals/ability.lua
@@ -71,7 +71,10 @@ xi.ability.adjustDamage = function(dmg, attacker, skill, target, skilltype, skil
         dmg = math.floor(dmg * xi.spells.damage.calculateNullification(target, element, true, false))
         dmg = math.floor(target:handleSevereDamage(dmg, false))
     elseif skilltype == xi.attackType.BREATH then
-        dmg = target:breathDmgTaken(dmg)
+        dmg = math.floor(dmg * xi.spells.damage.calculateDamageAdjustment(target, false, false, false, true))
+        dmg = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, element, false))
+        dmg = math.floor(dmg * xi.spells.damage.calculateNullification(target, element, false, true))
+        dmg = math.floor(target:handleSevereDamage(dmg, false))
     elseif skilltype == xi.attackType.RANGED then
         dmg = target:rangedDmgTaken(dmg)
     end

--- a/scripts/globals/additional_effects.lua
+++ b/scripts/globals/additional_effects.lua
@@ -96,8 +96,9 @@ xi.additionalEffect.calcDamage = function(attacker, element, defender, damage)
     params.bonusmab   = 0
     params.includemab = false -- May possibly need to include mab on case by case basis, further tests needed
     damage            = addBonusesAbility(attacker, element, defender, damage, params)
-    damage            = damage * applyResistanceAddEffect(attacker, defender, element, 0)
-    damage            = damage * xi.spells.damage.calculateNukeAbsorbOrNullify(defender, element)
+    damage            = math.floor(damage * applyResistanceAddEffect(attacker, defender, element, 0))
+    damage            = math.floor(damage * xi.spells.damage.calculateAbsorption(defender, element, true))
+    damage            = math.floor(damage * xi.spells.damage.calculateNullification(defender, element, true, false))
     -- Todo: make sure day/weather/affinity bonuses tie in right here
     damage            = finalMagicNonSpellAdjustments(attacker, defender, element, damage)
 

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -295,6 +295,8 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
         hitsdone = hitsdone + 1
     end
 
+    finaldmg = math.floor(finaldmg * xi.spells.damage.calculateDamageAdjustment(target, true, false, false, false))
+
     if finaldmg <= 0 then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
@@ -433,7 +435,7 @@ xi.spells.blue.useDrainSpell = function(caster, target, spell, params, damageCap
     end
 
     finalDamage = math.floor(finalDamage * xi.spells.damage.calculateEbullienceMultiplier(caster, spellGroup))
-    finalDamage = math.floor(finalDamage * xi.spells.damage.calculateTMDA(target, spellElement))
+    finalDamage = math.floor(finalDamage * xi.spells.damage.calculateDamageAdjustment(target, false, true, false, false))
     finalDamage = math.floor(finalDamage * xi.settings.main.BLUE_POWER)
 
     -- MP drain
@@ -495,7 +497,7 @@ xi.spells.blue.useBreathSpell = function(caster, target, spell, params)
     local breathSDT                   = 1 + caster:getMod(xi.mod.BREATH_DMG_DEALT) / 100
     local absorb                      = xi.spells.damage.calculateAbsorption(target, spellElement, false)
     local nullify                     = xi.spells.damage.calculateNullification(target, spellElement, false, true)
-    local targetMagicDamageAdjustment = xi.spells.damage.calculateTMDA(target, spellElement)
+    local targetMagicDamageAdjustment = xi.spells.damage.calculateDamageAdjustment(target, false, false, false, true)
     local multipleTargetReduction     = xi.spells.damage.calculateMTDR(spell)
     local elementalStaffBonus         = xi.spells.damage.calculateElementalStaffBonus(caster, spellElement)
     local elementalAffinityBonus      = xi.spells.damage.calculateElementalAffinityBonus(caster, spellElement)
@@ -589,9 +591,6 @@ xi.spells.blue.applySpellDamage = function(caster, target, spell, dmg, params, t
             -- TODO: verify Afflatus/enmity from absorb?
             return dmg
         end
-
-        local targetMagicDamageAdjustment = xi.spells.damage.calculateTMDA(target, spell:getElement())
-        dmg                               = math.floor(dmg * targetMagicDamageAdjustment)
 
         dmg = utils.oneforall(target, dmg)
     end

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -535,9 +535,6 @@ xi.spells.blue.useBreathSpell = function(caster, target, spell, params)
         dmg          = math.floor(dmg * nukeWallFactor)
     end
 
-    -- Apply damage
-    dmg = target:breathDmgTaken(dmg)
-
     -- Handle Magic Absorb message and HP recovery.
     if dmg < 0 then
         dmg = target:addHP(-dmg)
@@ -545,6 +542,8 @@ xi.spells.blue.useBreathSpell = function(caster, target, spell, params)
 
         return dmg
     end
+
+    dmg = math.floor(target:handleSevereDamage(dmg, false))
 
     -- Final adjustments.
     if dmg > 0 then

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -685,10 +685,11 @@ xi.job_utils.dragoon.useDamageBreath = function(wyvern, target, skill, action, d
     local element            = damageType - xi.damageType.ELEMENTAL
     local _, skillchainCount = xi.magicburst.formMagicBurst(element, target)
 
-    -- 'Breath accuracy is directly affected by a wyvern's current HP', but no data exists.
+    -- Breath accuracy is directly affected by a wyvern's current HP, but no data exists.
     local resist              = xi.combat.magicHitRate.calculateResistRate(wyvern, target, 0, 0, 0, element, 0, 0, bonusMacc)
     local sdt                 = xi.spells.damage.calculateSDT(target, element)
-    local nukeAbsorbOrNullify = xi.spells.damage.calculateNukeAbsorbOrNullify(target, element)
+    local absorb              = xi.spells.damage.calculateAbsorption(target, element, true)
+    local nullify             = xi.spells.damage.calculateNullification(target, element, true, true)
     local magicBurst          = 1
 
     if skillchainCount > 0 then
@@ -696,7 +697,7 @@ xi.job_utils.dragoon.useDamageBreath = function(wyvern, target, skill, action, d
     end
 
     -- It appears that MB breaths don't do more damage based on testing.
-    damage = damage * resist * sdt * nukeAbsorbOrNullify
+    damage = damage * resist * sdt * absorb * nullify
 
     if damage >= 0 then
         damage = xi.ability.adjustDamage(damage, wyvern, skill, target, xi.attackType.BREATH, damageType, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)

--- a/scripts/globals/job_utils/ninja.lua
+++ b/scripts/globals/job_utils/ninja.lua
@@ -46,7 +46,7 @@ end
 xi.job_utils.ninja.useMijinGakure = function(player, target, ability, action)
     local dmg        = math.floor(player:getHP() * 0.8)
     local resist     = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.NONE, xi.mod.INT, 0, 0)
-    local tmdaFactor = xi.spells.damage.calculateTMDA(target, xi.element.NONE)
+    local tmdaFactor = xi.spells.damage.calculateDamageAdjustment(target, false, true, false, false)
     local jpFactor   = 1 + player:getJobPointLevel(xi.jp.MIJIN_GAKURE_EFFECT) * 0.03
 
     dmg = math.floor(dmg * resist)

--- a/scripts/globals/job_utils/rune_fencer.lua
+++ b/scripts/globals/job_utils/rune_fencer.lua
@@ -525,7 +525,8 @@ local function getSwipeLungeDamageMultipliers(player, target, element, bonusMacc
     multipliers.dayAndWeather       = xi.spells.damage.calculateDayAndWeather(player, element, false)
     multipliers.magicBonusDiff      = xi.spells.damage.calculateMagicBonusDiff(player, target, 0, 0, element)
     multipliers.TMDA                = xi.spells.damage.calculateTMDA(target, element)
-    multipliers.nukeAbsorbOrNullify = xi.spells.damage.calculateNukeAbsorbOrNullify(target, element)
+    multipliers.absorb              = xi.spells.damage.calculateAbsorption(target, element, true)
+    multipliers.nullify             = xi.spells.damage.calculateNullification(target, element, true, false)
     multipliers.magicBurst          = 1
     multipliers.magicBurstBonus     = 1
 
@@ -553,7 +554,8 @@ local function calculateSwipeLungeDamage(player, target, skillModifier, gearBonu
     damage = math.floor(damage * multipliers.dayAndWeather)
     damage = math.floor(damage * multipliers.magicBonusDiff)
     damage = math.floor(damage * multipliers.TMDA)
-    damage = math.floor(damage * multipliers.nukeAbsorbOrNullify)
+    damage = math.floor(damage * multipliers.absorb)
+    damage = math.floor(damage * multipliers.nullify)
 
     -- Handle Phalanx
     if damage > 0 then
@@ -609,7 +611,7 @@ xi.job_utils.rune_fencer.useSwipeLunge = function(player, target, ability, actio
             local damage      = calculateSwipeLungeDamage(player, target, skillModifier, gearBonus, runeStrength, multipliers)
 
             -- set absorb flag in case we end up dealing 0 damage cumulatively. For example using a wind swipe/lunge vs Puk with full hp will report it "absorbed" 0 HP.
-            if multipliers.nukeAbsorbOrNullify == -1 then
+            if multipliers.absorb == -1 then
                 absorbed = true
             end
 

--- a/scripts/globals/job_utils/rune_fencer.lua
+++ b/scripts/globals/job_utils/rune_fencer.lua
@@ -524,7 +524,7 @@ local function getSwipeLungeDamageMultipliers(player, target, element, bonusMacc
     multipliers.resist              = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, element, 0, 0, bonusMacc)
     multipliers.dayAndWeather       = xi.spells.damage.calculateDayAndWeather(player, element, false)
     multipliers.magicBonusDiff      = xi.spells.damage.calculateMagicBonusDiff(player, target, 0, 0, element)
-    multipliers.TMDA                = xi.spells.damage.calculateTMDA(target, element)
+    multipliers.TMDA                = xi.spells.damage.calculateDamageAdjustment(target, false, true, false, false)
     multipliers.absorb              = xi.spells.damage.calculateAbsorption(target, element, true)
     multipliers.nullify             = xi.spells.damage.calculateNullification(target, element, true, false)
     multipliers.magicBurst          = 1

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -83,7 +83,7 @@ end
 function finalMagicNonSpellAdjustments(caster, target, ele, dmg)
     -- Handles target's HP adjustment and returns SIGNED dmg (negative values on absorb)
 
-    dmg = math.floor(dmg * xi.spells.damage.calculateTMDA(target, ele))
+    dmg = math.floor(dmg * xi.spells.damage.calculateDamageAdjustment(target, false, true, false, false))
     dmg = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, ele, true))
     dmg = math.floor(dmg * xi.spells.damage.calculateNullification(target, ele, true, false))
     dmg = math.floor(target:handleSevereDamage(dmg, false))

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -84,7 +84,8 @@ function finalMagicNonSpellAdjustments(caster, target, ele, dmg)
     -- Handles target's HP adjustment and returns SIGNED dmg (negative values on absorb)
 
     dmg = math.floor(dmg * xi.spells.damage.calculateTMDA(target, ele))
-    dmg = math.floor(dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, ele))
+    dmg = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, ele, true))
+    dmg = math.floor(dmg * xi.spells.damage.calculateNullification(target, ele, true, false))
     dmg = math.floor(target:handleSevereDamage(dmg, false))
 
     if dmg > 0 then

--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -668,7 +668,8 @@ local addEffectImmediate = function(mob, target, damage, ae, params)
 
     power = addBonusesAbility(mob, ae.ele, target, power, ae.bonusAbilityParams)
     power = power * applyResistanceAddEffect(mob, target, ae.ele, 0)
-    power = power * xi.spells.damage.calculateNukeAbsorbOrNullify(target, ae.ele)
+    power = power * xi.spells.damage.calculateAbsorption(target, ae.ele, true)
+    power = power * xi.spells.damage.calculateNullification(target, ae.ele, true, false)
 
     if ae.sub ~= xi.subEffect.TP_DRAIN and ae.sub ~= xi.subEffect.MP_DRAIN then
         power = finalMagicNonSpellAdjustments(mob, target, ae.ele, power)

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -510,7 +510,7 @@ xi.mobskills.mobFinalAdjustments = function(damage, mob, skill, target, attackTy
         damage = target:physicalDmgTaken(damage, damageType)
     elseif attackType == xi.attackType.MAGICAL then
         local element = utils.clamp(damageType - 5, xi.element.NONE, xi.element.DARK) -- Transform damage type to element
-        damage = math.floor(damage * xi.spells.damage.calculateTMDA(target, element))
+        damage = math.floor(damage * xi.spells.damage.calculateDamageAdjustment(target, false, true, false, false))
         damage = math.floor(damage * xi.spells.damage.calculateAbsorption(target, element, true))
         damage = math.floor(damage * xi.spells.damage.calculateNullification(target, element, true, false))
         damage = math.floor(target:handleSevereDamage(damage, false))

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -385,16 +385,17 @@ xi.mobskills.mobBreathMove = function(mob, target, skill, skillParams)
     local elementalSDT    = xi.spells.damage.calculateSDT(target, actionElement)
     local resistRate      = xi.combat.magicHitRate.calculateResistRate(mob, target, 0, 0, xi.skillRank.A_PLUS, actionElement, resistStat, 0, mAccuracyBonus)
     local dayAndWeather   = xi.spells.damage.calculateDayAndWeather(mob, actionElement, false)
-    local absorbOrNullify = xi.spells.damage.calculateNukeAbsorbOrNullify(target, actionElement)
+    local absorb          = xi.spells.damage.calculateAbsorption(target, actionElement, true)
+    local nullify         = xi.spells.damage.calculateNullification(target, actionElement, true, true)
 
     damage = math.floor(damage * systemBonus)
     damage = math.floor(damage * elementalSDT)
     damage = math.floor(damage * resistRate)
     damage = math.floor(damage * dayAndWeather)
     damage = utils.clamp(damage, 0, breathSkillDamageCap)
-    damage = math.floor(damage * absorbOrNullify)
+    damage = math.floor(damage * absorb * nullify)
 
-    if absorbOrNullify < 0 then -- Return early since the rest of the calculations are not needed if we absorbed/nullified.
+    if damage <= 0 then -- Return early since the rest of the calculations are not needed if we absorbed/nullified.
         return damage
     end
 
@@ -510,7 +511,8 @@ xi.mobskills.mobFinalAdjustments = function(damage, mob, skill, target, attackTy
     elseif attackType == xi.attackType.MAGICAL then
         local element = utils.clamp(damageType - 5, xi.element.NONE, xi.element.DARK) -- Transform damage type to element
         damage = math.floor(damage * xi.spells.damage.calculateTMDA(target, element))
-        damage = math.floor(damage * xi.spells.damage.calculateNukeAbsorbOrNullify(target, element))
+        damage = math.floor(damage * xi.spells.damage.calculateAbsorption(target, element, true))
+        damage = math.floor(damage * xi.spells.damage.calculateNullification(target, element, true, false))
         damage = math.floor(target:handleSevereDamage(damage, false))
     elseif attackType == xi.attackType.BREATH then
         -- Handle absorb messaging

--- a/scripts/globals/spells/absorb_spell.lua
+++ b/scripts/globals/spells/absorb_spell.lua
@@ -96,15 +96,18 @@ xi.spells.absorb.doDrainingSpell = function(caster, target, spell)
         displayCap   = caster:getMaxMP() - caster:getMP()
     end
 
-    -- Early return: Target absorbs or nullifies dark.
-    if xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.DARK) ~= 1 then
-        spell:setMsg(xi.msg.basic.MAGIC_RESIST)
-        return finalDamage
-    end
-
     -- Early return: Target is undead.
     if target:isUndead() then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+        return finalDamage
+    end
+
+    -- Early return: Target absorbs or nullifies dark.
+    if
+        xi.spells.damage.calculateAbsorption(target, xi.element.DARK, true) ~= 1 or
+        xi.spells.damage.calculateNullification(target, xi.element.DARK, true, false) ~= 1
+    then
+        spell:setMsg(xi.msg.basic.MAGIC_RESIST)
         return finalDamage
     end
 
@@ -215,7 +218,10 @@ xi.spells.absorb.doAbsorbTPSpell = function(caster, target, spell)
     local finalDamage = 0
 
     -- Early return: Target absorbs or nullifies dark.
-    if xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.DARK) ~= 1 then
+    if
+        xi.spells.damage.calculateAbsorption(target, xi.element.DARK, true) ~= 1 or
+        xi.spells.damage.calculateNullification(target, xi.element.DARK, true, false) ~= 1
+    then
         spell:setMsg(xi.msg.basic.MAGIC_RESIST)
         return finalDamage
     end

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -710,24 +710,39 @@ end
 -- Calculate: Target Magic Damage Adjustment (TMDA)
 -- SDT follow-up. This time for specific modifiers.
 -- Referred to on item as "Magic Damage Taken -%", "Damage Taken -%" (Ex. Defending Ring) and "Magic Damage Taken II -%" (Aegis)
-xi.spells.damage.calculateTMDA = function(target, spellElement)
-    local targetMagicDamageAdjustment = 1
+xi.spells.damage.calculateDamageAdjustment = function(target, isPhysical, isMagical, isRanged, isBreath)
+    local targetDamageTaken = 1
 
     -- The values set for this modifiers are base 10000.
     -- -2500 in item_mods.sql means -25% damage recived.
     -- 2500 would mean 25% ADDITIONAL damage taken.
-    -- The effects of the "Shell" spells are also included in this step.
 
-    local globalDamageTaken   = target:getMod(xi.mod.DMG) / 10000         -- Mod is base 10000
-    local magicDamageTaken    = target:getMod(xi.mod.DMGMAGIC) / 10000    -- Mod is base 10000
-    local magicDamageTakenII  = target:getMod(xi.mod.DMGMAGIC_II) / 10000 -- Mod is base 10000
-    local uMagicDamageTaken   = target:getMod(xi.mod.UDMGMAGIC) / 10000   -- Mod is base 10000.
-    local combinedDamageTaken = utils.clamp(magicDamageTaken + globalDamageTaken, -0.5, 0.5) -- The combination of regular "Damage Taken" and "Magic Damage Taken" caps at 50% both ways.
+    local globalDamageTaken           = target:getMod(xi.mod.DMG) / 10000
 
-    targetMagicDamageAdjustment = utils.clamp(targetMagicDamageAdjustment + combinedDamageTaken + magicDamageTakenII, 0.125, 1.875) -- "Magic Damage Taken II" bypasses the regular cap, but combined cap is 87.5% both ways.
-    targetMagicDamageAdjustment = utils.clamp(targetMagicDamageAdjustment + uMagicDamageTaken, 0, 2) -- Uncapped magic damage modifier. Cap is 100% both ways.
+    local physicalDamageTaken         = isPhysical and target:getMod(xi.mod.DMGPHYS) / 10000 or 0
+    local physicalDamageTakenII       = isPhysical and target:getMod(xi.mod.DMGPHYS_II) / 10000 or 0
+    local physicalDamageTakenUncapped = isPhysical and target:getMod(xi.mod.UDMGPHYS) / 10000 or 0
 
-    return targetMagicDamageAdjustment
+    local magicDamageTaken            = isMagical and target:getMod(xi.mod.DMGMAGIC) / 10000 or 0
+    local magicDamageTakenII          = isMagical and target:getMod(xi.mod.DMGMAGIC_II) / 10000 or 0
+    local magicDamageTakenUncapped    = isMagical and target:getMod(xi.mod.UDMGMAGIC) / 10000 or 0
+
+    local rangedDamageTaken           = isRanged and target:getMod(xi.mod.DMGRANGE) / 10000 or 0
+    local rangedDamageTakenUncapped   = isRanged and target:getMod(xi.mod.UDMGRANGE) / 10000 or 0
+
+    local breathDamageTaken           = isBreath and target:getMod(xi.mod.DMGBREATH) / 10000 or 0
+    local breathDamageTakenUncapped   = isBreath and target:getMod(xi.mod.UDMGBREATH) / 10000 or 0
+
+     -- The combination of regular "Damage Taken" and "X Damage Taken" caps at 50% both ways.
+    local combinedDamageTaken = utils.clamp(globalDamageTaken + physicalDamageTaken + magicDamageTaken + rangedDamageTaken + breathDamageTaken, -0.5, 0.5)
+
+    -- "X Damage Taken II" bypasses the regular cap, but combined cap is 87.5% both ways.
+    targetDamageTaken = utils.clamp(targetDamageTaken + combinedDamageTaken + physicalDamageTakenII + magicDamageTakenII, 0.125, 1.875)
+
+     -- Uncapped damage modifiers. Cap is 100% both ways anyway, just in case.
+    targetDamageTaken = utils.clamp(targetDamageTaken + physicalDamageTakenUncapped + magicDamageTakenUncapped + rangedDamageTakenUncapped + breathDamageTakenUncapped, 0, 2)
+
+    return targetDamageTaken
 end
 
 -- Divine seal applies its own multiplier to healing spells when used against undead.
@@ -1101,7 +1116,7 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
 
     if absorb > 0 then
         resistTier                  = xi.combat.magicHitRate.calculateResistRate(caster, target, spellGroup, skillType, 0, spellElement, statUsed, 0, bonusMacc)
-        targetMagicDamageAdjustment = xi.spells.damage.calculateTMDA(target, spellElement)
+        targetMagicDamageAdjustment = xi.spells.damage.calculateDamageAdjustment(target, false, true, false, false)
 
         -- If spell is NOT blue magic OR (if its blue magic AND has status effect)
         if

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -928,12 +928,18 @@ xi.spells.damage.calculateAbsorption = function(target, element, isMagic)
     end
 
     -- Absorb: Magic damage.
-    if isMagic and math.random(1, 100) <= target:getMod(xi.mod.MAGIC_ABSORB) then
+    if
+        isMagic and
+        math.random(1, 100) <= target:getMod(xi.mod.MAGIC_ABSORB)
+    then
         return -1
     end
 
     -- Absorb: Element damage.
-    if element > 0 and math.random(1, 100) <= target:getMod(xi.data.element.getElementalAbsorptionModifier(element)) then
+    if
+        element > 0 and
+        math.random(1, 100) <= target:getMod(xi.data.element.getElementalAbsorptionModifier(element))
+    then
         return-1
     end
 
@@ -941,24 +947,33 @@ xi.spells.damage.calculateAbsorption = function(target, element, isMagic)
     return 1
 end
 
-xi.spells.damage.calculateNullification = function(target, element, isMagic, isbreath)
+xi.spells.damage.calculateNullification = function(target, element, isMagic, isBreath)
     -- Nullify: All damage.
     if math.random(1, 100) <= target:getMod(xi.mod.NULL_DAMAGE) then
         return 0
     end
 
     -- Nullify: Magic damage.
-    if isMagic and math.random(1, 100) <= target:getMod(xi.mod.NULL_MAGICAL_DAMAGE) then
+    if
+        isMagic and
+        math.random(1, 100) <= target:getMod(xi.mod.NULL_MAGICAL_DAMAGE)
+    then
         return 0
     end
 
     -- Nullify: Breath damage.
-    if isBreath and math.random(1, 100) <= target:getMod(xi.mod.NULL_BREATH_DAMAGE) then
+    if
+        isBreath and
+        math.random(1, 100) <= target:getMod(xi.mod.NULL_BREATH_DAMAGE)
+    then
         return 0
     end
 
     -- Nullify: Element damage.
-    if element > 0 and math.random(1, 100) <= target:getMod(xi.data.element.getElementalNullificationModifier(element)) then
+    if
+        element > 0 and
+        math.random(1, 100) <= target:getMod(xi.data.element.getElementalNullificationModifier(element))
+    then
         return 0
     end
 

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -284,7 +284,8 @@ local function calculateHybridMagicDamage(tp, physicaldmg, attacker, target, wsP
     magicdmg = math.floor(target:handleSevereDamage(magicdmg, false))
 
     if magicdmg > 0 then
-        magicdmg = math.floor(magicdmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, wsParams.ele))
+        magicdmg = math.floor(magicdmg * xi.spells.damage.calculateAbsorption(target, wsParams.ele, true))
+        magicdmg = math.floor(magicdmg * xi.spells.damage.calculateNullification(target, wsParams.ele, true, false))
     end
 
     if magicdmg > 0 then -- handle nonzero damage if previous function does not absorb or nullify
@@ -900,7 +901,8 @@ xi.weaponskills.doMagicWeaponskill = function(attacker, target, wsID, wsParams, 
             return dmg
         end
 
-        dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, wsParams.ele)
+        dmg = dmg * xi.spells.damage.calculateAbsorption(target, wsParams.ele, true)
+        dmg = dmg * xi.spells.damage.calculateNullification(target, wsParams.ele, true, false)
 
         if dmg > 0 then
             dmg = dmg - target:getMod(xi.mod.PHALANX)

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -280,7 +280,7 @@ local function calculateHybridMagicDamage(tp, physicaldmg, attacker, target, wsP
     magicdmg = math.floor(addBonusesAbility(attacker, wsParams.ele, target, magicdmg, wsParams))
     magicdmg = math.floor(magicdmg + calcParams.bonusfTP * physicaldmg)
     magicdmg = math.floor(magicdmg * xi.combat.magicHitRate.calculateResistRate(attacker, target, 0, wsParams.skill, 0, wsParams.ele, 0, 0, calcParams.bonusAcc))
-    magicdmg = math.floor(magicdmg * xi.spells.damage.calculateTMDA(target, wsParams.ele))
+    magicdmg = math.floor(magicdmg * xi.spells.damage.calculateDamageAdjustment(target, false, true, false, false))
     magicdmg = math.floor(target:handleSevereDamage(magicdmg, false))
 
     if magicdmg > 0 then
@@ -891,7 +891,7 @@ xi.weaponskills.doMagicWeaponskill = function(attacker, target, wsID, wsParams, 
         -- Calculate magical bonuses and reductions
         dmg = math.floor(addBonusesAbility(attacker, wsParams.ele, target, dmg, wsParams))
         dmg = math.floor(dmg * xi.combat.magicHitRate.calculateResistRate(attacker, target, 0, wsParams.skill, 0, wsParams.ele, 0, 0, gearAcc))
-        dmg = math.floor(dmg * xi.spells.damage.calculateTMDA(target, wsParams.ele))
+        dmg = math.floor(dmg * xi.spells.damage.calculateDamageAdjustment(target, false, true, false, false))
         dmg = math.floor(target:handleSevereDamage(dmg, false))
 
         if dmg < 0 then

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -3243,12 +3243,6 @@ end
 function CBaseEntity:rangedDmgTaken(damage, damageType)
 end
 
----@nodiscard
----@param damage number
----@return integer
-function CBaseEntity:breathDmgTaken(damage)
-end
-
 ---@param damage number
 ---@return nil
 function CBaseEntity:handleAfflatusMiseryDamage(damage)

--- a/scripts/zones/Arrapago_Reef/mobs/Velionis.lua
+++ b/scripts/zones/Arrapago_Reef/mobs/Velionis.lua
@@ -46,7 +46,8 @@ entity.onSpikesDamage = function(mob, target, damage)
         params.includemab = false
         dmg = addBonusesAbility(mob, xi.element.FIRE, target, dmg, params)
         dmg = dmg * applyResistanceAddEffect(mob, target, xi.element.FIRE, 0)
-        dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.FIRE)
+        dmg = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, xi.element.FIRE, true))
+        dmg = math.floor(dmg * xi.spells.damage.calculateNullification(target, xi.element.FIRE, true, false))
         dmg = finalMagicNonSpellAdjustments(mob, target, xi.element.FIRE, dmg)
 
         if dmg < 0 then

--- a/scripts/zones/Attohwa_Chasm/mobs/Sargas.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Sargas.lua
@@ -28,7 +28,8 @@ entity.onSpikesDamage = function(mob, target, damage)
     params.includemab = false
     dmg = addBonusesAbility(mob, xi.element.THUNDER, target, dmg, params)
     dmg = dmg * applyResistanceAddEffect(mob, target, xi.element.THUNDER, 0)
-    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.THUNDER)
+    dmg = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, xi.element.THUNDER, true))
+    dmg = math.floor(dmg * xi.spells.damage.calculateNullification(target, xi.element.THUNDER, true, false))
     dmg = finalMagicNonSpellAdjustments(mob, target, xi.element.THUNDER, dmg)
 
     if dmg < 0 then

--- a/scripts/zones/Beaucedine_Glacier/mobs/Humbaba.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Humbaba.lua
@@ -34,7 +34,8 @@ entity.onSpikesDamage = function(mob, target, damage)
     params.includemab = false
     dmg = addBonusesAbility(mob, xi.element.ICE, target, dmg, params)
     dmg = dmg * applyResistanceAddEffect(mob, target, xi.element.ICE, 0)
-    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.ICE)
+    dmg = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, xi.element.ICE, true))
+    dmg = math.floor(dmg * xi.spells.damage.calculateNullification(target, xi.element.ICE, true, false))
     dmg = finalMagicNonSpellAdjustments(mob, target, xi.element.ICE, dmg)
 
     if dmg < 0 then

--- a/scripts/zones/Crawlers_Nest/mobs/Aqrabuamelu.lua
+++ b/scripts/zones/Crawlers_Nest/mobs/Aqrabuamelu.lua
@@ -73,7 +73,8 @@ entity.onSpikesDamage = function(mob, target, damage)
     params.includemab = false
     dmg = addBonusesAbility(mob, xi.element.ICE, target, dmg, params)
     dmg = dmg * applyResistanceAddEffect(mob, target, xi.element.ICE, 0)
-    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.ICE)
+    dmg = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, xi.element.ICE, true))
+    dmg = math.floor(dmg * xi.spells.damage.calculateNullification(target, xi.element.ICE, true, false))
     dmg = finalMagicNonSpellAdjustments(mob, target, xi.element.ICE, dmg)
 
     if dmg < 0 then

--- a/scripts/zones/Halvung/mobs/Copper_Borer.lua
+++ b/scripts/zones/Halvung/mobs/Copper_Borer.lua
@@ -25,7 +25,8 @@ entity.onSpikesDamage = function(mob, target, damage)
     params.includemab = false
     dmg = addBonusesAbility(mob, xi.element.FIRE, target, dmg, params)
     dmg = dmg * applyResistanceAddEffect(mob, target, xi.element.FIRE, 0)
-    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.FIRE)
+    dmg = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, xi.element.FIRE, true))
+    dmg = math.floor(dmg * xi.spells.damage.calculateNullification(target, xi.element.FIRE, true, false))
     dmg = finalMagicNonSpellAdjustments(mob, target, xi.element.FIRE, dmg)
 
     if dmg < 0 then

--- a/scripts/zones/Ordelles_Caves/mobs/Bombast.lua
+++ b/scripts/zones/Ordelles_Caves/mobs/Bombast.lua
@@ -20,7 +20,8 @@ entity.onSpikesDamage = function(mob, target, damage)
     params.includemab = false
     dmg = addBonusesAbility(mob, xi.element.FIRE, target, dmg, params)
     dmg = dmg * applyResistanceAddEffect(mob, target, xi.element.FIRE, 0)
-    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.FIRE)
+    dmg = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, xi.element.FIRE, true))
+    dmg = math.floor(dmg * xi.spells.damage.calculateNullification(target, xi.element.FIRE, true, false))
     dmg = finalMagicNonSpellAdjustments(mob, target, xi.element.FIRE, dmg)
 
     if dmg < 0 then

--- a/scripts/zones/RoMaeve/mobs/Martinet.lua
+++ b/scripts/zones/RoMaeve/mobs/Martinet.lua
@@ -43,7 +43,8 @@ entity.onSpikesDamage = function(mob, target, damage)
     params.includemab = false
     dmg = addBonusesAbility(mob, xi.element.THUNDER, target, dmg, params)
     dmg = dmg * applyResistanceAddEffect(mob, target, xi.element.THUNDER, 0)
-    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.THUNDER)
+    dmg = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, xi.element.THUNDER, true))
+    dmg = math.floor(dmg * xi.spells.damage.calculateNullification(target, xi.element.THUNDER, true, false))
     dmg = finalMagicNonSpellAdjustments(mob, target, xi.element.THUNDER, dmg)
 
     if dmg < 0 then

--- a/scripts/zones/Toraimarai_Canal/mobs/Brazen_Bones.lua
+++ b/scripts/zones/Toraimarai_Canal/mobs/Brazen_Bones.lua
@@ -29,7 +29,8 @@ entity.onSpikesDamage = function(mob, target, damage)
     params.includemab = false
     dmg = addBonusesAbility(mob, xi.element.ICE, target, dmg, params)
     dmg = dmg * applyResistanceAddEffect(mob, target, xi.element.ICE, 0)
-    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.ICE)
+    dmg = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, xi.element.ICE, true))
+    dmg = math.floor(dmg * xi.spells.damage.calculateNullification(target, xi.element.ICE, true, false))
     dmg = finalMagicNonSpellAdjustments(mob, target, xi.element.ICE, dmg)
 
     if dmg < 0 then

--- a/scripts/zones/Upper_Delkfutts_Tower/mobs/Autarch.lua
+++ b/scripts/zones/Upper_Delkfutts_Tower/mobs/Autarch.lua
@@ -27,7 +27,8 @@ entity.onSpikesDamage = function(mob, target, damage)
     params.includemab = false
     dmg = addBonusesAbility(mob, xi.element.THUNDER, target, dmg, params)
     dmg = dmg * applyResistanceAddEffect(mob, target, xi.element.THUNDER, 0)
-    dmg = dmg * xi.spells.damage.calculateNukeAbsorbOrNullify(target, xi.element.THUNDER)
+    dmg = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, xi.element.THUNDER, true))
+    dmg = math.floor(dmg * xi.spells.damage.calculateNullification(target, xi.element.THUNDER, true, false))
     dmg = finalMagicNonSpellAdjustments(mob, target, xi.element.THUNDER, dmg)
 
     if dmg < 0 then

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -15022,24 +15022,6 @@ int32 CLuaBaseEntity::rangedDmgTaken(double damage, sol::variadic_args va)
 }
 
 /************************************************************************
- *  Function: breathDmgTaken()
- *  Purpose : Returns the value of Breath Damage taken after calculation
- *  Example : local dmg = target:breathDmgTaken(dmg)
- *  Notes   : Passes argument to BreathDmgTaken member of battleutils
- ************************************************************************/
-
-int32 CLuaBaseEntity::breathDmgTaken(double damage)
-{
-    if (m_PBaseEntity->objtype == TYPE_NPC)
-    {
-        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->getName());
-        return 0;
-    }
-
-    return battleutils::BreathDmgTaken(static_cast<CBattleEntity*>(m_PBaseEntity), static_cast<int32>(damage));
-}
-
-/************************************************************************
  *  Function: handleAfflatusMiseryDamage()
  *  Purpose : Passes an argument to the HandleAfflatusMiseryDamage member of battleutils
  *  Example : target:handleAfflatusMiseryDamage(dmg)
@@ -20125,7 +20107,6 @@ void CLuaBaseEntity::Register()
 
     SOL_REGISTER("physicalDmgTaken", CLuaBaseEntity::physicalDmgTaken);
     SOL_REGISTER("rangedDmgTaken", CLuaBaseEntity::rangedDmgTaken);
-    SOL_REGISTER("breathDmgTaken", CLuaBaseEntity::breathDmgTaken);
     SOL_REGISTER("handleAfflatusMiseryDamage", CLuaBaseEntity::handleAfflatusMiseryDamage);
 
     SOL_REGISTER("isWeaponTwoHanded", CLuaBaseEntity::isWeaponTwoHanded);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -739,7 +739,6 @@ public:
 
     int32 physicalDmgTaken(double damage, sol::variadic_args va);
     int32 rangedDmgTaken(double damage, sol::variadic_args va);
-    int32 breathDmgTaken(double damage);
     void  handleAfflatusMiseryDamage(double damage);
 
     bool   isWeaponTwoHanded();

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -208,7 +208,6 @@ void ClaimMob(CBattleEntity* PDefender, CBattleEntity* PAttacker, bool passing =
 void DirtyExp(CBattleEntity* PDefender, CBattleEntity* PAttacker);
 void RelinquishClaim(CCharEntity* PDefender);
 
-int32 BreathDmgTaken(CBattleEntity* PDefender, int32 damage);
 int32 MagicDmgTaken(CBattleEntity* PDefender, int32 damage, ELEMENT element);
 int32 PhysicalDmgTaken(CBattleEntity* PDefender, int32 damage, DAMAGE_TYPE damageType, bool IsCovered = false);
 int32 RangedDmgTaken(CBattleEntity* PDefender, int32 damage, DAMAGE_TYPE damageType, bool IsCovered = false);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Separates absorption and nullification into 2 functions.
- Makes TMDA function handle all 4 damage categories.
- Applies and new logic where it should, replacing old function.
- Retires `BreathDmgTaken()`

## Steps to test these changes

Review by commit. Do breath skills and hope nothing explodes.
