### PR TITLE
[lua] Define 'xi' as a class so LLS can detect errors

### DIFF
--- a/scripts/actions/abilities/pets/acid_mist.lua
+++ b/scripts/actions/abilities/pets/acid_mist.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/aqua_breath.lua
+++ b/scripts/actions/abilities/pets/aqua_breath.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/back_heel.lua
+++ b/scripts/actions/abilities/pets/back_heel.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/beak_lunge.lua
+++ b/scripts/actions/abilities/pets/beak_lunge.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/big_scissors.lua
+++ b/scripts/actions/abilities/pets/big_scissors.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/blaster.lua
+++ b/scripts/actions/abilities/pets/blaster.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/blockhead.lua
+++ b/scripts/actions/abilities/pets/blockhead.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/brain_crush.lua
+++ b/scripts/actions/abilities/pets/brain_crush.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/bubble_curtain.lua
+++ b/scripts/actions/abilities/pets/bubble_curtain.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/bubble_shower.lua
+++ b/scripts/actions/abilities/pets/bubble_shower.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/chaotic_eye.lua
+++ b/scripts/actions/abilities/pets/chaotic_eye.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/charged_whisker.lua
+++ b/scripts/actions/abilities/pets/charged_whisker.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/chomp_rush.lua
+++ b/scripts/actions/abilities/pets/chomp_rush.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/claw_cyclone.lua
+++ b/scripts/actions/abilities/pets/claw_cyclone.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/corrosive_ooze.lua
+++ b/scripts/actions/abilities/pets/corrosive_ooze.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/cursed_sphere.lua
+++ b/scripts/actions/abilities/pets/cursed_sphere.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/cyclotail.lua
+++ b/scripts/actions/abilities/pets/cyclotail.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/dark_spore.lua
+++ b/scripts/actions/abilities/pets/dark_spore.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/double_claw.lua
+++ b/scripts/actions/abilities/pets/double_claw.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/drainkiss.lua
+++ b/scripts/actions/abilities/pets/drainkiss.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/dream_flower.lua
+++ b/scripts/actions/abilities/pets/dream_flower.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/dust_cloud.lua
+++ b/scripts/actions/abilities/pets/dust_cloud.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/filamented_hold.lua
+++ b/scripts/actions/abilities/pets/filamented_hold.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/fireball.lua
+++ b/scripts/actions/abilities/pets/fireball.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/foot_kick.lua
+++ b/scripts/actions/abilities/pets/foot_kick.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/frenzied_rage.lua
+++ b/scripts/actions/abilities/pets/frenzied_rage.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/frogkick.lua
+++ b/scripts/actions/abilities/pets/frogkick.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/geist_wall.lua
+++ b/scripts/actions/abilities/pets/geist_wall.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/gloeosuccus.lua
+++ b/scripts/actions/abilities/pets/gloeosuccus.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/grapple.lua
+++ b/scripts/actions/abilities/pets/grapple.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/harden_shell.lua
+++ b/scripts/actions/abilities/pets/harden_shell.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/head_butt.lua
+++ b/scripts/actions/abilities/pets/head_butt.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/hi-freq_field.lua
+++ b/scripts/actions/abilities/pets/hi-freq_field.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/hoof_volley.lua
+++ b/scripts/actions/abilities/pets/hoof_volley.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/infrasonics.lua
+++ b/scripts/actions/abilities/pets/infrasonics.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/intimidate.lua
+++ b/scripts/actions/abilities/pets/intimidate.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/jettatura.lua
+++ b/scripts/actions/abilities/pets/jettatura.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/lamb_chop.lua
+++ b/scripts/actions/abilities/pets/lamb_chop.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/leaf_dagger.lua
+++ b/scripts/actions/abilities/pets/leaf_dagger.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/mandibular_bite.lua
+++ b/scripts/actions/abilities/pets/mandibular_bite.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/metallic_body.lua
+++ b/scripts/actions/abilities/pets/metallic_body.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/needleshot.lua
+++ b/scripts/actions/abilities/pets/needleshot.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/nihility_song.lua
+++ b/scripts/actions/abilities/pets/nihility_song.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/nimble_snap.lua
+++ b/scripts/actions/abilities/pets/nimble_snap.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/noisome_powder.lua
+++ b/scripts/actions/abilities/pets/noisome_powder.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/numbing_noise.lua
+++ b/scripts/actions/abilities/pets/numbing_noise.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/numbshroom.lua
+++ b/scripts/actions/abilities/pets/numbshroom.lua
@@ -7,16 +7,20 @@ local abilityObject = {}
 local skillName = 'numbshroom'
 
 abilityObject.onAbilityCheck = function(player, target, ability)
