### PR TITLE
[sql] Update quantity of items sold by Goldsmith guild

### DIFF
--- a/sql/guild_shops.sql
+++ b/sql/guild_shops.sql
@@ -702,106 +702,159 @@ INSERT INTO `guild_shops` VALUES (5262,18232,114,114,240,60,180);   -- hydro_pum
 INSERT INTO `guild_shops` VALUES (5262,18236,21,21,240,60,180);     -- wind_fan
 
 -- Visala (Goldsmith Guild) Bastok Markets (S)
-INSERT INTO `guild_shops` VALUES (5272,644,1500,9200,165,33,65);     -- mythril_ore
-INSERT INTO `guild_shops` VALUES (5272,653,19900,36400,55,0,22);     -- mythril_ingot
-INSERT INTO `guild_shops` VALUES (5272,661,1171,1171,255,0,100);     -- brass_sheet
-INSERT INTO `guild_shops` VALUES (5272,663,20240,45600,80,16,32);    -- mythril_sheet
-INSERT INTO `guild_shops` VALUES (5272,673,210,1108,255,48,100);     -- brass_scales
-INSERT INTO `guild_shops` VALUES (5272,681,10500,30800,30,6,12);     -- mythril_chain
-INSERT INTO `guild_shops` VALUES (5272,736,315,1260,255,48,100);     -- silver_ore
-INSERT INTO `guild_shops` VALUES (5272,738,1000,6000,30,0,12);       -- platinum_ore
-INSERT INTO `guild_shops` VALUES (5272,744,4095,9996,80,0,32);       -- silver_ingot
-INSERT INTO `guild_shops` VALUES (5272,760,29172,74880,55,0,22);     -- silver_chain
-INSERT INTO `guild_shops` VALUES (5272,769,1288,7000,165,33,65);     -- red_rock
-INSERT INTO `guild_shops` VALUES (5272,770,1288,7000,165,33,65);     -- blue_rock
-INSERT INTO `guild_shops` VALUES (5272,771,1288,7000,165,33,65);     -- yellow_rock
-INSERT INTO `guild_shops` VALUES (5272,772,1288,7000,165,33,65);     -- green_rock
-INSERT INTO `guild_shops` VALUES (5272,773,1288,7000,165,33,65);     -- translucent_rock
-INSERT INTO `guild_shops` VALUES (5272,774,1288,7000,165,33,65);     -- purple_rock
-INSERT INTO `guild_shops` VALUES (5272,775,1288,7000,165,33,65);     -- black_rock
-INSERT INTO `guild_shops` VALUES (5272,776,1288,7000,165,0,65);      -- white_rock
-INSERT INTO `guild_shops` VALUES (5272,784,23400,124800,15,0,3);     -- jadeite
-INSERT INTO `guild_shops` VALUES (5272,785,106400,116736,15,0,3);    -- emerald
-INSERT INTO `guild_shops` VALUES (5272,786,45600,116736,15,0,3);     -- ruby
-INSERT INTO `guild_shops` VALUES (5272,787,106400,116736,15,0,3);    -- diamond
-INSERT INTO `guild_shops` VALUES (5272,788,12000,56160,15,0,6);      -- peridot
-INSERT INTO `guild_shops` VALUES (5272,789,106400,116736,15,0,3);    -- topaz
-INSERT INTO `guild_shops` VALUES (5272,790,3600,9000,15,0,6);        -- garnet
-INSERT INTO `guild_shops` VALUES (5272,791,23400,136032,15,1,3);     -- aquamarine
-INSERT INTO `guild_shops` VALUES (5272,795,1396,2794,80,16,32);      -- lapis_lazuli
-INSERT INTO `guild_shops` VALUES (5272,796,1396,2794,80,3,32);       -- light_opal
-INSERT INTO `guild_shops` VALUES (5272,797,44304,49608,15,3,6);      -- painite
-INSERT INTO `guild_shops` VALUES (5272,799,1396,2794,80,16,32);      -- onyx
-INSERT INTO `guild_shops` VALUES (5272,800,1396,2794,80,3,32);       -- amethyst
-INSERT INTO `guild_shops` VALUES (5272,801,23400,70200,15,0,3);      -- chrysoberyl
-INSERT INTO `guild_shops` VALUES (5272,802,23400,70200,15,0,3);      -- moonstone
-INSERT INTO `guild_shops` VALUES (5272,803,23400,70200,15,0,3);      -- sunstone
-INSERT INTO `guild_shops` VALUES (5272,804,106400,116736,15,0,3);    -- spinel
-INSERT INTO `guild_shops` VALUES (5272,805,23400,70200,15,2,3);      -- zircon
-INSERT INTO `guild_shops` VALUES (5272,806,1396,2794,80,16,32);      -- tourmaline
-INSERT INTO `guild_shops` VALUES (5272,807,1396,2794,80,3,32);       -- sardonyx
-INSERT INTO `guild_shops` VALUES (5272,808,9000,24000,15,3,6);       -- goshenite
-INSERT INTO `guild_shops` VALUES (5272,809,1396,2794,80,3,32);       -- clear_topaz
-INSERT INTO `guild_shops` VALUES (5272,810,23400,70200,15,0,3);      -- fluorite
-INSERT INTO `guild_shops` VALUES (5272,811,9000,27000,15,0,6);       -- ametrine
-INSERT INTO `guild_shops` VALUES (5272,812,106400,116736,15,0,3);    -- deathstone
-INSERT INTO `guild_shops` VALUES (5272,813,106400,116736,15,3,3);    -- angelstone
-INSERT INTO `guild_shops` VALUES (5272,814,1396,2794,80,3,32);       -- amber_stone
-INSERT INTO `guild_shops` VALUES (5272,815,9000,27000,15,3,6);       -- sphene
-INSERT INTO `guild_shops` VALUES (5272,1588,20400,20400,120,3,60);   -- slab_of_tufa
-INSERT INTO `guild_shops` VALUES (5272,12425,17100,43776,20,0,15);   -- silver_mask
-INSERT INTO `guild_shops` VALUES (5272,12433,18176,30208,20,0,15);   -- brass_mask
-INSERT INTO `guild_shops` VALUES (5272,12449,1503,4300,20,0,15);     -- brass_cap
-INSERT INTO `guild_shops` VALUES (5272,12472,153,214,20,0,20);       -- circlet
-INSERT INTO `guild_shops` VALUES (5272,12495,4398,4398,20,0,10);     -- silver_hairpin
-INSERT INTO `guild_shops` VALUES (5272,12496,117,234,20,0,20);       -- copper_hairpin
-INSERT INTO `guild_shops` VALUES (5272,12497,970,1190,20,0,15);      -- brass_hairpin
-INSERT INTO `guild_shops` VALUES (5272,12561,14000,24000,20,0,20);   -- brass_scale_mail
-INSERT INTO `guild_shops` VALUES (5272,12689,11000,22000,20,0,20);   -- brass_finger_gauntlets
-INSERT INTO `guild_shops` VALUES (5272,12705,1023,2620,20,0,15);     -- brass_mittens
-INSERT INTO `guild_shops` VALUES (5272,12833,3840,7360,20,0,15);     -- brass_subligar
-INSERT INTO `guild_shops` VALUES (5272,12945,11440,11440,20,0,15);   -- brass_greaves
-INSERT INTO `guild_shops` VALUES (5272,12961,2380,3720,20,0,15);     -- brass_leggings
-INSERT INTO `guild_shops` VALUES (5272,13196,52284,52284,20,0,10);   -- silver_belt
-INSERT INTO `guild_shops` VALUES (5272,13317,12800,12800,20,5,10);   -- pearl_earring
-INSERT INTO `guild_shops` VALUES (5272,13327,5850,5850,20,0,15);     -- silver_earring
-INSERT INTO `guild_shops` VALUES (5272,13330,1238,1238,20,5,10);     -- tml._earring
-INSERT INTO `guild_shops` VALUES (5272,13331,1522,1522,20,0,10);     -- sardonyx_earring
-INSERT INTO `guild_shops` VALUES (5272,13332,1186,1238,20,0,20);     -- clear_earring
-INSERT INTO `guild_shops` VALUES (5272,13333,1186,1238,20,0,20);     -- amethyst_earring
-INSERT INTO `guild_shops` VALUES (5272,13334,1186,1238,20,0,20);     -- lapis_laz._earring
-INSERT INTO `guild_shops` VALUES (5272,13340,12880,12880,20,0,10);   -- ametrine_earring
-INSERT INTO `guild_shops` VALUES (5272,13342,12250,12250,20,0,10);   -- sphene_earring
-INSERT INTO `guild_shops` VALUES (5272,13344,1987,5000,20,0,10);     -- sun_earring
-INSERT INTO `guild_shops` VALUES (5272,13454,72,179,20,0,20);        -- copper_ring
-INSERT INTO `guild_shops` VALUES (5272,13468,1875,2400,20,0,15);     -- tourmaline_ring
-INSERT INTO `guild_shops` VALUES (5272,13470,1875,2400,20,0,15);     -- clear_ring
-INSERT INTO `guild_shops` VALUES (5272,13471,1875,2400,20,0,15);     -- amethyst_ring
-INSERT INTO `guild_shops` VALUES (5272,13472,1875,2400,20,0,15);     -- lapis_lazuli_ring
-INSERT INTO `guild_shops` VALUES (5272,13473,1875,2400,20,0,15);     -- amber_ring
-INSERT INTO `guild_shops` VALUES (5272,13474,1875,2400,20,0,15);     -- onyx_ring
-INSERT INTO `guild_shops` VALUES (5272,13979,20088,20088,20,3,10);   -- silver_bangles
-INSERT INTO `guild_shops` VALUES (5272,16391,2700,13989,20,0,10);    -- brass_knuckles
-INSERT INTO `guild_shops` VALUES (5272,16407,2399,13554,20,5,10);    -- brass_baghnakhs
-INSERT INTO `guild_shops` VALUES (5272,16449,3422,15656,20,5,10);    -- brass_dagger
-INSERT INTO `guild_shops` VALUES (5272,16551,3631,15487,20,0,10);    -- sapara
-INSERT INTO `guild_shops` VALUES (5272,16641,2870,13845,20,0,10);    -- brass_axe
-INSERT INTO `guild_shops` VALUES (5272,16769,2245,13221,20,0,10);    -- brass_zaghnal
-INSERT INTO `guild_shops` VALUES (5272,17043,1735,1839,20,0,10);     -- brass_hammer
+INSERT INTO `guild_shops` VALUES (5272,736,315,1260,240,48,180);    -- chunk_of_silver_ore
+INSERT INTO `guild_shops` VALUES (5272,644,1500,9200,120,33,12);    -- chunk_of_mythril_ore
+-- INSERT INTO `guild_shops` VALUES (5272,737,1500,9200,120,0,0);      -- chunk_of_gold_ore TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (5272,738,6000,58032,120,0,0);     -- chunk_of_platinum_ore TODO: verify min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (5272,648,6000,58032,120,0,0);     -- copper_ingot TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (5272,650,6000,58032,120,0,0);     -- brass_ingot TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (5272,744,4095,9996,120,0,0);      -- silver_ingot
+INSERT INTO `guild_shops` VALUES (5272,653,19900,36400,120,0,0);    -- mythril_ingot
+-- INSERT INTO `guild_shops` VALUES (5272,745,6000,58032,120,0,0);     -- gold_ingot TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (5272,746,6000,58032,120,0,0);     -- platinum_ingot TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (5272,661,1171,1171,120,0,0);      -- brass_sheet
+INSERT INTO `guild_shops` VALUES (5272,663,20240,45600,120,16,0);   -- mythril_sheet
+-- INSERT INTO `guild_shops` VALUES (5272,752,20240,45600,120,0,0);    -- gold_sheet TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (5272,754,20240,45600,120,0,0);    -- platinum_sheet TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (5272,673,210,1108,121,48,3);      -- brass_scales
+INSERT INTO `guild_shops` VALUES (5272,760,29172,74880,120,0,0);    -- silver_chain
+INSERT INTO `guild_shops` VALUES (5272,681,10500,30800,121,6,3);    -- mythril_chain
+-- INSERT INTO `guild_shops` VALUES (5272,761,10500,30800,120,0,0);    -- gold_chain TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (5272,762,10500,30800,120,0,0);    -- platinum_chain TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (5272,769,1288,7000,240,33,4);     -- red_rock
+INSERT INTO `guild_shops` VALUES (5272,770,1288,7000,240,33,4);     -- blue_rock
+INSERT INTO `guild_shops` VALUES (5272,771,1288,7000,240,33,4);     -- yellow_rock
+INSERT INTO `guild_shops` VALUES (5272,772,1288,7000,240,33,4);     -- green_rock
+INSERT INTO `guild_shops` VALUES (5272,773,1288,7000,240,33,4);     -- translucent_rock
+INSERT INTO `guild_shops` VALUES (5272,774,1288,7000,240,33,4);     -- purple_rock
+INSERT INTO `guild_shops` VALUES (5272,775,1288,7000,240,33,4);     -- black_rock
+INSERT INTO `guild_shops` VALUES (5272,776,1288,7000,240,0,4);      -- white_rock
+INSERT INTO `guild_shops` VALUES (5272,795,1396,2794,120,16,18);    -- lapis_lazuli
+INSERT INTO `guild_shops` VALUES (5272,796,1396,2794,120,3,18);     -- light_opal
+INSERT INTO `guild_shops` VALUES (5272,799,1396,2794,120,16,18);    -- onyx
+INSERT INTO `guild_shops` VALUES (5272,800,1396,2794,120,3,18);     -- amethyst
+INSERT INTO `guild_shops` VALUES (5272,806,1396,2794,120,16,18);    -- tourmaline
+INSERT INTO `guild_shops` VALUES (5272,807,1396,2794,120,3,18);     -- sardonyx
+INSERT INTO `guild_shops` VALUES (5272,809,1396,2794,120,3,18);     -- clear_topaz
+INSERT INTO `guild_shops` VALUES (5272,814,1396,2794,120,3,18);     -- amber_stone
+INSERT INTO `guild_shops` VALUES (5272,788,12000,56160,24,0,0);     -- peridot
+INSERT INTO `guild_shops` VALUES (5272,790,3600,9000,24,0,0);       -- garnet
+INSERT INTO `guild_shops` VALUES (5272,811,9000,27000,24,0,0);      -- ametrine
+INSERT INTO `guild_shops` VALUES (5272,815,9000,27000,24,0,0);      -- sphene
+INSERT INTO `guild_shops` VALUES (5272,798,9000,27000,24,0,0);      -- turquoise
+INSERT INTO `guild_shops` VALUES (5272,808,9000,24000,24,0,0);      -- goshenite
+INSERT INTO `guild_shops` VALUES (5272,784,23400,124800,24,0,0);    -- jadeite
+INSERT INTO `guild_shops` VALUES (5272,803,23400,70200,24,0,0);     -- sunstone
+INSERT INTO `guild_shops` VALUES (5272,810,23400,70200,24,0,0);     -- fluorite
+INSERT INTO `guild_shops` VALUES (5272,801,23400,70200,24,0,0);     -- chrysoberyl
+INSERT INTO `guild_shops` VALUES (5272,791,23400,136032,24,0,0);    -- aquamarine
+INSERT INTO `guild_shops` VALUES (5272,805,23400,70200,24,0,0);     -- zircon
+INSERT INTO `guild_shops` VALUES (5272,797,44304,49608,24,0,0);     -- painite
+INSERT INTO `guild_shops` VALUES (5272,802,23400,70200,24,0,0);     -- moonstone
+INSERT INTO `guild_shops` VALUES (5272,785,106400,116736,24,0,0);   -- emerald
+INSERT INTO `guild_shops` VALUES (5272,786,45600,116736,24,0,0);    -- ruby
+INSERT INTO `guild_shops` VALUES (5272,804,106400,116736,24,0,0);   -- spinel
+INSERT INTO `guild_shops` VALUES (5272,789,106400,116736,24,0,0);   -- topaz
+INSERT INTO `guild_shops` VALUES (5272,794,106400,116736,24,0,0);   -- sapphire
+INSERT INTO `guild_shops` VALUES (5272,787,106400,116736,24,0,0);   -- diamond
+INSERT INTO `guild_shops` VALUES (5272,812,106400,116736,24,0,0);   -- deathstone
+INSERT INTO `guild_shops` VALUES (5272,813,106400,116736,24,0,0);   -- angelstone
+INSERT INTO `guild_shops` VALUES (5272,13327,5850,5850,24,0,0);     -- silver_earring
+-- INSERT INTO `guild_shops` VALUES (5272,13328,5850,5850,24,0,0);     -- mythril_earring TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (5272,13315,5850,5850,24,0,0);     -- gold_earring TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (5272,13316,5850,5850,24,0,0);     -- platinum_earring TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (5272,13317,12800,12800,24,0,0);   -- pearl_earring
+INSERT INTO `guild_shops` VALUES (5272,13319,12800,12800,24,0,0);   -- peridot_earring
+INSERT INTO `guild_shops` VALUES (5272,13320,12800,12800,24,0,0);   -- black_earring
+INSERT INTO `guild_shops` VALUES (5272,13330,1238,1238,24,0,0);     -- tourmaline_earring
+INSERT INTO `guild_shops` VALUES (5272,13331,1522,1522,24,0,0);     -- sardonyx_earring
+INSERT INTO `guild_shops` VALUES (5272,13332,1186,1238,24,0,0);     -- clear_earring
+INSERT INTO `guild_shops` VALUES (5272,13333,1186,1238,24,0,0);     -- amethyst_earring
+INSERT INTO `guild_shops` VALUES (5272,13334,1186,1238,24,0,0);     -- lapis_lazuli_earring
+-- INSERT INTO `guild_shops` VALUES (5272,13335,12880,12880,24,0,0);   -- amber_earring TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (5272,13336,12880,12880,24,0,0);   -- onyx_earring TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (5272,13337,12880,12880,24,0,0);   -- opal_earring TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (5272,13338,12880,12880,24,0,0);   -- blood_earring TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (5272,13339,12880,12880,24,0,0);   -- goshenite_earring TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (5272,13340,12880,12880,24,0,0);   -- ametrine_earring
+-- INSERT INTO `guild_shops` VALUES (5272,13341,12880,12880,24,0,0);   -- turquoise_earring TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (5272,13342,12250,12250,24,0,0);   -- sphene_earring
+INSERT INTO `guild_shops` VALUES (5272,13454,72,179,24,0,0);        -- copper_ring
+-- INSERT INTO `guild_shops` VALUES (5272,13465,72,179,24,0,0);        -- brass_ring TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (5272,13456,1875,2400,24,0,0);     -- silver_ring TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (5272,13446,21060,21060,24,0,0);   -- mythril_ring TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (5272,13445,1875,2400,24,0,0);     -- gold_ring TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (5272,13447,1875,2400,24,0,0);     -- platinum_ring TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (5272,13443,1875,2400,24,0,0);     -- opal_ring
+INSERT INTO `guild_shops` VALUES (5272,13444,1875,2400,24,0,0);     -- sardonyx_ring
+INSERT INTO `guild_shops` VALUES (5272,13468,1875,2400,24,0,0);     -- tourmaline_ring
+INSERT INTO `guild_shops` VALUES (5272,13470,1875,2400,24,0,0);     -- clear_ring
+INSERT INTO `guild_shops` VALUES (5272,13471,1875,2400,24,0,0);     -- amethyst_ring
+INSERT INTO `guild_shops` VALUES (5272,13472,1875,2400,24,0,0);     -- lapis_lazuli_ring
+INSERT INTO `guild_shops` VALUES (5272,13473,1875,2400,24,0,0);     -- amber_ring
+INSERT INTO `guild_shops` VALUES (5272,13474,1875,2400,24,0,0);     -- onyx_ring
+INSERT INTO `guild_shops` VALUES (5272,13979,20088,20088,24,3,0);   -- silver_bangles
+-- INSERT INTO `guild_shops` VALUES (5272,13983,20088,20088,24,0,0);   -- gold_bangles TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (5272,12496,117,234,24,0,0);       -- copper_hairpin
+INSERT INTO `guild_shops` VALUES (5272,12497,970,1190,24,0,0);      -- brass_hairpin
+INSERT INTO `guild_shops` VALUES (5272,12495,4398,4398,24,0,0);     -- silver_hairpin
+INSERT INTO `guild_shops` VALUES (5272,16391,2700,13989,24,0,0);    -- brass_knuckles
+INSERT INTO `guild_shops` VALUES (5272,16407,2399,13554,24,5,0);    -- brass_baghnakhs
+INSERT INTO `guild_shops` VALUES (5272,16449,3422,15656,24,5,0);    -- brass_dagger
+INSERT INTO `guild_shops` VALUES (5272,16551,3631,15487,24,0,0);    -- sapara
+-- INSERT INTO `guild_shops` VALUES (5272,16531,3631,15487,24,0,0);    -- brass_xiphos TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (5272,16641,2870,13845,24,0,0);    -- brass_axe
+INSERT INTO `guild_shops` VALUES (5272,16769,2245,13221,24,0,0);    -- brass_zaghnal
+-- INSERT INTO `guild_shops` VALUES (5272,17081,3631,15487,24,0,0);    -- brass_rod TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (5272,17043,1735,1839,24,0,0);     -- brass_hammer
+INSERT INTO `guild_shops` VALUES (5272,12472,153,214,24,0,0);       -- circlet
+-- INSERT INTO `guild_shops` VALUES (5272,12473,3631,15487,24,0,0);    -- poets_circlet TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (5272,12449,1503,4300,24,0,0);     -- brass_cap
+INSERT INTO `guild_shops` VALUES (5272,12433,18176,30208,24,0,0);   -- brass_mask
+INSERT INTO `guild_shops` VALUES (5272,12425,17100,43776,24,0,0);   -- silver_mask
+-- INSERT INTO `guild_shops` VALUES (5272,12577,3631,15487,24,0,0);    -- brass_harness TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (5272,12561,14000,24000,24,0,0);   -- brass_scale_mail
+INSERT INTO `guild_shops` VALUES (5272,12705,1023,2620,24,0,0);     -- brass_mittens
+-- INSERT INTO `guild_shops` VALUES (5272,12681,3631,15487,24,0,0);    -- silver_mittens TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (5272,12689,11000,22000,24,0,0);   -- brass_finger_gauntlets
+INSERT INTO `guild_shops` VALUES (5272,12833,3840,7360,24,0,0);     -- brass_subligar
+INSERT INTO `guild_shops` VALUES (5272,12961,2380,3720,24,0,0);     -- brass_leggings
+-- INSERT INTO `guild_shops` VALUES (5272,12817,3631,15487,24,0,0);    -- brass_cuisses TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (5272,12945,11440,11440,24,0,0);   -- brass_greaves
+INSERT INTO `guild_shops` VALUES (5272,13196,52284,52284,24,0,0);   -- silver_belt
+-- INSERT INTO `guild_shops` VALUES (5272,13209,3631,15487,24,0,0);    -- chain_belt TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (5272,13083,3631,15487,24,0,0);    -- chain_choker TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (5272,13082,3631,15487,24,0,0);    -- chain_gorget TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (5272,1588,20400,20400,240,3,180); -- slab_of_tufa
 
 -- Yabby Tanmikey (Goldsmith Guild) Mhaura (S)
