### PR TITLE
[lua] Broadside Barrage / Blind Side Barrage (Bird Family) Update

### DIFF
--- a/scripts/actions/mobskills/blind_side_barrage.lua
+++ b/scripts/actions/mobskills/blind_side_barrage.lua
@@ -17,12 +17,13 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 1
     local accmod  = 1
     local ftp     = 2.0
+    local power   = 3 + math.floor(mob:getMainLvl() / 5)
     local params  = { canCrit = true }
     local info    = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT, 0, 0, 0, params)
     local dmg     = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.MND_DOWN, 19, 0, 90) -- Does not decay
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.INT_DOWN, 19, 0, 90)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.MND_DOWN, power, 0, 120) -- Does not decay
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.INT_DOWN, power, 0, 120)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg

--- a/scripts/actions/mobskills/broadside_barrage.lua
+++ b/scripts/actions/mobskills/broadside_barrage.lua
@@ -17,12 +17,13 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 1
     local accmod  = 1
     local ftp     = 2.0
+    local power   = 3 + math.floor(mob:getMainLvl() / 5)
     local params  = { canCrit = true }
     local info    = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT, 0, 0, 0, params)
     local dmg     = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STR_DOWN, 19, 0, 90) -- Does not decay
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.VIT_DOWN, 19, 0, 90)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STR_DOWN, power, 0, 120) -- Does not decay
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.VIT_DOWN, power, 0, 120)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg


### PR DESCRIPTION
Updates Blind Side Barrage and Broadside Barrage with findings from Monti

**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Updates the TP moves Blind Side Barrage and Broadside Barrage with the correct stat down formula. 
Monti observed that Riverne Vultures gave -11, and that Bibiki Bay Ravens gave -10. I tested Seaboard Vultures which gave -19, and Tragopans which gave -17. After reviewing this, Winter came up with the formula 3 + math.floor(level / 5), which fits for all birds in our list. 

<img width="572" height="656" alt="image" src="https://github.com/user-attachments/assets/73d49b95-c72a-43d5-bc28-397e438f8f51" />

## Steps to test these changes

Test any of the birds in the screenshot provided and see that the -str, vit, mnd, int now scale with level. 

Thanks again to Monti for pointing this out. 
