### PR TITLE
[lua] Nightmare Scythe Blind Potency Correction

### DIFF
--- a/scripts/actions/weaponskills/nightmare_scythe.lua
+++ b/scripts/actions/weaponskills/nightmare_scythe.lua
@@ -31,7 +31,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     -- Handle status effect
     local effectId      = xi.effect.BLINDNESS
     local actionElement = xi.element.DARK
-    local power         = 15
+    local power         = 20
     local duration      = math.floor(6 * tp / 100 * applyResistanceAddEffect(player, target, actionElement, 0))
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Changes the power of Nightmare Scythe blind from 15 to 20
<img width="1312" height="1152" alt="image" src="https://github.com/user-attachments/assets/15ed9e19-0930-450f-8015-db097998a899" />

## Steps to test these changes

Nightmare Scythe things, check their accuracy

