### PR TITLE
[Combat] Additional effect function reaming, enhancement type addition, target bypass and cleanup

### DIFF
--- a/scripts/globals/combat/action_additional_effect_damage.lua
+++ b/scripts/globals/combat/action_additional_effect_damage.lua
@@ -56,7 +56,7 @@ end
 -----------------------------------
 -- Global functions called from "emtity.onAdditionalEffect()"
 -----------------------------------
-xi.combat.action.executeAdditionalDamage = function(actor, target, fedData)
+xi.combat.action.executeAddEffectDamage = function(actor, target, fedData)
     local params = validateParameters(fedData)
 
     -- Early return: No proc.

--- a/scripts/globals/combat/action_additional_effect_damage.lua
+++ b/scripts/globals/combat/action_additional_effect_damage.lua
@@ -25,8 +25,11 @@ local defaultsTable =
 -----------------------------------
 -- Local functions to ensure defaults are set.
 -----------------------------------
-local function validateParameters(fedData)
+local function validateParameters(actor, target, fedData)
     local params = {}
+
+    -- Additional effect target.
+    params.aeTarget        = fedData.aeTarget or target -- Default to the current attack target.
 
     -- Chance.
     params.chance          = fedData.chance or 100 -- Default: Always proc.
@@ -57,7 +60,7 @@ end
 -- Global functions called from "emtity.onAdditionalEffect()"
 -----------------------------------
 xi.combat.action.executeAddEffectDamage = function(actor, target, fedData)
-    local params = validateParameters(fedData)
+    local params = validateParameters(actor, target, fedData)
 
     -- Early return: No proc.
     if math.random(1, 100) > params.chance then
@@ -71,21 +74,22 @@ xi.combat.action.executeAddEffectDamage = function(actor, target, fedData)
     local isBreath   = params.attackType == xi.attackType.BREATH or false
 
     -- Calculate base power.
-    local damage = params.basePower + actor:getMod(params.actorStat) - target:getMod(params.targetStat)
+    local damage = params.basePower + actor:getMod(params.actorStat) - params.aeTarget:getMod(params.targetStat)
 
     -- Calculate mandatory multipliers.
-    local multiplierAbsorption         = xi.spells.damage.calculateAbsorption(target, params.magicalElement, params.isMagical)
-    local multiplierNullification      = xi.spells.damage.calculateNullification(target, params.magicalElement, isMagical, isBreath)
-    local multiplierDamageTypeSDT      = xi.combat.damage.calculateDamageAdjustment(target, isPhysical, isMagical, isRanged, isBreath)
-    local multiplierPhysicalElementSDT = xi.combat.damage.physicalElementSDT(target, params.physicalElement)
-    local multiplierMagicalElementSDT  = xi.combat.damage.magicalElementSDT(target, params.magicalElement)
+    local multiplierAbsorption         = xi.spells.damage.calculateAbsorption(params.aeTarget, params.magicalElement, params.isMagical)
+    local multiplierNullification      = xi.spells.damage.calculateNullification(params.aeTarget, params.magicalElement, isMagical, isBreath)
+    local multiplierDamageTypeSDT      = xi.combat.damage.calculateDamageAdjustment(params.aeTarget, isPhysical, isMagical, isRanged, isBreath)
+    local multiplierPhysicalElementSDT = xi.combat.damage.physicalElementSDT(params.aeTarget, params.physicalElement)
+    local multiplierMagicalElementSDT  = xi.combat.damage.magicalElementSDT(params.aeTarget, params.magicalElement)
     local multiplierElementalStaff     = xi.spells.damage.calculateElementalStaffBonus(actor, params.magicalElement)
     local multiplierElementalAffinity  = xi.spells.damage.calculateElementalAffinityBonus(actor, params.magicalElement)
     local multiplierDayWeather         = xi.spells.damage.calculateDayAndWeather(actor, params.magicalElement, false)
 
     -- Calculate optional multipliers.