-INSERT INTO `guild_shops` VALUES (528,640,9,20,255,48,100);
-INSERT INTO `guild_shops` VALUES (528,736,315,945,255,48,100);
-INSERT INTO `guild_shops` VALUES (528,769,1400,4200,165,33,65);
-INSERT INTO `guild_shops` VALUES (528,770,1400,4200,165,33,65);
-INSERT INTO `guild_shops` VALUES (528,771,1400,4200,165,33,65);
-INSERT INTO `guild_shops` VALUES (528,772,1400,4200,165,33,65);
-INSERT INTO `guild_shops` VALUES (528,773,1400,4200,165,33,65);
-INSERT INTO `guild_shops` VALUES (528,774,1400,4200,165,33,65);
-INSERT INTO `guild_shops` VALUES (528,775,1400,4200,165,33,65);
-INSERT INTO `guild_shops` VALUES (528,776,1400,4200,165,33,65);
-INSERT INTO `guild_shops` VALUES (528,2143,320,320,255,48,100);
-INSERT INTO `guild_shops` VALUES (528,2144,75,75,255,48,100);
+INSERT INTO `guild_shops` VALUES (528,736,315,1260,200,48,100);  -- chunk_of_silver_ore
+INSERT INTO `guild_shops` VALUES (528,644,1500,9200,200,0,0);    -- chunk_of_mythril_ore
+-- INSERT INTO `guild_shops` VALUES (528,737,1500,9200,200,0,0);    -- chunk_of_gold_ore TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (528,738,6000,58032,200,0,0);   -- chunk_of_platinum_ore TODO: verify min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (528,648,6000,58032,200,0,0);   -- copper_ingot TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (528,650,6000,58032,200,0,0);   -- brass_ingot TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (528,744,4095,9996,200,0,0);    -- silver_ingot
+INSERT INTO `guild_shops` VALUES (528,653,19900,36400,200,0,0);  -- mythril_ingot
+-- INSERT INTO `guild_shops` VALUES (528,745,6000,58032,200,0,0);   -- gold_ingot TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (528,746,6000,58032,200,0,0);   -- platinum_ingot TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (528,661,1171,1171,200,0,0);    -- brass_sheet
+INSERT INTO `guild_shops` VALUES (528,663,20240,45600,200,0,0);  -- mythril_sheet
+-- INSERT INTO `guild_shops` VALUES (528,752,20240,45600,200,0,0);  -- gold_sheet TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (528,754,20240,45600,200,0,0);  -- platinum_sheet TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (528,673,210,1108,200,0,0);     -- brass_scales
+INSERT INTO `guild_shops` VALUES (528,760,29172,74880,200,0,0);  -- silver_chain
+INSERT INTO `guild_shops` VALUES (528,681,10500,30800,200,0,0);  -- mythril_chain
+-- INSERT INTO `guild_shops` VALUES (528,761,10500,30800,200,0,0);  -- gold_chain TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (528,762,10500,30800,200,0,0);  -- platinum_chain TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (528,769,1400,4200,60,33,5);    -- red_rock
+INSERT INTO `guild_shops` VALUES (528,770,1400,4200,60,33,5);    -- blue_rock
+INSERT INTO `guild_shops` VALUES (528,771,1400,4200,60,33,5);    -- yellow_rock
+INSERT INTO `guild_shops` VALUES (528,772,1400,4200,60,33,5);    -- green_rock
+INSERT INTO `guild_shops` VALUES (528,773,1400,4200,60,33,5);    -- translucent_rock
+INSERT INTO `guild_shops` VALUES (528,774,1400,4200,60,33,5);    -- purple_rock
+INSERT INTO `guild_shops` VALUES (528,775,1400,4200,60,33,5);    -- black_rock
+INSERT INTO `guild_shops` VALUES (528,776,1400,4200,60,33,5);    -- white_rock
 
 -- Kueh Igunahmori (Leathercraft Guild) Southern San d'Oria (S)
 INSERT INTO `guild_shops` VALUES (529,505,62,349,255,48,100);
