### PR TITLE
[mobskill] Sonic Boom Audit

### DIFF
--- a/scripts/actions/mobskills/sonic_boom.lua
+++ b/scripts/actions/mobskills/sonic_boom.lua
@@ -9,12 +9,18 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
+-- Nightmare_Gylas sonic boom is static 90 seconds, 50% attack down, and can overwrite itself.
+
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local duration = xi.mobskills.calculateDuration(skill:getTP(), 120, 180)
+    if target:hasStatusEffect(xi.effect.ATTACK_DOWN) then
+        skill:setMsg(xi.msg.basic.SKILL_NO_EFFECT)
+    else
+        local duration = xi.mobskills.calculateDuration(skill:getTP(), 180, 360)
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ATTACK_DOWN, 25, 0, duration))
+        skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ATTACK_DOWN, 25, 0, duration))
 
-    return xi.effect.ATTACK_DOWN
+        return xi.effect.ATTACK_DOWN
+    end
 end
 
 return mobskillObject

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1690,10 +1690,10 @@ INSERT INTO `mob_skills` VALUES (1656,426,'crystal_weapon_wind',0,0.0,15.0,2000,
 -- INSERT INTO `mob_skills` VALUES (1663,1407,'blood_drain',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1664,1408,'subsonics',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1665,338,'marrow_drain',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1666,1410,'sonic_boom',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1667,1411,'jet_stream',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1668,1412,'slipstream',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1669,1413,'turbulence',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+-- INSERT INTO `mob_skills` VALUES (1666,137,'sonic_boom',2,10.0,10.0,2000,1500,4,0,0,0,0,0,0);
+-- INSERT INTO `mob_skills` VALUES (1667,139,'jet_stream',0,0.0,7.0,2000,1200,4,0,0,0,0,0,0);
+-- INSERT INTO `mob_skills` VALUES (1668,339,'slipstream',2,15.0,20.0,2000,1500,4,0,0,0,0,0,0);
+-- INSERT INTO `mob_skills` VALUES (1669,340,'turbulence',0,10.0,10.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1670,200,'tentacle',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1671,202,'ink_jet',0,0.0,7.0,2000,0,4,4,0,3,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1672,1416,'hard_membrane',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR audits the duration of sonic boom and adjusts the ability to not overwrite itself.

<img width="41" height="46" alt="image" src="https://github.com/user-attachments/assets/b79b07a2-bb58-4bd1-b2eb-3c03c3182a8f" />

After spending a whole day and half messing with triple bats, charming bats at various TP amounts and releasing them to receive the effect, its become quite clear that Sonic Boom's duration is directly proportional to the amount of TP the bat has and scales from 3 minutes to 9 minutes.

This PR also adjusts some commented out abilities belonging to Nightmare Galas in preparation for a future Dynamis audit.

## Steps to test these changes

!tp3000 some bats and enjoy more retail accuracy than ever before.
