### PR TITLE
[Chore] Add player check to all mobs that grant a title in onMobDeath

### DIFF
--- a/scripts/zones/Abyssea-Altepa/mobs/Rani.lua
+++ b/scripts/zones/Abyssea-Altepa/mobs/Rani.lua
@@ -18,7 +18,9 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.RANI_DECROWNER)
+    if player then
+        player:addTitle(xi.title.RANI_DECROWNER)
+    end
 end
 
 return entity

--- a/scripts/zones/Abyssea-Konschtat/mobs/Eccentric_Eve.lua
+++ b/scripts/zones/Abyssea-Konschtat/mobs/Eccentric_Eve.lua
@@ -6,7 +6,9 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.ECCENTRICITY_EXPUNGER)
+    if player then
+        player:addTitle(xi.title.ECCENTRICITY_EXPUNGER)
+    end
 end
 
 return entity

--- a/scripts/zones/Abyssea-Konschtat/mobs/Fistule.lua
+++ b/scripts/zones/Abyssea-Konschtat/mobs/Fistule.lua
@@ -54,7 +54,7 @@ entity.onMobRoam = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, isKiller)
-    if player ~= nil and not player:hasTitle(xi.title.FISTULE_DRAINER) then
+    if player then
         player:addTitle(xi.title.FISTULE_DRAINER)
     end
 end

--- a/scripts/zones/Abyssea-Konschtat/mobs/Kukulkan.lua
+++ b/scripts/zones/Abyssea-Konschtat/mobs/Kukulkan.lua
@@ -8,7 +8,9 @@ mixins = { require('scripts/mixins/families/peiste') }
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.KUKULKAN_DEFANGER)
+    if player then
+        player:addTitle(xi.title.KUKULKAN_DEFANGER)
+    end
 end
 
 return entity

--- a/scripts/zones/Abyssea-Konschtat/mobs/Turul.lua
+++ b/scripts/zones/Abyssea-Konschtat/mobs/Turul.lua
@@ -29,7 +29,9 @@ entity.onSpellPrecast = function(mob, spell)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.TURUL_GROUNDER)
+    if player then
+        player:addTitle(xi.title.TURUL_GROUNDER)
+    end
 end
 
 return entity

--- a/scripts/zones/Abyssea-La_Theine/mobs/Briareus.lua
+++ b/scripts/zones/Abyssea-La_Theine/mobs/Briareus.lua
@@ -60,7 +60,9 @@ entity.onMobMobskillChoose = function(mob, target, skillId)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.BRIAREUS_FELLER)
+    if player then
+        player:addTitle(xi.title.BRIAREUS_FELLER)
+    end
 end
 
 return entity

--- a/scripts/zones/Abyssea-Tahrongi/mobs/Iratham.lua
+++ b/scripts/zones/Abyssea-Tahrongi/mobs/Iratham.lua
@@ -18,7 +18,9 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.IRATHAM_CAPTURER)
+    if player then
+        player:addTitle(xi.title.IRATHAM_CAPTURER)
+    end
 end
 
 return entity

--- a/scripts/zones/Abyssea-Vunkerl/mobs/Sippoy.lua
+++ b/scripts/zones/Abyssea-Vunkerl/mobs/Sippoy.lua
@@ -16,7 +16,9 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.SIPPOY_CAPTURER)
+    if player then
+        player:addTitle(xi.title.SIPPOY_CAPTURER)
+    end
 end
 
 return entity

--- a/scripts/zones/Alzadaal_Undersea_Ruins/mobs/Oupire.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/mobs/Oupire.lua
@@ -14,8 +14,10 @@ entity.onAdditionalEffect = function(mob, target, damage)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.hunts.checkHunt(mob, player, 478)
-    player:addTitle(xi.title.OUPIRE_IMPALER)
+    if player then
+        player:addTitle(xi.title.OUPIRE_IMPALER)
+        xi.hunts.checkHunt(mob, player, 478)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Arrapago_Reef/mobs/Medusa.lua
+++ b/scripts/zones/Arrapago_Reef/mobs/Medusa.lua
@@ -28,32 +28,6 @@ entity.onMobEngage = function(mob, target)
 end
 
 entity.onMobFight = function(mob, target)
-    if mob:getBattleTime() % 60 < 2 and mob:getBattleTime() > 10 then
-        local mob1 = GetMobByID(ID.mob.MEDUSA + 1)
-        if mob1 and not mob1:isSpawned() then
-            mob1:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
-            SpawnMob(ID.mob.MEDUSA + 1):updateEnmity(target)
-        else
-            local mob2 = GetMobByID(ID.mob.MEDUSA + 2)
-            if mob2 and not mob2:isSpawned() then
-                mob2:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
-                SpawnMob(ID.mob.MEDUSA + 2):updateEnmity(target)
-            else
-                local mob3 = GetMobByID(ID.mob.MEDUSA + 3)
-                if mob3 and not mob3:isSpawned() then
-                    mob3:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
-                    SpawnMob(ID.mob.MEDUSA + 3):updateEnmity(target)
-                else
-                    local mob4 = GetMobByID(ID.mob.MEDUSA + 4)
-                    if mob4 and not mob4:isSpawned() then
-                        mob4:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
-                        SpawnMob(ID.mob.MEDUSA + 4):updateEnmity(target)
-                    end
-                end
-            end
-        end
-    end
-
     for i = ID.mob.MEDUSA + 1, ID.mob.MEDUSA + 4 do
         local pet = GetMobByID(i)
         if
@@ -63,20 +37,36 @@ entity.onMobFight = function(mob, target)
             pet:updateEnmity(target)
         end
     end
+
+    if mob:getBattleTime() % 60 < 2 and mob:getBattleTime() > 10 then
+        for i = ID.mob.MEDUSA + 1, ID.mob.MEDUSA + 4 do
+            local bodyguard = GetMobByID(ID.mob.MEDUSA + 1)
+            if bodyguard and not bodyguard:isSpawned() then
+                bodyguard:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
+                SpawnMob(i):updateEnmity(target)
+                break
+            end
+        end
+    end
 end
 
 entity.onMobDisengage = function(mob)
-    for i = 1, 4 do DespawnMob(ID.mob.MEDUSA + i) end
+    for i = ID.mob.MEDUSA + 1, ID.mob.MEDUSA + 4 do
+        DespawnMob(i)
+    end
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:showText(mob, ID.text.MEDUSA_DEATH)
-    player:addTitle(xi.title.GORGONSTONE_SUNDERER)
-    for i = 1, 4 do DespawnMob(ID.mob.MEDUSA + i) end
-end
+    if player then
+        player:addTitle(xi.title.GORGONSTONE_SUNDERER)
+        player:showText(mob, ID.text.MEDUSA_DEATH)
+    end
 
-entity.onMobDespawn = function(mob)
-    for i = 1, 4 do DespawnMob(ID.mob.MEDUSA + i) end
+    if optParams.isKiller or optParams.noKiller then
+        for i = ID.mob.MEDUSA + 1, ID.mob.MEDUSA + 4 do
+            DespawnMob(i)
+        end
+    end
 end
 
 return entity

--- a/scripts/zones/Arrapago_Remnants/mobs/Armored_Chariot.lua
+++ b/scripts/zones/Arrapago_Remnants/mobs/Armored_Chariot.lua
@@ -6,7 +6,9 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.SUN_CHARIOTEER)
+    if player then
+        player:addTitle(xi.title.SUN_CHARIOTEER)
+    end
 end
 
 return entity

--- a/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
@@ -269,7 +269,9 @@ entity.onMobDisengage = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.TIAMAT_TROUNCER)
+    if player then
+        player:addTitle(xi.title.TIAMAT_TROUNCER)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Batallia_Downs/mobs/Verthandi.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Verthandi.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.VERTHANDI_ENSNARER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
-    xi.hunts.checkHunt(mob, player, 553)
+    if player then
+        player:addTitle(xi.title.VERTHANDI_ENSNARER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
+        xi.hunts.checkHunt(mob, player, 553)
+    end
 end
 
 return entity

--- a/scripts/zones/Batallia_Downs/mobs/Yilbegan.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Yilbegan.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, nil)
-    xi.hunts.checkHunt(mob, player, 559)
+    if player then
+        player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, nil)
+        xi.hunts.checkHunt(mob, player, 559)
+    end
 end
 
 return entity

--- a/scripts/zones/Batallia_Downs_[S]/mobs/Sandworm.lua
+++ b/scripts/zones/Batallia_Downs_[S]/mobs/Sandworm.lua
@@ -11,7 +11,9 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.SANDWORM_WRANGLER)
+    if player then
+        player:addTitle(xi.title.SANDWORM_WRANGLER)
+    end
 end
 
 return entity

--- a/scripts/zones/Batallia_Downs_[S]/mobs/Verthandi.lua
+++ b/scripts/zones/Batallia_Downs_[S]/mobs/Verthandi.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.VERTHANDI_ENSNARER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
-    xi.hunts.checkHunt(mob, player, 553)
+    if player then
+        player:addTitle(xi.title.VERTHANDI_ENSNARER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
+        xi.hunts.checkHunt(mob, player, 553)
+    end
 end
 
 return entity

--- a/scripts/zones/Batallia_Downs_[S]/mobs/Yilbegan.lua
+++ b/scripts/zones/Batallia_Downs_[S]/mobs/Yilbegan.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, nil)
-    xi.hunts.checkHunt(mob, player, 559)
+    if player then
+        player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, nil)
+        xi.hunts.checkHunt(mob, player, 559)
+    end
 end
 
 return entity

