### PR TITLE
[core, sql] Fix HP Latent Calculations and Minstrel's Ring

### DIFF
--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -454,7 +454,7 @@ INSERT INTO `item_latents` VALUES (13294,237,3,2,75);    -- Enhances "Luminian K
 INSERT INTO `item_latents` VALUES (13294,238,3,2,75);    -- Enhances "Luminion Killer" effect while HP <=75% and TP <=100%
 
 -- Minstrel's Ring
-INSERT INTO `item_latents` VALUES (13295,455,25,2,75);  -- Song Spellcast -25% while HP <=75% and TP <=100%
+INSERT INTO `item_latents` VALUES (13295,455,25,2,76);  -- Song Spellcast -25% while HP <76% and TP <=100%
 
 -- Tracker's Ring
 INSERT INTO `item_latents` VALUES (13296,27,-2,2,75);    -- Enmity-2 while HP <=75% and TP <=100%

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -740,19 +740,19 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect, bo
     switch (latentEffect.GetConditionsID())
     {
         case LATENT::HP_UNDER_PERCENT:
-            expression = ((float)m_POwner->health.hp / m_POwner->health.maxhp) * 100 <= latentEffect.GetConditionsValue();
+            expression = ((float)m_POwner->health.hp / m_POwner->GetMaxHP()) * 100 <= latentEffect.GetConditionsValue();
             break;
         case LATENT::HP_OVER_PERCENT:
-            expression = ((float)m_POwner->health.hp / m_POwner->health.maxhp) * 100 >= latentEffect.GetConditionsValue();
+            expression = ((float)m_POwner->health.hp / m_POwner->GetMaxHP()) * 100 >= latentEffect.GetConditionsValue();
             break;
         case LATENT::HP_UNDER_TP_UNDER_100:
-            expression = ((float)m_POwner->health.hp / m_POwner->health.maxhp) * 100 <= latentEffect.GetConditionsValue() && m_POwner->health.tp < 1000;
+            expression = ((float)m_POwner->health.hp / m_POwner->GetMaxHP()) * 100 <= latentEffect.GetConditionsValue() && m_POwner->health.tp < 1000;
             break;
         case LATENT::HP_OVER_TP_UNDER_100:
-            expression = ((float)m_POwner->health.hp / m_POwner->health.maxhp) * 100 >= latentEffect.GetConditionsValue() && m_POwner->health.tp < 1000;
+            expression = ((float)m_POwner->health.hp / m_POwner->GetMaxHP()) * 100 >= latentEffect.GetConditionsValue() && m_POwner->health.tp < 1000;
             break;
         case LATENT::MP_UNDER_PERCENT:
-            expression = m_POwner->health.maxmp && ((float)m_POwner->health.mp / m_POwner->health.maxmp) * 100 <= latentEffect.GetConditionsValue();
+            expression = m_POwner->health.maxmp && ((float)m_POwner->health.mp / m_POwner->GetMaxMP()) * 100 <= latentEffect.GetConditionsValue();
             break;
         case LATENT::MP_UNDER:
             expression = m_POwner->health.mp <= latentEffect.GetConditionsValue();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR fixes latent HP and MP calculations to use total HP/MP after gear and buffs, instead of total Base HP/MP. It also changes the Minstrel's Ring to match the Sorcerer's Ring, which activates when HP < 76%, JP wiki source: https://wiki.ffo.jp/html/7159.html

## Steps to test these changes

- Set HP on BRD to 75% with a bunch of HP up gear equipped
- Verify Minstrel's Ring is cutting spellcasting time by 20%

## Unable to test `HP_OVER_TP_UNDER_100`
- I didn't see any items that used this latent effect, so I was unable to test it