### PR TITLE
[Module] [lua] ToAU Weaponskills calculateResist Fixes

### DIFF
--- a/modules/era/lua/toau/weaponskills/archery.lua
+++ b/modules/era/lua/toau/weaponskills/archery.lua
@@ -58,8 +58,7 @@ m:addOverride('xi.actions.weaponskills.dulling_arrow.onUseWeaponSkill', function
     local actionElement = xi.element.FIRE
     local power         = 10
     local skillType     = xi.skill.ARCHERY
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor(140 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 

--- a/modules/era/lua/toau/weaponskills/axe.lua
+++ b/modules/era/lua/toau/weaponskills/axe.lua
@@ -35,8 +35,7 @@ m:addOverride('xi.actions.weaponskills.smash_axe.onUseWeaponSkill', function(pla
     local actionElement = xi.element.THUNDER
     local power         = 1
     local skillType     = xi.skill.AXE
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor(tp / 500 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
@@ -59,8 +58,7 @@ m:addOverride('xi.actions.weaponskills.gale_axe.onUseWeaponSkill', function(play
     local actionElement = xi.element.WIND
     local power         = 5
     local skillType     = xi.skill.AXE
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor(90 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
@@ -166,8 +164,7 @@ m:addOverride('xi.actions.weaponskills.onslaught.onUseWeaponSkill', function(pla
     local actionElement = xi.element.EARTH
     local power         = 30
     local skillType     = xi.skill.AXE
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor(120 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 

--- a/modules/era/lua/toau/weaponskills/club.lua
+++ b/modules/era/lua/toau/weaponskills/club.lua
@@ -54,8 +54,7 @@ m:addOverride('xi.actions.weaponskills.brainshaker.onUseWeaponSkill', function(p
     local actionElement = xi.element.THUNDER
     local power         = 1
     local skillType     = xi.skill.CLUB
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor(tp / 500 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
@@ -102,8 +101,7 @@ m:addOverride('xi.actions.weaponskills.skullbreaker.onUseWeaponSkill', function(
     local actionElement = xi.element.FIRE
     local power         = 10
     local skillType     = xi.skill.CLUB
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor(140 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
     return tpHits, extraHits, criticalHit, damage
@@ -188,8 +186,7 @@ m:addOverride('xi.actions.weaponskills.randgrith.onUseWeaponSkill', function(pla
     local actionElement = xi.element.ICE
     local power         = 32
     local skillType     = xi.skill.CLUB
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor(120 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 

--- a/modules/era/lua/toau/weaponskills/dagger.lua
+++ b/modules/era/lua/toau/weaponskills/dagger.lua
@@ -21,8 +21,7 @@ m:addOverride('xi.actions.weaponskills.wasp_sting.onUseWeaponSkill', function(pl
     local actionElement = xi.element.WATER
     local power         = 1
     local skillType     = xi.skill.DAGGER
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor((75 + 15 * tp / 1000) * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
@@ -60,14 +59,11 @@ m:addOverride('xi.actions.weaponskills.shadowstitch.onUseWeaponSkill', function(
     -- Handle status effect
     local effectId      = xi.effect.BIND
     local actionElement = xi.element.ICE
+    local power         = 1
     local skillType     = xi.skill.DAGGER
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
-    if math.random(1, 100) <= tp / 30 * resist then
-        local power         = 1
-        local duration      = math.floor((5 + tp / 200) * resist)
-        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
-    end
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
+    local duration      = math.floor((5 + tp / 200) * resist)
+    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage
 end)
@@ -88,8 +84,7 @@ m:addOverride('xi.actions.weaponskills.viper_bite.onUseWeaponSkill', function(pl
     local actionElement = xi.element.WATER
     local power         = 3
     local skillType     = xi.skill.DAGGER
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor((30 + 6 * tp / 100) * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
@@ -269,8 +264,7 @@ m:addOverride('xi.actions.weaponskills.mordant_rime.onUseWeaponSkill', function(
     local effectId      = xi.effect.WEIGHT
     local actionElement = xi.element.WIND
     local skillType     = xi.skill.DAGGER
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     if math.random(1, 100) <= tp / 30 * resist then
         local power         = 25
         local duration      = math.floor(60 * resist)

--- a/modules/era/lua/toau/weaponskills/great_axe.lua
+++ b/modules/era/lua/toau/weaponskills/great_axe.lua
@@ -21,8 +21,7 @@ m:addOverride('xi.actions.weaponskills.shield_break.onUseWeaponSkill', function(
     local actionElement = xi.element.ICE
     local power         = 40
     local skillType     = xi.skill.GREAT_AXE
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor((120 + 6 * tp / 100) * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
@@ -68,8 +67,7 @@ m:addOverride('xi.actions.weaponskills.armor_break.onUseWeaponSkill', function(p
     local actionElement = xi.element.WIND
     local power         = 25
     local skillType     = xi.skill.GREAT_AXE
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor((120 + 6 * tp / 100) * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
@@ -103,8 +101,7 @@ m:addOverride('xi.actions.weaponskills.weapon_break.onUseWeaponSkill', function(
     local actionElement = xi.element.WATER
     local power         = 25
     local skillType     = xi.skill.GREAT_AXE
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor((120 + 6 * tp / 100) * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
@@ -135,7 +132,6 @@ m:addOverride('xi.actions.weaponskills.full_break.onUseWeaponSkill', function(pl
 
     -- Handle status effects.
     local skillType     = xi.skill.GREAT_AXE
-    local skillRank     = player:getSkillRank(skillType)
     local effects =
     {
         [1] = { xi.effect.ATTACK_DOWN,   xi.element.WATER, 12.5 },
@@ -147,7 +143,7 @@ m:addOverride('xi.actions.weaponskills.full_break.onUseWeaponSkill', function(pl
         local effectId      = effects[index][1]
         local actionElement = effects[index][2]
         local power         = effects[index][3]
-        local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+        local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
         local duration      = math.floor((120 + 6 * tp / 100) * resist)
         xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
     end
@@ -184,8 +180,7 @@ m:addOverride('xi.actions.weaponskills.metatron_torment.onUseWeaponSkill', funct
     local actionElement = xi.element.WIND
     local power         = 19
     local skillType     = xi.skill.GREAT_AXE
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor(120 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 

--- a/modules/era/lua/toau/weaponskills/great_katana.lua
+++ b/modules/era/lua/toau/weaponskills/great_katana.lua
@@ -34,8 +34,7 @@ m:addOverride('xi.actions.weaponskills.tachi_hobaku.onUseWeaponSkill', function(
     local effectId      = xi.effect.STUN
     local actionElement = xi.element.THUNDER
     local skillType     = xi.skill.GREAT_KATANA
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     if math.random(1, 100) <= tp / 30 * resist then
         local power         = 1
         local duration      = 3
@@ -131,8 +130,7 @@ m:addOverride('xi.actions.weaponskills.tachi_yukikaze.onUseWeaponSkill', functio
     local actionElement = xi.element.DARK
     local power         = 25
     local skillType     = xi.skill.GREAT_KATANA
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor(60 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
@@ -156,8 +154,7 @@ m:addOverride('xi.actions.weaponskills.tachi_gekko.onUseWeaponSkill', function(p
     local actionElement = xi.element.WIND
     local power         = 1
     local skillType     = xi.skill.GREAT_KATANA
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor(60 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
@@ -181,8 +178,7 @@ m:addOverride('xi.actions.weaponskills.tachi_kasha.onUseWeaponSkill', function(p
     local actionElement = xi.element.ICE
     local power         = 25
     local skillType     = xi.skill.GREAT_KATANA
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor(60 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 

--- a/modules/era/lua/toau/weaponskills/great_sword.lua
+++ b/modules/era/lua/toau/weaponskills/great_sword.lua
@@ -85,8 +85,7 @@ m:addOverride('xi.actions.weaponskills.shockwave.onUseWeaponSkill', function(pla
     local actionElement = xi.element.DARK
     local power         = 1
     local skillType     = xi.skill.GREAT_SWORD
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor((math.random(0, 30) + tp * 0.01) * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 

--- a/modules/era/lua/toau/weaponskills/hand_to_hand.lua
+++ b/modules/era/lua/toau/weaponskills/hand_to_hand.lua
@@ -35,8 +35,7 @@ m:addOverride('xi.actions.weaponskills.shoulder_tackle.onUseWeaponSkill', functi
     local actionElement = xi.element.THUNDER
     local power         = 1
     local skillType     = xi.skill.HAND_TO_HAND
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor(tp / 500 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 

--- a/modules/era/lua/toau/weaponskills/katana.lua
+++ b/modules/era/lua/toau/weaponskills/katana.lua
@@ -38,8 +38,7 @@ m:addOverride('xi.actions.weaponskills.blade_retsu.onUseWeaponSkill', function(p
     local actionElement = xi.element.ICE
     local power         = utils.clamp(30 + 3 * (player:getMainLvl() - target:getMainLvl()), 5, 35)
     local skillType     = xi.skill.KATANA
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor(xi.weaponskills.fTP(tp, { 30, 60, 120 }) * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
@@ -180,8 +179,7 @@ m:addOverride('xi.actions.weaponskills.blade_metsu.onUseWeaponSkill', function(p
     local actionElement = xi.element.ICE
     local power         = 10
     local skillType     = xi.skill.KATANA
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor(60 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
@@ -209,8 +207,7 @@ m:addOverride('xi.actions.weaponskills.blade_kamu.onUseWeaponSkill', function(pl
     local actionElement = xi.element.EARTH
     local power         = 10
     local skillType     = xi.skill.KATANA
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor(6 * tp / 100 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 

--- a/modules/era/lua/toau/weaponskills/marksmanship.lua
+++ b/modules/era/lua/toau/weaponskills/marksmanship.lua
@@ -55,8 +55,7 @@ m:addOverride('xi.actions.weaponskills.sniper_shot.onUseWeaponSkill', function(p
     local actionElement = xi.element.FIRE
     local power         = 10
     local skillType     = xi.skill.MARKSMANSHIP
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor(140 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 

--- a/modules/era/lua/toau/weaponskills/polearm.lua
+++ b/modules/era/lua/toau/weaponskills/polearm.lua
@@ -66,8 +66,7 @@ m:addOverride('xi.actions.weaponskills.leg_sweep.onUseWeaponSkill', function(pla
     local effectId      = xi.effect.STUN
     local actionElement = xi.element.THUNDER
     local skillType     = xi.skill.POLEARM
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     if math.random(1, 100) <= tp / 30 * resist then
         local power         = 1
         local duration      = math.floor(4 * resist)

--- a/modules/era/lua/toau/weaponskills/scythe.lua
+++ b/modules/era/lua/toau/weaponskills/scythe.lua
@@ -70,8 +70,7 @@ m:addOverride('xi.actions.weaponskills.nightmare_scythe.onUseWeaponSkill', funct
     local actionElement = xi.element.DARK
     local power         = 20
     local skillType     = xi.skill.SCYTHE
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor((6 * tp / 100) * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
@@ -124,8 +123,7 @@ m:addOverride('xi.actions.weaponskills.guillotine.onUseWeaponSkill', function(pl
     local actionElement = xi.element.WIND
     local power         = 1
     local skillType     = xi.skill.SCYTHE
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor((30 + 3 * tp / 100) * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 

--- a/modules/era/lua/toau/weaponskills/staff.lua
+++ b/modules/era/lua/toau/weaponskills/staff.lua
@@ -107,8 +107,7 @@ m:addOverride('xi.actions.weaponskills.shell_crusher.onUseWeaponSkill', function
     local actionElement = xi.element.WIND
     local power         = 25
     local skillType     = xi.skill.STAFF
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor((120 + 6 * tp / 100) * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
@@ -179,8 +178,7 @@ m:addOverride('xi.actions.weaponskills.gate_of_tartarus.onUseWeaponSkill', funct
     local actionElement = xi.element.WATER
     local power         = 18.75
     local skillType     = xi.skill.STAFF
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor(120 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
@@ -209,8 +207,7 @@ m:addOverride('xi.actions.weaponskills.vidohunir.onUseWeaponSkill', function(pla
     local actionElement = xi.element.THUNDER
     local power         = 10
     local skillType     = xi.skill.STAFF
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor(6 * tp / 100 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
@@ -240,8 +237,7 @@ m:addOverride('xi.actions.weaponskills.garland_of_bliss.onUseWeaponSkill', funct
     local actionElement = xi.element.WIND
     local power         = 12.5
     local skillType     = xi.skill.STAFF
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor((6 * tp / 100) * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 

--- a/modules/era/lua/toau/weaponskills/sword.lua
+++ b/modules/era/lua/toau/weaponskills/sword.lua
@@ -69,8 +69,7 @@ m:addOverride('xi.actions.weaponskills.flat_blade.onUseWeaponSkill', function(pl
     local effectId      = xi.effect.STUN
     local actionElement = xi.element.THUNDER
     local skillType     = xi.skill.SWORD
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     if math.random(1, 100) <= tp / 30 * resist then
         local power         = 1
         local duration      = math.floor(4 * resist)
@@ -350,8 +349,7 @@ m:addOverride('xi.actions.weaponskills.death_blossom.onUseWeaponSkill', function
     local actionElement = xi.element.THUNDER
     local power         = 10
     local skillType     = xi.skill.SWORD
-    local skillRank     = player:getSkillRank(skillType)
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, skillRank, actionElement, 0, effectId, 0)
+    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
     local duration      = math.floor(60 * resist) -- TODO: Chance to apply varies with TP.
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Corrects the calculateResistRate functions to only use skill and not skill + rank

## Steps to test these changes

Enable them in the init, use status weaponskills