### PR TITLE
[lua] Enwater conversion, retire ae.enwater from mobs.lua

### DIFF
--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -319,16 +319,6 @@ local additionalEffects =
         bonusAbilityParams = { bonusmab = 0, includemab = false },
     },
 
-    [xi.mob.ae.ENWATER] =
-    {
-        ele                = xi.element.WATER,
-        sub                = xi.subEffect.WATER_DAMAGE,
-        msg                = xi.msg.basic.ADD_EFFECT_DMG,
-        negMsg             = xi.msg.basic.ADD_EFFECT_HEAL,
-        mod                = xi.mod.INT,
-        bonusAbilityParams = { bonusmab = 0, includemab = false },
-    },
-
     [xi.mob.ae.EVASION_DOWN] =
     {
         chance      = 25,

--- a/scripts/zones/Bibiki_Bay/mobs/Dalham.lua
+++ b/scripts/zones/Bibiki_Bay/mobs/Dalham.lua
@@ -19,7 +19,16 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENWATER, { chance = 100 })
+    local pTable =
+    {
+        chance         = 100,
+        attackType     = xi.attackType.MAGICAL,
+        magicalElement = xi.element.WATER,
+        basePower      = math.floor(damage / 2),
+        actorStat      = xi.mod.INT,
+    }
+
+    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/Bibiki_Bay/mobs/Splacknuck.lua
+++ b/scripts/zones/Bibiki_Bay/mobs/Splacknuck.lua
@@ -34,7 +34,16 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENWATER)
+    local pTable =
+    {
+        chance         = 100,
+        attackType     = xi.attackType.MAGICAL,
+        magicalElement = xi.element.WATER,
+        basePower      = math.floor(damage / 2),
+        actorStat      = xi.mod.INT,
+    }
+
+    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Cape_Teriggan/mobs/Tegmine.lua
+++ b/scripts/zones/Cape_Teriggan/mobs/Tegmine.lua
@@ -35,7 +35,16 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENWATER)
+    local pTable =
+    {
+        chance         = 100,
+        attackType     = xi.attackType.MAGICAL,
+        magicalElement = xi.element.WATER,
+        basePower      = math.floor(damage / 2),
+        actorStat      = xi.mod.INT,
+    }
+
+    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Carpenters_Landing/mobs/Tempest_Tigon.lua
+++ b/scripts/zones/Carpenters_Landing/mobs/Tempest_Tigon.lua
@@ -67,11 +67,16 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    if math.random(1, 100) <= 50 then
-        return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENAERO, { chance = 50 })
-    else
-        return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENWATER, { chance = 50 })
-    end
+    local pTable =
+    {
+        chance         = 50,
+        attackType     = xi.attackType.MAGICAL,
+        magicalElement = math.random(1, 100) <= 50 and xi.element.WIND or xi.element.WATER,
+        basePower      = math.floor(damage / 2),
+        actorStat      = xi.mod.INT,
+    }
+
+    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Cloister_of_Tides/mobs/Leviathan_Prime_TBW.lua
+++ b/scripts/zones/Cloister_of_Tides/mobs/Leviathan_Prime_TBW.lua
@@ -38,7 +38,16 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENWATER, { chance = 100, power = math.random(20, 40) })
+    local pTable =
+    {
+        chance         = 100,
+        attackType     = xi.attackType.MAGICAL,
+        magicalElement = xi.element.WATER,
+        basePower      = math.floor(damage / 2),
+        actorStat      = xi.mod.INT,
+    }
+
+    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/Cloister_of_Tides/mobs/Leviathan_Prime_TSTBW.lua
+++ b/scripts/zones/Cloister_of_Tides/mobs/Leviathan_Prime_TSTBW.lua
@@ -41,7 +41,16 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENWATER, { chance = 100, power = math.random(15, 25) })
+    local pTable =
+    {
+        chance         = 100,
+        attackType     = xi.attackType.MAGICAL,
+        magicalElement = xi.element.WATER,
+        basePower      = math.floor(damage / 2),
+        actorStat      = xi.mod.INT,
+    }
+
+    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
 end
 
 entity.onMobEngage = function(mob, target)

--- a/scripts/zones/Cloister_of_Tides/mobs/Leviathan_Prime_WTB.lua
+++ b/scripts/zones/Cloister_of_Tides/mobs/Leviathan_Prime_WTB.lua
@@ -41,7 +41,16 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENWATER, { chance = 100, power = math.random(75, 125) })
+    local pTable =
+    {
+        chance         = 100,
+        attackType     = xi.attackType.MAGICAL,
+        magicalElement = xi.element.WATER,
+        basePower      = math.floor(damage / 2),
+        actorStat      = xi.mod.INT,
+    }
+
+    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
 end
 
 entity.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/zones/Dangruf_Wadi/mobs/Chocoboleech.lua
