### PR TITLE
[lua] CoP "Darkness Named" Gil Reward Silent

### DIFF
--- a/scripts/missions/cop/3_5_Darkness_Named.lua
+++ b/scripts/missions/cop/3_5_Darkness_Named.lua
@@ -46,7 +46,7 @@ mission.sections =
                             npcUtil.tradeHasExactly(trade, xi.item.GRAY_CHIP)
                         )
                     then
-                        return mission:progressEvent(52, 500 * xi.settings.main.GIL_RATE)
+                        return mission:progressEvent(52, xi.settings.main.GIL_RATE * 500)
                     end
                 end,
 
@@ -87,7 +87,7 @@ mission.sections =
                 [52] = function(player, csid, option, npc)
                     player:confirmTrade()
 
-                    npcUtil.giveCurrency(player, 'gil', 500)
+                    player:addGil(xi.settings.main.GIL_RATE * 500) -- Silent since the gil reward is baked into the CS.
                     npcUtil.giveKeyItem(player, xi.ki.PSOXJA_PASS)
                     mission:setVar(player, 'Status', 3)
                 end,


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Makes the gil reward from CoP Mission Darkness Named to be silent since the gil reward message is baked into the CS.

## Steps to test these changes

1. `!addmission 6 358`
2. `!setmissionstatus <me> 2 6 358`
3. Trade Ghebi a chip.
