### PR TITLE
[core] Add changing target support to OnMobSpellChoose

### DIFF
--- a/scripts/specs/types/MobEntity.lua
+++ b/scripts/specs/types/MobEntity.lua
@@ -30,7 +30,7 @@
 ---@field onMobWeaponSkill? fun(target: CBaseEntity, mob: CBaseEntity, mobSkill: CMobSkill, action: CAction): integer?
 ---@field onMobSkillTarget? fun(target: CBaseEntity, mob: CBaseEntity, mobSkill: CMobSkill): CBaseEntity?
 ---@field onAdditionalEffect? fun(mob: CBaseEntity, target: CBaseEntity, damage: integer): (integer?, integer?, integer?)
----@field onMobSpellChoose? fun(mob: CBaseEntity, target: CBaseEntity, spell: CSpell?): xi.magic.spell|0?
+---@field onMobSpellChoose? fun(mob: CBaseEntity, target: CBaseEntity, spell: CSpell?): xi.magic.spell|0?, CBaseEntity?
 ---@field onWeaponskillHit? fun(mob: CBaseEntity, attacker: CBaseEntity, weaponskillId: xi.weaponskill)
 ---@field onSpikesDamage? fun(mob: CBaseEntity, target: CBaseEntity, damage: integer): (integer?, integer?, integer?)
 ---@field onMagicHit? fun(caster: CBaseEntity, target: CBaseEntity, spell: CSpell)

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -340,7 +340,7 @@ int32 OnMagicCastingCheck(CBaseEntity* PChar, CBaseEntity* PTarget, CSpell* PSpe
 int32 OnSpellCast(CBattleEntity* PCaster, CBattleEntity* PTarget, CSpell* PSpell);
 void  OnSpellPrecast(CBattleEntity* PCaster, CSpell* PSpell);
 void  OnSpellInterrupted(CBattleEntity* PCaster, CSpell* PSpell);
-auto  OnMobSpellChoose(CBattleEntity* PCaster, CBattleEntity* PTarget, std::optional<SpellID> startingSpellId) -> std::optional<SpellID>;
+auto  OnMobSpellChoose(CBattleEntity* PCaster, CBattleEntity* PTarget, std::optional<SpellID> startingSpellId) -> std::tuple<std::optional<SpellID>, std::optional<CBattleEntity*>>;
 void  OnMagicHit(CBattleEntity* PCaster, CBattleEntity* PTarget, CSpell* PSpell);
 void  OnWeaponskillHit(CBattleEntity* PMob, CBaseEntity* PAttacker, uint16 PWeaponskill);
 bool  OnTrustSpellCastCheckBattlefieldTrusts(CBattleEntity* PCaster); // Triggered if spell is a trust spell during onCast to determine to interrupt spell or not


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

As the title says... adds support to change target with OnMobSpellChoose as the second return value

As an example, this script..

```lua
entity.onMobSpellChoose = function(mob, target, spellId)

    -- don't change self target
    if mob:getID() == target:getID() then
        return 0, nil
    end

    local newTarget = target

    if target:hasPet() then
        newTarget = target:getPet()
    end

    return xi.magic.spell.DEATH, newTarget
end

```

will cast Death on your pet first, and if that doesnt exist it will cast it on you. Here is the current behavior of the return params:

`return Param0, Param1`
Param0: If `nil` or 0, it will do nothing and not change the spell ID. Otherwise it will change the spell to that ID (if it exists)
Param1: if `nil`, the original target and AI behavior is preserved. if non-nil, the controller will cast on whatever target you filled in without the AI behavior

What is this AI behavior you might ask?
It's the support for default mobs with no scripts to target other mobs with spells like cures/hastes when they idle. If you want to preserve this behavior, see my example:

```lua
    -- don't change self target
    if mob:getID() == target:getID() then
        return 0, nil
    end
```

or
```lua
    -- don't change self target
    if mob:getID() == target:getID() then
        return 0
    end
```
## Steps to test these changes

Use script above, see pets get deathed first before you, modify the script to have different targets, nil target, etc