### PR TITLE
[Fix] Grand palace teleporters not wiping enmity

### DIFF
--- a/scripts/zones/Grand_Palace_of_HuXzoi/Zone.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/Zone.lua
@@ -36,8 +36,6 @@ zoneObject.onZoneIn = function(player, prevZone)
         player:setPos(-20, -1.5, -355.482, 192)
     end
 
-    player:setCharVar('Hu-Xzoi-TP', 0)
-
     return cs
 end
 
@@ -50,11 +48,11 @@ end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)
     if
-        player:getLocalVar('Hu-Xzoi-TP') == 0 and
+        player:getLocalVar('isTeleporting') == 0 and
         player:getAnimation() == xi.anim.NONE
     then
         -- prevent 2cs at same time
-        player:startEvent(149 + triggerArea:getTriggerAreaID())
+        player:startOptionalCutscene(149 + triggerArea:getTriggerAreaID()) -- Confirmed to wipe enmity.
     end
 end
 
@@ -63,13 +61,13 @@ end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)
     if csid >= 150 and csid <= 159 then
-        player:setLocalVar('Hu-Xzoi-TP', 1)
+        player:setLocalVar('isTeleporting', 1)
     end
 end
 
 zoneObject.onEventFinish = function(player, csid, option, npc)
     if csid >= 150 and csid <= 159 then
-        player:setLocalVar('Hu-Xzoi-TP', 0)
+        player:setLocalVar('isTeleporting', 0)
     end
 end
 

--- a/scripts/zones/The_Garden_of_RuHmet/Zone.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/Zone.lua
@@ -192,7 +192,7 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
                 player:startEvent(183)
             end
         elseif teleportEventsByArea[areaId] then
-            player:startOptionalCutscene(teleportEventsByArea[areaId])
+            player:startOptionalCutscene(teleportEventsByArea[areaId]) -- Confirmed to wipe enmity.
         end
     end
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
As title sais.

## Steps to test these changes
Agro a mob, run to a teleporter and actually accept the teleport before it hits you. The mob stops chasing.
