### PR TITLE
Add LLS version arg

### DIFF
--- a/scripts/commands/yell.lua
+++ b/scripts/commands/yell.lua
@@ -27,15 +27,21 @@ commandObj.onTrigger = function(player, value, target, days)
     end
 
     -- validate target
-    target = GetPlayerByName(target)
+    local targ
     if target == nil then
-        error(player, 'Invalid target specified')
+        error(player, 'You must enter a target player name.')
         return
+    else
+        targ = GetPlayerByName(target)
+        if targ == nil then
+            error(player, string.format('Player named "%s" not found!', target))
+            return
+        end
     end
 
     if value == 'unban' then
-        target:setCharVar('[YELL]Banned', 0)
-        player:printToPlayer(string.format('%s has been unbanned from using the /yell command.', target:getName()))
+        targ:setCharVar('[YELL]Banned', 0)
+        player:printToPlayer(string.format('%s has been unbanned from using the /yell command.', targ:getName()))
     elseif value == 'ban' then
         -- validate duration
         if
@@ -47,8 +53,8 @@ commandObj.onTrigger = function(player, value, target, days)
             days = 0
         end
 
-        target:setCharVar('[YELL]Banned', 1, GetSystemTime() + utils.days(days))
-        player:printToPlayer(string.format('%s has been banned from using the /yell command.', target:getName()))
+        targ:setCharVar('[YELL]Banned', 1, GetSystemTime() + utils.days(days))
+        player:printToPlayer(string.format('%s has been banned from using the /yell command.', targ:getName()))
     end
 end
 

--- a/tools/ci/lua_lang_server.py
+++ b/tools/ci/lua_lang_server.py
@@ -14,6 +14,12 @@ parser = argparse.ArgumentParser(
 )
 
 parser.add_argument(
+    "--version",
+    default=None,
+    help="Version of LLS to use. Defaults to latest.",
+)
+
+parser.add_argument(
     "--blame",
     default=None,
     action="store_true",
@@ -103,8 +109,8 @@ os_to_asset = {
     "Darwin": "darwin-x64.tar.gz",
 }
 
-# URL of the GitHub API for this specific release (3.15.0)
-api_url = "https://api.github.com/repos/LuaLS/lua-language-server/releases/tags/3.15.0"
+# URL of the GitHub API
+api_url = f"https://api.github.com/repos/LuaLS/lua-language-server/releases/{f"tags/{args.version}" if args.version else "latest"}"
 
 response = requests.get(api_url)
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Go back to using latest LLS, but add version arg so if there are issues in the future then this script doesn't need to be adjusted, just add this arg to the GitHub workflows.

Also fixes this issue:
```
File: /__w/server/server/scripts/commands/yell.lua:30:30
Code: param-type-mismatch
Severity: Warning
Message: Cannot assign `CBaseEntity?` to parameter `string`.
- `CBaseEntity` cannot match `string`
- Type `CBaseEntity` cannot match `string`
```

## Steps to test these changes
This should successfully pull and run version 3.16.1 (latest).
```
xiadmin@hostname:/server$ python ./tools/ci/lua_lang_server.py
NOT running git blame on each error line to find the last editor (use --blame to enable).
Current OS: Linux
Asset found: lua-language-server-3.16.1-linux-x64.tar.gz
```

Pass version arg to pull a different version.
```
xiadmin@hostname:/server$ python ./tools/ci/lua_lang_server.py --version 3.15.0
NOT running git blame on each error line to find the last editor (use --blame to enable).
Current OS: Linux
Asset found: lua-language-server-3.15.0-linux-x64.tar.gz
```