+    ---@cast ability CMobSkill
     local pet = player:getPet()
-    local checkResult = xi.actions.mobskills[skillName].onMobSkillCheck(target, pet, ability)
-    if checkResult ~= 0 then
-        return xi.msg.basic.PET_CANNOT_DO_ACTION, 0 -- TODO: verify exact message in packet.
+    if pet then
+        local checkResult = xi.actions.mobskills[skillName].onMobSkillCheck(target, pet, ability)
+        if checkResult ~= 0 then
+            return xi.msg.basic.PET_CANNOT_DO_ACTION, 0 -- TODO: verify exact message in packet.
+        end
     end
 
     return 0
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/palsy_pollen.lua
+++ b/scripts/actions/abilities/pets/palsy_pollen.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/power_attack.lua
+++ b/scripts/actions/abilities/pets/power_attack.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/purulent_ooze.lua
+++ b/scripts/actions/abilities/pets/purulent_ooze.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/queasyshroom.lua
+++ b/scripts/actions/abilities/pets/queasyshroom.lua
@@ -7,16 +7,20 @@ local abilityObject = {}
 local skillName = 'queasyshroom'
 
 abilityObject.onAbilityCheck = function(player, target, ability)
+    ---@cast ability CMobSkill
     local pet = player:getPet()
-    local checkResult = xi.actions.mobskills[skillName].onMobSkillCheck(target, pet, ability)
-    if checkResult ~= 0 then
-        return xi.msg.basic.PET_CANNOT_DO_ACTION, 0 -- TODO: verify exact message in packet.
+    if pet then
+        local checkResult = xi.actions.mobskills[skillName].onMobSkillCheck(target, pet, ability)
+        if checkResult ~= 0 then
+            return xi.msg.basic.PET_CANNOT_DO_ACTION, 0 -- TODO: verify exact message in packet.
+        end
     end
 
     return 0
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/rage.lua
+++ b/scripts/actions/abilities/pets/rage.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/random_needles.lua
+++ b/scripts/actions/abilities/pets/random_needles.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/razor_fang.lua
+++ b/scripts/actions/abilities/pets/razor_fang.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/recoil_dive.lua
+++ b/scripts/actions/abilities/pets/recoil_dive.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/rhino_attack.lua
+++ b/scripts/actions/abilities/pets/rhino_attack.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/rhino_guard.lua
+++ b/scripts/actions/abilities/pets/rhino_guard.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/ripper_fang.lua
+++ b/scripts/actions/abilities/pets/ripper_fang.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/roar.lua
+++ b/scripts/actions/abilities/pets/roar.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/sandblast.lua
+++ b/scripts/actions/abilities/pets/sandblast.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/sandpit.lua
+++ b/scripts/actions/abilities/pets/sandpit.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/scissor_guard.lua
+++ b/scripts/actions/abilities/pets/scissor_guard.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/scream.lua
+++ b/scripts/actions/abilities/pets/scream.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/scythe_tail.lua
+++ b/scripts/actions/abilities/pets/scythe_tail.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/secretion.lua
+++ b/scripts/actions/abilities/pets/secretion.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/shakeshroom.lua
+++ b/scripts/actions/abilities/pets/shakeshroom.lua
@@ -7,16 +7,20 @@ local abilityObject = {}
 local skillName = 'shakeshroom'
 
 abilityObject.onAbilityCheck = function(player, target, ability)
