### PR TITLE
[chests] Battle Gloves and Electrum Ring rates

### DIFF
--- a/scripts/globals/treasure.lua
+++ b/scripts/globals/treasure.lua
@@ -1109,8 +1109,8 @@ local lootTable =
     {
         [treasureType.CHEST] =
         {
-            { xi.item.NONE,          710 }, -- Gil
-            { xi.item.ELECTRUM_RING, 210 }, -- Item
+            { xi.item.NONE,          470 }, -- Gil
+            { xi.item.ELECTRUM_RING, 450 }, -- Item
             { xi.item.AMETRINE,       10 },
             { xi.item.GARNET,         10 },
             { xi.item.GOSHENITE,      10 },
@@ -1355,8 +1355,8 @@ local lootTable =
     {
         [treasureType.CHEST] =
         {
-            { xi.item.NONE,          720 }, -- Gil
-            { xi.item.BATTLE_GLOVES, 220 }, -- Item
+            { xi.item.NONE,          540 }, -- Gil
+            { xi.item.BATTLE_GLOVES, 400 }, -- Item
             { xi.item.AMBER_STONE,    10 },
             { xi.item.AMETHYST,       10 },
             { xi.item.CLEAR_TOPAZ,    10 },


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adjusts the drop rate of Battle Gloves and Electrum Ring.

Based on fairly limited data from my chest sheet: https://docs.google.com/spreadsheets/d/1oNcSn9VXIjLECzBFp01qFuA-vgZP6YRcfe5mzJnjQ7E/edit?gid=0#gid=0

I obtained 35 Electrum rings out of 73 possible rolls.

I also obtained 21 Battle Gloves out of 56 possible rolls, which is fairly close to the reported wiki value out of 93 
<img width="87" height="31" alt="image" src="https://github.com/user-attachments/assets/c2ce4fb7-082b-4aa9-bdc4-98fb1b35c549" />


## Steps to test these changes

Pop KRT or Davoi chests and see a higher drop rate on items.
