### PR TITLE
[lua] Castle Oztroja password door KI check and bug fix

### DIFF
--- a/scripts/zones/Castle_Oztroja/IDs.lua
+++ b/scripts/zones/Castle_Oztroja/IDs.lua
@@ -10,6 +10,7 @@ zones[xi.zone.CASTLE_OZTROJA] =
         CANNOT_REACH_TARGET                = 0,    -- Cannot reach target.
         ITS_LOCKED                         = 1,    -- It's locked.
         PROBABLY_WORKS_WITH_SOMETHING_ELSE = 3,    -- It probably works with something else.
+        UNLIT_TORCH                        = 4,    -- You find an unlit torch.
         TORCH_LIT                          = 5,    -- The torch is lit.
         INCORRECT                          = 11,   -- Incorrect.
         FIRST_WORD                         = 12,   -- The first word.

--- a/scripts/zones/Castle_Oztroja/npcs/_47j.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_47j.lua
@@ -12,12 +12,22 @@ local entity = {}
 entity.onTrigger = function(player, npc)
     local brassDoor = GetNPCByID(npc:getID() - 4)
 
-    if
-        npc:getAnimation() == xi.anim.CLOSE_DOOR and
-        brassDoor and
-        brassDoor:getAnimation() == xi.anim.CLOSE_DOOR
-    then
+    if not brassDoor then -- Nil check
+        return
+    end
+
+    if brassDoor:getAnimation() == xi.anim.OPEN_DOOR then -- Door is already open
+        return
+    end
+
+    if npc:getAnimation() == xi.anim.OPEN_DOOR then -- Torch is already lit
+        return
+    end
+
+    if player:hasKeyItem(xi.ki.YAGUDO_TORCH) then
         player:startEvent(10)
+    else
+        player:messageSpecial(ID.text.UNLIT_TORCH)
     end
 end
 

--- a/scripts/zones/Castle_Oztroja/npcs/_47k.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_47k.lua
@@ -12,12 +12,22 @@ local entity = {}
 entity.onTrigger = function(player, npc)
     local brassDoor = GetNPCByID(npc:getID() - 3)
 
-    if
-        npc:getAnimation() == xi.anim.CLOSE_DOOR and
-        brassDoor and
-        brassDoor:getAnimation() == xi.anim.CLOSE_DOOR
-    then
+    if not brassDoor then -- Nil check
+        return
+    end
+
+    if brassDoor:getAnimation() == xi.anim.OPEN_DOOR then -- Door is already open
+        return
+    end
+
+    if npc:getAnimation() == xi.anim.OPEN_DOOR then -- Torch is already lit
+        return
+    end
+
+    if player:hasKeyItem(xi.ki.YAGUDO_TORCH) then
         player:startEvent(10)
+    else
+        player:messageSpecial(ID.text.UNLIT_TORCH)
     end
 end
 

--- a/scripts/zones/Castle_Oztroja/npcs/_47l.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_47l.lua
@@ -12,19 +12,29 @@ local entity = {}
 entity.onTrigger = function(player, npc)
     local brassDoor = GetNPCByID(npc:getID() - 4)
 
-    if
-        npc:getAnimation() == xi.anim.CLOSE_DOOR and
-        brassDoor and
-        brassDoor:getAnimation() == xi.anim.CLOSE_DOOR
-    then
+    if not brassDoor then -- Nil check
+        return
+    end
+
+    if brassDoor:getAnimation() == xi.anim.OPEN_DOOR then -- Door is already open
+        return
+    end
+
+    if npc:getAnimation() == xi.anim.OPEN_DOOR then -- Torch is already lit
+        return
+    end
+
+    if player:hasKeyItem(xi.ki.YAGUDO_TORCH) then
         player:startEvent(10)
+    else
+        player:messageSpecial(ID.text.UNLIT_TORCH)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    local brassDoor = GetNPCByID(ID.npc.SECOND_PASSWORD_STATUE - 2)
-    local torch1 = GetNPCByID(ID.npc.SECOND_PASSWORD_STATUE + 1)
-    local torch2 = GetNPCByID(ID.npc.SECOND_PASSWORD_STATUE + 2)
+    local brassDoor = GetNPCByID(ID.npc.THIRD_PASSWORD_STATUE - 2)
+    local torch1 = GetNPCByID(ID.npc.THIRD_PASSWORD_STATUE + 1)
+    local torch2 = GetNPCByID(ID.npc.THIRD_PASSWORD_STATUE + 2)
 
     if
         torch1 and

--- a/scripts/zones/Castle_Oztroja/npcs/_47m.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_47m.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 -- Area: Castle Oztroja
 --  NPC: _47m (Torch Stand)
--- Notes: Opens door _471 near password #3
+-- Notes: Opens door _471 near password #2
 -- !pos -45.230 -17.832 17.668 151
 -----------------------------------
 local ID = zones[xi.zone.CASTLE_OZTROJA]
@@ -12,19 +12,29 @@ local entity = {}
 entity.onTrigger = function(player, npc)
     local brassDoor = GetNPCByID(npc:getID() - 3)
 
