### PR TITLE
[Core] Edit/reorder mobskill choosing logic so lua can know if its override should happen

### DIFF
--- a/scripts/specs/types/MobEntity.lua
+++ b/scripts/specs/types/MobEntity.lua
@@ -26,7 +26,7 @@
 ---@field onMobRoam? fun(mob: CBaseEntity)
 ---@field onMobDespawn? fun(mob: CBaseEntity)
 ---@field onPlayerAbilityUse? fun(mob: CBaseEntity, player: CBaseEntity, ability: CAbility)
----@field onMobMobskillChoose? fun(mob: CBaseEntity, target: CBaseEntity): integer?
+---@field onMobMobskillChoose? fun(mob: CBaseEntity, target: CBaseEntity, skillId: integer): integer?
 ---@field onMobWeaponSkill? fun(target: CBaseEntity, mob: CBaseEntity, mobSkill: CMobSkill, action: CAction): integer?
 ---@field onMobSkillTarget? fun(target: CBaseEntity, mob: CBaseEntity, mobSkill: CMobSkill): CBaseEntity?
 ---@field onAdditionalEffect? fun(mob: CBaseEntity, target: CBaseEntity, damage: integer): (any, any, integer?)

--- a/scripts/zones/Abyssea-La_Theine/mobs/Briareus.lua
+++ b/scripts/zones/Abyssea-La_Theine/mobs/Briareus.lua
@@ -47,7 +47,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local cueMove = mob:getLocalVar('CUE_MOVE')
     mob:setLocalVar('CUE_MOVE', 0)
 

--- a/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
@@ -225,7 +225,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     if mob:getAnimationSub() == 1 then
         mob:setLocalVar('skill_tp', mob:getTP())
     end

--- a/scripts/zones/Aydeewa_Subterrane/mobs/Great_Ameretat.lua
+++ b/scripts/zones/Aydeewa_Subterrane/mobs/Great_Ameretat.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts.mixins.families.morbol_toau') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return target:countEffectWithFlag(xi.effectFlag.DISPELABLE) > 0 and xi.mobSkill.VAMPIRIC_ROOT or 0
 end
 

--- a/scripts/zones/Balgas_Dais/mobs/Giant_Moa.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Giant_Moa.lua
@@ -33,7 +33,7 @@ local mobskillTable =
     [4] = { xi.mobSkill.CONTAGION_TRANSFER,      40 },
 }
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local randomRoll = math.random(1, 100)
     local weightSum  = 0
     for i = 1, #mobskillTable do

--- a/scripts/zones/Balgas_Dais/mobs/Gilagoge_Tlugvi.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Gilagoge_Tlugvi.lua
@@ -53,7 +53,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
     return xi.combat.action.executeAdditionalDispel(mob, target, pTable)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mobSkill.ENTANGLE
 end
 

--- a/scripts/zones/Balgas_Dais/mobs/Goga_Tlugvi.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Goga_Tlugvi.lua
@@ -48,7 +48,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
 end
 
 -- Only uses Leafstorm.
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mobSkill.LEAFSTORM
 end
 

--- a/scripts/zones/Balgas_Dais/mobs/Gola_Tlugvi.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Gola_Tlugvi.lua
@@ -47,7 +47,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
     return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.TP_DRAIN, { chance = 15, power = math.random (50, 1100) })
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mobSkill.DRILL_BRANCH
 end
 

