### PR TITLE
[lua, sql] Misareaux Coast NM Audit

### DIFF
--- a/scripts/actions/mobskills/soul_accretion.lua
+++ b/scripts/actions/mobskills/soul_accretion.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Soul Accretion
+-- Attempts to absorb one buff from a single target.
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    local dispel = mob:stealStatusEffect(target, bit.bor(xi.effectFlag.DISPELABLE, xi.effectFlag.FOOD))
+    local msg    = xi.msg.basic.SKILL_NO_EFFECT
+
+    if dispel > 0 then
+        msg = xi.msg.basic.EFFECT_DRAINED
+    end
+
+    skill:setMsg(msg)
+
+    return 1
+end
+
+return mobskillObject

--- a/scripts/enum/mob_skill.lua
+++ b/scripts/enum/mob_skill.lua
@@ -79,7 +79,10 @@ xi.mobSkill =
     AWFUL_EYE                =  386,
     HEAVY_BELLOW             =  387,
 
+    ULTRASONICS_1            =  392,
+
     SONIC_BOOM_1             =  393,
+    BLOOD_DRAIN_1            =  394,
     JET_STREAM_1             =  395,
 
     SMITE_OF_FURY            =  396,
@@ -96,6 +99,8 @@ xi.mobSkill =
     SONIC_BLADE              =  422, -- Mammet-800
 
     SANDSPIN                 =  426,
+
+    GLOEOSUCCUS              =  436,
 
     MICROQUAKE               =  441, -- Mammet-800
 
@@ -219,6 +224,9 @@ xi.mobSkill =
     JUDGMENT_BOLT_2          =  918, -- Confirmed usage: Untargetable avatar astral flow. (Ex. Kirin) (Ramuh model avatar)
     SEARING_LIGHT_2          =  919, -- Confirmed usage: Untargetable avatar astral flow. (Ex. Kirin, Crimson-toothed Pawberry) (Carbuncle model avatar)
 
+    GIGA_SCREAM_1            =  923,
+    DREAD_DIVE_1             =  924,
+
     DRILL_BRANCH_NM          =  927,
     PINECONE_BOMB_NM         =  928,
     LEAFSTORM_DISPEL         =  929,
@@ -260,6 +268,9 @@ xi.mobSkill =
     HOWL                     = 1062,
 
     RANGED_ATTACK_3          = 1154,
+
+    SUBSONICS_1              = 1155,
+    MARROW_DRAIN_1           = 1156,
 
     SLIPSTREAM_1             = 1157,
     TURBULENCE_1             = 1158,
@@ -353,6 +364,8 @@ xi.mobSkill =
     RANGED_ATTACK_TENZEN_1   = 1398, -- Tenzen Bow High
     RICEBALL_TENZEN          = 1399,
     RANGED_ATTACK_TENZEN_2   = 1400, -- Tenzen Bow Low
+
+    SOUL_ACCRETION           = 1401,
 
     HOWLING_MOON_3           = 1520, -- Unknown usage.
 

--- a/scripts/zones/Misareaux_Coast/IDs.lua
+++ b/scripts/zones/Misareaux_Coast/IDs.lua
@@ -48,6 +48,7 @@ zones[xi.zone.MISAREAUX_COAST] =
         GIGAS_WARWOLF    = GetTableOfIDs('Gigas_Warwolf'),
         GIGASS_SHEEP     = GetTableOfIDs('Gigass_Sheep'),
         GRATION          = GetFirstID('Gration'),
+        ODQAN            = GetTableOfIDs('Odqan'),
         OKYUPETE         = GetFirstID('Okyupete'),
         PM6_2_MOB_OFFSET = GetFirstID('Warder_Aglaia'),
         ZIPHIUS          = GetFirstID('Ziphius'),

--- a/scripts/zones/Misareaux_Coast/Zone.lua
+++ b/scripts/zones/Misareaux_Coast/Zone.lua
@@ -40,6 +40,23 @@ zoneObject.onGameHour = function(zone)
     end
 end
 
+zoneObject.onZoneWeatherChange = function(weather)
+    local ID = zones[xi.zone.MISAREAUX_COAST]
+    local odqan1 = GetMobByID(ID.mob.ODQAN[1])
+    local odqan2 = GetMobByID(ID.mob.ODQAN[2])
+
+    if weather == xi.weather.FOG and odqan1 and odqan2 then
+        -- Check which Odqan is allowed to spawn
+        if odqan1:getLocalVar('canSpawn') == 1 then
+            DisallowRespawn(odqan1:getID(), false)
+            DisallowRespawn(odqan2:getID(), true)
+        elseif odqan2:getLocalVar('canSpawn') == 1 then
+            DisallowRespawn(odqan2:getID(), false)
+            DisallowRespawn(odqan1:getID(), true)
+        end
+    end
+end
+
 zoneObject.onEventUpdate = function(player, csid, option, npc)
 end
 

