### PR TITLE
[lua] BCNM script polish

### DIFF
--- a/scripts/zones/Chamber_of_Oracles/mobs/Hoplomachus_XI-XXVI.lua
+++ b/scripts/zones/Chamber_of_Oracles/mobs/Hoplomachus_XI-XXVI.lua
@@ -39,8 +39,10 @@ entity.onMobSpellChoose = function(mob, target, spellId)
 
     local baseMobId = mob:getID()
 
-     -- Check for missing buffs on self and allies
+    -- Check for missing buffs on self and allies
     for i = 1, #buffTable do
+        local buffTargets = {}
+
         for j = 1, #groupTable do
             local allyEntity = GetMobByID(baseMobId + groupTable[j])
             if
@@ -48,8 +50,17 @@ entity.onMobSpellChoose = function(mob, target, spellId)
                 allyEntity:isAlive() and
                 not allyEntity:hasStatusEffect(buffTable[i][2])
             then
-                table.insert(spellList, { buffTable[i][1], allyEntity })
+                table.insert(buffTargets, allyEntity)
             end
+        end
+
+        -- Adds each missing buff to the spell list one time with a random target that is missing it
+        if #buffTargets > 0 then
+            table.insert(spellList,
+            {
+                buffTable[i][1],
+                buffTargets[math.random(#buffTargets)],
+            })
         end
     end
 

--- a/scripts/zones/Sacrificial_Chamber/mobs/Rauu_the_Whaleswooner.lua
+++ b/scripts/zones/Sacrificial_Chamber/mobs/Rauu_the_Whaleswooner.lua
@@ -72,6 +72,7 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 4)
     mob:setMod(xi.mod.LIGHT_RES_RANK, 4)
+    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpellChoose = function(mob, target, spellId)
@@ -106,6 +107,8 @@ entity.onMobSpellChoose = function(mob, target, spellId)
 
     -- Check for missing buffs on self and allies
     for i = 1, #buffTable do
+        local buffTargets = {}
+
         for j = 1, #groupTable do
             local allyEntity = GetMobByID(baseMobId + groupTable[j])
             if
@@ -113,8 +116,17 @@ entity.onMobSpellChoose = function(mob, target, spellId)
                 allyEntity:isAlive() and
                 not allyEntity:hasStatusEffect(buffTable[i][2])
             then
-                table.insert(spellList, { buffTable[i][1], allyEntity })
+                table.insert(buffTargets, allyEntity)
             end
+        end
+
+        -- Adds each missing buff to the spell list one time with a random target that is missing it
+        if #buffTargets > 0 then
+            table.insert(spellList,
+            {
+                buffTable[i][1],
+                buffTargets[math.random(#buffTargets)],
+            })
         end
     end
 

--- a/scripts/zones/Sacrificial_Chamber/mobs/Sable-tongued_Gonberry.lua
+++ b/scripts/zones/Sacrificial_Chamber/mobs/Sable-tongued_Gonberry.lua
@@ -15,14 +15,14 @@ local entity = {}
 
 local enfeebleTable =
 {
-    [1] = { xi.magic.spell.BURN,       xi.effect.BURN      },
-    [2] = { xi.magic.spell.SHOCK,      xi.effect.SHOCK     },
-    [3] = { xi.magic.spell.CHOKE,      xi.effect.CHOKE     },
-    [4] = { xi.magic.spell.BIO_II,     xi.effect.BIO       },
-    [5] = { xi.magic.spell.BLIND,      xi.effect.BLINDNESS },
-    [6] = { xi.magic.spell.SLEEPGA_II, xi.effect.SLEEP_II  },
-    [7] = { xi.magic.spell.STUN,       xi.effect.STUN      },
-
+    [1] = { xi.magic.spell.BURN,        xi.effect.BURN      },
+    [2] = { xi.magic.spell.SHOCK,       xi.effect.SHOCK     },
+    [3] = { xi.magic.spell.CHOKE,       xi.effect.CHOKE     },
+    [4] = { xi.magic.spell.BIO_II,      xi.effect.BIO       },
+    [5] = { xi.magic.spell.POISONGA_II, xi.effect.POISON    },
+    [6] = { xi.magic.spell.BLIND,       xi.effect.BLINDNESS },
+    [7] = { xi.magic.spell.SLEEPGA,     xi.effect.SLEEP_I   },
+    [8] = { xi.magic.spell.SLEEPGA_II,  xi.effect.SLEEP_I   },
 }
 
 entity.onMobInitialize = function(mob)
@@ -37,15 +37,16 @@ entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
         xi.magic.spell.AERO_III,
-        xi.magic.spell.BLIZZAGA_II,
-        xi.magic.spell.BLIZZARD_III,
-        xi.magic.spell.BURST,
-        xi.magic.spell.DRAIN,
         xi.magic.spell.FIRE_III,
+        xi.magic.spell.BLIZZARD_III,
+        xi.magic.spell.BLIZZAGA_II,
+        xi.magic.spell.THUNDAGA_II,
+        xi.magic.spell.STONEGA_III,
+        xi.magic.spell.BURST,
         xi.magic.spell.FLARE,
         xi.magic.spell.FLOOD,
-        xi.magic.spell.STONEGA_III,
-        xi.magic.spell.THUNDAGA_II,
+        xi.magic.spell.DRAIN,
+        xi.magic.spell.STUN,
     }
 
     if target:getMP() > 0 then

--- a/scripts/zones/Throne_Room/mobs/Duke_Amduscias.lua
+++ b/scripts/zones/Throne_Room/mobs/Duke_Amduscias.lua
@@ -1,58 +1,52 @@
------------------------------------
--- Area : Throne Room
--- Mob  : Duke Amduscias
--- BCNM : Kindred Spirits
--- Job  : Black Mage
------------------------------------
-mixins = { require('scripts/mixins/job_special') }
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
+local enfeebleTable =
+{
+    [1] = { xi.magic.spell.BURN,        xi.effect.BURN      },
+    [2] = { xi.magic.spell.SHOCK,       xi.effect.SHOCK     },
+    [3] = { xi.magic.spell.CHOKE,       xi.effect.CHOKE     },
+    [4] = { xi.magic.spell.BIO_II,      xi.effect.BIO       },
+    [5] = { xi.magic.spell.POISONGA_II, xi.effect.POISON    },
+    [6] = { xi.magic.spell.BLIND,       xi.effect.BLINDNESS },
+    [7] = { xi.magic.spell.SLEEPGA,     xi.effect.SLEEP_I   },
+    [8] = { xi.magic.spell.SLEEPGA_II,  xi.effect.SLEEP_I   },
+}
+
 entity.onMobInitialize = function(mob)
-    mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 6)
-    mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 7)
+    mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
+    mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 6)
+    mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 7)
     mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
