### PR TITLE
[lua, c++]  WoTG 37 + 46 - Spitewarden Mimicry

### DIFF
--- a/scripts/missions/wotg/37_Darkness_Descends.lua
+++ b/scripts/missions/wotg/37_Darkness_Descends.lua
@@ -44,7 +44,8 @@ mission.sections =
 
                 [10] = function(player, csid, option, npc)
                     if option == 5 then
-                        player:updateEvent(156, 10, 305, 183, 320, 847, 450, 0)
+                        local equip = player:getEquipmentModelIds()
+                        player:updateEvent(156, player:getFace(), equip.head, equip.body, equip.hands, equip.main, equip.sub, 0)
                     end
                 end,
             },

--- a/scripts/missions/wotg/46_When_Wills_Collide.lua
+++ b/scripts/missions/wotg/46_When_Wills_Collide.lua
@@ -81,13 +81,15 @@ mission.sections =
             {
                 [1] = function(player, csid, option, npc)
                     if option == 5 then
-                        player:updateEvent(12, 10, 305, 196, 320, 847, 450, 1)
+                        local equip = player:getEquipmentModelIds()
+                        player:updateEvent(119, player:getFace(), equip.head, equip.body, equip.hands, equip.main, equip.sub, 1)
                     end
                 end,
 
                 [2] = function(player, csid, option, npc)
                     if option == 5 then
-                        player:updateEvent(119, 10, 305, 196, 320, 847, 450, 0)
+                        local equip = player:getEquipmentModelIds()
+                        player:updateEvent(182, player:getFace(), equip.head, equip.body, equip.hands, equip.main, equip.sub, 0)
                     end
                 end,
             },

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -1251,6 +1251,11 @@ function CBaseEntity:setLook(look)
 end
 
 ---@nodiscard
+---@return table
+function CBaseEntity:getEquipmentModelIds()
+end
+
+---@nodiscard
 ---@return integer
 function CBaseEntity:getCostume()
 end

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -5846,6 +5846,34 @@ void CLuaBaseEntity::setLook(const sol::table& look)
 }
 
 /************************************************************************
+ *  Function: getEquipmentModelIds()
+ *  Purpose : Returns the player's visible equipment model IDs
+ *  Example : local equip = player:getEquipmentModelIds()
+ *  Note    : Returns table with keys: head, body, hands, main, sub
+ ************************************************************************/
+auto CLuaBaseEntity::getEquipmentModelIds() -> sol::table
+{
+    auto table = lua.create_table();
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("getEquipmentModelIds: caller is not a player (%s).", m_PBaseEntity->getName());
+        table["head"]  = 0;
+        table["body"]  = 0;
+        table["hands"] = 0;
+        table["main"]  = 0;
+        table["sub"]   = 0;
+        return table;
+    }
+    auto* PChar    = static_cast<CCharEntity*>(m_PBaseEntity);
+    table["head"]  = PChar->look.head;
+    table["body"]  = PChar->look.body;
+    table["hands"] = PChar->look.hands;
+    table["main"]  = PChar->look.main;
+    table["sub"]   = PChar->look.sub;
+    return table;
+}
+
+/************************************************************************
  *  Function: getCostume()
  *  Purpose : Returns the PC's appearance
  *  Example : player:getCostume()
@@ -19856,6 +19884,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("getModelId", CLuaBaseEntity::getModelId);
     SOL_REGISTER("setModelId", CLuaBaseEntity::setModelId);
     SOL_REGISTER("setLook", CLuaBaseEntity::setLook);
+    SOL_REGISTER("getEquipmentModelIds", CLuaBaseEntity::getEquipmentModelIds);
     SOL_REGISTER("getCostume", CLuaBaseEntity::getCostume);
     SOL_REGISTER("setCostume", CLuaBaseEntity::setCostume);
     SOL_REGISTER("getCostume2", CLuaBaseEntity::getCostume2);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -306,6 +306,7 @@ public:
     uint16 getModelId();
     void   setModelId(uint16 modelId, const sol::object& slotObj);
     void   setLook(const sol::table& look);
+    auto   getEquipmentModelIds() -> sol::table;
     uint16 getCostume();
     void   setCostume(uint16 costume);
     uint16 getCostume2();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Corrects model for the Fourth Spitewarden to mimicry the player's face and currently equipped gear (excluding legs/feet as those are unique to the model) in the cutscenes for missions 37 and 46. I Included a setLookfromPlayer function as well that can later be used for the battlefield mimicry function when entering WoTG 46 BCNM, but I could always remove it on request.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

`!zone 156`
`!addmission 5 36`
`!cs 10`

`!zone 182`
`!addmission 5 45`
`!cs 1`

<img width="509" height="596" alt="image" src="https://github.com/user-attachments/assets/61e80b3c-4e3c-45fb-a3b3-a693658aaa03" />
