### PR TITLE
[core][lua] Implement Tales' Beginning NPC for CoP, also some bug fixes I found along the way

### DIFF
--- a/scripts/missions/cop/1_1_The_Rites_of_Life.lua
+++ b/scripts/missions/cop/1_1_The_Rites_of_Life.lua
@@ -81,14 +81,9 @@ mission.sections =
 
                 [39] = function(player, csid, option, npc)
                     if player:getCharVar('[COP]TalesBeginning') > 0 then
-                        local lowerDelkfuttsIDs = zones[xi.zone.LOWER_DELKFUTTS_TOWER]
-                        local talesBeginning    = GetNPCByID(lowerDelkfuttsIDs.npc.TALES_BEGINNING)
-
-                        if talesBeginning then
-                            -- Send blank entry to hide all selectively shown NPCs again
-                            -- see https://github.com/atom0s/XiPackets/blob/main/world/server/0x0077/README.md
-                            player:enableEntities({})
-                        end
+                        -- Send blank entry to hide all selectively shown NPCs again
+                        -- see https://github.com/atom0s/XiPackets/blob/main/world/server/0x0077/README.md
+                        player:enableEntities({})
 
                         player:setCharVar('[COP]TalesBeginning', 0)
                     end

--- a/scripts/missions/cop/1_1_The_Rites_of_Life.lua
+++ b/scripts/missions/cop/1_1_The_Rites_of_Life.lua
@@ -27,9 +27,24 @@ mission.sections =
 
         [xi.zone.LOWER_DELKFUTTS_TOWER] =
         {
+            ['Tales_Beginning'] =
+            {
+                onTrigger = function(player, npc)
+                    return mission:progressEvent(53, 3) -- 3 prints "Chains of Promathia". I guess the cutscene was copy pasted?
+                end,
+            },
+
             onZoneIn = function(player, prevZone)
-                if prevZone == xi.zone.QUFIM_ISLAND then
+                if prevZone == xi.zone.QUFIM_ISLAND and player:getCharVar('[COP]TalesBeginning') == 0 then
                     return 22
+                end
+            end,
+
+            afterZoneIn = function(player)
+                if player:getCharVar('[COP]TalesBeginning') > 0 then
+                    local lowerDelkfuttsIDs = zones[xi.zone.LOWER_DELKFUTTS_TOWER]
+
+                    player:enableEntities({ lowerDelkfuttsIDs.npc.TALES_BEGINNING, lowerDelkfuttsIDs.npc.TALES_BEGINNING - 1 })
                 end
             end,
 
@@ -40,7 +55,16 @@ mission.sections =
                 -- so that on disconnect, it will resume at the latest state.  This
                 -- pattern should also change in section 3
                 [22] = function(player, csid, option, npc)
-                    player:startEvent(36)
+                    if option == 1 then
+                        player:startEvent(36)
+                    else
+                        local lowerDelkfuttsIDs = zones[xi.zone.LOWER_DELKFUTTS_TOWER]
+
+                        player:setCharVar('[COP]TalesBeginning', 1)
+                        player:enableEntities({ lowerDelkfuttsIDs.npc.TALES_BEGINNING, lowerDelkfuttsIDs.npc.TALES_BEGINNING - 1 })
+
+                        player:sendPartialMissionLog(xi.mission.log_id.COP, false) -- Send packet to update mission log with special text
+                    end
                 end,
 
                 [36] = function(player, csid, option, npc)
@@ -56,8 +80,27 @@ mission.sections =
                 end,
 
                 [39] = function(player, csid, option, npc)
+                    if player:getCharVar('[COP]TalesBeginning') > 0 then
+                        local lowerDelkfuttsIDs = zones[xi.zone.LOWER_DELKFUTTS_TOWER]
+                        local talesBeginning    = GetNPCByID(lowerDelkfuttsIDs.npc.TALES_BEGINNING)
+
+                        if talesBeginning then
+                            -- Send blank entry to hide all selectively shown NPCs again
+                            -- see https://github.com/atom0s/XiPackets/blob/main/world/server/0x0077/README.md
+                            player:enableEntities({})
+                        end
+
+                        player:setCharVar('[COP]TalesBeginning', 0)
+                    end
+
                     mission:begin(player)
                     mission:setVar(player, 'Status', 1)
+                end,
+
+                [53] = function(player, csid, option, npc)
+                    if option == 4 then -- It seems this parameter changes depending on the input to event 53
+                        player:startEvent(22, 0, 0, 0, 1) -- CoP intro CS with param[3] == 1 does not have the dialog that would eventually lead us to Tales' Beginning
+                    end
                 end,
             },
         },

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -1734,6 +1734,13 @@ end
 function CBaseEntity:getMissionStatus(missionLogID, missionStatusPosObj)
 end
 
