### PR TITLE
Core: Add CCharEntity::isInMogHouse(), add SendPacket common flag

### DIFF
--- a/scripts/commands/goto.lua
+++ b/scripts/commands/goto.lua
@@ -36,7 +36,7 @@ commandObj.onTrigger = function(player, target, forceZone)
     local targ = GetPlayerByName(target)
     -- if we found this player, they're on the same zone server
     -- if they're in mog house, goto them instead of setPos
-    if targ and not targ:isInMogHouse() then
+    if targ and not targ:inMogHouse() then
         player:setPos(targ:getXPos(), targ:getYPos(), targ:getZPos(), targ:getRotPos(), forceZone == 1 and targ:getZoneID() or nil)
     elseif not player:gotoPlayer(target) then
         error(player, string.format('Player named: %s not found!', target))

--- a/scripts/effects/leavegame.lua
+++ b/scripts/effects/leavegame.lua
@@ -19,7 +19,7 @@ local messages =
 effectObject.onEffectGain = function(target, effect)
     -- If you're a GM or in a MH, you get disconnected immediately.
     if
-        target:isInMogHouse() or
+        target:inMogHouse() or
         target:getGMLevel() > 0
     then
         target:leaveGame()

--- a/scripts/globals/moghouse.lua
+++ b/scripts/globals/moghouse.lua
@@ -134,8 +134,8 @@ local moghouseZoneLines =
     [1634954618] = 1, -- (257) EASTERN_ADOULIN
 }
 
-xi.moghouse.isInMogHouseInHomeNation = function(player)
-    if not player:isInMogHouse() then
+xi.moghouse.inMogHouseInHomeNation = function(player)
+    if not player:inMogHouse() then
         return false
     end
 
@@ -241,7 +241,7 @@ end
 
 xi.moghouse.onMoghouseZoneEvent = function(player, prevZone)
     -- Handle players zoning in their Mog House
-    if player:isInMogHouse() then
+    if player:inMogHouse() then
         return xi.moghouse.onMoghouseZoneIn(player, prevZone)
     end
 
@@ -311,7 +311,7 @@ xi.moghouse.onMoghouseZoneIn = function(player, prevZone)
     -- Reset: !exec player:setMoghouseFlag(0)
     -- Complete quests: !exec player:setMoghouseFlag(7)
     if
-        xi.moghouse.isInMogHouseInHomeNation(player) and
+        xi.moghouse.inMogHouseInHomeNation(player) and
         growingFlowers and
         aLadysHeart and
         flowerChild and
@@ -332,7 +332,7 @@ xi.moghouse.onMoghouseZoneIn = function(player, prevZone)
 end
 
 xi.moghouse.moogleTrade = function(player, npc, trade)
-    if player:isInMogHouse() then
+    if player:inMogHouse() then
         local numBronze = trade:getItemQty(xi.item.IMPERIAL_BRONZE_PIECE)
 
         if numBronze > 0 then
@@ -364,7 +364,7 @@ xi.moghouse.moogleTrade = function(player, npc, trade)
 end
 
 xi.moghouse.moogleTrigger = function(player, npc)
-    if player:isInMogHouse() then
+    if player:inMogHouse() then
         local lockerTs = xi.moghouse.getMogLockerExpiryTimestamp(player)
 
         if lockerTs ~= nil then

--- a/scripts/globals/teleports.lua
+++ b/scripts/globals/teleports.lua
@@ -220,7 +220,7 @@ end
 
 xi.teleport.toLeader = function(player)
     local leader = player:getPartyLeader()
-    if leader ~= nil and not leader:isInMogHouse() then
+    if leader ~= nil and not leader:inMogHouse() then
         player:gotoPlayer(leader:getName())
     end
 end

--- a/scripts/items/nexus_cape.lua
+++ b/scripts/items/nexus_cape.lua
@@ -11,7 +11,7 @@ itemObject.onItemCheck = function(target, item, param, caster)
     local leader = target:getPartyLeader()
     -- In a party and we were able to find the leader
     -- (currently fails in cross map server situations)
-    if leader ~= nil and not leader:isInMogHouse() then
+    if leader ~= nil and not leader:inMogHouse() then
         -- Don't try to teleport to self!
         if target:getID() ~= leader:getID() then
             local leaderZone = leader:getZoneID()

--- a/scripts/missions/amk/01_A_Moogle_Kupo_dEtat.lua
+++ b/scripts/missions/amk/01_A_Moogle_Kupo_dEtat.lua
@@ -19,7 +19,7 @@ mission.sections[1] = -- REMEMBER: Lua is 1-indexed!
     check = function(player, currentMission, missionStatus, vars)
         return currentMission == mission.missionId and
             xi.settings.main.ENABLE_AMK == 1 and
-            xi.moghouse.isInMogHouseInHomeNation(player) and
+            xi.moghouse.inMogHouseInHomeNation(player) and
             player:getMainLvl() >= 10 and
             player:getCharVar('HQuest[moghouseExpo]notSeen') == 0
     end,

--- a/scripts/missions/amk/02_Drenched_It_Began_with_a_Raindrop.lua
+++ b/scripts/missions/amk/02_Drenched_It_Began_with_a_Raindrop.lua
@@ -21,7 +21,7 @@ mission.sections[1] = -- REMEMBER: Lua is 1-indexed!
 {
     check = function(player, currentMission, missionStatus, vars)
         return currentMission == mission.missionId and
-            xi.moghouse.isInMogHouseInHomeNation(player)
+            xi.moghouse.inMogHouseInHomeNation(player)
     end,
 }
 

