### PR TITLE
[lua] Cleanup Tinnin mob logic script

### DIFF
--- a/scripts/actions/mobskills/polar_bulwark.lua
+++ b/scripts/actions/mobskills/polar_bulwark.lua
@@ -16,12 +16,8 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    -- addEx to pervent dispel
-    mob:addStatusEffectEx(xi.effect.MAGIC_SHIELD, 0, 1, 0, 45)
     skill:setMsg(xi.msg.basic.SKILL_GAIN_EFFECT)
-    if mob:getFamily() == 313 then -- Tinnin follows this up immediately with Nerve Gas
-        mob:useMobAbility(1836)
-    end
+    mob:addStatusEffectEx(xi.effect.MAGIC_SHIELD, 0, 1, 0, 45) -- addStatusEffectEx to pervent dispel.
 
     return xi.effect.MAGIC_SHIELD
 end

--- a/scripts/actions/mobskills/pyric_bulwark.lua
+++ b/scripts/actions/mobskills/pyric_bulwark.lua
@@ -8,7 +8,6 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    -- TODO: Used only when second/left head is alive (animationsub 0 or 1)
     if mob:getAnimationSub() <= 1 then
         return 0
     else
@@ -17,12 +16,8 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    -- addEx to pervent dispel
-    mob:addStatusEffectEx(xi.effect.PHYSICAL_SHIELD, 0, 1, 0, 45)
     skill:setMsg(xi.msg.basic.SKILL_GAIN_EFFECT)
-    if mob:getFamily() == 313 then -- Tinnin follows this up immediately with Nerve Gas
-        mob:useMobAbility(1836)
-    end
+    mob:addStatusEffectEx(xi.effect.PHYSICAL_SHIELD, 0, 1, 0, 45) -- addStatusEffectEx to pervent dispel.
 
     return xi.effect.PHYSICAL_SHIELD
 end

--- a/scripts/enum/mob_skill.lua
+++ b/scripts/enum/mob_skill.lua
@@ -595,6 +595,14 @@ xi.mobSkill =
 
     XENOGLOSSIA                   = 1823, -- Unique entry.
 
+    PYRIC_BLAST                   = 1828,
+    PYRIC_BULWARK                 = 1829,
+    POLAR_BLAST                   = 1830,
+    POLAR_BULWARK                 = 1831,
+    BAROFIELD                     = 1832,
+
+    NERVE_GAS                     = 1836,
+
     SANDBLAST_2                   = 1841,
     SANDPIT_2                     = 1842,
     VENOM_SPRAY_2                 = 1843,

--- a/scripts/zones/Wajaom_Woodlands/mobs/Tinnin.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Tinnin.lua
@@ -3,7 +3,6 @@
 --  ZNM: Tinnin
 -- !pos 276 0 -694
 -- Spawned with Monkey Wine: @additem 2573
--- Wiki: http://ffxiclopedia.wikia.com/wiki/Tinnin
 -----------------------------------
 mixins =
 {
@@ -14,105 +13,77 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
+local function regenerateHead(mob, animationSub)
+    -- Reset timer.
+    mob:setLocalVar('headTimer', GetSystemTime() + math.random(90, 210))
+
+    -- Set animationSub.
+    mob:setAnimationSub(animationSub - 1)
+
+    -- Handle health regeneration.
+    local multiplier = 0.05
+
+    -- 2 heads to 3 heads.
+    if animationSub == 1 then
+        if mob:getLocalVar('head3Regeneration') == 0 then
+            mob:setLocalVar('head3Regeneration', 1)
+            multiplier = 0.25
+
+            mob:setMod(xi.mod.REGEN, 10) -- Lower regeneration.
+            mob:setUnkillable(false)     -- Allow death.
+        end
+
+    -- 1 head to 2 heads.
+    elseif animationSub == 2 then
+        if mob:getLocalVar('head2Regeneration') == 0 then
+            mob:setLocalVar('head2Regeneration', 1)
+            multiplier = 0.25
+        end
+    end
+
+    mob:addHP(mob:getMaxHP() * multiplier)
+end
+
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.GIL_MIN, 12000)
     mob:setMobMod(xi.mobMod.GIL_MAX, 30000)
     mob:setMobMod(xi.mobMod.MUG_GIL, 8000)
-    mob:setMod(xi.mod.UDMGBREATH, -10000) -- immune to breath damage
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 300)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('[rage]timer', 3600) -- 60 minutes
     mob:setHP(mob:getMaxHP() / 2)
     mob:setUnkillable(true)
