### PR TITLE
[lua] Slapstick and Knockout Audit 

### DIFF
--- a/scripts/actions/abilities/pets/automaton/knockout.lua
+++ b/scripts/actions/abilities/pets/automaton/knockout.lua
@@ -1,5 +1,9 @@
 -----------------------------------
 -- Knockout
+-- Delivers a single hit attack. Damage varies with TP. Additional Effect : Evasion Down.
+-- Weaponskill is forced by a Wind Maneuver.
+-- https://www.bg-wiki.com/ffxi/Knockout (Adoulin)
+-- https://web.archive.org/web/20100401051051/https://www.geocities.jp/pupff/other/knockout.html (Original)
 -----------------------------------
 ---@type TAbilityAutomaton
 local abilityObject = {}
@@ -14,14 +18,12 @@ abilityObject.onAutomatonAbilityCheck = function(target, automaton, skill)
 end
 
 abilityObject.onAutomatonAbility = function(target, automaton, skill, master, action)
-    local params =
-    {
-        numHits = 1,
-        atkmulti = 1,
-        accBonus = 50,
-        weaponType = xi.skill.CLUB,
-        ftpMod = { 4.0, 5.0, 5.5 },
-    }
+    local params      = {}
+    params.numHits    = 1
+    params.weaponType = xi.skill.CLUB
+    params.ftpMod     = { 4.0, 4.5, 5.0 }
+    params.agi_wsc    = 0.85
+    params.accBonus   = 50
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.agi_wsc = 1.0
@@ -30,11 +32,14 @@ abilityObject.onAutomatonAbility = function(target, automaton, skill, master, ac
 
     local damage = xi.autows.doAutoPhysicalWeaponskill(automaton, target, 0, skill:getTP(), true, action, false, params, skill)
 
-    if damage > 0 then
-        if not target:hasStatusEffect(xi.effect.EVASION_DOWN) then
-            target:addStatusEffect(xi.effect.EVASION_DOWN, 10, 0, 30)
-        end
-    end
+    -- Handle status effect
+    local effectId      = xi.effect.EVASION_DOWN
+    local actionElement = xi.element.WIND
+    local skillType     = xi.skill.AUTOMATON_MELEE
+    local power         = 20
+    local resist        = xi.combat.magicHitRate.calculateResistRate(automaton, target, 0, skillType, 0, actionElement, 0, effectId, 0)
+    local duration      = math.floor(30 * resist)
+    xi.weaponskills.handleWeaponskillEffect(automaton, target, effectId, actionElement, damage, power, duration)
 
     return damage
 end

--- a/scripts/actions/abilities/pets/automaton/slapstick.lua
+++ b/scripts/actions/abilities/pets/automaton/slapstick.lua
@@ -1,5 +1,9 @@
 -----------------------------------
 -- Slapstick
+-- Delivers a threefold attack. Accuracy varies with TP.
+-- Weaponskill is forced by a Thunder Maneuver.
+-- https://www.bg-wiki.com/ffxi/Slapstick (Adoulin)
+-- https://web.archive.org/web/20100401153524/https://www.geocities.jp/pupff/other/slapstick.html (Original)
 -----------------------------------
 ---@type TAbilityAutomaton
 local abilityObject = {}
@@ -14,19 +18,19 @@ abilityObject.onAutomatonAbilityCheck = function(target, automaton, skill)
 end
 
 abilityObject.onAutomatonAbility = function(target, automaton, skill, master, action)
-    local params =
-    {
-        numHits = 3,
-        atkmulti = 1,
-        weaponType = xi.skill.CLUB,
-        ftpMod = { 1.5, 2.0, 3.0 },
-        str_wsc = 0.3,
-        dex_wsc = 0.3,
-    }
+    local params      = {}
+    params.numHits    = 3
+    params.weaponType = xi.skill.CLUB
+    params.ftpMod     = { 1.0, 1.0, 1.0 }
+    params.str_wsc    = 0.2
+    params.dex_wsc    = 0.2
+    params.accBonus   = math.floor(xi.weaponskills.fTP(skill:getTP(), { 0, 30, 50 }))
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.ftpMod = { 2.66, 2.66, 2.66 }
-        params.accBonus = 0.04 * skill:getTP()
+        params.ftpMod   = { 2.66, 2.66, 2.66 }
+        params.str_wsc    = 0.3
+        params.dex_wsc    = 0.3
+        params.accBonus = math.floor(xi.weaponskills.fTP(skill:getTP(), { 0, 40, 80 }))
     end
 
     local damage = xi.autows.doAutoPhysicalWeaponskill(automaton, target, 0, skill:getTP(), true, action, false, params, skill)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Audits Slapstick and Knockout Automaton WS

## Sources Used

* Slapstick
https://www.bg-wiki.com/ffxi/Slapstick (Adoulin)
https://web.archive.org/web/20100401153524/https://www.geocities.jp/pupff/other/slapstick.html (Original)

* Knockout
https://www.bg-wiki.com/ffxi/Knockout (Adoulin)
https://web.archive.org/web/20100401051051/https://www.geocities.jp/pupff/other/knockout.html (Original)

## Steps to test these changes

Use Stormwaker frame, use Wind or Thunder maneuver to trigger WS.
