### PR TITLE
[sql] Uncap Thunder Spirit Shock

### DIFF
--- a/sql/mob_spell_lists.sql
+++ b/sql/mob_spell_lists.sql
@@ -2251,7 +2251,7 @@ INSERT INTO `mob_spell_lists` VALUES ('ThunderSpirit',208,166,66,74);  -- thunde
 INSERT INTO `mob_spell_lists` VALUES ('ThunderSpirit',208,167,75,91);  -- thunder_iv (75~91)
 INSERT INTO `mob_spell_lists` VALUES ('ThunderSpirit',208,168,92,255); -- thunder_v (92~255)
 INSERT INTO `mob_spell_lists` VALUES ('ThunderSpirit',208,212,56,255); -- burst (56~255)
-INSERT INTO `mob_spell_lists` VALUES ('ThunderSpirit',208,239,16,50);  -- shock (16~50)
+INSERT INTO `mob_spell_lists` VALUES ('ThunderSpirit',208,239,16,255);  -- shock (16~255)
 
 -- WaterSpirit (209)
 INSERT INTO `mob_spell_lists` VALUES ('WaterSpirit',209,169,5,29);   -- water (5~29)


### PR DESCRIPTION
- Uncaps the level at which Thunder Spirit can cast shock to match the other ele spirits.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Increase the level cap on Shock from Thunder Spirit to 255 to match the other 5 elemental spirits. 

## Steps to test these changes

Summon Thunder Spirit above level 50. Wait for it to cast Shock. 

This is an SQL change and will require a DB update. 