+---@nodiscard
+---@param missionLogID integer
+---@param completed bool
+---@return nil
+function CBaseEntity:sendPartialMissionLog(missionLogID, completed)
+end
+
 ---@param recordID integer
 ---@param arg1 boolean?
 ---@param arg2 boolean?

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -1734,9 +1734,8 @@ end
 function CBaseEntity:getMissionStatus(missionLogID, missionStatusPosObj)
 end
 
----@nodiscard
 ---@param missionLogID integer
----@param completed bool
+---@param completed boolean
 ---@return nil
 function CBaseEntity:sendPartialMissionLog(missionLogID, completed)
 end

--- a/scripts/tests/missions/cop.lua
+++ b/scripts/tests/missions/cop.lua
@@ -21,7 +21,11 @@ describe('Chains of Promathia', function()
             -- zone into Lower Delkfutts Tower for a series of CS's
             player:gotoZone(xi.zone.QUFIM_ISLAND)
             player:gotoZone(xi.zone.LOWER_DELKFUTTS_TOWER)
-            player.events:expect({ eventId = 22 })
+
+            -- TODO: check Tales' Beginning with option 0, talking to the Tales' Beginning, which starts CS 53.
+            -- In CS 53, Send option 4 to accept CS, which will start CS 22 with out any options to select
+            -- Also verify charvar for TalesBeginning
+            player.events:expect({ eventId = 22, finishOption = 1 })
             player.events:expect({ eventId = 36 })
             player.events:expect({ eventId = 37 })
             player.events:expect({ eventId = 38 })

--- a/scripts/zones/Lower_Delkfutts_Tower/IDs.lua
+++ b/scripts/zones/Lower_Delkfutts_Tower/IDs.lua
@@ -41,6 +41,7 @@ zones[xi.zone.LOWER_DELKFUTTS_TOWER] =
     },
     npc =
     {
+        TALES_BEGINNING = GetFirstID('Tales_Beginning'), -- CoP 1-1 mission script uses this
     },
 }
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -8294,6 +8294,28 @@ uint32 CLuaBaseEntity::getMissionStatus(MissionLog logId, const sol::object& mis
     ShowError("Lua::getMissionStatus: missionLogID %i is invalid", static_cast<uint8_t>(logId));
     return 0;
 }
