### PR TITLE
[Module] Adjust CE/VE enmity for spells and abilities

### DIFF
--- a/modules/era/sql/era_abilities_enmity.sql
+++ b/modules/era/sql/era_abilities_enmity.sql
@@ -1,0 +1,17 @@
+------------------------------------
+-- Era Abilities Enmity Overrides
+-- CE = minimal (1), VE = era-accurate spike
+------------------------------------
+-- Source : https://kanican.livejournal.com/tag/enmity%20table%21/
+------------------------------------
+
+UPDATE `abilities` SET CE = 1, VE = 900  WHERE `name` = 'Shield Bash';
+UPDATE `abilities` SET CE = 1, VE = 1800 WHERE `name` = 'Sentinel';
+UPDATE `abilities` SET CE = 1, VE = 80   WHERE `name` = 'Divine Seal';
+UPDATE `abilities` SET CE = 1, VE = 80   WHERE `name` = 'Elemental Seal';
+UPDATE `abilities` SET CE = 1, VE = 0    WHERE `name` = 'Cover';
+UPDATE `abilities` SET CE = 1, VE = 300  WHERE `name` = 'Rampart';
+UPDATE `abilities` SET CE = 1, VE = 300  WHERE `name` = 'Modus Veritas';
+UPDATE `abilities` SET CE = 1, VE = 80   WHERE `name` = 'Pianissimo';
+UPDATE `abilities` SET CE = 1, VE = 300  WHERE `name` = 'Divine Emblem';
+UPDATE `abilities` SET CE = 1, VE = 300  WHERE `name` = 'Nether Void';

