### PR TITLE
[core] [lua] Adjust when magian trials are attached

### DIFF
--- a/scripts/commands/reloadmagians.lua
+++ b/scripts/commands/reloadmagians.lua
@@ -1,0 +1,19 @@
+-----------------------------------
+-- func: reloadmagians
+-- desc: Reloads the magian listeners
+-----------------------------------
+---@type TCommand
+local commandObj = {}
+
+commandObj.cmdprops =
+{
+    permission = 5,
+    parameters = 'b'
+}
+
+commandObj.onTrigger = function(player)
+    xi.magian.registerTrialListeners()
+    player:printToPlayer('Magian trials re-registered!')
+end
+
+return commandObj

--- a/scripts/globals/magian.lua
+++ b/scripts/globals/magian.lua
@@ -266,7 +266,7 @@ end
 -- since onItemEquip/unEquip functions only exist for two items.
 -- NOTE: This function isn't the most efficient, but is only executed on server
 -- start, or magian reload.
-local function registerTrialListeners()
+xi.magian.registerTrialListeners = function()
     xi.items = xi.items or {}
 
     for trialId, magianData in pairs(xi.magian.trials) do
@@ -1017,6 +1017,3 @@ xi.magian.onMobDeath = function(mob, player, optParams, trialTable)
         progressPlayerTrial(player, trialId, 1)
     end
 end
-
--- Once everything else is setup, register listeners with the appropriate items
-registerTrialListeners()

--- a/src/map/utils/itemutils.cpp
+++ b/src/map/utils/itemutils.cpp
@@ -563,6 +563,16 @@ void Initialize()
     PUnarmedH2HItem->setDmgType(DAMAGE_TYPE::HTH);
     PUnarmedH2HItem->setSkillType(SKILL_HAND_TO_HAND);
     PUnarmedH2HItem->setDamage(0);
+
+    // load magian trial data AFTER items
+    auto registerTrialListeners = lua["xi"]["magian"]["registerTrialListeners"];
+    if (!registerTrialListeners.valid())
+    {
+        ShowError("xi.magians.registerTrialListeners not valid!");
+    }
+
+    ShowInfo("do_init: loading Magian trial listeners");
+    registerTrialListeners();
 }
 
 /************************************************************************


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This fixes a potential bug with item scripts load order (item script functions that ALSO have magian listeners would be clobbered)

## Steps to test these changes

Check an item with a listener on it such as Gungnir (75)

<img width="552" height="600" alt="image" src="https://github.com/user-attachments/assets/11076e8d-0850-4e32-b202-e1f4750a8c69" />
