### PR TITLE
[sql] Corrects Comments + Stats on CoP Rings

### DIFF
--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -1569,28 +1569,52 @@ INSERT INTO `item_latents` VALUES (15532,369,-3,56,2);   -- Has a hidden effect 
 INSERT INTO `item_latents` VALUES (15532,370,1,56,2);    -- Latent Effect is triggered when the player's weapon is drawn and has more than 2 MP.
 
 -- Rajas Ring
-INSERT INTO `item_latents` VALUES (15543,8,1,51,45);     -- INT+1 above level 45
-INSERT INTO `item_latents` VALUES (15543,8,1,51,60);     -- INT+1 above level 60
-INSERT INTO `item_latents` VALUES (15543,8,1,51,75);     -- INT+1 above level 75
-INSERT INTO `item_latents` VALUES (15543,9,1,51,45);     -- MND+1 above level 45
-INSERT INTO `item_latents` VALUES (15543,9,1,51,60);     -- MND+1 above level 60
-INSERT INTO `item_latents` VALUES (15543,9,1,51,75);     -- MND+1 above level 75
-
--- Tamas Ring
-INSERT INTO `item_latents` VALUES (15544,2,5,51,45);     -- MP+5 above level 45
-INSERT INTO `item_latents` VALUES (15544,2,5,51,60);     -- MP+5 above level 60
-INSERT INTO `item_latents` VALUES (15544,2,5,51,75);     -- MP+5 above level 75
-INSERT INTO `item_latents` VALUES (15544,10,1,51,45);    -- INT+1 above level 45
-INSERT INTO `item_latents` VALUES (15544,10,1,51,60);    -- INT+1 above level 60
-INSERT INTO `item_latents` VALUES (15544,10,1,51,75);    -- INT+1 above level 75
-INSERT INTO `item_latents` VALUES (15544,11,1,51,45);    -- MND+1 above level 45
-INSERT INTO `item_latents` VALUES (15544,11,1,51,60);    -- MND+1 above level 60
-INSERT INTO `item_latents` VALUES (15544,11,1,51,75);    -- MND+1 above level 75
+INSERT INTO `item_latents` VALUES (15543,8,1,51,45);     -- STR+1 above level 45
+INSERT INTO `item_latents` VALUES (15543,8,1,51,60);     -- STR+1 above level 60
+INSERT INTO `item_latents` VALUES (15543,8,1,51,75);     -- STR+1 above level 75
+INSERT INTO `item_latents` VALUES (15543,9,1,51,45);     -- DEX+1 above level 45
+INSERT INTO `item_latents` VALUES (15543,9,1,51,60);     -- DEX+1 above level 60
+INSERT INTO `item_latents` VALUES (15543,9,1,51,75);     -- DEX+1 above level 75
 
 -- Sattva Ring