-    mob:setMod(xi.mod.REGEN, 50)
 
-    -- Regen Head every 1.5-4 minutes 90-240
-    mob:setLocalVar('headTimer', GetSystemTime() + math.random(60, 190))
+    mob:setMod(xi.mod.REGEN, 50)
+    mob:setMod(xi.mod.UDMGBREATH, -10000) -- Immune to breath damage
+
+    mob:setLocalVar('[rage]timer', 3600) -- 60 minutes
+
+    mob:setLocalVar('headTimer', GetSystemTime() + math.random(90, 210))
+    mob:setLocalVar('head2Regeneration', 0)
+    mob:setLocalVar('head3Regeneration', 0)
 
     -- Number of crits to lose a head
-    mob:setLocalVar('CritToTheFace', math.random(10, 30))
-    mob:setLocalVar('crits', 0)
+    mob:setLocalVar('criticalsThreshold', math.random(10, 30))
+    mob:setLocalVar('criticalsTaken', 0)
 end
 
 entity.onMobRoam = function(mob)
-    -- Regen head
-    local headTimer = mob:getLocalVar('headTimer')
-    if mob:getAnimationSub() == 2 and GetSystemTime() > headTimer then
-        mob:setAnimationSub(1)
-        mob:setLocalVar('headTimer', GetSystemTime() + math.random(60, 190))
-
-        -- First time it regens second head, 25%. Reduced afterwards.
-        if mob:getLocalVar('secondHead') == 0 then
-            mob:addHP(mob:getMaxHP() * .25)
-            mob:setLocalVar('secondHead', 1)
-        else
-            mob:addHP(mob:getMaxHP() * .05)
-        end
-
-    elseif mob:getAnimationSub() == 1 and GetSystemTime() > headTimer then
-        mob:setAnimationSub(0)
-        mob:setLocalVar('headTimer', GetSystemTime() + math.random(60, 190))
-
-        -- First time it regens third head, 25%. Reduced afterwards.
-        if mob:getLocalVar('thirdHead') == 0 then
-            mob:addHP(mob:getMaxHP() * .25)
-            mob:setMod(xi.mod.REGEN, 10)
-            mob:setLocalVar('thirdHead', 1)
-            mob:setUnkillable(false) -- It can be killed now that has all his heads
-        else
-            mob:addHP(mob:getMaxHP() * .05)
-        end
+    -- Regen head logic.
+    local animationSub = mob:getAnimationSub()
+    if animationSub == 0 then
+        return
     end
+
+    if GetSystemTime() < mob:getLocalVar('headTimer') then
+        return
+    end
+
+    regenerateHead(mob, animationSub)
 end
 
 entity.onMobFight = function(mob, target)
-    local headTimer = mob:getLocalVar('headTimer')
-    if mob:getAnimationSub() == 2 and GetSystemTime() > headTimer then
-        mob:setAnimationSub(1)
-        mob:setLocalVar('headTimer', GetSystemTime() + math.random(60, 190))
-
-        -- First time it regens second head, 25%. Reduced afterwards.
-        if mob:getLocalVar('secondHead') == 0 then
-            mob:addHP(mob:getMaxHP() * .25)
-            mob:setLocalVar('secondHead', 1)
-        else
-            mob:addHP(mob:getMaxHP() * .05)
-        end
-
-        if bit.band(mob:getBehavior(), xi.behavior.NO_TURN) > 0 then -- disable no turning for the forced mobskills upon head growth
-            mob:setBehavior(bit.band(mob:getBehavior(), bit.bnot(xi.behavior.NO_TURN)))
-        end
-
-        -- These need to be listed in reverse order as forced moves are added to the top of the queue.
-        mob:useMobAbility(1830) -- Polar Blast
-        mob:useMobAbility(1832) -- Barofield
-
-    elseif mob:getAnimationSub() == 1 and GetSystemTime() > headTimer then
-        mob:setAnimationSub(0)
-        mob:setLocalVar('headTimer', GetSystemTime() + math.random(60, 190))
-
-        -- First time it regens third head, 25%. Reduced afterwards.
-        if mob:getLocalVar('thirdHead') == 0 then
-            mob:setMod(xi.mod.REGEN, 10)
-            mob:addHP(mob:getMaxHP() * .25)
-            mob:setLocalVar('thirdHead', 1)
-            mob:setUnkillable(false) -- It can be killed now that has all his heads
-        else
-            mob:addHP(mob:getMaxHP() * .05)
-        end
-
-        if bit.band(mob:getBehavior(), xi.behavior.NO_TURN) > 0 then -- disable no turning for the forced mobskills upon head growth
-            mob:setBehavior(bit.band(mob:getBehavior(), bit.bnot(xi.behavior.NO_TURN)))
-        end
-
-        -- Reverse order, same deal.
-        mob:useMobAbility(1828) -- Pyric Blast
-        mob:useMobAbility(1830) -- Polar Blast
-        mob:useMobAbility(1832) -- Barofield
-    end
-
     local drawInTable =
     {
         conditions =
@@ -121,39 +92,68 @@ entity.onMobFight = function(mob, target)
         },
         position = mob:getPos(),
     }
