### PR TITLE
Update formula for Glittering Ruby effect

### DIFF
--- a/scripts/actions/abilities/pets/glittering_ruby.lua
+++ b/scripts/actions/abilities/pets/glittering_ruby.lua
@@ -22,7 +22,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     }
 
     local effectId    = utils.randomEntry(effects)
-    local effectPower = math.random(12, 14)
+    local effectPower = 3 + math.floor(pet:getMainLvl() / 5)
 
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Updates the Glittering Ruby formula to scale based on level, instead of random between 12-14.

Closes #8607 

## Steps to test these changes

1. Set job to SMN `!changejob SMN`
2. Set level to 48 (minimum level required for Glittering Ruby) `!setplayerlevel 48`
3. Grant Carbuncle as a spell if not already acquired: `!addspell Carbuncle`
4. Summon Carbuncle and perform Glittering Ruby. Stat increase is 12.
5. Change level to 50 `!setplayerlevel 50`
6. Resummon Carbuncle and perform Glittering Ruby. Stat increase is 13.
7. Change level to 70 `!setplayerlevel 70`
8. Resummon Carbuncle and perform Glittering Ruby. Stat increase is 17.
9. Change level to 75 `!setplayerlevel 75`
10. Resummon Carbuncle and perform Glittering Ruby. Stat increase is 18.
11. Change level to 99 `!setplayerlevel 99`
10. Resummon Carbuncle and perform Glittering Ruby. Stat increase is 22.
