### PR TITLE
[core] Adjust desynth success penalty for -1 to -7 range to 5.0f per difficulty

### DIFF
--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -610,7 +610,7 @@ auto calculateDesynthResult(CCharEntity* PChar) -> uint8
         }
         else if (synthDifficulty >= 1)
         {
-            successRate = 40.0f - 0.05f * (synthDifficulty - 1);
+            successRate = 40.0f - 5.0f * (synthDifficulty - 1);
         }
         else
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The Desynthesis successRate penalty was off by two digits in the -1 to -7 range. Changed the penalty per level from 0.05f to 5.0f.

## Steps to test these changes
Add print logging to synthutils at the -1/-7 desynthesis range (lines 605, 620) and rebuild

!additem 4100 20  (lightning crystals)
!additem 596 20 (quadav backplates)

Desynth items in game, after setting smithing levels:
!setskill smithing 51 (through 41)
Read out the console logs in map-server

Before:
<img width="1115" height="495" alt="image" src="https://github.com/user-attachments/assets/8436b7a0-8dc7-45e6-a594-1cb18f4bcf9c" />

After:
<img width="1115" height="533" alt="image" src="https://github.com/user-attachments/assets/020194db-0dd2-4dad-afba-373c2a2be5f0" />

Sources: https://www.bluegartr.com/threads/135055-Extensive-Desynthesis-Rate-Research

<img width="651" height="404" alt="image" src="https://github.com/user-attachments/assets/f58f5ce8-c0a3-442b-bed1-88dd4af865b6" />