### PR TITLE
[lua] Sky pop NMs 1.5x Weapon Damage

### DIFF
--- a/scripts/zones/RuAun_Gardens/mobs/Despot.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Despot.lua
@@ -45,6 +45,7 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.PETRIFY)
     mob:addImmunity(xi.immunity.TERROR)
     mob:addImmunity(xi.immunity.PLAGUE)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Faust.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Faust.lua
@@ -52,6 +52,7 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.SLOW)
     mob:addImmunity(xi.immunity.TERROR)
     mob:addImmunity(xi.immunity.PLAGUE)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Olla_Grande.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Olla_Grande.lua
@@ -16,6 +16,7 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.TERROR)
     mob:addImmunity(xi.immunity.PLAGUE)
     mob:setMod(xi.mod.REGAIN, 300)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Olla_Media.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Olla_Media.lua
@@ -16,6 +16,7 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.TERROR)
     mob:addImmunity(xi.immunity.PLAGUE)
     mob:setMod(xi.mod.REGAIN, 200)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Olla_Pequena.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Olla_Pequena.lua
@@ -16,6 +16,7 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.TERROR)
     mob:addImmunity(xi.immunity.PLAGUE)
     mob:setMod(xi.mod.REGAIN, 100)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Slave_Globe.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Slave_Globe.lua
@@ -10,6 +10,7 @@ local entity = {}
 entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Ullikummi.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Ullikummi.lua
@@ -12,6 +12,7 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.TERROR)
     mob:addImmunity(xi.immunity.PLAGUE)
     mob:addMod(xi.mod.REGAIN, 1000) -- Rapid Heavy Strike usage
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/VeLugannon_Palace/mobs/Brigandish_Blade.lua
+++ b/scripts/zones/VeLugannon_Palace/mobs/Brigandish_Blade.lua
@@ -16,15 +16,20 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
     mob:addImmunity(xi.immunity.TERROR)
     mob:addImmunity(xi.immunity.PLAGUE)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
 entity.onMobSpawn = function(mob)
     mob:setUnkillable(true)
     mob:setLocalVar('killable', 0)
+    mob:setLocalVar('defaultAttack', mob:getMod(xi.mod.ATT))
 end
 
 entity.onMobFight = function(mob, target)
     local killable = mob:getLocalVar('killable')
+    -- Gains significantly increased damage as HP decreases.
+    local hp = mob:getHPP()
+    local power = (100 - hp) * 5
 
     if
         mob:getHPP() == 1 and
@@ -36,6 +41,8 @@ entity.onMobFight = function(mob, target)
         mob:setMod(xi.mod.UDMGMAGIC, -10000)
         mob:setMod(xi.mod.UDMGBREATH, -10000)
     end
+
+    mob:setMod(xi.mod.ATT, mob:getLocalVar('defaultAttack') + power)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)

--- a/scripts/zones/VeLugannon_Palace/mobs/Steam_Cleaner.lua
+++ b/scripts/zones/VeLugannon_Palace/mobs/Steam_Cleaner.lua
@@ -11,6 +11,7 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.SILENCE)
     mob:addImmunity(xi.immunity.TERROR)
     mob:addImmunity(xi.immunity.PLAGUE)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/VeLugannon_Palace/mobs/Zipacna.lua
+++ b/scripts/zones/VeLugannon_Palace/mobs/Zipacna.lua
@@ -306,6 +306,7 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
     mob:addImmunity(xi.immunity.TERROR)
     mob:addImmunity(xi.immunity.PLAGUE)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
 entity.onMobSpawn = function(mob)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds 1.5x Weapon Damage to all Sky NMs with the exception of Mother Globe, where it was found that the Slave Globes get it instead. All Level, VIT & HP values were recorded and tested against LSB with identical values. Also adds a stacking attack buff to Brigandish Blade as his HP gets lower, with examples provided from retail and LSB. 

## Examples with 1.5x weapon damage applied

*Brigandish Blade

Retail - Lv99 RDM, 80 VIT, 561 DEF @ 100% HP
[19:41:54]The Brigandish Blade hits Veralice for 119 points of damage.

LSB Local - Lv99 RDM, 80 VIT, 561 DEF - Near max HP
<img width="562" height="37" alt="image" src="https://github.com/user-attachments/assets/6f13a1fa-8507-4ebd-ba14-52bc03ccd70b" />

