### PR TITLE
[lua] Additional Effect Animation param support

### DIFF
--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -617,6 +617,17 @@ local additionalEffects =
 }
 
 --[[
+    Helper function for xi.mob.onAddEffect that resolves the add-effect animation.
+--]]
+local addEffectAnimation = function(ae, params)
+    if params and params.sub ~= nil then
+        return params.sub
+    end
+
+    return ae.sub
+end
+
+--[[
     Helper function for xi.mob.onAddEffect that applies a status effect.
 --]]
 local addEffectStatus = function(mob, target, ae, params)
@@ -641,7 +652,8 @@ local addEffectStatus = function(mob, target, ae, params)
             ae.code(mob, target, power)
         end
 
-        return ae.sub, ae.msg, ae.eff
+        local subEffect = addEffectAnimation(ae, params)
+        return subEffect, ae.msg, ae.eff
     end
 
     return 0, 0, 0
@@ -650,14 +662,15 @@ end
 --[[
     Helper function for xi.mob.onAddEffect that dispels an effect.
 --]]
-local addEffectDispel = function(target, ae)
+local addEffectDispel = function(target, ae, params)
     local dispelledEffect = target:dispelStatusEffect(xi.effectFlag.DISPELABLE)
 
     if dispelledEffect == xi.effect.NONE then
         return 0, 0, 0
     end
 
-    return ae.sub, ae.msg, dispelledEffect
+    local subEffect = addEffectAnimation(ae, params)
+    return subEffect, ae.msg, dispelledEffect
 end
 
 --[[
@@ -714,7 +727,8 @@ local addEffectImmediate = function(mob, target, damage, ae, params)
             ae.code(mob, target, power)
         end
 
-        return ae.sub, message, power
+        local subEffect = addEffectAnimation(ae, params)
+        return subEffect, message, power
     end
 
     return 0, 0, 0
@@ -727,6 +741,7 @@ end
         chance: percent chance that effect procs on hit (default 20)
         power: power of effect
         duration: duration of effect, in seconds
+        sub: animation of the effect
         code: additional code that will run when effect procs, of form function(mob, target, power)
     params will override effect's default settings
 --]]
@@ -756,7 +771,7 @@ xi.mob.onAddEffect = function(mob, target, damage, effect, params)
 
             -- DISPEL
             elseif effect == xi.mob.ae.DISPEL and target then
-                return addEffectDispel(target, ae)
+                return addEffectDispel(target, ae, params)
 
             -- IMMEDIATE EFFECT
             else


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds the ability to override the animation for additional effects defined in mobs.lua

For example :

`return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.DISPEL, { chance = 100, sub = xi.subEffect.DEATH, })`

Otherwise, sub will default to the regular animation.

Tested all 3 types of AE : Damage, Status & Dispel, all work okay.

Marked as a draft for now as there may be a better way to handle this. 
    
## Steps to test these changes

Set up an additional effect, and define a different animation with sub = xi.subEffect

## Why do we need this? 

Thris has found some unconventional animations for some additional effects we haven't seen before and there is no doubt we will find more as capturing efforts continue.

Death for Petrification and Enblizzard for Terror.

https://youtu.be/egFMgHQyvuc?t=2

https://youtu.be/aRf8DXxyDVc?t=264
