### PR TITLE
[lua] WoTG 42 - Forget me Not - Lua Cleanup

### DIFF
--- a/scripts/missions/wotg/42_Forget_Me_Not.lua
+++ b/scripts/missions/wotg/42_Forget_Me_Not.lua
@@ -38,14 +38,12 @@ mission.sections =
 {
     {
         check = function(player, currentMission, missionStatus, vars)
-            return currentMission == mission.missionId
+            return currentMission == mission.missionId and mission:getVar(player, 'Status') == 0
         end,
 
         [xi.zone.BATALLIA_DOWNS] =
         {
             ['Cavernous_Maw'] = mission:progressEvent(4, 0, 1, 2964, 1700, 43, 0, 0, 0),
-
-            onZoneIn = completeMissionOnZoneIn,
 
             onEventFinish =
             {
@@ -57,8 +55,6 @@ mission.sections =
         {
             ['Cavernous_Maw'] = mission:progressEvent(503, 1, 26, 0, 6912, 235686, 1205, 183377, 1),
 
-            onZoneIn = completeMissionOnZoneIn,
-
             onEventFinish =
             {
                 [503] = mawOnEventFinish,
@@ -68,8 +64,6 @@ mission.sections =
         [xi.zone.SAUROMUGUE_CHAMPAIGN] =
         {
             ['Cavernous_Maw'] = mission:progressEvent(503, 2, 0, 0, 0, 0, 651, 636808, 1),
-
-            onZoneIn = completeMissionOnZoneIn,
 
             onEventFinish =
             {
@@ -81,8 +75,6 @@ mission.sections =
         {
             ['Cavernous_Maw'] = mission:progressEvent(8, 0, 0, 0, 0, 0, 6553607, 0, 1),
 
-            onZoneIn = completeMissionOnZoneIn,
-
             onEventFinish =
             {
                 [8] = mawOnEventFinish,
@@ -92,8 +84,6 @@ mission.sections =
         [xi.zone.ROLANBERRY_FIELDS_S] =
         {
             ['Cavernous_Maw'] = mission:progressEvent(703, 1, 0, 0, 0, 0, 0, 3, 1),
-
-            onZoneIn = completeMissionOnZoneIn,
 
             onEventFinish =
             {
@@ -105,20 +95,22 @@ mission.sections =
         {
             ['Cavernous_Maw'] = mission:progressEvent(703, 2, 300, 200, 100, 0, 5439495, 0, 1),
 
-            onZoneIn = completeMissionOnZoneIn,
-
             onEventFinish =
             {
                 [703] = mawOnEventFinish,
             },
         },
+    },
+
+    {
+        check = function(player, currentMission, missionStatus, vars)
+            return currentMission == mission.missionId and mission:getVar(player, 'Status') == 1
+        end,
 
         [xi.zone.GRAUBERG_S] =
         {
             onZoneIn = function(player, prevZone)
-                if mission:getVar(player, 'Status') == 1 then
-                    return 33
-                end
+                return 33
             end,
 
             onEventUpdate =
@@ -135,10 +127,23 @@ mission.sections =
                 [33] = function(player, csid, option, npc)
                     mission:setVar(player, 'Status', 2)
 
-                    xi.maws.goToMaw(player, mission:getVar(player, 'Option'))
+                    xi.maws.goToMaw(player, xi.maws.pastMaws[mission:getVar(player, 'Option')])
                 end,
             },
         },
+    },
+
+    {
+        check = function(player, currentMission, missionStatus, vars)
+            return currentMission == mission.missionId and mission:getVar(player, 'Status') == 2
+        end,
+
+        [xi.zone.BATALLIA_DOWNS]         = { onZoneIn = completeMissionOnZoneIn },
+        [xi.zone.ROLANBERRY_FIELDS]      = { onZoneIn = completeMissionOnZoneIn },
+        [xi.zone.SAUROMUGUE_CHAMPAIGN]   = { onZoneIn = completeMissionOnZoneIn },
+        [xi.zone.BATALLIA_DOWNS_S]       = { onZoneIn = completeMissionOnZoneIn },
+        [xi.zone.ROLANBERRY_FIELDS_S]    = { onZoneIn = completeMissionOnZoneIn },
+        [xi.zone.SAUROMUGUE_CHAMPAIGN_S] = { onZoneIn = completeMissionOnZoneIn },
     },
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Was completing the mission on zone into any of the zones that have a maw in them prior to watching any cutscenes. Fixed to not complete until after you do the cutscene chain from clicking a maw then getting CS + zoned -> Grauberg CS -> back to maw zone.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

`!addmission 5 41`
