### PR TITLE
[lua] Minotaur/KV party draw-in get pet master alliance

### DIFF
--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Minotaur.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Minotaur.lua
@@ -31,8 +31,19 @@ entity.onMobFight = function(mob, target)
         { x = 55.13, y = 1.00, z = 304.64 },
     }
 
+    -- If target is a pet, get the master for alliance lookup
+    local allianceTarget = target
+    if target:getObjType() ~= xi.objType.PC then
+        local master = target:getMaster()
+        if master and master:getObjType() == xi.objType.PC then
+            allianceTarget = master
+        else
+            return
+        end
+    end
+
     local drewIn = false
-    for _, member in ipairs(target:getAlliance()) do
+    for _, member in ipairs(allianceTarget:getAlliance()) do
         local randomPos = drawInPositions[math.random(#drawInPositions)]
         randomPos.rot = member:getRotPos()
 

--- a/scripts/zones/Western_Altepa_Desert/mobs/King_Vinegarroon.lua
+++ b/scripts/zones/Western_Altepa_Desert/mobs/King_Vinegarroon.lua
@@ -123,7 +123,18 @@ entity.onMobSkillTarget = function(target, mob, mobskill)
         if math.random(0, 100) >= 50 then
             mob:drawIn()
         else
-            for _, member in ipairs(target:getAlliance()) do
+            -- If target is a pet, get the master for alliance lookup
+            local allianceTarget = target
+            if target:getObjType() ~= xi.objType.PC then
+                local master = target:getMaster()
+                if master and master:getObjType() == xi.objType.PC then
+                    allianceTarget = master
+                else
+                    return
+                end
+            end
+
+            for _, member in ipairs(allianceTarget:getAlliance()) do
                 mob:drawIn(member, 0, 0)
             end
         end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes what's below when the target is a charmed pet. Only for Minotaur/KV, issue likely exists on other mobs with party draw-in.

<img width="1557" height="656" alt="image" src="https://github.com/user-attachments/assets/9393c2bc-d3a6-4eb2-8756-97d2efe06e9e" />

#deleteBST 
#deleteDrawIn

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
