### PR TITLE
[sql][mobs] Coffer Mimic Death Trap

### DIFF
--- a/scripts/actions/mobskills/death_trap.lua
+++ b/scripts/actions/mobskills/death_trap.lua
@@ -14,21 +14,21 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.POISON
-    local duration   = 60
-    local power      = mob:getMainLvl() / 3
-
-    if math.random(1, 100) <= 50 then
-        -- stun
-        typeEffect = xi.effect.STUN
-        duration   = 10
-        power      = 1
-    end
-
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 0, duration))
+    local stun   = xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STUN, 1, 0, math.random(10, 15))
+    local poison = xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, 10, 0, 300)
 
     mob:resetEnmity(target)
-    return typeEffect
+
+    if stun == xi.msg.basic.SKILL_ENFEEB_IS then
+        skill:setMsg(xi.msg.basic.SKILL_ENFEEB_IS)
+        return xi.effect.STUN
+    elseif poison == xi.msg.basic.SKILL_ENFEEB_IS then
+        skill:setMsg(xi.msg.basic.SKILL_ENFEEB_IS)
+        return xi.effect.POISON
+    else
+        skill:setMsg(xi.msg.basic.SKILL_NO_EFFECT)
+        return xi.effect.NONE
+    end
 end
 
 return mobskillObject

--- a/scripts/enum/mob_skill.lua
+++ b/scripts/enum/mob_skill.lua
@@ -267,6 +267,7 @@ xi.mobSkill =
 
     JUMP_1                        =  718,
 
+    DEATH_TRAP                    =  729, -- Lockpicked coffer mimics only
     MEIKYO_SHISUI_1               =  730, -- Tenzen, etc...
     MIJIN_GAKURE_1                =  731, -- Season's Greetings KSNM 30 (Ulagohvsdi Tlugvi)
     CALL_WYVERN                   =  732,

--- a/scripts/zones/Beadeaux/mobs/Mimic.lua
+++ b/scripts/zones/Beadeaux/mobs/Mimic.lua
@@ -8,7 +8,15 @@ mixins = { require('scripts/mixins/families/mimic') }
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 120)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 60)
+end
+
+entity.onMobEngage = function(mob, target)
+    mob:setTP(3000)
+end
+
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    return xi.mobSkill.DEATH_TRAP
 end
 
 return entity

--- a/scripts/zones/Castle_Oztroja/mobs/Mimic.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Mimic.lua
@@ -8,7 +8,15 @@ mixins = { require('scripts/mixins/families/mimic') }
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 120)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 60)
+end
+
+entity.onMobEngage = function(mob, target)
+    mob:setTP(3000)
+end
+
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    return xi.mobSkill.DEATH_TRAP
 end
 
 return entity

--- a/scripts/zones/Castle_Zvahl_Baileys/mobs/Mimic.lua
+++ b/scripts/zones/Castle_Zvahl_Baileys/mobs/Mimic.lua
@@ -8,7 +8,15 @@ mixins = { require('scripts/mixins/families/mimic') }
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 120)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 60)
+end
+
+entity.onMobEngage = function(mob, target)
+    mob:setTP(3000)
+end
+
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    return xi.mobSkill.DEATH_TRAP
 end
 
 return entity

--- a/scripts/zones/Crawlers_Nest/mobs/Mimic.lua
+++ b/scripts/zones/Crawlers_Nest/mobs/Mimic.lua
@@ -8,7 +8,15 @@ mixins = { require('scripts/mixins/families/mimic') }
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 120)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 60)
+end
+
+entity.onMobEngage = function(mob, target)
+    mob:setTP(3000)
+end
+
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    return xi.mobSkill.DEATH_TRAP
 end
 
 return entity

--- a/scripts/zones/Den_of_Rancor/mobs/Mimic.lua
+++ b/scripts/zones/Den_of_Rancor/mobs/Mimic.lua
@@ -8,7 +8,15 @@ mixins = { require('scripts/mixins/families/mimic') }
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 120)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 60)
+end
+
+entity.onMobEngage = function(mob, target)
+    mob:setTP(3000)
+end
+
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    return xi.mobSkill.DEATH_TRAP
 end
 
 return entity

--- a/scripts/zones/Garlaige_Citadel/mobs/Mimic.lua
+++ b/scripts/zones/Garlaige_Citadel/mobs/Mimic.lua
@@ -8,7 +8,15 @@ mixins = { require('scripts/mixins/families/mimic') }
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 120)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 60)
+end
+
+entity.onMobEngage = function(mob, target)
+    mob:setTP(3000)
+end
+
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    return xi.mobSkill.DEATH_TRAP
 end
 
 return entity

--- a/scripts/zones/Ifrits_Cauldron/mobs/Mimic.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Mimic.lua
@@ -8,7 +8,15 @@ mixins = { require('scripts/mixins/families/mimic') }
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 120)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 60)
+end
+
+entity.onMobEngage = function(mob, target)
+    mob:setTP(3000)
+end
+
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    return xi.mobSkill.DEATH_TRAP
 end
 
 return entity

--- a/scripts/zones/Kuftal_Tunnel/mobs/Mimic.lua
+++ b/scripts/zones/Kuftal_Tunnel/mobs/Mimic.lua
@@ -8,7 +8,15 @@ mixins = { require('scripts/mixins/families/mimic') }
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 120)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 60)
+end
+
+entity.onMobEngage = function(mob, target)
+    mob:setTP(3000)
+end
+
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    return xi.mobSkill.DEATH_TRAP
 end
 
 return entity

