### PR TITLE
[LUA] Fix Castle Zvahl Teleporters

### DIFF
--- a/scripts/zones/Castle_Zvahl_Keep/Zone.lua
+++ b/scripts/zones/Castle_Zvahl_Keep/Zone.lua
@@ -19,14 +19,14 @@ local teleportTable =
 }
 
 zoneObject.onInitialize = function(zone)
-    zone:registerCylindricalTriggerArea(1, -300, -20, 3) -- central porter on map 3
-    zone:registerCylindricalTriggerArea(2, -273, 5, 3) -- NE porter on map 3
+    zone:registerCylindricalTriggerArea(1, -300, -20, 3) -- Central porter on map 3
+    zone:registerCylindricalTriggerArea(2, -273,   5, 3) -- NE porter on map 3
     zone:registerCylindricalTriggerArea(3, -273, -45, 3) -- SE porter on map 3
-    zone:registerCylindricalTriggerArea(4, -327, 5, 3) -- NW porter on map 3
+    zone:registerCylindricalTriggerArea(4, -327,   5, 3) -- NW porter on map 3
     zone:registerCylindricalTriggerArea(5, -327, -45, 3) -- SW porter on map 3
-    zone:registerCylindricalTriggerArea(6, -527, 87, 3) -- N porter on map 4
-    zone:registerCylindricalTriggerArea(7, -527, 33, 3) -- S porter on map 4
-    zone:registerCylindricalTriggerArea(8, -460, 60, 3) -- Hidden room porter on map 4
+    zone:registerCylindricalTriggerArea(6, -527,  87, 3) -- N porter on map 4
+    zone:registerCylindricalTriggerArea(7, -527,  33, 3) -- S porter on map 4
+    zone:registerCylindricalTriggerArea(8, -460,  60, 3) -- Hidden room porter on map 4
 
     xi.treasure.initZone(zone)
 end
@@ -39,7 +39,8 @@ zoneObject.onZoneTick = function(zone)
         if teleporter and teleporter:getLocalVar('timer') < GetSystemTime() then
             -- If a player is already on the pad, teleport them
             for _, player in pairs(zone:getPlayers()) do
-                if player:getLocalVar(string.format('Zvhal_teleporter_%s', table.npc)) == 1 then
+                if player:getLocalVar(string.format('Zvahl_teleporter_%s', table.npc)) == 1 then
+                    player:delStatusEffect(xi.effect.INVISIBLE)
                     player:startCutscene(table.event)
                 end
             end
@@ -72,9 +73,10 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
     local table      = teleportTable[triggerArea:getTriggerAreaID()]
     local teleporter = GetNPCByID(table.npc)
 
-    player:setLocalVar(string.format('Zvhal_teleporter_%s', table.npc), 1)
+    player:setLocalVar(string.format('Zvahl_teleporter_%s', table.npc), 1)
 
     if teleporter and teleporter:getAnimation() == xi.animation.OPEN_DOOR then
+        player:delStatusEffect(xi.effect.INVISIBLE)
         player:startCutscene(table.event)
     end
 end
@@ -82,7 +84,7 @@ end
 zoneObject.onTriggerAreaLeave = function(player, triggerArea)
     local table = teleportTable[triggerArea:getTriggerAreaID()]
 
-    player:setLocalVar(string.format('Zvhal_teleporter_%s', table.npc), 0)
+    player:setLocalVar(string.format('Zvahl_teleporter_%s', table.npc), 0)
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)


### PR DESCRIPTION
- Teleporters now remove Invisible on successful teleport from either being already on the pad or walking onto it.
- Cleaned up misspelled localVar.
- Cleaned up some formatting on trigger area.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Castle Zvahl Keep teleporters now strip invisble when they port you per [video evidence](https://www.youtube.com/watch?v=w2HUN0o2rk0#t=36m24s). 

## Steps to test these changes

!zone {Castle Zvahl Keep}
/ma Invisible < me>
Walk onto a teleporter.
See invis drop.
/ma Invisible < me>
Walk onto a disabled teleporter.
See invis drop when the teleporter pops.
