### PR TITLE
[core, sql, lua] Enable fishing up snares for Pirate's Chart mini-quest

### DIFF
--- a/scripts/globals/pirates_chart.lua
+++ b/scripts/globals/pirates_chart.lua
@@ -110,6 +110,7 @@ local function removeFromConfrontation(player)
     player:changeMusic(1, 0)
     player:changeMusic(2, 101)
     player:changeMusic(3, 102)
+    player:setLocalVar('pChartActive', 0)
 end
 
 local function resetEvent(members)
@@ -304,6 +305,7 @@ xi.piratesChart.onEventUpdate = function(player, csid, option, npc)
     end
 
     player:confirmTrade()
+    player:setLocalVar('pChartActive', 1)
     npc:setLocalVar('pChartSpawnerID', player:getID())
     barnacledBox:setLocalVar('pChartSpawnerID', player:getID())
 
@@ -425,10 +427,8 @@ xi.piratesChart.onMobDeath = function(mob, player, optParams)
 end
 
 xi.piratesChart.onItemCheck = function(target, item, param, caster)
-    local targetID = target:getID()
-
-    for _, pirateMobID in ipairs(barnacleBuddyIDs) do
-        if targetID == pirateMobID then
+    for _, pirateMobID in pairs(barnacleBuddyIDs) do
+        if target:getID() == pirateMobID then
             return 0
         end
     end

--- a/sql/fishing_area.sql
+++ b/sql/fishing_area.sql
@@ -116,6 +116,7 @@ INSERT INTO `fishing_area` VALUES (101,1,'Whole Zone',0,0,0,NULL,0.000,0.000,0.0
 INSERT INTO `fishing_area` VALUES (102,1,'Whole Zone',0,0,0,NULL,0.000,0.000,0.000);
 -- Valkurm Dunes
 INSERT INTO `fishing_area` VALUES (103,1,'Whole Zone',0,0,0,NULL,0.000,0.000,0.000);
+INSERT INTO `fishing_area` VALUES (103,2,'Whole Zone',0,0,0,NULL,0.000,0.000,0.000);
 -- Jugner Forest
 INSERT INTO `fishing_area` VALUES (104,1,'Crystalwater Spring',1,20,20,'',300.000,1.000,-179.833);
 INSERT INTO `fishing_area` VALUES (104,2,'Lake Mechieume - Mouth',1,20,31,'',19.458,3.000,334.528);

--- a/sql/fishing_catch.sql
+++ b/sql/fishing_catch.sql
@@ -79,6 +79,7 @@ INSERT INTO `fishing_catch` VALUES (100,1,17);    -- West Ronfaure, Knightwell
 INSERT INTO `fishing_catch` VALUES (101,1,16);    -- East Ronfaure, Whole Zone
 INSERT INTO `fishing_catch` VALUES (102,1,23);    -- La Theine Plateau, Whole Zone
 INSERT INTO `fishing_catch` VALUES (103,1,26);    -- Valkurm Dunes, Whole Zone
+INSERT INTO `fishing_catch` VALUES (103,2,140);   -- Valkurm Dunes, Pirate's Chart Quest
 INSERT INTO `fishing_catch` VALUES (104,1,35);    -- Jugner Forest, Crystalwater Spring
 INSERT INTO `fishing_catch` VALUES (104,2,36);    -- Jugner Forest, Lake Mechieume - Mouth
 INSERT INTO `fishing_catch` VALUES (104,3,37);    -- Jugner Forest, Lake Mechieume - Main

--- a/sql/fishing_group.sql
+++ b/sql/fishing_group.sql
@@ -309,6 +309,10 @@ INSERT INTO `fishing_group` VALUES (26,13456,300,275,6);   -- Silver Ring
 INSERT INTO `fishing_group` VALUES (26,14117,500,300,9);   -- Rusty Leggings
 INSERT INTO `fishing_group` VALUES (26,14242,500,300,9);   -- Rusty Subligar
 
+-- Valkurm Dunes, Pirate's Chart mini-quest
+INSERT INTO `fishing_group` VALUES (140,5329,500,300,9);   -- Tarutaru Snare
+INSERT INTO `fishing_group` VALUES (140,5330,500,300,9);   -- Mithra Snare
+
 -- Batallia Downs, North Seaside / Batallia Downs, South Seaside
 
 INSERT INTO `fishing_group` VALUES (27,4360,1000,500,15);  -- Bastore Sardine

--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -2449,6 +2449,16 @@ fishresponse_t* FishingCheck(CCharEntity* PChar, uint8 fishingSkill, rod_t* rod,
         ChestPoolWeight = 0;
     }
 
+    // Pirate's Chart quest pool weighting: just catch items
+    if (PChar->GetLocalVar("pChartActive") == 1 && PChar->getZone() == ZONE_VALKURM_DUNES && area->areaId == 2)
+    {
+        FishPoolWeight  = 0;
+        ItemPoolWeight  = 100;
+        MobPoolWeight   = 0;
+        ChestPoolWeight = 0;
+        NoCatchWeight   = 0;
+    }
+
     if (FishPoolWeight == 0 && ItemPoolWeight == 0 && MobPoolWeight == 0 && ChestPoolWeight == 0)
     {
         NoCatchWeight = 1000;
@@ -2671,6 +2681,11 @@ void FishingAction(CCharEntity* PChar, const GP_CLI_COMMAND_FISHING_2_MODE mode,
 
             fishingarea_t*  fishingArea = GetFishingArea(PChar);
             fishresponse_t* response    = nullptr;
+
+            if (PChar->GetLocalVar("pChartActive") == 1 && PChar->getZone() == ZONE_VALKURM_DUNES)
+            {
+                fishingArea = FishingAreaList[ZONE_VALKURM_DUNES][2];
+            }
 
             if (PChar->hookedFish != nullptr)
             {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Enables fishing up snares for Pirate's Chart mini-quest

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
qm4 : !pos -168.6 4 -131.4 103
!additem 1874 -- Pirates Chart
Trade to qm
/fish
Should catch only mithra snare or tarutaru snare