--- a/scripts/zones/Beaucedine_Glacier/mobs/Lord_Ruthven.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Lord_Ruthven.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.RUTHVEN_ENTOMBER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
-    xi.hunts.checkHunt(mob, player, 556)
+    if player then
+        player:addTitle(xi.title.RUTHVEN_ENTOMBER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
+        xi.hunts.checkHunt(mob, player, 556)
+    end
 end
 
 return entity

--- a/scripts/zones/Beaucedine_Glacier/mobs/Yilbegan.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Yilbegan.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, nil)
-    xi.hunts.checkHunt(mob, player, 559)
+    if player then
+        player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, nil)
+        xi.hunts.checkHunt(mob, player, 559)
+    end
 end
 
 return entity

--- a/scripts/zones/Beaucedine_Glacier_[S]/mobs/Lord_Ruthven.lua
+++ b/scripts/zones/Beaucedine_Glacier_[S]/mobs/Lord_Ruthven.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.RUTHVEN_ENTOMBER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
-    xi.hunts.checkHunt(mob, player, 556)
+    if player then
+        player:addTitle(xi.title.RUTHVEN_ENTOMBER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
+        xi.hunts.checkHunt(mob, player, 556)
+    end
 end
 
 return entity

--- a/scripts/zones/Beaucedine_Glacier_[S]/mobs/Yilbegan.lua
+++ b/scripts/zones/Beaucedine_Glacier_[S]/mobs/Yilbegan.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, nil)
-    xi.hunts.checkHunt(mob, player, 559)
+    if player then
+        player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, nil)
+        xi.hunts.checkHunt(mob, player, 559)
+    end
 end
 
 return entity

--- a/scripts/zones/Behemoths_Dominion/mobs/Behemoth.lua
+++ b/scripts/zones/Behemoths_Dominion/mobs/Behemoth.lua
@@ -101,7 +101,9 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.BEHEMOTHS_BANE)
+    if player then
+        player:addTitle(xi.title.BEHEMOTHS_BANE)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Behemoths_Dominion/mobs/King_Behemoth.lua
+++ b/scripts/zones/Behemoths_Dominion/mobs/King_Behemoth.lua
@@ -138,7 +138,9 @@ entity.onSpellPrecast = function(mob, spell)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.BEHEMOTH_DETHRONER)
+    if player then
+        player:addTitle(xi.title.BEHEMOTH_DETHRONER)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Bhaflau_Remnants/mobs/Long-Bowed_Chariot.lua
+++ b/scripts/zones/Bhaflau_Remnants/mobs/Long-Bowed_Chariot.lua
@@ -35,7 +35,10 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.COMET_CHARIOTEER)
+    if player then
+        player:addTitle(xi.title.COMET_CHARIOTEER)
+    end
+
     if optParams.isKiller or optParams.noKiller then
         mob:getInstance():complete()
     end

--- a/scripts/zones/Caedarva_Mire/mobs/Khimaira.lua
+++ b/scripts/zones/Caedarva_Mire/mobs/Khimaira.lua
@@ -15,10 +15,6 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.AOE_HIT_ALL, 1)
 end
 
-entity.onMobRoam = function(mob)
-    mob:setMobMod(xi.mobMod.NO_MOVE, 0)
-end
-
 entity.onMobFight = function(mob, target)
     local targetPos = target:getPos()
     local drawInPositions =
@@ -55,8 +51,14 @@ entity.onMobFight = function(mob, target)
     end
 end
 
+entity.onMobDisengage = function(mob)
+    mob:setMobMod(xi.mobMod.NO_MOVE, 0)
+end
+
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.KHIMAIRA_CARVER)
+    if player then
+        player:addTitle(xi.title.KHIMAIRA_CARVER)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Castle_Oztroja/mobs/Tzee_Xicu_the_Manifest.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Tzee_Xicu_the_Manifest.lua
@@ -66,6 +66,7 @@ entity.spawnPoints =
 entity.onMobInitialize = function(mob)
     xi.pet.setMobPet(mob, 1, 'Yagudos_Elemental')
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
 end
 
 entity.onMobSpawn = function(mob)
@@ -73,7 +74,6 @@ entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.PARALYZE_RES_RANK, 8)
     mob:setMod(xi.mod.SLOW_RES_RANK, 8)
     mob:setMod(xi.mod.SILENCE_RES_RANK, 10)
-    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
 end
 
 entity.onMobEngage = function(mob, target)
@@ -93,7 +93,10 @@ entity.onAdditionalEffect = function(mob, target, damage)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.DEITY_DEBUNKER)
+    if player then
+        player:addTitle(xi.title.DEITY_DEBUNKER)
+    end
+
     if optParams.isKiller or optParams.noKiller then
         mob:showText(mob, ID.text.YAGUDO_KING_DEATH)
     end

--- a/scripts/zones/Castle_Zvahl_Keep/mobs/Baron_Vapula.lua
+++ b/scripts/zones/Castle_Zvahl_Keep/mobs/Baron_Vapula.lua
@@ -15,7 +15,7 @@ entity.phList =
     [ID.mob.BARON_VAPULA - 1] = ID.mob.BARON_VAPULA, -- -227.007 -52.125 83.768
 }
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
     mob:addImmunity(xi.immunity.SILENCE)
@@ -23,8 +23,10 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.hunts.checkHunt(mob, player, 354)
-    player:addTitle(xi.title.HELLSBANE)
+    if player then
+        player:addTitle(xi.title.HELLSBANE)
+        xi.hunts.checkHunt(mob, player, 354)
+    end
 end
 
 return entity

--- a/scripts/zones/Castle_Zvahl_Keep/mobs/Baronet_Romwe.lua
+++ b/scripts/zones/Castle_Zvahl_Keep/mobs/Baronet_Romwe.lua
@@ -15,16 +15,18 @@ entity.phList =
     [ID.mob.BARONET_ROMWE - 1] = ID.mob.BARONET_ROMWE, -- -335.444 -52.125 15.148
 }
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
-    mob:addImmunity(xi.immunity.TERROR)
     mob:addImmunity(xi.immunity.SILENCE)
+    mob:addImmunity(xi.immunity.TERROR)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.hunts.checkHunt(mob, player, 353)
-    player:addTitle(xi.title.HELLSBANE)
+    if player then
+        player:addTitle(xi.title.HELLSBANE)
+        xi.hunts.checkHunt(mob, player, 353)
+    end
 end
 
 return entity

--- a/scripts/zones/Castle_Zvahl_Keep/mobs/Count_Bifrons.lua
+++ b/scripts/zones/Castle_Zvahl_Keep/mobs/Count_Bifrons.lua
@@ -14,7 +14,7 @@ entity.phList =
     [ID.mob.COUNT_BIFRONS - 1] = ID.mob.COUNT_BIFRONS, -- -204.000 -52.125 -95.000
 }
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
     mob:addImmunity(xi.immunity.SILENCE)
@@ -22,8 +22,10 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.hunts.checkHunt(mob, player, 355)
-    player:addTitle(xi.title.HELLSBANE)
+    if player then
+        player:addTitle(xi.title.HELLSBANE)
+        xi.hunts.checkHunt(mob, player, 355)
+    end
 end
 
 return entity

--- a/scripts/zones/Castle_Zvahl_Keep/mobs/Viscount_Morax.lua
+++ b/scripts/zones/Castle_Zvahl_Keep/mobs/Viscount_Morax.lua
@@ -16,9 +16,6 @@ entity.phList =
 
 entity.onMobInitialize = function(mob)
     xi.pet.setMobPet(mob, 1, 'Demons_Elemental')
-end
-
-entity.onMobSpawn = function(mob)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
     mob:addImmunity(xi.immunity.SILENCE)
@@ -26,8 +23,10 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.hunts.checkHunt(mob, player, 356)
-    player:addTitle(xi.title.HELLSBANE)
+    if player then
+        player:addTitle(xi.title.HELLSBANE)
+        xi.hunts.checkHunt(mob, player, 356)
+    end
 end
 
 return entity

--- a/scripts/zones/Crawlers_Nest/mobs/Awd_Goggie.lua
+++ b/scripts/zones/Crawlers_Nest/mobs/Awd_Goggie.lua
@@ -11,7 +11,9 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.BOGEYDOWNER)
+    if player then
+        player:addTitle(xi.title.BOGEYDOWNER)
+    end
 end
 
 return entity

--- a/scripts/zones/Dragons_Aery/mobs/Fafnir.lua
+++ b/scripts/zones/Dragons_Aery/mobs/Fafnir.lua
@@ -98,7 +98,9 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.FAFNIR_SLAYER)
+    if player then
+        player:addTitle(xi.title.FAFNIR_SLAYER)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Dragons_Aery/mobs/Nidhogg.lua
+++ b/scripts/zones/Dragons_Aery/mobs/Nidhogg.lua
@@ -112,7 +112,9 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.NIDHOGG_SLAYER)
+    if player then
+        player:addTitle(xi.title.NIDHOGG_SLAYER)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Dynamis-Tavnazia/mobs/Diabolos_Club.lua
+++ b/scripts/zones/Dynamis-Tavnazia/mobs/Diabolos_Club.lua
@@ -11,8 +11,10 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.dynamis.megaBossOnDeath(mob, player, optParams)
-    player:addTitle(xi.title.NIGHTMARE_AWAKENER)
+    if player then
+        player:addTitle(xi.title.NIGHTMARE_AWAKENER)
+        xi.dynamis.megaBossOnDeath(mob, player, optParams)
+    end
 end
 
 return entity

