### PR TITLE
[lua] xi.mobSkillList enum support

### DIFF
--- a/scripts/enum/mob_skill_list.lua
+++ b/scripts/enum/mob_skill_list.lua
@@ -1,0 +1,7 @@
+xi = xi or {}
+
+---@enum xi.mobSkillList
+xi.mobSkillList =
+{
+    COUNTERSPORE_ATTACK = 2088,
+}

--- a/scripts/zones/Horlais_Peak/mobs/Archer_Pugil.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Archer_Pugil.lua
@@ -10,7 +10,7 @@ local entity = {}
 entity.onMobInitialize = function(mob)
     mob:setBehavior(xi.behavior.STANDBACK)
     mob:setMobMod(xi.mobMod.STANDBACK_RANGE, 12)
-    mob:setMobSkillAttack(2088) -- Will use Counterspore as their auto-attack.
+    mob:setMobSkillAttack(xi.mobSkillList.COUNTERSPORE_ATTACK)
 end
 
 return entity

--- a/scripts/zones/Horlais_Peak/mobs/Sniper_Pugil.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Sniper_Pugil.lua
@@ -10,7 +10,7 @@ local entity = {}
 entity.onMobInitialize = function(mob)
     mob:setBehavior(xi.behavior.STANDBACK)
     mob:setMobMod(xi.mobMod.STANDBACK_RANGE, 12)
-    mob:setMobSkillAttack(2088) -- Will use Counterspore as their auto-attack.
+    mob:setMobSkillAttack(xi.mobSkillList.COUNTERSPORE_ATTACK)
 end
 
 -- Mimics the "shared hate" behavior observed in captures. Archer Pugils assist the Sniper Pugil and seem to change targets after Sniper Pugil attacks.


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Creates support for the xi.mobSkillList enum namespace.
Mainly for mobs that use the mobSkillAttack mob mod to change their auto attacks. 
This allows us to clean up hard coded skill list IDs into something readable at a glance. 

## Steps to test these changes

Run Shooting Fish
