### PR TITLE
[sql] Implement Dangruf Wadi Spawn Slots

### DIFF
--- a/sql/mob_spawn_slots.sql
+++ b/sql/mob_spawn_slots.sql
@@ -621,6 +621,31 @@ INSERT INTO `mob_spawn_slots` VALUES (173, 2, 0);
 INSERT INTO `mob_spawn_slots` VALUES (173, 3, 0);
 INSERT INTO `mob_spawn_slots` VALUES (173, 4, 0);
 
+-- Dangruf Wadi
+INSERT INTO `mob_spawn_slots` VALUES (191,1,0);
+INSERT INTO `mob_spawn_slots` VALUES (191,2,0);
+INSERT INTO `mob_spawn_slots` VALUES (191,3,0);
+INSERT INTO `mob_spawn_slots` VALUES (191,4,0);
+INSERT INTO `mob_spawn_slots` VALUES (191,5,0);
+INSERT INTO `mob_spawn_slots` VALUES (191,6,0);
+INSERT INTO `mob_spawn_slots` VALUES (191,7,0);
+INSERT INTO `mob_spawn_slots` VALUES (191,8,0);
+INSERT INTO `mob_spawn_slots` VALUES (191,9,0);
+INSERT INTO `mob_spawn_slots` VALUES (191,10,0);
+INSERT INTO `mob_spawn_slots` VALUES (191,11,0);
+INSERT INTO `mob_spawn_slots` VALUES (191,12,0);
+INSERT INTO `mob_spawn_slots` VALUES (191,13,0);
+INSERT INTO `mob_spawn_slots` VALUES (191,14,0);
+INSERT INTO `mob_spawn_slots` VALUES (191,15,0);
+INSERT INTO `mob_spawn_slots` VALUES (191,16,0);
+INSERT INTO `mob_spawn_slots` VALUES (191,17,0);
+INSERT INTO `mob_spawn_slots` VALUES (191,18,0);
+INSERT INTO `mob_spawn_slots` VALUES (191,19,0);
+INSERT INTO `mob_spawn_slots` VALUES (191,20,0);
+INSERT INTO `mob_spawn_slots` VALUES (191,21,0);
+INSERT INTO `mob_spawn_slots` VALUES (191,22,0);
+INSERT INTO `mob_spawn_slots` VALUES (191,23,0);
+
 -- Ordelle's Caves
 INSERT INTO `mob_spawn_slots` VALUES (193,1,0);
 INSERT INTO `mob_spawn_slots` VALUES (193,2,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Implements Dangruf wadi spawn slots. For whatever reason there is only a single slot for 99 mobs. I have no explanation but it took me 2 hours to find it.

https://docs.google.com/spreadsheets/d/1Ioi5Bp0BABeHBnywTscdCnZQm6Er8tec-PwX6ir4B2w/edit?gid=227484020#gid=227484020
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!gotoid 17559563 or 17559564
Kill it
See same or other spawn
<!-- Clear and detailed steps to test your changes here -->
