### PR TITLE
Dosetsu Tree Retail Behavior

### DIFF
--- a/scripts/zones/Qufim_Island/IDs.lua
+++ b/scripts/zones/Qufim_Island/IDs.lua
@@ -48,10 +48,11 @@ zones[xi.zone.QUFIM_ISLAND] =
     },
     mob =
     {
+        DOSETSU_TREE      = GetFirstID('Dosetsu_Tree'),
+        KRAKEN_NM         = GetTableOfIDs('Kraken')[3],
+        OPHIOTAURUS       = GetFirstID('Ophiotaurus'),
         SLIPPERY_SUCKER   = GetFirstID('Slippery_Sucker'),
         TRICKSTER_KINETIX = GetFirstID('Trickster_Kinetix'),
-        OPHIOTAURUS       = GetFirstID('Ophiotaurus'),
-        KRAKEN_NM         = GetTableOfIDs('Kraken')[3],
     },
     npc =
     {

--- a/scripts/zones/Qufim_Island/Zone.lua
+++ b/scripts/zones/Qufim_Island/Zone.lua
@@ -1,6 +1,8 @@
 -----------------------------------
 -- Zone: Qufim_Island (126)
 -----------------------------------
+local ID = zones[xi.zone.QUFIM_ISLAND]
+-----------------------------------
 ---@type TZone
 local zoneObject = {}
 
@@ -33,6 +35,33 @@ zoneObject.onEventUpdate = function(player, csid, option, npc)
 end
 
 zoneObject.onEventFinish = function(player, csid, option, npc)
+end
+
+zoneObject.onZoneWeatherChange = function(weather)
+    -- NM Dosetsu Tree only spawns during thunder weather
+    local dosetsuTree = GetMobByID(ID.mob.DOSETSU_TREE)
+
+    if not dosetsuTree then
+        return
+    end
+
+    if weather == xi.weather.THUNDER or weather == xi.weather.THUNDERSTORMS then
+        -- Spawn if respawn is up
+        if
+            not dosetsuTree:isSpawned() and
+            GetSystemTime() > dosetsuTree:getLocalVar('respawn')
+        then
+            xi.mob.updateNMSpawnPoint(dosetsuTree)
+            SpawnMob(ID.mob.DOSETSU_TREE)
+        end
+    else
+        if
+            dosetsuTree:isSpawned() and
+            not dosetsuTree:isEngaged()
+        then
+            DespawnMob(ID.mob.DOSETSU_TREE)
+        end
+    end
 end
 
 return zoneObject

--- a/scripts/zones/Qufim_Island/mobs/Dosetsu_Tree.lua
+++ b/scripts/zones/Qufim_Island/mobs/Dosetsu_Tree.lua
@@ -1,0 +1,54 @@
+-----------------------------------
+-- Area: Qufim Island
+--   NM: Dosetsu Tree
+--  Only spawns during thunder weather
+--  Level: 38-40 Treant NM
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+-- Spawn points in F-8/G-9 area
+entity.spawnPoints =
+{
+    { x = -240.000, y = -20.795, z =  37.000 },  -- Original database point (F-8 area)
+    { x = -161.386, y = -20.190, z =  69.814 },  -- From packet capture (G-9 area)
+}
+
+entity.onMobInitialize = function(mob)
+    mob:addImmunity(xi.immunity.SILENCE)
+    mob:addImmunity(xi.immunity.PARALYZE)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+end
+
+entity.onMobSpawn = function(mob)
+    mob:setMobMod(xi.mobMod.NO_MOVE, 1)
+end
+
+entity.onMobEngage = function(mob, target)
+    mob:setMobMod(xi.mobMod.NO_MOVE, 0)
+end
+
+entity.onMobRoam = function(mob)
+    -- Re-root the mob once it returns to spawn point
+    if utils.distanceWithin(mob:getPos(), mob:getSpawnPos(), 2, false) then
+        mob:setMobMod(xi.mobMod.NO_MOVE, 1)
+    end
+end
+
+entity.onMobDisengage = function(mob)
+    local weather = mob:getWeather()
+    if
+        weather ~= xi.weather.THUNDER and
+        weather ~= xi.weather.THUNDERSTORMS
+    then
+        DespawnMob(mob:getID())
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    local respawn = math.random(3600, 7200) -- 1-2 hours during thunder weather
+    mob:setLocalVar('respawn', GetSystemTime() + respawn)
+end
+
+return entity

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -9444,7 +9444,7 @@ INSERT INTO `mob_groups` VALUES (44,1536,126,'Giant_Ranger_G',0,128,3226,0,0,30,
 INSERT INTO `mob_groups` VALUES (45,1530,126,'Giant_Hunter_G',0,128,3226,0,0,30,35,0);
 INSERT INTO `mob_groups` VALUES (46,2012,126,'Hunting_Chief',0,128,3226,0,0,35,35,0);
 
-INSERT INTO `mob_groups` VALUES (47,1093,126,'Dosetsu_Tree',75600,0,693,0,0,35,36,0);
+INSERT INTO `mob_groups` VALUES (47,1093,126,'Dosetsu_Tree',0,128,693,0,0,38,40,0);
 INSERT INTO `mob_groups` VALUES (48,2079,126,'Ingaevon',0,128,0,0,0,53,55,0);
 INSERT INTO `mob_groups` VALUES (49,2496,126,'Malefic_Fencer',0,128,0,0,0,32,32,0);
 INSERT INTO `mob_groups` VALUES (50,3531,126,'Seed_Mandragora',0,128,0,0,0,32,32,0);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes and audits the Dosetsu Tree NM in Qufim Island to correctly implement weather-based spawning behavior and combat immunities based on retail packet capture analysis.

* **Fixed spawn type**: Changed from `SPAWNTYPE_NORMAL (0)` to `SPAWNTYPE_SCRIPTED (128)` to prevent auto-spawn on server load
* **Added spawn point randomization**: NM now randomly spawns at one of two verified locations (F-8 or G-9 area)
* **Implemented combat immunities**: Added immunity to Silence, Paralyze, Light Sleep, and Dark Sleep
* **Weather-based spawning**: NM only spawns during Thunder or Thunderstorms weather and despawns when weather changes
* **Movement behavior**: NM is immobile until engaged, then can move normally during combat

## Steps to test these changes

### Test 1: Verify spawn type prevents auto-spawn

1. Restart the server or zone
2. Teleport to one of the spawn locations without thunder weather:
   ```
   !pos -240.00 -20.795 37.00 126
   ```
   Or the G-9 spawn point:
   ```
   !pos -161.386 -20.190 69.814 126
   ```
3. **Expected**: Dosetsu Tree should NOT be spawned

### Test 2: Weather-based spawning

1. Set weather to Thunder and spawn nm:
   ```
   !setweather 14
   !spawnmob 17293640
   ```
2. **Expected**: Dosetsu Tree should spawn at one of the two spawn points:
   - F-8 area: (-240.000, -20.795, 37.000)
   - G-9 area: (-161.386, -20.190, 69.814)

### Test 3: Weather-based despawning

1. With Dosetsu Tree spawned during thunder weather, change weather:
   ```
   !setweather 0
   ```
2. **Expected**: Dosetsu Tree should despawn when weather changes to non-thunder

### Test 4: Verify immunities are applied

1. Ensure thunder weather and spawn the mob:
   ```
   !setweather 14
   !spawnmob 17293640
   ```
2. Engage the mob and attempt the following:
   - Cast Silence - **Expected**: Resisted/Immune
   - Cast Paralyze - **Expected**: Resisted/Immune
   - Use Sleep (Light or Dark) - **Expected**: Resisted/Immune
   - Cast Poison - **Expected**: Should land (not immune)
   - Cast Dia - **Expected**: Should land (not immune)

### Test 5: Movement behavior

1. Spawn and observe the mob before engaging:
   ```
   !spawnmob 17293640
   ```
   **Expected**: Mob should be stationary (NO_MOVE = 1)

2. Engage the mob in combat:
   **Expected**: Mob should now be able to move (NO_MOVE = 0)

### Test 6: Spawn point randomization

1. Spawn and despawn the mob multiple times:
   ```
   !spawnmob 17293640
   !despawnmob 17293640
   ```
2. Repeat several times
3. **Expected**: Mob should appear at different spawn points (F-8 or G-9 area)

## Retail Captures / Evidence

[dotree.zip](https://github.com/user-attachments/files/24499284/dotree.zip)

