### PR TITLE
[core, sql, auth] Trust Tokens - Remember this computer for X days 2FA

### DIFF
--- a/sql/accounts_trust_tokens.sql
+++ b/sql/accounts_trust_tokens.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS `accounts_trust_tokens` (
+  `token` CHAR(64) NOT NULL,
+  `accid` INT UNSIGNED NOT NULL,
+  `expires` DATETIME NOT NULL,
+  PRIMARY KEY (`token`),
+  INDEX `idx_accid` (`accid`),
+  CONSTRAINT `fk_trust_accid` FOREIGN KEY (`accid`) REFERENCES `accounts`(`id`) ON DELETE CASCADE
+);

--- a/src/login/auth_session.cpp
+++ b/src/login/auth_session.cpp
@@ -108,7 +108,7 @@ void auth_session::read_func()
         do_write(jsonStringSize);
     };
 
-    const auto sendLoginResult = [&](const login_result errorCode, const uint8 len)
+    const auto sendLoginResult = [&](const login_result errorCode)
     {
         json loginErrorCodeReply;
         loginErrorCodeReply["result"] = errorCode; // "old style" backwards compatible error code
@@ -146,12 +146,14 @@ void auth_session::read_func()
         return;
     }
 
-    int8                   code             = loginHelpers::jsonGet<int8>(jsonBuffer, "command").value_or(0);
-    std::string            username         = loginHelpers::jsonGet<std::string>(jsonBuffer, "username").value_or("");
-    std::string            password         = loginHelpers::jsonGet<std::string>(jsonBuffer, "password").value_or("");
-    std::string            updated_password = loginHelpers::jsonGet<std::string>(jsonBuffer, "new_password").value_or("");
-    std::string            otp              = loginHelpers::jsonGet<std::string>(jsonBuffer, "otp").value_or("");
-    std::array<uint8_t, 3> version          = loginHelpers::jsonGet<uint8, 3>(jsonBuffer, "version").value_or(std::array<uint8_t, 3>{ 0, 0, 0 });
+    int8                   code                = loginHelpers::jsonGet<int8>(jsonBuffer, "command").value_or(0);
+    std::string            username            = loginHelpers::jsonGet<std::string>(jsonBuffer, "username").value_or("");
+    std::string            password            = loginHelpers::jsonGet<std::string>(jsonBuffer, "password").value_or("");
+    std::string            updated_password    = loginHelpers::jsonGet<std::string>(jsonBuffer, "new_password").value_or("");
+    std::string            otp                 = loginHelpers::jsonGet<std::string>(jsonBuffer, "otp").value_or("");
+    std::string            trust_token         = loginHelpers::jsonGet<std::string>(jsonBuffer, "trust_token").value_or("");
+    bool                   trust_this_computer = loginHelpers::jsonGet<bool>(jsonBuffer, "trust_this_computer").value_or(false);
+    std::array<uint8_t, 3> version             = loginHelpers::jsonGet<uint8, 3>(jsonBuffer, "version").value_or(std::array<uint8_t, 3>{ 0, 0, 0 });
 
     // Check major.minor but ignore trivial
     if (version[0] != SupportedXiloaderVersion[0] || version[1] != SupportedXiloaderVersion[1])
@@ -188,102 +190,131 @@ void auth_session::read_func()
             DebugSockets(fmt::format("LOGIN_ATTEMPT from {}", ipAddress));
 
             // Look up and validate account password
-            if (!validatePassword(username, password))
+            auto accountInfo = validatePassword(username, password);
+            if (!accountInfo)
             {
-                sendLoginResult(login_result::LOGIN_ERROR, 1);
+                sendLoginResult(login_result::LOGIN_ERROR);
                 return;
             }
 
-            bool usedOTP = false;
+            auto [accountID, status] = *accountInfo;
 
-            if (otpHelpers::doesAccountNeedOTP(username, "TOTP"))
+            // Reject banned/non-normal accounts before processing OTP or trust tokens
+            if (!(status & ACCOUNT_STATUS_CODE::NORMAL))
             {
-                if (!otpHelpers::validateTOTP(otp, otpHelpers::getAccountSecret(username, "TOTP")))
+                // Purge any lingering trust tokens for banned accounts
+                if (status & ACCOUNT_STATUS_CODE::BANNED)
                 {
-                    sendLoginResult(login_result::LOGIN_ERROR, 1);
-                    return;
+                    otpHelpers::removeAllTrustTokens(accountID);
                 }
-
-                usedOTP = true;
+                sendLoginResult(login_result::LOGIN_FAIL);
+                return;
             }
 
