### PR TITLE
[fix] Persist respawn task during zone sleep

### DIFF
--- a/src/map/spawn_handler.cpp
+++ b/src/map/spawn_handler.cpp
@@ -58,6 +58,21 @@ void SpawnHandler::registerForRespawn(CMobEntity* PMob, const std::optional<time
     }
 }
 
+auto SpawnHandler::isRegistered(CMobEntity* PMob) const -> bool
+{
+    if (!PMob)
+    {
+        return false;
+    }
+
+    if (SpawnSlot* slot = PMob->GetSpawnSlot())
+    {
+        return pendingSlotRespawns_.contains(slot);
+    }
+
+    return pendingRespawns_.contains(PMob->id);
+}
+
 // Every 30 seconds, attempt to spawn any mob pending respawn.
 // Mobs are respawned if:
 // - Their respawn timer is due within the next 15s (half interval)

--- a/src/map/spawn_handler.h
+++ b/src/map/spawn_handler.h
@@ -48,6 +48,7 @@ public:
 
     void Tick(timer::time_point now);
     void registerForRespawn(CMobEntity* PMob, std::optional<timer::duration> respawnTime = std::nullopt);
+    auto isRegistered(CMobEntity* PMob) const -> bool;
     void onTOTDChange(vanadiel_time::TOTD totd) const;
     void onWeatherChange(Weather weather) const;
     auto canSpawnNow(const CMobEntity* PMob) const -> bool;

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -95,6 +95,13 @@ CZone::CZone(ZONEID ZoneID, REGION_TYPE RegionID, CONTINENT_TYPE ContinentID, ui
     LoadZoneLines();
     LoadZoneWeather();
 
+    SpawnHandlerTimer = CTaskManager::getInstance()->AddTask(m_zoneName + "_SpawnHandler", timer::now(), this, CTaskManager::TASK_INTERVAL, kSpawnHandlerInterval, [](const timer::time_point tick, const CTaskManager::CTask* PTask)
+                                                             {
+                                                                 const auto* PZone = std::any_cast<CZone*>(PTask->m_data);
+                                                                 PZone->spawnHandler()->Tick(tick);
+                                                                 return 0;
+                                                             });
+
     // NOTE: Heavy resources like Navmesh are now loaded outside of the constructor in zoneutils::LoadZoneList
 }
 
@@ -953,17 +960,6 @@ void CZone::createZoneTimers()
         PZone->CheckTriggerAreas();
         return 0;
     });
-
-    if (!SpawnHandlerTimer)
-    {
-        SpawnHandlerTimer = CTaskManager::getInstance()->AddTask(m_zoneName + "_SpawnHandler", timer::now(), this, CTaskManager::TASK_INTERVAL, kSpawnHandlerInterval,
-        [](const timer::time_point tick, const CTaskManager::CTask* PTask)
-        {
-            const auto*  PZone = std::any_cast<CZone*>(PTask->m_data);
-            PZone->spawnHandler()->Tick(tick);
-            return 0;
-        });
-    }
 }
 
 void CZone::CharZoneIn(CCharEntity* PChar)

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -846,12 +846,6 @@ void CZone::ZoneServer(timer::time_point tick)
 
         ZoneTimerTriggerAreas->m_type = CTaskManager::TASK_REMOVE;
         ZoneTimerTriggerAreas         = nullptr;
-
-        if (SpawnHandlerTimer)
-        {
-            SpawnHandlerTimer->m_type = CTaskManager::TASK_REMOVE;
-            SpawnHandlerTimer         = nullptr;
-        }
     }
 }
 
@@ -960,14 +954,16 @@ void CZone::createZoneTimers()
         return 0;
     });
 
-    SpawnHandlerTimer = CTaskManager::getInstance()->AddTask(m_zoneName + "_SpawnHandler", timer::now(), this, CTaskManager::TASK_INTERVAL, kSpawnHandlerInterval,
-    [](const timer::time_point tick, const CTaskManager::CTask* PTask)
+    if (!SpawnHandlerTimer)
     {
-        const auto*  PZone = std::any_cast<CZone*>(PTask->m_data);
-        PZone->spawnHandler()->Tick(tick);
-        return 0;
-    });
-    // clang-format on
+        SpawnHandlerTimer = CTaskManager::getInstance()->AddTask(m_zoneName + "_SpawnHandler", timer::now(), this, CTaskManager::TASK_INTERVAL, kSpawnHandlerInterval,
+        [](const timer::time_point tick, const CTaskManager::CTask* PTask)
+        {
+            const auto*  PZone = std::any_cast<CZone*>(PTask->m_data);
+            PZone->spawnHandler()->Tick(tick);
+            return 0;
+        });
+    }
 }
 
 void CZone::CharZoneIn(CCharEntity* PChar)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
May have forgotten zones going to sleep was a thing.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Added a debug print and watched mobs respawn while zone was inactive

```
[01/19/26 08:24:46:424][map][debug] Spawning Tunnel_Worm in West_Ronfaure (zone empty) (SpawnHandler::Tick::<lambda_1>::operator ():96)
[01/19/26 08:27:48:303][map][debug] Spawning Hilltroll_Paladin in Mount_Zhayolm (zone empty) (SpawnHandler::Tick::<lambda_1>::operator ():96)
[01/19/26 08:27:48:303][map][debug] Spawning Hilltroll_Monk in Mount_Zhayolm (zone empty) (SpawnHandler::Tick::<lambda_1>::operator ():96)
```

<!-- Clear and detailed steps to test your changes here -->