--- a/scripts/zones/Dynamis-Tavnazia/mobs/Diabolos_Diamond.lua
+++ b/scripts/zones/Dynamis-Tavnazia/mobs/Diabolos_Diamond.lua
@@ -7,8 +7,10 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.dynamis.megaBossOnDeath(mob, player, optParams)
-    player:addTitle(xi.title.NIGHTMARE_AWAKENER)
+    if player then
+        player:addTitle(xi.title.NIGHTMARE_AWAKENER)
+        xi.dynamis.megaBossOnDeath(mob, player, optParams)
+    end
 end
 
 return entity

--- a/scripts/zones/Dynamis-Tavnazia/mobs/Diabolos_Heart.lua
+++ b/scripts/zones/Dynamis-Tavnazia/mobs/Diabolos_Heart.lua
@@ -7,8 +7,10 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.dynamis.megaBossOnDeath(mob, player, optParams)
-    player:addTitle(xi.title.NIGHTMARE_AWAKENER)
+    if player then
+        player:addTitle(xi.title.NIGHTMARE_AWAKENER)
+        xi.dynamis.megaBossOnDeath(mob, player, optParams)
+    end
 end
 
 return entity

--- a/scripts/zones/Dynamis-Tavnazia/mobs/Diabolos_Spade.lua
+++ b/scripts/zones/Dynamis-Tavnazia/mobs/Diabolos_Spade.lua
@@ -7,8 +7,10 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.dynamis.megaBossOnDeath(mob, player, optParams)
-    player:addTitle(xi.title.NIGHTMARE_AWAKENER)
+    if player then
+        player:addTitle(xi.title.NIGHTMARE_AWAKENER)
+        xi.dynamis.megaBossOnDeath(mob, player, optParams)
+    end
 end
 
 return entity

--- a/scripts/zones/Dynamis-Xarcabard/mobs/Dynamis_Lord.lua
+++ b/scripts/zones/Dynamis-Xarcabard/mobs/Dynamis_Lord.lua
@@ -49,9 +49,12 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.dynamis.megaBossOnDeath(mob, player, optParams)
-    player:addTitle(xi.title.LIFTER_OF_SHADOWS)
-    if optParams.isKiller then
+    if player then
+        player:addTitle(xi.title.LIFTER_OF_SHADOWS)
+        xi.dynamis.megaBossOnDeath(mob, player, optParams)
+    end
+
+    if optParams.isKiller or optParams.noKiller then
         DespawnMob(ID.mob.YING)
         DespawnMob(ID.mob.YING + 1)
     end

--- a/scripts/zones/East_Ronfaure/mobs/Krabkatoa.lua
+++ b/scripts/zones/East_Ronfaure/mobs/Krabkatoa.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.KRABKATOA_STEAMER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
-    xi.hunts.checkHunt(mob, player, 544)
+    if player then
+        player:addTitle(xi.title.KRABKATOA_STEAMER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
+        xi.hunts.checkHunt(mob, player, 544)
+    end
 end
 
 return entity

--- a/scripts/zones/East_Ronfaure/mobs/Yilbegan.lua
+++ b/scripts/zones/East_Ronfaure/mobs/Yilbegan.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, nil)
-    xi.hunts.checkHunt(mob, player, 559)
+    if player then
+        player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, nil)
+        xi.hunts.checkHunt(mob, player, 559)
+    end
 end
 
 return entity

--- a/scripts/zones/East_Ronfaure_[S]/mobs/Krabkatoa.lua
+++ b/scripts/zones/East_Ronfaure_[S]/mobs/Krabkatoa.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.KRABKATOA_STEAMER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
-    xi.hunts.checkHunt(mob, player, 544)
+    if player then
+        player:addTitle(xi.title.KRABKATOA_STEAMER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
+        xi.hunts.checkHunt(mob, player, 544)
+    end
 end
 
 return entity

--- a/scripts/zones/East_Ronfaure_[S]/mobs/Sandworm.lua
+++ b/scripts/zones/East_Ronfaure_[S]/mobs/Sandworm.lua
@@ -11,7 +11,9 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.SANDWORM_WRANGLER)
+    if player then
+        player:addTitle(xi.title.SANDWORM_WRANGLER)
+    end
 end
 
 return entity

--- a/scripts/zones/East_Ronfaure_[S]/mobs/Yilbegan.lua
+++ b/scripts/zones/East_Ronfaure_[S]/mobs/Yilbegan.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, nil)
-    xi.hunts.checkHunt(mob, player, 559)
+    if player then
+        player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, nil)
+        xi.hunts.checkHunt(mob, player, 559)
+    end
 end
 
 return entity

--- a/scripts/zones/Eastern_Altepa_Desert/mobs/Cactrot_Rapido.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/mobs/Cactrot_Rapido.lua
@@ -194,7 +194,9 @@ entity.onMobEngage = function(mob, target)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.CACTROT_DESACELERADOR)
+    if player then
+        player:addTitle(xi.title.CACTROT_DESACELERADOR)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Everbloom_Hollow/mobs/Lambton_Worm.lua
+++ b/scripts/zones/Everbloom_Hollow/mobs/Lambton_Worm.lua
@@ -6,7 +6,9 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.LAMBTON_WORM_DESEGMENTER)
+    if player then
+        player:addTitle(xi.title.LAMBTON_WORM_DESEGMENTER)
+    end
 end
 
 return entity

--- a/scripts/zones/FeiYin/mobs/Capricious_Cassie.lua
+++ b/scripts/zones/FeiYin/mobs/Capricious_Cassie.lua
@@ -118,7 +118,9 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.CASSIENOVA)
+    if player then
+        player:addTitle(xi.title.CASSIENOVA)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/FeiYin/mobs/Goliath.lua
+++ b/scripts/zones/FeiYin/mobs/Goliath.lua
@@ -18,7 +18,9 @@ entity.phList =
 }
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.GOLIATH_KILLER)
+    if player then
+        player:addTitle(xi.title.GOLIATH_KILLER)
+    end
 end
 
 return entity

--- a/scripts/zones/Garlaige_Citadel/mobs/Serket.lua
+++ b/scripts/zones/Garlaige_Citadel/mobs/Serket.lua
@@ -112,7 +112,9 @@ entity.onMobSpellChoose = function(mob, target, spellId)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.SERKET_BREAKER)
+    if player then
+        player:addTitle(xi.title.SERKET_BREAKER)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Garlaige_Citadel/mobs/Skewer_Sam.lua
+++ b/scripts/zones/Garlaige_Citadel/mobs/Skewer_Sam.lua
@@ -65,7 +65,9 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.BEAKBENDER)
+    if player then
+        player:addTitle(xi.title.BEAKBENDER)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Ghelsba_Outpost/mobs/Warchief_Vatgit.lua
+++ b/scripts/zones/Ghelsba_Outpost/mobs/Warchief_Vatgit.lua
@@ -7,7 +7,9 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.WARCHIEF_WRECKER)
+    if player then
+        player:addTitle(xi.title.WARCHIEF_WRECKER)
+    end
 end
 
 return entity

--- a/scripts/zones/Ghoyus_Reverie/mobs/Lambton_Worm.lua
+++ b/scripts/zones/Ghoyus_Reverie/mobs/Lambton_Worm.lua
@@ -6,7 +6,9 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.LAMBTON_WORM_DESEGMENTER)
+    if player then
+        player:addTitle(xi.title.LAMBTON_WORM_DESEGMENTER)
+    end
 end
 
 return entity

--- a/scripts/zones/Halvung/mobs/Gurfurlur_the_Menacing.lua
+++ b/scripts/zones/Halvung/mobs/Gurfurlur_the_Menacing.lua
@@ -16,32 +16,6 @@ entity.onMobEngage = function(mob, target)
 end
 
 entity.onMobFight = function(mob, target)
-    if mob:getBattleTime() % 60 < 2 and mob:getBattleTime() > 10 then
-        local mob1 = GetMobByID(ID.mob.GURFURLUR_THE_MENACING + 1)
-        if mob1 and not mob1:isSpawned() then
-            mob1:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
-            SpawnMob(ID.mob.GURFURLUR_THE_MENACING + 1):updateEnmity(target)
-        else
-            local mob2 = GetMobByID(ID.mob.GURFURLUR_THE_MENACING + 2)
-            if mob2 and not mob2:isSpawned() then
-                mob2:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
-                SpawnMob(ID.mob.GURFURLUR_THE_MENACING + 2):updateEnmity(target)
-            else
-                local mob3 = GetMobByID(ID.mob.GURFURLUR_THE_MENACING + 3)
-                if mob3 and not mob3:isSpawned() then
-                    mob3:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
-                    SpawnMob(ID.mob.GURFURLUR_THE_MENACING + 3):updateEnmity(target)
-                else
-                    local mob4 = GetMobByID(ID.mob.GURFURLUR_THE_MENACING + 4)
-                    if mob4 and not mob4:isSpawned() then
-                        mob4:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
-                        SpawnMob(ID.mob.GURFURLUR_THE_MENACING + 4):updateEnmity(target)
-                    end
-                end
-            end
-        end
-    end
-
     for i = ID.mob.GURFURLUR_THE_MENACING + 1, ID.mob.GURFURLUR_THE_MENACING + 4 do
         local pet = GetMobByID(i)
 
@@ -49,19 +23,35 @@ entity.onMobFight = function(mob, target)
             pet:updateEnmity(target)
         end
     end
+
+    if mob:getBattleTime() % 60 < 2 and mob:getBattleTime() > 10 then
+        for i = ID.mob.GURFURLUR_THE_MENACING + 1, ID.mob.GURFURLUR_THE_MENACING + 4 do
+            local bodyguard = GetMobByID(i)
+            if bodyguard and not bodyguard:isSpawned() then
+                bodyguard:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
+                SpawnMob(i):updateEnmity(target)
+                break
+            end
+        end
+    end
 end
 
 entity.onMobDisengage = function(mob)
