### PR TITLE
[lua] Tigress Strikes quest fixes

### DIFF
--- a/scripts/zones/Fort_Karugo-Narugo_[S]/npcs/Rotih_Moalghett.lua
+++ b/scripts/zones/Fort_Karugo-Narugo_[S]/npcs/Rotih_Moalghett.lua
@@ -10,15 +10,15 @@ local entity = {}
 entity.onTrigger = function(player, npc)
     if player:getQuestStatus(xi.questLog.CRYSTAL_WAR, xi.quest.id.crystalWar.THE_TIGRESS_STRIKES) == xi.questStatus.QUEST_ACCEPTED then
         if player:getCharVar('TigressStrikesProg') == 1 then
-            player:startEvent(101)
-        else
             player:startEvent(104)
+        else
+            player:startEvent(101)
         end
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    if csid == 104 then
+    if csid == 101 then
         player:setCharVar('TigressStrikesProg', 1)
     end
 end

--- a/scripts/zones/Fort_Karugo-Narugo_[S]/npcs/qm4.lua
+++ b/scripts/zones/Fort_Karugo-Narugo_[S]/npcs/qm4.lua
@@ -2,7 +2,7 @@
 -- Area: Fort Karugo Narugo [S]
 --  NPC: ???
 -- Type: Quest
--- !pos 280 -20 85 96
+-- !pos 208 -30 54 96
 -----------------------------------
 local ID = zones[xi.zone.FORT_KARUGO_NARUGO_S]
 -----------------------------------


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR makes two fixes to the WotG quest "The Tigress Strikes."

1. Corrects the cutscene event ID and follow-up dialogue event ID for the NPC Rotih Moalghett; they were reversed.
2. Corrects the fight QM from an unrelated nearby ??? to the proper QM. [Retail evidence](https://youtu.be/y_RMEldiDZ8?si=e0MYXNofFzY5mErt&t=558)

## Steps to test these changes

Move through the quest, ensure the cutscenes make sense and occur in order, confirm that the fight QM cutscene scenery matches the scenery you're currently standing in
