### PR TITLE
[lua] Breath Mobskill Adjustments

### DIFF
--- a/scripts/actions/mobskills/acid_breath.lua
+++ b/scripts/actions/mobskills/acid_breath.lua
@@ -10,21 +10,23 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.05
-    params.element           = xi.element.WATER
-    params.damageCap         = 200
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.05
+    params.damageCap        = 200
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.WATER
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.WATER
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.WATER)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
         local power    = 10
         local tick     = 5
@@ -33,7 +35,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STR_DOWN, power, tick, duration)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/aeolian_void.lua
+++ b/scripts/actions/mobskills/aeolian_void.lua
@@ -1,9 +1,7 @@
 -----------------------------------
 -- Aeolian Void
---
--- Description: Fan AoE damage plus Silence and Blind
--- Type: Earth Damage/Enfeebling
--- Utsusemi/Blink absorb: Ignores shadows
+-- Family: Sand Worm
+-- Description: Deals conal AoE Wind damage to targets in front of mob. Additional Effect: Blind, Silence
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -12,25 +10,16 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local params = {}
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
+    local damage = mob:getWeaponDmg() * 2
 
-    params.percentMultipier  = 0.25
-    params.element           = xi.element.EARTH
-    params.damageCap         = 300
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    local info = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.element.WIND, 1, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)
+    damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.EARTH, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    target:takeDamage(damage, mob, xi.attackType.MAGICAL, xi.damageType.WIND)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.EARTH)
-
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, 60)
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 15, 0, 60)
-    end
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, 180)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 50, 0, 180)
 
     return damage
 end

--- a/scripts/actions/mobskills/aqua_breath.lua
+++ b/scripts/actions/mobskills/aqua_breath.lua
@@ -10,24 +10,26 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.10
-    params.element           = xi.element.WATER
-    params.damageCap         = 500
-    params.bonusDamage       = 100
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.10
+    params.damageCap        = 500
+    params.bonusDamage      = 100
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.WATER
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.WATER
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.WATER)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/bad_breath.lua
+++ b/scripts/actions/mobskills/bad_breath.lua
@@ -10,22 +10,24 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.12
-    params.element           = xi.element.EARTH
-    params.damageCap         = 500 -- TODO: Capture cap
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.12
+    params.damageCap        = 500 -- TODO: Capture cap
+    params.bonusDamage      = 0
     -- TODO: Sources say this skill has a low magic accuracy.
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.EARTH
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.EARTH
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.EARTH, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.EARTH, { breakBind = false })
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType, { breakBind = false })
 
         -- TODO: Capture power/durations of various effects.
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 1250, 0, 60)
@@ -37,7 +39,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.WEIGHT, 50, 0, 60)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/blizzard_breath.lua
+++ b/scripts/actions/mobskills/blizzard_breath.lua
@@ -10,24 +10,26 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.125
-    params.element           = xi.element.ICE
-    params.damageCap         = 700
-    params.bonusDamage       = math.floor((mob:getMainLvl() + 2) * 1.5)
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.125
+    params.damageCap        = 700
+    params.bonusDamage      = math.floor((mob:getMainLvl() + 2) * 1.5)
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.ICE
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.ICE
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.ICE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.ICE)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/bubble_shower.lua
+++ b/scripts/actions/mobskills/bubble_shower.lua
@@ -10,23 +10,24 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.0625
-    params.element           = xi.element.WATER
-    params.damageCap         = 200
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
-
+    params.percentMultipier = 0.0625
+    params.damageCap        = 200
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.WATER
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.WATER
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
     -- TODO: Jug Pet differences
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.WATER)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
         local power    = 10
         local duration = 180
@@ -35,7 +36,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STR_DOWN, power, 9, duration)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/chaos_breath.lua
+++ b/scripts/actions/mobskills/chaos_breath.lua
@@ -10,24 +10,26 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.125
-    params.element           = xi.element.DARK
-    params.damageCap         = 700
-    params.bonusDamage       = math.floor((mob:getMainLvl() + 2) * 1.5)
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.125
+    params.damageCap        = 700
+    params.bonusDamage      = math.floor((mob:getMainLvl() + 2) * 1.5)
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.DARK
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.DARK
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.DARK, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.DARK)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/cold_breath.lua
+++ b/scripts/actions/mobskills/cold_breath.lua
@@ -10,26 +10,28 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.125
-    params.element           = xi.element.ICE
-    params.damageCap         = 600
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.125
+    params.damageCap        = 600
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.ICE
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.ICE
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.ICE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.ICE, { breakBind = false })
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType, { breakBind = false })
 
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 60)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/crosswind.lua
+++ b/scripts/actions/mobskills/crosswind.lua
@@ -17,24 +17,26 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.0833
-    params.element           = xi.element.WIND
-    params.damageCap         = 333
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.0833
+    params.damageCap        = 333
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.WIND
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.WIND
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.WIND, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.WIND)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/cryo_jet.lua
+++ b/scripts/actions/mobskills/cryo_jet.lua
@@ -1,8 +1,7 @@
 -----------------------------------
---  Cryo_Jet
---  Description:
---  Type: Magical
---  additional effect : Paralyze
+-- Cryo Jet
+-- Family: Ultima
+-- Description: Deals Ice breath damage to targets in front of mob. Additional Effect: Paralysis
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -11,32 +10,34 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.05
-    params.element           = xi.element.ICE
-    params.damageCap         = 490
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.05
+    params.damageCap        = 490
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.ICE
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.ICE
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.ICE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.ICE)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
+
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 15, 3, 120)
+
+        if target:hasStatusEffect(xi.effect.ELEMENTALRES_DOWN) then
+            target:delStatusEffectSilent(xi.effect.ELEMENTALRES_DOWN)
+        end
     end
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PARALYSIS, 15, 3, 120)
+    mob:setLocalVar('nuclearWaste', 0) -- TODO: Migrate logic to mob script.
 
-    if target:hasStatusEffect(xi.effect.ELEMENTALRES_DOWN) then
-        target:delStatusEffectSilent(xi.effect.ELEMENTALRES_DOWN)
-    end
-
-    mob:setLocalVar('nuclearWaste', 0)
-
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/dark_spore.lua
+++ b/scripts/actions/mobskills/dark_spore.lua
@@ -10,23 +10,23 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.25
-    params.element           = xi.element.DARK
-    params.damageCap         = 600 -- TODO: Capture damage capture.
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.25
+    params.damageCap        = 600 -- TODO: Capture damage cap.
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.DARK
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.DARK
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    -- TODO: Jug pet differences.
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.DARK, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
-
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.DARK)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
         local duration = 90
         -- TODO: Jugpet Differences
