### PR TITLE
[lua] Despot Panzerfaust fTP Adjustment

### DIFF
--- a/scripts/actions/mobskills/panzerfaust.lua
+++ b/scripts/actions/mobskills/panzerfaust.lua
@@ -14,8 +14,9 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 2
-    local accmod = 1
-    local ftp    = 3
+    local accmod  = 1
+    local ftp     = 2
+
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

After increasing the base damage of Despot to match retail hits Panzerfaust was looking overtuned, so I collected some damage logs and passed them over to Jimmayus for evalulation.

* Lowers the fTP of Panzerfaust from 3 to 2 after input from Jimmayus.

<img width="1198" height="222" alt="image" src="https://github.com/user-attachments/assets/69e0aa7b-cb00-425b-89e5-24f98b1d0f58" />

[Despot.log](https://github.com/user-attachments/files/24180423/Despot.log)


## Steps to test these changes

Fight any robots in Ru Aun Gardens
