### PR TITLE
Adding Enspell Damage Percent Multiplier Effect

### DIFF
--- a/scripts/enum/mod.lua
+++ b/scripts/enum/mod.lua
@@ -479,6 +479,8 @@ xi.mod =
     SPIKES                          = 342,
     ENSPELL_DMG                     = 343,
     ENSPELL_CHANCE                  = 856,
+    ENSPELL_DMG_BONUS               = 432, -- Adds to the base damage of the enspell before bonuses and reductions
+    ENSPELL_DMG_PCT                 = 1195, -- Adds to the multiplier applied to enspell damage after base damage is calculated, before day and weather bonuses and reductions
     SPIKES_DMG                      = 344,
     TP_BONUS                        = 345,
     SPIKES_DMG_BONUS                = 1079, -- Increases Blaze/Ice/Shock spikes damage by percentage (e.g. mod value 50 = +50% spikes damage)
@@ -757,8 +759,6 @@ xi.mod =
     QUICK_DRAW_DMG                  = 411, --
     QUICK_DRAW_MACC                 = 191, -- Quick draw magic accuracy
     QUAD_ATTACK                     = 430, -- Quadruple attack chance.
-
-    ENSPELL_DMG_BONUS               = 432,
 
     ABSORB_DMG_TO_MP                = 516, -- Unlike PLD gear mod, works on all damage types (Ethereal Earring)
 

--- a/sql/augments.sql
+++ b/sql/augments.sql
@@ -1100,7 +1100,7 @@ INSERT INTO `augments` VALUES (895,0,0,0,0,0);
 INSERT INTO `augments` VALUES (896,0,432,1,0,0); -- Sword Enhancement Spell Damage +1
 INSERT INTO `augments` VALUES (897,0,96,1,0,0); -- Enhances Souleater Effect +1%
 INSERT INTO `augments` VALUES (898,0,0,0,0,0);
-INSERT INTO `augments` VALUES (899,0,0,0,0,0); --  Sword Enhancement spell damage +1% (Percent Damage)
+INSERT INTO `augments` VALUES (899,0,1195,1,0,0); --  Sword Enhancement spell damage +1% (Percent Damage)
 INSERT INTO `augments` VALUES (900,0,0,0,0,0);
 INSERT INTO `augments` VALUES (901,0,0,0,0,0);
 INSERT INTO `augments` VALUES (902,0,0,0,0,0);

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -809,8 +809,9 @@ enum class Mod
 
     ENSPELL           = 341,  // stores the type of enspell active (0 if nothing)
     ENSPELL_DMG       = 343,  // stores the base damage of the enspell before reductions
-    ENSPELL_DMG_BONUS = 432,  //
+    ENSPELL_DMG_BONUS = 432,  // adds X to the base damage of the enspell before bonuses and reductions
     ENSPELL_CHANCE    = 856,  // Chance of enspell activating (0 = 100%, 10 = 10%, 30 = 30%, ...)
+    ENSPELL_DMG_PCT   = 1195, // adds X% to the multiplier applied to enspell damage after base damage is calculated, before day and weather bonuses and reductions
     SPIKES            = 342,  // store the type of spike spell active (0 if nothing)
     SPIKES_DMG        = 344,  // stores the base damage of the spikes before reductions
     SPIKES_DMG_BONUS  = 1079, // Increases Blaze/Ice/Shock spikes damage by percentage (e.g. mod value 50 = +50% spikes damage)
@@ -1148,7 +1149,7 @@ enum class Mod
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     // 570 through 825 used by WS DMG mods these are not spares.
     //
-    // SPARE IDs: 1195 and onward
+    // SPARE IDs: 1196 and onward
 };
 
 // temporary workaround for using enum class as unordered_map key until compilers support it

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -656,6 +656,66 @@ int32 CalculateEnspellDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender,
         }
     }
 
+    // --------------------------
+    // Enspell % multiplier bucket
+    // --------------------------
+
+    // Total % mod on the attacker (armor + both weapons)
+    int32 totalPctMod = PAttacker->getMod(Mod::ENSPELL_DMG_PCT);
+
+    // Exclude the other weapon's % contribution, same pattern as flat +n above
+    int32 excludePct = 0;
+    int32 weaponPct  = 0;
+
+    if (PChar)
+    {
+        // pWeaponHit is the weapon that procced this add-effect (hand-specific)
+        if (pWeaponHit)
+        {
+            weaponPct = pWeaponHit->getModifier(Mod::ENSPELL_DMG_PCT);
+        }
+
+        constexpr SLOTTYPE slots[] = { SLOT_MAIN, SLOT_SUB };
+        for (SLOTTYPE slot : slots)
+        {
+            if (auto* eq = PChar->getEquip(slot); eq && eq != pWeaponHit)
+            {
+                excludePct += eq->getModifier(Mod::ENSPELL_DMG_PCT);
+            }
+        }
+    }
+
+    // pctApplicable includes: non-weapon % + this-hand weapon %
+    int32 pctApplicable = totalPctMod - excludePct;
+
+    // Split into non-weapon vs weapon
+    int32 nonWeaponPct = pctApplicable - weaponPct;
+    if (nonWeaponPct < 0)
+    {
+        nonWeaponPct = 0; // safety clamp, shouldn't happen unless data is weird
+    }
+
+    float mult = 1.0f;
+
+    // 1) all NON-weapon enspell dmg % (armor/etc)
+    mult += (float)nonWeaponPct / 100.0f;
+
+    // 2) Composure bonus: only RDM main, only Tier I/II elemental (Fire..Water)
+    if (PChar &&
+        PChar->GetMJob() == JOB_RDM &&
+        PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_COMPOSURE) &&
+        (Tier == 1 || Tier == 2) &&
+        (element >= 1 && element <= 6))
+    {
+        mult += 2.0f; // +200% => triple
+    }
+
+    // 3) This hand's weapon-only enspell dmg % (Crocea Mors Path C etc)
+    mult += (float)weaponPct / 100.0f;
+
+    // 4) Apply multiplier exactly once
+    damage = (int32)std::floor(damage * mult);
+
     // matching day 10% bonus, matching weather 10% or 25% for double weather
     float  dBonus  = 1.0;
     float  resist  = 1.0;


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This adds enspell damage % multiplier calculations, including the base effect from RDM JA Composure to battleutils.cpp, wires up the augment for enspell damage %+, and adds the modifier entries to mod.lua and modifier.h.

## Steps to test these changes

Switch to RDM main (level 50+), use an enspell, engage a target and note the additional effect damage
Activate composure, engage a target and note the additional effect damage is 3x (+200%)
Use !additem with the augment ID 899 for +enspell dmg % on items and equip them
Note the additional effect damage multiplier scale