@@ -34,7 +34,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 30, 0, duration)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/diffusion_ray.lua
+++ b/scripts/actions/mobskills/diffusion_ray.lua
@@ -2,7 +2,6 @@
 -- Diffusion Ray
 -- Family: Chariots
 -- Description: Deals damage to enemies within a fan-shaped area originating from the caster.
--- Type: Magical Light (Element)
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -11,24 +10,26 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.20
-    params.element           = xi.element.LIGHT
-    params.damageCap         = 500
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.MND
+    params.percentMultipier = 0.20
+    params.damageCap        = 500
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.MND
+    params.element          = xi.element.LIGHT
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.LIGHT
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.LIGHT, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.LIGHT)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/dragon_breath.lua
+++ b/scripts/actions/mobskills/dragon_breath.lua
@@ -18,25 +18,28 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.15
-    params.element           = xi.element.FIRE
-    params.damageCap         = 1596
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.15
+    params.damageCap        = 1596
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.FIRE
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.FIRE
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info   = xi.mobskills.mobBreathMove(mob, target, skill, params)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
+
     info.damage  = utils.conalDamageAdjustment(mob, target, skill, info.damage, 0.2)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.FIRE)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/earth_breath.lua
+++ b/scripts/actions/mobskills/earth_breath.lua
@@ -14,24 +14,26 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.10
-    params.element           = xi.element.EARTH
-    params.damageCap         = 500
-    params.bonusDamage       = 100
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.10
+    params.damageCap        = 500
+    params.bonusDamage      = 100
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.EARTH
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.EARTH
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.EARTH, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.EARTH)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/fiery_breath.lua
+++ b/scripts/actions/mobskills/fiery_breath.lua
@@ -19,26 +19,28 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.2
-    params.element           = xi.element.FIRE
-    params.damageCap         = 1400
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.2
+    params.damageCap        = 1400
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.LIGHT
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.LIGHT
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
+
     info.damage = utils.conalDamageAdjustment(mob, target, skill, info.damage, 0.9)
 
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
-
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.FIRE)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/fire_break.lua
+++ b/scripts/actions/mobskills/fire_break.lua
@@ -10,24 +10,26 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.123
-    params.element           = xi.element.FIRE
-    params.damageCap         = 700 -- TODO: Capture damage cap.
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.123
+    params.damageCap        = 700 -- TODO: Capture damage cap.
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.FIRE
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.FIRE
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.FIRE)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/flame_breath.lua
+++ b/scripts/actions/mobskills/flame_breath.lua
@@ -10,24 +10,26 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.10
-    params.element           = xi.element.FIRE
-    params.damageCap         = 400
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.10
+    params.damageCap        = 400
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.FIRE
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.FIRE
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.FIRE)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/flame_thrower.lua
+++ b/scripts/actions/mobskills/flame_thrower.lua
@@ -1,7 +1,7 @@
 -----------------------------------
--- Flame_Thrower
--- Description: Uses a flamethrower that deals Fire damage to players in a fan-shaped area of effect. Additional effect: Plague
--- Type: Magical
+-- Flame Thrower
+-- Family: Ultima
+-- Description: Uses a flamethrower that deals Fire damage to players in a fan-shaped area of effect. Additional Effect: Plague
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -10,32 +10,34 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.05
-    params.element           = xi.element.FIRE
-    params.damageCap         = 490
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.05
+    params.damageCap        = 490
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.FIRE
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.FIRE
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.FIRE)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
+
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PLAGUE, 5, 3, 120)
+
+        if target:hasStatusEffect(xi.effect.ELEMENTALRES_DOWN) then
+            target:delStatusEffectSilent(xi.effect.ELEMENTALRES_DOWN)
+        end
     end
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PLAGUE, 5, 3, 120)
+    mob:setLocalVar('nuclearWaste', 0) -- TODO: Migrate to mob script
 
-    if target:hasStatusEffect(xi.effect.ELEMENTALRES_DOWN) then
-        target:delStatusEffectSilent(xi.effect.ELEMENTALRES_DOWN)
-    end
-
-    mob:setLocalVar('nuclearWaste', 0)
-
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/foul_breath.lua
+++ b/scripts/actions/mobskills/foul_breath.lua
@@ -16,26 +16,28 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.083
-    params.element           = xi.element.FIRE
-    params.damageCap         = 500
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.083
+    params.damageCap        = 500
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.FIRE
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.FIRE
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.FIRE)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.DISEASE, 1, 0, 180)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/frost_breath.lua
+++ b/scripts/actions/mobskills/frost_breath.lua
@@ -15,26 +15,28 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 1
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.083
-    params.element           = xi.element.ICE
-    params.damageCap         = 500
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.083
+    params.damageCap        = 500
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.ICE
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.ICE
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.ICE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.ICE)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 50, 0, 180)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/geotic_breath.lua
+++ b/scripts/actions/mobskills/geotic_breath.lua
@@ -19,25 +19,28 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.15
-    params.element           = xi.element.EARTH
-    params.damageCap         = 1150
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.15
+    params.damageCap        = 1150
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.EARTH
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.EARTH
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
+
     info.damage = utils.conalDamageAdjustment(mob, target, skill, info.damage, 0.2)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.EARTH, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.EARTH)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/glacial_breath.lua
+++ b/scripts/actions/mobskills/glacial_breath.lua
@@ -19,25 +19,28 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.083
-    params.element           = xi.element.ICE
-    params.damageCap         = 1400
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.083
+    params.damageCap        = 1400
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.ICE
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.ICE
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
+
     info.damage = utils.conalDamageAdjustment(mob, target, skill, info.damage, 0.2)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.ICE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.ICE)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/heat_breath.lua
+++ b/scripts/actions/mobskills/heat_breath.lua
@@ -10,24 +10,26 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.125
-    params.element           = xi.element.FIRE
-    params.damageCap         = 500
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.125
+    params.damageCap        = 500
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.FIRE
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.FIRE
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.FIRE)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/hecatomb_wave.lua
+++ b/scripts/actions/mobskills/hecatomb_wave.lua
@@ -10,26 +10,28 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.0476
-    params.element           = xi.element.WIND
-    params.damageCap         = 260
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.0476
+    params.damageCap        = 260
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.WIND
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.WIND
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.WIND, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.WIND)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 30, 0, math.random(60, 120))
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/hiemal_storm.lua
+++ b/scripts/actions/mobskills/hiemal_storm.lua
@@ -11,25 +11,28 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.382 -- TODO: Capture value.
-    params.element           = xi.element.ICE
-    params.damageCap         = 1300 -- TODO: Capture damage cap.
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.382 -- TODO: Capture value.
+    params.damageCap        = 1300 -- TODO: Capture damage cap.
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.ICE
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.ICE
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
+
     info.damage = utils.conalDamageAdjustment(mob, target, skill, info.damage, 0.9) -- TODO: Does this have a conal adjustment?
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.ICE, xi.mobskills.shadowBehavior.WIPE_SHADOWS, 1)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.ICE)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/high-tension_discharger.lua
+++ b/scripts/actions/mobskills/high-tension_discharger.lua
@@ -1,8 +1,7 @@
 -----------------------------------
