### PR TITLE
[lua] Remove resist rank check for mobs in calculateResistanceFactor 

### DIFF
--- a/scripts/globals/combat/magic_hit_rate.lua
+++ b/scripts/globals/combat/magic_hit_rate.lua
@@ -511,12 +511,6 @@ local function calculateResistanceFactor(actor, target, params)
         elseif playerElementalEvasion == 0 then
             maxResistTier = 2
         end
-
-    -- Non-players: Affected by resistance rank.
-    else
-        if params.resistanceRank <= -3 then
-            maxResistTier = 1
-        end
     end
 
     -- Calculate first 3 resist tiers.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Remove some code that was forcing minimum half-resists on mobs really weak to elements.

## Steps to test these changes

Before:
(always lands)
<img width="478" height="638" alt="image" src="https://github.com/user-attachments/assets/603a88f4-39eb-4495-9d0e-a107bcfa4c07" />

After:
<img width="351" height="662" alt="image" src="https://github.com/user-attachments/assets/5be8cb22-94fa-4ebd-ab0b-2efbbad55fdc" />
