### PR TITLE
[Module] Era physical_hit_cap

### DIFF
--- a/modules/soa/physical_hit_cap.lua
+++ b/modules/soa/physical_hit_cap.lua
@@ -1,0 +1,15 @@
+-----------------------------------
+-- Hit Rate Cap Override Module
+-- Reverts all melee hit caps to 95% to undo hit cap raise in December 2014.
+--
+-- Source: https://forum.square-enix.com/ffxi/threads/45365?p=534537#post534537
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('physical_hit_rate')
+
+m:addOverride('xi.combat.physicalHitRate.getPhysicalHitRateCap', function(attacker, slot)
+    return 0.95
+end)
+
+return m


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This module changes the physical hit rate cap to be 95% which was era accurate rather than 99% which is modern retail accurate.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

Target yourself:
!setmod haste_gear 30000
!setmod haste_ability 30000
!setmod haste_magic 30000
!setmod quad_attack 100
!exec target:setMod(xi.mod.ACC, 999)
!setmod acc 30000
!additem kraken_club

Engage an enemy, make them immortal with !immortal then track the accuracy on a parser.  This was tested several different times and accuracy did not exceed 95%

<!-- Clear and detailed steps to test your changes here -->