--- a/scripts/zones/Misareaux_Coast/mobs/Goaftrap.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Goaftrap.lua
@@ -6,7 +6,17 @@
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMod(xi.mod.DOUBLE_ATTACK, 20)
+    mob:addImmunity(xi.immunity.BIND)
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
+    mob:addImmunity(xi.immunity.GRAVITY)
+    mob:addImmunity(xi.immunity.PLAGUE)
+    mob:addImmunity(xi.immunity.TERROR)
+    mob:setMod(xi.mod.STORETP, 50)
+end
+
+entity.onMobMobskillChoose = function(mob, target)
+    return xi.mobSkill.GLOEOSUCCUS
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Misareaux_Coast/mobs/Odqan.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Odqan.lua
@@ -2,11 +2,40 @@
 -- Area: Misareaux Coast
 --   NM: Odqan
 -----------------------------------
+local ID = zones[xi.zone.MISAREAUX_COAST]
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobRoam = function(mob)
+    local weather = mob:getWeather()
+
+    if weather ~= xi.weather.FOG then
+        DespawnMob(mob:getID())
+    end
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 443)
+end
+
+entity.onMobDespawn = function(mob)
+    local odqan1 = GetMobByID(ID.mob.ODQAN[1])
+    local odqan2 = GetMobByID(ID.mob.ODQAN[2])
+
+    if odqan1 and odqan2 then
+        local respawnTime = math.random(7200, 18000) -- 2 to 5 hours
+
+        if math.random(1, 2) == 1 then
+            odqan1:setLocalVar('canSpawn', 0)
+            odqan2:setLocalVar('canSpawn', 1)
+            odqan2:setRespawnTime(respawnTime)
+        else
+            odqan2:setLocalVar('canSpawn', 0)
+            odqan1:setLocalVar('canSpawn', 1)
+            odqan1:setRespawnTime(respawnTime)
+        end
+    end
 end
 
 return entity

--- a/scripts/zones/Misareaux_Coast/mobs/Okyupete.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Okyupete.lua
@@ -17,6 +17,35 @@ entity.phList =
     [ID.mob.OKYUPETE - 8] = ID.mob.OKYUPETE,
 }
 
+entity.onMobInitialize = function(mob)
+    mob:addImmunity(xi.immunity.BIND)
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
+    mob:addImmunity(xi.immunity.GRAVITY)
+    mob:addImmunity(xi.immunity.PLAGUE)
+    mob:addImmunity(xi.immunity.TERROR)
+    mob:setMod(xi.mod.STORETP, 80)
+end
+
+entity.onMobSpawn = function(mob)
+    mob:setLocalVar('nextMove', xi.mobSkill.GIGA_SCREAM_1)
+end
+
+entity.onMobMobskillChoose = function(mob, target)
+    return mob:getLocalVar('nextMove')
+end
+
+-- Alternates between Giga Scream and Dread Dive
+entity.onMobWeaponSkill = function(target, mob, skill)
+    local skillId = skill:getID()
+
+    if skillId == xi.mobSkill.GIGA_SCREAM_1 then
+        mob:setLocalVar('nextMove', xi.mobSkill.DREAD_DIVE_1)
+    elseif skillId == xi.mobSkill.DREAD_DIVE_1 then
+        mob:setLocalVar('nextMove', xi.mobSkill.GIGA_SCREAM_1)
+    end
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 446)
     xi.magian.onMobDeath(mob, player, optParams, set{ 221, 649, 715, 946 })

--- a/scripts/zones/Misareaux_Coast/mobs/Upyri.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Upyri.lua
@@ -1,21 +1,61 @@
 -----------------------------------
 -- Area: Misareaux Coast
 --   NM: Upyri
