### PR TITLE
[core] Improve mob AI if no spells are available to cast

### DIFF
--- a/src/common/types/flag.h
+++ b/src/common/types/flag.h
@@ -1,0 +1,73 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+namespace xi
+{
+
+//
+// Flag<Tag>
+//
+// A strongly typed boolean flag.
+//
+
+template <typename Tag>
+class Flag
+{
+public:
+    constexpr explicit Flag(bool value) noexcept;
+
+    constexpr operator bool() const noexcept;
+
+    constexpr bool operator==(const Flag& other) const noexcept = default;
+    constexpr bool operator!=(const Flag& other) const noexcept = default;
+
+    static const Flag Yes;
+    static const Flag No;
+
+private:
+    bool value_ = false;
+};
+
+//
+// Implementation
+//
+
+template <typename Tag>
+constexpr Flag<Tag>::Flag(bool value) noexcept
+: value_(value)
+{
+}
+
+template <typename Tag>
+constexpr Flag<Tag>::operator bool() const noexcept
+{
+    return value_;
+}
+
+template <typename Tag>
+constexpr Flag<Tag> Flag<Tag>::Yes{ true };
+
+template <typename Tag>
+constexpr Flag<Tag> Flag<Tag>::No{ false };
+
+} // namespace xi

--- a/src/common/xi.h
+++ b/src/common/xi.h
@@ -39,6 +39,7 @@
 #include "helpers/eraseif.h"
 #include "helpers/overload.h"
 
+#include "types/flag.h"
 #include "types/fn.h"
 
 namespace xi

--- a/src/map/ai/controllers/automaton_controller.h
+++ b/src/map/ai/controllers/automaton_controller.h
@@ -70,7 +70,7 @@ protected:
 
     void         setCooldowns();
     void         setMagicCooldowns();
-    virtual bool CanCastSpells() override;
+    virtual bool CanCastSpells(IgnoreRecastsAndCosts ignoreRecastsAndCosts) override;
     virtual bool Cast(uint16 targid, SpellID spellid) override;
     virtual bool MobSkill(uint16 targid, uint16 wsid, std::optional<timer::duration> castTimeOverride) override;
 

--- a/src/map/ai/controllers/controller.h
+++ b/src/map/ai/controllers/controller.h
@@ -32,6 +32,8 @@ class CBattleEntity;
 class CController
 {
 public:
+    using IgnoreRecastsAndCosts = xi::Flag<struct IgnoreRecastsAndCostsTag>;
+
     CController(CBattleEntity* _POwner);
     virtual ~CController()
     {

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -464,7 +464,7 @@ auto CMobController::TrySpecialSkill() -> bool
 auto CMobController::TryCastSpell() -> bool
 {
     TracyZoneScoped;
-    if (!CanCastSpells())
+    if (!CanCastSpells(IgnoreRecastsAndCosts::No))
     {
         return false;
     }
@@ -543,7 +543,7 @@ auto CMobController::TryCastSpell() -> bool
     return false;
 }
 
-auto CMobController::CanCastSpells() -> bool
+auto CMobController::CanCastSpells(IgnoreRecastsAndCosts ignoreRecastsAndCosts) -> bool
 {
     TracyZoneScoped;
     if (!PMob->SpellContainer->HasSpells())
@@ -566,7 +566,17 @@ auto CMobController::CanCastSpells() -> bool
         }
     }
 
-    return IsMagicCastingEnabled();
+    if (!IsMagicCastingEnabled())
+    {
+        return false;
+    }
+
+    if (ignoreRecastsAndCosts == IgnoreRecastsAndCosts::No && !PMob->SpellContainer->IsAnySpellAvailable())
+    {
+        return false;
+    }
+
+    return true;
 }
 
 void CMobController::CastSpell(SpellID spellid)
@@ -1077,7 +1087,7 @@ void CMobController::DoRoamTick(timer::time_point tick)
                 }
                 else if (
                     (!PMob->PBattlefield || PMob->PBattlefield->GetStatus() != BATTLEFIELD_STATUS_OPEN) &&
-                    PMob->GetMJob() == JOB_SMN && CanCastSpells() &&
+                    PMob->GetMJob() == JOB_SMN && CanCastSpells(IgnoreRecastsAndCosts::No) &&
                     PMob->SpellContainer->HasBuffSpells() && m_Tick >= m_nextMagicTime)
                 {
                     // summon pet
@@ -1085,7 +1095,7 @@ void CMobController::DoRoamTick(timer::time_point tick)
                     // - Once battlefield is locked, behavior is back to normal with no rng added to pet summoning
                     TryCastSpell();
                 }
-                else if (CanCastSpells() && xirand::GetRandomNumber(10) < 3 && PMob->SpellContainer->HasBuffSpells())
+                else if (CanCastSpells(IgnoreRecastsAndCosts::No) && xirand::GetRandomNumber(10) < 3 && PMob->SpellContainer->HasBuffSpells())
                 {
                     // cast buff
                     TryCastSpell();
@@ -1475,7 +1485,7 @@ auto CMobController::CanMoveForward(const float currentDistance) -> bool
         (PMob->GetMaxMP() == 0 || PMob->GetMPP() >= standbackThreshold))
     {
         // Excluding Nins, mobs should not standback if can't cast magic
-        return PMob->GetMJob() != JOB_NIN && PMob->SpellContainer->HasSpells() && !CanCastSpells();
+        return PMob->GetMJob() != JOB_NIN && PMob->SpellContainer->HasSpells() && !CanCastSpells(IgnoreRecastsAndCosts::Yes);
     }
 
     if (PTarget && !PMob->CanSeeTarget(PTarget))

--- a/src/map/ai/controllers/mob_controller.h
+++ b/src/map/ai/controllers/mob_controller.h
@@ -71,7 +71,7 @@ protected:
     auto         CanPursueTarget(const CBattleEntity* PTarget) const -> bool;
     auto         CheckLock(CBattleEntity* PTarget) const -> bool;
     auto         CheckDetection(CBattleEntity* PTarget) -> bool;
-    virtual auto CanCastSpells() -> bool;
+    virtual auto CanCastSpells(IgnoreRecastsAndCosts ignoreRecastsAndCosts) -> bool;
     void         CastSpell(SpellID spellid);
     virtual void Move();
 

--- a/src/map/mob_spell_container.h
+++ b/src/map/mob_spell_container.h
@@ -47,6 +47,8 @@ public:
     std::optional<SpellID> GetSevereSpell(); // select spells like death, impact, meteor
     std::optional<SpellID> GetSpell();       // return a random spell
 
+    bool IsAnySpellAvailable();
+
     bool HasSpells() const;
     bool HasMPSpells() const;
     bool HasNaSpell(SpellID spellId) const;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Mobs would stand still doing nothing if they had ALL of their spells on cooldown, so this PR improves that

Essentially, mobs could be on cooldown to cast and just sit there trying to cast a spell that would never come.

## Steps to test these changes

Try Charming Trio and kite the leeches until both drain/aspir are on cooldown and watch the mobs still try to attack you despite having both spells on cooldown
Also spot check Automatons to make sure they still cast spells