--- a/scripts/missions/rov/1_01_Rhapsodies_of_Vanadiel.lua
+++ b/scripts/missions/rov/1_01_Rhapsodies_of_Vanadiel.lua
@@ -34,7 +34,7 @@ mission.sections[1] =
         return currentMission == mission.missionId and
             xi.settings.main.ENABLE_ROV == 1 and
             player:getMainLvl() >= 3 and
-            not player:isInMogHouse()
+            not player:inMogHouse()
     end,
 }
 

--- a/scripts/missions/sandoria/8_1_Coming_of_Age.lua
+++ b/scripts/missions/sandoria/8_1_Coming_of_Age.lua
@@ -182,7 +182,7 @@ mission.sections =
             onZoneIn = function(player, prevZone)
                 if
                     mission:getVar(player, 'Progress') < GetSystemTime() and
-                    not player:isInMogHouse()
+                    not player:inMogHouse()
                 then
                     return 16
                 end

--- a/scripts/missions/soa/1_1_Rumors_from_the_West.lua
+++ b/scripts/missions/soa/1_1_Rumors_from_the_West.lua
@@ -80,7 +80,7 @@ mission.sections =
             onZoneIn = function(player, prevZone)
                 local missionStatus = player:getMissionStatus(mission.areaId)
                 local seenCS = utils.mask.getBit(missionStatus, 0)
-                if not seenCS and not player:isInMogHouse() then
+                if not seenCS and not player:inMogHouse() then
                     return 878
                 end
             end,
@@ -100,7 +100,7 @@ mission.sections =
             onZoneIn = function(player, prevZone)
                 local missionStatus = player:getMissionStatus(mission.areaId)
                 local seenCS = utils.mask.getBit(missionStatus, 1)
-                if not seenCS and not player:isInMogHouse() then
+                if not seenCS and not player:inMogHouse() then
                     return 22
                 end
             end,
@@ -120,7 +120,7 @@ mission.sections =
             onZoneIn = function(player, prevZone)
                 local missionStatus = player:getMissionStatus(mission.areaId)
                 local seenCS = utils.mask.getBit(missionStatus, 2)
-                if not seenCS and not player:isInMogHouse() then
+                if not seenCS and not player:inMogHouse() then
                     return 839
                 end
             end,

--- a/scripts/quests/hiddenQuests/Moghouse_Exposition.lua
+++ b/scripts/quests/hiddenQuests/Moghouse_Exposition.lua
@@ -10,7 +10,7 @@ quest.sections    = {}
 quest.sections[1] = {}
 
 quest.sections[1].check = function(player, currentMission, missionStatus, vars)
-    return xi.moghouse.isInMogHouseInHomeNation(player) and
+    return xi.moghouse.inMogHouseInHomeNation(player) and
         quest:getVar(player, 'notSeen') == 1
 end
 
@@ -35,8 +35,8 @@ local moogleZoneInEvent =
 quest.sections[2] = {}
 
 quest.sections[2].check = function(player, currentMission, missionStatus, vars)
-    return not xi.moghouse.isInMogHouseInHomeNation(player) and
-        player:isInMogHouse() and
+    return not xi.moghouse.inMogHouseInHomeNation(player) and
+        player:inMogHouse() and
         quest:getVar(player, 'oNation') == 1
 end
 

--- a/scripts/quests/otherAreas/Give_a_Moogle_a_Break.lua
+++ b/scripts/quests/otherAreas/Give_a_Moogle_a_Break.lua
@@ -21,7 +21,7 @@ quest.sections[1] =
         local bedPlacedTime = quest:getVar(player, 'bedPlacedTime')
 
         return status == xi.questStatus.QUEST_AVAILABLE and
-            xi.moghouse.isInMogHouseInHomeNation(player) and
+            xi.moghouse.inMogHouseInHomeNation(player) and
             player:getFameLevel(player:getNation()) >= 3 and
             not quest:getMustZone(player) and
             quest:getLocalVar(player, 'questSeen') == 0 and

--- a/scripts/quests/otherAreas/Moogles_in_the_Wild.lua
+++ b/scripts/quests/otherAreas/Moogles_in_the_Wild.lua
@@ -22,7 +22,7 @@ quest.sections[1] =
 
         return status == xi.questStatus.QUEST_AVAILABLE and
             player:hasCompletedQuest(xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.THE_MOOGLE_PICNIC) and
-            xi.moghouse.isInMogHouseInHomeNation(player) and
+            xi.moghouse.inMogHouseInHomeNation(player) and
             player:getFameLevel(player:getNation()) >= 7 and
             not quest:getMustZone(player) and
             quest:getLocalVar(player, 'questSeen') == 0 and

--- a/scripts/quests/otherAreas/The_Moogles_Picnic.lua
+++ b/scripts/quests/otherAreas/The_Moogles_Picnic.lua
@@ -22,7 +22,7 @@ quest.sections[1] =
 
         return status == xi.questStatus.QUEST_AVAILABLE and
             player:hasCompletedQuest(xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.GIVE_A_MOOGLE_A_BREAK) and
-            xi.moghouse.isInMogHouseInHomeNation(player) and
+            xi.moghouse.inMogHouseInHomeNation(player) and
             player:getFameLevel(player:getNation()) >= 5 and
             not quest:getMustZone(player) and
             quest:getLocalVar(player, 'questSeen') == 0 and

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -735,7 +735,7 @@ end
 
 ---@nodiscard
 ---@return boolean
-function CBaseEntity:isInMogHouse()
+function CBaseEntity:inMogHouse()
 end
 
 ---@param triggerAreaId integer

--- a/scripts/zones/Southern_San_dOria_[S]/npcs/Moogle.lua
+++ b/scripts/zones/Southern_San_dOria_[S]/npcs/Moogle.lua
@@ -10,7 +10,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if not player:isInMogHouse() then
+    if not player:inMogHouse() then
         player:startEvent(61)
     else
         xi.moghouse.moogleTrigger(player, npc)

