### PR TITLE
[lua] Zipacna and Detector Roaming Fix; CallPets Persist Param

### DIFF
--- a/scripts/zones/VeLugannon_Palace/IDs.lua
+++ b/scripts/zones/VeLugannon_Palace/IDs.lua
@@ -30,8 +30,9 @@ zones[xi.zone.VELUGANNON_PALACE] =
     },
     mob =
     {
-        MIMIC            = GetFirstID('Mimic'),
         BRIGANDISH_BLADE = GetFirstID('Brigandish_Blade'),
+        DETECTOR         = GetTableOfIDs('Detector'),
+        MIMIC            = GetFirstID('Mimic'),
         STEAM_CLEANER    = GetFirstID('Steam_Cleaner'),
         ZIPACNA          = GetFirstID('Zipacna'),
     },

--- a/scripts/zones/VeLugannon_Palace/mobs/Detector.lua
+++ b/scripts/zones/VeLugannon_Palace/mobs/Detector.lua
@@ -9,7 +9,6 @@ local entity = {}
 
 local detectorPHTable =
 {
-
     ID.mob.STEAM_CLEANER - 26, -- E Lower Chamber
     ID.mob.STEAM_CLEANER - 24, -- E Lower Chamber
     ID.mob.STEAM_CLEANER - 22, -- W Lower Chamber
@@ -18,6 +17,256 @@ local detectorPHTable =
     ID.mob.STEAM_CLEANER - 16, -- NE Lower Chamber
     ID.mob.STEAM_CLEANER - 14, -- NW Lower Chamber
     ID.mob.STEAM_CLEANER - 12, -- NW Lower Chamber
+}
+
+-- Individual paths for each detector
+local detectorPaths =
+{
+    -- Steam Cleaner Placeholders
+    steamCleanerPHs =
+    {
+        [ID.mob.STEAM_CLEANER - 26] =
+        {
+            { x = 380, y = 16, z = -19 },
+            { x = 380, y = 16, z =   2 },
+            { x = 380, y = 16, z =  26 },
+            { x = 395, y = 16, z =  39 },
+            { x = 414, y = 16, z =  21 },
+            { x = 460, y = 16, z =  19 },
+            { x = 460, y = 16, z =  -6 },
+            { x = 459, y = 16, z = -26 },
+            { x = 446, y = 16, z = -36 },
+            { x = 430, y = 16, z = -25 },
+            { x = 423, y = 16, z = -20 },
+            { x = 410, y = 16, z = -20 },
+            { x = 380, y = 16, z = -19 },
+        },
+
+        [ID.mob.STEAM_CLEANER - 24] =
+        {
+            { x = 410, y = 16, z = -20 },
+            { x = 423, y = 16, z = -20 },
+            { x = 430, y = 16, z = -25 },
+            { x = 446, y = 16, z = -36 },
+            { x = 459, y = 16, z = -26 },
+            { x = 460, y = 16, z =  -6 },
+            { x = 460, y = 16, z =  19 },
+            { x = 414, y = 16, z =  21 },
+            { x = 395, y = 16, z =  39 },
+            { x = 380, y = 16, z =  26 },
+            { x = 380, y = 16, z =   2 },
+            { x = 380, y = 16, z = -19 },
+        },
+
+        [ID.mob.STEAM_CLEANER - 22] =
+        {
+            { x = -418, y = 16, z = -20 },
+            { x = -460, y = 16, z = -20 },
+            { x = -460, y = 16, z =  21 },
+            { x = -459, y = 16, z =  26 },
+            { x = -430, y = 16, z =  56 },
+            { x = -426, y = 16, z =  60 },
+            { x = -390, y = 16, z =  60 },
+            { x = -382, y = 16, z =  56 },
+            { x = -380, y = 16, z =  50 },
+            { x = -380, y = 16, z = -24 },
+            { x = -391, y = 16, z = -36 },
+            { x = -410, y = 16, z = -25 },
+            { x = -414, y = 16, z = -20 },
+        },
+
+        [ID.mob.STEAM_CLEANER - 20] =
+        {
+            { x = -414, y = 16, z = -20 },
+            { x = -410, y = 16, z = -25 },
+            { x = -391, y = 16, z = -36 },
+            { x = -380, y = 16, z = -24 },
+            { x = -380, y = 16, z =  50 },
+            { x = -382, y = 16, z =  56 },
+            { x = -390, y = 16, z =  60 },
+            { x = -426, y = 16, z =  60 },
+            { x = -430, y = 16, z =  56 },
+            { x = -459, y = 16, z =  26 },
+            { x = -460, y = 16, z =  21 },
+            { x = -460, y = 16, z = -20 },
+            { x = -418, y = 16, z = -20 },
+        },
+
+        [ID.mob.STEAM_CLEANER - 18] =
+        {
+            { x = 379, y = 16, z = 301 },
+            { x = 378, y = 16, z = 339 },
+            { x = 333, y = 16, z = 340 },
+            { x = 322, y = 16, z = 353 },
+            { x = 303, y = 16, z = 350 },
+            { x = 299, y = 16, z = 336 },
+            { x = 299, y = 16, z = 308 },
+            { x = 307, y = 16, z = 300 },
+            { x = 348, y = 16, z = 300 },
+            { x = 379, y = 16, z = 301 },
+        },
+
+        [ID.mob.STEAM_CLEANER - 16] =
+        {
+            { x = 379, y = 16, z = 301 },
+            { x = 348, y = 16, z = 300 },
+            { x = 307, y = 16, z = 300 },
+            { x = 299, y = 16, z = 308 },
+            { x = 299, y = 16, z = 336 },
+            { x = 303, y = 16, z = 350 },
+            { x = 322, y = 16, z = 353 },
+            { x = 333, y = 16, z = 340 },
+            { x = 378, y = 16, z = 339 },
+            { x = 379, y = 16, z = 301 },
+        },
+
+        [ID.mob.STEAM_CLEANER - 14] =
+        {
+            { x = -362, y = 16, z = 317 },
+            { x = -346, y = 16, z = 300 },
+            { x = -327, y = 16, z = 300 },
+            { x = -306, y = 16, z = 300 },
+            { x = -300, y = 16, z = 310 },
+            { x = -299, y = 16, z = 339 },
+            { x = -300, y = 16, z = 371 },
+            { x = -309, y = 16, z = 380 },
+            { x = -340, y = 16, z = 379 },
+            { x = -373, y = 16, z = 379 },
+            { x = -380, y = 16, z = 370 },
+            { x = -379, y = 16, z = 334 },
+            { x = -362, y = 16, z = 317 },
+        },
+
+        [ID.mob.STEAM_CLEANER - 12] =
+        {
+            { x = -362, y = 16, z = 317 },
+            { x = -379, y = 16, z = 334 },
+            { x = -380, y = 16, z = 370 },
+            { x = -373, y = 16, z = 379 },
+            { x = -340, y = 16, z = 379 },
+            { x = -309, y = 16, z = 380 },
+            { x = -300, y = 16, z = 371 },
+            { x = -299, y = 16, z = 339 },
+            { x = -300, y = 16, z = 310 },
+            { x = -306, y = 16, z = 300 },
+            { x = -327, y = 16, z = 300 },
+            { x = -346, y = 16, z = 300 },
+            { x = -362, y = 16, z = 317 },
+        },
+    },
+
+    -- Regular Detectors with pathing (non-PH)
+    regularDetectors =
+    {
+        [ID.mob.DETECTOR[53]] =
+        {
+            { x = 419, y = 16, z = -260 },
+            { x = 420, y = 16, z = -220 },
+            { x = 420, y = 16, z = -180 },
+            { x = 379, y = 16, z = -179 },
+            { x = 340, y = 16, z = -180 },
+            { x = 340, y = 16, z = -220 },
+            { x = 339, y = 16, z = -260 },
+            { x = 380, y = 16, z = -259 },
+            { x = 419, y = 16, z = -260 },
+        },
+
+        [ID.mob.DETECTOR[54]] =
+        {
+            { x = 419, y = 16, z = -260 },
+            { x = 380, y = 16, z = -259 },
+            { x = 339, y = 16, z = -260 },
+            { x = 340, y = 16, z = -220 },
+            { x = 340, y = 16, z = -180 },
+            { x = 379, y = 16, z = -179 },
+            { x = 420, y = 16, z = -180 },
+            { x = 420, y = 16, z = -220 },
+        },
+
+        [ID.mob.DETECTOR[55]] =
+        {
+            { x = -419, y = 16, z = -259 },
+            { x = -419, y = 16, z = -219 },
+            { x = -419, y = 16, z = -179 },
+            { x = -380, y = 16, z = -179 },
+            { x = -339, y = 16, z = -179 },
+            { x = -339, y = 16, z = -220 },
+            { x = -340, y = 16, z = -259 },
+            { x = -381, y = 16, z = -259 },
+            { x = -419, y = 16, z = -259 },
+        },
+
+        [ID.mob.DETECTOR[56]] =
+        {
+            { x = -419, y = 16, z = -259 },
+            { x = -381, y = 16, z = -259 },
+            { x = -340, y = 16, z = -259 },
+            { x = -339, y = 16, z = -220 },
+            { x = -339, y = 16, z = -179 },
+            { x = -380, y = 16, z = -179 },
+            { x = -419, y = 16, z = -179 },
+            { x = -419, y = 16, z = -219 },
+            { x = -419, y = 16, z = -259 },
+        },
+
+        [ID.mob.DETECTOR[65]] =
+        {
+            { x = 220, y = 16, z = 420 },
+            { x = 220, y = 16, z = 452 },
+            { x = 212, y = 16, z = 460 },
+            { x = 194, y = 16, z = 460 },
+            { x = 171, y = 16, z = 460 },
+            { x = 159, y = 16, z = 440 },
+            { x = 132, y = 16, z = 440 },
+            { x = 140, y = 16, z = 418 },
+            { x = 140, y = 16, z = 380 },
+            { x = 180, y = 16, z = 380 },
+            { x = 210, y = 16, z = 380 },
+            { x = 220, y = 16, z = 388 },
+        },
+
+        [ID.mob.DETECTOR[66]] =
+        {
+            { x = 220, y = 16, z = 388 },
+            { x = 210, y = 16, z = 380 },
+            { x = 180, y = 16, z = 380 },
+            { x = 140, y = 16, z = 380 },
+            { x = 140, y = 16, z = 418 },
+            { x = 132, y = 16, z = 440 },
+            { x = 159, y = 16, z = 440 },
+            { x = 171, y = 16, z = 460 },
+            { x = 194, y = 16, z = 460 },
+            { x = 212, y = 16, z = 460 },
+            { x = 220, y = 16, z = 452 },
+            { x = 220, y = 16, z = 420 },
+        },
+
+        [ID.mob.DETECTOR[67]] =
+        {
+            { x = -220, y = 16, z = 420 },
+            { x = -220, y = 16, z = 460 },
+            { x = -176, y = 16, z = 460 },
+            { x = -135, y = 16, z = 460 },
+            { x = -126, y = 16, z = 450 },
+            { x = -126, y = 16, z = 391 },
+            { x = -133, y = 16, z = 380 },
+            { x = -176, y = 16, z = 380 },
+            { x = -220, y = 16, z = 380 },
+        },
+
+        [ID.mob.DETECTOR[68]] =
+        {
+            { x = -220, y = 16, z = 380 },
+            { x = -176, y = 16, z = 380 },
+            { x = -133, y = 16, z = 380 },
+            { x = -126, y = 16, z = 391 },
+            { x = -126, y = 16, z = 450 },
+            { x = -135, y = 16, z = 460 },
+            { x = -176, y = 16, z = 460 },
+            { x = -220, y = 16, z = 460 },
+            { x = -220, y = 16, z = 420 },
+        },
+    },
 }
 
 local getMobToSpawn = function(detector)
