### PR TITLE
[core] Adjust desynth HQ2/3 algo, add comments

### DIFF
--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -666,16 +666,20 @@ auto calculateDesynthResult(CCharEntity* PChar) -> uint8
 
     // Calculate HQ2 and HQ3 upgrades.
     uint8 upgradeHQ = 0;
-    for (uint8 tries = 0; tries < 2; ++tries)
-    {
-        if (xirand::GetRandomNumber(0.0f, 100.f) < 50.0f)
-        {
-            upgradeHQ = 1;
 
-            if (xirand::GetRandomNumber(0.0f, 100.f) < 33.0f)
-            {
-                upgradeHQ = 2;
-            }
+    // https://www.bluegartr.com/threads/135055-Extensive-Desynthesis-Rate-Research?p=7789195&viewfull=1#post7789195
+    // https://wiki.ffo.jp/html/401.html
+    // In order to achieve a desynth HQ rate distribution of
+    // (NQ , HQ1, HQ2, HQ3)
+    // (40%, 30%, 20%, 10%)
+    // roll a 50% HQ2 rate, then a 33.33(...)% rate for HQ3
+    if (xirand::GetRandomNumber(0.0f, 100.f) < 50.0f)
+    {
+        upgradeHQ = 1;
+
+        if (xirand::GetRandomNumber(0.0f, 100.f) < 100.f / 3.0f)
+        {
+            upgradeHQ = 2;
         }
     }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Math nerd reviewed our conversation and realized he agreed to me with "33%" and not "33 & 1/3 pecent" i.e. 33.0f and not 33.33333333f so I went to fix rates to match that

## Steps to test these changes

Run this test jig and get
nq /hq /hq2 / hq3
40%/30%/20%/10%
<img width="411" height="109" alt="image" src="https://github.com/user-attachments/assets/aaacb7cd-2e40-4ca9-8e75-b8146d200fee" />

```C++
    uint32_t rolls = 0;

    uint32_t NQs  = 0;
    uint32_t HQ1s = 0;
    uint32_t HQ2s = 0;
    uint32_t HQ3s = 0;

    while (rolls++ < 100000000)
    {
        // Early return: We fail HQ check.
        if (xirand::GetRandomNumber(0.0f, 100.f) > 60.0f)
        {
            NQs++;
            continue;
        }

        uint8 upgradeHQ = 1;

        // https://www.bluegartr.com/threads/135055-Extensive-Desynthesis-Rate-Research?p=7789195&viewfull=1#post7789195
        // https://wiki.ffo.jp/html/401.html
        // In order to achieve a desynth HQ rate distribution of
        // (NQ , HQ1, HQ2, HQ3)
        // (40%, 30%, 20%, 10%)
        // roll a 50% HQ2 rate, then a 33.33(...)% rate for HQ2
        if (xirand::GetRandomNumber(0.0f, 100.f) < 50.0f)
        {
            upgradeHQ = 2;

            if (xirand::GetRandomNumber(0.0f, 100.f) < 33.33333333f)
            {
                upgradeHQ = 3;
            }
        }

        if (upgradeHQ == 1)
        {
            HQ1s++;
        }
        else if (upgradeHQ == 2)
        {
            HQ2s++;
        }
        else if (upgradeHQ == 3)
        {
            HQ3s++;
        }
    }
```