### PR TITLE
[Module] [lua] ToAU Staff Weaponskills

### DIFF
--- a/modules/era/lua/toau/weaponskills/archery.lua
+++ b/modules/era/lua/toau/weaponskills/archery.lua
@@ -57,7 +57,10 @@ m:addOverride('xi.actions.weaponskills.dulling_arrow.onUseWeaponSkill', function
     local effectId      = xi.effect.INT_DOWN
     local actionElement = xi.element.FIRE
     local power         = 10
-    local duration      = math.floor(140 * applyResistanceAddEffect(player, target, actionElement, 0))
+    local skillType     = xi.skill.ARCHERY
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor(140 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage

--- a/modules/era/lua/toau/weaponskills/axe.lua
+++ b/modules/era/lua/toau/weaponskills/axe.lua
@@ -34,7 +34,10 @@ m:addOverride('xi.actions.weaponskills.smash_axe.onUseWeaponSkill', function(pla
     local effectId      = xi.effect.STUN
     local actionElement = xi.element.THUNDER
     local power         = 1
-    local duration      = math.floor(tp / 500 * applyResistanceAddEffect(player, target, actionElement, 0))
+    local skillType     = xi.skill.AXE
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor(tp / 500 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
@@ -55,7 +58,10 @@ m:addOverride('xi.actions.weaponskills.gale_axe.onUseWeaponSkill', function(play
     local effectId      = xi.effect.CHOKE
     local actionElement = xi.element.WIND
     local power         = 5
-    local duration      = math.floor(90 * applyResistanceAddEffect(player, target, actionElement, 0))
+    local skillType     = xi.skill.AXE
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor(90 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
@@ -159,7 +165,10 @@ m:addOverride('xi.actions.weaponskills.onslaught.onUseWeaponSkill', function(pla
     local effectId      = xi.effect.ACCURACY_DOWN
     local actionElement = xi.element.EARTH
     local power         = 30
-    local duration      = math.floor(120 * applyResistanceAddEffect(player, target, actionElement, 0))
+    local skillType     = xi.skill.AXE
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor(120 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage

--- a/modules/era/lua/toau/weaponskills/club.lua
+++ b/modules/era/lua/toau/weaponskills/club.lua
@@ -53,7 +53,10 @@ m:addOverride('xi.actions.weaponskills.brainshaker.onUseWeaponSkill', function(p
     local effectId      = xi.effect.STUN
     local actionElement = xi.element.THUNDER
     local power         = 1
-    local duration      = math.floor(tp / 500 * applyResistanceAddEffect(player, target, actionElement, 0))
+    local skillType     = xi.skill.CLUB
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor(tp / 500 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
@@ -90,7 +93,7 @@ m:addOverride('xi.actions.weaponskills.skullbreaker.onUseWeaponSkill', function(
     local params   = {}
     params.numHits = 1
     params.ftpMod  = { 1.00, 1.00, 1.00 }
-    params.str_wsc = 0.3
+    params.str_wsc = 0.35
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
@@ -98,7 +101,10 @@ m:addOverride('xi.actions.weaponskills.skullbreaker.onUseWeaponSkill', function(
     local effectId      = xi.effect.INT_DOWN
     local actionElement = xi.element.FIRE
     local power         = 10
-    local duration      = math.floor(140 * applyResistanceAddEffect(player, target, actionElement, 0))
+    local skillType     = xi.skill.CLUB
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor(140 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
     return tpHits, extraHits, criticalHit, damage
 end)
@@ -181,7 +187,10 @@ m:addOverride('xi.actions.weaponskills.randgrith.onUseWeaponSkill', function(pla
     local effectId      = xi.effect.EVASION_DOWN
     local actionElement = xi.element.ICE
     local power         = 32
-    local duration      = math.floor(120 * applyResistanceAddEffect(player, target, actionElement, 0))
+    local skillType     = xi.skill.CLUB
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor(120 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage

--- a/modules/era/lua/toau/weaponskills/dagger.lua
+++ b/modules/era/lua/toau/weaponskills/dagger.lua
@@ -20,7 +20,10 @@ m:addOverride('xi.actions.weaponskills.wasp_sting.onUseWeaponSkill', function(pl
     local effectId      = xi.effect.POISON
     local actionElement = xi.element.WATER
     local power         = 1
-    local duration      = math.floor((75 + 15 * tp / 1000) * applyResistanceAddEffect(player, target, actionElement, 0))
+    local skillType     = xi.skill.DAGGER
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor((75 + 15 * tp / 1000) * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
@@ -55,11 +58,14 @@ m:addOverride('xi.actions.weaponskills.shadowstitch.onUseWeaponSkill', function(
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     -- Handle status effect
-    if math.random(1, 100) <= tp / 30 * applyResistanceAddEffect(player, target, xi.element.ICE, 0) then
-        local effectId      = xi.effect.BIND
-        local actionElement = xi.element.ICE
+    local effectId      = xi.effect.BIND
+    local actionElement = xi.element.ICE
+    local skillType     = xi.skill.DAGGER
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    if math.random(1, 100) <= tp / 30 * resist then
         local power         = 1
-        local duration      = math.floor((5 + tp / 200) * applyResistanceAddEffect(player, target, actionElement, 0))
+        local duration      = math.floor((5 + tp / 200) * resist)
         xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
     end
 
@@ -81,7 +87,10 @@ m:addOverride('xi.actions.weaponskills.viper_bite.onUseWeaponSkill', function(pl
     local effectId      = xi.effect.POISON
     local actionElement = xi.element.WATER
     local power         = 3
-    local duration      = math.floor((30 + 6 * tp / 100) * applyResistanceAddEffect(player, target, actionElement, 0))
+    local skillType     = xi.skill.DAGGER
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor((30 + 6 * tp / 100) * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
@@ -257,11 +266,14 @@ m:addOverride('xi.actions.weaponskills.mordant_rime.onUseWeaponSkill', function(
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
     -- Handle status effect
-    if math.random(1, 100) <= tp / 30 * applyResistanceAddEffect(player, target, xi.element.THUNDER, 0) then
-        local effectId      = xi.effect.WEIGHT
-        local actionElement = xi.element.WIND
+    local effectId      = xi.effect.WEIGHT
+    local actionElement = xi.element.WIND
+    local skillType     = xi.skill.DAGGER
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    if math.random(1, 100) <= tp / 30 * resist then
         local power         = 25
-        local duration      = math.floor(60 * applyResistanceAddEffect(player, target, actionElement, 0))
+        local duration      = math.floor(60 * resist)
         xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
     end
 

--- a/modules/era/lua/toau/weaponskills/great_axe.lua
+++ b/modules/era/lua/toau/weaponskills/great_axe.lua
@@ -20,7 +20,10 @@ m:addOverride('xi.actions.weaponskills.shield_break.onUseWeaponSkill', function(
     local effectId      = xi.effect.EVASION_DOWN
     local actionElement = xi.element.ICE
     local power         = 40
-    local duration      = math.floor((120 + 6 * tp / 100) * applyResistanceAddEffect(player, target, actionElement, 0))
+    local skillType     = xi.skill.GREAT_AXE
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor((120 + 6 * tp / 100) * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
@@ -64,7 +67,10 @@ m:addOverride('xi.actions.weaponskills.armor_break.onUseWeaponSkill', function(p
     local effectId      = xi.effect.DEFENSE_DOWN
     local actionElement = xi.element.WIND
     local power         = 25
-    local duration      = math.floor((120 + 6 * tp / 100) * applyResistanceAddEffect(player, target, actionElement, 0))
+    local skillType     = xi.skill.GREAT_AXE
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor((120 + 6 * tp / 100) * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
@@ -96,7 +102,10 @@ m:addOverride('xi.actions.weaponskills.weapon_break.onUseWeaponSkill', function(
     local effectId      = xi.effect.ATTACK_DOWN
     local actionElement = xi.element.WATER
     local power         = 25
-    local duration      = math.floor(120 + 6 * tp / 100 * applyResistanceAddEffect(player, target, actionElement, 0))
+    local skillType     = xi.skill.GREAT_AXE
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor((120 + 6 * tp / 100) * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
@@ -125,6 +134,8 @@ m:addOverride('xi.actions.weaponskills.full_break.onUseWeaponSkill', function(pl
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     -- Handle status effects.
+    local skillType     = xi.skill.GREAT_AXE
+    local skillRank     = player:getSkillRank(skillType)
     local effects =
     {
         [1] = { xi.effect.ATTACK_DOWN,   xi.element.WATER, 12.5 },
@@ -136,7 +147,8 @@ m:addOverride('xi.actions.weaponskills.full_break.onUseWeaponSkill', function(pl
         local effectId      = effects[index][1]
         local actionElement = effects[index][2]
         local power         = effects[index][3]
-        local duration      = math.floor(120 + 6 * tp / 100 * applyResistanceAddEffect(player, target, actionElement, 0))
+        local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+        local duration      = math.floor((120 + 6 * tp / 100) * resist)
         xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
     end
 
@@ -171,7 +183,10 @@ m:addOverride('xi.actions.weaponskills.metatron_torment.onUseWeaponSkill', funct
     local effectId      = xi.effect.DEFENSE_DOWN
     local actionElement = xi.element.WIND
     local power         = 19
-    local duration      = math.floor(120 * applyResistanceAddEffect(player, target, actionElement, 0))
+    local skillType     = xi.skill.GREAT_AXE
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor(120 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage

--- a/modules/era/lua/toau/weaponskills/great_katana.lua
+++ b/modules/era/lua/toau/weaponskills/great_katana.lua
@@ -31,9 +31,12 @@ m:addOverride('xi.actions.weaponskills.tachi_hobaku.onUseWeaponSkill', function(
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     -- Handle status effect
-    if math.random(1, 100) <= tp / 30 * applyResistanceAddEffect(player, target, xi.element.THUNDER, 0) then
-        local effectId      = xi.effect.STUN
-        local actionElement = xi.element.THUNDER
+    local effectId      = xi.effect.STUN
+    local actionElement = xi.element.THUNDER
+    local skillType     = xi.skill.GREAT_KATANA
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    if math.random(1, 100) <= tp / 30 * resist then
         local power         = 1
         local duration      = 3
         xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
@@ -127,7 +130,10 @@ m:addOverride('xi.actions.weaponskills.tachi_yukikaze.onUseWeaponSkill', functio
     local effectId      = xi.effect.BLINDNESS
     local actionElement = xi.element.DARK
     local power         = 25
-    local duration      = math.floor(60 * applyResistanceAddEffect(player, target, actionElement, 0))
+    local skillType     = xi.skill.GREAT_KATANA
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor(60 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
@@ -149,7 +155,10 @@ m:addOverride('xi.actions.weaponskills.tachi_gekko.onUseWeaponSkill', function(p
     local effectId      = xi.effect.SILENCE
     local actionElement = xi.element.WIND
     local power         = 1
-    local duration      = math.floor(60 * applyResistanceAddEffect(player, target, actionElement, 0))
+    local skillType     = xi.skill.GREAT_KATANA
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor(60 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
@@ -171,7 +180,10 @@ m:addOverride('xi.actions.weaponskills.tachi_kasha.onUseWeaponSkill', function(p
     local effectId      = xi.effect.PARALYSIS
     local actionElement = xi.element.ICE
     local power         = 25
-    local duration      = math.floor(60 * applyResistanceAddEffect(player, target, actionElement, 0))
+    local skillType     = xi.skill.GREAT_KATANA
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor(60 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage

--- a/modules/era/lua/toau/weaponskills/great_sword.lua
+++ b/modules/era/lua/toau/weaponskills/great_sword.lua
@@ -38,8 +38,8 @@ end)
 -- Frostbite
 -----------------------------------
 m:addOverride('xi.actions.weaponskills.frostbite.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
-    params.ftpMod     = { 1.0, 2.0, 2.5 }
+    local params      = {}
+    params.ftpMod     = { 1.00, 2.00, 2.50 }
     params.str_wsc    = 0.2
     params.int_wsc    = 0.2
     params.ele        = xi.element.ICE
@@ -55,13 +55,14 @@ end)
 -- Freezebite
 -----------------------------------
 m:addOverride('xi.actions.weaponskills.freezebite.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
-    params.ftpMod     = { 1.0, 1.5, 3.0 }
+    local params      = {}
+    params.ftpMod     = { 1.00, 1.50, 3.00 }
     params.str_wsc    = 0.3
     params.int_wsc    = 0.2
     params.ele        = xi.element.ICE
     params.skill      = xi.skill.GREAT_SWORD
     params.includemab = true
+    params.dStat      = xi.mod.INT
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
     return tpHits, extraHits, criticalHit, damage
@@ -83,7 +84,10 @@ m:addOverride('xi.actions.weaponskills.shockwave.onUseWeaponSkill', function(pla
     local effectId      = xi.effect.SLEEP_I
     local actionElement = xi.element.DARK
     local power         = 1
-    local duration      = math.floor((math.random(0, 30) + tp * 0.01) * applyResistanceAddEffect(player, target, actionElement, 0))
+    local skillType     = xi.skill.GREAT_SWORD
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor((math.random(0, 30) + tp * 0.01) * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
@@ -106,7 +110,7 @@ end)
 -- Sickle Moon
 -----------------------------------
 m:addOverride('xi.actions.weaponskills.sickle_moon.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 2
     params.ftpMod  = { 1.50, 2.00, 2.75 }
     params.str_wsc = 0.2
@@ -150,7 +154,7 @@ end)
 -- Scourge
 -----------------------------------
 m:addOverride('xi.actions.weaponskills.scourge.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
-    local params = {}
+    local params   = {}
     params.numHits = 1
     params.ftpMod  = { 3.0, 3.0, 3.0 }
     params.mnd_wsc = 0.4

--- a/modules/era/lua/toau/weaponskills/hand_to_hand.lua
+++ b/modules/era/lua/toau/weaponskills/hand_to_hand.lua
@@ -34,7 +34,10 @@ m:addOverride('xi.actions.weaponskills.shoulder_tackle.onUseWeaponSkill', functi
     local effectId      = xi.effect.STUN
     local actionElement = xi.element.THUNDER
     local power         = 1
-    local duration      = math.floor(tp / 500 * applyResistanceAddEffect(player, target, actionElement, 0))
+    local skillType     = xi.skill.HAND_TO_HAND
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor(tp / 500 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
@@ -60,7 +63,7 @@ end)
 m:addOverride('xi.actions.weaponskills.backhand_blow.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
     local params      = {}
     params.numHits    = 2
-    params.ftpMod     = { 1.00, 1.50, 2.00 }
+    params.ftpMod     = { 1.00, 1.00, 1.00 }
     params.str_wsc    = 0.3
     params.dex_wsc    = 0.3
     params.critVaries = { 0.40, 0.60, 0.80 }

--- a/modules/era/lua/toau/weaponskills/katana.lua
+++ b/modules/era/lua/toau/weaponskills/katana.lua
@@ -37,7 +37,10 @@ m:addOverride('xi.actions.weaponskills.blade_retsu.onUseWeaponSkill', function(p
     local effectId      = xi.effect.PARALYSIS
     local actionElement = xi.element.ICE
     local power         = utils.clamp(30 + 3 * (player:getMainLvl() - target:getMainLvl()), 5, 35)
-    local duration      = math.floor(xi.weaponskills.fTP(tp, { 30, 60, 120 }) * applyResistanceAddEffect(player, target, actionElement, 0))
+    local skillType     = xi.skill.KATANA
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor(xi.weaponskills.fTP(tp, { 30, 60, 120 }) * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
@@ -176,7 +179,10 @@ m:addOverride('xi.actions.weaponskills.blade_metsu.onUseWeaponSkill', function(p
     local effectId      = xi.effect.PARALYSIS
     local actionElement = xi.element.ICE
     local power         = 10
-    local duration      = math.floor(60 * applyResistanceAddEffect(player, target, actionElement, 0))
+    local skillType     = xi.skill.KATANA
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor(60 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
@@ -202,7 +208,10 @@ m:addOverride('xi.actions.weaponskills.blade_kamu.onUseWeaponSkill', function(pl
     local effectId      = xi.effect.ACCURACY_DOWN
     local actionElement = xi.element.EARTH
     local power         = 10
-    local duration      = math.floor(6 * tp / 100 * applyResistanceAddEffect(player, target, actionElement, 0))
+    local skillType     = xi.skill.KATANA
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor(6 * tp / 100 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage

--- a/modules/era/lua/toau/weaponskills/marksmanship.lua
+++ b/modules/era/lua/toau/weaponskills/marksmanship.lua
@@ -54,7 +54,10 @@ m:addOverride('xi.actions.weaponskills.sniper_shot.onUseWeaponSkill', function(p
     local effectId      = xi.effect.INT_DOWN
     local actionElement = xi.element.FIRE
     local power         = 10
-    local duration      = math.floor(140 * applyResistanceAddEffect(player, target, actionElement, 0))
+    local skillType     = xi.skill.MARKSMANSHIP
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor(140 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage

--- a/modules/era/lua/toau/weaponskills/polearm.lua
+++ b/modules/era/lua/toau/weaponskills/polearm.lua
@@ -63,11 +63,14 @@ m:addOverride('xi.actions.weaponskills.leg_sweep.onUseWeaponSkill', function(pla
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     -- Handle status effect
-    if math.random(1, 100) <= tp / 30 * applyResistanceAddEffect(player, target, xi.element.THUNDER, 0) then
-        local effectId      = xi.effect.STUN
-        local actionElement = xi.element.THUNDER
+    local effectId      = xi.effect.STUN
+    local actionElement = xi.element.THUNDER
+    local skillType     = xi.skill.POLEARM
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    if math.random(1, 100) <= tp / 30 * resist then
         local power         = 1
-        local duration      = math.floor(4 * applyResistanceAddEffect(player, target, actionElement, 0))
+        local duration      = math.floor(4 * resist)
         xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
     end
 

--- a/modules/era/lua/toau/weaponskills/scythe.lua
+++ b/modules/era/lua/toau/weaponskills/scythe.lua
@@ -69,7 +69,10 @@ m:addOverride('xi.actions.weaponskills.nightmare_scythe.onUseWeaponSkill', funct
     local effectId      = xi.effect.BLINDNESS
     local actionElement = xi.element.DARK
     local power         = 20
-    local duration      = math.floor((6 * tp / 100) * applyResistanceAddEffect(player, target, actionElement, 0))
+    local skillType     = xi.skill.SCYTHE
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor((6 * tp / 100) * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
@@ -120,7 +123,10 @@ m:addOverride('xi.actions.weaponskills.guillotine.onUseWeaponSkill', function(pl
     local effectId      = xi.effect.SILENCE
     local actionElement = xi.element.WIND
     local power         = 1
-    local duration      = math.floor((30 + 3 * tp / 100) * applyResistanceAddEffect(player, target, actionElement, 0))
+    local skillType     = xi.skill.SCYTHE
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor((30 + 3 * tp / 100) * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage

--- a/modules/era/lua/toau/weaponskills/staff.lua
+++ b/modules/era/lua/toau/weaponskills/staff.lua
@@ -1,0 +1,251 @@
+-----------------------------------
+-- Date : 2007-11-19 (One day prior to WoTG release)
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+
+local m = Module:new('toau_staff')
+
+-----------------------------------
+-- Heavy Swing
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.heavy_swing.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params   = {}
+    params.numHits = 1
+    params.ftpMod  = { 1.00, 1.25, 2.25 }
+    params.str_wsc = 0.3
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Rock Crusher
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.rock_crusher.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params      = {}
+    params.ftpMod     = { 1.00, 2.00, 2.50 }
+    params.str_wsc    = 0.2
+    params.int_wsc    = 0.2
+    params.ele        = xi.element.EARTH
+    params.skill      = xi.skill.STAFF
+    params.includemab = true
+    params.dStat      = xi.mod.INT
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Earth Crusher
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.earth_crusher.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params      = {}
+    params.ftpMod     = { 1.00, 2.3125, 3.625 }
+    params.str_wsc    = 0.3
+    params.int_wsc    = 0.3
+    params.ele        = xi.element.EARTH
+    params.skill      = xi.skill.STAFF
+    params.includemab = true
+    params.dStat      = xi.mod.INT
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Starburst
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.starburst.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params      = {}
+    params.ftpMod     = { 1.00, 2.00, 2.50 }
+    params.skill      = xi.skill.STAFF
+    params.includemab = true
+    params.ele        = xi.element.LIGHT
+    params.dStat      = xi.mod.INT
+
+    if math.random(1, 100) <= 50 then
+        params.ele = xi.element.DARK
+    end
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Sunburst
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.sunburst.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params      = {}
+    params.ftpMod     = { 1.00, 2.50, 4.00 }
+    params.skill      = xi.skill.STAFF
+    params.includemab = true
+    params.ele        = xi.element.LIGHT
+    params.dStat      = xi.mod.INT
+
+    if math.random(1, 100) <= 50 then
+        params.ele = xi.element.DARK
+    end
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Shell Crusher
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.shell_crusher.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params   = {}
+    params.numHits = 1
+    params.ftpMod  = { 1.00, 1.00, 1.00 }
+    params.str_wsc = 0.35
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
+
+    -- Handle status effect
+    local effectId      = xi.effect.DEFENSE_DOWN
+    local actionElement = xi.element.WIND
+    local power         = 25
+    local skillType     = xi.skill.STAFF
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor((120 + 6 * tp / 100) * resist)
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Full Swing
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.full_swing.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params  = {}
+    params.numHits = 1
+    params.ftpMod  = { 1.00, 3.00, 5.00 }
+    params.str_wsc = 0.5
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Spirit Taker
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.spirit_taker.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params   = {}
+    params.numHits = 1
+    params.ftpMod  = { 1.00, 1.50, 2.00 }
+    params.int_wsc = 0.5
+    params.mnd_wsc = 0.5
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
+
+    player:addMP(damage)
+
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Retribution
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.retribution.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params     = {}
+    params.numHits   = 1
+    params.ftpMod    = { 2.00, 2.50, 3.00 }
+    params.atkVaries = { 1.50, 1.50, 1.50 }
+    params.str_wsc   = 0.3
+    params.mnd_wsc   = 0.5
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Gate of Tartarus
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.gate_of_tartarus.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params   = {}
+    params.numHits = 1
+    params.ftpMod  = { 3.00, 3.00, 3.00 }
+    params.chr_wsc = 0.6
+
+    -- Apply aftermath
+    xi.aftermath.addStatusEffect(player, tp, xi.slot.MAIN, xi.aftermath.type.RELIC)
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
+
+    -- Handle status effect
+    local effectId      = xi.effect.ATTACK_DOWN
+    local actionElement = xi.element.WATER
+    local power         = 18.75
+    local skillType     = xi.skill.STAFF
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor(120 * resist)
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Vidohunir
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.vidohunir.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params      = {}
+    params.ftpMod     = { 1.75, 1.75, 1.75 }
+    params.int_wsc    = 0.3
+    params.ele        = xi.element.DARK
+    params.skill      = xi.skill.STAFF
+    params.includemab = true
+    -- params.dStat = xi.mod.INT
+
+    -- Apply aftermath
+    xi.aftermath.addStatusEffect(player, tp, xi.slot.MAIN, xi.aftermath.type.MYTHIC)
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
+
+    -- Handle status effect
+    local effectId      = xi.effect.MAGIC_DEF_DOWN
+    local actionElement = xi.element.THUNDER
+    local power         = 10
+    local skillType     = xi.skill.STAFF
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor(6 * tp / 100 * resist)
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+-----------------------------------
+-- Garland of Bliss
+-----------------------------------
+m:addOverride('xi.actions.weaponskills.garland_of_bliss.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
+    local params = {}
+    params.ftpMod     = { 2.25, 2.25, 2.25 }
+    params.str_wsc    = 0.3
+    params.mnd_wsc    = 0.3
+    params.ele        = xi.element.LIGHT
+    params.skill      = xi.skill.STAFF
+    params.includemab = true
+     -- params.dStat = xi.mod.MND
+
+    -- Apply Aftermath
+    xi.aftermath.addStatusEffect(player, tp, xi.slot.MAIN, xi.aftermath.type.MYTHIC)
+
+    local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
+
+    -- Handle status effect
+    local effectId      = xi.effect.DEFENSE_DOWN
+    local actionElement = xi.element.WIND
+    local power         = 12.5
+    local skillType     = xi.skill.STAFF
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor((6 * tp / 100) * resist)
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+
+    return tpHits, extraHits, criticalHit, damage
+end)
+
+return m

--- a/modules/era/lua/toau/weaponskills/sword.lua
+++ b/modules/era/lua/toau/weaponskills/sword.lua
@@ -66,11 +66,14 @@ m:addOverride('xi.actions.weaponskills.flat_blade.onUseWeaponSkill', function(pl
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     -- Handle status effect
-    if math.random(1, 100) <= tp / 30 * applyResistanceAddEffect(player, target, xi.element.THUNDER, 0) then
-        local effectId      = xi.effect.STUN
-        local actionElement = xi.element.THUNDER
+    local effectId      = xi.effect.STUN
+    local actionElement = xi.element.THUNDER
+    local skillType     = xi.skill.SWORD
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    if math.random(1, 100) <= tp / 30 * resist then
         local power         = 1
-        local duration      = math.floor(4 * applyResistanceAddEffect(player, target, actionElement, 0))
+        local duration      = math.floor(4 * resist)
         xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
     end
 
@@ -346,7 +349,10 @@ m:addOverride('xi.actions.weaponskills.death_blossom.onUseWeaponSkill', function
     local effectId      = xi.effect.MAGIC_EVASION_DOWN
     local actionElement = xi.element.THUNDER
     local power         = 10
-    local duration      = math.floor(60 * applyResistanceAddEffect(player, target, actionElement, 0)) -- TODO: Chance to apply varies with TP.
+    local skillType     = xi.skill.SWORD
+    local skillRank     = player:getSkillRank(skillType)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local duration      = math.floor(60 * resist) -- TODO: Chance to apply varies with TP.
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Adds ToAU Era Staff Weaponskills
* Converts modules over to combat.magicHitRate.calculateResistRate
* Fixes some other minor issues found in final audit. 

## Steps to test these changes

Enable any of the weaponskill modules (or the whole folder) use ToAU Era WS
