### PR TITLE
[sql] Update quantity of items sold by Tenshodo guild

### DIFF
--- a/sql/guild_shops.sql
+++ b/sql/guild_shops.sql
@@ -52,7 +52,7 @@ INSERT INTO `guild_shops` VALUES (5132,699,4740,29072,60,33,36);   -- oak_log
 INSERT INTO `guild_shops` VALUES (5132,701,6615,40572,60,33,36);   -- rosewood_log
 INSERT INTO `guild_shops` VALUES (5132,700,9075,19844,60,33,36);   -- mahogany_log
 INSERT INTO `guild_shops` VALUES (5132,702,9600,45568,60,33,36);   -- ebony_log
-INSERT INTO `guild_shops` VALUES (5132,704,108,662,240,100,36);    -- bamboo_stick
+INSERT INTO `guild_shops` VALUES (5132,704,96,673,240,100,36);     -- bamboo_stick
 INSERT INTO `guild_shops` VALUES (5132,721,704,2465,240,0,0);      -- rattan_lumber
 INSERT INTO `guild_shops` VALUES (5132,705,3,18,240,48,36);        -- arrowwood_lumber
 INSERT INTO `guild_shops` VALUES (5132,706,27,165,240,48,36);      -- lauan_lumber
@@ -134,7 +134,7 @@ INSERT INTO `guild_shops` VALUES (5132,17216,187,354,60,0,0);      -- light_cros
 INSERT INTO `guild_shops` VALUES (5132,17218,10311,67100,60,0,0);  -- zamburak
 INSERT INTO `guild_shops` VALUES (5132,17280,1172,5250,60,0,0);    -- boomerang
 INSERT INTO `guild_shops` VALUES (5132,17318,6,18,240,48,50);      -- wooden_arrow
-INSERT INTO `guild_shops` VALUES (5132,17320,10,14,240,0,0);       -- iron_arrow
+INSERT INTO `guild_shops` VALUES (5132,17320,7,18,240,0,0);        -- iron_arrow
 INSERT INTO `guild_shops` VALUES (5132,17321,28,34,240,0,0);       -- silver_arrow
 
 -- Shih Tayuun (Bonecraft Guild) Windurst Woods (S)
@@ -217,7 +217,7 @@ INSERT INTO `guild_shops` VALUES (5152,825,480,2944,240,16,36);      -- square_o
 INSERT INTO `guild_shops` VALUES (5152,826,12840,12840,120,0,0);     -- square_of_linen_cloth
 INSERT INTO `guild_shops` VALUES (5152,827,9180,48384,120,0,0);      -- square_of_wool_cloth
 INSERT INTO `guild_shops` VALUES (5152,828,21851,31710,60,0,0);      -- square_of_velvet_cloth
--- INSERT INTO `guild_shops` VALUES (5152,829,21851,31710,240,0,0);     -- square_of_silk_cloth TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (5152,829,35070,102480,240,0,0);    -- square_of_silk_cloth
 -- INSERT INTO `guild_shops` VALUES (5152,830,21851,31710,240,0,0);     -- square_of_rainbow_cloth TODO: missing min_price and max_price
 -- INSERT INTO `guild_shops` VALUES (5152,847,26,192,240,0,0);        -- bird_feather TODO: missing min_price and max_price
 INSERT INTO `guild_shops` VALUES (5152,841,26,192,240,0,0);           -- yagudo_feather
@@ -296,7 +296,7 @@ INSERT INTO `guild_shops` VALUES (516,825,480,2944,240,16,36);       -- square_o
 INSERT INTO `guild_shops` VALUES (516,826,12840,12840,120,0,0);      -- square_of_linen_cloth
 INSERT INTO `guild_shops` VALUES (516,827,9180,48384,120,0,0);       -- square_of_wool_cloth
 INSERT INTO `guild_shops` VALUES (516,828,21851,31710,60,0,0);       -- square_of_velvet_cloth
--- INSERT INTO `guild_shops` VALUES (516,829,21851,31710,240,0,0);      -- square_of_silk_cloth TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (516,829,35070,102480,240,0,0);     -- square_of_silk_cloth
 -- INSERT INTO `guild_shops` VALUES (516,830,21851,31710,240,0,0);      -- square_of_rainbow_cloth TODO: missing min_price and max_price
 -- INSERT INTO `guild_shops` VALUES (516,847,26,192,240,0,0);        -- bird_feather TODO: missing min_price and max_price
 INSERT INTO `guild_shops` VALUES (516,841,26,192,240,0,0);           -- yagudo_feather
@@ -734,12 +734,12 @@ INSERT INTO `guild_shops` VALUES (5262,16403,102009,102009,60,0,0); -- poison_ka
 INSERT INTO `guild_shops` VALUES (5262,16581,33368,167872,60,0,0);  -- holy_sword
 -- INSERT INTO `guild_shops` VALUES (5262,16523,19148,19148,60,0,0);   -- holy_degen TODO: missing min_price and max_price
 INSERT INTO `guild_shops` VALUES (5262,17041,18000,24000,60,0,0);      -- holy_mace TODO: missing min_price and max_price
--- INSERT INTO `guild_shops` VALUES (5262,17322,19148,19148,240,0,0);  -- fire_arrow TODO: missing min_price and max_price
--- INSERT INTO `guild_shops` VALUES (5262,17323,19148,19148,240,0,0);  -- ice_arrow TODO: missing min_price and max_price
--- INSERT INTO `guild_shops` VALUES (5262,17324,19148,19148,240,0,0);  -- lightning_arrow TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (5262,17322,81,330,240,0,0);          -- fire_arrow
+INSERT INTO `guild_shops` VALUES (5262,17323,81,330,240,0,0);          -- ice_arrow
+INSERT INTO `guild_shops` VALUES (5262,17324,81,330,240,0,0);          -- lightning_arrow
 -- INSERT INTO `guild_shops` VALUES (5262,17343,392,392,240,0,0);      -- bronze_bullet TODO: missing min_price and max_price
-INSERT INTO `guild_shops` VALUES (5262,17340,392,392,240,0,0);      -- bullet
-INSERT INTO `guild_shops` VALUES (5262,17341,392,392,240,0,0);      -- silver_bullet
+INSERT INTO `guild_shops` VALUES (5262,17340,58,436,240,0,0);       -- bullet
+INSERT INTO `guild_shops` VALUES (5262,17341,1745,2480,240,0,0);    -- silver_bullet
 -- INSERT INTO `guild_shops` VALUES (5262,17313,392,392,240,0,0);      -- grenade TODO: missing min_price and max_price
 -- INSERT INTO `guild_shops` VALUES (5262,17315,392,392,240,0,0);      -- riot_grenade TODO: missing min_price and max_price
 INSERT INTO `guild_shops` VALUES (5262,18228,114,114,240,60,180);   -- battery
@@ -1067,9 +1067,9 @@ INSERT INTO `guild_shops` VALUES (530,4419,12390,14000,240,0,0);   -- bowl_of_mu
 INSERT INTO `guild_shops` VALUES (530,4420,13124,13230,240,0,0);   -- bowl_of_tomato_soup
 INSERT INTO `guild_shops` VALUES (530,4417,2475,15972,240,0,0);    -- bowl_of_egg_soup
 INSERT INTO `guild_shops` VALUES (530,4355,1946,5515,240,0,0);     -- salmon_sub_sandwich
-INSERT INTO `guild_shops` VALUES (530,1554,431,754,120,48,40);     -- onz_of_turmeric
-INSERT INTO `guild_shops` VALUES (530,1555,1061,1854,120,48,40);   -- onz_of_coriander
-INSERT INTO `guild_shops` VALUES (530,1590,536,992,60,48,19);      -- sprig_of_holy_basil
+INSERT INTO `guild_shops` VALUES (530,1554,431,1522,120,48,40);    -- onz_of_turmeric
+INSERT INTO `guild_shops` VALUES (530,1555,1061,5325,120,48,40);   -- onz_of_coriander
+INSERT INTO `guild_shops` VALUES (530,1590,536,5836,60,48,19);     -- sprig_of_holy_basil
 INSERT INTO `guild_shops` VALUES (530,1475,411,4985,240,0,0);      -- onz_of_curry_powder
 INSERT INTO `guild_shops` VALUES (530,1840,1500,2800,240,48,84);   -- bag_of_semolina
 INSERT INTO `guild_shops` VALUES (530,2110,457,530,200,48,150);    -- jar_of_fish_stock
@@ -1081,12 +1081,12 @@ INSERT INTO `guild_shops` VALUES (530,5684,1900,11661,240,12,144); -- wedge_of_c
 INSERT INTO `guild_shops` VALUES (531,641,30,66,240,48,180);       -- chunk_of_tin_ore
 INSERT INTO `guild_shops` VALUES (531,643,675,3825,240,33,144);    -- chunk_of_iron_ore
 INSERT INTO `guild_shops` VALUES (531,644,1500,9800,240,0,0);      -- chunk_of_mythril_ore
-INSERT INTO `guild_shops` VALUES (531,1155,2400,2400,240,0,0);     -- handful_of_iron_sand
+INSERT INTO `guild_shops` VALUES (531,1155,436,2400,240,0,0);      -- handful_of_iron_sand
 INSERT INTO `guild_shops` VALUES (531,649,115,349,240,33,36);      -- bronze_ingot
 INSERT INTO `guild_shops` VALUES (531,651,2700,13680,240,33,36);   -- iron_ingot
 INSERT INTO `guild_shops` VALUES (531,652,3517,25620,60,0,0);      -- steel_ingot
 INSERT INTO `guild_shops` VALUES (531,653,19900,36400,60,0,0);     -- mythril_ingot
