### PR TITLE
[test] Tweak flaky tests

### DIFF
--- a/scripts/tests/packets/s2c/0x028_battle2/weaponskills.lua
+++ b/scripts/tests/packets/s2c/0x028_battle2/weaponskills.lua
@@ -214,10 +214,10 @@ local packets =
     ['Skillchain'] =
     {
         test = function(player, mob)
+            stub('xi.combat.physicalHitRate.getPhysicalHitRate', 1)
             mob:setUnkillable(true)
             player:changeJob(xi.job.SAM)
             player:setLevel(99)
-            player:setMod(xi.mod.ACC, 10000)
             player:addItem(xi.item.MASAMUNE_99)
             player:equipItem(xi.item.MASAMUNE_99, nil, xi.slot.MAIN)
 

--- a/scripts/tests/systems/spells/aoe.lua
+++ b/scripts/tests/systems/spells/aoe.lua
@@ -7,13 +7,13 @@ describe('AoE', function()
     before_each(function()
         p1 = xi.test.world:spawnPlayer(
             {
-                zone  = xi.zone.WEST_RONFAURE,
+                zone  = xi.zone.GM_HOME,
                 job   = xi.job.BLM,
                 level = 99,
             })
         p2 = xi.test.world:spawnPlayer(
             {
-                zone  = xi.zone.WEST_RONFAURE,
+                zone  = xi.zone.GM_HOME,
                 job   = xi.job.BLM,
                 level = 99,
             })


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Tweaks a few tests with recurring failures.

- Moves the AoE test to GM Home so casting mobs do not pollute the function under test
- Caps the hitrate for skillchain test

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
