### PR TITLE
[core] Help Desk support

### DIFF
--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -43,6 +43,10 @@ xi.settings.map =
     -- Enable or disable Recycle Bin (Set to false for items to be dropped immediately)
     ENABLE_ITEM_RECYCLE_BIN = true,
 
+    -- Self-unstuck feature (sends player to homepoint via Help Desk command)
+    SELF_UNSTUCK_ENABLED  = false,
+    SELF_UNSTUCK_COOLDOWN = 86400, -- Cooldown in seconds (default: 24 hours)
+
     -- AH fee structure, defaults are retail.
     AH_BASE_FEE_SINGLE = 1,
     AH_BASE_FEE_STACKS = 4,

--- a/sql/help_desk.sql
+++ b/sql/help_desk.sql
@@ -1,0 +1,16 @@
+--
+-- Table structure for table `help_desk`
+--
+
+DROP TABLE IF EXISTS `help_desk`;
+CREATE TABLE `help_desk` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `charid` int(10) unsigned NOT NULL,
+  `message` varchar(1024) NOT NULL,
+  `response` varchar(1024) DEFAULT NULL,
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `responded_at` datetime DEFAULT NULL,
+  `deleted_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_pending` (`charid`, `deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/src/common/ipc_structs.h
+++ b/src/common/ipc_structs.h
@@ -29,6 +29,7 @@
 #include "map/enums/msg_std.h"
 #include "map/enums/party_kind.h"
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -314,6 +315,27 @@ struct AssistChannelEvent
     uint32 senderId{};
     uint32 receiverId{};
     uint8  action{}; // GP_CLI_COMMAND_ASSIST_CHANNEL_KIND
+};
+
+struct GMCallRequest
+{
+    uint32                             callId{};
+    uint32                             charId{};
+    std::string                        charName{};
+    uint32                             accId{};
+    uint16                             zoneId{};
+    float                              posX{};
+    float                              posY{};
+    float                              posZ{};
+    std::string                        message{};
+    std::map<std::string, std::string> parameters{};
+};
+
+struct GMCallResponse
+{
+    uint32      callId{};
+    uint32      charId{};
+    std::string message{}; // Up to 1024 characters
 };
 
 } // namespace ipc

--- a/src/map/CMakeLists.txt
+++ b/src/map/CMakeLists.txt
@@ -64,6 +64,8 @@ set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/event_info.h
     ${CMAKE_CURRENT_SOURCE_DIR}/fishingcontest.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fishingcontest.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/gmcall_container.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gmcall_container.h
     ${CMAKE_CURRENT_SOURCE_DIR}/grades.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/grades.h
     ${CMAKE_CURRENT_SOURCE_DIR}/guild.cpp

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -795,6 +795,11 @@ auto CCharEntity::inMogHouse() const -> bool
     return m_moghouseID != 0;
 }
 
+auto CCharEntity::gmCallContainer() -> GMCallContainer&
+{
+    return gmCallContainer_;
+}
+
 int8 CCharEntity::getShieldSize()
 {
     CItemEquipment* PItem = getEquip(SLOT_SUB);

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -24,6 +24,7 @@
 
 #include "aman.h"
 #include "event_info.h"
+#include "gmcall_container.h"
 #include "item_container.h"
 #include "map_session.h"
 #include "monstrosity.h"
@@ -539,6 +540,8 @@ public:
     // The character is in ANY Mog House (their own or someone else's)
     auto inMogHouse() const -> bool;
 
+    auto gmCallContainer() -> GMCallContainer&;
+
     CharHistory_t m_charHistory{};
 
     int8  getShieldSize();
@@ -677,6 +680,7 @@ protected:
 private:
     // Lazily initialized AMAN data
     xi::optional<CAMANContainer> m_AMAN;
+    GMCallContainer              gmCallContainer_;
 
     std::unique_ptr<CItemContainer> m_Inventory;
     std::unique_ptr<CItemContainer> m_Mogsafe;

--- a/src/map/gmcall_container.cpp
+++ b/src/map/gmcall_container.cpp
@@ -1,0 +1,268 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "gmcall_container.h"
+#include "common/database.h"
+#include "common/ipc_structs.h"
+#include "common/logging.h"
+#include "entities/charentity.h"
+#include "ipc_client.h"
+#include "packets/s2c/0x0b6_set_gmmsg.h"
+
+#include <algorithm>
+#include <unordered_set>
+
+namespace
+{
+constexpr std::size_t MAX_GMCALL_PACKETS = 6; // Arbitrary limit. Observed 3 packets at most.
+
+const std::unordered_set<std::string> ALLOWED_GMCALL_PARAMS = {
+    "GENERIC.AREACODE",
+    "GENERIC.CLILANG",
+    "GENERIC.SELLANG",
+    "GENERIC.PLATFORM",
+    "GENERIC.VERSION",
+    "GAME.INFIELD",
+    "GAME.GMTIME",
+    "EXEC.LOGOUT",
+    "EXEC.POLEXIT",
+    "EXEC.RESCUE",
+    "GMREPORT.NOTICE",
+    "GMREPORT.GMCALL",
+    "GMREPORT.HARASSMENT",
+    "GMREPORT.STUCK",
+    "GMREPORT.BLOCK",
+    "GMCALL.INPUT",
+};
+} // namespace
+
+// Store one GMCALL packet for later processing
+auto GMCallContainer::addPacket(const GP_CLI_COMMAND_FAQ_GMCALL& packet) -> bool
+{
+    if (packet.pktId != pktId_)
+    {
+        clear();
+        pktId_ = packet.pktId;
+    }
+
+    if (packets_.size() >= MAX_GMCALL_PACKETS)
+    {
+        ShowWarning("GMCallContainer: Packet limit reached. Possible abuse.");
+        return false;
+    }
+
+    packets_.push_back(packet);
+
+    return packet.eos == 1; // Notify this was the last packet of the current GM call.
+}
+
+void GMCallContainer::clear()
+{
+    packets_.clear();
+    pktId_ = 0;
+}
+
+// Build the actual GM call out of multiple packets
+void GMCallContainer::processCall(const CCharEntity* PChar) const
+{
+    std::map<std::string, std::string> parameters;
+    std::string                        message;
+
+    // Reorder fragments by sequence ID
+    auto sortedPackets = packets_;
+    std::ranges::sort(sortedPackets,
+                      [](const auto& a, const auto& b)
+                      {
+                          return a.seq < b.seq;
+                      });
+
+    for (const auto& packet : sortedPackets)
+    {
+        std::size_t offset = 0;
+        for (uint8_t block = 0; block < packet.blkNum && offset < sizeof(packet.Data); ++block)
+        {
+            if (offset + sizeof(FFGpGMReportBlockHdr) > sizeof(packet.Data))
+            {
+                break;
+            }
+
+            const auto* header    = reinterpret_cast<const FFGpGMReportBlockHdr*>(&packet.Data[offset]);
+            const auto  blockSize = header->bkLength;
+
+            if (blockSize < sizeof(FFGpGMReportBlockHdr) || offset + blockSize > sizeof(packet.Data))
+            {
+                break;
+            }
+
+            switch (static_cast<GMReportBlockType>(header->bkType))
+            {
+                case GMReportBlockType::Position:
+                {
+                    // This contains client reported position but is not generally useful.
+                    break;
+                }
+                case GMReportBlockType::Version:
+                {
+                    if (blockSize >= sizeof(sub_block_01_t))
+                    {
+                        const auto* blk                 = reinterpret_cast<const sub_block_01_t*>(&packet.Data[offset]);
+                        parameters["VERSION.UNKNOWN00"] = std::to_string(blk->unknown00);
+                        parameters["VERSION.UNKNOWN01"] = fmt::format("{},{},{},{}", blk->unknown01[0], blk->unknown01[1], blk->unknown01[2], blk->unknown01[3]);
+                    }
+                    break;
+                }
+                case GMReportBlockType::Error:
+                {
+                    if (blockSize >= sizeof(FFGpGMReportECodeStruct))
+                    {
+                        const auto* blk              = reinterpret_cast<const FFGpGMReportECodeStruct*>(&packet.Data[offset]);
+                        parameters["ERROR.CODE"]     = std::to_string(blk->code);
+                        parameters["ERROR.COUNT"]    = std::to_string(blk->count);
+                        parameters["ERROR.TIMECODE"] = std::to_string(blk->timeCode);
+                    }
+                    break;
+                }
+                case GMReportBlockType::StringParam:
+                {
+                    const auto  strLen  = std::min<std::size_t>(blockSize - sizeof(FFGpGMReportBlockHdr), sizeof(sub_block_03_t::Str));
+                    const auto* strData = reinterpret_cast<const char*>(&packet.Data[offset + sizeof(FFGpGMReportBlockHdr)]);
+                    std::string param(strData, strnlen(strData, strLen));
+
+                    if (const auto colonPos = param.find(':'); colonPos != std::string::npos)
+                    {
+                        auto       key   = param.substr(0, colonPos);
+                        const auto value = param.substr(colonPos + 1);
+                        if (!ALLOWED_GMCALL_PARAMS.contains(key))
+                        {
+                            ShowWarning("GMCallContainer: Unknown parameter key. Ignoring.");
+                        }
+                        else
+                        {
+                            parameters[key] = value;
+                            if (key == "GMCALL.INPUT")
+                            {
+                                message = value;
+                            }
+                        }
+                    }
+                    break;
+                }
+                case GMReportBlockType::LobbyHistory:
+                {
+                    const auto  dataSize   = blockSize - sizeof(FFGpGMReportBlockHdr);
+                    const auto  numEntries = std::min(dataSize / sizeof(FFGpGMReportLobbyEntry), std::size_t(8));
+                    const auto* entries    = reinterpret_cast<const FFGpGMReportLobbyEntry*>(&packet.Data[offset + sizeof(FFGpGMReportBlockHdr)]);
+
+                    for (std::size_t i = 0; i < numEntries; ++i)
+                    {
+                        if (entries[i].ident == 0)
+                        {
+                            continue;
+                        }
+
+                        auto prefix                      = fmt::format("LOBBY.{}", i);
+                        parameters[prefix + ".CMD"]      = std::to_string(entries[i].cmd);
+                        parameters[prefix + ".OPT"]      = std::to_string(entries[i].opt);
+                        parameters[prefix + ".TIMECODE"] = std::to_string(entries[i].timeCode);
+                        parameters[prefix + ".IDENT"]    = std::to_string(entries[i].ident);
+                        parameters[prefix + ".NAME"]     = std::string(reinterpret_cast<const char*>(entries[i].name), strnlen(reinterpret_cast<const char*>(entries[i].name), sizeof(entries[i].name)));
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+
+            offset += blockSize;
+        }
+    }
+
+    uint32 callId = 0;
+    db::transaction([&]()
+                    {
+                        db::preparedStmt("INSERT INTO help_desk (charid, message) VALUES (?, ?)", PChar->id, message);
+                        if (const auto rset = db::preparedStmt("SELECT LAST_INSERT_ID() AS id"); rset && rset->next())
+                        {
+                            callId = rset->get<uint32>("id");
+                        }
+                    });
+
+    // Send the GM call to xi_world for rerouting to external listeners
+    message::send(ipc::GMCallRequest{
+        .callId     = callId,
+        .charId     = PChar->id,
+        .charName   = PChar->name,
+        .accId      = PChar->accid,
+        .zoneId     = PChar->getZone(),
+        .posX       = PChar->loc.p.x,
+        .posY       = PChar->loc.p.y,
+        .posZ       = PChar->loc.p.z,
+        .message    = message,
+        .parameters = parameters,
+    });
+}
+
+// On zone-in, check if the player has any pending unacknowledged response and build the packets if so.
+void GMCallContainer::sendPendingResponse(CCharEntity* PChar) const
+{
+    TracyZoneScoped;
+
+    const auto rset = db::preparedStmt("SELECT id, response "
+                                       "FROM help_desk "
+                                       "WHERE charid = ? AND response IS NOT NULL AND deleted_at IS NULL "
+                                       "ORDER BY id ASC LIMIT 1",
+                                       PChar->id);
+    FOR_DB_SINGLE_RESULT(rset)
+    {
+        const auto callId   = rset->get<uint32>("id");
+        const auto response = rset->get<std::string>("response");
+
+        // Max 244 characters per packet, with an upper limit of 1024 characters.
+        constexpr std::size_t maxPerPacket = sizeof(GP_SERV_COMMAND_SET_GMMSG::PacketData::Msg);
+        const auto            totalPackets = (response.size() + maxPerPacket - 1) / maxPerPacket;
+
+        for (std::size_t i = 0; i < totalPackets; ++i)
+        {
+            const auto chunkOffset = i * maxPerPacket;
+            const auto chunkSize   = std::min(response.size() - chunkOffset, maxPerPacket);
+            const auto chunk       = response.substr(chunkOffset, chunkSize);
+            const auto seqId       = static_cast<uint16_t>(i + 1);
+            const auto pktNum      = static_cast<uint16_t>((i == totalPackets - 1) ? 0 : seqId);
+
+            PChar->pushPacket<GP_SERV_COMMAND_SET_GMMSG>(callId, seqId, pktNum, chunk);
+        }
+    }
+}
+
+// Marks the oldest unacknowledged response as read/deleted.
+void GMCallContainer::acknowledgeOldestResponse(CCharEntity* PChar) const
+{
+    TracyZoneScoped;
+
+    db::preparedStmt("UPDATE help_desk "
+                     "SET deleted_at = NOW() "
+                     "WHERE charid = ? AND response IS NOT NULL AND deleted_at IS NULL "
+                     "ORDER BY id ASC LIMIT 1",
+                     PChar->id);
+
+    // Send another response if player has multiple queued.
+    sendPendingResponse(PChar);
+}

--- a/src/map/gmcall_container.h
+++ b/src/map/gmcall_container.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
 
-  Copyright (c) 2025 LandSandBoat Dev Teams
+  Copyright (c) 2026 LandSandBoat Dev Teams
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -19,20 +19,23 @@
 ===========================================================================
 */
 
-#include "0x0d4_faq_gmparam.h"
+#pragma once
 
-#include "entities/charentity.h"
-#include "packets/s2c/0x0b5_faq_gmparam.h"
+#include "packets/c2s/0x0d3_faq_gmcall.h"
 
-auto GP_CLI_COMMAND_FAQ_GMPARAM::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
+#include <vector>
+
+class CCharEntity;
+class GMCallContainer
 {
-    return PacketValidator()
-        .mustEqual(this->Option, 0, "Option not 0");
-}
+public:
+    auto addPacket(const GP_CLI_COMMAND_FAQ_GMCALL& packet) -> bool;
+    void processCall(const CCharEntity* PChar) const;
+    void sendPendingResponse(CCharEntity* PChar) const;
+    void acknowledgeOldestResponse(CCharEntity* PChar) const;
+    void clear();
 
-void GP_CLI_COMMAND_FAQ_GMPARAM::process(MapSession* PSession, CCharEntity* PChar) const
-{
-    // Respond to the player opening the Help Desk menu
-    // The client mostly ignores the response.
-    PChar->pushPacket<GP_SERV_COMMAND_FAQ_GMPARAM>(this->Id);
-}
+private:
+    uint8_t                                pktId_{};
+    std::vector<GP_CLI_COMMAND_FAQ_GMCALL> packets_;
+};

--- a/src/map/ipc_client.cpp
+++ b/src/map/ipc_client.cpp
@@ -45,6 +45,7 @@
 #include "packets/s2c/0x0cc_linkshell_message.h"
 #include "packets/s2c/0x0dc_group_solicit_req.h"
 
+#include "gmcall_container.h"
 #include "items/item_linkshell.h"
 #include "packets/c2s/0x0b7_assist_channel.h"
 
@@ -966,6 +967,21 @@ void IPCClient::handleMessage_AssistChannelEvent(const IPP& ipp, const ipc::Assi
         case GP_CLI_COMMAND_ASSIST_CHANNEL_KIND::IssueWarning:
             PChar->aman().addThumbsDown(message.senderId);
             break;
+    }
+}
+
+void IPCClient::handleMessage_GMCallRequest(const IPP& ipp, const ipc::GMCallRequest& message)
+{
+    TracyZoneScoped;
+}
+
+void IPCClient::handleMessage_GMCallResponse(const IPP& ipp, const ipc::GMCallResponse& message)
+{
+    TracyZoneScoped;
+
+    if (CCharEntity* PChar = zoneutils::GetChar(message.charId))
+    {
+        PChar->gmCallContainer().sendPendingResponse(PChar);
     }
 }
 

--- a/src/map/ipc_client.h
+++ b/src/map/ipc_client.h
@@ -87,6 +87,8 @@ public:
     void handleMessage_EntityInformationResponse(const IPP& ipp, const ipc::EntityInformationResponse& message);
     void handleMessage_SendPlayerToLocation(const IPP& ipp, const ipc::SendPlayerToLocation& message);
     void handleMessage_AssistChannelEvent(const IPP& ipp, const ipc::AssistChannelEvent& message) const;
+    void handleMessage_GMCallRequest(const IPP& ipp, const ipc::GMCallRequest& message);
+    void handleMessage_GMCallResponse(const IPP& ipp, const ipc::GMCallResponse& message);
 
     void handleUnknownMessage(const IPP& ipp, const std::span<uint8_t> message);
 

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -332,7 +332,7 @@ void PacketParserInitialize()
     PacketSize[0x0D2] = 0x04; PacketParser[0x0D2] = &ValidatedPacketHandler<GP_CLI_COMMAND_MAP_GROUP>;
     PacketSize[0x0D3] = 0x00; PacketParser[0x0D3] = &ValidatedPacketHandler<GP_CLI_COMMAND_FAQ_GMCALL>;
     PacketSize[0x0D4] = 0x04; PacketParser[0x0D4] = &ValidatedPacketHandler<GP_CLI_COMMAND_FAQ_GMPARAM>;
-    PacketSize[0x0D5] = 0x08; PacketParser[0x0D5] = &ValidatedPacketHandler<GP_CLI_COMMAND_ACK_GMMSG>;
+    PacketSize[0x0D5] = 0x06; PacketParser[0x0D5] = &ValidatedPacketHandler<GP_CLI_COMMAND_ACK_GMMSG>;
     PacketSize[0x0D8] = 0x00; PacketParser[0x0D8] = &ValidatedPacketHandler<GP_CLI_COMMAND_DUNGEON_PARAM>;
     PacketSize[0x0DB] = 0x00; PacketParser[0x0DB] = &ValidatedPacketHandler<GP_CLI_COMMAND_CONFIG_LANGUAGE>;
     PacketSize[0x0DC] = 0x0A; PacketParser[0x0DC] = &ValidatedPacketHandler<GP_CLI_COMMAND_CONFIG>;

--- a/src/map/packets/c2s/0x00c_gameok.cpp
+++ b/src/map/packets/c2s/0x00c_gameok.cpp
@@ -22,6 +22,7 @@
 #include "0x00c_gameok.h"
 
 #include "entities/charentity.h"
+#include "gmcall_container.h"
 #include "packets/char_status.h"
 #include "packets/char_sync.h"
 #include "packets/s2c/0x008_enterzone.h"
@@ -81,6 +82,7 @@ void GP_CLI_COMMAND_GAMEOK::process(MapSession* PSession, CCharEntity* PChar) co
     PChar->pushPacket<GP_SERV_COMMAND_MERIT>(PChar);
     charutils::SendInventory(PChar);
     blacklistutils::SendBlacklist(PChar);
+    PChar->gmCallContainer().sendPendingResponse(PChar);
 
     // TODO: While in mog house; treasure pool is not created.
     if (PChar->PTreasurePool != nullptr)

--- a/src/map/packets/c2s/0x0d3_faq_gmcall.cpp
+++ b/src/map/packets/c2s/0x0d3_faq_gmcall.cpp
@@ -25,17 +25,37 @@
 
 auto GP_CLI_COMMAND_FAQ_GMCALL::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
-    // Not implemented.
-    return PacketValidator();
+    return PacketValidator()
+        .oneOf<GP_CLI_COMMAND_FAQ_GMCALL_TYPE>(this->type)
+        .mustEqual(this->vers, 0, "vers not equal to 0")
+        .range("eos", this->eos, 0, 1);
 }
 
 void GP_CLI_COMMAND_FAQ_GMCALL::process(MapSession* PSession, CCharEntity* PChar) const
 {
-    PChar->m_charHistory.gmCalls++;
-    ShowDebugFmt("GP_CLI_COMMAND_FAQ_GMCALL: Not implemented. type: {}, pktId: {}, seq: {}, eos: {}, blkNum: {}",
-                 type,
-                 pktId,
-                 seq,
-                 eos,
-                 blkNum);
+    switch (static_cast<GP_CLI_COMMAND_FAQ_GMCALL_TYPE>(this->type))
+    {
+        case GP_CLI_COMMAND_FAQ_GMCALL_TYPE::AddHistory:
+        {
+            // Client sent extra information after acknowledging a response.
+            // Contains several blocks, none of which are worth collecting at this point.
+            break;
+        }
+        case GP_CLI_COMMAND_FAQ_GMCALL_TYPE::GMCall:
+        {
+            // User submitted a GM call. There can be many packets, but they should not be processed until eos == 1
+            if (PChar->gmCallContainer().addPacket(*this))
+            {
+                // Received eos 1 - store in DB and send to ZMQ
+                PChar->gmCallContainer().processCall(PChar);
+                PChar->m_charHistory.gmCalls++;
+            }
+            break;
+        }
+        case GP_CLI_COMMAND_FAQ_GMCALL_TYPE::GMNotice:
+        {
+            // Unknown usage.
+            break;
+        }
+    }
 }

--- a/src/map/packets/c2s/0x0d3_faq_gmcall.h
+++ b/src/map/packets/c2s/0x0d3_faq_gmcall.h
@@ -30,6 +30,15 @@ enum class GP_CLI_COMMAND_FAQ_GMCALL_TYPE : uint8_t
     GMNotice   = 3,
 };
 
+enum class GMReportBlockType : uint8_t
+{
+    Position     = 0x00,
+    Version      = 0x01,
+    Error        = 0x02,
+    StringParam  = 0x03,
+    LobbyHistory = 0x04,
+};
+
 struct FFGpGMReportBlockHdr
 {
     uint8_t  bkType;   // PS2: bkType
@@ -37,7 +46,7 @@ struct FFGpGMReportBlockHdr
     uint16_t bkOpt;    // PS2: bkOpt
 };
 
-struct sub_block_00_t
+struct FFGpGMReportCharBlock
 {
     FFGpGMReportBlockHdr header;
     uint16_t             zone;      // PS2: zone
@@ -53,7 +62,7 @@ struct sub_block_01_t
     uint32_t             unknown01[4];
 };
 
-struct sub_block_02_t
+struct FFGpGMReportECodeStruct
 {
     FFGpGMReportBlockHdr header;
     int16_t              code;     // PS2: code
@@ -67,20 +76,19 @@ struct sub_block_03_t
     uint8_t              Str[256]; // Unknown max size.
 };
 
-struct FFGpGMReportLobbyStruct
+struct FFGpGMReportLobbyEntry
 {
-    FFGpGMReportBlockHdr header;
-    uint16_t             cmd;      // PS2: cmd
-    uint16_t             opt;      // PS2: opt
-    uint32_t             timeCode; // PS2: timeCode
-    uint32_t             ident;    // PS2: ident
-    uint8_t              name[16]; // PS2: name
+    uint16_t cmd;      // PS2: cmd
+    uint16_t opt;      // PS2: opt
+    uint32_t timeCode; // PS2: timeCode
+    uint32_t ident;    // PS2: ident
+    uint8_t  name[16]; // PS2: name
 };
 
-struct sub_block_04_t
+struct FFGpGMReportLobbyStruct
 {
-    FFGpGMReportBlockHdr    header;
-    FFGpGMReportLobbyStruct characters[8];
+    FFGpGMReportBlockHdr   header;
+    FFGpGMReportLobbyEntry characters[8];
 };
 
 // https://github.com/atom0s/XiPackets/tree/main/world/client/0x00D3

--- a/src/map/packets/c2s/0x0d5_ack_gmmsg.cpp
+++ b/src/map/packets/c2s/0x0d5_ack_gmmsg.cpp
@@ -22,14 +22,14 @@
 #include "0x0d5_ack_gmmsg.h"
 
 #include "entities/charentity.h"
+#include "gmcall_container.h"
 
 auto GP_CLI_COMMAND_ACK_GMMSG::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
-    // Not implemented.
     return PacketValidator();
 }
 
 void GP_CLI_COMMAND_ACK_GMMSG::process(MapSession* PSession, CCharEntity* PChar) const
 {
-    ShowDebugFmt("GP_CLI_COMMAND_ACK_GMMSG: Not implemented. msgId: {}, seqId: {}, seqNum: {}", msgId, seqId, seqNum);
+    PChar->gmCallContainer().acknowledgeOldestResponse(PChar);
 }

--- a/src/map/packets/c2s/0x0f0_rescue.cpp
+++ b/src/map/packets/c2s/0x0f0_rescue.cpp
@@ -21,16 +21,40 @@
 
 #include "0x0f0_rescue.h"
 
+#include "common/earth_time.h"
+#include "common/settings.h"
 #include "entities/charentity.h"
+#include "enums/chat_message_type.h"
+#include "packets/s2c/0x017_chat_std.h"
+#include "utils/charutils.h"
 
 auto GP_CLI_COMMAND_RESCUE::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
-    // Unimplemented packet but State is always 0
     return PacketValidator()
-        .mustEqual(State, 0, "State not 0");
+        .mustEqual(State, 0, "State not 0")
+        .isNotJailed(PChar)
+        .isNotEngaged(PChar)
+        .isNotInEvent(PChar)
+        .isNotFishing(PChar)
+        .isNotCrafting(PChar);
 }
 
 void GP_CLI_COMMAND_RESCUE::process(MapSession* PSession, CCharEntity* PChar) const
 {
-    ShowDebugFmt("GP_CLI_COMMAND_RESCUE: Not implemented.");
+    if (!settings::get<bool>("map.SELF_UNSTUCK_ENABLED"))
+    {
+        return;
+    }
+
+    if (charutils::GetCharVar(PChar, "[GM]SelfUnstuck") != 0)
+    {
+        ShowInfoFmt("{} requested self-unstuck but is still on cooldown.", PChar->getName());
+        PChar->pushPacket<GP_SERV_COMMAND_CHAT_STD>(PChar, CHAT_MESSAGE_TYPE::MESSAGE_SYSTEM_1, "Self-unstuck is on cooldown.");
+        return;
+    }
+
+    ShowInfoFmt("{} requested self-unstuck, warping them to their Home Point.", PChar->getName());
+    const auto cooldown = settings::get<uint32>("map.SELF_UNSTUCK_COOLDOWN");
+    charutils::SetCharVar(PChar, "[GM]SelfUnstuck", 1, earth_time::timestamp() + cooldown);
+    PChar->requestedWarp = true;
 }

--- a/src/map/packets/c2s/validation.cpp
+++ b/src/map/packets/c2s/validation.cpp
@@ -26,6 +26,7 @@
 #include "items/item_linkshell.h"
 #include "status_effect_container.h"
 #include "trade_container.h"
+#include "utils/jailutils.h"
 
 auto PacketValidator::isNotResting(const CCharEntity* PChar) -> PacketValidator&
 {
@@ -239,6 +240,36 @@ auto PacketValidator::isEngaged(const CCharEntity* PChar) -> PacketValidator&
     if (!PChar->PAI->IsEngaged())
     {
         result_.addError("Character is not engaged.");
+    }
+
+    return *this;
+}
+
+auto PacketValidator::isNotEngaged(const CCharEntity* PChar) -> PacketValidator&
+{
+    if (PChar->PAI->IsEngaged())
+    {
+        result_.addError("Character is engaged.");
+    }
+
+    return *this;
+}
+
+auto PacketValidator::isNotInEvent(const CCharEntity* PChar) -> PacketValidator&
+{
+    if (PChar->isInEvent())
+    {
+        result_.addError("Character is in an event.");
+    }
+
+    return *this;
+}
+
+auto PacketValidator::isNotJailed(const CCharEntity* PChar) -> PacketValidator&
+{
+    if (jailutils::InPrison(PChar))
+    {
+        result_.addError("Character is jailed.");
     }
 
     return *this;

--- a/src/map/packets/c2s/validation.h
+++ b/src/map/packets/c2s/validation.h
@@ -221,6 +221,12 @@ public:
     auto isNotMounted(const CCharEntity* PChar) -> PacketValidator&;
     // Character must be engaged in combat
     auto isEngaged(const CCharEntity* PChar) -> PacketValidator&;
+    // Character must not be engaged in combat
+    auto isNotEngaged(const CCharEntity* PChar) -> PacketValidator&;
+    // Character must not be in an event
+    auto isNotInEvent(const CCharEntity* PChar) -> PacketValidator&;
+    // Character must not be jailed
+    auto isNotJailed(const CCharEntity* PChar) -> PacketValidator&;
 
     // Custom validation function
     template <typename Func>

--- a/src/map/packets/s2c/0x0b5_faq_gmparam.cpp
+++ b/src/map/packets/s2c/0x0b5_faq_gmparam.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
 
-  Copyright (c) 2025 LandSandBoat Dev Teams
+  Copyright (c) 2026 LandSandBoat Dev Teams
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -19,20 +19,15 @@
 ===========================================================================
 */
 
-#include "0x0d4_faq_gmparam.h"
+#include "0x0b5_faq_gmparam.h"
 
-#include "entities/charentity.h"
-#include "packets/s2c/0x0b5_faq_gmparam.h"
-
-auto GP_CLI_COMMAND_FAQ_GMPARAM::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
+GP_SERV_COMMAND_FAQ_GMPARAM::GP_SERV_COMMAND_FAQ_GMPARAM(const uint16_t id)
 {
-    return PacketValidator()
-        .mustEqual(this->Option, 0, "Option not 0");
-}
+    auto& packet = this->data();
 
-void GP_CLI_COMMAND_FAQ_GMPARAM::process(MapSession* PSession, CCharEntity* PChar) const
-{
-    // Respond to the player opening the Help Desk menu
-    // The client mostly ignores the response.
-    PChar->pushPacket<GP_SERV_COMMAND_FAQ_GMPARAM>(this->Id);
+    packet.RescueCount = 0;    // This value has been observed to be 0 and non-zero values.
+    packet.params[0]   = 1;    // The first value of this array used to be the number of GM calls in the queue.
+    packet.Id          = id;   // This value is reflected from what the client sent in its own 0x0D4
+    packet.Option      = 0;    // This value has been observed to be 0. This value may reflect the option(s) selected within the Help Desk menu.
+    packet.RescueTime  = 1800; // This value has been observed to be 1800.
 }

--- a/src/map/packets/s2c/0x0b5_faq_gmparam.h
+++ b/src/map/packets/s2c/0x0b5_faq_gmparam.h
@@ -38,6 +38,5 @@ public:
         uint16_t RescueTime;  // PS2: RescueTime
     };
 
-    // TODO: Unimplemented
-    GP_SERV_COMMAND_FAQ_GMPARAM() = default;
+    GP_SERV_COMMAND_FAQ_GMPARAM(uint16_t id);
 };

--- a/src/map/packets/s2c/0x0b6_set_gmmsg.cpp
+++ b/src/map/packets/s2c/0x0b6_set_gmmsg.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
 
-  Copyright (c) 2025 LandSandBoat Dev Teams
+  Copyright (c) 2026 LandSandBoat Dev Teams
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -19,20 +19,14 @@
 ===========================================================================
 */
 
-#include "0x0d4_faq_gmparam.h"
+#include "0x0b6_set_gmmsg.h"
 
-#include "entities/charentity.h"
-#include "packets/s2c/0x0b5_faq_gmparam.h"
-
-auto GP_CLI_COMMAND_FAQ_GMPARAM::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
+GP_SERV_COMMAND_SET_GMMSG::GP_SERV_COMMAND_SET_GMMSG(const uint32_t msgId, const uint16_t seqId, const uint16_t pktNum, const std::string& message)
 {
-    return PacketValidator()
-        .mustEqual(this->Option, 0, "Option not 0");
-}
+    auto& packet = this->data();
 
-void GP_CLI_COMMAND_FAQ_GMPARAM::process(MapSession* PSession, CCharEntity* PChar) const
-{
-    // Respond to the player opening the Help Desk menu
-    // The client mostly ignores the response.
-    PChar->pushPacket<GP_SERV_COMMAND_FAQ_GMPARAM>(this->Id);
+    packet.msgId  = msgId;
+    packet.seqId  = seqId;
+    packet.pktNum = pktNum;
+    std::memcpy(packet.Msg, message.data(), std::min(message.size(), sizeof(packet.Msg)));
 }

--- a/src/map/packets/s2c/0x0b6_set_gmmsg.h
+++ b/src/map/packets/s2c/0x0b6_set_gmmsg.h
@@ -37,6 +37,5 @@ public:
         uint8_t  Msg[244]; // PS2: Msg
     };
 
-    // TODO: Unimplemented
-    GP_SERV_COMMAND_SET_GMMSG() = default;
+    GP_SERV_COMMAND_SET_GMMSG(uint32_t msgId, uint16_t seqId, uint16_t pktNum, const std::string& message);
 };

--- a/src/map/packets/s2c/CMakeLists.txt
+++ b/src/map/packets/s2c/CMakeLists.txt
@@ -203,7 +203,9 @@ set(PACKET_S2C_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/0x0b4_config.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x0b4_config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x0b5_faq_gmparam.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x0b5_faq_gmparam.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x0b6_set_gmmsg.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x0b6_set_gmmsg.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x0b7_gmscitem.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x0bf_registration.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x0bf_registration.cpp

--- a/src/world/ipc_server.cpp
+++ b/src/world/ipc_server.cpp
@@ -712,6 +712,41 @@ void IPCServer::handleMessage_AssistChannelEvent(const IPP& ipp, const ipc::Assi
     rerouteMessageToCharId(message.receiverId, message);
 }
 
+void IPCServer::handleMessage_GMCallRequest(const IPP& ipp, const ipc::GMCallRequest& message)
+{
+    TracyZoneScoped;
+
+    ShowInfoFmt("GM Call #{} from {} (charId: {}, accId: {}, zone: {}): {}",
+                message.callId,
+                message.charName,
+                message.charId,
+                message.accId,
+                message.zoneId,
+                message.message);
+
+    // TODO: Route this to external clients
+}
+
+void IPCServer::handleMessage_GMCallResponse(const IPP& ipp, const ipc::GMCallResponse& message)
+{
+    TracyZoneScoped;
+
+    // Client can only read up to 1024 characters, drop any extra characters now.
+    auto truncatedMessage    = message;
+    truncatedMessage.message = truncatedMessage.message.substr(0, 1024);
+
+    db::preparedStmt("UPDATE help_desk "
+                     "SET response = ?, responded_at = NOW() "
+                     "WHERE id = ?",
+                     truncatedMessage.message,
+                     truncatedMessage.callId);
+
+    if (const auto maybeCharIPP = getIPPForCharId(truncatedMessage.charId))
+    {
+        sendMessage(*maybeCharIPP, truncatedMessage);
+    }
+}
+
 void IPCServer::handleUnknownMessage(const IPP& ipp, const std::span<uint8_t> message)
 {
     TracyZoneScoped;

--- a/src/world/ipc_server.h
+++ b/src/world/ipc_server.h
@@ -118,6 +118,8 @@ public:
     void handleMessage_EntityInformationResponse(const IPP& ipp, const ipc::EntityInformationResponse& message);
     void handleMessage_SendPlayerToLocation(const IPP& ipp, const ipc::SendPlayerToLocation& message);
     void handleMessage_AssistChannelEvent(const IPP& ipp, const ipc::AssistChannelEvent& message);
+    void handleMessage_GMCallRequest(const IPP& ipp, const ipc::GMCallRequest& message);
+    void handleMessage_GMCallResponse(const IPP& ipp, const ipc::GMCallResponse& message);
 
     void handleUnknownMessage(const IPP& ipp, const std::span<uint8_t> message);
 

--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -225,6 +225,7 @@ player_data = [
     "delivery_box.sql",
     "fishing_contest.sql",
     "fishing_contest_entries.sql",
+    "help_desk.sql",
     "ip_exceptions.sql",
     "linkshells.sql",
     "server_variables.sql",

--- a/tools/generate_ipc_stubs.py
+++ b/tools/generate_ipc_stubs.py
@@ -62,6 +62,9 @@ IPC_STRUCT_NAMES = [
     "SendPlayerToLocation",
 
     "AssistChannelEvent",
+
+    "GMCallRequest",
+    "GMCallResponse",
 ]
 
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Adds support for all packets in the Help Desk menu, used by players to call GMs.
- Adds very much custom support for self-unstuck if choosing "My character is stuck" option (it emits a dedicated packet)
  - Disabled by default, 24 hours cooldown
- Adds IPC for routing requests and responses from/to xi_world
- Adds SQL table for storing each call and the associated response

Note: Missing some changes in the IPC to route this to arbitrary clients, it will be a separate PR.

https://youtu.be/ON2YDm9ItYw

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
