### PR TITLE
[lua] Update Battlefield for Missing CS Params

### DIFF
--- a/scripts/battlefields/The_Shrouded_Maw/waking_dreams.lua
+++ b/scripts/battlefields/The_Shrouded_Maw/waking_dreams.lua
@@ -16,6 +16,7 @@ local content = BattlefieldQuest:new({
     entryNpc         = 'MC_Entrance',
     exitNpc          = 'Memento_Circle',
     requiredKeyItems = { xi.ki.VIAL_OF_DREAM_INCENSE, keep = true },
+    csParam8         = 5,
 
     questArea = xi.questLog.WINDURST,
     quest     = xi.quest.id.windurst.WAKING_DREAMS,

--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -450,6 +450,8 @@ function Battlefield:new(data)
     obj.armouryCrates    = data.armouryCrates or false
     obj.experimental     = data.experimental or false
     obj.allowedAreas     = data.allowedAreas
+    obj.csParam7         = data.csParam7 and data.csParam7 or 0
+    obj.csParam8         = data.csParam8 and data.csParam8 or 0
 
     obj.sections = obj.sections or { { [obj.zoneId] = {} } }
     obj.groups   = {}
@@ -888,7 +890,7 @@ function Battlefield:onEntryEventUpdate(player, csid, option, npc)
     end
 
     local autoSkipCS = self:getLocalVar(player, 'CS') == 1 and 100 or 0
-    player:updateEvent(result, self.index, autoSkipCS, clearTime, partySize, self:checkSkipCutscene(player))
+    player:updateEvent(result, self.index, autoSkipCS, clearTime, partySize, self:checkSkipCutscene(player), self.csParam7, self.csParam8)
     player:updateEventString(name)
 
     return (status < xi.battlefield.status.LOCKED and result < xi.battlefield.returnCode.LOCKED) and 1 or 0


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Adds the missing `eventUpdate()` parameters in the battlefield framework for `onEntryEventUpdate`
These params are used in some of the battlefields to specify code paths through the Event VM (EVM) and when omitted, cause certain parts of the events to fail, be skipped, etc.  The values in these fields are defaulted to 0 if not specified in the battlefield `content.options` such that omitting them will not change anything from what was currently happening.  As additional battlefields are captured, if these arguments are used in the `eventUpdate` params, they can be added to the appropriate battlefields very easily.

Example: Waking Dreams BCNM (Repeatable Diabolos Fight)
When entering the BCNM currently, you see the start of the diabolos summoning animation, which is then short-circuited by bad EVM Params causing the event to jump into the 'finishing' portion of the BCNM where it drops the player into the battlefield.  When we add the proper handling for the event params, we see the proper event play out in its entirety.

- Retail Capture Data : Event Update using 8 Params
```
[01:49:31] [ID View] INCOMING < CS Event + Params (0x034): NPC: 16818248 (Memento Circle), Event: 32000, Params: 0, 146932096, 384, 6, 0, 0, 0, 65536
[01:49:35] [NPCL] New: 16818285 (blank)
[01:49:35] [NPCL] New: 16818286 (Prishe)
[01:49:36] [ID View] OUTGOING > Event Option (0x05B): NPC: 16818248 (Memento Circle), Event: 32000, Option: 255
[01:49:36] [NPCL] New: 16818287 (Selh'teus)
[01:49:36] [NPCL] New: 16818288 (Tenzen)
[01:49:37] [NPCL] New: 16818289 (Diabolos)
[01:49:37] [NPCL] New: 16818292 (blank)
[01:49:38] [ID View] INCOMING < Event Update (0x05C): Params: 2, 2, 0, 86, 1, 0, 0, 5
```
- Shown EVM Code Flow : Shows that all the parameters are needed
  - When this option is omitted, it skips all the logic and jumps to `0x128D` causing the event to end early
```
     0x11FE [0x02] IF !(Work_Zone[9] == 1*) GOTO 0x120C
     0x1206 [0x1A] CALL_SUBROUTINE(address=0x1A8E)
     0x1209 [0x01] GOTO 0x1244
     0x120C [0x02] IF !(Work_Zone[9] == 2*) GOTO 0x121A
     0x1214 [0x1A] CALL_SUBROUTINE(address=0x1B87)
     0x1217 [0x01] GOTO 0x1244
     0x121A [0x02] IF !(Work_Zone[9] == 3*) GOTO 0x1228
     0x1222 [0x1A] CALL_SUBROUTINE(address=0x1CB0)
     0x1225 [0x01] GOTO 0x1244
     0x1228 [0x02] IF !(Work_Zone[9] == 4*) GOTO 0x1236
     0x1230 [0x1A] CALL_SUBROUTINE(address=0x1D88)
     0x1233 [0x01] GOTO 0x1244
     0x1236 [0x02] IF !(Work_Zone[9] == 5*) GOTO 0x1244
     0x123E [0x1A] CALL_SUBROUTINE(address=0x1E98)
     0x1241 [0x01] GOTO 0x1244
     0x1244 [0x01] GOTO 0x128D
     
     ... snip ...
     
     0x1E98 [0x2B] Diabolos (ID: 16818289/0x0100A071) [7734*]:
    → "So you have come, <Player>. You wish to challenge me again?"
     0x1E9F [0x23] WAIT_FOR_DIALOG_INTERACTION
     0x1EA0 [0x52] END_LOAD_SCHEDULER: End scheduler "dq00" with entities [LocalPlayer, LocalPlayer], work=152*
     0x1EAF [0x45] LOAD_SCHEDULED_TASK: Load scheduler "dq03" with entities [LocalPlayer, LocalPlayer], work=[152*, 0*]
     0x1EC0 [0x2B] Diabolos (ID: 16818289/0x0100A071) [7735*]:
    → "You shall have your rematch. Bask in the power of the unattainable dream!"
     0x1EC7 [0x23] WAIT_FOR_DIALOG_INTERACTION
```

Video Examples
- With the missing CS Params, the event ends early:
https://youtu.be/lNH_dc1H8eU
- With the additional CS Params, the event fully plays out:
https://youtu.be/B9HTdRAG-pM

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1 - `!zone The Shrouded Maw`
2 - Enter "Waking Dreams"
3 - Observe the CS

Result: The full entry CS now plays properly for the player.
