### PR TITLE
[lua] MNK AF2 Bug Fix no KI check

### DIFF
--- a/scripts/quests/bastok/MNK_AF2_The_First_Meeting.lua
+++ b/scripts/quests/bastok/MNK_AF2_The_First_Meeting.lua
@@ -51,20 +51,10 @@ quest.sections =
             ['Hide_Flap_2'] =
             {
                 onTrigger = function(player, npc)
-                    player:messageSpecial(davoiID.text.FIND_ORC_TENT)
-
-                    if
-                        player:checkDistance(npc) > 1 and
-                        player:hasKeyItem(xi.ki.LETTER_FROM_DALZAKK)
-                    then
-                        return quest:messageSpecial(davoiID.text.CLOSER_TO_SEARCH)
-                    elseif
-                        not GetMobByID(davoiID.mob.BILOPDOP):isAlive() and
-                        not GetMobByID(davoiID.mob.DELOKNOK):isAlive()
-                    then
+                    if player:checkDistance(npc) <= 1 then
                         return quest:progressEvent(108)
                     else
-                        return quest:noAction()
+                        return quest:messageSpecial(davoiID.text.CLOSER_TO_SEARCH)
                     end
                 end,
             },
@@ -78,22 +68,18 @@ quest.sections =
 
                     if player:hasKeyItem(xi.ki.SAN_DORIAN_MARTIAL_ARTS_SCROLL) then
                         player:messageSpecial(davoiID.text.FIND_NOTHING)
-                        return
-                    end
-
-                    if quest:getLocalVar(player, 'nmKilled') == 3 then
+                    elseif quest:getLocalVar(player, 'nmKilled') == 3 then
                         npcUtil.giveKeyItem(player, xi.ki.SAN_DORIAN_MARTIAL_ARTS_SCROLL)
-                        return
-                    end
-
-                    if
+                    elseif
+                        player:hasKeyItem(xi.ki.LETTER_FROM_DALZAKK) and
                         not GetMobByID(davoiID.mob.BILOPDOP):isSpawned() and
                         not GetMobByID(davoiID.mob.DELOKNOK):isSpawned()
                     then
                         player:messageSpecial(davoiID.text.FIND_NOTHING)
                         SpawnMob(davoiID.mob.BILOPDOP):updateClaim(player)
                         SpawnMob(davoiID.mob.DELOKNOK):updateEnmity(player)
-                        return
+                    else
+                        player:messageSpecial(davoiID.text.FIND_NOTHING)
                     end
                 end,
             },


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a bug where the check for LETTER_FROM_DALZAKK was not being performed allowing players to logically break the flow of the quest by getting the SAN_DORIAN_MARTIAL_ARTS_SCROLL before they even knew it existed.

Cleans up the logic while I'm here.

## Steps to test these changes

1. `!addquest 1 51`
2. `!zone <DAVOI>`
3. `!gotoname Hide_Flap_2`
4. Check the flap and test the interactions.
5. `!addkeyitem LETTER_FROM_DALZAKK`
6. Check flap again and test interactions.