-    local multiplierMagicDiff          = params.canMAB and xi.spells.damage.calculateMagicBonusDiff(actor, target, 0, 0, params.magicalElement) or 1
-    local multiplierResist             = params.canResist and xi.combat.magicHitRate.calculateResistRate(actor, target, 0, 0, xi.skillRank.A_PLUS, params.magicalElement, params.actorStat, 0, 0) or 1
+    local multiplierMagicDiff          = params.canMAB and xi.spells.damage.calculateMagicBonusDiff(actor, params.aeTarget, 0, 0, params.magicalElement) or 1
+    local multiplierResist             = params.canResist and xi.combat.magicHitRate.calculateResistRate(actor, params.aeTarget, 0, 0, xi.skillRank.A_PLUS, params.magicalElement, params.actorStat, 0, 0) or 1
+    local multiplierForcedResistTier   = params.canResist and xi.spells.damage.calculateAdditionalResistTier(actor, params.aeTarget, params.magicalElement) or 1
 
     -- Calculate final damage.
     damage = math.floor(damage * multiplierAbsorption)
@@ -98,21 +102,22 @@ xi.combat.action.executeAddEffectDamage = function(actor, target, fedData)
     damage = math.floor(damage * multiplierDayWeather)
     damage = math.floor(damage * multiplierMagicDiff)
     damage = math.floor(damage * multiplierResist)
+    damage = math.floor(damage * multiplierForcedResistTier)
 
     -- Phalanx, One for all, Stoneskin.
     if damage > 0 then
-        damage = utils.clamp(utils.handlePhalanx(target, damage), 0, 99999)
-        damage = utils.clamp(utils.handleOneForAll(target, damage), 0, 99999)
-        damage = utils.clamp(utils.handleStoneskin(target, damage), -99999, 99999)
+        damage = utils.clamp(utils.handlePhalanx(params.aeTarget, damage), 0, 99999)
+        damage = utils.clamp(utils.handleOneForAll(params.aeTarget, damage), 0, 99999)
+        damage = utils.clamp(utils.handleStoneskin(params.aeTarget, damage), 0, 99999)
     end
 
     -- Apply damage or healing on target.
     if damage > 0 then
         local actionDamageType = params.physicalElement > 0 and params.physicalElement or xi.damageType.ELEMENTAL + params.magicalElement
 
-        target:takeDamage(damage, actor, params.attackType, actionDamageType)
+        params.aeTarget:takeDamage(damage, actor, params.attackType, actionDamageType)
     elseif damage < 0 then
-        target:addHP(-damage)
+        params.aeTarget:addHP(-damage)
     end
 
     -- Return animation displayed, message in chat log and the number that the message should display (if any).

--- a/scripts/globals/combat/action_additional_effect_status.lua
+++ b/scripts/globals/combat/action_additional_effect_status.lua
@@ -115,7 +115,7 @@ xi.combat.action.executeAdditionalStatus = function(actor, target, fedData)
     return 0, 0, 0
 end
 
-xi.combat.action.executeAdditionalDispel = function(actor, target, fedData)
+xi.combat.action.executeAddEffectDispel = function(actor, target, fedData)
     local params = validateParameters(fedData)
 
     -- Early return: Incorrect effect ID.

--- a/scripts/globals/combat/action_additional_effect_status.lua
+++ b/scripts/globals/combat/action_additional_effect_status.lua
@@ -64,8 +64,8 @@ local function validateParameters(actor, target, fedData)
     params.absorbEffect = fedData.absorbEffect or false
 
     -- Animations and messaging.
-    params.animation    = fedData.animation or defaultsTable[params.effectId][1]
-    params.message      = fedData.message or defaultsTable[params.effectId][2]
+    params.animation    = fedData.animation or (defaultsTable[params.effectId][1] or 0)
+    params.message      = fedData.message or (defaultsTable[params.effectId][2] or 0)
 
     return params
 end
@@ -73,6 +73,32 @@ end
 -----------------------------------
 -- Global functions called from "emtity.onAdditionalEffect()"
 -----------------------------------
+xi.combat.action.executeAddEffectEnhancement = function(actor, target, fedData)
+    local params = validateParameters(actor, target, fedData)
+
+    -- Early return: Incorrect effect ID.
+    if params.effectId == xi.effect.NONE then
+        return 0, 0, 0
+    end
+
+    -- Early return: No proc.
+    if math.random(1, 100) > params.chance then
+        return 0, 0, 0
+    end
+
+    -- Early return: Target has an status effect that invalidates current (Outright incompatible or higher tier).
+    if xi.data.statusEffect.isEffectNullified(params.aeTarget, params.effectId, params.tier) then
+        return 0, 0, 0
+    end
+
+    -- Apply effect.
+    if params.aeTarget:addStatusEffect(params.effectId, params.power, params.tick, params.duration, params.subType, params.subPower, params.tier) then
+        return params.animation, params.message, params.effectId
+    end
+
+    return 0, 0, 0
+end
+
 xi.combat.action.executeAddEffectEnfeeblement = function(actor, target, fedData)
     local params = validateParameters(actor, target, fedData)
 

