### PR TITLE
Add development container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+{
+    "name": "LandSandBoat",
+    "runArgs": ["--name", "lsb-devcontainer", "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined", "--network=host"],
+    "build": {
+        "dockerfile": "../docker/ubuntu.Dockerfile",
+        "target": "devtools",
+        "context": ".."
+    },
+    "workspaceMount": "source=${localWorkspaceFolder},target=/server,type=bind,consistency=cached",
+    "workspaceFolder": "/server",
+    "remoteUser": "xiadmin",
+    "remoteEnv": { "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}" },
+    "features": {
+        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+    },
+    "customizations": {
+            "vscode": {
+                "settings": {
+                    "terminal.integrated.defaultProfile.linux": "bash",
+                    "terminal.integrated.profiles.linux": { "bash": { "path": "/bin/bash" } }
+                },
+                "extensions": [
+                    "sumneko.lua",
+                    "Chouzz.vscode-better-align",
+                    "ms-python.python",
+                    "ms-python.black-formatter",
+                    "eamodio.gitlens",
+                    "donjayamanne.githistory",
+                    "josetr.cmake-language-support-vscode",
+                    "ms-vscode.cpptools-themes",
+                    "ms-vscode.cpptools-extension-pack",
+                    "ms-vscode.cpptools",
+                    "jeff-hykin.better-cpp-syntax",
+                    "EditorConfig.EditorConfig",
+                    "github.vscode-github-actions",
+                    "bierner.github-markdown-preview",
+                    "xaver.clang-format"
+                ]
+            }
+    }
+}

--- a/.github/workflows/docker_test.yml
+++ b/.github/workflows/docker_test.yml
@@ -107,6 +107,7 @@ jobs:
 
       - name: Run xi_test
         id: xi_test
+        continue-on-error: true
         run: docker exec test-server /bin/bash -c './xi_test --keep-going --output log/tests.ctrf.json'
 
       - name: Publish Test Report

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -43,7 +43,7 @@ services:
     user: "1000:1000"
     command: ["/server/tools/ci/sanity_checks.sh", "origin/base"]
     volumes:
-      - ./:/server
+      - ${LOCAL_WORKSPACE_FOLDER:-./}:/server
 
   lls:
     image: landsandboat/devtools:ubuntu
@@ -55,7 +55,7 @@ services:
     user: "1000:1000"
     command: ["python", "/server/tools/ci/lua_lang_server.py"]
     volumes:
-      - ./:/server
+      - ${LOCAL_WORKSPACE_FOLDER:-./}:/server
 
   clang_tidy:
     <<: *common
@@ -69,7 +69,7 @@ services:
         ENABLE_CLANG_TIDY: "ON"
     command: /bin/sh -c "python /server/tools/ci/summarize_clang_tidy.py build.log > /server/log/clang_tidy_summary.md"
     volumes:
-      - ./log:/server/log
+      - ${LOCAL_WORKSPACE_FOLDER:-./}/log:/server/log
 
   build:
     <<: *common
@@ -89,7 +89,7 @@ services:
       XI_NETWORK_SQL_HOST: database
       XI_NETWORK_SQL_PORT: 3306
     volumes:
-      - ./.git:/server/.git
+      - ${LOCAL_WORKSPACE_FOLDER:-./}/.git:/server/.git
     depends_on:
       database:
         condition: service_healthy
@@ -104,7 +104,7 @@ services:
     volumes:
       - losmeshes:/server/losmeshes
       - navmeshes:/server/navmeshes
-      - ./log:/server/log
+      - ${LOCAL_WORKSPACE_FOLDER:-./}/log:/server/log
     depends_on:
       database:
         condition: service_healthy
@@ -119,7 +119,7 @@ services:
     volumes:
       - losmeshes:/server/losmeshes
       - navmeshes:/server/navmeshes
-      - ./log:/server/log
+      - ${LOCAL_WORKSPACE_FOLDER:-./}/log:/server/log
     depends_on:
       database:
         condition: service_healthy
@@ -138,7 +138,7 @@ services:
       - "54230:54230"
       - "54231:54231"
     volumes:
-      - ./log:/server/log
+      - ${LOCAL_WORKSPACE_FOLDER:-./}/log:/server/log
     depends_on:
       database:
         condition: service_healthy
@@ -155,7 +155,7 @@ services:
     ports:
       - "54002:54002"
     volumes:
-      - ./log:/server/log
+      - ${LOCAL_WORKSPACE_FOLDER:-./}/log:/server/log
     depends_on:
       database:
         condition: service_healthy
@@ -174,7 +174,7 @@ services:
     ports:
       - "8088:8088"
     volumes:
-      - ./log:/server/log
+      - ${LOCAL_WORKSPACE_FOLDER:-./}/log:/server/log
     depends_on:
       database:
         condition: service_healthy
@@ -194,7 +194,7 @@ services:
     volumes:
       - losmeshes:/server/losmeshes
       - navmeshes:/server/navmeshes
-      - ./log:/server/log
+      - ${LOCAL_WORKSPACE_FOLDER:-./}/log:/server/log
     depends_on:
       database:
         condition: service_healthy


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a [dev container](https://containers.dev/). Mounts your files into the [Ubuntu devtools](https://github.com/LandSandBoat/server/blob/de1e7197a7a465c65c27273945d13e9664d23e9a/docker/ubuntu.Dockerfile#L1-L119) image and sets you up in the same environment used for CI. Requires Docker and VS Code(?). When you open VS Code it will ask if you want to Reopen in Container, or there's a button on the bottom left you can use. 

<img width="210" height="51" alt="image" src="https://github.com/user-attachments/assets/c028368c-df30-4318-8958-d22c9656ca24" />

<img width="606" height="338" alt="image" src="https://github.com/user-attachments/assets/80bee99b-68f6-49d7-a002-a2c737d4b7cd" />

<img width="210" height="51" alt="image" src="https://github.com/user-attachments/assets/b04d65ff-d96c-4f97-affb-8cc45d2477c4" />

When you open it, it already has compiler, formatters, test tools, extensions preinstalled and ready to use. If the Dockerfile changes (e.g. upstream changes dependencies/versions) you'll be asked if you want to rebuild the container so it's easy to stay up to date without needing to manually manage your dependencies. Pretty cool, maybe not for everyone but give it a try.

If you're on Windows you'll probably have a bad time unless you have the repo checked out in the WSL filesystem. Even then I had RAM issues. YMMV. Oh and codespaces, check it out [(careful if you have payments setup because this isn't free, though there is a free quota)](https://docs.github.com/en/billing/concepts/product-billing/github-codespaces).

<img width="424" height="379" alt="image" src="https://github.com/user-attachments/assets/41f6061d-1fba-4aaa-8234-3d29d11b8cc1" />

Also small unrelated tweak to the Docker testing workflow that doesn't deserve its own PR. Just brings it in line with the runner workflow and tries to run startup checks even if xi_test fails.

## Steps to test these changes

Open, build, edit, run stuff. I've been using it for a while on a Debian host and it's been pretty great.
