### PR TITLE
[Module] Quest "Chocobo Wounds" era wait-time

### DIFF
--- a/modules/era/lua/chocobo_wounds_era_wait.lua
+++ b/modules/era/lua/chocobo_wounds_era_wait.lua
@@ -1,0 +1,54 @@
+-----------------------------------
+-- Chocobo Wounds Era Module
+-- 1 Vanad'iel day wait between feeds
+-- Safe for startup sanity checks
+-----------------------------------
+require('modules/module_utils')
+
+-- luacheck: globals Module xi VanadielUniqueDay
+
+local m = Module:new('chocobo_wounds_era_wait')
+
+m:addOverride('xi.server.onServerStart', function(super)
+    if super then
+        super()
+    end
+
+    xi.module.modifyInteractionEntry('scripts/quests/Jeuno/Chocobos_Wounds', function(quest)
+        local section = quest.sections[2] and quest.sections[2][xi.zone.UPPER_JEUNO]
+        if not section or not section['Chocobo'] then
+            return
+        end
+
+        local originalOnTrade = section['Chocobo'].onTrade
+
+        section['Chocobo'].onTrade = function(player, npc, trade)
+            if not player then
+                return 0
+            end
+
+            local today = VanadielUniqueDay()
+            local lastDay = quest:getVar(player, 'Timer')
+
+            -- Enforce 1 Vana'diel day wait
+            if lastDay == today then
+                return quest:progressEvent(73)
+            end
+
+            if originalOnTrade then
+                local result = originalOnTrade(player, npc, trade)
+
+                -- Only set timer if trade succeeded
+                if result then
+                    quest:setVar(player, 'Timer', today)
+                end
+
+                return result or 0
+            end
+
+            return 0
+        end
+    end)
+end)
+
+return m

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -1320,6 +1320,12 @@ void CParty::RefreshSync()
             NewMLevel = member->jobs.job[member->GetMJob()];
         }
 
+        CStatusEffect* syncEffect = member->StatusEffectContainer->GetStatusEffect(EFFECT_LEVEL_SYNC);
+        if (syncEffect != nullptr)
+        {
+            syncEffect->SetPower(syncLevel);
+        }
+
         if (member->GetMLevel() != NewMLevel)
         {
             charutils::RemoveAllEquipMods(member);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Changes the time required between Chocobo feeding attempts to Vanadiel day rollover.  You have to wait until the next game day before you can advance the quest via feeding attempts. 

## Steps to test these changes

Be at least level 20.  Accept the Chocobo Wounds quest from Brutus in Upper Jeuno.  Attempt to feed the Chocobo.  The quest will mention that the Chocobo is still terrified of you.  You now must wait until Vanadiel day rollover in order for the Chocobo to accept another trade and advance to the next step.  Repeat feedings attempts every hour until quest completes.  
