### PR TITLE
[core] Persist seals on zone/logout server setting

### DIFF
--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -312,6 +312,7 @@ xi.settings.main =
     FORCE_SPAWN_QM_RESET_TIME    = 300,   -- Number of seconds the ??? remains hidden for after the despawning of the mob it force spawns.
     EQUIP_FROM_OTHER_CONTAINERS  = false, -- true/false. Allows equipping items from Mog Satchel, Sack, and Case. Only possible with the use of client addons.
     REGIME_REWARD_THRESHOLD      = 15,    -- If the player is more than N levels below the minimum suggested range, do not award experience.
+    PERSIST_SEAL_TIMERS          = false, -- Persist seal (Beastmen/Kindred) recast timers across zone changes and logout.
 
     -- SYSTEM
     DISABLE_INACTIVITY_WATCHDOG = false, -- true/false. If this is enabled, the watchdog which detects if the main loop isn't being ticked will no longer be able to kill the process.

--- a/src/map/enums/CMakeLists.txt
+++ b/src/map/enums/CMakeLists.txt
@@ -14,6 +14,7 @@ set(ENUMS_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/item_types.h
     ${CMAKE_CURRENT_SOURCE_DIR}/item_lockflg.h
     ${CMAKE_CURRENT_SOURCE_DIR}/key_items.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/loot_recast.h
     ${CMAKE_CURRENT_SOURCE_DIR}/mission_log.h
     ${CMAKE_CURRENT_SOURCE_DIR}/music_slot.h
     ${CMAKE_CURRENT_SOURCE_DIR}/msg_basic.h

--- a/src/map/enums/loot_recast.h
+++ b/src/map/enums/loot_recast.h
@@ -1,0 +1,31 @@
+/*
+===========================================================================
+
+  Copyright (c) 2025 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include "common/cbasetypes.h"
+
+// IDs for RECAST_LOOT entries (special drop cooldowns)
+enum class LootRecastID : uint16
+{
+    Seal  = 1, // Beastmen's Seal, Kindred's Seal, etc.
+    Geode = 2, // Geodes and Avatarites
+};

--- a/src/map/recast_container.cpp
+++ b/src/map/recast_container.cpp
@@ -71,6 +71,11 @@ Recast_t* CRecastContainer::GetRecast(RECASTTYPE type, uint16 id)
     return nullptr;
 }
 
+Recast_t* CRecastContainer::GetLootRecast(LootRecastID id)
+{
+    return GetRecast(RECAST_LOOT, static_cast<uint16>(id));
+}
+
 /************************************************************************
  *                                                                       *
  *  Adding an entry to the container                                     *
@@ -80,6 +85,11 @@ Recast_t* CRecastContainer::GetRecast(RECASTTYPE type, uint16 id)
 void CRecastContainer::Add(RECASTTYPE type, uint16 id, timer::duration duration, timer::duration chargeTime, uint8 maxCharges)
 {
     Load(type, id, duration, chargeTime, maxCharges);
+}
+
+void CRecastContainer::AddLootRecast(LootRecastID id, timer::duration duration)
+{
+    Add(RECAST_LOOT, static_cast<uint16>(id), duration);
 }
 
 Recast_t* CRecastContainer::Load(RECASTTYPE type, uint16 id, timer::duration duration, timer::duration chargeTime, uint8 maxCharges)
@@ -215,6 +225,11 @@ bool CRecastContainer::Has(RECASTTYPE type, uint16 id)
         });
 
     return maybeRecast != PRecastList->end();
+}
+
+bool CRecastContainer::HasLootRecast(LootRecastID id)
+{
+    return Has(RECAST_LOOT, static_cast<uint16>(id));
 }
 
 /************************************************************************

--- a/src/map/recast_container.h
+++ b/src/map/recast_container.h
@@ -24,6 +24,7 @@
 
 #include "common/cbasetypes.h"
 #include "common/timer.h"
+#include "enums/loot_recast.h"
 
 #include <vector>
 
@@ -64,8 +65,10 @@ public:
     virtual void Del(RECASTTYPE type, uint16 id);
     virtual void DeleteByIndex(RECASTTYPE type, uint8 index);
     bool         Has(RECASTTYPE type, uint16 id);
+    bool         HasLootRecast(LootRecastID id);
     bool         HasRecast(RECASTTYPE type, uint16 id, timer::duration recast);
     virtual void Add(RECASTTYPE type, uint16 id, timer::duration duration, timer::duration chargeTime = 0s, uint8 maxCharges = 0);
+    void         AddLootRecast(LootRecastID id, timer::duration duration);
     Recast_t*    Load(RECASTTYPE type, uint16 id, timer::duration duration, timer::duration chargeTime = 0s, uint8 maxCharges = 0);
     virtual void ResetAbilities();
     virtual void ChangeJob()
@@ -74,6 +77,7 @@ public:
 
     virtual RecastList_t* GetRecastList(RECASTTYPE type);
     Recast_t*             GetRecast(RECASTTYPE type, uint16 id);
+    Recast_t*             GetLootRecast(LootRecastID id);
 
     CRecastContainer(CBattleEntity* PChar);
     virtual ~CRecastContainer()


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds new setting to main `PERSIST_SEAL_TIMERS` to allow servers to enable a setting to not wipe seal drop timers on logout or zone.
- Check if player has a timer on their `RECAST_SEAL` over 10 seconds and sets a charVar on zone out/log out to the timestamp the seal timer will expire. Checks if player has a value in the `SealTimerExpiry` var and sets the recast back on zone in/log in.

## Steps to test these changes
- Kill a mob in game and see it drop a beastmen or kindred seal
- Zone or logout and back in.
- `!exec print(player:hasRecast(3, 1))` and see it prints true, which means the seal timer is active
- Wait 5 min, zone in and out however many times you want
- `!exec print(player:hasRecast(3, 1))` and see it prints false after 5 min
