### PR TITLE
Spawn point and Steal update on Consul/Pontifex/Praetor/Legatus

### DIFF
--- a/scripts/zones/Quicksand_Caves/mobs/Antican_Legatus.lua
+++ b/scripts/zones/Quicksand_Caves/mobs/Antican_Legatus.lua
@@ -19,4 +19,8 @@ end
 entity.onMobDeath = function(mob, player, optParams)
 end
 
+entity.onMobDespawn = function(mob)
+    mob:setRespawnTime(math.random(1260, 1440)) -- 21 to 24 minutes
+end
+
 return entity

--- a/scripts/zones/Quicksand_Caves/mobs/Antican_Praetor.lua
+++ b/scripts/zones/Quicksand_Caves/mobs/Antican_Praetor.lua
@@ -19,4 +19,8 @@ end
 entity.onMobDeath = function(mob, player, optParams)
 end
 
+entity.onMobDespawn = function(mob)
+    mob:setRespawnTime(math.random(1260, 1440)) -- 21 to 24 minutes
+end
+
 return entity

--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -1041,6 +1041,7 @@ INSERT INTO `mob_droplist` VALUES (118,0,0,1000,1118,@ALWAYS);  -- Antican Pauld
 INSERT INTO `mob_droplist` VALUES (118,0,0,1000,645,@ALWAYS);   -- Chunk Of Darksteel Ore (Always, 100%)
 INSERT INTO `mob_droplist` VALUES (118,0,0,1000,1426,@VCOMMON); -- Warriors Testimony (Very Common, 24%)
 INSERT INTO `mob_droplist` VALUES (118,0,0,1000,1118,@VRARE);   -- Antican Pauldron (Very Rare, 1%)
+INSERT INTO `mob_droplist` VALUES (118,2,0,1000,751,0);         -- Platinum Beastcoin (Steal)
 
 -- ZoneID: 114 - Antican Decurio
 -- ZoneID: 125 - Antican Eques
@@ -19542,7 +19543,8 @@ INSERT INTO `mob_droplist` VALUES (2443,0,0,1000,4808,@UNCOMMON); -- Scroll Of W
 INSERT INTO `mob_droplist` VALUES (2443,0,0,1000,4779,@COMMON);   -- Scroll Of Water Iii (Common, 15%)
 INSERT INTO `mob_droplist` VALUES (2443,0,0,1000,4822,@RARE);     -- Scroll Of Flood (Rare, 5%)
 INSERT INTO `mob_droplist` VALUES (2443,0,0,1000,751,@VCOMMON);   -- Platinum Beastcoin (Very Common, 24)
-INSERT INTO `mob_droplist` VALUES (2440,0,0,1000,1443,@RARE);     -- Pinch Of Dried Mugwort (Rare, 5%)
+INSERT INTO `mob_droplist` VALUES (2443,0,0,1000,1443,@RARE);     -- Pinch Of Dried Mugwort (Rare, 5%)
+INSERT INTO `mob_droplist` VALUES (2443,2,0,1000,751,0);          -- Platinum Beastcoin (Steal)
 
 -- ZoneID: 159 - Tonberry Pursuer
 INSERT INTO `mob_droplist` VALUES (2444,0,0,1000,1119,@COMMON);   -- Tonberry Coat (Common, 15%)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR updates the spawn points on several NMs to be retail accurate as well as update the stealable items for the Pontifex and Consul.

Source: My Eyeballs

<img width="1032" height="759" alt="image" src="https://github.com/user-attachments/assets/8a48d6c0-fd9f-4cc1-bfd8-8a92e19d5bc4" />


## Steps to test these changes

Steal from the Pontifex or Consul and obtain a plat beastcoin.

Observe as the Consul/Pontifex/Legatus/Praetor now spawn in their correct positions.