+++ b/scripts/zones/Dangruf_Wadi/mobs/Chocoboleech.lua
@@ -10,7 +10,16 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENWATER)
+    local pTable =
+    {
+        chance         = 100,
+        attackType     = xi.attackType.MAGICAL,
+        magicalElement = xi.element.WATER,
+        basePower      = math.floor(damage / 2),
+        actorStat      = xi.mod.INT,
+    }
+
+    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Gusgen_Mines/mobs/Juggler_Hecatomb.lua
+++ b/scripts/zones/Gusgen_Mines/mobs/Juggler_Hecatomb.lua
@@ -18,7 +18,16 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENWATER)
+    local pTable =
+    {
+        chance         = 100,
+        attackType     = xi.attackType.MAGICAL,
+        magicalElement = xi.element.WATER,
+        basePower      = math.floor(damage / 2),
+        actorStat      = xi.mod.INT,
+    }
+
+    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
 end
 
 return entity

--- a/scripts/zones/Kuftal_Tunnel/mobs/Cancer.lua
+++ b/scripts/zones/Kuftal_Tunnel/mobs/Cancer.lua
@@ -13,7 +13,16 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENWATER)
+    local pTable =
+    {
+        chance         = 25,
+        attackType     = xi.attackType.MAGICAL,
+        magicalElement = xi.element.WATER,
+        basePower      = math.floor(damage / 2),
+        actorStat      = xi.mod.INT,
+    }
+
+    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Misareaux_Coast/mobs/Ziphius.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Ziphius.lua
@@ -10,7 +10,16 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENWATER)
+    local pTable =
+    {
+        chance         = 100,
+        attackType     = xi.attackType.MAGICAL,
+        magicalElement = xi.element.WATER,
+        basePower      = math.floor(damage / 2),
+        actorStat      = xi.mod.INT,
+    }
+
+    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Mount_Zhayolm/mobs/Chary_Apkallu.lua
+++ b/scripts/zones/Mount_Zhayolm/mobs/Chary_Apkallu.lua
@@ -13,7 +13,16 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENWATER)
+    local pTable =
+    {
+        chance         = 100,
+        attackType     = xi.attackType.MAGICAL,
+        magicalElement = xi.element.WATER,
+        basePower      = math.floor(damage / 2),
+        actorStat      = xi.mod.INT,
+    }
+
+    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Qufim_Island/mobs/Qoofim.lua
+++ b/scripts/zones/Qufim_Island/mobs/Qoofim.lua
@@ -10,7 +10,16 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENWATER)
+    local pTable =
+    {
+        chance         = 100,
+        attackType     = xi.attackType.MAGICAL,
+        magicalElement = xi.element.WATER,
+        basePower      = math.floor(damage / 2),
+        actorStat      = xi.mod.INT,
+    }
+
+    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/RuAun_Gardens/mobs/Genbu.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Genbu.lua
@@ -47,7 +47,16 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENWATER)
+    local pTable =
+    {
+        chance         = 100,
+        attackType     = xi.attackType.MAGICAL,
+        magicalElement = xi.element.WATER,
+        basePower      = math.floor(damage / 2),
+        actorStat      = xi.mod.INT,
+    }
+
+    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/The_Boyahda_Tree/mobs/Aquarius.lua
+++ b/scripts/zones/The_Boyahda_Tree/mobs/Aquarius.lua
@@ -53,7 +53,16 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENWATER)
+    local pTable =
+    {
+        chance         = 25,
+        attackType     = xi.attackType.MAGICAL,
+        magicalElement = xi.element.WATER,
+        basePower      = math.floor(damage / 2),
+        actorStat      = xi.mod.INT,
+    }
+
+    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Genbu.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Genbu.lua
@@ -30,7 +30,16 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENWATER)
+    local pTable =
+    {
+        chance         = 100,
+        attackType     = xi.attackType.MAGICAL,
+        magicalElement = xi.element.WATER,
+        basePower      = math.floor(damage / 2),
+        actorStat      = xi.mod.INT,
+    }
+
+    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
 end
 
 return entity

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Pyuu_the_Spatemaker.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Pyuu_the_Spatemaker.lua
@@ -31,7 +31,16 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENWATER)
+    local pTable =
+    {
+        chance         = 100,
+        attackType     = xi.attackType.MAGICAL,
+        magicalElement = xi.element.WATER,
+        basePower      = math.floor(damage / 2),
+        actorStat      = xi.mod.INT,
+    }
+
+    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Converts ae.enwater over to the new system, retires ae.enwater from mobs.lua

## Steps to test these changes

Fight Tempest Tigon in Carpenters Landing 
