### PR TITLE
[lua] Fix Einherjar abjuration drops

### DIFF
--- a/scripts/globals/einherjar/reservation.lua
+++ b/scripts/globals/einherjar/reservation.lua
@@ -58,7 +58,7 @@ xi.einherjar.meetsRequirementsForEntry = function(player, chamberId)
     -- since their lockout is applied at reservation
     if
         lockout ~= 0 and
-        (not chamberData.players[chamberData.leaderId] and player:getID() ~= chamberData.leaderId)
+        player:getID() ~= chamberData.leaderId
     then
         player:messageSpecial(texts.ENTRY_PROHIBITED, lockout)
         return false

--- a/scripts/globals/einherjar/treasure.lua
+++ b/scripts/globals/einherjar/treasure.lua
@@ -242,7 +242,7 @@ xi.einherjar.getArmouryCrateRewards = function(bossId, chamberId)
 
     -- 3. Wing specific abjuration (5% chance)
     if math.random(1, 100) <= 5 then
-        local selectedAbjuration = math.random(1, #abjurations[tier])
+        local selectedAbjuration = abjurations[tier][math.random(1, #abjurations[tier])]
         table.insert(rewards, selectedAbjuration)
         -- Captures show it is possible to get 2x of the same abjuration, even without Heitrun.
         -- TODO: Rate of secondary roll is likely between 5 and 10%.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR resolves an issue where abjuration drops in Einherjar armory crates were being replaced by beds (itemIDs 1-9, noble bed, chocobo bedding etc).

Ancillary change: This PR also cleans up some logic for trading glowing lamps.

## Steps to test these changes
Temporarily set the chance to 100% in the treasure script, run Einherjar, see an abjuration drop instead of an oak bed.
