### PR TITLE
[lua, sql] Soulflayer family adjustments

### DIFF
--- a/scripts/actions/mobskills/Immortal_mind.lua
+++ b/scripts/actions/mobskills/Immortal_mind.lua
@@ -2,7 +2,7 @@
 -- Immortal Mind
 -- Description: Gains Magic Attack Bonus and Magic Defense Bonus.
 -- Type: Self
--- Range: Self
+-- Range: AoE 10'
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -12,21 +12,18 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local mabTotal = 10
-    local mdbTotal = 10
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.MAGIC_ATK_BOOST, 50, 0, 120))
+    xi.mobskills.mobBuffMove(mob, xi.effect.MAGIC_DEF_BOOST, 100, 0, 120)
 
     local mabEffect = mob:getStatusEffect(xi.effect.MAGIC_ATK_BOOST)
     if mabEffect then
-        mabTotal = mabEffect:getPower() + 10
+        mabEffect:delEffectFlag(xi.effectFlag.DISPELABLE)
     end
 
     local mdbEffect = mob:getStatusEffect(xi.effect.MAGIC_DEF_BOOST)
     if mdbEffect then
-        mdbTotal = mdbEffect:getPower() + 10
+        mdbEffect:delEffectFlag(xi.effectFlag.DISPELABLE)
     end
-
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.MAGIC_ATK_BOOST, mabTotal, 0, 180))
-    xi.mobskills.mobBuffMove(mob, xi.effect.MAGIC_DEF_BOOST, mdbTotal, 0, 180)
 
     return xi.effect.MAGIC_ATK_BOOST
 end

--- a/scripts/actions/mobskills/Immortal_shield.lua
+++ b/scripts/actions/mobskills/Immortal_shield.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Immortal Shield
--- Description: Grants a Magic Shield effect for a time.
+-- Description: Grants a 1000 damage stoneskin effect, stacking up to 2 times.
 -- Type: Enhancing
 -- Range: Self
 -----------------------------------
@@ -11,10 +11,38 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
+-- TODO: Rework to utilize a magical damage only stoneskin effect
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    mob:addStatusEffect(xi.effect.MAGIC_SHIELD, 0, 1, 0, 45)
+    local currentStacks = mob:getLocalVar('immortalShieldStacks')
+    local stoneskinEffect = mob:getStatusEffect(xi.effect.STONESKIN)
+    local newPower = 1000
+
+    if stoneskinEffect then
+        -- Calculate new total power and remove old effect
+        newPower = stoneskinEffect:getPower() + 1000
+        mob:delStatusEffectSilent(xi.effect.STONESKIN)
+    end
+
+    -- Create stoneskin with combined power
+    mob:addStatusEffect(xi.effect.STONESKIN, newPower, 0, 600)
+    stoneskinEffect = mob:getStatusEffect(xi.effect.STONESKIN)
+
+    -- Make stoneskin undispellable
+    if stoneskinEffect then
+        stoneskinEffect:delEffectFlag(xi.effectFlag.DISPELABLE)
+    end
+
+    mob:setLocalVar('immortalShieldStacks', currentStacks + 1)
     skill:setMsg(xi.msg.basic.SKILL_GAIN_EFFECT)
-    return xi.effect.MAGIC_SHIELD
+
+    return xi.effect.STONESKIN
+end
+
+mobskillObject.onMobSkillFinalize = function(mob, skill)
+    -- Soulflayers change animation sub to indicate currently active shield stacks
+    -- 0 = no shield, 1 = one stack, 2 = two stacks
+    local stacks = mob:getLocalVar('immortalShieldStacks')
+    mob:setAnimationSub(stacks)
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/immortal_anathema.lua
+++ b/scripts/actions/mobskills/immortal_anathema.lua
@@ -13,7 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.CURSE_I, 25, 0, 300))
+    -- Potency from 25 at 1000 tp to 30 at 3000 tp
+    local potency = 25 + math.floor((mob:getTP() - 1000) / 200)
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.CURSE_I, potency, 0, 30))
 
     return xi.effect.CURSE_I
 end

--- a/scripts/actions/mobskills/mind_blast.lua
+++ b/scripts/actions/mobskills/mind_blast.lua
@@ -13,13 +13,16 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local damage = mob:getWeaponDmg() * 6
+    local damage = mob:getMainLvl() + 2
+    local dINT   = mob:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
+    damage       = damage + (dINT * 1.5)
 