-    for i = 1, 4 do DespawnMob(ID.mob.GURFURLUR_THE_MENACING + i) end
+    for i = ID.mob.GURFURLUR_THE_MENACING + 1, ID.mob.GURFURLUR_THE_MENACING + 4 do
+        DespawnMob(i)
+    end
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.TROLL_SUBJUGATOR)
-    for i = 1, 4 do DespawnMob(ID.mob.GURFURLUR_THE_MENACING + i) end
-end
+    if player then
+        player:addTitle(xi.title.TROLL_SUBJUGATOR)
+    end
 
-entity.onMobDespawn = function(mob)
-    for i = 1, 4 do DespawnMob(ID.mob.GURFURLUR_THE_MENACING + i) end
+    if optParams.isKiller or optParams.noKiller then
+        for i = ID.mob.GURFURLUR_THE_MENACING + 1, ID.mob.GURFURLUR_THE_MENACING + 4 do
+            DespawnMob(i)
+        end
+    end
 end
 
 return entity

--- a/scripts/zones/Horlais_Peak/mobs/Dread_Dragon.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Dread_Dragon.lua
@@ -13,7 +13,9 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.DREAD_DRAGON_SLAYER)
+    if player then
+        player:addTitle(xi.title.DREAD_DRAGON_SLAYER)
+    end
 end
 
 return entity

--- a/scripts/zones/Ifrits_Cauldron/mobs/Ash_Dragon.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Ash_Dragon.lua
@@ -99,7 +99,9 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.DRAGON_ASHER)
+    if player then
+        player:addTitle(xi.title.DRAGON_ASHER)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Jugner_Forest/mobs/Krabkatoa.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Krabkatoa.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.KRABKATOA_STEAMER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
-    xi.hunts.checkHunt(mob, player, 544)
+    if player then
+        player:addTitle(xi.title.KRABKATOA_STEAMER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
+        xi.hunts.checkHunt(mob, player, 544)
+    end
 end
 
 return entity

--- a/scripts/zones/Jugner_Forest/mobs/Yilbegan.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Yilbegan.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, nil)
-    xi.hunts.checkHunt(mob, player, 559)
+    if player then
+        player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, nil)
+        xi.hunts.checkHunt(mob, player, 559)
+    end
 end
 
 return entity

--- a/scripts/zones/Jugner_Forest_[S]/mobs/Krabkatoa.lua
+++ b/scripts/zones/Jugner_Forest_[S]/mobs/Krabkatoa.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.KRABKATOA_STEAMER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
-    xi.hunts.checkHunt(mob, player, 544)
+    if player then
+        player:addTitle(xi.title.KRABKATOA_STEAMER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
+        xi.hunts.checkHunt(mob, player, 544)
+    end
 end
 
 return entity

--- a/scripts/zones/Jugner_Forest_[S]/mobs/Yilbegan.lua
+++ b/scripts/zones/Jugner_Forest_[S]/mobs/Yilbegan.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, nil)
-    xi.hunts.checkHunt(mob, player, 559)
+    if player then
+        player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, nil)
+        xi.hunts.checkHunt(mob, player, 559)
+    end
 end
 
 return entity

--- a/scripts/zones/King_Ranperres_Tomb/mobs/Cemetery_Cherry.lua
+++ b/scripts/zones/King_Ranperres_Tomb/mobs/Cemetery_Cherry.lua
@@ -31,7 +31,6 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
     mob:addImmunity(xi.immunity.TERROR)
-    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 
     local saplingsRespawn = math.random(1800, 3600) -- 30 to 60 minutes
     mob:timer(saplingsRespawn * 1000, function(mobArg)
@@ -42,6 +41,7 @@ end
 entity.onMobSpawn = function(mob)
     mob:setLocalVar('wasKilled', 0)
     mob:setMod(xi.mod.DOUBLE_ATTACK, 15)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
 entity.onMobMobskillChoose = function(mob, target, skillId)
@@ -57,8 +57,13 @@ entity.onMobMobskillChoose = function(mob, target, skillId)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    mob:setLocalVar('wasKilled', 1)
-    player:addTitle(xi.title.MON_CHERRY)
+    if player then
+        player:addTitle(xi.title.MON_CHERRY)
+    end
+
+    if optParams.isKiller or optParams.noKiller then
+        mob:setLocalVar('wasKilled', 1)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/King_Ranperres_Tomb/mobs/Vrtra.lua
+++ b/scripts/zones/King_Ranperres_Tomb/mobs/Vrtra.lua
@@ -78,9 +78,17 @@ entity.spawnPoints =
 }
 
 entity.onMobInitialize = function(mob)
-    mob:setCarefulPathing(true)
-    mob:setMobMod(xi.mobMod.AOE_HIT_ALL, 1)
     xi.mob.updateNMSpawnPoint(mob)
+
+    mob:addImmunity(xi.immunity.BIND)
+    mob:addImmunity(xi.immunity.BLIND)
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.PLAGUE)
+    mob:addImmunity(xi.immunity.PETRIFY)
+    mob:addImmunity(xi.immunity.TERROR)
+    mob:setMobMod(xi.mobMod.AOE_HIT_ALL, 1)
+
+    mob:setCarefulPathing(true)
     mob:setRespawnTime(math.random(144, 240) * 1800) -- 3 to 5 days in 30 minute windows
 end
 
@@ -103,12 +111,6 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.ROAM_DISTANCE, 5)
     mob:setMobMod(xi.mobMod.SIGHT_RANGE, 30)
     mob:setMobMod(xi.mobMod.WEAPON_BONUS, 148) -- 245 total weapon damage
-    mob:addImmunity(xi.immunity.BIND)
-    mob:addImmunity(xi.immunity.BLIND)
-    mob:addImmunity(xi.immunity.DARK_SLEEP)
-    mob:addImmunity(xi.immunity.PLAGUE)
-    mob:addImmunity(xi.immunity.PETRIFY)
-    mob:addImmunity(xi.immunity.TERROR)
 end
 
 entity.onMobRoam = function(mob)

--- a/scripts/zones/Konschtat_Highlands/mobs/Steelfleece_Baldarich.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Steelfleece_Baldarich.lua
@@ -42,8 +42,10 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.THE_HORNSPLITTER)
-    xi.tutorial.onMobDeath(player)
+    if player then
+        player:addTitle(xi.title.THE_HORNSPLITTER)
+        xi.tutorial.onMobDeath(player)
+    end
 end
 
 return entity

--- a/scripts/zones/Konschtat_Highlands/mobs/Stray_Mary.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Stray_Mary.lua
@@ -20,14 +20,13 @@ entity.phList =
     [ID.mob.STRAY_MARY[2] - 5] = ID.mob.STRAY_MARY[2], -- -293.900  33.393 342.710
 }
 
-entity.onMobSpawn = function(mob)
-end
-
 entity.onMobDeath = function(mob, player, optParams)
-    xi.hunts.checkHunt(mob, player, 203)
-    player:addTitle(xi.title.MARYS_GUIDE)
-    xi.tutorial.onMobDeath(player)
-    xi.magian.onMobDeath(mob, player, optParams, set{ 710 })
+    if player then
+        player:addTitle(xi.title.MARYS_GUIDE)
+        xi.hunts.checkHunt(mob, player, 203)
+        xi.tutorial.onMobDeath(player)
+        xi.magian.onMobDeath(mob, player, optParams, set{ 710 })
+    end
 end
 
 return entity

--- a/scripts/zones/Konschtat_Highlands/mobs/Yilbegan.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Yilbegan.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, nil)
-    xi.hunts.checkHunt(mob, player, 559)
+    if player then
+        player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, nil)
+        xi.hunts.checkHunt(mob, player, 559)
+    end
 end
 
 return entity

--- a/scripts/zones/La_Theine_Plateau/mobs/Bloodtear_Baldurf.lua
+++ b/scripts/zones/La_Theine_Plateau/mobs/Bloodtear_Baldurf.lua
@@ -56,8 +56,10 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.THE_HORNSPLITTER)
-    xi.tutorial.onMobDeath(player)
+    if player then
+        player:addTitle(xi.title.THE_HORNSPLITTER)
+        xi.tutorial.onMobDeath(player)
+    end
 end
 
 return entity

--- a/scripts/zones/La_Theine_Plateau/mobs/Yilbegan.lua
+++ b/scripts/zones/La_Theine_Plateau/mobs/Yilbegan.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, nil)
-    xi.hunts.checkHunt(mob, player, 559)
+    if player then
+        player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, nil)
+        xi.hunts.checkHunt(mob, player, 559)
+    end
 end
 
 return entity

--- a/scripts/zones/Mamook/mobs/Gulool_Ja_Ja.lua
+++ b/scripts/zones/Mamook/mobs/Gulool_Ja_Ja.lua
@@ -23,51 +23,41 @@ entity.onMobEngage = function(mob, target)
 end
 
 entity.onMobFight = function(mob, target)
