### PR TITLE
Align mobPool enum with other enum naming

### DIFF
--- a/scripts/actions/mobskills/absorbing_kiss.lua
+++ b/scripts/actions/mobskills/absorbing_kiss.lua
@@ -14,7 +14,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     -- https://docs.google.com/spreadsheets/d/1TnrBzUAQ0hyuFVIjf5OLviIfhGw4vxN1x_4zv9gG4N4/edit?gid=368168805#gid=368168805&range=H31
     -- pic of -7/-8 stat to the right of that
-    if mob:getPool() == xi.mobPools.PEPPER then
+    if mob:getPool() == xi.mobPool.PEPPER then
         numAttributesDrained = 0 -- Reset in case of resists
 
         for i = xi.effect.STR_DOWN, xi.effect.CHR_DOWN do

--- a/scripts/actions/mobskills/blood_drain.lua
+++ b/scripts/actions/mobskills/blood_drain.lua
@@ -15,7 +15,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local shadow = xi.mobskills.shadowBehavior.NUMSHADOWS_1
 
     -- Asanbosam uses a modified blood drain that ignores shadows
-    if mob:getPool() == xi.mobPools.ASANBOSAM then
+    if mob:getPool() == xi.mobPool.ASANBOSAM then
         shadow = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
     end
 

--- a/scripts/actions/mobskills/charm.lua
+++ b/scripts/actions/mobskills/charm.lua
@@ -17,7 +17,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         return xi.effect.CHARM_I
     end
 
-    if mob:getPool() == xi.mobPools.OSSCHAART then
+    if mob:getPool() == xi.mobPool.OSSCHAART then
         duration = 30
     end
 

--- a/scripts/actions/mobskills/deep_kiss.lua
+++ b/scripts/actions/mobskills/deep_kiss.lua
@@ -11,7 +11,7 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     -- https://docs.google.com/spreadsheets/d/1TnrBzUAQ0hyuFVIjf5OLviIfhGw4vxN1x_4zv9gG4N4/edit?gid=368168805#gid=368168805&range=H32
-    if mob:getPool() == xi.mobPools.PHOEDME then
+    if mob:getPool() == xi.mobPool.PHOEDME then
         local numEffectsStolen = 0
 
         -- Steal all statuses until none are left

--- a/scripts/actions/mobskills/dread_shriek.lua
+++ b/scripts/actions/mobskills/dread_shriek.lua
@@ -23,7 +23,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     end
 
     -- Cyranuce M Cutauleon
-    if mob:getPool() == xi.mobPools.CYRANUCE_M_CUTAULEON then
+    if mob:getPool() == xi.mobPool.CYRANUCE_M_CUTAULEON then
         power = 100 -- yes, really
     end
 

--- a/scripts/actions/mobskills/drop_hammer.lua
+++ b/scripts/actions/mobskills/drop_hammer.lua
@@ -25,7 +25,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
 
-    if mob:getPool() == xi.mobPools.FAHRAFAHR_THE_BLOODIED then  -- Fahrafahr the Bloodied
+    if mob:getPool() == xi.mobPool.FAHRAFAHR_THE_BLOODIED then  -- Fahrafahr the Bloodied
         mob:resetEnmity(target)
     end
 

--- a/scripts/actions/mobskills/flat_blade.lua
+++ b/scripts/actions/mobskills/flat_blade.lua
@@ -10,7 +10,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getPool() ~= xi.mobPools.QUBIA_ARENA_TRION then
+    if mob:getPool() ~= xi.mobPool.QUBIA_ARENA_TRION then
         mob:messageBasic(xi.msg.basic.READIES_WS, 0, 35)
     end
 
@@ -18,7 +18,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    if mob:getPool() == xi.mobPools.QUBIA_ARENA_TRION then
+    if mob:getPool() == xi.mobPool.QUBIA_ARENA_TRION then
         target:showText(mob, zones[xi.zone.QUBIA_ARENA].text.FLAT_LAND)
     end
 

--- a/scripts/actions/mobskills/flying_hip_press.lua
+++ b/scripts/actions/mobskills/flying_hip_press.lua
@@ -15,11 +15,11 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local fTP = 2.0
 
