### PR TITLE
[lua, sql] Eastern Altepa NM Audits

### DIFF
--- a/scripts/zones/Eastern_Altepa_Desert/mobs/Cactrot_Rapido.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/mobs/Cactrot_Rapido.lua
@@ -171,6 +171,10 @@ entity.spawnPoints =
 entity.onMobInitialize = function(mob)
     xi.mob.updateNMSpawnPoint(mob)
     mob:setRespawnTime(math.random(172800, 259200)) -- When server restarts, reset timer
+    mob:addImmunity(xi.immunity.BIND)
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.STUN)
+    mob:addImmunity(xi.immunity.GRAVITY)
 end
 
 entity.onMobSpawn = function(mob)
@@ -178,6 +182,7 @@ entity.onMobSpawn = function(mob)
     mob:setBaseSpeed(72)
     mob:setAnimationSpeed(180)
     mob:pathThrough(pathNodes, bit.bor(xi.path.flag.PATROL, xi.path.flag.RUN))
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
 entity.onMobDisengage = function(mob)

--- a/scripts/zones/Eastern_Altepa_Desert/mobs/Dune_Widow.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/mobs/Dune_Widow.lua
@@ -66,6 +66,12 @@ entity.phList =
     [ID.mob.DUNE_WIDOW - 1] = ID.mob.DUNE_WIDOW,
 }
 
+entity.onMobInitialize = function(mob)
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.TERROR)
+    mob:addImmunity(xi.immunity.SILENCE)
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 408)
     xi.magian.onMobDeath(mob, player, optParams, set{ 712 })

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -8605,7 +8605,7 @@ INSERT INTO `mob_groups` VALUES (25,5891,114,'Sabotender_Corrido',7200,0,3090,90
 INSERT INTO `mob_groups` VALUES (26,1709,114,'Goblin_Robber',300,0,1145,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (27,676,114,'Centurio_XII-I',0,128,444,5000,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (28,1701,114,'Goblin_Poacher',300,0,1138,0,0,0,NULL);
-INSERT INTO `mob_groups` VALUES (29,1138,114,'Dune_Widow',0,32,720,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,1138,114,'Dune_Widow',0,32,720,4300,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (30,1705,114,'Goblin_Reaper',300,0,1142,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (31,1741,114,'Goblin_Trader',300,0,1179,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (32,1732,114,'Goblins_Spider',0,128,0,0,0,0,NULL);
@@ -8628,7 +8628,7 @@ INSERT INTO `mob_groups` VALUES (48,781,114,'Contantican_Warrior',0,128,0,0,0,0,
 INSERT INTO `mob_groups` VALUES (49,778,114,'Contantican_Black_Mage',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (50,779,114,'Contantican_Paladin',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (51,780,114,'Contantican_Ranger',0,128,0,0,0,0,NULL);
-INSERT INTO `mob_groups` VALUES (52,595,114,'Cactrot_Rapido',0,128,395,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,595,114,'Cactrot_Rapido',0,128,395,9800,0,0,NULL);
 
 -- garrison
 INSERT INTO `mob_groups` VALUES (53,1896,114,'Hastatus_XIII-LXXV',0,128,3226,0,0,0,NULL);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This pull request audits multiple NMs in Eastern Altepa Desert based on retail captures. Thank you to Wuku for some of the captures used.

**[Cactrot Rapido](https://www.youtube.com/watch?v=XhLv8aytpzA)** (ID: 17244539)

- Added immunities.
- Added observed 1.5x Weapon Damage mod.
- Adjusted HP.

**[Centurio XII-I](https://youtu.be/7e7D47mpJ8U)** (ID: 17244372)

- Adjusted level range.

**[Dune Widow](https://youtu.be/dhZRu8hPQtU)** (ID: 17244396)

- Added immunities.
- Adjusted HP.

## Steps to test these changes

!spawnmob any of the above IDs and witness the changes.