### PR TITLE
DRG AF Quest flow fix

### DIFF
--- a/scripts/zones/Batallia_Downs/IDs.lua
+++ b/scripts/zones/Batallia_Downs/IDs.lua
@@ -26,6 +26,7 @@ zones[xi.zone.BATALLIA_DOWNS] =
         FIND_NOTHING                  = 7264,  -- You dig and you dig, but find nothing.
         FOUND_ITEM_WITH_EASE          = 7339,  -- It appears your chocobo found this item with ease.
         SPARKLING_LIGHT               = 7358,  -- The ground is sparkling with a strange light.
+        SOMEONE_DUG                   = 7445,  -- Someone or something has dug a hole here.
         SENSE_AN_EVIL_PRESENCE        = 7446,  -- You sense an evil presence.
         SENSE_SOMETHING_LURKING       = 7448,  -- You sense something lurking close by!
         NO_GRASS_GROWING_HERE         = 7497,  -- There is no grass growing here...

--- a/scripts/zones/Batallia_Downs/npcs/qm2.lua
+++ b/scripts/zones/Batallia_Downs/npcs/qm2.lua
@@ -14,7 +14,7 @@ entity.onTrigger = function(player, npc)
     if
         player:getCharVar('ChasingQuotas_Progress') == 5 and
         sturmtigerKilled == 0 and
-        npcUtil.popFromQM(player, npc, ID.mob.STURMTIGER)
+        npcUtil.popFromQM(player, npc, ID.mob.STURMTIGER, { hide = 0, })
     then
         player:messageSpecial(ID.text.SENSE_AN_EVIL_PRESENCE)
     elseif sturmtigerKilled == 1 then
@@ -22,7 +22,7 @@ entity.onTrigger = function(player, npc)
         player:setCharVar('ChasingQuotas_Progress', 6)
         player:setCharVar('SturmtigerKilled', 0)
     else
-        player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)
+        player:messageSpecial(ID.text.SOMEONE_DUG)
     end
 end
 

--- a/scripts/zones/Eastern_Altepa_Desert/DefaultActions.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/DefaultActions.lua
@@ -3,6 +3,5 @@ local ID = zones[xi.zone.EASTERN_ALTEPA_DESERT]
 return {
     ['Beastmens_Banner'] = { messageSpecial = ID.text.BEASTMEN_BANNER },
     ['Lokpix'] = { event = 24 },
-    ['qm']     = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
     ['qm2']    = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
 }

--- a/scripts/zones/Eastern_Altepa_Desert/IDs.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/IDs.lua
@@ -28,6 +28,7 @@ zones[xi.zone.EASTERN_ALTEPA_DESERT] =
         AMK_DIGGING_OFFSET            = 7650,  -- You spot some familiar footprints. You are convinced that your moogle friend has been digging in the immediate vicinity.
         FOUND_ITEM_WITH_EASE          = 7659,  -- It appears your chocobo found this item with ease.
         ALREADY_OBTAINED_TELE         = 7678,  -- You already possess the gate crystal for this telepoint.
+        REMNANTS_OF_A_PAST_AGE        = 7682,  -- These are remnants of a past age, made from a rare kind of stone.
         FEEL_A_HOSTILE_GAZE           = 7683,  -- You feel a hostile gaze upon you!
         GARRISON_BASE                 = 7705,  -- Hm? What is this? %? How do I know this is not some [San d'Orian/Bastokan/Windurstian] trick?
         PLAYER_OBTAINS_ITEM           = 7778,  -- <name> obtains <item>!

--- a/scripts/zones/Eastern_Altepa_Desert/npcs/qm.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/npcs/qm.lua
@@ -15,13 +15,15 @@ entity.onTrigger = function(player, npc)
     if
         player:getCharVar('aCraftsmanWork') == 1 and
         decurioKilled == 0 and
-        npcUtil.popFromQM(player, npc, ID.mob.DECURIO_I_III)
+        npcUtil.popFromQM(player, npc, ID.mob.DECURIO_I_III, { hide = 0, })
     then
         player:messageSpecial(ID.text.FEEL_A_HOSTILE_GAZE)
     elseif decurioKilled == 1 then
         npcUtil.giveKeyItem(player, xi.ki.ALTEPA_POLISHING_STONE)
         player:setCharVar('aCraftsmanWork', 2)
         player:setCharVar('Decurio_I_IIIKilled', 0)
+    else
+        player:messageSpecial(ID.text.REMNANTS_OF_A_PAST_AGE)
     end
 end
 

--- a/scripts/zones/Northern_San_dOria/npcs/Miaux.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Miaux.lua
@@ -40,7 +40,7 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    if csid == 73 and option == 0 then -- first part of long CS -- declines questgiver
+    if csid == 73 and option == 2 then -- first part of long CS -- declines questgiver
         player:setCharVar('has_seen_drgaf1_quest_already', 1)
     elseif (csid == 73 or csid == 71) and option == 1 then
         player:addQuest(xi.questLog.SANDORIA, xi.quest.id.sandoria.A_CRAFTSMANS_WORK)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR fixes the quest flow for DRG AF1 to force the player to watch the intended cutscene rather than letting them skip it on initial decline.

Now the secondary cutscene will only play if the player decline the 2nd dialogue option rather than the first.

This also deletes the duplicate QM interaction for Deucrio's QM and plays the correct message when selected.
This also makes sure the QM doesn't disappear when spawned. (Sorry about that!)

This also touched Sturmtiger's QM to play the correct message when not activatable and also makes sure Sturmtiger's QM doesn't disappear when spawned.

## Steps to test these changes

Do DRG AF 1 or AF 2 and see improvements.