-INSERT INTO `guild_shops` VALUES (531,657,4690,21000,60,0,0);      -- lump_of_tama_hagane
+INSERT INTO `guild_shops` VALUES (531,657,4690,30520,60,0,0);      -- lump_of_tama_hagane
 INSERT INTO `guild_shops` VALUES (531,660,61,423,240,33,36);       -- bronze_sheet
 INSERT INTO `guild_shops` VALUES (531,662,4050,20520,240,33,36);   -- iron_sheet
 INSERT INTO `guild_shops` VALUES (531,666,14868,39984,60,0,0);     -- steel_sheet
@@ -1260,33 +1260,33 @@ INSERT INTO `guild_shops` VALUES (534,696,330,2024,200,48,150); -- yew_log
 INSERT INTO `guild_shops` VALUES (534,695,120,736,200,48,150);  -- willow_log
 INSERT INTO `guild_shops` VALUES (534,693,640,3928,240,48,180); -- walnut_log
 
--- Akamafula (Lower Jeuno) Tenshodo Merchent
-INSERT INTO `guild_shops` VALUES (60417,16896,517,592,20,10,20);
-INSERT INTO `guild_shops` VALUES (60417,16900,1404,1608,20,7,15);
-INSERT INTO `guild_shops` VALUES (60417,16960,3121,3575,20,5,10);
-INSERT INTO `guild_shops` VALUES (60417,16974,224510,224510,20,1,3);
-INSERT INTO `guild_shops` VALUES (60417,16975,11583,13266,20,5,10);
-INSERT INTO `guild_shops` VALUES (60417,16966,1836,2103,20,10,20);
-INSERT INTO `guild_shops` VALUES (60417,16982,4752,15760,20,0,10);
-INSERT INTO `guild_shops` VALUES (60417,16987,12253,14033,20,5,10);
-INSERT INTO `guild_shops` VALUES (60417,17265,25372,25732,20,5,10);
-INSERT INTO `guild_shops` VALUES (60417,17301,29,87,2970,594,1188);
-INSERT INTO `guild_shops` VALUES (60417,12456,552,858,20,10,20);
-INSERT INTO `guild_shops` VALUES (60417,12457,3272,5079,20,7,15);
-INSERT INTO `guild_shops` VALUES (60417,12458,8972,13927,20,5,10);
-INSERT INTO `guild_shops` VALUES (60417,13111,20061,29942,20,5,10);
-INSERT INTO `guild_shops` VALUES (60417,12584,833,1294,20,10,20);
-INSERT INTO `guild_shops` VALUES (60417,12585,4931,7654,20,7,15);
-INSERT INTO `guild_shops` VALUES (60417,12586,13266,14850,20,5,10);
-INSERT INTO `guild_shops` VALUES (60417,12712,458,712,20,10,20);
-INSERT INTO `guild_shops` VALUES (60417,12713,2713,4212,20,7,15);
-INSERT INTO `guild_shops` VALUES (60417,12714,2713,8316,20,5,10);
-INSERT INTO `guild_shops` VALUES (60417,12840,666,1034,20,10,20);
-INSERT INTO `guild_shops` VALUES (60417,12841,2713,6133,20,7,15);
-INSERT INTO `guild_shops` VALUES (60417,12842,10805,12096,20,5,10);
-INSERT INTO `guild_shops` VALUES (60417,12968,424,660,20,10,20);
-INSERT INTO `guild_shops` VALUES (60417,12969,2528,3924,20,7,15);
-INSERT INTO `guild_shops` VALUES (60417,12970,11071,12393,20,5,10);
+-- Akamafula (Lower Jeuno) Tenshodo Merchent -- TODO: Audit and update Akamafula.lua. Converted from a guild merchant to a standard shop as of April 2018.
+INSERT INTO `guild_shops` VALUES (60417,16896,517,884,20,10,20);     -- kunai
+INSERT INTO `guild_shops` VALUES (60417,16900,1404,2160,20,7,15);    -- wakizashi
+INSERT INTO `guild_shops` VALUES (60417,16960,3121,3575,20,5,10);    -- uchigatana
+-- INSERT INTO `guild_shops` VALUES (60417,16974,224510,697840,60,0,0); -- dotanuki TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60417,16975,11583,19800,20,5,10);  -- kanesada
+INSERT INTO `guild_shops` VALUES (60417,16966,1836,2103,20,10,20);   -- tachi
+INSERT INTO `guild_shops` VALUES (60417,16982,4752,15760,20,0,10);   -- nodachi
+INSERT INTO `guild_shops` VALUES (60417,16987,12253,14033,20,5,10);  -- okanehira
+INSERT INTO `guild_shops` VALUES (60417,17265,14428,35251,20,5,10);  -- tanegashima
+INSERT INTO `guild_shops` VALUES (60417,17301,29,87,2970,594,1188);  -- shuriken
+INSERT INTO `guild_shops` VALUES (60417,12456,552,858,20,10,20);     -- hachimaki
+INSERT INTO `guild_shops` VALUES (60417,12457,3272,5079,20,7,15);    -- cotton_hachimaki
+INSERT INTO `guild_shops` VALUES (60417,12458,8972,13927,20,5,10);   -- soil_hachimaki
+INSERT INTO `guild_shops` VALUES (60417,13111,20061,29942,20,5,10);  -- nodowa
+INSERT INTO `guild_shops` VALUES (60417,12584,833,1294,20,10,20);    -- kenpogi
+INSERT INTO `guild_shops` VALUES (60417,12585,4931,7654,20,7,15);    -- cotton_dogi
+INSERT INTO `guild_shops` VALUES (60417,12586,13266,17820,20,5,10);  -- soil_gi
+INSERT INTO `guild_shops` VALUES (60417,12712,458,712,20,10,20);     -- tekko
+INSERT INTO `guild_shops` VALUES (60417,12713,2713,4212,20,7,15);    -- cotton_tekko
+INSERT INTO `guild_shops` VALUES (60417,12714,2713,9979,20,5,10);    -- soil_tekko
+INSERT INTO `guild_shops` VALUES (60417,12840,666,1034,20,10,20);    -- sitabaki
+INSERT INTO `guild_shops` VALUES (60417,12841,2713,6133,20,7,15);    -- cotton_sitabaki
+INSERT INTO `guild_shops` VALUES (60417,12842,10805,14515,20,5,10);  -- soil_sitabaki
+INSERT INTO `guild_shops` VALUES (60417,12968,424,660,20,10,20);     -- kyahan
+INSERT INTO `guild_shops` VALUES (60417,12969,2528,3924,20,7,15);    -- cotton_kyahan
+INSERT INTO `guild_shops` VALUES (60417,12970,11071,12393,20,5,10);  -- soil_kyahan
 
 -- Blabbivix (Port Bastok) / Gaudylox (Northern San dOria) / Scavnix (Windurst Walls) (Chip Vendors pseudo guild shop)
 INSERT INTO `guild_shops` VALUES (60418,474,21000,21000,255,255,255);
@@ -1299,125 +1299,275 @@ INSERT INTO `guild_shops` VALUES (60418,480,21000,21000,255,255,255);
 INSERT INTO `guild_shops` VALUES (60418,481,21000,21000,255,255,255);
 
 -- Jabbar (Port Bastok) Tenshodo Merchant
