### PR TITLE
[core] Only interrupt mobskills on finish from action preventing effects

### DIFF
--- a/src/map/ai/states/mobskill_state.h
+++ b/src/map/ai/states/mobskill_state.h
@@ -62,6 +62,8 @@ private:
     timer::time_point          m_finishTime;
     timer::duration            m_castTime{};
     int16                      m_spentTP;
+
+    void reduceTpOnInterrupt();
 };
 
 #endif

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2341,6 +2341,13 @@ void CBattleEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
         return;
     }
 
+    // Forced interrupt via status effect
+    if (StatusEffectContainer->HasPreventActionEffect(false))
+    {
+        ActionInterrupts::AbilityInterrupt(this);
+        return;
+    }
+
     if (auto* PMob = dynamic_cast<CMobEntity*>(this))
     {
         // store the skill used

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -39,6 +39,7 @@ When a status effect is gained twice on a player. It can do one or more of the f
 
 #include "ai/ai_container.h"
 #include "ai/states/inactive_state.h"
+#include "ai/states/mobskill_state.h"
 
 #include "enmity_container.h"
 #include "entities/automatonentity.h"
@@ -764,15 +765,15 @@ void CStatusEffectContainer::ApplyStateAlteringEffects(CStatusEffect* StatusEffe
             }
         }
 
-        if (effect == EFFECT_SLEEP || effect == EFFECT_SLEEP_II || effect == EFFECT_STUN || effect == EFFECT_PETRIFICATION || effect == EFFECT_TERROR ||
-            effect == EFFECT_LULLABY || effect == EFFECT_PENALTY)
+        if (HasPreventActionEffect(false))
         {
             // change icon of sleep II and lullaby. Apparently they don't stop player movement.
             if (effect == EFFECT_SLEEP_II || effect == EFFECT_LULLABY)
             {
                 StatusEffect->SetIcon(EFFECT_SLEEP);
             }
-            if (!m_POwner->PAI->IsCurrentState<CInactiveState>())
+
+            if (!m_POwner->PAI->IsCurrentState<CInactiveState>() && !m_POwner->PAI->IsCurrentState<CMobSkillState>())
             {
                 m_POwner->PAI->Inactive(0ms, false);
             }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

As per retail evidence

Mobskills will only interrupt if they are currently stunned/slept at the end of the normal mobskill animation:

[2025-09-25 22-54-02.webm](https://github.com/user-attachments/assets/f885ff48-b1da-433e-9314-2a1729fddf96)

[2025-09-25 21-49-09.webm](https://github.com/user-attachments/assets/b0edb43d-c2d4-4ec1-ae2b-ca6aa3c9127c)

If the status wears off they will still finish their mobskill:

[2025-09-25 23-12-31.webm](https://github.com/user-attachments/assets/3b7d3607-d03c-460a-89c9-1e0a45119946)



## Steps to test these changes

<img width="453" height="101" alt="image" src="https://github.com/user-attachments/assets/fc42f2f1-140c-482b-9e0c-8597d1b770d9" />
<img width="480" height="139" alt="image" src="https://github.com/user-attachments/assets/878760eb-8f7b-4628-b343-98899e311fb2" />
<img width="362" height="134" alt="image" src="https://github.com/user-attachments/assets/4e0f26a7-c6aa-4197-ba81-15d2729e0afa" />


