### PR TITLE
[lua] [sql] BCNM Hostile Herbavores

### DIFF
--- a/scripts/actions/mobskills/sheep_charge_melee.lua
+++ b/scripts/actions/mobskills/sheep_charge_melee.lua
@@ -12,10 +12,10 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 1
-    local accmod = 1
-    local ftp    = 2.2
-    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
-    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
+    local accmod  = 1
+    local ftp     = 1.5
+    local info    = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
+    local dmg     = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg
 end

--- a/scripts/battlefields/Horlais_Peak/hostile_herbivores.lua
+++ b/scripts/battlefields/Horlais_Peak/hostile_herbivores.lua
@@ -23,62 +23,64 @@ content:addEssentialMobs({ 'Fighting_Sheep' })
 content.loot =
 {
     {
-        { itemId = xi.item.NONE,         weight = 50 }, -- Nothing
-        { itemId = xi.item.OCEAN_BELT,   weight = 95 }, -- Ocean Belt
-        { itemId = xi.item.JUNGLE_BELT,  weight = 95 }, -- Jungle Belt
-        { itemId = xi.item.STEPPE_BELT,  weight = 95 }, -- Steppe Belt
-        { itemId = xi.item.DESERT_BELT,  weight = 95 }, -- Desert Belt
-        { itemId = xi.item.FOREST_BELT,  weight = 95 }, -- Forest Belt
-        { itemId = xi.item.OCEAN_STONE,  weight = 95 }, -- Ocean Stone
-        { itemId = xi.item.JUNGLE_STONE, weight = 95 }, -- Jungle Stone
-        { itemId = xi.item.STEPPE_STONE, weight = 95 }, -- Steppe Stone
-        { itemId = xi.item.DESERT_STONE, weight = 95 }, -- Desert Stone
-        { itemId = xi.item.FOREST_STONE, weight = 95 }, -- Forest Stone
+        { itemId = xi.item.OCEAN_BELT,               weight = 100 },
+        { itemId = xi.item.JUNGLE_BELT,              weight = 100 },
+        { itemId = xi.item.STEPPE_BELT,              weight = 100 },
+        { itemId = xi.item.DESERT_BELT,              weight = 100 },
+        { itemId = xi.item.FOREST_BELT,              weight = 100 },
+        { itemId = xi.item.OCEAN_STONE,              weight = 100 },
+        { itemId = xi.item.JUNGLE_STONE,             weight = 100 },
+        { itemId = xi.item.STEPPE_STONE,             weight = 100 },
+        { itemId = xi.item.DESERT_STONE,             weight = 100 },
+        { itemId = xi.item.FOREST_STONE,             weight = 100 },
     },
 
     {
-        { itemId = xi.item.GUARDIANS_RING, weight = 64 }, -- Guardians Ring
-        { itemId = xi.item.KAMPFER_RING,   weight = 65 }, -- Kampfer Ring
-        { itemId = xi.item.CONJURERS_RING, weight = 65 }, -- Conjurers Ring
-        { itemId = xi.item.SHINOBI_RING,   weight = 65 }, -- Shinobi Ring
-        { itemId = xi.item.SLAYERS_RING,   weight = 65 }, -- Slayers Ring
-        { itemId = xi.item.SORCERERS_RING, weight = 65 }, -- Sorcerers Ring
-        { itemId = xi.item.SOLDIERS_RING,  weight = 64 }, -- Soldiers Ring
-        { itemId = xi.item.TAMERS_RING,    weight = 65 }, -- Tamers Ring
-        { itemId = xi.item.TRACKERS_RING,  weight = 64 }, -- Trackers Ring
-        { itemId = xi.item.DRAKE_RING,     weight = 65 }, -- Drake Ring
-        { itemId = xi.item.FENCERS_RING,   weight = 65 }, -- Fencers Ring
-        { itemId = xi.item.MINSTRELS_RING, weight = 65 }, -- Minstrels Ring
-        { itemId = xi.item.MEDICINE_RING,  weight = 64 }, -- Medicine Ring
-        { itemId = xi.item.ROGUES_RING,    weight = 65 }, -- Rogues Ring
-        { itemId = xi.item.RONIN_RING,     weight = 64 }, -- Ronin Ring
-        { itemId = xi.item.PLATINUM_RING,  weight = 30 }, -- Platinum Ring
+        { itemId = xi.item.GUARDIANS_RING,           weight = 63 },
+        { itemId = xi.item.KAMPFER_RING,             weight = 63 },
+        { itemId = xi.item.CONJURERS_RING,           weight = 63 },
+        { itemId = xi.item.SHINOBI_RING,             weight = 63 },
+        { itemId = xi.item.SLAYERS_RING,             weight = 63 },
+        { itemId = xi.item.SORCERERS_RING,           weight = 63 },
+        { itemId = xi.item.SOLDIERS_RING,            weight = 63 },
+        { itemId = xi.item.TAMERS_RING,              weight = 63 },
+        { itemId = xi.item.TRACKERS_RING,            weight = 62 },
+        { itemId = xi.item.DRAKE_RING,               weight = 62 },
+        { itemId = xi.item.FENCERS_RING,             weight = 62 },
+        { itemId = xi.item.MINSTRELS_RING,           weight = 62 },
+        { itemId = xi.item.MEDICINE_RING,            weight = 62 },
+        { itemId = xi.item.ROGUES_RING,              weight = 62 },
+        { itemId = xi.item.RONIN_RING,               weight = 62 },
+        { itemId = xi.item.PLATINUM_RING,            weight = 62 },
     },
 
     {
-        quantity = 2,
-        { itemId = xi.item.NONE,                weight = 100 }, -- Nothing
-        { itemId = xi.item.SCROLL_OF_QUAKE,     weight = 176 }, -- Scroll Of Quake
-        { itemId = xi.item.LIGHT_SPIRIT_PACT,   weight =  10 }, -- Light Spirit Pact
-        { itemId = xi.item.SCROLL_OF_FREEZE,    weight = 176 }, -- Scroll Of Freeze
-        { itemId = xi.item.SCROLL_OF_REGEN_III, weight = 176 }, -- Scroll Of Regen Iii
-        { itemId = xi.item.RERAISER,            weight =  60 }, -- Reraiser
-        { itemId = xi.item.VILE_ELIXIR,         weight =  60 }, -- Vile Elixir
-        { itemId = xi.item.SCROLL_OF_RAISE_II,  weight = 176 }, -- Scroll Of Raise Ii
+        { itemId = xi.item.NONE,                  weight = 500 },
+        { itemId = xi.item.RERAISER,              weight = 250 },
+        { itemId = xi.item.VILE_ELIXIR,           weight = 250 },
     },
 
     {
-        quantity = 2,
-        { itemId = xi.item.RAM_HORN,                 weight =  59 }, -- Ram Horn
-        { itemId = xi.item.MAHOGANY_LOG,             weight =  59 }, -- Mahogany Log
-        { itemId = xi.item.MYTHRIL_INGOT,            weight = 200 }, -- Mythril Ingot
-        { itemId = xi.item.MANTICORE_HIDE,           weight =  59 }, -- Manticore Hide
-        { itemId = xi.item.HANDFUL_OF_WYVERN_SCALES, weight =  90 }, -- Handful Of Wyvern Scales
-        { itemId = xi.item.WYVERN_SKIN,              weight =  90 }, -- Wyvern Skin
-        { itemId = xi.item.PETRIFIED_LOG,            weight = 176 }, -- Petrified Log
-        { itemId = xi.item.DARKSTEEL_INGOT,          weight =  59 }, -- Darksteel Ingot
-        { itemId = xi.item.RAM_SKIN,                 weight =  59 }, -- Ram Skin
-        { itemId = xi.item.PLATINUM_INGOT,           weight =  90 }, -- Platinum Ingot
+        { itemId = xi.item.SCROLL_OF_QUAKE,          weight = 50 },
+        { itemId = xi.item.SCROLL_OF_FREEZE,         weight = 50 },
+        { itemId = xi.item.SCROLL_OF_RAISE_II,       weight = 50 },
+        { itemId = xi.item.SCROLL_OF_REGEN_III,      weight = 50 },
+        { itemId = xi.item.LIGHT_SPIRIT_PACT,        weight = 50 },
+        { itemId = xi.item.MAHOGANY_LOG,             weight = 50 },
+        { itemId = xi.item.EBONY_LOG,                weight = 50 },
+        { itemId = xi.item.PETRIFIED_LOG,            weight = 50 },
+        { itemId = xi.item.PIECE_OF_WISTERIA_LUMBER, weight = 50 },
+        { itemId = xi.item.MYTHRIL_INGOT,            weight = 50 },
+        { itemId = xi.item.GOLD_INGOT,               weight = 50 },
+        { itemId = xi.item.DARKSTEEL_INGOT,          weight = 50 },
+        { itemId = xi.item.PLATINUM_INGOT,           weight = 50 },
+        { itemId = xi.item.RAM_SKIN,                 weight = 50 },
+        { itemId = xi.item.MANTICORE_HIDE,           weight = 50 },
+        { itemId = xi.item.WYVERN_SKIN,              weight = 50 },
+        { itemId = xi.item.RAM_HORN,                 weight = 50 },
+        { itemId = xi.item.DEMON_HORN,               weight = 50 },
+        { itemId = xi.item.CORAL_FRAGMENT,           weight = 50 },
+        { itemId = xi.item.HANDFUL_OF_WYVERN_SCALES, weight = 50 },
     },
 }
 