-    if mob:getBattleTime() % 60 < 2 and mob:getBattleTime() > 10 then
-        local mob1 = GetMobByID(ID.mob.GULOOL_JA_JA + 1)
-        if mob1 and not mob1:isSpawned() then
-            mob1:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
-            SpawnMob(ID.mob.GULOOL_JA_JA + 1):updateEnmity(target)
-        else
-            local mob2 = GetMobByID(ID.mob.GULOOL_JA_JA + 2)
-            if mob2 and not mob2:isSpawned() then
-                mob2:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
-                SpawnMob(ID.mob.GULOOL_JA_JA + 2):updateEnmity(target)
-            else
-                local mob3 = GetMobByID(ID.mob.GULOOL_JA_JA + 3)
-                if mob3 and not mob3:isSpawned() then
-                    mob3:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
-                    SpawnMob(ID.mob.GULOOL_JA_JA + 3):updateEnmity(target)
-                else
-                    local mob4 = GetMobByID(ID.mob.GULOOL_JA_JA + 4)
-                    if mob4 and not mob4:isSpawned() then
-                        mob4:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
-                        SpawnMob(ID.mob.GULOOL_JA_JA + 4):updateEnmity(target)
-                    end
-                end
-            end
-        end
-    end
-
     for i = ID.mob.GULOOL_JA_JA + 1, ID.mob.GULOOL_JA_JA + 4 do
         local pet = GetMobByID(i)
         if pet and pet:getCurrentAction() == xi.action.category.ROAMING then
             pet:updateEnmity(target)
         end
     end
+
+    if mob:getBattleTime() % 60 < 2 and mob:getBattleTime() > 10 then
+        for i = ID.mob.GULOOL_JA_JA + 1, ID.mob.GULOOL_JA_JA + 4 do
+            local bodyguard = GetMobByID(i)
+            if bodyguard and not bodyguard:isSpawned() then
+                bodyguard:setSpawn(mob:getXPos() + math.random(1, 5), mob:getYPos(), mob:getZPos() + math.random(1, 5))
+                SpawnMob(i):updateEnmity(target)
+                break
+            end
+        end
+    end
 end
 
 entity.onMobDisengage = function(mob)
-    for i = 1, 4 do DespawnMob(ID.mob.GULOOL_JA_JA + i) end
+    for i = ID.mob.GULOOL_JA_JA + 1, ID.mob.GULOOL_JA_JA + 4 do
+        DespawnMob(i)
+    end
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.SHINING_SCALE_RIFLER)
-    for i = 1, 4 do DespawnMob(ID.mob.GULOOL_JA_JA + i) end
-end
+    if player then
+        player:addTitle(xi.title.SHINING_SCALE_RIFLER)
+    end
 
-entity.onMobDespawn = function(mob)
-    for i = 1, 4 do DespawnMob(ID.mob.GULOOL_JA_JA + i) end
+    if optParams.isKiller or optParams.noKiller then
+        for i = ID.mob.GULOOL_JA_JA + 1, ID.mob.GULOOL_JA_JA + 4 do
+            DespawnMob(i)
+        end
+    end
 end
 
 return entity

--- a/scripts/zones/Maze_of_Shakhrami/mobs/Ichorous_Ire.lua
+++ b/scripts/zones/Maze_of_Shakhrami/mobs/Ichorous_Ire.lua
@@ -6,7 +6,9 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.JELLYBANE)
+    if player then
+        player:addTitle(xi.title.JELLYBANE)
+    end
 end
 
 return entity

--- a/scripts/zones/Meriphataud_Mountains/mobs/Orcus.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Orcus.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.ORCUS_TROPHY_HUNTER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
-    xi.hunts.checkHunt(mob, player, 550)
+    if player then
+        player:addTitle(xi.title.ORCUS_TROPHY_HUNTER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
+        xi.hunts.checkHunt(mob, player, 550)
+    end
 end
 
 return entity

--- a/scripts/zones/Meriphataud_Mountains/mobs/Yilbegan.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Yilbegan.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, nil)
-    xi.hunts.checkHunt(mob, player, 559)
+    if player then
+        player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, nil)
+        xi.hunts.checkHunt(mob, player, 559)
+    end
 end
 
 return entity

--- a/scripts/zones/Meriphataud_Mountains_[S]/mobs/Orcus.lua
+++ b/scripts/zones/Meriphataud_Mountains_[S]/mobs/Orcus.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.ORCUS_TROPHY_HUNTER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
-    xi.hunts.checkHunt(mob, player, 550)
+    if player then
+        player:addTitle(xi.title.ORCUS_TROPHY_HUNTER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
+        xi.hunts.checkHunt(mob, player, 550)
+    end
 end
 
 return entity

--- a/scripts/zones/Meriphataud_Mountains_[S]/mobs/Sandworm.lua
+++ b/scripts/zones/Meriphataud_Mountains_[S]/mobs/Sandworm.lua
@@ -11,7 +11,9 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.SANDWORM_WRANGLER)
+    if player then
+        player:addTitle(xi.title.SANDWORM_WRANGLER)
+    end
 end
 
 return entity

--- a/scripts/zones/Meriphataud_Mountains_[S]/mobs/Yilbegan.lua
+++ b/scripts/zones/Meriphataud_Mountains_[S]/mobs/Yilbegan.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, nil)
-    xi.hunts.checkHunt(mob, player, 559)
+    if player then
+        player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, nil)
+        xi.hunts.checkHunt(mob, player, 559)
+    end
 end
 
 return entity

--- a/scripts/zones/Monastic_Cavern/mobs/Overlord_Bakgodek.lua
+++ b/scripts/zones/Monastic_Cavern/mobs/Overlord_Bakgodek.lua
@@ -9,7 +9,7 @@ mixins = { require('scripts/mixins/job_special') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobInitialize = function(mob)
+entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 11)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 11)
@@ -28,8 +28,11 @@ entity.onAdditionalEffect = function(mob, target, damage)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.OVERLORD_OVERTHROWER)
-    if optParams.isKiller then
+    if player then
+        player:addTitle(xi.title.OVERLORD_OVERTHROWER)
+    end
+
+    if optParams.isKiller or optParams.noKiller then
         mob:showText(mob, ID.text.ORC_KING_DEATH)
     end
 end

--- a/scripts/zones/Mount_Zhayolm/mobs/Cerberus.lua
+++ b/scripts/zones/Mount_Zhayolm/mobs/Cerberus.lua
@@ -10,13 +10,9 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.AOE_HIT_ALL, 1)
 end
 
-entity.onMobRoam = function(mob)
-    mob:setMobMod(xi.mobMod.NO_MOVE, 0)
-end
-
 entity.onMobFight = function(mob, target)
     local targetPos = target:getPos()
-    local spawnPos = mob:getSpawnPos()
+    local spawnPos  = mob:getSpawnPos()
     local arenaBoundaries =
     {
         { { 335, -92 }, { 332, -94 } },
@@ -62,8 +58,14 @@ entity.onMobFight = function(mob, target)
     end
 end
 
+entity.onMobDisengage = function(mob)
+    mob:setMobMod(xi.mobMod.NO_MOVE, 0)
+end
+
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.CERBERUS_MUZZLER)
+    if player then
+        player:addTitle(xi.title.CERBERUS_MUZZLER)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/North_Gustaberg/mobs/Yilbegan.lua
+++ b/scripts/zones/North_Gustaberg/mobs/Yilbegan.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, nil)
-    xi.hunts.checkHunt(mob, player, 559)
+    if player then
+        player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, nil)
+        xi.hunts.checkHunt(mob, player, 559)
+    end
 end
 
 return entity

--- a/scripts/zones/North_Gustaberg_[S]/mobs/Sandworm.lua
+++ b/scripts/zones/North_Gustaberg_[S]/mobs/Sandworm.lua
@@ -11,7 +11,9 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.SANDWORM_WRANGLER)
+    if player then
+        player:addTitle(xi.title.SANDWORM_WRANGLER)
+    end
 end
 
 return entity

--- a/scripts/zones/North_Gustaberg_[S]/mobs/Yilbegan.lua
+++ b/scripts/zones/North_Gustaberg_[S]/mobs/Yilbegan.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, nil)
-    xi.hunts.checkHunt(mob, player, 559)
+    if player then
+        player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, nil)
+        xi.hunts.checkHunt(mob, player, 559)
+    end
 end
 
 return entity

--- a/scripts/zones/Ordelles_Caves/mobs/Morbolger.lua
+++ b/scripts/zones/Ordelles_Caves/mobs/Morbolger.lua
@@ -67,7 +67,9 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.MORBOLBANE)
+    if player then
+        player:addTitle(xi.title.MORBOLBANE)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Pashhow_Marshlands/mobs/Yilbegan.lua
+++ b/scripts/zones/Pashhow_Marshlands/mobs/Yilbegan.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, nil)
-    xi.hunts.checkHunt(mob, player, 559)
+    if player then
+        player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, nil)
+        xi.hunts.checkHunt(mob, player, 559)
+    end
 end
 
 return entity

--- a/scripts/zones/Pashhow_Marshlands_[S]/mobs/Yilbegan.lua
+++ b/scripts/zones/Pashhow_Marshlands_[S]/mobs/Yilbegan.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, nil)
-    xi.hunts.checkHunt(mob, player, 559)
+    if player then
+        player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, nil)
+        xi.hunts.checkHunt(mob, player, 559)
+    end
 end
 
 return entity

--- a/scripts/zones/Qulun_Dome/mobs/ZaDha_Adamantking.lua
+++ b/scripts/zones/Qulun_Dome/mobs/ZaDha_Adamantking.lua
@@ -11,20 +11,20 @@ local entity = {}
 
 entity.spawnPoints =
 {
-    { x =  281.000, y =  43.000, z =  96.000 }
+    { x = 281.000, y = 43.000, z = 96.000 }
 }
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
+end
+
+entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 11)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 11)
     mob:setMod(xi.mod.PARALYZE_RES_RANK, 8)
     mob:setMod(xi.mod.SLOW_RES_RANK, 8)
     mob:setMod(xi.mod.SILENCE_RES_RANK, 11)
-end
-
-entity.onMobSpawn = function(mob)
-    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
     mob:setMod(xi.mod.DOUBLE_ATTACK, 20)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
 entity.onMobEngage = function(mob, target)