-INSERT INTO `guild_shops` VALUES (60419,704,96,149,255,48,100);
-INSERT INTO `guild_shops` VALUES (60419,657,4690,21000,165,33,65);
-INSERT INTO `guild_shops` VALUES (60419,4928,1561,1747,30,6,12);
-INSERT INTO `guild_shops` VALUES (60419,4934,1561,1747,30,6,12);
-INSERT INTO `guild_shops` VALUES (60419,4937,1561,1747,30,6,12);
-INSERT INTO `guild_shops` VALUES (60419,4943,1561,1747,30,6,12);
-INSERT INTO `guild_shops` VALUES (60419,4878,37800,41370,30,6,12);
-INSERT INTO `guild_shops` VALUES (60419,4879,14070,15750,30,6,12);
-INSERT INTO `guild_shops` VALUES (60419,4880,14070,15750,30,6,12);
-INSERT INTO `guild_shops` VALUES (60419,1554,431,512,255,48,100);
-INSERT INTO `guild_shops` VALUES (60419,1555,1061,1259,255,48,100);
-INSERT INTO `guild_shops` VALUES (60419,1590,536,700,255,48,100);
-INSERT INTO `guild_shops` VALUES (60419,1475,579,1188,255,48,100);
-INSERT INTO `guild_shops` VALUES (60419,4876,39270,41370,15,0,6);
-INSERT INTO `guild_shops` VALUES (60419,4877,39270,41370,15,0,6);
-INSERT INTO `guild_shops` VALUES (60419,1164,30,120,2970,0,1188);
-INSERT INTO `guild_shops` VALUES (60419,4874,39270,41370,15,0,6);
-INSERT INTO `guild_shops` VALUES (60419,5164,1945,2854,255,48,100);
-INSERT INTO `guild_shops` VALUES (60419,1652,233,250,255,48,100);
-INSERT INTO `guild_shops` VALUES (60419,5236,509,525,255,48,100);
+INSERT INTO `guild_shops` VALUES (60419,704,96,673,60,48,50);        -- bamboo_stick
+INSERT INTO `guild_shops` VALUES (60419,915,2700,16120,60,0,0);      -- jar_of_toad_oil
+INSERT INTO `guild_shops` VALUES (60419,1134,810,5140,60,0,0);       -- sheet_of_bast_parchment
+INSERT INTO `guild_shops` VALUES (60419,829,35070,102480,60,0,0);    -- square_of_silk_cloth
+INSERT INTO `guild_shops` VALUES (60419,657,4690,30520,60,33,15);    -- lump_of_tama_hagane
+INSERT INTO `guild_shops` VALUES (60419,1161,30,187,60,0,0);         -- uchitake
+INSERT INTO `guild_shops` VALUES (60419,1164,30,187,60,0,0);         -- tsurara
+INSERT INTO `guild_shops` VALUES (60419,1167,30,187,60,0,0);         -- kawahori_ogi
+INSERT INTO `guild_shops` VALUES (60419,1170,30,187,60,0,0);         -- makibishi
+INSERT INTO `guild_shops` VALUES (60419,1173,30,187,60,0,0);         -- hiraishin
+INSERT INTO `guild_shops` VALUES (60419,1176,30,187,60,0,0);         -- mizu_deppo
+-- INSERT INTO `guild_shops` VALUES (60419,1179,66,174,60,0,0);         -- shihei TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60419,1182,66,174,60,0,0);         -- jusatsu TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60419,1185,66,174,60,0,0);         -- kaginawa TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60419,1188,66,174,60,0,0);         -- sairui_ran TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60419,1191,66,174,60,0,0);         -- kodoku TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60419,1194,66,174,60,0,0);         -- shinobi_tabi TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60419,4928,1561,6713,60,5,19);     -- scroll_of_katon_ichi
+INSERT INTO `guild_shops` VALUES (60419,4931,1561,6713,60,0,0);      -- scroll_of_hyoton_ichi
+INSERT INTO `guild_shops` VALUES (60419,4934,1561,6713,60,5,19);     -- scroll_of_huton_ichi
+INSERT INTO `guild_shops` VALUES (60419,4937,1561,6713,60,5,19);     -- scroll_of_doton_ichi
+INSERT INTO `guild_shops` VALUES (60419,4940,1561,6713,60,0,0);      -- scroll_of_raiton_ichi
+INSERT INTO `guild_shops` VALUES (60419,4943,1561,6713,60,5,19);     -- scroll_of_suiton_ichi
+-- INSERT INTO `guild_shops` VALUES (60419,4946,8972,13927,60,0,0);     -- scroll_of_utsusemi_ichi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60419,4949,8972,13927,60,0,0);     -- scroll_of_jubaku_ichi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60419,4952,8972,13927,60,0,0);     -- scroll_of_hojo_ichi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60419,4955,8972,13927,60,0,0);     -- scroll_of_kurayami_ichi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60419,4958,8972,13927,60,0,0);     -- scroll_of_dokumori_ichi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60419,4961,8972,13927,60,0,0);     -- scroll_of_tonko_ichi TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60419,4874,14070,102480,60,0,0);   -- scroll_of_absorb_str
+INSERT INTO `guild_shops` VALUES (60419,4875,14070,102480,60,0,0);   -- scroll_of_absorb_dex
+INSERT INTO `guild_shops` VALUES (60419,4876,14070,102480,60,0,0);   -- scroll_of_absorb_vit
+INSERT INTO `guild_shops` VALUES (60419,4877,14070,102480,60,0,0);   -- scroll_of_absorb_agi
+INSERT INTO `guild_shops` VALUES (60419,4878,14070,102480,60,0,0);   -- scroll_of_absorb_int
+INSERT INTO `guild_shops` VALUES (60419,4879,14070,102480,60,5,18);  -- scroll_of_absorb_mnd
+INSERT INTO `guild_shops` VALUES (60419,4880,14070,102480,60,5,18);  -- scroll_of_absorb_chr
+INSERT INTO `guild_shops` VALUES (60419,1554,431,1522,60,48,50);     -- onz_of_turmeric
+INSERT INTO `guild_shops` VALUES (60419,1555,1061,5325,60,48,50);    -- onz_of_coriander
+INSERT INTO `guild_shops` VALUES (60419,1590,536,5836,60,48,50);     -- sprig_of_holy_basil
+INSERT INTO `guild_shops` VALUES (60419,1475,411,4985,30,7,25);      -- onz_of_curry_powder
+INSERT INTO `guild_shops` VALUES (60419,5164,1945,10899,150,20,110); -- jar_of_ground_wasabi
+INSERT INTO `guild_shops` VALUES (60419,1652,150,704,150,48,110);    -- bottle_of_rice_vinegar
+INSERT INTO `guild_shops` VALUES (60419,5236,198,525,150,48,120);    -- clump_of_shungiku
+-- INSERT INTO `guild_shops` VALUES (60419,4964,8972,13927,60,0,0);     -- scroll_of_monomi_ichi TODO: missing min_price and max_price
 
 -- Silver Owl (Port Bastok) Tenshodo Merchant
-INSERT INTO `guild_shops` VALUES (60420,16896,517,592,20,10,20);
-INSERT INTO `guild_shops` VALUES (60420,16919,2728,3125,20,7,15);
-INSERT INTO `guild_shops` VALUES (60420,16975,11583,13266,20,5,10);
-INSERT INTO `guild_shops` VALUES (60420,16988,14676,16808,20,7,15);
-INSERT INTO `guild_shops` VALUES (60420,12456,552,858,20,10,20);
-INSERT INTO `guild_shops` VALUES (60420,12457,3272,5079,20,7,15);
-INSERT INTO `guild_shops` VALUES (60420,13111,20061,29942,20,5,10);
-INSERT INTO `guild_shops` VALUES (60420,13088,43890,52440,20,1,3);
-INSERT INTO `guild_shops` VALUES (60420,12584,833,1294,20,10,20);
-INSERT INTO `guild_shops` VALUES (60420,12585,4931,7654,20,7,15);
-INSERT INTO `guild_shops` VALUES (60420,12712,458,712,20,10,20);
-INSERT INTO `guild_shops` VALUES (60420,12713,2713,4212,20,7,15);
-INSERT INTO `guild_shops` VALUES (60420,12840,666,1034,20,10,20);
-INSERT INTO `guild_shops` VALUES (60420,12968,424,660,20,10,20);
-INSERT INTO `guild_shops` VALUES (60420,12969,2528,3924,20,7,15);
-INSERT INTO `guild_shops` VALUES (60420,16405,104,225,20,0,20);
-INSERT INTO `guild_shops` VALUES (60420,17314,7333,7446,15,0,6);
+-- INSERT INTO `guild_shops` VALUES (60420,16405,104,225,30,0,0);       -- cat_baghnakhs TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60420,16407,14428,35251,30,0,0);   -- brass_baghnakhs TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60420,16406,14428,35251,30,0,0);   -- baghnakhs
+INSERT INTO `guild_shops` VALUES (60420,16411,11746,46986,30,0,0);   -- claws
+-- INSERT INTO `guild_shops` VALUES (60420,16412,14428,35251,30,0,0);   -- mythril_claws TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60420,16413,14428,35251,30,0,0);   -- darksteel_claws TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60420,16419,45760,168396,30,0,0);  -- patas
+-- INSERT INTO `guild_shops` VALUES (60420,16420,14428,35251,30,0,0);   -- bone_patas TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60420,16421,14428,35251,30,0,0);   -- gold_patas TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60420,16896,517,884,30,10,25);     -- kunai
+INSERT INTO `guild_shops` VALUES (60420,16917,4226,4840,30,0,0);     -- suzume
+-- INSERT INTO `guild_shops` VALUES (60420,16915,14428,35251,30,0,0);     -- hien TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60420,16897,14428,35251,30,0,0);     -- kageboshi TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60420,16900,1404,2160,30,0,0);     -- wakizashi
+INSERT INTO `guild_shops` VALUES (60420,16919,2728,17167,30,7,25);   -- shinobi_gatana
+-- INSERT INTO `guild_shops` VALUES (60420,16901,14428,35251,30,0,0);   -- kodachi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60420,16913,14428,35251,30,0,0);   -- shinogi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60420,16902,14428,35251,30,0,0);   -- sakurafubuki TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60420,16924,14428,35251,30,0,0);   -- hocho TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60420,16903,14428,35251,30,0,0);   -- kabutowari TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60420,16960,3121,3575,30,0,0);     -- uchigatana
+-- INSERT INTO `guild_shops` VALUES (60420,16974,224510,697840,30,0,0); -- dotanuki TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60420,16975,11583,19800,30,5,25);  -- kanesada
+-- INSERT INTO `guild_shops` VALUES (60420,16962,14428,35251,30,0,0);   -- ashura TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60420,16966,1836,2103,30,5,25);    -- tachi
+INSERT INTO `guild_shops` VALUES (60420,16982,4752,15760,30,0,0);    -- nodachi
+-- INSERT INTO `guild_shops` VALUES (60420,16984,14428,35251,30,0,0);    -- jindachi TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60420,16987,12253,14033,30,0,0);   -- okanehira
+INSERT INTO `guild_shops` VALUES (60420,16988,14676,62218,30,7,15);  -- kotetsu
+-- INSERT INTO `guild_shops` VALUES (60420,16973,14428,35251,30,0,0);   -- homura TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60420,16967,14428,35251,30,0,0);   -- mikazuki TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60420,16990,14428,35251,30,0,0);   -- daihannya TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60420,16991,14428,35251,30,0,0);   -- odenta TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60420,16970,14428,35251,30,0,0);   -- hosodachi TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60420,17802,189945,464059,30,0,0); -- kiku_ichimonji
+-- INSERT INTO `guild_shops` VALUES (60420,16964,14428,35251,30,0,0);   -- zanbato TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60420,16972,14428,35251,30,0,0);   -- kazaridachi TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60420,16871,183516,404395,30,0,0); -- kamayari
+-- INSERT INTO `guild_shops` VALUES (60420,16841,14428,35251,30,0,0);   -- wyvern_spear TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60420,17259,72144,158976,30,0,0);  -- pirates_gun
+INSERT INTO `guild_shops` VALUES (60420,17265,14428,35251,30,0,0);   -- tanegashima
+-- INSERT INTO `guild_shops` VALUES (60420,17267,14428,35251,30,0,0);   -- negoroshiki TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60420,17301,29,184,30,0,0);        -- shuriken
+INSERT INTO `guild_shops` VALUES (60420,17302,90,1190,30,0,0);       -- juji_shuriken
+INSERT INTO `guild_shops` VALUES (60420,17303,7333,10120,30,0,0);    -- manji_shuriken
+INSERT INTO `guild_shops` VALUES (60420,17304,1472,57960,30,0,0);    -- fuma_shuriken TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60420,17309,14428,35251,30,0,0);   -- pinwheel TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60420,17284,14428,35251,30,0,0);   -- chakram TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60420,17285,101745,220248,30,0,0); -- moonring_blade
+INSERT INTO `guild_shops` VALUES (60420,17314,3926,7446,30,0,0);     -- quake_grenade
+INSERT INTO `guild_shops` VALUES (60420,17320,7,18,30,0,0);          -- iron_arrow
+INSERT INTO `guild_shops` VALUES (60420,17322,81,330,30,0,0);        -- fire_arrow
+INSERT INTO `guild_shops` VALUES (60420,17340,58,436,30,0,0);        -- bullet
+INSERT INTO `guild_shops` VALUES (60420,12456,552,858,30,10,19);     -- hachimaki
+INSERT INTO `guild_shops` VALUES (60420,12457,3272,5079,30,7,19);    -- cotton_hachimaki
+INSERT INTO `guild_shops` VALUES (60420,12458,8972,13927,30,0,0);    -- soil_hachimaki
+-- INSERT INTO `guild_shops` VALUES (60420,12460,8972,13927,30,0,0);    -- shinobi_hachigane TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60420,12459,8972,13927,30,0,0);    -- zunari_kabuto TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60420,13111,20061,29942,30,0,0);   -- nodowa
+INSERT INTO `guild_shops` VALUES (60420,13088,43890,52440,30,0,0);   -- darksteel_nodowa
+INSERT INTO `guild_shops` VALUES (60420,12584,833,1294,30,10,19);    -- kenpogi
+INSERT INTO `guild_shops` VALUES (60420,12585,4931,7654,30,7,19);    -- cotton_dogi
+-- INSERT INTO `guild_shops` VALUES (60420,13728,8972,13927,30,0,0);    -- jujitsu_gi TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60420,12586,13266,17820,30,0,0);   -- soil_gi
+-- INSERT INTO `guild_shops` VALUES (60420,12588,8972,13927,30,0,0);    -- shinobi_gi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60420,12587,8972,13927,30,0,0);    -- hara_ate TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60420,12712,458,712,30,10,19);     -- tekko
+INSERT INTO `guild_shops` VALUES (60420,12713,2713,4212,30,7,19);    -- cotton_tekko
+INSERT INTO `guild_shops` VALUES (60420,12714,2713,9979,30,0,0);     -- soil_tekko
+-- INSERT INTO `guild_shops` VALUES (60420,12716,8972,13927,30,0,0);    -- shinobi_tekko TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60420,12715,8972,13927,30,0,0);    -- kote TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60420,12840,666,1034,30,10,19);    -- sitabaki
+INSERT INTO `guild_shops` VALUES (60420,12841,3951,6133,30,10,19);   -- cotton_sitabaki
+INSERT INTO `guild_shops` VALUES (60420,12842,10805,14515,30,0,0);   -- soil_sitabaki
+-- INSERT INTO `guild_shops` VALUES (60420,12844,8972,13927,30,0,0);    -- shinobi_hakama TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60420,12843,8972,13927,30,0,0);    -- haidate TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60420,12968,424,660,30,10,19);     -- kyahan
+INSERT INTO `guild_shops` VALUES (60420,12969,2528,3924,30,7,19);    -- cotton_kyahan
+INSERT INTO `guild_shops` VALUES (60420,12970,11071,14871,30,0,0);   -- soil_kyahan
+-- INSERT INTO `guild_shops` VALUES (60420,13204,8972,13927,30,0,0);    -- heko_obi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60420,13205,8972,13927,30,0,0);    -- silver_obi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60420,13206,8972,13927,30,0,0);    -- gold_obi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60420,13207,8972,13927,30,0,0);    -- brocade_obi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60420,13208,8972,13927,30,0,0);    -- rainbow_obi TODO: missing min_price and max_price
 
 -- Achika (Norg) Tenshodo Merchant
