### PR TITLE
[lua] Tango with a Tracker Quest Bug Fix

### DIFF
--- a/scripts/quests/otherAreas/Tango_with_a_Tracker.lua
+++ b/scripts/quests/otherAreas/Tango_with_a_Tracker.lua
@@ -42,8 +42,7 @@ quest.sections =
     {
         check = function(player, status, vars)
             return vars.Prog == 1 and
-                (status == xi.questStatus.QUEST_ACCEPTED or
-                status == xi.questStatus.QUEST_COMPLETED)
+                status == xi.questStatus.QUEST_ACCEPTED
         end,
 
         [xi.zone.BONEYARD_GULLY] =
@@ -62,8 +61,7 @@ quest.sections =
     {
         check = function(player, status, vars)
             return vars.Prog == 2 and
-                (status == xi.questStatus.QUEST_ACCEPTED or
-                status == xi.questStatus.QUEST_COMPLETED)
+                status == xi.questStatus.QUEST_ACCEPTED
         end,
 
         [xi.zone.TAVNAZIAN_SAFEHOLD] =


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Removes the quest complete check from the quest.
Tango isn't repeatable so it was causing a loop where the player would get another KI for Tango.

## Steps to test these changes

`!addmission 6 818`
`!completemission 6 818`
`!addmission 6 828`
Talk to Despachiaire to get KI Letter from Shikaree X
`!zone <Boneyard Gully>`
Enter battlefield
Win. -- Quest Complete
Talk to Despachiaire again who won't give you another letter from Shikaree X
