### PR TITLE
Player Skill:acc fixes, fix mob RATT getting doubled from "skill"

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1061,11 +1061,8 @@ uint16 CBattleEntity::RATT(uint16 bonusAtt)
 
         skillLevel = std::max({ archery_acc, marksmanship_acc, throwing_acc });
     }
-    else // pets, mobs
-    {
-        skillLevel = m_modStat[Mod::RATT];
-    }
-    
+    // mobs and pets don't have "skill level" -- it's baked into m_modStat[Mod::RATT]
+
     int32 RATT = 8 + skillLevel + bonusAtt + m_modStat[Mod::RATT] + battleutils::GetRangedAttackBonuses(this) + std::floor(STR() * strMultiplier);
     // use max to prevent any underflow
     return std::max<int16>(1, RATT + (RATT * m_modStat[Mod::RATTP] / 100.f) + std::min<int16>((RATT * m_modStat[Mod::FOOD_RATTP] / 100.f), m_modStat[Mod::FOOD_RATT_CAP]));

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1065,7 +1065,7 @@ uint16 CBattleEntity::RATT(uint16 bonusAtt)
     {
         skillLevel = m_modStat[Mod::RATT];
     }
-
+    
     int32 RATT = 8 + skillLevel + bonusAtt + m_modStat[Mod::RATT] + battleutils::GetRangedAttackBonuses(this) + std::floor(STR() * strMultiplier);
     // use max to prevent any underflow
     return std::max<int16>(1, RATT + (RATT * m_modStat[Mod::RATTP] / 100.f) + std::min<int16>((RATT * m_modStat[Mod::FOOD_RATTP] / 100.f), m_modStat[Mod::FOOD_RATT_CAP]));
@@ -1077,15 +1077,15 @@ inline uint32 GetAccFromSkill(uint32 skill)
 
     if (skill > 600)
     {
-        accuracy = std::floor<uint32_t>(static_cast<float>(skill - 600) * 0.9f) + 540;
+        accuracy = std::floor<uint32_t>(static_cast<float>(skill - 600.f) * 0.9f) + 540;
     }
     else if (skill > 400)
     {
-        accuracy = std::floor(static_cast<float>(skill - 400) * 0.8f) + 380;
+        accuracy = std::floor(static_cast<float>(skill - 400.f) * 0.8f) + 380;
     }
     else if (skill > 200)
     {
-        accuracy = std::floor(static_cast<float>(skill - 200) * 0.8f) + 380;
+        accuracy = std::floor(static_cast<float>(skill - 200.f) * 0.9f) + 200;
     }
 
     return accuracy;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixed some copy paste typos with player skill:acc and a small inaccuracy, apparently `static_cast<float>(276 - 200) * .9f` results in 260 when `static_cast<float>(276 - 200.f) * .9f` results in 268... The multiplier for 200 skill was also off by .1.
Mobs no longer double up their RATT, whoops!

## Steps to test these changes

/checkparam and !getstat and see things look nice...