-INSERT INTO `guild_shops` VALUES (60421,12456,552,858,20,10,20);
-INSERT INTO `guild_shops` VALUES (60421,12457,3272,5079,20,7,15);
-INSERT INTO `guild_shops` VALUES (60421,12458,8972,13927,20,5,10);
-INSERT INTO `guild_shops` VALUES (60421,13111,20061,29942,20,5,10);
-INSERT INTO `guild_shops` VALUES (60421,13088,43890,52440,20,1,3);
-INSERT INTO `guild_shops` VALUES (60421,12584,833,1294,20,10,20);
-INSERT INTO `guild_shops` VALUES (60421,12585,4931,7654,20,7,15);
-INSERT INTO `guild_shops` VALUES (60421,12586,13266,14850,20,5,10);
-INSERT INTO `guild_shops` VALUES (60421,12712,458,712,20,10,20);
-INSERT INTO `guild_shops` VALUES (60421,12713,2713,4212,20,7,15);
-INSERT INTO `guild_shops` VALUES (60421,12714,2713,8316,20,5,10);
-INSERT INTO `guild_shops` VALUES (60421,12840,666,1034,20,10,20);
-INSERT INTO `guild_shops` VALUES (60421,12841,3951,6133,20,7,15);
-INSERT INTO `guild_shops` VALUES (60421,12842,10805,12096,20,5,10);
-INSERT INTO `guild_shops` VALUES (60421,12968,424,660,20,10,20);
-INSERT INTO `guild_shops` VALUES (60421,12969,2528,3924,20,7,15);
-INSERT INTO `guild_shops` VALUES (60421,12970,11071,12393,20,5,10);
+INSERT INTO `guild_shops` VALUES (60421,12456,552,858,60,10,36);    -- hachimaki
+INSERT INTO `guild_shops` VALUES (60421,12457,3272,5079,60,7,36);   -- cotton_hachimaki
+INSERT INTO `guild_shops` VALUES (60421,12458,8972,13927,60,5,36);  -- soil_hachimaki
+-- INSERT INTO `guild_shops` VALUES (60421,12460,8972,13927,60,0,0);   -- shinobi_hachigane TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60421,12459,8972,13927,60,0,0);   -- zunari_kabuto TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60421,13111,20061,29942,60,5,36); -- nodowa
+INSERT INTO `guild_shops` VALUES (60421,13088,43890,52440,60,0,0);  -- darksteel_nodowa
+INSERT INTO `guild_shops` VALUES (60421,12584,833,1294,60,10,36);   -- kenpogi
+INSERT INTO `guild_shops` VALUES (60421,12585,4931,7654,60,7,36);   -- cotton_dogi
+-- INSERT INTO `guild_shops` VALUES (60421,13728,8972,13927,60,0,0);   -- jujitsu_gi TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60421,12586,13266,17820,60,5,36); -- soil_gi
+-- INSERT INTO `guild_shops` VALUES (60421,12588,8972,13927,60,0,0);   -- shinobi_gi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60421,12587,8972,13927,60,0,0);   -- hara_ate TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60421,12712,458,712,60,10,36);    -- tekko
+INSERT INTO `guild_shops` VALUES (60421,12713,2713,4212,60,7,36);   -- cotton_tekko
+INSERT INTO `guild_shops` VALUES (60421,12714,2713,9979,60,5,36);   -- soil_tekko
+-- INSERT INTO `guild_shops` VALUES (60421,12716,8972,13927,60,0,0);   -- shinobi_tekko TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60421,12715,8972,13927,60,0,0);   -- kote TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60421,12840,666,1034,60,10,36);   -- sitabaki
+INSERT INTO `guild_shops` VALUES (60421,12841,3951,6133,60,7,36);   -- cotton_sitabaki
+INSERT INTO `guild_shops` VALUES (60421,12842,10805,14515,60,5,36); -- soil_sitabaki
+-- INSERT INTO `guild_shops` VALUES (60421,12844,8972,13927,60,0,0);   -- shinobi_hakama TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60421,12843,8972,13927,60,0,0);   -- haidate TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60421,12968,424,660,60,10,36);    -- kyahan
+INSERT INTO `guild_shops` VALUES (60421,12969,2528,3924,60,7,36);   -- cotton_kyahan
+INSERT INTO `guild_shops` VALUES (60421,12970,11071,14871,60,5,36); -- soil_kyahan
+-- INSERT INTO `guild_shops` VALUES (60421,13204,8972,13927,60,0,0);   -- heko_obi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60421,13205,8972,13927,60,0,0);   -- silver_obi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60421,13206,8972,13927,60,0,0);   -- gold_obi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60421,13207,8972,13927,60,0,0);   -- brocade_obi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60421,13208,8972,13927,60,0,0);   -- rainbow_obi TODO: missing min_price and max_price
 
 -- Chiyo (Norg) Tenshodo Merchant
