### PR TITLE
Add White Honey Pephredo Hive daily interaction

### DIFF
--- a/scripts/quests/ahtUrhgan/A_Taste_of_Honey.lua
+++ b/scripts/quests/ahtUrhgan/A_Taste_of_Honey.lua
@@ -10,6 +10,16 @@ quest.reward =
     item = xi.item.IRMIK_HELVASI
 }
 
+local pephredoOnTrigger = function(player, npc)
+    if
+        quest:getVar(player, npc:getID()) == 0 and
+        npcUtil.giveItem(player, xi.item.POT_OF_WHITE_HONEY)
+    then
+        quest:setVar(player, npc:getID(), 1, NextJstDay())
+        return quest:noAction()
+    end
+end
+
 quest.sections =
 {
     -- Section: Quest available
@@ -80,6 +90,11 @@ quest.sections =
                 end,
             },
         },
+
+        [xi.zone.WAJAOM_WOODLANDS] =
+        {
+            ['Pephredo_Hive'] = pephredoOnTrigger,
+        },
     },
 
     -- Section: Quest completed
@@ -122,6 +137,11 @@ quest.sections =
                     end
                 end,
             },
+        },
+
+        [xi.zone.WAJAOM_WOODLANDS] =
+        {
+            ['Pephredo_Hive'] = pephredoOnTrigger,
         },
     },
 }

--- a/scripts/zones/Wajaom_Woodlands/IDs.lua
+++ b/scripts/zones/Wajaom_Woodlands/IDs.lua
@@ -14,6 +14,7 @@ zones[xi.zone.WAJAOM_WOODLANDS] =
         KEYITEM_OBTAINED              = 6394, -- Obtained key item: <keyitem>.
         WARHORSE_HOOFPRINT            = 6401, -- You find the hoofprint of a gigantic warhorse...
         ITEM_RETURNED                 = 6403, -- The <item> is returned to you.
+        NOTHING_OUT_OF_ORDINARY       = 6405, -- There is nothing out of the ordinary here.
         FELLOW_MESSAGE_OFFSET         = 6420, -- I'm ready. I suppose.
         CARRIED_OVER_POINTS           = 7002, -- You have carried over <number> login point[/s].
         LOGIN_CAMPAIGN_UNDERWAY       = 7003, -- The [/January/February/March/April/May/June/July/August/September/October/November/December] <number> Login Campaign is currently underway!


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes #8457

* Adds interaction for Pephredo Hives when A Taste of Honey is active or completed.  Tracks with expiring quest var for JST midnight for reset.
* Adds missing 'Nothing out of Ordinary' text ID to Wajaom Woodlands
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
1. !addquest 6 12
2. Interact with Hive
3. Repeat
4. Check other Hives
<!-- Clear and detailed steps to test your changes here -->
