### PR TITLE
[core] Dont broadcast effect wears off messages

### DIFF
--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -611,7 +611,7 @@ void CStatusEffectContainer::DeleteStatusEffects()
     }
 }
 
-void CStatusEffectContainer::RemoveStatusEffect(CStatusEffect* PStatusEffect, EffectNotice notice)
+void CStatusEffectContainer::RemoveStatusEffect(CStatusEffect* PStatusEffect, const EffectNotice notice)
 {
     if (!PStatusEffect->deleted)
     {
@@ -622,26 +622,44 @@ void CStatusEffectContainer::RemoveStatusEffect(CStatusEffect* PStatusEffect, Ef
         m_POwner->delModifiers(&PStatusEffect->modList);
         if (m_POwner->objtype == TYPE_PC)
         {
-            CCharEntity* PChar = (CCharEntity*)m_POwner;
+            auto* PChar = static_cast<CCharEntity*>(m_POwner);
 
-            if (PStatusEffect->GetIcon() != 0)
+            if (notice != EffectNotice::Silent && PStatusEffect->GetIcon() != 0 && !(PStatusEffect->HasEffectFlag(EFFECTFLAG_NO_LOSS_MESSAGE)))
             {
-                if (notice != EffectNotice::Silent && !(PStatusEffect->HasEffectFlag(EFFECTFLAG_NO_LOSS_MESSAGE)))
+                // Notify owner that they lost their buff.
+                PChar->pushPacket<GP_SERV_COMMAND_BATTLE_MESSAGE>(PChar, PChar, PStatusEffect->GetIcon(), 0, MsgStd::EffectWearsOff);
+
+                // Notify origin entity if they are in the same zone, and we are in their spawn list.
+                const auto originId = PStatusEffect->GetOriginID();
+                if (originId != 0 && originId != PChar->id && m_POwner->loc.zone)
                 {
-                    PChar->pushPacket<GP_SERV_COMMAND_BATTLE_MESSAGE>(PChar, PChar, PStatusEffect->GetIcon(), 0, MsgStd::EffectWearsOff);
+                    auto* POriginEntity = m_POwner->loc.zone->GetCharByID(originId);
+                    if (POriginEntity && charutils::hasEntitySpawned(POriginEntity, PChar))
+                    {
+                        POriginEntity->pushPacket<GP_SERV_COMMAND_BATTLE_MESSAGE>(PChar, PChar, PStatusEffect->GetIcon(), 0, MsgStd::EffectWearsOff);
+                    }
                 }
             }
 
             if (PStatusEffect->GetStatusID() >= EFFECT_FIRE_MANEUVER && PStatusEffect->GetStatusID() <= EFFECT_DARK_MANEUVER)
             {
-                puppetutils::CheckAttachmentsForManeuver((CCharEntity*)m_POwner, PStatusEffect->GetStatusID(), false);
+                puppetutils::CheckAttachmentsForManeuver(static_cast<CCharEntity*>(m_POwner), PStatusEffect->GetStatusID(), false);
             }
         }
         else
         {
-            if (notice != EffectNotice::Silent && PStatusEffect->GetIcon() != 0 && (!(PStatusEffect->HasEffectFlag(EFFECTFLAG_NO_LOSS_MESSAGE))) && !m_POwner->isDead())
+            if (notice != EffectNotice::Silent && PStatusEffect->GetIcon() != 0 && !(PStatusEffect->HasEffectFlag(EFFECTFLAG_NO_LOSS_MESSAGE)) && !m_POwner->isDead())
             {
-                m_POwner->loc.zone->PushPacket(m_POwner, CHAR_INRANGE, std::make_unique<GP_SERV_COMMAND_BATTLE_MESSAGE>(m_POwner, m_POwner, PStatusEffect->GetIcon(), 0, MsgStd::EffectWearsOff));
+                // Notify origin entity if they are in the same zone, and we are in their spawn list.
+                const auto originId = PStatusEffect->GetOriginID();
+                if (originId != 0 && m_POwner->loc.zone)
+                {
+                    auto* POriginEntity = m_POwner->loc.zone->GetCharByID(originId);
+                    if (POriginEntity && charutils::hasEntitySpawned(POriginEntity, m_POwner))
+                    {
+                        POriginEntity->pushPacket<GP_SERV_COMMAND_BATTLE_MESSAGE>(m_POwner, m_POwner, PStatusEffect->GetIcon(), 0, MsgStd::EffectWearsOff);
+                    }
+                }
             }
         }
     }

--- a/src/map/status_effect_container.h
+++ b/src/map/status_effect_container.h
@@ -139,7 +139,7 @@ private:
     CBattleEntity* m_POwner = nullptr;
 
     // void ReplaceStatusEffect(EFFECT effect); //this needs to be implemented
-    void RemoveStatusEffect(CStatusEffect* PEffect, EffectNotice notice = EffectNotice::ShowMessage); // We remove the effect by its number in the container
+    void RemoveStatusEffect(CStatusEffect* PStatusEffect, EffectNotice notice = EffectNotice::ShowMessage); // We remove the effect by its number in the container
     void DeleteStatusEffects();
     auto SetEffectParams(CStatusEffect* StatusEffect) -> void; // We set the effect of the effect
     void HandleAura(CStatusEffect* PStatusEffect);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Gets rid of the broadcast when a mob status effect wears off. 
Instead only the (de)buffer will get the message, and only if the (de)buffed entity is in their spawn list.
This also adds similar code on the PC side as apparently it was missing until now.

I started modifying Wyvern for Empathy/SL but then realized we're not passing the casting entity anywhere, be it abilities or spells. I'll leave this in draft while I rework addStatusEffect binding to be... _saner_

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Test 1: P1 casts Dia/Slow/whatever on a mob. P1 gets wear off message. P2 does not.

Test 2: P1 (DRG) casts Regen on self. P2 (WHM) casts Haste on P1. P1 uses Spirit Link
- P1 should get Own/Wyvern Regen wear off. P1 should get own (only) Haste wear off.
- P2 should get Haste wears off on both P1 and the wyvern. P2 does not get Regen wears off messages.

<!-- Clear and detailed steps to test your changes here -->
