### PR TITLE
[core] Load hitbox for instance entities

### DIFF
--- a/src/map/instance_loader.cpp
+++ b/src/map/instance_loader.cpp
@@ -78,7 +78,7 @@ CInstance* CInstanceLoader::LoadInstance() const
                                  "Element, mob_pools.familyid, name_prefix, entityFlags, animationsub, "
                                  "(mob_family_system.HP / 100) AS hp_scale, (mob_family_system.MP / 100) AS mp_scale, hasSpellScript, spellList, mob_groups.poolid, "
                                  "allegiance, namevis, aggro, mob_pools.skill_list_id, mob_pools.true_detection, detects, "
-                                 "mob_family_system.charmable "
+                                 "mob_family_system.charmable, mob_pools.modelSize, mob_pools.modelHitboxSize "
                                  "FROM instance_entities INNER JOIN mob_spawn_points ON instance_entities.id = mob_spawn_points.mobid "
                                  "INNER JOIN mob_groups ON mob_groups.groupid = mob_spawn_points.groupid AND mob_groups.zoneid=((mob_spawn_points.mobid>>12)&0xFFF) "
                                  "INNER JOIN mob_pools ON mob_groups.poolid = mob_pools.poolid "
@@ -200,10 +200,12 @@ CInstance* CInstanceLoader::LoadInstance() const
 
             PMob->m_Pool = rset->get<uint32>("poolid");
 
-            PMob->allegiance = rset->get<ALLEGIANCE_TYPE>("allegiance");
-            PMob->namevis    = rset->get<uint8>("namevis");
-            const auto aggro = rset->get<uint32>("aggro");
-            PMob->m_Aggro    = aggro;
+            PMob->allegiance      = rset->get<ALLEGIANCE_TYPE>("allegiance");
+            PMob->namevis         = rset->get<uint8>("namevis");
+            PMob->modelHitboxSize = std::max<float>(0.0f, rset->getOrDefault<float>("modelHitboxSize", 0) / 10.f);
+            PMob->modelSize       = rset->getOrDefault<uint8>("modelSize", 0);
+            const auto aggro      = rset->get<uint32>("aggro");
+            PMob->m_Aggro         = aggro;
             // If a special instanced mob aggros, it should always aggro regardless of level.
             if (PMob->m_Type & MOBTYPE_EVENT)
             {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Loads model size and hitbox for instance mobs, this was missed because we have the same query in 5 different places.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Closes #9151

## Steps to test these changes
Enter instance, see mobs have hitboxes

<img width="980" height="1020" alt="image" src="https://github.com/user-attachments/assets/a217146b-ec24-49c6-a9c1-18638ce88232" />

<!-- Clear and detailed steps to test your changes here -->
