### PR TITLE
[lua] Comment out print in utils.defaultIfNil()

### DIFF
--- a/scripts/utils/utils.lua
+++ b/scripts/utils/utils.lua
@@ -1120,8 +1120,8 @@ end
 
 function utils.defaultIfNil(inputValue, defaultValue)
     if inputValue == nil then
-        local info = debug.getinfo(2, 'Sl')
-        print(string.format('nil value encounted at %s:%i, defaulting to %s', info.source, info.currentline, tostring(defaultValue)))
+        -- local info = debug.getinfo(2, 'Sl')
+        -- print(string.format('nil value encounted at %s:%i, defaulting to %s', info.source, info.currentline, tostring(defaultValue)))
 
         return defaultValue
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Comments out the debug print in utils.defaultIfNil(). Currently if used for a param(For example in a mobskill), it will print every time a param is defaulting if found to be nil(If param is not defined in the skill script).

Leaving it commented out incase anyone needs it but this will keep it from spamming map.exe.

## Steps to test these changes
Have a mob use a mobskill, see that map doesn't get spammed with prints of unused params.