-            // We've validated the password by this point, get account info
-            const auto rset = db::preparedStmt("SELECT accounts.id, accounts.status FROM accounts WHERE accounts.login = ?", username);
-            if (rset && rset->rowsCount() != 0 && rset->next())
+            bool otpVerified = false;
+
+            if (otpHelpers::doesAccountNeedOTP(accountID, "TOTP"))
             {
-                uint32 accountID = rset->get<uint32>("id");
-                uint32 status    = rset->get<uint32>("status");
+                bool trustedByToken = false;
 
-                if (status & ACCOUNT_STATUS_CODE::NORMAL)
+                // Try trust token first
+                if (!trust_token.empty())
                 {
-                    db::preparedStmt("UPDATE accounts SET accounts.timelastmodify = NULL WHERE accounts.id = ?", accountID);
+                    trustedByToken = otpHelpers::validateTrustToken(accountID, trust_token);
+                }
 
-                    const auto payload = ipc::toBytesWithHeader(ipc::AccountLogin{
-                        .accountId = accountID,
-                    });
-
-                    zmqDealerWrapper_.outgoingQueue_.enqueue(zmq::message_t(payload.data(), payload.size()));
-
-                    // set Satchel to the same size as inventory on all chars on their account if character has OTP
-                    // Note: Upgrades happen in-game with gobbiebag
-                    if (usedOTP)
+                // Fall back to OTP code if trust token invalid/missing
+                if (!trustedByToken)
+                {
+                    if (otp.empty() && !trust_token.empty())
                     {
-                        db::preparedStmt("UPDATE char_storage a JOIN char_storage b ON a.charid = b.charid "
-                                         "SET a.satchel = b.inventory "
-                                         "WHERE a.charid IN (SELECT charid FROM chars WHERE accid = ?)",
-                                         accountID);
-                    }
-                    // TODO: Lock out same account logging in multiple times. Can check data/view session existence on same IP/account?
-                    // Not a real problem because the account is locked out when a character is logged in.
-
-                    /*
-                    const auto rset = db::preparedStmt("SELECT charid "
-                            "FROM accounts_sessions "
-                            "WHERE accid = ? LIMIT 1", accountID);
-                    if (rset && rset->rowsCount() != 0 && rset->next())
-                    {
-                        // TODO: kick player out of map server if already logged in
-                        // uint32 charid = rset->get<uint32>("charid");
-
-                        // This error message doesn't work when sent this way. Unknown how to transmit "1039" error message to a client already logged in.
-                        // session_t& authenticatedSession = get_authenticated_session(socket_, session.sentAccountID);
-                        // if (auto data = authenticatedSession.buffer_.data()session)
-                        // {
-                        //  generateErrorMessage(data->buffer_.data(), 139);
-                        //  data->do_write(0x24);
-                        //  return;
-                        //}
-                        ref<uint8>(buffer_.data(), 0) = LOGIN_ERROR_ALREADY_LOGGED_IN;
-                        do_write(1);
+                        // Trust token was provided but invalid, and no OTP to fall back to
+                        sendLoginResult(login_result::LOGIN_ERROR_TRUST_TOKEN_INVALID);
                         return;
                     }
-                    */
 
-                    // Success
-                    unsigned char hash[16];
-                    uint32        hashData = earth_time::timestamp() ^ getpid();
-                    md5(reinterpret_cast<uint8*>(&hashData), hash, sizeof(hashData));
-
-                    json loginSuccessReply;
-                    loginSuccessReply["result"]       = static_cast<uint8>(login_result::LOGIN_SUCCESS);
-                    loginSuccessReply["account_id"]   = accountID;
-                    loginSuccessReply["session_hash"] = hash; // This has to be sent as an array, json.dump() tries to convert to UTF which fails
-
-                    sendJsonAsBuffer(loginSuccessReply);
-
-                    auto& session          = loginHelpers::get_authenticated_session(ipAddress, asStringFromUntrustedSource(hash, sizeof(hash)));
-                    session.accountID      = accountID;
-                    session.authorizedTime = timer::now();
+                    if (!otpHelpers::validateTOTP(otp, otpHelpers::getAccountSecret(username, "TOTP")))
+                    {
+                        sendLoginResult(login_result::LOGIN_ERROR);
+                        return;
+                    }
                 }
-                else if (status & ACCOUNT_STATUS_CODE::BANNED)
-                {
-                    sendLoginResult(login_result::LOGIN_FAIL, 33);
-                }
+
+                otpVerified = true;
             }
