### PR TITLE
[lua] Adjust when TP is gained during WS and remove H2H from "offhand extra hit logic", fix various h2h hit counts

### DIFF
--- a/scripts/actions/weaponskills/ascetics_fury.lua
+++ b/scripts/actions/weaponskills/ascetics_fury.lua
@@ -16,7 +16,7 @@ local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params      = {}
-    params.numHits    = 1
+    params.numHits    = 2
     params.ftpMod     = { 1, 1, 1 }
     params.atkVaries  = { 1.5, 1.5, 1.5 } -- https://w.atwiki.jp/studiogobli/pages/93.html
     params.critVaries = { 0.1, 0.2, 0.4 }

--- a/scripts/actions/weaponskills/backhand_blow.lua
+++ b/scripts/actions/weaponskills/backhand_blow.lua
@@ -15,7 +15,7 @@ local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
-    params.numHits = 1
+    params.numHits = 2
     params.ftpMod = { 1, 1, 1 }
     params.str_wsc = 0.3 params.dex_wsc = 0.3
     params.critVaries = { 0.4, 0.6, 0.8 }

--- a/scripts/actions/weaponskills/howling_fist.lua
+++ b/scripts/actions/weaponskills/howling_fist.lua
@@ -17,7 +17,7 @@ local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params     = {}
-    params.numHits   = 1
+    params.numHits   = 2
     params.ftpMod    = { 2.5, 2.75, 3.0 }
     params.atkVaries = { 1.5, 1.5, 1.5 } -- https://w.atwiki.jp/studiogobli/pages/93.html
     params.str_wsc   = 0.2

--- a/scripts/actions/weaponskills/one_inch_punch.lua
+++ b/scripts/actions/weaponskills/one_inch_punch.lua
@@ -16,7 +16,7 @@ local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
-    params.numHits = 1
+    params.numHits = 2
     params.ftpMod = { 1.0, 1.0, 1.0 }
     params.vit_wsc = 0.4
     -- Defense ignored is 0%, 30%, 50% as per http://www.bg-wiki.com/bg/One_Inch_Punch

--- a/scripts/actions/weaponskills/shoulder_tackle.lua
+++ b/scripts/actions/weaponskills/shoulder_tackle.lua
@@ -16,7 +16,7 @@ local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params   = {}
-    params.numHits = 1
+    params.numHits = 2
     params.ftpMod  = { 1, 1, 1 }
     params.vit_wsc = 0.3
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)

--- a/scripts/actions/weaponskills/spinning_attack.lua
+++ b/scripts/actions/weaponskills/spinning_attack.lua
@@ -17,7 +17,7 @@ local weaponskillObject = {}
 -- TODO: Radius 5y at 2334 TP
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
-    params.numHits = 1
+    params.numHits = 2
     params.ftpMod = { 1.0, 1.0, 1.0 }
     params.str_wsc = 0.35
 

--- a/scripts/actions/weaponskills/tornado_kick.lua
+++ b/scripts/actions/weaponskills/tornado_kick.lua
@@ -5,7 +5,7 @@
 -- Mods : STR:32% VIT:32%
 -- 100%TP     200%TP     300%TP
 -- 2.25x        2.75x    3.5x
--- Delivers a twofold attack. Damage varies with TP.
+-- Delivers a threefold attack. Damage varies with TP.
 -----------------------------------
 ---@type TWeaponSkill
 local weaponskillObject = {}

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -330,6 +330,7 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
     local ammoUsed                = 0
     local isRanged                = calcParams.attackInfo.slot == xi.slot.RANGED
     calcParams.hitsLanded         = 0
+    calcParams.mainHitsLanded     = 0
     calcParams.tpHitsLanded       = 0
     calcParams.shadowsAbsorbed    = 0
     calcParams.mainhandHitsLanded = 0
