### PR TITLE
[lua] Blade: Retsu duration correction

### DIFF
--- a/scripts/actions/weaponskills/blade_retsu.lua
+++ b/scripts/actions/weaponskills/blade_retsu.lua
@@ -32,7 +32,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local effectId      = xi.effect.PARALYSIS
     local actionElement = xi.element.ICE
     local power         = utils.clamp(30 + 3 * (player:getMainLvl() - target:getMainLvl()), 5, 35)
-    local duration      = math.floor(3 * tp / 100 * applyResistanceAddEffect(player, target, actionElement, 0))
+    local duration      = math.floor(xi.weaponskills.fTP(tp, { 30, 60, 120 }) * applyResistanceAddEffect(player, target, actionElement, 0))
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The old Blade: Retsu formula was linear and capping out on 90s, it should be 30, 60, 120s respectively at 1000, 2000 and 3000 TP
Utilizes weaponskills.ftp to get the correct durations

Source:
https://wiki.ffo.jp/html/717.html

## Steps to test these changes

Retsu things, check paralyze duration
