### PR TITLE
[core] Fix Trust EN_MOB_WEAKNESS

### DIFF
--- a/src/map/ai/helpers/gambits_container.cpp
+++ b/src/map/ai/helpers/gambits_container.cpp
@@ -380,7 +380,8 @@ void CGambitsContainer::Tick(timer::time_point tick)
                 }
                 else if (action.select == G_SELECT::EN_MOB_WEAKNESS)
                 {
-                    auto spell_id = POwner->SpellContainer->EnSpellAgainstTargetWeakness(target);
+                    CBattleEntity* battleTarget = POwner->GetBattleTarget();
+                    auto           spell_id     = POwner->SpellContainer->EnSpellAgainstTargetWeakness(battleTarget);
                     if (spell_id.has_value())
                     {
                         controller->Cast(POwner->targid, spell_id.value());


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR fixes a logic error in the "EN_MOB_WEAKNESS" ai.select case in trust behavior. It should always be checking the trust's battleTarget's weaknesses, not the trust's own weaknesses if your conditional is "do I have an enspell up". 

## Steps to test these changes

Confirmed setting a trust's select table to { ai.r.MA, ai.s.EN_MOB_WEAKNESS, 0 } did use the trust's battle target's weakness in deciding which enspell to use.
