### PR TITLE
[core, lua, test] Scripted respawns fixes

### DIFF
--- a/scripts/tests/systems/spawn_handler.lua
+++ b/scripts/tests/systems/spawn_handler.lua
@@ -279,6 +279,74 @@ describe('Spawn Handler', function()
         end)
     end)
 
+    describe('scripted spawns', function()
+        it('respawns Simurgh after kill within respawn window', function()
+            player:gotoZone(xi.zone.ROLANBERRY_FIELDS)
+            local ID = zones[xi.zone.ROLANBERRY_FIELDS]
+            local simurgh = player.entities:get(ID.mob.SIMURGH)
+
+            -- Initial spawn
+            xi.test.world:skipTime(7200)
+            xi.test.world:tick(xi.tick.SPAWN)
+            simurgh.assert:isSpawned()
+
+            player:claimAndKillMob(simurgh)
+
+            -- Skip 2 hours again for respawn
+            xi.test.world:skipTime(7200)
+            xi.test.world:tick(xi.tick.SPAWN)
+
+            simurgh.assert:isSpawned()
+        end)
+
+        it('King Arthro spawns when all Knight Crabs killed and blocks their respawn', function()
+            player:gotoZone(xi.zone.JUGNER_FOREST)
+            local ID = zones[xi.zone.JUGNER_FOREST]
+            local kingArthro = player.entities:get(ID.mob.KING_ARTHRO)
+
+            -- Gather all 10 Knight Crabs and wait for initial spawn
+            local knightCrabs = {}
+            for offset = 1, 10 do
+                knightCrabs[offset] = player.entities:get(ID.mob.KING_ARTHRO - offset)
+            end
+
+            xi.test.world:skipTime(12000)
+            xi.test.world:tick(xi.tick.SPAWN)
+
+            for _, crab in ipairs(knightCrabs) do
+                crab.assert:isSpawned()
+            end
+
+            -- Kill all 10 Knight Crabs
+            for _, crab in ipairs(knightCrabs) do
+                player:claimAndKillMob(crab)
+            end
+
+            -- King Arthro should spawn
+            xi.test.world:tick()
+            kingArthro.assert:isSpawned()
+
+            -- Let KA roam for some time - Knight Crabs should NOT respawn
+            xi.test.world:skipTime(3600)
+            xi.test.world:tick(xi.tick.SPAWN)
+            for _, crab in ipairs(knightCrabs) do
+                crab.assert.no:isSpawned()
+            end
+
+            -- Kill King Arthro
+            player:claimAndKillMob(kingArthro)
+
+            -- Skip 24 hours
+            xi.test.world:skipTime(86400)
+            xi.test.world:tick(xi.tick.SPAWN)
+
+            -- Knight Crabs should now be respawned
+            for _, crab in ipairs(knightCrabs) do
+                crab.assert:isSpawned()
+            end
+        end)
+    end)
+
     -- Nunyenunc NM and Carrion Crow PH in West Sarutabaruta
     describe('placeholder to NM', function()
         it('spawns NM when lottery succeeds', function()

--- a/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Noble_Mold.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Noble_Mold.lua
@@ -28,7 +28,7 @@ entity.onMobDespawn = function(mob)
     local ph = GetMobByID(mob:getID() - 1)
     if ph then
         DisallowRespawn(ph:getID(), false)
-        ph:setRespawnTime(ph:getRespawnTime())
+        ph:setRespawnTime(GetMobRespawnTime(ph:getID()))
     end
 end
 

--- a/scripts/zones/Xarcabard/mobs/Ereshkigal.lua
+++ b/scripts/zones/Xarcabard/mobs/Ereshkigal.lua
@@ -37,7 +37,7 @@ entity.onMobDespawn = function(mob)
     local ph = GetMobByID(mob:getID() - 1)
     if ph then
         DisallowRespawn(ph:getID(), false)
-        ph:setRespawnTime(ph:getRespawnTime())
+        ph:setRespawnTime(GetMobRespawnTime(ph:getID()))
     end
 end
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -17506,7 +17506,7 @@ void CLuaBaseEntity::setSpawn(float x, float y, float z, const sol::object& rot)
  *  Notes   : Used in mobs.lua...and directly in Charybdis
  ************************************************************************/
 
-uint32 CLuaBaseEntity::getRespawnTime()
+auto CLuaBaseEntity::getRespawnTime() const -> uint32
 {
     if (m_PBaseEntity->objtype != TYPE_MOB)
     {
@@ -17514,11 +17514,12 @@ uint32 CLuaBaseEntity::getRespawnTime()
         return 0;
     }
 
-    CMobEntity* PMob = static_cast<CMobEntity*>(m_PBaseEntity);
-
-    if (PMob->m_AllowRespawn)
+    if (auto* PMob = static_cast<CMobEntity*>(m_PBaseEntity); PMob->loc.zone)
     {
-        return static_cast<uint32>(timer::count_seconds(PMob->m_RespawnTime));
+        if (const auto remaining = PMob->loc.zone->spawnHandler()->getRemainingRespawnTime(PMob))
+        {
+            return static_cast<uint32>(timer::count_seconds(*remaining));
+        }
     }
 
     return 0;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -17529,13 +17529,7 @@ auto CLuaBaseEntity::getRespawnTime() const -> uint32
  *  Function: setRespawnTime()
  *  Purpose : Setting the respawn time for a Mob
  *  Example : mob:setRespawnTime(math.random(3600, 7200))
- *  Notes   : Haven't seen the second argument option being used
- *
- * Note: Removed optional (and unused) parameter 2:
- *      if (!lua_isnil(L, 2) && lua_isboolean(L, 2) && lua_toboolean(L, 2))
-        { // set optional parameter to true to only modify the timer
-            return 0;
-        }
+ *  Notes   : 0 disables respawn.
  ************************************************************************/
 
 void CLuaBaseEntity::setRespawnTime(const uint32 seconds) const
@@ -17547,6 +17541,18 @@ void CLuaBaseEntity::setRespawnTime(const uint32 seconds) const
     }
 
     auto* PMob = static_cast<CMobEntity*>(m_PBaseEntity);
+    if (seconds == 0)
+    {
+        PMob->m_RespawnTime  = 0s;
+        PMob->m_AllowRespawn = false;
+
+        if (PMob->loc.zone != nullptr)
+        {
+            PMob->loc.zone->spawnHandler()->unregister(PMob);
+        }
+
+        return;
+    }
 
     PMob->m_RespawnTime  = std::chrono::seconds(seconds);
     PMob->m_AllowRespawn = true;

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -852,12 +852,12 @@ public:
 
     void setNpcFlags(uint32 flags);
 
-    void   spawn(const sol::object& despawnSec, const sol::object& respawnSec);
-    bool   isSpawned();
-    auto   getSpawnPos() -> sol::table;
-    void   setSpawn(float x, float y, float z, const sol::object& rot);
-    uint32 getRespawnTime();
-    void   setRespawnTime(uint32 seconds) const;
+    void spawn(const sol::object& despawnSec, const sol::object& respawnSec);
+    bool isSpawned();
+    auto getSpawnPos() -> sol::table;
+    void setSpawn(float x, float y, float z, const sol::object& rot);
+    auto getRespawnTime() const -> uint32;
+    void setRespawnTime(uint32 seconds) const;
 
     void instantiateMob(uint32 groupID);
 

--- a/src/map/spawn_handler.cpp
+++ b/src/map/spawn_handler.cpp
@@ -73,6 +73,35 @@ auto SpawnHandler::isRegistered(CMobEntity* PMob) const -> bool
     return pendingRespawns_.contains(PMob->id);
 }
 
+auto SpawnHandler::getRemainingRespawnTime(CMobEntity* PMob) const -> std::optional<timer::duration>
+{
+    if (!PMob)
+    {
+        return std::nullopt;
+    }
+
+    const auto now = timer::now();
+
+    if (SpawnSlot* slot = PMob->GetSpawnSlot())
+    {
+        if (auto it = pendingSlotRespawns_.find(slot); it != pendingSlotRespawns_.end())
+        {
+            const auto remaining = it->second.respawnAt - now;
+            return remaining > timer::duration::zero() ? remaining : timer::duration::zero();
+        }
+    }
+    else
+    {
+        if (auto it = pendingRespawns_.find(PMob->id); it != pendingRespawns_.end())
+        {
+            const auto remaining = it->second - now;
+            return remaining > timer::duration::zero() ? remaining : timer::duration::zero();
+        }
+    }
+
+    return std::nullopt;
+}
+
 // Every 30 seconds, attempt to spawn any mob pending respawn.
 // Mobs are respawned if:
 // - Their respawn timer is due within the next 15s (half interval)

--- a/src/map/spawn_handler.cpp
+++ b/src/map/spawn_handler.cpp
@@ -21,6 +21,8 @@
 
 #include "spawn_handler.h"
 
+#include <vector>
+
 #include "common/timer.h"
 #include "common/vana_time.h"
 #include "entities/mobentity.h"
@@ -55,6 +57,23 @@ void SpawnHandler::registerForRespawn(CMobEntity* PMob, const std::optional<time
     else
     {
         pendingRespawns_[PMob->id] = respawnAt;
+    }
+}
+
+void SpawnHandler::unregister(CMobEntity* PMob)
+{
+    if (!PMob)
+    {
+        return;
+    }
+
+    if (SpawnSlot* slot = PMob->GetSpawnSlot())
+    {
+        pendingSlotRespawns_.erase(slot);
+    }
+    else
+    {
+        pendingRespawns_.erase(PMob->id);
     }
 }
 
@@ -112,6 +131,8 @@ void SpawnHandler::Tick(const timer::time_point now)
 {
     const timer::time_point spawnThreshold = now + spawnWindow_;
 
+    std::vector<CMobEntity*> mobsToSpawn;
+
     // Process non-slotted mobs
     std::erase_if(pendingRespawns_, [&](const auto& pair)
                   {
@@ -133,9 +154,14 @@ void SpawnHandler::Tick(const timer::time_point now)
                           return false;
                       }
 
-                      PMob->Spawn();
+                      mobsToSpawn.push_back(PMob);
                       return true;
                   });
+
+    for (auto* PMob : mobsToSpawn)
+    {
+        PMob->Spawn();
+    }
 
     // Process slotted spawns
     std::erase_if(pendingSlotRespawns_, [&](const auto& pair)

--- a/src/map/spawn_handler.h
+++ b/src/map/spawn_handler.h
@@ -49,6 +49,7 @@ public:
     void Tick(timer::time_point now);
     void registerForRespawn(CMobEntity* PMob, std::optional<timer::duration> respawnTime = std::nullopt);
     auto isRegistered(CMobEntity* PMob) const -> bool;
+    auto getRemainingRespawnTime(CMobEntity* PMob) const -> std::optional<timer::duration>;
     void onTOTDChange(vanadiel_time::TOTD totd) const;
     void onWeatherChange(Weather weather) const;
     auto canSpawnNow(const CMobEntity* PMob) const -> bool;

--- a/src/map/spawn_handler.h
+++ b/src/map/spawn_handler.h
@@ -48,6 +48,7 @@ public:
 
     void Tick(timer::time_point now);
     void registerForRespawn(CMobEntity* PMob, std::optional<timer::duration> respawnTime = std::nullopt);
+    void unregister(CMobEntity* PMob);
     auto isRegistered(CMobEntity* PMob) const -> bool;
     auto getRemainingRespawnTime(CMobEntity* PMob) const -> std::optional<timer::duration>;
     void onTOTDChange(vanadiel_time::TOTD totd) const;

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -686,6 +686,10 @@ void LoadMOBList(const std::vector<uint16>& zoneIds)
                     // Skip mobs already registered via setRespawnTime in onMobInitialize - let SpawnHandler handle them
                     if (PZone->spawnHandler()->isRegistered(PMob))
                     {
+                        if (PMob->m_SpawnType == SPAWNTYPE_SCRIPTED && PMob->m_RespawnTime > 0s)
+                        {
+                            PMob->m_AllowRespawn = true;
+                        }
                         return;
                     }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Mobs with respawn time set to 0 in SQL (SPAWNTYPE_SCRIPTED) but setRespawnTime in initialize are being set to never spawn.

- Adds the condition to register them if the onMobInitialize call specified a new respawn timer
- Modify setRespawnTimer to treat 0 as a disable
- Modify getRespawnTimer to return the actual remaining time
- Tweaks the way Noble Mold and Ereshkigal re-registers the PH
- Adds tests for Simurgh and King Arthro

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
