### PR TITLE
[lua] Head Wind bug fix

### DIFF
--- a/scripts/zones/Boneyard_Gully/mobs/Shikaree_X_HW.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Shikaree_X_HW.lua
@@ -85,14 +85,20 @@ entity.onMobWeaponSkill = function(target, mob, skill)
     local skillID     = skill:getID()
     local battlefield = mob:getBattlefield()
 
-    -- Solo skill message when only one Shikaree is alive (scState 4 = SOLO)
-    if battlefield and battlefield:getLocalVar('scState') == 4 then
-        mob:messageText(mob, ID.text.SHIKAREE_X_OFFSET + 4)
+    if not battlefield then
+        return
     end
 
     -- 2-Hour message.
     if skillID == xi.mobSkill.FAMILIAR_1 then
         mob:messageText(mob, ID.text.SHIKAREE_X_2HR)
+        return
+    end
+
+    -- Solo skill message when only one Shikaree is alive (scState 4 = SOLO)
+    if battlefield:getLocalVar('scState') == 4 then
+        mob:messageText(mob, ID.text.SHIKAREE_X_OFFSET + 4)
+        return
     end
 
     -- Handle skillchain progression
@@ -101,7 +107,7 @@ entity.onMobWeaponSkill = function(target, mob, skill)
 
     if skillID == scSkill then
         -- Transition from STARTING to EXECUTING when leader's skill fires
-        if battlefield and battlefield:getLocalVar('scState') == 2 then
+        if battlefield:getLocalVar('scState') == 2 then
             battlefield:setLocalVar('scState', 3)
         end
 

--- a/scripts/zones/Boneyard_Gully/mobs/Shikaree_Y_HW.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Shikaree_Y_HW.lua
@@ -76,14 +76,16 @@ entity.onMobWeaponSkill = function(target, mob, skill)
         return
     end
 
-    -- Solo skill message when only one Shikaree is alive (scState 4 = SOLO)
-    if battlefield:getLocalVar('scState') == 4 then
-        mob:messageText(mob, ID.text.SHIKAREE_Y_OFFSET + 4)
-    end
-
     -- 2-Hour message.
     if skillID == xi.mobSkill.BLOOD_WEAPON_1 then
         mob:messageText(mob, ID.text.SHIKAREE_Y_2HR)
+        return
+    end
+
+    -- Solo skill message when only one Shikaree is alive (scState 4 = SOLO)
+    if battlefield:getLocalVar('scState') == 4 then
+        mob:messageText(mob, ID.text.SHIKAREE_Y_OFFSET + 4)
+        return
     end
 
     -- Handle skillchain progression

--- a/scripts/zones/Boneyard_Gully/mobs/Shikaree_Z_HW.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Shikaree_Z_HW.lua
@@ -3,7 +3,6 @@
 --  Mob: Shikaree Z (Head Wind)
 -- BCNM: Head Wind
 -----------------------------------
-mixins = { require('scripts/mixins/job_special') }
 local ID = zones[xi.zone.BONEYARD_GULLY]
 -----------------------------------
 ---@type TMobEntity
@@ -100,6 +99,7 @@ entity.onMobWeaponSkill = function(target, mob, skill)
     -- Solo skill message when only one Shikaree is alive (scState 4 = SOLO)
     if battlefield:getLocalVar('scState') == 4 then
         mob:messageText(mob, ID.text.SHIKAREE_Z_OFFSET + 4)
+        return
     end
 
     -- Handle skillchain progression


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Missing early battlefield return on Shikaree X
- Adjusts order of messaging on all Shikaree to properly report 2hr message
- Reworks the Head Wind lua file to be a bit easier to read

## Steps to test these changes

- Enter the Head Wind batttlefield and see that Shikaree follow expected logic
