### PR TITLE
[lua] Fix Corsair rolls

### DIFF
--- a/scripts/globals/job_utils/corsair.lua
+++ b/scripts/globals/job_utils/corsair.lua
@@ -137,6 +137,18 @@ local function corsairSetup(caster, ability, action, effect, job)
     checkForJobBonus(caster, job)
 end
 
+local function hasBeenInitialized(ability, caster)
+    return caster:getLocalVar('[cor]init' .. ability:getID()) >= GetSystemTime()
+end
+
+local function setInitialized(ability, caster, initialize)
+    if initialize == nil then
+        initialize = true
+    end
+
+    caster:setLocalVar('[cor]init' .. ability:getID(), initialize and GetSystemTime() + 1 or 0)
+end
+
 -- in_ability == current_ability if not using doubleup. current_ability is used to set the message whether you're using a doubleup or not.
 local function applyRoll(caster, target, inAbility, action, total, isDoubleup, currentAbility)
     local abilityId    = inAbility:getID()
@@ -184,7 +196,7 @@ local function applyRoll(caster, target, inAbility, action, total, isDoubleup, c
         end
     else
         -- success
-        if caster:getID() == target:getID() then
+        if not hasBeenInitialized(currentAbility, caster) then
             if isDoubleup then
                 currentAbility:setMsg(xi.msg.basic.DOUBLEUP)      -- success on doubleup for COR has different message than from just using Phantom Roll
             else
@@ -202,7 +214,7 @@ end
 
 -- TODO: Binding does not exist, implement this (old code remains)
 xi.job_utils.corsair.useCuttingCards = function(caster, target, ability, action)
-    if caster:getID() == target:getID() then
+    if not hasBeenInitialized(ability, caster) then
         local roll = math.random(1, 6)
 
         caster:setLocalVar('corsairRollTotal', roll)
@@ -218,11 +230,12 @@ xi.job_utils.corsair.useCuttingCards = function(caster, target, ability, action)
     ability:setMsg(435 + math.floor((total - 1) / 2) * 2)
     action:setAnimation(target:getID(), 132 + (total) - 1)
 
+    setInitialized(ability, caster)
     return total
 end
 
 xi.job_utils.corsair.useDoubleUp = function(caster, target, ability, action)
-    if caster:getID() == target:getID() then -- the COR handles all the calculations
+    if not hasBeenInitialized(ability, caster) then
         local duEffect = caster:getStatusEffect(xi.effect.DOUBLE_UP_CHANCE)
         local prevRoll = caster:getStatusEffect(duEffect:getSubPower())
         local roll     = prevRoll:getSubPower()
@@ -273,12 +286,15 @@ xi.job_utils.corsair.useDoubleUp = function(caster, target, ability, action)
             action:setAnimation(target:getID(), prevAbility:getAnimation())
         end
 
+        setInitialized(ability, caster)
         return total
     end
+
+    setInitialized(ability, caster)
 end
 
 xi.job_utils.corsair.useWildCard = function(caster, target, ability, action)
-    if caster:getID() == target:getID() then
+    if not hasBeenInitialized(ability, caster) then
         local roll = math.random(1, 6)
         caster:setLocalVar('corsairRollTotal', roll)
         action:info(caster:getID(), roll)
@@ -290,6 +306,7 @@ xi.job_utils.corsair.useWildCard = function(caster, target, ability, action)
     ability:setMsg(435 + math.floor((total - 1) / 2) * 2)
     action:setAnimation(target:getID(), 132 + total - 1)
 
+    setInitialized(ability, caster)
     return total
 end
 
@@ -305,6 +322,7 @@ xi.job_utils.corsair.onRollAbilityCheck = function(player, target, ability)
     elseif atMaxCorsairBusts(player) then
         return xi.msg.basic.CANNOT_PERFORM, 0
     else
+        setInitialized(ability, player, false)
         return 0, 0
     end
 end
@@ -315,13 +333,15 @@ xi.job_utils.corsair.onRollUseAbility = function(caster, target, ability, action
     local effectId  = corsairRollMods[abilityId][4]
     local bonusJob  = corsairRollMods[abilityId][6]
 
-    if caster:getID() == target:getID() then
+    if not hasBeenInitialized(ability, caster) then
         corsairSetup(caster, ability, action, effectId, bonusJob)
     end
 
     local total = caster:getLocalVar('corsairRollTotal')
+    total = applyRoll(caster, target, ability, action, total, false, ability)
 
-    return applyRoll(caster, target, ability, action, total, false, ability)
+    setInitialized(ability, caster)
+    return total
 end
 
 -- Called by Double Up ability onAbilityCheck
@@ -331,6 +351,7 @@ xi.job_utils.corsair.onDoubleUpAbilityCheck = function(player, target, ability)
     if not player:hasStatusEffect(xi.effect.DOUBLE_UP_CHANCE) then
         return xi.msg.basic.NO_ELIGIBLE_ROLL, 0
     else
+        setInitialized(ability, player, false)
         return 0, 0
     end
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Current issue: The Phantom Roll and Double Up Corsair abilities require an initialization step before passing the results to each party member target of the ability. In the past, `caster:getID() == target:getID()` was a sufficient check to determine whether this pass of the onAbilityUse function was the *first* one, and therefore it was appropriate to attempt initialization. However, some changes (perhaps to TargetFind or how it's used) have made it so that the caster is not guaranteed to be the first party member in the onAbilityUse queue. As a result, sometimes a different party member is processed first, causing strange bugs to happen (e.g. roll results of 0, or no result appended to the roll message). 

This PR makes it so that it is not necessary for the caster to be processed first to guarantee each ability is appropriately initialized. For every AoE corsair job ability, I've added an "initialization" local var which expires after 2 seconds. It also expires in the "onAbilityCheck" for Phantom Roll and Double Up. This variable is set just before each onUseAbility's "return" to guarantee it is run after all important initialization steps (for example, the message setting in applyRoll). [EDIT: The message setting behavior in applyRoll is not working properly, see comment below.]

There is still an ongoing issue where phantom roll trust gambits are not including player characters in the AoE, which is not fixed in this PR.

## Steps to test these changes

* Enter a party with two corsairs
* Use phantom roll and double up with both corsairs, confirm that the rolls apply as expected