-    if mob:getPool() == xi.mobPools.BUGBOY then
+    if mob:getPool() == xi.mobPool.BUGBOY then
         fTP = 7.0
     end
 
-    if mob:getPool() == xi.mobPools.BUGBEAR_MATMAN then
+    if mob:getPool() == xi.mobPool.BUGBEAR_MATMAN then
         fTP = 10.0
     end
 

--- a/scripts/actions/mobskills/heavy_armature.lua
+++ b/scripts/actions/mobskills/heavy_armature.lua
@@ -6,7 +6,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getPool() == xi.mobPools.ARMED_GEARS then
+    if mob:getPool() == xi.mobPool.ARMED_GEARS then
         return 0
     else
         return 1

--- a/scripts/actions/mobskills/hurricane_wing.lua
+++ b/scripts/actions/mobskills/hurricane_wing.lua
@@ -27,7 +27,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     target:takeDamage(damage, mob, xi.attackType.MAGICAL, xi.damageType.WIND)
 
-    if mob:getPool() == xi.mobPools.NIDHOGG then
+    if mob:getPool() == xi.mobPool.NIDHOGG then
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 160, 0, 30)
     else
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 100, 0, 30)

--- a/scripts/actions/mobskills/qn_aern_rdm.lua
+++ b/scripts/actions/mobskills/qn_aern_rdm.lua
@@ -6,7 +6,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getPool() == xi.mobPools.QNAERN_RDM and mob:getHPP() <= 70 then
+    if mob:getPool() == xi.mobPool.QNAERN_RDM and mob:getHPP() <= 70 then
         return 0
     else
         return 1

--- a/scripts/actions/mobskills/qn_aern_whm.lua
+++ b/scripts/actions/mobskills/qn_aern_whm.lua
@@ -6,7 +6,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getPool() == xi.mobPools.QNAERN_WHM and mob:getHPP() <= 50 then
+    if mob:getPool() == xi.mobPool.QNAERN_WHM and mob:getHPP() <= 50 then
         return 0
     else
         return 1

--- a/scripts/actions/mobskills/red_lotus_blade.lua
+++ b/scripts/actions/mobskills/red_lotus_blade.lua
@@ -11,8 +11,8 @@ local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
     if
-        mob:getPool() ~= xi.mobPools.QUBIA_ARENA_TRION and
-        mob:getPool() ~= xi.mobPools.THRONE_ROOM_VOLKER
+        mob:getPool() ~= xi.mobPool.QUBIA_ARENA_TRION and
+        mob:getPool() ~= xi.mobPool.THRONE_ROOM_VOLKER
     then
         mob:messageBasic(xi.msg.basic.READIES_WS, 0, 34)
     end
@@ -21,9 +21,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    if mob:getPool() == xi.mobPools.QUBIA_ARENA_TRION then -- Trion: uBia_Arena only
+    if mob:getPool() == xi.mobPool.QUBIA_ARENA_TRION then -- Trion: uBia_Arena only
         target:showText(mob, zones[xi.zone.QUBIA_ARENA].text.RLB_LAND)
-    elseif mob:getPool() == xi.mobPools.THRONE_ROOM_VOLKER then -- Volker: Throne_Room only
+    elseif mob:getPool() == xi.mobPool.THRONE_ROOM_VOLKER then -- Volker: Throne_Room only
         target:showText(mob, zones[xi.zone.THRONE_ROOM].text.FEEL_MY_PAIN)
     end
 

--- a/scripts/actions/mobskills/restoral.lua
+++ b/scripts/actions/mobskills/restoral.lua
@@ -16,7 +16,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     So math.random() for now!
     ]]
     local heal = math.random(900, 1400)
-    if mob:getPool() == xi.mobPools.ARMED_GEARS then
+    if mob:getPool() == xi.mobPool.ARMED_GEARS then
         heal = heal * 2.5
     end
 

--- a/scripts/actions/mobskills/sand_blast.lua
+++ b/scripts/actions/mobskills/sand_blast.lua
@@ -14,7 +14,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 40, 0, 180))
 
     if
