### PR TITLE
fix: Handle dead players executing an event (BCNM exit), lock BCNM on aggro

### DIFF
--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -91,7 +91,8 @@ xi.battlefield.returnCode =
     INCREMENT_REQUEST = 3,
     LOCKED            = 4,
     REQS_NOT_MET      = 5,
-    BATTLEFIELD_FULL  = 6
+    BATTLEFIELD_FULL  = 6,
+    PARTY_ENGAGED     = 9, -- Used as 2nd parameter to LOCKED
 }
 
 xi.battlefield.leaveCode =
@@ -777,6 +778,16 @@ end
 -- will still send the appropriate position packet, but not change the values for the player.
 
 function Battlefield:onEntryEventUpdate(player, csid, option, npc)
+    -- Can't enter if party locked the battlefield
+    local isEnteringExisting = player:getLocalVar('[BCNM]EnterExisting') == 1
+    if isEnteringExisting and not player:hasStatusEffect(xi.effect.BATTLEFIELD) then
+        player:setLocalVar('[BCNM]EnterExisting', 0)
+        player:setLocalVar('[battlefield]area', 0)
+        player:updateEvent(xi.battlefield.returnCode.LOCKED, xi.battlefield.returnCode.PARTY_ENGAGED)
+        player:setLocalVar('noPosUpdate', 1)
+        return 0
+    end
+
     local clearTime = 1
     local name      = 'Meme'
     local partySize = 1

--- a/src/map/ai/states/death_state.cpp
+++ b/src/map/ai/states/death_state.cpp
@@ -54,7 +54,7 @@ CDeathState::CDeathState(CBattleEntity* PEntity, timer::duration death_time)
 bool CDeathState::Update(timer::time_point tick)
 {
     // It's completed
-    if (IsCompleted() || m_PEntity->animation != ANIMATION_DEATH)
+    if (IsCompleted() || !m_PEntity->isDead())
     {
         return true;
     }

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -850,19 +850,19 @@ bool CBattlefield::Cleanup(timer::time_point time, bool force)
 
 bool CBattlefield::CheckInProgress()
 {
-    // clang-format off
-    ForEachEnemy([&](CMobEntity* PMob)
-    {
-        if (!PMob->PEnmityContainer->GetEnmityList()->empty())
-        {
-            if (m_Status == BATTLEFIELD_STATUS_OPEN)
-            {
-                SetStatus(BATTLEFIELD_STATUS_LOCKED);
-            }
-            m_Attacked = true;
-        }
-    });
-    // clang-format on
+    ForEachEnemy([&](const CMobEntity* PMob)
+                 {
+                     // Any entry in enmity list or currently chasing someone
+                     if (!PMob->PEnmityContainer->GetEnmityList()->empty() || PMob->GetBattleTargetID())
+                     {
+                         if (m_Status == BATTLEFIELD_STATUS_OPEN)
+                         {
+                             SetStatus(BATTLEFIELD_STATUS_LOCKED);
+                         }
+
+                         m_Attacked = true;
+                     }
+                 });
 
     // mobs might have 0 enmity but we wont allow anymore players to enter
     return m_Status != BATTLEFIELD_STATUS_OPEN;

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -3168,7 +3168,7 @@ void CCharEntity::tryStartNextEvent()
         }
         else
         {
-            animation = ANIMATION_NONE;
+            animation = this->isDead() ? ANIMATION_DEATH : ANIMATION_NONE;
         }
 
         sendServerStatus_ = true;

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2272,13 +2272,6 @@ int32 OnEventFinish(CCharEntity* PChar, uint16 eventID, uint32 result)
         return -1;
     }
 
-    if (PChar->currentEvent->scriptFile.find("/bcnms/") > 0 && PChar->health.hp <= 0)
-    { // for some reason the event doesnt enforce death afterwards
-        PChar->animation = ANIMATION_DEATH;
-        PChar->pushPacket<GP_SERV_COMMAND_RES>(PChar, GP_SERV_COMMAND_RES_TYPE::Homepoint);
-        PChar->updatemask |= UPDATE_HP;
-    }
-
     return 0;
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Tweaks the conditions leading to Death AI state being cleared
  - Animation check is deeply unreliable and was causing dead players being expelled from a BCNM to be killed twice as it was playing the event and as the event finished (on top of the original death so 3 times)
-  Tweaked some of the recent code changes to also reset the player to ANIMATION_DEATH on event end if PC is dead
- Removed a piece of dead code that might have been used in the past to handle that very specific case but never triggers today
- Tweaked the BCNM lock check to also check if any mob is currently chasing someone so that the BCNM gets locked on any aggro (supertanking)
- Added retail accurate event update for BCNM being locked due to mobs being engaged

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
