### PR TITLE
Fix Nerve Gas ID for Tinnin Bulwarks

### DIFF
--- a/scripts/actions/mobskills/polar_bulwark.lua
+++ b/scripts/actions/mobskills/polar_bulwark.lua
@@ -20,7 +20,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     mob:addStatusEffectEx(xi.effect.MAGIC_SHIELD, 0, 1, 0, 45)
     skill:setMsg(xi.msg.basic.SKILL_GAIN_EFFECT)
     if mob:getFamily() == 313 then -- Tinnin follows this up immediately with Nerve Gas
-        mob:useMobAbility(1580)
+        mob:useMobAbility(1836)
     end
 
     return xi.effect.MAGIC_SHIELD

--- a/scripts/actions/mobskills/pyric_bulwark.lua
+++ b/scripts/actions/mobskills/pyric_bulwark.lua
@@ -21,7 +21,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     mob:addStatusEffectEx(xi.effect.PHYSICAL_SHIELD, 0, 1, 0, 45)
     skill:setMsg(xi.msg.basic.SKILL_GAIN_EFFECT)
     if mob:getFamily() == 313 then -- Tinnin follows this up immediately with Nerve Gas
-        mob:useMobAbility(1580)
+        mob:useMobAbility(1836)
     end
 
     return xi.effect.PHYSICAL_SHIELD


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR corrects a mobskill ID in Pyric Bulwark and Polar Bulwark; when used by Tinnin, those moves should be followed by Nerve Gas (ID 1836), not Damnation Dive (ID 1580).

## Steps to test these changes

Fight Tinnin, see that he doesn't contort himself into a pretzel doing the wrong TP move
