### PR TITLE
[lua] Adds immunity to Centurio X-I

### DIFF
--- a/scripts/zones/Quicksand_Caves/mobs/Centurio_X-I.lua
+++ b/scripts/zones/Quicksand_Caves/mobs/Centurio_X-I.lua
@@ -31,9 +31,11 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:addMod(xi.mod.SILENCE_MEVA, 35)
-    mob:addMod(xi.mod.SLEEP_MEVA, 50)
-    mob:addMod(xi.mod.LULLABY_MEVA, 50)
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
+    mob:addImmunity(xi.immunity.PETRIFY)
+    mob:addImmunity(xi.immunity.SILENCE)
+
     mob:addMod(xi.mod.SPELLINTERRUPT, 25)
 end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Converts the resistances to immunities as observed in captures.

## Steps to test these changes

1. `!zone <Quicksand Caves>`
2. `!gotoname <Centurio_X-I>`
3. If not up `!spawnmob Centurio_X-I`
4. Cast spells on Centurio X-I

## Capture
```
[01:46:16] Vascili casts Silence.¨The Centurio X-I completely resists the spell.
[01:46:55] Vascili casts Sleep.¨The Centurio X-I completely resists the spell.
[01:47:08] Vascili casts Break.¨The Centurio X-I completely resists the spell.
[01:48:09] Slashtangent casts Foe Lullaby.¨The Centurio X-I completely resists the spell.
```

https://youtu.be/jFijj5ZG50U
https://drive.google.com/drive/folders/1N_xYKW29n4NfIb6Pd2mpo0-WHv438MKt?usp=sharing