### PR TITLE
[core] Exit synth state if dead

### DIFF
--- a/src/map/ai/states/synth_state.cpp
+++ b/src/map/ai/states/synth_state.cpp
@@ -24,6 +24,7 @@
 #include "entities/battleentity.h"
 
 #include "ai/ai_container.h"
+#include "trade_container.h"
 #include "utils/synthutils.h"
 
 CSynthState::CSynthState(CCharEntity* PChar, SKILLTYPE skill)
@@ -63,6 +64,15 @@ CSynthState::CSynthState(CCharEntity* PChar, SKILLTYPE skill)
 
 bool CSynthState::Update(timer::time_point tick)
 {
+    // Exit state if dead
+    if (m_PEntity->isDead())
+    {
+        synthutils::doSynthCriticalFail(m_PEntity);
+
+        m_PEntity->CraftContainer->Clean(); // Clean to reset m_ItemCount to 0
+        return true;
+    }
+
     if (SynthReady())
     {
         synthutils::sendSynthDone(m_PEntity);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Apparently there was an edge case where if you died while synthing your synth state stack would retain the stop state and you couldn't HP or accept raises

## Steps to test these changes

Start synth, die and get raised/homepoint
