### PR TITLE
Parry things - Enable parrying for wyvern, implement known parry formula from retail, other rate fixes with guard/block/parry

### DIFF
--- a/src/map/utils/attackutils.cpp
+++ b/src/map/utils/attackutils.cpp
@@ -234,27 +234,7 @@ uint8 getHitCount(uint8 hits)
 
 bool IsParried(CBattleEntity* PAttacker, CBattleEntity* PDefender)
 {
-    auto isParriedFunc = lua["xi"]["combat"]["physical"]["isParried"];
-
-    if (isParriedFunc.valid())
-    {
-        try
-        {
-            bool result = isParriedFunc(PDefender, PAttacker);
-            return result;
-        }
-        catch (const sol::error& err)
-        {
-            ShowError("attackutils::IsParried(): %s", err.what());
-            return false;
-        }
-    }
-    else
-    {
-        ShowError("attackutils::IsParried() failed to run Lua function");
-    }
-
-    return false;
+    return luautils::callGlobal<bool>("xi.combat.physical.isParried", PDefender, PAttacker);
 }
 
 bool IsGuarded(CBattleEntity* PAttacker, CBattleEntity* PDefender)

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1919,57 +1919,6 @@ float GetBlockRate(CBattleEntity* PAttacker, CBattleEntity* PDefender)
     return blockRate;
 }
 
-uint8 GetParryRate(CBattleEntity* PAttacker, CBattleEntity* PDefender)
-{
-    CItemWeapon* PWeapon = GetEntityWeapon(PDefender, SLOT_MAIN);
-    if ((PWeapon != nullptr && PWeapon->getID() != 0 && PWeapon->getID() != 65535 && PWeapon->getSkillType() != SKILL_HAND_TO_HAND) &&
-        PDefender->PAI->IsEngaged())
-    {
-        // http://wiki.ffxiclopedia.org/wiki/Talk:Parrying_Skill
-        // {(Parry Skill x .125) + ([Player Agi - Enemy Dex] x .125)} x Diff
-
-        float skill = (float)(PDefender->GetSkill(SKILL_PARRY) + PDefender->getMod(Mod::PARRY) + PWeapon->getILvlParry());
-
-        float diff = 1.0f + (((float)PDefender->GetMLevel() - PAttacker->GetMLevel()) / 15.0f);
-
-        if (PWeapon->isTwoHanded())
-        {
-            // two handed weapons get a bonus
-            diff += 0.1f;
-        }
-
-        if (diff < 0.4f)
-        {
-            diff = 0.4f;
-        }
-        if (diff > 1.4f)
-        {
-            diff = 1.4f;
-        }
-
-        float dex = PAttacker->DEX();
-        float agi = PDefender->AGI();
-
-        auto parryRate = std::clamp<uint8>((uint8)((skill * 0.1f + (agi - dex) * 0.125f + 10.0f) * diff), 5, 25);
-
-        // Issekigan grants parry rate bonus. From best available data, if you already capped out at 25% parry it grants another 25% bonus for ~50%
-        // parry rate
-        if ((PDefender->objtype == TYPE_PC || PDefender->objtype == TYPE_TRUST) && PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_ISSEKIGAN))
-        {
-            int16 issekiganBonus = PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_ISSEKIGAN)->GetPower();
-            parryRate += issekiganBonus;
-        }
-
-        // Inquartata grants a flat parry rate bonus.
-        int16 inquartataBonus = PDefender->getMod(Mod::INQUARTATA);
-        parryRate += inquartataBonus;
-
-        return parryRate;
-    }
-
-    return 0;
-}
-
 uint8 GetGuardRate(CBattleEntity* PAttacker, CBattleEntity* PDefender)
 {
     CItemWeapon* PWeapon = GetEntityWeapon(PDefender, SLOT_MAIN);

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -154,7 +154,6 @@ uint8 GetRangedCritHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
 int8  GetDexCritBonus(CBattleEntity* PAttacker, CBattleEntity* PDefender);
 int8  GetAGICritBonus(CBattleEntity* PAttacker, CBattleEntity* PDefender);
 float GetBlockRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
-uint8 GetParryRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
 uint8 GetGuardRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
 float GetDamageRatio(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool isCritical, float bonusAttPercent, SKILLTYPE weaponType, SLOTTYPE weaponSlot, bool isCannonball);
 

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -941,6 +941,9 @@ void CalculateWyvernStats(CBattleEntity* PMaster, CPetEntity* PPet)
     // innate + 40 subtle blow
     PPet->setModifier(Mod::SUBTLE_BLOW, 40);
 
+    // Wyverns can parry... yes really.
+    PPet->setMobMod(MOBMOD_CAN_PARRY, 1);
+
     // Job Point: Wyvern Max HP
     if (PMaster->objtype == TYPE_PC)
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

in core: 
Remove unused parry calc code, update parry lua call
Enable parry for pet wyverns

in lua:
Add stun/sleep etc status checking to parry/guard
Implement the currently known (much more accurate, but incomplete) known parrying formula based off level 43 chigoes:
https://docs.google.com/spreadsheets/d/1wtS0d4nNqosMwFuHWb7fkCcj4naAvwhnPocf3qSGJjk/edit?gid=0#gid=0

Fix some `>` that should be `>=`
Improve accuracy of random calls where random was between (1, 100) and now is (1, 10000), when testing these values it turns out they were averaging slightly low... which unfortunately led me down to another RNG based rabbit hole...

## Steps to test these changes

Parry and get a good ballpark (expecting 12% here)
<img width="549" height="43" alt="image" src="https://github.com/user-attachments/assets/ec0838b2-a6bf-4c4c-9bcb-3c19a4131586" />

Random sample via test script
`[map][lua] Parry rate: 11.936296-12.063680%~ (lua_print:224)`

```lua
xi = xi or {}
xi.test = xi.test or {}

local function calculate_wald_binomial_ci(successes, trials)
    local p_hat = successes / trials
    local z_critical = 1.96

    local standard_error = math.sqrt((p_hat * (1 - p_hat)) / trials)
    local margin_of_error = z_critical * standard_error

    local lower_bound = p_hat - margin_of_error
    local upper_bound = p_hat + margin_of_error

    return lower_bound, upper_bound
end

xi.test.test = function(defender, attacker)
    local parried = 0
    local notparried = 0

    for count = 0, 1000000
    do
        if xi.combat.physical.isParried(defender, attacker) then
            parried = parried + 1
        else
            notparried = notparried + 1
        end
    end

    local lower, upper = calculate_wald_binomial_ci(parried, parried + notparried)
    print(string.format("Parry rate: %f-%f%%%%~", lower*100, upper*100))
end

```