### PR TITLE
[Core] Cleanup `TryCastSpell()` function and fix irresponsive mobs after failed casting attempt

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -36,6 +36,7 @@
 #include "mob_spell_container.h"
 #include "mobskill.h"
 #include "party.h"
+#include "recast_container.h"
 #include "status_effect_container.h"
 #include "utils/battleutils.h"
 #include "utils/petutils.h"
@@ -512,11 +513,17 @@ auto CMobController::TryCastSpell() -> bool
         return false; // No spell Id.
     }
 
-    // Check if we can actually cast this spell before committing to it
+    // Check if spell exists.
     CSpell* PSpell = spell::GetSpell(chosenSpellId.value());
     if (!PSpell)
     {
         return false; // No spell object.
+    }
+
+    // Check spell cooldown.
+    if (PMob->PRecastContainer->Has(RECAST_MAGIC, static_cast<Recast>(chosenSpellId.value())))
+    {
+        return false; // Spell is on cooldown.
     }
 
     // Check if mob can afford to cast this spell


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Attempt to streamline spell casting attempt logic.
- Attempt to fix an issue caused by mobs attempting to cast an spell on cooldown.  when (and only when) the casting was from a lua override.

The issue came from the fact the cooldown check was done on the mob spell container BEFORE the override happened.

## Steps to test these changes
Have mobs cast without crashing the server.