+/************************************************************************
+ *  Function: sendPartialMissionLog()
+ *  Purpose : Sends the packet for mission log
+ *  Example : player:sendPartialMissionLog(player:getNation())
+ *  Notes   : getMissionStatus(log id[,index 0-7])
+ ************************************************************************/
+
+void CLuaBaseEntity::sendPartialMissionLog(MissionLog logId, bool completed) const
+{
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->getName());
+        return;
+    }
+
+    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
+
+    if (static_cast<uint8_t>(logId) < MAX_MISSIONAREA)
+    {
+        charutils::SendPartialMissionLog(PChar, logId, completed);
+    }
+}
 
 /************************************************************************
  *  Function: setEminenceCompleted()
@@ -19737,6 +19759,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("completeMission", CLuaBaseEntity::completeMission);
     SOL_REGISTER("setMissionStatus", CLuaBaseEntity::setMissionStatus);
     SOL_REGISTER("getMissionStatus", CLuaBaseEntity::getMissionStatus);
+    SOL_REGISTER("sendPartialMissionLog", CLuaBaseEntity::sendPartialMissionLog);
     SOL_REGISTER("getEminenceCompleted", CLuaBaseEntity::getEminenceCompleted);
     SOL_REGISTER("getNumEminenceCompleted", CLuaBaseEntity::getNumEminenceCompleted);
     SOL_REGISTER("setEminenceCompleted", CLuaBaseEntity::setEminenceCompleted);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -3027,7 +3027,7 @@ void CLuaBaseEntity::updateToEntireZone(uint8 statusID, uint8 animation, const s
 // Sends an arbitrary entity update to a specific player only
 void CLuaBaseEntity::sendEntityUpdateToPlayer(CLuaBaseEntity* entityToUpdate, uint8 entityUpdate, uint8 updateMask)
 {
-    if (m_PBaseEntity->objtype == TYPE_PC && entityToUpdate->GetBaseEntity())
+    if (m_PBaseEntity->objtype == TYPE_PC && entityToUpdate && entityToUpdate->GetBaseEntity())
     {
         CCharEntity* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -3038,7 +3038,7 @@ void CLuaBaseEntity::sendEntityUpdateToPlayer(CLuaBaseEntity* entityToUpdate, ui
 // Seems to be needed for Chocobo Racing
 void CLuaBaseEntity::sendEmptyEntityUpdateToPlayer(CLuaBaseEntity* entityToUpdate)
 {
-    if (m_PBaseEntity->objtype == TYPE_PC && entityToUpdate->GetBaseEntity())
+    if (m_PBaseEntity->objtype == TYPE_PC && entityToUpdate && entityToUpdate->GetBaseEntity())
     {
         auto packet = std::make_unique<CBasicPacket>();
         packet->setType(0x0E);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -417,6 +417,7 @@ public:
 
     void   setMissionStatus(MissionLog logId, const sol::object& arg2Obj, const sol::object& arg3Obj) const;
     uint32 getMissionStatus(MissionLog logId, const sol::object& missionStatusPosObj) const;
+    void   sendPartialMissionLog(MissionLog logId, bool completed) const;
 
     void   setEminenceCompleted(uint16 recordID, const sol::object& arg1, const sol::object& arg2);
     bool   getEminenceCompleted(uint16 recordID);

--- a/src/map/packets/s2c/0x056_mission.cpp
+++ b/src/map/packets/s2c/0x056_mission.cpp
@@ -28,29 +28,38 @@ GP_SERV_COMMAND_MISSION::MISSION::MISSION(const CCharEntity* PChar)
 {
     auto& packet = this->data();
 
+    // Set packet.TalesBeginning.X to zero if declined
+    auto declinedRoZStart = PChar->getCharVar("[ROZ]TalesBeginning");
+    auto declinedCoPStart = PChar->getCharVar("[COP]TalesBeginning");
+    auto declinedACPStart = PChar->getCharVar("[ACP]TalesBeginning");
+    auto declinedAMKStart = PChar->getCharVar("[AMK]TalesBeginning");
+    auto declinedASAStart = PChar->getCharVar("[ASA]TalesBeginning");
+    auto declinedSoAStart = PChar->getCharVar("[SOA]TalesBeginning");
+    auto declinedRoVStart = PChar->getCharVar("[ROV]TalesBeginning");
+
     packet.Port           = 0xFFFF;
     packet.Nation         = PChar->profile.nation;
     packet.NationMission  = PChar->m_missionLog[PChar->profile.nation].current;
-    packet.Expansion_RotZ = PChar->m_missionLog[static_cast<uint8_t>(MissionLog::Zilart)].current;
-    packet.Expansion_CoP  = PChar->m_missionLog[static_cast<uint8_t>(MissionLog::CoP)].current;
+    packet.Expansion_RotZ = declinedRoZStart > 0 ? 0 : PChar->m_missionLog[static_cast<uint8_t>(MissionLog::Zilart)].current;
+    packet.Expansion_CoP  = declinedCoPStart > 0 ? 0 : PChar->m_missionLog[static_cast<uint8_t>(MissionLog::CoP)].current;
     // This updates status for multi-legged CoP missions
     packet.Expansion_CoP2       = PChar->m_missionLog[static_cast<uint8_t>(MissionLog::CoP)].statusUpper << 16 | PChar->m_missionLog[static_cast<uint8_t>(MissionLog::CoP)].statusLower;
-    packet.Expansion_Addons.ACP = PChar->m_missionLog[static_cast<uint8_t>(MissionLog::ACP)].current;
-    packet.Expansion_Addons.AMK = PChar->m_missionLog[static_cast<uint8_t>(MissionLog::AMK)].current;
-    packet.Expansion_Addons.ASA = PChar->m_missionLog[static_cast<uint8_t>(MissionLog::ASA)].current;
+    packet.Expansion_Addons.ACP = declinedACPStart > 0 ? 0 : PChar->m_missionLog[static_cast<uint8_t>(MissionLog::ACP)].current;
+    packet.Expansion_Addons.AMK = declinedAMKStart > 0 ? 0 : PChar->m_missionLog[static_cast<uint8_t>(MissionLog::AMK)].current;
+    packet.Expansion_Addons.ASA = declinedASAStart > 0 ? 0 : PChar->m_missionLog[static_cast<uint8_t>(MissionLog::ASA)].current;
 
     // TODO: What's with the magic numbers?
-    packet.Expansion_SoA = (PChar->m_missionLog[static_cast<uint8_t>(MissionLog::SoA)].current * 2) + 0x6E;
-    packet.Expansion_RoV = PChar->m_missionLog[static_cast<uint8_t>(MissionLog::RoV)].current + 0x6C;
+    packet.Expansion_SoA = declinedSoAStart > 0 ? 0 : (PChar->m_missionLog[static_cast<uint8_t>(MissionLog::SoA)].current * 2) + 0x6E;
+    packet.Expansion_RoV = declinedRoVStart > 0 ? 0 : PChar->m_missionLog[static_cast<uint8_t>(MissionLog::RoV)].current + 0x6C;
 
-    // TODO: This is where you set the bits indicating the player has declined starting an expansion
+    // This is where you set the bits indicating the player has declined starting an expansion
     // Not all expansions make use of the system!
     packet.TalesBeginning = {
-        .RoTZ = 0,
-        .ACP  = 0,
-        .ASA  = 0,
-        .CoP  = 0,
-        .SoA  = 0,
-        .RoV  = 0
+        .RoTZ = (declinedRoZStart > 0), // These Resolve to 0 or 1
+        .ACP  = (declinedACPStart > 0),
+        .ASA  = (declinedASAStart > 0),
+        .CoP  = (declinedCoPStart > 0),
+        .SoA  = (declinedSoAStart > 0),
+        .RoV  = (declinedRoVStart > 0)
     };
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements the Tales' Beginning NPC which allows you to skip viewing the CoP CS and resume it
Also some crash fixes with lack of nullptr checking I found along the way

Caps:
https://youtu.be/zUL7D4ZqoSM
https://1drv.ms/u/c/87e665e10555c452/Ee_k8_fkMqJElM7IgKHy6FkBExdGfHi9CnbqzjQwCKGHUw?e=SFMKt0

## Steps to test these changes

Zone in on a new char eligible for CoP, decline, talk to the NPC and be able to decline again, or accept and watch the CS
The above, but zone out and zone back in and see the NPC