+    ---@cast ability CMobSkill
     local pet = player:getPet()
-    local checkResult = xi.actions.mobskills[skillName].onMobSkillCheck(target, pet, ability)
-    if checkResult ~= 0 then
-        return xi.msg.basic.PET_CANNOT_DO_ACTION, 0 -- TODO: verify exact message in packet.
+    if pet then
+        local checkResult = xi.actions.mobskills[skillName].onMobSkillCheck(target, pet, ability)
+        if checkResult ~= 0 then
+            return xi.msg.basic.PET_CANNOT_DO_ACTION, 0 -- TODO: verify exact message in packet.
+        end
     end
 
     return 0
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/sheep_charge.lua
+++ b/scripts/actions/abilities/pets/sheep_charge.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/sheep_song.lua
+++ b/scripts/actions/abilities/pets/sheep_song.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/silence_gas.lua
+++ b/scripts/actions/abilities/pets/silence_gas.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/snow_cloud.lua
+++ b/scripts/actions/abilities/pets/snow_cloud.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/somersault.lua
+++ b/scripts/actions/abilities/pets/somersault.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/soporific.lua
+++ b/scripts/actions/abilities/pets/soporific.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/spinning_top.lua
+++ b/scripts/actions/abilities/pets/spinning_top.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/spiral_spin.lua
+++ b/scripts/actions/abilities/pets/spiral_spin.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/spoil.lua
+++ b/scripts/actions/abilities/pets/spoil.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/spore.lua
+++ b/scripts/actions/abilities/pets/spore.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/suction.lua
+++ b/scripts/actions/abilities/pets/suction.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/sudden_lunge.lua
+++ b/scripts/actions/abilities/pets/sudden_lunge.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/tail_blow.lua
+++ b/scripts/actions/abilities/pets/tail_blow.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/tortoise_stomp.lua
+++ b/scripts/actions/abilities/pets/tortoise_stomp.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/toxic_spit.lua
+++ b/scripts/actions/abilities/pets/toxic_spit.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/tp_drainkiss.lua
+++ b/scripts/actions/abilities/pets/tp_drainkiss.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/venom.lua
+++ b/scripts/actions/abilities/pets/venom.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/venom_spray.lua
+++ b/scripts/actions/abilities/pets/venom_spray.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/water_wall.lua
+++ b/scripts/actions/abilities/pets/water_wall.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/whirl_claws.lua
+++ b/scripts/actions/abilities/pets/whirl_claws.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/wild_carrot.lua
+++ b/scripts/actions/abilities/pets/wild_carrot.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/wild_oats.lua
+++ b/scripts/actions/abilities/pets/wild_oats.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/actions/abilities/pets/wing_slap.lua
+++ b/scripts/actions/abilities/pets/wing_slap.lua
@@ -11,6 +11,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    ---@cast petskill CMobSkill
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/enum/msg.lua
+++ b/scripts/enum/msg.lua
@@ -62,7 +62,7 @@ xi.msg.area =
 -- Basic Messages
 -----------------------------------
 
