### PR TITLE
[lua] WoTG 41 - Her Memories - Lua Cleanup

### DIFF
--- a/scripts/missions/wotg/helpers.lua
+++ b/scripts/missions/wotg/helpers.lua
@@ -117,7 +117,7 @@ xi.wotg.helpers.checkMemoryFragments = function(player)
         end
     end
 
-    if numFragments == 3 then
+    if numFragments == 4 then
         player:messageName(ID.text.REPORT_TO_CAIT_SITH, nil)
 
         player:completeMission(xi.mission.log_id.WOTG, xi.mission.id.wotg.HER_MEMORIES)

--- a/scripts/quests/crystalWar/Her_Memories_Carnelian_Footfalls.lua
+++ b/scripts/quests/crystalWar/Her_Memories_Carnelian_Footfalls.lua
@@ -80,8 +80,9 @@ quest.sections =
             onEventFinish =
             {
                 [172] = function(player, csid, option, npc)
-                    xi.wotg.helpers.checkMemoryFragments(player)
-                    quest:complete(player)
+                    if quest:complete(player) then
+                        xi.wotg.helpers.checkMemoryFragments(player)
+                    end
                 end,
             },
         },

--- a/scripts/quests/crystalWar/Her_Memories_Homecoming_Queen.lua
+++ b/scripts/quests/crystalWar/Her_Memories_Homecoming_Queen.lua
@@ -48,9 +48,9 @@ local function handleQuestCompletion(player, csid, option, npc)
             player:delKeyItem(questData[2])
         end
 
-        xi.wotg.helpers.checkMemoryFragments(player)
-
-        quest:complete(player)
+        if quest:complete(player) then
+            xi.wotg.helpers.checkMemoryFragments(player)
+        end
     end
 end
 

--- a/scripts/quests/crystalWar/Her_Memories_Of_Malign_Maladies.lua
+++ b/scripts/quests/crystalWar/Her_Memories_Of_Malign_Maladies.lua
@@ -155,9 +155,8 @@ quest.sections =
             onEventFinish =
             {
                 [169] = function(player, csid, option, npc)
-                    xi.wotg.helpers.checkMemoryFragments(player)
-
                     if quest:complete(player) then
+                        xi.wotg.helpers.checkMemoryFragments(player)
                         player:delKeyItem(xi.ki.FEY_STONE)
                     end
                 end,

--- a/scripts/quests/crystalWar/Her_Memories_Operation_Cupid.lua
+++ b/scripts/quests/crystalWar/Her_Memories_Operation_Cupid.lua
@@ -121,8 +121,9 @@ quest.sections =
             onEventFinish =
             {
                 [24] = function(player, csid, option, npc)
-                    xi.wotg.helpers.checkMemoryFragments(player)
-                    quest:complete(player)
+                    if quest:complete(player) then
+                        xi.wotg.helpers.checkMemoryFragments(player)
+                    end
                 end,
             },
         },

--- a/scripts/zones/Bastok_Markets_[S]/IDs.lua
+++ b/scripts/zones/Bastok_Markets_[S]/IDs.lua
@@ -12,6 +12,7 @@ zones[xi.zone.BASTOK_MARKETS_S] =
         GIL_OBTAINED                  = 6392,  -- Obtained <number> gil.
         KEYITEM_OBTAINED              = 6394,  -- Obtained key item: <keyitem>.
         ITEM_RETURNED_TO_CHAR         = 6403,  -- The <keyitem> is returned to you.
+        REPORT_TO_CAIT_SITH           = 6993,  -- You have obtained all of Lilisette's memory fragments. Make haste and report to Cait Sith.
         CARRIED_OVER_POINTS           = 7002,  -- You have carried over <number> login point[/s].
         LOGIN_CAMPAIGN_UNDERWAY       = 7003,  -- The [/January/February/March/April/May/June/July/August/September/October/November/December] <number> Login Campaign is currently underway!
         LOGIN_NUMBER                  = 7004,  -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.

--- a/scripts/zones/Southern_San_dOria_[S]/IDs.lua
+++ b/scripts/zones/Southern_San_dOria_[S]/IDs.lua
@@ -12,6 +12,7 @@ zones[xi.zone.SOUTHERN_SAN_DORIA_S] =
         ITEM_OBTAINED                 = 6391,  -- Obtained: <item>.
         GIL_OBTAINED                  = 6392,  -- Obtained <number> gil.
         KEYITEM_OBTAINED              = 6394,  -- Obtained key item: <keyitem>.
+        REPORT_TO_CAIT_SITH           = 6993,  -- You have obtained all of Lilisette's memory fragments. Make haste and report to Cait Sith.
         CARRIED_OVER_POINTS           = 7002,  -- You have carried over <number> login point[/s].
         LOGIN_CAMPAIGN_UNDERWAY       = 7003,  -- The [/January/February/March/April/May/June/July/August/September/October/November/December] <number> Login Campaign is currently underway!
         LOGIN_NUMBER                  = 7004,  -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.

--- a/scripts/zones/Windurst_Waters_[S]/IDs.lua
+++ b/scripts/zones/Windurst_Waters_[S]/IDs.lua
@@ -15,6 +15,7 @@ zones[xi.zone.WINDURST_WATERS_S] =
         KEYITEM_LOST                  = 6395,  -- Lost key item: <keyitem>.
         NOT_HAVE_ENOUGH_GIL           = 6396,  -- You do not have enough gil.
         ITEMS_OBTAINED                = 6400,  -- You obtain <number> <item>!
+        REPORT_TO_CAIT_SITH           = 6993,  -- You have obtained all of Lilisette's memory fragments. Make haste and report to Cait Sith.
         CARRIED_OVER_POINTS           = 7002,  -- You have carried over <number> login point[/s].
         LOGIN_CAMPAIGN_UNDERWAY       = 7003,  -- The [/January/February/March/April/May/June/July/August/September/October/November/December] <number> Login Campaign is currently underway!
         LOGIN_NUMBER                  = 7004,  -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Move all `xi.wotg.helpers.checkMemoryFragments(player)` to be inside of `if quest:complete(player) then` so that you complete the quest and get the fragment reward before checking how many fragments you have. When it then checks how many fragments you have I changed it to correctly check for 4 fragments instead of 3. Added the text ID to IDs.lua so that the helper function doesn't error spam the map log when trying to do `player:messageName(ID.text.REPORT_TO_CAIT_SITH, nil)`.

Resolves https://github.com/LandSandBoat/server/issues/7254

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

`!cnation 1`
`!addmission 5 40`
`!addquest 7 64` and follow a mission guide