-    damage = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.THUNDER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    damage = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.THUNDER, 2, xi.mobskills.magicalTpBonus.NO_EFFECT)
     damage = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.THUNDER, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
 
     target:takeDamage(damage, mob, xi.attackType.MAGICAL, xi.damageType.THUNDER)
-    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 20, 0, 180)
+
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 20, 0, 45)
 
     return damage
 end

--- a/scripts/actions/mobskills/tribulation.lua
+++ b/scripts/actions/mobskills/tribulation.lua
@@ -16,7 +16,7 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local typeEffect = nil
-    local blinded    = xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 20, 0, 120)
+    local blinded    = xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 110, 0, 120)
     local bio        = xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIO, 39, 0, 120)
 
     skill:setMsg(xi.msg.basic.SKILL_ENFEEB_IS)

--- a/scripts/enum/mob_skill.lua
+++ b/scripts/enum/mob_skill.lua
@@ -646,7 +646,12 @@ xi.mobSkill =
 
     WATER_BOMB                    = 1959,
 
+    MIND_BLAST                    = 1963,
+    IMMORTAL_MIND                 = 1964,
     IMMORTAL_SHIELD               = 1965,
+    MIND_PURGE                    = 1966,
+    TRIBULATION                   = 1967,
+    IMMORTAL_ANATHEMA             = 1968,
 
     ECLOSION                      = 1970, -- Unique entry.
 

--- a/scripts/mixins/families/soulflayer.lua
+++ b/scripts/mixins/families/soulflayer.lua
@@ -1,0 +1,46 @@
+-----------------------------------
+--- Soulflayer Family Mixin
+--  https://ffxiclopedia.fandom.com/wiki/Category:Soulflayers
+--  https://www.bg-wiki.com/ffxi/Category:Soulflayers
+--
+--  Soulflayers animate a stacking floating orb around them after using Immortal Shield
+--
+--  Animation Sub 0 No shield active
+--  Animation Sub 1 One Floating Orb (1 stack of Immortal Shield)
+--  Animation Sub 2 Two Floating Orbs (2 stacks of Immortal Shield)
+-----------------------------------
+require('scripts/globals/mixins')
+-----------------------------------
+g_mixins = g_mixins or {}
+g_mixins.families = g_mixins.families or {}
+
+g_mixins.families.soulflayer = function(soulflayerMob)
+    soulflayerMob:addListener('SPAWN', 'SOULFLAYER_SPAWN', function(mob)
+        -- Apply family wide bonuses
+        mob:setAnimationSub(0)
+        mob:setMod(xi.mod.DEFP, 20)
+        mob:setMod(xi.mod.MDEF, 120)
+        mob:setMod(xi.mod.MATT, 30)
+        mob:setMod(xi.mod.UDMGBREATH, -2500)
+        mob:setMod(xi.mod.UDMGMAGIC, -2500)
+    end)
+
+    soulflayerMob:addListener('COMBAT_TICK', 'SOULFLAYER_COMBAT_TICK', function(mob)
+        local shieldStacks = mob:getLocalVar('immortalShieldStacks')
+
+        if shieldStacks > 0 then
+            local remainingStoneskin = mob:getMod(xi.mod.STONESKIN)
+
+            -- If 2 stacks and stoneskin dropped below 1000, reduce to 1 stack
+            if shieldStacks == 2 and remainingStoneskin < 1000 then
+                mob:setLocalVar('immortalShieldStacks', 1)
+                mob:setAnimationSub(1)
+            elseif remainingStoneskin <= 0 then
+                mob:setLocalVar('immortalShieldStacks', 0)
+                mob:setAnimationSub(0)
+            end
+        end
+    end)
+end
+
+return g_mixins.families.soulflayer

--- a/scripts/zones/Arrapago_Reef/mobs/Soulflayer.lua
+++ b/scripts/zones/Arrapago_Reef/mobs/Soulflayer.lua
@@ -1,15 +1,11 @@
 -----------------------------------