@@ -36,7 +36,10 @@ entity.onAdditionalEffect = function(mob, target, damage)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.ADAMANTKING_USURPER)
+    if player then
+        player:addTitle(xi.title.ADAMANTKING_USURPER)
+    end
+
     if optParams.isKiller then
         mob:showText(mob, ID.text.QUADAV_KING_DEATH)
     end

--- a/scripts/zones/Ranguemont_Pass/mobs/Taisaijin.lua
+++ b/scripts/zones/Ranguemont_Pass/mobs/Taisaijin.lua
@@ -21,7 +21,9 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.BYE_BYE_TAISAI)
+    if player then
+        player:addTitle(xi.title.BYE_BYE_TAISAI)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Riverne-Site_A01/mobs/Ouryu.lua
+++ b/scripts/zones/Riverne-Site_A01/mobs/Ouryu.lua
@@ -51,37 +51,36 @@ local function landWithoutTouchdown(mob)
     mob:setLocalVar('mistmeltUsed', 0)
 end
 
-entity.onMobSpawn = function(mob)
-    mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
-    mob:setMobMod(xi.mobMod.NO_STANDBACK, 1)
-    -- resetting so it doesn't respawn in flight mode
-    mob:setMobSkillAttack(0)
-    -- subanim 0 is only used when it spawns until first flight
-    mob:setAnimationSub(initialGroundPhaseAnimationSub)
-    if mob:hasStatusEffect(xi.effect.ALL_MISS) then
-        mob:delStatusEffect(xi.effect.ALL_MISS)
-    end
-
-    -- Level 90 + 2 + 53 = 145 Base Weapon Damage
-    mob:setMobMod(xi.mobMod.WEAPON_BONUS, 53)
-    mob:setMod(xi.mod.UDMGRANGE, -5000)
-    mob:setMod(xi.mod.UDMGMAGIC, -5000)
-    mob:setMod(xi.mod.UDMGBREATH, -5000)
+entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.SLOW)
     mob:addImmunity(xi.immunity.TERROR)
     mob:addImmunity(xi.immunity.STUN)
     mob:addImmunity(xi.immunity.PLAGUE)
     mob:addImmunity(xi.immunity.ELEGY)
     mob:addImmunity(xi.immunity.PETRIFY)
+end
+
+entity.onMobSpawn = function(mob)
+    -- resetting so it doesn't respawn in flight mode
+    mob:setMobSkillAttack(0)
+    mob:setSpellList(548)
+    mob:setAnimationSub(initialGroundPhaseAnimationSub)
+    mob:delStatusEffect(xi.effect.ALL_MISS)
+
+    -- Level 90 + 2 + 53 = 145 Base Weapon Damage
+    mob:setMod(xi.mod.UDMGRANGE, -5000)
+    mob:setMod(xi.mod.UDMGMAGIC, -5000)
+    mob:setMod(xi.mod.UDMGBREATH, -5000)
     mob:setMod(xi.mod.UFASTCAST, 90)
+    mob:setMod(xi.mod.DOUBLE_ATTACK, 10)
+    mob:setMod(xi.mod.REFRESH, 200)
+    mob:setMobMod(xi.mobMod.WEAPON_BONUS, 53)
     mob:setMobMod(xi.mobMod.DETECTION, bit.bor(xi.detects.SIGHT, xi.detects.HEARING))
     mob:setMobMod(xi.mobMod.SIGHT_RANGE, 20)
     mob:setMobMod(xi.mobMod.SOUND_RANGE, 15)
-    -- consider making new mob group so spell list can be set there
-    mob:setSpellList(548)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 60)
-    mob:setMod(xi.mod.DOUBLE_ATTACK, 10)
-    mob:setMod(xi.mod.REFRESH, 200)
+    mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
+    mob:setMobMod(xi.mobMod.NO_STANDBACK, 1)
 
     -- can use invincible on ground or air
     xi.mix.jobSpecial.config(mob, {
@@ -208,7 +207,10 @@ entity.onAdditionalEffect = function(mob, target, damage)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.OURYU_OVERWHELMER)
+    if player then
+        player:addTitle(xi.title.OURYU_OVERWHELMER)
+    end
+
     if optParams.isKiller or optParams.noKiller then
         local battlefield = mob:getBattlefield()
         if battlefield then

--- a/scripts/zones/Riverne-Site_B01/mobs/Boroka.lua
+++ b/scripts/zones/Riverne-Site_B01/mobs/Boroka.lua
@@ -76,7 +76,10 @@ entity.onMobWeaponSkill = function(mob, target, skill)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.BOROKA_BELEAGUERER)
+    if player then
+        player:addTitle(xi.title.BOROKA_BELEAGUERER)
+    end
+
     mob:setRespawnTime(math.random(75600, 86400)) -- 21-24 hour respawn
 end
 

--- a/scripts/zones/Rolanberry_Fields/mobs/Simurgh.lua
+++ b/scripts/zones/Rolanberry_Fields/mobs/Simurgh.lua
@@ -99,7 +99,9 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.SIMURGH_POACHER)
+    if player then
+        player:addTitle(xi.title.SIMURGH_POACHER)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Rolanberry_Fields/mobs/Verthandi.lua
+++ b/scripts/zones/Rolanberry_Fields/mobs/Verthandi.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.VERTHANDI_ENSNARER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
-    xi.hunts.checkHunt(mob, player, 553)
+    if player then
+        player:addTitle(xi.title.VERTHANDI_ENSNARER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
+        xi.hunts.checkHunt(mob, player, 553)
+    end
 end
 
 return entity

--- a/scripts/zones/Rolanberry_Fields/mobs/Yilbegan.lua
+++ b/scripts/zones/Rolanberry_Fields/mobs/Yilbegan.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, nil)
-    xi.hunts.checkHunt(mob, player, 559)
+    if player then
+        player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, nil)
+        xi.hunts.checkHunt(mob, player, 559)
+    end
 end
 
 return entity

--- a/scripts/zones/Rolanberry_Fields_[S]/mobs/Sandworm.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/mobs/Sandworm.lua
@@ -11,7 +11,9 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.SANDWORM_WRANGLER)
+    if player then
+        player:addTitle(xi.title.SANDWORM_WRANGLER)
+    end
 end
 
 return entity

--- a/scripts/zones/Rolanberry_Fields_[S]/mobs/Verthandi.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/mobs/Verthandi.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.VERTHANDI_ENSNARER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
-    xi.hunts.checkHunt(mob, player, 553)
+    if player then
+        player:addTitle(xi.title.VERTHANDI_ENSNARER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
+        xi.hunts.checkHunt(mob, player, 553)
+    end
 end
 
 return entity

--- a/scripts/zones/Rolanberry_Fields_[S]/mobs/Yilbegan.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/mobs/Yilbegan.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, nil)
-    xi.hunts.checkHunt(mob, player, 559)
+    if player then
+        player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, nil)
+        xi.hunts.checkHunt(mob, player, 559)
+    end
 end
 
 return entity

--- a/scripts/zones/Ruhotz_Silvermines/mobs/Lambton_Worm.lua
+++ b/scripts/zones/Ruhotz_Silvermines/mobs/Lambton_Worm.lua
@@ -6,7 +6,9 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.LAMBTON_WORM_DESEGMENTER)
+    if player then
+        player:addTitle(xi.title.LAMBTON_WORM_DESEGMENTER)
+    end
 end
 
 return entity

--- a/scripts/zones/Sauromugue_Champaign/mobs/Roc.lua
+++ b/scripts/zones/Sauromugue_Champaign/mobs/Roc.lua
@@ -69,7 +69,9 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.ROC_STAR)
+    if player then
+        player:addTitle(xi.title.ROC_STAR)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Sauromugue_Champaign/mobs/Verthandi.lua
+++ b/scripts/zones/Sauromugue_Champaign/mobs/Verthandi.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.VERTHANDI_ENSNARER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
-    xi.hunts.checkHunt(mob, player, 553)
+    if player then
+        player:addTitle(xi.title.VERTHANDI_ENSNARER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
+        xi.hunts.checkHunt(mob, player, 553)
+    end
 end
 
 return entity

--- a/scripts/zones/Sauromugue_Champaign/mobs/Yilbegan.lua
+++ b/scripts/zones/Sauromugue_Champaign/mobs/Yilbegan.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, nil)
-    xi.hunts.checkHunt(mob, player, 559)
+    if player then
+        player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, nil)
+        xi.hunts.checkHunt(mob, player, 559)
+    end
 end
 
 return entity

--- a/scripts/zones/Sauromugue_Champaign_[S]/mobs/Sandworm.lua
+++ b/scripts/zones/Sauromugue_Champaign_[S]/mobs/Sandworm.lua
@@ -11,7 +11,9 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.SANDWORM_WRANGLER)
+    if player then
+        player:addTitle(xi.title.SANDWORM_WRANGLER)
+    end
 end
 
 return entity

--- a/scripts/zones/Sauromugue_Champaign_[S]/mobs/Verthandi.lua
+++ b/scripts/zones/Sauromugue_Champaign_[S]/mobs/Verthandi.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.VERTHANDI_ENSNARER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
-    xi.hunts.checkHunt(mob, player, 553)
+    if player then
+        player:addTitle(xi.title.VERTHANDI_ENSNARER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
+        xi.hunts.checkHunt(mob, player, 553)
+    end
 end
 
 return entity

--- a/scripts/zones/Sauromugue_Champaign_[S]/mobs/Yilbegan.lua
+++ b/scripts/zones/Sauromugue_Champaign_[S]/mobs/Yilbegan.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, nil)
-    xi.hunts.checkHunt(mob, player, 559)
+    if player then
+        player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, nil)
+        xi.hunts.checkHunt(mob, player, 559)
+    end
 end
 
 return entity

