### PR TITLE
[lua] Allow defaultIfNil() to accept tables/boolean.

### DIFF
--- a/scripts/utils/utils.lua
+++ b/scripts/utils/utils.lua
@@ -1121,7 +1121,7 @@ end
 function utils.defaultIfNil(inputValue, defaultValue)
     if inputValue == nil then
         local info = debug.getinfo(2, 'Sl')
-        print(string.format('nil value encounted at %s:%i, defaulting to %i', info.source, info.currentline, defaultValue))
+        print(string.format('nil value encounted at %s:%i, defaulting to %s', info.source, info.currentline, tostring(defaultValue)))
 
         return defaultValue
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Small change to the print since it would error out when attempting to input anything other than an integer (such as a table or boolean) as the defaultValue.

## Steps to test these changes

Call defaultIfNil() ingame with exec.

`!exec defaultIfNil(nil, 1)` - See that map.exe print that it is falling back to 1.

`!exec defaultIfNil(nil, { 1, 1, 1})` - See that map.exe print that is it falling back to table {1, 1, 1}

`!exec defaultIfNil(nil, true)` - See that map.exe print that it is falling back to true.

<img width="1706" height="141" alt="image" src="https://github.com/user-attachments/assets/bfc214be-ac33-43b5-a1a4-4bf90fa3b2af" />

