### PR TITLE
[fix, lua] Dont trigger resonance on blinked WS

### DIFF
--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -530,13 +530,14 @@ xi.mobskills.mobFinalAdjustments = function(damage, mob, skill, target, attackTy
         end
 
         -- Remove shadows
-        damage = utils.takeShadows(target, damage, shadowsToRemove)
+        local shadowsUsed = 0
+        damage, shadowsUsed = utils.takeShadows(target, damage, shadowsToRemove)
 
         -- Dealt zero damage, so shadows took all hits.
         if damage == 0 then
             skill:setMsg(xi.msg.basic.SHADOW_ABSORB)
 
-            return 0
+            return shadowsUsed
         end
 
     elseif shadowsToRemove == xi.mobskills.shadowBehavior.WIPE_SHADOWS then -- Remove all shadows

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -275,7 +275,14 @@ xi.summon.avatarFinalAdjustments = function(dmg, mob, skill, target, skilltype, 
     end
 
     -- Handle shadows depending on shadow behavior / skilltype
-    dmg = utils.takeShadows(target, dmg, shadowbehav)
+    local preShadowDmg = dmg
+    local shadowsUsed  = 0
+    dmg, shadowsUsed = utils.takeShadows(target, dmg, shadowbehav)
+
+    if preShadowDmg > 0 and dmg == 0 then
+        skill:setMsg(xi.msg.basic.SHADOW_ABSORB)
+        return shadowsUsed
+    end
 
     -- handle Third Eye using shadowbehav as a guide
     local teye = target:getStatusEffect(xi.effect.THIRD_EYE)

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -942,6 +942,7 @@ xi.weaponskills.takeWeaponskillDamage = function(defender, attacker, wsParams, p
     elseif wsResults.shadowsAbsorbed > 0 then
         action:messageID(defender:getID(), xi.msg.basic.SHADOW_ABSORB)
         action:param(defender:getID(), wsResults.shadowsAbsorbed)
+        action:resolution(defender:getID(), xi.action.resolution.MISS)
     else
         if primaryMsg then
             action:messageID(defender:getID(), xi.msg.basic.SKILL_MISS)

--- a/scripts/utils/combat_utils.lua
+++ b/scripts/utils/combat_utils.lua
@@ -28,7 +28,8 @@ end
 ---@param actor CBaseEntity
 ---@param damage integer
 ---@param shadowsToRemove integer?
----@return integer
+---@return integer damage
+---@return integer shadowsUsed
 function utils.takeShadows(actor, damage, shadowsToRemove)
     shadowsToRemove = shadowsToRemove or 1
 
@@ -43,7 +44,7 @@ function utils.takeShadows(actor, damage, shadowsToRemove)
 
     -- No shadows, return full damage
     if shadowPower == 0 then
-        return damage
+        return damage, 0
     end
 
     local shadowsRemaining = shadowPower
@@ -67,7 +68,8 @@ function utils.takeShadows(actor, damage, shadowsToRemove)
         -- Handle Utsusemi removal
         if shadowPower >= shadowsToRemove then
             shadowsRemaining = shadowPower - shadowsToRemove
-            damage = 0
+            shadowsUsed      = shadowsToRemove
+            damage           = 0
 
             -- Update remaining Copy Image icon
             if shadowsRemaining > 0 then
@@ -86,7 +88,8 @@ function utils.takeShadows(actor, damage, shadowsToRemove)
             end
         else
             -- Partial shadow consumption, take damage.
-            damage = damage * ((shadowsToRemove - shadowPower) / shadowsToRemove)
+            shadowsUsed      = shadowPower
+            damage           = damage * ((shadowsToRemove - shadowPower) / shadowsToRemove)
             shadowsRemaining = 0
         end
     end
@@ -98,7 +101,7 @@ function utils.takeShadows(actor, damage, shadowsToRemove)
         actor:delStatusEffect(xi.effect.BLINK)
     end
 
-    return damage
+    return damage, shadowsUsed
 end
 
 -- Calculates Phalanx damage reduction.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Weaponskills absorbed by shadows should not open or close a skillchain. It's happening because this specific code path wasn't setting the hit resolution to miss.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
