### PR TITLE
Roc/Simurgh draw in adjustment

### DIFF
--- a/scripts/zones/Rolanberry_Fields/mobs/Simurgh.lua
+++ b/scripts/zones/Rolanberry_Fields/mobs/Simurgh.lua
@@ -93,7 +93,7 @@ entity.onMobFight = function(mob, target)
         position = mob:getPos(),
         offset = 5,
         degrees = 180,
-        wait = 3,
+        wait = 10,
     }
     utils.drawIn(target, drawInTable)
 end

--- a/scripts/zones/Sauromugue_Champaign/mobs/Roc.lua
+++ b/scripts/zones/Sauromugue_Champaign/mobs/Roc.lua
@@ -29,8 +29,6 @@ entity.spawnPoints =
     { x =  188.566, y = -1.168, z = -296.794 },
     { x =  215.711, y =  0.404, z = -312.421 },
     { x =  212.596, y = -0.216, z = -249.303 },
-    { x =  189.023, y =  0.348, z = -196.885 },
-    { x =  195.192, y = -0.067, z = -194.328 },
     { x =  199.956, y =  0.000, z = -278.615 },
     { x =  191.796, y =  0.263, z = -250.968 }
 }
@@ -61,9 +59,9 @@ entity.onMobFight = function(mob, target)
             target:checkDistance(mob) > mob:getMeleeRange(target),
         },
         position = mob:getPos(),
-        offset = 10,
+        offset = 5,
         degrees = 180,
-        wait = 15,
+        wait = 10,
     }
     utils.drawIn(target, drawInTable)
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adjusts the draw in parameters to more closely resemble retail while removing problematic spawn locations for Roc.

https://youtu.be/yn8U_HPFSGY
https://youtu.be/rs1ziSDYO-k

## Steps to test these changes

Bind Roc and Simurgh and observe a more retail accurate wait time and draw in position compared to retail.