@@ -59,8 +308,32 @@ local getMobToSpawn = function(detector)
     return steamCleaner
 end
 
+entity.onMobSpawn = function(mob)
+    local mobID = mob:getID()
+    local path = detectorPaths.steamCleanerPHs[mobID] or detectorPaths.regularDetectors[mobID]
+
+    -- Check if this detector has a defined path
+    if path then
+        -- Start pathing along this detector's unique route
+        mob:pathThrough(path, bit.bor(xi.path.flag.COORDS))
+    end
+end
+
 entity.onMobEngage = function(mob, target)
     mob:setLocalVar('petRespawn', GetSystemTime() + 10)
+end
+
+entity.onMobRoam = function(mob)
+    local mobID = mob:getID()
+    local path = detectorPaths.steamCleanerPHs[mobID] or detectorPaths.regularDetectors[mobID]
+
+    -- Check if this detector should be pathing
+    if path then
+        -- If not currently pathing, resume this detector's path
+        if not mob:isFollowingPath() then
+            mob:pathThrough(path, bit.bor(xi.path.flag.COORDS))
+        end
+    end
 end
 
 entity.onMobFight = function(mob, target)
@@ -80,13 +353,20 @@ entity.onMobFight = function(mob, target)
 
     -- Check if we should spawn a new pet
     local shouldSpawnPet = petCount < 5 and
