### PR TITLE
[lua] KS99 Early Bird Catches the Wyrm Draw-in fix

### DIFF
--- a/scripts/zones/Balgas_Dais/mobs/Wyrm.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Wyrm.lua
@@ -66,11 +66,6 @@ local arenaCenters =
 -- Draw In Handler
 -----------------------------------
 local function handleDrawIn(mob, target, battlefield)
-    -- Early return: Distance from target check.
-    if mob:checkDistance(target) < 19.5 then
-        return
-    end
-
     -- Early return: No battlefield.
     if not battlefield then
         return
@@ -82,8 +77,11 @@ local function handleDrawIn(mob, target, battlefield)
         return
     end
 
-    -- Early return: Distance from center check.
-    if target:checkDistance(center.x, center.y, center.z) <= 22 then
+    -- Early return: Distance from center check & distance from target check.
+    if
+        target:checkDistance(center.x, center.y, center.z) <= 22 and
+        mob:checkDistance(target) < 19.5
+    then
         return
     end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The KS99 Wyrm Draw-in logic had an early return for mob distance that would prevent the arena draw-in from triggering as long as you kept the mob close. Changes the seperate returns to a combined and condition so that draw in will trigger if either condition is met.

## Steps to test these changes

Try to pull Wyrm out of the arena in the ground phase, fail