--- High-Tension_Discharger
--- Description: Discharges a powerful current that deals Lightning damage to players in a fan-shaped area.
--- Additional effect: Stun
--- Type: Magical
+-- High-Tension Discharger
+-- Family: Ultima
+-- Description: Discharges a powerful current that deals Lightning damage to players in a fan-shaped area. Additional Effect: Stun
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -11,32 +10,34 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.05
-    params.element           = xi.element.THUNDER
-    params.damageCap         = 490
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.05
+    params.damageCap        = 490
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.THUNDER
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.THUNDER
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.THUNDER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.THUNDER)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
+
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STUN, 1, 3, 4)
+
+        if target:hasStatusEffect(xi.effect.ELEMENTALRES_DOWN) then
+            target:delStatusEffectSilent(xi.effect.ELEMENTALRES_DOWN)
+        end
     end
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 3, 4)
+    mob:setLocalVar('nuclearWaste', 0) -- TODO: Migrate to mob script
 
-    if target:hasStatusEffect(xi.effect.ELEMENTALRES_DOWN) then
-        target:delStatusEffectSilent(xi.effect.ELEMENTALRES_DOWN)
-    end
-
-    mob:setLocalVar('nuclearWaste', 0)
-
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/hydro_canon.lua
+++ b/scripts/actions/mobskills/hydro_canon.lua
@@ -11,32 +11,34 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.05
-    params.element           = xi.element.WATER
-    params.damageCap         = 490
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.05
+    params.damageCap        = 490
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.WATER
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.WATER
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.WATER)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
+
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, 50, 3, 120)
+
+        if target:hasStatusEffect(xi.effect.ELEMENTALRES_DOWN) then
+            target:delStatusEffectSilent(xi.effect.ELEMENTALRES_DOWN)
+        end
     end
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.POISON, 50, 3, 120)
+    mob:setLocalVar('nuclearWaste', 0) -- TODO: Migrate to mob script
 
-    if target:hasStatusEffect(xi.effect.ELEMENTALRES_DOWN) then
-        target:delStatusEffectSilent(xi.effect.ELEMENTALRES_DOWN)
-    end
-
-    mob:setLocalVar('nuclearWaste', 0)
-
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/incinerate.lua
+++ b/scripts/actions/mobskills/incinerate.lua
@@ -10,24 +10,26 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.1375
-    params.element           = xi.element.FIRE
-    params.damageCap         = 700
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.1375
+    params.damageCap        = 700
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.FIRE
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.FIRE
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.FIRE)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/infernal_pestilence.lua
+++ b/scripts/actions/mobskills/infernal_pestilence.lua
@@ -11,26 +11,28 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.05
-    params.element           = xi.element.WATER
-    params.damageCap         = 200
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.05
+    params.damageCap        = 200
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.WATER
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.WATER
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.MAGICAL, xi.damageType.WATER)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PLAGUE, 5, 3, 780)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/laser_shower.lua
+++ b/scripts/actions/mobskills/laser_shower.lua
@@ -15,31 +15,33 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.20 -- TODO: Capture Value
-    params.element           = xi.element.LIGHT
-    params.damageCap         = 1600
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.20 -- TODO: Capture Value
+    params.damageCap        = 1600
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.LIGHT
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.LIGHT
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local dis = ((mob:checkDistance(target) * 2) / 20) -- TODO: Verify this skill has a damage adjustment based on range from mob.
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    info.damage = info.damage * dis
+    local distance = ((mob:checkDistance(target) * 2) / 20) -- TODO: Verify this skill has a damage adjustment based on range from mob.
+    info.damage = info.damage * distance
     info.damage = utils.clamp(info.damage, 50, 1600)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.LIGHT, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.LIGHT)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
         -- TODO: Capture effect power/duration
-        xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.DEFENSE_DOWN, 25, 0, 60)
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.DEFENSE_DOWN, 25, 0, 60)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/magma_fan.lua
+++ b/scripts/actions/mobskills/magma_fan.lua
@@ -10,26 +10,28 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.0833
-    params.element           = xi.element.FIRE
-    params.damageCap         = 600 -- TODO: Capture cap
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.0833
+    params.damageCap        = 600 -- TODO: Capture cap
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
     -- https://docs.google.com/spreadsheets/d/1YBoveP-weMdidrirY-vPDzHyxbEI2ryECINlfCnFkLI/edit?pli=1&gid=57955395#gid=57955395&range=A566
     -- TODO: Spreadsheet states this can crit.
