### PR TITLE
[fix,lua] Define criticalHit for ranged automaton damage display

### DIFF
--- a/scripts/globals/automatonweaponskills.lua
+++ b/scripts/globals/automatonweaponskills.lua
@@ -127,6 +127,7 @@ xi.autows.doAutoRangedWeaponskill = function(attacker, target, wsID, wsParams, t
         forcedFirstCrit = false,
         extraOffhandHit = false,
         flourishEffect = false,
+        criticalHit = false,
         alpha = 1,
         bonusWSmods = math.max(attacker:getMainLvl() - target:getMainLvl(), 0),
         bonusTP = wsParams.bonusTP or 0,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Was causing stack traces on the setCritical call because it wasn't initialized.

Closes #9136
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
