### PR TITLE
[sql] Fix Item ID of GP Item Carapace Subligar

### DIFF
--- a/sql/guild_item_points.sql
+++ b/sql/guild_item_points.sql
@@ -1067,7 +1067,7 @@ INSERT INTO `guild_item_points` VALUES (6,13062,3,542,10320,7); -- Green Gorget 
 -- Bonecraft / Apprentice
 INSERT INTO `guild_item_points` VALUES (6,17352,4,780,12960,0); -- Horn (780 / 12960)
 INSERT INTO `guild_item_points` VALUES (6,17371,4,840,12960,0); -- Horn +1 (840 / 12960)
-INSERT INTO `guild_item_points` VALUES (6,17371,4,1540,15840,1); -- Carapace Subligar (1540 / 15840)
+INSERT INTO `guild_item_points` VALUES (6,12837,4,1540,15840,1); -- Carapace Subligar (1540 / 15840)
 INSERT INTO `guild_item_points` VALUES (6,12914,4,1610,15840,1); -- Carapace Subligar +1 (1610 / 15840)
 INSERT INTO `guild_item_points` VALUES (6,13461,4,1812,16560,2); -- Carapace Ring (1812 / 16560)
 INSERT INTO `guild_item_points` VALUES (6,13503,4,2537,16560,2); -- Carapace Ring +1 (2537 / 16560)


### PR DESCRIPTION
The Carapace Subligar entry was using the Horn +1 entry.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

NQ Carapace Subligar was using the item ID of Horn +1.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
