### PR TITLE
[Magic] Add tiers to enfeeblement songs

### DIFF
--- a/scripts/data/status_effect_tables.lua
+++ b/scripts/data/status_effect_tables.lua
@@ -283,16 +283,24 @@ xi.data.statusEffect.isEffectNullified = function(target, effectId, effectTier)
         return true
     end
 
+    if effectTier == 0 then
+        return false
+    end
+
+    -- Check if current effect is in place with a higher tier.
+    if target:hasStatusEffect(effectId) then
+        if target:getStatusEffect(effectId):getTier() >= effectTier then
+            return true
+        end
+    end
+
     -- Check effects that can block current effect from being applied, based on tier.
-    local tierToCheck             = utils.defaultIfNil(effectId, 0)
     local tierNullificatingEffect = xi.data.statusEffect.getNullificatingEffectByTier(effectId)
     if
-        tierToCheck > 0 and
         tierNullificatingEffect > 0 and
         target:hasStatusEffect(tierNullificatingEffect)
     then
-        local blockingTier = target:getStatusEffect(tierNullificatingEffect):getTier()
-        if blockingTier > tierToCheck then
+        if target:getStatusEffect(tierNullificatingEffect):getTier() >= effectTier then
             return true
         end
     end

--- a/scripts/globals/spells/enfeebling_song.lua
+++ b/scripts/globals/spells/enfeebling_song.lua
@@ -13,54 +13,55 @@ xi.spells.enfeebling = xi.spells.enfeebling or {}
 local column =
 {
     SONG_EFFECT     = 1,
-    SONG_POWER_BASE = 2,
-    SONG_POWER_CAP  = 3,
-    SONG_DURATION   = 4,
-    SONG_MODIFIER   = 5,
+    SONG_TIER       = 2,
+    SONG_POWER_BASE = 3,
+    SONG_POWER_CAP  = 4,
+    SONG_DURATION   = 5,
+    SONG_MODIFIER   = 6,
 }
 
 local pTable =
 {
-    -- [Spell ID                         ] = { Effect,             Base,  Cap, Dur, Modifier               },
+    -- [Spell ID                         ] = { Effect,          Tier, Base,  Cap, Dur, Modifier               },
     -- Requiem: https://www.bg-wiki.com/ffxi/Category:Requiem
-    [xi.magic.spell.FOE_REQUIEM          ] = { xi.effect.REQUIEM,     1,  300,  64, xi.mod.REQUIEM_EFFECT  },
-    [xi.magic.spell.FOE_REQUIEM_II       ] = { xi.effect.REQUIEM,     2,  300,  80, xi.mod.REQUIEM_EFFECT  },
-    [xi.magic.spell.FOE_REQUIEM_III      ] = { xi.effect.REQUIEM,     3,  300,  96, xi.mod.REQUIEM_EFFECT  },
-    [xi.magic.spell.FOE_REQUIEM_IV       ] = { xi.effect.REQUIEM,     4,  300, 112, xi.mod.REQUIEM_EFFECT  },
-    [xi.magic.spell.FOE_REQUIEM_V        ] = { xi.effect.REQUIEM,     5,  300, 128, xi.mod.REQUIEM_EFFECT  },
-    [xi.magic.spell.FOE_REQUIEM_VI       ] = { xi.effect.REQUIEM,     6,  300, 144, xi.mod.REQUIEM_EFFECT  },
-    [xi.magic.spell.FOE_REQUIEM_VII      ] = { xi.effect.REQUIEM,     8,  300, 160, xi.mod.REQUIEM_EFFECT  },
+    [xi.magic.spell.FOE_REQUIEM          ] = { xi.effect.REQUIEM,  1,    1,  300,  64, xi.mod.REQUIEM_EFFECT  },
+    [xi.magic.spell.FOE_REQUIEM_II       ] = { xi.effect.REQUIEM,  2,    2,  300,  80, xi.mod.REQUIEM_EFFECT  },
+    [xi.magic.spell.FOE_REQUIEM_III      ] = { xi.effect.REQUIEM,  3,    3,  300,  96, xi.mod.REQUIEM_EFFECT  },
+    [xi.magic.spell.FOE_REQUIEM_IV       ] = { xi.effect.REQUIEM,  4,    4,  300, 112, xi.mod.REQUIEM_EFFECT  },
+    [xi.magic.spell.FOE_REQUIEM_V        ] = { xi.effect.REQUIEM,  5,    5,  300, 128, xi.mod.REQUIEM_EFFECT  },
+    [xi.magic.spell.FOE_REQUIEM_VI       ] = { xi.effect.REQUIEM,  6,    6,  300, 144, xi.mod.REQUIEM_EFFECT  },
+    [xi.magic.spell.FOE_REQUIEM_VII      ] = { xi.effect.REQUIEM,  7,    8,  300, 160, xi.mod.REQUIEM_EFFECT  },
     -- Lullaby: https://www.bg-wiki.com/ffxi/Category:Lullaby
-    [xi.magic.spell.FOE_LULLABY          ] = { xi.effect.SLEEP_I,     1,    1,  30, xi.mod.LULLABY_EFFECT  },
-    [xi.magic.spell.FOE_LULLABY_II       ] = { xi.effect.SLEEP_I,     1,    1,  60, xi.mod.LULLABY_EFFECT  },
-    [xi.magic.spell.HORDE_LULLABY        ] = { xi.effect.SLEEP_I,     1,    1,  30, xi.mod.LULLABY_EFFECT  },
-    [xi.magic.spell.HORDE_LULLABY_II     ] = { xi.effect.SLEEP_I,     1,    1,  60, xi.mod.LULLABY_EFFECT  },
+    [xi.magic.spell.FOE_LULLABY          ] = { xi.effect.SLEEP_I,  1,    1,    1,  30, xi.mod.LULLABY_EFFECT  },
+    [xi.magic.spell.FOE_LULLABY_II       ] = { xi.effect.SLEEP_I,  1,    1,    1,  60, xi.mod.LULLABY_EFFECT  },
+    [xi.magic.spell.HORDE_LULLABY        ] = { xi.effect.SLEEP_I,  1,    1,    1,  30, xi.mod.LULLABY_EFFECT  },
+    [xi.magic.spell.HORDE_LULLABY_II     ] = { xi.effect.SLEEP_I,  1,    1,    1,  60, xi.mod.LULLABY_EFFECT  },
     -- Finale: https://www.bg-wiki.com/ffxi/Category:Finale
-    [xi.magic.spell.MAGIC_FINALE         ] = { xi.effect.NONE,        1,    1,   0, xi.mod.FINALE_EFFECT   },
+    [xi.magic.spell.MAGIC_FINALE         ] = { xi.effect.NONE,     1,    1,    1,   0, xi.mod.FINALE_EFFECT   },
     -- Elegy: https://www.bg-wiki.com/ffxi/Category:Elegy
-    [xi.magic.spell.BATTLEFIELD_ELEGY    ] = { xi.effect.ELEGY,    2500, 5000, 120, xi.mod.ELEGY_EFFECT    },
-    [xi.magic.spell.CARNAGE_ELEGY        ] = { xi.effect.ELEGY,    5000, 5000, 180, xi.mod.ELEGY_EFFECT    },
+    [xi.magic.spell.BATTLEFIELD_ELEGY    ] = { xi.effect.ELEGY,    1, 2500, 5000, 120, xi.mod.ELEGY_EFFECT    },
+    [xi.magic.spell.CARNAGE_ELEGY        ] = { xi.effect.ELEGY,    1, 5000, 5000, 180, xi.mod.ELEGY_EFFECT    },
     -- Threnody: https://www.bg-wiki.com/ffxi/Category:Threnody
-    [xi.magic.spell.FIRE_THRENODY        ] = { xi.effect.THRENODY,   50,   95,  60, xi.mod.THRENODY_EFFECT },
-    [xi.magic.spell.ICE_THRENODY         ] = { xi.effect.THRENODY,   50,   95,  60, xi.mod.THRENODY_EFFECT },
-    [xi.magic.spell.WIND_THRENODY        ] = { xi.effect.THRENODY,   50,   95,  60, xi.mod.THRENODY_EFFECT },
-    [xi.magic.spell.EARTH_THRENODY       ] = { xi.effect.THRENODY,   50,   95,  60, xi.mod.THRENODY_EFFECT },
-    [xi.magic.spell.LIGHTNING_THRENODY   ] = { xi.effect.THRENODY,   50,   95,  60, xi.mod.THRENODY_EFFECT },
-    [xi.magic.spell.WATER_THRENODY       ] = { xi.effect.THRENODY,   50,   95,  60, xi.mod.THRENODY_EFFECT },
-    [xi.magic.spell.LIGHT_THRENODY       ] = { xi.effect.THRENODY,   50,   95,  60, xi.mod.THRENODY_EFFECT },
-    [xi.magic.spell.DARK_THRENODY        ] = { xi.effect.THRENODY,   50,   95,  60, xi.mod.THRENODY_EFFECT },
-    [xi.magic.spell.FIRE_THRENODY_II     ] = { xi.effect.THRENODY,  160,  205,  90, xi.mod.THRENODY_EFFECT },
-    [xi.magic.spell.ICE_THRENODY_II      ] = { xi.effect.THRENODY,  160,  205,  90, xi.mod.THRENODY_EFFECT },
-    [xi.magic.spell.WIND_THRENODY_II     ] = { xi.effect.THRENODY,  160,  205,  90, xi.mod.THRENODY_EFFECT },
-    [xi.magic.spell.EARTH_THRENODY_II    ] = { xi.effect.THRENODY,  160,  205,  90, xi.mod.THRENODY_EFFECT },
-    [xi.magic.spell.LIGHTNING_THRENODY_II] = { xi.effect.THRENODY,  160,  205,  90, xi.mod.THRENODY_EFFECT },
-    [xi.magic.spell.WATER_THRENODY_II    ] = { xi.effect.THRENODY,  160,  205,  90, xi.mod.THRENODY_EFFECT },
-    [xi.magic.spell.LIGHT_THRENODY_II    ] = { xi.effect.THRENODY,  160,  205,  90, xi.mod.THRENODY_EFFECT },
-    [xi.magic.spell.DARK_THRENODY_II     ] = { xi.effect.THRENODY,  160,  205,  90, xi.mod.THRENODY_EFFECT },
+    [xi.magic.spell.FIRE_THRENODY        ] = { xi.effect.THRENODY, 1,   50,   95,  60, xi.mod.THRENODY_EFFECT },
+    [xi.magic.spell.ICE_THRENODY         ] = { xi.effect.THRENODY, 1,   50,   95,  60, xi.mod.THRENODY_EFFECT },
+    [xi.magic.spell.WIND_THRENODY        ] = { xi.effect.THRENODY, 1,   50,   95,  60, xi.mod.THRENODY_EFFECT },
+    [xi.magic.spell.EARTH_THRENODY       ] = { xi.effect.THRENODY, 1,   50,   95,  60, xi.mod.THRENODY_EFFECT },
+    [xi.magic.spell.LIGHTNING_THRENODY   ] = { xi.effect.THRENODY, 1,   50,   95,  60, xi.mod.THRENODY_EFFECT },
+    [xi.magic.spell.WATER_THRENODY       ] = { xi.effect.THRENODY, 1,   50,   95,  60, xi.mod.THRENODY_EFFECT },
+    [xi.magic.spell.LIGHT_THRENODY       ] = { xi.effect.THRENODY, 1,   50,   95,  60, xi.mod.THRENODY_EFFECT },
+    [xi.magic.spell.DARK_THRENODY        ] = { xi.effect.THRENODY, 1,   50,   95,  60, xi.mod.THRENODY_EFFECT },
+    [xi.magic.spell.FIRE_THRENODY_II     ] = { xi.effect.THRENODY, 2,  160,  205,  90, xi.mod.THRENODY_EFFECT },
+    [xi.magic.spell.ICE_THRENODY_II      ] = { xi.effect.THRENODY, 2,  160,  205,  90, xi.mod.THRENODY_EFFECT },
+    [xi.magic.spell.WIND_THRENODY_II     ] = { xi.effect.THRENODY, 2,  160,  205,  90, xi.mod.THRENODY_EFFECT },
+    [xi.magic.spell.EARTH_THRENODY_II    ] = { xi.effect.THRENODY, 2,  160,  205,  90, xi.mod.THRENODY_EFFECT },
+    [xi.magic.spell.LIGHTNING_THRENODY_II] = { xi.effect.THRENODY, 2,  160,  205,  90, xi.mod.THRENODY_EFFECT },
+    [xi.magic.spell.WATER_THRENODY_II    ] = { xi.effect.THRENODY, 2,  160,  205,  90, xi.mod.THRENODY_EFFECT },
+    [xi.magic.spell.LIGHT_THRENODY_II    ] = { xi.effect.THRENODY, 2,  160,  205,  90, xi.mod.THRENODY_EFFECT },
+    [xi.magic.spell.DARK_THRENODY_II     ] = { xi.effect.THRENODY, 2,  160,  205,  90, xi.mod.THRENODY_EFFECT },
     -- Virelai: https://www.bg-wiki.com/ffxi/Category:Virelai
-    [xi.magic.spell.MAIDENS_VIRELAI      ] = { xi.effect.CHARM_I,     0,    0,  30, xi.mod.VIRELAI_EFFECT  },
+    [xi.magic.spell.MAIDENS_VIRELAI      ] = { xi.effect.CHARM_I,  1,    0,    0,  30, xi.mod.VIRELAI_EFFECT  },
     -- Nocturne: https://www.bg-wiki.com/ffxi/Category:Nocturne
-    [xi.magic.spell.PINING_NOCTURNE      ] = { xi.effect.NOCTURNE,   15,   25, 120, 0                      },
+    [xi.magic.spell.PINING_NOCTURNE      ] = { xi.effect.NOCTURNE, 1,   15,   25, 120, 0                      },
 }
 
 -----------------------------------
