### PR TITLE
[lua] Quest SOB6 Wild Card Bug Fix Wrong Zone Referenced

### DIFF
--- a/scripts/quests/windurst/SOB6_Wild_Card.lua
+++ b/scripts/quests/windurst/SOB6_Wild_Card.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Wild Card
---
+-- Log ID: 2, Quest ID: 77
 -- Honoi-Gumoi: !pos -195 -11 -120 238
 -----------------------------------
 
@@ -69,7 +69,7 @@ quest.sections =
             },
         },
 
-        [xi.zone.CASTLE_ZVAHL_BAILEYS] =
+        [xi.zone.TORAIMARAI_CANAL] =
         {
             ['Treasure_Coffer'] =
             {


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a bug where the wrong zone was referenced.

## Steps to test these changes

1. `!addquest 2 77`
2. `!setquestvar <me> 2 77 Prog 2`
3. `!zone TORAIMARAI_CANAL`
4. `!gotoname Treasure_Coffer`
5. Open chest
6. Get Joker Card