### PR TITLE
[lua] Add missing 1.5x to BCNM/KSNM/ENM enemies

### DIFF
--- a/scripts/zones/Chamber_of_Oracles/mobs/Purson.lua
+++ b/scripts/zones/Chamber_of_Oracles/mobs/Purson.lua
@@ -17,6 +17,7 @@ entity.onMobSpawn = function(mob)
     mob:setMagicCastingEnabled(false) -- Does not cast spells.
     mob:setMod(xi.mod.DOUBLE_ATTACK, 40)
     mob:setMod(xi.mod.REGAIN, 50)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
 entity.onMobEngage = function(mob, target)
@@ -35,9 +36,6 @@ entity.onMobSkillTarget = function(target, mob, skill) -- Will reset enmity on m
     if skillID == xi.mobSkill.GREAT_WHIRLWIND_1 then
         mob:resetEnmity(target)
     end
-end
-
-entity.onMobDeath = function(mob, player, optParams)
 end
 
 return entity

--- a/scripts/zones/Horlais_Peak/mobs/Evil_Oscar.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Evil_Oscar.lua
@@ -70,6 +70,7 @@ end
 entity.onMobInitialize = function(mob)
     -- Melee attacks have Additional effect: Weight.
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)

--- a/scripts/zones/Mine_Shaft_2716/mobs/Bugboy.lua
+++ b/scripts/zones/Mine_Shaft_2716/mobs/Bugboy.lua
@@ -6,8 +6,8 @@
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
-    mob:setMobMod(xi.mobMod.WEAPON_BONUS, 20)
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/QuBia_Arena/mobs/Air_Pot.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Air_Pot.lua
@@ -20,6 +20,7 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
     mob:setMobMod(xi.mobMod.NO_LINK, 1)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
  -- If Air Pot is engaged first, despawn all other pots.

--- a/scripts/zones/QuBia_Arena/mobs/Anansi.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Anansi.lua
@@ -14,6 +14,7 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 25)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/QuBia_Arena/mobs/Earth_Pot.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Earth_Pot.lua
@@ -20,6 +20,7 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
     mob:setMobMod(xi.mobMod.NO_LINK, 1)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
 -- If Earth Pot is engaged first, despawn all other pots.

--- a/scripts/zones/QuBia_Arena/mobs/Fire_Pot.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Fire_Pot.lua
@@ -20,6 +20,7 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
     mob:setMobMod(xi.mobMod.NO_LINK, 1)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
 -- If Fire Pot is engaged first, despawn all other pots.

--- a/scripts/zones/QuBia_Arena/mobs/Ice_Pot.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Ice_Pot.lua
@@ -20,6 +20,7 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
     mob:setMobMod(xi.mobMod.NO_LINK, 1)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
 -- If Ice Pot is engaged first, despawn all other pots.

--- a/scripts/zones/QuBia_Arena/mobs/Thunder_Pot.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Thunder_Pot.lua
@@ -20,6 +20,7 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
     mob:setMobMod(xi.mobMod.NO_LINK, 1)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
  -- If Thunder Pot is engaged first, despawn all other pots.

--- a/scripts/zones/QuBia_Arena/mobs/Water_Pot.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Water_Pot.lua
@@ -20,6 +20,7 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
     mob:setMobMod(xi.mobMod.NO_LINK, 1)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
  -- If Water Pot is engaged first, despawn all other pots.

--- a/scripts/zones/Waughroon_Shrine/mobs/Osschaart.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Osschaart.lua
@@ -193,6 +193,7 @@ end
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ASTRAL_PET_OFFSET, 4) -- Sets Avatar at offset +4, so it can be called properly for Astral Flow
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 25)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
     mob:setMod(xi.mod.DOUBLE_ATTACK, 15)
     mob:setMod(xi.mod.WIND_RES_RANK, 8) -- Should be extremely hard to silence, but possible with high enough accuracy or elemental seal
 end

--- a/scripts/zones/Waughroon_Shrine/mobs/Queen_Jelly.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Queen_Jelly.lua
@@ -14,6 +14,7 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/Waughroon_Shrine/mobs/The_Waughroon_Kid.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/The_Waughroon_Kid.lua
@@ -9,11 +9,11 @@ local entity = {}
 entity.onMobInitialize = function(mob)
     -- Melee attacks have Additional effect: Weight.
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
 entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.ATT, 300)
-    mob:setMobMod(xi.mobMod.WEAPON_BONUS, 30)
     mob:setMod(xi.mod.REGEN, 60) -- Observed a 2% HP per tic Regen
     mob:setLocalVar('counterstanceUsed', 0)
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds missing 1.5x base damage to some enemies who were missing it. 

## Steps to test these changes

Go fight any of the buffed monsters
