### PR TITLE
[core] [lua] Add getter/setter for new hitbox/model sizes

### DIFF
--- a/scripts/actions/abilities/pets/attachments/disruptor.lua
+++ b/scripts/actions/abilities/pets/attachments/disruptor.lua
@@ -12,7 +12,7 @@ attachmentObject.onEquip = function(pet)
             master:countEffect(xi.effect.DARK_MANEUVER) > 0 and
             automaton:getLocalVar('dispel') < VanadielTime() and
             target:hasStatusEffectByFlag(xi.effectFlag.DISPELABLE) and
-            (automaton:checkDistance(target) - target:getModelSize()) < 7
+            automaton:checkDistance(target) < (7 + target:getHitboxSize() + automaton:getHitboxSize()) -- needs verification
         then
             automaton:useMobAbility(xi.automaton.abilities.DISRUPTOR)
         end

--- a/scripts/actions/abilities/pets/attachments/eraser.lua
+++ b/scripts/actions/abilities/pets/attachments/eraser.lua
@@ -44,7 +44,7 @@ attachmentObject.onEquip = function(pet)
             then
                 erasetarget = automaton
             elseif
-                (automaton:checkDistance(master) - master:getModelSize()) < 7 and
+                automaton:checkDistance(target) < (7 + target:getHitboxSize() + automaton:getHitboxSize()) and -- needs verification
                 (master:hasStatusEffectByFlag(xi.effectFlag.ERASABLE) or checkEffects(master))
             then
                 erasetarget = master

--- a/scripts/actions/abilities/pets/attachments/flashbulb.lua
+++ b/scripts/actions/abilities/pets/attachments/flashbulb.lua
@@ -12,7 +12,7 @@ attachmentObject.onEquip = function(pet)
             not automaton:hasRecast(xi.recast.ABILITY, xi.automaton.abilities.FLASHBULB) and
             master and
             master:countEffect(xi.effect.LIGHT_MANEUVER) > 0 and
-            (automaton:checkDistance(target) - target:getModelSize()) < 7
+            automaton:checkDistance(target) < (7 + target:getHitboxSize() + automaton:getHitboxSize()) -- needs verification
         then
             automaton:useMobAbility(xi.automaton.abilities.FLASHBULB)
         end

--- a/scripts/actions/abilities/pets/attachments/strobe.lua
+++ b/scripts/actions/abilities/pets/attachments/strobe.lua
@@ -13,7 +13,7 @@ attachmentObject.onEquip = function(pet, attachment)
         if
             master and
             master:countEffect(xi.effect.FIRE_MANEUVER) > 0 and
-            (automaton:checkDistance(target) - target:getModelSize()) <= 15
+            automaton:checkDistance(target) <= (15 + target:getHitboxSize() + automaton:getHitboxSize()) -- needs verification
         then
             automaton:useMobAbility(xi.automaton.abilities.PROVOKE)
         end

--- a/scripts/actions/abilities/pets/attachments/strobe_ii.lua
+++ b/scripts/actions/abilities/pets/attachments/strobe_ii.lua
@@ -13,7 +13,7 @@ attachmentObject.onEquip = function(pet, attachment)
         if
             master and
             master:countEffect(xi.effect.FIRE_MANEUVER) > 0 and
-            (automaton:checkDistance(target) - target:getModelSize()) <= 15
+            automaton:checkDistance(target) <= (15 + target:getHitboxSize() + automaton:getHitboxSize()) -- needs verification
         then
             automaton:useMobAbility(xi.automaton.abilities.PROVOKE)
         end

--- a/scripts/globals/combat/ranged_utilities.lua
+++ b/scripts/globals/combat/ranged_utilities.lua
@@ -9,29 +9,30 @@ xi.combat.ranged = xi.combat.ranged or {}
 xi.combat.ranged.maxInnerPenalty = 25
 xi.combat.ranged.maxOuterPenalty = 20
 
--- This table provides the default sweet spot ranges for various weapon types, assuming a mob size of 1
+-- This table provides the default sweet spot ranges for various weapon types, agnostic of mob sizes altogether
 xi.combat.ranged.sweetSpotDefaults = {
-    ['throwing'] = { 0.0, 3.5  },
-    ['cannon'  ] = { 5.0, 6.0  },
-    ['gun'     ] = { 5.0, 6.0  },
-    ['shortbow'] = { 6.0, 8.0  },
-    ['crossbow'] = { 7.0, 10.0 },
-    ['longbow' ] = { 8.0, 11.0 },
+    ['throwing'] = { 0.0, 1.3 },
+    ['cannon'  ] = { 3.0, 4.3 }, -- needs re-verification
+    ['gun'     ] = { 3.0, 4.3 },
+    ['shortbow'] = { 4.0, 6.4 },
+    ['crossbow'] = { 5.0, 8.4 },
+    ['longbow' ] = { 6.0, 9.5 },
 }
 
 -- This table provides the sweet spot ranges for weapons, assuming a mob size of 1