--- a/scripts/zones/Silver_Sea_Remnants/mobs/Long-Armed_Chariot.lua
+++ b/scripts/zones/Silver_Sea_Remnants/mobs/Long-Armed_Chariot.lua
@@ -6,7 +6,9 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.MOON_CHARIOTEER)
+    if player then
+        player:addTitle(xi.title.MOON_CHARIOTEER)
+    end
 end
 
 return entity

--- a/scripts/zones/Tahrongi_Canyon/mobs/Yilbegan.lua
+++ b/scripts/zones/Tahrongi_Canyon/mobs/Yilbegan.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, nil)
-    xi.hunts.checkHunt(mob, player, 559)
+    if player then
+        player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, nil)
+        xi.hunts.checkHunt(mob, player, 559)
+    end
 end
 
 return entity

--- a/scripts/zones/The_Boyahda_Tree/mobs/Voluptuous_Vivian.lua
+++ b/scripts/zones/The_Boyahda_Tree/mobs/Voluptuous_Vivian.lua
@@ -72,18 +72,15 @@ entity.onMobInitialize = function(mob)
     xi.mob.updateNMSpawnPoint(mob)
     mob:setMobMod(xi.mobMod.GIL_MIN, 20000)
     mob:setMobMod(xi.mobMod.GIL_MAX, 20000)
-    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
-end
 
-entity.onMobSpawn = function(mob)
-    mob:setMobMod(xi.mobMod.NO_MOVE, 0)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
     mob:addImmunity(xi.immunity.PARALYZE)
 end
 
-entity.onMobRoam = function(mob)
+entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.NO_MOVE, 0)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
 entity.onMobFight = function(mob, target)
@@ -105,8 +102,14 @@ entity.onMobFight = function(mob, target)
     end
 end
 
+entity.onMobDisengage = function(mob)
+    mob:setMobMod(xi.mobMod.NO_MOVE, 0)
+end
+
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.THE_VIVISECTOR)
+    if player then
+        player:addTitle(xi.title.THE_VIVISECTOR)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/The_Eldieme_Necropolis/mobs/Lich_C_Magnus.lua
+++ b/scripts/zones/The_Eldieme_Necropolis/mobs/Lich_C_Magnus.lua
@@ -6,7 +6,9 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.LICH_BANISHER)
+    if player then
+        player:addTitle(xi.title.LICH_BANISHER)
+    end
 end
 
 return entity

--- a/scripts/zones/The_Eldieme_Necropolis/mobs/Skull_of_Envy.lua
+++ b/scripts/zones/The_Eldieme_Necropolis/mobs/Skull_of_Envy.lua
@@ -6,8 +6,10 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.hunts.checkHunt(mob, player, 189)
-    player:addTitle(xi.title.SKULLCRUSHER)
+    if player then
+        player:addTitle(xi.title.SKULLCRUSHER)
+        xi.hunts.checkHunt(mob, player, 189)
+    end
 end
 
 return entity

--- a/scripts/zones/The_Eldieme_Necropolis/mobs/Skull_of_Gluttony.lua
+++ b/scripts/zones/The_Eldieme_Necropolis/mobs/Skull_of_Gluttony.lua
@@ -6,8 +6,10 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.hunts.checkHunt(mob, player, 184)
-    player:addTitle(xi.title.SKULLCRUSHER)
+    if player then
+        player:addTitle(xi.title.SKULLCRUSHER)
+        xi.hunts.checkHunt(mob, player, 184)
+    end
 end
 
 return entity

--- a/scripts/zones/The_Eldieme_Necropolis/mobs/Skull_of_Greed.lua
+++ b/scripts/zones/The_Eldieme_Necropolis/mobs/Skull_of_Greed.lua
@@ -6,8 +6,10 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.hunts.checkHunt(mob, player, 185)
-    player:addTitle(xi.title.SKULLCRUSHER)
+    if player then
+        player:addTitle(xi.title.SKULLCRUSHER)
+        xi.hunts.checkHunt(mob, player, 185)
+    end
 end
 
 return entity

--- a/scripts/zones/The_Eldieme_Necropolis/mobs/Skull_of_Lust.lua
+++ b/scripts/zones/The_Eldieme_Necropolis/mobs/Skull_of_Lust.lua
@@ -6,8 +6,10 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.hunts.checkHunt(mob, player, 187)
-    player:addTitle(xi.title.SKULLCRUSHER)
+    if player then
+        player:addTitle(xi.title.SKULLCRUSHER)
+        xi.hunts.checkHunt(mob, player, 187)
+    end
 end
 
 return entity

--- a/scripts/zones/The_Eldieme_Necropolis/mobs/Skull_of_Pride.lua
+++ b/scripts/zones/The_Eldieme_Necropolis/mobs/Skull_of_Pride.lua
@@ -6,8 +6,10 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.hunts.checkHunt(mob, player, 188)
-    player:addTitle(xi.title.SKULLCRUSHER)
+    if player then
+        player:addTitle(xi.title.SKULLCRUSHER)
+        xi.hunts.checkHunt(mob, player, 188)
+    end
 end
 
 return entity

--- a/scripts/zones/The_Eldieme_Necropolis/mobs/Skull_of_Sloth.lua
+++ b/scripts/zones/The_Eldieme_Necropolis/mobs/Skull_of_Sloth.lua
@@ -6,8 +6,10 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.hunts.checkHunt(mob, player, 186)
-    player:addTitle(xi.title.SKULLCRUSHER)
+    if player then
+        player:addTitle(xi.title.SKULLCRUSHER)
+        xi.hunts.checkHunt(mob, player, 186)
+    end
 end
 
 return entity

--- a/scripts/zones/The_Eldieme_Necropolis/mobs/Skull_of_Wrath.lua
+++ b/scripts/zones/The_Eldieme_Necropolis/mobs/Skull_of_Wrath.lua
@@ -6,8 +6,10 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.hunts.checkHunt(mob, player, 190)
-    player:addTitle(xi.title.SKULLCRUSHER)
+    if player then
+        player:addTitle(xi.title.SKULLCRUSHER)
+        xi.hunts.checkHunt(mob, player, 190)
+    end
 end
 
 return entity

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Kirin.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Kirin.lua
@@ -85,8 +85,10 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.KIRIN_CAPTIVATOR)
-    player:showText(mob, ID.text.KIRIN_OFFSET + 1)
+    if player then
+        player:addTitle(xi.title.KIRIN_CAPTIVATOR)
+        player:showText(mob, ID.text.KIRIN_OFFSET + 1)
+    end
 end
 
 return entity

--- a/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
@@ -68,6 +68,15 @@ local function enterFlight(mob)
 end
 
 entity.onMobInitialize = function(mob)
+    mob:addImmunity(xi.immunity.BIND)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
+    mob:addImmunity(xi.immunity.PARALYZE)
+    mob:addImmunity(xi.immunity.SILENCE)
+    mob:addImmunity(xi.immunity.PETRIFY)
+    mob:addImmunity(xi.immunity.PLAGUE)
+    mob:addImmunity(xi.immunity.GRAVITY)
+    mob:addImmunity(xi.immunity.TERROR)
+
     mob:setCarefulPathing(true)
     mob:setMobMod(xi.mobMod.AOE_HIT_ALL, 1)
 
@@ -100,18 +109,6 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.ROAM_DISTANCE, 5)
     mob:setMobMod(xi.mobMod.WEAPON_BONUS, 158) -- 255 total weapon damage
     mob:setBehavior(bit.bor(mob:getBehavior(), xi.behavior.NO_TURN))
-    mob:addImmunity(xi.immunity.BIND)
-    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
-    mob:addImmunity(xi.immunity.PARALYZE)
-    mob:addImmunity(xi.immunity.SILENCE)
-    mob:addImmunity(xi.immunity.PETRIFY)
-    mob:addImmunity(xi.immunity.PLAGUE)
-    mob:addImmunity(xi.immunity.GRAVITY)
-    mob:addImmunity(xi.immunity.TERROR)
-end
-
-entity.onMobRoam = function(mob)
-    mob:setMobMod(xi.mobMod.NO_MOVE, 0)
 end
 
 entity.onMobEngage = function(mob, target)
@@ -267,10 +264,14 @@ entity.onMobDisengage = function(mob)
         mob:setMobSkillAttack(0)
         mob:setLocalVar('changeHP', 0)
     end
+
+    mob:setMobMod(xi.mobMod.NO_MOVE, 0)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.WORLD_SERPENT_SLAYER)
+    if player then
+        player:addTitle(xi.title.WORLD_SERPENT_SLAYER)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Valley_of_Sorrows/mobs/Adamantoise.lua
+++ b/scripts/zones/Valley_of_Sorrows/mobs/Adamantoise.lua
@@ -67,21 +67,28 @@ entity.spawnPoints =
     { x = -24.813, y = -0.148, z = -14.807 }
 }
 
-entity.onMobSpawn = function(mob)
-    mob:setLocalVar('[rage]timer', 1800) -- 30 minutes
+entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
-    mob:setMod(xi.mod.DMGMAGIC, -3500)
-    mob:setMobMod(xi.mobMod.WEAPON_BONUS, 36) -- 108 total weapon damage
-    mob:setMod(xi.mod.DEF, 4112)
-    mob:setMod(xi.mod.ATT, 450)
+end
 
+entity.onMobSpawn = function(mob)
     -- Despawn the ???
     GetNPCByID(ID.npc.ADAMANTOISE_QM):setStatus(xi.status.DISAPPEAR)
