### PR TITLE
[Action Choose] Make optional target table contain entities instead of offsets

### DIFF
--- a/scripts/globals/combat/entity_behavior.lua
+++ b/scripts/globals/combat/entity_behavior.lua
@@ -91,19 +91,14 @@ xi.combat.behavior.chooseAction = function(actor, mainTarget, optionalTargets, a
 
                 -- Check allies.
                 if actionAllowAllies and optionalTargets then
-                    local actorId = actor:getID()
-                    for i = 1, #optionalTargets do
-                        local value = optionalTargets[i]
-                        if value ~= 0 then
-                            local allyEntity = GetMobByID(actorId + value)
-                            if
-                                allyEntity and
-                                allyEntity:isAlive() and
-                                allyEntity:checkDistance(actor) <= 8 and
-                                allyEntity:getHPP() <= actionCondition
-                            then
-                                table.insert(actionList, { actionId, allyEntity, actionWeight })
-                            end
+                    for _, allyEntity in pairs(optionalTargets) do
+                        if
+                            allyEntity and
+                            allyEntity:isAlive() and
+                            allyEntity:checkDistance(actor) <= 8 and
+                            allyEntity:getHPP() <= actionCondition
+                        then
+                            table.insert(actionList, { actionId, allyEntity, actionWeight })
                         end
                     end
                 end
@@ -118,20 +113,15 @@ xi.combat.behavior.chooseAction = function(actor, mainTarget, optionalTargets, a
                 -- Check allies.
                 else
                     if actionAllowAllies and optionalTargets then
-                        local actorId = actor:getID()
-                        for i = 1, #optionalTargets do
-                            local value = optionalTargets[i]
-                            if value ~= 0 then
-                                local allyEntity = GetMobByID(actorId + value)
-                                if
-                                    allyEntity and
-                                    allyEntity:isAlive() and
-                                    allyEntity:checkDistance(actor) <= 8 and
-                                    allyEntity:getHPP() <= actionCondition
-                                then
-                                    table.insert(actionList, { actionId, actor, actionWeight })
-                                    break
-                                end
+                        for _, allyEntity in pairs(optionalTargets) do
+                            if
+                                allyEntity and
+                                allyEntity:isAlive() and
+                                allyEntity:checkDistance(actor) <= 8 and
+                                allyEntity:getHPP() <= actionCondition
+                            then
+                                table.insert(actionList, { actionId, actor, actionWeight })
+                                break
                             end
                         end
                     end
@@ -146,19 +136,14 @@ xi.combat.behavior.chooseAction = function(actor, mainTarget, optionalTargets, a
 
                 -- Check allies.
                 if actionAllowAllies and optionalTargets then
-                    local actorId = actor:getID()
-                    for i = 1, #optionalTargets do
-                        local value = optionalTargets[i]
-                        if value ~= 0 then
-                            local allyEntity = GetMobByID(actorId + value)
-                            if
-                                allyEntity and
-                                allyEntity:isAlive() and
-                                allyEntity:checkDistance(actor) <= 8 and
-                                allyEntity:hasStatusEffect(actionCondition)
-                            then
-                                table.insert(actionList, { actionId, allyEntity, actionWeight })
-                            end
+                    for _, allyEntity in pairs(optionalTargets) do
+                        if
+                            allyEntity and
+                            allyEntity:isAlive() and
+                            allyEntity:checkDistance(actor) <= 8 and
+                            allyEntity:hasStatusEffect(actionCondition)
+                        then
+                            table.insert(actionList, { actionId, allyEntity, actionWeight })
                         end
                     end
                 end
@@ -172,19 +157,14 @@ xi.combat.behavior.chooseAction = function(actor, mainTarget, optionalTargets, a
 
                 -- Check allies.
                 if actionAllowAllies and optionalTargets then
-                    local actorId = actor:getID()
-                    for i = 1, #optionalTargets do
-                        local value = optionalTargets[i]
-                        if value ~= 0 then
-                            local allyEntity = GetMobByID(actorId + value)
-                            if
-                                allyEntity and
-                                allyEntity:isAlive() and
-                                allyEntity:checkDistance(actor) <= 8 and
-                                not allyEntity:hasStatusEffect(actionCondition)
-                            then
-                                table.insert(actionList, { actionId, allyEntity, actionWeight })
-                            end
+                    for _, allyEntity in pairs(optionalTargets) do
+                        if
+                            allyEntity and
+                            allyEntity:isAlive() and
+                            allyEntity:checkDistance(actor) <= 8 and
+                            not allyEntity:hasStatusEffect(actionCondition)
+                        then
+                            table.insert(actionList, { actionId, allyEntity, actionWeight })
                         end
                     end
                 end
@@ -199,20 +179,15 @@ xi.combat.behavior.chooseAction = function(actor, mainTarget, optionalTargets, a
                 -- Check allies.
                 else
                     if actionAllowAllies and optionalTargets then
-                        local actorId = actor:getID()
-                        for i = 1, #optionalTargets do
-                            local value = optionalTargets[i]
-                            if value ~= 0 then
-                                local allyEntity = GetMobByID(actorId + value)
-                                if
-                                    allyEntity and
-                                    allyEntity:isAlive() and
-                                    allyEntity:checkDistance(actor) <= 8 and
-                                    not allyEntity:hasStatusEffect(actionCondition)
-                                then
-                                    table.insert(actionList, { actionId, actor, actionWeight })
-                                    break
-                                end
+                        for _, allyEntity in pairs(optionalTargets) do
+                            if
+                                allyEntity and
+                                allyEntity:isAlive() and
+                                allyEntity:checkDistance(actor) <= 8 and
+                                not allyEntity:hasStatusEffect(actionCondition)
+                            then
+                                table.insert(actionList, { actionId, actor, actionWeight })
+                                break
                             end
                         end
                     end

--- a/scripts/zones/Sacrificial_Chamber/mobs/Rauu_the_Whaleswooner.lua
+++ b/scripts/zones/Sacrificial_Chamber/mobs/Rauu_the_Whaleswooner.lua
@@ -38,10 +38,9 @@ entity.onMobSpellChoose = function(mob, target, spellId)
 
     local groupTable =
     {
-        [1] = -1, -- Qull the Fallstopper
-        [2] =  0, -- Rauu the Whaleswooner
-        [3] =  1, -- Hyohh the Conchblower
-        [4] =  2, -- Pevv the Riverleaper
+        GetMobByID(mob:getID() - 1), -- Qull the Fallstopper
+        GetMobByID(mob:getID() + 1), -- Hyohh the Conchblower
+        GetMobByID(mob:getID() + 2), -- Pevv the Riverleaper
     }
 
     return xi.combat.behavior.chooseAction(mob, target, groupTable, spellList)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Change made so mobs can easily target players as optional targets.

## Steps to test these changes

Run "Amphibian Assault" BCNM without issues