--- a/scripts/zones/Monastic_Cavern/mobs/Mimic.lua
+++ b/scripts/zones/Monastic_Cavern/mobs/Mimic.lua
@@ -8,7 +8,15 @@ mixins = { require('scripts/mixins/families/mimic') }
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 120)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 60)
+end
+
+entity.onMobEngage = function(mob, target)
+    mob:setTP(3000)
+end
+
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    return xi.mobSkill.DEATH_TRAP
 end
 
 return entity

--- a/scripts/zones/Newton_Movalpolos/mobs/Mimic.lua
+++ b/scripts/zones/Newton_Movalpolos/mobs/Mimic.lua
@@ -8,7 +8,15 @@ mixins = { require('scripts/mixins/families/mimic') }
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 120)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 60)
+end
+
+entity.onMobEngage = function(mob, target)
+    mob:setTP(3000)
+end
+
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    return xi.mobSkill.DEATH_TRAP
 end
 
 return entity

--- a/scripts/zones/Quicksand_Caves/mobs/Mimic.lua
+++ b/scripts/zones/Quicksand_Caves/mobs/Mimic.lua
@@ -8,7 +8,15 @@ mixins = { require('scripts/mixins/families/mimic') }
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 120)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 60)
+end
+
+entity.onMobEngage = function(mob, target)
+    mob:setTP(3000)
+end
+
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    return xi.mobSkill.DEATH_TRAP
 end
 
 return entity

--- a/scripts/zones/RuAun_Gardens/mobs/Mimic.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Mimic.lua
@@ -8,7 +8,15 @@ mixins = { require('scripts/mixins/families/mimic') }
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 60)
+end
+
+entity.onMobEngage = function(mob, target)
+    mob:setTP(3000)
+end
+
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    return xi.mobSkill.DEATH_TRAP
 end
 
 return entity

--- a/scripts/zones/Sea_Serpent_Grotto/mobs/Mimic.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/mobs/Mimic.lua
@@ -8,7 +8,15 @@ mixins = { require('scripts/mixins/families/mimic') }
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 120)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 60)
+end
+
+entity.onMobEngage = function(mob, target)
+    mob:setTP(3000)
+end
+
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    return xi.mobSkill.DEATH_TRAP
 end
 
 return entity

--- a/scripts/zones/Temple_of_Uggalepih/mobs/Mimic.lua
+++ b/scripts/zones/Temple_of_Uggalepih/mobs/Mimic.lua
@@ -8,7 +8,15 @@ mixins = { require('scripts/mixins/families/mimic') }
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 120)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 60)
+end
+
+entity.onMobEngage = function(mob, target)
+    mob:setTP(3000)
+end
+
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    return xi.mobSkill.DEATH_TRAP
 end
 
 return entity

--- a/scripts/zones/The_Boyahda_Tree/mobs/Mimic.lua
+++ b/scripts/zones/The_Boyahda_Tree/mobs/Mimic.lua
@@ -7,4 +7,16 @@ mixins = { require('scripts/mixins/families/mimic') }
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 60)
+end
+
+entity.onMobEngage = function(mob, target)
+    mob:setTP(3000)
+end
+
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    return xi.mobSkill.DEATH_TRAP
+end
+
 return entity

--- a/scripts/zones/The_Eldieme_Necropolis/mobs/Mimic.lua
+++ b/scripts/zones/The_Eldieme_Necropolis/mobs/Mimic.lua
@@ -7,4 +7,16 @@ mixins = { require('scripts/mixins/families/mimic') }
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 60)
+end
+
+entity.onMobEngage = function(mob, target)
+    mob:setTP(3000)
+end
+
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    return xi.mobSkill.DEATH_TRAP
+end
+
 return entity

--- a/scripts/zones/Toraimarai_Canal/mobs/Mimic.lua
+++ b/scripts/zones/Toraimarai_Canal/mobs/Mimic.lua
@@ -8,7 +8,15 @@ mixins = { require('scripts/mixins/families/mimic') }
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 120)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 60)
+end
+
+entity.onMobEngage = function(mob, target)
+    mob:setTP(3000)
+end
+
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    return xi.mobSkill.DEATH_TRAP
 end
 
 return entity

--- a/scripts/zones/VeLugannon_Palace/mobs/Mimic.lua
+++ b/scripts/zones/VeLugannon_Palace/mobs/Mimic.lua
@@ -8,7 +8,15 @@ mixins = { require('scripts/mixins/families/mimic') }
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 120)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 60)
+end
+
+entity.onMobEngage = function(mob, target)
+    mob:setTP(3000)
+end
+
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    return xi.mobSkill.DEATH_TRAP
 end
 
 return entity

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -753,7 +753,7 @@ INSERT INTO `mob_skills` VALUES (725,60,'impale',0,0.0,7.0,2000,1500,4,0,0,0,0,0
 INSERT INTO `mob_skills` VALUES (726,61,'drain_whip',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (727,63,'bad_breath',1,0.0,40.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (728,64,'sweet_breath',1,0.0,40.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (729,473,'death_trap',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (729,398,'death_trap',1,0.0,30.0,2000,0,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (730,438,'meikyo_shisui',0,0.0,7.0,2000,0,1,2,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (731,18,'mijin_gakure',1,0.0,20.0,2000,0,4,2,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (732,438,'call_wyvern',0,0.0,7.0,2000,0,1,2,0,0,0,0,0);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR brings back the commented out death trap ID so that Coffer Mimics can use it with zero ready time.  

This also makes Death Trap more correct, both according to my caps and Jimmy's sheet.
I know skills still need to be hooked into magic resisting and whatnot, but this makes it far more correct than it was.

Fixes Mimics to instantly use its TP move when engaging the target.
Also fixes the despawn time to 60 seconds.

https://youtu.be/dx45Lm9yUlc

## Steps to test these changes

Pop a mimic, get trapped idiot.