+
+    mob:setMod(xi.mod.DEF, 4112)
+    mob:setMod(xi.mod.ATT, 450)
+    mob:setMod(xi.mod.DMGMAGIC, -3500)
+
+    mob:setMobMod(xi.mobMod.WEAPON_BONUS, 36) -- 108 total weapon damage
+
+    mob:setLocalVar('[rage]timer', 1800) -- 30 minutes
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.TORTOISE_TORTURER)
+    if player then
+        player:addTitle(xi.title.TORTOISE_TORTURER)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Valley_of_Sorrows/mobs/Aspidochelone.lua
+++ b/scripts/zones/Valley_of_Sorrows/mobs/Aspidochelone.lua
@@ -85,27 +85,39 @@ local outOfShell = function(mob)
     mob:setMod(xi.mod.UDMGRANGE, 0)
     mob:setMod(xi.mod.UDMGPHYS, 0)
     mob:setMobMod(xi.mobMod.NO_MOVE, 0)
+    mob:setAnimationSub(2)
+    mob:setTP(3000) -- Immediately TPs coming out of shell
+end
+
+entity.onMobInitialize = function(mob)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
 end
 
 entity.onMobSpawn = function(mob)
     -- Despawn the ???
     GetNPCByID(ID.npc.ADAMANTOISE_QM):setStatus(xi.status.DISAPPEAR)
 
-    outOfShell(mob) -- Ensure out of shell mods are set on spawn
+    mob:setMobAbilityEnabled(true)
+    mob:setAutoAttackEnabled(true)
+    mob:setAnimationSub(0)
 
-    mob:setLocalVar('[rage]timer', 3600) -- 60 minutes
-    mob:setLocalVar('dmgToChange', mob:getHP() - 1000)
-    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
-    mob:addImmunity(xi.immunity.DARK_SLEEP)
-    mob:addMod(xi.mod.DOUBLE_ATTACK, 20)
-    mob:setMod(xi.mod.UDMGMAGIC, -3000)
-    mob:setMod(xi.mod.CURSERES, 100)
-    mob:setMobMod(xi.mobMod.WEAPON_BONUS, 45) -- 130 total weapon damage
-    mob:setMobMod(xi.mobMod.AOE_HIT_ALL, 1)
     mob:setMod(xi.mod.DEF, 702)
     mob:setMod(xi.mod.ATT, 395)
     mob:setMod(xi.mod.EVA, 310)
-    mob:setAnimationSub(0)
+    mob:setMod(xi.mod.REGEN, 0)
+    mob:setMod(xi.mod.UDMGRANGE, 0)
+    mob:setMod(xi.mod.UDMGPHYS, 0)
+    mob:setMod(xi.mod.DOUBLE_ATTACK, 20)
+    mob:setMod(xi.mod.UDMGMAGIC, -3000)
+    mob:setMod(xi.mod.CURSERES, 100)
+
+    mob:setMobMod(xi.mobMod.WEAPON_BONUS, 45) -- 130 total weapon damage
+    mob:setMobMod(xi.mobMod.AOE_HIT_ALL, 1)
+    mob:setMobMod(xi.mobMod.NO_MOVE, 0)
+
+    mob:setLocalVar('[rage]timer', 3600) -- 60 minutes
+    mob:setLocalVar('dmgToChange', mob:getHP() - 1000)
 end
 
 entity.onMobFight = function(mob, target)
@@ -119,8 +131,6 @@ entity.onMobFight = function(mob, target)
         mob:getHPP() == 100)
     then
         outOfShell(mob)
-        mob:setAnimationSub(2)
-        mob:setTP(3000) -- Immediately TPs coming out of shell
     end
 
     if
@@ -131,8 +141,6 @@ entity.onMobFight = function(mob, target)
 
         if mob:getAnimationSub() == 1 then
             outOfShell(mob)
-            mob:setAnimationSub(2)
-            mob:setTP(3000) -- Immediately TPs coming out of shell
         elseif
             mob:getAnimationSub() == 2 or
             mob:getAnimationSub() == 0
@@ -148,7 +156,9 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.ASPIDOCHELONE_SINKER)
+    if player then
+        player:addTitle(xi.title.ASPIDOCHELONE_SINKER)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Wajaom_Woodlands/mobs/Hydra.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Hydra.lua
@@ -54,7 +54,9 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.HYDRA_HEADHUNTER)
+    if player then
+        player:addTitle(xi.title.HYDRA_HEADHUNTER)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Waughroon_Shrine/mobs/Dark_Dragon.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Dark_Dragon.lua
@@ -15,7 +15,9 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.DARK_DRAGON_SLAYER)
+    if player then
+        player:addTitle(xi.title.DARK_DRAGON_SLAYER)
+    end
 end
 
 return entity

--- a/scripts/zones/West_Sarutabaruta/mobs/Orcus.lua
+++ b/scripts/zones/West_Sarutabaruta/mobs/Orcus.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.ORCUS_TROPHY_HUNTER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
-    xi.hunts.checkHunt(mob, player, 550)
+    if player then
+        player:addTitle(xi.title.ORCUS_TROPHY_HUNTER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
+        xi.hunts.checkHunt(mob, player, 550)
+    end
 end
 
 return entity

--- a/scripts/zones/West_Sarutabaruta/mobs/Yilbegan.lua
+++ b/scripts/zones/West_Sarutabaruta/mobs/Yilbegan.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, nil)
-    xi.hunts.checkHunt(mob, player, 559)
+    if player then
+        player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, nil)
+        xi.hunts.checkHunt(mob, player, 559)
+    end
 end
 
 return entity

--- a/scripts/zones/West_Sarutabaruta_[S]/mobs/Orcus.lua
+++ b/scripts/zones/West_Sarutabaruta_[S]/mobs/Orcus.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.ORCUS_TROPHY_HUNTER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
-    xi.hunts.checkHunt(mob, player, 550)
+    if player then
+        player:addTitle(xi.title.ORCUS_TROPHY_HUNTER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
+        xi.hunts.checkHunt(mob, player, 550)
+    end
 end
 
 return entity

--- a/scripts/zones/West_Sarutabaruta_[S]/mobs/Sandworm.lua
+++ b/scripts/zones/West_Sarutabaruta_[S]/mobs/Sandworm.lua
@@ -11,7 +11,9 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.SANDWORM_WRANGLER)
+    if player then
+        player:addTitle(xi.title.SANDWORM_WRANGLER)
+    end
 end
 
 return entity

--- a/scripts/zones/West_Sarutabaruta_[S]/mobs/Yilbegan.lua
+++ b/scripts/zones/West_Sarutabaruta_[S]/mobs/Yilbegan.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, nil)
-    xi.hunts.checkHunt(mob, player, 559)
+    if player then
+        player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, nil)
+        xi.hunts.checkHunt(mob, player, 559)
+    end
 end
 
 return entity

--- a/scripts/zones/Western_Altepa_Desert/mobs/King_Vinegarroon.lua
+++ b/scripts/zones/Western_Altepa_Desert/mobs/King_Vinegarroon.lua
@@ -145,7 +145,9 @@ entity.onMobSkillTarget = function(target, mob, mobskill)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.VINEGAR_EVAPORATOR)
+    if player then
+        player:addTitle(xi.title.VINEGAR_EVAPORATOR)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Xarcabard/mobs/Lord_Ruthven.lua
+++ b/scripts/zones/Xarcabard/mobs/Lord_Ruthven.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.RUTHVEN_ENTOMBER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
-    xi.hunts.checkHunt(mob, player, 556)
+    if player then
+        player:addTitle(xi.title.RUTHVEN_ENTOMBER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
+        xi.hunts.checkHunt(mob, player, 556)
+    end
 end
 
 return entity

--- a/scripts/zones/Xarcabard/mobs/Yilbegan.lua
+++ b/scripts/zones/Xarcabard/mobs/Yilbegan.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, nil)
-    xi.hunts.checkHunt(mob, player, 559)
+    if player then
+        player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, nil)
+        xi.hunts.checkHunt(mob, player, 559)
+    end
 end
 
 return entity

--- a/scripts/zones/Xarcabard_[S]/mobs/Lord_Ruthven.lua
+++ b/scripts/zones/Xarcabard_[S]/mobs/Lord_Ruthven.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.RUTHVEN_ENTOMBER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
-    xi.hunts.checkHunt(mob, player, 556)
+    if player then
+        player:addTitle(xi.title.RUTHVEN_ENTOMBER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, xi.keyItem.BLACK_ABYSSITE)
+        xi.hunts.checkHunt(mob, player, 556)
+    end
 end
 
 return entity

--- a/scripts/zones/Xarcabard_[S]/mobs/Yilbegan.lua
+++ b/scripts/zones/Xarcabard_[S]/mobs/Yilbegan.lua
@@ -25,9 +25,11 @@ entity.onMobDespawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
-    xi.voidwalker.onMobDeath(mob, player, optParams, nil)
-    xi.hunts.checkHunt(mob, player, 559)
+    if player then
+        player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
+        xi.voidwalker.onMobDeath(mob, player, optParams, nil)
+        xi.hunts.checkHunt(mob, player, 559)
+    end
 end
 
 return entity

--- a/scripts/zones/Zhayolm_Remnants/mobs/Battleclad_Chariot.lua
+++ b/scripts/zones/Zhayolm_Remnants/mobs/Battleclad_Chariot.lua
@@ -26,7 +26,10 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.STAR_CHARIOTEER)
+    if player then
+        player:addTitle(xi.title.STAR_CHARIOTEER)
+    end
+
     if optParams.isKiller or optParams.noKiller then
         mob:getInstance():complete()
     end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Add player check for all mobs that granted titles.
- Additionally, cleaned up some mob scripts while I was there.

## Steps to test these changes
Have a mob die without a player. Somehow.
