### PR TITLE
[lua] Typhoon Hits

### DIFF
--- a/scripts/actions/mobskills/typhoon.lua
+++ b/scripts/actions/mobskills/typhoon.lua
@@ -2,7 +2,7 @@
 --  Typhoon
 --  Description: Spins around dealing damage to targets in an area of effect.
 --  Type: Physical
---  Utsusemi/Blink absorb: 2-4 shadows
+--  Utsusemi/Blink absorb: 1-2 Shadows
 --  Range: 10' radial
 -----------------------------------
 ---@type TMobSkill
@@ -13,11 +13,11 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local numhits = 4
-    local accmod = 1
-    local ftp    = 1
-    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
-    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
+    local numhits = 2
+    local accmod  = 1
+    local ftp     = 1
+    local info    = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
+    local dmg     = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
 
     return dmg


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Updates the number of hits on the TP move Typhoon

Typhoon was set at 4 hits which was leading wildly high damage in some cases. 
Retail Typhoon Example : Hits vary from 200-400 on my 99 RDM. Jimmys sheet denotes 1 hit, 1 ftp, but this variance in damage suggests 2 hits. We tried using Turms mittens, but it's just too difficult to verify without getting extremely lucky. If needed, I can produce more screenshots.
<img width="567" height="894" alt="image" src="https://github.com/user-attachments/assets/ef71edc0-83e6-4955-8d0c-1a2b6b5d343d" />

My local with 2 hits , 1 ftp. As you can see the numbers and damage variance line up very closely with my screenshot and produces much closer numbers. 
<img width="505" height="780" alt="image" src="https://github.com/user-attachments/assets/69674b12-d003-46e2-9fb7-4274819edc04" />


## Steps to test these changes

Fight Faust
