### PR TITLE
fix: Store calculated weapon delay in uint32

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -450,10 +450,10 @@ bool CBattleEntity::Rest(float rate)
     return didRest;
 }
 
-uint16 CBattleEntity::GetWeaponDelay(bool tp)
+uint32 CBattleEntity::GetWeaponDelay(bool tp)
 {
     TracyZoneScoped;
-    uint16 finalDelay = 8000; // 480 (base) * 1000 / 60 (milisecond conversion)
+    uint32 finalDelay = 8000; // 480 (base) * 1000 / 60 (milisecond conversion)
 
     if (auto* weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_MAIN]))
     {
@@ -524,7 +524,7 @@ uint16 CBattleEntity::GetWeaponDelay(bool tp)
 
         // Store upper and lower values.
         uint16 minDelay = weaponDelay * 0.2;
-        uint16 maxDelay = weaponDelay * 2;
+        uint32 maxDelay = weaponDelay * 2;
 
         // Apply delay modifications.
         finalDelay = weaponDelay - martialArts;
@@ -533,7 +533,7 @@ uint16 CBattleEntity::GetWeaponDelay(bool tp)
         finalDelay = finalDelay * delayModMultiplier;
 
         // Clamp
-        finalDelay = std::clamp<uint16>(finalDelay, minDelay, maxDelay);
+        finalDelay = std::clamp<uint32>(finalDelay, minDelay, maxDelay);
     }
 
     return finalDelay;

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -378,7 +378,7 @@ public:
     void  UpdateHealth(); // recalculation of the maximum amount of hp and mp, as well as adjusting their current values
     uint8 UpdateSpeed(bool run = false) override;
 
-    uint16 GetWeaponDelay(bool tp);              // returns delay of combined weapons
+    uint32 GetWeaponDelay(bool tp);              // returns delay of combined weapons
     float  GetMeleeRange() const;                // returns the distance considered to be within melee range of the entity
     int16  GetRangedWeaponDelay(bool forTPCalc); // returns delay of ranged weapon + ammo where applicable
     int16  GetAmmoDelay();                       // returns delay of ammo (for cooldown between shots)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
RDM/NIN with relic dagger + relic sword leads to an assertion failure on the clamp as the combined delay exceeds uint16

Closes #8724

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
