### PR TITLE
[sql] Add Living Rod's Hidden Effect

### DIFF
--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -2105,6 +2105,9 @@ INSERT INTO `item_latents` VALUES (16976,23,18,6,1000);  -- Attack+18 while TP <
 INSERT INTO `item_latents` VALUES (16976,25,5,6,1000);   -- Accuracy+5 while TP <100%
 INSERT INTO `item_latents` VALUES (16976,287,6,6,1000);  -- DMG+6 while TP <100%
 
+-- Living Rod
+INSERT INTO `item_latents` VALUES (17070,370,1,52,6);    -- Regen Effect +1/tick in Water weather
+
 -- Mistilteinn
 INSERT INTO `item_latents` VALUES (17073,369,1,7,2);     -- Adds Refresh 1MP per tick
 INSERT INTO `item_latents` VALUES (17073,406,30,7,2);    -- Drains 30TP if TP >= 30


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds [Living Rod](https://ffxiclopedia.fandom.com/wiki/Living_Rod)'s hidden effect (+1 Regen in Water based weather).

I confirmed on retail that it is +1 regen in water weather.

Shout out to Hito on Phoenix discord for pointing out it was missing.

## Steps to test these changes
1. !additem Living Rod
2. !setweather 6 or 7
2b. !zone 72 (Alzadaal Undersea always has water weather)
3. See that equipping the rod adds +1 auto regen.
