### PR TITLE
Self Destruct NM fix

### DIFF
--- a/scripts/zones/Castle_Zvahl_Baileys/mobs/Dark_Spark.lua
+++ b/scripts/zones/Castle_Zvahl_Baileys/mobs/Dark_Spark.lua
@@ -16,4 +16,17 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_DELAY, 0)
 end
 
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    local skillList =
+    {
+        xi.mobSkill.BERSERK_BOMB,
+    }
+
+    if mob:getHPP() < 10 then
+        table.insert(skillList, xi.mobSkill.SELF_DESTRUCT_BOMB)
+    end
+
+    return skillList[math.random(1, #skillList)]
+end
+
 return entity

--- a/scripts/zones/Den_of_Rancor/mobs/Friar_Rush.lua
+++ b/scripts/zones/Den_of_Rancor/mobs/Friar_Rush.lua
@@ -33,6 +33,10 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    return xi.mobSkill.BERSERK_BOMB
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 394)
 end

--- a/scripts/zones/Den_of_Rancor/mobs/Rancor_Torch.lua
+++ b/scripts/zones/Den_of_Rancor/mobs/Rancor_Torch.lua
@@ -21,6 +21,19 @@ entity.onMobDeath = function(mob, player, optParams)
     player:setCharVar('rancorCurse', 0) -- Player has been cleansed of the curse
 end
 
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    local skillList =
+    {
+        xi.mobSkill.BERSERK_BOMB,
+    }
+
+    if mob:getHPP() < 20 then
+        table.insert(skillList, xi.mobSkill.SELF_DESTRUCT_BOMB)
+    end
+
+    return skillList[math.random(1, #skillList)]
+end
+
 -- Turns off all the lights once the NM despawns
 entity.onMobDespawn = function(mob)
     for npcId = ID.npc.LANTERN_OFFSET + 15, ID.npc.LANTERN_OFFSET + 18 do

--- a/scripts/zones/Ifrits_Cauldron/mobs/Magma.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Magma.lua
@@ -23,4 +23,17 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 200)
 end
 
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    local skillList =
+    {
+        xi.mobSkill.BERSERK_BOMB,
+    }
+
+    if mob:getHPP() < 10 then
+        table.insert(skillList, xi.mobSkill.SELF_DESTRUCT_BOMB)
+    end
+
+    return skillList[math.random(1, #skillList)]
+end
+
 return entity

--- a/scripts/zones/Konschtat_Highlands/mobs/Forger.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Forger.lua
@@ -11,6 +11,10 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 300)
 end
 
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    return xi.mobSkill.BERSERK_BOMB
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.tutorial.onMobDeath(player)
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR fixes the Self-Destruct behavior for various NMs which was changed when adjusting the correct behavior for the Bomb Queen fight.

Some NMs do not self destruct, some NMs are only capable of self-destructing at low HP.

This adjustment will also be needed when the mobskill of self destruct is fixed to do 1:1 breath damage for certain NMs.

Most of the NMs I've seen trigger below 10%.

https://youtu.be/qiLlTVIhUik?si=NBsSx9oervicdcqS&t=6425

Magma torch below 20%  It likely varies, but the framework will be there.

## Steps to test these changes

Fight Friar Rush or Dark Spark and observe the correct behavior.
