### PR TITLE
[lua] Lower ranged hit rate bounds to 5%

### DIFF
--- a/scripts/globals/combat/physical_hit_rate.lua
+++ b/scripts/globals/combat/physical_hit_rate.lua
@@ -214,7 +214,7 @@ xi.combat.physicalHitRate.getRangedHitRate = function(attacker, target, bonus, i
     local hitrate = accuracyAndEvasionToHitRate(attacker, target, acc, eva)
 
     -- Apply hitrate caps
-    hitrate = utils.clamp(hitrate, 0.2, 0.95)
+    hitrate = utils.clamp(hitrate, 0.05, 0.95)
 
     return hitrate
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

mobs racc (level 30-odd gigas vs over 700 evasion)
<img width="392" height="174" alt="image" src="https://github.com/user-attachments/assets/12ecab18-4541-4988-bede-8d3242ea53b5" />
5%~

player racc floor (250~ racc) vs lvl 100 uragnite
<img width="366" height="158" alt="image" src="https://github.com/user-attachments/assets/e70e4cae-974f-46fa-8bc1-b6c126253045" />
5%~

## Steps to test these changes

check racc floor (or don't and just print it when you have low racc)