### PR TITLE
[Core] Add safety checks to modifier ID 0

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1623,7 +1623,10 @@ uint8 CBattleEntity::GetDeathType()
 
 void CBattleEntity::addModifier(Mod type, int16 amount)
 {
-    m_modStat[type] += amount;
+    if (type != Mod::NONE)
+    {
+        m_modStat[type] += amount;
+    }
 }
 
 void CBattleEntity::addModifiers(std::vector<CModifier>* modList)
@@ -1631,7 +1634,10 @@ void CBattleEntity::addModifiers(std::vector<CModifier>* modList)
     TracyZoneScoped;
     for (auto modifier : *modList)
     {
-        m_modStat[modifier.getModID()] += modifier.getModAmount();
+        if (modifier.getModID() != Mod::NONE)
+        {
+            m_modStat[modifier.getModID()] += modifier.getModAmount();
+        }
     }
 }
 
@@ -1724,7 +1730,10 @@ void CBattleEntity::addEquipModifiers(std::vector<CModifier>* modList, uint8 ite
 
 void CBattleEntity::setModifier(Mod type, int16 amount)
 {
-    m_modStat[type] = amount;
+    if (type != Mod::NONE)
+    {
+        m_modStat[type] = amount;
+    }
 }
 
 void CBattleEntity::setModifiers(std::vector<CModifier>* modList)
@@ -1732,7 +1741,10 @@ void CBattleEntity::setModifiers(std::vector<CModifier>* modList)
     TracyZoneScoped;
     for (auto& i : *modList)
     {
-        m_modStat[i.getModID()] = i.getModAmount();
+        if (i.getModID() != Mod::NONE)
+        {
+            m_modStat[i.getModID()] = i.getModAmount();
+        }
     }
 }
 
@@ -1744,7 +1756,10 @@ void CBattleEntity::setModifiers(std::vector<CModifier>* modList)
 
 void CBattleEntity::delModifier(Mod type, int16 amount)
 {
-    m_modStat[type] -= amount;
+    if (type != Mod::NONE)
+    {
+        m_modStat[type] -= amount;
+    }
 }
 
 void CBattleEntity::saveModifiers()
@@ -1909,6 +1924,12 @@ void CBattleEntity::delEquipModifiers(std::vector<CModifier>* modList, uint8 ite
 int16 CBattleEntity::getMod(Mod modID)
 {
     TracyZoneScoped;
+
+    if (modID == Mod::NONE)
+    {
+        return 0;
+    }
+
     return m_modStat[modID];
 }
 
@@ -1920,6 +1941,12 @@ int16 CBattleEntity::getMod(Mod modID)
 int16 CBattleEntity::getMaxGearMod(Mod modID)
 {
     TracyZoneScoped;
+
+    if (modID == Mod::NONE)
+    {
+        return 0;
+    }
+
     CCharEntity* PChar       = dynamic_cast<CCharEntity*>(this);
     uint16       maxModValue = 0;
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -14160,6 +14160,11 @@ int16 CLuaBaseEntity::getMod(uint16 modID)
         return 0;
     }
 
+    if (modID == 0)
+    {
+        return 0;
+    }
+
     return static_cast<CBattleEntity*>(m_PBaseEntity)->getMod(static_cast<Mod>(modID));
 }
 
@@ -14178,6 +14183,11 @@ void CLuaBaseEntity::setMod(uint16 modID, int16 value)
         return;
     }
 
+    if (modID == 0)
+    {
+        return;
+    }
+
     static_cast<CBattleEntity*>(m_PBaseEntity)->setModifier(static_cast<Mod>(modID), value);
 }
 
@@ -14193,6 +14203,11 @@ void CLuaBaseEntity::delMod(uint16 modID, int16 value)
     if (m_PBaseEntity->objtype == TYPE_NPC)
     {
         ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->getName());
+        return;
+    }
+
+    if (modID == 0)
+    {
         return;
     }
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
As title sais, adds a couple of safety cjecks to try to ensure mod ID returns a value of 0 when checked and when attempting to change its value.

Close #9023 

## Steps to test these changes

Everything should work the same. On downstream servers, it may or may not fix some issues.