-        mob:getPool() == xi.mobPools.FEELER_ANTLION and
+        mob:getPool() == xi.mobPool.FEELER_ANTLION and
         mob:getLocalVar('SAND_BLAST') == 1
     then
         local alastorId = mob:getID() + 6

--- a/scripts/actions/mobskills/savage_blade.lua
+++ b/scripts/actions/mobskills/savage_blade.lua
@@ -10,7 +10,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getPool() ~= xi.mobPools.QUBIA_ARENA_TRION then
+    if mob:getPool() ~= xi.mobPool.QUBIA_ARENA_TRION then
         mob:messageBasic(xi.msg.basic.READIES_WS, 0, 42)
     end
 
@@ -18,7 +18,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    if mob:getPool() == xi.mobPools.QUBIA_ARENA_TRION then -- Trion@QuBia_Arena only
+    if mob:getPool() == xi.mobPool.QUBIA_ARENA_TRION then -- Trion@QuBia_Arena only
         target:showText(mob, zones[xi.zone.QUBIA_ARENA].text.SAVAGE_LAND)
     end
 

--- a/scripts/actions/mobskills/shadow_spread.lua
+++ b/scripts/actions/mobskills/shadow_spread.lua
@@ -15,8 +15,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     local sleepDuration = 60
     if
-        mob:getPool() == xi.mobPools.WREAKER or
-        mob:getPool() == xi.mobPools.AGONIZER
+        mob:getPool() == xi.mobPool.WREAKER or
+        mob:getPool() == xi.mobPool.AGONIZER
     then
         sleepDuration = 120
     end

--- a/scripts/actions/mobskills/soothing_aroma.lua
+++ b/scripts/actions/mobskills/soothing_aroma.lua
@@ -8,7 +8,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getHPP() >= 50 and mob:getPool() == xi.mobPools.RASKOVNIK then
+    if mob:getHPP() >= 50 and mob:getPool() == xi.mobPool.RASKOVNIK then
         -- Raskovnik doesn't use this for the 1st half of its HP.
         return 1
     end

--- a/scripts/actions/mobskills/spirits_within.lua
+++ b/scripts/actions/mobskills/spirits_within.lua
@@ -10,7 +10,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getPool() ~= xi.mobPools.THRONE_ROOM_VOLKER then
+    if mob:getPool() ~= xi.mobPool.THRONE_ROOM_VOLKER then
         mob:messageBasic(xi.msg.basic.READIES_WS, 0, 39)
     end
 
@@ -18,7 +18,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    if mob:getPool() == xi.mobPools.THRONE_ROOM_VOLKER then -- Volker@Throne_Room only
+    if mob:getPool() == xi.mobPool.THRONE_ROOM_VOLKER then -- Volker@Throne_Room only
         target:showText(mob, zones[xi.zone.THRONE_ROOM].text.RETURN_TO_THE_DARKNESS)
     end
 

--- a/scripts/actions/mobskills/vorpal_blade.lua
+++ b/scripts/actions/mobskills/vorpal_blade.lua
@@ -27,7 +27,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
         else
             return 1
         end
-    elseif mob:getPool() ~= xi.mobPools.THRONE_ROOM_VOLKER then
+    elseif mob:getPool() ~= xi.mobPool.THRONE_ROOM_VOLKER then
         mob:messageBasic(xi.msg.basic.READIES_WS, 0, 40)
     end
 
@@ -35,7 +35,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    if mob:getPool() == xi.mobPools.THRONE_ROOM_VOLKER then -- Volker@Throne_Room only
+    if mob:getPool() == xi.mobPool.THRONE_ROOM_VOLKER then -- Volker@Throne_Room only
         target:showText(mob, zones[xi.zone.THRONE_ROOM].text.BLADE_ANSWER)
     end
 

