### PR TITLE
[lua] Stops ZM-1 from Progressing when you choose NOT to start ZM

### DIFF
--- a/scripts/missions/rotz/01_The_New_Frontier.lua
+++ b/scripts/missions/rotz/01_The_New_Frontier.lua
@@ -33,7 +33,9 @@ mission.sections =
             onEventFinish =
             {
                 [1] = function(player, csid, option, npc)
-                    mission:complete(player)
+                    if option == 1 then
+                        mission:complete(player)
+                    end
                 end,
             },
         },


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes an issue where if you selected "Maybe Later" about starting ZM it would still progress you to ZM-2 even though you never watched the cs.
Select Maybe Later = Option 0
Select Start ZM = Option 1

## Steps to test these changes

1. `!setrank 6` or higher
2. `!zone <Sea Serpent Grotto>`
3. Zone into Norg.
4. Select "Maybe Later" observe you're still on "The New Frontier"
5. Rezone into Norg and start ZM observe you are on now ZM 2 after the CS.
