### PR TITLE
[sql] Fix Self-Destruct/Diamondhide blu spell mobskill IDs

### DIFF
--- a/sql/blue_spell_list.sql
+++ b/sql/blue_spell_list.sql
@@ -31,7 +31,7 @@ INSERT INTO `blue_spell_list` VALUES (529,683,2,7,1,3,0,0); -- Bludgeon
 INSERT INTO `blue_spell_list` VALUES (530,569,4,0,1,0,0,0); -- Refueling
 INSERT INTO `blue_spell_list` VALUES (531,676,3,13,1,0,0,0); -- Ice Break
 INSERT INTO `blue_spell_list` VALUES (532,535,4,0,1,0,0,0); -- Blitzstrahl
-INSERT INTO `blue_spell_list` VALUES (533,511,3,14,2,0,0,0); -- Self-Destruct
+INSERT INTO `blue_spell_list` VALUES (533,509,3,14,2,0,0,0); -- Self-Destruct
 INSERT INTO `blue_spell_list` VALUES (534,523,4,10,1,0,0,0); -- Mysterious Light
 INSERT INTO `blue_spell_list` VALUES (535,1646,1,14,1,0,0,0); -- Cold Wave
 INSERT INTO `blue_spell_list` VALUES (536,466,1,4,1,0,0,0); -- Poison Breath
@@ -105,7 +105,7 @@ INSERT INTO `blue_spell_list` VALUES (626,591,3,0,1,0,0,0); -- Bomb Toss
 INSERT INTO `blue_spell_list` VALUES (628,1081,3,15,1,8,0,0); -- Frypan
 INSERT INTO `blue_spell_list` VALUES (629,360,3,15,1,0,0,0); -- Flying Hip Press
 INSERT INTO `blue_spell_list` VALUES (631,777,3,9,1,5,0,0); -- Hydro Shot
-INSERT INTO `blue_spell_list` VALUES (632,1744,3,0,1,0,0,0); -- Diamondhide
+INSERT INTO `blue_spell_list` VALUES (632,1897,3,0,1,0,0,0); -- Diamondhide
 INSERT INTO `blue_spell_list` VALUES (633,1745,5,21,1,0,0,0); -- Enervation
 INSERT INTO `blue_spell_list` VALUES (634,785,5,14,2,0,0,0); -- Light of Penance
 INSERT INTO `blue_spell_list` VALUES (636,1734,4,4,1,0,0,0); -- Warm-Up


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR fixes two mobskill IDs for blue magic spells.

1. Self-destruct, currently only learnable from the BCNM "3, 2, 1", and only if you survive 9,999 damage
2. Diamondhide, currently only learnable from the non-heavy armored Trolls, which is the opposite of retail. [JP Wiki](https://wiki.ffo.jp/html/3161.html): 
> It can be learned from heavily armored trolls (wearing green armor). It cannot be learned from monks or puppeteer trolls .

## Steps to test these changes

Learn Self-Destruct from Bombs; learn Diamondhide from armored trolls
