### PR TITLE
[lua] Bastok [S] + Grauberg [S] locked doors

### DIFF
--- a/scripts/zones/Bastok_Markets_[S]/DefaultActions.lua
+++ b/scripts/zones/Bastok_Markets_[S]/DefaultActions.lua
@@ -1,6 +1,7 @@
--- local ID = zones[xi.zone.BASTOK_MARKETS_S]
+local ID = zones[xi.zone.BASTOK_MARKETS_S]
 
 return {
+    ['_2f0']             = { messageSpecial = ID.text.GATE_IS_LOCKED },
     ['Adelinde']         = { event = 103 },
     ['Angry_Bull']       = { event = 102 },
     ['Benjamin']         = { event = 146 },

--- a/scripts/zones/Bastok_Markets_[S]/IDs.lua
+++ b/scripts/zones/Bastok_Markets_[S]/IDs.lua
@@ -17,6 +17,7 @@ zones[xi.zone.BASTOK_MARKETS_S] =
         LOGIN_NUMBER                  = 7004,  -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.
         MEMBERS_LEVELS_ARE_RESTRICTED = 7024,  -- Your party is unable to participate because certain members' levels are restricted.
         FISHING_MESSAGE_OFFSET        = 7069,  -- You can't fish here.
+        GATE_IS_LOCKED                = 7215,  -- The gate is locked.
         BLINGBRIX_SHOP_DIALOG         = 7219,  -- Blingbrix good Gobbie from Boodlix's! Boodlix's Emporium help fighting fighters and maging mages. Gil okay, okay?
         MOG_LOCKER_OFFSET             = 7485,  -- Your Mog Locker lease is valid until <timestamp>, kupo.
         REGIME_CANCELED               = 7723,  -- Current training regime canceled.

--- a/scripts/zones/Grauberg_[S]/DefaultActions.lua
+++ b/scripts/zones/Grauberg_[S]/DefaultActions.lua
@@ -1,12 +1,12 @@
 local ID = zones[xi.zone.GRAUBERG_S]
 
 return {
+    ['_2h3']              = { messageSpecial = ID.text.GATE_IS_LOCKED },
     ['qm2']               = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
     ['qm3']               = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
     ['qm_reset']          = { messageSpecial = ID.text.AIR_WARPED_AND_DISTORTED },
     ['Emmerich']          = { event =  8 },
     ['Vanja']             = { event =  9 },
     ['Childerich']        = { event = 10 },
-    ['_2h3']              = { messageSpecial = 7214 },
     ['Veridical_Conflux'] = { messageSpecial = ID.text.MYSTERIOUS_COLUMN_ROTATES },
 }

--- a/scripts/zones/Grauberg_[S]/IDs.lua
+++ b/scripts/zones/Grauberg_[S]/IDs.lua
@@ -18,6 +18,7 @@ zones[xi.zone.GRAUBERG_S] =
         LOGIN_NUMBER                  = 7004, -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.
         MEMBERS_LEVELS_ARE_RESTRICTED = 7024, -- Your party is unable to participate because certain members' levels are restricted.
         FISHING_MESSAGE_OFFSET        = 7069, -- You can't fish here.
+        GATE_IS_LOCKED                = 7215,  -- The gate is locked.
         A_SHIVER_RUNS_DOWN            = 7439, -- A shiver runs down your spine...
         ATTEND_TO_MORE_PRESSING       = 7440, -- Perhaps you should first attend to more pressing matters...
         CAMPAIGN_RESULTS_TALLIED      = 7606, -- Campaign results tallied.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Prevents players from opening the door to Bastok Markets [S] Metalworks and walk into black nothingness. Also corrected ID shift at Grauberg S door I previously fixed but did not ID shift protect💀 

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Click doors, see they don't open.
Bastok Markets [S] `!gotoid 17133995`
Grauberg [S] `!gotoid 17142513`