### PR TITLE
Fix Bloodtear Baldurf spawn

### DIFF
--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -17,12 +17,12 @@ end
 -----------------------------------
 
 -- is a lottery NM already spawned or primed to pop?
-local function lotteryPrimed(phList)
+local function lotteryPrimed(phList, nmId)
     local nm
 
     for k, v in pairs(phList) do
         nm = GetMobByID(v)
-        if nm ~= nil and (nm:isSpawned() or nm:getRespawnTime() ~= 0) then
+        if v == nmId and nm ~= nil and (nm:isSpawned() or nm:getRespawnTime() ~= 0) then
             return true
         end
     end
@@ -150,7 +150,7 @@ xi.mob.phOnDespawn = function(ph, phNmId, chance, cooldown, params)
 
     if
         GetSystemTime() <= pop or
-        lotteryPrimed(phList) or
+        lotteryPrimed(phList, nmId) or
         math.random(1, 1000) > chance
     then
         return false


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Bloodtear Baldurf's phList looks like this:

```lua
entity.phList =
{
    [ID.mob.LUMBERING_LAMBERT] = ID.mob.BLOODTEAR, -- -216 -8 -107
    [ID.mob.BLOODTEAR]         = ID.mob.LUMBERING_LAMBERT, -- Bloodtear can't spawn if Lumbering is up
}
```
Which means, whenever its placeholder (Lumbering Lambert) is killed, xi.mob.phOnDespawn returns false early if Lumbering Lambert has a non-zero getRespawnTime(), which is always true. Therefore, Bloodtear Baldurf can never spawn. This issue does not occur with Steelfleece Baldarich because that mob does not include itself as an index in its own phList unlike Baldurf. (Despite what the commit message on this PR says.)

## Steps to test these changes

* Spawn Lumbering Lambert via killing its placeholders (Rampaging Ram), *not* directly via SpawnMob
* Confirm that lotteryPrimed is not returning early due to Lambert's respawn time
