### PR TITLE
[lua] Mob skill status effect audit

### DIFF
--- a/scripts/actions/mobskills/amatsu_hanaikusa.lua
+++ b/scripts/actions/mobskills/amatsu_hanaikusa.lua
@@ -27,9 +27,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
 
-    if info.hitslanded > 0 then
-        target:addStatusEffect(xi.effect.PARALYSIS, power, 0, duration)
-    end
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PARALYSIS, power, 0, duration)
 
     return dmg
 end

--- a/scripts/actions/mobskills/amatsu_tsukioboro.lua
+++ b/scripts/actions/mobskills/amatsu_tsukioboro.lua
@@ -27,9 +27,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
 
-    if info.hitslanded > 0 then
-        target:addStatusEffect(xi.effect.SILENCE, power, 0, duration)
-    end
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.SILENCE, power, 0, duration)
 
     return dmg
 end

--- a/scripts/actions/mobskills/amatsu_yukiarashi.lua
+++ b/scripts/actions/mobskills/amatsu_yukiarashi.lua
@@ -27,9 +27,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
 
-    if info.hitslanded > 0 then
-        target:addStatusEffect(xi.effect.BLINDNESS, power, 0, duration)
-    end
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BLINDNESS, power, 0, duration)
 
     return dmg
 end

--- a/scripts/actions/mobskills/crescent_fang.lua
+++ b/scripts/actions/mobskills/crescent_fang.lua
@@ -17,11 +17,9 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local damage = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT, 1, 2, 3)
     local totaldamage = xi.mobskills.mobFinalAdjustments(damage.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, numhits)
 
-    if damage.hitslanded > 0 then
-        target:addStatusEffect(xi.effect.PARALYSIS, 50, 0, 90)
-    end
-
     target:takeDamage(totaldamage, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
+
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PARALYSIS, 50, 0, 90)
 
     return totaldamage
 end

--- a/scripts/actions/mobskills/lunar_cry.lua
+++ b/scripts/actions/mobskills/lunar_cry.lua
@@ -30,8 +30,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     local buffValue = cycleBuffs[moonCycle]
 
-    target:addStatusEffect(xi.effect.ACCURACY_DOWN, buffValue, 0, 180)
-    target:addStatusEffect(xi.effect.EVASION_DOWN, 32-buffValue, 0, 180)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ACCURACY_DOWN, buffValue, 0, 180)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.EVASION_DOWN, 32 - buffValue, 0, 180)
     skill:setMsg(xi.msg.basic.SKILL_ENFEEB_2)
     return 0
 end

--- a/scripts/actions/mobskills/moonlit_charge.lua
+++ b/scripts/actions/mobskills/moonlit_charge.lua
@@ -16,8 +16,10 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     local damage = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT, 1, 2, 3)
     local totaldamage = xi.mobskills.mobFinalAdjustments(damage.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
-    target:addStatusEffect(xi.effect.BLINDNESS, 20, 0, 30)
+
     target:takeDamage(totaldamage, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
+
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BLINDNESS, 20, 0, 30)
 
     return totaldamage
 end

--- a/scripts/actions/mobskills/smouldering_swarm.lua
+++ b/scripts/actions/mobskills/smouldering_swarm.lua
@@ -22,7 +22,9 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
 
     target:takeDamage(damage, mob, xi.attackType.MAGICAL, xi.damageType.FIRE)
-    target:addStatusEffect(xi.effect.BURN, 10, 3, duration)
+
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BURN, 10, 3, duration)
+
     return damage
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Corrects a few skills that were applying status effects directly to their targets instead of routing it through mobStatusEffectMove.

## Steps to test these changes

- See mob skills potentially get properly resisted now
