### PR TITLE
[docker,ci] Remove some bloat

### DIFF
--- a/.github/workflows/runner_build.yml
+++ b/.github/workflows/runner_build.yml
@@ -159,15 +159,17 @@ jobs:
 
       - name: Setup Clang (Linux)
         if: ${{ runner.os == 'Linux' && startsWith(inputs.compiler, 'clang') && env.SKIP_BUILD != 'true' }}
+        env:
+          clang_version: ${{ inputs.compiler_version && format('-{0}', inputs.compiler_version) || '' }}
         run: |
-          sudo apt-get update && sudo apt-get install --assume-yes --no-install-recommends --quiet g++-14
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh ${{ inputs.compiler_version }} all
-          echo "CC=/usr/bin/${{ inputs.compiler_version && format('clang-{0}', inputs.compiler_version) || 'clang' }}" >> $GITHUB_ENV
-          echo "CXX=/usr/bin/${{ inputs.compiler_version && format('clang++-{0}', inputs.compiler_version) || 'clang++' }}" >> $GITHUB_ENV
-          echo "CXXFLAGS=-stdlib=libstdc++" >> $GITHUB_ENV
-          echo "LDFLAGS=-fuse-ld=lld" >> $GITHUB_ENV
+          sudo apt-get update && sudo apt-get install --assume-yes --no-install-recommends --quiet \
+            g++ \
+            clang${{ env.clang_version }} \
+            clang-tidy${{ env.clang_version }} \
+            libclang-rt${{ env.clang_version }}-dev \
+            llvm${{ env.clang_version }}-dev
+          echo "CC=/usr/bin/clang${{ env.clang_version }}" >> $GITHUB_ENV
+          echo "CXX=/usr/bin/clang++${{ env.clang_version }}" >> $GITHUB_ENV
 
       - name: Setup MSVC
         if: ${{ runner.os == 'Windows' && env.SKIP_BUILD != 'true' }}

--- a/docker/README.md
+++ b/docker/README.md
@@ -216,11 +216,14 @@ docker build -f docker/ubuntu.Dockerfile .
 The Dockerfiles also support a few build args:
 
 ```
+BASE_TAG
 UNAME=xiadmin
 UGROUP=xiadmin
 UID=1000
 GID=1000
 COMPILER=gcc
+GCC_VERSION
+LLVM_VERSION
 CMAKE_BUILD_TYPE=Release
 TRACY_ENABLE=OFF
 ENABLE_CLANG_TIDY=OFF

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -12,8 +12,6 @@ apk --update-cache add \
     bash \
     binutils \
     git \
-    libc++ \
-    llvm-libunwind \
     lua5.1-dev \
     luajit \
     mariadb-client \
@@ -25,6 +23,7 @@ apk --update-cache add \
     tzdata \
     zeromq \
     zlib
+apk cache clean
 EOF
 
 # Setup runtime user.
@@ -64,8 +63,6 @@ apk --update-cache add \
     ccache \
     cmake \
     g++ \
-    libc++-dev \
-    llvm-libunwind-dev \
     linux-headers \
     luajit-dev \
     make \
@@ -123,8 +120,8 @@ if [[ $COMPILER == clang* || $ENABLE_CLANG_TIDY == ON ]]; then
         clang$LLVM_VERSION \
         clang$LLVM_VERSION-extra-tools \
         compiler-rt \
-        lld$LLVM_VERSION \
         llvm$LLVM_VERSION
+    apk cache clean
 fi
 EOF
 
@@ -160,8 +157,6 @@ cp -p /xiadmin/build/xi_* /server/ 2> /dev/null || true
 if [[ $COMPILER == clang* || $ENABLE_CLANG_TIDY == ON ]]; then
     export CC=/usr/bin/clang-$LLVM_VERSION
     export CXX=/usr/bin/clang++-$LLVM_VERSION
-    export CXXFLAGS="-stdlib=libstdc++"
-    export LDFLAGS="-fuse-ld=lld"
 fi
 
 cmake -G Ninja -S /server -B /xiadmin/build --fresh \
@@ -184,8 +179,6 @@ EOF
 # Service #
 ###########
 FROM base AS service
-
-RUN apk cache clean
 
 USER $UNAME
 


### PR DESCRIPTION
We really only need clang. libc++ has issues and this will reduce image sizes. Also clears some APT caches.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Removes messy libc++ support from the Dockerfiles. Removes some unused/unnecessary LLVM tools. Clean package cache to cut down on Docker layer sizes. Cuts down image sizes (mostly Ubuntu). If libc++ testing is needed it can be done pretty easily inside the devcontainer.

<img width="1019" height="101" alt="image" src="https://github.com/user-attachments/assets/09a68bc9-adc3-4252-a6d4-30af6d803824" />

<img width="1020" height="60" alt="image" src="https://github.com/user-attachments/assets/a338acc2-3941-405d-af7a-b2c25e1bd6bf" />

<img width="1022" height="59" alt="image" src="https://github.com/user-attachments/assets/b7bceecb-738d-4b6f-96a6-681d85ac7608" />


## Steps to test these changes

https://github.com/cocosolos/server/actions/runs/20873604670/attempts/1