-    if
-        npc:getAnimation() == xi.anim.CLOSE_DOOR and
-        brassDoor and
-        brassDoor:getAnimation() == xi.anim.CLOSE_DOOR
-    then
+    if not brassDoor then -- Nil check
+        return
+    end
+
+    if brassDoor:getAnimation() == xi.anim.OPEN_DOOR then -- Door is already open
+        return
+    end
+
+    if npc:getAnimation() == xi.anim.OPEN_DOOR then -- Torch is already lit
+        return
+    end
+
+    if player:hasKeyItem(xi.ki.YAGUDO_TORCH) then
         player:startEvent(10)
+    else
+        player:messageSpecial(ID.text.UNLIT_TORCH)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    local brassDoor = GetNPCByID(ID.npc.SECOND_PASSWORD_STATUE - 2)
-    local torch1 = GetNPCByID(ID.npc.SECOND_PASSWORD_STATUE + 1)
-    local torch2 = GetNPCByID(ID.npc.SECOND_PASSWORD_STATUE + 2)
+    local brassDoor = GetNPCByID(ID.npc.THIRD_PASSWORD_STATUE - 2)
+    local torch1 = GetNPCByID(ID.npc.THIRD_PASSWORD_STATUE + 1)
+    local torch2 = GetNPCByID(ID.npc.THIRD_PASSWORD_STATUE + 2)
 
     if
         torch1 and

--- a/scripts/zones/Castle_Oztroja/npcs/_47y.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_47y.lua
@@ -12,19 +12,29 @@ local entity = {}
 entity.onTrigger = function(player, npc)
     local brassDoor = GetNPCByID(npc:getID() - 3)
 
-    if
-        npc:getAnimation() == xi.anim.CLOSE_DOOR and
-        brassDoor and
-        brassDoor:getAnimation() == xi.anim.CLOSE_DOOR
-    then
+    if not brassDoor then -- Nil check
+        return
+    end
+
+    if brassDoor:getAnimation() == xi.anim.OPEN_DOOR then -- Door is already open
+        return
+    end
+
+    if npc:getAnimation() == xi.anim.OPEN_DOOR then -- Torch is already lit
+        return
+    end
+
+    if player:hasKeyItem(xi.ki.YAGUDO_TORCH) then
         player:startEvent(10)
+    else
+        player:messageSpecial(ID.text.UNLIT_TORCH)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    local brassDoor = GetNPCByID(ID.npc.THIRD_PASSWORD_STATUE - 2)
-    local torch1 = GetNPCByID(ID.npc.THIRD_PASSWORD_STATUE + 1)
-    local torch2 = GetNPCByID(ID.npc.THIRD_PASSWORD_STATUE + 2)
+    local brassDoor = GetNPCByID(ID.npc.SECOND_PASSWORD_STATUE - 2)
+    local torch1 = GetNPCByID(ID.npc.SECOND_PASSWORD_STATUE + 1)
+    local torch2 = GetNPCByID(ID.npc.SECOND_PASSWORD_STATUE + 2)
 
     if
         torch1 and

--- a/scripts/zones/Castle_Oztroja/npcs/_47z.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_47z.lua
@@ -12,19 +12,29 @@ local entity = {}
 entity.onTrigger = function(player, npc)
     local brassDoor = GetNPCByID(npc:getID() - 4)
 
-    if
-        npc:getAnimation() == xi.anim.CLOSE_DOOR and
-        brassDoor and
-        brassDoor:getAnimation() == xi.anim.CLOSE_DOOR
-    then
+    if not brassDoor then -- Nil check
+        return
+    end
+
+    if brassDoor:getAnimation() == xi.anim.OPEN_DOOR then -- Door is already open
+        return
+    end
+
+    if npc:getAnimation() == xi.anim.OPEN_DOOR then -- Torch is already lit
+        return
+    end
+
+    if player:hasKeyItem(xi.ki.YAGUDO_TORCH) then
         player:startEvent(10)
+    else
+        player:messageSpecial(ID.text.UNLIT_TORCH)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    local brassDoor = GetNPCByID(ID.npc.THIRD_PASSWORD_STATUE - 2)
-    local torch1 = GetNPCByID(ID.npc.THIRD_PASSWORD_STATUE + 1)
-    local torch2 = GetNPCByID(ID.npc.THIRD_PASSWORD_STATUE + 2)
+    local brassDoor = GetNPCByID(ID.npc.SECOND_PASSWORD_STATUE - 2)
+    local torch1 = GetNPCByID(ID.npc.SECOND_PASSWORD_STATUE + 1)
+    local torch2 = GetNPCByID(ID.npc.SECOND_PASSWORD_STATUE + 2)
 
     if
         torch1 and


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a bug added in with PR https://github.com/LandSandBoat/server/pull/8666 in which password doors 2 and 3 no longer opened their respective torches.
Adds a check that the player has the Yagudo Torch key item to even light the torches.
Removes the Door lua files and replaces with default actions.
Adds event if player clicks torch without having the Yagudo Torch key item.

## Steps to test these changes

1. `!zone <Castle Oztroja>`
2. Click on torches with/without Yagudo Torch KI.

## Capture
https://drive.google.com/drive/folders/1Jl6wuGKsaYp8p-QvsPaOPEwGVIi36x7i?usp=sharing