--- a/scripts/zones/Balgas_Dais/mobs/Macan_Gadangan.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Macan_Gadangan.lua
@@ -40,7 +40,7 @@ entity.onMobFight = function(mob, target)
 end
 
 -- We only use Frenzied Rage if our spells are interrupted
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local mobskillList =
     {
         xi.mobSkill.CHARGED_WHISKER,

--- a/scripts/zones/Balgas_Dais/mobs/Nenaunir.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Nenaunir.lua
@@ -33,7 +33,7 @@ entity.onMobSpellChoose = function(mob, target, spellId)
 end
 
 -- Only uses Healing Breeze as a weapon skill.
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mobSkill.HEALING_BREEZE
 end
 

--- a/scripts/zones/Balgas_Dais/mobs/Nenaunirs_Wife.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Nenaunirs_Wife.lua
@@ -15,7 +15,7 @@ entity.onMobEngage = function(mob, target)
 end
 
 -- Only uses Stomping as a weapon skill.
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mobSkill.STOMPING
 end
 

--- a/scripts/zones/Balgas_Dais/mobs/Ulagohvsdi_Tlugvi.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Ulagohvsdi_Tlugvi.lua
@@ -49,7 +49,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
 end
 
 -- Only uses Pinecone Bomb.
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mobSkill.PINECONE_BOMB
 end
 

--- a/scripts/zones/Bearclaw_Pinnacle/mobs/Snoll_Tzar.lua
+++ b/scripts/zones/Bearclaw_Pinnacle/mobs/Snoll_Tzar.lua
@@ -75,7 +75,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     if
         mob:getAnimationSub() == 7 and
         math.random(1, 100) <= 75

--- a/scripts/zones/Beaucedine_Glacier_[S]/mobs/Dryptotaur.lua
+++ b/scripts/zones/Beaucedine_Glacier_[S]/mobs/Dryptotaur.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/families/tauri') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpMoves =
     {
         xi.mobSkill.TRICLIP_1,

--- a/scripts/zones/Bhaflau_Thickets/mobs/Ameretat.lua
+++ b/scripts/zones/Bhaflau_Thickets/mobs/Ameretat.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts.mixins.families.morbol_toau') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return target:countEffectWithFlag(xi.effectFlag.DISPELABLE) > 0 and xi.mobSkill.VAMPIRIC_ROOT or 0
 end
 

--- a/scripts/zones/Boneyard_Gully/mobs/Bladmall.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Bladmall.lua
@@ -162,7 +162,7 @@ end
 -----------------------------------
 -- TP Moves - If in shell, use Venom Shell, otherwise, select from other skills
 -----------------------------------
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     if mob:getAnimationSub() == 1 then
         return xi.mobSkill.VENOM_SHELL_1
     end

--- a/scripts/zones/Boneyard_Gully/mobs/Parata.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Parata.lua
@@ -156,7 +156,7 @@ end
 -----------------------------------
 -- TP Moves - If in shell, use Venom Shell, otherwise, select from other skills
 -----------------------------------
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     if mob:getAnimationSub() == 1 then
         return xi.mobSkill.VENOM_SHELL_1
     end

--- a/scripts/zones/Boneyard_Gully/mobs/Shikaree_X_HW.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Shikaree_X_HW.lua
@@ -65,7 +65,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpMoves =
     {
         xi.mobSkill.DANCING_EDGE,

--- a/scripts/zones/Boneyard_Gully/mobs/Shikaree_X_ROS_TWT.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Shikaree_X_ROS_TWT.lua
@@ -175,7 +175,7 @@ end
 -----------------------------------
 -- Solo weaponskill messages.
 -----------------------------------
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     if mob:getLocalVar('scStep') == 0 then
         mob:messageText(mob, messages.SOLO_WEAPONSKILL)
     end

--- a/scripts/zones/Boneyard_Gully/mobs/Shikaree_Y_HW.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Shikaree_Y_HW.lua
@@ -53,7 +53,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpMoves =
     {
         xi.mobSkill.GUILLOTINE_1,

--- a/scripts/zones/Boneyard_Gully/mobs/Shikaree_Y_ROS_TWT.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Shikaree_Y_ROS_TWT.lua
@@ -178,7 +178,7 @@ end
 -----------------------------------
 -- Solo weaponskill messages.
 -----------------------------------
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     if mob:getLocalVar('scStep') == 0 then
         mob:messageText(mob, messages.SOLO_WEAPONSKILL)
     end

--- a/scripts/zones/Boneyard_Gully/mobs/Shikaree_Z_HW.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Shikaree_Z_HW.lua
@@ -72,7 +72,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpMoves =
     {
         xi.mobSkill.IMPULSE_DRIVE,

--- a/scripts/zones/Boneyard_Gully/mobs/Shikaree_Zs_Wyvern.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Shikaree_Zs_Wyvern.lua
@@ -17,7 +17,7 @@ entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.REGAIN, 70)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local battlefield = mob:getBattlefield()
     if not battlefield then
         return 0

--- a/scripts/zones/Castle_Zvahl_Keep_[S]/mobs/Titanotaur.lua
+++ b/scripts/zones/Castle_Zvahl_Keep_[S]/mobs/Titanotaur.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/families/tauri') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpMoves =
     {
         xi.mobSkill.TRICLIP_1,

--- a/scripts/zones/Dynamis-Valkurm/mobs/Cirrate_Christelle.lua
+++ b/scripts/zones/Dynamis-Valkurm/mobs/Cirrate_Christelle.lua
@@ -16,7 +16,7 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.WEAPON_BONUS, 50)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     -- TODO: Need to implement skill ID changes based on which NMs were killed. Needs more captures.
 end
 

--- a/scripts/zones/Dynamis-Valkurm/mobs/Nantina.lua
+++ b/scripts/zones/Dynamis-Valkurm/mobs/Nantina.lua
@@ -12,7 +12,7 @@ entity.onMobSpawn = function(mob)
     mob:setLocalVar('nantina_skill_count', 0)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     -- Blow x9 > Uppercut x3 > Attractant
     local skillCount = mob:getLocalVar('nantina_skill_count')
 

--- a/scripts/zones/Empyreal_Paradox/mobs/Ealdnarche.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Ealdnarche.lua
@@ -29,7 +29,7 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local spellList =
     {
         xi.mobSkill.OMEGA_JAVELIN_1,

--- a/scripts/zones/Empyreal_Paradox/mobs/Kamlanaut.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Kamlanaut.lua
@@ -50,7 +50,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpList =
     {
         xi.mobSkill.GREAT_WHEEL_1,

--- a/scripts/zones/Empyreal_Paradox/mobs/Prishe.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Prishe.lua
@@ -229,7 +229,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     if
         target:hasStatusEffect(xi.effect.PHYSICAL_SHIELD) or
         target:hasStatusEffect(xi.effect.MAGIC_SHIELD)

--- a/scripts/zones/Empyreal_Paradox/mobs/Promathia.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Promathia.lua
@@ -85,7 +85,7 @@ entity.onSpellPrecast = function(mob, spell)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local battlefield = mob:getBattlefield()
     if not battlefield then
         return

--- a/scripts/zones/Empyreal_Paradox/mobs/Promathia_2.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Promathia_2.lua
@@ -97,7 +97,7 @@ entity.onMobSpellChoose = function(mob, target, spellId)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpList = {}
     if
         mob:hasStatusEffect(xi.effect.PHYSICAL_SHIELD) or

--- a/scripts/zones/Empyreal_Paradox/mobs/Selhteus.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Selhteus.lua
@@ -296,7 +296,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mobSkill.REVELATION_1
 end
 

--- a/scripts/zones/FeiYin/mobs/Sluagh.lua
+++ b/scripts/zones/FeiYin/mobs/Sluagh.lua
@@ -32,7 +32,7 @@ entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.STORETP, 125) -- 6 hits to 1k tp
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mobSkill.GRAVE_REEL
 end
 

--- a/scripts/zones/Full_Moon_Fountain/mobs/Carbuncle_Prime.lua
+++ b/scripts/zones/Full_Moon_Fountain/mobs/Carbuncle_Prime.lua
@@ -20,7 +20,7 @@ entity.onMobSpawn = function(mob)
     mob:addImmunity(xi.immunity.GRAVITY)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     -- use healing_ruby_ii with only a 5% chance (as much rarer than the other carby skills)
     if math.random(1, 20) == 1 then
         return 911

--- a/scripts/zones/Ghelsba_Outpost/mobs/Cyranuce_M_Cutauleon.lua
+++ b/scripts/zones/Ghelsba_Outpost/mobs/Cyranuce_M_Cutauleon.lua
@@ -11,7 +11,7 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     if mob:getHPP() <= 15 then
         return xi.mobSkill.CHAOS_BREATH
     end

--- a/scripts/zones/Ghelsba_Outpost/mobs/Kalamainu.lua
+++ b/scripts/zones/Ghelsba_Outpost/mobs/Kalamainu.lua
@@ -19,7 +19,7 @@ entity.onMobEngage = function(mob, target)
     mob:useMobAbility(xi.mobSkill.SECRETION_1)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local mobskillTable =
     {
         [1] = { xi.mobSkill.TAIL_BLOW_1,         10 },

--- a/scripts/zones/Ghelsba_Outpost/mobs/Kilioa.lua
+++ b/scripts/zones/Ghelsba_Outpost/mobs/Kilioa.lua
@@ -19,7 +19,7 @@ entity.onMobEngage = function(mob, target)
     mob:useMobAbility(xi.mobSkill.SECRETION_1)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local mobskillTable =
     {
         [1] = { xi.mobSkill.TAIL_BLOW_1,         10 },

--- a/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Eozdei.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Eozdei.lua
@@ -17,7 +17,7 @@ entity.onPath = function(mob)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local form = mob:getAnimationSub()
     local tpMoves = { xi.mobSkill.REACTOR_COOL }
 

--- a/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Ixghrah.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Ixghrah.lua
@@ -77,7 +77,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     -- Only uses Actinic Burst when using TP normally
     return xi.mobSkill.ACTINIC_BURST
 end

--- a/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Jailer_of_Temperance.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Jailer_of_Temperance.lua
@@ -101,7 +101,7 @@ entity.onMobFight = function(mob)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local form = mob:getAnimationSub()
     local tpMoves = { xi.mobSkill.REACTOR_COOL }
 

--- a/scripts/zones/Grauberg_[S]/mobs/Vasiliceratops.lua
+++ b/scripts/zones/Grauberg_[S]/mobs/Vasiliceratops.lua
@@ -30,7 +30,7 @@ entity.onMobInitialize = function(mob)
     mob:setBaseSpeed(100)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return 2099 -- Batterhorn is only TP move
 end
 

--- a/scripts/zones/Halvung/mobs/Big_Bomb.lua
+++ b/scripts/zones/Halvung/mobs/Big_Bomb.lua
@@ -15,7 +15,7 @@ entity.onMobSpawn = function(mob)
     mob:addImmunity(xi.immunity.STUN)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mix.growingBomb.onMobMobskillChoose(mob, target)
 end
 

--- a/scripts/zones/Halvung/mobs/Friars_Lantern_Grow.lua
+++ b/scripts/zones/Halvung/mobs/Friars_Lantern_Grow.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/families/growing_bomb') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mix.growingBomb.onMobMobskillChoose(mob, target)
 end
 

--- a/scripts/zones/Hazhalm_Testing_Grounds/mobs/Freke.lua
+++ b/scripts/zones/Hazhalm_Testing_Grounds/mobs/Freke.lua
@@ -34,7 +34,7 @@ entity.onMobSpawn = function(mob)
     mob:setLocalVar('gohSequence', 0)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local gohSequence = mob:getLocalVar('gohSequence')
 
     if gohSequence == 1 then

--- a/scripts/zones/Hazhalm_Testing_Grounds/mobs/Hakenmann.lua
+++ b/scripts/zones/Hazhalm_Testing_Grounds/mobs/Hakenmann.lua
@@ -32,7 +32,7 @@ entity.onMobSpawn = function(mob)
     mob:setLocalVar('tpMoveCount', 3)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     if mob:getLocalVar('tpMoveCount') == 0 then
         mob:setLocalVar('tpMoveCount', 3)
     end

--- a/scripts/zones/Hazhalm_Testing_Grounds/mobs/Hildesvini.lua
+++ b/scripts/zones/Hazhalm_Testing_Grounds/mobs/Hildesvini.lua
@@ -30,7 +30,7 @@ entity.onMobSpawn = function(mob)
     despawnDjiggas()
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local anyAlive = utils.any(DJIGGAS, function(_, mobId)
         local djigga = GetMobByID(mobId)
         if djigga and djigga:isAlive() then

--- a/scripts/zones/Hazhalm_Testing_Grounds/mobs/Mokkuralfi.lua
+++ b/scripts/zones/Hazhalm_Testing_Grounds/mobs/Mokkuralfi.lua
@@ -20,7 +20,7 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 10)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     if
         mob:getHPP() <= 20 and
         mob:getLocalVar('xenoglossia') == 0

--- a/scripts/zones/Hazhalm_Testing_Grounds/mobs/Motsognir.lua
+++ b/scripts/zones/Hazhalm_Testing_Grounds/mobs/Motsognir.lua
@@ -90,7 +90,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     -- Motsognir gains access to more TP moves as its HP goes down
     local mobskillList =
     {

--- a/scripts/zones/Horlais_Peak/mobs/Aries.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Aries.lua
@@ -152,7 +152,7 @@ end
 -----------------------------------
 -- Favors certain moves over others.
 -----------------------------------
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local abilityRoll    = math.random(1, 100)
     local probabilitySum = 0
 

--- a/scripts/zones/Horlais_Peak/mobs/Compound_Eyes.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Compound_Eyes.lua
@@ -35,7 +35,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local skillList =
     {
         xi.mobSkill.DEATH_RAY,

--- a/scripts/zones/Horlais_Peak/mobs/Dragonian_Minstrel.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Dragonian_Minstrel.lua
@@ -25,7 +25,7 @@ entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.DOUBLE_ATTACK, 50)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local skills =
     {
         xi.mobSkill.VOIDSONG_1,

--- a/scripts/zones/Horlais_Peak/mobs/Gerjis.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Gerjis.lua
@@ -16,7 +16,7 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local skills =
     {
         xi.mobSkill.GERJIS_GRIP,

--- a/scripts/zones/Horlais_Peak/mobs/Houndfly.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Houndfly.lua
@@ -10,7 +10,7 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     -- Only uses Venom
     return xi.mobSkill.VENOM_1
 end

--- a/scripts/zones/Horlais_Peak/mobs/Huntfly.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Huntfly.lua
@@ -13,7 +13,7 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 15)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local skillList =
     {
         xi.mobSkill.CURSED_SPHERE_1,

--- a/scripts/zones/Horlais_Peak/mobs/Sobbing_Eyes.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Sobbing_Eyes.lua
@@ -37,7 +37,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local skillList =
     {
         xi.mobSkill.DEATH_RAY,

--- a/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Bastard.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Bastard.lua
@@ -30,7 +30,7 @@ entity.onMobSpawn = function(mob)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mobSkill.SELF_DESTRUCT_BOMB
 end
 

--- a/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Prince.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Prince.lua
@@ -30,7 +30,7 @@ entity.onMobSpawn = function(mob)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mobSkill.SELF_DESTRUCT_BOMB
 end
 

--- a/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Princess.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Princess.lua
@@ -30,7 +30,7 @@ entity.onMobSpawn = function(mob)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mobSkill.SELF_DESTRUCT_BOMB
 end
 

--- a/scripts/zones/Jugner_Forest/mobs/Cernunnos.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Cernunnos.lua
@@ -9,7 +9,7 @@ entity.onMobDeath = function(mob, player, optParams)
     player:setLocalVar('cernunnosDefeated', 1)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpMoves =
     {
         xi.mobSkill.DRILL_BRANCH_NM,

--- a/scripts/zones/King_Ranperres_Tomb/mobs/Cemetery_Cherry.lua
+++ b/scripts/zones/King_Ranperres_Tomb/mobs/Cemetery_Cherry.lua
@@ -44,7 +44,7 @@ entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.DOUBLE_ATTACK, 15)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpMoves =
     {
         xi.mobSkill.DRILL_BRANCH_NM,

--- a/scripts/zones/Lower_Delkfutts_Tower/mobs/Disaster_Idol.lua
+++ b/scripts/zones/Lower_Delkfutts_Tower/mobs/Disaster_Idol.lua
@@ -25,7 +25,7 @@ entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.REGEN, 5)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local skillList =
     {
         xi.mobSkill.KARTSTRAHL,

--- a/scripts/zones/Lufaise_Meadows/mobs/Amaltheia.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Amaltheia.lua
@@ -69,7 +69,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpMoves =
     {
         xi.mobSkill.RAGE_2,

--- a/scripts/zones/Lufaise_Meadows/mobs/Atomic_Cluster.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Atomic_Cluster.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/families/bomb_cluster') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mix.clusters.onMobMobskillChoose(mob, target)
 end
 

--- a/scripts/zones/Lufaise_Meadows/mobs/Cluster.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Cluster.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/families/bomb_cluster') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mix.clusters.onMobMobskillChoose(mob, target)
 end
 

--- a/scripts/zones/Lufaise_Meadows/mobs/Sengann.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Sengann.lua
@@ -20,7 +20,7 @@ entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.STORETP, 78)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mobSkill.BARBED_CRESCENT_1
 end
 

--- a/scripts/zones/Mamook/mobs/Mamool_Ja.lua
+++ b/scripts/zones/Mamook/mobs/Mamool_Ja.lua
@@ -124,7 +124,7 @@ entity.onMobSpawn = function(mob)
     mob:setLocalVar('justSpawned', 1)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     if mob:getAnimationSub() >= 1 then
         return xi.mobSkill.FORCEFUL_BLOW -- Will ONLY use Forceful Blow when it's weapon is broken.
     end

--- a/scripts/zones/Mine_Shaft_2716/mobs/Chekochuk.lua
+++ b/scripts/zones/Mine_Shaft_2716/mobs/Chekochuk.lua
@@ -69,7 +69,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mobSkill.GOBLIN_DICE_HEAL + math.random(0, 10)
 end
 

--- a/scripts/zones/Mine_Shaft_2716/mobs/Movamuq.lua
+++ b/scripts/zones/Mine_Shaft_2716/mobs/Movamuq.lua
@@ -38,7 +38,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mobSkill.FRYPAN_1
 end
 

--- a/scripts/zones/Mine_Shaft_2716/mobs/Swipostik.lua
+++ b/scripts/zones/Mine_Shaft_2716/mobs/Swipostik.lua
@@ -69,7 +69,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mobSkill.BOMB_TOSS_1
 end
 

--- a/scripts/zones/Mine_Shaft_2716/mobs/Trikotrak.lua
+++ b/scripts/zones/Mine_Shaft_2716/mobs/Trikotrak.lua
@@ -37,7 +37,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mobSkill.SMOKEBOMB_1
 end
 

--- a/scripts/zones/Misareaux_Coast/mobs/Atomic_Cluster.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Atomic_Cluster.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/families/bomb_cluster') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mix.clusters.onMobMobskillChoose(mob, target)
 end
 

--- a/scripts/zones/Misareaux_Coast/mobs/Boggelmann.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Boggelmann.lua
@@ -9,7 +9,7 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpMoves =
     {
         xi.mobSkill.AWFUL_EYE,

--- a/scripts/zones/Misareaux_Coast/mobs/Goaftrap.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Goaftrap.lua
@@ -15,7 +15,7 @@ entity.onMobInitialize = function(mob)
     mob:setMod(xi.mod.STORETP, 50)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mobSkill.GLOEOSUCCUS
 end
 

--- a/scripts/zones/Misareaux_Coast/mobs/Okyupete.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Okyupete.lua
@@ -31,7 +31,7 @@ entity.onMobSpawn = function(mob)
     mob:setLocalVar('nextMove', xi.mobSkill.GIGA_SCREAM_1)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return mob:getLocalVar('nextMove')
 end
 

--- a/scripts/zones/Misareaux_Coast/mobs/Upyri.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Upyri.lua
@@ -14,7 +14,7 @@ entity.onMobInitialize = function(mob)
     mob:addMod(xi.mod.REGAIN, 150)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpMoves =
     {
         xi.mobSkill.BLOOD_DRAIN_1,

--- a/scripts/zones/Monarch_Linn/mobs/Mammet-19_Epsilon.lua
+++ b/scripts/zones/Monarch_Linn/mobs/Mammet-19_Epsilon.lua
@@ -85,7 +85,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     switch (mob:getAnimationSub()): caseof
     {
         [forms.UNARMED] = function()

--- a/scripts/zones/Monarch_Linn/mobs/Mammet-800.lua
+++ b/scripts/zones/Monarch_Linn/mobs/Mammet-800.lua
@@ -220,7 +220,7 @@ end
 -----------------------------------
 -- Select TP moves based on current form.
 -----------------------------------
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local selectedMove = math.random(1, #tpMoves)
 
     return tpMoves[selectedMove]

--- a/scripts/zones/Mount_Zhayolm/mobs/Sweeping_Cluster.lua
+++ b/scripts/zones/Mount_Zhayolm/mobs/Sweeping_Cluster.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/families/bomb_cluster') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mix.clusters.onMobMobskillChoose(mob, target)
 end
 

--- a/scripts/zones/Newton_Movalpolos/mobs/Bugbear_Matman.lua
+++ b/scripts/zones/Newton_Movalpolos/mobs/Bugbear_Matman.lua
@@ -15,7 +15,7 @@ entity.onMobSpawn = function(mob)
     mob:addMod(xi.mod.REGAIN, 50)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     -- Below 30% Bugbear Matman heavily prefers Heavy Whisk
     if mob:getHPP() <= 30 and math.random(1, 100) <= 60 then
         return 358

--- a/scripts/zones/North_Gustaberg_[S]/mobs/Olgoi-Khorkhoi.lua
+++ b/scripts/zones/North_Gustaberg_[S]/mobs/Olgoi-Khorkhoi.lua
@@ -45,7 +45,7 @@ entity.onMobSpellChoose = function(mob, target, spellId)
     return spellList[math.random(1, #spellList)]
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mobSkill.SANDSPIN -- Sandspin is only TP move
 end
 

--- a/scripts/zones/Nyzul_Isle/mobs/Eriri_Samariri.lua
+++ b/scripts/zones/Nyzul_Isle/mobs/Eriri_Samariri.lua
@@ -6,7 +6,7 @@
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     if math.random(1, 4) > 1 then
         return 1957
     end

--- a/scripts/zones/Nyzul_Isle/mobs/Shielded_Chariot.lua
+++ b/scripts/zones/Nyzul_Isle/mobs/Shielded_Chariot.lua
@@ -8,7 +8,7 @@ mixins = { require('scripts/mixins/families/chariot') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     if mob:getHPP() > 25 then
         return 0
     elseif math.random(1, 2) == 2 then

--- a/scripts/zones/Pashhow_Marshlands_[S]/mobs/Sugaar.lua
+++ b/scripts/zones/Pashhow_Marshlands_[S]/mobs/Sugaar.lua
@@ -39,7 +39,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
     return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.SILENCE, { chance = 15, duration = 30 })
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     -- seems overly complicated, but is reusable code for other mobs that use skills in a sequence
     local mobskillList =
     {

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Stegotaur.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Stegotaur.lua
@@ -15,7 +15,7 @@ entity.onMobSpawn = function(mob)
     mob:setLocalVar('fomorHateAdj', 1)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpMoves =
     {
         xi.mobSkill.TRICLIP_1,

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Taurus.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Taurus.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/families/tauri') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpMoves =
     {
         xi.mobSkill.TRICLIP_1,

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Tres_Duendes.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Tres_Duendes.lua
@@ -55,7 +55,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local form = mob:getAnimationSub()
     local tpMoves =
     {

--- a/scripts/zones/Promyvion-Vahzl/mobs/Propagator.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Propagator.lua
@@ -11,7 +11,7 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 240)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpMoves =
     {
         xi.mobSkill.PROMYVION_BARRIER_2,

--- a/scripts/zones/Promyvion-Vahzl/mobs/Wailer.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Wailer.lua
@@ -61,7 +61,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     -- Only allow the Memory move that matches the current element
     return elementalTPMoves[mob:getLocalVar('currentAbsorb')]
 end

--- a/scripts/zones/QuBia_Arena/mobs/Chahnameed.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Chahnameed.lua
@@ -16,7 +16,7 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 200)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local skillList =
     {
         xi.mobSkill.INFERNAL_PESTILENCE,

--- a/scripts/zones/QuBia_Arena/mobs/Chahnameeds_Intenstine.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Chahnameeds_Intenstine.lua
@@ -11,7 +11,7 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local skillList =
     {
         xi.mobSkill.INFERNAL_PESTILENCE,

--- a/scripts/zones/QuBia_Arena/mobs/Chahnameeds_Liver.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Chahnameeds_Liver.lua
@@ -11,7 +11,7 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local skillList =
     {
         xi.mobSkill.INFERNAL_PESTILENCE,

--- a/scripts/zones/QuBia_Arena/mobs/Chahnameeds_Stomach.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Chahnameeds_Stomach.lua
@@ -12,7 +12,7 @@ entity.onMobInitialize = function(mob)
     mob:addMod(xi.mod.REGAIN, 100)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local skillList =
     {
         xi.mobSkill.INFERNAL_PESTILENCE,

--- a/scripts/zones/QuBia_Arena/mobs/Generic_Doll.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Generic_Doll.lua
@@ -51,7 +51,7 @@ local dollSkillLists =
     [5] = { xi.mobSkill.TYPHOON                             },
 }
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local battlefield = mob:getBattlefield()
     if not battlefield then
         return

--- a/scripts/zones/Riverne-Site_A01/mobs/Atomic_Cluster.lua
+++ b/scripts/zones/Riverne-Site_A01/mobs/Atomic_Cluster.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/families/bomb_cluster') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mix.clusters.onMobMobskillChoose(mob, target)
 end
 

--- a/scripts/zones/Riverne-Site_B01/mobs/Boroka.lua
+++ b/scripts/zones/Riverne-Site_B01/mobs/Boroka.lua
@@ -29,7 +29,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
     return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.WEIGHT, { power = 50 })
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpList =
     {
         xi.mobSkill.BACK_HEEL_1,

--- a/scripts/zones/Riverne-Site_B01/mobs/Nitro_Cluster.lua
+++ b/scripts/zones/Riverne-Site_B01/mobs/Nitro_Cluster.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/families/bomb_cluster') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mix.clusters.onMobMobskillChoose(mob, target)
 end
 

--- a/scripts/zones/Riverne-Site_B01/mobs/Unstable_Cluster.lua
+++ b/scripts/zones/Riverne-Site_B01/mobs/Unstable_Cluster.lua
@@ -5,7 +5,7 @@
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpList =
     {
         xi.mobSkill.REFUELING_1

--- a/scripts/zones/Rolanberry_Fields_[S]/mobs/Delicieuse_Delphine.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/mobs/Delicieuse_Delphine.lua
@@ -27,7 +27,7 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     mob:setLocalVar('impaleCount', 2)
 
     return 316 -- Impale

--- a/scripts/zones/Rolanberry_Fields_[S]/mobs/Lamina.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/mobs/Lamina.lua
@@ -42,7 +42,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
     return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.SLOW, { chance = 5, duration = 30, power = 10 })
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mobSkill.PEDAL_PIROUETTE -- Petal Pirouette is only TP move
 end
 

--- a/scripts/zones/Sacrarium/mobs/Stegotaur.lua
+++ b/scripts/zones/Sacrarium/mobs/Stegotaur.lua
@@ -15,7 +15,7 @@ entity.onMobSpawn = function(mob)
     mob:setLocalVar('fomorHateAdj', 4) -- treated as negative in fomor_hate mixin
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpMoves =
     {
         xi.mobSkill.TRICLIP_1,

--- a/scripts/zones/Sacrarium/mobs/Teratotaur.lua
+++ b/scripts/zones/Sacrarium/mobs/Teratotaur.lua
@@ -15,7 +15,7 @@ entity.onMobSpawn = function(mob)
     mob:setLocalVar('fomorHateAdj', 4) -- treated as negative in fomor_hate mixin
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpMoves =
     {
         xi.mobSkill.TRICLIP_1,

--- a/scripts/zones/Sea_Serpent_Grotto/mobs/Glyryvilu.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/mobs/Glyryvilu.lua
@@ -21,7 +21,7 @@ entity.onMobSpawn = function(mob)
 end
 
 -- This quest NM has a special JUICED version of Cross Attack that will need to be fixed when mob skills are updated.  It's likely 4X base damage.
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local skillList =
     {
         xi.mobSkill.CROSS_ATTACK_1,

--- a/scripts/zones/Sealions_Den/mobs/Mammet-22_Zeta.lua
+++ b/scripts/zones/Sealions_Den/mobs/Mammet-22_Zeta.lua
@@ -96,7 +96,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local form  = mob:getAnimationSub()
     local moves = tpMoves[form]
 

--- a/scripts/zones/Sealions_Den/mobs/Omega.lua
+++ b/scripts/zones/Sealions_Den/mobs/Omega.lua
@@ -29,7 +29,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local hpp      = mob:getHPP()
     local tpSkills = {}
 

--- a/scripts/zones/Sealions_Den/mobs/Tenzen.lua
+++ b/scripts/zones/Sealions_Den/mobs/Tenzen.lua
@@ -152,7 +152,7 @@ entity.onMobEngage = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local form         = mob:getAnimationSub()
     local shouldOisoya = mob:getLocalVar('[Tenzen]ShouldOisoya') == 1
     local skill        = 0

--- a/scripts/zones/Sealions_Den/mobs/Ultima.lua
+++ b/scripts/zones/Sealions_Den/mobs/Ultima.lua
@@ -95,7 +95,7 @@ entity.onMobFight = function(mob, target)
     }
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local phase    = mob:getLocalVar('phase')
     local tpSkills = {}
 

--- a/scripts/zones/Spire_of_Dem/mobs/Ingester.lua
+++ b/scripts/zones/Spire_of_Dem/mobs/Ingester.lua
@@ -20,7 +20,7 @@ entity.onMobInitialize = function(mob)
     mob:setMod(xi.mod.DOUBLE_ATTACK, 20)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     -- 20% chance to prefer Fission
     if
         math.random(1, 100) <= 20 and

--- a/scripts/zones/Spire_of_Dem/mobs/Progenerator.lua
+++ b/scripts/zones/Spire_of_Dem/mobs/Progenerator.lua
@@ -23,7 +23,7 @@ entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.STORETP, 62)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpMoves =
     {
         xi.mobSkill.SPIRIT_ABSORPTION_2,

--- a/scripts/zones/Spire_of_Holla/mobs/Cogitator.lua
+++ b/scripts/zones/Spire_of_Holla/mobs/Cogitator.lua
@@ -14,7 +14,7 @@ entity.onMobInitialize = function(mob)
     mob:setMod(xi.mod.DOUBLE_ATTACK, 15)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local skills =
     {
         xi.mobSkill.NEGATIVE_WHIRL_1,

--- a/scripts/zones/Spire_of_Holla/mobs/Wreaker.lua
+++ b/scripts/zones/Spire_of_Holla/mobs/Wreaker.lua
@@ -19,7 +19,7 @@ entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.STORETP, 155)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpMoves =
     {
         xi.mobSkill.SHADOW_SPREAD,

--- a/scripts/zones/Spire_of_Mea/mobs/Delver.lua
+++ b/scripts/zones/Spire_of_Mea/mobs/Delver.lua
@@ -19,7 +19,7 @@ entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.STORETP, 62)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpMoves =
     {
         xi.mobSkill.CAROUSEL_1,

--- a/scripts/zones/Spire_of_Vahzl/mobs/Agonizer.lua
+++ b/scripts/zones/Spire_of_Vahzl/mobs/Agonizer.lua
@@ -19,7 +19,7 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpMoves =
     {
         xi.mobSkill.SHADOW_SPREAD,

--- a/scripts/zones/Spire_of_Vahzl/mobs/Cumulator.lua
+++ b/scripts/zones/Spire_of_Vahzl/mobs/Cumulator.lua
@@ -19,7 +19,7 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpMoves =
     {
         xi.mobSkill.CAROUSEL_1,

--- a/scripts/zones/Spire_of_Vahzl/mobs/Procreator.lua
+++ b/scripts/zones/Spire_of_Vahzl/mobs/Procreator.lua
@@ -21,7 +21,7 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpMoves =
     {
         xi.mobSkill.SPIRIT_ABSORPTION_2,

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Awzdei.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Awzdei.lua
@@ -17,7 +17,7 @@ entity.onPath = function(mob)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local form = mob:getAnimationSub()
     local tpMoves = { xi.mobSkill.REACTOR_COOL }
 

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Ixaern_DRG.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Ixaern_DRG.lua
@@ -105,7 +105,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     -- When Ix'Aern DRG readies a mob skill, all his pets use a corresponding breath attack
     local mobskill, breathSkill = utils.randomEntryIdx(breathList)
     for _, i in ipairs(pets) do

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Ixzdei_BLM.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Ixzdei_BLM.lua
@@ -152,7 +152,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local form = mob:getAnimationSub()
     local tpMoves = { xi.mobSkill.REACTOR_COOL }
 

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Ixzdei_RDM.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Ixzdei_RDM.lua
@@ -91,7 +91,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local form = mob:getAnimationSub()
     local tpMoves = { xi.mobSkill.REACTOR_COOL }
 

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Qnzdei.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Qnzdei.lua
@@ -97,7 +97,7 @@ entity.onPath = function(mob)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local form = mob:getAnimationSub()
     local tpMoves = { xi.mobSkill.REACTOR_COOL }
 

--- a/scripts/zones/The_Shrouded_Maw/mobs/Diabolos.lua
+++ b/scripts/zones/The_Shrouded_Maw/mobs/Diabolos.lua
@@ -156,7 +156,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpSkills =
     {
         [1] = { xi.mobSkill.NOCTOSHIELD_1,     50 },

--- a/scripts/zones/The_Shrouded_Maw/mobs/Diabolos_DN.lua
+++ b/scripts/zones/The_Shrouded_Maw/mobs/Diabolos_DN.lua
@@ -160,7 +160,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local skills =
     {
         { skill = xi.mobSkill.NOCTOSHIELD_1,     weight = 50 },

--- a/scripts/zones/The_Shrouded_Maw/mobs/Diabolos_WD.lua
+++ b/scripts/zones/The_Shrouded_Maw/mobs/Diabolos_WD.lua
@@ -162,7 +162,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local skills =
     {
         { skill = xi.mobSkill.NOCTOSHIELD_1,     weight = 50 },

--- a/scripts/zones/Throne_Room/mobs/Shadow_Lord_Phase_1.lua
+++ b/scripts/zones/Throne_Room/mobs/Shadow_Lord_Phase_1.lua
@@ -111,7 +111,7 @@ entity.onMobFight = function(mob, target)
     }
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local mobskillTable =
     {
         [1] = { xi.mobSkill.KICK_BACK,   25 },

--- a/scripts/zones/Uleguerand_Range/mobs/Brontotaur.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Brontotaur.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/families/tauri') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpMoves =
     {
         xi.mobSkill.TRICLIP_1,

--- a/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
@@ -205,7 +205,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     if mob:getAnimationSub() == 1 then
         mob:setLocalVar('skill_tp', mob:getTP())
     end

--- a/scripts/zones/Uleguerand_Range/mobs/Molech.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Molech.lua
@@ -9,7 +9,7 @@ mixins = { require('scripts/mixins/families/tauri') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpMoves =
     {
         xi.mobSkill.TRICLIP_1,

--- a/scripts/zones/Uleguerand_Range/mobs/Tyrannotaur.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Tyrannotaur.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/families/tauri') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpMoves =
     {
         xi.mobSkill.TRICLIP_1,

--- a/scripts/zones/VeLugannon_Palace/mobs/Zipacna.lua
+++ b/scripts/zones/VeLugannon_Palace/mobs/Zipacna.lua
@@ -329,7 +329,7 @@ entity.onMobSpawn = function(mob)
     end
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     -- Zipacna heavily prefers using Crystal Rain and Crystal Weapon
     local roll = math.random(1, 100)
 

--- a/scripts/zones/Wajaom_Woodlands/mobs/Ameretat.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Ameretat.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts.mixins.families.morbol_toau') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return target:countEffectWithFlag(xi.effectFlag.DISPELABLE) > 0 and xi.mobSkill.VAMPIRIC_ROOT or 0
 end
 

--- a/scripts/zones/Wajaom_Woodlands/mobs/Great_Ameretat.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Great_Ameretat.lua
@@ -9,7 +9,7 @@ local ID = zones[xi.zone.WAJAOM_WOODLANDS]
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return target:countEffectWithFlag(xi.effectFlag.DISPELABLE) > 0 and xi.mobSkill.VAMPIRIC_ROOT or 0
 end
 

--- a/scripts/zones/Wajaom_Woodlands/mobs/Jaded_Jody.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Jaded_Jody.lua
@@ -28,7 +28,7 @@ entity.onMobSpawn = function(mob)
     xi.mix.toau_morbol.config(mob, { nightRoaming = 1, })
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     return target:countEffectWithFlag(xi.effectFlag.DISPELABLE) > 0 and xi.mobSkill.VAMPIRIC_ROOT or 0
 end
 

--- a/scripts/zones/Waughroon_Shrine/mobs/Macha.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Macha.lua
@@ -21,7 +21,7 @@ entity.onMobSpellChoose = function(mob, target, spellId)
     return spellList[math.random(1, #spellList)]
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local skillList =
     {
         xi.mobSkill.HELLDIVE_1,

--- a/scripts/zones/Waughroon_Shrine/mobs/Neman.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Neman.lua
@@ -10,7 +10,7 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.CHARMABLE, 1)
 end
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local skillList =
     {
         xi.mobSkill.HELLDIVE_1,

--- a/scripts/zones/Xarcabard_[S]/mobs/Gorgotaur.lua
+++ b/scripts/zones/Xarcabard_[S]/mobs/Gorgotaur.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/families/tauri') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpMoves =
     {
         xi.mobSkill.TRICLIP_1,

--- a/scripts/zones/Xarcabard_[S]/mobs/Tarbotaur.lua
+++ b/scripts/zones/Xarcabard_[S]/mobs/Tarbotaur.lua
@@ -7,7 +7,7 @@ mixins = { require('scripts/mixins/families/tauri') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobMobskillChoose = function(mob, target)
+entity.onMobMobskillChoose = function(mob, target, skillId)
     local tpMoves =
     {
         xi.mobSkill.TRICLIP_1,

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -3780,7 +3780,7 @@ std::tuple<int32, uint8, uint8> OnUseWeaponSkill(CBattleEntity* PChar, CBaseEnti
     return std::make_tuple(dmg, tpHitsLanded, extraHitsLanded);
 }
 
-uint16 OnMobMobskillChoose(CBattleEntity* PMob, CBattleEntity* PTarget)
+uint16 OnMobMobskillChoose(CBattleEntity* PMob, CBattleEntity* PTarget, uint16 chosenSkillId)
 {
     TracyZoneScoped;
 
@@ -3795,7 +3795,7 @@ uint16 OnMobMobskillChoose(CBattleEntity* PMob, CBattleEntity* PTarget)
         return 0;
     }
 
-    auto result = onMobMobskillChoose(PMob, PTarget);
+    auto result = onMobMobskillChoose(PMob, PTarget, chosenSkillId);
     if (!result.valid())
     {
         sol::error err = result;
@@ -3803,7 +3803,7 @@ uint16 OnMobMobskillChoose(CBattleEntity* PMob, CBattleEntity* PTarget)
         return 0;
     }
 
-    uint16 retVal = result.get_type(0) == sol::type::number ? result.get<uint16>(0) : 0;
+    uint16 retVal = result.get_type(0) == sol::type::number ? result.template get<uint16>(0) : 0;
     if (retVal > 0)
     {
         return retVal;

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -381,7 +381,7 @@ void OnBattlefieldKick(CCharEntity* PChar);
 void OnBattlefieldRegister(CCharEntity* PChar, CBattlefield* PBattlefield);
 void OnBattlefieldDestroy(CBattlefield* PBattlefield);
 
-uint16 OnMobMobskillChoose(CBattleEntity* PMob, CBattleEntity* PTarget);
+uint16 OnMobMobskillChoose(CBattleEntity* PMob, CBattleEntity* PTarget, uint16 chosenSkillId);
 int32  OnMobWeaponSkill(CBaseEntity* PChar, CBaseEntity* PMob, CMobSkill* PMobSkill, action_t* action);
 int32  OnMobSkillCheck(CBaseEntity* PChar, CBaseEntity* PMob, CMobSkill* PMobSkill); // triggers before mob weapon skill is used, returns 0 if the move is valid
 auto   OnMobSkillTarget(CBattleEntity* PTarget, CBaseEntity* PMob, CMobSkill* PMobSkill) -> CBattleEntity*;


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The issue: Mobs that use mobskills as auto-attacks will have a conflict if the mobskill choosing process is done in lua in `entity.onMobMobskillChoose()`
My proposed solution: Allow lua to know what the mobskill was gonna be, so we can add a check to NOT execute an override (return 0)

## Steps to test these changes
Fight mobs and see them behave properly.

Ignore the lua changes. Focus on the changes that happen in core.
