### PR TITLE
[lua] Hitrate fixes

### DIFF
--- a/scripts/globals/combat/physical_hit_rate.lua
+++ b/scripts/globals/combat/physical_hit_rate.lua
@@ -164,7 +164,7 @@ local function accuracyAndEvasionToHitRate(attacker, target, acc, eva)
 
         -- Accuracy Penalty, only applies to PCs -- TODO: does this apply to player pets?
         elseif attacker:isPC() and attacker:getMainLvl() < target:getMainLvl() then
-            acc = acc - dlvl * 4
+            acc = acc + dlvl * 4
         end
     end
 

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -754,10 +754,10 @@ xi.weaponskills.doRangedWeaponskill = function(attacker, target, wsID, wsParams,
         bonusWSmods             = wsParams.bonusWSmods or 0,
         attackType              = xi.attackType.RANGED,
     }
+
     if wsParams.accVaries then
-        -- applied to all hits (This is a penalty!)
-        local accLost       = calcParams.accStat * (1 - xi.weaponskills.fTP(tp, wsParams.accVaries))
-        calcParams.bonusAcc = calcParams.bonusAcc - accLost
+        local accMod        = xi.weaponskills.fTP(tp, wsParams.accVaries)
+        calcParams.bonusAcc = calcParams.bonusAcc + accMod
     end
 
     -- Split Shot/Piercing Arrow and Empyreal Arrow/Detonator are confirmed for this. Theoretically Last Stand could have a bonus too, and if so it would likely be first hit only.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Apparently I forgot to update the ranged WS hit rate function with the new static values. Silly me for forgetting that weaponskills.lua is a copypasted nightmare.

Also, subtracting a negative number results in a gain... so hit rate penalty was not working properly.

## Steps to test these changes

Add some prints in weaponskill.lua to verify hit rate is correct relative to the acc you feed it
Verify hit rate reduces as you drop in level relative to a mob in zones that are level corrected