### PR TITLE
[core] Add a small delay check between actions from PC after spell cast

### DIFF
--- a/src/map/ai/controllers/player_controller.h
+++ b/src/map/ai/controllers/player_controller.h
@@ -50,13 +50,19 @@ public:
     timer::time_point getLastAttackTime();
     void              setLastAttackTime(timer::time_point);
 
+    timer::time_point getLastSpellFinishedTime();
+    void              setLastSpellFinishedTime(timer::time_point);
+
     void              setLastErrMsgTime(timer::time_point);
     timer::time_point getLastErrMsgTime();
 
     CWeaponSkill* getLastWeaponSkill();
 
+    bool canAct();
+
 protected:
     timer::time_point m_lastAttackTime{ timer::now() };
+    timer::time_point m_spellFinishedTime{ timer::now() };
     timer::time_point m_errMsgTime{ timer::now() };
     CWeaponSkill*     m_lastWeaponSkill{ nullptr };
 };

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1308,6 +1308,9 @@ void CCharEntity::OnCastFinished(CMagicState& state, action_t& action)
         taChar = battleutils::getAvailableTrickAttackChar(this, PTarget);
     }
 
+    auto* controller{ static_cast<CPlayerController*>(PAI->GetController()) };
+    controller->setLastSpellFinishedTime(timer::now());
+
     CBattleEntity::OnCastFinished(state, action);
 
     for (auto&& actionTarget : action.targets)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a 2.5s delay after finishing a spell cast to allow (most) actions
The timing is a bit hard to get right if not only because ping is much different on a local vs to japan, 1s seems about right

Note: there is a penalty on retail where if you cast _just_ before you could actually start casting that you are forced to wait some small amount of time before actually being able to cast (even if you were off by .1s.) This isn't yet implemented

## Steps to test these changes

Cast spells repeatedly, get delay similar to retail

Good timing:

[2025-11-20 00-11-38.webm](https://github.com/user-attachments/assets/153f0940-cad4-42e5-90af-02cd2747b75a)

Trying to cast too early a lot:

[2026-01-31 23-25-25.webm](https://github.com/user-attachments/assets/8ff811de-dad2-4e36-b8b5-15c9b7c75419)