+-- TODO: this needs re-verification due to better understanding of hitbox sizes
 xi.combat.ranged.sweetSpots = {
-    [xi.item.YOICHINOYUMI_75               ] = { 7.5, 11 },
-    [xi.item.YOICHINOYUMI_80               ] = { 7.5, 11 },
-    [xi.item.YOICHINOYUMI_85               ] = { 7.5, 11 },
-    [xi.item.YOICHINOYUMI_90               ] = { 7.5, 11 },
-    [xi.item.YOICHINOYUMI_95               ] = { 7.5, 11 },
-    [xi.item.YOICHINOYUMI_99               ] = { 7.5, 11 },
-    [xi.item.YOICHINOYUMI_99_II            ] = { 7.5, 11 },
-    [xi.item.YOICHINOYUMI_119              ] = { 7.5, 11 },
-    [xi.item.YOICHINOYUMI_119_II           ] = { 7.5, 11 },
-    [xi.item.YOICHINOYUMI_119_III          ] = { 7.5, 11 },
-    [xi.item.YOICHINOYUMI_119_III_NO_QUIVER] = { 7.5, 11 },
+    [xi.item.YOICHINOYUMI_75               ] = { 5.5, 9.5 },
+    [xi.item.YOICHINOYUMI_80               ] = { 5.5, 9.5 },
+    [xi.item.YOICHINOYUMI_85               ] = { 5.5, 9.5 },
+    [xi.item.YOICHINOYUMI_90               ] = { 5.5, 9.5 },
+    [xi.item.YOICHINOYUMI_95               ] = { 5.5, 9.5 },
+    [xi.item.YOICHINOYUMI_99               ] = { 5.5, 9.5 },
+    [xi.item.YOICHINOYUMI_99_II            ] = { 5.5, 9.5 },
+    [xi.item.YOICHINOYUMI_119              ] = { 5.5, 9.5 },
+    [xi.item.YOICHINOYUMI_119_II           ] = { 5.5, 9.5 },
+    [xi.item.YOICHINOYUMI_119_III          ] = { 5.5, 9.5 },
+    [xi.item.YOICHINOYUMI_119_III_NO_QUIVER] = { 5.5, 9.5 },
 }
 
 xi.combat.ranged.getSweetSpotByAttacker = function(attacker)
@@ -70,8 +71,8 @@ xi.combat.ranged.attackDistancePenalty = function(attacker, defender)
     local sweetSpotStart = sweetSpot[1]
     local sweetSpotEnd = sweetSpot[2]
     local distance = attacker:checkDistance(defender)
-    local centroidStart = sweetSpotStart + defender:getModelSize() + attacker:getModelSize() - 1
-    local centroidEnd = sweetSpotEnd + defender:getModelSize() + attacker:getModelSize() - 1
+    local centroidStart = sweetSpotStart + defender:getHitboxSize() + attacker:getHitboxSize()
+    local centroidEnd = sweetSpotEnd + defender:getHitboxSize() + attacker:getHitboxSize()
     local cSkillMax = attacker:getMaxSkillLevel(attacker:getMainLvl(), xi.job.WAR, xi.skill.EVASION)
 
     local penaltyPercentage
@@ -100,7 +101,7 @@ xi.combat.ranged.accuracyDistancePenalty = function(attacker, defender)
     local sweetSpotEnd = sweetSpot[2]
     local distance = attacker:checkDistance(defender)
 
-    local centroidEnd = sweetSpotEnd + defender:getModelSize() + attacker:getModelSize() - 1
+    local centroidEnd = sweetSpotEnd + defender:getHitboxSize() + attacker:getHitboxSize()
 
     if distance <= centroidEnd then
         return 0