--- a/scripts/globals/combat/action_additional_effect_status.lua
+++ b/scripts/globals/combat/action_additional_effect_status.lua
@@ -70,7 +70,7 @@ end
 -----------------------------------
 -- Global functions called from "emtity.onAdditionalEffect()"
 -----------------------------------
-xi.combat.action.executeAdditionalStatus = function(actor, target, fedData)
+xi.combat.action.executeAddEffectEnfeeblement = function(actor, target, fedData)
     local params = validateParameters(fedData)
 
     -- Early return: Incorrect effect ID.

--- a/scripts/zones/Abyssea-La_Theine/mobs/Piasa.lua
+++ b/scripts/zones/Abyssea-La_Theine/mobs/Piasa.lua
@@ -19,7 +19,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
@@ -252,7 +252,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDisengage = function(mob)

--- a/scripts/zones/Balgas_Dais/mobs/Gilagoge_Tlugvi.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Gilagoge_Tlugvi.lua
@@ -50,7 +50,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         element = xi.element.DARK,
     }
 
-    return xi.combat.action.executeAdditionalDispel(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDispel(mob, target, pTable)
 end
 
 entity.onMobMobskillChoose = function(mob, target, skillId)

--- a/scripts/zones/Balgas_Dais/mobs/King_of_Coins.lua
+++ b/scripts/zones/Balgas_Dais/mobs/King_of_Coins.lua
@@ -40,7 +40,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         element = xi.element.DARK,
     }
 
-    return xi.combat.action.executeAdditionalDispel(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDispel(mob, target, pTable)
 end
 
 entity.onMobSpellChoose = function(mob, target, spellId)

--- a/scripts/zones/Batallia_Downs/mobs/Eyegouger.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Eyegouger.lua
@@ -23,7 +23,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         duration = 60,
     }
 
