### PR TITLE
[core] Teleport pets on player cutscene teleport

### DIFF
--- a/src/map/packets/c2s/0x05c_eventendxzy.cpp
+++ b/src/map/packets/c2s/0x05c_eventendxzy.cpp
@@ -21,8 +21,11 @@
 
 #include "0x05c_eventendxzy.h"
 
+#include "ai/ai_container.h"
+#include "enmity_container.h"
 #include "entities/charentity.h"
 #include "lua/luautils.h"
+#include "notoriety_container.h"
 #include "packets/s2c/0x052_eventucoff.h"
 #include "packets/s2c/0x05b_wpos.h"
 #include "packets/s2c/0x065_wpos2.h"
@@ -50,9 +53,11 @@ void GP_CLI_COMMAND_EVENTENDXZY::process(MapSession* PSession, CCharEntity* PCha
 
     PChar->SetLocalVar("noPosUpdate", 0);
 
+    position_t newPos = PChar->loc.p;
+
     if (updatePosition)
     {
-        position_t newPos = {
+        newPos = {
             x,
             y,
             z,
@@ -65,7 +70,34 @@ void GP_CLI_COMMAND_EVENTENDXZY::process(MapSession* PSession, CCharEntity* PCha
     }
     else
     {
-        PChar->pushPacket<GP_SERV_COMMAND_WPOS2>(PChar, PChar->loc.p, POSMODE::CLEAR);
+        PChar->pushPacket<GP_SERV_COMMAND_WPOS2>(PChar, newPos, POSMODE::CLEAR);
+    }
+
+    auto* PPet = PChar->PPet;
+
+    if (PPet && !PPet->isDead())
+    {
+        PPet->loc.p = newPos;
+
+        PPet->PAI->Disengage();
+
+        // clear all enmity towards a charmed mob when it is teleported
+        // use two loops to avoid modifying the container while iterating over it
+        std::list<CMobEntity*> mobsToPacify;
+
+        // first collect the mobs with hate towards the formerly charmed mob
+        for (auto* entityWithEnmity : *PPet->PNotorietyContainer)
+        {
+            if (auto* mobToPacify = dynamic_cast<CMobEntity*>(entityWithEnmity))
+            {
+                mobsToPacify.emplace_back(mobToPacify);
+            }
+        }
+        // then remove the formerly charmed mob from those mobs enmity containers
+        for (const auto* mobToPacify : mobsToPacify)
+        {
+            mobToPacify->PEnmityContainer->Clear(PPet->id);
+        }
     }
 
     PChar->pushPacket<GP_SERV_COMMAND_EVENTUCOFF>(PChar, GP_SERV_COMMAND_EVENTUCOFF_MODE::EventRecvPending);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Teleport pets on player cutscene teleport.. otherwise the pets would wallhack to you, which would look bad

## Steps to test these changes

Teleport and see your pet come with you
