### PR TITLE
[AEs] Add en-spell check to additional effect functions. Clean mob AE sections

### DIFF
--- a/scripts/effects/enaero.lua
+++ b/scripts/effects/enaero.lua
@@ -5,16 +5,14 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.ENSPELL, xi.element.WIND)
-    target:addMod(xi.mod.ENSPELL_DMG, effect:getPower())
+    effect:addMod(xi.mod.ENSPELL, xi.element.WIND)
+    effect:addMod(xi.mod.ENSPELL_DMG, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:setMod(xi.mod.ENSPELL_DMG, 0)
-    target:setMod(xi.mod.ENSPELL, 0)
 end
 
 return effectObject

--- a/scripts/effects/enaero_ii.lua
+++ b/scripts/effects/enaero_ii.lua
@@ -5,16 +5,14 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.ENSPELL, xi.element.WIND + 8) -- Tier IIs have higher "enspell IDs"
-    target:addMod(xi.mod.ENSPELL_DMG, effect:getPower())
+    effect:addMod(xi.mod.ENSPELL, xi.element.WIND + 8) -- Tier IIs have higher "enspell IDs"
+    effect:addMod(xi.mod.ENSPELL_DMG, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:setMod(xi.mod.ENSPELL_DMG, 0)
-    target:setMod(xi.mod.ENSPELL, 0)
 end
 
 return effectObject

--- a/scripts/effects/enblizzard.lua
+++ b/scripts/effects/enblizzard.lua
@@ -5,16 +5,14 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.ENSPELL, xi.element.ICE)
-    target:addMod(xi.mod.ENSPELL_DMG, effect:getPower())
+    effect:addMod(xi.mod.ENSPELL, xi.element.ICE)
+    effect:addMod(xi.mod.ENSPELL_DMG, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:setMod(xi.mod.ENSPELL_DMG, 0)
-    target:setMod(xi.mod.ENSPELL, 0)
 end
 
 return effectObject

--- a/scripts/effects/enblizzard_ii.lua
+++ b/scripts/effects/enblizzard_ii.lua
@@ -5,16 +5,14 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.ENSPELL, xi.element.ICE + 8) -- Tier IIs have higher "enspell IDs"
-    target:addMod(xi.mod.ENSPELL_DMG, effect:getPower())
+    effect:addMod(xi.mod.ENSPELL, xi.element.ICE + 8) -- Tier IIs have higher "enspell IDs"
+    effect:addMod(xi.mod.ENSPELL_DMG, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:setMod(xi.mod.ENSPELL_DMG, 0)
-    target:setMod(xi.mod.ENSPELL, 0)
 end
 
 return effectObject

--- a/scripts/effects/endark.lua
+++ b/scripts/effects/endark.lua
@@ -7,22 +7,16 @@ local effectObject = {}
 effectObject.onEffectGain = function(target, effect)
     local jpValue = target:getJobPointLevel(xi.jp.ENDARK_EFFECT)
 
-    target:addMod(xi.mod.ENSPELL, xi.element.DARK)
-    target:addMod(xi.mod.ENSPELL_DMG, effect:getPower() + jpValue)
-    target:addMod(xi.mod.ATT, jpValue)
-    target:addMod(xi.mod.ACC, jpValue)
+    effect:addMod(xi.mod.ENSPELL, xi.element.DARK)
+    effect:addMod(xi.mod.ENSPELL_DMG, effect:getPower() + jpValue)
+    effect:addMod(xi.mod.ATT, jpValue)
+    effect:addMod(xi.mod.ACC, jpValue)
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    local jpValue = target:getJobPointLevel(xi.jp.ENDARK_EFFECT)
-
-    target:setMod(xi.mod.ENSPELL_DMG, 0)
-    target:setMod(xi.mod.ENSPELL, 0)
-    target:delMod(xi.mod.ATT, jpValue)
-    target:delMod(xi.mod.ACC, jpValue)
 end
 
 return effectObject

--- a/scripts/effects/enfire.lua
+++ b/scripts/effects/enfire.lua
@@ -5,16 +5,14 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.ENSPELL, xi.element.FIRE)
-    target:addMod(xi.mod.ENSPELL_DMG, effect:getPower())
+    effect:addMod(xi.mod.ENSPELL, xi.element.FIRE)
+    effect:addMod(xi.mod.ENSPELL_DMG, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:setMod(xi.mod.ENSPELL_DMG, 0)
-    target:setMod(xi.mod.ENSPELL, 0)
 end
 
 return effectObject

--- a/scripts/effects/enfire_ii.lua
+++ b/scripts/effects/enfire_ii.lua
@@ -5,16 +5,14 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.ENSPELL, xi.element.FIRE + 8) -- Tier IIs have higher "enspell IDs"
-    target:addMod(xi.mod.ENSPELL_DMG, effect:getPower())
+    effect:addMod(xi.mod.ENSPELL, xi.element.FIRE + 8) -- Tier IIs have higher "enspell IDs"
+    effect:addMod(xi.mod.ENSPELL_DMG, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:setMod(xi.mod.ENSPELL_DMG, 0)
-    target:setMod(xi.mod.ENSPELL, 0)
 end
 
 return effectObject

--- a/scripts/effects/enlight.lua
+++ b/scripts/effects/enlight.lua
@@ -7,20 +7,15 @@ local effectObject = {}
 effectObject.onEffectGain = function(target, effect)
     local jpValue = target:getJobPointLevel(xi.jp.ENLIGHT_EFFECT)
 
-    target:addMod(xi.mod.ENSPELL, xi.element.LIGHT)
-    target:addMod(xi.mod.ENSPELL_DMG, effect:getPower() + jpValue)
-    target:addMod(xi.mod.ACC, jpValue)
+    effect:addMod(xi.mod.ENSPELL, xi.element.LIGHT)
+    effect:addMod(xi.mod.ENSPELL_DMG, effect:getPower() + jpValue)
+    effect:addMod(xi.mod.ACC, jpValue)
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    local jpValue = target:getJobPointLevel(xi.jp.ENLIGHT_EFFECT)
-
-    target:setMod(xi.mod.ENSPELL_DMG, 0)
-    target:setMod(xi.mod.ENSPELL, 0)
-    target:delMod(xi.mod.ACC, jpValue)
 end
 
 return effectObject

--- a/scripts/effects/enstone.lua
+++ b/scripts/effects/enstone.lua
@@ -5,16 +5,14 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.ENSPELL, xi.element.EARTH)
-    target:addMod(xi.mod.ENSPELL_DMG, effect:getPower())
+    effect:addMod(xi.mod.ENSPELL, xi.element.EARTH)
+    effect:addMod(xi.mod.ENSPELL_DMG, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:setMod(xi.mod.ENSPELL_DMG, 0)
-    target:setMod(xi.mod.ENSPELL, 0)
 end
 
 return effectObject

--- a/scripts/effects/enstone_ii.lua
+++ b/scripts/effects/enstone_ii.lua
@@ -5,16 +5,14 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.ENSPELL, xi.element.EARTH + 8) -- Tier IIs have higher "enspell IDs"
-    target:addMod(xi.mod.ENSPELL_DMG, effect:getPower())
+    effect:addMod(xi.mod.ENSPELL, xi.element.EARTH + 8) -- Tier IIs have higher "enspell IDs"
+    effect:addMod(xi.mod.ENSPELL_DMG, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:setMod(xi.mod.ENSPELL_DMG, 0)
-    target:setMod(xi.mod.ENSPELL, 0)
 end
 
 return effectObject

--- a/scripts/effects/enthunder.lua
+++ b/scripts/effects/enthunder.lua
@@ -5,16 +5,14 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.ENSPELL, xi.element.THUNDER)
-    target:addMod(xi.mod.ENSPELL_DMG, effect:getPower())
+    effect:addMod(xi.mod.ENSPELL, xi.element.THUNDER)
+    effect:addMod(xi.mod.ENSPELL_DMG, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:setMod(xi.mod.ENSPELL_DMG, 0)
-    target:setMod(xi.mod.ENSPELL, 0)
 end
 
 return effectObject

--- a/scripts/effects/enthunder_ii.lua
+++ b/scripts/effects/enthunder_ii.lua
@@ -5,16 +5,14 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.ENSPELL, xi.element.THUNDER + 8) -- Tier IIs have higher "enspell IDs"
-    target:addMod(xi.mod.ENSPELL_DMG, effect:getPower())
+    effect:addMod(xi.mod.ENSPELL, xi.element.THUNDER + 8) -- Tier IIs have higher "enspell IDs"
+    effect:addMod(xi.mod.ENSPELL_DMG, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:setMod(xi.mod.ENSPELL_DMG, 0)
-    target:setMod(xi.mod.ENSPELL, 0)
 end
 
 return effectObject

--- a/scripts/effects/enwater.lua
+++ b/scripts/effects/enwater.lua
@@ -5,16 +5,14 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.ENSPELL, xi.element.WATER)
-    target:addMod(xi.mod.ENSPELL_DMG, effect:getPower())
+    effect:addMod(xi.mod.ENSPELL, xi.element.WATER)
+    effect:addMod(xi.mod.ENSPELL_DMG, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:setMod(xi.mod.ENSPELL_DMG, 0)
-    target:setMod(xi.mod.ENSPELL, 0)
 end
 
 return effectObject

--- a/scripts/effects/enwater_ii.lua
+++ b/scripts/effects/enwater_ii.lua
@@ -5,16 +5,14 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.ENSPELL, xi.element.WATER + 8) -- Tier IIs have higher "enspell IDs"
-    target:addMod(xi.mod.ENSPELL_DMG, effect:getPower())
+    effect:addMod(xi.mod.ENSPELL, xi.element.WATER + 8) -- Tier IIs have higher "enspell IDs"
+    effect:addMod(xi.mod.ENSPELL_DMG, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:setMod(xi.mod.ENSPELL_DMG, 0)
-    target:setMod(xi.mod.ENSPELL, 0)
 end
 
 return effectObject

--- a/scripts/globals/combat/action_additional_effect_damage.lua
+++ b/scripts/globals/combat/action_additional_effect_damage.lua
@@ -56,11 +56,44 @@ local function validateParameters(actor, target, fedData)
     return params
 end
 
+local function hasEnspell(actor)
+    local enspellTable =
+    {
+        [ 1] = xi.effect.ENFIRE,
+        [ 2] = xi.effect.ENFIRE_II,
+        [ 3] = xi.effect.ENBLIZZARD,
+        [ 4] = xi.effect.ENBLIZZARD_II,
+        [ 5] = xi.effect.ENAERO,
+        [ 6] = xi.effect.ENAERO_II,
+        [ 7] = xi.effect.ENSTONE,
+        [ 8] = xi.effect.ENSTONE_II,
+        [ 9] = xi.effect.ENTHUNDER,
+        [10] = xi.effect.ENTHUNDER_II,
+        [11] = xi.effect.ENWATER,
+        [12] = xi.effect.ENWATER_II,
+        [13] = xi.effect.ENLIGHT,
+        [14] = xi.effect.ENDARK,
+    }
+
+    for i = 1, #enspellTable do
+        if actor:hasStatusEffect(enspellTable[i]) then
+            return true
+        end
+    end
+
+    return false
+end
+
 -----------------------------------
 -- Global functions called from "emtity.onAdditionalEffect()"
 -----------------------------------
 xi.combat.action.executeAddEffectDamage = function(actor, target, fedData)
     local params = validateParameters(actor, target, fedData)
+
+    -- Early return: En-spell overrides innate/weapon additional effects.
+    if hasEnspell(actor) then
+        return 0, 0, 0
+    end
 
     -- Early return: No proc.
     if math.random(1, 100) > params.chance then

--- a/scripts/globals/combat/action_additional_effect_status.lua
+++ b/scripts/globals/combat/action_additional_effect_status.lua
@@ -70,11 +70,44 @@ local function validateParameters(actor, target, fedData)
     return params
 end
 
+local function hasEnspell(actor)
+    local enspellTable =
+    {
+        [ 1] = xi.effect.ENFIRE,
+        [ 2] = xi.effect.ENFIRE_II,
+        [ 3] = xi.effect.ENBLIZZARD,
+        [ 4] = xi.effect.ENBLIZZARD_II,
+        [ 5] = xi.effect.ENAERO,
+        [ 6] = xi.effect.ENAERO_II,
+        [ 7] = xi.effect.ENSTONE,
+        [ 8] = xi.effect.ENSTONE_II,
+        [ 9] = xi.effect.ENTHUNDER,
+        [10] = xi.effect.ENTHUNDER_II,
+        [11] = xi.effect.ENWATER,
+        [12] = xi.effect.ENWATER_II,
+        [13] = xi.effect.ENLIGHT,
+        [14] = xi.effect.ENDARK,
+    }
+
+    for i = 1, #enspellTable do
+        if actor:hasStatusEffect(enspellTable[i]) then
+            return true
+        end
+    end
+
+    return false
+end
+
 -----------------------------------
 -- Global functions called from "emtity.onAdditionalEffect()"
 -----------------------------------
 xi.combat.action.executeAddEffectEnhancement = function(actor, target, fedData)
     local params = validateParameters(actor, target, fedData)
+
+    -- Early return: En-spell overrides innate/weapon additional effects.
+    if hasEnspell(actor) then
+        return 0, 0, 0
+    end
 
     -- Early return: Incorrect effect ID.
     if params.effectId == xi.effect.NONE then
@@ -101,6 +134,11 @@ end
 
 xi.combat.action.executeAddEffectEnfeeblement = function(actor, target, fedData)
     local params = validateParameters(actor, target, fedData)
+
+    -- Early return: En-spell overrides innate/weapon additional effects.
+    if hasEnspell(actor) then
+        return 0, 0, 0
+    end
 
     -- Early return: Incorrect effect ID.
     if params.effectId == xi.effect.NONE then
@@ -146,6 +184,11 @@ end
 
 xi.combat.action.executeAddEffectDispel = function(actor, target, fedData)
     local params = validateParameters(actor, target, fedData)
+
+    -- Early return: En-spell overrides innate/weapon additional effects.
+    if hasEnspell(actor) then
+        return 0, 0, 0
+    end
 
     -- Early return: Incorrect effect ID.
     if params.effectId ~= xi.effect.NONE then

--- a/scripts/zones/Batallia_Downs/mobs/Lumber_Jack.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Lumber_Jack.lua
@@ -30,10 +30,6 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    if mob:hasStatusEffect(xi.effect.ENSTONE) then
-        return 0, 0, 0
-    end
-
     local pTable =
     {
         chance    = 20,

--- a/scripts/zones/Jugner_Forest/mobs/King_Arthro.lua
+++ b/scripts/zones/Jugner_Forest/mobs/King_Arthro.lua
@@ -60,20 +60,15 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    -- TODO: All en-spells overwrite innate additional effects. The check should probably be contained in this functions already.
-    if mob:hasStatusEffect(xi.effect.ENWATER) then
-        return 0, 0, 0
-    else
-        local pTable =
-        {
-            chance   = 25,
-            effectId = xi.effect.PARALYSIS,
-            power    = 20,
-            duration = 60,
-        }
+    local pTable =
+    {
+        chance   = 25,
+        effectId = xi.effect.PARALYSIS,
+        power    = 20,
+        duration = 60,
+    }
 
-        return xi.combat.action.executeAddEffectEnfeeblement(mob, target, pTable)
-    end
+    return xi.combat.action.executeAddEffectEnfeeblement(mob, target, pTable)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Olla_Grande.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Olla_Grande.lua
@@ -32,9 +32,6 @@ entity.onAdditionalEffect = function(mob, target, damage)
     return xi.combat.action.executeAddEffectDispel(mob, target, pTable)
 end
 
-entity.onMobDeath = function(mob, player, optParams)
-end
-
 entity.onMobDespawn = function(mob)
     GetNPCByID(ID.npc.OLLAS_QM):updateNPCHideTime(xi.settings.main.FORCE_SPAWN_QM_RESET_TIME)
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
All En-spells additional effects override weapon AEs or mob innate AEs. This adds a check to the AE functions for En-effects, so we do not have to code it in the mob sections for every possible en-spell the mob/entity may, or may not have.
TL;DR -> Look at King Arthro script. This PR is to clean the AE section.

This also cleans the en-spell effect scripts.

## Steps to test these changes
None.
