### PR TITLE
[lua] ToAU Archery weaponskill module

### DIFF
--- a/modules/era/lua/toau/weaponskills/archery.lua
+++ b/modules/era/lua/toau/weaponskills/archery.lua
@@ -1,0 +1,147 @@
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+-- Date : 2007-11-19 (One day prior to WoTG release)
+-----------------------------------
+local m = Module:new('toau_archery')
+-----------------------------------
+
+-----------------------------------
+-- Flaming Arrow
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.flaming_arrow.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params      = {}
+    params.numHits    = 1
+    params.ftpMod     = { 0.50, 0.75, 1.00 }
+    params.str_wsc    = 0.16
+    params.agi_wsc    = 0.25
+    params.hybridWS   = true
+    params.ele        = xi.element.FIRE
+    params.skill      = xi.skill.ARCHERY
+    params.includemab = true
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doRangedWeaponskill(player, target, wsID, params, tp, action, primary)
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Piercing Arrow
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.piercing_arrow.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params               = {}
+    params.numHits             = 1
+    params.ftpMod              = { 1.00, 1.00, 1.00 }
+    params.str_wsc             = 0.16
+    params.agi_wsc             = 0.25
+    params.ignoredDefense      = { 0.00, 0.35, 0.50 }
+    params.rangedAccuracyBonus = 30
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doRangedWeaponskill(player, target, wsID, params, tp, action, primary)
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Dulling Arrow
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.dulling_arrow.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params      = {}
+    params.numHits    = 1
+    params.ftpMod     = { 1.00, 1.00, 1.00 }
+    params.str_wsc    = 0.16
+    params.agi_wsc    = 0.25
+    params.critVaries = { 0.10, 0.30, 0.50 }
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doRangedWeaponskill(player, target, wsID, params, tp, action, primary)
+
+    -- Handle status effect
+    local effectId      = xi.effect.INT_DOWN
+    local actionElement = xi.element.FIRE
+    local power         = 10
+    local duration      = math.floor(140 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Sidewinder
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.sidewinder.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params               = {}
+    params.numHits             = 1
+    params.ftpMod              = { 5.00, 5.00, 5.00 }
+    params.str_wsc             = 0.16
+    params.agi_wsc             = 0.25
+    params.rangedAccuracyBonus = math.floor(-25 * xi.weaponskills.fTP(tp, { 2, 1, 0 }))
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doRangedWeaponskill(player, target, wsID, params, tp, action, primary)
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Blast Arrow
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.blast_arrow.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params               = {}
+    params.numHits             = 1
+    params.ftpMod              = { 2.00, 2.00, 2.00 }
+    params.str_wsc             = 0.16
+    params.agi_wsc             = 0.25
+    params.rangedAccuracyBonus = math.floor(25 * xi.weaponskills.fTP(tp, { 0, 1, 2 }))
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doRangedWeaponskill(player, target, wsID, params, tp, action, primary)
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Arching Arrow
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.arching_arrow.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params               = {}
+    params.numHits             = 1
+    params.ftpMod              = { 3.50, 3.50, 3.50 }
+    params.str_wsc             = 0.16
+    params.agi_wsc             = 0.25
+    params.critVaries          = { 0.10, 0.30, 0.50 }
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doRangedWeaponskill(player, target, wsID, params, tp, action, primary)
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Empyreal Arrow
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.empyreal_arrow.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params               = {}
+    params.numHits             = 1
+    params.ftpMod              = { 1.50, 2.00, 2.50 }
+    params.atkVaries           = { 2.00, 2.00, 2.00 }
+    params.str_wsc             = 0.16
+    params.agi_wsc             = 0.25
+    params.rangedAccuracyBonus = 100
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doRangedWeaponskill(player, target, wsID, params, tp, action, primary)
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Namas Arrow
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.namas_arrow.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params               = {}
+    params.numHits             = 1
+    params.ftpMod              = { 2.75, 2.75, 2.75 }
+    params.str_wsc             = 0.4
+    params.agi_wsc             = 0.4
+    params.overrideCE          = 160
+    params.overrideVE          = 480
+    params.rangedAccuracyBonus = 100
+
+    -- Apply aftermath
+    xi.aftermath.addStatusEffect(player, tp, xi.slot.RANGED, xi.aftermath.type.RELIC)
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doRangedWeaponskill(player, target, wsID, params, tp, action, primary)
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+return m


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a ToAU Archery weaponskill module
Date : 2007-11-19 (One day prior to WoTG release)

Sidewinder accuracy penalty sourced here:
https://wiki.ffo.jp/html/2540.html

## Steps to test these changes

enable the module in the init, use archery weaponskills
