### PR TITLE
[core] [lua] Move Guard checking to lua, use Parry formula

### DIFF
--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -138,38 +138,6 @@ void CAttack::SetCritical(bool value)
 
 /************************************************************************
  *                                                                      *
- *  Sets the guarded flag.                                              *
- *                                                                      *
- ************************************************************************/
-void CAttack::SetGuarded(bool isGuarded)
-{
-    m_isGuarded = isGuarded;
-}
-
-/************************************************************************
- *                                                                      *
- *  Gets the guarded flag.                                              *
- *                                                                      *
- ************************************************************************/
-bool CAttack::IsGuarded()
-{
-    m_isGuarded = attackutils::IsGuarded(m_attacker, m_victim);
-    if (m_isGuarded)
-    {
-        if (m_damageRatio > 1.0f)
-        {
-            m_damageRatio -= 1.0f;
-        }
-        else
-        {
-            m_damageRatio = 0;
-        }
-    }
-    return m_isGuarded;
-}
-
-/************************************************************************
- *                                                                      *
  *  Gets the evaded flag.                                               *
  *                                                                      *
  ************************************************************************/
@@ -201,6 +169,28 @@ bool CAttack::IsBlocked() const
 bool CAttack::IsParried() const
 {
     return m_isParried;
+}
+
+bool CAttack::IsGuarded() const
+{
+    return m_isGuarded;
+}
+
+bool CAttack::CheckGuarded()
+{
+    m_isGuarded = attackutils::IsGuarded(m_attacker, m_victim);
+    if (m_isGuarded)
+    {
+        if (m_damageRatio > 1.0f)
+        {
+            m_damageRatio -= 1.0f;
+        }
+        else
+        {
+            m_damageRatio = 0;
+        }
+    }
+    return m_isGuarded;
 }
 
 bool CAttack::CheckParried()

--- a/src/map/attack.h
+++ b/src/map/attack.h
@@ -87,12 +87,12 @@ public:
     auto IsFirstSwing() const -> bool;
     auto SetAsFirstSwing(bool isFirst = true) -> void;
     auto GetDamageRatio() const -> float;
-    auto SetGuarded(bool g) -> void;
-    auto IsGuarded() -> bool;
     auto IsEvaded() const -> bool;
     auto SetEvaded(bool e) -> void;
     auto IsBlocked() const -> bool;
     auto IsParried() const -> bool;
+    bool IsGuarded() const;
+    auto CheckGuarded() -> bool;
     auto CheckParried() -> bool;
     auto IsAnticipated() const -> bool;
     auto IsDeflected() const -> bool;

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2940,7 +2940,7 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                 }
 
                 // Guarded. TODO: Stuff guards that shouldn't.
-                if (attack.IsGuarded())
+                if (attack.CheckGuarded())
                 {
                     actionResult.resolution = ActionResolution::Guard;
                     battleutils::HandleTacticalGuard(PTarget);
@@ -2988,14 +2988,6 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
 
             if (PTarget->objtype == TYPE_PC)
             {
-                if (attack.IsGuarded() || !settings::get<bool>("map.GUARD_OLD_SKILLUP_STYLE"))
-                {
-                    if (battleutils::GetGuardRate(this, PTarget) > 0)
-                    {
-                        charutils::TrySkillUP((CCharEntity*)PTarget, SKILL_GUARD, GetMLevel());
-                    }
-                }
-
                 if (attack.IsBlocked() || !settings::get<bool>("map.BLOCK_OLD_SKILLUP_STYLE"))
                 {
                     if (battleutils::GetBlockRate(this, PTarget) > 0)

--- a/src/map/utils/attackutils.cpp
+++ b/src/map/utils/attackutils.cpp
@@ -239,11 +239,7 @@ bool IsParried(CBattleEntity* PAttacker, CBattleEntity* PDefender)
 
 bool IsGuarded(CBattleEntity* PAttacker, CBattleEntity* PDefender)
 {
-    if (facing(PDefender->loc.p, PAttacker->loc.p, 64))
-    {
-        return (xirand::GetRandomNumber(100) < battleutils::GetGuardRate(PAttacker, PDefender));
-    }
-    return false;
+    return luautils::callGlobal<bool>("xi.combat.physical.isGuarded", PDefender, PAttacker);
 }
 
 bool IsBlocked(CBattleEntity* PAttacker, CBattleEntity* PDefender)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Move Guard checking to lua, use Parry formula
Also update Shield & Guard skillup checks in lua
Remove Guard skillup check in C++

some details about using the guard formula for parry:

when I spot check guard against parry formula, guard is up 1%. The `deltaSkill - 6` is probably lower by 6 on the same target, but it's unknown if this scales. Given how fake Guard's formula is, it's probably more accurate to just copy Parry for now.

fixes #8652
## Steps to test these changes

Guard a lot and see guard rates within reasonable numbers of the formula

(expected rate was 14% here)
<img width="563" height="34" alt="image" src="https://github.com/user-attachments/assets/7a7fa3f3-a07a-4274-a059-e154b7d96cc6" />
