### PR TITLE
[core] Adjust RNG calls in synthutils to not truncate

### DIFF
--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -474,7 +474,7 @@ auto calcSynthResult(CCharEntity* PChar) -> uint8
     uint8 currentHQTier   = 0; // Recipe current available HQ tier, based on current skill ID being checked.
     float chanceHQ        = 0;
     uint8 maxChanceHQ     = 50;
-    uint8 randomRoll      = 0; // 1 to 100.
+    float randomRoll      = 0; // 1.0f to 100.f
 
     if (PChar->CraftContainer->getCraftType() == CRAFT_DESYNTHESIS)
     {
@@ -495,10 +495,10 @@ auto calcSynthResult(CCharEntity* PChar) -> uint8
         }
 
         // Skill is involved.
-        successRate     = 95;                                 // Assume sucess rate is maxed.
-        randomRoll      = 1 + xirand::GetRandomNumber(100);   // Random call must be called for each involved skill. 1 to 100 both included.
-        currentHQTier   = 0;                                  // This is reset at the start of every loop. "finalHQTier" is not.
-        synthDifficulty = getSynthDifficulty(PChar, skillID); // Get synth difficulty for current skill.
+        successRate     = 95;                                   // Assume sucess rate is maxed.
+        randomRoll      = xirand::GetRandomNumber(1.0f, 100.f); // Random call must be called for each involved skill. 1 to 100 both included.
+        currentHQTier   = 0;                                    // This is reset at the start of every loop. "finalHQTier" is not.
+        synthDifficulty = getSynthDifficulty(PChar, skillID);   // Get synth difficulty for current skill.
 
         // Skill is at or over synth recipe level.
         if (synthDifficulty <= 0)
@@ -617,17 +617,17 @@ auto calcSynthResult(CCharEntity* PChar) -> uint8
             chanceHQ = maxChanceHQ;
         }
 
-        randomRoll = 1 + xirand::GetRandomNumber(100);
+        randomRoll = xirand::GetRandomNumber(1.0f, 100.f);
 
         if (randomRoll <= chanceHQ) // We HQ. Proceed to selct HQ Tier
         {
             synthResult = SYNTHESIS_HQ;
-            randomRoll  = 1 + xirand::GetRandomNumber(100);
+            randomRoll  = xirand::GetRandomNumber(1.0f, 100.f);
 
             if (randomRoll <= 25) // 25% Chance after HQ to upgrade to HQ2
             {
                 synthResult = SYNTHESIS_HQ2;
-                randomRoll  = 1 + xirand::GetRandomNumber(100);
+                randomRoll  = xirand::GetRandomNumber(1.0f, 100.f);
 
                 if (randomRoll <= 25) // 25% Chance after HQ2 to upgrade to HQ3
                 {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes  #9345
Addresses part of #7841 

## Steps to test these changes

Synth, still get HQs.
