### PR TITLE
[lua] Tres Duendes form change fix

### DIFF
--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Tres_Duendes.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Tres_Duendes.lua
@@ -26,7 +26,7 @@ entity.onMobFight = function(mob, target)
     local form = mob:getAnimationSub()
 
     if GetSystemTime() > nextFormShiftTime and mob:canUseAbilities() then
-        mob:setLocalVar('nextFormShiftTime', GetSystemTime() + 30)
+        mob:setLocalVar('nextFormShiftTime', GetSystemTime() + 60)
 
         local formConfigs =
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Minor fix, corrects Tres Duendes form change interval to be 60 seconds instead of 30.

## Source
https://youtu.be/-XRWxsJlZeo
https://1drv.ms/u/c/87e665e10555c452/IQB2-r8s_zUKQKLz85i_bfBYAfZkd7dbsFMChs_OxwwatZ8?e=kfRp5b