--- a/scripts/zones/Horlais_Peak/mobs/Fighting_Sheep.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Fighting_Sheep.lua
@@ -8,14 +8,13 @@
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMod(xi.mod.ICE_MEVA, 75) -- Todo: Move to mob_resists.sql
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
+    mob:setMod(xi.mod.BIND_RES_RANK, 8)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setMobSkillAttack(701)
-end
-
-entity.onMobDeath = function(mob, player, optParams)
+    mob:setMobSkillAttack(701) -- Uses Sheep Charge as its' melee attack
 end
 
 return entity

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -10474,7 +10474,7 @@ INSERT INTO `mob_groups` VALUES (18,1923,139,'Helltail_Harry',0,128,0,0,0,45,45,
 INSERT INTO `mob_groups` VALUES (19,804,139,'Cottontail',0,128,0,2400,0,38,39,0);
 INSERT INTO `mob_groups` VALUES (20,3693,139,'Sobbing_Eyes',0,128,0,2500,2500,42,42,0);
 INSERT INTO `mob_groups` VALUES (21,773,139,'Compound_Eyes',0,128,0,1400,1400,39,39,0);
-INSERT INTO `mob_groups` VALUES (22,1337,139,'Fighting_Sheep',0,128,0,5000,0,55,55,0);
+INSERT INTO `mob_groups` VALUES (22,1337,139,'Fighting_Sheep',0,128,0,5400,0,53,53,0);
 INSERT INTO `mob_groups` VALUES (23,249,139,'Armsmaster_Dekbuk',0,128,0,0,0,60,60,0);
 INSERT INTO `mob_groups` VALUES (24,2436,139,'Longarmed_Gottditt',0,128,0,0,0,60,60,0);
 INSERT INTO `mob_groups` VALUES (25,2202,139,'Keeneyed_Aufwuf',0,128,0,0,0,60,60,0);

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -2304,8 +2304,9 @@ INSERT INTO `mob_skill_lists` VALUES ('Demonic_Tiphia',700,334);
 INSERT INTO `mob_skill_lists` VALUES ('Demonic_Tiphia',700,335);
 INSERT INTO `mob_skill_lists` VALUES ('Demonic_Tiphia',700,336);
 INSERT INTO `mob_skill_lists` VALUES ('Fighting_Sheep_Auto_Attack',701,274); -- sheep_charge_hostile_herbivore
-INSERT INTO `mob_skill_lists` VALUES ('Fighting_Sheep',702,264); -- sheep_song
-INSERT INTO `mob_skill_lists` VALUES ('Fighting_Sheep',702,261); -- rage
+INSERT INTO `mob_skill_lists` VALUES ('Fighting_Sheep',702,260); -- Lamb Chop
+INSERT INTO `mob_skill_lists` VALUES ('Fighting_Sheep',702,261); -- Rage
+INSERT INTO `mob_skill_lists` VALUES ('Fighting_Sheep',702,264); -- Sheep Song
 INSERT INTO `mob_skill_lists` VALUES ('Cactrot_Rapido',703,321);
 INSERT INTO `mob_skill_lists` VALUES ('Cactrot_Rapido',703,322);
 INSERT INTO `mob_skill_lists` VALUES ('Cactrot_Rapido',703,324);

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -298,7 +298,7 @@ INSERT INTO `mob_skills` VALUES (270,14,'roar',1,0.0,10.0,2000,1500,4,0,0,0,0,0,
 INSERT INTO `mob_skills` VALUES (271,15,'razor_fang',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (272,16,'ranged_attack',0,0.0,25.0,2000,0,4,4,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (273,17,'claw_cyclone',4,0.0,15.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (274,6,'sheep_charge_melee',0,0.0,7.0,2000,0,4,0,0,1,0,0,0); -- Hostile Herbivores BCNM melee specials
+INSERT INTO `mob_skills` VALUES (274,6,'sheep_charge_melee',0,0.0,7.0,2000,0,4,4,0,1,0,0,0); -- Hostile Herbivores BCNM melee specials
 INSERT INTO `mob_skills` VALUES (275,809,'sand_blast',1,0.0,8.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (276,810,'sand_pit',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (277,811,'venom_spray',4,0.0,10.0,2000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Updates the BCNM Hostile Herbavores with a capture from retail.
* Corrects level and HP
* Adds missing immunities and resistance ranks
* Adds the flag to its melee attack that stops it from consuming TP, so they can use TP moves as normal
* Adds the mob skill Lamb Chop to their skill list
* Changes the fTP of the melee attack version of Sheep Charge from 2.2 fTP to 1.5
* Updates the loot list with missing items

[23:05:33]The Fighting Sheep uses Sheep Charge.
The Left-HandedYoko takes 135 points of damage.
Left-HandedYoko has 208 defense at level 50. 

Adjustment to 1.5 on my local
<img width="414" height="40" alt="image" src="https://github.com/user-attachments/assets/73410391-79a2-460c-9682-033500385309" />

## Captures
https://youtu.be/WNE0QQ9Ltzo?si=zRL-_aYrXhAx3L-3&t=4277
[BCNM_Captures.zip](https://github.com/user-attachments/files/24268712/BCNM_Captures.zip)

## Steps to test these changes

Run Hostile Herbavores in Horlais Peak!
