### PR TITLE
[lua] Familiar does not boost stats other than HP

### DIFF
--- a/scripts/actions/abilities/pets/rage.lua
+++ b/scripts/actions/abilities/pets/rage.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Generic jug pet skill
--- TODO: verify functionality with regards to jug pet differences from regular mobs
+-- 50% ATTP, -50% DEFP for 4 (0 TP) to 9 (3000 TP) minutes
 -----------------------------------
 ---@type TAbilityPet
 local abilityObject = {}
@@ -11,6 +11,8 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, owner, action)
+    -- TODO: Either the mobskill below is wrong or the Ready move is customized.
+    -- Should grant a stackable BERSERK effect of 50%/-50% for 4 to 9 minutes depending on TP.
     local result = xi.actions.mobskills[skillName].onMobWeaponSkill(target, pet, petskill)
 
     return result

--- a/scripts/effects/berserk.lua
+++ b/scripts/effects/berserk.lua
@@ -13,7 +13,7 @@ effectObject.onEffectGain = function(target, effect)
 
     effect:addMod(xi.mod.ATTP, power)
     effect:addMod(xi.mod.RATTP, power)
-    effect:addMod(xi.mod.DEFP, -25)
+    effect:addMod(xi.mod.DEFP, -25) -- TODO: This is supposed to mirror power in most cases
 
     -- Job Point Bonuses
     effect:addMod(xi.mod.ATT, jpEffect)

--- a/scripts/globals/pets.lua
+++ b/scripts/globals/pets.lua
@@ -164,15 +164,6 @@ xi.pet.applyFamiliarBuffs = function(owner, pet)
     -- wakes up pets
     pet:addHP(addedHP)
 
-    -- adds % bonuses to the following stats
-    -- TODO are these the only stats boosted?
-    pet:addMod(xi.mod.ATTP, familiarBoost)
-    pet:addMod(xi.mod.RATTP, familiarBoost)
-    pet:addMod(xi.mod.DEFP, familiarBoost)
-    pet:addMod(xi.mod.ACC, pet:getMod(xi.mod.ACC) * familiarBoostPerc)
-    pet:addMod(xi.mod.RACC, pet:getMod(xi.mod.RACC) * familiarBoostPerc)
-    pet:addMod(xi.mod.EVA, pet:getMod(xi.mod.EVA) * familiarBoostPerc)
-
     -- TODO does familiar give some bonus resistance to crowd control? Is it only for mob pets?
     -- Lots of reports of mobs using Familiar and the pet having higher chance to resist bind/sleep/etc
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Familiar has been boosting all pet stats for more than a decade but it's not a thing.

<img width="1872" height="985" alt="Screenshot 2026-02-02 173028" src="https://github.com/user-attachments/assets/14830ece-ab0b-46e1-ac6d-25ad7a46e536" />

Added some comments around LullabyMelodia Rage but did not make changes at this point. Supposed to be 50% ATTP/DEFP for 4 to 9 minutes.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