@@ -957,7 +958,10 @@ xi.weaponskills.takeWeaponskillDamage = function(defender, attacker, wsParams, p
         wsResults.extraHitsLanded = 0
     end
 
-    finaldmg = defender:takeWeaponskillDamage(attacker, finaldmg, attack.type, attack.damageType, attack.slot, primaryMsg, wsResults.tpHitsLanded * attackerTPMult, (wsResults.extraHitsLanded * 10) + wsResults.bonusTP, targetTPMult)
+    -- Core does not modify the TP for the 10 TP/hit like it should, so we're doing it here
+    local storeTPModifier = 1 + attacker:getMod(xi.mod.STORETP) / 100 -- TODO, make a global function to get this (inhibit TP is not accounted for properly in core)
+
+    finaldmg = defender:takeWeaponskillDamage(attacker, finaldmg, attack.type, attack.damageType, attack.slot, primaryMsg, wsResults.tpHitsLanded * attackerTPMult, (wsResults.extraHitsLanded * 10 * storeTPModifier) + wsResults.bonusTP, targetTPMult)
     if wsResults.tpHitsLanded + wsResults.extraHitsLanded > 0 then
         action:recordDamage(defender, attack.type, math.abs(finaldmg), wsResults.criticalHit)
     end

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -330,6 +330,7 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
     local ammoUsed                = 0
     local isRanged                = calcParams.attackInfo.slot == xi.slot.RANGED
     calcParams.hitsLanded         = 0
+    calcParams.tpHitsLanded       = 0
     calcParams.shadowsAbsorbed    = 0
     calcParams.mainhandHitsLanded = 0
     calcParams.offhandHitsLanded  = 0
@@ -374,12 +375,13 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
         if isJump then
             attacker:addTP(mainhandTPGain * attackerTPMult)
         end
+
+        calcParams.tpHitsLanded   = 1 -- Store number of TP hits that have landed thus far
+        calcParams.mainHitsLanded = 0
     end
 
     finaldmg = finaldmg + hitdmg
 
-    calcParams.tpHitsLanded   = calcParams.hitsLanded -- Store number of TP hits that have landed thus far
-    calcParams.mainHitsLanded = calcParams.tpHitsLanded
     -- Finish first/mainhand hit
 
     local numMainHandMultis = isRanged and 0 or getMultiAttacks(attacker, target, wsParams, true, false)
@@ -423,9 +425,11 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
     end
 
     local offhandSkill = attacker:getWeaponSkillType(xi.slot.SUB)
+    local isH2H        = false
     if calcParams.skillType == xi.skill.HAND_TO_HAND then
         offhandSkill = xi.skill.HAND_TO_HAND
         subTPGain    = mainhandTPGain
+        isH2H        = true
     end
 
     calcParams.guaranteedHit = false -- Accuracy bonus from SA/TA applies only to first main and offhand hit
@@ -446,7 +450,6 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
 
     -- Use up any remaining hits in the WS's numhits
     while hitsDone < 8 and mainhandHitsDone < mainhandHits and finaldmg < targetHp do
-        calcParams.hitsLanded = 0
         hitdmg, calcParams    = getSingleHitDamage(attacker, target, dmg, ftp, wsParams, calcParams)
 
         if calcParams.melee then
@@ -456,19 +459,20 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
         if hitdmg > 0 then
             attacker:trySkillUp(calcParams.skillType, targetLvl)
 
+            -- When dual wielding, the mainhand appears to count the second hit as a TP hit unless it's a 1 hit WS where the offhand will gain TP
+            -- H2H also does this on retail (much more easy to verify)
+            -- Needs better verification
+            if (isH2H or calcParams.extraOffhandHit) and hitsDone == 1 then
+                calcParams.tpHitsLanded = calcParams.tpHitsLanded + 1
+            elseif wsParams.isBarrage then
+                calcParams.tpHitsLanded = calcParams.tpHitsLanded + 1
+            else -- Otherwise, add a hit to the "extra" hits which is 10 tp each
+                calcParams.mainHitsLanded = calcParams.mainHitsLanded + 1
+            end
+
             if isJump then
                 attacker:addTP(mainhandTPGain * attackerTPMult)
             end
-        end
-
-        -- When dual wielding, the mainhand appears to count the second hit as a TP hit unless it's a 1 hit WS where the offhand will gain TP
-        -- Needs better verification
-        if calcParams.extraOffhandHit and hitsDone == 1 then
-            calcParams.tpHitsLanded = calcParams.tpHitsLanded + calcParams.hitsLanded
-        elseif wsParams.isBarrage then
-            calcParams.tpHitsLanded = calcParams.tpHitsLanded + calcParams.hitsLanded
-        else -- Otherwise, add a hit to the "extra" hits which is 10 tp each
-            calcParams.mainHitsLanded = calcParams.mainHitsLanded + calcParams.hitsLanded
         end
 
         finaldmg                  = finaldmg + hitdmg
@@ -495,7 +499,6 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
     local mainhandMultiHitsDone = 0
 
     while hitsDone < 8 and mainhandMultiHitsDone < numMainHandMultis and finaldmg < targetHp do
-        calcParams.hitsLanded = 0
         hitdmg, calcParams    = getSingleHitDamage(attacker, target, dmg, ftp, wsParams, calcParams)
 
         if calcParams.melee then
@@ -505,18 +508,18 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
         if hitdmg > 0 then
             attacker:trySkillUp(calcParams.skillType, targetLvl)
 
+            -- When dual wielding, the mainhand appears to count the second hit as a TP hit unless it's a 1 hit WS where the offhand will gain TP
+            -- Needs better verification, in this case (1 hit ws with multis)  a DA/TA/QA may not count as TP hit and we'd move this into the offhand hit proc.
+            -- Either way, this won't "cheat" players out of TP in the current implementation.
+            if calcParams.extraOffhandHit and hitsDone == 1 then
+                calcParams.tpHitsLanded = calcParams.tpHitsLanded + 1
+            else -- Otherwise, add a hit to the "extra" hits which is 10 tp each
+                calcParams.mainHitsLanded = calcParams.mainHitsLanded + 1
+            end
+
             if isJump then
                 attacker:addTP(mainhandTPGain * attackerTPMult)
             end
-        end
-
-        -- When dual wielding, the mainhand appears to count the second hit as a TP hit unless it's a 1 hit WS where the offhand will gain TP
-        -- Needs better verification, in this case (1 hit ws with multis)  a DA/TA/QA may not count as TP hit and we'd move this into the offhand hit proc.
-        -- Either way, this won't "cheat" players out of TP in the current implementation.
-        if calcParams.extraOffhandHit and hitsDone == 1 then
-            calcParams.tpHitsLanded = calcParams.tpHitsLanded + calcParams.hitsLanded
-        else -- Otherwise, add a hit to the "extra" hits which is 10 tp each
-            calcParams.mainHitsLanded = calcParams.mainHitsLanded + calcParams.hitsLanded
         end
 
         finaldmg                  = finaldmg + hitdmg
@@ -536,10 +539,7 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
 
     -- Update params for accuracy cap/pdif purposes
     if calcParams.extraOffhandHit then
-        if offhandSkill ~= xi.skill.HAND_TO_HAND then
-            calcParams.attackInfo.slot = xi.slot.SUB
-        end
-
+        calcParams.attackInfo.slot       = xi.slot.SUB
         calcParams.attackInfo.weaponType = offhandSkill
     end
 
@@ -560,17 +560,17 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
         if hitdmg > 0 then
             attacker:trySkillUp(offhandSkill, targetLvl)
 
+            -- If this is the second swing of the WS (1 hit ws) the offhand appears to count for TP gain
+            -- Needs better verification
+            if calcParams.extraOffhandHit and hitsDone == 1 then
+                calcParams.tpHitsLanded = calcParams.tpHitsLanded + 1
+            else -- Otherwise, add a hit to the "extra" hits which is 10 tp each
+                calcParams.offhandHitsLanded = calcParams.offhandHitsLanded + 1
+            end
+
             if isJump then
                 attacker:addTP(subTPGain * attackerTPMult)
             end
-        end
-
-        -- If this is the second swing of the WS (1 hit ws) the offhand appears to count for TP gain
-        -- Needs better verification
-        if calcParams.extraOffhandHit and hitsDone == 1 then
-            calcParams.tpHitsLanded = calcParams.tpHitsLanded + calcParams.hitsLanded
-        else -- Otherwise, add a hit to the "extra" hits which is 10 tp each
-            calcParams.offhandHitsLanded = calcParams.hitsLanded
         end
 
         finaldmg = finaldmg + hitdmg
@@ -598,12 +598,13 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
             if isJump then
                 attacker:addTP(subTPGain * attackerTPMult)
             end
+
+            calcParams.offhandHitsLanded = calcParams.offhandHitsLanded + 1
         end
 
-        finaldmg                     = finaldmg + hitdmg
-        hitsDone                     = hitsDone + 1
-        offhandMultiHitsDone         = offhandMultiHitsDone + 1
-        calcParams.offhandHitsLanded = calcParams.offhandHitsLanded + calcParams.hitsLanded
+        finaldmg             = finaldmg + hitdmg
+        hitsDone             = hitsDone + 1
+        offhandMultiHitsDone = offhandMultiHitsDone + 1
     end
 
     calcParams.extraHitsLanded = calcParams.mainHitsLanded + calcParams.offhandHitsLanded
@@ -666,7 +667,7 @@ xi.weaponskills.doPhysicalWeaponskill = function(attacker, target, wsID, wsParam
     calcParams.guaranteedHit           = calcParams.sneakApplicable or calcParams.trickApplicable
     calcParams.mightyStrikesApplicable = attacker:hasStatusEffect(xi.effect.MIGHTY_STRIKES)
     calcParams.forcedFirstCrit         = calcParams.sneakApplicable or calcParams.assassinApplicable
-    calcParams.extraOffhandHit         = attacker:isDualWielding() or attack.weaponType == xi.skill.HAND_TO_HAND
+    calcParams.extraOffhandHit         = attacker:isDualWielding()
     calcParams.hybridHit               = wsParams.hybridWS
     calcParams.flourishEffect          = attacker:getStatusEffect(xi.effect.BUILDING_FLOURISH)
     calcParams.bonusTP                 = wsParams.bonusTP or 0


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

hopefully closes #9064 

tl;dr: we were doing jank with TP gain when damage was non-zero, and h2h was also doing strange things so this PR corrects all of it. H2H just has a single edge case in the main hits TP loop now.

Also adds stp modifier to the 10 tp from extra hits
## Steps to test these changes
use H2H WS, get TP per fist*2+(num hits above the first two hits * 10 * stp) TP return
Also spot check DW, single wield, 2h. E