### PR TITLE
[lua] callPets ignoreInactive param

### DIFF
--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -818,6 +818,7 @@ xi.mob.callPets = function(mob, petIds, params)
     --      params.ignoreBusy:     allow pets to get summoned even if owner is busy, interupting any action it was performing
     --      params.noAnimation:    no animation packet from owner when calling pet
     --      params.inactiveTime:   how long for the call pet to take (owner will be inactive during period)
+    --      params.ignoreInactive: summoner does not become inactive while summoning a pet
     --          this implies using summoner start/stop entity animation packet (which most mobs use when calling either pets or additional helpers)
     -- if inactiveTime is zero, the following will determine an action packet to signal the mob is calling a pet
     --      params.callPetJob will map to a particular mobskill action packet
@@ -1044,8 +1045,10 @@ xi.mob.callPets = function(mob, petIds, params)
     end
 
     if params.inactiveTime > 0 then
-        -- put owner into inactive state until the timer fires
-        mob:stun(params.inactiveTime)
+        if not params.ignoreInactive then
+            -- put owner into inactive state until the timer fires
+            mob:stun(params.inactiveTime)
+        end
 
         -- start call pet animation
         if not params.noAnimation then


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Wraps the stun that is called in the callPets function in a new param that allows it to act while summoning. 
For example :

local callPetParams =
{
    inactiveTime = 5000,
    ignoreInactive = true,
    dieWithOwner = true,
    maxSpawns = 1,
}

This would be used on enemies like Bomb Queen, who continue to act while summoning. 
https://youtu.be/uqdaG2Kq6dk?t=275

## Steps to test these changes

Enable it on any summoner and see that they can continue to act while summoning.
