### PR TITLE
[lua] summoner pet mixin bugfix

### DIFF
--- a/scripts/mixins/pet_summon_setup.lua
+++ b/scripts/mixins/pet_summon_setup.lua
@@ -26,7 +26,7 @@ g_mixins.pet_summon_setup = function(mob)
         -- Apply resistance ranks
         for element = xi.element.FIRE, xi.element.DARK do
             local resistanceRankMod   = xi.data.element.getElementalResistanceRankModifier(element)
-            local resistanceRankValue = xi.pets.summon.resistanceRanks(element)
+            local resistanceRankValue = xi.pets.summon.resistanceRanks[chosenSummon][element]
             mobArg:setMod(resistanceRankMod, resistanceRankValue)
         end
     end)

--- a/scripts/zones/Sacrificial_Chamber/mobs/Tonberrys_Elemental.lua
+++ b/scripts/zones/Sacrificial_Chamber/mobs/Tonberrys_Elemental.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/pet_summon_setup') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobInitialize = function(mob)
+entity.onMobSpawn = function(mob)
     local possibleSummons =
     {
         xi.pets.summon.type.FIRE_SPIRIT,
@@ -17,7 +17,7 @@ entity.onMobInitialize = function(mob)
 
     local summonBitmask = 0
     for _, entry in ipairs(possibleSummons) do
-        utils.mask.setBit(summonBitmask, entry, true)
+        summonBitmask = utils.mask.setBit(summonBitmask, entry, true)
     end
 
     mob:setLocalVar('[Summon]mask', summonBitmask)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a nil error on the summoner pet mixin and allows it to work correctly
<img width="1362" height="33" alt="image" src="https://github.com/user-attachments/assets/2c2386ec-9ae1-4530-a4f7-402d62eb33e4" />


## Steps to test these changes

Run Jungle Boogeymen and see that the elemental switches forms correctly on spawn
