### PR TITLE
[lua] Weaponskills: change accVaries to static values

### DIFF
--- a/modules/era/lua/toau/weaponskills/great_katana.lua
+++ b/modules/era/lua/toau/weaponskills/great_katana.lua
@@ -201,7 +201,7 @@ m:addOverride('xi.actions.weaponskills.tachi_rana.onUseWeaponSkill', function(pl
     params.numHits   = 3
     params.ftpMod    = { 1.00, 1.00, 1.00 }
     params.str_wsc   = 0.35
-    params.accVaries = { 1.00, 1.25, 1.50 }
+    params.accVaries = { 0, 30, 60 } -- TODO: verify exact number
 
     -- Apply aftermath
     xi.aftermath.addStatusEffect(player, tp, xi.slot.MAIN, xi.aftermath.type.MYTHIC)

--- a/modules/era/lua/toau/weaponskills/polearm.lua
+++ b/modules/era/lua/toau/weaponskills/polearm.lua
@@ -83,7 +83,7 @@ m:addOverride('xi.actions.weaponskills.penta_thrust.onUseWeaponSkill', function(
     params.ftpMod    = { 1.00, 1.00, 1.00 }
     params.str_wsc   = 0.2
     params.dex_wsc   = 0.2
-    params.accVaries = { 0.80, 0.90, 1.00 }
+    params.accVaries = { 0, 30, 50 } -- TODO: Unknown what 3k used to be, 50 is guessed. This was updated in 2013. 1k may also have been a penalty but that is unverifiable. JP patch notes indicate 1k and 3k anchor points were changed but not 3k
     params.atkVaries = { 0.875, 0.875, 0.875 }
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)

--- a/scripts/actions/weaponskills/README.md
+++ b/scripts/actions/weaponskills/README.md
@@ -7,9 +7,9 @@ Example: `ftpMod = { 1.0, 2.0, 5.0 }`
 
 NOTE: The below modifiers should _ONLY_ be set if applicable to the WS.
 ----------------------------
-`accVaries`  : Table of 3 floating point elements to represent points on the piecemeal function for modifiers (points at 1000, 2000, and 3000 TP).
+`accVaries`  : Table of 3 integer elements to represent points on the piecemeal function for modifiers (points at 1000, 2000, and 3000 TP). 30 at 2k = +30 acc at exactly 2,000 tp
 
-Example: `accVaries = { 0.8, 0.9, 1.0 }`
+Example: `accVaries = { 0, 30, 60 }`
 
 `atkVaries`  : Table of 3 floating point elements to represent points on the piecemeal function for modifiers (points at 1000, 2000, and 3000 TP).
 

--- a/scripts/actions/weaponskills/asuran_fists.lua
+++ b/scripts/actions/weaponskills/asuran_fists.lua
@@ -21,7 +21,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 8
     params.ftpMod = { 1, 1, 1 }
     params.str_wsc = 0.1 params.vit_wsc = 0.1
-    params.accVaries = { 0.8, 0.9, 1.0 } -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
+    params.accVaries = { 0, 30, 60 } -- TODO: verify exact number
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.multiHitfTP = true -- http://wiki.ffo.jp/html/2424.html

--- a/scripts/actions/weaponskills/blade_ku.lua
+++ b/scripts/actions/weaponskills/blade_ku.lua
@@ -27,7 +27,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     -- Sufficient data for ACC bonus/penalty does not exist; assuming no penalty and 10% increase per 1000 TP
     -- http://wiki.ffo.jp/html/732.html does not list ACC Bonus
     -- https://www.bg-wiki.com/ffxi/Blade:_Ku does not list ACC Bonus
-    params.accVaries = { 1.0, 1.1, 1.2 } -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
+    params.accVaries = { 0, 30, 60 } -- TODO: verify exact number
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftpMod = { 1.25, 1.25, 1.25 }

--- a/scripts/actions/weaponskills/blast_arrow.lua
+++ b/scripts/actions/weaponskills/blast_arrow.lua
@@ -18,7 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftpMod = { 2.0, 2.0, 2.0 }
     params.str_wsc = 0.16 params.agi_wsc = 0.25
-    params.accVaries = { 0.8, 0.9, 1.0 } -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
+    params.accVaries = { 0, 30, 60 } -- TODO: verify exact number
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.str_wsc = 0.2 params.agi_wsc = 0.5

--- a/scripts/actions/weaponskills/blast_shot.lua
+++ b/scripts/actions/weaponskills/blast_shot.lua
@@ -18,7 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftpMod = { 2.0, 2.0, 2.0 }
     params.agi_wsc = 0.3
-    params.accVaries = { 0.8, 0.9, 1.0 } -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
+    params.accVaries = { 0, 30, 60 } -- TODO: verify exact number
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.agi_wsc = 0.7

--- a/scripts/actions/weaponskills/dancing_edge.lua
+++ b/scripts/actions/weaponskills/dancing_edge.lua
@@ -20,7 +20,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 5
     params.ftpMod = { 1.1875, 1.1875, 1.1875 }
     params.dex_wsc = 0.3 params.chr_wsc = 0.4
-    params.accVaries = { 0.8, 0.9, 1.0 } -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
+    params.accVaries = { 0, 30, 60 } -- TODO: verify exact number
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.dex_wsc = 0.4

--- a/scripts/actions/weaponskills/decimation.lua
+++ b/scripts/actions/weaponskills/decimation.lua
@@ -20,7 +20,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 3
     params.ftpMod = { 1.25, 1.25, 1.25 }
     params.str_wsc = 0.5
-    params.accVaries = { 0.8, 0.9, 1.0 } -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
+    params.accVaries = { 0, 30, 60 } -- TODO: verify exact number
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftpMod = { 1.75, 1.75, 1.75 }

--- a/scripts/actions/weaponskills/penta_thrust.lua
+++ b/scripts/actions/weaponskills/penta_thrust.lua
@@ -20,7 +20,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 5
     params.ftpMod = { 1.0, 1.0, 1.0 }
     params.str_wsc = 0.2 params.dex_wsc = 0.2
-    params.accVaries = { 0.8, 0.9, 1.0 } -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
+    params.accVaries = { 0, 30, 60 } -- TODO: verify exact number
     params.atkVaries = { 0.875, 0.875, 0.875 }
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/actions/weaponskills/realmrazer.lua
+++ b/scripts/actions/weaponskills/realmrazer.lua
@@ -19,7 +19,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 7
     params.ftpMod = { 0.88, 0.88, 0.88 }
     params.mnd_wsc = player:getMerit(xi.merit.REALMRAZER) * 0.17
-    params.accVaries = { 0.8, 0.9, 1.0 } -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
+    params.accVaries = { 0, 30, 60 } -- TODO: verify exact number
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.mnd_wsc = 0.7 + (player:getMerit(xi.merit.REALMRAZER) * 0.03)

--- a/scripts/actions/weaponskills/ruinator.lua
+++ b/scripts/actions/weaponskills/ruinator.lua
@@ -20,7 +20,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 4
     params.ftpMod = { 1.08, 1.08, 1.08 }
     params.str_wsc = player:getMerit(xi.merit.RUINATOR) * 0.17
-    params.accVaries = { 0.8, 0.9, 1.0 } -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
+    params.accVaries = { 0, 30, 60 } -- TODO: verify exact number
     params.atkVaries = { 1.1, 1.1, 1.1 }
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/actions/weaponskills/sidewinder.lua
+++ b/scripts/actions/weaponskills/sidewinder.lua
@@ -18,7 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftpMod = { 5.0, 5.0, 5.0 }
     params.str_wsc = 0.16 params.agi_wsc = 0.25
-    params.accVaries = { 0.8, 0.9, 1.0 } -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
+    params.accVaries = { -50, 0, 0 } -- TODO: verify 3k
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.str_wsc = 0.2 params.agi_wsc = 0.5

--- a/scripts/actions/weaponskills/slug_shot.lua
+++ b/scripts/actions/weaponskills/slug_shot.lua
@@ -19,7 +19,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftpMod = { 5.0, 5.0, 5.0 }
     params.agi_wsc = 0.3
-    params.accVaries = { 0.8, 0.9, 1.0 } -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
+    params.accVaries = { -50, 0, 0 } -- TODO: verify 3,000 TP point. Data is unknown.
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.agi_wsc = 0.7

--- a/scripts/actions/weaponskills/swift_blade.lua
+++ b/scripts/actions/weaponskills/swift_blade.lua
@@ -23,7 +23,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     -- Sufficient data for ACC bonus/penalty does not exist; assuming no penalty and 10% increase per 1000 TP
     -- http://wiki.ffo.jp/html/382.html does not list ACC Bonus
     -- https://www.bg-wiki.com/ffxi/Swift_Blade does not list ACC Bonus
-    params.accVaries = { 1.0, 1.1, 1.2 } -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
+    params.accVaries = { 0, 30, 60 } -- TODO: verify exact number
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.str_wsc = 0.5 params.mnd_wsc = 0.5

--- a/scripts/actions/weaponskills/tachi_rana.lua
+++ b/scripts/actions/weaponskills/tachi_rana.lua
@@ -20,7 +20,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 3
     params.ftpMod = { 1.0, 1.0, 1.0 }
     params.str_wsc = 0.35
-    params.accVaries = { 0.8, 0.9, 1.0 } -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
+    params.accVaries = { 0, 30, 60 } -- TODO: verify exact number
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.str_wsc = 0.5

--- a/scripts/actions/weaponskills/true_strike.lua
+++ b/scripts/actions/weaponskills/true_strike.lua
@@ -21,7 +21,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.ftpMod = { 1.0, 1.0, 1.0 }
     params.str_wsc = 0.5
     params.critVaries = { 1.0, 1.0, 1.0 }
-    params.accVaries  = { 0.5, 0.7, 1.0 } -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
+    params.accVaries = { -50, -50, -50 } -- TODO: verify exact number.
     params.atkVaries  = { 2.0, 2.0, 2.0 }
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -685,9 +685,8 @@ xi.weaponskills.doPhysicalWeaponskill = function(attacker, target, wsID, wsParam
     end
 
     if wsParams.accVaries then
-        -- applied to all hits (This is a penalty!)
-        local accLost       = calcParams.accStat * (1 - xi.weaponskills.fTP(tp, wsParams.accVaries))
-        calcParams.bonusAcc = calcParams.bonusAcc - accLost
+        local accMod        = xi.weaponskills.fTP(tp, wsParams.accVaries)
+        calcParams.bonusAcc = calcParams.bonusAcc + accMod
     end
 
     calcParams.firstHitRate = xi.weaponskills.getHitRate(attacker, target, calcParams.bonusAcc + 100, xi.attackAnimation.RIGHT_ATTACK)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

tl;dr: accVaries being a penalty and a % was bogus (shocker)
Penta thrust data which was previously a penalty:
https://docs.google.com/spreadsheets/d/1XluQWmC_UaoQ4kKHeMxr5pAwA5zl2sNAixD_A3tf4Hk/edit?gid=0#gid=0

We already knew that Slugwinder was a static penalty, so this put the nail in the coffin, so we're going to use penta thrust values for things that aren't known (or Zero in the case of 3k slugwinder, because its intended to be inaccurate. I don't have any data to the contrary)

## Steps to test these changes

Use all modified WS with no error
