### PR TITLE
[core] Enable 8th table of key items

### DIFF
--- a/src/common/mmo.h
+++ b/src/common/mmo.h
@@ -242,7 +242,7 @@ struct keyitems_table_t
 
 struct keyitems_t
 {
-    std::array<keyitems_table_t, 7> tables;
+    std::array<keyitems_table_t, 8> tables; // 8 tables of key items as of December 2025
 };
 
 struct position_t

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -2791,17 +2791,17 @@ void CCharEntity::UpdateMoghancement()
         uint8 currentTable = m_moghancementID >> 9;
         if (newTable == currentTable)
         {
-            pushPacket<GP_SERV_COMMAND_SCENARIOITEM>(this, static_cast<KEYS_TABLE>(newTable));
+            pushPacket<GP_SERV_COMMAND_SCENARIOITEM>(this, newTable);
         }
         else
         {
             if (newTable != 0)
             {
-                pushPacket<GP_SERV_COMMAND_SCENARIOITEM>(this, static_cast<KEYS_TABLE>(newTable));
+                pushPacket<GP_SERV_COMMAND_SCENARIOITEM>(this, newTable);
             }
             if (currentTable != 0)
             {
-                pushPacket<GP_SERV_COMMAND_SCENARIOITEM>(this, static_cast<KEYS_TABLE>(currentTable));
+                pushPacket<GP_SERV_COMMAND_SCENARIOITEM>(this, currentTable);
             }
         }
         charutils::SaveKeyItems(this);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -8857,15 +8857,14 @@ void CLuaBaseEntity::addKeyItem(const KeyItem keyItemID) const
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     uint8 table = static_cast<uint16_t>(keyItemID) >> 9;
 
-    if (table >= MAX_KEYS_TABLE)
+    if (table >= PChar->keys.tables.size())
     {
-        // Bail out if an invalid keyitem is being added
-        ShowWarning("CLuaBaseEntity::addKeyItem() - Attempting to add invalid key item: %d", static_cast<uint16_t>(keyItemID));
+        ShowErrorFmt("CLuaBaseEntity::addKeyItem() - Index {} exceeds key items table capacity.", table);
         return;
     }
 
     charutils::addKeyItem(PChar, keyItemID);
-    PChar->pushPacket<GP_SERV_COMMAND_SCENARIOITEM>(PChar, static_cast<KEYS_TABLE>(table));
+    PChar->pushPacket<GP_SERV_COMMAND_SCENARIOITEM>(PChar, table);
 
     if (table == 6)
     {
@@ -8911,15 +8910,14 @@ void CLuaBaseEntity::delKeyItem(const KeyItem keyItemID) const
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     uint8 table = static_cast<uint16_t>(keyItemID) >> 9;
 
-    if (table >= MAX_KEYS_TABLE)
+    if (table >= PChar->keys.tables.size())
     {
-        // Bail out if an invalid keyitem is being added
-        ShowWarning("CLuaBaseEntity::delKeyItem() - Attempting to delete invalid key item: %d", static_cast<uint16_t>(keyItemID));
+        ShowErrorFmt("CLuaBaseEntity::delKeyItem() - Index {} exceeds key items table capacity.", table);
         return;
     }
 
     charutils::delKeyItem(PChar, keyItemID);
-    PChar->pushPacket<GP_SERV_COMMAND_SCENARIOITEM>(PChar, static_cast<KEYS_TABLE>(table));
+    PChar->pushPacket<GP_SERV_COMMAND_SCENARIOITEM>(PChar, table);
 
     charutils::SaveKeyItems(PChar);
 }
@@ -8935,7 +8933,7 @@ bool CLuaBaseEntity::seenKeyItem(const KeyItem keyItemID) const
 {
     if (m_PBaseEntity->objtype != TYPE_PC)
     {
-        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->getName());
+        ShowWarning("CLuaBaseEntity::seenKeyItem() - Invalid entity type calling function (%s).", m_PBaseEntity->getName());
         return false;
     }
 
@@ -8960,15 +8958,14 @@ void CLuaBaseEntity::unseenKeyItem(const KeyItem keyItemID) const
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     uint8 table = static_cast<uint16_t>(keyItemID) >> 9;
 
-    if (table >= MAX_KEYS_TABLE)
+    if (table >= PChar->keys.tables.size())
     {
-        // Bail out if an invalid keyitem is being added
-        ShowWarning("CLuaBaseEntity::unseenKeyItem() - Attempting to unsee invalid key item: %d", static_cast<uint16_t>(keyItemID));
+        ShowErrorFmt("CLuaBaseEntity::unseenKeyItem() - Index {} exceeds key items table capacity.", table);
         return;
     }
 
     charutils::unseenKeyItem(PChar, keyItemID);
