### PR TITLE
[lua] Death Blossom MEVA Down Element

### DIFF
--- a/scripts/actions/weaponskills/death_blossom.lua
+++ b/scripts/actions/weaponskills/death_blossom.lua
@@ -32,10 +32,13 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     -- Handle status effect
-    local effectId = xi.effect.MAGIC_EVASION_DOWN
-    local power    = 10
-    local duration = math.floor(tp / 50 - 5)
-    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, 0, damage, power, duration)
+    local effectId      = xi.effect.MAGIC_EVASION_DOWN
+    local actionElement = xi.element.THUNDER
+    local power         = 10
+    local skillType     = xi.skill.SWORD
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
+    local duration      = math.floor(60 * resist) -- TODO: Chance of lowering magic evasion varies with TP.
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Adds the thunder element to Death Blossoms MEVA Down effect after testing on Ghrah.
* Also fixes the duration at 60 seconds and runs it through calculateResistRate
https://www.bg-wiki.com/ffxi/Death_Blossom

The weaponskill also states that chance of lower magic evasion varies with TP, but the bonus accuracy is unknown. Left a TODO comment to add this if it is ever discovered.

## Testing

https://www.youtube.com/watch?v=QkMuucI_PPU

## Steps to test these changes

Death Blossom things, see that it won't land on things with high lightning evasion.

Thanks to Tao for getting Death Blossom and testing this. 
