### PR TITLE
Move chest/coffer tradeComplete() outside of timers

### DIFF
--- a/scripts/globals/treasure.lua
+++ b/scripts/globals/treasure.lua
@@ -1933,8 +1933,8 @@ xi.treasure.onTrade = function(player, npc, trade, bypassType, bypassReward)
     -- Gil
     if itemId == xi.item.NONE then
         -- Distribute gil.
+        player:tradeComplete()
         player:timer(2000, function(playerEntity)
-            playerEntity:tradeComplete()
             playerEntity:messageSpecial(ID.text.CHEST_UNLOCKED)
             handleGilDistribution(playerEntity, treasureLevel)
             openAndMoveTreasure(npc, respawnType.REGULAR)
@@ -1946,8 +1946,8 @@ xi.treasure.onTrade = function(player, npc, trade, bypassType, bypassReward)
 
     -- Items (Gems or others)
     else
+        player:tradeComplete()
         player:timer(2000, function(playerEntity)
-            playerEntity:tradeComplete()
             playerEntity:addTreasure(itemId, npc)
             playerEntity:messageSpecial(ID.text.CHEST_UNLOCKED)
             openAndMoveTreasure(npc, respawnType.REGULAR)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- `tradeComplete()` was inside the timer function when chests and coffers granted items or gil.  This resulted in the key not being consumed despited giving rewards to the player.
- Moved outside timer function, now works as intended.

## Steps to test these changes

`!additem <whatever key you want>`
Trade to a chest/coffer
