### PR TITLE
[core, lua] Move Ability AoE type and radius calculation to lua 

### DIFF
--- a/scripts/enum/recast.lua
+++ b/scripts/enum/recast.lua
@@ -19,6 +19,8 @@ xi.recastID =
     MEDITATE       = 134,
     BLOODPACT_RAGE = 173,
     BLOODPACT_WARD = 174,
+    PHANTOM_ROLL   = 193,
+    DOUBLE_UP      = 194,
     QUICKDRAW      = 195,
     STRATAGEM      = 231,
 }

--- a/scripts/globals/combat/ability_aoe.lua
+++ b/scripts/globals/combat/ability_aoe.lua
@@ -1,0 +1,42 @@
+-----------------------------------
+-- Global file for ability AoE type and radius calculations.
+-----------------------------------
+xi = xi or {}
+xi.combat = xi.combat or {}
+xi.combat.abilityAoE = xi.combat.abilityAoE or {}
+
+---Calculate ability AoE type and radius based on caster modifiers.
+---@param caster CBaseEntity
+---@param ability CAbility
+---@return [xi.aoeType, number]
+xi.combat.abilityAoE.calculateTypeAndRadius = function(caster, ability)
+    local baseType   = ability:getAOE()
+    local baseRadius = ability:getRadius()
+    local recastId   = ability:getRecastID()
+
+    -- Epeolatry makes Liement a 10y AoE
+    if
+        ability:getID() == xi.jobAbility.LIEMENT and
+        caster:getMod(xi.mod.LIEMENT_EXTENDS_TO_AREA) > 0
+    then
+        return { xi.aoeType.ROUND, 10 }
+    end
+
+    -- Contradance makes Healing Waltz a 10y AoE
+    if
+        ability:getID() == xi.jobAbility.HEALING_WALTZ and
+        caster:hasStatusEffect(xi.effect.CONTRADANCE)
+    then
+        return { xi.aoeType.ROUND, 10 }
+    end
+
+    -- Luzaf's Ring increases COR roll radius (8y -> 16y)
+    if
+        recastId == xi.recastID.PHANTOM_ROLL or
+        recastId == xi.recastID.DOUBLE_UP
+    then
+        return { xi.aoeType.ROUND, baseRadius + caster:getMod(xi.mod.ROLL_RANGE) }
+    end
+
+    return { baseType, baseRadius }
+end

--- a/scripts/globals/job_utils/corsair.lua
+++ b/scripts/globals/job_utils/corsair.lua
@@ -298,8 +298,6 @@ xi.job_utils.corsair.onRollAbilityCheck = function(player, target, ability)
     local abilityId = ability:getID()
     local effectId  = corsairRollMods[abilityId][4]
 
-    ability:setRange(ability:getRange() + player:getMod(xi.mod.ROLL_RANGE))
-
     if player:hasStatusEffect(effectId) then
         return xi.msg.basic.ROLL_ALREADY_ACTIVE, 0
     elseif atMaxCorsairBusts(player) then
@@ -326,8 +324,6 @@ end
 
 -- Called by Double Up ability onAbilityCheck
 xi.job_utils.corsair.onDoubleUpAbilityCheck = function(player, target, ability)
-    ability:setRange(ability:getRange() + player:getMod(xi.mod.ROLL_RANGE))
-
     if not player:hasStatusEffect(xi.effect.DOUBLE_UP_CHANCE) then
         return xi.msg.basic.NO_ELIGIBLE_ROLL, 0
     else

--- a/scripts/specs/core/CAbility.lua
+++ b/scripts/specs/core/CAbility.lua
@@ -30,6 +30,16 @@ function CAbility:getRange()
 end
 
 ---@nodiscard
+---@return integer
+function CAbility:getRadius()
+end
+
+---@nodiscard
+---@return xi.aoeType
+function CAbility:getAOE()
+end
+
+---@nodiscard
 ---@return string
 function CAbility:getName()
 end

--- a/src/map/lua/lua_ability.cpp
+++ b/src/map/lua/lua_ability.cpp
@@ -56,6 +56,16 @@ uint16 CLuaAbility::getRange()
     return static_cast<uint16>(m_PLuaAbility->getRange());
 }
 
+auto CLuaAbility::getRadius() const -> uint8
+{
+    return m_PLuaAbility->getRadius();
+}
+
+auto CLuaAbility::getAOE() const -> uint8
+{
+    return m_PLuaAbility->getAOE();
+}
+
 const std::string& CLuaAbility::getName()
 {
     return m_PLuaAbility->getName();
@@ -126,6 +136,8 @@ void CLuaAbility::Register()
     SOL_REGISTER("getRecast", CLuaAbility::getRecast);
     SOL_REGISTER("getRecastID", CLuaAbility::getRecastID);
     SOL_REGISTER("getRange", CLuaAbility::getRange);
+    SOL_REGISTER("getRadius", CLuaAbility::getRadius);
+    SOL_REGISTER("getAOE", CLuaAbility::getAOE);
     SOL_REGISTER("getName", CLuaAbility::getName);
     SOL_REGISTER("getAnimation", CLuaAbility::getAnimation);
     SOL_REGISTER("getAddType", CLuaAbility::getAddType);

--- a/src/map/lua/lua_ability.h
+++ b/src/map/lua/lua_ability.h
@@ -45,7 +45,9 @@ public:
     auto   getMsg() -> MsgBasic;
     uint16 getRecast();
     uint16 getRecastID();
-    uint16 getRange();
+    auto   getRange() -> uint16;
+    auto   getRadius() const -> uint8;
+    auto   getAOE() const -> uint8;
     auto   getName() -> const std::string&;
     auto   getAnimation() -> ActionAnimation;
     uint16 getAddType(); // see map/ability.h for definitions. These can tell if the ability is a Merit ability, Astral Flow only ability, etc


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Same pattern as spells. This fixes Luzaf Ring not affecting COR rolls currently.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
- Use COR rolls with Luzaf's Ring, see it affects up to 16 yalms.
- Use Liement with Epeolatry -> 10y AoE
- Use Healing Waltz with Contradance -> 10y AoE

<!-- Clear and detailed steps to test your changes here -->
