### PR TITLE
[lua] Add nil check to black dragon title obtainment

### DIFF
--- a/scripts/zones/Balgas_Dais/mobs/Black_Dragon.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Black_Dragon.lua
@@ -15,7 +15,9 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.BLACK_DRAGON_SLAYER)
+    if player then
+        player:addTitle(xi.title.BLACK_DRAGON_SLAYER)
+    end
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

`player` can be nil in some cases, so add a nil check to prevent errors

## Steps to test these changes

!hp 0 the dragon, get no errors