--- a/scripts/actions/mobskills/wild_rage.lua
+++ b/scripts/actions/mobskills/wild_rage.lua
@@ -22,7 +22,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local ftp    = 2.1
 
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
-    if mob:getPool() == xi.mobPools.PLATOON_SCORPION then
+    if mob:getPool() == xi.mobPool.PLATOON_SCORPION then
         -- should not have to verify because platoon scorps only in battlefield
         local numScorpsDead = mob:getBattlefield():getLocalVar('[ODS]NumScorpsDead')
 
@@ -33,7 +33,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, xi.mobskills.shadowBehavior.NUMSHADOWS_3)
 
-    if mob:getPool() == xi.mobPools.KING_VINEGARROON then
+    if mob:getPool() == xi.mobPool.KING_VINEGARROON then
         xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.POISON, 25, 3, 60)
     end
 

--- a/scripts/actions/spells/black/sleepga.lua
+++ b/scripts/actions/spells/black/sleepga.lua
@@ -10,7 +10,7 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     if caster:isMob() then
-        if caster:getPool() == xi.mobPools.AMNAF_PSYCHEFLAYER then
+        if caster:getPool() == xi.mobPool.AMNAF_PSYCHEFLAYER then
             caster:resetEnmity(target)
         end
 

--- a/scripts/enum/mob_pool.lua
+++ b/scripts/enum/mob_pool.lua
@@ -4,8 +4,8 @@
 -----------------------------------
 xi = xi or {}
 
