### PR TITLE
[lua] Status Resistance Rank 11 = 0% hit rate

### DIFF
--- a/scripts/globals/combat/magic_hit_rate.lua
+++ b/scripts/globals/combat/magic_hit_rate.lua
@@ -589,6 +589,11 @@ xi.combat.magicHitRate.calculateResistRate = function(actor, target, spellGroup,
         resistanceRank = utils.clamp(resistanceRank, -3, 11)
     end
 
+    -- https://www.bg-wiki.com/ffxi/Resist#Modifying_Negative_Status_Resistance_Ranks
+    if effectId > 0 and resistanceRank == 11 then
+        return 0 -- cannot land, ever. This is different than "Completely resists". Same effect as trying to land Stun on an earth elemental, it can never land but it's not "immune"
+    end
+
     -- Get Actor Magic Accuracy and target Magic Evasion
     local magicAcc     = xi.combat.magicHitRate.calculateActorMagicAccuracy(actor, target, spellGroup, skillType, skillRank, actionElement, statUsed, effectId, bonusMacc)
     local magicEva     = xi.combat.magicHitRate.calculateTargetMagicEvasion(actor, target, actionElement, effectId, resistanceRank)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
With a status resistance rank of 11, mhitrate is 0. This is testable with Stun or Break vs Earth Elemental. You are unable to land Break without an immunobreak or Stymie (this does not apply with Stun because it's not Enfeeling Magic)

## Steps to test these changes

only Stymie should allow sleep to land without immunobreak:
<img width="775" height="518" alt="image" src="https://github.com/user-attachments/assets/8826b650-cacc-4226-9f65-21b86d0f6aa4" />

1 or more immunobreaks can land (1 immunobreak means 5% mhit rate, but 2 would go up to potentially 95% if you had enough macc)
<img width="450" height="192" alt="image" src="https://github.com/user-attachments/assets/c2b6d3f1-46ff-411c-a898-6b4b11b423da" />
