### PR TITLE
[core] Trigger onPlayerAbilityUse for all PC abilities

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1901,21 +1901,21 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
 
             if (value < 0)
             {
-                actionResult.messageID = ability::GetAbsorbMessage(static_cast<MSGBASIC_ID>(actionResult.messageID));
+                actionResult.messageID = ability::GetAbsorbMessage(actionResult.messageID);
                 actionResult.param     = -value;
             }
 
             state.ApplyEnmity();
+        }
 
-            // Some mobs respond to abilities (ex. Absolute Virtue / Ob)
-            for (CBattleEntity* PBattleEntity : *PNotorietyContainer)
+        // Some mobs respond to abilities (ex. Absolute Virtue / Ob)
+        for (CBattleEntity* PBattleEntity : *PNotorietyContainer)
+        {
+            if (auto* PMob = dynamic_cast<CMobEntity*>(PBattleEntity))
             {
-                if (CMobEntity* PMob = dynamic_cast<CMobEntity*>(PBattleEntity))
+                if (PMob->getMobMod(MOBMOD_ABILITY_RESPONSE) && PMob->getZone() == this->getZone())
                 {
-                    if (PMob->getMobMod(MOBMOD_ABILITY_RESPONSE) && PMob->getZone() == this->getZone())
-                    {
-                        luautils::OnPlayerAbilityUse(PMob, this, PAbility);
-                    }
+                    luautils::OnPlayerAbilityUse(PMob, this, PAbility);
                 }
             }
         }
@@ -1924,13 +1924,6 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
         StatusEffectContainer->DelStatusEffect(PAbility->getPostActionEffectCleanup());
 
         charutils::ApplyAbilityRecast(this, PAbility, charge, baseChargeTime, action.recast);
-
-        // TODO: refactor
-        //  if (this->getMijinGakure())
-        //{
-        //     m_ActionType = ACTION_FALL;
-        //     ActionFall();
-        // }
     }
     else if (errMsg)
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Triggers `onPlayerAbilityUse` on mobs making use of it (mostly AV) for any PC abilities. 

The existing code is using an if (petskill) / elseif (aoe abilities) / else construct that only calls the lua function in the else branch. This means **Benediction** for example does not call the lua function (unless you're solo which is kinda stupid in its own right)

This PR also means preparing petskills will trigger it which somewhat goes against the semantics of `onPlayerAbilityUse` but I figure that's probably okay since it's technically a player ability.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Credits @wccbuck for steps to reproduce

## Steps to test these changes
Fight AV (with debug) as WHM partied, use Benediction, watch it get logged.

<!-- Clear and detailed steps to test your changes here -->