-INSERT INTO `guild_shops` VALUES (60422,4876,39270,41370,15,3,6);
-INSERT INTO `guild_shops` VALUES (60422,4879,14070,15750,30,6,12);
-INSERT INTO `guild_shops` VALUES (60422,4880,14070,15750,30,6,12);
-INSERT INTO `guild_shops` VALUES (60422,4928,1561,1747,30,6,12);
-INSERT INTO `guild_shops` VALUES (60422,4931,1561,1747,30,6,12);
-INSERT INTO `guild_shops` VALUES (60422,4934,1561,1747,30,6,12);
-INSERT INTO `guild_shops` VALUES (60422,4937,1561,1747,30,6,12);
-INSERT INTO `guild_shops` VALUES (60422,4940,1561,1747,30,6,12);
-INSERT INTO `guild_shops` VALUES (60422,4943,1561,1747,30,6,12);
-INSERT INTO `guild_shops` VALUES (60422,4877,39270,41370,15,3,6);
-INSERT INTO `guild_shops` VALUES (60422,4878,37800,41370,30,6,12);
+INSERT INTO `guild_shops` VALUES (60422,4874,14070,102480,60,0,0);  -- scroll_of_absorb_str
+INSERT INTO `guild_shops` VALUES (60422,4875,14070,102480,60,0,0);  -- scroll_of_absorb_dex
+INSERT INTO `guild_shops` VALUES (60422,4876,14070,102480,60,0,0);  -- scroll_of_absorb_vit
+INSERT INTO `guild_shops` VALUES (60422,4877,14070,102480,60,0,0);  -- scroll_of_absorb_agi
+INSERT INTO `guild_shops` VALUES (60422,4878,14070,102480,60,0,0);  -- scroll_of_absorb_int
+INSERT INTO `guild_shops` VALUES (60422,4879,14070,102480,60,5,30); -- scroll_of_absorb_mnd
+INSERT INTO `guild_shops` VALUES (60422,4880,14070,102480,60,5,30); -- scroll_of_absorb_chr
+INSERT INTO `guild_shops` VALUES (60422,4928,1561,6713,60,5,30);    -- scroll_of_katon_ichi
+INSERT INTO `guild_shops` VALUES (60422,4931,1561,6713,60,5,30);    -- scroll_of_hyoton_ichi
+INSERT INTO `guild_shops` VALUES (60422,4934,1561,6713,60,5,30);    -- scroll_of_huton_ichi
+INSERT INTO `guild_shops` VALUES (60422,4937,1561,6713,60,5,30);    -- scroll_of_doton_ichi
+INSERT INTO `guild_shops` VALUES (60422,4940,1561,6713,60,5,30);    -- scroll_of_raiton_ichi
+INSERT INTO `guild_shops` VALUES (60422,4943,1561,6713,60,5,30);    -- scroll_of_suiton_ichi
+-- INSERT INTO `guild_shops` VALUES (60422,4946,8972,13927,60,0,0);    -- scroll_of_utsusemi_ichi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60422,4949,8972,13927,60,0,0);    -- scroll_of_jubaku_ichi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60422,4952,8972,13927,60,0,0);    -- scroll_of_hojo_ichi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60422,4955,8972,13927,60,0,0);    -- scroll_of_kurayami_ichi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60422,4958,8972,13927,60,0,0);    -- scroll_of_dokumori_ichi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60422,4961,8972,13927,60,0,0);    -- scroll_of_tonko_ichi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60422,4964,8972,13927,60,0,0);    -- scroll_of_monomi_ichi TODO: missing min_price and max_price
 
 -- Jirokichi (Norg) Tenshodo Merchant
-INSERT INTO `guild_shops` VALUES (60423,16406,14428,34214,20,5,10);
-INSERT INTO `guild_shops` VALUES (60423,16411,11746,21322,20,5,10);
-INSERT INTO `guild_shops` VALUES (60423,16419,45760,76416,20,5,10);
-INSERT INTO `guild_shops` VALUES (60423,16896,517,592,20,10,20);
-INSERT INTO `guild_shops` VALUES (60423,16917,4226,4226,20,7,15);
-INSERT INTO `guild_shops` VALUES (60423,16900,1404,1608,20,7,15);
-INSERT INTO `guild_shops` VALUES (60423,16919,2728,3125,20,7,15);
-INSERT INTO `guild_shops` VALUES (60423,16960,3121,3575,20,7,15);
-INSERT INTO `guild_shops` VALUES (60423,16975,11583,13266,20,5,10);
-INSERT INTO `guild_shops` VALUES (60423,16966,1836,2103,20,10,20);
-INSERT INTO `guild_shops` VALUES (60423,16982,4752,15760,20,5,10);
-INSERT INTO `guild_shops` VALUES (60423,16987,12253,14033,20,5,10);
-INSERT INTO `guild_shops` VALUES (60423,16988,14676,16808,20,5,10);
-INSERT INTO `guild_shops` VALUES (60423,17802,189945,464059,20,2,3);
-INSERT INTO `guild_shops` VALUES (60423,16871,183516,404395,20,2,3);
-INSERT INTO `guild_shops` VALUES (60423,17259,72144,158976,20,5,10);
-INSERT INTO `guild_shops` VALUES (60423,17301,29,87,2970,594,1188);
-INSERT INTO `guild_shops` VALUES (60423,17302,347,993,2970,594,1188);
-INSERT INTO `guild_shops` VALUES (60423,17303,7333,10120,2970,594,1188);
-INSERT INTO `guild_shops` VALUES (60423,17285,101745,101745,20,1,5);
-INSERT INTO `guild_shops` VALUES (60423,17314,7333,7446,15,3,6);
-INSERT INTO `guild_shops` VALUES (60423,17320,7,10,2970,594,1188);
-INSERT INTO `guild_shops` VALUES (60423,17322,81,187,2970,594,1188);
-INSERT INTO `guild_shops` VALUES (60423,17340,58,436,2970,594,1188);
+-- INSERT INTO `guild_shops` VALUES (60423,16405,104,225,60,0,0);        -- cat_baghnakhs TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60423,16407,14428,35251,60,0,0);    -- brass_baghnakhs TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60423,16406,14428,35251,60,5,10);   -- baghnakhs
+INSERT INTO `guild_shops` VALUES (60423,16411,11746,46986,60,5,10);   -- claws
+-- INSERT INTO `guild_shops` VALUES (60423,16412,14428,35251,60,0,0);    -- mythril_claws TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60423,16413,14428,35251,60,0,0);    -- darksteel_claws TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60423,16419,45760,168396,60,5,10);  -- patas
+-- INSERT INTO `guild_shops` VALUES (60423,16420,14428,35251,60,0,0);    -- bone_patas TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60423,16421,14428,35251,60,0,0);    -- gold_patas TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60423,16896,517,884,60,10,50);      -- kunai
+INSERT INTO `guild_shops` VALUES (60423,16917,4226,4840,60,7,50);     -- suzume
+-- INSERT INTO `guild_shops` VALUES (60423,16915,14428,35251,60,0,0);    -- hien TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60423,16897,14428,35251,60,0,0);    -- kageboshi TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60423,16900,1404,2160,60,7,50);     -- wakizashi
+INSERT INTO `guild_shops` VALUES (60423,16919,2728,17167,60,7,50);    -- shinobi_gatana
+-- INSERT INTO `guild_shops` VALUES (60423,16901,14428,35251,60,0,0);    -- kodachi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60423,16913,14428,35251,60,0,0);    -- shinogi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60423,16902,14428,35251,60,0,0);    -- sakurafubuki TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60423,16924,14428,35251,60,0,0);    -- hocho TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60423,16903,14428,35251,60,0,0);    -- kabutowari TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60423,16960,3121,3575,60,7,50);     -- uchigatana
+-- INSERT INTO `guild_shops` VALUES (60423,16974,224510,697840,60,0,0);  -- dotanuki TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60423,16975,11583,19800,60,5,30);   -- kanesada
+-- INSERT INTO `guild_shops` VALUES (60423,16962,14428,35251,60,0,0);    -- ashura TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60423,16966,1836,2103,60,10,50);    -- tachi
+INSERT INTO `guild_shops` VALUES (60423,16982,4752,15760,60,5,20);    -- nodachi
+-- INSERT INTO `guild_shops` VALUES (60423,16984,14428,35251,60,0,0);    -- jindachi TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60423,16987,12253,14033,60,5,19);   -- okanehira
+INSERT INTO `guild_shops` VALUES (60423,16988,14676,62218,60,5,19);   -- kotetsu
+-- INSERT INTO `guild_shops` VALUES (60423,16973,14428,35251,60,0,0);    -- homura TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60423,16967,14428,35251,60,0,0);    -- mikazuki TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60423,16990,14428,35251,60,0,0);    -- daihannya TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60423,16991,14428,35251,60,0,0);    -- odenta TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60423,16970,14428,35251,60,0,0);    -- hosodachi TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60423,17802,189945,464059,60,2,10); -- kiku_ichimonji
+-- INSERT INTO `guild_shops` VALUES (60423,16964,14428,35251,60,0,0);    -- zanbato TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60423,16972,14428,35251,60,0,0);    -- kazaridachi TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60423,16871,183516,404395,60,2,10); -- kamayari
+-- INSERT INTO `guild_shops` VALUES (60423,16841,14428,35251,60,0,0);    -- wyvern_spear TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60423,17259,72144,158976,60,5,10);  -- pirates_gun
+INSERT INTO `guild_shops` VALUES (60423,17265,14428,35251,60,0,0);    -- tanegashima
+-- INSERT INTO `guild_shops` VALUES (60423,17267,14428,35251,60,0,0);    -- negoroshiki TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60423,17301,29,184,60,10,40);       -- shuriken
+INSERT INTO `guild_shops` VALUES (60423,17302,52,1190,60,10,30);      -- juji_shuriken
+INSERT INTO `guild_shops` VALUES (60423,17303,7333,10120,60,0,0);     -- manji_shuriken
+INSERT INTO `guild_shops` VALUES (60423,17304,1472,57960,60,0,0);     -- fuma_shuriken TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60423,17309,14428,35251,60,0,0);    -- pinwheel TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60423,17284,14428,35251,60,0,0);    -- chakram TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60423,17285,101745,220248,60,0,0);  -- moonring_blade
+INSERT INTO `guild_shops` VALUES (60423,17314,3926,7446,60,0,0);      -- quake_grenade
+INSERT INTO `guild_shops` VALUES (60423,17320,7,18,60,10,20);         -- iron_arrow
+INSERT INTO `guild_shops` VALUES (60423,17322,81,330,60,10,20);       -- fire_arrow
+INSERT INTO `guild_shops` VALUES (60423,17340,58,436,60,10,10);       -- bullet
 
 -- Vuliaie (Norg) Tenshodo Merchant
