### PR TITLE
[lua] Check for level sync effect when registering BCNM

### DIFF
--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -1319,7 +1319,7 @@ end
 
 function xi.battlefield.rejectLevelSyncedParty(player, npc)
     for _, member in pairs(player:getAlliance()) do
-        if member:hasStatusEffect(xi.effect.LEVEL_RESTRICTION) then
+        if member:hasStatusEffect(xi.effect.LEVEL_SYNC) then
             local zoneId = player:getZoneID()
             local ID     = zones[zoneId]
 

--- a/scripts/globals/garrison.lua
+++ b/scripts/globals/garrison.lua
@@ -682,7 +682,7 @@ xi.garrison.validateEntry = function(zoneData, player, npc, guardNation)
     end
 
     local membersLevelRestricted = utils.any(membersInZone, function(_, v)
-        return v:hasStatusEffect(xi.effect.LEVEL_RESTRICTION)
+        return v:hasStatusEffect(xi.effect.LEVEL_RESTRICTION) or v:hasStatusEffect(xi.effect.LEVEL_SYNC)
     end)
 
     if membersLevelRestricted then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
#8754 conflicts with other players trying to enter an opened battlefield since the member inside has LEVEL_RESTRICTION.

I was under the impression level sync silently granted LEVEL_RESTRICTION for some reason (it does not) and may have forgotten to retest entering the BCNM with a partied player. This PR changes which effect is checked when attempting to register a BCNM.

I tightened the Garrison check because there might be quests or other events in the Garrison areas that apply LEVEL_RESTRICTION.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
- P1 + P2 partied
- P1 applies level sync
- P1 attempts to register a BCNM by trading -> Error message
- P1 attempts to register a BCNM by triggering (ENMs etc) -> Error message

With level sync disabled:
- P1 attempts to register a BCNM by trading -> Menu
- P1 attempts to register a BCNM by triggering (ENMs etc) -> Menu
- P1 enters and gets LEVEL_RESTRICTION applied
- P2 can click and enter

<!-- Clear and detailed steps to test your changes here -->
