### PR TITLE
[Chore] Rename some mob entity functions and correct parameters fed to them

### DIFF
--- a/scripts/globals/pets/avatar.lua
+++ b/scripts/globals/pets/avatar.lua
@@ -148,12 +148,12 @@ xi.pets.avatar.onMobDeath = function(pet)
     end
 end
 
-xi.pets.avatar.onMobMagicPrepare = function(pet)
+-- Is this unused? wtf is this for?
+xi.pets.avatar.onMobSpellChoose = function(pet)
     -- Note that:
     -- returning -1 (or a spell the spirit cannot cast) in this function forces TryCastSpell to exit without choosing/casting a spell, but
     -- will still set the m_LastMagicTime to ensure next call of this function is after the cast delay
     -- Also, if we return nothing (or zero) TryCastSpell will default to normal mob casting behavior (nukes from spell list, etc)
-    printDebug(pet, string.format('onMobMagicPrepare: %u', pet:getMobMod(xi.mobMod.MAGIC_COOL))) -- for debugging magic cooldown
     local master = pet:getMaster()
     if
         not master or

--- a/scripts/specs/types/MobEntity.lua
+++ b/scripts/specs/types/MobEntity.lua
@@ -30,7 +30,7 @@
 ---@field onMobWeaponSkill? fun(target: CBaseEntity, mob: CBaseEntity, mobSkill: CMobSkill, action: CAction): integer?
 ---@field onMobSkillTarget? fun(target: CBaseEntity, mob: CBaseEntity, mobSkill: CMobSkill): CBaseEntity?
 ---@field onAdditionalEffect? fun(mob: CBaseEntity, target: CBaseEntity, damage: integer): (integer?, integer?, integer?)
----@field onMobMagicPrepare? fun(mob: CBaseEntity, target: CBaseEntity, spell: CSpell?): xi.magic.spell|0?
+---@field onMobSpellChoose? fun(mob: CBaseEntity, target: CBaseEntity, spell: CSpell?): xi.magic.spell|0?
 ---@field onWeaponskillHit? fun(mob: CBaseEntity, attacker: CBaseEntity, weaponskillId: xi.weaponskill)
 ---@field onSpikesDamage? fun(mob: CBaseEntity, target: CBaseEntity, damage: integer): (integer?, integer?, integer?)
 ---@field onMagicHit? fun(caster: CBaseEntity, target: CBaseEntity, spell: CSpell)

--- a/scripts/specs/types/MobEntity.lua
+++ b/scripts/specs/types/MobEntity.lua
@@ -26,7 +26,7 @@
 ---@field onMobRoam? fun(mob: CBaseEntity)
 ---@field onMobDespawn? fun(mob: CBaseEntity)
 ---@field onPlayerAbilityUse? fun(mob: CBaseEntity, player: CBaseEntity, ability: CAbility)
----@field onMobWeaponSkillPrepare? fun(mob: CBaseEntity, target: CBaseEntity): integer?
+---@field onMobMobskillChoose? fun(mob: CBaseEntity, target: CBaseEntity): integer?
 ---@field onMobWeaponSkill? fun(target: CBaseEntity, mob: CBaseEntity, mobSkill: CMobSkill, action: CAction): integer?
 ---@field onMobSkillTarget? fun(target: CBaseEntity, mob: CBaseEntity, mobSkill: CMobSkill): CBaseEntity?
 ---@field onAdditionalEffect? fun(mob: CBaseEntity, target: CBaseEntity, damage: integer): (integer?, integer?, integer?)

--- a/scripts/zones/Abyssea-Konschtat/mobs/Hadal_Satiator.lua
+++ b/scripts/zones/Abyssea-Konschtat/mobs/Hadal_Satiator.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/families/gorger_nm') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local tpMoves =
     {
         xi.mobSkill.PROMYVION_BARRIER_2,

--- a/scripts/zones/Abyssea-La_Theine/mobs/Briareus.lua
+++ b/scripts/zones/Abyssea-La_Theine/mobs/Briareus.lua
@@ -50,7 +50,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local cueMove = mob:getLocalVar('CUE_MOVE')
     mob:setLocalVar('CUE_MOVE', 0)
 

--- a/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
@@ -225,7 +225,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     if mob:getAnimationSub() == 1 then
         mob:setLocalVar('skill_tp', mob:getTP())
     end

--- a/scripts/zones/Aydeewa_Subterrane/mobs/Great_Ameretat.lua
+++ b/scripts/zones/Aydeewa_Subterrane/mobs/Great_Ameretat.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts.mixins.families.morbol_toau') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     return target:countEffectWithFlag(xi.effectFlag.DISPELABLE) > 0 and xi.mobSkill.VAMPIRIC_ROOT or 0
 end
 

--- a/scripts/zones/Balgas_Dais/mobs/Giant_Moa.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Giant_Moa.lua
@@ -27,7 +27,7 @@ local mobskillTable =
     [4] = { xi.mobSkill.CONTAGION_TRANSFER,      40 },
 }
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local randomRoll = math.random(1, 100)
     local weightSum  = 0
     for i = 1, #mobskillTable do

--- a/scripts/zones/Balgas_Dais/mobs/Gilagoge_Tlugvi.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Gilagoge_Tlugvi.lua
@@ -42,7 +42,7 @@ end
 -----------------------------------
 -- Only uses one TP move.
 -----------------------------------
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     return xi.mobSkill.ENTANGLE
 end
 

--- a/scripts/zones/Balgas_Dais/mobs/Goga_Tlugvi.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Goga_Tlugvi.lua
@@ -40,7 +40,7 @@ end
 -----------------------------------
 -- Only uses one TP move.
 -----------------------------------
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     return xi.mobSkill.LEAFSTORM
 end
 

--- a/scripts/zones/Balgas_Dais/mobs/Gola_Tlugvi.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Gola_Tlugvi.lua
@@ -41,7 +41,7 @@ end
 -----------------------------------
 -- Only uses one TP move.
 -----------------------------------
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     return xi.mobSkill.DRILL_BRANCH
 end
 

--- a/scripts/zones/Balgas_Dais/mobs/King_of_Batons.lua
+++ b/scripts/zones/Balgas_Dais/mobs/King_of_Batons.lua
@@ -36,7 +36,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
     return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.HP_DRAIN, { power = math.random(25, 125) })
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
         xi.magic.spell.FIRE_IV,
@@ -62,6 +62,7 @@ entity.onMobMagicPrepare = function(mob, target, spellId)
         xi.magic.spell.ASPIR,
         xi.magic.spell.BLAZE_SPIKES,
     }
+
     return spellList[math.random(1, #spellList)]
 end
 

--- a/scripts/zones/Balgas_Dais/mobs/King_of_Coins.lua
+++ b/scripts/zones/Balgas_Dais/mobs/King_of_Coins.lua
@@ -36,7 +36,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
     return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.DISPEL)
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
         xi.magic.spell.FIRE_III,

--- a/scripts/zones/Balgas_Dais/mobs/King_of_Cups.lua
+++ b/scripts/zones/Balgas_Dais/mobs/King_of_Cups.lua
@@ -36,7 +36,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
     return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ABSORB_STATUS)
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
         xi.magic.spell.BANISH_III,
@@ -58,6 +58,7 @@ entity.onMobMagicPrepare = function(mob, target, spellId)
         xi.magic.spell.PROTECT_IV,
         xi.magic.spell.ERASE,
     }
