### PR TITLE
[lua] Royal Jelly bugfix

### DIFF
--- a/scripts/zones/Waughroon_Shrine/mobs/Princess_Jelly.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Princess_Jelly.lua
@@ -115,13 +115,6 @@ local function spawnQueenJelly(bfNum, target, zone)
         queen:setPos(centers[bfNum][1], centers[bfNum][2], centers[bfNum][3], 0)
         queen:setLocalVar('target', target:getID())
 
-        queen:timer(3000, function(queenArg)
-            local player = GetPlayerByID(queenArg:getLocalVar('target'))
-            if player ~= nil and player:isAlive() then
-                queen:updateClaim(player)
-            end
-        end)
-
         for i = 1, 8 do
             DespawnMob(queen:getID() + i)
         end

--- a/scripts/zones/Waughroon_Shrine/mobs/Queen_Jelly.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Queen_Jelly.lua
@@ -18,6 +18,18 @@ end
 
 entity.onMobSpawn = function(mob)
     mob:setBaseSpeed(60)
+    local battlefield = mob:getBattlefield()
+
+    if not battlefield then
+        return
+    end
+
+    local players = battlefield:getPlayers()
+    for _, player in pairs(players) do
+        if player:isAlive() then
+            mob:updateClaim(player)
+        end
+    end
 end
 
 entity.onMobSpellChoose = function(mob, target, spellId)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Rewrites enmity handling for Queen Jelly spawn, removes the timer and instead fetches players on spawn to assign enmity to.

## Steps to test these changes

Run the BCNM Royal Jelly in Waughroon Shrine