+        xi.magic.spell.AERO_III,
+        xi.magic.spell.WATER_III,
+        xi.magic.spell.FIRE_III,
+        xi.magic.spell.FIRAGA_II,
+        xi.magic.spell.BLIZZAGA_II,
+        xi.magic.spell.THUNDAGA_II,
         xi.magic.spell.FLARE,
         xi.magic.spell.FLOOD,
-        xi.magic.spell.FIRAGA_II,
-        xi.magic.spell.FIRE_III,
-        xi.magic.spell.AERO_III,
-        xi.magic.spell.THUNDAGA_II,
         xi.magic.spell.DRAIN,
+        xi.magic.spell.STUN,
     }
+
+    if target:getMP() > 0 then
+        table.insert(spellList, xi.magic.spell.ASPIR)
+    end
 
     if not mob:hasStatusEffect(xi.effect.BLAZE_SPIKES) then
         table.insert(spellList, xi.magic.spell.BLAZE_SPIKES)
     end
 
-    if not target:hasStatusEffect(xi.effect.BURN) then
-        table.insert(spellList, xi.magic.spell.BURN)
-    end
-
-    if not target:hasStatusEffect(xi.effect.SHOCK) then
-        table.insert(spellList, xi.magic.spell.SHOCK)
-    end
-
-    if not target:hasStatusEffect(xi.effect.CHOKE) then
-        table.insert(spellList, xi.magic.spell.CHOKE)
-    end
-
-    if not target:hasStatusEffect(xi.effect.SLEEP_II) then
-        table.insert(spellList, xi.magic.spell.SLEEPGA_II)
-    end
-
-    if not target:hasStatusEffect(xi.effect.BIO) then
-        table.insert(spellList, xi.magic.spell.BIO_II)
-    end
-
-    if target:getMP() > 0 then
-        table.insert(spellList, xi.magic.spell.ASPIR)
+    for i = 1, #enfeebleTable do
+        if not target:hasStatusEffect(enfeebleTable[i][2]) then
+            table.insert(spellList, enfeebleTable[i][1])
+        end
     end
 
     return spellList[math.random(1, #spellList)]


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Improves WHM and PLD caster script logic by placing targets eligible for each buff (Protect, Shell, Haste etc.) into a table named buffTargets, then picks 1 random target missing the buff and inserts it into the spell list. This keeps the spell list more aggressive and evens out spell probabilities since large groups with many missing buffs was scaling up exponentially and causing mobs to cast these more than they should.

* Converts Duke Amduscias to the updated BLM format, adds a few missing spells and corrects status check on sleep for both Duke Amduscias and Sable-Tongued Gonberry (Kindred Spirits, Jungle Boogeymen)

I plan to go back and update other casters I have coded in this same fashion so that there is cohesive format across the entire BCNM system that can be used for future content. 

## Steps to test these changes

Test out Amphibian Assault and Legion XI