+    params.element          = xi.element.FIRE
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.WATER
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.FIRE)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/magnetite_cloud.lua
+++ b/scripts/actions/mobskills/magnetite_cloud.lua
@@ -10,26 +10,28 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.15
-    params.element           = xi.element.EARTH
-    params.damageCap         = 509 -- TODO: Capture Cap
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.15
+    params.damageCap        = 509 -- TODO: Capture Cap
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.EARTH
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.EARTH
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.EARTH, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.EARTH)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.WEIGHT, 75, 0, 60)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/methane_breath.lua
+++ b/scripts/actions/mobskills/methane_breath.lua
@@ -10,24 +10,26 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.0625
-    params.element           = xi.element.FIRE
-    params.damageCap         = 400
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.0625
+    params.damageCap        = 400
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.FIRE
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.FIRE
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.FIRE)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/numbing_breath.lua
+++ b/scripts/actions/mobskills/numbing_breath.lua
@@ -10,26 +10,27 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.0625
-    params.element           = xi.element.ICE
-    params.damageCap         = 500 -- TODO: Capture damage cap.
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.0625
+    params.damageCap        = 500 -- TODO: Capture damage cap.
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.ICE
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.ICE
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.ICE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
-
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.ICE)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 20, 0, math.random(120, 180))
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/pet_flame_breath.lua
+++ b/scripts/actions/mobskills/pet_flame_breath.lua
@@ -10,24 +10,26 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.13
-    params.element           = xi.element.FIRE
-    params.damageCap         = 400 -- TODO: Capture cap
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.13
+    params.damageCap        = 400 -- TODO: Capture cap
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.FIRE
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.FIRE
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.FIRE)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/pet_frost_breath.lua
+++ b/scripts/actions/mobskills/pet_frost_breath.lua
@@ -10,24 +10,26 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.13
-    params.element           = xi.element.ICE
-    params.damageCap         = 400 -- TODO: Capture cap
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.13
+    params.damageCap        = 400 -- TODO: Capture cap
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.ICE
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.ICE
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.ICE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.ICE)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/pet_gust_breath.lua
+++ b/scripts/actions/mobskills/pet_gust_breath.lua
@@ -10,24 +10,27 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.13
-    params.element           = xi.element.WIND
-    params.damageCap         = 400 -- TODO: Capture cap.
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.13
+    params.element          = xi.element.WIND
+    params.damageCap        = 400 -- TODO: Capture cap.
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.WIND
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.WIND
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.WIND, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.WIND)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/pet_hydro_breath.lua
+++ b/scripts/actions/mobskills/pet_hydro_breath.lua
@@ -10,24 +10,26 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.13
-    params.element           = xi.element.WATER
-    params.damageCap         = 400 -- TODO: Capture cap.
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.13
+    params.damageCap        = 400 -- TODO: Capture cap.
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.WATER
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.WATER
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.WATER)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/pet_lightning_breath.lua
+++ b/scripts/actions/mobskills/pet_lightning_breath.lua
@@ -10,24 +10,25 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.13
-    params.element           = xi.element.THUNDER
-    params.damageCap         = 400 -- TODO: Capture cap
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.13
+    params.damageCap        = 400 -- TODO: Capture cap
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.THUNDER
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.THUNDER
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.THUNDER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.THUNDER)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/pet_sand_breath.lua
+++ b/scripts/actions/mobskills/pet_sand_breath.lua
@@ -10,24 +10,26 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.13
-    params.element           = xi.element.EARTH
-    params.damageCap         = 400 -- TODO: Capture cap
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.13
+    params.damageCap        = 400 -- TODO: Capture cap
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.EARTH
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.EARTH
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.EARTH, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.EARTH)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/plague_breath.lua
+++ b/scripts/actions/mobskills/plague_breath.lua
@@ -10,21 +10,23 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.0625
-    params.element           = xi.element.WATER
-    params.damageCap         = 500
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.0625
+    params.damageCap        = 500
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.WATER
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.WATER
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.WATER)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
         local power    = math.max(1, mob:getMainLvl() / 10)
         local duration = math.random(45, 60)
@@ -32,7 +34,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, power, 3, duration)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/poison_breath_crawler.lua
+++ b/scripts/actions/mobskills/poison_breath_crawler.lua
@@ -10,21 +10,23 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.103
-    params.element           = xi.element.WATER
-    params.damageCap         = 405
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.103
+    params.damageCap        = 405
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.WATER
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.WATER
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.WATER)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
         local power    = 1
         local duration = 60 -- TODO: Capture duration
@@ -32,7 +34,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, power, 3, duration)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/poison_breath_dragon.lua
+++ b/scripts/actions/mobskills/poison_breath_dragon.lua
@@ -10,21 +10,23 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.10
-    params.element           = xi.element.WATER
-    params.damageCap         = 400
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.10
+    params.damageCap        = 400
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.WATER
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.WATER
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.WATER)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
         local power    = 50
         local duration = math.random(120, 180)
@@ -32,7 +34,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, power, 3, duration)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/poison_breath_hound.lua
+++ b/scripts/actions/mobskills/poison_breath_hound.lua
@@ -7,30 +7,26 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if
-        mob:getLocalVar('debuff_Skull') == 1 -- TODO: Dynamis
-    then
-        return 1
-    else
-        return 0
-    end
+    return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.0625
-    params.element           = xi.element.WATER
-    params.damageCap         = 400
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.0625
+    params.damageCap        = 400
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.WATER
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.WATER
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.WATER)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
         local power    = 1
         local duration = 300
@@ -38,7 +34,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, power, 3, duration)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/polar_blast.lua
+++ b/scripts/actions/mobskills/polar_blast.lua
@@ -15,21 +15,23 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     end
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.01 -- TODO: Capture breath values.
-    params.element           = xi.element.ICE
-    params.damageCap         = 700 -- TODO: Capture cap
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.01 -- TODO: Capture breath values.
+    params.damageCap        = 700 -- TODO: Capture cap
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.ICE
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.ICE
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.ICE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.ICE)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 15, 0, 60) -- TODO: Capture power and duration
     end
@@ -43,7 +45,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         mob:setBehavior(bit.bor(mob:getBehavior(), xi.behavior.NO_TURN))
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/pyric_blast.lua
+++ b/scripts/actions/mobskills/pyric_blast.lua
@@ -16,21 +16,23 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     end
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.01 -- TODO: Capture breath values.
-    params.element           = xi.element.FIRE
-    params.damageCap         = 700 -- TODO: Capture cap
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.01 -- TODO: Capture breath values.
+    params.damageCap        = 700 -- TODO: Capture cap
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.FIRE
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.FIRE
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.FIRE)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PLAGUE, 5, 3, 60) -- TODO: Capture power/duration
     end
@@ -43,7 +45,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         mob:setBehavior(bit.bor(mob:getBehavior(), xi.behavior.NO_TURN))
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/radiant_breath.lua
+++ b/scripts/actions/mobskills/radiant_breath.lua
@@ -10,21 +10,23 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.125
-    params.element           = xi.element.LIGHT
-    params.damageCap         = 700
-    params.bonusDamage       = (mob:getMainLvl() + 2) * 2
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT -- TODO: Light based skills are often MND, need captures.
+    params.percentMultipier = 0.125
+    params.damageCap        = 700
+    params.bonusDamage      = (mob:getMainLvl() + 2) * 2
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT -- TODO: Light based skills are often MND, need captures.
+    params.element          = xi.element.LIGHT
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.LIGHT
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.LIGHT, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.LIGHT)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
          -- TODO: Function name is duration. We might want to rename to something more universal.
         local power = xi.mobskills.calculateDuration(skill:getTP(), 1250, 1250) -- TODO: Capture power values
@@ -33,7 +35,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, 120)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/sable_breath.lua
+++ b/scripts/actions/mobskills/sable_breath.lua
@@ -17,25 +17,28 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.20
-    params.element           = xi.element.DARK
-    params.damageCap         = 1400
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.20
+    params.damageCap        = 1400
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.DARK
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.DARK
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
+
     info.damage = utils.conalDamageAdjustment(mob, target, skill, info.damage, 0.2)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.DARK, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.DARK)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/sand_breath.lua
