### PR TITLE
[lua] Physical Mobskill SDT Multipliers

### DIFF
--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -565,6 +565,7 @@ xi.mobskills.mobFinalAdjustments = function(damage, mob, skill, target, attackTy
     utils.handleAutomatonAutoAnalyzer(target, skill, damage)
 
     if attackType == xi.attackType.PHYSICAL then
+        damage = damage * xi.combat.damage.physicalElementSDT(target, damageType)
         damage = target:physicalDmgTaken(damage, damageType)
     elseif attackType == xi.attackType.MAGICAL then
         local element = utils.clamp(damageType - 5, xi.element.NONE, xi.element.DARK) -- Transform damage type to element
@@ -585,6 +586,7 @@ xi.mobskills.mobFinalAdjustments = function(damage, mob, skill, target, attackTy
         damage = math.floor(target:handleSevereDamage(damage, false))
         damage = math.floor(target:checkDamageCap(damage))
     elseif attackType == xi.attackType.RANGED then
+        damage = damage * xi.combat.damage.physicalElementSDT(target, damageType)
         damage = target:rangedDmgTaken(damage)
     end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Plugs in missing SDT(Blunt, Piercing, Slash) multipliers for physical mobskills.

Bug was from a horizon bug report but also tested myself on LSB as well, the SDT checks were missing so things like elementals would take full damage.

After Fix
<img width="476" height="36" alt="image" src="https://github.com/user-attachments/assets/bc5c7779-be8c-4c8b-8af2-e63a8c29a256" />

Note: Tested with 75 BST, no merits on test build (For damage reference.) Double Claw was hitting for 630~ prior to fix.

## Steps to test these changes

Summon a jugpet or avatar with physical skills. Go hit a physical resistant mob such as an elemental, see that the physical skills get reduced accordingly.
