### PR TITLE
[lua] Bug Fix SMN AF 1 Quest - Flow

### DIFF
--- a/scripts/quests/windurst/SMN_AF1_The_Puppet_Master.lua
+++ b/scripts/quests/windurst/SMN_AF1_The_Puppet_Master.lua
@@ -79,15 +79,13 @@ quest.sections =
                         return quest:progressEvent(256, 0, xi.ki.TUNING_FORK_OF_EARTH, 0, xi.item.EARTH_PENDULUM):progress() -- Takes priority over quest "Trial by Earth"
                     elseif
                         questProgress == 1 and
-                        not player:hasItem(xi.item.EARTH_PENDULUM)
+                        not player:hasItem(xi.item.EARTH_PENDULUM) and
+                        player:getQuestStatus(xi.questLog.BASTOK, xi.quest.id.bastok.TRIAL_BY_EARTH) ~= xi.questStatus.QUEST_ACCEPTED -- Progress is locked as long as the player is on Trial by Earth as confirmed in captures
                     then
                         return quest:progressEvent(257, 0, xi.item.EARTH_PENDULUM)
                     elseif questProgress == 1 then
                         return quest:event(253, 0, 0, 0, 0, 0, xi.item.EARTH_PENDULUM, 1)
-                    elseif
-                        questProgress == 2 and
-                        player:getQuestStatus(xi.questLog.BASTOK, xi.quest.id.bastok.TRIAL_BY_EARTH) ~= xi.questStatus.QUEST_ACCEPTED -- Progress is locked as long as the player is on Trial by Earth as confirmed in captures
-                    then
+                    elseif questProgress == 2 then
                         return quest:progressEvent(258)
                     end
                 end,


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a bug where the quest lockout was put in the wrong spot.
The lockout is meant to bar you from getting a new pendulum if you have "Trial by Earth" flagged and not being able to complete the quest.

## Steps to test these changes

1. `!addquest 2 81`
2. Talk to Juroro get pendulum.
3. Talk to Juroro again and flag "Trial by Earth"
4. Throw pendulum on floor.
5. Talk to Juroro who won't give you another one.
6. `!delquest 1 61`
7. Talk to Juroro
8. Get new pendulum.