### PR TITLE
[lua] Minor JoL and AV adjustments, set mob MACC to A+ rank from skill with no skill rank from main jobs

### DIFF
--- a/scripts/globals/combat/magic_hit_rate.lua
+++ b/scripts/globals/combat/magic_hit_rate.lua
@@ -47,6 +47,12 @@ local function magicAccuracyFromSkill(actor, params)
     if params.skillType > 0 then
         magicAcc = actor:getSkillLevel(params.skillType)
 
+        -- If a mob is casting something its main/sub jobs cannot (i.e. JoL casting black magic) this is _exceptional_
+        -- So give them A+ rank base magic accuracy
+        if magicAcc == 0 and actor:isMob() then
+            magicAcc = xi.data.skillLevel.getSkillCap(actor:getMainLvl(), xi.skillRank.A_PLUS)
+        end
+
         if params.skillType == xi.skill.SINGING then
             if actor:isPC() then
                 -- Add ranged skill level ONLY if it's an instrument.

--- a/scripts/zones/AlTaieu/mobs/Absolute_Virtue.lua
+++ b/scripts/zones/AlTaieu/mobs/Absolute_Virtue.lua
@@ -166,10 +166,10 @@ local entity = {}
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ABILITY_RESPONSE, 1)
     mob:setMobMod(xi.mobMod.AOE_HIT_ALL, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
 
     --[[
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
-    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
     mob:setMod(xi.mod.SOULEATERRES, 4)
     mob:setMod(xi.mod.UFASTCAST, 100)
     mob:setMod(xi.mod.MAIN_DMG_RATING, 150)

--- a/scripts/zones/AlTaieu/mobs/Jailer_of_Love.lua
+++ b/scripts/zones/AlTaieu/mobs/Jailer_of_Love.lua
@@ -135,6 +135,19 @@ local spawnSharks = function(mob)
     end
 end
 
+local cleanupPets = function(mob)
+    if mob then
+        mob:clearTimerQueue()
+    end
+
+    for i = ID.mob.JAILER_OF_LOVE + 1, ID.mob.JAILER_OF_LOVE + 27 do
+        local pet = GetMobByID(i)
+        if pet and pet:isSpawned() then
+            DespawnMob(i)
+        end
+    end
+end
+
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
 end
@@ -146,6 +159,8 @@ local function getAbsorbMod(element)
 end
 
 entity.onMobSpawn = function(mob)
+    mob:setAnimationSub(0)
+
     mob:setBehavior(xi.behavior.STANDBACK)
     mob:setMobMod(xi.mobMod.STANDBACK_RANGE, 13) -- Guessed, seems approximate based on era videos
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)      -- Seems to be 20~22 depending if a TP move is in the way
@@ -195,8 +210,6 @@ entity.onMobEngage = function(mob, target)
 end
 
 entity.onMobFight = function(mob, target)
-    -- mob:setAnimationSub(2) -- TODO: this was from ASB. necessary?
-
     local distance = mob:checkDistance(target)
     local drawInTable =
     {
@@ -297,21 +310,14 @@ end
 entity.onMobWeaponSkill = function(target, mob, skill)
     local skillId = skill:getID()
 
-    if skillId == 734 then
+    if skillId == xi.mobSkill.ASTRAL_FLOW_1 then
         astralFlowPets()
     end
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    for i = ID.mob.JAILER_OF_LOVE + 1, ID.mob.JAILER_OF_LOVE + 27 do
-        local pet = GetMobByID(i)
-        if pet and pet:isSpawned() then
-            DespawnMob(i)
-        end
-    end
-end
+    cleanupPets(mob)
 
-entity.onMobDespawn = function(mob)
     if math.random(1, 100) <= 25 then -- 25% chance to spawn Absolute Virtue
         local highestEnmityTarget = nil
         local highestEnmity = -1
@@ -336,11 +342,28 @@ entity.onMobDespawn = function(mob)
             end
         end
 
-        SpawnMob(ID.mob.ABSOLUTE_VIRTUE)
-        if highestEnmityTarget then
-            GetMobByID(ID.mob.ABSOLUTE_VIRTUE):updateEnmity(highestEnmityTarget)
+        local av = GetMobByID(ID.mob.ABSOLUTE_VIRTUE)
+
+        if av then
+            local pos = mob:getPos()
+
+            av:setSpawn(pos.x, pos.y, pos.z, pos.rot)
+
+            mob:timer(10000, function(mobArg)
+                SpawnMob(ID.mob.ABSOLUTE_VIRTUE)
+
+                if highestEnmityTarget then
+                    av:updateEnmity(highestEnmityTarget)
+                    av:updateClaim(highestEnmityTarget)
+                end
+            end)
         end
     end
+end
+
+entity.onMobDespawn = function(mob)
+    -- In case JoL despawns on its own, despawn the mobs. note: mob:isAlive returns false here
+    cleanupPets(mob)
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

AV: Despawn after 180s, spawn claimed, spawn 10 seconds after death https://youtu.be/Xcz5hVp0nso?t=114

JoL: Cleanup timers on death or despawn, spawn AV on death not despawn. Some animsub jank fixes (hopefully) too.

## Steps to test these changes

Spawn JoL, see it do JoL things. AV spawns similarly to video linked above