-                        GetSystemTime() > petTimer and
-                        (not currentPet or not currentPet:isSpawned()) and
-                        summoningPet == 0
+        GetSystemTime() > petTimer and
+        (not currentPet or not currentPet:isSpawned()) and
+        summoningPet == 0
 
     if shouldSpawnPet then
         local mobToSpawn = getMobToSpawn(mob)
-        if xi.mob.callPets(mob, mobToSpawn:getID(), { inactiveTime = 5000, ignoreBusy = true }) then
+        local callPetParams =
+        {
+            inactiveTime    = 5000,
+            ignoreBusy      = true,
+            persistOnDeath  = true,
+        }
+
+        if xi.mob.callPets(mob, mobToSpawn:getID(), callPetParams) then
             mob:setLocalVar('petCount', petCount + 1)
             mob:setLocalVar('currentPet', mobToSpawn:getID())
             mob:setLocalVar('summoningPet', 1)
@@ -101,11 +381,18 @@ end
 
 entity.onMobDisengage = function(mob)
     local caretakerId = mob:getID() + 1
+    local mobID = mob:getID()
+    local path = detectorPaths.steamCleanerPHs[mobID] or detectorPaths.regularDetectors[mobID]
 
     mob:resetLocalVars()
 
     if GetMobByID(caretakerId):isSpawned() then
         DespawnMob(caretakerId)
