### PR TITLE
[lua] Primal Rend dCHR Scaling

### DIFF
--- a/scripts/actions/weaponskills/primal_rend.lua
+++ b/scripts/actions/weaponskills/primal_rend.lua
@@ -21,6 +21,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.ele = xi.element.LIGHT
     params.skill = xi.skill.AXE
     params.includemab = true
+    params.dStat = xi.mod.CHR -- TODO : Verify maximum bonus of 651
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftpMod = { 3.0625, 5.8398, 7.5625 }

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -839,6 +839,8 @@ xi.weaponskills.doMagicWeaponskill = function(attacker, target, wsID, wsParams, 
     -- But other magic WS vary. Some don't even have a component, the general case is dINT/2 + 8
     if attack.slot == xi.slot.RANGED then
         fint = utils.clamp((attacker:getStat(dStat) - target:getStat(xi.mod.INT)) * 2, -32, 32)
+    elseif dStat == xi.mod.CHR then
+        fint = utils.clamp((attacker:getStat(dStat) - target:getStat(xi.mod.INT)) * 1.5, -651, 651) -- TODO: unknown lower cap but on dINT it normally mirrors https://www.bg-wiki.com/ffxi/Primal_Rend
     else
         fint = math.floor(utils.clamp(8 + (attacker:getStat(dStat) - target:getStat(xi.mod.INT)) / 2, -32, 32))
     end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Don't say I never did anything nice for Beastmasters. 
Adds dCHR scaling to Primal Rend and adds an exception to weaponskills.lua to clamp the bonus to 1.5x

Source : https://w.atwiki.jp/studiogobli/pages/77.html

pCHR - mINT x 1.5

## Steps to test these changes

Change job to BST, Primal Rend things, put on CHR gear, see Primal Rend do more
