### PR TITLE
[core] Misc static analysis fixes [nil checks, truncation, casts]

### DIFF
--- a/src/login/cert_helpers.h
+++ b/src/login/cert_helpers.h
@@ -41,8 +41,9 @@ inline void generateSelfSignedCert()
             {
                 ShowInfo(fmt::format("Found existing login.key"));
             }
+
+            fclose(fileHandle);
         }
-        fclose(fileHandle);
     }
 
     if (std::filesystem::exists("login.cert"))

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -137,17 +137,21 @@ auto CMobController::CheckLock(CBattleEntity* PTarget) const -> bool
     {
         if (PTarget->objtype == TYPE_PC)
         {
-            const CCharEntity* PChar = dynamic_cast<CCharEntity*>(PTarget);
-            if (PChar->m_Locked)
+            const auto* PChar = dynamic_cast<const CCharEntity*>(PTarget);
+            if (PChar && PChar->m_Locked)
             {
                 return !CanPursueTarget(PTarget);
             }
         }
         else if (PTarget->objtype == TYPE_PET)
         {
-            const CPetEntity*  PPet  = dynamic_cast<CPetEntity*>(PTarget);
-            const CCharEntity* PChar = dynamic_cast<CCharEntity*>(PPet->PMaster);
+            const auto* PPet = dynamic_cast<CPetEntity*>(PTarget);
+            if (!PPet)
+            {
+                return false;
+            }
 
+            const auto* PChar = dynamic_cast<const CCharEntity*>(PPet->PMaster);
             if (PChar == nullptr)
             {
                 return false;

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -137,7 +137,7 @@ auto CMobController::CheckLock(CBattleEntity* PTarget) const -> bool
     {
         if (PTarget->objtype == TYPE_PC)
         {
-            const auto* PChar = dynamic_cast<const CCharEntity*>(PTarget);
+            const auto* PChar = dynamic_cast<CCharEntity*>(PTarget);
             if (PChar && PChar->m_Locked)
             {
                 return !CanPursueTarget(PTarget);
@@ -151,7 +151,7 @@ auto CMobController::CheckLock(CBattleEntity* PTarget) const -> bool
                 return false;
             }
 
-            const auto* PChar = dynamic_cast<const CCharEntity*>(PPet->PMaster);
+            const auto* PChar = dynamic_cast<CCharEntity*>(PPet->PMaster);
             if (PChar == nullptr)
             {
                 return false;

--- a/src/map/ai/controllers/pet_controller.cpp
+++ b/src/map/ai/controllers/pet_controller.cpp
@@ -120,6 +120,11 @@ void CPetController::DoRoamTick(timer::time_point tick)
         }
     }
 
+    if (!PPet->PMaster)
+    {
+        return;
+    }
+
     float currentDistance = distance(PPet->loc.p, PPet->PMaster->loc.p);
 
     if (currentDistance > PetRoamDistance)

--- a/src/map/ai/states/despawn_state.cpp
+++ b/src/map/ai/states/despawn_state.cpp
@@ -37,7 +37,7 @@ CDespawnState::CDespawnState(CBaseEntity* _PEntity, bool instantDespawn)
         _PEntity->loc.zone->PushPacket(_PEntity, CHAR_INRANGE, std::make_unique<GP_SERV_COMMAND_SCHEDULOR>(_PEntity, _PEntity, FourCC::FadeOut));
     }
 
-    if (auto* PMob = dynamic_cast<CMobEntity*>(_PEntity); PMob->m_AllowRespawn && PMob->loc.zone != nullptr)
+    if (auto* PMob = dynamic_cast<CMobEntity*>(_PEntity); PMob && PMob->m_AllowRespawn && PMob->loc.zone != nullptr)
     {
         PMob->loc.zone->spawnHandler()->registerForRespawn(PMob);
     }

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -183,6 +183,11 @@ bool CMagicState::Update(timer::time_point tick)
         else if (PTarget->objtype == TYPE_PC)
         {
             CCharEntity* PChar = dynamic_cast<CCharEntity*>(PTarget);
+            if (!PChar)
+            {
+                return false;
+            }
+
             if (PChar->m_Locked)
             {
                 m_PEntity->OnCastInterrupted(*this, action, msg, true);

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -196,7 +196,13 @@ bool CMobSkillState::Update(timer::time_point tick)
         Complete();
     }
 
-    if (IsCompleted() && tick > m_finishTime && m_PEntity)
+    if (!m_PEntity)
+    {
+        ShowError("CMobSkillState: m_Pentity is nullptr");
+        return false;
+    }
+
+    if (IsCompleted() && tick > m_finishTime)
     {
         auto* PTarget = GetTarget();
         if (PTarget && PTarget->objtype == TYPE_MOB && PTarget != m_PEntity && m_PEntity->allegiance == ALLEGIANCE_TYPE::PLAYER)

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -196,7 +196,7 @@ bool CMobSkillState::Update(timer::time_point tick)
         Complete();
     }
 
-    if (IsCompleted() && tick > m_finishTime)
+    if (IsCompleted() && tick > m_finishTime && m_PEntity)
     {
         auto* PTarget = GetTarget();
         if (PTarget && PTarget->objtype == TYPE_MOB && PTarget != m_PEntity && m_PEntity->allegiance == ALLEGIANCE_TYPE::PLAYER)

--- a/src/map/ai/states/petskill_state.cpp
+++ b/src/map/ai/states/petskill_state.cpp
@@ -125,7 +125,14 @@ bool CPetSkillState::Update(timer::time_point tick)
         m_finishTime = tick + m_PSkill->getAnimationTime();
         Complete();
     }
-    if (IsCompleted() && tick > m_finishTime && m_PEntity)
+
+    if (!m_PEntity)
+    {
+        ShowError("CPetSkillState: m_Pentity is nullptr");
+        return false;
+    }
+
+    if (IsCompleted() && tick > m_finishTime)
     {
         auto* PTarget = GetTarget();
         if (PTarget && PTarget->objtype == TYPE_MOB && PTarget != m_PEntity && m_PEntity->allegiance == ALLEGIANCE_TYPE::PLAYER)

--- a/src/map/ai/states/petskill_state.cpp
+++ b/src/map/ai/states/petskill_state.cpp
@@ -125,7 +125,7 @@ bool CPetSkillState::Update(timer::time_point tick)
         m_finishTime = tick + m_PSkill->getAnimationTime();
         Complete();
     }
-    if (IsCompleted() && tick > m_finishTime)
+    if (IsCompleted() && tick > m_finishTime && m_PEntity)
     {
         auto* PTarget = GetTarget();
         if (PTarget && PTarget->objtype == TYPE_MOB && PTarget != m_PEntity && m_PEntity->allegiance == ALLEGIANCE_TYPE::PLAYER)

--- a/src/map/ai/states/weaponskill_state.cpp
+++ b/src/map/ai/states/weaponskill_state.cpp
@@ -169,7 +169,7 @@ bool CWeaponSkillState::Update(timer::time_point tick)
         m_finishTime = tick + delay;
         Complete();
     }
-    else if (tick > m_finishTime)
+    else if (tick > m_finishTime && m_PEntity)
     {
         if (m_PEntity->objtype == TYPE_PC)
         {

--- a/src/map/ai/states/weaponskill_state.cpp
+++ b/src/map/ai/states/weaponskill_state.cpp
@@ -120,7 +120,13 @@ void CWeaponSkillState::SpendCost()
 
 bool CWeaponSkillState::Update(timer::time_point tick)
 {
-    if (m_PEntity && m_PEntity->isAlive() && !IsCompleted())
+    if (!m_PEntity)
+    {
+        ShowError("CWeaponSkillState: m_Pentity is nullptr");
+        return false;
+    }
+
+    if (m_PEntity->isAlive() && !IsCompleted())
     {
         CBattleEntity* PTarget = dynamic_cast<CBattleEntity*>(GetTarget());
         action_t       action;
@@ -169,7 +175,7 @@ bool CWeaponSkillState::Update(timer::time_point tick)
         m_finishTime = tick + delay;
         Complete();
     }
-    else if (tick > m_finishTime && m_PEntity)
+    else if (tick > m_finishTime)
     {
         if (m_PEntity->objtype == TYPE_PC)
         {

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -543,7 +543,7 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
         auto* PChar = dynamic_cast<CCharEntity*>(PEntity);
         if (!PChar)
         {
-            return;
+            return false;
         }
 
         if (!(m_Rules & BCRULES::RULES_ALLOW_SUBJOBS))

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -541,6 +541,11 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
     if (PEntity->objtype == TYPE_PC)
     {
         auto* PChar = dynamic_cast<CCharEntity*>(PEntity);
+        if (!PChar)
+        {
+            return;
+        }
+
         if (!(m_Rules & BCRULES::RULES_ALLOW_SUBJOBS))
         {
             PChar->StatusEffectContainer->DelStatusEffect(EFFECT_SJ_RESTRICTION);
@@ -575,7 +580,7 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
             }
         }
 
-        m_EnteredPlayers.erase(m_EnteredPlayers.find(PEntity->id));
+        m_EnteredPlayers.erase(PEntity->id);
 
         if (leavecode != 255)
         {

--- a/src/map/battlefield_handler.cpp
+++ b/src/map/battlefield_handler.cpp
@@ -50,39 +50,28 @@ CBattlefieldHandler::CBattlefieldHandler(CZone* PZone)
 {
 }
 
-CBattlefieldHandler::~CBattlefieldHandler()
-{
-    for (auto& [area, PBattlefield] : m_Battlefields)
-    {
-        destroy(PBattlefield);
-    }
-    m_Battlefields.clear();
-}
+CBattlefieldHandler::~CBattlefieldHandler() = default;
 
 void CBattlefieldHandler::HandleBattlefields(timer::time_point tick)
 {
     TracyZoneScoped;
-    // todo: use raw pointers otherwise might be harming lua
-    // dont want this to run again if we removed a battlefield
-    for (auto& PBattlefield : m_Battlefields)
+    for (auto& [area, PBattlefield] : m_Battlefields)
     {
-        if (!PBattlefield.second->CanCleanup())
+        if (!PBattlefield->CanCleanup())
         {
-            PBattlefield.second->onTick(tick);
+            PBattlefield->onTick(tick);
         }
     }
 
-    // can't std::remove_if in map so i'll workaround it
     for (auto it = m_Battlefields.begin(); it != m_Battlefields.end();)
     {
-        auto* PBattlefield = it->second;
+        auto* PBattlefield = it->second.get();
         if (PBattlefield->CanCleanup())
         {
             if (PBattlefield->Cleanup(tick, false))
             {
-                it = m_Battlefields.erase(it);
                 ShowDebug("[CBattlefieldHandler]HandleBattlefields cleaned up Battlefield %s", PBattlefield->GetName().c_str());
-                destroy(PBattlefield);
+                it = m_Battlefields.erase(it);
                 continue;
             }
         }
@@ -131,7 +120,7 @@ uint8 CBattlefieldHandler::LoadBattlefield(CCharEntity* PChar, const Battlefield
         return BATTLEFIELD_RETURN_CODE_CUTSCENE;
     }
 
-    auto* PBattlefield = new CBattlefield(registration.id, m_PZone, registration.area, PChar);
+    auto battlefield = std::make_unique<CBattlefield>(registration.id, m_PZone, registration.area, PChar);
 
     const auto rset = db::preparedStmt("SELECT name, fastestName, fastestTime, fastestPartySize "
                                        "FROM bcnm_records "
@@ -149,16 +138,18 @@ uint8 CBattlefieldHandler::LoadBattlefield(CCharEntity* PChar, const Battlefield
     const auto recordtime      = std::chrono::seconds(rset->get<uint32>("fastestTime"));
     const auto recordPartySize = rset->get<size_t>("fastestPartySize");
 
-    PBattlefield->SetName(name);
-    PBattlefield->SetRecord(recordholder, recordtime, recordPartySize);
-    PBattlefield->SetTimeLimit(registration.timeLimit);
-    PBattlefield->SetLevelCap(registration.levelCap);
-    PBattlefield->SetMaxParticipants(registration.maxPlayers);
-    PBattlefield->SetRuleMask(registration.rules);
-    PBattlefield->m_isMission = registration.isMission;
-    PBattlefield->m_showTimer = registration.showTimer;
+    battlefield->SetName(name);
+    battlefield->SetRecord(recordholder, recordtime, recordPartySize);
+    battlefield->SetTimeLimit(registration.timeLimit);
+    battlefield->SetLevelCap(registration.levelCap);
+    battlefield->SetMaxParticipants(registration.maxPlayers);
+    battlefield->SetRuleMask(registration.rules);
+    battlefield->m_isMission = registration.isMission;
+    battlefield->m_showTimer = registration.showTimer;
 
-    m_Battlefields.insert(std::make_pair(PBattlefield->GetArea(), PBattlefield));
+    const auto area = battlefield->GetArea();
+    m_Battlefields.insert(std::make_pair(area, std::move(battlefield)));
+    auto* PBattlefield = m_Battlefields[area].get();
 
     if (!PChar->StatusEffectContainer->GetStatusEffect(EFFECT_BATTLEFIELD))
     {
@@ -179,21 +170,21 @@ CBattlefield* CBattlefieldHandler::GetBattlefield(CBaseEntity* PEntity, bool che
 
     if (checkRegistered && entity && entity->objtype == TYPE_PC)
     {
-        for (auto& battlefield : m_Battlefields)
+        for (auto& [area, battlefield] : m_Battlefields)
         {
-            if (battlefield.second->IsRegistered(static_cast<CCharEntity*>(entity)))
+            if (battlefield->IsRegistered(static_cast<CCharEntity*>(entity)))
             {
-                return battlefield.second;
+                return battlefield.get();
             }
         }
         return nullptr;
     }
 
-    for (auto& battlefield : m_Battlefields)
+    for (auto& [area, battlefield] : m_Battlefields)
     {
-        if (battlefield.second->GetEntity(entity))
+        if (battlefield->GetEntity(entity))
         {
-            return battlefield.second;
+            return battlefield.get();
         }
     }
     return nullptr;
@@ -202,16 +193,16 @@ CBattlefield* CBattlefieldHandler::GetBattlefield(CBaseEntity* PEntity, bool che
 CBattlefield* CBattlefieldHandler::GetBattlefieldByArea(uint8 area) const
 {
     const auto it = m_Battlefields.find(area);
-    return it != m_Battlefields.end() ? it->second : nullptr;
+    return it != m_Battlefields.end() ? it->second.get() : nullptr;
 }
 
 CBattlefield* CBattlefieldHandler::GetBattlefieldByInitiator(uint32 charID)
 {
-    for (auto& battlefield : m_Battlefields)
+    for (auto& [area, battlefield] : m_Battlefields)
     {
-        if (battlefield.second->GetInitiator().id == charID)
+        if (battlefield->GetInitiator().id == charID)
         {
-            return battlefield.second;
+            return battlefield.get();
         }
     }
     return nullptr;
@@ -230,11 +221,11 @@ uint8 CBattlefieldHandler::RegisterBattlefield(CCharEntity* PChar, const Battlef
     // Could not find this character registered, try find by id and initiator
     if (!PBattlefield)
     {
-        for (const auto& battlefield : m_Battlefields)
+        for (const auto& [area, battlefield] : m_Battlefields)
         {
-            if (battlefield.second->GetInitiator().id == registration.initiator && battlefield.second->GetID() == registration.id)
+            if (battlefield->GetInitiator().id == registration.initiator && battlefield->GetID() == registration.id)
             {
-                PBattlefield = battlefield.second;
+                PBattlefield = battlefield.get();
                 break;
             }
         }
@@ -289,9 +280,9 @@ bool CBattlefieldHandler::RemoveFromBattlefield(CBaseEntity* PEntity, CBattlefie
 
 bool CBattlefieldHandler::IsRegistered(CCharEntity* PChar)
 {
-    for (const auto& battlefield : m_Battlefields)
+    for (const auto& [area, battlefield] : m_Battlefields)
     {
-        if (battlefield.second->IsRegistered(PChar))
+        if (battlefield->IsRegistered(PChar))
         {
             return true;
         }

--- a/src/map/battlefield_handler.h
+++ b/src/map/battlefield_handler.h
@@ -67,10 +67,10 @@ public:
     void          addOrphanedPlayer(CCharEntity* PChar);
 
 private:
-    CZone*                       m_PZone;
-    uint8                        m_MaxBattlefields; // usually 3 except dynamis, einherjar, besieged, ...
-    std::map<int, CBattlefield*> m_Battlefields;    // area
-    std::map<uint32, uint8>      m_ReservedAreas;   // <charid, area>
+    CZone*                                       m_PZone;
+    uint8                                        m_MaxBattlefields; // usually 3 except dynamis, einherjar, besieged, ...
+    std::map<int, std::unique_ptr<CBattlefield>> m_Battlefields;    // area
+    std::map<uint32, uint8>                      m_ReservedAreas;   // <charid, area>
 
     // Players that need to be kicked from whatever battlefield they were in
     std::vector<std::pair<uint32, timer::time_point>> m_orphanedPlayers;

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -3135,13 +3135,15 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
         {
             if (StatusEffectContainer && StatusEffectContainer->HasStatusEffect(EFFECT_SANGE))
             {
-                auto*       PChar = dynamic_cast<CCharEntity*>(this);
-                const auto* PAmmo = dynamic_cast<CItemWeapon*>(PChar->getEquip(SLOT_AMMO));
-
-                if (PChar && PAmmo && PAmmo->isShuriken()) // Not sure how they wouldn't have a shuriken by this point, but just in case...
+                auto* PChar = dynamic_cast<CCharEntity*>(this);
+                if (PChar)
                 {
-                    // Removing ammo here is safe because you can only create one Daken attack per attack round
-                    battleutils::RemoveAmmo(PChar, 1);
+                    const auto* PAmmo = dynamic_cast<CItemWeapon*>(PChar->getEquip(SLOT_AMMO));
+                    if (PAmmo && PAmmo->isShuriken())
+                    {
+                        // Removing ammo here is safe because you can only create one Daken attack per attack round
+                        battleutils::RemoveAmmo(PChar, 1);
+                    }
                 }
             }
         }

--- a/src/map/ipc_client.cpp
+++ b/src/map/ipc_client.cpp
@@ -299,7 +299,7 @@ void IPCClient::handleMessage_ChatMessageAlliance(const IPP& ipp, const ipc::Cha
     {
         PZone->ForEachChar([allianceid, &PAlliance](CCharEntity* PChar)
         {
-            if (PChar->PParty && PChar->PParty && PChar->PParty->m_PAlliance && PChar->PParty->m_PAlliance->m_AllianceID == allianceid)
+            if (PChar->PParty && PChar->PParty->m_PAlliance && PChar->PParty->m_PAlliance->m_AllianceID == allianceid)
             {
                 PAlliance = PChar->PParty->m_PAlliance;
                 return;

--- a/src/map/job_points.cpp
+++ b/src/map/job_points.cpp
@@ -102,6 +102,11 @@ void CJobPoints::RaiseJobPoint(JOBPOINT_TYPE jpType)
     JobPoints_t*    job      = GetJobPointsByType(jpType);
     JobPointType_t* jobPoint = GetJobPointType(jpType);
 
+    if (!job || !jobPoint)
+    {
+        return;
+    }
+
     uint8 cost = JobPointCost(jobPoint->value);
 
     if (cost != 0 && job->currentJp >= cost)

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -868,11 +868,12 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect, bo
         {
             size_t partyCount = 0;
             size_t trustCount = 0;
-            auto*  PLeader    = m_POwner->PParty != nullptr ? dynamic_cast<CCharEntity*>(m_POwner->PParty->GetLeader()) : nullptr;
+            auto*  PParty     = m_POwner->PParty;
+            auto*  PLeader    = PParty ? dynamic_cast<CCharEntity*>(PParty->GetLeader()) : nullptr;
             if (PLeader)
             {
                 trustCount = PLeader->PTrusts.size();
-                partyCount = m_POwner->PParty->members.size();
+                partyCount = PParty->members.size();
             }
 
             expression = latentEffect.GetConditionsValue() <= (partyCount + trustCount);

--- a/src/map/linkshell.cpp
+++ b/src/map/linkshell.cpp
@@ -506,7 +506,10 @@ uint32 RegisterNewLinkshell(const std::string& name, uint16 color)
             if (rset && rset->rowsCount() && rset->next())
             {
                 const auto id = rset->get<uint32>("linkshellid");
-                return LoadLinkshell(id)->getID();
+                if (auto* PLinkshell = LoadLinkshell(id))
+                {
+                    return PLinkshell->getID();
+                }
             }
         }
     }

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -3921,9 +3921,13 @@ uint16 CLuaBaseEntity::getEquipID(SLOTTYPE slot)
             return 0;
         }
 
-        CCharEntity* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity);
-        CItem*       PItem = PChar->getEquip(slot);
+        const auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity);
+        if (!PChar)
+        {
+            return 0;
+        }
 
+        const CItem* PItem = PChar->getEquip(slot);
         if (PItem && PItem->isType(ITEM_EQUIPMENT))
         {
             return PItem->getID();
@@ -4023,7 +4027,7 @@ uint32 CLuaBaseEntity::getItemCount(uint16 itemID)
 {
     if (m_PBaseEntity->objtype != TYPE_PC)
     {
-        return false;
+        return 0;
     }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
@@ -12958,7 +12962,7 @@ uint16 CLuaBaseEntity::getBaseWeaponDelay(uint16 slot)
     if (m_PBaseEntity->objtype != TYPE_PC)
     {
         ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->getName());
-        return false;
+        return 0;
     }
     CCharEntity* PCharEntity = dynamic_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -18520,6 +18524,10 @@ void CLuaBaseEntity::drawIn(const sol::variadic_args& va) const
     }
 
     const auto mobObj = dynamic_cast<CMobEntity*>(m_PBaseEntity);
+    if (!mobObj)
+    {
+        return;
+    }
 
     if (va.size() == 0)
     {

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1949,9 +1949,12 @@ void OnZoneIn(CCharEntity* PChar)
     TracyZoneScoped;
 
     CZone* destinationZone = zoneutils::GetZone(PChar->loc.destination);
-    if (!PChar->inMogHouse() && destinationZone == nullptr)
+    if (!destinationZone)
     {
-        ShowWarning("Attempt to Zone In player to invalid/disabled zone %d.", PChar->loc.destination);
+        if (!PChar->inMogHouse())
+        {
+            ShowWarning("Attempt to Zone In player to invalid/disabled zone %d.", PChar->loc.destination);
+        }
         return;
     }
 

--- a/src/map/merit.cpp
+++ b/src/map/merit.cpp
@@ -348,6 +348,10 @@ Merit_t* CMeritPoints::GetMeritPointer(MERIT_TYPE merit)
 void CMeritPoints::RaiseMerit(MERIT_TYPE merit)
 {
     Merit_t* PMerit = GetMeritPointer(merit);
+    if (!PMerit)
+    {
+        return;
+    }
 
     if (m_MeritPoints >= PMerit->next && PMerit->count < PMerit->upgrade && GetMeritCountInSameCategory(merit) < meritCatInfo[GetMeritCategory(merit)].MaxPoints)
     {
@@ -381,6 +385,10 @@ void CMeritPoints::RaiseMerit(MERIT_TYPE merit)
 void CMeritPoints::LowerMerit(MERIT_TYPE merit)
 {
     Merit_t* PMerit = GetMeritPointer(merit);
+    if (!PMerit)
+    {
+        return;
+    }
 
     if (PMerit->count > 0)
     {

--- a/src/map/packets/c2s/0x01a_action.cpp
+++ b/src/map/packets/c2s/0x01a_action.cpp
@@ -211,6 +211,11 @@ void GP_CLI_COMMAND_ACTION::process(MapSession* PSession, CCharEntity* PChar) co
 
             const CBaseEntity* PNpc = PChar->GetEntity(this->ActIndex, TYPE_NPC | TYPE_MOB);
 
+            if (!PNpc)
+            {
+                return;
+            }
+
             // MONs are allowed to use doors, but nothing else
             if (PChar->m_PMonstrosity != nullptr &&
                 PNpc->look.size != 0x02 &&
@@ -222,7 +227,7 @@ void GP_CLI_COMMAND_ACTION::process(MapSession* PSession, CCharEntity* PChar) co
             }
 
             // NOTE: Moogles inside of mog houses are the exception for not requiring Spawned or Status checks.
-            if (PNpc != nullptr && distance(PNpc->loc.p, PChar->loc.p) <= 6.0f && ((PNpc->PAI->IsSpawned() && PNpc->status == STATUS_TYPE::NORMAL) || PChar->inMogHouse()))
+            if (distance(PNpc->loc.p, PChar->loc.p) <= 6.0f && ((PNpc->PAI->IsSpawned() && PNpc->status == STATUS_TYPE::NORMAL) || PChar->inMogHouse()))
             {
                 PNpc->PAI->Trigger(PChar);
                 PChar->m_charHistory.npcInteractions++;

--- a/src/map/packets/c2s/0x034_trade_list.cpp
+++ b/src/map/packets/c2s/0x034_trade_list.cpp
@@ -70,7 +70,7 @@ void GP_CLI_COMMAND_TRADE_LIST::process(MapSession* PSession, CCharEntity* PChar
 
     if (!PTarget ||
         PTarget->id != PChar->TradePending.id ||
-        PChar->TradePending.id != PTarget->id)
+        PChar->id != PTarget->TradePending.id)
     {
         ShowWarningFmt("GP_CLI_COMMAND_TRADE_LIST: Could not find trade targets.");
         return;

--- a/src/map/packets/c2s/0x106_bazaar_buy.cpp
+++ b/src/map/packets/c2s/0x106_bazaar_buy.cpp
@@ -73,7 +73,7 @@ void GP_CLI_COMMAND_BAZAAR_BUY::process(MapSession* PSession, CCharEntity* PChar
     {
         PChar->pushPacket<GP_SERV_COMMAND_BAZAAR_BUY>(PTarget, GP_BAZAAR_BUY_STATE::ERR);
 
-        if (settings::get<bool>("logging.DEBUG_BAZAARS") && PChar->id == PTarget->id)
+        if (settings::get<bool>("logging.DEBUG_BAZAARS"))
         {
             if (PChar->id == PTarget->id)
             {

--- a/src/map/packets/s2c/0x056_mission_other.cpp
+++ b/src/map/packets/s2c/0x056_mission_other.cpp
@@ -141,7 +141,7 @@ GP_SERV_COMMAND_MISSION::OTHER::OTHER(const CCharEntity* PChar, MissionComplete 
     {
         case MissionComplete::Campaign1:
         {
-            for (uint16 missionID = 256; missionID < 256; missionID++)
+            for (uint16 missionID = 0; missionID < 256; missionID++)
             {
                 if (PChar->m_campaignLog.complete[missionID])
                 {

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -630,7 +630,7 @@ void CParty::AddMember(CBattleEntity* PEntity)
     {
         CCharEntity* PChar = dynamic_cast<CCharEntity*>(PEntity);
 
-        if (!PEntity)
+        if (!PChar)
         {
             ShowWarning("Non-Player passed into function (%s).", PEntity->getName());
             return;

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1885,7 +1885,7 @@ void CStatusEffectContainer::HandleAura(CStatusEffect* PStatusEffect)
         PEntity = PEntity->PMaster;
     }
 
-    float aura_range = 6.0f + (PEntity->getMod(Mod::AURA_SIZE) / 100); // Adding to this mod should be the value you want * 100
+    float aura_range = 6.0f + (PEntity->getMod(Mod::AURA_SIZE) / 100.0f); // Adding to this mod should be the value you want * 100
 
     if (PEntity->objtype == TYPE_PC)
     {

--- a/src/map/trade_container.cpp
+++ b/src/map/trade_container.cpp
@@ -71,7 +71,7 @@ uint32 CTradeContainer::getConfirmedStatus(uint8 slotID)
     {
         return m_confirmed[slotID];
     }
-    return false;
+    return 0;
 }
 
 uint32 CTradeContainer::getItemQuantity(uint16 itemID)

--- a/src/map/transport.cpp
+++ b/src/map/transport.cpp
@@ -446,6 +446,13 @@ Elevator_t* CTransportHandler::getElevator(uint8 elevatorID)
 
 void CTransportHandler::insertElevator(Elevator_t elevator)
 {
+    // Double check that the NPC entities all exist
+    if (!elevator.LowerDoor || !elevator.UpperDoor || !elevator.Elevator)
+    {
+        ShowError("Elevator could not load NPC entity. Ignoring this elevator.");
+        return;
+    }
+
     // check to see if this elevator already exists
     for (auto& i : ElevatorList)
     {
@@ -456,13 +463,6 @@ void CTransportHandler::insertElevator(Elevator_t elevator)
             ShowError("Elevator already exists.");
             return;
         }
-    }
-
-    // Double check that the NPC entities all exist
-    if (elevator.LowerDoor == nullptr || elevator.UpperDoor == nullptr || elevator.Elevator == nullptr)
-    {
-        ShowError("Elevator %d could not load NPC entity. Ignoring this elevator.", elevator.Elevator->id);
-        return;
     }
 
     // Have permanent elevators wait until their next cycle to begin moving

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2108,7 +2108,7 @@ int32 TakePhysicalDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, PHY
             auto* sub_weapon = dynamic_cast<CItemWeapon*>(PAttacker->m_Weapons[SLOT_SUB]);
 
             if (sub_weapon && sub_weapon->getDmgType() > DAMAGE_TYPE::NONE && sub_weapon->getDmgType() < DAMAGE_TYPE::HTH &&
-                weapon->getSkillType() != SKILL_HAND_TO_HAND)
+                weapon && weapon->getSkillType() != SKILL_HAND_TO_HAND)
             {
                 delay = delay / 2;
             }

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4913,7 +4913,7 @@ float HandleTranquilHeart(CBattleEntity* PEntity)
     if (PEntity->objtype == TYPE_PC && charutils::hasTrait((CCharEntity*)PEntity, TRAIT_TRANQUIL_HEART))
     {
         int16 healingSkill = PEntity->GetSkill(SKILL_HEALING_MAGIC);
-        reductionPercent   = ((healingSkill / 10) * .5f);
+        reductionPercent   = ((healingSkill / 10.0f) * 0.5f);
 
         // Reduction Percent Caps at 25%
         if (reductionPercent > 25)

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -3467,6 +3467,11 @@ auto GetSkillChainEffect(const CBattleEntity* PDefender, uint8 primary, uint8 se
         }
     }
 
+    if (!PSCEffect)
+    {
+        return ActionProcSkillChain::None;
+    }
+
     Mod resistanceRankMods[] = { Mod::FIRE_RES_RANK, Mod::ICE_RES_RANK, Mod::WIND_RES_RANK, Mod::EARTH_RES_RANK, Mod::THUNDER_RES_RANK, Mod::ICE_RES_RANK, Mod::LIGHT_RES_RANK, Mod::DARK_RES_RANK };
 
     // Reset the effects resistance rank mods

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1767,7 +1767,7 @@ uint32 getItemCount(CCharEntity* PChar, uint16 ItemID)
 {
     if (ItemID == 0)
     {
-        return false;
+        return 0;
     }
 
     uint32 itemCount = 0;
@@ -2615,7 +2615,7 @@ bool hasValidStyle(CCharEntity* PChar, CItemEquipment* PItem, CItemEquipment* AI
 
         // Marvelous Cheer special case
         // It is not technically a Wind Instrument, but it can lockstyle one.
-        if (AItem->getID() == MARVELOUS_CHEER && PWeapon->getSkillType() == SKILL_WIND_INSTRUMENT)
+        if (PWeapon && AItem->getID() == MARVELOUS_CHEER && PWeapon->getSkillType() == SKILL_WIND_INSTRUMENT)
         {
             return HasItem(PChar, AItem->getID());
         }
@@ -3542,13 +3542,13 @@ void BuildingCharAbilityTable(CCharEntity* PChar)
 
     for (auto PAbility : ability::GetAbilities(PChar->GetSJob()))
     {
+        if (!PAbility)
+        {
+            continue;
+        }
+
         if (PChar->GetSLevel() >= PAbility->getLevel())
         {
-            if (PAbility == nullptr)
-            {
-                continue;
-            }
-
             if (PAbility->getLevel() != 0 && PAbility->getID() < ABILITY_HEALING_RUBY)
             {
                 if (PAbility->getID() != ABILITY_PET_COMMANDS && CheckAbilityAddtype(PChar, PAbility) && !(PAbility->getAddType() & ADDTYPE_MAIN_ONLY))

--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -1374,31 +1374,27 @@ bool BaitLoss(CCharEntity* PChar, RemoveFly removeFly, SendUpdate sendUpdate)
 void RodBreak(CCharEntity* PChar)
 {
     CItemWeapon* PRanged = dynamic_cast<CItemWeapon*>(PChar->getEquip(SLOT_RANGED));
-    rod_t*       PRod    = FishingRods[PRanged->getID()];
-
     if (PRanged == nullptr)
     {
-        ShowWarning("PRod was null.");
+        ShowWarning("PRanged was null.");
         return;
     }
 
+    rod_t* PRod = FishingRods[PRanged->getID()];
     if (PRod == nullptr)
     {
         ShowWarning("PRod was null.");
         return;
     }
 
-    if (PRanged != nullptr && PRod != nullptr)
+    if (PRod->breakable && PRod->brokenRodId > 0)
     {
-        if (PRod->breakable && PRod->brokenRodId > 0)
-        {
-            BaitLoss(PChar, RemoveFly::Yes, SendUpdate::No);
-            charutils::UnequipItem(PChar, SLOT_RANGED, false);
-            uint8 location = PRanged->getLocationID();
-            charutils::UpdateItem(PChar, location, PRanged->getSlotID(), -1);
-            charutils::AddItem(PChar, location, PRod->brokenRodId, 1);
-            PChar->pushPacket<GP_SERV_COMMAND_ITEM_SAME>();
-        }
+        BaitLoss(PChar, RemoveFly::Yes, SendUpdate::No);
+        charutils::UnequipItem(PChar, SLOT_RANGED, false);
+        uint8 location = PRanged->getLocationID();
+        charutils::UpdateItem(PChar, location, PRanged->getSlotID(), -1);
+        charutils::AddItem(PChar, location, PRod->brokenRodId, 1);
+        PChar->pushPacket<GP_SERV_COMMAND_ITEM_SAME>();
     }
 }
 

--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -1573,17 +1573,20 @@ int32 CatchMonster(CCharEntity* PChar, uint32 MobID)
     CMobEntity* PMob          = dynamic_cast<CMobEntity*>(zoneutils::GetEntity(MobID, TYPE_MOB));
     fishmob_t*  mob           = FishZoneMobList[PChar->getZone()][MobID];
 
-    if ((PMob == nullptr) || (mob == nullptr) || PMob->isAlive() || (PMob != nullptr && mob->questOnly && PMob->GetLocalVar("catchable") == 0))
+    if (!PMob || !mob)
     {
-        if (!PMob->isAlive())
-        {
-            ShowError("Invalid MobID %i for fished monster", MobID);
-        }
-
+        ShowError("Invalid MobID %i for fished monster", MobID);
         PChar->animation = ANIMATION_FISHING_STOP;
         PChar->updatemask |= UPDATE_HP;
         PChar->pushPacket<GP_SERV_COMMAND_TALKNUM>(PChar, MessageOffset + FISHMESSAGEOFFSET_LOST);
+        return 0;
+    }
 
+    if (PMob->isAlive() || (mob->questOnly && PMob->GetLocalVar("catchable") == 0))
+    {
+        PChar->animation = ANIMATION_FISHING_STOP;
+        PChar->updatemask |= UPDATE_HP;
+        PChar->pushPacket<GP_SERV_COMMAND_TALKNUM>(PChar, MessageOffset + FISHMESSAGEOFFSET_LOST);
         return 0;
     }
 
@@ -2170,21 +2173,12 @@ fishresponse_t* FishingCheck(CCharEntity* PChar, uint8 fishingSkill, rod_t* rod,
     std::vector<fishmob_t*>                  MobPool;
     std::map<uint32, std::map<uint16, int8>> ChestPool;
 
-    FishPool.clear();
-    ItemPool.clear();
-    MobPool.clear();
-    ChestPool.clear();
-
     FishPool = GetFishPool(PChar->getZone(), area->areaId, bait->baitID);
     ItemPool = GetItemPool(PChar->getZone(), area->areaId);
     MobPool  = GetMobPool(PChar->getZone());
-    ChestPool.clear();
 
     std::set<uint32> RemoveList;
-    RemoveList.clear();
-
     std::set<uint32> NoCatchList;
-    NoCatchList.clear();
 
     // Build Hookable Fish Pool
     if (!FishPool.empty())

--- a/src/map/utils/gardenutils.cpp
+++ b/src/map/utils/gardenutils.cpp
@@ -96,7 +96,7 @@ void UpdateGardening(CCharEntity* PChar, SendPacket sendPacket)
             CItem* PItem = PContainer->GetItem(slotID);
             if (PItem != nullptr && PItem->isType(ITEM_FURNISHING))
             {
-                CItemFlowerpot* PPotItem = static_cast<CItemFlowerpot*>(PItem);
+                CItemFlowerpot* PPotItem = dynamic_cast<CItemFlowerpot*>(PItem);
                 if (PPotItem != nullptr && PPotItem->canGrow() && vanatime >= PPotItem->getStageTimestamp())
                 {
                     uint8  stageDuration        = GetStageDuration(PPotItem);

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -470,7 +470,7 @@ uint16 GetSubJobStats(uint8 rank, uint16 level, uint16 stat)
             }
             break;
         default:
-            sJobStat = stat / 2;
+            sJobStat = stat / 2.0f;
             break;
     }
     return sJobStat;

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1096,7 +1096,7 @@ void CalculateLuopanStats(CBattleEntity* PMaster, CPetEntity* PPet)
 
     if (PMaster->StatusEffectContainer->HasStatusEffect(EFFECT_BOLSTER))
     {
-        uint8 bolsterJPVal = dynamic_cast<CCharEntity*>(PMaster)->PJobPoints->GetJobPointValue(JP_BOLSTER_EFFECT);
+        uint8 bolsterJPVal = static_cast<CCharEntity*>(PMaster)->PJobPoints->GetJobPointValue(JP_BOLSTER_EFFECT);
         PPet->health.maxhp += (uint32)floor(PPet->health.maxhp * (0.03 * bolsterJPVal));
     }
 
@@ -1813,7 +1813,7 @@ void LoadPet(CBattleEntity* PMaster, uint32 PetID, bool spawningFromZone)
         // spawn the luopan at the targets position with offsets from the action packet
         // this is calculated in the action packet to avoid incorrect placement after casting
         // m_ActionOffsetPos is a combination of targets pos + action offset pos
-        PPet->loc.p = dynamic_cast<CCharEntity*>(PMaster)->m_ActionOffsetPos;
+        PPet->loc.p = static_cast<CCharEntity*>(PMaster)->m_ActionOffsetPos;
     }
     else
     {

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -1357,7 +1357,12 @@ auto IsResidentialArea(const CCharEntity* PChar) -> bool
 void AfterZoneIn(CBaseEntity* PEntity)
 {
     auto* PChar = dynamic_cast<CCharEntity*>(PEntity);
-    if (PChar != nullptr && (PChar->PBattlefield == nullptr || !PChar->PBattlefield->isEntered(PChar)))
+    if (!PChar)
+    {
+        return;
+    }
+
+    if (!PChar->PBattlefield || !PChar->PBattlefield->isEntered(PChar))
     {
         GetZone(PChar->getZone())->updateCharLevelRestriction(PChar);
     }

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -286,6 +286,7 @@ void CZoneEntities::InsertPET(CBaseEntity* PPet)
     if (PPet == nullptr)
     {
         ShowError("CZone::InsertPET: entity is null");
+        return;
     }
 
     if (PPet->PInstance)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Several more landmines surfaced by cppcheck/PVS

- Fix potentially bad furniture being cast as a Flowerpoint inconditionally
- Return immediately when inserting a nullptr pet into the zone
- Fixes the wrong variable being checked for nullptr when adding a member to a party
- Fix wrong checks when checking if a trade is valid
- Fix wrong iteration when sending Campaign Ops missions to the client
- Smart pointers in battlefield handlers, resolves a memory leak in certain conditions.
- Fix truncation for Tranquil Heart and AURA_SIZE mod
- Reorders or adds missing nullptr checks in a lot of places

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