--- Area: Caedarva Mire
---  Mob: Mahjlaef the Paintorn (ZNM T3)
+-- Area: Arrapago Reef
+--   Mob: Soulflayer
 -----------------------------------
 mixins = { require('scripts/mixins/families/soulflayer') }
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
-
-entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 300)
-end
 
 entity.onMobMobskillChoose = function(mob, target)
     local shield = mob:getLocalVar('immortalShieldStacks')

--- a/scripts/zones/Caedarva_Mire/mobs/Soulflayer.lua
+++ b/scripts/zones/Caedarva_Mire/mobs/Soulflayer.lua
@@ -1,15 +1,11 @@
 -----------------------------------
 -- Area: Caedarva Mire
---  Mob: Mahjlaef the Paintorn (ZNM T3)
+--   Mob: Soulflayer
 -----------------------------------
 mixins = { require('scripts/mixins/families/soulflayer') }
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
-
-entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 300)
-end
 
 entity.onMobMobskillChoose = function(mob, target)
     local shield = mob:getLocalVar('immortalShieldStacks')

--- a/scripts/zones/Caedarva_Mire/mobs/Vidhuwa_the_Wrathborn.lua
+++ b/scripts/zones/Caedarva_Mire/mobs/Vidhuwa_the_Wrathborn.lua
@@ -2,8 +2,48 @@
 -- Area: Caedarva Mire
 --   NM: Vidhuwa the Wrathborn
 -----------------------------------
