### PR TITLE
Add missing script for moggiebag

### DIFF
--- a/scripts/items/moggiebag.lua
+++ b/scripts/items/moggiebag.lua
@@ -1,0 +1,18 @@
+-----------------------------------
+-- ID: 19246
+-- Item: Moggiebag
+-- Moogle's secret cache dispenses between 100 and 10,000 gil.
+-----------------------------------
+---@type TItem
+local itemObject = {}
+
+itemObject.onItemCheck = function(target, item, param, caster)
+    return xi.itemUtils.itemBoxOnItemCheck(target)
+end
+
+itemObject.onItemUse = function(target)
+    local amount = math.random(100, 10000)
+    npcUtil.giveCurrency(target, 'gil', amount)
+end
+
+return itemObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This item was listed in item_usable.sql but had no script. It looked to be fully created except for the missing script so I added it and my all players one for Xmas last night. Several similar items also exist like this with different gil ranges and total charges, so this one can serve as a template for the others with minor changes.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
`!additem moggiebag` and use it, see gill added to player with accompanying message in chatlog.

***NOTE:*** Both BG wiki and 'clopedia claim the range as 100 to 10,000 gil, but ffxiclopedia adds "in increments of 100". That appears to be incorrect, because during the current free period on retail I got a value of 5230.