### PR TITLE
[lua] KSNM Copycat Improvement

### DIFF
--- a/scripts/zones/Waughroon_Shrine/mobs/Osschaart.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Osschaart.lua
@@ -247,6 +247,11 @@ entity.onMobFight = function(mob, target)
     local twoHourHPP = mob:getLocalVar('twoHourHPP')
     local twoHourUsed = mob:getLocalVar('twoHourUsed')
 
+    -- Add a busy check here after variables are defined to prevent charm/two-hour usage while busy
+    if xi.combat.behavior.isEntityBusy(mob) then
+        return
+    end
+
     -- Handle charm timer first
     if
         lastCharmTime == 0 or
@@ -254,6 +259,7 @@ entity.onMobFight = function(mob, target)
     then
         charm(mob)
         mob:setLocalVar('lastCharmTime', currentTime)
+        return
     end
 
     -- Then check if we should use the copied two-hour ability


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a busy check to the onMobFight logic to prevent abilities from firing off while busy (and potentially missing them entirely) - Ensures that the 2 hour can never be skipped.  Also adds a return after calling the charm function in the rare edge case that charm and 2 hour are called in the same tick.

## Steps to test these changes

Run Copycat in Waughroon Shrine!
