### PR TITLE
[lua] Adds default action to wooden gate in Sacrarium

### DIFF
--- a/scripts/zones/Sacrarium/DefaultActions.lua
+++ b/scripts/zones/Sacrarium/DefaultActions.lua
@@ -1,5 +1,6 @@
 local ID = zones[xi.zone.SACRARIUM]
 
 return {
+    ['_0s8']                  = { messageSpecial = ID.text.CANNOT_BE_OPENED },
     ['qm_tavnazian_cookbook'] = { messageSpecial = ID.text.MUSTY_OLD_MANUSCRIPTS },
 }

--- a/scripts/zones/Sacrarium/IDs.lua
+++ b/scripts/zones/Sacrarium/IDs.lua
@@ -17,6 +17,7 @@ zones[xi.zone.SACRARIUM] =
         LOGIN_NUMBER                  = 7004, -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.
         MEMBERS_LEVELS_ARE_RESTRICTED = 7024, -- Your party is unable to participate because certain members' levels are restricted.
         CONQUEST_BASE                 = 7068, -- Tallying conquest results...
+        CANNOT_BE_OPENED              = 7231, -- The door cannot be opened...
         LARGE_KEYHOLE_DESCRIPTION     = 7234, -- The gate is securely closed with two locks. This keyhole is engraved with a sealion insignia.
         SMALL_KEYHOLE_DESCRIPTION     = 7235, -- The gate is securely closed with two locks. This keyhole is engraved with a coral insignia.
         KEYHOLE_DAMAGED               = 7236, -- The keyhole is damaged.  The gate cannot be opened from this side.


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a default action to the Wooden door in Sacrarium to prevent it from opening during the CS, and in the one instance where it can play after the mission CS and before getting the RELIQUIARIUM_KEY.

## Steps to test these changes

1. `!zone <Sacrarium>`
2. `!gotoname <_0s8>`
3. Click door on outside.

## Capture
https://youtu.be/kZjPlW6xnZM
https://drive.google.com/drive/folders/1S1cNajvhXY-QlIjlKtnWrZeFF4srZeq9?usp=drive_link