### PR TITLE
[lua] Avoid underflow in dig coordinate local vars

### DIFF
--- a/scripts/globals/hobbies/chocobo_digging/logic.lua
+++ b/scripts/globals/hobbies/chocobo_digging/logic.lua
@@ -368,8 +368,8 @@ xi.chocoboDig.start = function(player)
     -----------------------------------
 
     -- Set player variables, no matter the result.
-    player:setLocalVar('[DIG]LastXPos', currentX)
-    player:setLocalVar('[DIG]LastZPos', currentZ)
+    player:setLocalVar('[DIG]LastXPos', math.abs(currentX))
+    player:setLocalVar('[DIG]LastZPos', math.abs(currentZ))
     player:setLocalVar('[DIG]LastXPosSign', currentXSign)
     player:setLocalVar('[DIG]LastZPosSign', currentZSign)
     player:setLocalVar('[DIG]LastDigTime', GetSystemTime())


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

In xi.chocoboDig.start, there's some logic to save the last dig coordinate to a local var, and a second local var for the sign (±) of each coordinate since localvars can't be negative. However, negative coordinates are still fed into the local var which causes underflow and incorrect math to happen. This PR saves the absolute value of the coordinate so that things work as expected.

Another option is to do away with saving the sign variable completely, and just do math on the x/z var with like a +10000 offset. But this was a simpler fix.

## Steps to test these changes

Dig, move around, dig again.
