### PR TITLE
[core, lua] Add support to remove battlefield effect from trust

### DIFF
--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -557,6 +557,18 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
             petutils::DetachPet(PChar);
         }
 
+        // Remove Battlefield effect from Trusts
+        if (!PChar->PTrusts.empty())
+        {
+            for (auto* PTrust : PChar->PTrusts)
+            {
+                if (PTrust && PTrust->StatusEffectContainer)
+                {
+                    PTrust->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_CONFRONTATION, EffectNotice::Silent);
+                }
+            }
+        }
+
         m_Zone->updateCharLevelRestriction(PChar);
 
         if (leavecode == BATTLEFIELD_LEAVE_CODE_EXIT && PChar->StatusEffectContainer->HasStatusEffectByFlag(EFFECTFLAG_CONFRONTATION))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [X] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [X] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [X] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
* Added the removal of the battlefield effect for trusts exiting a battlefield
trust were not having the battlefield status effect removed after exiting a battlefield when the master was exited, fixes #9456.

## Steps to test these changes
* !togglegm
* choose a bcnm/battlefield that trust can be called in and enter
* call trust
* win
* exit
* trust can still engage a target

<!-- Clear and detailed steps to test your changes here -->