-    return xi.combat.action.executeAdditionalStatus(mob, target, pTable)
+    return xi.combat.action.executeAddEffectEnfeeblement(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Beaucedine_Glacier/mobs/Kirata.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Kirata.lua
@@ -81,7 +81,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Bhaflau_Thickets/mobs/Nis_Puk.lua
+++ b/scripts/zones/Bhaflau_Thickets/mobs/Nis_Puk.lua
@@ -88,7 +88,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Bibiki_Bay/mobs/Dalham.lua
+++ b/scripts/zones/Bibiki_Bay/mobs/Dalham.lua
@@ -28,7 +28,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/Bibiki_Bay/mobs/Splacknuck.lua
+++ b/scripts/zones/Bibiki_Bay/mobs/Splacknuck.lua
@@ -43,7 +43,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Cape_Teriggan/mobs/Tegmine.lua
+++ b/scripts/zones/Cape_Teriggan/mobs/Tegmine.lua
@@ -44,7 +44,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Carpenters_Landing/mobs/Tempest_Tigon.lua
+++ b/scripts/zones/Carpenters_Landing/mobs/Tempest_Tigon.lua
@@ -76,7 +76,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Castle_Zvahl_Baileys/mobs/Marquis_Naberius.lua
+++ b/scripts/zones/Castle_Zvahl_Baileys/mobs/Marquis_Naberius.lua
@@ -49,7 +49,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Cloister_of_Flames/mobs/Ifrit_Prime_TBF.lua
+++ b/scripts/zones/Cloister_of_Flames/mobs/Ifrit_Prime_TBF.lua
@@ -47,7 +47,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/Cloister_of_Flames/mobs/Ifrit_Prime_TSTBF.lua
+++ b/scripts/zones/Cloister_of_Flames/mobs/Ifrit_Prime_TSTBF.lua
@@ -50,7 +50,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobEngage = function(mob, target)

--- a/scripts/zones/Cloister_of_Flames/mobs/Ifrit_Prime_WTB.lua
+++ b/scripts/zones/Cloister_of_Flames/mobs/Ifrit_Prime_WTB.lua
@@ -50,7 +50,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/zones/Cloister_of_Frost/mobs/Shiva_Prime_TBI.lua
+++ b/scripts/zones/Cloister_of_Frost/mobs/Shiva_Prime_TBI.lua
@@ -47,7 +47,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/Cloister_of_Frost/mobs/Shiva_Prime_TSTBI.lua
+++ b/scripts/zones/Cloister_of_Frost/mobs/Shiva_Prime_TSTBI.lua
@@ -50,7 +50,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobEngage = function(mob, target)

--- a/scripts/zones/Cloister_of_Frost/mobs/Shiva_Prime_WTB.lua
+++ b/scripts/zones/Cloister_of_Frost/mobs/Shiva_Prime_WTB.lua
@@ -50,7 +50,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/zones/Cloister_of_Gales/mobs/Garuda_Prime_TBW.lua
+++ b/scripts/zones/Cloister_of_Gales/mobs/Garuda_Prime_TBW.lua
@@ -47,7 +47,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/Cloister_of_Gales/mobs/Garuda_Prime_TSTBW.lua
+++ b/scripts/zones/Cloister_of_Gales/mobs/Garuda_Prime_TSTBW.lua
@@ -50,7 +50,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobEngage = function(mob, target)

--- a/scripts/zones/Cloister_of_Gales/mobs/Garuda_Prime_WTB.lua
+++ b/scripts/zones/Cloister_of_Gales/mobs/Garuda_Prime_WTB.lua
@@ -50,7 +50,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/zones/Cloister_of_Storms/mobs/Ramuh_Prime_TBL.lua
+++ b/scripts/zones/Cloister_of_Storms/mobs/Ramuh_Prime_TBL.lua
@@ -47,7 +47,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/Cloister_of_Storms/mobs/Ramuh_Prime_TSTBL.lua
+++ b/scripts/zones/Cloister_of_Storms/mobs/Ramuh_Prime_TSTBL.lua
@@ -50,7 +50,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobEngage = function(mob, target)

--- a/scripts/zones/Cloister_of_Storms/mobs/Ramuh_Prime_WTB.lua
+++ b/scripts/zones/Cloister_of_Storms/mobs/Ramuh_Prime_WTB.lua
@@ -50,7 +50,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/zones/Cloister_of_Tides/mobs/Leviathan_Prime_TBW.lua
+++ b/scripts/zones/Cloister_of_Tides/mobs/Leviathan_Prime_TBW.lua
@@ -47,7 +47,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/Cloister_of_Tides/mobs/Leviathan_Prime_TSTBW.lua
+++ b/scripts/zones/Cloister_of_Tides/mobs/Leviathan_Prime_TSTBW.lua
@@ -50,7 +50,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobEngage = function(mob, target)

--- a/scripts/zones/Cloister_of_Tides/mobs/Leviathan_Prime_WTB.lua
+++ b/scripts/zones/Cloister_of_Tides/mobs/Leviathan_Prime_WTB.lua
@@ -50,7 +50,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/zones/Cloister_of_Tremors/mobs/Titan_Prime_TBE.lua
+++ b/scripts/zones/Cloister_of_Tremors/mobs/Titan_Prime_TBE.lua
@@ -50,7 +50,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/Cloister_of_Tremors/mobs/Titan_Prime_TSTBE.lua
+++ b/scripts/zones/Cloister_of_Tremors/mobs/Titan_Prime_TSTBE.lua
@@ -50,7 +50,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobEngage = function(mob, target)

--- a/scripts/zones/Cloister_of_Tremors/mobs/Titan_Prime_WTB.lua
+++ b/scripts/zones/Cloister_of_Tremors/mobs/Titan_Prime_WTB.lua
@@ -50,7 +50,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/zones/Dangruf_Wadi/mobs/Chocoboleech.lua
+++ b/scripts/zones/Dangruf_Wadi/mobs/Chocoboleech.lua
@@ -19,7 +19,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Fort_Ghelsba/mobs/Kegpaunch_Doshgnosh.lua
+++ b/scripts/zones/Fort_Ghelsba/mobs/Kegpaunch_Doshgnosh.lua
@@ -19,7 +19,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Grauberg_[S]/mobs/Sarcopsylla.lua
+++ b/scripts/zones/Grauberg_[S]/mobs/Sarcopsylla.lua
@@ -34,7 +34,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Grauberg_[S]/mobs/Scitalis.lua
+++ b/scripts/zones/Grauberg_[S]/mobs/Scitalis.lua
@@ -40,7 +40,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Gusgen_Mines/mobs/Juggler_Hecatomb.lua
+++ b/scripts/zones/Gusgen_Mines/mobs/Juggler_Hecatomb.lua
@@ -27,7 +27,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 return entity

--- a/scripts/zones/Halvung/mobs/Copper_Borer.lua
+++ b/scripts/zones/Halvung/mobs/Copper_Borer.lua
@@ -22,7 +22,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onSpikesDamage = function(mob, target, damage)

--- a/scripts/zones/Hazhalm_Testing_Grounds/mobs/Djigga.lua
+++ b/scripts/zones/Hazhalm_Testing_Grounds/mobs/Djigga.lua
@@ -19,7 +19,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         message      = xi.msg.basic.NONE,
     }
 