-INSERT INTO `guild_shops` VALUES (60424,704,96,149,375,75,150);
-INSERT INTO `guild_shops` VALUES (60424,915,2700,16120,165,33,165);
-INSERT INTO `guild_shops` VALUES (60424,1134,810,2095,255,48,100);
-INSERT INTO `guild_shops` VALUES (60424,1155,436,645,165,33,165);
-INSERT INTO `guild_shops` VALUES (60424,657,4690,21000,165,33,65);
-INSERT INTO `guild_shops` VALUES (60424,1415,55147,55147,165,33,65);
-INSERT INTO `guild_shops` VALUES (60424,1161,66,174,2970,594,1188);
-INSERT INTO `guild_shops` VALUES (60424,1164,30,120,2970,594,1188);
-INSERT INTO `guild_shops` VALUES (60424,1167,58,107,2970,594,1188);
-INSERT INTO `guild_shops` VALUES (60424,1170,58,107,2970,594,1188);
-INSERT INTO `guild_shops` VALUES (60424,1173,56,174,2970,594,1188);
-INSERT INTO `guild_shops` VALUES (60424,1176,44,174,2970,594,1188);
-INSERT INTO `guild_shops` VALUES (60424,1472,369,369,255,48,100);
-INSERT INTO `guild_shops` VALUES (60424,1554,431,512,255,48,100);
-INSERT INTO `guild_shops` VALUES (60424,1555,1061,1259,255,48,100);
-INSERT INTO `guild_shops` VALUES (60424,1590,536,700,255,48,100);
-INSERT INTO `guild_shops` VALUES (60424,1475,579,1188,255,48,100);
-INSERT INTO `guild_shops` VALUES (60424,5164,1945,2854,255,48,100);
-INSERT INTO `guild_shops` VALUES (60424,1652,233,250,255,48,100);
-INSERT INTO `guild_shops` VALUES (60424,5235,1284,1350,255,48,100);
+INSERT INTO `guild_shops` VALUES (60424,704,96,673,240,75,50);       -- bamboo_stick
+INSERT INTO `guild_shops` VALUES (60424,915,2700,16120,60,33,18);    -- jar_of_toad_oil
+INSERT INTO `guild_shops` VALUES (60424,1134,810,5140,60,48,10);     -- sheet_of_bast_parchment
+INSERT INTO `guild_shops` VALUES (60424,829,35070,102480,60,0,0);    -- square_of_silk_cloth
+INSERT INTO `guild_shops` VALUES (60424,1155,436,2400,240,33,190);   -- handful_of_iron_sand
+INSERT INTO `guild_shops` VALUES (60424,657,4690,30520,120,33,80);   -- lump_of_tama_hagane
+INSERT INTO `guild_shops` VALUES (60424,1415,55147,232354,60,33,16); -- pot_of_urushi
+INSERT INTO `guild_shops` VALUES (60424,1161,30,187,240,10,80);      -- uchitake
+INSERT INTO `guild_shops` VALUES (60424,1164,30,187,240,10,80);      -- tsurara
+INSERT INTO `guild_shops` VALUES (60424,1167,30,187,240,10,80);      -- kawahori_ogi
+INSERT INTO `guild_shops` VALUES (60424,1170,30,187,240,10,80);      -- makibishi
+INSERT INTO `guild_shops` VALUES (60424,1173,30,187,240,10,80);      -- hiraishin
+INSERT INTO `guild_shops` VALUES (60424,1176,30,187,240,10,80);      -- mizu_deppo
+-- INSERT INTO `guild_shops` VALUES (60424,1179,66,174,60,0,0);      -- shihei TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60424,1182,66,174,60,0,0);      -- jusatsu TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60424,1185,66,174,60,0,0);      -- kaginawa TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60424,1188,66,174,60,0,0);      -- sairui_ran TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60424,1191,66,174,60,0,0);      -- kodoku TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60424,1194,66,174,60,0,0);      -- shinobi_tabi TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60424,1472,369,1476,200,48,150);   -- gardenia_seed
+INSERT INTO `guild_shops` VALUES (60424,1554,431,1522,240,48,170);   -- onz_of_turmeric
+INSERT INTO `guild_shops` VALUES (60424,1555,1061,5325,240,48,170);  -- onz_of_coriander
+INSERT INTO `guild_shops` VALUES (60424,1590,536,5836,240,48,170);   -- sprig_of_holy_basil
+INSERT INTO `guild_shops` VALUES (60424,1475,411,4985,120,48,110);   -- onz_of_curry_powder
+INSERT INTO `guild_shops` VALUES (60424,5164,1945,10899,200,48,150); -- jar_of_ground_wasabi
+INSERT INTO `guild_shops` VALUES (60424,1652,150,704,200,48,150);    -- bottle_of_rice_vinegar
+INSERT INTO `guild_shops` VALUES (60424,5235,187,1350,200,48,150);   -- head_of_napa
 
 -- Wahraga / Gathweeda (Alchemy Guild) Aht Urhgan Whitegate
 INSERT INTO `guild_shops` VALUES (60425,912,192,360,240,0,0);        -- beehive_chip
@@ -1488,12 +1638,12 @@ INSERT INTO `guild_shops` VALUES (60425,16403,102009,102009,60,0,0); -- poison_k
 INSERT INTO `guild_shops` VALUES (60425,16581,33368,167872,60,0,0);  -- holy_sword
 -- INSERT INTO `guild_shops` VALUES (60425,16523,19148,19148,60,0,0);   -- holy_degen TODO: missing min_price and max_price
 INSERT INTO `guild_shops` VALUES (60425,17041,18000,24000,60,0,0);      -- holy_mace TODO: missing min_price and max_price
--- INSERT INTO `guild_shops` VALUES (60425,17322,19148,19148,240,0,0);  -- fire_arrow TODO: missing min_price and max_price
--- INSERT INTO `guild_shops` VALUES (60425,17323,19148,19148,240,0,0);  -- ice_arrow TODO: missing min_price and max_price
--- INSERT INTO `guild_shops` VALUES (60425,17324,19148,19148,240,0,0);  -- lightning_arrow TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60425,17322,81,330,240,0,0);          -- fire_arrow
+INSERT INTO `guild_shops` VALUES (60425,17323,81,330,240,0,0);          -- ice_arrow
+INSERT INTO `guild_shops` VALUES (60425,17324,81,330,240,0,0);          -- lightning_arrow
 -- INSERT INTO `guild_shops` VALUES (60425,17343,392,392,240,0,0);      -- bronze_bullet TODO: missing min_price and max_price
-INSERT INTO `guild_shops` VALUES (60425,17340,392,392,240,0,0);      -- bullet
-INSERT INTO `guild_shops` VALUES (60425,17341,392,392,240,0,0);      -- silver_bullet
+INSERT INTO `guild_shops` VALUES (60425,17340,58,436,240,0,0);       -- bullet
+INSERT INTO `guild_shops` VALUES (60425,17341,1745,2480,240,0,0);    -- silver_bullet
 -- INSERT INTO `guild_shops` VALUES (60425,17313,392,392,240,0,0);      -- grenade TODO: missing min_price and max_price
 -- INSERT INTO `guild_shops` VALUES (60425,17315,392,392,240,0,0);      -- riot_grenade TODO: missing min_price and max_price
 INSERT INTO `guild_shops` VALUES (60425,2131,75,242,240,48,180);     -- triturator
@@ -1594,12 +1744,12 @@ INSERT INTO `guild_shops` VALUES (60427,640,9,36,240,48,180);        -- chunk_of
 INSERT INTO `guild_shops` VALUES (60427,641,30,66,240,48,180);       -- chunk_of_tin_ore
 INSERT INTO `guild_shops` VALUES (60427,643,675,3825,240,33,180);    -- chunk_of_iron_ore
 INSERT INTO `guild_shops` VALUES (60427,644,1500,9800,240,0,0);      -- chunk_of_mythril_ore
-INSERT INTO `guild_shops` VALUES (60427,1155,2400,2400,240,0,0);     -- handful_of_iron_sand
+INSERT INTO `guild_shops` VALUES (60427,1155,436,2400,240,0,0);      -- handful_of_iron_sand
 INSERT INTO `guild_shops` VALUES (60427,649,115,349,240,33,36);      -- bronze_ingot
 INSERT INTO `guild_shops` VALUES (60427,651,2700,13680,240,33,36);   -- iron_ingot
 INSERT INTO `guild_shops` VALUES (60427,652,3517,25620,60,0,0);      -- steel_ingot
 INSERT INTO `guild_shops` VALUES (60427,653,19900,36400,60,0,0);     -- mythril_ingot
-INSERT INTO `guild_shops` VALUES (60427,657,4690,21000,60,0,0);      -- lump_of_tama_hagane
+INSERT INTO `guild_shops` VALUES (60427,657,4690,30520,60,0,0);      -- lump_of_tama_hagane
 INSERT INTO `guild_shops` VALUES (60427,660,61,423,240,33,36);       -- bronze_sheet
 INSERT INTO `guild_shops` VALUES (60427,662,4050,20520,240,33,36);   -- iron_sheet
 INSERT INTO `guild_shops` VALUES (60427,666,14868,39984,60,0,0);     -- steel_sheet
@@ -1689,7 +1839,7 @@ INSERT INTO `guild_shops` VALUES (60428,700,9075,19844,60,33,36);   -- mahogany_
 INSERT INTO `guild_shops` VALUES (60428,702,9600,45568,60,33,36);   -- ebony_log
 -- INSERT INTO `guild_shops` VALUES (60428,727,704,2465,240,0,0);      -- dogwood_log TODO: missing min_price and max_price
 -- INSERT INTO `guild_shops` VALUES (60428,729,9600,45568,240,0,0);    -- bloodwood_log TODO: missing min_price and max_price