+++ b/scripts/actions/mobskills/sand_breath.lua
@@ -10,26 +10,28 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.083
-    params.element           = xi.element.EARTH
-    params.damageCap         = 333
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.083
+    params.damageCap        = 333
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.EARTH
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.EARTH
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.EARTH, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.EARTH)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 20, 0, 120) -- TODO: Capture power.
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/seaspray.lua
+++ b/scripts/actions/mobskills/seaspray.lua
@@ -10,27 +10,29 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.125
-    params.element           = xi.element.WATER
-    params.damageCap         = 500
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.125
+    params.damageCap        = 500
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.WATER
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.WATER
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.WATER)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
         local duration = math.random(30, 60)
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 3500, 0, duration)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/silence_gas.lua
+++ b/scripts/actions/mobskills/silence_gas.lua
@@ -10,28 +10,30 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.25
-    params.element           = xi.element.DARK
-    params.damageCap         = 800 -- TODO: Capture cap
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.25
+    params.damageCap        = 800 -- TODO: Capture cap
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.DARK
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.DARK
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.DARK, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.DARK)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
         -- TODO: Jugpet Differences
         local duration = math.random(15, 60)
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, duration)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/smoke_discharger.lua
+++ b/scripts/actions/mobskills/smoke_discharger.lua
@@ -1,8 +1,7 @@
 -----------------------------------
---  Smoke_Discharger
---  Description:
---  Type: Magical
---  additional effect : Petrification.
+-- Smoke Discharger
+-- Family: Ultima
+-- Description: Deals Earth damage to targets in front of mob. Additional Effect: Petrification
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -11,32 +10,34 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.05
-    params.element           = xi.element.EARTH
-    params.damageCap         = 490
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.05
+    params.damageCap        = 490
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.EARTH
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.EARTH
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.EARTH, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.EARTH)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
+
+        xi.mobskills.mobStatusEffectMove(mob, target, skill, xi.effect.PETRIFICATION, 1, 3, 45)
+
+        if target:hasStatusEffect(xi.effect.ELEMENTALRES_DOWN) then
+            target:delStatusEffectSilent(xi.effect.ELEMENTALRES_DOWN)
+        end
     end
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PETRIFICATION, 1, 3, 45)
+    mob:setLocalVar('nuclearWaste', 0) -- TODO: Migrate to mob script
 
-    if target:hasStatusEffect(xi.effect.ELEMENTALRES_DOWN) then
-        target:delStatusEffectSilent(xi.effect.ELEMENTALRES_DOWN)
-    end
-
-    mob:setLocalVar('nuclearWaste', 0)
-
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/splash_breath.lua
+++ b/scripts/actions/mobskills/splash_breath.lua
@@ -10,24 +10,26 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.10
-    params.element           = xi.element.WATER
-    params.damageCap         = 400
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.10
+    params.damageCap        = 400
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.WATER
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.WATER
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.WATER)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/sulfurous_breath.lua
+++ b/scripts/actions/mobskills/sulfurous_breath.lua
@@ -14,24 +14,26 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     end
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.20
-    params.element           = xi.element.FIRE
-    params.damageCap         = 700
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.20
+    params.damageCap        = 700
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.FIRE
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.FIRE
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.FIRE)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/sweet_breath.lua
+++ b/scripts/actions/mobskills/sweet_breath.lua
@@ -10,27 +10,29 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.0909
-    params.element           = xi.element.DARK
-    params.damageCap         = 500
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.0909
+    params.damageCap        = 500
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.DARK
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.DARK
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.DARK, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.DARK)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
         local duration = math.random(15, 60)
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLEEP_I, 1, 0, duration)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/thunder_breath.lua
+++ b/scripts/actions/mobskills/thunder_breath.lua
@@ -17,24 +17,26 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 1
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.125
-    params.element           = xi.element.THUNDER
-    params.damageCap         = 700
-    params.bonusDamage       =  math.floor((mob:getMainLvl() + 2) * 1.5)
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.125
+    params.damageCap        = 700
+    params.bonusDamage      =  math.floor((mob:getMainLvl() + 2) * 1.5)
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.THUNDER
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.THUNDER
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.THUNDER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.THUNDER)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/thunderbolt_raptor.lua
+++ b/scripts/actions/mobskills/thunderbolt_raptor.lua
@@ -15,26 +15,28 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.0833
-    params.element           = xi.element.THUNDER
-    params.damageCap         = 500
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.0833
+    params.damageCap        = 500
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.THUNDER
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.THUNDER
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.THUNDER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.THUNDER)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STUN, 1, 0, 7)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/turbofan.lua
+++ b/scripts/actions/mobskills/turbofan.lua
@@ -1,8 +1,7 @@
 -----------------------------------
 -- Turbofan
---  Description:
---  Type: Magical
---  additional effect : Silence.
+-- Family: Ultima
+-- Description: Deals Wind damage to targets in front of mob. Additional Effect: Silence
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -11,32 +10,34 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.05
-    params.element           = xi.element.WIND
-    params.damageCap         = 490
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.05
+    params.damageCap        = 490
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.WIND
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.WIND
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.WIND, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.WIND)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
+
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 3, 30)
+
+        if target:hasStatusEffect(xi.effect.ELEMENTALRES_DOWN) then
+            target:delStatusEffectSilent(xi.effect.ELEMENTALRES_DOWN)
+        end
     end
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.SILENCE, 1, 3, 30)
+    mob:setLocalVar('nuclearWaste', 0) -- TODO: Migrate to mob script
 
-    if target:hasStatusEffect(xi.effect.ELEMENTALRES_DOWN) then
-        target:delStatusEffectSilent(xi.effect.ELEMENTALRES_DOWN)
-    end
-
-    mob:setLocalVar('nuclearWaste', 0)
-
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/vapor_spray.lua
+++ b/scripts/actions/mobskills/vapor_spray.lua
@@ -10,24 +10,26 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.10
-    params.element           = xi.element.WATER
-    params.damageCap         = 500
-    params.bonusDamage       = 1
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.10
+    params.damageCap        = 500
+    params.bonusDamage      = 1
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.WATER
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.WATER
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.WATER)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/violent_rupture.lua
+++ b/scripts/actions/mobskills/violent_rupture.lua
@@ -9,21 +9,23 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.10
-    params.element           = xi.element.FIRE
-    params.damageCap         = 200
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.10
+    params.damageCap        = 200
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.FIRE
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.FIRE
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.FIRE)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
         local power = 50
         local duration = 120
@@ -31,7 +33,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STR_DOWN, power, 3, duration)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/wind_breath.lua
+++ b/scripts/actions/mobskills/wind_breath.lua
@@ -10,24 +10,26 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
-mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+mobskillObject.onMobWeaponSkill = function(target, mob, skill, action)
     local params = {}
 