-    return xi.combat.action.executeAdditionalDispel(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDispel(mob, target, pTable)
 end
 
 return entity

--- a/scripts/zones/Hazhalm_Testing_Grounds/mobs/Djigga_Hildesvini.lua
+++ b/scripts/zones/Hazhalm_Testing_Grounds/mobs/Djigga_Hildesvini.lua
@@ -25,7 +25,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         message      = xi.msg.basic.NONE,
     }
 
-    return xi.combat.action.executeAdditionalDispel(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDispel(mob, target, pTable)
 end
 
 return entity

--- a/scripts/zones/Jugner_Forest_[S]/mobs/Boll_Weevil.lua
+++ b/scripts/zones/Jugner_Forest_[S]/mobs/Boll_Weevil.lua
@@ -18,7 +18,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         duration = 60,
     }
 
-    return xi.combat.action.executeAdditionalStatus(mob, target, pTable)
+    return xi.combat.action.executeAddEffectEnfeeblement(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/King_Ranperres_Tomb/mobs/Vrtra.lua
+++ b/scripts/zones/King_Ranperres_Tomb/mobs/Vrtra.lua
@@ -189,7 +189,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDisengage = function(mob)

--- a/scripts/zones/Kuftal_Tunnel/mobs/Cancer.lua
+++ b/scripts/zones/Kuftal_Tunnel/mobs/Cancer.lua
@@ -22,7 +22,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Kuftal_Tunnel/mobs/Yowie.lua
+++ b/scripts/zones/Kuftal_Tunnel/mobs/Yowie.lua
@@ -94,7 +94,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Labyrinth_of_Onzozo/mobs/Hellion.lua
+++ b/scripts/zones/Labyrinth_of_Onzozo/mobs/Hellion.lua
@@ -51,7 +51,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Meriphataud_Mountains/mobs/Chonchon.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Chonchon.lua
@@ -20,7 +20,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Misareaux_Coast/mobs/Ziphius.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Ziphius.lua
@@ -19,7 +19,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Monarch_Linn/mobs/Ouryu.lua
+++ b/scripts/zones/Monarch_Linn/mobs/Ouryu.lua
@@ -159,7 +159,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDisengage = function(mob)

--- a/scripts/zones/Mount_Zhayolm/mobs/Brass_Borer.lua
+++ b/scripts/zones/Mount_Zhayolm/mobs/Brass_Borer.lua
@@ -72,7 +72,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob)

--- a/scripts/zones/Mount_Zhayolm/mobs/Chary_Apkallu.lua
+++ b/scripts/zones/Mount_Zhayolm/mobs/Chary_Apkallu.lua
@@ -22,7 +22,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Nyzul_Isle/mobs/Hellion.lua
+++ b/scripts/zones/Nyzul_Isle/mobs/Hellion.lua
@@ -20,7 +20,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Ordelles_Caves/mobs/Donggu.lua
+++ b/scripts/zones/Ordelles_Caves/mobs/Donggu.lua
@@ -31,7 +31,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         duration = 60,
     }
 
-    return xi.combat.action.executeAdditionalStatus(mob, target, pTable)
+    return xi.combat.action.executeAddEffectEnfeeblement(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Desmodont.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Desmodont.lua
@@ -30,7 +30,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         duration = 60,
     }
 
