### PR TITLE
[lua] Enthunder conversion, retire ae.enthunder in mobs.lua

### DIFF
--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -289,16 +289,6 @@ local additionalEffects =
         bonusAbilityParams = { bonusmab = 0, includemab = false },
     },
 
-    [xi.mob.ae.ENTHUNDER] =
-    {
-        ele                = xi.element.THUNDER,
-        sub                = xi.subEffect.LIGHTNING_DAMAGE,
-        msg                = xi.msg.basic.ADD_EFFECT_DMG,
-        negMsg             = xi.msg.basic.ADD_EFFECT_HEAL,
-        mod                = xi.mod.INT,
-        bonusAbilityParams = { bonusmab = 0, includemab = false },
-    },
-
     [xi.mob.ae.EVASION_DOWN] =
     {
         chance      = 25,

--- a/scripts/zones/Cloister_of_Storms/mobs/Ramuh_Prime_TBL.lua
+++ b/scripts/zones/Cloister_of_Storms/mobs/Ramuh_Prime_TBL.lua
@@ -38,7 +38,16 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENTHUNDER, { chance = 100, power = math.random(20, 40) })
+    local pTable =
+    {
+        chance         = 100,
+        attackType     = xi.attackType.MAGICAL,
+        magicalElement = xi.element.THUNDER,
+        basePower      = math.floor(damage / 2),
+        actorStat      = xi.mod.INT,
+    }
+
+    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/Cloister_of_Storms/mobs/Ramuh_Prime_TSTBL.lua
+++ b/scripts/zones/Cloister_of_Storms/mobs/Ramuh_Prime_TSTBL.lua
@@ -41,7 +41,16 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENTHUNDER, { chance = 100, power = math.random(15, 25) })
+    local pTable =
+    {
+        chance         = 100,
+        attackType     = xi.attackType.MAGICAL,
+        magicalElement = xi.element.THUNDER,
+        basePower      = math.floor(damage / 2),
+        actorStat      = xi.mod.INT,
+    }
+
+    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
 end
 
 entity.onMobEngage = function(mob, target)

--- a/scripts/zones/Cloister_of_Storms/mobs/Ramuh_Prime_WTB.lua
+++ b/scripts/zones/Cloister_of_Storms/mobs/Ramuh_Prime_WTB.lua
@@ -41,7 +41,16 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENTHUNDER, { chance = 100, power = math.random(75, 125) })
+    local pTable =
+    {
+        chance         = 100,
+        attackType     = xi.attackType.MAGICAL,
+        magicalElement = xi.element.THUNDER,
+        basePower      = math.floor(damage / 2),
+        actorStat      = xi.mod.INT,
+    }
+
+    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
 end
 
 entity.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/zones/Temple_of_Uggalepih/mobs/Flauros.lua
+++ b/scripts/zones/Temple_of_Uggalepih/mobs/Flauros.lua
@@ -24,7 +24,16 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENTHUNDER)
+    local pTable =
+    {
+        chance         = 100,
+        attackType     = xi.attackType.MAGICAL,
+        magicalElement = xi.element.THUNDER,
+        basePower      = math.floor(damage / 2),
+        actorStat      = xi.mod.INT,
+    }
+
+    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
 end
 
 entity.onMobSpawn = function(mob)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Converts enthunder to the new system, retires ae.enthunder

## Steps to test these changes

Fight Flauros
