### PR TITLE
[Treasure] Change inventory check placement

### DIFF
--- a/scripts/globals/treasure.lua
+++ b/scripts/globals/treasure.lua
@@ -1774,12 +1774,6 @@ xi.treasure.onTrade = function(player, npc, trade, bypassType, bypassReward)
         return
     end
 
-    -- Early return: Player has no room for items.
-    if player:getFreeSlotsCount() == 0 then
-        player:messageSpecial(ID.text.CHEST_UNLOCKED - 6)
-        return
-    end
-
     -----------------------------------
     -- Handle failure states.
     -----------------------------------
@@ -1860,6 +1854,12 @@ xi.treasure.onTrade = function(player, npc, trade, bypassType, bypassReward)
     -- Handle quest item reward.
     -----------------------------------
     if bypassType == 1 then
+        -- Early return: Player has no room for items.
+        if player:getFreeSlotsCount() == 0 then
+            player:messageSpecial(ID.text.CHEST_UNLOCKED - 6)
+            return
+        end
+
         kneelBeforeChest(player, npc)
 
         player:timer(2000, function(playerEntity)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
As title sais: Places the inventory space check where an item is actually given to the player directly.

## Steps to test these changes
Open chests with full inventory
