### PR TITLE
[core, lua] Targetfind fixes

### DIFF
--- a/scripts/globals/combat/magic_aoe.lua
+++ b/scripts/globals/combat/magic_aoe.lua
@@ -42,6 +42,25 @@ xi.combat.magicAoE.calculateSongRadius = function(caster, spell)
     return math.floor(baseRadius * multiplier)
 end
 
+-- Handle AoE for mobs (non-player, non-trust entities)
+-- Return the appropriate end result based on base type of the spell
+-- TODO: To be removed when spell definitions are reworked
+local calculateMobAoE = function(baseType, baseRadius)
+    if
+        baseType == xi.magic.aoe.RADIAL_MANI or
+        baseType == xi.magic.aoe.RADIAL_ACCE or
+        baseType == xi.magic.aoe.DIFFUSION
+    then
+        return { xi.magic.aoe.NONE, 0 }
+    end
+
+    if baseType == xi.magic.aoe.PIANISSIMO then
+        return { xi.magic.aoe.RADIAL, baseRadius }
+    end
+
+    return { baseType, baseRadius }
+end
+
 ---Calculate spell AoE type and radius based on caster modifiers.
 ---@param caster CBaseEntity
 ---@param spell CSpell
@@ -57,7 +76,7 @@ xi.combat.magicAoE.calculateTypeAndRadius = function(caster, spell)
         not caster:isPC() and
         not caster:isTrust()
     then
-        return { baseType, baseRadius }
+        return calculateMobAoE(baseType, baseRadius)
     end
 
     -- Majesty converts Cure and Protect spells to 10y AoE

--- a/scripts/tests/systems/targetfind.lua
+++ b/scripts/tests/systems/targetfind.lua
@@ -183,6 +183,7 @@ describe('TargetFind', function()
                 break
             end
         end
+
         assert(qultada, 'Qultada was not summoned')
 
         qultada:useJobAbility(xi.ja.CORSAIRS_ROLL, qultada)
@@ -255,6 +256,7 @@ describe('TargetFind', function()
                 break
             end
         end
+
         assert(valaineral, 'Valaineral was not summoned')
 
         player:setHP(1)

--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -153,10 +153,7 @@ void CTrustEntity::OnAbility(CAbilityState& state, action_t& action)
         if (PAbility->isAoE())
         {
             PAI->TargetFind->reset();
-
-            float distance = PAbility->getRange();
-
-            PAI->TargetFind->findWithinArea(this, AOE_RADIUS::ATTACKER, distance, FINDFLAGS_NONE, PAbility->getValidTarget());
+            PAI->TargetFind->findWithinArea(this, AOE_RADIUS::ATTACKER, PAbility->getRadius(), FINDFLAGS_NONE, PAbility->getValidTarget());
 
             auto prevMsg = MsgBasic::NONE;
             for (auto&& PTargetFound : PAI->TargetFind->m_targets)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Resolves a few issues.

- Ensure buffer is added first (i.e. Corsair rolling). This ensures the roll logic that relies on buffer being added first works correctly
  - closes #8908 
- Trusts pass the correct value for targetfinding radius (used to pass distance which is now separate from radius)
- Add a quick hack to convert spell AoE type for the mob early return path - closes #8895 
  - These will become spell flags rather than "aoe types" when I rewrite spells configuration and the block will be removed
- Adds a handful of tests for targetfind

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
