### PR TITLE
WAR AF1 missing event interaction fix

### DIFF
--- a/scripts/quests/bastok/WAR_AF1_The_Doorman.lua
+++ b/scripts/quests/bastok/WAR_AF1_The_Doorman.lua
@@ -50,21 +50,47 @@ quest.sections =
             ['Hide_Flap_1'] =
             {
                 onTrigger = function(player, npc)
-                    if not player:hasKeyItem(xi.ki.SWORD_GRIP_MATERIAL) then
-                        if quest:getLocalVar(player, 'nmKilled') == 3 then
-                            return quest:keyItem(xi.ki.SWORD_GRIP_MATERIAL)
-                        elseif
-                            not GetMobByID(davoiID.mob.GAVOTVUT):isSpawned() and
-                            not GetMobByID(davoiID.mob.BARAKBOK):isSpawned()
-                        then
-                            SpawnMob(davoiID.mob.GAVOTVUT):updateClaim(player)
-                            SpawnMob(davoiID.mob.BARAKBOK):updateClaim(player)
+                    player:messageSpecial(davoiID.text.FIND_ORC_TENT)
 
-                            quest:setLocalVar(player, 'nmClaimed', 1)
+                    if player:checkDistance(npc) > 1 then
+                        return quest:messageSpecial(davoiID.text.CLOSER_TO_SEARCH)
+                    elseif
+                        not GetMobByID(davoiID.mob.GAVOTVUT):isAlive() and
+                        not GetMobByID(davoiID.mob.BARAKBOK):isAlive()
+                    then
+                        return quest:progressEvent(110)
+                    else
+                        return quest:noAction()
+                    end
+                end,
+            },
 
-                            -- TODO: Determine if a specific message is displayed here
-                            return quest:noAction()
-                        end
+            onEventFinish =
+            {
+                [110] = function(player, csid, option, npc)
+                    if option ~= 0 then
+                        return
+                    end
+
+                    if player:hasKeyItem(xi.ki.SWORD_GRIP_MATERIAL) then
+                        player:messageSpecial(davoiID.text.YOU_FIND_NOTHING)
+                        return
+                    end
+
+                    if quest:getLocalVar(player, 'nmKilled') == 3 then
+                        npcUtil.giveKeyItem(player, xi.ki.SWORD_GRIP_MATERIAL)
+                        return
+                    end
+
+                    if
+                        not GetMobByID(davoiID.mob.GAVOTVUT):isSpawned() and
+                        not GetMobByID(davoiID.mob.BARAKBOK):isSpawned()
+                    then
+                        player:messageSpecial(davoiID.text.YOU_FIND_NOTHING)
+                        SpawnMob(davoiID.mob.GAVOTVUT):updateClaim(player)
+                        SpawnMob(davoiID.mob.BARAKBOK):updateClaim(player)
+                        quest:setLocalVar(player, 'nmClaimed', 1)
+                        return
                     end
                 end,
             },


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adds the missing interaction that the Warrior AF1 quest is suppose to have with the Orcish Tent.

Big ups to Wiggo because I forgot to run captain as I spawned these NMs.

https://www.youtube.com/watch?v=jFK658xJbPA

## Steps to test these changes

Accept the warrior AF1 quest and enjoy the added flavor on popping the NMs.