@@ -148,6 +149,7 @@ xi.spells.enfeebling.useEnfeeblingSong = function(caster, target, spell)
     local spellId      = spell:getID()
     local spellElement = spell:getElement()
     local spellEffect  = pTable[spellId][column.SONG_EFFECT]
+    local spellTier    = pTable[spellId][column.SONG_TIER]
 
     ------------------------------
     -- STEP 1: Check spell nullification.
@@ -165,7 +167,7 @@ xi.spells.enfeebling.useEnfeeblingSong = function(caster, target, spell)
     end
 
     -- Target already has an status effect that nullifies current.
-    if xi.data.statusEffect.isEffectNullified(target, spellEffect, 0) then
+    if xi.data.statusEffect.isEffectNullified(target, spellEffect, spellTier) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
         return spellEffect
     end
@@ -239,7 +241,7 @@ xi.spells.enfeebling.useEnfeeblingSong = function(caster, target, spell)
     ------------------------------
     -- STEP 5: Attempt to apply the status effect. Check for magic burst.
     ------------------------------
-    if target:addStatusEffect(spellEffect, power, tick, duration, 0, subEffect) then
+    if target:addStatusEffect(spellEffect, power, tick, duration, 0, subEffect, spellTier) then
         local _, skillchainCount = xi.magicburst.formMagicBurst(target, spellElement)
         if skillchainCount > 0 then
             spell:setMsg(xi.msg.basic.MAGIC_BURST_ENFEEB)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
What title sais. This will ensure that, for instance, only sleep II and sleepga II can overwrite lullabies (any of the 4)

## Steps to test these changes
Cast lullaby. Cast sleep I (no effect). Cast sleep II (overwrite)