--- a/src/common/types/flag.h
+++ b/src/common/types/flag.h
@@ -71,3 +71,12 @@ template <typename Tag>
 constexpr Flag<Tag> Flag<Tag>::No{ false };
 
 } // namespace xi
+
+//
+// Common flags
+//
+// TODO: When lots of callsites are moved to be inside xi::, then these flags can also be moved
+//     : inside xi::
+//
+
+using SendPacket = xi::Flag<struct SendPacketTag>;

--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -314,7 +314,7 @@ void CTargetFind::addAllInParty(CBattleEntity* PTarget, bool withPet)
     {
         static_cast<CCharEntity*>(PTarget)->ForPartyWithTrusts([this, withPet](CBattleEntity* PMember)
         {
-            if (!PMember->isInMogHouse())
+            if (!PMember->inMogHouse())
             {
                 addEntity(PMember, withPet);
             }

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -176,7 +176,7 @@ bool CBattleEntity::isInMogHouse()
 {
     if (this->objtype == TYPE_PC)
     {
-        return static_cast<CCharEntity*>(this)->m_moghouseID;
+        return static_cast<CCharEntity*>(this)->isInMogHouse();
     }
 
     return false;

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -172,11 +172,11 @@ bool CBattleEntity::isInGarrison()
     return luautils::callGlobal<bool>("xi.garrison.isInGarrison", this);
 }
 
-bool CBattleEntity::isInMogHouse()
+bool CBattleEntity::inMogHouse()
 {
     if (this->objtype == TYPE_PC)
     {
-        return static_cast<CCharEntity*>(this)->isInMogHouse();
+        return static_cast<CCharEntity*>(this)->inMogHouse();
     }
 
     return false;

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -352,7 +352,7 @@ public:
     bool isInAssault();
     bool isInDynamis();
     bool isInGarrison();
-    bool isInMogHouse();
+    bool inMogHouse();
     bool hasImmunity(uint32 imID);
     bool isAsleep();
     bool isMounted();

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -332,7 +332,7 @@ CCharEntity::~CCharEntity()
         StatusEffectContainer->DelStatusEffectSilent(EFFECT_LEVEL_RESTRICTION);
     }
 
-    if (PParty && loc.destination != 0 && !isInMogHouse())
+    if (PParty && loc.destination != 0 && !inMogHouse())
     {
         if (PParty->m_PAlliance)
         {
@@ -775,7 +775,7 @@ auto CCharEntity::aman() -> CAMANContainer&
     return *m_AMAN;
 }
 
-auto CCharEntity::isInMogHouse() const -> bool
+auto CCharEntity::inMogHouse() const -> bool
 {
     return m_moghouseID != 0;
 }
@@ -1052,7 +1052,7 @@ void CCharEntity::Tick(timer::time_point tick)
         m_deathSyncTime = tick + death_update_frequency;
     }
 
-    if (isInMogHouse())
+    if (inMogHouse())
     {
         gardenutils::UpdateGardening(this, SendPacket::Yes);
     }

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1049,7 +1049,7 @@ void CCharEntity::Tick(timer::time_point tick)
 
     if (m_moghouseID != 0)
     {
-        gardenutils::UpdateGardening(this, true);
+        gardenutils::UpdateGardening(this, SendPacket::Yes);
     }
 }
 

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -332,7 +332,7 @@ CCharEntity::~CCharEntity()
         StatusEffectContainer->DelStatusEffectSilent(EFFECT_LEVEL_RESTRICTION);
     }
 
-    if (PParty && loc.destination != 0 && m_moghouseID == 0)
+    if (PParty && loc.destination != 0 && !isInMogHouse())
     {
         if (PParty->m_PAlliance)
         {
@@ -775,6 +775,11 @@ auto CCharEntity::aman() -> CAMANContainer&
     return *m_AMAN;
 }
 
+auto CCharEntity::isInMogHouse() const -> bool
+{
+    return m_moghouseID != 0;
+}
+
 int8 CCharEntity::getShieldSize()
 {
     CItemEquipment* PItem = getEquip(SLOT_SUB);
@@ -1047,7 +1052,7 @@ void CCharEntity::Tick(timer::time_point tick)
         m_deathSyncTime = tick + death_update_frequency;
     }
 
-    if (m_moghouseID != 0)
+    if (isInMogHouse())
     {
         gardenutils::UpdateGardening(this, SendPacket::Yes);
     }

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -535,7 +535,7 @@ public:
     uint16 m_moghancementID;
 
     // The character is in ANY Mog House (their own or someone else's)
-    auto isInMogHouse() const -> bool;
+    auto inMogHouse() const -> bool;
 
     CharHistory_t m_charHistory{};
 

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -534,6 +534,9 @@ public:
     uint32 m_moghouseID;
     uint16 m_moghancementID;
 
+    // The character is in ANY Mog House (their own or someone else's)
+    auto isInMogHouse() const -> bool;
+
     CharHistory_t m_charHistory{};
 
     int8  getShieldSize();

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -2905,13 +2905,13 @@ uint8 CLuaBaseEntity::getContinentID()
 }
 
 /************************************************************************
- *  Function: isInMogHouse()
+ *  Function: inMogHouse()
  *  Purpose : Returns true if a PC is in their Mog House
- *  Example : if player:isInMogHouse() then -- watch Netflix and chill
+ *  Example : if player:inMogHouse() then -- watch Netflix and chill
  *  Notes   :
  ************************************************************************/
 
-bool CLuaBaseEntity::isInMogHouse()
+bool CLuaBaseEntity::inMogHouse()
 {
     if (m_PBaseEntity->objtype != TYPE_PC)
     {
@@ -2919,7 +2919,7 @@ bool CLuaBaseEntity::isInMogHouse()
         return false;
     }
 
-    return static_cast<CCharEntity*>(m_PBaseEntity)->isInMogHouse();
+    return static_cast<CCharEntity*>(m_PBaseEntity)->inMogHouse();
 }
 
 /************************************************************************
@@ -19506,7 +19506,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("getPreviousZoneLineID", CLuaBaseEntity::getPreviousZoneLineID);
     SOL_REGISTER("getCurrentRegion", CLuaBaseEntity::getCurrentRegion);
     SOL_REGISTER("getContinentID", CLuaBaseEntity::getContinentID);
-    SOL_REGISTER("isInMogHouse", CLuaBaseEntity::isInMogHouse);
+    SOL_REGISTER("inMogHouse", CLuaBaseEntity::inMogHouse);
 
     SOL_REGISTER("getPos", CLuaBaseEntity::getPos);
     SOL_REGISTER("showPosition", CLuaBaseEntity::showPosition);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -2919,7 +2919,7 @@ bool CLuaBaseEntity::isInMogHouse()
         return false;
     }
 
-    return static_cast<CCharEntity*>(m_PBaseEntity)->m_moghouseID;
+    return static_cast<CCharEntity*>(m_PBaseEntity)->isInMogHouse();
 }
 
 /************************************************************************

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -196,7 +196,7 @@ public:
     uint32 getPreviousZoneLineID();
     uint8  getCurrentRegion();
     uint8  getContinentID();
-    bool   isInMogHouse();
+    bool   inMogHouse();
 
     bool isPlayerInTriggerArea(uint32 triggerAreaId);
     void onPlayerTriggerAreaEnter(uint32 triggerAreaId);

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1949,7 +1949,7 @@ void OnZoneIn(CCharEntity* PChar)
     TracyZoneScoped;
 
     CZone* destinationZone = zoneutils::GetZone(PChar->loc.destination);
-    if (!PChar->m_moghouseID && destinationZone == nullptr)
+    if (!PChar->isInMogHouse() && destinationZone == nullptr)
     {
         ShowWarning("Attempt to Zone In player to invalid/disabled zone %d.", PChar->loc.destination);
         return;

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1949,7 +1949,7 @@ void OnZoneIn(CCharEntity* PChar)
     TracyZoneScoped;
 
     CZone* destinationZone = zoneutils::GetZone(PChar->loc.destination);
-    if (!PChar->isInMogHouse() && destinationZone == nullptr)
+    if (!PChar->inMogHouse() && destinationZone == nullptr)
     {
         ShowWarning("Attempt to Zone In player to invalid/disabled zone %d.", PChar->loc.destination);
         return;

--- a/src/map/packets/c2s/0x00a_login.cpp
+++ b/src/map/packets/c2s/0x00a_login.cpp
@@ -118,7 +118,8 @@ void GP_CLI_COMMAND_LOGIN::process(MapSession* PSession, CCharEntity* PChar) con
             PChar->m_charHistory.mhEntrances++;
             // TODO: Does this even work with Mog House sharing?
             charutils::updateMannequins(PChar);
-            gardenutils::UpdateGardening(PChar, false);
+            
+            gardenutils::UpdateGardening(PChar, SendPacket::No);
         }
     }
 

--- a/src/map/packets/c2s/0x00a_login.cpp
+++ b/src/map/packets/c2s/0x00a_login.cpp
@@ -113,12 +113,12 @@ void GP_CLI_COMMAND_LOGIN::process(MapSession* PSession, CCharEntity* PChar) con
         charutils::SaveZonesVisited(PChar);
         charutils::SavePlayTime(PChar);
 
-        if (PChar->m_moghouseID != 0)
+        if (PChar->isInMogHouse())
         {
             PChar->m_charHistory.mhEntrances++;
+
             // TODO: Does this even work with Mog House sharing?
             charutils::updateMannequins(PChar);
-            
             gardenutils::UpdateGardening(PChar, SendPacket::No);
         }
     }

--- a/src/map/packets/c2s/0x00a_login.cpp
+++ b/src/map/packets/c2s/0x00a_login.cpp
@@ -113,7 +113,7 @@ void GP_CLI_COMMAND_LOGIN::process(MapSession* PSession, CCharEntity* PChar) con
         charutils::SaveZonesVisited(PChar);
         charutils::SavePlayTime(PChar);
 
-        if (PChar->isInMogHouse())
+        if (PChar->inMogHouse())
         {
             PChar->m_charHistory.mhEntrances++;
 

--- a/src/map/packets/c2s/0x00c_gameok.cpp
+++ b/src/map/packets/c2s/0x00c_gameok.cpp
@@ -90,7 +90,7 @@ void GP_CLI_COMMAND_GAMEOK::process(MapSession* PSession, CCharEntity* PChar) co
     PChar->loc.zone->SpawnTransport(PChar);
 
     // respawn any pets from last zone
-    if (PChar->loc.zone->CanUseMisc(MISC_PET) && !PChar->isInMogHouse())
+    if (PChar->loc.zone->CanUseMisc(MISC_PET) && !PChar->inMogHouse())
     {
         if (PChar->shouldPetPersistThroughZoning())
         {

--- a/src/map/packets/c2s/0x00c_gameok.cpp
+++ b/src/map/packets/c2s/0x00c_gameok.cpp
@@ -90,7 +90,7 @@ void GP_CLI_COMMAND_GAMEOK::process(MapSession* PSession, CCharEntity* PChar) co
     PChar->loc.zone->SpawnTransport(PChar);
 
     // respawn any pets from last zone
-    if (PChar->loc.zone->CanUseMisc(MISC_PET) && !PChar->m_moghouseID)
+    if (PChar->loc.zone->CanUseMisc(MISC_PET) && !PChar->isInMogHouse())
     {
         if (PChar->shouldPetPersistThroughZoning())
         {

--- a/src/map/packets/c2s/0x01a_action.cpp
+++ b/src/map/packets/c2s/0x01a_action.cpp
@@ -131,7 +131,7 @@ void GP_CLI_COMMAND_ACTION::process(MapSession* PSession, CCharEntity* PChar) co
             }
 
             // NOTE: Moogles inside of mog houses are the exception for not requiring Spawned or Status checks.
-            if (PNpc != nullptr && distance(PNpc->loc.p, PChar->loc.p) <= 6.0f && ((PNpc->PAI->IsSpawned() && PNpc->status == STATUS_TYPE::NORMAL) || PChar->m_moghouseID != 0))
+            if (PNpc != nullptr && distance(PNpc->loc.p, PChar->loc.p) <= 6.0f && ((PNpc->PAI->IsSpawned() && PNpc->status == STATUS_TYPE::NORMAL) || PChar->isInMogHouse()))
             {
                 PNpc->PAI->Trigger(PChar);
                 PChar->m_charHistory.npcInteractions++;
@@ -300,7 +300,7 @@ void GP_CLI_COMMAND_ACTION::process(MapSession* PSession, CCharEntity* PChar) co
         break;
         case GP_CLI_COMMAND_ACTION_ACTIONID::Fish:
         {
-            if (PChar->m_moghouseID != 0)
+            if (PChar->isInMogHouse())
             {
                 ShowWarningFmt("GP_CLI_COMMAND_ACTION: Player {} trying to fish in Mog House", PChar->getName());
                 PChar->pushPacket<GP_SERV_COMMAND_EVENTUCOFF>(PChar, GP_SERV_COMMAND_EVENTUCOFF_MODE::Fishing);
@@ -386,7 +386,7 @@ void GP_CLI_COMMAND_ACTION::process(MapSession* PSession, CCharEntity* PChar) co
         break;
         case GP_CLI_COMMAND_ACTION_ACTIONID::SendResRdy:
         {
-            if (PChar->m_moghouseID != 0) // TODO: For now this is only in the moghouse
+            if (PChar->isInMogHouse()) // TODO: For now this is only in the moghouse
             {
                 PChar->loc.zone->SpawnConditionalNPCs(PChar);
             }

--- a/src/map/packets/c2s/0x01a_action.cpp
+++ b/src/map/packets/c2s/0x01a_action.cpp
@@ -131,7 +131,7 @@ void GP_CLI_COMMAND_ACTION::process(MapSession* PSession, CCharEntity* PChar) co
             }
 
             // NOTE: Moogles inside of mog houses are the exception for not requiring Spawned or Status checks.
-            if (PNpc != nullptr && distance(PNpc->loc.p, PChar->loc.p) <= 6.0f && ((PNpc->PAI->IsSpawned() && PNpc->status == STATUS_TYPE::NORMAL) || PChar->isInMogHouse()))
+            if (PNpc != nullptr && distance(PNpc->loc.p, PChar->loc.p) <= 6.0f && ((PNpc->PAI->IsSpawned() && PNpc->status == STATUS_TYPE::NORMAL) || PChar->inMogHouse()))
             {
                 PNpc->PAI->Trigger(PChar);
                 PChar->m_charHistory.npcInteractions++;
@@ -300,7 +300,7 @@ void GP_CLI_COMMAND_ACTION::process(MapSession* PSession, CCharEntity* PChar) co
         break;
         case GP_CLI_COMMAND_ACTION_ACTIONID::Fish:
         {
-            if (PChar->isInMogHouse())
+            if (PChar->inMogHouse())
             {
                 ShowWarningFmt("GP_CLI_COMMAND_ACTION: Player {} trying to fish in Mog House", PChar->getName());
                 PChar->pushPacket<GP_SERV_COMMAND_EVENTUCOFF>(PChar, GP_SERV_COMMAND_EVENTUCOFF_MODE::Fishing);
@@ -386,7 +386,7 @@ void GP_CLI_COMMAND_ACTION::process(MapSession* PSession, CCharEntity* PChar) co
         break;
         case GP_CLI_COMMAND_ACTION_ACTIONID::SendResRdy:
         {
-            if (PChar->isInMogHouse()) // TODO: For now this is only in the moghouse
+            if (PChar->inMogHouse()) // TODO: For now this is only in the moghouse
             {
                 PChar->loc.zone->SpawnConditionalNPCs(PChar);
             }

--- a/src/map/packets/c2s/0x037_item_use.cpp
+++ b/src/map/packets/c2s/0x037_item_use.cpp
@@ -48,7 +48,7 @@ auto GP_CLI_COMMAND_ITEM_USE::validate(MapSession* PSession, const CCharEntity* 
 {
     return PacketValidator()
         .isNotMonstrosity(PChar)
-        .mustEqual(PChar->m_moghouseID, 0, "Player is in moghouse")
+        .mustEqual(PChar->isInMogHouse(), false, "Player is in moghouse")
         .mustEqual(ItemNum, 0, "ItemNum not 0")
         .oneOf("Category", static_cast<CONTAINER_ID>(Category), validContainers);
 }

--- a/src/map/packets/c2s/0x037_item_use.cpp
+++ b/src/map/packets/c2s/0x037_item_use.cpp
@@ -48,7 +48,7 @@ auto GP_CLI_COMMAND_ITEM_USE::validate(MapSession* PSession, const CCharEntity* 
 {
     return PacketValidator()
         .isNotMonstrosity(PChar)
-        .mustEqual(PChar->isInMogHouse(), false, "Player is in moghouse")
+        .mustEqual(PChar->inMogHouse(), false, "Player is in moghouse")
         .mustEqual(ItemNum, 0, "ItemNum not 0")
         .oneOf("Category", static_cast<CONTAINER_ID>(Category), validContainers);
 }

--- a/src/map/packets/c2s/0x05e_maprect.cpp
+++ b/src/map/packets/c2s/0x05e_maprect.cpp
@@ -116,7 +116,7 @@ void GP_CLI_COMMAND_MAPRECT::process(MapSession* PSession, CCharEntity* PChar) c
                     break;
             }
 
-            bool moghouseExitRegular          = MyRoomExitMode == static_cast<uint8>(GP_CLI_COMMAND_MAPRECT_MYROOMEXITMODE::AreaEnteredFrom) && PChar->isInMogHouse();
+            bool moghouseExitRegular          = MyRoomExitMode == static_cast<uint8>(GP_CLI_COMMAND_MAPRECT_MYROOMEXITMODE::AreaEnteredFrom) && PChar->inMogHouse();
             bool requestedMoghouseFloorChange = startingZone == destinationZone && (MyRoomExitMode == static_cast<uint8>(GP_CLI_COMMAND_MAPRECT_MYROOMEXITMODE::Mog1F) || MyRoomExitMode == static_cast<uint8>(GP_CLI_COMMAND_MAPRECT_MYROOMEXITMODE::Mog2F));
             bool moghouse2FUnlocked           = PChar->profile.mhflag & 0x20;
             auto startingRegion               = zoneutils::GetCurrentRegion(startingZone);
@@ -139,11 +139,11 @@ void GP_CLI_COMMAND_MAPRECT::process(MapSession* PSession, CCharEntity* PChar) c
 
             bool moghouseExitQuestZoneline = moghouseQuestComplete &&
                                              startingRegion == destinationRegion &&
-                                             PChar->isInMogHouse() &&
+                                             PChar->inMogHouse() &&
                                              moghouseSameRegion &&
                                              !requestedMoghouseFloorChange;
 
-            bool moghouseExitMogGardenZoneline = destinationZone == ZONE_MOG_GARDEN && PChar->isInMogHouse();
+            bool moghouseExitMogGardenZoneline = destinationZone == ZONE_MOG_GARDEN && PChar->inMogHouse();
 
             // Validate travel
             if (moghouseExitRegular || moghouseExitQuestZoneline || moghouseExitMogGardenZoneline)

--- a/src/map/packets/c2s/0x05e_maprect.cpp
+++ b/src/map/packets/c2s/0x05e_maprect.cpp
@@ -116,7 +116,7 @@ void GP_CLI_COMMAND_MAPRECT::process(MapSession* PSession, CCharEntity* PChar) c
                     break;
             }
 
-            bool moghouseExitRegular          = MyRoomExitMode == static_cast<uint8>(GP_CLI_COMMAND_MAPRECT_MYROOMEXITMODE::AreaEnteredFrom) && PChar->m_moghouseID > 0;
+            bool moghouseExitRegular          = MyRoomExitMode == static_cast<uint8>(GP_CLI_COMMAND_MAPRECT_MYROOMEXITMODE::AreaEnteredFrom) && PChar->isInMogHouse();
             bool requestedMoghouseFloorChange = startingZone == destinationZone && (MyRoomExitMode == static_cast<uint8>(GP_CLI_COMMAND_MAPRECT_MYROOMEXITMODE::Mog1F) || MyRoomExitMode == static_cast<uint8>(GP_CLI_COMMAND_MAPRECT_MYROOMEXITMODE::Mog2F));
             bool moghouse2FUnlocked           = PChar->profile.mhflag & 0x20;
             auto startingRegion               = zoneutils::GetCurrentRegion(startingZone);
@@ -139,11 +139,11 @@ void GP_CLI_COMMAND_MAPRECT::process(MapSession* PSession, CCharEntity* PChar) c
 
             bool moghouseExitQuestZoneline = moghouseQuestComplete &&
                                              startingRegion == destinationRegion &&
-                                             PChar->m_moghouseID > 0 &&
+                                             PChar->isInMogHouse() &&
                                              moghouseSameRegion &&
                                              !requestedMoghouseFloorChange;
 
-            bool moghouseExitMogGardenZoneline = destinationZone == ZONE_MOG_GARDEN && PChar->m_moghouseID > 0;
+            bool moghouseExitMogGardenZoneline = destinationZone == ZONE_MOG_GARDEN && PChar->isInMogHouse();
 
             // Validate travel
             if (moghouseExitRegular || moghouseExitQuestZoneline || moghouseExitMogGardenZoneline)

--- a/src/map/packets/c2s/0x0be_merits.cpp
+++ b/src/map/packets/c2s/0x0be_merits.cpp
@@ -61,7 +61,7 @@ void GP_CLI_COMMAND_MERITS::process(MapSession* PSession, CCharEntity* PChar) co
 
         case GP_CLI_COMMAND_MERITS_KIND::EditMode:
         {
-            if (PChar->isInMogHouse()) // Note: This has been verified as allowed in a shared mog house.
+            if (PChar->inMogHouse()) // Note: This has been verified as allowed in a shared mog house.
             {
                 if (const auto merit = static_cast<MERIT_TYPE>(Param2 << 1); PChar->PMeritPoints->IsMeritExist(merit))
                 {

--- a/src/map/packets/c2s/0x0be_merits.cpp
+++ b/src/map/packets/c2s/0x0be_merits.cpp
@@ -61,7 +61,7 @@ void GP_CLI_COMMAND_MERITS::process(MapSession* PSession, CCharEntity* PChar) co
 
         case GP_CLI_COMMAND_MERITS_KIND::EditMode:
         {
-            if (PChar->m_moghouseID) // Note: This has been verified as allowed in a shared mog house.
+            if (PChar->isInMogHouse()) // Note: This has been verified as allowed in a shared mog house.
             {
                 if (const auto merit = static_cast<MERIT_TYPE>(Param2 << 1); PChar->PMeritPoints->IsMeritExist(merit))
                 {

--- a/src/map/packets/c2s/0x0bf_job_points_spend.cpp
+++ b/src/map/packets/c2s/0x0bf_job_points_spend.cpp
@@ -29,7 +29,7 @@
 auto GP_CLI_COMMAND_JOB_POINTS_SPEND::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
     return PacketValidator()
-        .mustEqual(PChar->isInMogHouse(), true, "Character not in a mog house.") // Has been verified to work in ANY Mog House.
+        .mustEqual(PChar->inMogHouse(), true, "Character not in a mog house.") // Has been verified to work in ANY Mog House.
         .mustEqual(PChar->PJobPoints && PChar->PJobPoints->IsJobPointExist(static_cast<JOBPOINT_TYPE>(Index)), true, "Job point does not exist.");
 }
 

--- a/src/map/packets/c2s/0x0bf_job_points_spend.cpp
+++ b/src/map/packets/c2s/0x0bf_job_points_spend.cpp
@@ -29,7 +29,7 @@
 auto GP_CLI_COMMAND_JOB_POINTS_SPEND::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
     return PacketValidator()
-        .mustNotEqual(PChar->m_moghouseID, 0, "Character not in a mog house.") // Has been verified to work in ANY Mog House.
+        .mustEqual(PChar->isInMogHouse(), true, "Character not in a mog house.") // Has been verified to work in ANY Mog House.
         .mustEqual(PChar->PJobPoints && PChar->PJobPoints->IsJobPointExist(static_cast<JOBPOINT_TYPE>(Index)), true, "Job point does not exist.");
 }
 

--- a/src/map/packets/s2c/0x00a_login.cpp
+++ b/src/map/packets/s2c/0x00a_login.cpp
@@ -192,7 +192,7 @@ GP_SERV_COMMAND_LOGIN::GP_SERV_COMMAND_LOGIN(CCharEntity* PChar, const EventInfo
         packet.PosHead.server_status = ANIMATION_EVENT;
     }
 
-    if (PChar->m_moghouseID != 0)
+    if (PChar->isInMogHouse())
     {
         packet.LoginState = SAVE_LOGIN_STATE::SAVE_LOGIN_STATE_MYROOM;
 

--- a/src/map/packets/s2c/0x00a_login.cpp
+++ b/src/map/packets/s2c/0x00a_login.cpp
@@ -192,7 +192,7 @@ GP_SERV_COMMAND_LOGIN::GP_SERV_COMMAND_LOGIN(CCharEntity* PChar, const EventInfo
         packet.PosHead.server_status = ANIMATION_EVENT;
     }
 
-    if (PChar->isInMogHouse())
+    if (PChar->inMogHouse())
     {
         packet.LoginState = SAVE_LOGIN_STATE::SAVE_LOGIN_STATE_MYROOM;
 

--- a/src/map/packets/s2c/0x08c_merit.cpp
+++ b/src/map/packets/s2c/0x08c_merit.cpp
@@ -43,7 +43,7 @@ GP_SERV_COMMAND_MERIT::GP_SERV_COMMAND_MERIT(CCharEntity* PChar)
             packet.merits[i].next  = PMerit->next;
         }
 
-        if (!PChar->m_moghouseID)
+        if (!PChar->isInMogHouse())
         {
             for (uint8 i = 0; i < MAX_MERITS_IN_PACKET; ++i)
             {

--- a/src/map/packets/s2c/0x08c_merit.cpp
+++ b/src/map/packets/s2c/0x08c_merit.cpp
@@ -43,7 +43,7 @@ GP_SERV_COMMAND_MERIT::GP_SERV_COMMAND_MERIT(CCharEntity* PChar)
             packet.merits[i].next  = PMerit->next;
         }
 
-        if (!PChar->isInMogHouse())
+        if (!PChar->inMogHouse())
         {
             for (uint8 i = 0; i < MAX_MERITS_IN_PACKET; ++i)
             {

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -7095,7 +7095,7 @@ void SendToZone(CCharEntity* PChar, uint16 zoneId)
                      "moghouse = ?, boundary = ? "
                      "WHERE charid = ?",
                      PChar->loc.destination,
-                     (PChar->isInMogHouse() || PChar->loc.destination == PChar->getZone()) ? PChar->loc.prevzone : PChar->getZone(),
+                     (PChar->inMogHouse() || PChar->loc.destination == PChar->getZone()) ? PChar->loc.prevzone : PChar->getZone(),
                      PChar->loc.p.rotation,
                      PChar->loc.p.x,
                      PChar->loc.p.y,

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -7095,7 +7095,7 @@ void SendToZone(CCharEntity* PChar, uint16 zoneId)
                      "moghouse = ?, boundary = ? "
                      "WHERE charid = ?",
                      PChar->loc.destination,
-                     (PChar->m_moghouseID || PChar->loc.destination == PChar->getZone()) ? PChar->loc.prevzone : PChar->getZone(),
+                     (PChar->isInMogHouse() || PChar->loc.destination == PChar->getZone()) ? PChar->loc.prevzone : PChar->getZone(),
                      PChar->loc.p.rotation,
                      PChar->loc.p.x,
                      PChar->loc.p.y,

--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -1286,7 +1286,7 @@ bool isInsideCylinder(areavector_t center, areavector_t p, uint16 radius, uint8 
 
 fishingarea_t* GetFishingArea(CCharEntity* PChar)
 {
-    if (PChar->isInMogHouse())
+    if (PChar->inMogHouse())
     {
         ShowWarning("fishingutils::GetFishingArea() - Player %s is attempting to fish from Mog House", PChar->name);
         return nullptr;

--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -1286,7 +1286,7 @@ bool isInsideCylinder(areavector_t center, areavector_t p, uint16 radius, uint8 
 
 fishingarea_t* GetFishingArea(CCharEntity* PChar)
 {
-    if (PChar->m_moghouseID > 0)
+    if (PChar->isInMogHouse())
     {
         ShowWarning("fishingutils::GetFishingArea() - Player %s is attempting to fish from Mog House", PChar->name);
         return nullptr;

--- a/src/map/utils/gardenutils.cpp
+++ b/src/map/utils/gardenutils.cpp
@@ -84,7 +84,7 @@ void Initialize()
     LoadResultList();
 }
 
-void UpdateGardening(CCharEntity* PChar, bool sendPacket)
+void UpdateGardening(CCharEntity* PChar, SendPacket sendPacket)
 {
     TracyZoneScoped;
     uint32 vanatime = earth_time::vanadiel_timestamp();

--- a/src/map/utils/gardenutils.h
+++ b/src/map/utils/gardenutils.h
@@ -47,7 +47,7 @@ namespace gardenutils
 
 void Initialize();
 
-void                      UpdateGardening(CCharEntity* PChar, bool sendPacket);
+void                      UpdateGardening(CCharEntity* PChar, SendPacket sendPacket);
 std::tuple<uint16, uint8> CalculateResults(CCharEntity* PChar, CItemFlowerpot* PItem);
 void                      GrowToNextStage(CItemFlowerpot* PItem, bool growFromFeed = false);
 uint8                     GetStageDuration(CItemFlowerpot* PItem, bool growFromFeed = false);

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -1361,7 +1361,7 @@ auto GetZoneIPP(uint16 zoneId) -> uint64
 
 auto IsResidentialArea(const CCharEntity* PChar) -> bool
 {
-    return PChar->isInMogHouse();
+    return PChar->inMogHouse();
 }
 
 void AfterZoneIn(CBaseEntity* PEntity)

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -1361,7 +1361,7 @@ auto GetZoneIPP(uint16 zoneId) -> uint64
 
 auto IsResidentialArea(const CCharEntity* PChar) -> bool
 {
-    return PChar->m_moghouseID != 0;
+    return PChar->isInMogHouse();
 }
 
 void AfterZoneIn(CBaseEntity* PEntity)

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -882,7 +882,7 @@ void CZoneEntities::SpawnNPCs(CCharEntity* PChar)
 {
     TracyZoneScoped;
 
-    if (PChar->m_moghouseID)
+    if (PChar->isInMogHouse())
     {
         return;
     }
@@ -1182,7 +1182,7 @@ void CZoneEntities::SpawnConditionalNPCs(CCharEntity* PChar)
     TracyZoneScoped;
 
     // Player information
-    const bool inMogHouse       = PChar->m_moghouseID > 0;
+    const bool inMogHouse       = PChar->isInMogHouse();
     const bool inMHinHomeNation = inMogHouse && [&]()
     {
         switch (zoneutils::GetCurrentRegion(PChar->getZone()))
@@ -1640,7 +1640,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
                 TracyZoneCString("CHAR_INZONE");
                 FOR_EACH_PAIR_CAST_SECOND(CCharEntity*, PCurrentChar, m_charList)
                 {
-                    if (PCurrentChar->m_moghouseID == 0)
+                    if (!PCurrentChar->isInMogHouse())
                     {
                         if (PEntity != PCurrentChar)
                         {

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -882,7 +882,7 @@ void CZoneEntities::SpawnNPCs(CCharEntity* PChar)
 {
     TracyZoneScoped;
 
-    if (PChar->isInMogHouse())
+    if (PChar->inMogHouse())
     {
         return;
     }
@@ -1182,7 +1182,7 @@ void CZoneEntities::SpawnConditionalNPCs(CCharEntity* PChar)
     TracyZoneScoped;
 
     // Player information
-    const bool inMogHouse       = PChar->isInMogHouse();
+    const bool inMogHouse       = PChar->inMogHouse();
     const bool inMHinHomeNation = inMogHouse && [&]()
     {
         switch (zoneutils::GetCurrentRegion(PChar->getZone()))
@@ -1640,7 +1640,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
                 TracyZoneCString("CHAR_INZONE");
                 FOR_EACH_PAIR_CAST_SECOND(CCharEntity*, PCurrentChar, m_charList)
                 {
-                    if (!PCurrentChar->isInMogHouse())
+                    if (!PCurrentChar->inMogHouse())
                     {
                         if (PEntity != PCurrentChar)
                         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

We were talking about MH and I saw some opportunities for quick cleanup that highlight some concepts we should be adopting:
- Things should be readable at the callsite for the casual reader:
  - Comparing a value to mhflag doesn't mean anything, unless you already know what mhflag does
  - A random `true` doesn't mean anything to anyone until you dig in, which pulls you away from the current file, etc. 

This reads so much easier:
```cpp
    if (isInMogHouse())
    {
        gardenutils::UpdateGardening(this, SendPacket::Yes);
    }
```

Than this does:
```cpp
    if (m_moghouseID != 0)
    {
        gardenutils::UpdateGardening(this, true);
    }
```