+
     return spellList[math.random(1, #spellList)]
 end
 

--- a/scripts/zones/Balgas_Dais/mobs/King_of_Swords.lua
+++ b/scripts/zones/Balgas_Dais/mobs/King_of_Swords.lua
@@ -36,7 +36,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
     return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ATTACK_DOWN)
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
         xi.magic.spell.PROTECT_IV,

--- a/scripts/zones/Balgas_Dais/mobs/Nenaunir.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Nenaunir.lua
@@ -21,13 +21,14 @@ entity.onMobEngage = function(mob, target)
     mob:useMobAbility(xi.mobSkill.WHISTLE)
 end
 
-entity.onMobMagicPrepare = function(mob, spell)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
         xi.magic.spell.DIAGA,
         xi.magic.spell.STONE_II,
         xi.magic.spell.BIND
     }
+
     return spellList[math.random(1, #spellList)]
 end
 

--- a/scripts/zones/Balgas_Dais/mobs/Nenaunir.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Nenaunir.lua
@@ -33,7 +33,7 @@ entity.onMobSpellChoose = function(mob, target, spellId)
 end
 
 -- Only uses Healing Breeze as a weapon skill.
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     return xi.mobSkill.HEALING_BREEZE
 end
 

--- a/scripts/zones/Balgas_Dais/mobs/Nenaunirs_Wife.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Nenaunirs_Wife.lua
@@ -15,7 +15,7 @@ entity.onMobEngage = function(mob, target)
 end
 
 -- Only uses Stomping as a weapon skill.
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     return xi.mobSkill.STOMPING
 end
 

--- a/scripts/zones/Balgas_Dais/mobs/Queen_of_Batons.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Queen_of_Batons.lua
@@ -26,7 +26,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
     return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.PARALYZE)
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
         xi.magic.spell.FIRE_IV,
@@ -52,6 +52,7 @@ entity.onMobMagicPrepare = function(mob, target, spellId)
         xi.magic.spell.ASPIR,
         xi.magic.spell.BLAZE_SPIKES,
     }
