### PR TITLE
[test] Wait a little longer before asserting KA respawn

### DIFF
--- a/scripts/tests/systems/spawn_handler.lua
+++ b/scripts/tests/systems/spawn_handler.lua
@@ -336,8 +336,8 @@ describe('Spawn Handler', function()
             -- Kill King Arthro
             player:claimAndKillMob(kingArthro)
 
-            -- Skip 24 hours
-            xi.test.world:skipTime(86400)
+            -- Skip past max respawn window (24h 10m)
+            xi.test.world:skipTime(87000)
             xi.test.world:tick(xi.tick.SPAWN)
 
             -- Knight Crabs should now be respawned


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Sometimes KA respawn is randomized to 24 hours and 5 minutes which was causing the test to fail as it waited only 24 hours.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
