### PR TITLE
[ci] Allow some log failures if retry passes

### DIFF
--- a/.github/workflows/docker_test.yml
+++ b/.github/workflows/docker_test.yml
@@ -130,7 +130,7 @@ jobs:
           github-report: true
           summary: true
           pull-request: false
-          status-check: true
+          status-check: ${{ github.event_name != 'pull_request' }}
           status-check-name: "xi_test (${{ format('docker-{0}', inputs.os) }})"
           annotate: true
           upload-artifact: true

--- a/.github/workflows/docker_test.yml
+++ b/.github/workflows/docker_test.yml
@@ -152,7 +152,7 @@ jobs:
                   if grep -qi "warning\|error\|crash\|critical" "$log_file"; then
                       found_issues=true
                       log_name=$(basename "$log_file" .log | sed 's/.*/\u&/; s/-\(.\)/ \u\1/g')
-                      echo "### :x: ${log_name} Checks Failed" >> $GITHUB_STEP_SUMMARY
+                      echo "### :warning: ${log_name} Checks" >> $GITHUB_STEP_SUMMARY
                       echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
                       grep -i "warning\|error\|crash\|critical" "$log_file" >> $GITHUB_STEP_SUMMARY
                       echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
@@ -160,12 +160,9 @@ jobs:
                   fi
               fi
           done
-          if [[ "$found_issues" == "false" ]]; then
-              if [[ "${{ steps.startup_checks.outcome }}" != "success" ]]; then
-                  echo "### :x: Startup checks failed, but no specific errors were found." >> $GITHUB_STEP_SUMMARY
-                  echo "Check the logs for details." >> $GITHUB_STEP_SUMMARY
-                  found_issues=true
-              fi
+          if [[ "$found_issues" == "false" && "${{ steps.startup_checks.outcome }}" != "success" ]]; then
+              echo "### :x: Startup checks failed, but no specific errors were found." >> $GITHUB_STEP_SUMMARY
+              echo "Check the logs for details." >> $GITHUB_STEP_SUMMARY
           fi
           echo "<details><summary><h4>View Logs</h4></summary>" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -179,7 +176,6 @@ jobs:
               fi
           done
           echo "</details>" >> $GITHUB_STEP_SUMMARY
-          echo "issues_found=$found_issues" >> $GITHUB_OUTPUT
 
       - name: Stop container
         run: |
@@ -187,7 +183,7 @@ jobs:
           docker rm test-server
 
       - name: Fail Workflow if Checks Failed
-        if: ${{ steps.xi_test.outcome == 'failure' || steps.startup_checks.outcome == 'failure' || steps.summarize_checks.outputs.issues_found == 'true' }}
+        if: ${{ steps.xi_test.outcome == 'failure' || steps.startup_checks.outcome == 'failure' }}
         run: |
           echo "Startup checks failed. See summary for details."
           exit 1

--- a/.github/workflows/runner_test.yml
+++ b/.github/workflows/runner_test.yml
@@ -202,7 +202,7 @@ jobs:
                   if grep -qi "warning\|error\|crash\|critical" "$log_file"; then
                       found_issues=true
                       log_name=$(basename "$log_file" .log | sed 's/.*/\u&/; s/-\(.\)/ \u\1/g')
-                      echo "### :x: ${log_name} Checks Failed" >> $GITHUB_STEP_SUMMARY
+                      echo "### :warning: ${log_name} Checks" >> $GITHUB_STEP_SUMMARY
                       echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
                       grep -i "warning\|error\|crash\|critical" "$log_file" >> $GITHUB_STEP_SUMMARY
                       echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
@@ -210,12 +210,9 @@ jobs:
                   fi
               fi
           done
-          if [[ "$found_issues" == "false" ]]; then
-              if [[ "${{ steps.startup_checks.outcome }}" != "success" ]]; then
-                  echo "### :x: Startup checks failed, but no specific errors were found." >> $GITHUB_STEP_SUMMARY
-                  echo "Check the logs for details." >> $GITHUB_STEP_SUMMARY
-                  found_issues=true
-              fi
+          if [[ "$found_issues" == "false" && "${{ steps.startup_checks.outcome }}" != "success" ]]; then
+              echo "### :x: Startup checks failed, but no specific errors were found." >> $GITHUB_STEP_SUMMARY
+              echo "Check the logs for details." >> $GITHUB_STEP_SUMMARY
           fi
           echo "<details><summary><h4>View Logs</h4></summary>" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -229,10 +226,9 @@ jobs:
               fi
           done
           echo "</details>" >> $GITHUB_STEP_SUMMARY
-          echo "issues_found=$found_issues" >> $GITHUB_OUTPUT
 
       - name: Fail Workflow if Checks Failed
-        if: ${{ steps.xi_test.outcome == 'failure' || steps.startup_checks.outcome == 'failure' || steps.summarize_checks.outputs.issues_found == 'true' }}
+        if: ${{ steps.xi_test.outcome == 'failure' || steps.startup_checks.outcome == 'failure' }}
         run: |
           echo "Startup checks failed. See summary for details."
           exit 1

--- a/.github/workflows/runner_test.yml
+++ b/.github/workflows/runner_test.yml
@@ -176,7 +176,7 @@ jobs:
           github-report: true
           summary: true
           pull-request: false
-          status-check: true
+          status-check: ${{ github.event_name != 'pull_request' }}
           status-check-name: 'xi_test (${{ inputs.runner }})'
           annotate: true
           upload-artifact: true


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Startup checks script already fails if there are errors, then will retry. If a retry succeeds, we don't want to fail the workflow due to logs from the failed attempt. Still report them in the summary for information purposes. Should prevent failures due to this error if it succeeds on a retry:

```
[map][critical] Failed to create MapSocket: bind: Address already in use (MapNetworking:89)
```

Also removes the attempt to publish a status check for PR runs. Think this is what's causing that "Resource not accessible by integration" warning. I don't think the status check is necessary here since it's handled as part of the workflow.

## Steps to test these changes

Workflow should pass without any warnings. Any real log errors should be showing up in every retry and will be failed by the startup checks script.
