### PR TITLE
[lua] Move despot PH ID storage to lua state

### DIFF
--- a/scripts/zones/RuAun_Gardens/mobs/Despot.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Despot.lua
@@ -48,19 +48,26 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
-    local ph = GetMobByID(mob:getLocalVar('ph'))
-    if ph then
-        local pos = ph:getPos()
-        mob:setPos(pos.x, pos.y, pos.z, pos.r)
-        local killerId = ph:getLocalVar('killer')
-        if killerId ~= 0 then
-            local killer = GetPlayerByID(killerId)
-            if
-                killer and
-                not killer:isEngaged() and
-                killer:checkDistance(mob) <= 50
-            then
-                mob:updateClaim(killer)
+    local zone = mob:getZone()
+
+    if zone then
+        local ph = GetMobByID(zone:getLocalVar('DespotPlaceholderID'))
+        if ph then
+            local pos      = ph:getPos()
+            local killerId = ph:getLocalVar('killer')
+
+            mob:setPos(pos.x, pos.y, pos.z, pos.r)
+
+            if killerId ~= 0 then
+                local killer = GetPlayerByID(killerId)
+
+                if
+                    killer and
+                    not killer:isEngaged() and
+                    killer:checkDistance(mob) <= 50
+                then
+                    mob:updateClaim(killer)
+                end
             end
         end
     end
@@ -108,7 +115,6 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    mob:removeListener('PH_VAR')
 end
 
 return entity

--- a/scripts/zones/RuAun_Gardens/mobs/Groundskeeper.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Groundskeeper.lua
@@ -18,12 +18,15 @@ end
 
 entity.onMobDespawn = function(mob)
     local params = {}
+
     params.immediate = true
     if xi.mob.phOnDespawn(mob, ID.mob.DESPOT, 5, 7200, params) then -- 2 hours
+        local zone = mob:getZone()
         local phId = mob:getID()
-        GetMobByID(ID.mob.DESPOT):addListener('SPAWN', 'PH_VAR', function(m)
-            m:setLocalVar('ph', phId)
-        end)
+
+        if zone then
+            zone:setLocalVar('DespotPlaceholderID', phId)
+        end
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Move Despot PH from localvar to lua state

note: this could be done in a zone local var too in theory, but this works just the same

## Steps to test these changes

Spawn despot, don't see this lua error:
`[map][warn] luautils::GetMobByID Mob doesn't exist (0) (luautils::GetMobByID:1313)`
Also despot spawns where the PH last died & is claimed to you (if you are within 50 yalms)
