### PR TITLE
[Fix] ToAU mission 7 getting stuck on CS option

### DIFF
--- a/scripts/missions/toau/07_Westerly_Winds.lua
+++ b/scripts/missions/toau/07_Westerly_Winds.lua
@@ -41,6 +41,14 @@ mission.sections =
                 end,
             },
 
+            onEventUpdate =
+            {
+                [3028] = function(player, csid, option, npc)
+                    local param1 = option == 2 and 0 or 2 -- Hides "It's a prince" option after selecting it.
+                    player:updateEvent(param1, 1, 0, 0, 0, 0, 0, 0, 0)
+                end,
+            },
+
             onEventFinish =
             {
                 [3027] = function(player, csid, option, npc)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds missing event update when a concrete option was chosen.

Without it, the dialog would get stuck, because the first parameter controls (read: hides) which options appear. It would then only allow to pich the same option over and over without advancing the CS.
<img width="380" height="101" alt="imagen" src="https://github.com/user-attachments/assets/26eec9d7-3cba-407c-9d00-bd40a595350a" />

## Steps to test these changes
Run ToAU7. Talk to naja. Be presented this options:
<img width="369" height="89" alt="imagen" src="https://github.com/user-attachments/assets/22f9585c-c063-4497-a688-61dbc984ea19" />
Select `It's a prince.` when promted. Be presented this options:
<img width="370" height="89" alt="imagen" src="https://github.com/user-attachments/assets/41c7c90f-9c1c-46f5-b1f3-515727d20de1" />

Option `Went home.` finishes the cutscene (and the mission), no matter if the other option was ever chosen.