### PR TITLE
Move mobWeaponskill listener so it may always trigger

### DIFF
--- a/documentation/AI_Events.txt
+++ b/documentation/AI_Events.txt
@@ -48,11 +48,11 @@ ABILITY_USE - Entity, Target, Ability, action
 ABILITY_TAKE - Target, Entity, Ability, action
 ABILITY_STATE_EXIT - Entity, Ability
 
-WEAPONSKILL_STATE_ENTER - Entity, Skillid
-WEAPONSKILL_BEFORE_USE - Entity, Skillid
-WEAPONSKILL_USE - Entity, Target, Skillid, TP, action
-WEAPONSKILL_TAKE - Target, Entity, Skillid, TP, action
-WEAPONSKILL_STATE_EXIT - Entity, Skillid
+WEAPONSKILL_STATE_ENTER - userEntity, skillId
+WEAPONSKILL_BEFORE_USE  - userEntity, skillId
+WEAPONSKILL_USE         - userEntity, targetEntity, skillId, TP, action
+WEAPONSKILL_TAKE        - userEntity, targetEntity, Skillid, TP, action
+WEAPONSKILL_STATE_EXIT  - userEntity, skillId
 
 MAGIC_START       - Entity, Spell, action
 MAGIC_USE         - Entity, Target, Spell, action

--- a/scripts/globals/abyssea/lights.lua
+++ b/scripts/globals/abyssea/lights.lua
@@ -539,7 +539,7 @@ xi.abyssea.AddDeathListeners = function(mob)
         end
     end)
 
