### PR TITLE
[Fix] Treasure weakness time

### DIFF
--- a/scripts/globals/treasure.lua
+++ b/scripts/globals/treasure.lua
@@ -1830,7 +1830,7 @@ xi.treasure.onTrade = function(player, npc, trade, bypassType, bypassReward)
         player:timer(2000, function(playerEntity)
             local weaknessDuration = 5 + player:getMainLvl() - treasureLevel
             weaknessDuration       = math.floor(weaknessDuration / 5)
-            weaknessDuration       = utils.clamp(weaknessDuration, 5, 60)
+            weaknessDuration       = utils.clamp(weaknessDuration, 5, 60) * 60 -- Clamp and convert to seconds.
 
             playerEntity:addStatusEffect(xi.effect.WEAKNESS, 1, 0, weaknessDuration)
             playerEntity:messageSpecial(ID.text.CHEST_UNLOCKED + 2)

--- a/scripts/globals/treasure.lua
+++ b/scripts/globals/treasure.lua
@@ -1637,16 +1637,6 @@ local function moveTreasure(npc, respawnTime)
     end)
 end
 
-local function openAndMoveTreasure(npc, respawnTime)
-    npc:entityAnimationPacket(xi.animationString.OPEN_CRATE_GLOW)
-    moveTreasure(npc, respawnTime)
-end
-
-local function trapAndMoveTreasure(npc, respawnTime)
-    npc:entityAnimationPacket(xi.animationString.OPEN_CRATE_SMOKE)
-    moveTreasure(npc, respawnTime)
-end
-
 local function handleGilDistribution(player, treasureLevel)
     local zoneId              = player:getZoneID()
     local playersInZoneTable  = {} -- Table with player objects both in alliance and in current player zone.
@@ -1834,7 +1824,8 @@ xi.treasure.onTrade = function(player, npc, trade, bypassType, bypassReward)
 
             playerEntity:addStatusEffect(xi.effect.WEAKNESS, 1, 0, weaknessDuration)
             playerEntity:messageSpecial(ID.text.CHEST_UNLOCKED + 2)
-            trapAndMoveTreasure(npc, respawnType.REGULAR)
+            npc:entityAnimationPacket(xi.animationString.OPEN_CRATE_SMOKE)
+            moveTreasure(npc, respawnType.REGULAR)
         end)
 
         player:timer(4000, function(playerEntity)
@@ -1883,7 +1874,8 @@ xi.treasure.onTrade = function(player, npc, trade, bypassType, bypassReward)
         player:timer(2000, function(playerEntity)
             if npcUtil.giveItem(playerEntity, bypassReward) then
                 playerEntity:messageSpecial(ID.text.CHEST_UNLOCKED)
-                openAndMoveTreasure(npc, respawnType.REGULAR)
+                npc:entityAnimationPacket(xi.animationString.OPEN_CRATE_GLOW)
+                moveTreasure(npc, respawnType.REGULAR)
             end
         end)
 
@@ -1903,7 +1895,8 @@ xi.treasure.onTrade = function(player, npc, trade, bypassType, bypassReward)
         player:timer(2000, function(playerEntity)
             playerEntity:messageSpecial(ID.text.CHEST_UNLOCKED - 1, bypassReward) -- TODO: message -2 seems to be for other party members?
             playerEntity:addKeyItem(bypassReward)
-            openAndMoveTreasure(npc, respawnType.REGULAR)
+            npc:entityAnimationPacket(xi.animationString.OPEN_CRATE_GLOW)
+            moveTreasure(npc, respawnType.REGULAR)
         end)
 
         player:timer(4000, function(playerEntity)
@@ -1925,7 +1918,8 @@ xi.treasure.onTrade = function(player, npc, trade, bypassType, bypassReward)
         player:timer(2000, function(playerEntity)
             playerEntity:messageSpecial(ID.text.CHEST_UNLOCKED - 1, treasureMap) -- TODO: message -2 seems to be for other party members?
             playerEntity:addKeyItem(treasureMap)
-            openAndMoveTreasure(npc, respawnType.REGULAR)
+            npc:entityAnimationPacket(xi.animationString.OPEN_CRATE_GLOW)
+            moveTreasure(npc, respawnType.REGULAR)
         end)
 
         player:timer(4000, function(playerEntity)
@@ -1969,7 +1963,8 @@ xi.treasure.onTrade = function(player, npc, trade, bypassType, bypassReward)
         player:timer(2000, function(playerEntity)
             playerEntity:messageSpecial(ID.text.CHEST_UNLOCKED)
             handleGilDistribution(playerEntity, treasureLevel)
-            openAndMoveTreasure(npc, respawnType.REGULAR)
+            npc:entityAnimationPacket(xi.animationString.OPEN_CRATE_GLOW)
+            moveTreasure(npc, respawnType.REGULAR)
         end)
 
         player:timer(4000, function(playerEntity)
@@ -1983,7 +1978,8 @@ xi.treasure.onTrade = function(player, npc, trade, bypassType, bypassReward)
         player:timer(2000, function(playerEntity)
             playerEntity:addTreasure(itemId, npc)
             playerEntity:messageSpecial(ID.text.CHEST_UNLOCKED)
-            openAndMoveTreasure(npc, respawnType.REGULAR)
+            npc:entityAnimationPacket(xi.animationString.OPEN_CRATE_GLOW)
+            moveTreasure(npc, respawnType.REGULAR)
         end)
 
         player:timer(4000, function(playerEntity)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Calculation was done in minutes but never converted to seconds, resulting in laughable weakness durations.

## Steps to test these changes
Fail to open a treasure. Get weakened for minutes or even an hour.