### PR TITLE
[lua] Move Oggbi's Default Action back to Default Actions lua

### DIFF
--- a/scripts/quests/bastok/MNK_AF1_Ghosts_of_the_Past.lua
+++ b/scripts/quests/bastok/MNK_AF1_Ghosts_of_the_Past.lua
@@ -46,8 +46,6 @@ quest.sections =
                         player:getMainLvl() >= xi.settings.main.AF1_QUEST_LEVEL
                     then
                         return quest:progressEvent(231)
-                    else
-                        return quest:event(230)
                     end
                 end,
             },

--- a/scripts/zones/Port_Bastok/DefaultActions.lua
+++ b/scripts/zones/Port_Bastok/DefaultActions.lua
@@ -35,6 +35,7 @@ return {
     ['Mustafa']          = { text = ID.text.ARRIVING_PASSENGER_DIALOG },
     ['Nicadio']          = { event = 32 },
     ['Odyssean_Passage'] = { messageSpecial = ID.text.NOTHING_HAPPENS },
+    ['Oggbi']            = { event = 230 },
     ['Otto']             = { event = 20 },
     ['Panana']           = { event = 43 },
     ['Patient_Wheel']    = { event = 325 },


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Moves event 230 back to the default action lua.
During https://github.com/LandSandBoat/server/pull/9326 it was moved into the quest IF but now if you're not flagging the quest Oggbi has no on trigger interaction.

## Steps to test these changes

Talk to Oggbi.