--- a/scripts/globals/job_utils/geomancer.lua
+++ b/scripts/globals/job_utils/geomancer.lua
@@ -177,14 +177,12 @@ xi.job_utils.geomancer.geoOnConcentricPulseAbilityCheck = function(player, targe
     end
 
     -- player out of range of luopan
-    -- TODO: Luopan hitbox + player hitbox
-    if player:checkDistance(pet) > ability:getRange() then
+    if player:checkDistance(pet) > ability:getRange() + player:getHitboxSize() + pet:getHitboxSize() then
         return xi.msg.basic.TARG_OUT_OF_RANGE_2, 0
     end
 
     -- target out of range of luopan
-    -- TODO: Luopan hitbox + target hitbox
-    if target:checkDistance(pet) > ability:getRange() then
+    if target:checkDistance(pet) > ability:getRange() + target:getHitboxSize() + pet:getHitboxSize() then
         return xi.msg.basic.TARG_OUT_OF_RANGE_2, pet:getTargID()
     end
 

--- a/scripts/globals/job_utils/puppetmaster.lua
+++ b/scripts/globals/job_utils/puppetmaster.lua
@@ -149,7 +149,7 @@ xi.job_utils.puppetmaster.onAbilityCheckRepair = function(player, target, abilit
         return xi.msg.basic.REQUIRES_A_PET, 0
     elseif not pet:isAutomaton() then
         return xi.msg.basic.NO_EFFECT_ON_PET, 0
-    elseif pet:checkDistance(player) > 20.0 then -- TODO: Includes both hitboxes
+    elseif pet:checkDistance(player) > 20.0 + player:getHitboxSize() + pet:getHitboxSize() then
         return xi.msg.basic.TOO_FAR_AWAY_2, 0
     else
         local id = player:getEquipID(xi.slot.AMMO)

--- a/scripts/globals/znm.lua
+++ b/scripts/globals/znm.lua
@@ -277,7 +277,7 @@ xi.znm.soultrapper.getZeniValue = function(target, player)
     zeni = zeni * utils.clamp((1 / distance) * 8, 1, 1.5)
 
     -- Size Component
-    zeni = zeni + (target:getModelSize() * 5)
+    zeni = zeni + (target:getHitboxSize() * 5) -- needs verification
 
     -- Angle/Facing Component
     if isFacing then

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -3698,6 +3698,23 @@ function CBaseEntity:getModelSize()
 end
 
 ---@nodiscard
+---@param newSize number
+---@return nil
+function CBaseEntity:setModelSize(newSize)
+end
+
+---@nodiscard
+---@return number
+function CBaseEntity:getHitboxSize()
+end
+
+---@nodiscard
+---@param newSize number
+---@return nil
+function CBaseEntity:setHitboxSize(newSize)
+end
+
+---@nodiscard
 ---@param target CBaseEntity
 ---@return number
 function CBaseEntity:getMeleeRange(target)

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -16988,7 +16988,63 @@ uint8 CLuaBaseEntity::getModelSize()
         return 0;
     }
 
-    return PEntity->m_ModelRadius;
+    return PEntity->modelSize;
+}
+
+/************************************************************************
+ *  Function: setModelSize()
+ *  Purpose : sets the Model Size (visual) of the entity
+ *  Example : mob:setModelSize(2)
+ *  Notes   :
+ ************************************************************************/
+
+void CLuaBaseEntity::setModelSize(uint8 newSize)
+{
+    auto* PEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
+    if (!PEntity)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->getName());
+        return;
+    }
+
+    PEntity->modelSize = std::clamp<uint8>(newSize, 0, 3);
+}
+
+/************************************************************************
+ *  Function: getHitboxSize()
+ *  Purpose : Returns the hitbox size of the entity
+ *  Example : local size = mob:getHitboxSize()
+ *  Notes   :
+ ************************************************************************/
+
+float CLuaBaseEntity::getHitboxSize()
+{
+    auto* PEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
+    if (!PEntity)
+    {
+        return 0;
+    }
+
+    return PEntity->modelHitboxSize;
+}
+
+/************************************************************************
+ *  Function: setHitboxSize()
+ *  Purpose : sets the hitbox size of the entity
+ *  Example : mob:setHitboxSize(1.1)
+ *  Notes   :
+ ************************************************************************/
+
+void CLuaBaseEntity::setHitboxSize(const float newSize)
+{
+    auto* PEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
+    if (!PEntity)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->getName());
+        return;
+    }
+
+    PEntity->modelHitboxSize = newSize;
 }
 
 /************************************************************************
@@ -20126,6 +20182,9 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("isNM", CLuaBaseEntity::isNM);
 
     SOL_REGISTER("getModelSize", CLuaBaseEntity::getModelSize);
+    SOL_REGISTER("setModelSize", CLuaBaseEntity::setModelSize);
+    SOL_REGISTER("getHitboxSize", CLuaBaseEntity::getHitboxSize);
+    SOL_REGISTER("setHitboxSize", CLuaBaseEntity::setHitboxSize);
     SOL_REGISTER("getMeleeRange", CLuaBaseEntity::getMeleeRange);
     SOL_REGISTER("setMobFlags", CLuaBaseEntity::setMobFlags);
     SOL_REGISTER("getMobFlags", CLuaBaseEntity::getMobFlags);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -839,6 +839,9 @@ public:
     bool   isNM();
 
     uint8  getModelSize();
+    void   setModelSize(uint8 newSize);
+    float  getHitboxSize();
+    void   setHitboxSize(float newSize);
     float  getMeleeRange(CLuaBaseEntity* target);
     void   setMobFlags(uint32 flags, const sol::object& mobId); // Used to manipulate the mob's flags, such as changing size.
     uint32 getMobFlags();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Add getter/setter for new hitbox/model sizes
Adjust lua calls where necessary for old method, add some todos, also remove some todos

Note: the ranged stuff was changed to better align to [Sruon's distance testing](https://sruonlsb.notion.site/FFXI-Range-Radius-testing-2b23768470138076bf5cfa5020e375bc) and much of it needs retesting but its likely pretty close. This is because the ranged stuff wasn't tested with collision sizes in mind, and reversing them shows things are off by .1 or .2. So shouldn't effect much


## Steps to test these changes

Check abilities/actions/ra don't error and the new lua functions work
