### PR TITLE
[lua] Check song modifier ID before using it

### DIFF
--- a/scripts/globals/spells/enfeebling_song.lua
+++ b/scripts/globals/spells/enfeebling_song.lua
@@ -174,7 +174,8 @@ xi.spells.enfeebling.useEnfeeblingSong = function(caster, target, spell)
     -- STEP 2: Check if spell resists.
     ------------------------------
     -- Check the amount of Song+ and All_Song+ gear.
-    local gearBoost = caster:getMod(pTable[spellId][column.SONG_MODIFIER]) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
+    local modifier  = pTable[spellId][column.SONG_MODIFIER]
+    local gearBoost = (modifier > 0 and caster:getMod(modifier) or 0) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
 
     -- Finale has innate +175 to magic accuracy.
     local bonusMagicAcc = 0

--- a/scripts/globals/spells/enhancing_song.lua
+++ b/scripts/globals/spells/enhancing_song.lua
@@ -271,7 +271,8 @@ xi.spells.enhancing.useEnhancingSong = function(caster, target, spell)
     local tier            = pTable[spellId][column.EFFECT_TIER]
     local songEffect      = pTable[spellId][column.EFFECT_MAIN]
     local subEffect       = 0
-    local instrumentBoost = caster:getMod(pTable[spellId][column.MODIFIER]) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
+    local modifier        = pTable[spellId][column.MODIFIER]
+    local instrumentBoost = (modifier > 0 and caster:getMod(modifier) or 0) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
     local soulVoicePower  = pTable[spellId][column.SOUL_VOICE]
 
     -- Calculate Song Pottency, Duration and SubEffect.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

If for any reason (for example, malformed data entry for equipment or status effects), a player character ends up with a nonzero value for Mod ID 0, that value will be added as a bonus similar to "ALL SONGS EFFECT" to any bard song that doesn't have a designated effect mod. This PR avoids that issue by checking to make sure the mod ID is greater than zero before performing the getMod lookup.

## Steps to test these changes

!setmod 0 100
Cast Goblin Gavotte, don't see a 21-minute song duration
