### PR TITLE
[lua] Minor Staff Weaponskills fixes, useful comments

### DIFF
--- a/scripts/actions/weaponskills/earth_crusher.lua
+++ b/scripts/actions/weaponskills/earth_crusher.lua
@@ -20,6 +20,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.ele = xi.element.EARTH
     params.skill = xi.skill.STAFF
     params.includemab = true
+    params.dStat = xi.mod.INT
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.str_wsc = 0.4 params.int_wsc = 0.4

--- a/scripts/actions/weaponskills/garland_of_bliss.lua
+++ b/scripts/actions/weaponskills/garland_of_bliss.lua
@@ -22,6 +22,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.ele        = xi.element.LIGHT
     params.skill      = xi.skill.STAFF
     params.includemab = true
+    -- params.dStat = xi.mod.MND -- (pMND-mMND)×2 (Not supported in weaponskills.lua currently)
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftpMod  = { 2.25, 2.25, 2.25 }
@@ -38,7 +39,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local effectId      = xi.effect.DEFENSE_DOWN
     local actionElement = xi.element.WIND
     local power         = 12.5
-    local duration      = math.floor((30 + 3 * tp / 100) * applyResistanceAddEffect(player, target, actionElement, 0))
+    local duration      = math.floor(6 * tp / 100 * applyResistanceAddEffect(player, target, actionElement, 0))
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/actions/weaponskills/gate_of_tartarus.lua
+++ b/scripts/actions/weaponskills/gate_of_tartarus.lua
@@ -34,7 +34,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     -- Handle status effect
     local effectId      = xi.effect.ATTACK_DOWN
     local actionElement = xi.element.WATER
-    local power         = 20
+    local power         = 18.75 -- TODO : JP Wiki claims this power scales with ilvl. Denotes 18.75% at base. https://wiki.ffo.jp/html/3093.html
     local duration      = math.floor(120 * applyResistanceAddEffect(player, target, actionElement, 0))
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 

--- a/scripts/actions/weaponskills/omniscience.lua
+++ b/scripts/actions/weaponskills/omniscience.lua
@@ -22,6 +22,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.ele        = xi.element.DARK
     params.skill      = xi.skill.STAFF
     params.includemab = true
+    -- params.dStat = xi.mod.MND (pMND-mMND)×2 (Not supported in weaponskills.lua currently)
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.mnd_wsc = 0.8
@@ -34,9 +35,10 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     -- Handle status effect
     local effectId      = xi.effect.MAGIC_ATK_DOWN
+    local actionElement = xi.element.DARK
     local power         = 10
-    local duration      = math.floor(6 * tp / 100)
-    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, 0, damage, power, duration)
+    local duration      = math.floor(6 * tp / 100 * applyResistanceAddEffect(player, target, actionElement, 0))
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end

--- a/scripts/actions/weaponskills/rock_crusher.lua
+++ b/scripts/actions/weaponskills/rock_crusher.lua
@@ -20,6 +20,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.ele = xi.element.EARTH
     params.skill = xi.skill.STAFF
     params.includemab = true
+    params.dStat = xi.mod.INT
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.str_wsc = 0.4 params.int_wsc = 0.4

--- a/scripts/actions/weaponskills/starburst.lua
+++ b/scripts/actions/weaponskills/starburst.lua
@@ -18,6 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.ftpMod = { 1.0, 2.0, 2.5 }
     params.skill = xi.skill.STAFF
     params.includemab = true
+    params.dStat = xi.mod.INT
     -- 50/50 shot of being light or dark
     params.ele = xi.element.LIGHT
     if math.random(1, 100) <= 50 then

--- a/scripts/actions/weaponskills/sunburst.lua
+++ b/scripts/actions/weaponskills/sunburst.lua
@@ -20,6 +20,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.mnd_wsc = 0.4
     params.skill = xi.skill.STAFF
     params.includemab = true
+    params.dStat = xi.mod.INT
     -- 50/50 shot of being light or dark
     params.ele = xi.element.LIGHT
     if math.random(1, 100) <= 50 then

--- a/scripts/actions/weaponskills/vidohunir.lua
+++ b/scripts/actions/weaponskills/vidohunir.lua
@@ -22,6 +22,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.ele        = xi.element.DARK
     params.skill      = xi.skill.STAFF
     params.includemab = true
+    -- params.dStat = xi.mod.INT (pINT-mINT)×2 (Not supported in weaponskills.lua currently)
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.int_wsc = 0.8


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Corrects the duration scaling of Garland of Bliss to 60 / 120 / 180 seconds respectively. 
https://www.bg-wiki.com/ffxi/Garland_of_Bliss

* Leaves commented out line in the Garland of Bliss lua to support dStat, denoting the formula needed. (Not supported currently)

(pMND-mMND)×2

https://w.atwiki.jp/studiogobli/pages/77.html

* Adds the correct actionElement to Omniscience (Dark) and changes the effect handling so that it can be resisted.

https://www.bg-wiki.com/ffxi/Omniscience

* Leaves commented out line in the Omniscience lua to support dStat, denoting the formula needed (Not supported)

(pMND-mMND)×2

https://w.atwiki.jp/studiogobli/pages/77.html

* Leaves commented out line in the Vidohunir lua to support dStat, denoting the formula needed (Also not supported)

(pINT-mINT)×2

https://w.atwiki.jp/studiogobli/pages/77.html

* Corrects the attack down of Gate of Tartarus to 18.75%, JP Wiki notes that ilvl versions of this relic weapon make this effect stronger. 

https://wiki.ffo.jp/html/3093.html

* Adds dStat params to Sunburst, Starburst, Earth Crusher and Rock Crusher. These were already being supported in the backend, but this clarifies they are recieving the bonus at a quick glance. 

## Steps to test these changes

Use Staff Weaponskills
