### PR TITLE
[lua] ToAU Marksmanship weaponskill module

### DIFF
--- a/modules/era/lua/toau/weaponskills/marksmanship.lua
+++ b/modules/era/lua/toau/weaponskills/marksmanship.lua
@@ -1,0 +1,175 @@
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+-- Date : 2007-11-19 (One day prior to WoTG release)
+-----------------------------------
+local m = Module:new('toau_marksmanship')
+-----------------------------------
+
+-----------------------------------
+-- Hot Shot
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.hot_shot.onUseWeaponSkill', function(player, target, wsID, tp, primary, action)
+    local params      = {}
+    params.numHits    = 1
+    params.ftpMod     = { 0.50, 0.75, 1.00 }
+    params.agi_wsc    = 0.3
+    params.hybridWS   = true
+    params.ele        = xi.element.FIRE
+    params.skill      = xi.skill.MARKSMANSHIP
+    params.includemab = true
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doRangedWeaponskill(player, target, wsID, params, tp, action, primary)
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Split Shot
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.split_shot.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params               = {}
+    params.numHits             = 1
+    params.ftpMod              = { 1.00, 1.00, 1.00 }
+    params.agi_wsc             = 0.3
+    params.ignoredDefense      = { 0.00, 0.35, 0.50 }
+    params.rangedAccuracyBonus = 30
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doRangedWeaponskill(player, target, wsID, params, tp, action, primary)
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Sniper Shot
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.sniper_shot.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params      = {}
+    params.numHits    = 1
+    params.ftpMod     = { 1.00, 1.00, 1.00 }
+    params.agi_wsc    = 0.3
+    params.critVaries = { 0.10, 0.30, 0.50 }
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doRangedWeaponskill(player, target, wsID, params, tp, action, primary)
+
+    -- Handle status effect
+    local effectId      = xi.effect.INT_DOWN
+    local actionElement = xi.element.FIRE
+    local power         = 10
+    local duration      = math.floor(140 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Slug Shot
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.slug_shot.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params               = {}
+    params.numHits             = 1
+    params.ftpMod              = { 5.00, 5.00, 5.00 }
+    params.agi_wsc             = 0.3
+    params.rangedAccuracyBonus = math.floor(-25 * xi.weaponskills.fTP(tp, { 2, 1, 0 }))
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doRangedWeaponskill(player, target, wsID, params, tp, action, primary)
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Blast Shot
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.blast_shot.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params               = {}
+    params.numHits             = 1
+    params.ftpMod              = { 2.00, 2.00, 2.00 }
+    params.agi_wsc             = 0.3
+    params.rangedAccuracyBonus = math.floor(25 * xi.weaponskills.fTP(tp, { 0, 1, 2 }))
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doRangedWeaponskill(player, target, wsID, params, tp, action, primary)
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Heavy Shot
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.heavy_shot.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params      = {}
+    params.numHits    = 1
+    params.ftpMod     = { 3.50, 3.50, 3.50 }
+    params.agi_wsc    = 0.3
+    params.critVaries = { 0.10, 0.30, 0.50 }
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doRangedWeaponskill(player, target, wsID, params, tp, action, primary)
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Detonator
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.detonator.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params               = {}
+    params.numHits             = 1
+    params.ftpMod              = { 1.5, 2.0, 2.5 }
+    params.atkVaries           = { 2.0, 2.0, 2.0 }
+    params.agi_wsc             = 0.3
+    params.rangedAccuracyBonus = 100
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doRangedWeaponskill(player, target, wsID, params, tp, action, primary)
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Coronach
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.coronach.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params               = {}
+    params.numHits             = 1
+    params.ftpMod              = { 3.0, 3.0, 3.0 }
+    params.dex_wsc             = 0.4
+    params.agi_wsc             = 0.4
+    params.overrideCE          = 80
+    params.overrideVE          = 240
+    params.rangedAccuracyBonus = 100
+
+    xi.aftermath.addStatusEffect(player, tp, xi.slot.MAIN, xi.aftermath.type.RELIC)
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doRangedWeaponskill(player, target, wsID, params, tp, action, primary)
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Trueflight
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.trueflight.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params      = {}
+    params.ftpMod     = { 4.0, 4.25, 4.75 }
+    params.agi_wsc    = 0.3
+    params.ele        = xi.element.LIGHT
+    params.skill      = xi.skill.MARKSMANSHIP
+    params.includemab = true
+    params.dStat      = xi.mod.AGI
+
+    xi.aftermath.addStatusEffect(player, tp, xi.slot.MAIN, xi.aftermath.type.MYTHIC)
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Leaden Salute
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.leaden_salute.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params      = {}
+    params.ftpMod     = { 4.0, 4.25, 4.75 }
+    params.agi_wsc    = 0.3
+    params.ele        = xi.element.DARK
+    params.skill      = xi.skill.MARKSMANSHIP
+    params.includemab = true
+    params.dStat      = xi.mod.AGI
+
+    xi.aftermath.addStatusEffect(player, tp, xi.slot.MAIN, xi.aftermath.type.MYTHIC)
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+return m


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a ToAU era weaponskill module for Marksmanship
Date : 2007-11-19 (One day prior to WoTG release)

Accuracy penalty for Slug Shot sourced from :
https://wiki.ffo.jp/html/2547.html


## Steps to test these changes

Enable it in the module init, use marksmanship weaponskills