-    mob:addListener('WEAPONSKILL_TAKE', 'ABYSSEA_WS_DEATH_CHECK', function(target, user, wsid)
+    mob:addListener('WEAPONSKILL_TAKE', 'ABYSSEA_WS_DEATH_CHECK', function(user, target, wsid)
         -- TODO: Make this human-readable, and break out from the listener
         local magicalWS =
         {

--- a/scripts/mixins/abyssea_weakness.lua
+++ b/scripts/mixins/abyssea_weakness.lua
@@ -36,7 +36,7 @@ g_mixins.abyssea_weakness = function(mob)
             end
         end)
 
-        mob:addListener('WEAPONSKILL_TAKE', 'ABYSSEA_WS_PROC_CHECK', function(target, user, wsid)
+        mob:addListener('WEAPONSKILL_TAKE', 'ABYSSEA_WS_PROC_CHECK', function(user, target, wsid)
             if target:canChangeState() then
                 if wsid == target:getLocalVar('[RedWeakness]') then
                     xi.abyssea.procMonster(target, user, xi.abyssea.triggerType.RED)

--- a/scripts/mixins/dynamis_beastmen.lua
+++ b/scripts/mixins/dynamis_beastmen.lua
@@ -54,7 +54,7 @@ g_mixins.dynamis_beastmen = function(dynamisBeastmenMob)
         end
     end)
 
-    dynamisBeastmenMob:addListener('WEAPONSKILL_TAKE', 'DYNAMIS_WS_PROC_CHECK', function(target, user, wsid)
+    dynamisBeastmenMob:addListener('WEAPONSKILL_TAKE', 'DYNAMIS_WS_PROC_CHECK', function(user, target, wsid)
         if
             procjobs[target:getMainJob()] == 'ws' and
             math.random(0, 99) < 25 and

--- a/scripts/mixins/dynamis_dreamland.lua
+++ b/scripts/mixins/dynamis_dreamland.lua
@@ -68,7 +68,7 @@ g_mixins.dynamis_dreamland = function(dynamisDreamlandMob)
         end
     end)
 
-    dynamisDreamlandMob:addListener('WEAPONSKILL_TAKE', 'DYNAMIS_WS_PROC_CHECK', function(target, user, wsid)
+    dynamisDreamlandMob:addListener('WEAPONSKILL_TAKE', 'DYNAMIS_WS_PROC_CHECK', function(user, target, wsid)
         local currency = target:getLocalVar('dynamis_currency')
         local vanaHour = VanadielHour()
 

--- a/scripts/mixins/families/chigoe.lua
+++ b/scripts/mixins/families/chigoe.lua
@@ -41,11 +41,11 @@ g_mixins.families.chigoe = function(chigoeMob)
         mob:setHP(0)
     end)
 
-    chigoeMob:addListener('WEAPONSKILL_TAKE', 'CHIGOE_WEAPONSKILL_TAKE', function(mob, wsid)
+    chigoeMob:addListener('WEAPONSKILL_TAKE', 'CHIGOE_WEAPONSKILL_TAKE', function(mob, target, wsid)
         if wsid then
-            mob:setMobMod(xi.mobMod.EXP_BONUS, -100)
-            mob:setMobMod(xi.mobMod.NO_DROPS, 1)
-            mob:setHP(0)
+            target:setMobMod(xi.mobMod.EXP_BONUS, -100)
+            target:setMobMod(xi.mobMod.NO_DROPS, 1)
+            target:setHP(0)
         end
     end)
 

--- a/scripts/mixins/families/maat.lua
+++ b/scripts/mixins/families/maat.lua
@@ -96,7 +96,7 @@ g_mixins.families.maat = function(maatMob)
         mob:messageText(mob, ID.text.YOUVE_COME_A_LONG_WAY)
     end)
 
-    maatMob:addListener('WEAPONSKILL_TAKE', 'MAAT_WEAPONSKILL_TAKE', function(target, user, wsid, tp, action)
+    maatMob:addListener('WEAPONSKILL_TAKE', 'MAAT_WEAPONSKILL_TAKE', function(user, target, wsid, tp, action)
         local ID = zones[target:getZoneID()]
         target:messageText(target, ID.text.THAT_LL_HURT_IN_THE_MORNING)
     end)

--- a/scripts/zones/Ceizak_Battlegrounds/mobs/Unfettered_Twitherym.lua
+++ b/scripts/zones/Ceizak_Battlegrounds/mobs/Unfettered_Twitherym.lua
@@ -94,14 +94,14 @@ entity.onMobSpawn = function(mob)
         end
     end)
 
-    mob:addListener('WEAPONSKILL_TAKE', 'SKILLCHAIN_DETECT', function(mobArg, _, skillID)
-        if mobArg:hasStatusEffect(xi.effect.SKILLCHAIN) then
-            if mobArg:getLocalVar('chosenElement') ~= 0 then
-                local skillchainEffect = mobArg:getStatusEffect(xi.effect.SKILLCHAIN)
+    mob:addListener('WEAPONSKILL_TAKE', 'SKILLCHAIN_DETECT', function(user, target, skillID)
+        if target:hasStatusEffect(xi.effect.SKILLCHAIN) then
+            if target:getLocalVar('chosenElement') ~= 0 then
+                local skillchainEffect = target:getStatusEffect(xi.effect.SKILLCHAIN)
                 local power            = skillchainEffect:getPower()
 
-                if isSkillchainCorrect(mobArg, power) then
-                    resetDamageModifiers(mobArg)
+                if isSkillchainCorrect(target, power) then
+                    resetDamageModifiers(target)
                     mobArg:setLocalVar('chosenElement', 0)
                     for phase, _ in pairs(phaseDTApplied) do
                         phaseDTApplied[phase] = false

--- a/scripts/zones/Lebros_Cavern/mobs/Brittle_Rock.lua
+++ b/scripts/zones/Lebros_Cavern/mobs/Brittle_Rock.lua
@@ -21,9 +21,9 @@ entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.CURSE_MEVA, 9999)
     mob:setMod(xi.mod.EVA, 0)
     mob:setMobMod(xi.mobMod.NO_DROPS, 1)
-    mob:addListener('WEAPONSKILL_TAKE', 'BRITTLE_ROCK_WEAPONSKILL_TAKE', function(mobArg, user, wsid)
+    mob:addListener('WEAPONSKILL_TAKE', 'BRITTLE_ROCK_WEAPONSKILL_TAKE', function(user, target, wsid)
         if wsid == 1838 then
-            mobArg:setHP(0)
+            target:setHP(0)
         end
     end)
 end

--- a/scripts/zones/Mamool_Ja_Training_Grounds/mobs/Dilapidated_Gate.lua
+++ b/scripts/zones/Mamool_Ja_Training_Grounds/mobs/Dilapidated_Gate.lua
@@ -11,7 +11,7 @@ entity.onMobSpawn = function(mob)
     mob:hideName(true)
     mob:setAutoAttackEnabled(false)
     mob:setMobMod(xi.mobMod.NO_MOVE, 1)
-    mob:addListener('WEAPONSKILL_TAKE', 'DILAPIDATED_GATE_WEAPONSKILL_TAKE', function(target, attacker, skillId, tp, action)
+    mob:addListener('WEAPONSKILL_TAKE', 'DILAPIDATED_GATE_WEAPONSKILL_TAKE', function(attacker, target, skillId, tp, action)
         if skillId == 1733 or skillId == 1923 then -- firespit
             target:setLocalVar('hits', target:getLocalVar('hits') + 1)
         elseif skillId == 1736 or skillId == 1925 then --Axe Throw or Stave Toss

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -177,6 +177,8 @@ bool CMobSkillState::Update(timer::time_point tick)
     }
     if (IsCompleted() && tick > m_finishTime)
     {
+        m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_STATE_EXIT", m_PEntity, m_PSkill->getID());
+
         // Only act if they're able
         if (!m_PEntity->StatusEffectContainer->HasPreventActionEffect(false))
         {
@@ -198,13 +200,10 @@ bool CMobSkillState::Update(timer::time_point tick)
                     PSummoner->StatusEffectContainer->GetStatusEffect(EFFECT_AVATARS_FAVOR)->SetPower(power > 11 ? power : 11);
                 }
             }
-
-            m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_STATE_EXIT", m_PEntity, m_PSkill->getID());
         }
         else // Switch into inactive state when done
         {
             // Exit listener here because changing states will invalidate m_PEntity/m_PSkill
-            m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_STATE_EXIT", m_PEntity, m_PSkill->getID());
             reduceTpOnInterrupt(); // Cleanup will call this only if IsCompleted is false, which is not the case here
 
             m_PEntity->PAI->Inactive(0ms, false);
@@ -212,6 +211,7 @@ bool CMobSkillState::Update(timer::time_point tick)
 
         return true;
     }
+
     return false;
 }
 

--- a/src/map/ai/states/weaponskill_state.cpp
+++ b/src/map/ai/states/weaponskill_state.cpp
@@ -152,7 +152,7 @@ bool CWeaponSkillState::Update(timer::time_point tick)
                 uint32 weaponskillDamage = weaponskillVar & 0xFFFFFF;
 
                 m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_USE", m_PEntity, PTarget, m_PSkill->getID(), m_spent, &action, weaponskillDamage);
-                PTarget->PAI->EventHandler.triggerListener("WEAPONSKILL_TAKE", PTarget, m_PEntity, m_PSkill->getID(), m_spent, &action);
+                PTarget->PAI->EventHandler.triggerListener("WEAPONSKILL_TAKE", m_PEntity, PTarget, m_PSkill->getID(), m_spent, &action);
 
                 if (m_PEntity->objtype == TYPE_PC)
                 {

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -2526,7 +2526,7 @@ void CBattleEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
         {
             damage = luautils::OnMobWeaponSkill(PTargetFound, this, PSkill, &action);
             this->PAI->EventHandler.triggerListener("WEAPONSKILL_USE", this, PTargetFound, PSkill->getID(), state.GetSpentTP(), &action, damage);
-            PTargetFound->PAI->EventHandler.triggerListener("WEAPONSKILL_TAKE", PTargetFound, this, PSkill->getID(), state.GetSpentTP(), &action);
+            PTargetFound->PAI->EventHandler.triggerListener("WEAPONSKILL_TAKE", this, PTargetFound, PSkill->getID(), state.GetSpentTP(), &action);
         }
 
         if (msg == 0)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

What title sais. Purpose is for the listener called "Weaponskill STATE EXIT" to always trigger when you EXIT the weaponskill state.

## Steps to test these changes

We will see.
