### PR TITLE
[lua] Fix Ro'Maeve Moongates

### DIFF
--- a/scripts/zones/RoMaeve/Zone.lua
+++ b/scripts/zones/RoMaeve/Zone.lua
@@ -7,7 +7,7 @@ local ID = zones[xi.zone.ROMAEVE]
 local zoneObject = {}
 
 local function handleFullMoon()
-    local shouldDoorsOpen = (getVanadielMoonCycle() == xi.moonCycle.FULL_MOON and VanadielHour() >= 18 and VanadielHour() < 6)
+    local shouldDoorsOpen = (getVanadielMoonCycle() == xi.moonCycle.FULL_MOON and (VanadielHour() >= 18 or VanadielHour() < 6))
 
     -- Set targetable status.
     local moongate1 = GetNPCByID(ID.npc.MOONGATE_OFFSET)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The Ro'Maeve zone script cleanup made the Moongates unable to open, since a number can't be both greater than 18 and less than 6. This PR allows the Moongates to open at night under a full moon.

## Steps to test these changes

Wait for full moon, or temporarily set the script to your current moon phase (testing using SetTimeOffset seems to disable onGameHour zone object checks), see doors open.
