### PR TITLE
passing the correct table object to giveItem so the player gets 99 ar…

### DIFF
--- a/scripts/zones/Xarcabard/npcs/qm6.lua
+++ b/scripts/zones/Xarcabard/npcs/qm6.lua
@@ -20,7 +20,7 @@ end
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 6 then
         player:setCharVar('unbridledPassion', 6)
-    elseif csid == 7 and npcUtil.giveItem(player, xi.item.ICE_ARROW) then
+    elseif csid == 7 and npcUtil.giveItem(player, { { xi.item.ICE_ARROW, 99 } }) then
         player:setCharVar('unbridledPassion', 7)
     end
 end

--- a/scripts/zones/Xarcabard/npcs/qm6.lua
+++ b/scripts/zones/Xarcabard/npcs/qm6.lua
@@ -20,7 +20,7 @@ end
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 6 then
         player:setCharVar('unbridledPassion', 6)
-    elseif csid == 7 and npcUtil.giveItem(player, xi.item.ICE_ARROW) then
+    elseif csid == 7 and npcUtil.giveItem(player, {{xi.item.ICE_ARROW, 99}}) then
         player:setCharVar('unbridledPassion', 7)
     end
 end


### PR DESCRIPTION
…rows

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This change is to provide the  correct amount of ice arrows to the player after they have completed the part of RNG AF 3 in Xarcabard.

Retail Catpure:
https://www.youtube.com/watch?v=LexfPVBsCR8&t=2952s

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

1. !quest 2 74
2. Add Quest
3. !setplayervar Chonk unbridledPassion 6
4. !pos -254.883 -17.003 -150.818 112
5. click ???
6. get arrows

<!-- Clear and detailed steps to test your changes here -->