----@enum xi.mobPools
-xi.mobPools =
+---@enum xi.mobPool
+xi.mobPool =
 {
     AGONIZER               = 63,   -- Agonizer (CoP 5-2 Spire Battle)
     ARMED_GEARS            = 243,  -- Armed Gears Restoral

--- a/scripts/items/blackened_muddy_siredon.lua
+++ b/scripts/items/blackened_muddy_siredon.lua
@@ -11,9 +11,9 @@ itemObject.onItemCheck = function(target, player)
     local result = xi.msg.basic.ITEM_UNABLE_TO_USE
 
     if
-        target:getPool() == xi.mobPools.SHIKAREE_X or
-        target:getPool() == xi.mobPools.SHIKAREE_Y or
-        target:getPool() == xi.mobPools.SHIKAREE_Z
+        target:getPool() == xi.mobPool.SHIKAREE_X or
+        target:getPool() == xi.mobPool.SHIKAREE_Y or
+        target:getPool() == xi.mobPool.SHIKAREE_Z
     then
         result = 0
     elseif target:checkDistance(player) > 10 then
@@ -28,7 +28,7 @@ itemObject.onItemUse = function(target, player)
     local siredonCount = target:getLocalVar('siredonCount')
 
     -- Shikaree Z rejects the second siredon
-    if pool == xi.mobPools.SHIKAREE_Z and siredonCount >= 1 then
+    if pool == xi.mobPool.SHIKAREE_Z and siredonCount >= 1 then
         target:messageText(target, ID.text.SHIKAREE_Z_OFFSET + 6) -- SIREDON_REJECT
         return
     end
@@ -36,9 +36,9 @@ itemObject.onItemUse = function(target, player)
     -- Determine which accept message to use based on pool and count
     local messageOffsets =
     {
-        [xi.mobPools.SHIKAREE_X] = { ID.text.SHIKAREE_X_OFFSET + 5, ID.text.SHIKAREE_X_OFFSET + 6 },
-        [xi.mobPools.SHIKAREE_Y] = { ID.text.SHIKAREE_Y_OFFSET + 5, ID.text.SHIKAREE_Y_OFFSET + 6 },
-        [xi.mobPools.SHIKAREE_Z] = { ID.text.SHIKAREE_Z_OFFSET + 5 },
+        [xi.mobPool.SHIKAREE_X] = { ID.text.SHIKAREE_X_OFFSET + 5, ID.text.SHIKAREE_X_OFFSET + 6 },
+        [xi.mobPool.SHIKAREE_Y] = { ID.text.SHIKAREE_Y_OFFSET + 5, ID.text.SHIKAREE_Y_OFFSET + 6 },
+        [xi.mobPool.SHIKAREE_Z] = { ID.text.SHIKAREE_Z_OFFSET + 5 },
     }
 
     local messages = messageOffsets[pool]

--- a/scripts/mixins/families/chigoe_pet.lua
+++ b/scripts/mixins/families/chigoe_pet.lua
@@ -17,7 +17,7 @@ g_mixins.families.chigoe_pet = function(hostMob)
         end
 
         local numChigoesToSpawn = 1
-        if mob:getPool() == xi.mobPools.PEALLAIDH then
+        if mob:getPool() == xi.mobPool.PEALLAIDH then
             numChigoesToSpawn = 2
         end
 

--- a/scripts/mixins/families/gorger_nm.lua
+++ b/scripts/mixins/families/gorger_nm.lua
@@ -21,11 +21,11 @@ g_mixins.families = g_mixins.families or {}
 
 local fissionAdds =
 {
-    [xi.mobPools.HADAL_SATIATOR] = 3,
-    [xi.mobPools.INGESTER      ] = 4,
-    [xi.mobPools.PROCREATOR    ] = 4,
-    [xi.mobPools.PROGENERATOR  ] = 4,
-    [xi.mobPools.PROPAGATOR    ] = 2,
+    [xi.mobPool.HADAL_SATIATOR] = 3,
+    [xi.mobPool.INGESTER      ] = 4,
+    [xi.mobPool.PROCREATOR    ] = 4,
+    [xi.mobPool.PROGENERATOR  ] = 4,
+    [xi.mobPool.PROPAGATOR    ] = 2,
 }
 
 xi.mix.gorger.canUseFission = function(mob)

--- a/scripts/mixins/families/hpemde.lua
+++ b/scripts/mixins/families/hpemde.lua
@@ -13,7 +13,7 @@ local function dive(mob)
     mob:setMobAbilityEnabled(false)
 
     -- Om'hpedme in north half of Al'Taieu do not dive or become untargetable
-    if mob:getPool() ~= xi.mobPools.HPEMDE_NO_DIVING then
+    if mob:getPool() ~= xi.mobPool.HPEMDE_NO_DIVING then
         mob:hideName(true)
         mob:setUntargetable(true)
         mob:setAnimationSub(5)
@@ -58,7 +58,7 @@ g_mixins.families.hpemde = function(hpemdeMob)
         end
 
         if
-            mob:getPool() ~= xi.mobPools.HPEMDE_NO_DIVING and
+            mob:getPool() ~= xi.mobPool.HPEMDE_NO_DIVING and
             mob:getAnimationSub() ~= 5
         then
             dive(mob)

--- a/scripts/mixins/families/zdei.lua
+++ b/scripts/mixins/families/zdei.lua
@@ -20,12 +20,12 @@ g_mixins.families.zdei = function(zdeiMob)
     -- Assign rotation speed and direction based off of pools
     local rotationPools =
     {
-        [xi.mobPools.EOZDEI_LEFT]   = -16,
-        [xi.mobPools.EOZDEI_RIGHT]  =  16,
-        [xi.mobPools.AWZDEI_LEFT]   = -16,
-        [xi.mobPools.AWZDEI_RIGHT]  =  16,
-        [xi.mobPools.AWZDEI_FAST_L] = -32,
-        [xi.mobPools.AWZDEI_FAST_R] =  32,
+        [xi.mobPool.EOZDEI_LEFT]   = -16,
+        [xi.mobPool.EOZDEI_RIGHT]  =  16,
+        [xi.mobPool.AWZDEI_LEFT]   = -16,
+        [xi.mobPool.AWZDEI_RIGHT]  =  16,
+        [xi.mobPool.AWZDEI_FAST_L] = -32,
+        [xi.mobPool.AWZDEI_FAST_R] =  32,
     }
 
     zdeiMob:addListener('SPAWN', 'ZDEI_SPAWN', function(mob)


### PR DESCRIPTION
Removes plural from filename and enum definition from xi.mobPools to xi.mobPool

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Closes #8564 

Other enum definitions use singular case, while mob pools were defined as xi.mobPools.*.  Renames the enum and filename to `xi.mobPool` and `mob_pool.lua`
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No impact to gameplay
<!-- Clear and detailed steps to test your changes here -->
