### PR TITLE
[core] Don't teleport pets unless they can't path to you

### DIFF
--- a/scripts/tests/systems/targetfind.lua
+++ b/scripts/tests/systems/targetfind.lua
@@ -57,6 +57,11 @@ describe('TargetFind', function()
         fafnir.assert:isAlive()
         fafnir:updateClaim(p1)
 
+        -- move wyverns to their masters
+        wyv1:setPos(p1:getPos())
+        wyv2:setPos(p2:getPos())
+        wyv3:setPos(p3:getPos())
+
         -- Use Spike Flail
         fafnir:setTP(3000)
         fafnir:useMobAbility(952, p1)
@@ -89,6 +94,11 @@ describe('TargetFind', function()
         p1.entities:moveTo('Nidhogg')
         p2.entities:moveTo('Nidhogg')
         local nidhogg = p3.entities:moveTo('Nidhogg')
+
+        -- move wyverns to their masters
+        wyv1:setPos(p1:getPos())
+        wyv2:setPos(p2:getPos())
+        wyv3:setPos(p3:getPos())
 
         -- Spawn Nidhogg and claim it to the party
         nidhogg:spawn()

--- a/src/map/ai/controllers/pet_controller.cpp
+++ b/src/map/ai/controllers/pet_controller.cpp
@@ -124,22 +124,21 @@ void CPetController::DoRoamTick(timer::time_point tick)
 
     if (currentDistance > PetRoamDistance)
     {
-        if (currentDistance < 35.0f)
+        if (!PPet->PAI->PathFind->IsFollowingPath() ||
+            distance(PPet->PAI->PathFind->GetDestination(), PPet->PMaster->loc.p) > 2.0f) // recalculate path only if owner moves more than X yalms
         {
-            if (!PPet->PAI->PathFind->IsFollowingPath() ||
-                distance(PPet->PAI->PathFind->GetDestination(), PPet->PMaster->loc.p) > 2.0f) // recalculate path only if owner moves more than X yalms
+            if (!PPet->PAI->PathFind->PathAround(PPet->PMaster->loc.p, 2.0f, PATHFLAG_RUN | PATHFLAG_WALLHACK))
             {
-                if (!PPet->PAI->PathFind->PathAround(PPet->PMaster->loc.p, 2.0f, PATHFLAG_RUN | PATHFLAG_WALLHACK))
+                if (!PPet->PAI->PathFind->PathInRange(PPet->PMaster->loc.p, 2.0f, PATHFLAG_RUN | PATHFLAG_WALLHACK))
                 {
-                    PPet->PAI->PathFind->PathInRange(PPet->PMaster->loc.p, 2.0f, PATHFLAG_RUN | PATHFLAG_WALLHACK);
+                    // If we got here, the pet isn't able to path to master
+                    // But it cant, so maybe we teleported or dropped down a hole
+                    PPet->PAI->PathFind->WarpTo(PPet->PMaster->loc.p, PetRoamDistance);
                 }
             }
-            PPet->PAI->PathFind->FollowPath(m_Tick);
         }
-        else if (PPet->GetSpeed() > 0)
-        {
-            PPet->PAI->PathFind->WarpTo(PPet->PMaster->loc.p, PetRoamDistance);
-        }
+
+        PPet->PAI->PathFind->FollowPath(m_Tick);
     }
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
See title

The 35 yalm teleport check was just wrong and sort of jank

Review the function as in the file, the diff looks weird.

## Steps to test these changes

Summon a pet, go down holes and see the pet teleport to you (I did not exhaustively test this, but I tested Giddeus, Den of Rancor, Eldieme Necropolis)
Summon a pet, go through the teleporters near the throne room and have your pet path to you (this is retail behavior and yes they do wallhack to do this)