-INSERT INTO `guild_shops` VALUES (60428,704,108,662,240,100,36);    -- bamboo_stick
+INSERT INTO `guild_shops` VALUES (60428,704,96,673,240,100,36);     -- bamboo_stick
 INSERT INTO `guild_shops` VALUES (60428,721,704,2465,240,0,0);      -- rattan_lumber
 INSERT INTO `guild_shops` VALUES (60428,705,3,18,240,48,36);        -- arrowwood_lumber
 INSERT INTO `guild_shops` VALUES (60428,706,27,165,240,48,36);      -- lauan_lumber
@@ -1773,7 +1923,7 @@ INSERT INTO `guild_shops` VALUES (60428,17216,187,354,60,0,0);      -- light_cro
 INSERT INTO `guild_shops` VALUES (60428,17218,10311,67100,60,0,0);  -- zamburak
 INSERT INTO `guild_shops` VALUES (60428,17280,1172,5250,60,0,0);    -- boomerang
 INSERT INTO `guild_shops` VALUES (60428,17318,6,18,240,48,50);      -- wooden_arrow
-INSERT INTO `guild_shops` VALUES (60428,17320,10,14,240,0,0);       -- iron_arrow
+INSERT INTO `guild_shops` VALUES (60428,17320,7,18,240,0,0);        -- iron_arrow
 INSERT INTO `guild_shops` VALUES (60428,17321,28,34,240,0,0);       -- silver_arrow
 
 -- Bornahn (Goldsmithing Guild) Al Zahbi
@@ -1925,7 +2075,7 @@ INSERT INTO `guild_shops` VALUES (60430,825,480,640,240,16,32);     -- sqaure_of
 INSERT INTO `guild_shops` VALUES (60430,826,12840,12840,120,0,0);   -- square_of_linen_cloth
 -- INSERT INTO `guild_shops` VALUES (60430,2288,12840,12840,120,0,0);  -- square_of_karakul_cloth TODO: missing min_price and max_price
 INSERT INTO `guild_shops` VALUES (60430,828,21851,31710,60,0,0);    -- square_of_velvet_cloth
--- INSERT INTO `guild_shops` VALUES (60430,829,21851,31710,240,0,0);   -- square_of_silk_cloth TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60430,829,35070,102480,240,0,0);  -- square_of_silk_cloth
 -- INSERT INTO `guild_shops` VALUES (60430,830,21851,31710,240,0,0);   -- square_of_rainbow_cloth TODO: missing min_price and max_price
 -- INSERT INTO `guild_shops` VALUES (60430,2289,21851,31710,240,0,0);  -- square_of_wamoura_cloth TODO: missing min_price and max_price
 INSERT INTO `guild_shops` VALUES (60430,2148,815,989,240,0,0);      -- puk_wing
@@ -1990,60 +2140,108 @@ INSERT INTO `guild_shops` VALUES (60430,2128,75,86,240,75,180);     -- spindle
 INSERT INTO `guild_shops` VALUES (60430,2145,75,180,240,33,180);    -- spool_of_zephyr_thread
 
 -- Tsutsuroon (Tenshodo Merchant) Nashmau