--- a/modules/era/sql/era_spell_enmity.sql
+++ b/modules/era/sql/era_spell_enmity.sql
@@ -1,0 +1,219 @@
+------------------------------------
+-- Era Abilities Enmity Overrides
+-- CE = minimal (1), VE = era-accurate spike
+------------------------------------
+-- Source : https://kanican.livejournal.com/tag/enmity%20table%21/
+------------------------------------
+
+-- White Magic
+
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Poisona';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Paralyna';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Blindna';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Silena';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Cursna';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Viruna';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Stona';
+UPDATE `spell_list` SET CE = 1, VE = 480 WHERE `name` = 'Erase';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Esuna';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Aquaveil';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Blink';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Stoneskin';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Phalanx';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Phalanx II';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Haste';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Refresh';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Regen';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Regen II';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Regen III';
+UPDATE `spell_list` SET CE = 1, VE = 320 WHERE `name` = 'Paralyze';
+UPDATE `spell_list` SET CE = 1, VE = 320 WHERE `name` = 'Paralyze II';
+UPDATE `spell_list` SET CE = 1, VE = 320 WHERE `name` = 'Silence';
+UPDATE `spell_list` SET CE = 1, VE = 320 WHERE `name` = 'Slow';
+UPDATE `spell_list` SET CE = 1, VE = 320 WHERE `name` = 'Slow II';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Sacrifice';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Auspice';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Repose';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Enthunder';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Enstone';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Enaero';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Enfire';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Enblizzard';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Enwater';
+UPDATE `spell_list` SET CE = 1, VE = 240 WHERE `name` = 'Enthunder II';
+UPDATE `spell_list` SET CE = 1, VE = 240 WHERE `name` = 'Enstone II';
+UPDATE `spell_list` SET CE = 1, VE = 240 WHERE `name` = 'Enaero II';
+UPDATE `spell_list` SET CE = 1, VE = 240 WHERE `name` = 'Enfire II';
+UPDATE `spell_list` SET CE = 1, VE = 240 WHERE `name` = 'Enblizzard II';
+UPDATE `spell_list` SET CE = 1, VE = 240 WHERE `name` = 'Enwater II';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Barvirus';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Barparalyze';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Barsilence';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Barpetrify';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Barpoison';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Barblind';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Barsleep';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Barfire';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Barblizzard';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Baraero';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Barstone';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Barthunder';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Barwater';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Sandstorm';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Rainstorm';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Windstorm';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Firestorm';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Hailstorm';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Thunderstorm';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Voidstorm';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Aurorastorm';
+
+-- Black Magic
+
+UPDATE `spell_list` SET CE = 1, VE = 320 WHERE `name` = 'Poison';
+UPDATE `spell_list` SET CE = 1, VE = 320 WHERE `name` = 'Poison II';
+UPDATE `spell_list` SET CE = 1, VE = 320 WHERE `name` = 'Poisonga';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Blind';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Blind II';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Bind';
+UPDATE `spell_list` SET CE = 1, VE = 320 WHERE `name` = 'Bio';
+UPDATE `spell_list` SET CE = 1, VE = 320 WHERE `name` = 'Bio II';
+UPDATE `spell_list` SET CE = 1, VE = 320 WHERE `name` = 'Bio III';
+UPDATE `spell_list` SET CE = 1, VE = 480 WHERE `name` = 'Blaze Spikes';
+UPDATE `spell_list` SET CE = 1, VE = 480 WHERE `name` = 'Ice Spikes';
+UPDATE `spell_list` SET CE = 1, VE = 480 WHERE `name` = 'Shock Spikes';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Burn';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Choke';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Shock';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Frost';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Rasp';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Drown';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Sleep';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Sleep II';
+UPDATE `spell_list` SET CE = 1, VE = 80  WHERE `name` = 'Gravity';
+UPDATE `spell_list` SET CE = 1, VE = 300 WHERE `name` = 'Dispel';
+UPDATE `spell_list` SET CE = 1, VE = 640 WHERE `name` = 'Absorb-STR';
+UPDATE `spell_list` SET CE = 1, VE = 640 WHERE `name` = 'Absorb-DEX';
+UPDATE `spell_list` SET CE = 1, VE = 640 WHERE `name` = 'Absorb-VIT';
+UPDATE `spell_list` SET CE = 1, VE = 640 WHERE `name` = 'Absorb-INT';
+UPDATE `spell_list` SET CE = 1, VE = 640 WHERE `name` = 'Absorb-MND';
+UPDATE `spell_list` SET CE = 1, VE = 640 WHERE `name` = 'Absorb-CHR';
+UPDATE `spell_list` SET CE = 1, VE = 640 WHERE `name` = 'Absorb-AGI';
+UPDATE `spell_list` SET CE = 1, VE = 640 WHERE `name` = 'Absorb-ACC';
+
+-- Songs
+
+UPDATE `spell_list` SET CE = 100, VE = 240 WHERE `name` = 'Foe Requiem';
+UPDATE `spell_list` SET CE = 100, VE = 240 WHERE `name` = 'Foe Requiem II';
+UPDATE `spell_list` SET CE = 100, VE = 240 WHERE `name` = 'Foe Requiem III';
+UPDATE `spell_list` SET CE = 100, VE = 240 WHERE `name` = 'Foe Requiem IV';
+UPDATE `spell_list` SET CE = 100, VE = 240 WHERE `name` = 'Foe Requiem V';
+UPDATE `spell_list` SET CE = 100, VE = 240 WHERE `name` = 'Foe Requiem VI';
+UPDATE `spell_list` SET CE = 240, VE = 0   WHERE `name` = 'Horde Lullaby';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Armys Paeon';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Armys Paeon II';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Armys Paeon III';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Armys Paeon IV';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Armys Paeon V';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Mages Ballad';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Mages Ballad II';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Knights Minne';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Knights Minne II';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Knights Minne III';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Knights Minne IV';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Valor Minuet';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Valor Minuet II';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Valor Minuet III';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Valor Minuet IV';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Sword Madrigal';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Blade Madrigal';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Hunters Prelude';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Archers Prelude';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Sheepfoe Mambo';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Dragonfoe Mambo';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Fowl Aubade';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Herb Pastoral';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Shining Fantasia';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Scops Operetta';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Puppets Operetta';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Gold Capriccio';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Warding Round';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Goblin Gavotte';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Advancing March';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Victory March';
+UPDATE `spell_list` SET CE = 100, VE = 240 WHERE `name` = 'Battlefield Elegy';
+UPDATE `spell_list` SET CE = 100, VE = 240 WHERE `name` = 'Carnage Elegy';
+UPDATE `spell_list` SET CE = 160, VE = 160 WHERE `name` = 'Sinewy Etude';
+UPDATE `spell_list` SET CE = 160, VE = 160 WHERE `name` = 'Dextrous Etude';
+UPDATE `spell_list` SET CE = 160, VE = 160 WHERE `name` = 'Vivacious Etude';
+UPDATE `spell_list` SET CE = 160, VE = 160 WHERE `name` = 'Quick Etude';
+UPDATE `spell_list` SET CE = 160, VE = 160 WHERE `name` = 'Learned Etude';
+UPDATE `spell_list` SET CE = 160, VE = 160 WHERE `name` = 'Spirited Etude';
+UPDATE `spell_list` SET CE = 160, VE = 160 WHERE `name` = 'Enchanting Etude';
+UPDATE `spell_list` SET CE = 160, VE = 160 WHERE `name` = 'Herculean Etude';
+UPDATE `spell_list` SET CE = 160, VE = 160 WHERE `name` = 'Uncanny Etude';
+UPDATE `spell_list` SET CE = 160, VE = 160 WHERE `name` = 'Vital Etude';
+UPDATE `spell_list` SET CE = 160, VE = 160 WHERE `name` = 'Swift Etude';
+UPDATE `spell_list` SET CE = 160, VE = 160 WHERE `name` = 'Sage Etude';
+UPDATE `spell_list` SET CE = 160, VE = 160 WHERE `name` = 'Logical Etude';
+UPDATE `spell_list` SET CE = 160, VE = 160 WHERE `name` = 'Bewitching Etude';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Fire Carol';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Ice Carol';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Wind Carol';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Earth Carol';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Lightning Carol';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Water Carol';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Light Carol';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Dark Carol';
+UPDATE `spell_list` SET CE = 100, VE = 240 WHERE `name` = 'Fire Threnody';
+UPDATE `spell_list` SET CE = 100, VE = 240 WHERE `name` = 'Ice Threnody';
+UPDATE `spell_list` SET CE = 100, VE = 240 WHERE `name` = 'Wind Threnody';
+UPDATE `spell_list` SET CE = 100, VE = 240 WHERE `name` = 'Earth Threnody';
+UPDATE `spell_list` SET CE = 100, VE = 240 WHERE `name` = 'Lightning Threnody';
+UPDATE `spell_list` SET CE = 100, VE = 240 WHERE `name` = 'Water Threnody';
+UPDATE `spell_list` SET CE = 100, VE = 240 WHERE `name` = 'Light Threnody';
+UPDATE `spell_list` SET CE = 100, VE = 240 WHERE `name` = 'Dark Threnody';
+UPDATE `spell_list` SET CE = 100, VE = 240 WHERE `name` = 'Magic Finale';
+UPDATE `spell_list` SET CE = 240, VE = 0   WHERE `name` = 'Foe Lullaby';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Goddesss Hymnus';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Chocobo Mazurka';
+UPDATE `spell_list` SET CE = 240, VE = 240 WHERE `name` = 'Maidens Virelai';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Raptor Mazurka';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Foe Sirvente';
+UPDATE `spell_list` SET CE = 20,  VE = 80  WHERE `name` = 'Adventurers Dirge';
+
+-- Ninjitsu
+
+UPDATE `spell_list` SET CE = 80, VE = 240 WHERE `name` = 'Monomi Ichi';
+UPDATE `spell_list` SET CE = 80, VE = 240 WHERE `name` = 'Aisha Ichi';
+UPDATE `spell_list` SET CE = 1,  VE = 300 WHERE `name` = 'Utsusemi Ichi';
+UPDATE `spell_list` SET CE = 1,  VE = 300 WHERE `name` = 'Utsusemi Ni';
+UPDATE `spell_list` SET CE = 80, VE = 240 WHERE `name` = 'Jubaku Ichi';
+UPDATE `spell_list` SET CE = 80, VE = 240 WHERE `name` = 'Hojo Ichi';
+UPDATE `spell_list` SET CE = 80, VE = 240 WHERE `name` = 'Hojo Ni';
+UPDATE `spell_list` SET CE = 80, VE = 240 WHERE `name` = 'Kurayami Ichi';
+UPDATE `spell_list` SET CE = 80, VE = 240 WHERE `name` = 'Kurayami Ni';
+UPDATE `spell_list` SET CE = 80, VE = 240 WHERE `name` = 'Dokumori Ichi';
+
+-- Summoning Magic
+
+UPDATE `spell_list` SET CE = 90, VE = 300 WHERE `name` = 'Fire Spirit';
+UPDATE `spell_list` SET CE = 90, VE = 300 WHERE `name` = 'Ice Spirit';
+UPDATE `spell_list` SET CE = 90, VE = 300 WHERE `name` = 'Air Spirit';
+UPDATE `spell_list` SET CE = 90, VE = 300 WHERE `name` = 'Earth Spirit';
+UPDATE `spell_list` SET CE = 90, VE = 300 WHERE `name` = 'Thunder Spirit';
+UPDATE `spell_list` SET CE = 90, VE = 300 WHERE `name` = 'Water Spirit';
+UPDATE `spell_list` SET CE = 90, VE = 300 WHERE `name` = 'Light Spirit';
+UPDATE `spell_list` SET CE = 90, VE = 300 WHERE `name` = 'Dark Spirit';
+UPDATE `spell_list` SET CE = 90, VE = 300 WHERE `name` = 'Carbuncle';
+UPDATE `spell_list` SET CE = 90, VE = 300 WHERE `name` = 'Fenrir';
+UPDATE `spell_list` SET CE = 90, VE = 300 WHERE `name` = 'Ifrit';
+UPDATE `spell_list` SET CE = 90, VE = 300 WHERE `name` = 'Titan';
+UPDATE `spell_list` SET CE = 90, VE = 300 WHERE `name` = 'Leviathan';
+UPDATE `spell_list` SET CE = 90, VE = 300 WHERE `name` = 'Garuda';
+UPDATE `spell_list` SET CE = 90, VE = 300 WHERE `name` = 'Shiva';
+UPDATE `spell_list` SET CE = 90, VE = 300 WHERE `name` = 'Ramuh';
+UPDATE `spell_list` SET CE = 90, VE = 300 WHERE `name` = 'Diabolos';
+UPDATE `spell_list` SET CE = 90, VE = 300 WHERE `name` = 'Odin';
+UPDATE `spell_list` SET CE = 90, VE = 300 WHERE `name` = 'Alexander';
+UPDATE `spell_list` SET CE = 90, VE = 300 WHERE `name` = 'Cait Sith';


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This module overrides Combat Enmity (CE) and Volatile Enmity (VE) values for spells, songs, ninjutsu, summoning magic, and abilities to match Era FFXI values. All values have been sourced from Kanican’s Era guide (https://kanican.livejournal.com/) and cross-verified against multiple references.

This ensures that enmity generation behaves accurately for Era servers, while leaving MP costs, recast times, and spell/ability effects unchanged. 

## Steps to test these changes

Apply the SQL module to a test database or ensure it loads on server start.
Log in with a test character.
Cast spells and use abilities listed in the module, such as: White/Black Magic: Poisona, Bio, Absorb-STR
Songs: Foe Requiem, Armys Paeon
Ninjutsu: Utsusemi Ichi/Ni
Summoning: Ifrit, Titan
Job Abilities: Shield Bash, Sentinel
Observe enmity generated:
CE should generally be minimal (1) for most spells/abilities.
VE should match historical Era spikes.
Confirm other attributes (MP cost, recast, potency) remain unchanged.