+mixins = { require('scripts/mixins/families/soulflayer') }
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
+
+entity.onMobMobskillChoose = function(mob, target)
+    local shield = mob:getLocalVar('immortalShieldStacks')
+    local tpList =
+    {
+        xi.mobSkill.MIND_BLAST,
+        xi.mobSkill.TRIBULATION,
+        xi.mobSkill.IMMORTAL_ANATHEMA,
+    }
+
+    -- Add mind purge only if target has dispellable effects
+    if target:hasStatusEffectByFlag(xi.effectFlag.DISPELABLE) then
+        table.insert(tpList, xi.mobSkill.MIND_PURGE)
+    end
+
+    -- Add immortal shield if below max stacks
+    if shield < 2 then
+        table.insert(tpList, xi.mobSkill.IMMORTAL_SHIELD)
+    end
+
+    -- Add immortal mind if there are 3+ allies within 10 yalms
+    local allyCount = 0
+    for _, otherMob in pairs(mob:getZone():getMobs()) do
+        if
+            otherMob:getID() ~= mob:getID() and
+            otherMob:isAlive() and
+            mob:checkDistance(otherMob) <= 10
+        then
+            allyCount = allyCount + 1
+        end
+    end
+
+    if allyCount >= 3 then
+        table.insert(tpList, xi.mobSkill.IMMORTAL_MIND)
+    end
+
+    return tpList[math.random(1, #tpList)]
+end
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 471)

--- a/scripts/zones/Hazhalm_Testing_Grounds/mobs/Soulflayer.lua
+++ b/scripts/zones/Hazhalm_Testing_Grounds/mobs/Soulflayer.lua
@@ -3,12 +3,52 @@
 --   Mob: Soulflayer (Einherjar)
 -- Notes: Full immunity to blind and dark sleep
 -----------------------------------
+mixins = { require('scripts/mixins/families/soulflayer') }
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.BLIND)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
+end
+
+entity.onMobMobskillChoose = function(mob, target)
+    local shield = mob:getLocalVar('immortalShieldStacks')
+    local tpList =
+    {
+        xi.mobSkill.MIND_BLAST,
+        xi.mobSkill.TRIBULATION,
+        xi.mobSkill.IMMORTAL_ANATHEMA,
+    }
+
+    -- Add mind purge only if target has dispellable effects
+    if target:hasStatusEffectByFlag(xi.effectFlag.DISPELABLE) then
+        table.insert(tpList, xi.mobSkill.MIND_PURGE)
+    end
+
+    -- Add immortal shield if below max stacks
+    if shield < 2 then
+        table.insert(tpList, xi.mobSkill.IMMORTAL_SHIELD)
+    end
+
+    -- Add immortal mind if there are 3+ allies within 10 yalms
+    local allyCount = 0
+    for _, otherMob in pairs(mob:getZone():getMobs()) do
+        if
+            otherMob:getID() ~= mob:getID() and
+            otherMob:isAlive() and
+            mob:checkDistance(otherMob) <= 10
+        then
+            allyCount = allyCount + 1
+        end
+    end
+
+    if allyCount >= 3 then
+        table.insert(tpList, xi.mobSkill.IMMORTAL_MIND)
+    end
+
+    return tpList[math.random(1, #tpList)]
 end
 
 return entity

--- a/scripts/zones/Nyzul_Isle/mobs/Psycheflayer.lua
+++ b/scripts/zones/Nyzul_Isle/mobs/Psycheflayer.lua
@@ -3,6 +3,8 @@
 -- Area: Nyzul Isle
 -- Info: Specified Mob Group and Eliminate all Group
 -----------------------------------
+mixins = { require('scripts/mixins/families/soulflayer') }
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
 
@@ -11,6 +13,44 @@ entity.onMobSpawn = function(mob)
 
     -- There was a mob pool check for 8072 here but that doesn't exist anymore so it was removed.
     -- If I had to guess it was for Nyzul Isle and is now obsolete?
+end
+
+entity.onMobMobskillChoose = function(mob, target)
+    local shield = mob:getLocalVar('immortalShieldStacks')
+    local tpList =
+    {
+        xi.mobSkill.MIND_BLAST,
+        xi.mobSkill.TRIBULATION,
+        xi.mobSkill.IMMORTAL_ANATHEMA,
+    }
+
+    -- Add mind purge only if target has dispellable effects
+    if target:hasStatusEffectByFlag(xi.effectFlag.DISPELABLE) then
+        table.insert(tpList, xi.mobSkill.MIND_PURGE)
+    end
+
+    -- Add immortal shield if below max stacks
+    if shield < 2 then
+        table.insert(tpList, xi.mobSkill.IMMORTAL_SHIELD)
+    end
+
+    -- Add immortal mind if there are 3+ allies within 10 yalms
+    local allyCount = 0
+    for _, otherMob in pairs(mob:getZone():getMobs()) do
+        if
+            otherMob:getID() ~= mob:getID() and
+            otherMob:isAlive() and
+            mob:checkDistance(otherMob) <= 10
+        then
+            allyCount = allyCount + 1
+        end
+    end
+
+    if allyCount >= 3 then
+        table.insert(tpList, xi.mobSkill.IMMORTAL_MIND)
+    end
+
+    return tpList[math.random(1, #tpList)]
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1987,12 +1987,12 @@ INSERT INTO `mob_skills` VALUES (1959,1361,'water_bomb',2,0.0,10.0,2000,1500,4,0
 INSERT INTO `mob_skills` VALUES (1960,1362,'frog_cheer',1,0.0,15.0,2000,1500,2,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1961,1363,'providence',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1962,1364,'frog_chorus',1,0.0,20.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1963,1327,'mind_blast',4,0.0,10.0,2000,1000,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1964,1328,'immortal_mind',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1965,1329,'immortal_shield',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1966,1330,'mind_purge',0,0.0,7.0,2000,1000,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1967,1331,'tribulation',1,0.0,15.0,2000,1000,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1968,1332,'immortal_anathema',1,0.0,15.0,2000,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1963,1327,'mind_blast',4,0.0,12.0,2000,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1964,1328,'immortal_mind',1,0.0,10.0,2000,700,1,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1965,1329,'immortal_shield',0,0.0,7.0,2000,1000,1,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1966,1330,'mind_purge',0,0.0,7.0,2000,1600,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1967,1331,'tribulation',1,0.0,12.0,2000,1600,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1968,1332,'immortal_anathema',1,0.0,10.0,2000,5300,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1969,1333,'reprobation',1,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1970,1344,'eclosion',0,0.0,7.0,4000,0,1,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1971,1715,'.',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Reviews all Soulflayer mob skills and sets their AOE types/ranges based on retail observations.
- Implements the Immortal Shield TP move animation sub interaction through a mixin. Current TODO to rework this to a new magical only stoneskin effect.
- Sets up Soulflayers to utilize the onMobMobskillChoose TP selection for several moves.

## Sources
- https://www.dropbox.com/scl/fi/cxir1zy1rs4fea0q7egtg/2026-2-1_19_17.zip?rlkey=lcdbyleuve6lgosxls60dkj98&st=bf1drn9z&dl=0