### PR TITLE
[cpp] Update level sync power on sync refresh

### DIFF
--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -1320,6 +1320,12 @@ void CParty::RefreshSync()
             NewMLevel = member->jobs.job[member->GetMJob()];
         }
 
+        CStatusEffect* syncEffect = member->StatusEffectContainer->GetStatusEffect(EFFECT_LEVEL_SYNC);
+        if (syncEffect != nullptr)
+        {
+            syncEffect->SetPower(syncLevel);
+        }
+
         if (member->GetMLevel() != NewMLevel)
         {
             charutils::RemoveAllEquipMods(member);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Level sync's power should be equivalent to the current sync target's level. This power wasn't being updated when the sync leveled up. This adds an update to the power of level sync on sync refresh.

## Steps to test these changes

1. Login two characters and level sync them
2. Check the power of the level sync is their current level
3. Level up the sync target
4. This is where the bug fix occurs. Previously, power would be the same. Now it is updated to the new level.
