### PR TITLE
[core] Don't queue pet abilities if not in engaged/idle state

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -18230,6 +18230,18 @@ void CLuaBaseEntity::usePetAbility(uint16 skillId, const sol::object& target) co
 {
     CBattleEntity* PTarget{ nullptr };
 
+    // Don't queue an ability if we're not in auto attack state or no state
+    if (!m_PBaseEntity->PAI->IsCurrentState<CAttackState>() && !m_PBaseEntity->PAI->IsStateStackEmpty())
+    {
+        return;
+    }
+
+    // Don't queue an ability if we are unable to act
+    if (auto PBattleEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity); PBattleEntity && PBattleEntity->StatusEffectContainer->HasPreventActionEffect())
+    {
+        return;
+    }
+
     if (!battleutils::GetPetSkill(skillId))
     {
         return;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
See title,

changes this 
<img width="573" height="294" alt="image" src="https://github.com/user-attachments/assets/b4482ac4-6f17-484d-b9d6-319827aa966f" />

into this
<img width="597" height="229" alt="image" src="https://github.com/user-attachments/assets/e5b9e142-673b-4a9c-ab5c-827e8751c0f7" />

## Steps to test these changes

see above, but also test Perfect Defense from Alexander
