### PR TITLE
[lua] Adds TODO and tradeComplete to quest "Water Way to Go"

### DIFF
--- a/scripts/quests/windurst/Water_Way_to_Go.lua
+++ b/scripts/quests/windurst/Water_Way_to_Go.lua
@@ -4,6 +4,7 @@
 -- !addquest 2 16
 -- Ohbiru-Dohbiru : !pos 23 -5 -193 238
 -- Giddeus Spring : !pos -258 -2 -249 145
+-- TODO: Wikis claim that this can be repeated. However, captures don't indicate this. Needs testing/verifying.
 -----------------------------------
 
 local quest = Quest:new(xi.questLog.WINDURST, xi.quest.id.windurst.WATER_WAY_TO_GO)
@@ -98,6 +99,7 @@ quest.sections =
 
                 [355] = function(player, csid, option, npc)
                     if quest:complete(player) then
+                        player:tradeComplete()
                         -- Note: Message display for gil reward is handled by the event
                         player:addGil(900)
                         player:setLocalVar('Quest[2][17]mustZone', 1)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a TODO to the top of the file. Wikis claim that this quest can be repeated. However, this is not observed in any capture. Needs verifying/testing.

Adds a trade complete to the end of the quest to make sure the Giddeous Water is removed from he player's inventory.

## Steps to test these changes

1. `!compeltequest 2 15`
2. Have fame for Windurst 3 or higher.
3. `!zone <Windurst Waters>`'
4. Talk to Ohbiru-Dohbiru `!pos 23 -5 -193 238`
5. `!zone <Giddeous>`
6. `!gotoname Giddeus_Spring`
7. Trade Canteen to Spring
8. `!zone <Windurst Waters>`'
9. Trade Spring Water to Ohbiru-Dohbiru `!pos 23 -5 -193 238`
10. Quest Complete