### PR TITLE
[lua] AE : Dark parameter fix

### DIFF
--- a/scripts/zones/King_Ranperres_Tomb/mobs/Vrtra.lua
+++ b/scripts/zones/King_Ranperres_Tomb/mobs/Vrtra.lua
@@ -185,7 +185,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         chance         = 25,
         attackType     = xi.attackType.MAGICAL,
         magicalElement = xi.element.DARK,
-        power          = damage / 2,
+        basePower      = damage / 2,
         actorStat      = xi.mod.INT,
     }
 

--- a/scripts/zones/Labyrinth_of_Onzozo/mobs/Hellion.lua
+++ b/scripts/zones/Labyrinth_of_Onzozo/mobs/Hellion.lua
@@ -47,7 +47,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         chance         = 100,
         attackType     = xi.attackType.MAGICAL,
         magicalElement = xi.element.DARK,
-        power          = damage / 2,
+        basePower      = damage / 2,
         actorStat      = xi.mod.INT,
     }
 

--- a/scripts/zones/Nyzul_Isle/mobs/Hellion.lua
+++ b/scripts/zones/Nyzul_Isle/mobs/Hellion.lua
@@ -16,7 +16,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         chance         = 100,
         attackType     = xi.attackType.MAGICAL,
         magicalElement = xi.element.DARK,
-        power          = damage / 2,
+        basePower      = damage / 2,
         actorStat      = xi.mod.INT,
     }
 

--- a/scripts/zones/Promyvion-Vahzl/mobs/Provoker.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Provoker.lua
@@ -56,7 +56,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         chance         = 100,
         attackType     = xi.attackType.MAGICAL,
         magicalElement = mob:getLocalVar('element'),
-        power          = damage / 2,
+        basePower      = damage / 2,
         actorStat      = xi.mod.INT,
     }
 

--- a/scripts/zones/Xarcabard/mobs/Ereshkigal.lua
+++ b/scripts/zones/Xarcabard/mobs/Ereshkigal.lua
@@ -26,7 +26,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         chance         = 100,
         attackType     = xi.attackType.MAGICAL,
         magicalElement = xi.element.DARK,
-        power          = damage / 2,
+        basePower      = damage / 2,
         actorStat      = xi.mod.INT,
     }
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The damage additional effect system is looking for basePower and not power, switches these additional effects over to basePower so the param does not default to 0.

## Steps to test these changes

Fight Vrtra