-INSERT INTO `item_latents` VALUES (15545,5,5,51,45);     -- MP+5 above level 45
-INSERT INTO `item_latents` VALUES (15545,5,5,51,60);     -- MP+5 above level 60
-INSERT INTO `item_latents` VALUES (15545,5,5,51,75);     -- MP+5 above level 75
+INSERT INTO `item_latents` VALUES (15544,2,1,51,33);     -- HP+1 above level 33
+INSERT INTO `item_latents` VALUES (15544,2,1,51,36);     -- HP+1 above level 36
+INSERT INTO `item_latents` VALUES (15544,2,1,51,39);     -- HP+1 above level 39
+INSERT INTO `item_latents` VALUES (15544,2,1,51,42);     -- HP+1 above level 42
+INSERT INTO `item_latents` VALUES (15544,2,1,51,45);     -- HP+1 above level 45
+INSERT INTO `item_latents` VALUES (15544,2,1,51,48);     -- HP+1 above level 48
+INSERT INTO `item_latents` VALUES (15544,2,1,51,51);     -- HP+1 above level 51
+INSERT INTO `item_latents` VALUES (15544,2,1,51,54);     -- HP+1 above level 54
+INSERT INTO `item_latents` VALUES (15544,2,1,51,57);     -- HP+1 above level 57
+INSERT INTO `item_latents` VALUES (15544,2,1,51,60);     -- HP+1 above level 60
+INSERT INTO `item_latents` VALUES (15544,2,1,51,63);     -- HP+1 above level 63
+INSERT INTO `item_latents` VALUES (15544,2,1,51,66);     -- HP+1 above level 66
+INSERT INTO `item_latents` VALUES (15544,2,1,51,69);     -- HP+1 above level 69
+INSERT INTO `item_latents` VALUES (15544,2,1,51,72);     -- HP+1 above level 72
+INSERT INTO `item_latents` VALUES (15544,2,1,51,75);     -- HP+1 above level 75
+INSERT INTO `item_latents` VALUES (15544,10,1,51,45);    -- VIT+1 above level 45
+INSERT INTO `item_latents` VALUES (15544,10,1,51,60);    -- VIT+1 above level 60
+INSERT INTO `item_latents` VALUES (15544,10,1,51,75);    -- VIT+1 above level 75
+INSERT INTO `item_latents` VALUES (15544,11,1,51,45);    -- AGI+1 above level 45
+INSERT INTO `item_latents` VALUES (15544,11,1,51,60);    -- AGI+1 above level 60
+INSERT INTO `item_latents` VALUES (15544,11,1,51,75);    -- AGI+1 above level 75
+
+-- Tamas Ring
+INSERT INTO `item_latents` VALUES (15545,5,1,51,33);     -- MP+1 above level 33
+INSERT INTO `item_latents` VALUES (15545,5,1,51,36);     -- MP+1 above level 36
+INSERT INTO `item_latents` VALUES (15545,5,1,51,39);     -- MP+1 above level 39
+INSERT INTO `item_latents` VALUES (15545,5,1,51,42);     -- MP+1 above level 42
+INSERT INTO `item_latents` VALUES (15545,5,1,51,45);     -- MP+1 above level 45
+INSERT INTO `item_latents` VALUES (15545,5,1,51,48);     -- MP+1 above level 48
+INSERT INTO `item_latents` VALUES (15545,5,1,51,51);     -- MP+1 above level 51
+INSERT INTO `item_latents` VALUES (15545,5,1,51,54);     -- MP+1 above level 54
+INSERT INTO `item_latents` VALUES (15545,5,1,51,57);     -- MP+1 above level 57
+INSERT INTO `item_latents` VALUES (15545,5,1,51,60);     -- MP+1 above level 60
+INSERT INTO `item_latents` VALUES (15545,5,1,51,63);     -- MP+1 above level 63
+INSERT INTO `item_latents` VALUES (15545,5,1,51,66);     -- MP+1 above level 66
+INSERT INTO `item_latents` VALUES (15545,5,1,51,69);     -- MP+1 above level 69
+INSERT INTO `item_latents` VALUES (15545,5,1,51,72);     -- MP+1 above level 72
+INSERT INTO `item_latents` VALUES (15545,5,1,51,75);     -- MP+1 above level 75
 INSERT INTO `item_latents` VALUES (15545,12,1,51,45);    -- INT+1 above level 45
 INSERT INTO `item_latents` VALUES (15545,12,1,51,60);    -- INT+1 above level 60
 INSERT INTO `item_latents` VALUES (15545,12,1,51,75);    -- INT+1 above level 75


### PR DESCRIPTION
- Corrects the commenting for the CoP Rings.
- Expands the latent to increase HP/MP by 1 every 3 levels.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Corrects the commenting on Rajas/Sattva/Tamas rings. 
Expands the HP/MP latents from +5 every 15 levels to +1 every 3 levels. 

## Steps to test these changes

Equip either ring and level by 3s from 30 to 75. 
See values jump by 1 with every change.

Thank you @siknoz for the fast [capture](https://www.youtube.com/watch?v=Wo9vwYR4SsU)!
