### PR TITLE
[lua] Waking Dreams Small Cleanup - Remove TODO - Add Diablos Immunities - Add logic to keep/remove KI properly

### DIFF
--- a/scripts/battlefields/The_Shrouded_Maw/waking_dreams.lua
+++ b/scripts/battlefields/The_Shrouded_Maw/waking_dreams.lua
@@ -15,7 +15,7 @@ local content = BattlefieldQuest:new({
     index            = 2,
     entryNpc         = 'MC_Entrance',
     exitNpc          = 'Memento_Circle',
-    requiredKeyItems = { xi.ki.VIAL_OF_DREAM_INCENSE },
+    requiredKeyItems = { xi.ki.VIAL_OF_DREAM_INCENSE, keep = true },
 
     questArea = xi.questLog.WINDURST,
     quest     = xi.quest.id.windurst.WAKING_DREAMS,
@@ -30,6 +30,7 @@ function content:setupBattlefield(battlefield)
 end
 
 function content:onEventFinishWin(player, csid, option, npc)
+    player:delKeyItem(xi.ki.VIAL_OF_DREAM_INCENSE)
     npcUtil.giveKeyItem(player, xi.ki.WHISPER_OF_DREAMS)
     player:addTitle(xi.title.HEIR_TO_THE_REALM_OF_DREAMS)
 end

--- a/scripts/zones/The_Shrouded_Maw/mobs/Diabolos.lua
+++ b/scripts/zones/The_Shrouded_Maw/mobs/Diabolos.lua
@@ -17,6 +17,15 @@ local entity = {}
 -- TODO: Diabolos Prime
 -- Note: Diabolos Prime fight drops all tiles at once.
 
+entity.onMobInitialize = function(mob)
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
+    mob:addImmunity(xi.immunity.PETRIFY)
+    mob:addImmunity(xi.immunity.SILENCE)
+    mob:addImmunity(xi.immunity.SLOW)
+    mob:addImmunity(xi.immunity.TERROR)
+end
+
 entity.onMobFight = function(mob, target)
     local drawInTable =
     {

--- a/scripts/zones/Windurst_Waters/npcs/Kerutoto.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Kerutoto.lua
@@ -23,9 +23,6 @@ entity.onTrigger = function(player, npc)
             + (player:hasSpell(xi.magic.spell.DIABOLOS) and 32 or 16) -- Pact or gil
         player:startEvent(920, xi.item.DIABOLOSS_POLE, xi.item.DIABOLOSS_EARRING, xi.item.DIABOLOSS_RING, xi.item.DIABOLOSS_TORQUE, 0, 0, 0, availRewards)
     elseif
-        -- TODO: There is no current way to reobtain the KI in case of BCNM failure.  This KI
-        -- is consumed on battlefield entry.
-
         not player:hasKeyItem(xi.ki.VIAL_OF_DREAM_INCENSE) and
         (
             player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.DARKNESS_NAMED) and


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The KI ``Vial of Dream Incense`` is meant to be kept until the player wins the battle.
Changes the param to keep the KI upon entry. This allows the players to retry the fight upon failure.
Adds a remove KI upon victory to match retail.

Adds immunities to Diablos.

## Steps to test these changes

1. `!addquest 2 93`
2. `!addkeyitem VIAL_OF_DREAM_INCENSE`
3. `!zone <THE_SHROUDED_MAW>`
4. Click circle and enter battlefield. Observe KI still in Temp Key Items.
5. Cast immune spells on Diablos to test.
6. Win Fight. Observe KI removed from Temp Key Items.

Captures:
RDM/BLM Spells
https://drive.google.com/drive/folders/1OSgTu_gjyft8qq9b8uCIhBtYC_1weSUt?usp=sharing 

Light Sleep - Terror - 
https://youtu.be/bvR8X4ZRiCs
https://www.dropbox.com/s/tqkea72ho3u1gvi/Waking%20Dreams%20(Diabolos%20Prime)%20-%20enfeebles.rar?dl=0