+    end
+
+    -- Resume this detector's path after combat
+    if path then
+        mob:pathThrough(path, bit.bor(xi.path.flag.COORDS))
     end
 end
 
@@ -114,17 +401,12 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    local caretakerId = mob:getID() + 1
     local steamCleaner = GetMobByID(ID.mob.STEAM_CLEANER)
 
     mob:resetLocalVars()
     -- Ensure Steam Cleaner can be summoned again
     if steamCleaner then
         steamCleaner:setLocalVar('midSummon', 0)
-    end
-
-    if GetMobByID(caretakerId):isSpawned() then
-        DespawnMob(caretakerId)
     end
 end
 

--- a/scripts/zones/VeLugannon_Palace/mobs/Zipacna.lua
+++ b/scripts/zones/VeLugannon_Palace/mobs/Zipacna.lua
@@ -367,6 +367,28 @@ entity.onMobRoam = function(mob)
     end
 end
 
+entity.onMobDisengage = function(mob)
+    -- Resume pathing based on current direction and nearest checkpoint
+    local mobPos = mob:getPos()
+
+    -- Determine if we're closer to blue or yellow side
+    if mobPos.x < 0 then
+        -- Blue (west) side
+        if currentDirection == pathingDirection.TO_EAST then
+            mob:pathThrough(pathNodes[paths.BLUE_TO_BLUE], xi.path.flag.COORDS)
+        else
+            mob:pathThrough(pathNodes[paths.BLUE_TO_BASEMENT], bit.bor(xi.path.flag.COORDS, xi.path.flag.REVERSE))
+        end
+    else
+        -- Yellow (east) side
+        if currentDirection == pathingDirection.TO_EAST then
+            mob:pathThrough(pathNodes[paths.YELLOW_TO_BASEMENT], xi.path.flag.COORDS)
+        else
+            mob:pathThrough(pathNodes[paths.YELLOW_TO_YELLOW], bit.bor(xi.path.flag.COORDS, xi.path.flag.REVERSE))
+        end
+    end
+end
+
 entity.onMobDespawn = function(mob)
     xi.mob.updateNMSpawnPoint(mob)
     mob:setRespawnTime(math.random(10800, 14400)) -- respawn 3-4 hrs


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Corrected an issue with Zipacna not resuming his path on disengage. Added logic to determine the right path to go back to roaming whem leaving combat.
- Detectors in certain location of Ve'Lugannon are supposed to patrol in circles. Added logic for all detectors to follow paths as observed on retail.
- CallPets will automatically kill its pet on roam if the owner is dead, this was causing Steam Cleaner and Caretakers to kill themselves on disengage. Added a param to the callPets util `persistOnDeath` to stop this behavior. 
- Also adjusted Detector logic to not despawn their pets on their despawn.

## Steps to test these changes
- Fight detectors, wait for SC or Caretaker to spawn; or pull Zipacna
- Zone out, zome back in
- See that SC/Caretaker is alive; or see that Zipacna is properly back to patrolling