-    PChar->pushPacket<GP_SERV_COMMAND_SCENARIOITEM>(PChar, static_cast<KEYS_TABLE>(table));
+    PChar->pushPacket<GP_SERV_COMMAND_SCENARIOITEM>(PChar, table);
 
     charutils::SaveKeyItems(PChar);
 }

--- a/src/map/packets/s2c/0x055_scenarioitem.cpp
+++ b/src/map/packets/s2c/0x055_scenarioitem.cpp
@@ -20,21 +20,19 @@
 */
 
 #include "0x055_scenarioitem.h"
-
 #include "entities/charentity.h"
 
-GP_SERV_COMMAND_SCENARIOITEM::GP_SERV_COMMAND_SCENARIOITEM(const CCharEntity* PChar, const KEYS_TABLE keyTable)
+GP_SERV_COMMAND_SCENARIOITEM::GP_SERV_COMMAND_SCENARIOITEM(const CCharEntity* PChar, const uint8_t keyTable)
 {
     auto& packet = this->data();
-
-    if (keyTable >= MAX_KEYS_TABLE)
+    if (keyTable >= PChar->keys.tables.size())
     {
-        ShowWarningFmt("KeyTable ({}) exceeds MAX_KEYS_TABLE.", keyTable);
+        ShowErrorFmt("Index {} exceeds key items table capacity.", keyTable);
         return;
     }
 
-    std::memcpy(packet.GetItemFlag, &(PChar->keys.tables[keyTable].keyList), sizeof(packet.GetItemFlag));
-    std::memcpy(packet.LookItemFlag, &(PChar->keys.tables[keyTable].seenList), sizeof(packet.LookItemFlag));
+    std::memcpy(packet.GetItemFlag, &PChar->keys.tables[keyTable].keyList, sizeof(packet.GetItemFlag));
+    std::memcpy(packet.LookItemFlag, &PChar->keys.tables[keyTable].seenList, sizeof(packet.LookItemFlag));
 
     packet.TableIndex = keyTable;
 }

--- a/src/map/packets/s2c/0x055_scenarioitem.h
+++ b/src/map/packets/s2c/0x055_scenarioitem.h
@@ -21,25 +21,9 @@
 
 #pragma once
 
-#include "common/cbasetypes.h"
-
 #include "base.h"
 
 class CCharEntity;
-
-// TODO: Do we really need this enum?
-enum KEYS_TABLE : uint8
-{
-    KEYS_TABLE_0,
-    KEYS_TABLE_1,
-    KEYS_TABLE_2,
-    KEYS_TABLE_3,
-    KEYS_TABLE_4,
-    KEYS_TABLE_5,
-    KEYS_TABLE_6,
-};
-#define MAX_KEYS_TABLE 7
-DECLARE_FORMAT_AS_UNDERLYING(KEYS_TABLE);
 
 // https://github.com/atom0s/XiPackets/tree/main/world/server/0x0055
 // This packet is sent by the server to populate the clients key item information.
@@ -54,5 +38,5 @@ public:
         uint16_t padding00;        // PS2: (New; did not exist.)
     };
 
-    GP_SERV_COMMAND_SCENARIOITEM(const CCharEntity* PChar, KEYS_TABLE keyTable);
+    GP_SERV_COMMAND_SCENARIOITEM(const CCharEntity* PChar, uint8_t keyTable);
 };

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1438,9 +1438,9 @@ void SendRecordsOfEminenceLog(CCharEntity* PChar)
 
 void SendKeyItems(CCharEntity* PChar)
 {
-    for (uint8 table = 0; table < MAX_KEYS_TABLE; table++)
+    for (uint8 table = 0; table < PChar->keys.tables.size(); table++)
     {
-        PChar->pushPacket<GP_SERV_COMMAND_SCENARIOITEM>(PChar, static_cast<KEYS_TABLE>(table));
+        PChar->pushPacket<GP_SERV_COMMAND_SCENARIOITEM>(PChar, table);
     }
 }
 
@@ -4122,9 +4122,9 @@ auto hasKeyItem(const CCharEntity* PChar, const KeyItem keyItemId) -> bool
     const auto keyItemTable = static_cast<uint16_t>(keyItemId) / 512;
     const auto keyItemIndex = static_cast<uint16_t>(keyItemId) % 512;
 
