### PR TITLE
[core] Do not manually delete spawnSlots

### DIFF
--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -182,10 +182,6 @@ CMobEntity::~CMobEntity()
     if (spawnSlot)
     {
         spawnSlot->RemoveMob(this);
-        if (spawnSlot->IsEmpty())
-        {
-            destroy(spawnSlot);
-        }
     }
 
     if (PParty)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Manually destroying spawn slots is not needed - the destructor properly cleans it up anyway

## Steps to test these changes

run xi_map in debug mode, let it launch, run `exit` as a command on xi_map and get no errors on exit