-            else // No account match
+
+            db::preparedStmt("UPDATE accounts SET accounts.timelastmodify = NULL WHERE accounts.id = ?", accountID);
+
+            const auto payload = ipc::toBytesWithHeader(ipc::AccountLogin{
+                .accountId = accountID,
+            });
+
+            zmqDealerWrapper_.outgoingQueue_.enqueue(zmq::message_t(payload.data(), payload.size()));
+
+            // set Satchel to the same size as inventory on all chars on their account if character has OTP
+            // Note: Upgrades happen in-game with gobbiebag
+            if (otpVerified)
             {
-                sendLoginResult(login_result::LOGIN_FAIL, 1);
+                db::preparedStmt("UPDATE char_storage a JOIN char_storage b ON a.charid = b.charid "
+                                 "SET a.satchel = b.inventory "
+                                 "WHERE a.charid IN (SELECT charid FROM chars WHERE accid = ?)",
+                                 accountID);
             }
+            // TODO: Lock out same account logging in multiple times. Can check data/view session existence on same IP/account?
+            // Not a real problem because the account is locked out when a character is logged in.
+
+            /*
+            const auto rset = db::preparedStmt("SELECT charid "
+                    "FROM accounts_sessions "
+                    "WHERE accid = ? LIMIT 1", accountID);
+            if (rset && rset->rowsCount() != 0 && rset->next())
+            {
+                // TODO: kick player out of map server if already logged in
+                // uint32 charid = rset->get<uint32>("charid");
+
+                // This error message doesn't work when sent this way. Unknown how to transmit "1039" error message to a client already logged in.
+                // session_t& authenticatedSession = get_authenticated_session(socket_, session.sentAccountID);
+                // if (auto data = authenticatedSession.buffer_.data()session)
+                // {
+                //  generateErrorMessage(data->buffer_.data(), 139);
+                //  data->do_write(0x24);
+                //  return;
+                //}
+                ref<uint8>(buffer_.data(), 0) = LOGIN_ERROR_ALREADY_LOGGED_IN;
+                do_write(1);
+                return;
+            }
+            */
+
+            // Success
+            unsigned char hash[16];
+            uint32        hashData = earth_time::timestamp() ^ getpid();
+            md5(reinterpret_cast<uint8*>(&hashData), hash, sizeof(hashData));
+
+            json loginSuccessReply;
+            loginSuccessReply["result"]       = static_cast<uint8>(login_result::LOGIN_SUCCESS);
+            loginSuccessReply["account_id"]   = accountID;
+            loginSuccessReply["session_hash"] = hash; // This has to be sent as an array, json.dump() tries to convert to UTF which fails
+
+            if (trust_this_computer && otpVerified)
+            {
+                try
+                {
+                    auto newToken = otpHelpers::generateTrustToken();
+                    otpHelpers::saveTrustToken(accountID, newToken);
+                    loginSuccessReply["trust_token"] = newToken;
+                }
+                catch (const std::runtime_error& e)
+                {
+                    ShowError(fmt::format("Failed to generate trust token: {}", e.what()));
+                }
+            }
+
+            sendJsonAsBuffer(loginSuccessReply);
+
+            auto& session          = loginHelpers::get_authenticated_session(ipAddress, asStringFromUntrustedSource(hash, sizeof(hash)));
+            session.accountID      = accountID;
+            session.authorizedTime = timer::now();
         }
         break;
         case login_cmd::LOGIN_CREATE:
@@ -295,7 +326,7 @@ void auth_session::read_func()
             {
                 ShowWarningFmt("login_parse: New account attempt <{}> but is disabled in settings.",
                                username);
-                sendLoginResult(login_result::LOGIN_ERROR_CREATE_DISABLED, 1);
+                sendLoginResult(login_result::LOGIN_ERROR_CREATE_DISABLED);
                 return;
             }
 
