### PR TITLE
[Module] [lua] original pDif caps

### DIFF
--- a/modules/era/lua/base/combat/original_pdif_caps.lua
+++ b/modules/era/lua/base/combat/original_pdif_caps.lua
@@ -1,0 +1,29 @@
+-----------------------------------
+-- Original pDIF caps for the base game.
+-- Date : 2007-08-27 (One day before the ToAU 2H update)
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+
+local m = Module:new('original_pdif_caps')
+
+xi.combat.physical.pDifWeaponCapTable[xi.skill.HAND_TO_HAND    ] = { 2, 2 }
+xi.combat.physical.pDifWeaponCapTable[xi.skill.DAGGER          ] = { 2, 2 }
+xi.combat.physical.pDifWeaponCapTable[xi.skill.SWORD           ] = { 2, 2 }
+xi.combat.physical.pDifWeaponCapTable[xi.skill.GREAT_SWORD     ] = { 2, 2 }
+xi.combat.physical.pDifWeaponCapTable[xi.skill.AXE             ] = { 2, 2 }
+xi.combat.physical.pDifWeaponCapTable[xi.skill.GREAT_AXE       ] = { 2, 2 }
+xi.combat.physical.pDifWeaponCapTable[xi.skill.SCYTHE          ] = { 2, 2 }
+xi.combat.physical.pDifWeaponCapTable[xi.skill.POLEARM         ] = { 2, 2 }
+xi.combat.physical.pDifWeaponCapTable[xi.skill.KATANA          ] = { 2, 2 }
+xi.combat.physical.pDifWeaponCapTable[xi.skill.GREAT_KATANA    ] = { 2, 2 }
+xi.combat.physical.pDifWeaponCapTable[xi.skill.CLUB            ] = { 2, 2 }
+xi.combat.physical.pDifWeaponCapTable[xi.skill.STAFF           ] = { 2, 2 }
+xi.combat.physical.pDifWeaponCapTable[xi.skill.AUTOMATON_MELEE ] = { 2, 2 }
+xi.combat.physical.pDifWeaponCapTable[xi.skill.AUTOMATON_RANGED] = { 3, 3 }
+xi.combat.physical.pDifWeaponCapTable[xi.skill.AUTOMATON_MAGIC ] = { 2, 2 }
+xi.combat.physical.pDifWeaponCapTable[xi.skill.ARCHERY         ] = { 3, 3 }
+xi.combat.physical.pDifWeaponCapTable[xi.skill.MARKSMANSHIP    ] = { 3, 3 }
+xi.combat.physical.pDifWeaponCapTable[xi.skill.THROWING        ] = { 3, 3 }
+
+return m


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a module for original pDif caps - for any servers trying to emulate damage as it was before Aug. 28th 2007 when 2H pDif changed.

## Steps to test these changes

Enable in the init, do a lot less damage
