### PR TITLE
Era: adjust CE/VE for era abilities

### DIFF
--- a/modules/era/sql/era_abilities_enmity.sql
+++ b/modules/era/sql/era_abilities_enmity.sql
@@ -1,0 +1,15 @@
+-- ----------------------------------
+-- Era SpellAbilities Enmity Overrides
+-- CE = minimal (1), VE = era-accurate spike
+-- ----------------------------------
+
+UPDATE `abilities` SET CE = 1, VE = 900  WHERE `name` = 'Shield Bash';
+UPDATE `abilities` SET CE = 1, VE = 1800 WHERE `name` = 'Sentinel';
+UPDATE `abilities` SET CE = 1, VE = 80   WHERE `name` = 'Divine Seal';
+UPDATE `abilities` SET CE = 1, VE = 80   WHERE `name` = 'Elemental Seal';
+UPDATE `abilities` SET CE = 1, VE = 0    WHERE `name` = 'Cover';
+UPDATE `abilities` SET CE = 1, VE = 300  WHERE `name` = 'Rampart';
+UPDATE `abilities` SET CE = 1, VE = 300  WHERE `name` = 'Modus Veritas';
+UPDATE `abilities` SET CE = 1, VE = 80   WHERE `name` = 'Pianissimo';
+UPDATE `abilities` SET CE = 1, VE = 300  WHERE `name` = 'Divine Emblem';
+UPDATE `abilities` SET CE = 1, VE = 300  WHERE `name` = 'Nether Void';


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This module overrides Combat Enmity (CE) and Volatile Enmity (VE) values for abilities to match Era FFXI values. All values have been sourced from Kanican’s Era guide (https://kanican.livejournal.com/) and cross-verified against multiple references.

This ensures that enmity generation behaves accurately for Era servers, while leaving ability effects unchanged.

## Steps to test these changes

Apply the SQL module to a test database or ensure it loads on server start.
Log in with a test character.
Use abilities listed in the module such as Shield Bash, Sentinel.
Observe enmity generated:
CE should generally be minimal (1) for abilities.
VE should match historical Era spikes.
Confirm other attributes recast and potency remain unchanged.