@@ -303,7 +334,7 @@ void auth_session::read_func()
             const auto rset = db::preparedStmt("SELECT accounts.id FROM accounts WHERE accounts.login = ?", username);
             if (!rset)
             {
-                sendLoginResult(login_result::LOGIN_ERROR_CREATE, 1);
+                sendLoginResult(login_result::LOGIN_ERROR_CREATE);
                 return;
             }
 
@@ -319,7 +350,7 @@ void auth_session::read_func()
                 }
                 else
                 {
-                    sendLoginResult(login_result::LOGIN_ERROR_CREATE, 1);
+                    sendLoginResult(login_result::LOGIN_ERROR_CREATE);
                     return;
                 }
 
@@ -343,16 +374,16 @@ void auth_session::read_func()
 
                 if (!rset2)
                 {
-                    sendLoginResult(login_result::LOGIN_ERROR_CREATE, 1);
+                    sendLoginResult(login_result::LOGIN_ERROR_CREATE);
                     return;
                 }
 
-                sendLoginResult(login_result::LOGIN_SUCCESS_CREATE, 1);
+                sendLoginResult(login_result::LOGIN_SUCCESS_CREATE);
                 return;
             }
             else
             {
-                sendLoginResult(login_result::LOGIN_ERROR_CREATE_TAKEN, 1);
+                sendLoginResult(login_result::LOGIN_ERROR_CREATE_TAKEN);
                 return;
             }
             break;
@@ -360,44 +391,29 @@ void auth_session::read_func()
         case login_cmd::LOGIN_CHANGE_PASSWORD:
         {
             // Look up and validate account password
-            if (!validatePassword(username, password))
+            auto accountInfo = validatePassword(username, password);
+            if (!accountInfo)
             {
-                sendLoginResult(login_result::LOGIN_ERROR_CHANGE_PASSWORD, 1);
+                sendLoginResult(login_result::LOGIN_ERROR_CHANGE_PASSWORD);
                 return;
             }
+
+            auto [accid, status] = *accountInfo;
 
             if (otpHelpers::doesAccountNeedOTP(username, "TOTP"))
             {
                 if (!otpHelpers::validateTOTP(otp, otpHelpers::getAccountSecret(username, "TOTP")))
                 {
-                    sendLoginResult(login_result::LOGIN_ERROR_CHANGE_PASSWORD, 1);
+                    sendLoginResult(login_result::LOGIN_ERROR_CHANGE_PASSWORD);
                     return;
                 }
             }
-
-            // Is this check redundant?
-            const auto rset = db::preparedStmt("SELECT accounts.id, accounts.status "
-                                               "FROM accounts "
-                                               "WHERE accounts.login = ?",
-                                               username);
-            if (rset == nullptr || rset->rowsCount() == 0)
-            {
-                ShowWarningFmt("login_parse: user <{}> could not be found using the provided information. Aborting.", username);
-
-                sendLoginResult(login_result::LOGIN_ERROR, 1);
-                return;
-            }
-
-            rset->next();
-
-            uint32 accid  = rset->get<uint32>("id");
-            uint8  status = rset->get<uint8>("status");
 
             if (status & ACCOUNT_STATUS_CODE::BANNED)
             {
                 ShowInfoFmt("login_parse: banned user <{}> detected. Aborting.", username);
 
-                sendLoginResult(login_result::LOGIN_ERROR_CHANGE_PASSWORD, 1);
+                sendLoginResult(login_result::LOGIN_ERROR_CHANGE_PASSWORD);
             }
 
             if (status & ACCOUNT_STATUS_CODE::NORMAL)
@@ -406,7 +422,7 @@ void auth_session::read_func()
                 if (updated_password == "")
                 {
                     ShowWarningFmt("login_parse: Empty password: Could not update password for user <{}>.", username);
-                    sendLoginResult(login_result::LOGIN_ERROR_CHANGE_PASSWORD, 1);
+                    sendLoginResult(login_result::LOGIN_ERROR_CHANGE_PASSWORD);
                     return;
                 }
 
@@ -420,9 +436,11 @@ void auth_session::read_func()
                 if (!rset2)
                 {
                     ShowWarningFmt("login_parse: Error trying to update password in database for user <{}>.", username);
-                    sendLoginResult(login_result::LOGIN_ERROR_CHANGE_PASSWORD, 1);
+                    sendLoginResult(login_result::LOGIN_ERROR_CHANGE_PASSWORD);
                     return;
                 }
+
+                otpHelpers::removeAllTrustTokens(accid);
 
                 json loginErrorChangePasswordReply;
                 loginErrorChangePasswordReply["result"]       = login_result::LOGIN_SUCCESS_CHANGE_PASSWORD;
@@ -481,7 +499,10 @@ void auth_session::read_func()
             if (otpHelpers::validateTOTP(otp, secret) || strcmpi(otp.c_str(), recoveryCode.c_str()) == 0)
             {
                 // validated
-                const auto rset = db::preparedStmt("DELETE FROM accounts_totp WHERE accounts_totp.accid = ? LIMIT 1", loginHelpers::getAccountId(username));
+                uint32     accid = loginHelpers::getAccountId(username);
+                const auto rset  = db::preparedStmt("DELETE FROM accounts_totp WHERE accounts_totp.accid = ? LIMIT 1", accid);
+
+                otpHelpers::removeAllTrustTokens(accid);
 
                 json sendSuccess;
                 sendSuccess["result"] = login_result::LOGIN_SUCCESS_REMOVE_TOTP;
@@ -578,13 +599,18 @@ void auth_session::do_write(std::size_t length)
         });
 }
 
