### PR TITLE
[core] addStatusEffect: support non-whole number duration

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -13527,7 +13527,7 @@ bool CLuaBaseEntity::addStatusEffect(sol::variadic_args va)
         auto effectIcon = va[0].as<uint16>();                      // The same
         auto power      = static_cast<uint16>(va[1].as<double>()); // Can come in as a lua_number, capture as double and truncate
         auto tick       = static_cast<uint32>(va[2].as<double>());
-        auto duration   = static_cast<uint32>(va[3].as<double>());
+        auto duration   = va[3].as<double>();
 
         // Optional
         auto subType         = va[4].is<uint32>() ? va[4].as<uint32>() : 0;
@@ -13541,7 +13541,7 @@ bool CLuaBaseEntity::addStatusEffect(sol::variadic_args va)
                                                    effectIcon,
                                                    power,
                                                    std::chrono::seconds(tick),
-                                                   std::chrono::seconds(duration),
+                                                   std::chrono::milliseconds(static_cast<uint64_t>(duration * 1000)),
                                                    subType,
                                                    subPower,
                                                    tier);
@@ -13598,7 +13598,7 @@ auto CLuaBaseEntity::addStatusEffectEx(sol::variadic_args va) -> bool
     auto effectIcon = va[1].as<uint16>();
     auto power      = static_cast<uint16>(va[2].as<double>()); // Can come in as a lua_number, capture as double and truncate
     auto tick       = static_cast<uint32>(va[3].as<double>());
-    auto duration   = static_cast<uint32>(va[4].as<double>());
+    auto duration   = va[4].as<double>();
 
     // Optional
     auto subType         = va[5].is<uint32>() ? va[5].as<uint32>() : 0;
@@ -13614,7 +13614,7 @@ auto CLuaBaseEntity::addStatusEffectEx(sol::variadic_args va) -> bool
                           effectIcon,
                           power,
                           std::chrono::seconds(tick),
-                          std::chrono::seconds(duration),
+                          std::chrono::milliseconds(static_cast<uint64_t>(duration * 1000)),
                           subType,
                           subPower,
                           tier,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Status effects can resolve in durations that aren't whole seconds, so we need to support that

https://docs.google.com/spreadsheets/d/10kGMO7VqgI_G2XuQjkipYNnWuuIZr0J7Ro8vs7bM5WQ/edit?gid=1684442499#gid=1684442499
## Steps to test these changes

`!exec player:addStatusEffect(xi.effect.STUN, 0, 0, 3.5)` and see it last 3.5 seconds (use the debugger to verify, much easier...)