### PR TITLE
[Fix] Oversight with BRD hands quest

### DIFF
--- a/scripts/quests/jeuno/helpers.lua
+++ b/scripts/quests/jeuno/helpers.lua
@@ -454,7 +454,33 @@ function xi.jeuno.helpers.BorghertzQuests:new(params)
 
         {
             check = function(player, status, vars)
-                return status == xi.questStatus.QUEST_ACCEPTED
+                return status == xi.questStatus.QUEST_ACCEPTED and
+                    not player:hasKeyItem(xi.keyItem.OLD_GAUNTLETS)
+            end,
+
+            [xi.zone.UPPER_JEUNO] =
+            {
+                ['Guslam'] = quest:event(43),
+            },
+
+            -- Old gauntlets coffer logic.
+            [params.oldGauntletZoneId] =
+            {
+                ['Treasure_Coffer'] =
+                {
+                    onTrade = function(player, npc, trade)
+                        xi.treasure.onTrade(player, npc, trade, 2, xi.keyItem.OLD_GAUNTLETS)
+
+                        return quest:noAction()
+                    end,
+                },
+            },
+        },
+
+        {
+            check = function(player, status, vars)
+                return status == xi.questStatus.QUEST_ACCEPTED and
+                    player:hasKeyItem(xi.keyItem.OLD_GAUNTLETS)
             end,
 
             [xi.zone.CASTLE_ZVAHL_BAILEYS] =
@@ -563,16 +589,7 @@ function xi.jeuno.helpers.BorghertzQuests:new(params)
                     end,
                 },
 
-                ['Guslam'] =
-                {
-                    onTrigger = function(player, npc)
-                        if player:hasKeyItem(xi.keyItem.OLD_GAUNTLETS) then
-                            return quest:progressEvent(26)
-                        else
-                            return quest:event(43)
-                        end
-                    end,
-                },
+                ['Guslam'] = quest:progressEvent(26),
 
                 onEventFinish =
                 {
@@ -587,21 +604,6 @@ function xi.jeuno.helpers.BorghertzQuests:new(params)
                             else
                                 quest:setVar(player, 'Prog', 3) -- Skip intermediaries.
                             end
-                        end
-                    end,
-                },
-            },
-
-            -- Old gauntlets coffer logic.
-            [params.oldGauntletZoneId] =
-            {
-                ['Treasure_Coffer'] =
-                {
-                    onTrade = function(player, npc, trade)
-                        if not player:hasKeyItem(xi.keyItem.OLD_GAUNTLETS) then
-                            xi.treasure.onTrade(player, npc, trade, 2, xi.keyItem.OLD_GAUNTLETS)
-
-                            return quest:noAction()
                         end
                     end,
                 },


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes oversight with the BRD AF hands quest (concretely) caused by the treasure logic happening in the same zone (and quest section) as the dark spark zone, causing it to get overriden.

## Steps to test these changes

Run BRD quest normally.