-bool auth_session::validatePassword(std::string username, std::string password)
+std::optional<std::pair<uint32, uint32>> auth_session::validatePassword(std::string username, std::string password)
 {
+    uint32 accountID = 0;
+    uint32 status    = 0;
+
     auto passHash = [&]() -> std::string
     {
-        const auto rset = db::preparedStmt("SELECT accounts.password FROM accounts WHERE accounts.login = ?", username);
+        const auto rset = db::preparedStmt("SELECT accounts.id, accounts.status, accounts.password FROM accounts WHERE accounts.login = ?", username);
         if (rset && rset->rowsCount() != 0 && rset->next())
         {
+            accountID = rset->get<uint32>("id");
+            status    = rset->get<uint32>("status");
             return rset->get<std::string>("password");
         }
         return "";
@@ -595,7 +621,7 @@ bool auth_session::validatePassword(std::string username, std::string password)
         // It's a BCrypt hash, so we can validate it.
         if (!BCrypt::validatePassword(password, passHash))
         {
-            return false;
+            return std::nullopt;
         }
     }
     else
@@ -607,16 +633,16 @@ bool auth_session::validatePassword(std::string username, std::string password)
         {
             if (rset->get<std::string>(0) != passHash)
             {
-                return false;
+                return std::nullopt;
             }
 
             passHash = BCrypt::generateHash(password);
             db::preparedStmt("UPDATE accounts SET accounts.password = ? WHERE accounts.login = ?", passHash, username);
             if (!BCrypt::validatePassword(password, passHash))
             {
-                return false;
+                return std::nullopt;
             }
         }
     }
-    return true;
+    return std::make_pair(accountID, status);
 }

--- a/src/login/auth_session.h
+++ b/src/login/auth_session.h
@@ -62,6 +62,7 @@ enum class login_result : uint8_t
     LOGIN_SUCCESS_CREATE_TOTP       = 0x10,
     LOGIN_SUCCESS_VERIFY_TOTP       = 0x11,
     LOGIN_SUCCESS_REMOVE_TOTP       = 0x12,
+    LOGIN_ERROR_TRUST_TOKEN_INVALID = 0x13,
 };
 
 constexpr std::array<uint8, 3> SupportedXiloaderVersion = { 2, 0, 0 };
@@ -136,5 +137,5 @@ protected:
 private:
     ZMQDealerWrapper& zmqDealerWrapper_;
 
-    bool validatePassword(std::string username, std::string password);
+    std::optional<std::pair<uint32, uint32>> validatePassword(std::string username, std::string password);
 };

--- a/src/login/otp_helpers.h
+++ b/src/login/otp_helpers.h
@@ -23,6 +23,7 @@
 #include <cctype>
 #include <chrono>
 #include <openssl/hmac.h>
+#include <openssl/rand.h>
 #include <openssl/sha.h>
 #include <stdexcept>
 #include <string>
