### PR TITLE
[core] Include main target on conal skills even if out of cone

### DIFF
--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -108,7 +108,7 @@ void CTargetFind::findWithinArea(CBattleEntity* PTarget, AOE_RADIUS radiusType, 
     bool withPet = PETS_CAN_AOE_BUFF || (m_findFlags & FINDFLAGS_PET) || (m_PMasterTarget->objtype != m_PBattleEntity->objtype);
 
     // add original target first except for self-centered moves
-    if (radiusType != AOE_RADIUS::ATTACKER)
+    if (radiusType != AOE_RADIUS::ATTACKER || m_conal)
     {
         addEntity(PTarget, false); // pet will be added later
         m_PTarget = PTarget;
@@ -480,7 +480,8 @@ bool CTargetFind::validEntity(CBattleEntity* PTarget)
 
     // this is first target, always add him first
     // Exception: for self-centered AoEs, all targets must pass radius validation
-    if (m_PTarget == nullptr && !m_selfCenteredAoE)
+    // Conals always add the main target
+    if (m_PTarget == nullptr && (!m_selfCenteredAoE || m_conal))
     {
         return true;
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds the main target on conal skills, even if the target is well outside of the cone shape.

Spent some time testing on retail and discussed it with @siknoz and we've come to the conclusion that conal abilities are always targeted at someone even if said character does not meet the cone requirements. 
Further targets are added based on meeting explicitly the cone check.

Even BLU breath spells work the same way on retail, you have to target an enemy that can be anywhere not necessarily in front of you and it will both hit it and the mobs in front of you.

I'm thinking about rewriting targetfind entirely so this is merely a bandaid fix for the time being.

- Dahak [testing video](https://youtu.be/1_0qhGoaTec)
  -  Good example of Flame Breath around 16:58 hitting the main tank (outside cone) and a char (inside cone) but not the 3rd char (outside cone, between the two)
- BLU targeting [video 1](https://www.youtube.com/watch?v=mDWIuCTboSU) 
- BLU targeting [video 2](https://www.youtube.com/watch?v=cV4KZ_XIe80)

## Steps to test these changes
- Fafnir Dragon Breath with main target standing outside of the 45 degrees cone
- BLU Breath spells

<!-- Clear and detailed steps to test your changes here -->
