### PR TITLE
[lua] Fixes astral flow not going off

### DIFF
--- a/scripts/mixins/families/avatar.lua
+++ b/scripts/mixins/families/avatar.lua
@@ -98,7 +98,7 @@ g_mixins.families.avatar = function(avatarMob)
         if abilityId > 0 then
             mob:timer(astralDelayMs, function(mobArg)
                 if mobArg:isAlive() then
-                    mobArg:useMobAbility(abilityId)
+                    mobArg:useMobAbility(abilityId, target)
                 end
             end)
         end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Astral flow was not firing off because of an edge case where it needs its target defined in the useMobAbility until re-write
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Go to kirin, !hp 30 and watch the astral flow go off
<!-- Clear and detailed steps to test your changes here -->