-    if (keyItemTable >= MAX_KEYS_TABLE)
+    if (keyItemTable >= PChar->keys.tables.size())
     {
-        ShowWarning("Attempt to check for keyItem out of range (%d)!", static_cast<uint16_t>(keyItemId));
+        ShowErrorFmt("charutils::hasKeyItem() - Index {} exceeds key items table capacity.", keyItemTable);
         return false;
     }
 
@@ -4136,9 +4136,9 @@ auto seenKeyItem(CCharEntity* PChar, KeyItem keyItemId) -> bool
     const auto keyItemTable = static_cast<uint16_t>(keyItemId) / 512;
     const auto keyItemIndex = static_cast<uint16_t>(keyItemId) % 512;
 
-    if (keyItemTable >= MAX_KEYS_TABLE)
+    if (keyItemTable >= PChar->keys.tables.size())
     {
-        ShowWarning("Attempt to see for keyItem out of range (%d)!", static_cast<uint16_t>(keyItemId));
+        ShowErrorFmt("charutils::seenKeyItem() - Index {} exceeds key items table capacity.", keyItemTable);
         return false;
     }
 
@@ -4150,9 +4150,9 @@ void markSeenKeyItem(CCharEntity* PChar, KeyItem keyItemId)
     const auto keyItemTable = static_cast<uint16_t>(keyItemId) / 512;
     const auto keyItemIndex = static_cast<uint16_t>(keyItemId) % 512;
 
-    if (keyItemTable >= MAX_KEYS_TABLE)
+    if (keyItemTable >= PChar->keys.tables.size())
     {
-        ShowWarning("Attempt to mark keyItem in table out of range (%d)!", static_cast<uint16_t>(keyItemId));
+        ShowErrorFmt("charutils::markSeenKeyItem() - Index {} exceeds key items table capacity.", keyItemTable);
         return;
     }
 
@@ -4164,9 +4164,9 @@ void unseenKeyItem(CCharEntity* PChar, KeyItem keyItemId)
     const auto keyItemTable = static_cast<uint16_t>(keyItemId) / 512;
     const auto keyItemIndex = static_cast<uint16_t>(keyItemId) % 512;
 
-    if (keyItemTable >= MAX_KEYS_TABLE)
+    if (keyItemTable >= PChar->keys.tables.size())
     {
-        ShowWarning("Attempt to unsee for keyItem out of range (%d)!", static_cast<uint16_t>(keyItemId));
+        ShowErrorFmt("charutils::unseenKeyItem() - Index {} exceeds key items table capacity.", keyItemTable);
         return;
     }
 
@@ -4178,9 +4178,9 @@ void addKeyItem(CCharEntity* PChar, KeyItem keyItemId)
     const auto keyItemTable = static_cast<uint16_t>(keyItemId) / 512;
     const auto keyItemIndex = static_cast<uint16_t>(keyItemId) % 512;
 
-    if (keyItemTable >= MAX_KEYS_TABLE)
+    if (keyItemTable >= PChar->keys.tables.size())
     {
-        ShowWarning("Attempt to add for keyItem out of range (%d)!", static_cast<uint16_t>(keyItemId));
+        ShowErrorFmt("charutils::addKeyItem() - Index {} exceeds key items table capacity.", keyItemTable);
         return;
     }
 
@@ -4192,9 +4192,9 @@ void delKeyItem(CCharEntity* PChar, KeyItem keyItemId)
     const auto keyItemTable = static_cast<uint16_t>(keyItemId) / 512;
     const auto keyItemIndex = static_cast<uint16_t>(keyItemId) % 512;
 
-    if (keyItemTable >= MAX_KEYS_TABLE)
+    if (keyItemTable >= PChar->keys.tables.size())
     {
-        ShowWarning("Attempt to delete keyItem out of range (%d)!", static_cast<uint16_t>(keyItemId));
+        ShowErrorFmt("charutils::delKeyItem() - Index {} exceeds key items table capacity.", keyItemTable);
         return;
     }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
New table of keyitems as of December 2025 version update.
Little bit of cleanup here and there, bumped all log messages to Error instead of Warning.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Tested that it correctly updated in DB

<img width="249" height="102" alt="image" src="https://github.com/user-attachments/assets/cccff575-e0b1-4d05-af25-109afdffa07f" />

8 packets on zone-in

<img width="652" height="217" alt="image" src="https://github.com/user-attachments/assets/f1e63076-5db6-49ed-b68d-6291a267f502" />

## Steps to test these changes
!addkeyitem 3371

<!-- Clear and detailed steps to test your changes here -->