----@enum xi.basic
+---@enum xi.msg.basic
 xi.msg.basic =
 {
     NONE                            = 0,  -- Display nothing

--- a/scripts/globals/instance.lua
+++ b/scripts/globals/instance.lua
@@ -329,6 +329,9 @@ end
 xi.instance.onTrade = function(player, npc, trade)
 end
 
+---@param player CBaseEntity
+---@param npc CBaseEntity
+---@param instanceZoneID xi.zone
 xi.instance.onTrigger = function(player, npc, instanceZoneID)
     local zoneLookup = xi.instance.lookup[instanceZoneID]
 

--- a/scripts/globals/mog_tablets.lua
+++ b/scripts/globals/mog_tablets.lua
@@ -226,7 +226,7 @@ end
 
 xi.mogTablet.moogleOnTrigger = function(player, npc)
     -- NOTE: This setting doesn't exist yet, because this feature isn't ready!
-    if xi.settings.ENABLE_MOG_TABLETS then
+    if xi.settings.map.ENABLE_MOG_TABLETS then
         local allTabletsFound = false
         if allTabletsFound then
             player:startEvent(10109)

--- a/scripts/items/astral_cube.lua
+++ b/scripts/items/astral_cube.lua
@@ -18,7 +18,7 @@ end
 
 itemObject.onItemUse = function(target)
     target:addKeyItem(keyItemId)
-    target:messageBasic(xi.basic.OBTAINED_KEY_ITEM, 6413, keyItemId)
+    target:messageBasic(xi.msg.basic.OBTAINED_KEY_ITEM, 6413, keyItemId)
 end
 
 return itemObject

--- a/scripts/items/chocobo_chair.lua
+++ b/scripts/items/chocobo_chair.lua
@@ -18,7 +18,7 @@ end
 
 itemObject.onItemUse = function(target)
     target:addKeyItem(keyItemId)
-    target:messageBasic(xi.basic.OBTAINED_KEY_ITEM, 6411, keyItemId)
+    target:messageBasic(xi.msg.basic.OBTAINED_KEY_ITEM, 6411, keyItemId)
 end
 
 return itemObject

--- a/scripts/items/ephramadian_throne.lua
+++ b/scripts/items/ephramadian_throne.lua
@@ -18,7 +18,7 @@ end
 
 itemObject.onItemUse = function(target)
     target:addKeyItem(keyItemId)
-    target:messageBasic(xi.basic.OBTAINED_KEY_ITEM, 6409, keyItemId)
+    target:messageBasic(xi.msg.basic.OBTAINED_KEY_ITEM, 6409, keyItemId)
 end
 
 return itemObject

--- a/scripts/items/portable_container.lua
+++ b/scripts/items/portable_container.lua
@@ -18,7 +18,7 @@ end
 
 itemObject.onItemUse = function(target)
     target:addKeyItem(keyItemId)
-    target:messageBasic(xi.basic.OBTAINED_KEY_ITEM, 6408, keyItemId)
+    target:messageBasic(xi.msg.basic.OBTAINED_KEY_ITEM, 6408, keyItemId)
 end
 
 return itemObject

--- a/scripts/items/shadow_throne.lua
+++ b/scripts/items/shadow_throne.lua
@@ -18,7 +18,7 @@ end
 
 itemObject.onItemUse = function(target)
     target:addKeyItem(keyItemId)
-    target:messageBasic(xi.basic.OBTAINED_KEY_ITEM, 6410, keyItemId)
+    target:messageBasic(xi.msg.basic.OBTAINED_KEY_ITEM, 6410, keyItemId)
 end
 
 return itemObject

--- a/scripts/missions/soa/4_3_8_The_Lightsland.lua
+++ b/scripts/missions/soa/4_3_8_The_Lightsland.lua
@@ -71,7 +71,7 @@ mission.sections =
                     end
 
                     -- Experience is given after this cutscene regardless of mission complete.
-                    player:addExp(500 * xi.settings.EXP_RATE)
+                    player:addExp(500 * xi.settings.map.EXP_RATE)
                 end,
 
                 [1531] = function(player, csid, option, npc)

--- a/scripts/missions/soa/4_6_1_The_Charlatan.lua
+++ b/scripts/missions/soa/4_6_1_The_Charlatan.lua
@@ -75,7 +75,7 @@ mission.sections =
                     end
 
                     -- Experience is given after this cutscene regardless of mission complete.
-                    player:addExp(500 * xi.settings.EXP_RATE)
+                    player:addExp(500 * xi.settings.map.EXP_RATE)
                 end,
 
                 [1548] = function(player, csid, option, npc)

--- a/scripts/specs/core/Globals.lua
+++ b/scripts/specs/core/Globals.lua
@@ -6,7 +6,7 @@
 ---@class xi
 ---@field actions xi.actions
 ---@field settings xi.settings
----@field zones table
+---@field zones table<string, table>
 ---@field commands table<string, TCommand>
 xi = xi or {}
 

--- a/scripts/specs/core/Globals.lua
+++ b/scripts/specs/core/Globals.lua
@@ -1,5 +1,29 @@
 ---@meta
 
+--- Global xi object
+--- Only tables injected from core (or living outside the scripts/ tree) need explicit documentation here.
+--- LLS should wire the tables defined in lua automagically.
+---@class xi
+---@field actions xi.actions
+---@field settings xi.settings
+---@field zones table
+---@field commands table<string, TCommand>
+xi = xi or {}
+
+---@class xi.actions
+---@field abilities table<string, TAbility>
+---@field mobskills table<string, TMobSkill>
+---@field spells table<string, TSpell>
+---@field weaponskills table<string, TWeaponSkill>
+
+---@class xi.settings
+---@field main table
+---@field map table
+---@field login table
+---@field network table
+---@field logging table
+---@field search table
+
 ---@return integer
 function GarbageCollectStep()
 end

--- a/scripts/specs/types/MobSkill.lua
+++ b/scripts/specs/types/MobSkill.lua
@@ -2,4 +2,4 @@
 
 ---@class TMobSkill
 ---@field onMobSkillCheck? fun(PTarget: CBaseEntity, PMob: CBaseEntity, PMobSkill: CMobSkill): integer?
----@field onMobWeaponSkill? fun(PTarget: CBaseEntity, PMob: CBaseEntity, PMobSkill: CMobSkill, action: CAction): integer?
+---@field onMobWeaponSkill? fun(PTarget: CBaseEntity, PMob: CBaseEntity, PMobSkill: CMobSkill, action: CAction?): integer?

--- a/scripts/zones/AlTaieu/mobs/Jailer_of_Love.lua
+++ b/scripts/zones/AlTaieu/mobs/Jailer_of_Love.lua
@@ -58,11 +58,11 @@ local astralFlowPets = function()
             -- Picking annoying abilities for now...
             pet:timer(1500, function(petArg)
                 if petArg:getFamily() == 269 then -- xzomit
-                    petArg:useMobAbility(xi.mobskill.MANTLE_PIERCE)
+                    petArg:useMobAbility(xi.mobSkill.MANTLE_PIERCE)
                 elseif petArg:getFamily() == 144 then -- hpemde
-                    petArg:useMobAbility(xi.mobskill.SINUATE_RUSH)
+                    petArg:useMobAbility(xi.mobSkill.SINUATE_RUSH)
                 elseif petArg:getFamily() == 194 then -- shark
-                    petArg:useMobAbility(xi.mobskill.AERIAL_COLLISION)
+                    petArg:useMobAbility(xi.mobSkill.AERIAL_COLLISION)
                 end
             end)
         end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Define 'xi' as a class. LLS is then capable of walking the tree with that change.
- Document a handful of core-injected tables LLS doesn't presently know about
- Resolve a few issues that got raised as a result
  - Typos in Jailer of Love script
  - Wrong setting in a handful of SOA missions
  - Wrong message table in a handful of chairs
  - Proper enum for xi.msg.basic
  - Handful of missing nil checks in Funguar jugpet skills
  - "Cast" all jugpet abilities to CMobSkill
    - Kinda jank but we're mixing CPetSkill and CMobSkill and CAbility in some of these code paths because... reasons.
    - I tried to define onMobWeaponskill to accept CMobSkill|CPetSkill|CAbility but realistically passing different types like that is eventually going to blow up if any of them start diverging and we dont have a strong common interface.

With these changes LLS should be able to spot wrong usage of most things in the xi global space. 
This is not a silver bullet and the receiving functions also need to be annotated correctly going forward...

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