--- NOTES/TO DO: Tends to use weapon skills twice in a row during night time, based on retail testing.
--- There is about a 1-2 second delay, and will use the same move twice. He will rarely use a weaponskill 3 times in a row. Let's say about a 10% chance.
--- Will weapon skill normally during the day.
--- Also, may only use Soul Accretion at night.
--- Special Attacks: Hits harder at night than during the day.
--- Earring may or may not drop only if the ToD was at night.
+-- TODO: Determine if earring can only drop at night
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobDeath = function(mob, player, optParams)
+entity.onMobInitialize = function(mob)
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
+    mob:addImmunity(xi.immunity.PETRIFY)
+    mob:addImmunity(xi.immunity.SILENCE)
+    mob:addMod(xi.mod.REGAIN, 150)
+end
+
+entity.onMobMobskillChoose = function(mob, target)
+    local tpMoves =
+    {
+        xi.mobSkill.BLOOD_DRAIN_1,
+        xi.mobSkill.MARROW_DRAIN_1,
+        xi.mobSkill.SUBSONICS_1,
+        xi.mobSkill.ULTRASONICS_1,
+    }
+
+    local totd = VanadielTOTD()
+    if
+        totd == xi.time.NIGHT or
+        totd == xi.time.MIDNIGHT
+    then
+        table.insert(tpMoves, xi.mobSkill.SOUL_ACCRETION)
+    end
+
+    return tpMoves[math.random(1, #tpMoves)]
+end
+
+entity.onMobWeaponSkill = function(target, mob, skill)
+    local skillId     = skill:getID()
+    local totd        = VanadielTOTD()
+    local repeatCount = mob:getLocalVar('repeatSkillCount')
+
+    if
+        (totd == xi.time.NIGHT or totd == xi.time.MIDNIGHT) and
+        (skillId == xi.mobSkill.SOUL_ACCRETION or skillId == xi.mobSkill.BLOOD_DRAIN_1)
+    then
+        if repeatCount < 1 then
+            mob:setLocalVar('repeatSkillCount', repeatCount + 1)
+            mob:queue(0, function(mobArg)
+                mobArg:useMobAbility(skillId)
+            end)
+        else
+            mob:setLocalVar('repeatSkillCount', 0)
+        end
+    end
 end
 
 entity.onMobDespawn = function(mob)
-    mob:setRespawnTime(math.random(75600, 86400))   -- 21 to 24 hr
+    mob:setRespawnTime(math.random(75600, 86400)) -- 21 to 24 hr
 end
 
 return entity

--- a/scripts/zones/Misareaux_Coast/mobs/Ziphius.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Ziphius.lua
@@ -5,6 +5,14 @@
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
+end
+
+entity.onAdditionalEffect = function(mob, target, damage)
+    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENWATER)
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 445)
 end

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -989,7 +989,7 @@ INSERT INTO `mob_groups` VALUES (35,1555,25,'Gigas_Catapulter',330,0,983,0,0,41,
 INSERT INTO `mob_groups` VALUES (36,6279,25,'Orcish_Footsoldier',330,0,283,0,0,41,44,0);
 INSERT INTO `mob_groups` VALUES (37,1592,25,'Gigass_Sheep',0,128,0,0,0,34,36,0);
 INSERT INTO `mob_groups` VALUES (38,6281,25,'Orcish_Gladiator',330,0,3255,0,0,41,44,0);
-INSERT INTO `mob_groups` VALUES (39,2945,25,'Odqan',7200,8,1839,0,0,50,51,0);
+INSERT INTO `mob_groups` VALUES (39,2945,25,'Odqan',7200,0,1839,0,0,50,51,0);
 INSERT INTO `mob_groups` VALUES (40,2556,25,'Mantrap',300,0,3077,0,0,45,49,0);
 INSERT INTO `mob_groups` VALUES (41,3073,25,'Overgrown_Rose',330,0,1964,0,0,47,50,0);
 INSERT INTO `mob_groups` VALUES (42,4105,25,'Upyri',86400,0,2526,0,0,43,47,0);

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1415,7 +1415,7 @@ INSERT INTO `mob_skills` VALUES (1397,1042,'oisoya',0,0.0,15.0,2000,1000,4,0,0,0
 INSERT INTO `mob_skills` VALUES (1398,1034,'tenzen_ranged_high',0,0.0,25.0,2000,0,4,4,0,0,0,0,0); -- tenzen ranged attack
 INSERT INTO `mob_skills` VALUES (1399,1032,'riceball',0,0.0,15.0,2000,1500,1,0,0,0,0,0,0);        -- riceball eating
 INSERT INTO `mob_skills` VALUES (1400,1033,'tenzen_ranged_low',0,0.0,25.0,2000,0,4,4,0,0,0,0,0);  -- tenzen ranged attack
--- INSERT INTO `mob_skills` VALUES (1401,1145,'soul_accretion',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1401,138,'soul_accretion',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1402,1146,'.',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1403,1056,'explosive_impulse',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1404,1148,'ocher_blast',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds typical immunities, Store TP, and skill list behavior to Goaftrap and Okyupete that are WOTG 2009 NMs.
- Upyri now has special behavior regarding its TP skills on day vs night, and repeats certain moves at night
- Odqan now randomly chooses which ID to spawn at the next time it spawns, and its spawn is manually controlled through it and the Zone lua. Previously, having it set to SPAWNTYPE_FOG would force spawn both Odqans every fog weather, regardless of respawn time.

## Sources
- Upyri
https://youtu.be/nqD7sj2VB1U
https://drive.google.com/open?id=1_8zrSjlK7VVOEZ98ppydnLWeh3ceSK5o

- Okyupete and Goaftrap
https://www.dropbox.com/scl/fi/5tzk80lrd8z51ufyhyx0v/2025-11-19_18_46.zip?rlkey=k2s4yj8xzj7x7tp1now2yjjsc&st=fb64wsug&dl=0