### PR TITLE
[core] PacketValidator: Don't get leader of null party

### DIFF
--- a/src/map/packets/c2s/validation.cpp
+++ b/src/map/packets/c2s/validation.cpp
@@ -186,6 +186,10 @@ auto PacketValidator::isAllianceLeader(const CCharEntity* PChar) -> PacketValida
     {
         result_.addError("Not in an alliance.");
     }
+    else if (PChar->PParty->m_PAlliance->getMainParty() == nullptr)
+    {
+        result_.addError("No alliance main party.");
+    }
     else if (PChar->PParty->m_PAlliance->getMainParty()->GetLeader() != PChar)
     {
         result_.addError("Not the alliance leader.");


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
The PacketValidator function `isAllianceLeader` can cause an access violation exception if `m_PAlliance->getMainParty()` is nullptr. This can happen in situations difficult to reproduce due to a variety of blind spots with the party/alliance system when running on a server with multiple processes. If different members of an alliance are in zones running on separate processes, and `m_PAlliance->getMainParty()` cannot successfully retrieve the main party, then attempting to get the leader of that party will result in a server crash. 

This PR simply checks to make sure getMainParty() returned something real before attempting to get its leader.

## Steps to test these changes

* Create an alliance of two parties of two members each
* Put the two parties in different zones running on different server processes
* Disband the alliance, confirm that server doesn't crash