Brigandish Blade also hits harder as his HP gets lower, Genbu has a similar mechanic, where he gains more attack as his HP gets lower. I'm estimating this to be about 5 attack per 1% missing HP based off my capture vs. my local.

Retail - Lv99 RDM, 80 VIT, 561 DEF - 1% HP
[19:45:12]The Brigandish Blade hits Veralice for 247 points of damage.

LSB Local - Lv99 RDM, 80 VIT, 561 DEF - 1% HP 
<img width="558" height="17" alt="image" src="https://github.com/user-attachments/assets/04bffa7a-9ee7-420c-ad75-0335e5cc1a4d" />

*Despot

Retail - Lv99 BST, 120 VIT, 761 DEF
[16:27:28]The Despot hits Klair for 105 points of damage.

LSB Local - Lv99 BST, 120 VIT, 761 DEF
<img width="897" height="254" alt="image" src="https://github.com/user-attachments/assets/1ed511ba-5f18-4e2b-801c-f004caa09b13" />

*Steam Cleaner

Retail - Lv99 BST, 120 VIT, 761 DEF
[17:58:40]The Steam Cleaner hits Klair for 86 points of damage.

LSB Local - Lv99 BST, 120 VIT, 761 DEF
<img width="521" height="19" alt="image" src="https://github.com/user-attachments/assets/e3c09b0f-9625-4f3c-8ad2-f9075e7428f9" />

*Ullikummi 

Retail - Lv99 RDM, 80 VIT, 561 DEF
[20:22:08]Ullikummi hits Veralice for 126 points of damage.

LSB Local - Lv99 RDM, 80 VIT, 561 DEF
<img width="476" height="26" alt="image" src="https://github.com/user-attachments/assets/f8bee3b1-be6c-4ff8-a604-f69eecee54d6" />

*Zipacna

Retail - Lv99 RDM, 80 VIT, 540 DEF
<img width="740" height="28" alt="image" src="https://github.com/user-attachments/assets/ec6ff446-a921-44f7-81bc-5ee6b3dcddc5" />

LSB Local - Lv99 RDM, 80 VIT, 540 DEF
<img width="554" height="29" alt="image" src="https://github.com/user-attachments/assets/7387f083-e1b5-416e-9ee8-e0c971317f2d" />

*Faust

Retail - Lv99 BST, 120 VIT, 761 DEF
[17:43:35]Faust hits Klair for 119 points of damage.

LSB Local - Lv99 BST, 120 VIT, 761 DEF
<img width="447" height="24" alt="image" src="https://github.com/user-attachments/assets/b467159a-2a78-4e6a-85b8-e73886c8a703" />

*Slave Globe - 
Retail - Lv99 BST, 120 VIT, 761 DEF
[16:49:22]The Slave Globe hits Klair for 108 points of damage.

LSB Local - - Lv99 BST, 120 VIT, 761 DEF
<img width="520" height="24" alt="image" src="https://github.com/user-attachments/assets/30510af7-c393-4f20-ad23-f122b2381dd3" />

*Olla Grande

Retail - Lv99 RDM, 80 VIT, 561 DEF
[20:41:39]The Olla Grande hits Veralice for 129 points of damage.

LSB Local 
<img width="524" height="29" alt="image" src="https://github.com/user-attachments/assets/75988aac-ce9b-4a74-b97a-257d5d70d0c8" />

*Olla Pequena

Retail - Lv99 RDM, 80 VIT, 561 DEF
[20:37:18]The Olla Pequena hits Veralice for 131 points of damage.

LSB Local - Lv99 RDM, 80 VIT, 561 DEF
<img width="529" height="20" alt="image" src="https://github.com/user-attachments/assets/978bafdc-f817-4246-a57f-66d5b0bf9daa" />

*Olla Media

Retail - Lv99 RDM, 80 VIT, 561 DEF
[20:38:19]The Olla Media hits Veralice for 131 points of damage.

LSB Local - Lv99 RDM, 80 VIT, 561 DEF
<img width="516" height="30" alt="image" src="https://github.com/user-attachments/assets/8d2641b3-f209-41a8-be3f-ec523b872954" />

## Capture
[SkyPopWDCaps.zip](https://github.com/user-attachments/files/24023486/SkyPopWDCaps.zip)

## Steps to test these changes

Pop any of the NMs in Sky and compare them to retail!