-INSERT INTO `guild_shops` VALUES (60431,16896,517,592,20,10,20);
-INSERT INTO `guild_shops` VALUES (60431,16917,4226,4226,20,7,15);
-INSERT INTO `guild_shops` VALUES (60431,16900,1404,1608,20,7,15);
-INSERT INTO `guild_shops` VALUES (60431,16919,2728,3125,20,7,15);
-INSERT INTO `guild_shops` VALUES (60431,16960,3121,3575,20,5,10);
-INSERT INTO `guild_shops` VALUES (60431,16975,11583,13266,20,5,10);
-INSERT INTO `guild_shops` VALUES (60431,16966,1836,2103,20,10,20);
-INSERT INTO `guild_shops` VALUES (60431,16982,4752,15760,20,0,10);
-INSERT INTO `guild_shops` VALUES (60431,16987,12253,14033,20,5,10);
-INSERT INTO `guild_shops` VALUES (60431,16988,14676,16808,20,7,15);
-INSERT INTO `guild_shops` VALUES (60431,17802,189945,464059,20,2,3);
-INSERT INTO `guild_shops` VALUES (60431,16871,183516,404395,20,2,3);
-INSERT INTO `guild_shops` VALUES (60431,17259,72144,158976,20,5,10);
-INSERT INTO `guild_shops` VALUES (60431,17301,29,87,2970,594,1188);
-INSERT INTO `guild_shops` VALUES (60431,17302,347,993,2970,594,1188);
-INSERT INTO `guild_shops` VALUES (60431,17304,1472,3285,2970,594,1188);
-INSERT INTO `guild_shops` VALUES (60431,17322,81,187,2970,594,1188);
-INSERT INTO `guild_shops` VALUES (60431,17340,58,436,8910,0,3564);
-INSERT INTO `guild_shops` VALUES (60431,12456,552,858,20,10,20);
-INSERT INTO `guild_shops` VALUES (60431,12457,3272,5079,20,7,15);
-INSERT INTO `guild_shops` VALUES (60431,12458,8972,13927,20,5,10);
-INSERT INTO `guild_shops` VALUES (60431,13111,20061,29942,20,5,10);
-INSERT INTO `guild_shops` VALUES (60431,12584,833,1294,20,10,20);
-INSERT INTO `guild_shops` VALUES (60431,12585,4931,7654,20,7,15);
-INSERT INTO `guild_shops` VALUES (60431,12586,13266,14850,20,5,10);
-INSERT INTO `guild_shops` VALUES (60431,12712,458,712,20,10,20);
-INSERT INTO `guild_shops` VALUES (60431,12713,2713,4212,20,7,15);
-INSERT INTO `guild_shops` VALUES (60431,12714,2713,8316,20,5,10);
-INSERT INTO `guild_shops` VALUES (60431,12840,666,1034,20,10,20);
-INSERT INTO `guild_shops` VALUES (60431,12841,2713,6133,20,7,15);
-INSERT INTO `guild_shops` VALUES (60431,12842,10805,12096,20,5,10);
-INSERT INTO `guild_shops` VALUES (60431,12968,424,660,20,10,20);
-INSERT INTO `guild_shops` VALUES (60431,12969,2528,3924,20,7,15);
-INSERT INTO `guild_shops` VALUES (60431,12970,11071,12393,20,5,10);
-INSERT INTO `guild_shops` VALUES (60431,704,96,149,375,75,150);
-INSERT INTO `guild_shops` VALUES (60431,915,2700,16120,165,33,165);
-INSERT INTO `guild_shops` VALUES (60431,1134,810,2095,255,48,100);
-INSERT INTO `guild_shops` VALUES (60431,1155,436,645,165,33,165);
-INSERT INTO `guild_shops` VALUES (60431,657,4690,21000,165,33,65);
-INSERT INTO `guild_shops` VALUES (60431,1415,55147,55147,165,33,65);
-INSERT INTO `guild_shops` VALUES (60431,1161,66,174,2970,594,1188);
-INSERT INTO `guild_shops` VALUES (60431,1164,30,120,2970,594,1188);
-INSERT INTO `guild_shops` VALUES (60431,1167,58,107,2970,594,1188);
-INSERT INTO `guild_shops` VALUES (60431,1170,58,107,2970,594,1188);
-INSERT INTO `guild_shops` VALUES (60431,1173,56,174,2970,594,1188);
-INSERT INTO `guild_shops` VALUES (60431,1176,44,174,2970,594,1188);
-INSERT INTO `guild_shops` VALUES (60431,1472,369,369,255,48,100);
-INSERT INTO `guild_shops` VALUES (60431,1554,431,512,255,48,100);
-INSERT INTO `guild_shops` VALUES (60431,1555,1061,1259,255,48,100);
-INSERT INTO `guild_shops` VALUES (60431,1590,536,700,255,48,100);
-INSERT INTO `guild_shops` VALUES (60431,1475,579,1188,255,48,100);
-INSERT INTO `guild_shops` VALUES (60431,5164,1945,2854,255,48,100);
-INSERT INTO `guild_shops` VALUES (60431,1652,233,250,255,48,100);
-INSERT INTO `guild_shops` VALUES (60431,5235,1284,1350,255,48,100);
+INSERT INTO `guild_shops` VALUES (60431,16896,517,884,60,10,50);      -- kunai
+INSERT INTO `guild_shops` VALUES (60431,16917,4226,4840,60,7,50);     -- suzume
+-- INSERT INTO `guild_shops` VALUES (60431,16915,14428,35251,60,0,0);    -- hien TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60431,16897,14428,35251,60,0,0);    -- kageboshi TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60431,16900,1404,2160,60,7,50);     -- wakizashi
+INSERT INTO `guild_shops` VALUES (60431,16919,2728,17167,60,7,50);    -- shinobi_gatana
+-- INSERT INTO `guild_shops` VALUES (60431,16901,14428,35251,60,0,0);    -- kodachi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60431,16913,14428,35251,60,0,0);    -- shinogi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60431,16902,14428,35251,60,0,0);    -- sakurafubuki TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60431,16924,14428,35251,60,0,0);    -- hocho TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60431,16903,14428,35251,60,0,0);    -- kabutowari TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60431,16960,3121,3575,60,5,50);     -- uchigatana
+-- INSERT INTO `guild_shops` VALUES (60431,16974,224510,697840,60,0,0);  -- dotanuki TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60431,16975,11583,19800,60,5,30);   -- kanesada
+-- INSERT INTO `guild_shops` VALUES (60431,16962,14428,35251,60,0,0);    -- ashura TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60431,16966,1836,2103,60,10,50);    -- tachi
+INSERT INTO `guild_shops` VALUES (60431,16982,4752,19172,60,0,20);    -- nodachi
+-- INSERT INTO `guild_shops` VALUES (60431,16984,14428,35251,60,0,0);    -- jindachi TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60431,16987,12253,51946,60,5,19);   -- okanehira
+INSERT INTO `guild_shops` VALUES (60431,16988,14676,62218,60,7,19);   -- kotetsu
+-- INSERT INTO `guild_shops` VALUES (60431,16973,14428,35251,60,0,0);    -- homura TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60431,16967,14428,35251,60,0,0);    -- mikazuki TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60431,16990,14428,35251,60,0,0);    -- daihannya TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60431,16991,14428,35251,60,0,0);    -- odenta TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60431,16970,14428,35251,60,0,0);    -- hosodachi TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60431,17802,189945,464059,60,2,10); -- kiku_ichimonji
+-- INSERT INTO `guild_shops` VALUES (60431,16964,14428,35251,60,0,0);    -- zanbato TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60431,16972,14428,35251,60,0,0);    -- kazaridachi TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60431,16871,183516,404395,60,2,10); -- kamayari
+-- INSERT INTO `guild_shops` VALUES (60431,16841,14428,35251,60,0,0);    -- wyvern_spear TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60431,17259,72144,158976,60,5,10);  -- pirates_gun
+INSERT INTO `guild_shops` VALUES (60431,17265,14428,35251,60,0,0);    -- tanegashima
+-- INSERT INTO `guild_shops` VALUES (60431,17267,14428,35251,60,0,0);    -- negoroshiki TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60431,17301,29,87,60,10,40);        -- shuriken
+INSERT INTO `guild_shops` VALUES (60431,17302,90,1190,60,10,30);      -- juji_shuriken
+INSERT INTO `guild_shops` VALUES (60431,17303,7333,10120,60,0,0);     -- manji_shuriken
+INSERT INTO `guild_shops` VALUES (60431,17304,1472,57960,60,5,10);    -- fuma_shuriken
+-- INSERT INTO `guild_shops` VALUES (60431,17309,14428,35251,60,0,0);    -- pinwheel TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60431,17284,14428,35251,60,0,0);    -- chakram TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60431,17285,101745,220248,60,0,10); -- moonring_blade
+INSERT INTO `guild_shops` VALUES (60431,17314,3926,7446,60,0,0);      -- quake_grenade
+INSERT INTO `guild_shops` VALUES (60431,17320,7,18,60,0,0);           -- iron_arrow
+INSERT INTO `guild_shops` VALUES (60431,17322,81,330,60,10,40);       -- fire_arrow
+INSERT INTO `guild_shops` VALUES (60431,17340,58,436,60,10,30);       -- bullet
+INSERT INTO `guild_shops` VALUES (60431,12456,552,858,60,10,36);      -- hachimaki
+INSERT INTO `guild_shops` VALUES (60431,12457,3272,5079,60,7,36);     -- cotton_hachimaki
+INSERT INTO `guild_shops` VALUES (60431,12458,8972,13927,60,5,36);    -- soil_hachimaki
+-- INSERT INTO `guild_shops` VALUES (60431,12460,8972,13927,60,0,0);     -- shinobi_hachigane TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60431,12459,8972,13927,60,0,0);     -- zunari_kabuto TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60431,13111,20061,29942,60,5,30);   -- nodowa
+INSERT INTO `guild_shops` VALUES (60431,13088,43890,52440,60,0,0);    -- darksteel_nodowa
+INSERT INTO `guild_shops` VALUES (60431,12584,833,1294,60,10,36);     -- kenpogi
+INSERT INTO `guild_shops` VALUES (60431,12585,4931,7654,60,7,36);     -- cotton_dogi
+-- INSERT INTO `guild_shops` VALUES (60431,13728,8972,13927,60,0,0);     -- jujitsu_gi TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60431,12586,13266,17820,60,5,36);   -- soil_gi
+-- INSERT INTO `guild_shops` VALUES (60431,12588,8972,13927,60,0,0);     -- shinobi_gi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60431,12587,8972,13927,60,0,0);     -- hara_ate TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60431,12712,458,712,60,10,36);      -- tekko
+INSERT INTO `guild_shops` VALUES (60431,12713,2713,4212,60,7,36);     -- cotton_tekko
+INSERT INTO `guild_shops` VALUES (60431,12714,2713,9979,60,5,36);     -- soil_tekko
+-- INSERT INTO `guild_shops` VALUES (60431,12716,8972,13927,60,0,0);     -- shinobi_tekko TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60431,12715,8972,13927,60,0,0);     -- kote TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60431,12840,666,1034,60,10,36);     -- sitabaki
+INSERT INTO `guild_shops` VALUES (60431,12841,2713,6133,60,7,36);     -- cotton_sitabaki
+INSERT INTO `guild_shops` VALUES (60431,12842,10805,14515,60,5,36);   -- soil_sitabaki
+-- INSERT INTO `guild_shops` VALUES (60431,12844,8972,13927,60,0,0);     -- shinobi_hakama TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60431,12843,8972,13927,60,0,0);     -- haidate TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60431,12968,424,660,60,10,36);      -- kyahan
+INSERT INTO `guild_shops` VALUES (60431,12969,2528,3924,60,7,36);     -- cotton_kyahan
+INSERT INTO `guild_shops` VALUES (60431,12970,11071,14871,60,5,36);   -- soil_kyahan
+-- INSERT INTO `guild_shops` VALUES (60431,13204,8972,13927,60,0,0);     -- heko_obi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60431,13205,8972,13927,60,0,0);     -- silver_obi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60431,13206,8972,13927,60,0,0);     -- gold_obi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60431,13207,8972,13927,60,0,0);     -- brocade_obi TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60431,13208,8972,13927,60,0,0);     -- rainbow_obi TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60431,704,96,673,240,75,50);        -- bamboo_stick
+INSERT INTO `guild_shops` VALUES (60431,915,2700,16120,60,33,18);     -- jar_of_toad_oil
+INSERT INTO `guild_shops` VALUES (60431,1134,810,5140,60,48,10);      -- sheet_of_bast_parchment
+INSERT INTO `guild_shops` VALUES (60431,829,35070,102480,60,0,0);     -- square_of_silk_cloth
+INSERT INTO `guild_shops` VALUES (60431,1155,436,2400,240,33,190);    -- handful_of_iron_sand
+INSERT INTO `guild_shops` VALUES (60431,657,4690,30520,120,33,80);    -- lump_of_tama_hagane
+INSERT INTO `guild_shops` VALUES (60431,1415,55147,232354,60,33,14);  -- pot_of_urushi
+INSERT INTO `guild_shops` VALUES (60431,1161,30,187,240,10,80);       -- uchitake
+INSERT INTO `guild_shops` VALUES (60431,1164,30,187,240,10,80);       -- tsurara
+INSERT INTO `guild_shops` VALUES (60431,1167,30,187,240,10,80);       -- kawahori_ogi
+INSERT INTO `guild_shops` VALUES (60431,1170,30,187,240,10,80);       -- makibishi
+INSERT INTO `guild_shops` VALUES (60431,1173,30,187,240,10,80);       -- hiraishin
+INSERT INTO `guild_shops` VALUES (60431,1176,30,187,240,10,80);       -- mizu_deppo
+-- INSERT INTO `guild_shops` VALUES (60431,1179,66,174,60,0,0);          -- shihei TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60431,1182,66,174,60,0,0);          -- jusatsu TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60431,1185,66,174,60,0,0);          -- kaginawa TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60431,1188,66,174,60,0,0);          -- sairui_ran TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60431,1191,66,174,60,0,0);          -- kodoku TODO: missing min_price and max_price
+-- INSERT INTO `guild_shops` VALUES (60431,1194,66,174,60,0,0);          -- shinobi_tabi TODO: missing min_price and max_price
+INSERT INTO `guild_shops` VALUES (60431,1472,369,1476,200,48,150);    -- gardenia_seed
+INSERT INTO `guild_shops` VALUES (60431,1554,431,1522,240,48,170);    -- onz_of_turmeric
+INSERT INTO `guild_shops` VALUES (60431,1555,1061,5325,240,48,170);   -- onz_of_coriander
+INSERT INTO `guild_shops` VALUES (60431,1590,536,5836,240,48,170);    -- sprig_of_holy_basil
+INSERT INTO `guild_shops` VALUES (60431,1475,411,4985,120,48,110);    -- onz_of_curry_powder
+INSERT INTO `guild_shops` VALUES (60431,5164,1945,10899,200,48,150);  -- jar_of_ground_wasabi
+INSERT INTO `guild_shops` VALUES (60431,1652,150,704,200,48,150);     -- bottle_of_rice_vinegar
+INSERT INTO `guild_shops` VALUES (60431,5235,187,1350,200,48,150);    -- head_of_napa
 
 -- Ilita (Port Bastok) / Paunelie (Southern San dOria) / Khel Pahlhama (Port Windurst) (Linkshells pseudo guild shop)
 INSERT INTO `guild_shops` VALUES (60432,512,6000,6000,25,10,25);    -- New Linkshell


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Updates the initial_quantity and max_quantity of items in the Tenshodo guild shop [with this data](https://docs.google.com/spreadsheets/d/1tCWYRF1TGo8ZbNydLNpO0OKTuGL8ISox9VdPPMumWDM/edit?gid=1156131126#gid=1156131126) from Sruon.

- Reorders items according to how they appear in retail.
- Adds comments to every entry.
- Adds missing items the guild buys from players but doesn't restock. Entries are commented out with a TODO as necessary due to missing min and max prices.
- Sets item cost consistent across the guilds.
- Verifies that the max_price for stocked items isn't lower than the cost recorded in the audit.
- This PR doesn't correct the daily_increase of stocked items. That'll require further auditing.
- Places a TODO on Akamafula. This NPC was converted to a standard shop in the April 2018 update but is still set as a guild. This will need an audit at min and max Tenshodo fame in retail. I added comments and made prices consistent but otherwise left Akamafula alone.

## Steps to test these changes
- Create or modify entries.
- Run dbtool without errors.
- Verify database reflects the changes.