+
     if drawInTable.conditions[1] then
         if utils.drawIn(target, drawInTable) then
             mob:addTP(3000) -- Uses a mobskill upon drawing in a player. Not necessarily on the person drawn in.
         end
     end
+
+    -- Regen head logic.
+    local animationSub = mob:getAnimationSub()
+    if animationSub == 0 then
+        return -- No heads to regen.
+    end
+
+    if GetSystemTime() < mob:getLocalVar('headTimer') then
+        return -- Can't regen head yet.
+    end
+
+    regenerateHead(mob, animationSub)
+
+    -- Mobskill chain logic.
+    if bit.band(mob:getBehavior(), xi.behavior.NO_TURN) > 0 then -- disable no turning for the forced mobskills upon head growth
+        mob:setBehavior(bit.band(mob:getBehavior(), bit.bnot(xi.behavior.NO_TURN)))
+    end
+
+    -- Reverse order, same deal.
+    mob:useMobAbility(xi.mobSkill.BAROFIELD)
+end
+
+entity.onMobWeaponSkill = function(target, mob, skill)
+    local skillId = skill:getID()
+
+    -- Barofield -> Polar Blast -> Pyric Blast chain.
+    if skillId == xi.mobSkill.BAROFIELD then
+        mob:useMobAbility(xi.mobSkill.POLAR_BLAST)
+    elseif skillId == xi.mobSkill.POLAR_BLAST then
+        if mob:getAnimationSub() == 0 then
+            mob:useMobAbility(xi.mobSkill.PYRIC_BLAST)
+        end
+
+    -- Pyric/Polar Bulwark -> Nerve Gas
+    elseif skillId == xi.mobSkill.PYRIC_BULWARK then
+        mob:useMobAbility(xi.mobSkill.NERVE_GAS)
+    elseif skillId == xi.mobSkill.POLAR_BULWARK then
+        mob:useMobAbility(xi.mobSkill.NERVE_GAS)
+    end
 end
 
 entity.onCriticalHit = function(mob)
-    local critNum = mob:getLocalVar('crits')
-
-    if (critNum + 1) > mob:getLocalVar('CritToTheFace') then  -- Lose a head
-        if mob:getAnimationSub() == 0 then
-            mob:setAnimationSub(1)
-            mob:setLocalVar('headTimer', GetSystemTime() + math.random(60, 190))
-        elseif mob:getAnimationSub() == 1 then
-            mob:setAnimationSub(2)
-            mob:setLocalVar('headTimer', GetSystemTime() + math.random(60, 190))
-        else
-            -- Meh
-        end
-
-        -- Number of crits to lose a head, re-randoming
-        mob:setLocalVar('CritToTheFace', math.random(10, 30))
-
-        critNum = 0 -- reset the crits on the NM
-    else
-        critNum = critNum + 1
+    local animationSub = mob:getAnimationSub()
+    if animationSub == 2 then
+        return -- No heads to loose.
     end
 
-    mob:setLocalVar('crits', critNum)
-end
+    local criticalCounter = mob:getLocalVar('criticalsTaken') + 1
+    if criticalCounter >= mob:getLocalVar('criticalsThreshold') then
+        criticalCounter = 0 -- Reset critical count.
+        mob:setAnimationSub(animationSub + 1)
+        mob:setLocalVar('headTimer', GetSystemTime() + math.random(90, 210))
+        mob:setLocalVar('criticalsThreshold', math.random(10, 30)) -- Reset critical threshold.
+    end
 
-entity.onMobDeath = function(mob, player, optParams)
+    mob:setLocalVar('criticalsTaken', criticalCounter)
 end
 
 return entity


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
As title sais.
- Enums mobskill magic numbers.
- Resets variables properly.
- Simplifies logic.
- Removes combat logic from mobskill scripts.

## Steps to test these changes
Fight Tinnin. Retail accuracy is besides the point, the aim isn't to fix it's behavior.
