### PR TITLE
[lua] Quest NM Marquis Andrealphus Bug Fix

### DIFF
--- a/scripts/zones/Castle_Zvahl_Baileys/mobs/Marquis_Andrealphus.lua
+++ b/scripts/zones/Castle_Zvahl_Baileys/mobs/Marquis_Andrealphus.lua
@@ -11,22 +11,9 @@ local zvahlID = zones[xi.zone.CASTLE_ZVAHL_BAILEYS]
 local entity = {}
 
 local doSubstitute = function(mob, target)
-    local hpp = mob:getHPP()
-
     -- Interaction with pets/trusts is currently unknown, set to only activate if the target is a PC
-    if
-        hpp <= 66 and
-        target:isPC()
-    then
+    if target:isPC() then
         mob:useMobAbility(xi.mobSkill.SUBSTITUTE) -- Casts "Escape" on the currently tanking player
-        mob:setLocalVar('castEscape', 1)
-        mob:messageText(mob, zvahlID.text.BEGONE_FROM_THESE_HALLS)
-    elseif
-        hpp <= 33 and
-        target:isPC()
-    then
-        mob:useMobAbility(xi.mobSkill.SUBSTITUTE) -- Casts "Escape" on the currently tanking player
-        mob:setLocalVar('castEscape', 2)
         mob:messageText(mob, zvahlID.text.BEGONE_FROM_THESE_HALLS)
     end
 end
@@ -55,14 +42,16 @@ entity.onMobFight = function(mob, target)
 
     -- When the NM's health hits ~66% and ~33% it will attempt to cast escape on whoever is currently tanking
     if
-        hpp <= 66 and
-        escapePlayer == 0
-    then
-        doSubstitute(mob, target)
-    elseif
         hpp <= 33 and
         escapePlayer < 2
     then
+        mob:setLocalVar('castEscape', 2)
+        doSubstitute(mob, target)
+    elseif
+        hpp <= 66 and
+        escapePlayer == 0
+    then
+        mob:setLocalVar('castEscape', 1)
         doSubstitute(mob, target)
     end
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Updates the mobs logic to fix a bug that caused it to spam trying to cast substitute if the player runs out of range.

## Steps to test these changes

Spawn the mob.
!hp 1000
Run away as it starts casting.
Observe that it does not endlessly spam the move anymore.
