### PR TITLE
[lua] Pet Summon Setup Fix

### DIFF
--- a/scripts/mixins/pet_summon_setup.lua
+++ b/scripts/mixins/pet_summon_setup.lua
@@ -10,9 +10,9 @@ g_mixins.pet_summon_setup = function(mob)
         -- Fetches the possible elements for this mob
         local summonBitmask = mobArg:getLocalVar('[Summon]mask')
         local summonTable = {}
-        for i = 1, #xi.pets.summon.type do
-            if utils.mask.getBit(summonBitmask, i) then
-                table.insert(summonTable, i)
+        for _, id in pairs(xi.pets.summon.type) do
+            if utils.mask.getBit(summonBitmask, id) then
+                table.insert(summonTable, id)
             end
         end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Includes a minimal fix to properly reference the table in summon.lua by switching to id in pairs. The code was using the # (length) operator to reference the table, but because the table it references is not a array, lua sees #xi.pets.summon.type == 0, therefore when it goes to do i = 1, #xi.pets.summon.type do, it is doing i = 1, 0 do, and returning nil

## Steps to test these changes

Hop into Jungle Boogeymen after a fresh restart (since its a listener) and see that the nil error on setup is gone and the elemental spawns as the the correct elements
