### PR TITLE
[lua] Fix Dawn Phase 2

### DIFF
--- a/scripts/battlefields/Empyreal_Paradox/dawn.lua
+++ b/scripts/battlefields/Empyreal_Paradox/dawn.lua
@@ -110,7 +110,7 @@ content.groups =
                 if ally:isMob() then
                     ally:resetLocalVars()
 
-                    if ally:getPool() == xi.mobPools.PRISHE_DAWN then
+                    if ally:getPool() == xi.mobPool.PRISHE_DAWN then
                         local prishePos = prisheCoords[battlefieldArea]
                         ally:setPos(prishePos.x, prishePos.y, prishePos.z, prishePos.r)
 
@@ -118,7 +118,7 @@ content.groups =
                         ally:setLocalVar('[helperNpc]engageWaitTime', 180)
                         ally:setLocalVar('engageWait', GetSystemTime() + 180)
 
-                    elseif ally:getPool() == xi.mobPools.SELHTEUS_DAWN then
+                    elseif ally:getPool() == xi.mobPool.SELHTEUS_DAWN then
                         local selhteusPos = selhteusCoords[battlefieldArea]
                         ally:setPos(selhteusPos.x, selhteusPos.y, selhteusPos.z, selhteusPos.r)
                     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR replaces two instances of `xi.mobPools` with `xi.mobPool`, which were stopping phase 2 of the Dawn fight.

## Steps to test these changes

Do Dawn fight, see phase 2
