### PR TITLE
[lua, sql][module] White Mage Era Audits

### DIFF
--- a/modules/abyssea/lua/job_adjustments.lua
+++ b/modules/abyssea/lua/job_adjustments.lua
@@ -13,12 +13,12 @@ local m = Module:new('job_adjustments')
 -- Warrior
 -----------------------------------
 
--- Remove Triple Attack from Warrior's Charge
+-- Warrior's Charge: Remove Triple Attack bonus
 m:addOverride('xi.effects.warriors_charge.onEffectGain', function(target, effect)
     effect:addMod(xi.mod.DOUBLE_ATTACK, 100)
 end)
 
--- Set Warrior's Charge recast to be reduced by merits
+-- Warrior's Charge: Apply merit recast reduction
 m:addOverride('xi.job_utils.warrior.useWarriorsCharge', function(player, target, ability, action)
     local recastReduction = player:getMerit(xi.merit.WARRIORS_CHARGE) - 150
     action:setRecast(action:getRecast() - recastReduction)
@@ -26,6 +26,44 @@ m:addOverride('xi.job_utils.warrior.useWarriorsCharge', function(player, target,
     player:addStatusEffect(xi.effect.WARRIORS_CHARGE, 1, 0, 60)
 
     return xi.effect.WARRIORS_CHARGE
+end)
+
+-----------------------------------
+-- White Mage
+-----------------------------------
+
+-- Martyr: Apply merit recast reduction, remove merit healing bonus
+m:addOverride('xi.job_utils.white_mage.useMartyr', function(player, target, ability, action)
+    local recastReduction = player:getMerit(xi.merit.MARTYR) - 150
+    action:setRecast(action:getRecast() - recastReduction)
+
+    local damageHP = math.floor(player:getHP() * 0.25)
+    local healHP = damageHP * 2
+    healHP = utils.clamp(healHP, 0, target:getMaxHP() - target:getHP())
+
+    -- If stoneskin is present, it should absorb damage
+    damageHP = utils.handleStoneskin(player, damageHP)
+    player:delHP(damageHP)
+    target:addHP(healHP)
+
+    return healHP
+end)
+
+-- Devotion: Apply merit recast reduction, remove merit MP bonus
+m:addOverride('xi.job_utils.white_mage.useDevotion', function(player, target, ability, action)
+    local recastReduction = player:getMerit(xi.merit.DEVOTION) - 150
+    action:setRecast(action:getRecast() - recastReduction)
+
+    local damageHP = math.floor(player:getHP() * 0.25)
+    local healMP = damageHP
+    healMP = utils.clamp(healMP, 0, target:getMaxMP() - target:getMP())
+
+    -- If stoneskin is present, it should absorb damage
+    damageHP = utils.handleStoneskin(player, damageHP)
+    player:delHP(damageHP)
+    target:addMP(healMP)
+
+    return healMP
 end)
 
 return m

--- a/modules/abyssea/sql/job_adjustments.sql
+++ b/modules/abyssea/sql/job_adjustments.sql
@@ -1,16 +1,54 @@
 ------------------------------------
 -- Abyssea Job SQL Adjustments
 -- This module reverts relevant SQL tables for jobs to their pre-Abyssea values
-------------------------------------
--- Source : https://www.bg-wiki.com/ffxi/Version_Update_(03/26/2012)
+-- Unless otherwise noted, all changes here are sourced from: https://www.bg-wiki.com/ffxi/Version_Update_(03/26/2012)
 ------------------------------------
 
 ------------------------------------
 -- Warrior
 ------------------------------------
 
--- Reverts Warrior's Charge cooldown to 15 minutes
+-- Warrior's Charge: Revert recast from 5 to 15 minutes
 UPDATE abilities SET recastTime = 900 WHERE name = 'warriors_charge';
 
--- Change warrior's Charge merit value to reduce cooldown by 150 seconds per merit
+-- Warrior's Charge merit: Revert value to 150 seconds per level
 UPDATE merits SET value = 150 WHERE name = 'warriors_charge';
+
+------------------------------------
+-- White Mage
+------------------------------------
+
+-- Martyr: Revert recast from 10 to 20 minutes
+UPDATE abilities SET recastTime = 1200 WHERE name = 'martyr';
+
+-- Devotion: Revert recast from 10 to 20 minutes
+UPDATE abilities SET recastTime = 1200 WHERE name = 'devotion';
+
+-- Martyr merit: Revert value to 150 seconds per level
+UPDATE merits SET value = 150 WHERE name = 'martyr';
+
+-- Devotion merit: Revert value to 150 seconds per level
+UPDATE merits SET value = 150 WHERE name = 'devotion';
+
+-- Animus Solace: Disable merit upgrades
+UPDATE merits SET upgrade = 0 WHERE name = 'animus_solace';
+
+-- Animus Misery: Disable merit upgrades
+UPDATE merits SET upgrade = 0 WHERE name = 'animus_misery';
+
+------------------------------------
+-- WHM Spell Cast Times
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(02/13/2012)
+------------------------------------
+
+-- Esuna: Revert cast time from 1 to 3 seconds
+UPDATE spell_list SET castTime = 3000 WHERE name = 'esuna';
+
+-- Sacrifice: Revert cast time from 1 to 1.5 seconds
+UPDATE spell_list SET castTime = 1500 WHERE name = 'sacrifice';
+
+-- Blindna: Revert cast time from 1 to 3 seconds
+UPDATE spell_list SET castTime = 3000 WHERE name = 'blindna';
+
+-- Cursna: Revert cast time from 1 to 3 seconds
+UPDATE spell_list SET castTime = 3000 WHERE name = 'cursna';

--- a/modules/wotg/sql/job_adjustments.sql
+++ b/modules/wotg/sql/job_adjustments.sql
@@ -1,0 +1,34 @@
+------------------------------------
+-- Wings of the Goddess Job SQL Adjustments
+-- This module reverts relevant SQL tables for jobs to their pre-WotG values
+------------------------------------
+-- Source : https://www.bg-wiki.com/ffxi/Version_Update_(04/08/2009)
+------------------------------------
+
+------------------------------------
+-- White Mage
+------------------------------------
+
+-- Banish II: Revert cast time from 2.5 to 3.75 seconds
+UPDATE `spell_list` SET `castTime` = 3750 WHERE `name` = 'banish_ii';
+
+-- Banish III: Revert cast time from 3 to 5.5 seconds
+UPDATE `spell_list` SET `castTime` = 5500 WHERE `name` = 'banish_iii';
+
+-- Raise II: Revert MP from 150 to 200, cast time from 14 to 20 seconds
+UPDATE `spell_list` SET `mpCost` = 200, `castTime` = 20000 WHERE `name` = 'raise_ii';
+
+-- Raise III: Revert MP from 150 to 250, cast time from 13 to 20 seconds
+UPDATE `spell_list` SET `mpCost` = 250, `castTime` = 20000 WHERE `name` = 'raise_iii';
+
+-- Reraise: Revert WHM level from 25 to 33
+UPDATE `spell_list` SET `jobs` = 0x00002100000000000000000000000000000000230000 WHERE `name` = 'reraise';
+
+-- Reraise II: Revert WHM level from 56 to 60, MP from 150 to 175, cast time from 7.5 to 8 seconds
+UPDATE `spell_list` SET `jobs` = 0x00003C00000000000000000000000000000000460000, `mpCost` = 175, `castTime` = 8000 WHERE `name` = 'reraise_ii';
+
+-- Reraise III: Revert WHM level from 70 to 75, MP from 150 to 200, cast time from 7 to 8 seconds
+UPDATE `spell_list` SET `jobs` = 0x00004B000000000000000000000000000000005B0000, `mpCost` = 200, `castTime` = 8000 WHERE `name` = 'reraise_iii';
+
+-- Martyr: Revert range from 20 to 6 yalms
+UPDATE `abilities` SET `range` = 6.0 WHERE `name` = 'martyr';

--- a/scripts/actions/abilities/devotion.lua
+++ b/scripts/actions/abilities/devotion.lua
@@ -13,8 +13,8 @@ abilityObject.onAbilityCheck = function(player, target, ability)
     return xi.job_utils.white_mage.checkDevotion(player, target, ability)
 end
 
-abilityObject.onUseAbility = function(player, target, ability)
-    return xi.job_utils.white_mage.useDevotion(player, target, ability)
+abilityObject.onUseAbility = function(player, target, ability, action)
+    return xi.job_utils.white_mage.useDevotion(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/martyr.lua
+++ b/scripts/actions/abilities/martyr.lua
@@ -13,8 +13,8 @@ abilityObject.onAbilityCheck = function(player, target, ability)
     return xi.job_utils.white_mage.checkMartyr(player, target, ability)
 end
 
-abilityObject.onUseAbility = function(player, target, ability)
-    return xi.job_utils.white_mage.useMartyr(player, target, ability)
+abilityObject.onUseAbility = function(player, target, ability, action)
+    return xi.job_utils.white_mage.useMartyr(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/globals/job_utils/white_mage.lua
+++ b/scripts/globals/job_utils/white_mage.lua
@@ -107,7 +107,7 @@ xi.job_utils.white_mage.useBenediction = function(player, target, ability)
     return heal
 end
 
-xi.job_utils.white_mage.useDevotion = function(player, target, ability)
+xi.job_utils.white_mage.useDevotion = function(player, target, ability, action)
     -- Plus 5 percent mp recovers per extra devotion merit
     local meritBonus = player:getMerit(xi.merit.DEVOTION) - 5
     local mpPercent  = (25 + meritBonus) / 100
@@ -137,7 +137,7 @@ xi.job_utils.white_mage.useDivineSeal = function(player, target, ability)
     return xi.effect.DIVINE_SEAL
 end
 
-xi.job_utils.white_mage.useMartyr = function(player, target, ability)
+xi.job_utils.white_mage.useMartyr = function(player, target, ability, action)
     -- Plus 5 percent hp recovers per extra martyr merit
     local meritBonus = player:getMerit(xi.merit.MARTYR) - 5
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds White Mage era changes to the existing Abyssea module and adjusts some comments.
- Adds new WotG module folder and job adjustments to revert several cast times and spell levels.

## Steps to test these changes

- Load module, see that White Mage has differing cast times and MP costs when using spells listed in this module
