### PR TITLE
[lua] Fix Map Error From Quest Test My Mettle

### DIFF
--- a/scripts/quests/otherAreas/Test_My_Mettle.lua
+++ b/scripts/quests/otherAreas/Test_My_Mettle.lua
@@ -64,7 +64,10 @@ quest.sections =
                 [120] = function(player, csid, option, npc)
                     local eventCancelled = bit.rshift(option, 31) == 1 and true or false
 
-                    if not eventCancelled then
+                    if
+                        option ~= 0 and
+                        not eventCancelled
+                    then
                         local betAmount, vanaHoursRemaining = getSelectedOption(option)
 
                         if player:getGil() >= betAmount then


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a map error caused when the player declines the quest.
`Error running handler: .\scripts\quests\otherAreas\Test_My_Mettle.lua:75: attempt to perform arithmetic on a nil value`

Unsure what eventCancelled is supposed to do but leaving it there just in case.
Going through every dialogue option and combo option 0 was only triggered upon declining the quest.

## Steps to test these changes

Start the quest and turn down the quest via the menu options.
Observe no map error.
