### PR TITLE
[lua] Catastrophe HP Drain Fixes

### DIFF
--- a/scripts/actions/weaponskills/catastrophe.lua
+++ b/scripts/actions/weaponskills/catastrophe.lua
@@ -17,6 +17,7 @@ local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
+    local targetHP = target:getHP()
     params.numHits = 1
     params.ftpMod = { 2.75, 2.75, 2.75 }
     params.agi_wsc = 0.4 params.int_wsc = 0.4
@@ -30,8 +31,12 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
+    -- Handle HP Drain
     if not target:isUndead() then
-        local drain = math.floor(damage * 0.4)
+        local drain = math.floor(damage * math.random(30, 70) / 100) -- TODO: JP Wiki States 50% Heal but all current proof i have shows 30-70%
+
+        drain = utils.clamp(drain, 0, targetHP)
+
         player:addHP(drain)
     end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Changes the HP Drain of Catastrophe to damage = damage * math.random(30, 70) / 100

https://www.bg-wiki.com/ffxi/Catastrophe
https://www.bluegartr.com/threads/73538-Catastrophe-WS-Build/page2

https://youtu.be/LcF9zurPKtg?t=266
766 Heals to 1118,
703 cata 352 heal,
50%
https://youtu.be/LcF9zurPKtg?t=291
882 Heals to 1181,
468 cata 299 Heal,
63.89%
https://youtu.be/UMQs7FP_MV0?t=80
208 heals to 567,
787 cata 359 heal,
45.62%
https://youtu.be/03Miyj8PmWo?t=153
1163 heals to 1230 (Soul eater 12% draining ~140 hp),
353 cata ~207 heal after accounting for soul eater drain,
58.64%
https://youtu.be/03Miyj8PmWo?t=191
1041 heals to 1120,
227 cata 79 heal,
34.8%
https://youtu.be/USqKVQhR2fA?t=55
736 heals to 1172,
1014 cata 436 heal,
43%
https://youtu.be/USqKVQhR2fA?t=79
599 heals to 1069,
941 cata 470 heal,
49.95%
https://youtu.be/USqKVQhR2fA?t=127
828 heals to 1326 heals to full,
916 cata 498 heal,
54.37% (possibly more as he healed to full)

Also runs the drain through utils.clamp so it cant drain more than the targets remaining HP

https://wiki.ffo.jp/html/3088.html

Proof : https://youtu.be/5uiWleKI4FM?si=n3sFNPrfDA3-T3gw&t=158 (HP heal of 35 against a Lv. 1 bee)
 ## Steps to test these changes

Catastrophe things, see HP return is now 30-70% of damage instead of a hard 40% always
