### PR TITLE
[core, lua] Deprecate isLevelSync in favor of checking LEVEL_RESTRICTION/LEVEL_SYNC directly

### DIFF
--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -1319,7 +1319,7 @@ end
 
 function xi.battlefield.rejectLevelSyncedParty(player, npc)
     for _, member in pairs(player:getAlliance()) do
-        if member:isLevelSync() then
+        if member:hasStatusEffect(xi.effect.LEVEL_RESTRICTION) then
             local zoneId = player:getZoneID()
             local ID     = zones[zoneId]
 

--- a/scripts/globals/garrison.lua
+++ b/scripts/globals/garrison.lua
@@ -682,7 +682,7 @@ xi.garrison.validateEntry = function(zoneData, player, npc, guardNation)
     end
 
     local membersLevelRestricted = utils.any(membersInZone, function(_, v)
-        return v:isLevelSync()
+        return v:hasStatusEffect(xi.effect.LEVEL_RESTRICTION)
     end)
 
     if membersLevelRestricted then

--- a/scripts/globals/roe.lua
+++ b/scripts/globals/roe.lua
@@ -63,7 +63,7 @@ local checks =
     end,
 
     levelSync = function(self, player, params)  -- Player is Level Sync'd
-        return self.reqs.levelSync and player:isLevelSync() and true or false
+        return self.reqs.levelSync and player:hasStatusEffect(xi.effect.LEVEL_SYNC) and true or false
     end,
 
     jobLvl = function(self, player, params)  -- Player has job at minimum level X

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -2441,11 +2441,6 @@ function CBaseEntity:disableLevelSync()
 end
 
 ---@nodiscard
----@return boolean
-function CBaseEntity:isLevelSync()
-end
-
----@nodiscard
 ---@return integer
 function CBaseEntity:checkSoloPartyAlliance()
 end

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -11628,31 +11628,6 @@ void CLuaBaseEntity::disableLevelSync()
 }
 
 /************************************************************************
- *  Function: isLevelSync()
- *  Purpose :
- *  Example : player:isLevelSync()
- *  Notes   :
- ************************************************************************/
-
-bool CLuaBaseEntity::isLevelSync()
-{
-    if (m_PBaseEntity->objtype != TYPE_PC)
-    {
-        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->getName());
-        return false;
-    }
-
-    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
-
-    if (PChar->PParty)
-    {
-        return PChar->PParty->GetSyncTarget() && PChar->PParty->GetSyncTarget() != PChar;
-    }
-
-    return false;
-}
-
-/************************************************************************
  *  Function: checkSoloPartyAlliance()
  *  Purpose : Checks if Entity is solo, in a party, or in an alliance
  *  Example : local popularityCheck = player:checkSoloPartyAlliance()
@@ -19894,7 +19869,6 @@ void CLuaBaseEntity::Register()
 
     SOL_REGISTER("reloadParty", CLuaBaseEntity::reloadParty);
     SOL_REGISTER("disableLevelSync", CLuaBaseEntity::disableLevelSync);
-    SOL_REGISTER("isLevelSync", CLuaBaseEntity::isLevelSync);
 
     SOL_REGISTER("checkSoloPartyAlliance", CLuaBaseEntity::checkSoloPartyAlliance);
 

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -577,7 +577,6 @@ public:
 
     void reloadParty();
     void disableLevelSync();
-    bool isLevelSync();
 
     uint8 checkSoloPartyAlliance(); // Check if Player is in Party or Alliance (0=Solo 1=Party 2=Alliance)
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
isLevelSync was originally introduced for RoE purposes (the Level Sync challenges) but it has since then made its way into several scripts for checking if a PC is level restricted.

This causes several issues:
- The binding does not even work if you're the sync target
  - I believe this was done on purpose based on the belief the RoE challenge do not give credit if you're the sync target, which is provably false.
- The binding only works if you're in a party
- The binding only checks if the party has a sync target _which it might not during the 30s gap where level sync is being disabled_ but still be level restricted
- The binding ignores entirely LEVEL_RESTRICTION since it wasn't its primary goal

All these reasons lead it to being a very poor check for verifying if you're level restricted, therefore I believe the best path forward is to deprecate it entirely in favor of just checking for xi.effect.LEVEL_RESTRICTION - something that is applied way more reliably.

Bonus: This will now reward level sync targets with RoE credits, as is the case on retail

<img width="2266" height="508" alt="Screenshot 2025-11-22 011928" src="https://github.com/user-attachments/assets/a98a211c-741a-4cc2-a6c2-4c982a9bb87c" />


<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
