### PR TITLE
Fix Apkallu mixin run away behavior

### DIFF
--- a/scripts/mixins/families/apkallu.lua
+++ b/scripts/mixins/families/apkallu.lua
@@ -36,7 +36,7 @@ g_mixins.families.apkallu = function(apkalluMob)
         end
 
         if closest ~= nil then
-            mob:follow(closest, xi.follow.RUN_AWAY)
+            mob:follow(closest, xi.followType.RUN_AWAY)
             mob:setLocalVar('RunAway', 2)
         end
     end)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The Apkallu mixin passed in "xi.follow.RUN_AWAY" as follow behavior into the mob:follow() function, but the correct enum table is "xi.followType".

## Steps to test these changes

Fight Apkallus, see them run, see no errors in log
