### PR TITLE
[lua] Ouryu Cometh Loot Bugfix

### DIFF
--- a/scripts/battlefields/Riverne_Site_A01/ouryu_cometh.lua
+++ b/scripts/battlefields/Riverne_Site_A01/ouryu_cometh.lua
@@ -42,11 +42,6 @@ content.groups =
     {
         mobs           = { 'Ouryu' },
         superlinkGroup = 1,
-
-        -- This death handler needs to be defined locally since there is no armoury crate.
-        allDeath = function(battlefield, mob)
-            battlefield:setStatus(xi.battlefield.status.WON)
-        end,
     },
 
     {

--- a/scripts/zones/Riverne-Site_A01/mobs/Ouryu.lua
+++ b/scripts/zones/Riverne-Site_A01/mobs/Ouryu.lua
@@ -200,6 +200,12 @@ end
 
 entity.onMobDeath = function(mob, player, optParams)
     player:addTitle(xi.title.OURYU_OVERWHELMER)
+    if optParams.isKiller or optParams.noKiller then
+        local battlefield = mob:getBattlefield()
+        if battlefield then
+            battlefield:setStatus(xi.battlefield.status.WON)
+        end
+    end
 end
 
 return entity


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Moves the battlefield victory into Ouryus onDeath so loot has time to process

## Steps to test these changes

Run Ouryu Cometh in Riverne A, see loot drop