-    return xi.combat.action.executeAdditionalStatus(mob, target, pTable)
+    return xi.combat.action.executeAddEffectEnfeeblement(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Promyvion-Vahzl/mobs/Provoker.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Provoker.lua
@@ -60,7 +60,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Qufim_Island/mobs/Atkorkamuy.lua
+++ b/scripts/zones/Qufim_Island/mobs/Atkorkamuy.lua
@@ -28,7 +28,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/Qufim_Island/mobs/Qoofim.lua
+++ b/scripts/zones/Qufim_Island/mobs/Qoofim.lua
@@ -19,7 +19,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Riverne-Site_A01/mobs/Ouryu.lua
+++ b/scripts/zones/Riverne-Site_A01/mobs/Ouryu.lua
@@ -204,7 +204,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/RoMaeve/mobs/Rogue_Receptacle.lua
+++ b/scripts/zones/RoMaeve/mobs/Rogue_Receptacle.lua
@@ -49,7 +49,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Rolanberry_Fields_[S]/mobs/Erle.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/mobs/Erle.lua
@@ -30,7 +30,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/RuAun_Gardens/mobs/Byakko.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Byakko.lua
@@ -46,7 +46,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/RuAun_Gardens/mobs/Genbu.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Genbu.lua
@@ -56,7 +56,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/RuAun_Gardens/mobs/Seiryu.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Seiryu.lua
@@ -69,7 +69,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/RuAun_Gardens/mobs/Suzaku.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Suzaku.lua
@@ -49,7 +49,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Temenos/mobs/Mystic_Avatar_Carbuncle.lua
+++ b/scripts/zones/Temenos/mobs/Mystic_Avatar_Carbuncle.lua
@@ -19,7 +19,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 return entity

--- a/scripts/zones/Temple_of_Uggalepih/mobs/Flauros.lua
+++ b/scripts/zones/Temple_of_Uggalepih/mobs/Flauros.lua
@@ -33,7 +33,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/The_Boyahda_Tree/mobs/Aquarius.lua
+++ b/scripts/zones/The_Boyahda_Tree/mobs/Aquarius.lua
@@ -62,7 +62,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Byakko.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Byakko.lua
@@ -22,7 +22,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 return entity

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Genbu.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Genbu.lua
@@ -39,7 +39,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 return entity

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Olla_Grande.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Olla_Grande.lua
@@ -29,7 +29,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         element = xi.element.DARK,
     }
 
-    return xi.combat.action.executeAdditionalDispel(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDispel(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Olla_Media.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Olla_Media.lua
@@ -29,7 +29,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         element = xi.element.DARK,
     }
 
-    return xi.combat.action.executeAdditionalDispel(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDispel(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Olla_Pequena.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Olla_Pequena.lua
@@ -29,7 +29,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         element = xi.element.DARK,
     }
 
-    return xi.combat.action.executeAdditionalDispel(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDispel(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Seiryu.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Seiryu.lua
@@ -30,7 +30,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Suzaku.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Suzaku.lua
@@ -21,7 +21,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 return entity

--- a/scripts/zones/Toraimarai_Canal/mobs/Brazen_Bones.lua
+++ b/scripts/zones/Toraimarai_Canal/mobs/Brazen_Bones.lua
@@ -50,7 +50,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
@@ -253,7 +253,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDisengage = function(mob)

--- a/scripts/zones/West_Sarutabaruta_[S]/mobs/Ramponneau.lua
+++ b/scripts/zones/West_Sarutabaruta_[S]/mobs/Ramponneau.lua
@@ -37,7 +37,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Western_Altepa_Desert/mobs/Dahu.lua
+++ b/scripts/zones/Western_Altepa_Desert/mobs/Dahu.lua
@@ -59,7 +59,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobRoam = function(mob)

--- a/scripts/zones/Xarcabard/mobs/Ereshkigal.lua
+++ b/scripts/zones/Xarcabard/mobs/Ereshkigal.lua
@@ -30,7 +30,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Pyuu_the_Spatemaker.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Pyuu_the_Spatemaker.lua
@@ -41,7 +41,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
         actorStat      = xi.mod.INT,
     }
 
-    return xi.combat.action.executeAdditionalDamage(mob, target, pTable)
+    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Voluptuous_Vilma.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Voluptuous_Vilma.lua
@@ -56,7 +56,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
             duration = 60,
         }
 
-        return xi.combat.action.executeAdditionalStatus(mob, target, pTable)
+        return xi.combat.action.executeAddEffectEnfeeblement(mob, target, pTable)
     end
 
     return xi.mob.onAddEffect(mob, target, damage, chosenEffect)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Allows additional effects to trigger on other entities not the current combat target.
- Renames functions to make them clearer.
- Adds extra damage multiplier to damaging AEs
- Cleanup of Phalanx, one-for-all and stoneskin util functions.

## Steps to test these changes
Review by commit.
Fight mobs that apply additional effects suing this new system.
