### PR TITLE
[sql] Rolanberry Fields NM Audits

### DIFF
--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -8305,7 +8305,7 @@ INSERT INTO `mob_groups` VALUES (3,1991,110,'Horrid_Fluke',0,128,895,0,0,28,30,0
 INSERT INTO `mob_groups` VALUES (4,5868,110,'Greater_Pugil_fished',0,128,147,0,0,31,33,0);
 INSERT INTO `mob_groups` VALUES (5,418,110,'Big_Leech',0,128,79,0,0,34,36,0);
 
-INSERT INTO `mob_groups` VALUES (6,3625,110,'Silk_Caterpillar',0,128,2248,675,0,28,30,0);
+INSERT INTO `mob_groups` VALUES (6,3625,110,'Silk_Caterpillar',0,128,2248,700,0,28,30,0);
 INSERT INTO `mob_groups` VALUES (7,941,110,'Death_Wasp',300,0,584,0,0,22,26,0);
 INSERT INTO `mob_groups` VALUES (8,2735,110,'Moon_Bat',300,2,461,0,0,23,26,0);
 INSERT INTO `mob_groups` VALUES (9,1757,110,'Goobbue_Farmer',300,0,1200,0,0,28,32,0);
@@ -8338,7 +8338,7 @@ INSERT INTO `mob_groups` VALUES (35,1267,110,'Evil_Weapon',300,0,0,0,0,36,38,0);
 INSERT INTO `mob_groups` VALUES (36,6025,110,'Ravenous_Crawler',7200,0,3097,3500,0,42,42,0);
 INSERT INTO `mob_groups` VALUES (37,1266,110,'Evil_Spirit',300,1,264,0,0,35,38,0);
 INSERT INTO `mob_groups` VALUES (38,5729,110,'Eldritch_Edge',0,32,2993,5096,0,55,55,0);
-INSERT INTO `mob_groups` VALUES (39,1124,110,'Drooling_Daisy',0,32,712,0,0,39,40,0);
+INSERT INTO `mob_groups` VALUES (39,1124,110,'Drooling_Daisy',0,32,712,1400,0,39,40,0);
 INSERT INTO `mob_groups` VALUES (40,6658,110,'Goblin_Digger',300,0,1040,0,0,28,32,0);
 INSERT INTO `mob_groups` VALUES (41,3630,110,'Simurgh',0,128,2255,46200,0,58,58,0);
 INSERT INTO `mob_groups` VALUES (42,3745,110,'Sprite',0,128,2001,0,0,61,63,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Audits for a couple NMs in Rolanberry Fields based on retail captures. Thank you to Wuku and Hiox for the captures. The changes in this pull request include:

**[Drooling Daisy](https://www.youtube.com/watch?v=tl9AWmIro20)** (ID: 17228236)

- Adjusted HP.

**[Silk Caterpillar](https://www.youtube.com/watch?v=xcj9Nl2l2GI)** (ID: 17227782)

- Adjusted HP.

## Steps to test these changes

!spawnmob the above IDs and observe the changes.