-    params.percentMultipier  = 0.10
-    params.element           = xi.element.WIND
-    params.damageCap         = 400
-    params.bonusDamage       = 0
-    params.mAccuracyBonus    = { 0, 0, 0 }
-    params.resistStat        = xi.mod.INT
+    params.percentMultipier = 0.10
+    params.damageCap        = 400
+    params.bonusDamage      = 0
+    params.mAccuracyBonus   = { 0, 0, 0 }
+    params.resistStat       = xi.mod.INT
+    params.element          = xi.element.WIND
+    params.attackType       = xi.attackType.BREATH
+    params.damageType       = xi.damageType.WIND
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
-    local info = xi.mobskills.mobBreathMove(mob, target, skill, params)
-    local damage = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.BREATH, xi.damageType.WIND, xi.mobskills.shadowBehavior.IGNORE_SHADOWS, 1)
+    local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 
-    if not xi.mobskills.hasMissMessage(mob, target, skill, damage) then
-        target:takeDamage(damage, mob, xi.attackType.BREATH, xi.damageType.WIND)
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    return damage
+    return info.damage
 end
 
 return mobskillObject

--- a/scripts/enum/msg.lua
+++ b/scripts/enum/msg.lua
@@ -259,6 +259,7 @@ xi.msg.basic =
     STATUS_INCREASED                = 562, -- The status parameters of <target> have increased.
     PET_CANNOT_DO_ACTION            = 574, -- <player>'s pet is currently unable to perform that action.
     PET_NOT_ENOUGH_TP               = 575, -- <player>'s pet does not have enough TP to perform that action.
+    PET_MAGIC_BURST                 = 747, -- <pet> uses <skill>. Magic Burst! <target> takes <number> points of damage.
     SPIRIT_BOND                     = 800, -- Spirit Bond Activates. <Player> takes <number> points of damage. -- Wyvern Spirit bond
 
     -- Food

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -419,74 +419,190 @@ end
 
 -----------------------------------
 -- Documentation: xi.mobskills.mobBreathMove
