### PR TITLE
[lua] Add Trust Setting to Bastok -> Sandy 2-3

### DIFF
--- a/scripts/missions/bastok/2_3_1_The_Emissary_Sandoria.lua
+++ b/scripts/missions/bastok/2_3_1_The_Emissary_Sandoria.lua
@@ -30,13 +30,9 @@ mission.sections =
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
                     if missionStatus == 3 then
-                        if xi.settings.main.ENABLE_TRUST_QUESTS == 1 then
-                            local needsHalverTrust = (not player:hasSpell(xi.magic.spell.HALVER) and not player:findItem(xi.item.CIPHER_OF_HALVERS_ALTER_EGO)) and 1 or 0
+                        local needsHalverTrust = (xi.settings.main.ENABLE_TRUST_QUESTS == 1 and not player:hasSpell(xi.magic.spell.HALVER) and not player:findItem(xi.item.CIPHER_OF_HALVERS_ALTER_EGO)) and 1 or 0
 
-                            return mission:progressEvent(501, { [7] = needsHalverTrust })
-                        else
-                            return mission:progressEvent(501)
-                        end
+                        return mission:progressEvent(501, { [7] = needsHalverTrust })
                     elseif missionStatus > 3 then
                         return mission:messageText(chateauID.text.HALVER_OFFSET + 266)
                     end

--- a/scripts/missions/bastok/2_3_3_The_Emissary_Sandoria2.lua
+++ b/scripts/missions/bastok/2_3_3_The_Emissary_Sandoria2.lua
@@ -30,7 +30,7 @@ mission.sections =
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
                     if missionStatus == 8 then
-                        local needsHalverTrust = (not player:hasSpell(xi.magic.spell.HALVER) and not player:findItem(xi.item.CIPHER_OF_HALVERS_ALTER_EGO)) and 1 or 0
+                        local needsHalverTrust = (xi.settings.main.ENABLE_TRUST_QUESTS == 1 and not player:hasSpell(xi.magic.spell.HALVER) and not player:findItem(xi.item.CIPHER_OF_HALVERS_ALTER_EGO)) and 1 or 0
 
                         return mission:progressEvent(503, { [7] = needsHalverTrust })
                     elseif missionStatus <= 10 then
@@ -45,6 +45,7 @@ mission.sections =
                     player:setMissionStatus(mission.areaId, 9)
 
                     if
+                        xi.settings.main.ENABLE_TRUST_QUESTS == 1 and
                         not player:hasSpell(xi.magic.spell.HALVER) and
                         not player:findItem(xi.item.CIPHER_OF_HALVERS_ALTER_EGO)
                     then

--- a/scripts/missions/windurst/2_3_1_The_Three_Kingdoms_Sandoria.lua
+++ b/scripts/missions/windurst/2_3_1_The_Three_Kingdoms_Sandoria.lua
@@ -30,13 +30,9 @@ mission.sections =
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
                     if missionStatus == 3 then
-                        if xi.settings.main.ENABLE_TRUST_QUESTS == 1 then
-                            local needsHalverTrust = (not player:hasSpell(xi.magic.spell.HALVER) and not player:findItem(xi.item.CIPHER_OF_HALVERS_ALTER_EGO)) and 1 or 0
+                        local needsHalverTrust = (xi.settings.main.ENABLE_TRUST_QUESTS == 1 and not player:hasSpell(xi.magic.spell.HALVER) and not player:findItem(xi.item.CIPHER_OF_HALVERS_ALTER_EGO)) and 1 or 0
 
-                            return mission:progressEvent(502, { [7] = needsHalverTrust })
-                        else
-                            return mission:progressEvent(502)
-                        end
+                        return mission:progressEvent(502, { [7] = needsHalverTrust })
                     else
                         return mission:messageText(chateauID.text.HALVER_OFFSET + 279)
                     end

--- a/scripts/missions/windurst/2_3_3_The_Three_Kingdoms_Sandoria2.lua
+++ b/scripts/missions/windurst/2_3_3_The_Three_Kingdoms_Sandoria2.lua
@@ -29,13 +29,9 @@ mission.sections =
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
                     if missionStatus == 8 then
-                        if xi.settings.main.ENABLE_TRUST_QUESTS == 1 then
-                            local needsHalverTrust = (not player:hasSpell(xi.magic.spell.HALVER) and not player:findItem(xi.item.CIPHER_OF_HALVERS_ALTER_EGO)) and 1 or 0
+                        local needsHalverTrust = (xi.settings.main.ENABLE_TRUST_QUESTS == 1 and not player:hasSpell(xi.magic.spell.HALVER) and not player:findItem(xi.item.CIPHER_OF_HALVERS_ALTER_EGO)) and 1 or 0
 
-                            return mission:progressEvent(504, { [7] = needsHalverTrust })
-                        else
-                            return mission:progressEvent(504)
-                        end
+                        return mission:progressEvent(504, { [7] = needsHalverTrust })
                     else
                         return mission:messageText(chateauID.text.HALVER_OFFSET + 279)
                     end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds missing trust setting check on Bastok 2-3 Sandy Leg.

## Steps to test these changes

Set `ENABLE_TRUST_QUESTS` in main.lua to 0
`!addmission 1 8`
`!setmissionstatus <me> 8 1`
Talk to Halver
