### PR TITLE
[core] Null check before attempting to interrupt item

### DIFF
--- a/src/map/ai/states/item_state.cpp
+++ b/src/map/ai/states/item_state.cpp
@@ -263,6 +263,11 @@ auto CItemState::CanChangeState() -> bool
 
 void CItemState::TryInterrupt(CBattleEntity* PTarget)
 {
+    if (!m_PItem)
+    {
+        return;
+    }
+
     // todo: interrupt on being hit
 
     if (PTarget)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Narrow window where the item can be consumed but PC is still in ItemState due to animation

Closes #9527

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