--- skillParams.percentMultipier  = #             : % Multiplier on mob's current HP. Damage = mobCurrentHP * percentMultipier
--- skillParams.element           = element enum  : Element of breath attack. Default: 1
--- skillParams.damageCap         = #             : Maximum damage this attack can do. Default: mob:getHP() / 5
--- skillParams.bonusDamage       = #             : Flat damage added after multipliers.
--- skillParams.mAccuracyBonus    = { #, #, # }   : Accuracy bonus or penalties based on fTP.
--- skillParams.resistStat        = xi.mod.<Stat> : Determines which base stat attribute is used when calculating resist. (INT, MND, etc.)
+-- params.percentMultipier     = #                   : % Multiplier on mob's current HP. Damage = mobCurrentHP * percentMultipier
+-- params.damageCap            = #                   : Maximum damage the skill can deal regardless of current HP.
+-- params.bonusDamage          = #                   : Flat damage added after multipliers.
+-- params.element              = element enum        : Element of breath attack. Default: 1
+-- params.attackType           = attackType enum     : attackType of the skill.
+-- params.damageType           = damageType enum     : damageType of the skill.
+-- params.shadowBehavior       = shadowBehavior enum : How many shadows the skill will consume.
+-- params.skipDamageAdjustment = bool                : Determines whether to skip damage taken % modifiers (Shell etc.)
+-- params.skipStoneSkin        = bool                : Determines whether the skill should bypass stoneskin.
+-- params.mAccuracyBonus       = { #, #, # }         : Flat magic accuracy bonus or penalties based on fTP scale.
+-- params.resistStat           = xi.mod.<Stat>       : Determines which base stat attribute is used when calculating resist. (INT, MND, etc.)
+-- params.canMagicBurst        = bool                : Determines if the skill can perform a magic burst.
+-- params.primaryMessage       = msg enum            : Sets the default message of the skill.
 -----------------------------------
--- return value of xi.mobskills.mobMagicalMove
+-- return value of xi.mobskills.mobBreathMove
+---@alias breathMobSkillRetVal { damage: number, hitsLanded: number, attackType: xi.attackType, damageType: xi.damageType }
 
 ---@param mob CBaseEntity
 ---@param target CBaseEntity
 ---@param skill CPetSkill|CMobSkill
+---@param action CAction
 ---@param skillParams table
----@return magicalMobSkillRetVal
-xi.mobskills.mobBreathMove = function(mob, target, skill, skillParams)
+---@return breathMobSkillRetVal
+xi.mobskills.mobBreathMove = function(mob, target, skill, action, skillParams)
+    local returnInfo = {}
+
     local mobCurrentHP = skill:getMobHP()
 
     local percentMultipier     = skillParams.percentMultipier or 0.10
-    local actionElement        = skillParams.element or 0
     local breathSkillDamageCap = skillParams.damageCap or math.floor(mobCurrentHP / 5)
     local bonusDamage          = skillParams.bonusDamage or 0
     local mAccuracyBonusfTP    = skillParams.mAccuracyBonus or { 0, 0, 0 }
+    local actionElement        = skillParams.element or 0
+    local attackType           = skillParams.attackType or xi.attackType.BREATH
+    local damageType           = skillParams.damageType or xi.damageType.ELEMENTAL
+    local shadowsToRemove      = skillParams.shadowBehavior or xi.mobskills.shadowBehavior.IGNORE_SHADOWS
+    -- Note: Breath skills so far have not been found to use MAB/MDEF. If we find an outlier, add here.
+    local skipStoneskin        = skillParams.skipStoneSkin and true or false
+    -- TODO: handle different types of Stoneskin(Magical, Physical, Agnostic)
     local resistStat           = skillParams.resistStat or xi.mod.INT
+    local canMagicBurst        = skillParams.canMagicBurst and true or false
+    local primaryMessage       = skillParams.primaryMessage or xi.msg.basic.DAMAGE
     -- TODO: Critical Hit Param? See Magma Fan mobskill.
 
-    local damage = mobCurrentHP * percentMultipier + bonusDamage
+    -- Initialize default returnInfo returns
+    returnInfo.damage     = 0
+    returnInfo.hitsLanded = 0
+    returnInfo.attackType = attackType
+    returnInfo.damageType = damageType
 
-    -- Clamp minimum damage based on current hp.
-    if damage < 1 then
-        damage = 1
+    -- Set skill's default message.
+    skill:setMsg(primaryMessage)
+
+    if mob:hasStatusEffect(xi.effect.HYSTERIA) then
+        skill:setMsg(xi.msg.basic.NONE)
+
+        return returnInfo
     end
 
-    -- Flat MACC bonus/penalty based on fTP scale
-    local mAccuracyBonus = 0
-    mAccuracyBonus = xi.combat.physical.calculateTPfactor(skill:getTP(), mAccuracyBonusfTP)
+    -- Calculate base damage
+    local damage     = math.floor(mobCurrentHP * percentMultipier + bonusDamage)
+    local hitsLanded = 1
 
-    local systemBonus     = 1 + utils.getEcosystemStrengthBonus(mob:getEcosystem(), target:getEcosystem()) / 4
-    local elementalSDT    = xi.combat.damage.magicalElementSDT(target, actionElement)
-    local resistRate      = xi.combat.magicHitRate.calculateResistRate(mob, target, 0, 0, xi.skillRank.A_PLUS, actionElement, resistStat, 0, mAccuracyBonus)
-    local dayAndWeather   = xi.spells.damage.calculateDayAndWeather(mob, actionElement, false)
-    local absorb          = xi.spells.damage.calculateAbsorption(target, actionElement, true)
-    local nullify         = xi.spells.damage.calculateNullification(target, actionElement, true, true)
+    -- TODO: SAM Yaegasumi ability.
+
+    -- Handle Shadows (Utsusemi, Blink, etc.)
+    damage = xi.mobskills.handleShadows(mob, target, skill, damage, attackType, shadowsToRemove)
+
+    if skill:getMsg() == xi.msg.basic.SHADOW_ABSORB then
+        -- Note: Damage in this case equals the amount of shadows consumed for the purpose of messaging.
+        --       takeDamage() is gated by returnInfo.hitsLanded being greater than 0 to prevent chip damage through shadows.
+        returnInfo.damage     = damage
+        returnInfo.hitsLanded = 0
+
+        return returnInfo
+    end
+
+    -- Calculate if skill will be absorbed or nullified.
+    local absorbDamage  = 1
+    local nullifyDamage = 1
+
+    nullifyDamage = xi.spells.damage.calculateNullification(target, actionElement, false, true)
+
+    if nullifyDamage == 0 then
+        -- Note: Nullification takes precedence over elemental absorption.
+        -- Note: We still count nullifies as a "hit" since additional status effects tied to the skill itself will still apply.
+        returnInfo.damage     = 0
+        returnInfo.hitsLanded = hitsLanded
+
+        return returnInfo
+    end
+
+    absorbDamage = xi.spells.damage.calculateAbsorption(target, actionElement, false)
+
+    -- Calulate TP and TP_BONUS if applicable.
+    -- TODO: Do mobs benefit from Fencer job trait's TP_BONUS?
+    -- Best way to test will likely be to find a mob that uses a magical skill with fTP scaling and has varying jobs to compare (WAR 45 min for Fencer, 80 BST, 85 BRD).
+    local bonusTP = mob:getMod(xi.mod.TP_BONUS)
+    local tpValue = math.min(skill:getTP() + bonusTP, 3000)
+
+    -- Flat MACC bonus/penalty based on fTP scale if defined.
+    local mAccuracyBonus = 0
+
+    mAccuracyBonus = xi.combat.physical.calculateTPfactor(tpValue, mAccuracyBonusfTP)
+
+    -- Damage Multipliers
+    local systemBonus            = 1 -- 1 + utils.getEcosystemStrengthBonus(mob:getEcosystem(), target:getEcosystem()) / 4
+    local elementalSDT           = 1
+    local resistRate             = 1
+    local dayAndWeather          = 1
+    local breathDamageAdjustment = 1
+    local magicBurst             = 1
+    local magicBurstBonus        = 1
+
+    -- If skill was not absorbed, calculate resist and damage adjustments.
+    -- Note: Elemental absorb mechanics such as Liement are calculated BEFORE resist/damage adjustments (such as shell/magic bursts).
+    if absorbDamage > 0 then
+        if canMagicBurst then
+            local _, skillchainCount = xi.magicburst.formMagicBurst(target, actionElement)
+
+            if skillchainCount > 0 then
+                if mob:isPet() and mob:getMaster() ~= nil then
+                    mAccuracyBonus = mAccuracyBonus + 25 -- TODO: This is based off a previous function. Would eventually like to get a capture for this.
+
+                    -- TODO: Do jug pet breaths gain damage or only an accuracy bonus?
+                    -- magicBurst      = calculateMobMagicBurst(target, actionElement, skillchainCount)
+                    -- magicBurstBonus = xi.spells.damage.calculateIfMagicBurstBonus(mob, target, 0, 0, actionElement)
+
+                    skill:setMsg(xi.msg.basic.PET_MAGIC_BURST)
+                end
+            end
+        end
+
+        resistRate             = xi.combat.magicHitRate.calculateResistRate(mob, target, 0, 0, xi.skillRank.A_PLUS, actionElement, resistStat, 0, mAccuracyBonus)
+        breathDamageAdjustment = xi.combat.damage.calculateDamageAdjustment(target, false, false, false, true)
+    end
+
+    -- TODO: Need more research about monster correlation.
+    -- local systemBonus     = 1 + utils.getEcosystemStrengthBonus(mob:getEcosystem(), target:getEcosystem()) / 4
+    elementalSDT  = xi.combat.damage.magicalElementSDT(target, actionElement)
+    dayAndWeather = xi.spells.damage.calculateDayAndWeather(mob, actionElement, false)
 
     damage = math.floor(damage * systemBonus)
     damage = math.floor(damage * elementalSDT)
     damage = math.floor(damage * resistRate)
     damage = math.floor(damage * dayAndWeather)
+    damage = math.floor(damage * breathDamageAdjustment)
     damage = utils.clamp(damage, 0, breathSkillDamageCap)
-    damage = math.floor(damage * absorb * nullify)
+    damage = math.floor(damage * absorbDamage)
+    damage = math.floor(damage * magicBurst)
+    damage = math.floor(damage * magicBurstBonus)
 
-    if damage <= 0 then -- Return early since the rest of the calculations are not needed if we absorbed/nullified.
-        return { damage = damage }
+    -- If we absorbed, then return early as the rest is not needed.
+    if absorbDamage < 0  then
+        -- Messaging is handled in core. Returning a negative damage value automatically sets the absorb message.
+
+        returnInfo.damage     = damage
+        returnInfo.hitsLanded = hitsLanded
+        -- Note: We still count absorbs as a "hit" since additional status effects tied to the skill itself will still apply even if absorbed.
+
+        return returnInfo
     end
 
-    -- The values set for this modifiers are base 10000.
-    -- -2500 in item_mods.sql means -25% damage recived.
-    -- 2500 would mean 25% ADDITIONAL damage taken.
-    -- The effects of the "Shell" spells are also included in this step. The effect also aplies a negative value.
-    local globalDamageTaken   = target:getMod(xi.mod.DMG) / 10000                               -- Mod is base 10000
-    local breathDamageTaken   = target:getMod(xi.mod.DMGBREATH) / 10000                         -- Mod is base 10000
-    local uBreathDamageTaken  = target:getMod(xi.mod.UDMGBREATH) / 10000                        -- Mod is base 10000
-    local combinedDamageTaken = utils.clamp(breathDamageTaken + globalDamageTaken, -0.5, 0.5)   -- The combination of regular "Damage Taken" and "Breath Damage Taken" caps at 50%. There is no BDTII known as of yet.
-    combinedDamageTaken       = utils.clamp(1 + combinedDamageTaken + uBreathDamageTaken, 0, 2) -- Uncapped breath damage modifier. Cap is 100% both ways.
+    damage = math.floor(target:handleSevereDamage(damage, false))
+    damage = math.floor(target:checkDamageCap(damage))
+    damage = math.floor(utils.handleAutomatonAutoAnalyzer(target, skill, damage))
+    damage = utils.handlePhalanx(target, damage)
+    damage = utils.handleOneForAll(target, damage)
 
-    -- Apply "Damage taken" mods to damage.
-    damage = math.floor(damage * combinedDamageTaken)
+    if not skipStoneskin then
+        -- TODO: Some Stoneskin effects only absorb certain damage types.
+        damage = utils.handleStoneskin(target, damage)
+    end
 
-    return { damage = damage }
+    target:updateEnmityFromDamage(mob, damage)
+    target:handleAfflatusMiseryDamage(damage)
+
+    -- Calculate TP return of the mob skill.
+    xi.mobskills.calculateSkillTPReturn(damage, mob, skill, target, attackType, hitsLanded)
+
+    returnInfo.damage     = damage
+    returnInfo.hitsLanded = hitsLanded
+
+    return returnInfo
 end
 
 ---@param info magicalMobSkillRetVal|physicalMobSkillRetVal
@@ -671,28 +787,16 @@ xi.mobskills.calculateSkillTPReturn = function(damage, mob, skill, target, attac
     end
 end
 
-xi.mobskills.hasMissMessage = function(mob, target, skill, damage)
-    local missMessages =
-    {
-        xi.msg.basic.EVADES,
-        xi.msg.basic.HIT_MISS,
-        xi.msg.basic.JA_MISS,
-        xi.msg.basic.JA_MISS_2,
-        xi.msg.basic.SKILL_MISS,
-        xi.msg.basic.RANGED_ATTACK_MISS,
-        xi.msg.basic.SHADOW_ABSORB,
-        xi.msg.basic.ANTICIPATE,
-        xi.msg.basic.SKILL_RECOVERS_HP
-    }
-
-    local skillMsg = skill:getMsg()
-
-    -- The attack was a miss, shadow absorbed, or anticipated.
-    for _, msg in ipairs(missMessages) do
-        if skillMsg == msg then
-
-            return true
-        end
+---@param actor CBaseEntity
+---@param target CBaseEntity
+---@param skill CPetSkill|CMobSkill
+---@param action CAction
+---@param info table
+---@return boolean
+-- Used as a conditional filter for target:takeDamage so the target doesn't take chip damage through shadows.
+xi.mobskills.processDamage = function(actor, target, skill, action, info)
+    if info.hitsLanded > 0 then
+        return true
     end
 
     return false
@@ -880,4 +984,58 @@ end
 ---@return xi.action.knockback
 xi.mobskills.calculateKnockback = function(target, attacker, skill, action)
     return utils.clamp(skill:getKnockback() - target:getMod(xi.mod.KNOCKBACK_REDUCTION), xi.action.knockback.NONE, xi.action.knockback.LEVEL7)
+end
+
+---@param actor CBaseEntity
+---@param target CBaseEntity
+---@param skill CMobSkill|CPetSkill
+---@param damage integer
+---@param attackType xi.attackType
+---@param shadowsToRemove xi.mobskills.shadowBehavior|integer?
+xi.mobskills.handleShadows = function(actor, target, skill, damage, attackType, shadowsToRemove)
+    -- Handle shadows depending on shadow behavior / attackType
+    if
+        shadowsToRemove ~= nil and
+        shadowsToRemove ~= xi.mobskills.shadowBehavior.WIPE_SHADOWS and
+        shadowsToRemove ~= xi.mobskills.shadowBehavior.IGNORE_SHADOWS
+    then
+        -- Utsusemi preservation (mostly AoE physical)
+        if skill:isAoE() or skill:isConal() then
+            shadowsToRemove = utils.attemptShadowMitigation(target, shadowsToRemove)
+        end
+
+        local shadowsUsed = 0
+        damage, shadowsUsed = utils.takeShadows(target, damage, shadowsToRemove)
+
+        -- Shadows absorbed everything
+        if damage == 0 then
+            skill:setMsg(xi.msg.basic.SHADOW_ABSORB)
+
+            return shadowsUsed
+        end
+
+    elseif shadowsToRemove == xi.mobskills.shadowBehavior.WIPE_SHADOWS then
+        target:delStatusEffect(xi.effect.COPY_IMAGE)
+        target:delStatusEffect(xi.effect.BLINK)
+        target:delStatusEffect(xi.effect.THIRD_EYE)
+    end
+
+    -- Physical / Ranged handling
+    if
+        attackType == xi.attackType.PHYSICAL or
+        attackType == xi.attackType.RANGED
+    then
+        -- Third Eye does not block AoE attacks
+        if not skill:isSingle() then
+            target:delStatusEffect(xi.effect.THIRD_EYE)
+        end
+
+        -- Anticipate check (Third Eye)
+        if xi.combat.physicalHitRate.checkAnticipated(actor, target) then
+            skill:setMsg(xi.msg.basic.ANTICIPATE)
+            return 0
+        end
+    end
+
+    return damage
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Backports some features/mobskill handling from my future updated Magical mobskill PR.

* Adds action to onMobWeaponSkill() in mobskill scripts. This is already exposed but was missing from the scripts.

* Corrects order of Nullification and Absorb. Nullification takes precedence over absorb.

* Eliminates usage of mobFinalAdjustments() for mobBreathMove(). The functions within have been integrated in to the mobBreathMove() function.

* Uses function processDamage() to prevent chip damage through shadows. (Replaces hasMissMessage())

* Note: Captures show status effects will still apply even if an attack if absorbed or nullified. (We still count hitsLanded when absorb or nullify occurs)

* Fixes double spacing in breath skill script params.

* Converts mobskill "Aeolian Void" to a magic skill using values from Jimmayus's spreadsheet.


## Steps to test these changes

I tested the skills by hand.

If you want to test yourself:

1. `!setmod FIRE_ABSORB 100 <me>`
2. `!exec target:useMobAbility(800, player)`
 -- Skill ID 800 = Heat Breath
 See that you will absorb the damage.
 3. `!setmod FIRE_NULL 100 <me>`
 4. `!exec target:useMobAbility(800, player)`
 -- See that you now nullify the damage over absorbing it.
 
 5. Breath skills usually ignore shadows but the capability to have differing shadow behavior is preserved.
 -- Open the heat_breath.lua script. Adjust shadowBehavior to NUMSHADOWS_1 from IGNORE_SHADOWS.
 -- Cast Utsusemi on yourself and see that it will now only take 1 shadow.
 -- Note, the messaging will still display 0 shadows taken, a known issue until the rest of mobskills are ported so we don't take chip damage.
