### PR TITLE
[Module] Restore pre-RMT drop tables

### DIFF
--- a/modules/era/sql/pre_rmt_drops.sql
+++ b/modules/era/sql/pre_rmt_drops.sql
@@ -1,3 +1,10 @@
+------------------------------------
+-- Pre RMT Drops
+-- This module reverts RMT changes from a ToAU era Patch in 2007
+------------------------------------
+-- Source : http://www.playonline.com/pcd/update/ff11us/20070308c2bbd1/detail.html
+------------------------------------
+
 DROP PROCEDURE IF EXISTS replace_drop;
 DELIMITER $$
 CREATE PROCEDURE replace_drop(
@@ -34,3 +41,17 @@ CALL replace_drop('Rolanberry_Fields', 'Simurgh', 'trotter_boots', 'strider_boot
 CALL replace_drop('Ordelles_Caves', 'Stroper_Chyme', 'shikaree_ring', 'archers_ring');
 
 -- Astral Ring (Coffer chests in Castle of Oztroja) handled in modules/era/lua/rmt_drops.lua
+
+-- Define rate variables
+SET @COMMON   = 150;  -- 15%
+SET @UNCOMMON = 100;  -- 10%
+SET @RARE     = 50;   -- 5%
+SET @VRARE = 10;   -- 1%
+
+INSERT INTO `mob_droplist` VALUES (2588,0,0,1000,1313,@RARE); -- Sea Serpent Grotto - Voll the Sharkfinned - Siren's Hair (5%)
+INSERT INTO `mob_droplist` VALUES (2813,0,0,1000,1313,@RARE); -- Sea Serpent Grotto - Zuug the Shoreleaper - Siren's Hair (5%)
+INSERT INTO `mob_droplist` VALUES (1973,0,0,1000,1313,@RARE); -- Sea Serpent Grotto - Pahh the Gullcaller - Siren's Hair (5%)
+INSERT INTO `mob_droplist` VALUES (2673,0,0,1000,1313,@RARE); -- Sea Serpent Grotto - Worr the Clawfisted - Siren's Hair (5%)
+INSERT INTO `mob_droplist` VALUES (1825,0,0,1000,1313,@RARE); -- Sea Serpent Grotto - Novv the Whitehearted - Siren's Hair (5%)
+INSERT INTO `mob_droplist` VALUES (128,0,0,1000,1312,@RARE);  -- Cape Terrigan - Devil Manta (Fished) - Angel Skin - (5%)
+INSERT INTO `mob_droplist` VALUES (149,0,0,1000,836,@VRARE);  -- The Boyahda Tree - Aquarius - Damascene Cloth (1%)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This restores drop tables to pre-rmt nerf.  Sirens Hair has been added to the 5 Sahagin NM's in Sea-Serpents-Grotto.  Damascene Cloth has been added to Aquarius.  Angel skin has been added to the fished Devil Manta in Cape T.

Source: http://www.playonline.com/pcd/update/ff11us/20070308c2bbd1/detail.html
≪Mar. 8, 2007 (JST) Update Details≫
Items added via this module were removed in the March 8th 2007 patch.
This patch was the addition of additional ToAU missions as well as the Level 7 Besieged expansion. 

## Steps to test these changes

Kill each mob and verify that the added items drop. 

Aquarius-Damascene Cloth
Voll the Sharkfinned-lock of sirens hair
Zuug the Shoreleaper-lock of sirens hair
Pahh the Gullcaller-lock of sirens hair
Worr the Clawfisted-lock of sirens hair
Novv the Whitehearted-lock of sirens hair
Devil Manta-Angel Skin (Fished) 