@@ -1404,29 +1457,132 @@ INSERT INTO `guild_shops` VALUES (60428,17320,21,26,5940,0,2376);
 INSERT INTO `guild_shops` VALUES (60428,17321,48,60,2970,0,1188);
 
 -- Bornahn (Goldsmithing Guild) Al Zahbi
-INSERT INTO `guild_shops` VALUES (60429,640,9,36,255,48,100);
-INSERT INTO `guild_shops` VALUES (60429,644,1500,6000,165,0,65);
-INSERT INTO `guild_shops` VALUES (60429,673,210,600,255,48,100);
-INSERT INTO `guild_shops` VALUES (60429,681,10500,16000,30,6,12);
-INSERT INTO `guild_shops` VALUES (60429,736,315,945,255,48,100);
-INSERT INTO `guild_shops` VALUES (60429,769,1400,4200,165,33,65);
-INSERT INTO `guild_shops` VALUES (60429,770,1400,4200,165,33,65);
-INSERT INTO `guild_shops` VALUES (60429,771,1400,4200,165,33,65);
-INSERT INTO `guild_shops` VALUES (60429,772,1400,4200,165,33,65);
-INSERT INTO `guild_shops` VALUES (60429,773,1400,4200,165,33,65);
-INSERT INTO `guild_shops` VALUES (60429,774,1400,4200,165,33,65);
-INSERT INTO `guild_shops` VALUES (60429,775,1400,4200,165,33,65);
-INSERT INTO `guild_shops` VALUES (60429,776,1400,4200,165,0,65);
-INSERT INTO `guild_shops` VALUES (60429,795,1396,2794,80,16,32);
-INSERT INTO `guild_shops` VALUES (60429,796,1396,2794,80,0,32);
-INSERT INTO `guild_shops` VALUES (60429,799,1396,2794,80,16,32);
-INSERT INTO `guild_shops` VALUES (60429,800,1396,2794,80,0,32);
-INSERT INTO `guild_shops` VALUES (60429,806,1396,2794,80,16,32);
-INSERT INTO `guild_shops` VALUES (60429,807,1396,2794,80,0,32);
-INSERT INTO `guild_shops` VALUES (60429,809,1396,2794,80,0,32);
-INSERT INTO `guild_shops` VALUES (60429,814,1396,2794,80,0,32);
-INSERT INTO `guild_shops` VALUES (60429,2144,75,75,255,48,100);
-INSERT INTO `guild_shops` VALUES (60429,13446,21060,21060,20,0,10);
+INSERT INTO `guild_shops` VALUES (60429,640,9,36,240,48,180);      -- chunk_of_copper_ore
+INSERT INTO `guild_shops` VALUES (60429,642,93,620,120,0,0);       -- chunk_of_zinc_ore
+INSERT INTO `guild_shops` VALUES (60429,736,315,1260,240,48,180);  -- chunk_of_silver_ore
+INSERT INTO `guild_shops` VALUES (60429,644,1500,9200,120,33,12);  -- chunk_of_mythril_ore
+-- INSERT INTO `guild_shops` VALUES (60429,737,1500,9200,120,0,0);    -- chunk_of_gold_ore TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60429,738,6000,58032,120,0,0);   -- chunk_of_platinum_ore TODO: verify min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60429,648,6000,58032,120,0,0);   -- copper_ingot TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60429,650,6000,58032,120,0,0);   -- brass_ingot TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60429,744,4095,9996,120,0,0);    -- silver_ingot
+INSERT INTO `guild_shops` VALUES (60429,653,19900,36400,120,0,0);  -- mythril_ingot
+-- INSERT INTO `guild_shops` VALUES (60429,745,6000,58032,120,0,0);   -- gold_ingot TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60429,746,6000,58032,120,0,0);   -- platinum_ingot TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60429,661,1171,1171,120,0,0);    -- brass_sheet
+INSERT INTO `guild_shops` VALUES (60429,663,20240,45600,120,16,0); -- mythril_sheet
+-- INSERT INTO `guild_shops` VALUES (60429,752,20240,45600,120,0,0);  -- gold_sheet TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60429,754,20240,45600,120,0,0);  -- platinum_sheet TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60429,673,210,1108,121,48,3);    -- brass_scales
+INSERT INTO `guild_shops` VALUES (60429,760,29172,74880,120,0,0);  -- silver_chain
+INSERT INTO `guild_shops` VALUES (60429,681,10500,30800,121,6,3);  -- mythril_chain
+-- INSERT INTO `guild_shops` VALUES (60429,761,10500,30800,120,0,0);  -- gold_chain TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60429,762,10500,30800,120,0,0);  -- platinum_chain TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60429,769,1288,7000,240,33,4);   -- red_rock
+INSERT INTO `guild_shops` VALUES (60429,770,1288,7000,240,33,4);   -- blue_rock
+INSERT INTO `guild_shops` VALUES (60429,771,1288,7000,240,33,4);   -- yellow_rock
+INSERT INTO `guild_shops` VALUES (60429,772,1288,7000,240,33,4);   -- green_rock
+INSERT INTO `guild_shops` VALUES (60429,773,1288,7000,240,33,4);   -- translucent_rock
+INSERT INTO `guild_shops` VALUES (60429,774,1288,7000,240,33,4);   -- purple_rock
+INSERT INTO `guild_shops` VALUES (60429,775,1288,7000,240,33,4);   -- black_rock
+INSERT INTO `guild_shops` VALUES (60429,776,1288,7000,240,0,4);    -- white_rock
+INSERT INTO `guild_shops` VALUES (60429,795,1396,2794,120,16,18);  -- lapis_lazuli
+INSERT INTO `guild_shops` VALUES (60429,796,1396,2794,120,3,18);   -- light_opal
+INSERT INTO `guild_shops` VALUES (60429,799,1396,2794,120,16,18);  -- onyx
+INSERT INTO `guild_shops` VALUES (60429,800,1396,2794,120,3,18);   -- amethyst
+INSERT INTO `guild_shops` VALUES (60429,806,1396,2794,120,16,18);  -- tourmaline
+INSERT INTO `guild_shops` VALUES (60429,807,1396,2794,120,3,18);   -- sardonyx
+INSERT INTO `guild_shops` VALUES (60429,809,1396,2794,120,3,18);   -- clear_topaz
+INSERT INTO `guild_shops` VALUES (60429,814,1396,2794,120,3,18);   -- amber_stone
+INSERT INTO `guild_shops` VALUES (60429,788,12000,56160,24,0,0);   -- peridot
+INSERT INTO `guild_shops` VALUES (60429,790,3600,9000,24,0,0);     -- garnet
+INSERT INTO `guild_shops` VALUES (60429,811,9000,27000,24,0,0);    -- ametrine
+INSERT INTO `guild_shops` VALUES (60429,815,9000,27000,24,0,0);    -- sphene
+INSERT INTO `guild_shops` VALUES (60429,798,9000,27000,24,0,0);    -- turquoise
+INSERT INTO `guild_shops` VALUES (60429,808,9000,24000,24,0,0);    -- goshenite
+INSERT INTO `guild_shops` VALUES (60429,784,23400,124800,24,0,0);  -- jadeite
+INSERT INTO `guild_shops` VALUES (60429,803,23400,70200,24,0,0);   -- sunstone
+INSERT INTO `guild_shops` VALUES (60429,810,23400,70200,24,0,0);   -- fluorite
+INSERT INTO `guild_shops` VALUES (60429,801,23400,70200,24,0,0);   -- chrysoberyl
+INSERT INTO `guild_shops` VALUES (60429,791,23400,136032,24,0,0);  -- aquamarine
+INSERT INTO `guild_shops` VALUES (60429,805,23400,70200,24,0,0);   -- zircon
+INSERT INTO `guild_shops` VALUES (60429,797,44304,49608,24,0,0);   -- painite
+INSERT INTO `guild_shops` VALUES (60429,802,23400,70200,24,0,0);   -- moonstone
+INSERT INTO `guild_shops` VALUES (60429,785,106400,116736,24,0,0); -- emerald
+INSERT INTO `guild_shops` VALUES (60429,786,45600,116736,24,0,0);  -- ruby
+INSERT INTO `guild_shops` VALUES (60429,804,106400,116736,24,0,0); -- spinel
+INSERT INTO `guild_shops` VALUES (60429,789,106400,116736,24,0,0); -- topaz
+INSERT INTO `guild_shops` VALUES (60429,794,106400,116736,24,0,0); -- sapphire
+INSERT INTO `guild_shops` VALUES (60429,787,106400,116736,24,0,0); -- diamond
+INSERT INTO `guild_shops` VALUES (60429,812,106400,116736,24,0,0); -- deathstone
+INSERT INTO `guild_shops` VALUES (60429,813,106400,116736,24,0,0); -- angelstone
+INSERT INTO `guild_shops` VALUES (60429,13327,5850,5850,24,0,0);   -- silver_earring
+-- INSERT INTO `guild_shops` VALUES (60429,13328,5850,5850,24,0,0);   -- mythril_earring TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60429,13315,5850,5850,24,0,0);   -- gold_earring TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60429,13316,5850,5850,24,0,0);   -- platinum_earring TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60429,13317,12800,12800,24,0,0); -- pearl_earring
+INSERT INTO `guild_shops` VALUES (60429,13319,12800,12800,24,0,0); -- peridot_earring
+INSERT INTO `guild_shops` VALUES (60429,13320,12800,12800,24,0,0); -- black_earring
+INSERT INTO `guild_shops` VALUES (60429,13330,1238,1238,24,0,0);   -- tourmaline_earring
+INSERT INTO `guild_shops` VALUES (60429,13331,1522,1522,24,0,0);   -- sardonyx_earring
+INSERT INTO `guild_shops` VALUES (60429,13332,1186,1238,24,0,0);   -- clear_earring
+INSERT INTO `guild_shops` VALUES (60429,13333,1186,1238,24,0,0);   -- amethyst_earring
+INSERT INTO `guild_shops` VALUES (60429,13334,1186,1238,24,0,0);   -- lapis_lazuli_earring
+-- INSERT INTO `guild_shops` VALUES (60429,13335,12880,12880,24,0,0); -- amber_earring TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60429,13336,12880,12880,24,0,0); -- onyx_earring TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60429,13337,12880,12880,24,0,0); -- opal_earring TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60429,13338,12880,12880,24,0,0); -- blood_earring TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60429,13339,12880,12880,24,0,0); -- goshenite_earring TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60429,13340,12880,12880,24,0,0); -- ametrine_earring
+-- INSERT INTO `guild_shops` VALUES (60429,13341,12880,12880,24,0,0); -- turquoise_earring TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60429,13342,12250,12250,24,0,0); -- sphene_earring
+INSERT INTO `guild_shops` VALUES (60429,13454,72,179,24,0,0);      -- copper_ring
+-- INSERT INTO `guild_shops` VALUES (60429,13465,72,179,24,0,0);      -- brass_ring TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60429,13456,1875,2400,24,0,0);   -- silver_ring TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60429,13446,21060,21060,24,0,0); -- mythril_ring TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60429,13445,1875,2400,24,0,0);   -- gold_ring TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60429,13447,1875,2400,24,0,0);   -- platinum_ring TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60429,13443,1875,2400,24,0,0);   -- opal_ring
+INSERT INTO `guild_shops` VALUES (60429,13444,1875,2400,24,0,0);   -- sardonyx_ring
+INSERT INTO `guild_shops` VALUES (60429,13468,1875,2400,24,0,0);   -- tourmaline_ring
+INSERT INTO `guild_shops` VALUES (60429,13470,1875,2400,24,0,0);   -- clear_ring
+INSERT INTO `guild_shops` VALUES (60429,13471,1875,2400,24,0,0);   -- amethyst_ring
+INSERT INTO `guild_shops` VALUES (60429,13472,1875,2400,24,0,0);   -- lapis_lazuli_ring
+INSERT INTO `guild_shops` VALUES (60429,13473,1875,2400,24,0,0);   -- amber_ring
+INSERT INTO `guild_shops` VALUES (60429,13474,1875,2400,24,0,0);   -- onyx_ring
+INSERT INTO `guild_shops` VALUES (60429,13979,20088,20088,24,3,0); -- silver_bangles
+-- INSERT INTO `guild_shops` VALUES (60429,13983,20088,20088,24,0,0); -- gold_bangles TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60429,12496,117,234,24,0,0);     -- copper_hairpin
+INSERT INTO `guild_shops` VALUES (60429,12497,970,1190,24,0,0);    -- brass_hairpin
+INSERT INTO `guild_shops` VALUES (60429,12495,4398,4398,24,0,0);   -- silver_hairpin
+INSERT INTO `guild_shops` VALUES (60429,16391,2700,13989,24,0,0);  -- brass_knuckles
+INSERT INTO `guild_shops` VALUES (60429,16407,2399,13554,24,5,0);  -- brass_baghnakhs
+INSERT INTO `guild_shops` VALUES (60429,16449,3422,15656,24,5,0);  -- brass_dagger
+INSERT INTO `guild_shops` VALUES (60429,16551,3631,15487,24,0,0);  -- sapara
+-- INSERT INTO `guild_shops` VALUES (60429,16531,3631,15487,24,0,0);  -- brass_xiphos TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60429,16641,2870,13845,24,0,0);  -- brass_axe
+INSERT INTO `guild_shops` VALUES (60429,16769,2245,13221,24,0,0);  -- brass_zaghnal
+-- INSERT INTO `guild_shops` VALUES (60429,17081,3631,15487,24,0,0);  -- brass_rod TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60429,17043,1735,1839,24,0,0);   -- brass_hammer
+INSERT INTO `guild_shops` VALUES (60429,12472,153,214,24,0,0);     -- circlet
+-- INSERT INTO `guild_shops` VALUES (60429,12473,3631,15487,24,0,0);  -- poets_circlet TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60429,12449,1503,4300,24,0,0);   -- brass_cap
+INSERT INTO `guild_shops` VALUES (60429,12433,18176,30208,24,0,0); -- brass_mask
+INSERT INTO `guild_shops` VALUES (60429,12425,17100,43776,24,0,0); -- silver_mask
+-- INSERT INTO `guild_shops` VALUES (60429,12577,3631,15487,24,0,0);  -- brass_harness TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60429,12561,14000,24000,24,0,0); -- brass_scale_mail
+INSERT INTO `guild_shops` VALUES (60429,12705,1023,2620,24,0,0);   -- brass_mittens
+-- INSERT INTO `guild_shops` VALUES (60429,12681,3631,15487,24,0,0);  -- silver_mittens TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60429,12689,11000,22000,24,0,0); -- brass_finger_gauntlets
+INSERT INTO `guild_shops` VALUES (60429,12833,3840,7360,24,0,0);   -- brass_subligar
+INSERT INTO `guild_shops` VALUES (60429,12961,2380,3720,24,0,0);   -- brass_leggings
+-- INSERT INTO `guild_shops` VALUES (60429,12817,3631,15487,24,0,0);  -- brass_cuisses TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60429,12945,11440,11440,24,0,0); -- brass_greaves
+INSERT INTO `guild_shops` VALUES (60429,13196,52284,52284,24,0,0); -- silver_belt
+-- INSERT INTO `guild_shops` VALUES (60429,13209,3631,15487,24,0,0);  -- chain_belt TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60429,13083,3631,15487,24,0,0);  -- chain_choker TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60429,13082,3631,15487,24,0,0);  -- chain_gorget TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60429,2144,75,75,240,48,180);    -- workshop_anvil
 
 -- Taten-Bilten (Clothcraft Guild) Al Zahbi
 INSERT INTO `guild_shops` VALUES (60430,833,15,18,240,75,180);      -- clump_of_moko_grass


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Updates the initial_quantity and max_quantity of items in the Clothcraft guild shop [with this data](https://docs.google.com/spreadsheets/d/1tCWYRF1TGo8ZbNydLNpO0OKTuGL8ISox9VdPPMumWDM/edit?gid=1156131126#gid=1156131126) from Sruon.

- Reorders items according to how they appear in retail.
- Adds missing items the guild buys from players but doesn't restock. These additional entries are commented out with a TODO due to missing min and max prices.
- This PR doesn't alter min_price, max_price or daily_increase. That'll require further auditing.
- Platinum Ore was an exception. The cost was significantly undervalued at 1k-6k gil. In order to avoid disabling an active entry, I found an old entry of 58k on the wiki and increased the price to 6k-58k with a TODO. This should be safe because Platinum Ores no longer have no initial stock after this audit and were already set to 0 daily_restock.

## Steps to test these changes
- Create or modify entries.
- Run dbtool without errors.
- Verify database reflects the changes.