@@ -158,11 +159,10 @@ inline std::string getNewBase32Secret()
     return newSecret;
 }
 
-inline bool doesAccountNeedOTP(const std::string& account, const std::string& secretType)
+inline bool doesAccountNeedOTP(uint32 accid, const std::string& secretType)
 {
     if (secretType == "TOTP")
     {
-        const auto accid = loginHelpers::getAccountId(account);
         if (accid != 0)
         {
             const auto rset = db::preparedStmt("SELECT validated FROM accounts_totp where accid = ?", accid);
@@ -182,6 +182,11 @@ inline bool doesAccountNeedOTP(const std::string& account, const std::string& se
         }
     }
     return false;
+}
+
+inline bool doesAccountNeedOTP(const std::string& account, const std::string& secretType)
+{
+    return doesAccountNeedOTP(loginHelpers::getAccountId(account), secretType);
 }
 
 inline std::string createAccountSecret(const std::string& account, const std::string& secretType)
@@ -268,6 +273,85 @@ inline std::string getAccountRecoveryCode(const std::string& account, const std:
         }
     }
     return "";
+}
+
+inline std::string toHexString(const unsigned char* data, size_t len)
+{
+    static const char hexChars[] = "0123456789abcdef";
+    std::string       result;
+    result.reserve(len * 2);
+    for (size_t i = 0; i < len; ++i)
+    {
+        result += hexChars[(data[i] >> 4) & 0x0F];
+        result += hexChars[data[i] & 0x0F];
+    }
+    return result;
+}
+
+inline bool isValidTrustTokenFormat(const std::string& token)
+{
+    if (token.size() != 64)
+    {
+        return false;
+    }
+    for (char c : token)
+    {
+        if (!std::isxdigit(static_cast<unsigned char>(c)))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+inline std::string hashTrustToken(const std::string& token)
+{
+    unsigned char hash[SHA256_DIGEST_LENGTH];
+    SHA256(reinterpret_cast<const unsigned char*>(token.data()), token.size(), hash);
+    return toHexString(hash, SHA256_DIGEST_LENGTH);
+}
+
+inline std::string generateTrustToken()
+{
+    unsigned char bytes[32];
+    if (RAND_bytes(bytes, sizeof(bytes)) != 1)
+    {
+        throw std::runtime_error("Failed to generate random bytes for trust token");
+    }
+    return toHexString(bytes, sizeof(bytes));
+}
+
+inline void saveTrustToken(uint32 accid, const std::string& token)
+{
+    // Delete expired tokens for this account first
+    db::preparedStmt("DELETE FROM accounts_trust_tokens WHERE accid = ? AND expires <= NOW()", accid);
+
+    // Insert new token with 30 day expiry (store hashed)
+    db::preparedStmt("INSERT INTO accounts_trust_tokens (token, accid, expires) VALUES (?, ?, DATE_ADD(NOW(), INTERVAL 30 DAY))", hashTrustToken(token), accid);
+}
+
+inline bool validateTrustToken(uint32 accid, const std::string& token)
+{
+    if (!isValidTrustTokenFormat(token))
+    {
+        return false;
+    }
+
+    // Delete expired tokens for this account
+    db::preparedStmt("DELETE FROM accounts_trust_tokens WHERE accid = ? AND expires <= NOW()", accid);
+
+    // Check for valid token (compare hashed)
+    const auto rset = db::preparedStmt("SELECT token FROM accounts_trust_tokens WHERE token = ? AND accid = ? AND expires > NOW()", hashTrustToken(token), accid);
+    if (rset && rset->rowsCount() != 0 && rset->next())
+    {
+        return true;
+    }
+    return false;
+}
+
+inline void removeAllTrustTokens(uint32 accid)
+{
+    db::preparedStmt("DELETE FROM accounts_trust_tokens WHERE accid = ?", accid);
 }
 
 } // namespace otpHelpers


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

## Summary

When a user has TOTP enabled, they currently have to enter a one-time code on every login. This adds trust tokens so a client can send `"trust_this_computer": true` along with a valid OTP login, receive back a `trust_token` in the response, and use that token on future logins to skip the OTP prompt for 30 days (server configurable). 

### What changed

**`sql/accounts_trust_tokens.sql`** - New table storing hashed trust tokens per account with an expiration timestamp. Foreign key on `accid` with `ON DELETE CASCADE`.

**`src/login/otp_helpers.h`** - New helper functions:
- `generateTrustToken()` - 32 random bytes via OpenSSL `RAND_bytes`, returned as hex
- `hashTrustToken()` - SHA-256 hash before storing (raw token never hits the DB)
- `saveTrustToken()` - cleans expired tokens for the account, inserts new one with 30-day expiry
- `validateTrustToken()` - cleans expired tokens, checks if hashed token exists for the account
- `removeAllTrustTokens()` - wipes all tokens for an account (called on password change and TOTP removal)
- New `doesAccountNeedOTP(uint32 accid, ...)` overload that takes an account ID directly instead of looking it up by username again

**`src/login/auth_session.cpp`** - Login flow changes:
- `validatePassword()` now returns `std::optional<std::pair<uint32, uint32>>` (account ID + status) instead of `bool`, eliminating a redundant second DB query that fetched the same info
- Login attempt reads `trust_token` and `trust_this_computer` from the JSON payload
- OTP check tries the trust token first; falls back to the actual TOTP code if the token is missing or invalid
- On successful login with `trust_this_computer == true` and a verified OTP, a new trust token is generated and returned in the response JSON
- Password change and TOTP removal both call `removeAllTrustTokens()` to invalidate all trusted devices
- `sendLoginResult` no longer takes an unused `len` parameter

**`src/login/auth_session.h`** - Signature change for `validatePassword`.

### Security notes
- Tokens are 256-bit random, stored as SHA-256 hashes (the raw token only lives client-side)
- Expired tokens are cleaned up on every validate/save call
- All tokens are revoked when the password changes or TOTP is removed
- 30-day expiry

## Dependencies

https://github.com/LandSandBoat/xiloader/pull/46

## Steps to test these changes


**Prerequisites:** A running LSB server with the `accounts_trust_tokens` table created, and an account with TOTP enabled.

- [x] **Normal TOTP login still works** - Log in with username, password, and a valid TOTP code without sending `trust_this_computer`. Login succeeds and no `trust_token` is in the response.
- [x] **Trust token generation** - Log in with username, password, valid TOTP code, and `"trust_this_computer": true`. Login succeeds and response JSON contains a `trust_token` (64 hex chars). A row exists in `accounts_trust_tokens` with `expires` ~30 days out.
- [x] **Trust token login (skip OTP)** - Log in with username, password, and the `trust_token` from above, no OTP code. Login succeeds.
- [x] **Invalid trust token failure** - Bogus `trust_token` fails.
- [x] **Expired trust token** - when trust token expires the normal untrusted flow is shown
- [x] **Password change revokes all trust tokens** - Generate and verify a trust token works, then change the password. Old trust token should no longer work (row gone from DB).
- [x] **TOTP removal revokes all trust tokens** - Generate and verify a trust token works, then remove TOTP (via OTP or recovery code). `accounts_trust_tokens` should be empty for that account.
- [x] **Account without TOTP unaffected** - Log in with an account that has no TOTP. Works as before, no trust token logic involved.
- [x] **Satchel upgrade works with trust token login** - `otpVerified` is set `true` when the account requires OTP regardless of whether the user authenticated via trust token or direct TOTP code. Confirm satchel size query still runs.

## Screenshots of xiloader

## New [ ] Trust this computer option

<img width="1111" height="627" alt="image" src="https://github.com/user-attachments/assets/23738967-4753-4f9f-8509-2f66c5335f03" />

## Successful login with trust, shows message specifying how long it is trusted for (server specific, falls back to 30 days)

<img width="1107" height="301" alt="image" src="https://github.com/user-attachments/assets/99f13e6e-7aa7-474c-a06f-c5e73c4e97e7" />

## Example of a trusted computer (Dynamically updates when username changes)

<img width="1106" height="284" alt="image" src="https://github.com/user-attachments/assets/2ff2a237-8a16-415d-965e-caeea0373cfe" />

## Bogus token auto revoke

<img width="1107" height="235" alt="image" src="https://github.com/user-attachments/assets/e2b79847-96cc-48b8-b17c-53dc27dc065d" />

## Revoke Trust option

<img width="1112" height="626" alt="image" src="https://github.com/user-attachments/assets/b09d59f1-8e7f-4462-8e86-2c8cda149ae1" />
