### PR TITLE
[core] ACTION entity lookup order change for trusts

### DIFF
--- a/src/map/packets/c2s/0x01a_action.cpp
+++ b/src/map/packets/c2s/0x01a_action.cpp
@@ -209,10 +209,16 @@ void GP_CLI_COMMAND_ACTION::process(MapSession* PSession, CCharEntity* PChar) co
                 return;
             }
 
-            const CBaseEntity* PNpc = PChar->GetEntity(this->ActIndex, TYPE_NPC | TYPE_MOB);
-
+            CBaseEntity* PNpc = PChar->GetEntity(this->ActIndex, TYPE_NPC | TYPE_MOB | TYPE_TRUST);
             if (!PNpc)
             {
+                return;
+            }
+
+            // Releasing a trust
+            if (auto* PTrust = dynamic_cast<CTrustEntity*>(PNpc))
+            {
+                PChar->RemoveTrust(PTrust);
                 return;
             }
 
@@ -231,12 +237,6 @@ void GP_CLI_COMMAND_ACTION::process(MapSession* PSession, CCharEntity* PChar) co
             {
                 PNpc->PAI->Trigger(PChar);
                 PChar->m_charHistory.npcInteractions++;
-            }
-
-            // Releasing a trust
-            if (auto* PTrust = dynamic_cast<CTrustEntity*>(PChar->GetEntity(this->ActIndex, TYPE_TRUST)))
-            {
-                PChar->RemoveTrust(PTrust);
             }
 
             if (!PChar->isNpcLocked())


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Closes #9444 and #9451 

Reorders the way the NPC is retrieved in the ACTION packet so that PNpc isn't nullptr when PC is "talking" to a trust.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