+
     return spellList[math.random(1, #spellList)]
 end
 

--- a/scripts/zones/Balgas_Dais/mobs/Queen_of_Cups.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Queen_of_Cups.lua
@@ -26,7 +26,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
     return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.SILENCE)
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
         xi.magic.spell.BANISH_III,

--- a/scripts/zones/Balgas_Dais/mobs/Ulagohvsdi_Tlugvi.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Ulagohvsdi_Tlugvi.lua
@@ -62,7 +62,7 @@ end
 -----------------------------------
 -- Only uses one TP move.
 -----------------------------------
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     return xi.mobSkill.PINECONE_BOMB
 end
 

--- a/scripts/zones/Balgas_Dais/mobs/Ulagohvsdi_Tlugvi.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Ulagohvsdi_Tlugvi.lua
@@ -16,42 +16,6 @@ local entity = {}
 -- TODO: TP move characteristics (like AOE type). Update the TP move lua file if necessary.
 -- TODO: Check if the next tree is already aggroed and targeting someone else, does it switch to the 2HR'ing mobs target?
 
-local elementalNinjutsuWeights =
-{
-    { id = xi.magic.spell.DOTON_NI,  chance = 15 },
-    { id = xi.magic.spell.HUTON_NI,  chance = 40 },
-    { id = xi.magic.spell.HYOTON_NI, chance = 5  },
-    { id = xi.magic.spell.KATON_NI,  chance = 5  },
-    { id = xi.magic.spell.RAITON_NI, chance = 20 },
-    { id = xi.magic.spell.SUITON_NI, chance = 15 },
-}
-
-local enfeebleNinjutsuWeights =
-{
-    { id = xi.magic.spell.KURAYAMI_NI, chance = 15 },
-    { id = xi.magic.spell.DOKUMORI_NI, chance = 50 },
-    { id = xi.magic.spell.HOJO_NI,     chance = 25 },
-    { id = xi.magic.spell.JUBAKU_NI,   chance = 10 },
-}
-
------------------------------------
--- Reroll spells with proper weights.
------------------------------------
-local reRollActionWeights = function(weights)
-    local abilityRoll    = math.random(1, 100)
-    local probabilitySum = 0
-
-    for _, skill in ipairs(weights) do
-        probabilitySum = probabilitySum + skill.chance
-
-        if abilityRoll <= probabilitySum then
-            return skill.id
-        end
-    end
-
-    return 0
-end
-
 -----------------------------------
 -- Enable additional effects on melee.
 -----------------------------------
@@ -77,24 +41,22 @@ end
 -----------------------------------
 -- Ninjutsu usage is not evenly distributed.
 -----------------------------------
-entity.onMobMagicPrepare = function(mob, target, spell)
-    local spellID = spell:getID()
+entity.onMobSpellChoose = function(mob, target, spellId)
+    local spellList =
+    {
+        xi.magic.spell.DOKUMORI_NI,
+        xi.magic.spell.DOTON_NI,
+        xi.magic.spell.HOJO_NI,
+        xi.magic.spell.HUTON_NI,
+        xi.magic.spell.HYOTON_NI,
+        xi.magic.spell.JUBAKU_NI,
+        xi.magic.spell.KATON_NI,
+        xi.magic.spell.KURAYAMI_NI,
+        xi.magic.spell.RAITON_NI,
+        xi.magic.spell.SUITON_NI,
+    }
 
-    -- If we're casting elemental ninjutsu then follow the weights.
-    for _, spellData in ipairs(elementalNinjutsuWeights) do
-        if spellData.id == spellID then
-            return reRollActionWeights(elementalNinjutsuWeights)
-        end
-    end
-
-    -- If we're casting enfeebling ninjutsu then follow the weights.
-    for _, spellData in ipairs(enfeebleNinjutsuWeights) do
-        if spellData.id == spellID then
-            return reRollActionWeights(enfeebleNinjutsuWeights)
-        end
-    end
-
-    return spellID
+    return spellList[math.random(1, #spellList)]
 end
 
 -----------------------------------

--- a/scripts/zones/Bearclaw_Pinnacle/mobs/Snow_Devil_blm.lua
+++ b/scripts/zones/Bearclaw_Pinnacle/mobs/Snow_Devil_blm.lua
@@ -20,13 +20,14 @@ entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.DESPAWN_TIME_REDUCTION, 15)
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
         xi.magic.spell.ICE_THRENODY,
         xi.magic.spell.BLIZZARD_IV,
         xi.magic.spell.BLIZZAGA_III,
     }
+
     return spellList[math.random(1, #spellList)]
 end
 

--- a/scripts/zones/Beaucedine_Glacier_[S]/mobs/Dryptotaur.lua
+++ b/scripts/zones/Beaucedine_Glacier_[S]/mobs/Dryptotaur.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/families/tauri') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local tpMoves =
     {
         xi.mobSkill.TRICLIP_1,

--- a/scripts/zones/Bhaflau_Thickets/mobs/Ameretat.lua
+++ b/scripts/zones/Bhaflau_Thickets/mobs/Ameretat.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts.mixins.families.morbol_toau') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     return target:countEffectWithFlag(xi.effectFlag.DISPELABLE) > 0 and xi.mobSkill.VAMPIRIC_ROOT or 0
 end
 

--- a/scripts/zones/Boneyard_Gully/mobs/Shikaree_X.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Shikaree_X.lua
@@ -174,7 +174,7 @@ end
 -----------------------------------
 -- Solo weaponskill messages.
 -----------------------------------
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     if mob:getLocalVar('scStep') == 0 then
         mob:messageText(mob, messages.SOLO_WEAPONSKILL)
     end

--- a/scripts/zones/Boneyard_Gully/mobs/Shikaree_Y.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Shikaree_Y.lua
@@ -177,7 +177,7 @@ end
 -----------------------------------
 -- Solo weaponskill messages.
 -----------------------------------
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     if mob:getLocalVar('scStep') == 0 then
         mob:messageText(mob, messages.SOLO_WEAPONSKILL)
     end

--- a/scripts/zones/Castle_Zvahl_Keep_[S]/mobs/Titanotaur.lua
+++ b/scripts/zones/Castle_Zvahl_Keep_[S]/mobs/Titanotaur.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/families/tauri') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local tpMoves =
     {
         xi.mobSkill.TRICLIP_1,

--- a/scripts/zones/Dynamis-Beaucedine/mobs/Angra_Mainyu.lua
+++ b/scripts/zones/Dynamis-Beaucedine/mobs/Angra_Mainyu.lua
@@ -32,26 +32,21 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
-    if mob:getHPP() <= 25 then
-        return 244 -- Death
-    else
-        -- Can cast Blindga, Death, Graviga, Silencega, and Sleepga II.
-        -- Casts Graviga every time before he teleports.
-        local rnd = math.random(1, 100)
+entity.onMobSpellChoose = function(mob, target, spellId)
+    local spellList =
+    {
+        xi.magic.spell.BLINDGA,
+        xi.magic.spell.DEATH,
+        xi.magic.spell.GRAVIGA,
+        xi.magic.spell.SLEEPGA_II,
+        xi.magic.spell.SILENCEGA,
+    }
 
-        if rnd <= 20 then
-            return 361 -- Blindga
-        elseif rnd <= 40 then
-            return 244 -- Death
-        elseif rnd <= 60 then
-            return 366 -- Graviga
-        elseif rnd <= 80 then
-            return 274 -- Sleepga II
-        else
-            return 359 -- Silencega
-        end
+    if mob:getHPP() <= 25 then
+        return xi.magic.spell.DEATH
     end
+
+    return spellList[math.random(1, #spellList)]
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Dynamis-Valkurm/mobs/Cirrate_Christelle.lua
+++ b/scripts/zones/Dynamis-Valkurm/mobs/Cirrate_Christelle.lua
@@ -16,7 +16,7 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.WEAPON_BONUS, 50)
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     -- TODO: Need to implement skill ID changes based on which NMs were killed. Needs more captures.
 end
 

--- a/scripts/zones/Dynamis-Valkurm/mobs/Nantina.lua
+++ b/scripts/zones/Dynamis-Valkurm/mobs/Nantina.lua
@@ -12,7 +12,7 @@ entity.onMobSpawn = function(mob)
     mob:setLocalVar('nantina_skill_count', 0)
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     -- Blow x9 > Uppercut x3 > Attractant
     local skillCount = mob:getLocalVar('nantina_skill_count')
 

--- a/scripts/zones/Full_Moon_Fountain/mobs/Carbuncle_Prime.lua
+++ b/scripts/zones/Full_Moon_Fountain/mobs/Carbuncle_Prime.lua
@@ -20,7 +20,7 @@ entity.onMobSpawn = function(mob)
     mob:addImmunity(xi.immunity.GRAVITY)
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     -- use healing_ruby_ii with only a 5% chance (as much rarer than the other carby skills)
     if math.random(1, 20) == 1 then
         return 911

--- a/scripts/zones/Ghelsba_Outpost/mobs/Cyranuce_M_Cutauleon.lua
+++ b/scripts/zones/Ghelsba_Outpost/mobs/Cyranuce_M_Cutauleon.lua
@@ -11,7 +11,7 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     if mob:getHPP() <= 15 then
         return xi.mobSkill.CHAOS_BREATH
     end

--- a/scripts/zones/Grauberg_[S]/mobs/Vasiliceratops.lua
+++ b/scripts/zones/Grauberg_[S]/mobs/Vasiliceratops.lua
@@ -30,7 +30,7 @@ entity.onMobInitialize = function(mob)
     mob:setBaseSpeed(100)
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     return 2099 -- Batterhorn is only TP move
 end
 

--- a/scripts/zones/Hazhalm_Testing_Grounds/mobs/Freke.lua
+++ b/scripts/zones/Hazhalm_Testing_Grounds/mobs/Freke.lua
@@ -34,7 +34,7 @@ entity.onMobSpawn = function(mob)
     mob:setLocalVar('gohSequence', 0)
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local gohSequence = mob:getLocalVar('gohSequence')
 
     if gohSequence == 1 then

--- a/scripts/zones/Hazhalm_Testing_Grounds/mobs/Hakenmann.lua
+++ b/scripts/zones/Hazhalm_Testing_Grounds/mobs/Hakenmann.lua
@@ -32,7 +32,7 @@ entity.onMobSpawn = function(mob)
     mob:setLocalVar('tpMoveCount', 3)
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     if mob:getLocalVar('tpMoveCount') == 0 then
         mob:setLocalVar('tpMoveCount', 3)
     end

--- a/scripts/zones/Hazhalm_Testing_Grounds/mobs/Hildesvini.lua
+++ b/scripts/zones/Hazhalm_Testing_Grounds/mobs/Hildesvini.lua
@@ -30,7 +30,7 @@ entity.onMobSpawn = function(mob)
     despawnDjiggas()
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local anyAlive = utils.any(DJIGGAS, function(_, mobId)
         local djigga = GetMobByID(mobId)
         if djigga and djigga:isAlive() then

--- a/scripts/zones/Hazhalm_Testing_Grounds/mobs/Mokkuralfi.lua
+++ b/scripts/zones/Hazhalm_Testing_Grounds/mobs/Mokkuralfi.lua
@@ -20,7 +20,7 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 10)
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     if
         mob:getHPP() <= 20 and
         mob:getLocalVar('xenoglossia') == 0

--- a/scripts/zones/Hazhalm_Testing_Grounds/mobs/Mokkuralfi.lua
+++ b/scripts/zones/Hazhalm_Testing_Grounds/mobs/Mokkuralfi.lua
@@ -31,7 +31,7 @@ entity.onMobWeaponSkillPrepare = function(mob, target)
     end
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     if mob:getLocalVar('tga4Next') ~= 0 then
         mob:setLocalVar('tga4Next', 0)
         return xi.magic.spell.THUNDAGA_IV

--- a/scripts/zones/Hazhalm_Testing_Grounds/mobs/Motsognir.lua
+++ b/scripts/zones/Hazhalm_Testing_Grounds/mobs/Motsognir.lua
@@ -90,30 +90,31 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobWeaponSkillPrepare = function(mob)
+entity.onMobMobskillChoose = function(mob, target)
     -- Motsognir gains access to more TP moves as its HP goes down
-    local mobHPP = mob:getHPP()
-    local skills =
+    local mobskillList =
     {
         xi.mobSkill.HELLSNAP,
         xi.mobSkill.HELLCLAP,
         xi.mobSkill.CACKLE,
     }
 
+    local mobHPP = mob:getHPP()
+
     if mobHPP <= 75 then
-        table.insert(skills, xi.mobSkill.NECROBANE)
-        table.insert(skills, xi.mobSkill.NECROPURGE)
+        table.insert(mobskillList, xi.mobSkill.NECROBANE)
+        table.insert(mobskillList, xi.mobSkill.NECROPURGE)
     end
 
     if mobHPP <= 50 then
-        table.insert(skills, xi.mobSkill.BILGESTORM)
+        table.insert(mobskillList, xi.mobSkill.BILGESTORM)
     end
 
     if mobHPP <= 25 then
-        table.insert(skills, xi.mobSkill.THUNDRIS_SHRIEK)
+        table.insert(mobskillList, xi.mobSkill.THUNDRIS_SHRIEK)
     end
 
-    return utils.randomEntry(skills)
+    return mobskillList[math.random(1, #mobskillList)]
 end
 
 entity.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/zones/Horlais_Peak/mobs/Aries.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Aries.lua
@@ -158,7 +158,7 @@ end
 -----------------------------------
 -- Favors certain moves over others.
 -----------------------------------
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local abilityRoll    = math.random(1, 100)
     local probabilitySum = 0
 

--- a/scripts/zones/Horlais_Peak/mobs/Pilwiz.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Pilwiz.lua
@@ -12,11 +12,8 @@ entity.onMobInitialize = function(mob)
     mob:setMod(xi.mod.SLEEP_MEVA, 50)
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     return xi.magic.spell.STONEGA_II
-end
-
-entity.onMobDeath = function(mob, player, optParams)
 end
 
 return entity

--- a/scripts/zones/Mamook/mobs/Mamool_Ja.lua
+++ b/scripts/zones/Mamook/mobs/Mamool_Ja.lua
@@ -124,7 +124,7 @@ entity.onMobSpawn = function(mob)
     mob:setLocalVar('justSpawned', 1)
 end
 
-entity.onMobWeaponSkillPrepare = function(mob)
+entity.onMobMobskillChoose = function(mob, target)
     if mob:getAnimationSub() >= 1 then
         return xi.mobSkill.FORCEFUL_BLOW -- Will ONLY use Forceful Blow when it's weapon is broken.
     end

--- a/scripts/zones/Misareaux_Coast/mobs/Boggelmann.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Boggelmann.lua
@@ -9,7 +9,7 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local tpMoves =
     {
         xi.mobSkill.AWFUL_EYE,

--- a/scripts/zones/Monarch_Linn/mobs/Mammet-19_Epsilon.lua
+++ b/scripts/zones/Monarch_Linn/mobs/Mammet-19_Epsilon.lua
@@ -79,7 +79,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     switch (mob:getAnimationSub()): caseof
     {
         [forms.UNARMED] = function()

--- a/scripts/zones/Monarch_Linn/mobs/Mammet-800.lua
+++ b/scripts/zones/Monarch_Linn/mobs/Mammet-800.lua
@@ -220,7 +220,7 @@ end
 -----------------------------------
 -- Select TP moves based on current form.
 -----------------------------------
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local selectedMove = math.random(1, #tpMoves)
 
     return tpMoves[selectedMove]

--- a/scripts/zones/Navukgo_Execution_Chamber/mobs/Karababa.lua
+++ b/scripts/zones/Navukgo_Execution_Chamber/mobs/Karababa.lua
@@ -24,7 +24,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local powerup = mob:getLocalVar('powerup')
     local rnd = math.random(1, 6)
     local warp = mob:getLocalVar('warp')
@@ -33,25 +33,25 @@ entity.onMobMagicPrepare = function(mob, target, spellId)
         mob:showText(mob, ID.text.KARABABA_QUIT)
         mob:setLocalVar('warp', 2)
         mob:setLocalVar('wait', GetSystemTime() + 8)
-        return 261
+        return xi.magic.spell.WARP
     elseif rnd == 1 then
         mob:showText(mob, ID.text.KARABARA_FIRE)
-        return 205 - powerup
+        return xi.magic.spell.FLARE_II - powerup
     elseif rnd == 2 then
         mob:showText(mob, ID.text.KARABARA_ICE)
-        return 207 - powerup
+        return xi.magic.spell.FREEZE_II - powerup
     elseif rnd == 3 then
         mob:showText(mob, ID.text.KARABARA_WIND)
-        return 209 - powerup
+        return xi.magic.spell.TORNADO_II - powerup
     elseif rnd == 4 then
         mob:showText(mob, ID.text.KARABARA_EARTH)
-        return 211 - powerup
+        return xi.magic.spell.QUAKE_II - powerup
     elseif rnd == 5 then
         mob:showText(mob, ID.text.KARABARA_LIGHTNING)
-        return 213 - powerup
+        return xi.magic.spell.BURST_II - powerup
     elseif rnd == 6 then
         mob:showText(mob, ID.text.KARABARA_WATER)
-        return 215 - powerup
+        return xi.magic.spell.FLOOD_II - powerup
     end
 end
 

--- a/scripts/zones/Newton_Movalpolos/mobs/Bugbear_Matman.lua
+++ b/scripts/zones/Newton_Movalpolos/mobs/Bugbear_Matman.lua
@@ -15,7 +15,7 @@ entity.onMobSpawn = function(mob)
     mob:addMod(xi.mod.REGAIN, 50)
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     -- Below 30% Bugbear Matman heavily prefers Heavy Whisk
     if mob:getHPP() <= 30 and math.random(1, 100) <= 60 then
         return 358
@@ -27,7 +27,10 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    GetNPCByID(ID.npc.MOBLIN_SHOWMAN):setStatus(xi.status.NORMAL)
+    local showman = GetNPCByID(ID.npc.MOBLIN_SHOWMAN)
+    if showman then
+        showman:setStatus(xi.status.NORMAL)
+    end
 end
 
 return entity

--- a/scripts/zones/North_Gustaberg_[S]/mobs/Olgoi-Khorkhoi.lua
+++ b/scripts/zones/North_Gustaberg_[S]/mobs/Olgoi-Khorkhoi.lua
@@ -45,7 +45,7 @@ entity.onMobSpellChoose = function(mob, target, spellId)
     return spellList[math.random(1, #spellList)]
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     return xi.mobSkill.SANDSPIN -- Sandspin is only TP move
 end
 

--- a/scripts/zones/North_Gustaberg_[S]/mobs/Olgoi-Khorkhoi.lua
+++ b/scripts/zones/North_Gustaberg_[S]/mobs/Olgoi-Khorkhoi.lua
@@ -35,13 +35,14 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 15)
 end
 
-entity.onMobMagicPrepare = function(mob, target)
-    -- uses only stone II and Stonega
-    if math.random(1, 100) <= 50 then
-        return xi.magic.spell.STONE_II
-    end
+entity.onMobSpellChoose = function(mob, target, spellId)
+    local spellList =
+    {
+        xi.magic.spell.STONE_II,
+        xi.magic.spell.STONEGA,
+    }
 
-    return xi.magic.spell.STONEGA
+    return spellList[math.random(1, #spellList)]
 end
 
 entity.onMobWeaponSkillPrepare = function(mob, target)

--- a/scripts/zones/Nyzul_Isle/mobs/Eriri_Samariri.lua
+++ b/scripts/zones/Nyzul_Isle/mobs/Eriri_Samariri.lua
@@ -6,7 +6,7 @@
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     if math.random(1, 4) > 1 then
         return 1957
     end

--- a/scripts/zones/Nyzul_Isle/mobs/Shielded_Chariot.lua
+++ b/scripts/zones/Nyzul_Isle/mobs/Shielded_Chariot.lua
@@ -8,7 +8,7 @@ mixins = { require('scripts/mixins/families/chariot') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     if mob:getHPP() > 25 then
         return 0
     elseif math.random(1, 2) == 2 then

--- a/scripts/zones/Pashhow_Marshlands_[S]/mobs/Sugaar.lua
+++ b/scripts/zones/Pashhow_Marshlands_[S]/mobs/Sugaar.lua
@@ -39,7 +39,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
     return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.SILENCE, { chance = 15, duration = 30 })
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     -- seems overly complicated, but is reusable code for other mobs that use skills in a sequence
     local mobskillList =
     {

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Stegotaur.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Stegotaur.lua
@@ -15,7 +15,7 @@ entity.onMobSpawn = function(mob)
     mob:setLocalVar('fomorHateAdj', 1)
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local tpMoves =
     {
         xi.mobSkill.TRICLIP_1,

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Taurus.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Taurus.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/families/tauri') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local tpMoves =
     {
         xi.mobSkill.TRICLIP_1,

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Tres_Duendes.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Tres_Duendes.lua
@@ -55,7 +55,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local form = mob:getAnimationSub()
     local tpMoves =
     {

--- a/scripts/zones/Promyvion-Vahzl/mobs/Propagator.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Propagator.lua
@@ -11,7 +11,7 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 240)
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local tpMoves =
     {
         xi.mobSkill.PROMYVION_BARRIER_2,

--- a/scripts/zones/Promyvion-Vahzl/mobs/Wailer.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Wailer.lua
@@ -61,7 +61,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     -- Only allow the Memory move that matches the current element
     return elementalTPMoves[mob:getLocalVar('currentAbsorb')]
 end

--- a/scripts/zones/QuBia_Arena/mobs/Air_Pot.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Air_Pot.lua
@@ -32,7 +32,7 @@ entity.onMobEngage = function(mob)
     DespawnMob(mobId + 3) -- Water
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
         xi.magic.spell.GRAVITY,
@@ -41,6 +41,7 @@ entity.onMobMagicPrepare = function(mob, target, spellId)
         xi.magic.spell.AEROGA_III,
         xi.magic.spell.AERO_IV,
     }
+
     return spellList[math.random(1, #spellList)]
 end
 

--- a/scripts/zones/QuBia_Arena/mobs/Anansi.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Anansi.lua
@@ -24,13 +24,14 @@ entity.onAdditionalEffect = function(mob, target, damage)
     return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.POISON, { chance = 20, power = 50, duration = 40 }) -- Very powerful additional effect: poison
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId) -- Anansi only casts Paralyga, Slowga, and Poisonga II
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
         xi.magic.spell.PARALYGA,
         xi.magic.spell.SLOWGA,
         xi.magic.spell.POISONGA_II,
     }
+
     return spellList[math.random(1, #spellList)]
 end
 

--- a/scripts/zones/QuBia_Arena/mobs/Annihilated_Anthony.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Annihilated_Anthony.lua
@@ -32,7 +32,7 @@ entity.onMobEngage = function(mob, target)
     DespawnMob(mobId + 3) -- Punctured Percy
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
         xi.magic.spell.AERO_III,
@@ -59,6 +59,7 @@ entity.onMobMagicPrepare = function(mob, target, spellId)
         xi.magic.spell.TORNADO,
         xi.magic.spell.WATER_III,
     }
+
     return spellList[math.random(1, #spellList)]
 end
 

--- a/scripts/zones/QuBia_Arena/mobs/Earth_Pot.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Earth_Pot.lua
@@ -32,7 +32,7 @@ entity.onMobEngage = function(mob)
     DespawnMob(mobId + 2) -- Water
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
         xi.magic.spell.SLOW,
@@ -41,6 +41,7 @@ entity.onMobMagicPrepare = function(mob, target, spellId)
         xi.magic.spell.STONEGA_III,
         xi.magic.spell.STONE_IV,
     }
+
     return spellList[math.random(1, #spellList)]
 end
 

--- a/scripts/zones/QuBia_Arena/mobs/Fire_Pot.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Fire_Pot.lua
@@ -32,7 +32,7 @@ entity.onMobEngage = function(mob)
     DespawnMob(mobId + 5) -- Water
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
         xi.magic.spell.BURN,
@@ -40,6 +40,7 @@ entity.onMobMagicPrepare = function(mob, target, spellId)
         xi.magic.spell.FIRAGA_III,
         xi.magic.spell.FIRE_IV,
     }
+
     return spellList[math.random(1, #spellList)]
 end
 

--- a/scripts/zones/QuBia_Arena/mobs/Ice_Pot.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Ice_Pot.lua
@@ -32,7 +32,7 @@ entity.onMobEngage = function(mob)
     DespawnMob(mobId + 4) -- Water
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
         xi.magic.spell.PARALYZE,
@@ -41,6 +41,7 @@ entity.onMobMagicPrepare = function(mob, target, spellId)
         xi.magic.spell.BLIZZAGA_III,
         xi.magic.spell.BLIZZARD_IV,
     }
+
     return spellList[math.random(1, #spellList)]
 end
 

--- a/scripts/zones/QuBia_Arena/mobs/Mauled_Murdock.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Mauled_Murdock.lua
@@ -31,7 +31,7 @@ entity.onMobEngage = function(mob, target)
     DespawnMob(mobId + 1) -- Punctured Percy
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
         xi.magic.spell.AERO_III,
@@ -57,6 +57,7 @@ entity.onMobMagicPrepare = function(mob, target, spellId)
         xi.magic.spell.TORNADO,
         xi.magic.spell.WATER_III,
     }
+
     return spellList[math.random(1, #spellList)]
 end
 

--- a/scripts/zones/QuBia_Arena/mobs/Punctured_Percy.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Punctured_Percy.lua
@@ -31,7 +31,7 @@ entity.onMobEngage = function(mob, target)
     DespawnMob(mobId - 1) -- Mauled Murdock
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
         xi.magic.spell.AERO_III,
@@ -57,6 +57,7 @@ entity.onMobMagicPrepare = function(mob, target, spellId)
         xi.magic.spell.TORNADO,
         xi.magic.spell.WATER_III,
     }
+
     return spellList[math.random(1, #spellList)]
 end
 

--- a/scripts/zones/QuBia_Arena/mobs/Shredded_Samson.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Shredded_Samson.lua
@@ -31,7 +31,7 @@ entity.onMobEngage = function(mob, target)
     DespawnMob(mobId + 2) -- Punctured Percy
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
         xi.magic.spell.AERO_III,
@@ -57,6 +57,7 @@ entity.onMobMagicPrepare = function(mob, target, spellId)
         xi.magic.spell.TORNADO,
         xi.magic.spell.WATER_III,
     }
+
     return spellList[math.random(1, #spellList)]
 end
 

--- a/scripts/zones/QuBia_Arena/mobs/Thunder_Pot.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Thunder_Pot.lua
@@ -32,7 +32,7 @@ entity.onMobEngage = function(mob)
     DespawnMob(mobId + 1) -- Water
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
         xi.magic.spell.STUN,
@@ -41,6 +41,7 @@ entity.onMobMagicPrepare = function(mob, target, spellId)
         xi.magic.spell.THUNDAGA_III,
         xi.magic.spell.THUNDER_IV,
     }
+
     return spellList[math.random(1, #spellList)]
 end
 

--- a/scripts/zones/QuBia_Arena/mobs/Water_Pot.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Water_Pot.lua
@@ -32,7 +32,7 @@ entity.onMobEngage = function(mob)
     DespawnMob(mobId - 1) -- Thunder
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
         xi.magic.spell.POISON_II,
@@ -41,6 +41,7 @@ entity.onMobMagicPrepare = function(mob, target, spellId)
         xi.magic.spell.WATERGA_III,
         xi.magic.spell.WATER_IV,
     }
+
     return spellList[math.random(1, #spellList)]
 end
 

--- a/scripts/zones/Rolanberry_Fields_[S]/mobs/Delicieuse_Delphine.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/mobs/Delicieuse_Delphine.lua
@@ -27,7 +27,7 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     mob:setLocalVar('impaleCount', 2)
 
     return 316 -- Impale

--- a/scripts/zones/Rolanberry_Fields_[S]/mobs/Lamina.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/mobs/Lamina.lua
@@ -42,7 +42,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
     return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.SLOW, { chance = 5, duration = 30, power = 10 })
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     return xi.mobSkill.PEDAL_PIROUETTE -- Petal Pirouette is only TP move
 end
 

--- a/scripts/zones/Sacrarium/mobs/Stegotaur.lua
+++ b/scripts/zones/Sacrarium/mobs/Stegotaur.lua
@@ -15,7 +15,7 @@ entity.onMobSpawn = function(mob)
     mob:setLocalVar('fomorHateAdj', 4) -- treated as negative in fomor_hate mixin
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local tpMoves =
     {
         xi.mobSkill.TRICLIP_1,

--- a/scripts/zones/Sacrarium/mobs/Teratotaur.lua
+++ b/scripts/zones/Sacrarium/mobs/Teratotaur.lua
@@ -15,7 +15,7 @@ entity.onMobSpawn = function(mob)
     mob:setLocalVar('fomorHateAdj', 4) -- treated as negative in fomor_hate mixin
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local tpMoves =
     {
         xi.mobSkill.TRICLIP_1,

--- a/scripts/zones/Sealions_Den/mobs/Mammet-22_Zeta.lua
+++ b/scripts/zones/Sealions_Den/mobs/Mammet-22_Zeta.lua
@@ -91,7 +91,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     switch (mob:getAnimationSub()): caseof
     {
         [forms.UNARMED] = function()

--- a/scripts/zones/Sealions_Den/mobs/Ultima.lua
+++ b/scripts/zones/Sealions_Den/mobs/Ultima.lua
@@ -17,7 +17,7 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.SKILL_LIST, 728)
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local stage = mob:getLocalVar('stage')
     if stage == 0 then
         local checker = math.random(1, 100)

--- a/scripts/zones/Spire_of_Dem/mobs/Ingester.lua
+++ b/scripts/zones/Spire_of_Dem/mobs/Ingester.lua
@@ -20,7 +20,7 @@ entity.onMobInitialize = function(mob)
     mob:setMod(xi.mod.DOUBLE_ATTACK, 20)
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     -- 20% chance to prefer Fission
     if
         math.random(1, 100) <= 20 and

--- a/scripts/zones/Spire_of_Dem/mobs/Progenerator.lua
+++ b/scripts/zones/Spire_of_Dem/mobs/Progenerator.lua
@@ -23,7 +23,7 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.WEAPON_BONUS, 15)
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local tpMoves =
     {
         xi.mobSkill.SPIRIT_ABSORPTION_2,

--- a/scripts/zones/Spire_of_Holla/mobs/Cogitator.lua
+++ b/scripts/zones/Spire_of_Holla/mobs/Cogitator.lua
@@ -14,7 +14,7 @@ entity.onMobInitialize = function(mob)
     mob:setMod(xi.mod.DOUBLE_ATTACK, 15)
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local skills =
     {
         xi.mobSkill.NEGATIVE_WHIRL_1,

--- a/scripts/zones/Spire_of_Holla/mobs/Wreaker.lua
+++ b/scripts/zones/Spire_of_Holla/mobs/Wreaker.lua
@@ -19,7 +19,7 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.WEAPON_BONUS, 15)
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local tpMoves =
     {
         xi.mobSkill.SHADOW_SPREAD,

--- a/scripts/zones/Spire_of_Mea/mobs/Delver.lua
+++ b/scripts/zones/Spire_of_Mea/mobs/Delver.lua
@@ -19,7 +19,7 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.WEAPON_BONUS, 15)
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local tpMoves =
     {
         xi.mobSkill.CAROUSEL_1,

--- a/scripts/zones/Spire_of_Vahzl/mobs/Agonizer.lua
+++ b/scripts/zones/Spire_of_Vahzl/mobs/Agonizer.lua
@@ -19,7 +19,7 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.WEAPON_BONUS, 25)
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local tpMoves =
     {
         xi.mobSkill.SHADOW_SPREAD,

--- a/scripts/zones/Spire_of_Vahzl/mobs/Cumulator.lua
+++ b/scripts/zones/Spire_of_Vahzl/mobs/Cumulator.lua
@@ -19,7 +19,7 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.WEAPON_BONUS, 25)
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local tpMoves =
     {
         xi.mobSkill.CAROUSEL_1,

--- a/scripts/zones/Spire_of_Vahzl/mobs/Procreator.lua
+++ b/scripts/zones/Spire_of_Vahzl/mobs/Procreator.lua
@@ -21,7 +21,7 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.WEAPON_BONUS, 25)
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local tpMoves =
     {
         xi.mobSkill.SPIRIT_ABSORPTION_2,

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Ixaern_DRG.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Ixaern_DRG.lua
@@ -105,7 +105,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     -- When Ix'Aern DRG readies a mob skill, all his pets use a corresponding breath attack
     local mobskill, breathSkill = utils.randomEntryIdx(breathList)
     for _, i in ipairs(pets) do

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Ixaern_DRGs_Wynav.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Ixaern_DRGs_Wynav.lua
@@ -19,7 +19,7 @@ entity.onMobSpawn = function(mob)
     xi.mix.jobSpecial.config(mob, { specials = { { id = xi.jsa.SOUL_VOICE, hpp = math.random(10, 75) } } })
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
         xi.magic.spell.ARMYS_PAEON_V,
@@ -31,6 +31,7 @@ entity.onMobMagicPrepare = function(mob, target, spellId)
         xi.magic.spell.CARNAGE_ELEGY,
         xi.magic.spell.MAGIC_FINALE,
     }
+
     if mob:hasStatusEffect(xi.effect.SOUL_VOICE) then
         -- Virelai possible.
         table.insert(spellList, xi.magic.spell.MAIDENS_VIRELAI)

--- a/scripts/zones/Uleguerand_Range/mobs/Brontotaur.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Brontotaur.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/families/tauri') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local tpMoves =
     {
         xi.mobSkill.TRICLIP_1,

--- a/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
@@ -204,7 +204,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     if mob:getAnimationSub() == 1 then
         mob:setLocalVar('skill_tp', mob:getTP())
     end

--- a/scripts/zones/Uleguerand_Range/mobs/Molech.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Molech.lua
@@ -9,7 +9,7 @@ mixins = { require('scripts/mixins/families/tauri') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local tpMoves =
     {
         xi.mobSkill.TRICLIP_1,

--- a/scripts/zones/Uleguerand_Range/mobs/Tyrannotaur.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Tyrannotaur.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/families/tauri') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local tpMoves =
     {
         xi.mobSkill.TRICLIP_1,

--- a/scripts/zones/VeLugannon_Palace/mobs/Zipacna.lua
+++ b/scripts/zones/VeLugannon_Palace/mobs/Zipacna.lua
@@ -328,7 +328,7 @@ entity.onMobSpawn = function(mob)
     end
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     -- Zipacna heavily prefers using Crystal Rain and Crystal Weapon
     local roll = math.random(1, 100)
 

--- a/scripts/zones/Wajaom_Woodlands/mobs/Ameretat.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Ameretat.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts.mixins.families.morbol_toau') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     return target:countEffectWithFlag(xi.effectFlag.DISPELABLE) > 0 and xi.mobSkill.VAMPIRIC_ROOT or 0
 end
 

--- a/scripts/zones/Wajaom_Woodlands/mobs/Great_Ameretat.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Great_Ameretat.lua
@@ -9,7 +9,7 @@ local ID = zones[xi.zone.WAJAOM_WOODLANDS]
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     return target:countEffectWithFlag(xi.effectFlag.DISPELABLE) > 0 and xi.mobSkill.VAMPIRIC_ROOT or 0
 end
 

--- a/scripts/zones/Wajaom_Woodlands/mobs/Jaded_Jody.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Jaded_Jody.lua
@@ -28,7 +28,7 @@ entity.onMobSpawn = function(mob)
     xi.mix.toau_morbol.config(mob, { nightRoaming = 1, })
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     return target:countEffectWithFlag(xi.effectFlag.DISPELABLE) > 0 and xi.mobSkill.VAMPIRIC_ROOT or 0
 end
 

--- a/scripts/zones/Waughroon_Shrine/mobs/Macha.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Macha.lua
@@ -21,7 +21,7 @@ entity.onMobSpellChoose = function(mob, target, spellId)
     return spellList[math.random(1, #spellList)]
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local skillList =
     {
         xi.mobSkill.HELLDIVE_1,

--- a/scripts/zones/Waughroon_Shrine/mobs/Macha.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Macha.lua
@@ -11,12 +11,13 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
         xi.magic.spell.DISPELGA,
         xi.magic.spell.SLEEP,
     }
+
     return spellList[math.random(1, #spellList)]
 end
 

--- a/scripts/zones/Waughroon_Shrine/mobs/Neman.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Neman.lua
@@ -10,7 +10,7 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.CHARMABLE, 1)
 end
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local skillList =
     {
         xi.mobSkill.HELLDIVE_1,

--- a/scripts/zones/Waughroon_Shrine/mobs/Osschaart.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Osschaart.lua
@@ -302,7 +302,7 @@ end
 -----------------------------------
 --- MagicPrepare: Osschaarts spell list
 -----------------------------------
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
         xi.magic.spell.AEROGA_III,
@@ -325,6 +325,7 @@ entity.onMobMagicPrepare = function(mob, target, spellId)
         xi.magic.spell.BIND,
         xi.magic.spell.STUN,
     }
+
     return spellList[math.random(1, #spellList)]
 end
 

--- a/scripts/zones/Waughroon_Shrine/mobs/Princess_Jelly.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Princess_Jelly.lua
@@ -8,18 +8,6 @@ local waughroonID = zones[xi.zone.WAUGHROON_SHRINE]
 ---@type TMobEntity
 local entity = {}
 
-local elementalSpells =
-{
-    { xi.magic.spell.BURN,  xi.magic.spell.FIRE },
-    { xi.magic.spell.DROWN, xi.magic.spell.WATER },
-    { xi.magic.spell.SHOCK, xi.magic.spell.THUNDER },
-    { xi.magic.spell.RASP , xi.magic.spell.STONE },
-    { xi.magic.spell.CHOKE, xi.magic.spell.AERO },
-    { xi.magic.spell.FROST, xi.magic.spell.BLIZZARD },
-    { xi.magic.spell.DIA,   xi.magic.spell.BANISH },
-    { xi.magic.spell.BIO,   xi.magic.spell.DRAIN },
-}
-
 local centers =
 {
     { -177.5,  60, -142 },
@@ -140,17 +128,24 @@ local function spawnQueenJelly(bfNum, target, zone)
     end
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
-    local element = mob:getLocalVar('mobElement')
-    local spell   = math.random(1, 100)
+entity.onMobSpellChoose = function(mob, target, spellId)
+    local spellTable =
+    {
+        [xi.element.FIRE   ] = { xi.magic.spell.BIND, xi.magic.spell.BURN,  xi.magic.spell.FIRE     },
+        [xi.element.ICE    ] = { xi.magic.spell.BIND, xi.magic.spell.FROST, xi.magic.spell.BLIZZARD },
+        [xi.element.WIND   ] = { xi.magic.spell.BIND, xi.magic.spell.CHOKE, xi.magic.spell.AERO     },
+        [xi.element.EARTH  ] = { xi.magic.spell.BIND, xi.magic.spell.RASP , xi.magic.spell.STONE    },
+        [xi.element.THUNDER] = { xi.magic.spell.BIND, xi.magic.spell.SHOCK, xi.magic.spell.THUNDER  },
+        [xi.element.WATER  ] = { xi.magic.spell.BIND, xi.magic.spell.DROWN, xi.magic.spell.WATER    },
+        [xi.element.LIGHT  ] = { xi.magic.spell.BIND, xi.magic.spell.DIA,   xi.magic.spell.BANISH   },
+        [xi.element.DARK   ] = { xi.magic.spell.BIND, xi.magic.spell.BIO,   xi.magic.spell.DRAIN    },
+    }
 
-    if spell > 60 then
-        return elementalSpells[element][1] -- element's DoT
-    elseif spell > 20 then
-        return elementalSpells[element][2] -- element's nuke
-    else
-        return 258
-    end
+    local list      = mob:getLocalVar('mobElement')
+    list            = list > 0 and list or 1
+    local spellList = spellTable[list]
+
+    return spellList[math.random(1, #spellList)]
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/Waughroon_Shrine/mobs/Queen_Jelly.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Queen_Jelly.lua
@@ -20,7 +20,7 @@ entity.onMobSpawn = function(mob)
     mob:setBaseSpeed(60)
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
         xi.magic.spell.FIRE,
@@ -41,6 +41,7 @@ entity.onMobMagicPrepare = function(mob, target, spellId)
         xi.magic.spell.DRAIN,
         xi.magic.spell.BINDGA,
     }
+
     return spellList[math.random(1, #spellList)]
 end
 

--- a/scripts/zones/Waughroon_Shrine/mobs/Titanis_Dax.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Titanis_Dax.lua
@@ -23,7 +23,7 @@ entity.onMobSpawn = function(mob)
     })
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellTable =
     {
         [1] =
@@ -37,7 +37,11 @@ entity.onMobMagicPrepare = function(mob, target, spellId)
             xi.magic.spell.MAGIC_FINALE,
         },
     }
-    local spellList = spellTable[mob:getLocalVar('spellList')]
+
+    local list      = mob:getLocalVar('spellList')
+    list            = list > 0 and list or 1
+    local spellList = spellTable[list]
+
     return spellList[math.random(1, #spellList)]
 end
 

--- a/scripts/zones/Waughroon_Shrine/mobs/Titanis_Jax.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Titanis_Jax.lua
@@ -23,7 +23,7 @@ entity.onMobSpawn = function(mob)
     })
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellTable =
     {
         [1] =
@@ -51,7 +51,11 @@ entity.onMobMagicPrepare = function(mob, target, spellId)
             xi.magic.spell.WIND_CAROL,
         },
     }
-    local spellList = spellTable[mob:getLocalVar('spellList')]
+
+    local list      = mob:getLocalVar('spellList')
+    list            = list > 0 and list or 1
+    local spellList = spellTable[list]
+
     return spellList[math.random(1, #spellList)]
 end
 

--- a/scripts/zones/Waughroon_Shrine/mobs/Titanis_Max.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Titanis_Max.lua
@@ -23,7 +23,7 @@ entity.onMobSpawn = function(mob)
     })
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellTable =
     {
         [1] =
@@ -37,7 +37,11 @@ entity.onMobMagicPrepare = function(mob, target, spellId)
             xi.magic.spell.VALOR_MINUET_IV,
         },
     }
-    local spellList = spellTable[mob:getLocalVar('spellList')]
+
+    local list      = mob:getLocalVar('spellList')
+    list            = list > 0 and list or 1
+    local spellList = spellTable[list]
+
     return spellList[math.random(1, #spellList)]
 end
 

--- a/scripts/zones/Waughroon_Shrine/mobs/Titanis_Xax.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Titanis_Xax.lua
@@ -23,7 +23,7 @@ entity.onMobSpawn = function(mob)
     })
 end
 
-entity.onMobMagicPrepare = function(mob, target, spellId)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellTable =
     {
         [1] =
@@ -37,7 +37,11 @@ entity.onMobMagicPrepare = function(mob, target, spellId)
             xi.magic.spell.CARNAGE_ELEGY,
         },
     }
-    local spellList = spellTable[mob:getLocalVar('spellList')]
+
+    local list      = mob:getLocalVar('spellList')
+    list            = list > 0 and list or 1
+    local spellList = spellTable[list]
+
     return spellList[math.random(1, #spellList)]
 end
 

--- a/scripts/zones/Xarcabard_[S]/mobs/Gorgotaur.lua
+++ b/scripts/zones/Xarcabard_[S]/mobs/Gorgotaur.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/families/tauri') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local tpMoves =
     {
         xi.mobSkill.TRICLIP_1,

--- a/scripts/zones/Xarcabard_[S]/mobs/Tarbotaur.lua
+++ b/scripts/zones/Xarcabard_[S]/mobs/Tarbotaur.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/families/tauri') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobWeaponSkillPrepare = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target)
     local tpMoves =
     {
         xi.mobSkill.TRICLIP_1,

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -496,7 +496,7 @@ auto CMobController::TryCastSpell() -> bool
 
     // Try to get an override spell from the script (if available)
     auto PSpellTarget            = PTarget ? PTarget : PMob;
-    auto possibleOverriddenSpell = luautils::OnMobMagicPrepare(PMob, PSpellTarget, chosenSpellId);
+    auto possibleOverriddenSpell = luautils::OnMobSpellChoose(PMob, PSpellTarget, chosenSpellId);
     if (possibleOverriddenSpell.has_value())
     {
         chosenSpellId = possibleOverriddenSpell;

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -352,7 +352,7 @@ auto CMobController::MobSkill(int listId) -> bool
 
         auto skillList{ battleutils::GetMobSkillList(listId) };
 
-        if (auto overrideSkill = luautils::OnMobWeaponSkillPrepare(PMob, PTarget); overrideSkill > 0)
+        if (auto overrideSkill = luautils::OnMobMobskillChoose(PMob, PTarget); overrideSkill > 0)
         {
             skillList = { overrideSkill };
         }

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -2825,7 +2825,7 @@ void OnSpellInterrupted(CBattleEntity* PCaster, CSpell* PSpell)
     }
 }
 
-std::optional<SpellID> OnMobMagicPrepare(CBattleEntity* PCaster, CBattleEntity* PTarget, std::optional<SpellID> startingSpellId)
+std::optional<SpellID> OnMobSpellChoose(CBattleEntity* PCaster, CBattleEntity* PTarget, std::optional<SpellID> startingSpellId)
 {
     TracyZoneScoped;
 
@@ -2834,8 +2834,8 @@ std::optional<SpellID> OnMobMagicPrepare(CBattleEntity* PCaster, CBattleEntity* 
         return {};
     }
 
-    sol::function onMobMagicPrepare = getEntityCachedFunction(PCaster, "onMobMagicPrepare");
-    if (!onMobMagicPrepare.valid())
+    sol::function onMobSpellChoose = getEntityCachedFunction(PCaster, "onMobSpellChoose");
+    if (!onMobSpellChoose.valid())
     {
         return {};
     }
@@ -2846,11 +2846,11 @@ std::optional<SpellID> OnMobMagicPrepare(CBattleEntity* PCaster, CBattleEntity* 
         PSpell = spell::GetSpell(startingSpellId.value());
     }
 
-    auto result = onMobMagicPrepare(PCaster, PTarget, PSpell);
+    auto result = onMobSpellChoose(PCaster, PTarget, PSpell);
     if (!result.valid())
     {
         sol::error err = result;
-        ShowError("luautils::OnMobMagicPrepare: %s", err.what());
+        ShowError("luautils::OnMobSpellChoose: %s", err.what());
         ReportErrorToPlayer(PCaster, err.what());
         return {};
     }

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -3729,7 +3729,7 @@ std::tuple<int32, uint8, uint8> OnUseWeaponSkill(CBattleEntity* PChar, CBaseEnti
     return std::make_tuple(dmg, tpHitsLanded, extraHitsLanded);
 }
 
-uint16 OnMobWeaponSkillPrepare(CBattleEntity* PMob, CBattleEntity* PTarget)
+uint16 OnMobMobskillChoose(CBattleEntity* PMob, CBattleEntity* PTarget)
 {
     TracyZoneScoped;
 
@@ -3738,17 +3738,17 @@ uint16 OnMobWeaponSkillPrepare(CBattleEntity* PMob, CBattleEntity* PTarget)
         return 0;
     }
 
-    sol::function onMobWeaponSkillPrepare = getEntityCachedFunction(PMob, "onMobWeaponSkillPrepare");
-    if (!onMobWeaponSkillPrepare.valid())
+    sol::function onMobMobskillChoose = getEntityCachedFunction(PMob, "onMobMobskillChoose");
+    if (!onMobMobskillChoose.valid())
     {
         return 0;
     }
 
-    auto result = onMobWeaponSkillPrepare(PMob, PTarget);
+    auto result = onMobMobskillChoose(PMob, PTarget);
     if (!result.valid())
     {
         sol::error err = result;
-        ShowError("luautils::onMobWeaponSkillPrepare: %s", err.what());
+        ShowError("luautils::onMobMobskillChoose: %s", err.what());
         return 0;
     }
 

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -381,7 +381,7 @@ void OnBattlefieldKick(CCharEntity* PChar);
 void OnBattlefieldRegister(CCharEntity* PChar, CBattlefield* PBattlefield);
 void OnBattlefieldDestroy(CBattlefield* PBattlefield);
 
-uint16 OnMobWeaponSkillPrepare(CBattleEntity* PMob, CBattleEntity* PTarget);
+uint16 OnMobMobskillChoose(CBattleEntity* PMob, CBattleEntity* PTarget);
 int32  OnMobWeaponSkill(CBaseEntity* PChar, CBaseEntity* PMob, CMobSkill* PMobSkill, action_t* action);
 int32  OnMobSkillCheck(CBaseEntity* PChar, CBaseEntity* PMob, CMobSkill* PMobSkill); // triggers before mob weapon skill is used, returns 0 if the move is valid
 auto   OnMobSkillTarget(CBattleEntity* PTarget, CBaseEntity* PMob, CMobSkill* PMobSkill) -> CBattleEntity*;

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -340,7 +340,7 @@ int32 OnMagicCastingCheck(CBaseEntity* PChar, CBaseEntity* PTarget, CSpell* PSpe
 int32 OnSpellCast(CBattleEntity* PCaster, CBattleEntity* PTarget, CSpell* PSpell);
 void  OnSpellPrecast(CBattleEntity* PCaster, CSpell* PSpell);
 void  OnSpellInterrupted(CBattleEntity* PCaster, CSpell* PSpell);
-auto  OnMobMagicPrepare(CBattleEntity* PCaster, CBattleEntity* PTarget, std::optional<SpellID> startingSpellId) -> std::optional<SpellID>;
+auto  OnMobSpellChoose(CBattleEntity* PCaster, CBattleEntity* PTarget, std::optional<SpellID> startingSpellId) -> std::optional<SpellID>;
 void  OnMagicHit(CBattleEntity* PCaster, CBattleEntity* PTarget, CSpell* PSpell);
 void  OnWeaponskillHit(CBattleEntity* PMob, CBaseEntity* PAttacker, uint16 PWeaponskill);
 bool  OnTrustSpellCastCheckBattlefieldTrusts(CBattleEntity* PCaster); // Triggered if spell is a trust spell during onCast to determine to interrupt spell or not


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Rename `onMobMagicPrepare` to `onMobSpellChoose`
- Rename `onMobWeaponSkillPrepare` to `onMobMobskillChoose`

For the sake of know what this functions actually do and what they are meant for: Overriding action choices.
With this, the parameters fed to them in lua where also corrected, since they were inconsistently used to say the least.
Spell choosing logic was also audited in lua to be consistent.

## Steps to test these changes

None.
