### PR TITLE
[c++] Add server settings for adjusting weapon haste cap

### DIFF
--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -122,24 +122,25 @@ xi.settings.main =
     ALL_MAPS                       = 0,  -- Set to 1 to give starting characters all the maps.
     UNLOCK_OUTPOST_WARPS           = 0,  -- Set to 1 to give starting characters all outpost warps.  2 to add Tu'Lia and Tavnazia.
 
-    SHOP_PRICE      = 1.000, -- Multiplies prices in NPC shops.
-    GIL_RATE        = 1.000, -- Multiplies gil earned from quests.  Won't always display in game.
-    BAYLD_RATE      = 1.000, -- Multiples bayld earned from quests.
+    SHOP_PRICE          = 1.000, -- Multiplies prices in NPC shops.
+    GIL_RATE            = 1.000, -- Multiplies gil earned from quests.  Won't always display in game.
+    BAYLD_RATE          = 1.000, -- Multiples bayld earned from quests.
     -- Note: EXP rates are also influenced by conf setting
-    EXP_RATE        = 1.000, -- Multiplies exp from script (except FoV/GoV).
-    CAPACITY_RATE   = 1.000, -- Multiplies capacy points gained.
-    BOOK_EXP_RATE   = 1.000, -- Multiplies exp from FoV/GoV book pages.
-    TABS_RATE       = 1.000, -- Multiplies tabs earned from fov.
-    ROE_EXP_RATE    = 1.000, -- Multiplies exp earned from records of eminence.
-    SPARKS_RATE     = 1.000, -- Multiplies sparks earned from records of eminence.
-    CURE_POWER      = 1.000, -- Multiplies amount healed from Healing Magic, including the relevant Blue Magic.
-    ELEMENTAL_POWER = 1.000, -- Multiplies damage dealt by Elemental and non-drain Dark Magic.
-    DIVINE_POWER    = 1.000, -- Multiplies damage dealt by Divine Magic.
-    NINJUTSU_POWER  = 1.000, -- Multiplies damage dealt by Ninjutsu Magic.
-    BLUE_POWER      = 1.000, -- Multiplies damage dealt by Blue Magic.
-    DARK_POWER      = 1.000, -- Multiplies amount drained by Dark Magic.
-    ITEM_POWER      = 1.000, -- Multiplies the effect of items such as Potions and Ethers.
+    EXP_RATE            = 1.000, -- Multiplies exp from script (except FoV/GoV).
+    CAPACITY_RATE       = 1.000, -- Multiplies capacity points gained.
+    BOOK_EXP_RATE       = 1.000, -- Multiplies exp from FoV/GoV book pages.
+    TABS_RATE           = 1.000, -- Multiplies tabs earned from fov.
+    ROE_EXP_RATE        = 1.000, -- Multiplies exp earned from records of eminence.
+    SPARKS_RATE         = 1.000, -- Multiplies sparks earned from records of eminence.
+    CURE_POWER          = 1.000, -- Multiplies amount healed from Healing Magic, including the relevant Blue Magic.
+    ELEMENTAL_POWER     = 1.000, -- Multiplies damage dealt by Elemental and non-drain Dark Magic.
+    DIVINE_POWER        = 1.000, -- Multiplies damage dealt by Divine Magic.
+    NINJUTSU_POWER      = 1.000, -- Multiplies damage dealt by Ninjutsu Magic.
+    BLUE_POWER          = 1.000, -- Multiplies damage dealt by Blue Magic.
+    DARK_POWER          = 1.000, -- Multiplies amount drained by Dark Magic.
+    ITEM_POWER          = 1.000, -- Multiplies the effect of items such as Potions and Ethers.
     WEAPON_SKILL_POWER  = 1.000, -- Multiplies damage dealt by Weapon Skills.
+    DELAY_REDUCTION_CAP = 0.80,  -- Set the cap for melee swing haste effect. (0.80 = 80% retail delay reduction max, 0.93 = 93% ToAU delay reduction max)
 
     -- STR:ATT/RATT ratios. For players only. Mobs are hardcoded to 0.5
     TWO_HANDED_STR_ATTACK_MULTIPLIER         = 1.0,  -- 1.0: 1 STR = 1 Attack. This has been 0.5 and 0.75 in previous eras

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -517,7 +517,8 @@ uint32 CBattleEntity::GetWeaponDelay(bool tp)
                 hasteAbility = std::clamp<float>(hasteAbility, -0.25f, 0.25f);
                 hasteGear    = std::clamp<float>(hasteGear, -0.25f, 0.25f);
 
-                hasteMultiplier = std::clamp<float>(1.0f - hasteMagic - hasteAbility - hasteGear, 0.2f, 2.0f);
+                float hasteCap  = 1.0f - settings::get<float>("main.DELAY_REDUCTION_CAP");
+                hasteMultiplier = std::clamp<float>(1.0f - hasteMagic - hasteAbility - hasteGear, hasteCap, 2.0f);
             }
         }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds a server setting to set what value to cap out weapon haste caps.

## Steps to test these changes

- Set haste cap to 0.07 and give yourself all the haste buffs, see the cap is raised from 80% to 93%
