### PR TITLE
[sql] Implement Castle O spawn slots

### DIFF
--- a/sql/mob_spawn_slots.sql
+++ b/sql/mob_spawn_slots.sql
@@ -371,6 +371,47 @@ INSERT INTO `mob_spawn_slots` VALUES (145,113,0);
 INSERT INTO `mob_spawn_slots` VALUES (150, 1, 0);
 INSERT INTO `mob_spawn_slots` VALUES (150, 2, 0);
 
+-- Oldton Movalpolos
+INSERT INTO `mob_spawn_slots` VALUES (151,1,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,2,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,3,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,4,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,5,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,6,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,7,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,8,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,9,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,10,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,11,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,12,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,13,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,14,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,15,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,16,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,17,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,18,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,19,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,20,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,21,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,22,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,23,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,24,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,25,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,26,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,27,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,28,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,29,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,30,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,31,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,32,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,33,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,34,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,35,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,36,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,37,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,38,0);
+INSERT INTO `mob_spawn_slots` VALUES (151,39,0);
+
 -- Korroloka Tunnel
 INSERT INTO `mob_spawn_slots` VALUES (173, 1, 0);
 INSERT INTO `mob_spawn_slots` VALUES (173, 2, 0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Implement Castle O with new system and new info. Going ID by ID to find the correct spawn information.

While doing this ran into a fun little experiment with mee deggi where I confirmed that it does indeed spawn anytime within the time the PH to when it spawns...and also re-spawns the PH regardless if the NM is alive or not. Will come in a different PR but need to do little more research on it.

https://docs.google.com/spreadsheets/d/1Ioi5Bp0BABeHBnywTscdCnZQm6Er8tec-PwX6ir4B2w/edit?gid=2124211904#gid=2124211904

<img width="1164" height="453" alt="image" src="https://github.com/user-attachments/assets/71945330-92e3-4b60-aef3-9593c00ff1f3" />


<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!gotoid 17396087
Kill it
See it spawn 17396087 or 17396090
<!-- Clear and detailed steps to test your changes here -->
